### PR TITLE
refactor(scheduler): big improvements to the scheduler to better place work

### DIFF
--- a/api/cmd/helix/qapairs.go
+++ b/api/cmd/helix/qapairs.go
@@ -7,6 +7,7 @@ import (
 	"github.com/helixml/helix/api/pkg/dataprep/qapairs"
 	"github.com/helixml/helix/api/pkg/openai"
 	"github.com/helixml/helix/api/pkg/pubsub"
+	"github.com/helixml/helix/api/pkg/scheduler"
 	"github.com/spf13/cobra"
 )
 
@@ -27,8 +28,8 @@ func newQapairCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			helixInference := openai.NewInternalHelixServer(&serverConfig, ps)
-
+			scheduler := scheduler.NewScheduler(&serverConfig)
+			helixInference := openai.NewInternalHelixServer(&serverConfig, ps, scheduler)
 			client, err := createDataPrepOpenAIClient(&serverConfig, helixInference)
 			if err != nil {
 				return err

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -62,8 +62,10 @@ type TogetherAI struct {
 }
 
 type Helix struct {
-	OwnerID   string `envconfig:"TOOLS_PROVIDER_HELIX_OWNER_ID" default:"helix-internal"` // Will be used for sesions
-	OwnerType string `envconfig:"TOOLS_PROVIDER_HELIX_OWNER_TYPE" default:"system"`       // Will be used for sesions
+	OwnerID   string        `envconfig:"TOOLS_PROVIDER_HELIX_OWNER_ID" default:"helix-internal"` // Will be used for sesions
+	OwnerType string        `envconfig:"TOOLS_PROVIDER_HELIX_OWNER_TYPE" default:"system"`       // Will be used for sesions
+	ModelTTL  time.Duration `envconfig:"HELIX_MODEL_TTL" default:"10s"`                          // How long to keep models warm before allowing other work to be scheduled
+	RunnerTTL time.Duration `envconfig:"HELIX_RUNNER_TTL" default:"30s"`                         // How long before runners are considered dead
 }
 
 type Tools struct {

--- a/api/pkg/controller/controller.go
+++ b/api/pkg/controller/controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/helixml/helix/api/pkg/openai/manager"
 	"github.com/helixml/helix/api/pkg/pubsub"
 	"github.com/helixml/helix/api/pkg/rag"
+	"github.com/helixml/helix/api/pkg/scheduler"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/tools"
 	"github.com/helixml/helix/api/pkg/types"
@@ -38,6 +39,7 @@ type ControllerOptions struct {
 	// OpenAIClient         openai.Client
 	ProviderManager      manager.ProviderManager
 	DataprepOpenAIClient openai.Client
+	Scheduler            scheduler.Scheduler
 }
 
 type Controller struct {
@@ -68,6 +70,8 @@ type Controller struct {
 
 	// the current buffer of scheduling decisions
 	schedulingDecisions []*types.GlobalSchedulingDecision
+
+	scheduler scheduler.Scheduler
 }
 
 func NewController(
@@ -108,6 +112,7 @@ func NewController(
 		},
 		activeRunners:       xsync.NewMapOf[string, *types.RunnerState](),
 		schedulingDecisions: []*types.GlobalSchedulingDecision{},
+		scheduler:           options.Scheduler,
 	}
 
 	toolsOpenAIClient, err := controller.getClient(ctx, options.Config.Inference.Provider)

--- a/api/pkg/controller/inference_test.go
+++ b/api/pkg/controller/inference_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/helixml/helix/api/pkg/openai/manager"
 	"github.com/helixml/helix/api/pkg/pubsub"
 	"github.com/helixml/helix/api/pkg/rag"
+	"github.com/helixml/helix/api/pkg/scheduler"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"go.uber.org/mock/gomock"
@@ -69,6 +70,8 @@ func (suite *ControllerSuite) SetupTest() {
 	cfg.Tools.Enabled = false
 	cfg.Inference.Provider = types.ProviderTogetherAI
 
+	scheduler := scheduler.NewScheduler(cfg)
+
 	c, err := NewController(context.Background(), ControllerOptions{
 		Config:          cfg,
 		Store:           suite.store,
@@ -77,6 +80,7 @@ func (suite *ControllerSuite) SetupTest() {
 		Filestore:       filestoreMock,
 		Extractor:       extractorMock,
 		RAG:             suite.rag,
+		Scheduler:       scheduler,
 	})
 	suite.NoError(err)
 

--- a/api/pkg/controller/sessions.go
+++ b/api/pkg/controller/sessions.go
@@ -842,6 +842,11 @@ func (c *Controller) AddSessionToQueue(session *types.Session) {
 }
 
 func (c *Controller) HandleRunnerResponse(ctx context.Context, taskResponse *types.RunnerTaskResponse) (*types.RunnerTaskResponse, error) {
+	err := c.scheduler.Release(taskResponse.SessionID)
+	if err != nil {
+		log.Error().Err(err).Msgf("error releasing session: %s", taskResponse.SessionID)
+	}
+
 	session, err := c.Options.Store.GetSession(ctx, taskResponse.SessionID)
 	if err != nil {
 		return nil, err

--- a/api/pkg/openai/helix_openai_server.go
+++ b/api/pkg/openai/helix_openai_server.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/helixml/helix/api/pkg/config"
-	"github.com/helixml/helix/api/pkg/model"
 	"github.com/helixml/helix/api/pkg/pubsub"
+	"github.com/helixml/helix/api/pkg/scheduler"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/rs/zerolog/log"
 )
@@ -40,12 +40,14 @@ type InternalHelixServer struct {
 
 	schedulingDecisionsMu sync.Mutex
 	schedulingDecisions   []*types.GlobalSchedulingDecision
+	scheduler             scheduler.Scheduler
 }
 
-func NewInternalHelixServer(cfg *config.ServerConfig, pubsub pubsub.PubSub) *InternalHelixServer {
+func NewInternalHelixServer(cfg *config.ServerConfig, pubsub pubsub.PubSub, scheduler scheduler.Scheduler) *InternalHelixServer {
 	return &InternalHelixServer{
-		cfg:    cfg,
-		pubsub: pubsub,
+		cfg:       cfg,
+		pubsub:    pubsub,
+		scheduler: scheduler,
 	}
 }
 
@@ -55,23 +57,55 @@ func (c *InternalHelixServer) GetNextLLMInferenceRequest(ctx context.Context, fi
 	c.queueMu.Lock()
 	defer c.queueMu.Unlock()
 
-	filteredReqs, err := filterLLMInferenceRequest(c.queue, filter)
+	// Doing all the scheduling work here to avoid making too many changes at once. Schedule any
+	// requests that are currently in the queue.
+	taken := 0
+	for _, req := range c.queue {
+		work, err := scheduler.NewLLMWorkload(req)
+		if err != nil {
+			log.Warn().Err(err).Str("id", req.RequestID).Msg("creating workload")
+			continue
+		}
+		err = c.scheduler.Schedule(work)
+		if err != nil {
+			retry, err := scheduler.ErrorHandlingStrategy(err, work)
+
+			// If we can retry, break out of the loop and try again later
+			if retry {
+				break
+			}
+
+			// If we can't retry, write an error to the request and continue so it takes it off
+			// the queue
+			// TODO(Phil): Not sure how to write an error back as a response
+			log.Error().Err(err).Str("id", work.ID()).Msg("error scheduling")
+		}
+		taken++
+	}
+	// Clear processed queue
+	c.queue = c.queue[taken:]
+
+	// Default to requesting warm work
+	newWorkOnly := false
+
+	// Only get new work if the filter has a memory requirement (see runner/controller.go)
+	if filter.Memory != 0 {
+		newWorkOnly = true
+	}
+
+	// Now for this runner, get work
+	req, err := c.scheduler.WorkForRunner(runnerID, scheduler.WorkloadTypeLLMInferenceRequest, newWorkOnly)
 	if err != nil {
-		return nil, fmt.Errorf("error filtering requests: %w", err)
+		return nil, fmt.Errorf("error getting work for runner: %w", err)
 	}
 
-	if len(filteredReqs) == 0 {
-		return nil, nil
+	if req != nil {
+		c.addSchedulingDecision(filter, runnerID, runnerID, req.LLMInferenceRequest().SessionID, req.LLMInferenceRequest().InteractionID)
+		log.Info().Str("runnerID", runnerID).Interface("filter", filter).Interface("req", req).Int("len(queue)", len(c.queue)).Msgf("🟠 helix_openai_server GetNextLLMInferenceRequest END")
+		return req.LLMInferenceRequest(), nil
 	}
+	return nil, nil
 
-	req, index := pickRequest(filteredReqs)
-
-	c.queue = append(c.queue[:index], c.queue[index+1:]...)
-
-	c.addSchedulingDecision(filter, runnerID, runnerID, req.SessionID, req.InteractionID)
-	log.Info().Str("runnerID", runnerID).Interface("filter", filter).Interface("req", req).Int("len(queue)", len(c.queue)).Msgf("🟠 helix_openai_server GetNextLLMInferenceRequest END")
-
-	return req, nil
 }
 
 func (c *InternalHelixServer) enqueueRequest(req *types.RunnerLLMInferenceRequest) {
@@ -81,69 +115,16 @@ func (c *InternalHelixServer) enqueueRequest(req *types.RunnerLLMInferenceReques
 	c.queue = append(c.queue, req)
 }
 
-func pickRequest(reqs []*types.RunnerLLMInferenceRequest) (*types.RunnerLLMInferenceRequest, int) {
-	if len(reqs) == 0 {
-		return nil, 0
-	}
-
-	// First look for any requests with priority
-	for idx, req := range reqs {
-		if req.Priority {
-			return req, idx
-		}
-	}
-
-	// If no requests have priority, return the first one (oldest)
-	return reqs[0], 0
-}
-
-func filterLLMInferenceRequest(reqs []*types.RunnerLLMInferenceRequest, filter types.InferenceRequestFilter) ([]*types.RunnerLLMInferenceRequest, error) {
-	var filteredReqs []*types.RunnerLLMInferenceRequest
-
-	filterModel := types.ModelName(filter.ModelName)
-
-	for _, req := range reqs {
-		requestModel := types.ModelName(req.Request.Model)
-
-		if filter.ModelName != "" && requestModel != filter.ModelName {
-			continue
-		}
-
-		var memoryRequirement uint64
-
-		model, err := model.GetModel(requestModel)
-		if err == nil {
-			memoryRequirement = model.GetMemoryRequirements(types.SessionModeInference)
-		}
-
-		if filter.Memory != 0 && memoryRequirement > filter.Memory {
-			continue
-		}
-
-		if filter.Older != 0 && req.CreatedAt.After(time.Now().Add(-filter.Older)) {
-			continue
-		}
-
-		log.Trace().
-			Str("filter_model", filterModel.String()).
-			Str("request_id", req.RequestID).
-			Str("memory_filter_gb", fmt.Sprintf("%.2f", GiB(int64(filter.Memory)))).
-			Str("memory_requirement_gb", fmt.Sprintf("%.2f", GiB(int64(memoryRequirement)))).
-			Msgf("🟠 helix_openai_server GetNextLLMInferenceRequest")
-
-		filteredReqs = append(filteredReqs, req)
-	}
-
-	return filteredReqs, nil
-
-}
-
-func GiB(bytes int64) float32 {
-	return float32(bytes) / 1024 / 1024 / 1024
-}
-
 // ProcessRunnerResponse is called on both partial streaming and full responses coming from the runner
 func (c *InternalHelixServer) ProcessRunnerResponse(ctx context.Context, resp *types.RunnerLLMInferenceResponse) error {
+	if resp.Done || resp.Error != "" {
+		err := c.scheduler.Release(
+			resp.RequestID,
+		)
+		if err != nil {
+			return fmt.Errorf("error releasing allocation: %w", err)
+		}
+	}
 	bts, err := json.Marshal(resp)
 	if err != nil {
 		return fmt.Errorf("error marshalling runner response: %w", err)

--- a/api/pkg/scheduler/allocator.go
+++ b/api/pkg/scheduler/allocator.go
@@ -1,0 +1,277 @@
+package scheduler
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/helixml/helix/api/pkg/model"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/puzpuzpuz/xsync/v3"
+	"github.com/rs/zerolog/log"
+)
+
+// WorkloadAllocator defines an interface for managing the allocation of workloads to runners.
+type WorkloadAllocator interface {
+	AllocateNewSlot(runnerID string, req *Workload) (*Slot, error)
+	AllocateSlot(slotID uuid.UUID, req *Workload) error
+	ReleaseSlot(slotID uuid.UUID) error
+	DeadSlots(deadRunnerIDs []string) []*Slot
+	WarmSlots(req *Workload) []*Slot
+	RunnerSlots(id string) []*Slot
+	ReconcileSlots(props *types.RunnerState) error
+}
+
+// TimeoutFunc defines a function type that determines if a runner has timed out based on the last activity.
+type TimeoutFunc func(runnerID string, lastActivityTime time.Time) bool
+
+// allocator implements the WorkloadAllocator interface, managing runners, slots, and workload allocation.
+type allocator struct {
+	slots            *xsync.MapOf[uuid.UUID, *Slot] // Maps slot ID to Slot details.
+	modelTimeoutFunc TimeoutFunc                    // Function to check if models have timed out.
+}
+
+// NewWorkloadAllocator creates a new allocator instance with timeout functions for models and runners.
+func NewWorkloadAllocator(modelTTL TimeoutFunc) *allocator {
+	return &allocator{
+		slots:            xsync.NewMapOf[uuid.UUID, *Slot](),
+		modelTimeoutFunc: modelTTL,
+	}
+}
+
+// AllocateSlot assigns a workload to a specific slot, validating the model and slot before scheduling.
+func (a *allocator) AllocateSlot(slotID uuid.UUID, req *Workload) error {
+	// Validate model
+	if _, err := model.GetModel(req.ModelName()); err != nil {
+		return fmt.Errorf("unable to get model (%s): %v", req.ModelName(), err)
+	}
+
+	// Validate slot
+	slot, ok := a.slots.Load(slotID)
+	if !ok {
+		return fmt.Errorf("slot not found: %s", slot.ID.String())
+	}
+
+	// Ensure the slot is not already scheduled or active.
+	if slot.IsScheduled() {
+		return fmt.Errorf("slot has scheduled work: %s", slot.ID.String())
+	}
+	if slot.IsActive() {
+		return fmt.Errorf("slot already active: %s", slot.ID.String())
+	}
+
+	log.Trace().
+		Str("runner_id", slot.RunnerID).
+		Str("slot_id", slot.ID.String()).
+		Str("model_name", slot.ModelName().String()).
+		Uint64("total_memory", slot.Memory()).
+		Str("request_id", req.ID()).
+		Msg("allocating slot")
+
+	// Schedule the slot.
+	slot.Schedule()
+
+	return nil
+}
+
+// AllocateNewSlot creates a new slot for a workload and allocates it to the best available runner.
+func (a *allocator) AllocateNewSlot(runnerID string, req *Workload) (*Slot, error) {
+	// Create a new slot and schedule the workload.
+	slot := NewSlot(runnerID, req, a.modelTimeoutFunc)
+	log.Trace().
+		Str("runner_id", slot.RunnerID).
+		Str("slot_id", slot.ID.String()).
+		Str("model_name", slot.ModelName().String()).
+		Uint64("total_memory", slot.Memory()).
+		Str("request_id", req.ID()).
+		Msg("creating new slot")
+
+	// Ensure the slot is stored.
+	a.slots.Store(slot.ID, slot)
+
+	// Schedule and store the new slot.
+	return slot, a.AllocateSlot(slot.ID, req)
+}
+
+// ReleaseSlot frees the resources allocated to a specific slot.
+func (a *allocator) ReleaseSlot(slotID uuid.UUID) error {
+	// Find the slot.
+	slot, ok := a.slots.Load(slotID)
+	if !ok {
+		return fmt.Errorf("slot not found: %s", slotID.String())
+	}
+
+	log.Trace().
+		Str("runner_id", slot.RunnerID).
+		Str("slot_id", slot.ID.String()).
+		Str("model_name", slot.ModelName().String()).
+		Uint64("total_memory", slot.Memory()).
+		Msg("releasing slot")
+
+	// Release the slot.
+	slot.Release()
+
+	return nil
+}
+
+// ReconcileSlots updates the state of a runner and reconciles its slots with the allocator's records.
+func (a *allocator) ReconcileSlots(props *types.RunnerState) error {
+	// Log runner state update.
+	l := log.With().
+		Str("runner_id", props.ID).
+		Int64("total_memory", int64(props.TotalMemory)).
+		Int64("free_memory", int64(props.FreeMemory)).
+		Logger()
+
+	// Mark found slots.
+	runnerSlots := a.RunnerSlots(props.ID)
+	foundSlots := make(map[uuid.UUID]bool, len(runnerSlots))
+	for _, s := range runnerSlots {
+		foundSlots[s.ID] = false
+	}
+
+	// Reconcile the runner's view of running models with the allocator's.
+	for _, m := range props.ModelInstances {
+		for _, s := range runnerSlots {
+			// If we've already seen this slot previously, skip. This might happen because there are
+			// multiple instances of the same model running on a runner
+			if foundSlots[s.ID] {
+				continue
+			}
+
+			// If it's not the same model name, skip
+			if m.ModelName != s.ModelName() {
+				continue
+			}
+
+			// If it's not the same mode then skip
+			if m.Mode != s.Mode() {
+				continue
+			}
+
+			// If it's not the same LoraDir then skip
+			if m.LoraDir != s.LoraDir() {
+				continue
+			}
+
+			// Else we found it
+			foundSlots[s.ID] = true
+
+			// No need to keep searching the rest of the slots, move onto the next model
+			break
+		}
+	}
+
+	// Remove stale or unused slots.
+	notFound := FilterMap(foundSlots, func(found bool) bool {
+		return !found
+	})
+	if len(notFound) > 0 {
+		l.Trace().
+			Int("num_total_slots", a.slots.Size()).
+			Int("num_slots_not_found", len(notFound)).
+			Msg("reconciling slots with runner")
+	}
+
+	for id := range notFound {
+		s, ok := a.slots.Load(id)
+		if !ok {
+			continue
+		}
+
+		// Check to make sure it's stale
+		if !s.IsStale() {
+			continue
+		}
+
+		if s.IsScheduled() {
+			continue
+		}
+
+		// If we get here then it's ok to delete
+		l.Trace().
+			Str("slot_id", id.String()).
+			Str("model_name", string(s.ModelName())).
+			Bool("is_stale", s.IsStale()).
+			Bool("is_scheduling", s.IsScheduled()).
+			Msg("deleting slot")
+		a.slots.Delete(id)
+	}
+
+	// Warn if the runner's state doesn't match the allocator's records.
+	if len(props.ModelInstances) != len(a.RunnerSlots(props.ID)) {
+		l.Debug().
+			Int("runner_models_len", len(props.ModelInstances)).
+			Int("controlplane_models_len", len(a.RunnerSlots(props.ID))).
+			Msg("runner model mismatch, ignoring runner models")
+	}
+
+	return nil
+}
+
+// WarmSlots returns a list of available slots with warm models waiting for work.
+func (a *allocator) WarmSlots(req *Workload) []*Slot {
+	cosyWarm := make([]*Slot, 0, a.slots.Size())
+
+	a.slots.Range(func(id uuid.UUID, slot *Slot) bool {
+		// If it's not the same model name, skip
+		if slot.ModelName() != req.ModelName() {
+			return true
+		}
+
+		// If it's not the same runtime, skip
+		if slot.ModelName().InferenceRuntime() != req.ModelName().InferenceRuntime() {
+			return true
+		}
+
+		// If the slot is already running another job, skip
+		if slot.IsActive() {
+			return true
+		}
+
+		// If the slot is scheduled to run another job, skip
+		if slot.IsScheduled() {
+			return true
+		}
+
+		// If it doesn't have the right LoraDir then skip
+		if slot.LoraDir() != req.LoraDir() {
+			return true
+		}
+
+		// Add available slots to the list.
+		cosyWarm = append(cosyWarm, slot)
+		return true
+	})
+	return cosyWarm
+}
+
+// RunnerSlots returns all slots associated with a specific runner ID.
+func (a *allocator) RunnerSlots(id string) []*Slot {
+	allSlots := Values(a.slots)
+	// Filter slots to include only those belonging to the specified runner.
+	return Filter(allSlots, func(s *Slot) bool {
+		return s.RunnerID == id
+	})
+}
+
+// DeadSlots checks for any runners that have timed out and removes them.
+// It returns the slots associated with the dead runners.
+func (a *allocator) DeadSlots(deadRunnerIDs []string) []*Slot {
+	deadSlots := make([]*Slot, 0)
+	// Iterate through runners to check if any have timed out.
+	for _, runnerID := range deadRunnerIDs {
+		// Remove all slots from the allocator.
+		slots := make([]*Slot, 0, a.slots.Size())
+		runnerSlots := a.RunnerSlots(runnerID)
+		for _, slot := range runnerSlots {
+			a.slots.Delete(slot.ID)
+			slots = append(slots, slot)
+		}
+
+		// Add these slots to the list of dead slots for rescheduling.
+		deadSlots = append(deadSlots, slots...)
+	}
+
+	return deadSlots
+}

--- a/api/pkg/scheduler/cluster.go
+++ b/api/pkg/scheduler/cluster.go
@@ -1,0 +1,92 @@
+package scheduler
+
+import (
+	"time"
+
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/puzpuzpuz/xsync/v3"
+	"github.com/rs/zerolog/log"
+)
+
+type Cluster interface {
+	UpdateRunner(props *types.RunnerState)
+	DeadRunnerIDs() []string
+	RunnerIDs() []string
+	TotalMemory(runnerID string) uint64
+}
+
+type cluster struct {
+	runners           *xsync.MapOf[string, *runner] // Maps a runner ID to its properties.
+	runnerTimeoutFunc TimeoutFunc                   // Function to check if runners have timed out.
+}
+
+func NewCluster(runnerTimeoutFunc TimeoutFunc) *cluster {
+	return &cluster{
+		runners:           xsync.NewMapOf[string, *runner](),
+		runnerTimeoutFunc: runnerTimeoutFunc,
+	}
+}
+
+// UpdateRunner updates the state of a runner and reconciles its slots with the allocator's records.
+func (c *cluster) UpdateRunner(props *types.RunnerState) {
+	log.Trace().
+		Str("runner_id", props.ID).
+		Int64("total_memory", int64(props.TotalMemory)).
+		Int64("free_memory", int64(props.FreeMemory)).
+		Msg("updating runner state")
+
+	// Update runner properties and activity.
+	runner, _ := c.runners.LoadOrStore(props.ID, &runner{})
+	runner.Update(props)
+}
+
+func (c *cluster) DeadRunnerIDs() []string {
+	deadRunners := make([]string, 0)
+
+	// Iterate through runners to check if any have timed out.
+	c.runners.Range(func(runnerID string, r *runner) bool {
+		if r.HasTimedOut(c.runnerTimeoutFunc) {
+			deadRunners = append(deadRunners, runnerID)
+		}
+		return true
+	})
+
+	for _, runnerID := range deadRunners {
+		log.Warn().
+			Str("runner_id", runnerID).
+			Msg("runner timed out")
+		c.runners.Delete(runnerID)
+	}
+
+	return deadRunners
+}
+
+func (c *cluster) RunnerIDs() []string {
+	return Keys(c.runners)
+}
+
+func (c *cluster) TotalMemory(runnerID string) uint64 {
+	runner, ok := c.runners.Load(runnerID)
+	if !ok {
+		return 0
+	}
+	return runner.TotalMemory()
+}
+
+type runner struct {
+	RunnerProperties   *types.RunnerState
+	RunnerLastActivity time.Time
+}
+
+func (r *runner) Update(s *types.RunnerState) {
+	r.RunnerProperties = s
+	r.RunnerLastActivity = time.Now()
+}
+
+func (r *runner) HasTimedOut(timeoutFunc TimeoutFunc) bool {
+	return timeoutFunc(r.RunnerProperties.ID, r.RunnerLastActivity)
+}
+
+func (r *runner) TotalMemory() uint64 {
+	return r.RunnerProperties.TotalMemory
+}

--- a/api/pkg/scheduler/errors.go
+++ b/api/pkg/scheduler/errors.go
@@ -1,0 +1,46 @@
+package scheduler
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+)
+
+var (
+	ErrRunnersAreFull     = errors.New("runners are full")
+	ErrNoRunnersAvailable = errors.New("no runners available")
+	ErrModelWontFit       = errors.New("model won't fit in any runner")
+)
+
+// ErrorHandlingStrategy is a function that handles errors returned by the scheduler.
+// If the error is temporary and can be retried later, retry will return true. Otherwise it will
+// return false and an error.
+func ErrorHandlingStrategy(schedulerError error, work *Workload) (bool, error) {
+	l := log.With().
+		Str("request_id", work.ID()).
+		Str("model_id", work.ModelName().String()).
+		Uint64("model_size", work.Model().GetMemoryRequirements(work.Mode())).
+		Logger()
+
+	// If the runners are just full with work, keep the work in the queue and retry later.
+	if errors.Is(schedulerError, ErrRunnersAreFull) {
+		l.Trace().Err(schedulerError).Msgf("unable to schedule, retrying...")
+		return true, nil
+	}
+
+	// If there are no runners available, fail the request.
+	if errors.Is(schedulerError, ErrNoRunnersAvailable) {
+		l.Warn().Err(schedulerError).Msgf("no runners available to schedule work")
+		return false, fmt.Errorf("no runners available to schedule work: %w", schedulerError)
+	}
+
+	// If the model won't fit in any available runner, fail the request.
+	if errors.Is(schedulerError, ErrModelWontFit) {
+		l.Warn().Err(schedulerError).Msgf("model won't fit in any runner, please add a bigger runner")
+		return false, fmt.Errorf("model won't fit in any runner: %w", schedulerError)
+	}
+
+	// Else a generic error occurred, fail the request.
+	return false, fmt.Errorf("scheduling session (%s): %w", work.ID(), schedulerError)
+}

--- a/api/pkg/scheduler/placement.go
+++ b/api/pkg/scheduler/placement.go
@@ -1,0 +1,102 @@
+package scheduler
+
+import (
+	"fmt"
+	"math"
+	"slices"
+
+	"github.com/helixml/helix/api/pkg/model"
+	"github.com/rs/zerolog/log"
+)
+
+type PlacementStrategy func(Cluster, WorkloadAllocator, *Workload) (string, error)
+
+func MaxUtilizationStrategy(c Cluster, a WorkloadAllocator, req *Workload) (string, error) {
+	// Prioritize runners to maximize utilization.
+	prioritizedRunners := runnersByMaxUtilisation(c, a)
+
+	// Find the first runner that can fit the workload.
+	var bestRunnerID string
+	maxAvailable := float64(0)
+	modelRequirement := req.Model().GetMemoryRequirements(req.Mode())
+	for _, runner := range prioritizedRunners {
+		runnerTotal := c.TotalMemory(runner)
+		maxAvailable = math.Max(float64(runnerTotal), maxAvailable)
+
+		available, err := availableMemory(c, a, runner)
+		if err != nil {
+			return "", fmt.Errorf("getting available memory for runner (%s): %v", runner, err)
+		}
+		if available >= modelRequirement {
+			bestRunnerID = runner
+			break
+		}
+	}
+	if bestRunnerID == "" {
+		if len(prioritizedRunners) == 0 {
+			return "", ErrNoRunnersAvailable
+		}
+		if maxAvailable < float64(modelRequirement) {
+			log.Trace().Float64("max_available", maxAvailable).Float64("model_requirement", float64(modelRequirement)).Msg("model won't fit in any runner")
+			return "", ErrModelWontFit
+		}
+		return "", ErrRunnersAreFull
+	}
+
+	return bestRunnerID, nil
+}
+
+// runnersByMaxUtilisation sorts runners by their available memory in descending order,
+// prioritizing runners with the least free memory for better utilization.
+func runnersByMaxUtilisation(c Cluster, a WorkloadAllocator) []string {
+	runners := c.RunnerIDs()
+	// Sort runners based on available memory, from least available to most available.
+	slices.SortFunc(
+		runners,
+		func(i, j string) int {
+			// Calculate available memory for runner i.
+			memA, err := availableMemory(c, a, i)
+			if err != nil {
+				log.Err(err).Msg("sorting a by utilization")
+			}
+			// Calculate available memory for runner j.
+			memB := uint64(0)
+			if j != "" {
+				memB, err = availableMemory(c, a, j)
+				if err != nil {
+					log.Err(err).Msg("sorting b by utilization")
+				}
+			}
+			// Sort by available memory (descending).
+			return int(memA) - int(memB)
+		},
+	)
+	return runners
+}
+
+// availableMemory calculates the available memory for a specific runner by subtracting
+// the memory usage of all non-stale slots assigned to that runner.
+func availableMemory(c Cluster, a WorkloadAllocator, runnerID string) (uint64, error) {
+	var available int64 // This could potentially be negative after subtracting too many things
+
+	// Start with the total memory of the runner.
+	available = int64(c.TotalMemory(runnerID))
+
+	// Subtract the memory of all non-stale slots assigned to this runner.
+	runnerSlots := a.RunnerSlots(runnerID)
+	for _, slot := range runnerSlots {
+		if !slot.IsStale() {
+			// Get the memory requirements for the slot's model.
+			m, err := model.GetModel(slot.ModelName())
+			if err != nil {
+				return 0, fmt.Errorf("getting slot model (%s): %v", slot.ModelName(), err)
+			}
+			available -= int64(m.GetMemoryRequirements(slot.Mode()))
+		}
+	}
+	if available < 0 {
+		available = 0
+	}
+
+	return uint64(available), nil
+}

--- a/api/pkg/scheduler/scheduler.go
+++ b/api/pkg/scheduler/scheduler.go
@@ -1,0 +1,243 @@
+package scheduler
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/model"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/puzpuzpuz/xsync/v3"
+	"github.com/rs/zerolog/log"
+)
+
+// Scheduler is is the main entrypoint to the scheduler package.
+// It provides methods to schedule, release, and assign workloads to runners.
+// The underlying workload management is handled by the WorkloadAllocator interface.
+type Scheduler interface {
+	Schedule(request *Workload) error
+	Release(id string) error
+	WorkForRunner(id string, workType WorkloadType, newWorkOnly bool) (*Workload, error)
+	UpdateRunner(props *types.RunnerState)
+}
+
+// scheduler is a struct implementing the Scheduler interface.
+// It includes a workload allocator (allocator) and a thread-safe map (workStore) to store scheduled workloads.
+type scheduler struct {
+	allocator         WorkloadAllocator                  // Interface to allocate workload to different slots/models.
+	workStore         *xsync.MapOf[uuid.UUID, *Workload] // Map to store the work associated with a slot.
+	cluster           Cluster                            // Cluster to manage runner state.
+	placementStrategy PlacementStrategy
+}
+
+var _ Scheduler = &scheduler{}
+
+// NewScheduler creates a new scheduler with a workload allocator.
+// It returns a Scheduler instance for managing workloads.
+func NewScheduler(cfg *config.ServerConfig) *scheduler {
+	allocator := NewWorkloadAllocator(
+		NewTimeoutFunc(cfg.Providers.Helix.ModelTTL),
+	)
+	cluster := NewCluster(
+		NewTimeoutFunc(cfg.Providers.Helix.RunnerTTL),
+	)
+	scheduler := &scheduler{
+		allocator:         allocator,
+		cluster:           cluster,
+		workStore:         xsync.NewMapOf[uuid.UUID, *Workload](),
+		placementStrategy: MaxUtilizationStrategy, // TODO: Make this configurable.
+	}
+
+	// Start a goroutine to log the current state of the scheduler every 5 seconds.
+	ticker := time.NewTicker(time.Second * 1)
+	go func() {
+		for range ticker.C {
+			scheduler.logState()
+		}
+	}()
+
+	return scheduler
+}
+
+// NewTimeoutFunc returns a function to check if a runner has been idle for a specified timeout duration.
+func NewTimeoutFunc(timeout time.Duration) TimeoutFunc {
+	return func(runnerID string, lastActivity time.Time) bool {
+		// Check if the model has been unused for more than the specified timeout duration.
+		return time.Since(lastActivity) > timeout
+	}
+}
+
+// Schedule assigns work based on the current workload and available slots.
+// It attempts to allocate the workload to a warm slot or creates a new slot if none are available.
+func (s *scheduler) Schedule(work *Workload) (err error) {
+	if work == nil {
+		return fmt.Errorf("workload is nil")
+	}
+	// Validate model.
+	if _, err := model.GetModel(work.ModelName()); err != nil {
+		return fmt.Errorf("unable to get model (%s): %v", work.ModelName(), err)
+	}
+
+	// Validate session mode.
+	if work.Mode() == types.SessionModeNone {
+		return fmt.Errorf("session mode isn't set")
+	}
+
+	var slot *Slot // Holds the slot where the work will be scheduled.
+
+	// Try to find warm slots, which are ready to take new work.
+	slots := s.allocator.WarmSlots(work)
+	log.Trace().
+		Int("warm_slots", len(slots)).
+		Str("work_id", work.ID()).
+		Msg("finding warm slots")
+
+	// If warm slots are available, select a random one.
+	if len(slots) > 0 {
+		// Randomly select one warm slot from the available warm slots.
+		slot = slots[rand.Intn(len(slots))]
+
+		// Allocate work to the selected warm slot.
+		err = s.allocator.AllocateSlot(slot.ID, work)
+		if err != nil {
+			// Return error if unable to allocate work to the warm model.
+			return fmt.Errorf("unable to allocate work to a warm model: %w", err)
+		}
+	} else {
+		// If no warm slots are available, pick a runner to allocate a slot to.
+		bestRunnerID, err := s.placementStrategy(s.cluster, s.allocator, work)
+		if err != nil {
+			return fmt.Errorf("unable to place work on any runner: %w", err)
+		}
+
+		// Create an allocate slot
+		slot, err = s.allocator.AllocateNewSlot(bestRunnerID, work)
+		if err != nil {
+			// Return error if unable to allocate a new slot.
+			return fmt.Errorf("unable to allocate new work: %w", err)
+		}
+	}
+
+	// Store the work associated with the slot for future deallocation.
+	if slot == nil {
+		// If the slot is nil, return an error.
+		return fmt.Errorf("slot is nil")
+	}
+
+	s.workStore.Store(slot.ID, work)
+
+	return nil
+}
+
+// Release frees the resources associated with a specific scheduled request.
+// It finds the request by its ID, releases the allocated slot, and removes the associated work from the store.
+func (s *scheduler) Release(id string) error {
+	// Find the slot ID associated with the request.
+	slotID, ok := s.find(id)
+	if !ok {
+		// If the request is not found, return an error.
+		return fmt.Errorf("request not found: %s", id)
+	}
+
+	// Release the resources allocated to the slot.
+	err := s.allocator.ReleaseSlot(slotID)
+	if err != nil {
+		// If there is an error during deallocation, return it.
+		return fmt.Errorf("problem deallocating: %w", err)
+	}
+
+	// Remove the work associated with the slot from the store.
+	s.workStore.Delete(slotID)
+
+	return nil
+}
+
+// WorkForRunner retrieves work for a specific runner by its ID.
+// It checks the runner's slots and assigns the work if any slot is ready.
+// If newWorkOnly is set, it will only return work from new slots
+func (s *scheduler) WorkForRunner(id string, workType WorkloadType, newWorkOnly bool) (*Workload, error) {
+	// Before retrieving work, check for dead runners and attempt to reschedule their work.
+	deadSlots := s.allocator.DeadSlots(s.cluster.DeadRunnerIDs())
+	for _, dead := range deadSlots {
+		// Get work associated with the dead slot.
+		work, ok := s.workStore.Load(dead.ID)
+		if !ok {
+			continue // Work not owned by this scheduler, ignore it.
+		}
+
+		// Attempt to reschedule the work.
+		log.Trace().
+			Str("runner_id", id).
+			Str("slot_id", dead.ID.String()).
+			Msg("rescheduling work for dead slot")
+		err := s.Schedule(work)
+		if err != nil {
+			log.Error().
+				Err(err).
+				Str("runner_id", id).
+				Str("slot_id", dead.ID.String()).
+				Msg("failed to reschedule work for dead slot")
+			continue
+		}
+	}
+
+	// Iterate through the slots assigned to the runner.
+	for _, slot := range s.allocator.RunnerSlots(id) {
+		// If the slot is ready for scheduling, retrieve the associated work.
+		if slot.IsScheduled() {
+			work, ok := s.workStore.Load(slot.ID)
+			if !ok {
+				continue // Work not owned by this scheduler, ignore it.
+			}
+			if work.WorkloadType != workType {
+				continue // Work is not of the requested type, ignore it.
+			}
+			if newWorkOnly && !slot.IsNew() {
+				continue // Work is not new, ignore it.
+			}
+			slot.Start() // Mark the work in the slot as started.
+			return work, nil
+		}
+	}
+	// If no work is found for the runner, return nil.
+	return nil, nil
+}
+
+// UpdateRunner updates the state of a runner and reconciles its slots with the allocator's records.
+func (s *scheduler) UpdateRunner(props *types.RunnerState) {
+	// Update the runner's state in the cluster.
+	s.cluster.UpdateRunner(props)
+	// Reconcile the runner's slots with the allocator's records.
+	s.allocator.ReconcileSlots(props)
+}
+
+// find searches for the slot ID associated with a given workload ID.
+func (s *scheduler) find(id string) (uuid.UUID, bool) {
+	var result uuid.UUID
+	// Iterate through the workStore to find the matching workload ID.
+	s.workStore.Range(func(slotID uuid.UUID, w *Workload) bool {
+		if w.ID() == id {
+			result = slotID
+			return false
+		}
+		return true
+	})
+	return result, result != uuid.Nil
+}
+
+func (s *scheduler) logState() {
+	for _, runnerID := range s.cluster.RunnerIDs() {
+		currentSlots := s.allocator.RunnerSlots(runnerID)
+		activeSlots := Filter(currentSlots, func(slot *Slot) bool {
+			return slot.IsActive()
+		})
+		log.Info().
+			Str("runner_id", runnerID).
+			Int("active_slots", len(activeSlots)).
+			Int("total_slots", len(currentSlots)).
+			Msg("runner state")
+	}
+
+}

--- a/api/pkg/scheduler/scheduler_test.go
+++ b/api/pkg/scheduler/scheduler_test.go
@@ -1,0 +1,314 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/model"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/sashabaranov/go-openai"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScheduler_NoRunnersAvailable(t *testing.T) {
+	config, _ := config.LoadServerConfig()
+	scheduler := NewScheduler(&config)
+	err := createTestWork(scheduler, "test-request-1", types.Model_Ollama_Llama3_8b)
+	assert.ErrorContains(t, err, "no runners available")
+}
+
+func TestScheduler_TimeoutRunner(t *testing.T) {
+	config, _ := config.LoadServerConfig()
+	scheduler := NewScheduler(&config)
+
+	// Monkeypatch the scheduler's cluster
+	timeoutRunner1Func := func(id string, t time.Time) bool {
+		return id == "test-runner-1"
+	}
+	cluster := NewCluster(timeoutRunner1Func)
+	scheduler.cluster = cluster
+
+	model, _ := model.GetModel(types.Model_Ollama_Llama3_8b)
+	scheduler.UpdateRunner(&types.RunnerState{
+		ID:          "test-runner-1",
+		TotalMemory: model.GetMemoryRequirements(types.SessionModeInference) * 2,
+	})
+
+	// Schedule a job
+	err := createTestWork(scheduler, "test-request-1", types.Model_Ollama_Llama3_8b)
+	assert.NoError(t, err)
+
+	scheduler.UpdateRunner(&types.RunnerState{
+		ID:          "test-runner-2",
+		TotalMemory: model.GetMemoryRequirements(types.SessionModeInference) * 2,
+	})
+
+	// Simulate not updating the runner for a while so that subsequent jobs get rescheduled
+	work, err := scheduler.WorkForRunner("test-runner-2", WorkloadTypeLLMInferenceRequest, false)
+	assert.NoError(t, err)
+
+	// Assert that the work, originally scheduled for runner-1 is now on runner-2
+	assert.Equal(t, work.ID(), "test-request-1")
+}
+
+func TestScheduler_ThreeJobsOnSingleRunnerThatCanFitTwo(t *testing.T) {
+	config, _ := config.LoadServerConfig()
+	scheduler := NewScheduler(&config)
+	model, _ := model.GetModel(types.Model_Ollama_Llama3_8b)
+	scheduler.UpdateRunner(&types.RunnerState{
+		ID:          "test-runner",
+		TotalMemory: model.GetMemoryRequirements(types.SessionModeInference) * 2,
+	})
+
+	// Test requests
+	err := createTestWork(scheduler, "test-request-1", types.Model_Ollama_Llama3_8b)
+	assert.NoError(t, err)
+
+	err = createTestWork(scheduler, "test-request-2", types.Model_Ollama_Llama3_8b)
+	assert.NoError(t, err)
+
+	err = createTestWork(scheduler, "test-request-3", types.Model_Ollama_Llama3_8b)
+	assert.ErrorContains(t, err, "full")
+}
+
+func TestScheduler_TestWarmSlot(t *testing.T) {
+	config, _ := config.LoadServerConfig()
+	scheduler := NewScheduler(&config)
+	model, _ := model.GetModel(types.Model_Ollama_Llama3_8b)
+	scheduler.UpdateRunner(&types.RunnerState{
+		ID:          "test-runner",
+		TotalMemory: model.GetMemoryRequirements(types.SessionModeInference) * 2,
+	})
+
+	// Test request
+	err := createTestWork(scheduler, "test-request-1", types.Model_Ollama_Llama3_8b)
+	assert.NoError(t, err)
+
+	// Simulate the runner starting the work
+	scheduler.WorkForRunner("test-runner", WorkloadTypeLLMInferenceRequest, false)
+	// Simulate the runner finishing the work
+	err = scheduler.Release("test-request-1")
+	assert.NoError(t, err)
+
+	// Start request-2
+	err = createTestWork(scheduler, "test-request-2", types.Model_Ollama_Llama3_8b)
+	assert.NoError(t, err)
+
+	// Make sure there's only one slot
+	assert.Equal(t, len(scheduler.allocator.RunnerSlots("test-runner")), 1)
+}
+
+func TestScheduler_TestRemoveStaleSlots(t *testing.T) {
+	config, _ := config.LoadServerConfig()
+	config.Providers.Helix.ModelTTL = 1 * time.Microsecond
+	scheduler := NewScheduler(&config)
+	model, _ := model.GetModel(types.Model_Ollama_Llama3_8b)
+	scheduler.UpdateRunner(&types.RunnerState{
+		ID:          "test-runner",
+		TotalMemory: 2 * model.GetMemoryRequirements(types.SessionModeInference),
+	})
+
+	// Test request
+	err := createTestWork(scheduler, "test-request-1", types.Model_Ollama_Llama3_8b)
+	assert.NoError(t, err)
+
+	// Test request 2
+	err = createTestWork(scheduler, "test-request-2", types.Model_Ollama_Llama3_8b)
+	assert.NoError(t, err)
+
+	// Simulate the runner starting the work
+	scheduler.WorkForRunner("test-runner", WorkloadTypeLLMInferenceRequest, false)
+	scheduler.WorkForRunner("test-runner", WorkloadTypeLLMInferenceRequest, false)
+	// Simulate the runner finishing the work
+	err = scheduler.Release("test-request-1")
+	assert.NoError(t, err)
+	err = scheduler.Release("test-request-2")
+	assert.NoError(t, err)
+
+	// Start request-3, a new model type
+	err = createTestWork(scheduler, "test-request-3", types.Model_Ollama_Phi3)
+	assert.NoError(t, err)
+
+	// Simulate the runner starting the work
+	scheduler.WorkForRunner("test-runner", WorkloadTypeLLMInferenceRequest, false)
+
+	// Simulate runner updating control plane with removed models
+	scheduler.UpdateRunner(&types.RunnerState{
+		ID:          "test-runner",
+		TotalMemory: model.GetMemoryRequirements(types.SessionModeInference),
+		ModelInstances: []*types.ModelInstanceState{
+			{
+				ModelName: types.Model_Ollama_Llama3_8b,
+				Mode:      types.SessionModeInference,
+			}, {
+				ModelName: types.Model_Ollama_Phi3,
+				Mode:      types.SessionModeInference,
+			},
+		},
+	})
+
+	assert.Equal(t, len(scheduler.allocator.RunnerSlots("test-runner")), 2)
+}
+
+func TestScheduler_FullWhenJobsWarm(t *testing.T) {
+	config, _ := config.LoadServerConfig()
+	scheduler := NewScheduler(&config)
+	model, _ := model.GetModel(types.Model_Ollama_Llama3_8b)
+	scheduler.UpdateRunner(&types.RunnerState{
+		ID:          "test-runner",
+		TotalMemory: model.GetMemoryRequirements(types.SessionModeInference),
+	})
+
+	// Test request
+	err := createTestWork(scheduler, "test-request-1", types.Model_Ollama_Llama3_8b)
+	assert.NoError(t, err)
+
+	// Simulate runner doing work
+	scheduler.WorkForRunner("test-runner", WorkloadTypeLLMInferenceRequest, false)
+	err = scheduler.Release("test-request-1")
+	assert.NoError(t, err)
+
+	// Even though the work has finished, the slot is still warm, so it should report full when a
+	// new model is requested
+	err = createTestWork(scheduler, "test-request-2", types.Model_Ollama_Phi3)
+	assert.ErrorContains(t, err, "full")
+}
+
+func TestScheduler_MaximiseUtilization(t *testing.T) {
+	config, _ := config.LoadServerConfig()
+	scheduler := NewScheduler(&config)
+	model, _ := model.GetModel(types.Model_Ollama_Llama3_8b)
+	scheduler.UpdateRunner(&types.RunnerState{
+		ID:          "test-runner-1",
+		TotalMemory: 2 * model.GetMemoryRequirements(types.SessionModeInference),
+	})
+
+	// Add one request
+	err := createTestWork(scheduler, "test-request-1", types.Model_Ollama_Llama3_8b)
+	assert.NoError(t, err)
+
+	// Add a second runner
+	scheduler.UpdateRunner(&types.RunnerState{
+		ID:          "test-runner-2",
+		TotalMemory: 2 * model.GetMemoryRequirements(types.SessionModeInference),
+	})
+	assert.NoError(t, err)
+
+	// When scheduling a second request, it should fill the first runner, not the second
+	err = createTestWork(scheduler, "test-request-2", types.Model_Ollama_Llama3_8b)
+	assert.NoError(t, err)
+
+	// Check that NO work has been scheduler's cluster
+	work, err := scheduler.WorkForRunner("test-runner-2", WorkloadTypeLLMInferenceRequest, false)
+	assert.NoError(t, err)
+	if work != nil {
+		t.Error("second runner should have no work because we're maximizing utilization (represented by nil)")
+	}
+}
+
+// Session scheduling is largely the same
+func TestScheduler_TestSessionScheduler(t *testing.T) {
+	config, _ := config.LoadServerConfig()
+	config.Providers.Helix.ModelTTL = 1 * time.Microsecond
+	scheduler := NewScheduler(&config)
+	model, _ := model.GetModel(types.Model_Ollama_Llama3_8b)
+	scheduler.UpdateRunner(&types.RunnerState{
+		ID:          "test-runner",
+		TotalMemory: model.GetMemoryRequirements(types.SessionModeInference) * 2,
+	})
+
+	// Test request
+	err := createTestSession(scheduler, "test-request-1", types.Model_Ollama_Llama3_8b, "")
+	assert.NoError(t, err)
+	err = createTestSession(scheduler, "test-request-2", types.Model_Ollama_Llama3_8b, "")
+	assert.NoError(t, err)
+	err = createTestSession(scheduler, "test-request-3", types.Model_Ollama_Phi3, "")
+	assert.ErrorContains(t, err, "full")
+
+	// Simulate runner taking and finishing work
+	scheduler.WorkForRunner("test-runner", WorkloadTypeSession, false)
+	err = scheduler.Release("test-request-1")
+	assert.NoError(t, err)
+
+	scheduler.WorkForRunner("test-runner", WorkloadTypeSession, false)
+	err = scheduler.Release("test-request-2")
+	assert.NoError(t, err)
+
+	// Now work should fit, since the test is always stale
+	err = createTestWork(scheduler, "test-request-4", types.Model_Ollama_Phi3)
+	assert.NoError(t, err)
+}
+
+func TestScheduler_LoraDirSession(t *testing.T) {
+	config, _ := config.LoadServerConfig()
+	scheduler := NewScheduler(&config)
+	model, _ := model.GetModel(types.Model_Axolotl_Mistral7b)
+	scheduler.UpdateRunner(&types.RunnerState{
+		ID:          "test-runner-1",
+		TotalMemory: model.GetMemoryRequirements(types.SessionModeInference),
+	})
+
+	// Test request
+	err := createTestSession(scheduler, "test-request-1", types.Model_Axolotl_Mistral7b, "test")
+	assert.NoError(t, err)
+
+	// Simulate runner taking and finishing work
+	scheduler.WorkForRunner("test-runner-1", WorkloadTypeSession, false)
+	err = scheduler.Release("test-request-1")
+	assert.NoError(t, err)
+
+	// Add a second runner
+	scheduler.UpdateRunner(&types.RunnerState{
+		ID:          "test-runner-2",
+		TotalMemory: model.GetMemoryRequirements(types.SessionModeInference),
+	})
+
+	// Reschedule lora work, must always scheduler's cluster
+	err = createTestSession(scheduler, "test-request-2", types.Model_Axolotl_Mistral7b, "test")
+	assert.NoError(t, err)
+
+	// Check that NO work has been scheduler's cluster
+	work, err := scheduler.WorkForRunner("test-runner-2", WorkloadTypeSession, false)
+	assert.NoError(t, err)
+	if work != nil {
+		t.Error("second runner should have no work because of the warm lora dir")
+	}
+
+	// Schedule a second lora dir, must scheduler's cluster
+	err = createTestSession(scheduler, "test-request-3", types.Model_Axolotl_Mistral7b, "new")
+	assert.NoError(t, err)
+	work, err = scheduler.WorkForRunner("test-runner-2", WorkloadTypeSession, false)
+	assert.NoError(t, err)
+	if work == nil {
+		t.Error("second runner should have work because of the new lora dir")
+	}
+}
+
+func createTestWork(scheduler Scheduler, name string, model types.ModelName) error {
+	req := &types.RunnerLLMInferenceRequest{
+		RequestID: name,
+		Request: &openai.ChatCompletionRequest{
+			Model: model.String(),
+		},
+	}
+	work, err := NewLLMWorkload(req)
+	if err != nil {
+		return err
+	}
+	return scheduler.Schedule(work)
+}
+
+func createTestSession(scheduler Scheduler, name string, model types.ModelName, loraDir string) error {
+	req := &types.Session{
+		ID:        name,
+		ModelName: model,
+		Mode:      types.SessionModeInference,
+		LoraDir:   loraDir,
+	}
+	work, err := NewSessonWorkload(req)
+	if err != nil {
+		return err
+	}
+	return scheduler.Schedule(work)
+}

--- a/api/pkg/scheduler/slot.go
+++ b/api/pkg/scheduler/slot.go
@@ -1,0 +1,134 @@
+package scheduler
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+type Slot struct {
+	ID               uuid.UUID // An ID representing this unique model on a runner
+	RunnerID         string    // The runner that this slot is assigned to
+	work             *Workload // The work that is currently assigned to this slot
+	lastActivityTime time.Time // Private because I don't want people misinterpreting this
+	isActive         bool      // Private because I don't want people misinterpreting this
+	isScheduled      bool      // Private because I don't want people misinterpreting this
+	mu               *sync.RWMutex
+	timeoutFunc      TimeoutFunc
+	isNew            bool
+}
+
+func NewSlot(runnerID string, work *Workload, timeoutFunc TimeoutFunc) *Slot {
+	return &Slot{
+		ID:               uuid.New(),
+		RunnerID:         runnerID,
+		work:             work,
+		lastActivityTime: time.Now(),
+		isActive:         false,
+		isScheduled:      false,
+		isNew:            true, // Is new when slot is created
+		mu:               &sync.RWMutex{},
+		timeoutFunc:      timeoutFunc,
+	}
+}
+
+// True if the model is not active and hasn't been active for at least ModelTTL
+func (s *Slot) IsStale() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// If work is active, not stale
+	if s.isActive {
+		return false
+	}
+
+	// If work is scheduled, it is not stale
+	if s.isScheduled {
+		return false
+	}
+
+	// Now run the timeout function check
+	return s.timeoutFunc(s.RunnerID, s.lastActivityTime)
+}
+
+// True if this slot is currently active with work
+func (s *Slot) IsActive() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.isActive
+}
+
+// Schedule sets a slot ready for scheduling
+func (s *Slot) Schedule() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.isScheduled = true
+	s.lastActivityTime = time.Now()
+}
+
+// True if work is scheduled on this slot
+func (s *Slot) IsScheduled() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.isScheduled
+}
+
+// Sets a slot as no longer active
+func (s *Slot) Release() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.isActive = false
+	s.lastActivityTime = time.Now()
+}
+
+// Marks the work as started
+func (s *Slot) Start() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.isScheduled = false
+	s.lastActivityTime = time.Now()
+	s.isActive = true
+	s.isNew = false
+}
+
+func (s *Slot) Mode() types.SessionMode {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.work.Mode()
+}
+
+func (s *Slot) ModelName() types.ModelName {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.work.ModelName()
+}
+
+func (s *Slot) Memory() uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.work.Model().GetMemoryRequirements(s.Mode())
+}
+
+func (s *Slot) LoraDir() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.work.LoraDir()
+}
+
+func (s *Slot) IsNew() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.isNew
+}

