### PR TITLE
fix bug where sdxl finetune is running and base sdxl inference request hangs forever

### DIFF
--- a/api/pkg/controller/sessions.go
+++ b/api/pkg/controller/sessions.go
@@ -58,7 +58,9 @@ func (c *Controller) getMatchingSessionFilterIndex(ctx context.Context, filter t
 		// look to see if we have any rejection matches that we should not include
 		reject := false
 		for _, rejectEntry := range filter.Reject {
-			if rejectEntry.ModelName == session.ModelName && rejectEntry.Mode == session.Mode {
+			if rejectEntry.ModelName == session.ModelName && rejectEntry.Mode == session.Mode &&
+				((rejectEntry.FinetuneFile == types.FINETUNE_FILE_NONE && session.FinetuneFile == "") ||
+					(rejectEntry.FinetuneFile != "" && rejectEntry.FinetuneFile == session.FinetuneFile)) {
 				reject = true
 			}
 		}

--- a/api/pkg/runner/controller.go
+++ b/api/pkg/runner/controller.go
@@ -246,7 +246,12 @@ func (r *Runner) getNextGlobalSession(ctx context.Context) (*types.Session, erro
 	// before trying to run another type of model
 
 	r.activeModelInstances.Range(func(key string, modelInstance *ModelInstance) bool {
-		queryParams.Add("reject", fmt.Sprintf("%s:%s", modelInstance.filter.ModelName, modelInstance.filter.Mode))
+		queryParams.Add("reject", fmt.Sprintf(
+			"%s:%s:%s",
+			modelInstance.filter.ModelName,
+			modelInstance.filter.Mode,
+			modelInstance.filter.FinetuneFile,
+		))
 		return true
 	})
 

--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -499,21 +499,23 @@ func (apiServer *HelixAPIServer) getNextRunnerSession(res http.ResponseWriter, r
 
 	if ok && len(rejectPairs) > 0 {
 		for _, rejectPair := range rejectPairs {
-			pair := strings.Split(rejectPair, ":")
-			if len(pair) != 2 {
+			triple := strings.Split(rejectPair, ":")
+			if len(triple) != 3 {
 				return nil, fmt.Errorf("invalid reject pair: %s", rejectPair)
 			}
-			rejectModelName, err := types.ValidateModelName(pair[0], false)
+			rejectModelName, err := types.ValidateModelName(triple[0], false)
 			if err != nil {
 				return nil, err
 			}
-			rejectModelMode, err := types.ValidateSessionMode(pair[1], false)
+			rejectModelMode, err := types.ValidateSessionMode(triple[1], false)
 			if err != nil {
 				return nil, err
 			}
+			rejectFinetuneFile := triple[2]
 			reject = append(reject, types.SessionFilterModel{
-				ModelName: rejectModelName,
-				Mode:      rejectModelMode,
+				ModelName:    rejectModelName,
+				Mode:         rejectModelMode,
+				FinetuneFile: rejectFinetuneFile,
 			})
 		}
 	}

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -71,8 +71,9 @@ type Session struct {
 }
 
 type SessionFilterModel struct {
-	Mode      SessionMode `json:"mode"`
-	ModelName ModelName   `json:"model_name"`
+	Mode         SessionMode `json:"mode"`
+	ModelName    ModelName   `json:"model_name"`
+	FinetuneFile string      `json:"finetune_file"`
 }
 
 type SessionFilter struct {


### PR DESCRIPTION
include finetuneFile as part of the rejection filter so that we don't ignore requests for _different_ finetunes than we're currently running (which we can't service)