### PR TITLE
Stop running keycloak in dev mode in production

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -92,7 +92,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 30
-    command: ["start-dev", "--import-realm"]
+    command: ["start", "--import-realm", "--proxy", "edge"]
   llamaindex:
     image: europe-docker.pkg.dev/helixml/helix/llamaindex:latest
     # ports:


### PR DESCRIPTION
Tiny change to add more stability to keycloak