### PR TITLE
Revamp frontend text inference, improve RAG

### DIFF
--- a/api/pkg/prompts/templates/knowledge.tmpl
+++ b/api/pkg/prompts/templates/knowledge.tmpl
@@ -15,7 +15,7 @@ Here is some background knowledge context that you may refer to in your answer:
 {{- range .KnowledgeResults }}
 <article>
 {{- if .Source }}
-Source: {{ .Source }}
+Source URL: {{ .Source }}
 {{- end }}
 {{- if .Description }}
 Description: {{ .Description }}
@@ -24,10 +24,10 @@ Content: {{ .Content }}
 </article>
 {{- end }}
 
-If you have used the background knowledge in your answer, then provide a list of markdown bullet 
-points at the end of your answer with the relevant sources used such as 
-- [Source 1 URL]
-- [Source 2 URL]
+If you have used the background knowledge in your answer, then provide a list of bullet
+points at the end of your answer with the relevant source URLs used such as:
+- [https://example1.com](https://example1.com)
+- [https://example2.com](https://example2.com)
 
 Do not repeat the same source link twice. Only include sources that were actually used in the answer.
 
@@ -40,8 +40,8 @@ curl https://my.webhookrelay.com/webhookrelay/downloads/install-cli.sh | bash
 And then run login command to authenticate.
 
 You can find more information about this topic in:
-- https://example.com/agent/install.
-- https://example.com/agent/login.
+- [https://example.com/agent/install](https://example.com/agent/install)
+- [https://example.com/agent/login](https://example.com/agent/login)
 "	
 {{- end }}
 

--- a/api/pkg/prompts/templates/knowledge.tmpl
+++ b/api/pkg/prompts/templates/knowledge.tmpl
@@ -2,8 +2,12 @@
 We have found the following context you may refer to in your answer:
 {{- range .RagResults }}
 <article>
+<document_id>
 DocumentID: {{ .DocumentID }}
+</document_id>
+<content>
 Content: {{ .Content }}
+</content>
 </article>
 {{- end }}
 
@@ -15,12 +19,18 @@ Here is some background knowledge context that you may refer to in your answer:
 {{- range .KnowledgeResults }}
 <article>
 {{- if .Source }}
+<source>
 Source URL: {{ .Source }}
+</source>
 {{- end }}
 {{- if .Description }}
+<description>
 Description: {{ .Description }}
+</description>
 {{- end }}
+<content>
 Content: {{ .Content }}
+</content>
 </article>
 {{- end }}
 
@@ -29,7 +39,7 @@ points at the end of your answer with the relevant source URLs used such as:
 - [https://example1.com](https://example1.com)
 - [https://example2.com](https://example2.com)
 
-Do not repeat the same source link twice. Only include sources that were actually used in the answer.
+Do not repeat the same source link twice. Only include sources that were actually used in the answer. Only include sources that were in the <source> tags.
 
 For example:
 "

--- a/api/pkg/server/openai_chat_handlers.go
+++ b/api/pkg/server/openai_chat_handlers.go
@@ -198,6 +198,12 @@ func (s *HelixAPIServer) createChatCompletion(rw http.ResponseWriter, r *http.Re
 		}
 
 		writeChunk(rw, bts)
+		// Flush the stream to ensure the client receives the data immediately
+		if flusher, ok := rw.(http.Flusher); ok {
+			flusher.Flush()
+		} else {
+			log.Warn().Msg("ResponseWriter does not support Flusher interface")
+		}
 	}
 
 }

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -445,6 +445,12 @@ func (s *HelixAPIServer) handleStreamingSession(ctx context.Context, user *types
 		}
 
 		writeChunk(rw, bts)
+		// Flush the stream to ensure the client receives the data immediately
+		if flusher, ok := rw.(http.Flusher); ok {
+			flusher.Flush()
+		} else {
+			log.Warn().Msg("ResponseWriter does not support Flusher interface")
+		}
 	}
 
 	// Update last interaction

--- a/api/pkg/server/session_legacy_handlers.go
+++ b/api/pkg/server/session_legacy_handlers.go
@@ -424,6 +424,13 @@ func (apiServer *HelixAPIServer) handleStreamingResponse(res http.ResponseWriter
 					return err
 				}
 
+				// Flush the stream to ensure the client receives the data immediately
+				if flusher, ok := res.(http.Flusher); ok {
+					flusher.Flush()
+				} else {
+					log.Warn().Msg("ResponseWriter does not support Flusher interface")
+				}
+
 				// Close connection
 				close(doneCh)
 				return nil
@@ -447,6 +454,13 @@ func (apiServer *HelixAPIServer) handleStreamingResponse(res http.ResponseWriter
 				return err
 			}
 
+			// Flush the stream to ensure the client receives the data immediately
+			if flusher, ok := res.(http.Flusher); ok {
+				flusher.Flush()
+			} else {
+				log.Warn().Msg("ResponseWriter does not support Flusher interface")
+			}
+
 			// Close connection
 			close(doneCh)
 			return nil
@@ -466,6 +480,13 @@ func (apiServer *HelixAPIServer) handleStreamingResponse(res http.ResponseWriter
 		err = writeChunk(res, chunk)
 		if err != nil {
 			return err
+		}
+
+		// Flush the stream to ensure the client receives the data immediately
+		if flusher, ok := res.(http.Flusher); ok {
+			flusher.Flush()
+		} else {
+			log.Warn().Msg("ResponseWriter does not support Flusher interface")
 		}
 
 		return nil
@@ -490,6 +511,13 @@ func (apiServer *HelixAPIServer) handleStreamingResponse(res http.ResponseWriter
 	if err != nil {
 		system.NewHTTPError500("error writing chunk '%s': %s", string(respData), err)
 		return
+	}
+
+	// Flush the stream to ensure the client receives the data immediately
+	if flusher, ok := res.(http.Flusher); ok {
+		flusher.Flush()
+	} else {
+		log.Warn().Msg("ResponseWriter does not support Flusher interface")
 	}
 
 	// After subscription, start the session, otherwise

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,7 +25,6 @@
       .blinker-class {
         animation: blink 1s linear infinite;
         color: yellow; font-weight:bold;
-        font-size: 1.5em;
       }
 
       @keyframes blink {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,6 +22,23 @@
         margin: 0;
         padding: 0;
       }
+      .blinker-class {
+        animation: blink 1s linear infinite;
+        color: yellow; font-weight:bold;
+        font-size: 1.5em;
+      }
+
+      @keyframes blink {
+        25% {
+          opacity: 0.5;
+        }
+        50% {
+          opacity: 0;
+        }
+        75% {
+          opacity: 0.5;
+        }
+      }
     </style>
     <script type="text/javascript">window.$crisp=[];window.CRISP_WEBSITE_ID="d69e5955-fa6a-4fe6-b1bb-c87cf7515d09";(function(){d=document;s=d.createElement("script");s.src="https://client.crisp.chat/l.js";s.async=1;d.getElementsByTagName("head")[0].appendChild(s);})();</script>
     <script type="text/javascript">

--- a/frontend/src/components/app/PreviewPanel.tsx
+++ b/frontend/src/components/app/PreviewPanel.tsx
@@ -278,6 +278,10 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({
                 session.interactions.map((interaction: any, i: number) => {
                   const interactionsLength = session.interactions.length || 0;
                   const isLastInteraction = i == interactionsLength - 1;
+                  console.log('----')
+                  console.log('interaction', interaction);
+                  console.log('isLastInteraction', isLastInteraction);
+                  console.log('interaction.finished', interaction.finished);
                   const isLive = isLastInteraction && !interaction.finished;
 
                   if(!session) return null;

--- a/frontend/src/components/app/PreviewPanel.tsx
+++ b/frontend/src/components/app/PreviewPanel.tsx
@@ -278,10 +278,6 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({
                 session.interactions.map((interaction: any, i: number) => {
                   const interactionsLength = session.interactions.length || 0;
                   const isLastInteraction = i == interactionsLength - 1;
-                  console.log('----')
-                  console.log('interaction', interaction);
-                  console.log('isLastInteraction', isLastInteraction);
-                  console.log('interaction.finished', interaction.finished);
                   const isLive = isLastInteraction && !interaction.finished;
 
                   if(!session) return null;

--- a/frontend/src/components/app/PreviewPanel.tsx
+++ b/frontend/src/components/app/PreviewPanel.tsx
@@ -8,6 +8,7 @@ import Avatar from '@mui/material/Avatar';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
 import SendIcon from '@mui/icons-material/Send';
+import CircularProgress from '@mui/material/CircularProgress';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Dialog from '@mui/material/Dialog';
@@ -25,7 +26,8 @@ import InteractionLiveStream from '../session/InteractionLiveStream';
 
 import { ISession, ISessionRAGResult, IKnowledgeSearchResult } from '../../types';
 
-interface PreviewPanelProps {
+interface PreviewPanelProps { 
+  loading: boolean;
   name: string;
   avatar: string;
   image: string;
@@ -44,6 +46,7 @@ interface PreviewPanelProps {
 }
 
 const PreviewPanel: React.FC<PreviewPanelProps> = ({
+  loading,
   name,
   avatar,
   image,
@@ -198,7 +201,8 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({
                 ml: 2,
                 mb: 3,
               }}
-              endIcon={<SendIcon />}
+              endIcon={loading ? <CircularProgress size={16} /> : <SendIcon />}
+              disabled={loading}
             >
               Send
             </Button>

--- a/frontend/src/components/app/PreviewPanel.tsx
+++ b/frontend/src/components/app/PreviewPanel.tsx
@@ -78,7 +78,11 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({
   };
 
   const handleSearchModeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setIsSearchMode(event.target.checked);
+    const newSearchMode = event.target.checked;
+    setIsSearchMode(newSearchMode);
+    if (newSearchMode && inputValue.trim() !== '') {
+      onSearch(inputValue.trim());
+    }
   };
 
   const handleChunkClick = (chunk: ISessionRAGResult) => {

--- a/frontend/src/components/create/ModelPicker.tsx
+++ b/frontend/src/components/create/ModelPicker.tsx
@@ -19,8 +19,8 @@ const ModelPicker: FC<{
   const { models } = useContext(AccountContext)
 
   useEffect(() => {
-    // Set the first model as default if current model is not in the list
-    if (models.length > 0 && (!model || !models.some(m => m.id === model))) {
+    // Set the first model as default if current model is not set or not in the list
+    if (models.length > 0 && (!model || model === '' || !models.some(m => m.id === model))) {
       onSetModel(models[0].id);
     }
   }, [models, model, onSetModel])

--- a/frontend/src/components/session/InteractionLiveStream.tsx
+++ b/frontend/src/components/session/InteractionLiveStream.tsx
@@ -42,10 +42,7 @@ export const InteractionLiveStream: FC<{
     progress,
     status,
     isStale,
-  } = useLiveInteraction({
-    session_id,
-    interaction,
-  })
+  } = useLiveInteraction(session_id, interaction)
 
   const showLoading = !message && progress==0 && !status
 

--- a/frontend/src/components/session/InteractionLiveStream.tsx
+++ b/frontend/src/components/session/InteractionLiveStream.tsx
@@ -62,27 +62,7 @@ export const InteractionLiveStream: FC<{
   if(!serverConfig || !serverConfig.filestore_prefix) return null
 
   // TODO: get the nice blinking cursor to work nicely with the markdown module
-  const sourceTextWithBlinkingCursor =  `
-${replaceMessageText(message, session, getFileURL)}
-<style>
-  .blinker-class {
-    animation: blink 1s linear infinite;
-  }
-
-  @keyframes blink {
-    25% {
-      opacity: 0.5;
-    }
-    50% {
-      opacity: 0;
-    }
-    75% {
-      opacity: 0.5;
-    }
-  }
-</style>
-<span style="color: yellow; font-weight:bold;" class="blinker-class">┃</span>
-`
+  const blinker = `<span class="blinker-class">┃</span>`
   
   return (
     <>
@@ -95,7 +75,7 @@ ${replaceMessageText(message, session, getFileURL)}
         message && (
           <div>
             <Markdown
-              text={ replaceMessageText(message, session, getFileURL) }
+              text={ replaceMessageText(message, session, getFileURL) + blinker }
             />
           </div>
         )

--- a/frontend/src/components/session/InteractionLiveStream.tsx
+++ b/frontend/src/components/session/InteractionLiveStream.tsx
@@ -61,7 +61,6 @@ export const InteractionLiveStream: FC<{
 
   if(!serverConfig || !serverConfig.filestore_prefix) return null
 
-  // TODO: get the nice blinking cursor to work nicely with the markdown module
   const blinker = `<span class="blinker-class">┃</span>`
   
   return (

--- a/frontend/src/components/session/Markdown.tsx
+++ b/frontend/src/components/session/Markdown.tsx
@@ -20,6 +20,14 @@ export const InteractionMarkdown: FC<{
   const theme = useTheme()
   if(!text) return null
 
+  // Function to add <br> tags for single newlines
+  const addLineBreaks = (text: string) => {
+    return text.replace(/(?<!\n)\n(?!\n)/g, '<br>\n');
+  };
+
+  // Apply the line break transformation to the text
+  text = addLineBreaks(text);
+
   return (
     <Box
       sx={{

--- a/frontend/src/components/session/Markdown.tsx
+++ b/frontend/src/components/session/Markdown.tsx
@@ -36,7 +36,8 @@ export const InteractionMarkdown: FC<{
       <Markdown
         children={text}
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeRaw, rehypeSanitize]}
+        // TODO re-add rehypeSanitize while not breaking the flashing yellow cursor
+        rehypePlugins={[rehypeRaw]}
         className="interactionMessage"
         components={{
           code(props) {

--- a/frontend/src/contexts/all.tsx
+++ b/frontend/src/contexts/all.tsx
@@ -26,6 +26,11 @@ import {
   SessionsContextProvider,
 } from './sessions'
 
+// Import the new StreamingProvider
+import {
+  StreamingContextProvider,
+} from './streaming'
+
 const AllContextProvider: FC = ({ children }) => {
   return (
     <RouterContextProvider>
@@ -34,7 +39,9 @@ const AllContextProvider: FC = ({ children }) => {
           <ThemeProviderWrapper>
             <AccountContextProvider>
               <SessionsContextProvider>
-                {children}
+                <StreamingContextProvider>
+                  {children}
+                </StreamingContextProvider>
               </SessionsContextProvider>
             </AccountContextProvider>
           </ThemeProviderWrapper>

--- a/frontend/src/contexts/streaming.tsx
+++ b/frontend/src/contexts/streaming.tsx
@@ -1,6 +1,7 @@
-import React, { createContext, useContext, ReactNode, useState, useEffect, useCallback, useRef } from 'react';
-import { ISession, ISessionChatRequest, SESSION_MODE_INFERENCE, SESSION_TYPE_TEXT, IWebsocketEvent, WEBSOCKET_EVENT_TYPE_SESSION_UPDATE, IInteraction } from '../types';
+import React, { createContext, useContext, ReactNode, useState, useCallback } from 'react';
+import { ISession, ISessionChatRequest, SESSION_MODE_INFERENCE, SESSION_TYPE_TEXT, IWebsocketEvent, WEBSOCKET_EVENT_TYPE_WORKER_TASK_RESPONSE, WORKER_TASK_RESPONSE_TYPE_PROGRESS, WORKER_TASK_RESPONSE_TYPE_STREAM, IInteraction } from '../types';
 import useApi from '../hooks/useApi';
+import useWebsocket from '../hooks/useWebsocket';
 
 interface StreamingContextType {
   NewSession: (message: string, appId: string) => Promise<ISession>;
@@ -21,86 +22,39 @@ export const useStreaming = (): StreamingContextType => {
 export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const api = useApi();
   const [currentResponses, setCurrentResponses] = useState<Map<string, Partial<IInteraction>>>(new Map());
-  const [socket, setSocket] = useState<WebSocket | null>(null);
-  const socketRef = useRef<WebSocket | null>(null);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
 
-  const connectWebSocket = useCallback((sessionId: string) => {
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const wsUrl = `${protocol}//${window.location.host}/api/v1/ws?session_id=${sessionId}`;
-    console.log('Attempting to connect WebSocket:', wsUrl);
+  const handleWebsocketEvent = useCallback((parsedData: IWebsocketEvent) => {
+    console.log('WebSocket message received:', parsedData);
+    if (!currentSessionId) return;
 
-    const newSocket = new WebSocket(wsUrl);
-    socketRef.current = newSocket;
+    if (parsedData.type === WEBSOCKET_EVENT_TYPE_WORKER_TASK_RESPONSE && parsedData.worker_task_response) {
+      const workerResponse = parsedData.worker_task_response;
+      setCurrentResponses(prev => {
+        const current = prev.get(currentSessionId) || {};
+        let updatedInteraction: Partial<IInteraction> = { ...current };
 
-    // Start logging WebSocket state immediately
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-    }
-    intervalRef.current = setInterval(() => {
-      console.log('Current WebSocket state:', newSocket.readyState);
-    }, 1000);
-
-    newSocket.onopen = () => {
-      console.log('WebSocket connected successfully');
-    };
-
-    newSocket.onmessage = (event) => {
-      console.log('WebSocket message received:', event.data);
-      try {
-        const parsedData: IWebsocketEvent = JSON.parse(event.data);
-        if (parsedData.type === WEBSOCKET_EVENT_TYPE_SESSION_UPDATE && parsedData.session) {
-          const lastInteraction = parsedData.session.interactions[parsedData.session.interactions.length - 1];
-          if (lastInteraction && lastInteraction.creator === 'assistant') {
-            setCurrentResponses(prev => {
-              const current = prev.get(sessionId) || {};
-              return new Map(prev).set(sessionId, {
-                ...current,
-                message: ((current.message || '') + (lastInteraction.message || '')),
-                status: lastInteraction.status,
-                progress: lastInteraction.progress,
-              });
-            });
+        if (workerResponse.type === WORKER_TASK_RESPONSE_TYPE_STREAM && workerResponse.message) {
+          updatedInteraction.message = (current.message || '') + workerResponse.message;
+        } else if (workerResponse.type === WORKER_TASK_RESPONSE_TYPE_PROGRESS) {
+          if (workerResponse.message) {
+            updatedInteraction.message = workerResponse.message;
+          }
+          if (workerResponse.progress !== undefined) {
+            updatedInteraction.progress = workerResponse.progress;
+          }
+          if (workerResponse.status) {
+            updatedInteraction.status = workerResponse.status;
           }
         }
-      } catch (error) {
-        console.error('Error parsing WebSocket message:', error);
-      }
-    };
 
-    newSocket.onerror = (error) => {
-      console.error('WebSocket error:', error);
-    };
-
-    newSocket.onclose = (event) => {
-      console.log('WebSocket closed:', event);
-      // Clear the interval when the WebSocket closes
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-    };
-
-    setSocket(newSocket);
-    return newSocket;
-  }, []);
-
-  // close websocket connection when component unmounts
-  useEffect(() => {
-    return () => {
-      if (socketRef.current) {
-        console.log('Closing WebSocket connection');
-        socketRef.current.close();
-      }
-      // Clear the interval when the component unmounts
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-    };
-  }, []);
+        return new Map(prev).set(currentSessionId, updatedInteraction);
+      });
+    }
+  }, [currentSessionId]);
 
   const NewSession = async (message: string, appId: string): Promise<ISession> => {
+    console.log('NewSession', appId)
     const sessionChatRequest = {
       mode: SESSION_MODE_INFERENCE,
       type: SESSION_TYPE_TEXT,
@@ -122,8 +76,12 @@ export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ ch
         throw new Error('Failed to create new session');
       }
       setCurrentResponses(prev => new Map(prev).set(newSessionData.id, { message: '', status: '', progress: 0 }));
-      connectWebSocket(newSessionData.id);
-      
+      setCurrentSessionId(newSessionData.id);
+
+      // TODO: when we have multiple concurrent streaming sessions, rather than
+      // multiple websocket connections we can just have one and filter for a
+      // set of session_ids
+      useWebsocket(newSessionData.id, handleWebsocketEvent);
       return newSessionData;
     } catch (error) {
       console.error('Error creating new session:', error);

--- a/frontend/src/contexts/streaming.tsx
+++ b/frontend/src/contexts/streaming.tsx
@@ -1,0 +1,26 @@
+import React, { createContext, useContext, ReactNode } from 'react';
+
+interface StreamingContextType {
+  // We'll leave this empty for now
+}
+
+const StreamingContext = createContext<StreamingContextType | undefined>(undefined);
+
+export const useStreaming = (): StreamingContextType => {
+  const context = useContext(StreamingContext);
+  if (context === undefined) {
+    throw new Error('useStreaming must be used within a StreamingProvider');
+  }
+  return context;
+};
+
+export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  // For now, we're not doing anything in this provider
+  const value = {};
+
+  return (
+    <StreamingContext.Provider value={value}>
+      {children}
+    </StreamingContext.Provider>
+  );
+};

--- a/frontend/src/contexts/streaming.tsx
+++ b/frontend/src/contexts/streaming.tsx
@@ -145,7 +145,8 @@ export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ ch
               sessionData = parsedData;
               if (sessionData && sessionData.id) {
                 setCurrentSessionId(sessionData.id);
-                setCurrentResponses(prev => new Map(prev).set(sessionData!.id, { message: '', status: '', progress: 0 }));
+                const messageSegment = parsedData.choices[0]?.delta?.content;
+                setCurrentResponses(prev => new Map(prev).set(sessionData!.id, { message: messageSegment || '', status: '', progress: 0 }));
               } else {
                 console.error('Invalid session data received:', sessionData);
                 throw new Error('Invalid session data');

--- a/frontend/src/contexts/streaming.tsx
+++ b/frontend/src/contexts/streaming.tsx
@@ -1,7 +1,9 @@
 import React, { createContext, useContext, ReactNode } from 'react';
+import { ISession, ISessionChatRequest, SESSION_MODE_INFERENCE, SESSION_TYPE_TEXT } from '../types';
+import useApi from '../hooks/useApi';
 
 interface StreamingContextType {
-  // We'll leave this empty for now
+  NewSession: (message: string, appId: string) => Promise<ISession>;
 }
 
 const StreamingContext = createContext<StreamingContextType | undefined>(undefined);
@@ -15,8 +17,39 @@ export const useStreaming = (): StreamingContextType => {
 };
 
 export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  // For now, we're not doing anything in this provider
-  const value = {};
+  const api = useApi();
+
+  const NewSession = async (message: string, appId: string): Promise<ISession> => {
+    const sessionChatRequest = {
+      mode: SESSION_MODE_INFERENCE,
+      type: SESSION_TYPE_TEXT,
+      stream: true,
+      legacy: true,
+      app_id: appId,
+      messages: [{
+        role: 'user',
+        content: {
+          content_type: 'text',
+          parts: [message]
+        },
+      }]
+    };
+
+    try {
+      const newSessionData = await api.post('/api/v1/sessions/chat', sessionChatRequest);
+      if (!newSessionData) {
+        throw new Error('Failed to create new session');
+      }
+      return newSessionData;
+    } catch (error) {
+      console.error('Error creating new session:', error);
+      throw error;
+    }
+  };
+
+  const value = {
+    NewSession,
+  };
 
   return (
     <StreamingContext.Provider value={value}>

--- a/frontend/src/contexts/streaming.tsx
+++ b/frontend/src/contexts/streaming.tsx
@@ -1,11 +1,12 @@
 import React, { createContext, useContext, ReactNode, useState, useCallback, useEffect } from 'react';
 import ReconnectingWebSocket from 'reconnecting-websocket';
-import { ISession, IWebsocketEvent, WEBSOCKET_EVENT_TYPE_WORKER_TASK_RESPONSE, WORKER_TASK_RESPONSE_TYPE_PROGRESS, IInteraction, ISessionChatRequest, SESSION_TYPE_TEXT } from '../types';
+import { ISession, IWebsocketEvent, WEBSOCKET_EVENT_TYPE_WORKER_TASK_RESPONSE, WORKER_TASK_RESPONSE_TYPE_PROGRESS, IInteraction, ISessionChatRequest, SESSION_TYPE_TEXT, ISessionType } from '../types';
 import useApi from '../hooks/useApi';
 import useAccount from '../hooks/useAccount';
 import { createParser, type ParsedEvent, type ReconnectInterval } from 'eventsource-parser';
 
 interface NewInferenceParams {
+  type: ISessionType;
   message: string;
   appId?: string;
   assistantId?: string;
@@ -81,6 +82,7 @@ export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ ch
   }, [account.token, currentSessionId, handleWebsocketEvent]);
 
   const NewInference = async ({
+    type,
     message,
     appId = '',
     assistantId = '',
@@ -91,7 +93,7 @@ export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ ch
   }: NewInferenceParams): Promise<ISession> => {
     console.log('NewInference', appId);
     const sessionChatRequest: ISessionChatRequest = {
-      type: SESSION_TYPE_TEXT,
+      type,
       stream: true,
       app_id: appId,
       assistant_id: assistantId,
@@ -148,7 +150,6 @@ export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ ch
               resolveStream();
               return;
             }
-            console.log('event.data', event.data);
             try {
               const parsedData = JSON.parse(event.data);
               if (!sessionData) {

--- a/frontend/src/contexts/streaming.tsx
+++ b/frontend/src/contexts/streaming.tsx
@@ -32,7 +32,6 @@ export const useStreaming = (): StreamingContextType => {
 };
 
 export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const api = useApi();
   const account = useAccount();
   const [currentResponses, setCurrentResponses] = useState<Map<string, Partial<IInteraction>>>(new Map());
   const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
@@ -138,6 +137,7 @@ export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ ch
           if (event.data === "[DONE]") {
             return;
           }
+          console.log('event.data', event.data);
           try {
             const parsedData = JSON.parse(event.data);
             if (!sessionData) {

--- a/frontend/src/contexts/streaming.tsx
+++ b/frontend/src/contexts/streaming.tsx
@@ -27,7 +27,6 @@ export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ ch
   const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
 
   const handleWebsocketEvent = useCallback((parsedData: IWebsocketEvent) => {
-    console.log('WebSocket message received:', parsedData);
     if (!currentSessionId) return;
 
     if (parsedData.type === WEBSOCKET_EVENT_TYPE_WORKER_TASK_RESPONSE && parsedData.worker_task_response) {
@@ -49,7 +48,6 @@ export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ ch
             updatedInteraction.status = workerResponse.status;
           }
         }
-        console.log('updatedInteraction', updatedInteraction);
         return new Map(prev).set(currentSessionId, updatedInteraction);
       });
     }

--- a/frontend/src/contexts/streaming.tsx
+++ b/frontend/src/contexts/streaming.tsx
@@ -1,9 +1,11 @@
-import React, { createContext, useContext, ReactNode } from 'react';
-import { ISession, ISessionChatRequest, SESSION_MODE_INFERENCE, SESSION_TYPE_TEXT } from '../types';
+import React, { createContext, useContext, ReactNode, useState, useEffect, useCallback, useRef } from 'react';
+import { ISession, ISessionChatRequest, SESSION_MODE_INFERENCE, SESSION_TYPE_TEXT, IWebsocketEvent, WEBSOCKET_EVENT_TYPE_SESSION_UPDATE, IInteraction } from '../types';
 import useApi from '../hooks/useApi';
 
 interface StreamingContextType {
   NewSession: (message: string, appId: string) => Promise<ISession>;
+  currentResponses: Map<string, Partial<IInteraction>>;
+  updateCurrentResponse: (sessionId: string, interaction: Partial<IInteraction>) => void;
 }
 
 const StreamingContext = createContext<StreamingContextType | undefined>(undefined);
@@ -18,6 +20,85 @@ export const useStreaming = (): StreamingContextType => {
 
 export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const api = useApi();
+  const [currentResponses, setCurrentResponses] = useState<Map<string, Partial<IInteraction>>>(new Map());
+  const [socket, setSocket] = useState<WebSocket | null>(null);
+  const socketRef = useRef<WebSocket | null>(null);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  const connectWebSocket = useCallback((sessionId: string) => {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const wsUrl = `${protocol}//${window.location.host}/api/v1/ws?session_id=${sessionId}`;
+    console.log('Attempting to connect WebSocket:', wsUrl);
+
+    const newSocket = new WebSocket(wsUrl);
+    socketRef.current = newSocket;
+
+    // Start logging WebSocket state immediately
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+    intervalRef.current = setInterval(() => {
+      console.log('Current WebSocket state:', newSocket.readyState);
+    }, 1000);
+
+    newSocket.onopen = () => {
+      console.log('WebSocket connected successfully');
+    };
+
+    newSocket.onmessage = (event) => {
+      console.log('WebSocket message received:', event.data);
+      try {
+        const parsedData: IWebsocketEvent = JSON.parse(event.data);
+        if (parsedData.type === WEBSOCKET_EVENT_TYPE_SESSION_UPDATE && parsedData.session) {
+          const lastInteraction = parsedData.session.interactions[parsedData.session.interactions.length - 1];
+          if (lastInteraction && lastInteraction.creator === 'assistant') {
+            setCurrentResponses(prev => {
+              const current = prev.get(sessionId) || {};
+              return new Map(prev).set(sessionId, {
+                ...current,
+                message: ((current.message || '') + (lastInteraction.message || '')),
+                status: lastInteraction.status,
+                progress: lastInteraction.progress,
+              });
+            });
+          }
+        }
+      } catch (error) {
+        console.error('Error parsing WebSocket message:', error);
+      }
+    };
+
+    newSocket.onerror = (error) => {
+      console.error('WebSocket error:', error);
+    };
+
+    newSocket.onclose = (event) => {
+      console.log('WebSocket closed:', event);
+      // Clear the interval when the WebSocket closes
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+
+    setSocket(newSocket);
+    return newSocket;
+  }, []);
+
+  // close websocket connection when component unmounts
+  useEffect(() => {
+    return () => {
+      if (socketRef.current) {
+        console.log('Closing WebSocket connection');
+        socketRef.current.close();
+      }
+      // Clear the interval when the component unmounts
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, []);
 
   const NewSession = async (message: string, appId: string): Promise<ISession> => {
     const sessionChatRequest = {
@@ -40,6 +121,9 @@ export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ ch
       if (!newSessionData) {
         throw new Error('Failed to create new session');
       }
+      setCurrentResponses(prev => new Map(prev).set(newSessionData.id, { message: '', status: '', progress: 0 }));
+      connectWebSocket(newSessionData.id);
+      
       return newSessionData;
     } catch (error) {
       console.error('Error creating new session:', error);
@@ -47,8 +131,17 @@ export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ ch
     }
   };
 
+  const updateCurrentResponse = (sessionId: string, interaction: Partial<IInteraction>) => {
+    setCurrentResponses(prev => {
+      const current = prev.get(sessionId) || {};
+      return new Map(prev).set(sessionId, { ...current, ...interaction });
+    });
+  };
+
   const value = {
     NewSession,
+    currentResponses,
+    updateCurrentResponse,
   };
 
   return (

--- a/frontend/src/hooks/useCreateInputs.ts
+++ b/frontend/src/hooks/useCreateInputs.ts
@@ -10,7 +10,6 @@ import {
   ISerializedPage,
   ICreateSessionConfig,
   ISessionLearnRequest,
-  ISessionChatRequest,
 } from '../types'
 
 import {
@@ -53,7 +52,6 @@ export interface IFinetuneInputs {
   uploadProgressHandler: (progressEvent: AxiosProgressEvent) => void,
   getFormData: (mode: ISessionMode, type: ISessionType, model: string) => FormData,
   getSessionLearnRequest: (type: ISessionType, data_entity_id: string) => ISessionLearnRequest,
-  getSessionChatRequest: (type: ISessionType) => ISessionChatRequest,
   getUploadedFiles: () => FormData,
   reset: () => Promise<void>,
 }
@@ -176,43 +174,6 @@ export const useCreateInputs = () => {
     sessionConfig,
   ])
 
-  const getSessionChatRequest = useCallback((type: ISessionType, model: string): ISessionChatRequest => {
-    const urlParams = new URLSearchParams(window.location.search)
-    const appID = urlParams.get('app_id') || ''
-    let assistantID = urlParams.get('assistant_id') || ''
-    const ragSourceID = urlParams.get('rag_source_id') || ''
-
-    // if we have an app but no assistant ID let's default to the first one
-    if(appID && !assistantID) {
-      assistantID = '0'
-    }
-
-    const req: ISessionChatRequest = {
-      type,
-      model,
-      stream: true,
-      legacy: true,
-      app_id: appID,
-      assistant_id: assistantID,
-      rag_source_id: ragSourceID,
-      tools: sessionConfig.activeToolIDs,
-      messages: [{
-        role: 'user',
-        content: {
-          content_type: 'text',
-          parts: [
-            inputValue,
-          ]
-        },
-      }]
-    }
-
-    return req
-  }, [
-    sessionConfig,
-    inputValue,
-  ])
-
   const getUploadedFiles = useCallback((): FormData => {
     const formData = new FormData()
     finetuneFiles.forEach((file) => {
@@ -286,7 +247,6 @@ export const useCreateInputs = () => {
     loadFromLocalStorage,
     getFormData,
     getSessionLearnRequest,
-    getSessionChatRequest,
     getUploadedFiles,
     uploadProgressHandler,
     reset,

--- a/frontend/src/hooks/useLiveInteraction.ts
+++ b/frontend/src/hooks/useLiveInteraction.ts
@@ -1,72 +1,41 @@
-import React, { useState, useMemo, useEffect } from 'react'
-import useWebsocket from './useWebsocket'
+import { useState, useEffect } from 'react';
+import { IInteraction } from '../types';
+import { useStreaming } from '../contexts/streaming';
 
-import {
-  WEBSOCKET_EVENT_TYPE_WORKER_TASK_RESPONSE,
-  WORKER_TASK_RESPONSE_TYPE_PROGRESS,
-  WORKER_TASK_RESPONSE_TYPE_STREAM,
-  IInteraction,
-} from '../types'
-
-export const useLiveInteraction = ({
-  session_id,
-  interaction,
-  staleThreshold = 10000,
-}: {
-  session_id: string,
-  interaction: IInteraction,
-  // after how much time without an event do we mark ourselves as stale?
-  // this gives the UI a chance to say "you've been in the queue for a while"
-  staleThreshold?: number,
-}) => {
-  const [ message, setMessage ] = useState(interaction.message)
-  const [ progress, setProgress ] = useState(interaction.progress)
-  const [ status, setStatus ] = useState(interaction.status)
-  const [ recentTimestamp, setRecentTimestamp ] = useState(Date.now())
-  const [ stateCounter, setStaleCounter ] = useState(0)
-
-  const isStale = useMemo(() => {
-    return (Date.now() - recentTimestamp) > staleThreshold
-  }, [
-    recentTimestamp,
-    staleThreshold,
-    stateCounter,
-  ])
-
-  useWebsocket(session_id, (parsedData) => {
-    if(!session_id) return
-    setRecentTimestamp(Date.now())
-    if(parsedData.type == WEBSOCKET_EVENT_TYPE_WORKER_TASK_RESPONSE && parsedData.worker_task_response) {
-      const workerResponse = parsedData.worker_task_response
-      if(workerResponse.type == WORKER_TASK_RESPONSE_TYPE_STREAM && workerResponse.message) {
-        setMessage(m => m + workerResponse.message)
-      } else if(workerResponse.type == WORKER_TASK_RESPONSE_TYPE_PROGRESS) {
-        if(workerResponse.message) {
-          setMessage(workerResponse.message)
-        }
-        if(workerResponse.progress) {
-          setProgress(workerResponse.progress)
-        }
-        if(workerResponse.status) {
-          setStatus(workerResponse.status)
-        }
-      }
-    }
-  })
-
-  useEffect(() => {
-    const intervalID = setInterval(() => {
-      setStaleCounter(c => c + 1)
-    }, 1000)
-    return () => clearInterval(intervalID)
-  }, [])
-
-  return {
-    message,
-    progress,
-    status,
-    isStale,
-  }
+interface LiveInteractionResult {
+  message: string;
+  status: string;
+  progress: number;
+  isComplete: boolean;
 }
 
-export default useLiveInteraction
+const useLiveInteraction = (sessionId: string, initialInteraction: IInteraction | null): LiveInteractionResult => {
+  const [interaction, setInteraction] = useState<IInteraction | null>(initialInteraction);
+  const { currentResponses } = useStreaming();
+
+  useEffect(() => {
+    if (sessionId) {
+      const currentResponse = currentResponses.get(sessionId);
+      if (currentResponse) {
+        setInteraction((prevInteraction: IInteraction | null): IInteraction => {
+          if (prevInteraction === null) {
+            return currentResponse as IInteraction;
+          }
+          return {
+            ...prevInteraction,
+            ...currentResponse,
+          };
+        });
+      }
+    }
+  }, [sessionId, currentResponses]);
+
+  return {
+    message: interaction?.message || '',
+    status: interaction?.status || '',
+    progress: interaction?.progress || 0,
+    isComplete: interaction?.state === 'complete',
+  };
+};
+
+export default useLiveInteraction;

--- a/frontend/src/hooks/useLiveInteraction.ts
+++ b/frontend/src/hooks/useLiveInteraction.ts
@@ -7,11 +7,13 @@ interface LiveInteractionResult {
   status: string;
   progress: number;
   isComplete: boolean;
+  isStale: boolean;
 }
 
 const useLiveInteraction = (sessionId: string, initialInteraction: IInteraction | null): LiveInteractionResult => {
   const [interaction, setInteraction] = useState<IInteraction | null>(initialInteraction);
   const { currentResponses } = useStreaming();
+  const [isStale, setIsStale] = useState(false);
 
   useEffect(() => {
     if (sessionId) {
@@ -26,6 +28,11 @@ const useLiveInteraction = (sessionId: string, initialInteraction: IInteraction 
             ...currentResponse,
           };
         });
+        setIsStale(false);
+      } else {
+        // XXX this is not what isStale is intended to mean, it's meant to have
+        // a timer, did we lose that somewhere?
+        setIsStale(true);
       }
     }
   }, [sessionId, currentResponses]);
@@ -35,6 +42,7 @@ const useLiveInteraction = (sessionId: string, initialInteraction: IInteraction 
     status: interaction?.status || '',
     progress: interaction?.progress || 0,
     isComplete: interaction?.state === 'complete',
+    isStale,
   };
 };
 

--- a/frontend/src/hooks/useWebsocket.ts
+++ b/frontend/src/hooks/useWebsocket.ts
@@ -15,14 +15,6 @@ export const useWebsocket = (
   const account = useAccount()
 
   useEffect(() => {
-    console.log('useWebsocket', session_id)
-    console.log('useWebsocket stack:');
-    const stack = new Error().stack;
-    if (stack) {
-      console.log(stack);
-    } else {
-      console.log('Stack trace not available');
-    }
     if(!account.token) return
     if(!session_id) return
     const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'

--- a/frontend/src/hooks/useWebsocket.ts
+++ b/frontend/src/hooks/useWebsocket.ts
@@ -15,6 +15,14 @@ export const useWebsocket = (
   const account = useAccount()
 
   useEffect(() => {
+    console.log('useWebsocket', session_id)
+    console.log('useWebsocket stack:');
+    const stack = new Error().stack;
+    if (stack) {
+      console.log(stack);
+    } else {
+      console.log('Stack trace not available');
+    }
     if(!account.token) return
     if(!session_id) return
     const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -111,7 +111,7 @@ const App: FC = () => {
 
   const [knowledgeErrors, setKnowledgeErrors] = useState<boolean>(false);
 
-  const [model, setModel] = useState('');
+  const [model, setModel] = useState(account.models[0]?.id || '');
 
   const [knowledgeList, setKnowledgeList] = useState<IKnowledgeSource[]>([]);
   const fetchKnowledgeTimeoutRef = useRef<NodeJS.Timeout | null>(null);

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -412,7 +412,7 @@ const App: FC = () => {
     }
   }, [app, name, description, shared, global, secrets, allowedDomains, apps, snackbar, validate, tools, isNewApp, systemPrompt, knowledgeSources, avatar, image, navigate, model]);
 
-  const { NewSession } = useStreaming();
+  const { NewInference } = useStreaming();
 
   const onInference = async () => {
     if(!app) return
@@ -425,7 +425,10 @@ const App: FC = () => {
     if(app.id == "new") return
     
     try {
-      const newSessionData = await NewSession(inputValue, app.id);
+      const newSessionData = await NewInference({
+        message: inputValue,
+        appId: app.id,
+      });
       setInputValue('');
       session.loadSession(newSessionData.id);
     } catch (error) {

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -118,9 +118,9 @@ const App: FC = () => {
   const lastFetchTimeRef = useRef<number>(0);
 
   const [searchResults, setSearchResults] = useState<IKnowledgeSearchResult[]>([]);
-  const [selectedChunk, setSelectedChunk] = useState<ISessionRAGResult | null>(null);
 
   const [hasKnowledgeSources, setHasKnowledgeSources] = useState(true);
+  const [loading, setLoading] = useState(false);
 
   // for now, all the STATE related code for the various tabs is still in this file
   // that's because synchronising state between the components and the app page
@@ -425,15 +425,18 @@ const App: FC = () => {
     if(app.id == "new") return
     
     try {
+      setLoading(true);
+      setInputValue('');
       const newSessionData = await NewInference({
         message: inputValue,
         appId: app.id,
       });
-      setInputValue('');
       session.loadSession(newSessionData.id);
+      setLoading(false);
     } catch (error) {
       console.error('Error creating new session:', error);
       snackbar.error('Failed to create new session');
+      setLoading(false);
     }
   }
 
@@ -912,6 +915,7 @@ const App: FC = () => {
               </Box>
             </Grid>
             <PreviewPanel
+              loading={loading}
               name={name}
               avatar={avatar}
               image={image}

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -428,6 +428,7 @@ const App: FC = () => {
       const newSessionData = await NewInference({
         message: inputValue,
         appId: app.id,
+        type: SESSION_TYPE_TEXT,
       });
       console.log('about to load session', newSessionData.id);
       session.loadSession(newSessionData.id);

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -40,7 +40,6 @@ import {
   IAssistantGPTScript,
   IAppUpdate,
   ISession,
-  SESSION_MODE_INFERENCE,
   SESSION_TYPE_TEXT,
   WEBSOCKET_EVENT_TYPE_SESSION_UPDATE,
   ITool,
@@ -49,7 +48,6 @@ import {
   IApp,
   IKnowledgeSource,
   IKnowledgeSearchResult,
-  ISessionRAGResult,
 } from '../types'
 
 
@@ -431,6 +429,7 @@ const App: FC = () => {
         message: inputValue,
         appId: app.id,
       });
+      console.log('about to load session', newSessionData.id);
       session.loadSession(newSessionData.id);
       setLoading(false);
     } catch (error) {

--- a/frontend/src/pages/Create.tsx
+++ b/frontend/src/pages/Create.tsx
@@ -124,8 +124,8 @@ const Create: FC = () => {
       session,
     })
     await sessions.loadSessions()
-    router.navigate('session', { session_id: session.id })
     setLoading(false)
+    router.navigate('session', { session_id: session.id })
   }
 
   const onStartFinetune = async (eventName: string) => {

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -135,6 +135,7 @@ const Session: FC = () => {
         assistantID = '0'
       }
 
+      setInputValue("")
       newSession = await NewInference({
         message: prompt,
         appId: appID,
@@ -142,20 +143,21 @@ const Session: FC = () => {
         ragSourceId: ragSourceID,
         modelName: session.data.model_name,
         loraDir: session.data.lora_dir,
-        sessionId: session.data.id
+        sessionId: session.data.id,
+        type: session.data.type,
       })
     } else {
       const formData = new FormData()
       formData.set('input', prompt)
       formData.set('model_name', session.data.model_name)
 
+      setInputValue("")
       newSession = await api.put(`/api/v1/sessions/${session.data?.id}`, formData)
     }
     
     if(!newSession) return
     session.reload()
 
-    setInputValue("")
   }, [
     session.data,
     session.reload,

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -509,6 +509,9 @@ const Session: FC = () => {
   // those links with dangerouslySetInnerHTML so it's not easy
   // to add callback handlers to those links
   // so we just call a global function that is setup here
+  //
+  // update 2024-10-08 Luke: is it still true that we're rendering links with
+  // dangerouslySetInnerHTML?
   useEffect(() => {
     const w = window as any
     w._helixHighlightAllFiles = () => {

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -70,7 +70,7 @@ const Session: FC = () => {
   const loadingHelpers = useLoading()
   const theme = useTheme()
   const themeConfig = useThemeConfig()
-  const { NewInference: NewSession } = useStreaming()
+  const { NewInference } = useStreaming()
 
   const isOwner = account.user?.id == session.data?.owner
   const sessionID = router.params.session_id
@@ -135,7 +135,7 @@ const Session: FC = () => {
         assistantID = '0'
       }
 
-      newSession = await NewSession({
+      newSession = await NewInference({
         message: prompt,
         appId: appID,
         assistantId: assistantID,
@@ -159,7 +159,7 @@ const Session: FC = () => {
   }, [
     session.data,
     session.reload,
-    NewSession,
+    NewInference,
   ])
 
   const onUpdateSharing = useCallback(async (value: boolean) => {


### PR DESCRIPTION
* Fix missing first part of messages by switching to OpenAI style SSE API
* Fix switching between different sessions while data is streaming
* Drive-by improvements to RAG prompts for more accurate citations
* Bring back the cute little flashing yellow cursor
* Fix flushing in the OpenAI API endpoints to make them much more responsive (should fix the embed too)
* Spinner while waiting for first response from sessions endpoint
* Search immediately when switching the knowledge search toggle on app editor
* Add line breaks to LLM responses that have single linebreaks
* Fix missing model spec for new apps
* Clear text box immediately on submission