### PR TITLE
fix(ui): allow users to update github apps to be global/shared

### DIFF
--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
-import FormGroup from '@mui/material/FormGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import Checkbox from '@mui/material/Checkbox';
-import Tooltip from '@mui/material/Tooltip';
 import Box from '@mui/material/Box';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormGroup from '@mui/material/FormGroup';
+import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import React from 'react';
 import ModelPicker from '../create/ModelPicker';
 
 interface AppSettingsProps {
@@ -130,7 +130,7 @@ const AppSettings: React.FC<AppSettingsProps> = ({
                 onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                   setShared(event.target.checked)
                 }}
-                disabled={isReadOnly}
+                // Never disable share checkbox -- required for github apps and normal apps
               />
             }
             label="Shared?"
@@ -147,7 +147,7 @@ const AppSettings: React.FC<AppSettingsProps> = ({
                   onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                     setGlobal(event.target.checked)
                   }}
-                  disabled={isReadOnly}
+                  // Never disable global checkbox -- required for github apps and normal apps
                 />
               }
               label="Global?"


### PR DESCRIPTION
This makes two changes:

1. Never disable the shared/global checkboxes.
2. Check if the app is a github app, if it is, only update the shared and global settings.