### PR TITLE
fix: make host.docker.internal work on linux

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -65,6 +65,8 @@ services:
     depends_on:
       - postgres
       - keycloak
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   postgres:
     image: postgres:12.13-alpine
     restart: always

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,6 +42,8 @@ services:
     depends_on:
       - postgres
       - keycloak
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   postgres:
     image: postgres:12.13-alpine
     restart: always


### PR DESCRIPTION
 linux will still need Environment=OLLAMA_HOST=0.0.0.0 to be added to the ollama systemd unit