### PR TITLE
Fix issue where the import of keycloak config was failing in prod dep…

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -100,10 +100,10 @@ services:
       - KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD-oh-hallo-insecure-password}
       - KC_PROXY_HEADERS=forwarded|xforwarded
       - KC_HEALTH_ENABLED=true
-      - KC_HOSTNAME_PATH==/auth
+      - KC_HOSTNAME_PATH=/auth
       - KC_HTTP_RELATIVE_PATH=/auth/
-      - KC_HOSTNAME_URL=${KEYCLOAK_HOSTNAME:-http://localhost/auth/}
-      - KC_HOSTNAME_ADMIN_URL=${KEYCLOAK_HOSTNAME:-http://localhost/auth/}
+      - KC_HOSTNAME_URL=${KEYCLOAK_FRONTEND_URL:-http://localhost/auth/}
+      - KC_HOSTNAME_ADMIN_URL=${KEYCLOAK_FRONTEND_URL:-http://localhost/auth/}
     volumes:
       - ./realm.json:/opt/keycloak/data/import/realm.json
     healthcheck:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -93,7 +93,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 30
-    command: ["start-dev"]
+    command: ["start-dev", "--import-realm"]
   llamaindex:
     image: europe-docker.pkg.dev/helixml/helix/llamaindex:latest
     # ports:


### PR DESCRIPTION
…loyments

- Minor typo on docker-compmose.dev.yaml
- misisng import on docker-compose.yaml
- Reuse existing FRONTEND_URL env var.