### PR TITLE
hotfix: add passthru HF_TOKEN env var

### DIFF
--- a/api/pkg/model/axolotl_mistral7b.go
+++ b/api/pkg/model/axolotl_mistral7b.go
@@ -242,6 +242,12 @@ func (l *Mistral7bInstruct01) GetCommand(ctx context.Context, sessionFilter type
 			os.Getenv("CUDA_VISIBLE_DEVICES"),
 		))
 	}
+	if os.Getenv("HF_TOKEN") != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf(
+			"HF_TOKEN=%s",
+			os.Getenv("HF_TOKEN"),
+		))
+	}
 
 	return cmd, nil
 }

--- a/charts/helix-runner/templates/deployment.yaml
+++ b/charts/helix-runner/templates/deployment.yaml
@@ -56,6 +56,8 @@ spec:
               value: "true"
             - name: RUNTIME_AXOLOTL_WARMUP_MODELS
               value: "mistralai/Mistral-7B-Instruct-v0.1,stabilityai/stable-diffusion-xl-base-1.0"
+            - name: HF_TOKEN
+              value: {{ .Values.runner.huggingfaceToken }}
             - name: RUNTIME_OLLAMA_ENABLED
               value: "true"
             - name: RUNTIME_OLLAMA_WARMUP_MODELS

--- a/charts/helix-runner/values-example-3090.yaml
+++ b/charts/helix-runner/values-example-3090.yaml
@@ -5,6 +5,9 @@ runner:
   # Memory based on the available GPU memory. In this example
   # 3090 has 24GB of memory
   memory: 24GB
+  # huggingface token (for gated models, e.g. fine tuning mistral-7B, accept
+  # terms on https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.1)
+  huggingfaceToken: <your-hf-token>
 
 # How many runners do you want to run?
 replicaCount: 1

--- a/charts/helix-runner/values.yaml
+++ b/charts/helix-runner/values.yaml
@@ -24,6 +24,9 @@ runner:
   memory: 24GB
   # IPC mode
   shareProcessNamespace: true
+  # huggingface token (for gated models, e.g. fine tuning mistral-7B, accept
+  # terms on https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.1)
+  huggingfaceToken: ""
 
 resources: {}
   # limits:


### PR DESCRIPTION
mistral-7b became gated, breaking our text finetuning, allow operators to unlock it by passing their HF_TOKEN in the runner environment