--- a/api/pkg/scheduler/util.go
+++ b/api/pkg/scheduler/util.go
@@ -1,0 +1,47 @@
+package scheduler
+
+import "github.com/puzpuzpuz/xsync/v3"
+
+// Values returns a slice of all values in the map.
+func Values[K, V comparable](m *xsync.MapOf[K, V]) []V {
+	values := make([]V, 0, m.Size())
+	m.Range(func(key K, value V) bool {
+		values = append(values, value)
+		return true
+	})
+	return values
+}
+
+func Keys[K comparable, V any](m *xsync.MapOf[K, V]) []K {
+	keys := make([]K, 0, m.Size())
+	// Collect all map keys.
+	m.Range(func(key K, _ V) bool {
+		keys = append(keys, key)
+		return true
+	})
+	return keys
+}
+
+// Filter filters a slice based on a predicate function and returns a new slice with matching elements.
+func Filter[v any](s []v, f func(v) bool) []v {
+	vals := make([]v, 0, len(s))
+	// Iterate through the slice and append elements that satisfy the predicate.
+	for _, value := range s {
+		if f(value) {
+			vals = append(vals, value)
+		}
+	}
+	return vals
+}
+
+// FilterMap filters a map based on a predicate function and returns a new map with matching entries.
+func FilterMap[k comparable, v any](m map[k]v, f func(v) bool) map[k]v {
+	newMap := make(map[k]v, len(m))
+	// Iterate through the map and copy entries that satisfy the predicate.
+	for k, v := range m {
+		if f(v) {
+			newMap[k] = v
+		}
+	}
+	return newMap
+}

