### PR TITLE
fix: be more patient with typesense 

### DIFF
--- a/api/pkg/rag/rag_typesense.go
+++ b/api/pkg/rag/rag_typesense.go
@@ -31,6 +31,7 @@ func NewTypesense(settings *types.RAGSettings) (*Typesense, error) {
 		typesense.WithServer(settings.Typesense.URL),
 		typesense.WithAPIKey(settings.Typesense.APIKey),
 		typesense.WithNumRetries(3),
+		typesense.WithConnectionTimeout(300*time.Second),
 	)
 
 	err := retry.Do(func() error {


### PR DESCRIPTION
when it is busy, 5 seconds to retry write requests might result in overload