### PR TITLE
Fix warmups, dev websockets, ollama keepalive

### DIFF
--- a/api/cmd/helix/runner.go
+++ b/api/cmd/helix/runner.go
@@ -201,14 +201,14 @@ var WarmupSession_Model_Mistral7b = types.Session{
 	OwnerType:    "user",
 }
 
-var WarmupSession_Model_Ollama_Mistral7b = types.Session{
+var WarmupSession_Model_Ollama_Llama3_8b = types.Session{
 	ID:           types.WarmupTextSessionID,
 	Name:         "warmup-text",
 	Created:      time.Now(),
 	Updated:      time.Now(),
 	Mode:         "inference",
 	Type:         types.SessionTypeText,
-	ModelName:    "mistral:7b-instruct",
+	ModelName:    "llama3:instruct",
 	LoraDir:      "",
 	Interactions: []*types.Interaction{ITX_A, ITX_B},
 	Owner:        "warmup-user",
@@ -299,9 +299,9 @@ func runnerCLI(cmd *cobra.Command, options *RunnerOptions) error {
 		if options.Runner.Config.Runtimes.Ollama.Enabled {
 			for _, modelName := range options.Runner.Config.Runtimes.Ollama.WarmupModels {
 				switch modelName {
-				case types.Model_Ollama_Mistral7b.String():
+				case types.Model_Ollama_Llama3_8b.String():
 					log.Info().Msgf("Adding warmup session for model %s", modelName)
-					useWarmupSessions = append(useWarmupSessions, WarmupSession_Model_Ollama_Mistral7b)
+					useWarmupSessions = append(useWarmupSessions, WarmupSession_Model_Ollama_Llama3_8b)
 				}
 			}
 		}

--- a/api/pkg/config/runner_config.go
+++ b/api/pkg/config/runner_config.go
@@ -28,14 +28,12 @@ type Models struct {
 type Runtimes struct {
 	Axolotl struct {
 		Enabled      bool          `envconfig:"RUNTIME_AXOLOTL_ENABLED" default:"true"`
-		WarmupModels []string      `envconfig:"RUNTIME_AXOLOTL_WARMUP_MODELS" default:"mistralai/Mistral-7B-Instruct-v0.1,stabilityai/stable-diffusion-xl-base-1.0"`
-		InstanceTTL  time.Duration `envconfig:"RUNTIME_AXOLOTL_INSTANCE_TTL" default:"60s"`
+		WarmupModels []string      `envconfig:"RUNTIME_AXOLOTL_WARMUP_MODELS" default:"mistralai/Mistral-7B-Instruct-v0.1"`
+		InstanceTTL  time.Duration `envconfig:"RUNTIME_AXOLOTL_INSTANCE_TTL" default:"10s"`
 	}
 	Ollama struct {
-		Enabled      bool     `envconfig:"RUNTIME_OLLAMA_ENABLED" default:"true"`
-		WarmupModels []string `envconfig:"RUNTIME_OLLAMA_WARMUP_MODELS" default:"llama3:instruct,mixtral:instruct,codellama:70b-instruct-q2_K,adrienbrault/nous-hermes2theta-llama3-8b:q8_0,phi3:instruct"`
-		// Ollama instance can be kept for much longer as it automatically unloads
-		// the model from memory when it's not used
-		InstanceTTL time.Duration `envconfig:"RUNTIME_OLLAMA_INSTANCE_TTL" default:"60s"`
+		Enabled      bool          `envconfig:"RUNTIME_OLLAMA_ENABLED" default:"true"`
+		WarmupModels []string      `envconfig:"RUNTIME_OLLAMA_WARMUP_MODELS" default:"llama3:instruct,mixtral:instruct,codellama:70b-instruct-q2_K,adrienbrault/nous-hermes2theta-llama3-8b:q8_0,phi3:instruct"`
+		InstanceTTL  time.Duration `envconfig:"RUNTIME_OLLAMA_INSTANCE_TTL" default:"10s"`
 	}
 }

--- a/api/pkg/model/models.go
+++ b/api/pkg/model/models.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/helixml/helix/api/pkg/types"
 )
@@ -15,12 +14,6 @@ func GetModel(modelName types.ModelName) (Model, error) {
 	modelName, err = types.TransformModelName(modelName.String(), true)
 	if err != nil {
 		return nil, err
-	}
-	if strings.HasPrefix(modelName.String(), "gpt-3") {
-		modelName = types.Model_Ollama_Llama3_8b
-	}
-	if strings.HasPrefix(modelName.String(), "gpt-4") {
-		modelName = types.Model_Ollama_Llama3_70b
 	}
 	model, ok := models[modelName]
 	if !ok {

--- a/api/pkg/runner/ollama_model_instance.go
+++ b/api/pkg/runner/ollama_model_instance.go
@@ -146,6 +146,7 @@ func (i *OllamaModelInstance) Start(session *types.Session) error {
 	ollamaHost := fmt.Sprintf("0.0.0.0:%d", port)
 
 	cmd.Env = append(cmd.Env,
+		"OLLAMA_KEEP_ALIVE=-1",
 		"HTTP_PROXY="+os.Getenv("HTTP_PROXY"),
 		"HTTPS_PROXY="+os.Getenv("HTTPS_PROXY"),
 		"OLLAMA_HOST="+ollamaHost,                 // Bind on localhost with random port

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -143,10 +143,10 @@ services:
     restart: always
     volumes:
       - ./llamaindex/src:/home/app/src
-  gptscript_runner:    
+  gptscript_runner:
     build:
       context: .
-      dockerfile: Dockerfile.gptscript        
+      dockerfile: Dockerfile.gptscript
     restart: always
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
@@ -155,7 +155,7 @@ services:
       - CONCURRENCY=20 # number of tasks to run concurrently
       - MAX_TASKS=0  # max number of tasks to run before exiting. Set to 0 to run forever
     depends_on:
-      - api      
+      - api
   dev_gpu_runner:
     profiles: ["dev_gpu_runner"]
     build:

--- a/docker-compose.runner.yaml
+++ b/docker-compose.runner.yaml
@@ -13,7 +13,7 @@ services:
       - API_TOKEN=${RUNNER_TOKEN-oh-hallo-insecure-token}
       - MEMORY_STRING=12GB
       - ALLOW_MULTIPLE_COPIES=true
-      - RUNNER_WARMUP_MODELS=mistral:7b-instruct # Ollama runner
+      - RUNNER_WARMUP_MODELS=llama3:instruct # Ollama runner
     deploy:
       resources:
         reservations:

--- a/frontend/src/hooks/useWebsocket.ts
+++ b/frontend/src/hooks/useWebsocket.ts
@@ -18,8 +18,8 @@ export const useWebsocket = (
     if(!account.token) return
     if(!session_id) return
     const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const wsHostname = window.location.hostname
-    const url = `${wsProtocol}//${wsHostname}/api/v1/ws/user?access_token=${account.token}&session_id=${session_id}`
+    const wsHost = window.location.host
+    const url = `${wsProtocol}//${wsHost}/api/v1/ws/user?access_token=${account.token}&session_id=${session_id}`
     const rws = new ReconnectingWebSocket(url)
     const messageHandler = (event: MessageEvent<any>) => {
       const parsedData = JSON.parse(event.data) as IWebsocketEvent


### PR DESCRIPTION
* Stop loading sdxl by default, neatly sidestepping the headache that was warmup models over-filling GPU memory. SDXL will still work, it just might take a bit longer on the first request to download the weights.
* Also fix bug that was stopping llama3:instruct getting loaded as a warmup model.
* Fix frontend websocket bug in development
* Make ollama keep model weights in memory forever, which is what our scheduler is designed for.