### PR TITLE
we don't need the balance transfer code any more - remove

### DIFF
--- a/api/pkg/controller/handlers.go
+++ b/api/pkg/controller/handlers.go
@@ -10,14 +10,6 @@ import (
 )
 
 func (c *Controller) GetStatus(ctx types.RequestContext) (types.UserStatus, error) {
-	balanceTransfers, err := c.Options.Store.GetBalanceTransfers(ctx.Ctx, store.OwnerQuery{
-		Owner:     ctx.Owner,
-		OwnerType: ctx.OwnerType,
-	})
-	if err != nil {
-		return types.UserStatus{}, err
-	}
-
 	usermeta, err := c.Options.Store.GetUserMeta(ctx.Ctx, ctx.Owner)
 
 	if err != nil || usermeta == nil {
@@ -27,24 +19,11 @@ func (c *Controller) GetStatus(ctx types.RequestContext) (types.UserStatus, erro
 		}
 	}
 
-	// add up the total value of all balance transfers
-	credits := 0
-	for _, balanceTransfer := range balanceTransfers {
-		credits += balanceTransfer.Amount
-	}
 	return types.UserStatus{
-		Admin:   ctx.Admin,
-		User:    ctx.Owner,
-		Credits: credits,
-		Config:  usermeta.Config,
+		Admin:  ctx.Admin,
+		User:   ctx.Owner,
+		Config: usermeta.Config,
 	}, nil
-}
-
-func (c *Controller) GetTransactions(ctx types.RequestContext) ([]*types.BalanceTransfer, error) {
-	return c.Options.Store.GetBalanceTransfers(ctx.Ctx, store.OwnerQuery{
-		Owner:     ctx.Owner,
-		OwnerType: ctx.OwnerType,
-	})
 }
 
 func (c *Controller) CreateAPIKey(ctx types.RequestContext, name string) (string, error) {

--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -266,10 +266,6 @@ func (apiServer *HelixAPIServer) status(res http.ResponseWriter, req *http.Reque
 	return apiServer.Controller.GetStatus(apiServer.getRequestContext(req))
 }
 
-func (apiServer *HelixAPIServer) getTransactions(res http.ResponseWriter, req *http.Request) ([]*types.BalanceTransfer, error) {
-	return apiServer.Controller.GetTransactions(apiServer.getRequestContext(req))
-}
-
 func (apiServer *HelixAPIServer) filestoreConfig(res http.ResponseWriter, req *http.Request) (filestore.FilestoreConfig, error) {
 	return apiServer.Controller.FilestoreConfig(apiServer.getOwnerContext(req))
 }

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -135,7 +135,6 @@ func (apiServer *HelixAPIServer) ListenAndServe(ctx context.Context, cm *system.
 	subrouter.HandleFunc("/stripe/webhook", apiServer.subscriptionWebhook).Methods("POST")
 
 	authRouter.HandleFunc("/status", system.DefaultWrapper(apiServer.status)).Methods("GET")
-	authRouter.HandleFunc("/transactions", system.DefaultWrapper(apiServer.getTransactions)).Methods("GET")
 
 	// the auth here is handled because we prefix the user path based on the auth context
 	// e.g. /sessions/123 becomes /users/456/sessions/123

--- a/api/pkg/store/migrations/0009_drop_balance_transfer.down.sql
+++ b/api/pkg/store/migrations/0009_drop_balance_transfer.down.sql
@@ -1,0 +1,10 @@
+create table balance_transfer (
+  id varchar(255) PRIMARY KEY,
+  created timestamp default current_timestamp,
+  owner varchar(255) NOT NULL,
+  owner_type varchar(255) NOT NULL,
+  payment_type varchar(255) NOT NULL,
+  amount integer NOT NULL,
+  -- this is the JSON representation of the job data
+  data json not null
+);

--- a/api/pkg/store/migrations/0009_drop_balance_transfer.up.sql
+++ b/api/pkg/store/migrations/0009_drop_balance_transfer.up.sql
@@ -1,0 +1,1 @@
+drop table if exists balance_transfer;

--- a/api/pkg/store/postgres.go
+++ b/api/pkg/store/postgres.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"strings"
 
-	"time"
-
 	"database/sql"
 
 	_ "github.com/lib/pq"
@@ -632,105 +630,6 @@ func (d *PostgresStore) UpdateSessionMeta(
 	}
 
 	return d.GetSession(ctx, data.ID)
-}
-
-func (d *PostgresStore) GetBalanceTransfers(
-	ctx context.Context,
-	query OwnerQuery,
-) ([]*types.BalanceTransfer, error) {
-	var transfers []*types.BalanceTransfer
-	var rows *sql.Rows
-	var err error
-
-	rows, err = d.pgDb.Query(`
-		SELECT
-			id, created, owner, owner_type, payment_type, amount, data
-		FROM
-			balance_transfer
-		WHERE
-			owner = $1 AND owner_type = $2
-		ORDER BY
-			created ASC
-	`, query.Owner, query.OwnerType)
-
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var id string
-		var created time.Time
-		var owner string
-		var ownerType types.OwnerType
-		var paymentType types.PaymentType
-		var amount int
-		var data []byte
-
-		err = rows.Scan(&id, &created, &owner, &ownerType, &paymentType, &amount, &data)
-		if err != nil {
-			return nil, err
-		}
-
-		var transferData types.BalanceTransferData
-		err = json.Unmarshal(data, &transferData)
-		if err != nil {
-			return nil, err
-		}
-
-		transfer := &types.BalanceTransfer{
-			ID:          id,
-			Created:     created,
-			Owner:       owner,
-			OwnerType:   ownerType,
-			PaymentType: paymentType,
-			Amount:      amount,
-			Data:        transferData,
-		}
-
-		transfers = append(transfers, transfer)
-	}
-
-	err = rows.Err()
-	if err != nil {
-		return nil, err
-	}
-
-	return transfers, nil
-}
-
-func (d *PostgresStore) CreateBalanceTransfer(
-	ctx context.Context,
-	transfer types.BalanceTransfer,
-) error {
-	transferData, err := json.Marshal(transfer.Data)
-	if err != nil {
-		return err
-	}
-	sqlStatement := `
-insert into
-balance_transfer (
-	id,
-	owner,
-	owner_type,
-	payment_type,
-	amount,
-	data
-)
-values ($1, $2, $3, $4, $5, $6)`
-	_, err = d.pgDb.Exec(
-		sqlStatement,
-		transfer.ID,
-		transfer.Owner,
-		transfer.OwnerType,
-		transfer.PaymentType,
-		transfer.Amount,
-		transferData,
-	)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func (d *PostgresStore) CreateAPIKey(ctx context.Context, owner OwnerQuery, name string) (string, error) {

--- a/api/pkg/store/types.go
+++ b/api/pkg/store/types.go
@@ -6,11 +6,6 @@ import (
 	"github.com/lukemarsden/helix/api/pkg/types"
 )
 
-type GetBalanceTransfersQuery struct {
-	Owner     string          `json:"owner"`
-	OwnerType types.OwnerType `json:"owner_type"`
-}
-
 type GetJobsQuery struct {
 	Owner     string          `json:"owner"`
 	OwnerType types.OwnerType `json:"owner_type"`
@@ -55,10 +50,6 @@ type Store interface {
 	CreateUserMeta(ctx context.Context, UserMeta types.UserMeta) (*types.UserMeta, error)
 	UpdateUserMeta(ctx context.Context, UserMeta types.UserMeta) (*types.UserMeta, error)
 	EnsureUserMeta(ctx context.Context, UserMeta types.UserMeta) (*types.UserMeta, error)
-
-	// balance transfers
-	GetBalanceTransfers(ctx context.Context, query OwnerQuery) ([]*types.BalanceTransfer, error)
-	CreateBalanceTransfer(ctx context.Context, balanceTransfer types.BalanceTransfer) error
 
 	// api keys
 	CreateAPIKey(ctx context.Context, owner OwnerQuery, name string) (string, error)

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -7,21 +7,6 @@ import (
 	"time"
 )
 
-type BalanceTransferData struct {
-	JobID           string `json:"job_id"`
-	StripePaymentID string `json:"stripe_payment_id"`
-}
-
-type BalanceTransfer struct {
-	ID          string              `json:"id"`
-	Created     time.Time           `json:"created"`
-	Owner       string              `json:"owner"`
-	OwnerType   OwnerType           `json:"owner_type"`
-	PaymentType PaymentType         `json:"payment_type"`
-	Amount      int                 `json:"amount"`
-	Data        BalanceTransferData `json:"data"`
-}
-
 type Module struct {
 	ID       string `json:"id"`
 	Title    string `json:"title"`
@@ -250,10 +235,9 @@ type RequestContext struct {
 }
 
 type UserStatus struct {
-	Admin   bool       `json:"admin"`
-	User    string     `json:"user"`
-	Credits int        `json:"credits"`
-	Config  UserConfig `json:"config"`
+	Admin  bool       `json:"admin"`
+	User   string     `json:"user"`
+	Config UserConfig `json:"config"`
 }
 
 // a single envelope that is broadcast to users

--- a/frontend/src/contexts/account.tsx
+++ b/frontend/src/contexts/account.tsx
@@ -8,7 +8,6 @@ import { extractErrorMessage } from '../hooks/useErrorCallback'
 
 import {
   IKeycloakUser,
-  IBalanceTransfer,
   ISession,
   IApiKey,
   IServerConfig,
@@ -27,7 +26,6 @@ export interface IAccountContext {
   token?: string,
   serverConfig: IServerConfig,
   userConfig: IUserConfig,
-  transactions: IBalanceTransfer[],
   apiKeys: IApiKey[],
   onLogin: () => void,
   onLogout: () => void,
@@ -42,7 +40,6 @@ export const AccountContext = createContext<IAccountContext>({
     stripe_enabled: false,
   },
   userConfig: {},
-  transactions: [],
   apiKeys: [],
   onLogin: () => {},
   onLogout: () => {},
@@ -61,7 +58,6 @@ export const useAccountContext = (): IAccountContext => {
     filestore_prefix: '',
     stripe_enabled: false,
   })
-  const [ transactions, setTransactions ] = useState<IBalanceTransfer[]>([])
   const [ apiKeys, setApiKeys ] = useState<IApiKey[]>([])
 
   const keycloak = useMemo(() => {
@@ -85,12 +81,6 @@ export const useAccountContext = (): IAccountContext => {
     apiKeys,
   ])
 
-  const loadTransactions = useCallback(async () => {
-    const result = await api.get<IBalanceTransfer[]>('/api/v1/transactions')
-    if(!result) return
-    setTransactions(result)
-  }, [])
-
   const loadStatus = useCallback(async () => {
     const statusResult = await api.get('/api/v1/status')
     if(!statusResult) return
@@ -113,13 +103,11 @@ export const useAccountContext = (): IAccountContext => {
 
   const loadAll = useCallback(async () => {
     await bluebird.all([
-      loadTransactions(),
       loadStatus(),
       loadServerConfig(),
       loadApiKeys(),
     ])
   }, [
-    loadTransactions,
     loadStatus,
     loadServerConfig,
     loadApiKeys,
@@ -206,7 +194,6 @@ export const useAccountContext = (): IAccountContext => {
     serverConfig,
     userConfig,
     credits,
-    transactions,
     apiKeys,
     onLogin,
     onLogout,
@@ -218,7 +205,6 @@ export const useAccountContext = (): IAccountContext => {
     serverConfig,
     userConfig,
     credits,
-    transactions,
     apiKeys,
     onLogin,
     onLogout,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -71,21 +71,6 @@ export interface IUserConfig {
   stripe_subscription_id?: string,
 }
 
-export interface IBalanceTransferData {
-  job_id?: string,
-  stripe_payment_id?: string,
-}
-
-export interface IBalanceTransfer {
-  id: string,
-  created: number,
-  owner: string,
-  owner_type: string,
-  payment_type: string,
-  amount: number,
-  data: IBalanceTransferData,
-}
-
 export type IOwnerType = 'user' | 'system' | 'org';
 
 export interface IApiKey {


### PR DESCRIPTION
This removes the balance transfer code that we don't actually need any more - it uses `drop table if exists balance_transfer;` in case the table was never actually created