--- a/api/pkg/scheduler/workload.go
+++ b/api/pkg/scheduler/workload.go
@@ -1,0 +1,108 @@
+package scheduler
+
+import (
+	"fmt"
+
+	"github.com/helixml/helix/api/pkg/model"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+type WorkloadType string
+
+const (
+	WorkloadTypeLLMInferenceRequest WorkloadType = "llm"
+	WorkloadTypeSession             WorkloadType = "session"
+)
+
+type Workload struct {
+	WorkloadType       WorkloadType
+	llmInfereceRequest *types.RunnerLLMInferenceRequest
+	session            *types.Session
+}
+
+func NewLLMWorkload(work *types.RunnerLLMInferenceRequest) (*Workload, error) {
+	workload := &Workload{
+		WorkloadType:       WorkloadTypeLLMInferenceRequest,
+		llmInfereceRequest: work,
+	}
+	return validate(workload)
+}
+
+func NewSessonWorkload(work *types.Session) (*Workload, error) {
+	workload := &Workload{
+		WorkloadType: WorkloadTypeSession,
+		session:      work,
+	}
+	return validate(workload)
+}
+
+// Check model conversion so we don't have to do it later
+func validate(work *Workload) (*Workload, error) {
+	_, err := model.GetModel(work.ModelName())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get model: %v", err)
+	}
+	return work, nil
+}
+
+func (w *Workload) ID() string {
+	switch w.WorkloadType {
+	case WorkloadTypeLLMInferenceRequest:
+		return w.llmInfereceRequest.RequestID
+	case WorkloadTypeSession:
+		return w.session.ID
+	}
+	panic(fmt.Sprintf("unknown workload type: %s", w.WorkloadType))
+}
+
+func (w *Workload) ModelName() types.ModelName {
+	switch w.WorkloadType {
+	case WorkloadTypeLLMInferenceRequest:
+		return types.ModelName(w.llmInfereceRequest.Request.Model)
+	case WorkloadTypeSession:
+		return w.session.ModelName
+	}
+	panic(fmt.Sprintf("unknown workload type: %s", w.WorkloadType))
+}
+
+func (w *Workload) Model() model.Model {
+	model, err := model.GetModel(w.ModelName())
+	if err != nil {
+		panic(fmt.Sprintf("failed to get model: %v", err)) // This should never happen because we checked it in the constructor
+	}
+	return model
+}
+
+func (w *Workload) Mode() types.SessionMode {
+	switch w.WorkloadType {
+	case WorkloadTypeLLMInferenceRequest:
+		return types.SessionModeInference
+	case WorkloadTypeSession:
+		return w.session.Mode
+	}
+	panic(fmt.Sprintf("unknown workload type: %s", w.WorkloadType))
+}
+
+func (w *Workload) LLMInferenceRequest() *types.RunnerLLMInferenceRequest {
+	if w.WorkloadType != WorkloadTypeLLMInferenceRequest {
+		panic(fmt.Sprintf("workload is not  an LLM inference request: %#v", w))
+	}
+	return w.llmInfereceRequest
+}
+
+func (w *Workload) Session() *types.Session {
+	if w.WorkloadType != WorkloadTypeSession {
+		panic(fmt.Sprintf("workload is not a session: %#v", w))
+	}
+	return w.session
+}
+
+func (w *Workload) LoraDir() string {
+	switch w.WorkloadType {
+	case WorkloadTypeSession:
+		return w.session.LoraDir
+	case WorkloadTypeLLMInferenceRequest:
+		return ""
+	}
+	panic(fmt.Sprintf("unknown workload type: %s", w.WorkloadType))
+}

