### PR TITLE
check ollama is ready before sending it a request

### DIFF
--- a/api/pkg/runner/llm_ollama_model_instance.go
+++ b/api/pkg/runner/llm_ollama_model_instance.go
@@ -504,7 +504,7 @@ func (i *OllamaInferenceModelInstance) getOllamaStatus() string {
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			log.Warn().Msg("Ollama ps command timed out after 1 second")
-			return "Timed out"
+			return "Starting Ollama"
 		}
 		log.Error().Err(err).Msgf("Failed to execute ollama ps command with environment OLLAMA_HOST=127.0.0.1:%d", i.port)
 		return "Unknown"
@@ -512,7 +512,7 @@ func (i *OllamaInferenceModelInstance) getOllamaStatus() string {
 
 	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
 	if len(lines) < 2 {
-		return "Empty (!)"
+		return "Loading model"
 	}
 
 	// Join all lines except the first (header) line
@@ -575,7 +575,7 @@ func (i *OllamaInferenceModelInstance) processInteraction(inferenceReq *types.Ru
 	timeout := 300 * time.Second
 	for {
 		status := i.getOllamaStatus()
-		if strings.Contains(status, "Forever") {
+		if status != "Starting Ollama" {
 			break
 		}
 		if time.Since(startTime) > timeout {

--- a/api/pkg/runner/llm_ollama_model_instance.go
+++ b/api/pkg/runner/llm_ollama_model_instance.go
@@ -572,7 +572,7 @@ func (i *OllamaInferenceModelInstance) processInteraction(inferenceReq *types.Ru
 	// Ensure Ollama is ready before sending a request
 	log.Info().Msg("waiting for Ollama to be ready")
 	startTime := time.Now()
-	timeout := 60 * time.Second
+	timeout := 300 * time.Second
 	for {
 		status := i.getOllamaStatus()
 		if strings.Contains(status, "Forever") {


### PR DESCRIPTION
* to avoid falling down a crack and having requests hang forever
* belt and braces also timeout inference requests after 600 seconds, inference should never take >10 minutes