### PR TITLE
fix: inline code block rendering

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,7 +36,6 @@
     "axios": "^1.3.4",
     "bluebird": "^3.7.2",
     "keycloak-js": "^22.0.4",
-    "lang-detector": "^1.0.6",
     "localdata": "^0.1.4",
     "lodash": "^4.17.21",
     "pretty-bytes": "^6.0.0",

--- a/frontend/src/components/session/Markdown.tsx
+++ b/frontend/src/components/session/Markdown.tsx
@@ -6,7 +6,6 @@ import {Prism as SyntaxHighlighterTS} from 'react-syntax-highlighter'
 import remarkGfm from 'remark-gfm'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize from 'rehype-sanitize'
-import detectLang from 'lang-detector'
 // you can change the theme by picking one from here
 // https://react-syntax-highlighter.github.io/react-syntax-highlighter/demo/prism.html
 import {oneDark} from 'react-syntax-highlighter/dist/esm/styles/prism'
@@ -43,20 +42,18 @@ export const InteractionMarkdown: FC<{
           code(props) {
             const {children, className, node, ...rest} = props
             const match = /language-(\w+)/.exec(className || '')
-            let lang = match ? match[0] : ''
-
-            if(!lang) {
-              lang = (detectLang(String(children)) || '').toLowerCase()
-            }
-
-            return (
+            return match ? (
               <SyntaxHighlighter
                 {...rest}
                 PreTag="div"
-                children={String(children).replace(/\n$/, '').replace(/^\s+/, '')}
-                language={ lang }
+                children={String(children).replace(/\n$/, '')}
+                language={match[1]}
                 style={oneDark}
               />
+            ) : (
+              <code {...rest} className={className}>
+                {children}
+              </code>
             )
           }
         }}

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -652,6 +652,7 @@ const App: FC = () => {
     setHasLoaded(true);
   }, [app])
 
+  // TODO: also poll for session updates to avoid missing updates when the backend is faster than the frontend
   useWebsocket(sessionID, (parsedData) => {
     if(parsedData.type === WEBSOCKET_EVENT_TYPE_SESSION_UPDATE && parsedData.session) {
       const newSession: ISession = parsedData.session

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2232,13 +2232,6 @@ keycloak-js@^22.0.4:
     base64-js "^1.5.1"
     js-sha256 "^0.9.0"
 
-lang-detector@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/lang-detector/-/lang-detector-1.0.6.tgz#96157ea7e702f19778f1ef6488c593ebf7511fa2"
-  integrity sha512-YRt/OzgBlrCf8AGiFLWXuqbvEuOI9xHJQe73iKRGGfOZrylDyBAMUWWhWwVdCQxxX0yN5V52PDypqXnlVb4C/w==
-  dependencies:
-    underscore "^1.8.2"
-
 lie@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
@@ -3704,11 +3697,6 @@ unbzip2-stream@1.4.3:
   dependencies:
     buffer "^5.2.1"
     through "^2.3.8"
-
-underscore@^1.8.2:
-  version "1.13.6"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
-  integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
 undici-types@~5.26.4:
   version "5.26.5"


### PR DESCRIPTION
sacrifice language detection in favor of making inline code blocks no longer appear as if they were non-inline