### PR TITLE
typesense: Also bound the maximum delay to 10 seconds

### DIFF
--- a/api/pkg/rag/rag_typesense.go
+++ b/api/pkg/rag/rag_typesense.go
@@ -67,6 +67,7 @@ func (t *Typesense) waitForTypesense() {
 		retry.Attempts(0),
 		retry.Delay(2*time.Second),
 		retry.LastErrorOnly(true),
+		retry.MaxDelay(10*time.Second),
 		retry.OnRetry(func(n uint, err error) {
 			log.Warn().
 				Err(err).


### PR DESCRIPTION
So we don't wait 2x longer than needed because of exponential backoff