### PR TITLE
make eviction more reliable

### DIFF
--- a/api/pkg/runner/controller.go
+++ b/api/pkg/runner/controller.go
@@ -373,6 +373,7 @@ func (r *Runner) checkForStaleModelInstances(_ context.Context, newModel model.M
 			log.Info().Msgf("Killing stale model instance %s", m.ID())
 			err := m.Stop()
 			if err != nil {
+				r.addSchedulingDecision(fmt.Sprintf("error stopping model instance %s: %s", m.ID(), err.Error()))
 				log.Error().Msgf("error stopping model instance %s: %s", m.ID(), err.Error())
 			}
 			r.activeModelInstances.Delete(m.ID())

--- a/api/pkg/runner/llm_ollama_model_instance.go
+++ b/api/pkg/runner/llm_ollama_model_instance.go
@@ -429,12 +429,6 @@ func (i *OllamaInferenceModelInstance) Stale() bool {
 		return false
 	}
 
-	// If we are fetching the next request, we don't want to mark it as stale
-	// as we might be getting the request
-	if i.fetching.Load() {
-		return false
-	}
-
 	return time.Since(i.lastActivity) > i.runnerOptions.Config.Runtimes.Ollama.InstanceTTL
 }
 


### PR DESCRIPTION
since controlplane stops overscheduling now, we don't need this, and we also need to be able to reliably evict stale models