### PR TITLE
add dockerfile for typesense baked weights; update refs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -316,6 +316,42 @@ depends_on:
 ---
 kind: pipeline
 type: docker
+name: build-typesense_baked_models
+
+volumes:
+  - name: dockersocket
+    host:
+      path: /var/run/docker.sock
+
+steps:
+- name: publish-typesense_baked_models
+  image: plugins/docker
+  pull: always
+  settings:
+    dockerfile: Dockerfile.typesense
+    auto_tag: true
+    daemon_off: true
+    registry: registry.helix.ml
+    repo: registry.helix.ml/helix/typesense
+    username: admin
+    password:
+      from_secret: helix_registry_password
+  volumes:
+  - name: dockersocket
+    path: /var/run/docker.sock
+  when:
+    branch:
+    - main
+    event:
+    - tag
+    - push
+
+depends_on:
+- default
+
+---
+kind: pipeline
+type: docker
 name: build-llamaindex
 
 volumes:

--- a/Dockerfile.typesense
+++ b/Dockerfile.typesense
@@ -1,0 +1,9 @@
+FROM typesense/typesense:27.0
+RUN apt update && apt install -y curl
+RUN mkdir -p /models/all-MiniLM-L12-v2 && cd /models/all-MiniLM-L12-v2 && \
+    curl -sL -O https://huggingface.co/typesense/models/resolve/main/all-MiniLM-L12-v2/config.json && \
+    curl -sL -O https://huggingface.co/typesense/models/resolve/main/all-MiniLM-L12-v2/model.onnx && \
+    curl -sL -O https://huggingface.co/typesense/models/resolve/main/all-MiniLM-L12-v2/vocab.txt
+
+COPY scripts/typesense-entrypoint.sh /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/charts/helix-controlplane/Chart.yaml
+++ b/charts/helix-controlplane/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/helix-controlplane/values.yaml
+++ b/charts/helix-controlplane/values.yaml
@@ -17,7 +17,7 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
-  
+
 tika:
   enabled: true
   image:
@@ -28,8 +28,8 @@ typesense:
   enabled: true
   apiKey: typesense
   image:
-    repository: typesense/typesense
-    tag: "27.0"
+    repository: registry.helix.ml/helix/typesense
+    tag: "latest"
   persistence:
     ## @param backend.persistence.enabled Enable persistence using Persistent Volume Claims
     ##

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -136,7 +136,9 @@ services:
     ports:
       - 9998:9998
   typesense:
-    image: typesense/typesense:27.0
+    build:
+      context: .
+      dockerfile: Dockerfile.typesense
     command: ["--data-dir", "/data", "--api-key", "typesense"]
     ports:
       - 8108:8108

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -106,7 +106,7 @@ services:
     ports:
       - 9998:9998
   typesense:
-    image: typesense/typesense:27.0
+    image: registry.helix.ml/helix/typesense:latest
     command: ["--data-dir", "/data", "--api-key", "typesense"]
     ports:
       - 8108:8108

--- a/scripts/typesense-entrypoint.sh
+++ b/scripts/typesense-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Create directory and symlink if necessary
+mkdir -p /data/models
+if [ ! -e /data/models/all-MiniLM-L12-v2 ]; then
+    ln -s /models/all-MiniLM-L12-v2 /data/models/all-MiniLM-L12-v2
+fi
+
+# Execute the Typesense server with all passed arguments
+exec /opt/typesense-server "$@"

--- a/scripts/typesense-entrypoint.sh
+++ b/scripts/typesense-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Create directory and symlink if necessary
 mkdir -p /data/models


### PR DESCRIPTION
typesense shouldn't need to download its embedding model, as this breaks corporate users