### PR TITLE
228 global tools

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -133,3 +133,37 @@ steps:
 
 depends_on:
 - default
+
+---
+kind: pipeline
+type: docker
+name: build-demos
+
+volumes:
+  - name: dockersocket
+    host:
+      path: /var/run/docker.sock
+
+steps:
+- name: publish-demos
+  image: plugins/gar
+  pull: always
+  settings:
+    dockerfile: Dockerfile.demos
+    auto_tag: true
+    repo: helixml/helix/demos
+    location: europe
+    json_key:
+      from_secret: gar_json_key_b64
+  volumes:
+  - name: dockersocket
+    path: /var/run/docker.sock
+  when:
+    branch:
+    - main
+    event:
+    - tag
+    - push
+
+depends_on:
+- default

--- a/Dockerfile.demos
+++ b/Dockerfile.demos
@@ -6,5 +6,5 @@ RUN go mod download
 COPY demos ./demos
 WORKDIR /app/demos
 RUN go build -o /demos
-EXPOSE 8080
+EXPOSE 80
 ENTRYPOINT [ "/demos" ]

--- a/api/pkg/controller/sessions.go
+++ b/api/pkg/controller/sessions.go
@@ -455,6 +455,12 @@ func (c *Controller) checkForActions(session *types.Session) (*types.Session, er
 			log.Error().Err(err).Msgf("error loading tool from session config, perhaps stale tool ID found, session: %s, tool: %s", session.ID, id)
 			continue
 		}
+
+		// if the tool exists but the user cannot access it - then something funky is being attempted and we should deny it
+		if !tool.Global && tool.Owner != session.Owner {
+			return nil, system.NewHTTPError403(fmt.Sprintf("you do not have access to the tool with the id: %s", tool.ID))
+		}
+
 		tools = append(tools, tool)
 	}
 

