### PR TITLE
Fix/app model for tools

### DIFF
--- a/api/pkg/apps/github.go
+++ b/api/pkg/apps/github.go
@@ -389,6 +389,7 @@ func (githubApp *GithubApp) processConfig(config *types.AppHelixConfig) (*types.
 						RequestPrepTemplate:     api.RequestPrepTemplate,
 						ResponseSuccessTemplate: api.ResponseSuccessTemplate,
 						ResponseErrorTemplate:   api.ResponseErrorTemplate,
+						Model:                   assistant.Model,
 					},
 				},
 			})

--- a/api/pkg/apps/local.go
+++ b/api/pkg/apps/local.go
@@ -67,6 +67,7 @@ func NewLocalApp(filename string) (*LocalApp, error) {
 						RequestPrepTemplate:     api.RequestPrepTemplate,
 						ResponseSuccessTemplate: api.ResponseSuccessTemplate,
 						ResponseErrorTemplate:   api.ResponseErrorTemplate,
+						Model:                   assistant.Model,
 					},
 				},
 			})

--- a/api/pkg/controller/inference.go
+++ b/api/pkg/controller/inference.go
@@ -343,6 +343,20 @@ func (c *Controller) selectAndConfigureTool(ctx context.Context, user *types.Use
 		return nil, nil, false, fmt.Errorf("tool not found for action: %s", isActionable.Api)
 	}
 
