### PR TITLE
feat: add ability to override app query parameters in OpenAI API request

### DIFF
--- a/api/pkg/controller/sessions.go
+++ b/api/pkg/controller/sessions.go
@@ -79,6 +79,7 @@ func (c *Controller) StartSession(ctx types.RequestContext, req types.InternalSe
 			RAGSourceID:             req.RAGSourceID,
 			LoraID:                  req.LoraID,
 			AssistantID:             req.AssistantID,
+			AppQueryParams:          req.AppQueryParams,
 		},
 	}
 

--- a/api/pkg/tools/tools_api.go
+++ b/api/pkg/tools/tools_api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/helixml/helix/api/pkg/types"
+	"github.com/rs/zerolog/log"
 
 	openai "github.com/lukemarsden/go-openai2"
 )
@@ -81,6 +82,7 @@ func (c *ChainStrategy) prepareRequest(ctx context.Context, tool *types.Tool, ac
 	if tool.Config.API.Query != nil {
 		q := req.URL.Query()
 		for k, v := range tool.Config.API.Query {
+			log.Debug().Str("key", k).Str("value", v).Msg("Adding query param")
 			q.Add(k, v)
 		}
 

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -157,7 +157,8 @@ type SessionMetadata struct {
 	// the fine tuned data entity we produced from this session
 	LoraID string `json:"finetune_data_entity_id"`
 	// which assistant are we talking to?
-	AssistantID string `json:"assistant_id"`
+	AssistantID    string            `json:"assistant_id"`
+	AppQueryParams map[string]string `json:"app_query_params"` // Passing through user defined app params
 }
 
 // the packet we put a list of sessions into so pagination is supported and we know the total amount
@@ -264,6 +265,7 @@ type InternalSessionRequest struct {
 	UploadedDataID          string
 	RAGSourceID             string
 	LoraID                  string
+	AppQueryParams          map[string]string // Passing through user defined app params
 }
 
 type UpdateSessionRequest struct {


### PR DESCRIPTION
This PR adds the ability of OpenAI API requests to override the default API query parameters specified in a `helix.yaml` file.

To do this, first specify a query parameter in the helix.yaml. Next, in the OpenAI request, add a query parameter  that you want to override. Any key that matches a query param in `helix.yaml` will be overridden for all tools.

For example:

```
curl -XPOST -H "Authorization: Bearer hl-xxxxxxxxx" https://example.helix.ml/v1/chat/completions?page=7 --data-raw '{"model": "nop", "messages": [{"role": "user", "content": "Get some data from the api please?"}] }'
```

Will override a `helix.yaml` that has the following spec:
```
name: test
description: test app
assistants:
- name: my API
  apis:
    - name: Example api
      description: Lists something about something
      url: http://test-url:8000
      schema: ./api/openapi.yaml
      query:
        page: "1"
```