--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -3,7 +3,6 @@ package server
 import (
 	"archive/tar"
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -354,15 +353,6 @@ func (apiServer *HelixAPIServer) getConfig() (types.ServerConfigForFrontend, err
 		return types.ServerConfigForFrontend{}, system.NewHTTPError500("we currently only support local filestore")
 	}
 
-	tools := []types.Tool{}
-	for _, id := range apiServer.Options.ToolsGlobalIDS {
-		tool, err := apiServer.Store.GetTool(context.Background(), id)
-		if err != nil {
-			return types.ServerConfigForFrontend{}, err
-		}
-		tools = append(tools, *tool)
-	}
-
 	return types.ServerConfigForFrontend{
 		FilestorePrefix:         filestorePrefix,
 		StripeEnabled:           apiServer.Stripe.Enabled(),
@@ -370,7 +360,6 @@ func (apiServer *HelixAPIServer) getConfig() (types.ServerConfigForFrontend, err
 		GoogleAnalyticsFrontend: apiServer.Janitor.Options.GoogleAnalyticsFrontend,
 		EvalUserID:              apiServer.Options.EvalUserID,
 		ToolsEnabled:            apiServer.Options.Config.Tools.Enabled,
-		GlobalTools:             tools,
 	}, nil
 }
 

--- a/api/pkg/server/tool_handlers.go
+++ b/api/pkg/server/tool_handlers.go
@@ -24,7 +24,7 @@ import (
 func (s *HelixAPIServer) listTools(rw http.ResponseWriter, r *http.Request) ([]*types.Tool, *system.HTTPError) {
 	userContext := s.getRequestContext(r)
 
-	tools, err := s.Store.ListTools(r.Context(), &store.ListToolsQuery{
+	userTools, err := s.Store.ListTools(r.Context(), &store.ListToolsQuery{
 		Owner:     userContext.Owner,
 		OwnerType: userContext.OwnerType,
 	})
@@ -32,7 +32,36 @@ func (s *HelixAPIServer) listTools(rw http.ResponseWriter, r *http.Request) ([]*
 		return nil, system.NewHTTPError500(err.Error())
 	}
 
-	return tools, nil
+	// remove global tools from the list in case this is the admin user who created the global tool
+
+	nonGlobalUserTools := []*types.Tool{}
+	for _, tool := range userTools {
+		if !tool.Global {
+			nonGlobalUserTools = append(nonGlobalUserTools, tool)
+		}
+	}
+
+	globalTools, err := s.Store.ListTools(r.Context(), &store.ListToolsQuery{
+		Global: true,
+	})
+	if err != nil {
+		return nil, system.NewHTTPError500(err.Error())
+	}
+
+	// Concatenate globalTools to userTools list
+	allTools := append(nonGlobalUserTools, globalTools...)
+	sanitizedTools := []*types.Tool{}
+
+	// remove api keys from global tools in the response
+	for _, tool := range allTools {
+		if !userContext.Admin && tool.Global {
+			tool.Config.API.Headers = map[string]string{}
+			tool.Config.API.Query = map[string]string{}
+		}
+		sanitizedTools = append(sanitizedTools, tool)
+	}
+
+	return sanitizedTools, nil
 }
 
 // createTool godoc
@@ -52,6 +81,11 @@ func (s *HelixAPIServer) createTool(rw http.ResponseWriter, r *http.Request) (*t
 	}
 
 	userContext := s.getRequestContext(r)
+
+	// only let admins create global tools
+	if tool.Global && !userContext.Admin {
+		return nil, system.NewHTTPError403("only admin users can create global tools")
+	}
 
 	// Getting existing tools for the user
 	existingTools, err := s.Store.ListTools(r.Context(), &store.ListToolsQuery{
@@ -123,8 +157,16 @@ func (s *HelixAPIServer) updateTool(rw http.ResponseWriter, r *http.Request) (*t
 		return nil, system.NewHTTPError500(err.Error())
 	}
 
-	if existing.Owner != userContext.Owner {
-		return nil, system.NewHTTPError404(store.ErrNotFound.Error())
+	// let any admin update a global tool
+	// but otherwise you must own the tool to update it
+	if tool.Global {
+		if !userContext.Admin {
+			return nil, system.NewHTTPError403("only admin users can update global tools")
+		}
+	} else {
+		if existing.Owner != userContext.Owner {
+			return nil, system.NewHTTPError404(store.ErrNotFound.Error())
+		}
 	}
 
 	tool.Owner = existing.Owner
@@ -206,8 +248,16 @@ func (s *HelixAPIServer) deleteTool(rw http.ResponseWriter, r *http.Request) (*t
 		return nil, system.NewHTTPError500(err.Error())
 	}
 
-	if existing.Owner != userContext.Owner {
-		return nil, system.NewHTTPError404(store.ErrNotFound.Error())
+	// let any admin delete a global tool
+	// but otherwise you must own the tool to update it
+	if existing.Global {
+		if !userContext.Admin {
+			return nil, system.NewHTTPError403("only admin users can delete global tools")
+		}
+	} else {
+		if existing.Owner != userContext.Owner {
+			return nil, system.NewHTTPError404(store.ErrNotFound.Error())
+		}
 	}
 
 	err = s.Store.DeleteTool(r.Context(), id)

--- a/api/pkg/server/tool_handlers_test.go
+++ b/api/pkg/server/tool_handlers_test.go
@@ -75,7 +75,7 @@ func (suite *ToolsTestSuite) SetupTest() {
 }
 
 func (suite *ToolsTestSuite) TestListTools() {
-	tools := []*types.Tool{
+	userTools := []*types.Tool{
 		{
 			ID:   "tool_1",
 			Name: "tool_1_name",
@@ -86,6 +86,8 @@ func (suite *ToolsTestSuite) TestListTools() {
 		},
 	}
 
+	globalTools := []*types.Tool{}
+
 	suite.store.EXPECT().CheckAPIKey(gomock.Any(), "hl-API_KEY").Return(&types.ApiKey{
 		Owner:     suite.userID,
 		OwnerType: types.OwnerTypeUser,
@@ -94,7 +96,11 @@ func (suite *ToolsTestSuite) TestListTools() {
 	suite.store.EXPECT().ListTools(gomock.Any(), &store.ListToolsQuery{
 		Owner:     suite.userID,
 		OwnerType: types.OwnerTypeUser,
-	}).Return(tools, nil)
+	}).Return(globalTools, nil)
+
+	suite.store.EXPECT().ListTools(gomock.Any(), &store.ListToolsQuery{
+		Global: true,
+	}).Return(userTools, nil)
 
 	req, err := http.NewRequest("GET", "/api/v1/tools", http.NoBody)
 	suite.NoError(err)
@@ -111,7 +117,7 @@ func (suite *ToolsTestSuite) TestListTools() {
 
 	var resp []*types.Tool
 	suite.NoError(json.NewDecoder(rec.Body).Decode(&resp))
-	suite.Equal(tools, resp)
+	suite.Equal(userTools, resp)
 }
 
 func (suite *ToolsTestSuite) TestCreateTool() {

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -34,6 +34,7 @@ type GetBotsQuery struct {
 type ListToolsQuery struct {
 	Owner     string          `json:"owner"`
 	OwnerType types.OwnerType `json:"owner_type"`
+	Global    bool            `json:"global"`
 }
 
 //go:generate mockgen -source $GOFILE -destination store_mocks.go -package $GOPACKAGE

--- a/api/pkg/store/store_tools.go
+++ b/api/pkg/store/store_tools.go
@@ -69,6 +69,7 @@ func (s *PostgresStore) ListTools(ctx context.Context, q *ListToolsQuery) ([]*ty
 	err := s.gdb.WithContext(ctx).Where(&types.Tool{
 		Owner:     q.Owner,
 		OwnerType: q.OwnerType,
+		Global:    q.Global,
 	}).Find(&tools).Error
 	if err != nil {
 		return nil, err

--- a/api/pkg/tools/tools_api.go
+++ b/api/pkg/tools/tools_api.go
@@ -161,7 +161,7 @@ func unmarshalParams(data string) (map[string]string, error) {
 	return params, nil
 }
 
-func (c *ChainStrategy) getApiSystemPrompt(tool *types.Tool) (openai.ChatCompletionMessage, error) {
+func (c *ChainStrategy) getApiSystemPrompt(_ *types.Tool) (openai.ChatCompletionMessage, error) {
 	return openai.ChatCompletionMessage{
 		Role:    openai.ChatMessageRoleSystem,
 		Content: apiSystemPrompt,

--- a/api/pkg/tools/tools_api_response.go
+++ b/api/pkg/tools/tools_api_response.go
@@ -23,7 +23,7 @@ func (c *ChainStrategy) interpretResponse(ctx context.Context, tool *types.Tool,
 	return c.handleSuccessResponse(ctx, tool, currentMessage, resp.StatusCode, bts)
 }
 
-func (c *ChainStrategy) handleSuccessResponse(ctx context.Context, tool *types.Tool, currentMessage string, statusCode int, body []byte) (*RunActionResponse, error) {
+func (c *ChainStrategy) handleSuccessResponse(ctx context.Context, _ *types.Tool, currentMessage string, _ int, body []byte) (*RunActionResponse, error) {
 	messages := []openai.ChatCompletionMessage{
 		{
 			Role:    openai.ChatMessageRoleSystem,
@@ -66,7 +66,7 @@ func (c *ChainStrategy) handleSuccessResponse(ctx context.Context, tool *types.T
 	}, nil
 }
 
-func (c *ChainStrategy) handleErrorResponse(ctx context.Context, tool *types.Tool, statusCode int, body []byte) (*RunActionResponse, error) {
+func (c *ChainStrategy) handleErrorResponse(ctx context.Context, _ *types.Tool, statusCode int, body []byte) (*RunActionResponse, error) {
 	messages := []openai.ChatCompletionMessage{
 		{
 			Role:    openai.ChatMessageRoleSystem,

--- a/api/pkg/tools/validation.go
+++ b/api/pkg/tools/validation.go
@@ -45,7 +45,7 @@ func (c *ChainStrategy) validateAndDefaultAPI(ctx context.Context, tool *types.T
 	return tool, nil
 }
 
-func (c *ChainStrategy) validateOperationIDs(ctx context.Context, tool *types.Tool, schema *openapi3.T) error {
+func (c *ChainStrategy) validateOperationIDs(_ context.Context, _ *types.Tool, schema *openapi3.T) error {
 
 	for path, pathItem := range schema.Paths.Map() {
 

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -498,7 +498,6 @@ type ServerConfigForFrontend struct {
 	GoogleAnalyticsFrontend string `json:"google_analytics_frontend"`
 	EvalUserID              string `json:"eval_user_id"`
 	ToolsEnabled            bool   `json:"tools_enabled"`
-	GlobalTools             []Tool `json:"global_tools"`
 }
 
 type CreateSessionRequest struct {
@@ -643,6 +642,7 @@ type Tool struct {
 	Name        string    `json:"name"`
 	Description string    `json:"description"`
 	ToolType    ToolType  `json:"tool_type"`
+	Global      bool      `json:"global"`
 	// TODO: tool configuration
 	// such as OpenAPI spec, function code, etc.
 	Config ToolConfig `json:"config" gorm:"jsonb"`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -104,6 +104,12 @@ services:
       - POSTGRES_DATABASE=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=${POSTGRES_ADMIN_PASSWORD-postgres}
+  demos:
+    profiles: ["demos"]
+    image: europe-docker.pkg.dev/helixml/helix/demos:latest
+    restart: always
+    environment:
+      - PORT=80
 
 volumes:
   helix-keycloak-db:

--- a/frontend/src/components/datagrid/Tools.tsx
+++ b/frontend/src/components/datagrid/Tools.tsx
@@ -8,6 +8,8 @@ import Chip from '@mui/material/Chip'
 import DataGrid2, { IDataGrid2_Column } from './DataGrid'
 import ClickLink from '../widgets/ClickLink'
 import useAccount from '../../hooks/useAccount'
+import Row from '../widgets/Row'
+import Cell from '../widgets/Cell'
 
 import useTheme from '@mui/material/styles/useTheme'
 import useThemeConfig from '../../hooks/useThemeConfig'
@@ -55,6 +57,14 @@ const ToolsDataGrid: FC<React.PropsWithChildren<{
       }
     },
     {
+      name: 'type',
+      header: 'Type',
+      defaultFlex: 0,
+      render: ({ data }) => {
+        return data.global ? 'Global' : 'User'
+      }
+    },
+    {
       name: 'updated',
       header: 'Updated',
       defaultFlex: 0,
@@ -90,22 +100,32 @@ const ToolsDataGrid: FC<React.PropsWithChildren<{
             data.config.api.actions.map((action, index) => {
               return (
                 <Box key={index}>
-                  <Stack direction="row" spacing={1}>
-                    <Box sx={{width: '50%'}}>
-                      <Typography sx={{minWidth: '300px'}}>
+                  <Row sx={{mt:1}}>
+                    <Cell sx={{width:'50%'}}>
+                      <Typography>
                         {action.name}
                       </Typography>
+                    </Cell>
+                    <Cell sx={{width:'50%'}}>
+                      <Row>
+                        <Cell sx={{width: '70px'}}>
+                          <Chip color="secondary" size="small" label={action.method.toUpperCase()} />
+                        </Cell>
+                        <Cell>
+                          <Typography>
+                            {action.path}
+                          </Typography>
+                        </Cell>
+                      </Row>
+                    </Cell>
+                  </Row>
+                  <Row>
+                    <Cell>
                       <Typography variant="caption" sx={{color: '#999'}}>
                         {action.description}
                       </Typography>
-                    </Box>
-                    <Stack direction="row" spacing={1} sx={{pt:1}}>
-                      <Chip color="secondary" size="small" label={action.method.toUpperCase()} />
-                      <Typography>
-                        {action.path}
-                      </Typography>
-                    </Stack>
-                  </Stack>
+                    </Cell>
+                  </Row>
                 </Box>
               )
             })
@@ -120,6 +140,7 @@ const ToolsDataGrid: FC<React.PropsWithChildren<{
       minWidth: 120,
       defaultWidth: 120,
       render: ({ data }) => {
+        if(data.global && !account.admin) return null
         return (
           <Box
             sx={{
@@ -154,6 +175,7 @@ const ToolsDataGrid: FC<React.PropsWithChildren<{
     onEdit,
     onDelete,
     account.token,
+    account.admin,
   ])
 
   return (

--- a/frontend/src/components/widgets/StringMapEditor.tsx
+++ b/frontend/src/components/widgets/StringMapEditor.tsx
@@ -8,10 +8,12 @@ import DeleteIcon from '@mui/icons-material/Delete'
 const StringMapEditor: FC<React.PropsWithChildren<{
   data: Record<string, string>,
   entityTitle?: string,
+  disabled?: boolean,
   onChange: (data: Record<string, string>) => void,
 }>> = ({
   data,
   entityTitle = 'key',
+  disabled = false,
   onChange,
 }) => {
   const [record, setRecord] = useState<Record<string, string>>(data)
@@ -55,6 +57,7 @@ const StringMapEditor: FC<React.PropsWithChildren<{
             size="small"
             variant="outlined"
             value={record[key]}
+            disabled={ disabled }
             onChange={(e: ChangeEvent<HTMLInputElement>) => handleChangeValue(key, e.target.value)}
           />
           <IconButton onClick={() => handleDeleteEntry(key)}>
@@ -68,6 +71,7 @@ const StringMapEditor: FC<React.PropsWithChildren<{
           label={`new ${entityTitle}`}
           variant="outlined"
           value={newKey}
+          disabled={ disabled }
           onChange={(e: ChangeEvent<HTMLInputElement>) => setNewKey(e.target.value)}
           onKeyPress={(e) => e.key === 'Enter' && handleAddEntry()}
         />
@@ -77,6 +81,7 @@ const StringMapEditor: FC<React.PropsWithChildren<{
           label="new value"
           variant="outlined"
           value={newValue}
+          disabled={ disabled }
           onChange={(e: ChangeEvent<HTMLInputElement>) => setNewValue(e.target.value)}
           onKeyPress={(e) => e.key === 'Enter' && handleAddEntry()}
         />

--- a/frontend/src/contexts/account.tsx
+++ b/frontend/src/contexts/account.tsx
@@ -44,7 +44,6 @@ export const AccountContext = createContext<IAccountContext>({
     google_analytics_frontend: '',
     eval_user_id: '',
     tools_enabled: true,
-    global_tools: [],
   },
   userConfig: {},
   apiKeys: [],
@@ -71,7 +70,6 @@ export const useAccountContext = (): IAccountContext => {
     google_analytics_frontend: '',
     eval_user_id: '',
     tools_enabled: true,
-    global_tools: [],
   })
   const [ apiKeys, setApiKeys ] = useState<IApiKey[]>([])
 

--- a/frontend/src/hooks/useTools.ts
+++ b/frontend/src/hooks/useTools.ts
@@ -1,4 +1,4 @@
-import React, { FC, useState, useCallback, useEffect } from 'react'
+import React, { FC, useState, useCallback, useMemo } from 'react'
 import useApi from '../hooks/useApi'
 
 import {
@@ -13,6 +13,18 @@ export const useTools = () => {
   const api = useApi()
   
   const [ data, setData ] = useState<ITool[]>([])
+
+  const userTools = useMemo(() => {
+    return data.filter(tool => !tool.global)
+  }, [
+    data,
+  ])
+
+  const globalTools = useMemo(() => {
+    return data.filter(tool => tool.global)
+  }, [
+    data,
+  ])
   
   const loadData = useCallback(async () => {
     const result = await api.get<ITool[]>(`/api/v1/tools`, undefined, {
@@ -68,6 +80,8 @@ export const useTools = () => {
 
   return {
     data,
+    userTools,
+    globalTools,
     loadData,
     createTool,
     updateTool,

--- a/frontend/src/pages/New.tsx
+++ b/frontend/src/pages/New.tsx
@@ -729,7 +729,7 @@ const New: FC = () => {
                         <Typography variant="body1">Your Tools:</Typography>
                         <Divider sx={{mt:2,mb:2}} />
                         {
-                          tools.data.map((tool) => {
+                          tools.userTools.map((tool) => {
                             return (
                               <FormControlLabel
                                 key={tool.id}
@@ -757,10 +757,10 @@ const New: FC = () => {
                         }
                       </Grid>
                       <Grid item xs={ 12 } md={ 6 }>
-                        <Typography variant="body1">Demo Tools:</Typography>
+                        <Typography variant="body1">Global Tools:</Typography>
                         <Divider sx={{mt:2,mb:2}} />
                         {
-                          account.serverConfig.global_tools.map((tool) => {
+                          tools.globalTools.map((tool) => {
                             return (
                               <FormControlLabel
                                 key={tool.id}

--- a/frontend/src/pages/Tool.tsx
+++ b/frontend/src/pages/Tool.tsx
@@ -47,7 +47,7 @@ const Tool: FC = () => {
     navigate,
   } = useRouter()
 
-  const isAdmin = false//account.admin
+  const isAdmin = account.admin
   
   const themeConfig = useThemeConfig()
   const theme = useTheme()

--- a/frontend/src/pages/Tool.tsx
+++ b/frontend/src/pages/Tool.tsx
@@ -47,7 +47,7 @@ const Tool: FC = () => {
     navigate,
   } = useRouter()
 
-  const isAdmin = account.admin
+  const isAdmin = false//account.admin
   
   const themeConfig = useThemeConfig()
   const theme = useTheme()

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -252,7 +252,6 @@ export interface IServerConfig {
   google_analytics_frontend: string,
   eval_user_id: string,
   tools_enabled: boolean,
-  global_tools: ITool[],
 }
 
 export interface IConversation {
@@ -434,6 +433,7 @@ export interface ITool {
   owner_type: IOwnerType,
   name: string,
   description: string,
+  global: boolean,
   tool_type: IToolType,
   config: IToolConfig,
 }


### PR DESCRIPTION
This turns global tools into a flag that can be edited by admins.

Global tools will appear in the users list of tools alongside their own tools - but they will be read-only

Only admins can CRUD a global tool (but everyone can Read)

The form is disabled if the user is looking at the details of a global tool and the query params and headers are removed so we can safely show the tool details to non-admins

This also builds and runs the demo container so we can add our demos as global tools

![image](https://github.com/helixml/helix/assets/1676629/f7c718c8-81a4-46cd-8b35-8ff9ce4e4613)
![image](https://github.com/helixml/helix/assets/1676629/355e4af0-b261-4ec1-9e2b-848f09cdfccb)
