### PR TITLE
handle LLM sending backticks with no "json"

### DIFF
--- a/api/pkg/dataprep/qapairs/qapairs.go
+++ b/api/pkg/dataprep/qapairs/qapairs.go
@@ -7,11 +7,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 	"text/template"
 	"time"
 
 	"github.com/helixml/helix/api/pkg/openai"
+	"github.com/helixml/helix/api/pkg/tools"
 	"github.com/helixml/helix/api/pkg/types"
 
 	ext_openai "github.com/lukemarsden/go-openai2"
@@ -327,17 +327,7 @@ func chatWithModel(client openai.Client, model, system, user, debug string, json
 	log.Printf("XXX Raw response (%s) to %s json=%t: %s\n", resp.ID, debug, jsonSchema != nil, answer)
 
 	if jsonSchema == nil {
-		if strings.Contains(answer, "```json") {
-			answer = strings.Split(answer, "```json")[1]
-		}
-		// sometimes LLMs in their wisdom puts a message after the enclosing ```json``` block
-		parts := strings.Split(answer, "```")
-		answer = parts[0]
-
-		// LLMs are sometimes bad at correct JSON escaping, trying to escape
-		// characters like _ that don't need to be escaped. Just remove all
-		// backslashes for now... unless we're sure the model generated valid JSON
-		answer = strings.Replace(answer, "\\", "", -1)
+		answer = tools.AttemptFixJSON(answer)
 	}
 
 	return TryVariousJSONFormats(answer, fmt.Sprintf("%s respID=%s", debug, resp.ID))

--- a/api/pkg/tools/tools_api.go
+++ b/api/pkg/tools/tools_api.go
@@ -145,20 +145,8 @@ func (c *ChainStrategy) getAPIRequestParameters(ctx context.Context, sessionID, 
 }
 
 func unmarshalParams(data string) (map[string]string, error) {
-	if strings.Contains(data, "```json") {
-		data = strings.Split(data, "```json")[1]
-	}
-	// sometimes LLMs in their wisdom puts a message after the enclosing ```json``` block
-	parts := strings.Split(data, "```")
-	data = parts[0]
-
-	// LLMs are sometimes bad at correct JSON escaping, trying to escape
-	// characters like _ that don't need to be escaped. Just remove all
-	// backslashes for now...
-	data = strings.Replace(data, "\\", "", -1)
-
 	var initial map[string]interface{}
-	err := json.Unmarshal([]byte(data), &initial)
+	err := unmarshalJSON(data, &initial)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response from inference API: %w (%s)", err, data)
 	}

--- a/api/pkg/tools/tools_api_test.go
+++ b/api/pkg/tools/tools_api_test.go
@@ -648,6 +648,15 @@ func Test_unmarshalParams(t *testing.T) {
 				"id": "1000",
 			},
 		},
+		{
+			name: "``` in json variant",
+			args: args{
+				data: "```\n{\"id\": 1000}```blah blah blah I am very stupid LLM that cannot follow instructions about backticks",
+			},
+			want: map[string]string{
+				"id": "1000",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/api/pkg/tools/utils.go
+++ b/api/pkg/tools/utils.go
@@ -5,7 +5,12 @@ import (
 	"strings"
 )
 
-func unmarshalJSON(data string, v interface{}) error {
+func AttemptFixJSON(data string) string {
+	// sometimes LLM just gives us a single ``` line at the start; just strip that off
+	if strings.HasPrefix(data, "```\n") {
+		data = strings.Split(data, "```\n")[1]
+	}
+
 	if strings.Contains(data, "```json") {
 		data = strings.Split(data, "```json")[1]
 	}
@@ -18,10 +23,10 @@ func unmarshalJSON(data string, v interface{}) error {
 	// backslashes for now...
 	data = strings.Replace(data, "\\", "", -1)
 
-	// LLMs are sometimes bad at correct JSON escaping, trying to escape
-	// characters like _ that don't need to be escaped. Just remove all
-	// backslashes for now...
-	data = strings.Replace(data, "\\", "", -1)
+	return data
+}
 
-	return json.Unmarshal([]byte(data), v)
+func unmarshalJSON(data string, v interface{}) error {
+	fixedData := AttemptFixJSON(data)
+	return json.Unmarshal([]byte(fixedData), v)
 }


### PR DESCRIPTION
1. factor json munging code into one place
2. add a test that covers the case we see where model includes backticks but not the word json at the start
3. make the test pass