### PR TITLE
Keycloak 23 import fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">
   <a href="https://app.tryhelix.ai/">SaaS</a> •
   <a href="https://docs.helix.ml/docs/controlplane">Private Deployment</a> •
-  <a href="https://docs.helix.ml/docs/overview">Docs</a> •  
+  <a href="https://docs.helix.ml/docs/overview">Docs</a> •
   <a href="https://discord.gg/VJftd844GE">Discord</a>
 </p>
 
@@ -36,6 +36,11 @@ Create an `.env` file with settings based on the example values and edit it:
 
 ```
 cp .env.example-prod .env
+```
+
+Ensure keycloak realm settings are up to date with your .env file
+```
+./update-realm-settings.sh
 ```
 
 To start the services:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -20,6 +20,11 @@ docker volume rm helix_helix-postgres-db
 ```
 This will force the creation of the postgres db needed for keycloak on the next step.
 
+Ensure keycloak realm settings are up to date with your .env file
+```
+./update-realm-settings.sh
+```
+
 ```
 ./stack up
 ```

--- a/update-realm-settings.sh
+++ b/update-realm-settings.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# Load environment variables from .env file
+if [[ -f .env ]]; then
+    source .env
+else
+    echo "Error: .env file not found"
+    exit 1
+fi
+
+# Check if realm.json file exists
+if [[ ! -f realm.json ]]; then
+    echo "Error: realm.json file not found"
+    exit 1
+fi
+
+# Function to update field in realm.json file
+update_realm_attribute() {
+    # Update field in realm.json
+    jq --arg frontendUrl ${KEYCLOAK_FRONTEND_URL:-"http://localhost/auth"} '.attributes.frontendUrl |= $frontendUrl' realm.json > tmp.json
+    mv tmp.json realm.json
+}
+
+update_realm_client() {
+    # Update field in realm.json
+    jq --arg clientId frontend --arg baseUrl ${SERVER_URL:-"http://localhost/"} '( .clients[] | select(.clientId == $clientId) ).baseUrl |= $baseUrl' realm.json > tmp.json
+    mv tmp.json realm.json
+}
+
+# Update fields in realm.json file
+update_realm_attribute
+update_realm_client
+# Add more fields as needed
+
+echo "Realm JSON file updated successfully"


### PR DESCRIPTION
The helix realm setting were hardcoding localhost, which are causing trouble on new installs where custom DNS hostnames were specified for keycloak