+	// If assistant has configured a model, give the hint to the tool that it should use that model too
+	if assistant != nil && assistant.Model != "" {
+		if selectedTool.Config.API.Model == "" {
+			log.Info().
+				Str("assistant_id", assistant.ID).
+				Str("assistant_name", assistant.Name).
+				Str("assistant_model", assistant.Model).
+				Str("tool_name", selectedTool.Name).
+				Msg("assistant has configured a model, and tool has no model specified, using assistant model for tool")
+
+			selectedTool.Config.API.Model = assistant.Model
+		}
+	}
+
 	if len(opts.QueryParams) > 0 && selectedTool.Config.API != nil {
 		selectedTool.Config.API.Query = make(map[string]string)
 

--- a/api/pkg/controller/inference.go
+++ b/api/pkg/controller/inference.go
@@ -304,6 +304,10 @@ func (c *Controller) selectAndConfigureTool(ctx context.Context, user *types.Use
 	if assistant != nil && assistant.IsActionableTemplate != "" {
 		options = append(options, tools.WithIsActionableTemplate(assistant.IsActionableTemplate))
 	}
+	// If assistant has configured a model, use it
+	if assistant != nil && assistant.Model != "" {
+		options = append(options, tools.WithModel(assistant.Model))
+	}
 
 	history := types.HistoryFromChatCompletionRequest(req)
 

--- a/api/pkg/controller/inference.go
+++ b/api/pkg/controller/inference.go
@@ -13,7 +13,6 @@ import (
 	"github.com/helixml/helix/api/pkg/pubsub"
 	"github.com/helixml/helix/api/pkg/rag"
 	"github.com/helixml/helix/api/pkg/store"
-	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/tools"
 	"github.com/helixml/helix/api/pkg/types"
 
@@ -172,14 +171,6 @@ func (c *Controller) getClient(ctx context.Context, provider types.Provider) (oa
 
 	return client, nil
 
-}
-
-func (c *Controller) authorizeUserToApp(user *types.User, app *types.App) error {
-	if (!app.Global && !app.Shared) && app.Owner != user.ID {
-		return system.NewHTTPError403(fmt.Sprintf("you do not have access to the app with the id: %s", app.ID))
-	}
-
-	return nil
 }
 
 func (c *Controller) evaluateToolUsage(ctx context.Context, user *types.User, req openai.ChatCompletionRequest, opts *ChatCompletionOptions) (*openai.ChatCompletionResponse, bool, error) {

--- a/api/pkg/controller/sessions.go
+++ b/api/pkg/controller/sessions.go
@@ -624,6 +624,10 @@ func (c *Controller) checkForActions(session *types.Session) (*types.Session, er
 	if assistant != nil && assistant.IsActionableTemplate != "" {
 		options = append(options, tools.WithIsActionableTemplate(assistant.IsActionableTemplate))
 	}
+	// If assistant has configured a model, use it
+	if assistant != nil && assistant.Model != "" {
+		options = append(options, tools.WithModel(assistant.Model))
+	}
 
 	isActionable, err := c.ToolsPlanner.IsActionable(ctx, session.ID, lastInteraction.ID, activeTools, messageHistory, options...)
 	if err != nil {

--- a/api/pkg/runner/controller_inference_test.go
+++ b/api/pkg/runner/controller_inference_test.go
@@ -82,10 +82,6 @@ func (m *MockReadCloser) Close() error {
 }
 
 func TestCreateInferenceModelInstance(t *testing.T) {
-	return
-
-	// XXX try to fix hanging tests
-
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	curShellCommander := ollamaCommander

--- a/api/pkg/tools/informative_or_actionable.go
+++ b/api/pkg/tools/informative_or_actionable.go
@@ -122,7 +122,6 @@ func (c *ChainStrategy) isActionable(ctx context.Context, sessionID, interaction
 		Model:    c.cfg.Tools.Model,
 		Messages: messages,
 	}
-
 	// Use model if specified by options (e.g. use assistant model from app
 	// instead of default set by TOOLS_MODEL)
 	if opts.model != "" {

--- a/api/pkg/tools/informative_or_actionable.go
+++ b/api/pkg/tools/informative_or_actionable.go
@@ -123,6 +123,12 @@ func (c *ChainStrategy) isActionable(ctx context.Context, sessionID, interaction
 		Messages: messages,
 	}
 
+	// Use model if specified by options (e.g. use assistant model from app
+	// instead of default set by TOOLS_MODEL)
+	if opts.model != "" {
+		req.Model = opts.model
+	}
+
 	// Required for the correct openai context to be set
 	ctx = oai.SetContextValues(ctx, &oai.ContextValues{
 		OwnerID:       "system",

--- a/api/pkg/tools/tool_options.go
+++ b/api/pkg/tools/tool_options.go
@@ -1,20 +1,24 @@
 package tools
 
-type isActionableOptions struct {
-	isActionableTemplate string
-}
-
 // Option is a function on the options for a connection.
 type Option func(*Options) error
 
 // Options can be used to create a customized connection.
 type Options struct {
 	isActionableTemplate string
+	model                string
 }
 
 func WithIsActionableTemplate(isActionableTemplate string) Option {
 	return func(o *Options) error {
 		o.isActionableTemplate = isActionableTemplate
+		return nil
+	}
+}
+
+func WithModel(model string) Option {
+	return func(o *Options) error {
+		o.model = model
 		return nil
 	}
 }

--- a/api/pkg/tools/tools_api.go
+++ b/api/pkg/tools/tools_api.go
@@ -140,7 +140,7 @@ func (c *ChainStrategy) getAPIRequestParameters(ctx context.Context, sessionID, 
 		Model:    c.cfg.Tools.Model,
 		Messages: messages,
 	}
-	// override with app model if specified, otherwise fallback to TOOLS_MODEL
+	// override with tool model if specified, otherwise fallback to TOOLS_MODEL
 	// env var
 	if tool.Config.API.Model != "" {
 		req.Model = tool.Config.API.Model

--- a/api/pkg/tools/tools_api.go
+++ b/api/pkg/tools/tools_api.go
@@ -135,11 +135,15 @@ func (c *ChainStrategy) getAPIRequestParameters(ctx context.Context, sessionID, 
 			Content: "Return the corresponding json for the last user input",
 		},
 	)
-
 	req := openai.ChatCompletionRequest{
 		Stream:   false,
 		Model:    c.cfg.Tools.Model,
 		Messages: messages,
+	}
+	// override with app model if specified, otherwise fallback to TOOLS_MODEL
+	// env var
+	if tool.Config.API.Model != "" {
+		req.Model = tool.Config.API.Model
 	}
 
 	ctx = oai.SetContextValues(ctx, &oai.ContextValues{

--- a/api/pkg/tools/tools_api_response.go
+++ b/api/pkg/tools/tools_api_response.go
@@ -87,7 +87,7 @@ func (c *ChainStrategy) handleErrorResponse(ctx context.Context, sessionID, inte
 		Model:    c.cfg.Tools.Model,
 		Messages: messages,
 	}
-	// override with app model if specified
+	// override with tool model if specified
 	if tool.Config.API.Model != "" {
 		req.Model = tool.Config.API.Model
 	}

--- a/api/pkg/tools/tools_api_response.go
+++ b/api/pkg/tools/tools_api_response.go
@@ -28,7 +28,7 @@ func (c *ChainStrategy) interpretResponse(ctx context.Context, sessionID, intera
 
 func (c *ChainStrategy) handleSuccessResponse(ctx context.Context, sessionID, interactionID string, tool *types.Tool, history []*types.ToolHistoryMessage, statusCode int, body []byte) (*RunActionResponse, error) {
 	messages := c.prepareSuccessMessages(tool, history, body)
-	req := c.prepareChatCompletionRequest(messages, false)
+	req := c.prepareChatCompletionRequest(messages, false, tool.Config.API.Model)
 
 	ctx = c.setContextAndStep(ctx, sessionID, interactionID, types.LLMCallStepInterpretResponse)
 
@@ -49,7 +49,7 @@ func (c *ChainStrategy) handleSuccessResponse(ctx context.Context, sessionID, in
 
 func (c *ChainStrategy) handleSuccessResponseStream(ctx context.Context, sessionID, interactionID string, tool *types.Tool, history []*types.ToolHistoryMessage, statusCode int, body []byte) (*openai.ChatCompletionStream, error) {
 	messages := c.prepareSuccessMessages(tool, history, body)
-	req := c.prepareChatCompletionRequest(messages, true)
+	req := c.prepareChatCompletionRequest(messages, true, tool.Config.API.Model)
 
 	ctx = c.setContextAndStep(ctx, sessionID, interactionID, types.LLMCallStepInterpretResponse)
 
@@ -86,6 +86,10 @@ func (c *ChainStrategy) handleErrorResponse(ctx context.Context, sessionID, inte
 		Stream:   false,
 		Model:    c.cfg.Tools.Model,
 		Messages: messages,
+	}
+	// override with app model if specified
+	if tool.Config.API.Model != "" {
+		req.Model = tool.Config.API.Model
 	}
 
 	ctx = oai.SetContextValues(ctx, &oai.ContextValues{
@@ -162,12 +166,16 @@ func (c *ChainStrategy) prepareSuccessMessages(tool *types.Tool, history []*type
 	return messages
 }
 
-func (c *ChainStrategy) prepareChatCompletionRequest(messages []openai.ChatCompletionMessage, stream bool) openai.ChatCompletionRequest {
-	return openai.ChatCompletionRequest{
+func (c *ChainStrategy) prepareChatCompletionRequest(messages []openai.ChatCompletionMessage, stream bool, overrideModel string) openai.ChatCompletionRequest {
+	req := openai.ChatCompletionRequest{
 		Stream:   stream,
 		Model:    c.cfg.Tools.Model,
 		Messages: messages,
 	}
+	if overrideModel != "" {
+		req.Model = overrideModel
+	}
+	return req
 }
 
 func (c *ChainStrategy) setContextAndStep(ctx context.Context, sessionID, interactionID string, step types.LLMCallStep) context.Context {

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -918,6 +918,8 @@ type ToolApiConfig struct {
 	RequestPrepTemplate     string `json:"request_prep_template" yaml:"request_prep_template"`         // Template for request preparation, leave empty for default
 	ResponseSuccessTemplate string `json:"response_success_template" yaml:"response_success_template"` // Template for successful response, leave empty for default
 	ResponseErrorTemplate   string `json:"response_error_template" yaml:"response_error_template"`     // Template for error response, leave empty for default
+
+	Model string `json:"model" yaml:"model"`
 }
 
 // ToolApiConfig is parsed from the OpenAPI spec


### PR DESCRIPTION
For app use of tools, default to the app model instead of using TOOLS_MODEL. Still fallback to TOOLS_MODEL if that's not specified.