### PR TITLE
give running models a 2 second headstart to claim any session

### DIFF
--- a/api/pkg/controller/sessions.go
+++ b/api/pkg/controller/sessions.go
@@ -5,6 +5,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/lukemarsden/helix/api/pkg/store"
@@ -18,6 +19,13 @@ const DEBUG = true
 // this function expects the sessionQueueMtx to be locked when it is run
 func (c *Controller) getMatchingSessionFilterIndex(ctx context.Context, filter types.SessionFilter) int {
 	for i, session := range c.sessionQueue {
+
+		if filter.Older != types.Duration(0) {
+			if time.Now().Add(-time.Duration(filter.Older)).After(session.Created) {
+				continue
+			}
+		}
+
 		if filter.Mode != "" && session.Mode != filter.Mode {
 			continue
 		}

--- a/api/pkg/controller/sessions.go
+++ b/api/pkg/controller/sessions.go
@@ -20,8 +20,16 @@ const DEBUG = true
 func (c *Controller) getMatchingSessionFilterIndex(ctx context.Context, filter types.SessionFilter) int {
 	for i, session := range c.sessionQueue {
 
+		// include sessions that are older than filter.Older
+		// so - filter out ones that are too new
 		if filter.Older != types.Duration(0) {
-			if time.Now().Add(-time.Duration(filter.Older)).After(session.Created) {
+			now := time.Now()
+			tooNewThreshold := now.Add(-time.Duration(filter.Older))
+			if session.Created.After(tooNewThreshold) { // too new
+				log.Info().Msgf(
+					"skipping session %s because it is too new (session created at %s which is after threshold %s)",
+					session.ID, session.Created, tooNewThreshold,
+				)
 				continue
 			}
 		}

--- a/api/pkg/runner/controller.go
+++ b/api/pkg/runner/controller.go
@@ -238,6 +238,16 @@ func (r *Runner) getNextGlobalSession(ctx context.Context) (*types.Session, erro
 	// this means "only give me sessions that will fit in this much RAM"
 	queryParams.Add("memory", fmt.Sprintf("%d", freeMemory))
 
+	// give currently running models a head start on claiming jobs - this is for
+	// when we have > 1 runner
+	//
+	// TODO: using timing for this prioitization heuristic is flaky and adds
+	// latency unnecessarily, instead we could have a bidding system where the
+	// api requests bids from all the connected runners and they bid on how
+	// quickly they could service the request (e.g. what is their queue length,
+	// do they have the model loaded into memory)
+	queryParams.Add("older", "2s")
+
 	// now let's loop over our running model instances and de-prioritise them
 	// we might still get sessions of this type but only if there isn't another
 	// type in the queue - this is to avoid running only one type of model

--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -517,6 +517,17 @@ func (apiServer *HelixAPIServer) getNextRunnerSession(res http.ResponseWriter, r
 			})
 		}
 	}
+
+	older := req.URL.Query().Get("older")
+
+	var olderDuration time.Duration
+	if older != "" {
+		olderDuration, err = time.ParseDuration(older)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	filter := types.SessionFilter{
 		Mode:         sessionMode,
 		Type:         sessionType,
@@ -524,6 +535,7 @@ func (apiServer *HelixAPIServer) getNextRunnerSession(res http.ResponseWriter, r
 		Memory:       memory,
 		Reject:       reject,
 		FinetuneFile: finetuneFile,
+		Older:        types.Duration(olderDuration),
 	}
 
 	// alow the worker to filter what tasks it wants


### PR DESCRIPTION
by giving running models a head start on claiming sessions, we avoid the case where there's, say, a base mistral already loaded into gpu memory and ready to go on runner 1, but runner 2 beats runner 1 in the race to poll for a session, then runner 2 gets it even though this introduces more latency to the user and is suboptimal because the request could have been serviced on runner 1 immediately