### PR TITLE
fix(ui): allow uploads of jsonl files

### DIFF
--- a/frontend/src/components/widgets/FileUpload.tsx
+++ b/frontend/src/components/widgets/FileUpload.tsx
@@ -1,7 +1,7 @@
-import React, { FC } from 'react'
 import Box from '@mui/material/Box'
 import { SxProps } from '@mui/system'
-import { useDropzone, DropzoneOptions } from 'react-dropzone'
+import { FC } from 'react'
+import { DropzoneOptions, useDropzone } from 'react-dropzone'
 
 const FileUpload: FC<{
   sx?: SxProps,
@@ -15,49 +15,50 @@ const FileUpload: FC<{
   onlyDocuments = false,
   onUpload,
 }) => {
-  const opts: DropzoneOptions = {
-    onDrop: onUpload,
-  }
-  if(onlyImages) {
-    opts.accept = {
-      'image/jpeg': [],
-      'image/png': [],
-      'image/gif': [],
+    const opts: DropzoneOptions = {
+      onDrop: onUpload,
     }
-  }
-  if(onlyDocuments) {
-    opts.accept = {
-      'text/plain': [],
-      'text/html': [],
-      'text/css': [],
-      'text/csv': [],
-      'text/javascript': [],
-      'application/javascript': [],
-      'application/json': [],
-      'application/xml': [],
-      'application/pdf': [],
-      'application/msword': [],
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document': [],
-      'application/vnd.ms-excel': [],
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': [],
-      'application/vnd.ms-powerpoint': [],
-      'application/vnd.openxmlformats-officedocument.presentationml.presentation': [],
-      'application/rtf': [],
-      'application/vnd.oasis.opendocument.text': [],
-      'application/vnd.oasis.opendocument.spreadsheet': [],
-      'application/vnd.oasis.opendocument.presentation': [],
-    }
-  }
-  const {getRootProps, getInputProps, isDragActive} = useDropzone(opts)
-
-  return (
-    <Box {...getRootProps()} sx={ sx }>
-      <input {...getInputProps()} />
-      {
-        children
+    if (onlyImages) {
+      opts.accept = {
+        'image/jpeg': [],
+        'image/png': [],
+        'image/gif': [],
       }
-    </Box>
-  )
-}
+    }
+    if (onlyDocuments) {
+      opts.accept = {
+        'text/plain': [],
+        'text/html': [],
+        'text/css': [],
+        'text/csv': [],
+        'text/javascript': [],
+        'application/javascript': [],
+        'application/json': ['finetune_dataset.jsonl'],
+        'application/xml': [],
+        'application/pdf': [],
+        'application/msword': [],
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document': [],
+        'application/vnd.ms-excel': [],
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': [],
+        'application/vnd.ms-powerpoint': [],
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation': [],
+        'application/rtf': [],
+        'application/vnd.oasis.opendocument.text': [],
+        'application/vnd.oasis.opendocument.spreadsheet': [],
+        'application/vnd.oasis.opendocument.presentation': [],
+        'application/jsonl': ['.jsonl'],
+      }
+    }
+    const { getRootProps, getInputProps, isDragActive } = useDropzone(opts)
+
+    return (
+      <Box {...getRootProps()} sx={sx}>
+        <input {...getInputProps()} />
+        {
+          children
+        }
+      </Box>
+    )
+  }
 
 export default FileUpload


### PR DESCRIPTION
You can also directly upload a sharegpt-style jsonl file to train on directly. But it MUST be called `finetune_dataset.jsonl` and it must have the following format:

```jsonl
{"conversations":[{"from":"human","value":"test test"},{"from":"gpt","value":"yes this is a test"}]}
{"conversations": ...
```