### PR TITLE
fix: app id from previous session

### DIFF
--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -106,6 +106,10 @@ func (s *HelixAPIServer) startChatSessionHandler(rw http.ResponseWriter, req *ht
 			http.Error(rw, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return
 		}
+		// If the session has an AppID, use it as the next interaction
+		if session.ParentApp != "" {
+			startReq.AppID = session.ParentApp
+		}
 	} else {
 		// Create session
 		session = &types.Session{


### PR DESCRIPTION
check for app id on the session if there was an existing one and reuse it in the next call. 

<img width="1348" alt="image" src="https://github.com/user-attachments/assets/3f2ef994-7f7b-4731-ab9c-867ca0ae2720">