--- a/api/pkg/server/openai_chat_handlers_test.go
+++ b/api/pkg/server/openai_chat_handlers_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/helixml/helix/api/pkg/openai/manager"
 	"github.com/helixml/helix/api/pkg/pubsub"
 	"github.com/helixml/helix/api/pkg/rag"
+	"github.com/helixml/helix/api/pkg/scheduler"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 )
@@ -83,6 +84,7 @@ func (suite *OpenAIChatSuite) SetupTest() {
 		Filestore:       filestoreMock,
 		Extractor:       extractorMock,
 		RAG:             suite.rag,
+		Scheduler:       scheduler.NewScheduler(cfg),
 	})
 	suite.NoError(err)
 

--- a/api/pkg/server/runner_handlers.go
+++ b/api/pkg/server/runner_handlers.go
@@ -53,7 +53,7 @@ func (apiServer *HelixAPIServer) runnerLLMInferenceRequestHandler(res http.Respo
 		Older:     olderDuration,
 	}, runnerID)
 
-	return nextReq, nil
+	return nextReq, err
 }
 
 func (apiServer *HelixAPIServer) getNextRunnerSession(res http.ResponseWriter, req *http.Request) (*types.Session, error) {
@@ -188,6 +188,8 @@ func (apiServer *HelixAPIServer) handleRunnerMetrics(res http.ResponseWriter, re
 	if err != nil {
 		return nil, err
 	}
+
+	apiServer.scheduler.UpdateRunner(runnerState)
 
 	runnerState, err = apiServer.Controller.AddRunnerMetrics(req.Context(), runnerState)
 	if err != nil {

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/helixml/helix/api/pkg/openai"
 	"github.com/helixml/helix/api/pkg/openai/manager"
 	"github.com/helixml/helix/api/pkg/pubsub"
+	"github.com/helixml/helix/api/pkg/scheduler"
 	"github.com/helixml/helix/api/pkg/server/spa"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/stripe"
@@ -66,6 +67,7 @@ type HelixAPIServer struct {
 	inferenceServer   openai.HelixServer // Helix OpenAI server
 	knowledgeManager  knowledge.KnowledgeManager
 	router            *mux.Router
+	scheduler         scheduler.Scheduler
 }
 
 func NewServer(
@@ -80,6 +82,7 @@ func NewServer(
 	controller *controller.Controller,
 	janitor *janitor.Janitor,
 	knowledgeManager knowledge.KnowledgeManager,
+	scheduler scheduler.Scheduler,
 ) (*HelixAPIServer, error) {
 	if cfg.WebServer.URL == "" {
 		return nil, fmt.Errorf("server url is required")
@@ -116,6 +119,7 @@ func NewServer(
 		providerManager:  providerManager,
 		pubsub:           ps,
 		knowledgeManager: knowledgeManager,
+		scheduler:        scheduler,
 	}, nil
 }
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -12,7 +12,7 @@ services:
     env_file:
       - .env
     environment:
-      - LOG_LEVEL=debug
+      - LOG_LEVEL=${LOG_LEVEL:-debug}
       - APP_URL=${SERVER_URL:-http://localhost:8080}
       - POSTGRES_HOST=postgres
       - POSTGRES_DATABASE=postgres

--- a/scripts/k6/openai.js
+++ b/scripts/k6/openai.js
@@ -24,7 +24,7 @@ export default function () {
     "messages": [
       {
         "role": "user",
-        "content": test_data[Math.floor(Math.random() * test_data.length)]
+        "content": test_data[Math.floor(Math.random() * test_data.length)] + " Your answer must be shorter than 30 words."
       },
     ],
     stream: false,


### PR DESCRIPTION
A big refactor of the scheduler to move scheduling logic into the controller. Now, nearly all information from the runner is ignored. The only two things that are respected are:
1. The total memory set on the CLI
2. The models that are actually running.

Everything else is controlled by the control plane. Some design decisions:

- This doesn't change anything on the runner side, yet. The runners still poll and do what they do. They are still responsible for killing models when over-scheduling.
- This doesn't change anything under the current "queues". There's two queues, one for runners and one for sessions. They still exist and all the code that says "todo remove" is still there. Ideally I want to move the queues into the scheduler. Future task.
- runners and segmented by a new concept called a slot. A slot is responsible for managing the workload for a specific model/mode.
- Slots get assigned to runners and stay there while they are active.
- They are considered warm if the model TTL does not expire. They can pick up work super quick - as quick as the runner polls for work.
- There's now a TTL on runners too. If they don't send an update for some TTL period, the associated slots will be removed and and scheduled elsewhere.

## TODOs:

- [x] make env var for ttl values
- [x] ~if old TTL values exist then use those and print a deprecation warning.~ Nope, in the runner.
- [x] Document and review allocator and strategy code
- [x] session queue summary
- [x] don't take the whole queue. Only keep queueing until we get all runners full error. Might as well buffer in the queue.
- [x] remove generic (see chat)
- [x] implement lora dir scheduling

## Future work:

- Pull queue into scheduler. Remove old code.
- Remove unnecessary scheduling code in runner.
- adding other workload strategies (currently only supports max utilisation strategy)