### PR TITLE
feat: expose RUNTIME_AXOLOTL_ENABLED in runner chart

### DIFF
--- a/charts/helix-runner/Chart.yaml
+++ b/charts/helix-runner/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/helix-runner/templates/deployment.yaml
+++ b/charts/helix-runner/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: RUNTIME_AXOLOTL_ENABLED
-              value: "true"
+              value: {{ .Values.runner.axolotl }}
             - name: RUNTIME_AXOLOTL_WARMUP_MODELS
               value: "mistralai/Mistral-7B-Instruct-v0.1"
             - name: HF_TOKEN

--- a/charts/helix-runner/values.yaml
+++ b/charts/helix-runner/values.yaml
@@ -27,6 +27,7 @@ runner:
   # huggingface token (for gated models, e.g. fine tuning mistral-7B, accept
   # terms on https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.1)
   huggingfaceToken: ""
+  axolotl: "true"
 
 # Both node selectors and resources need to target
 resources:


### PR DESCRIPTION
- expose RUNTIME_AXOLOTL_ENABLED as per https://github.com/helixml/helix/issues/359 
- enables low cost experiments to be run by setting this to false
- this has been tested on g2-standard-8 instances with nvidia-l4 GPU in GCP for simple llama3 tests