### PR TITLE
fix: tell helm the correct url for a localhost port-forward

### DIFF
--- a/charts/helix-controlplane/Chart.yaml
+++ b/charts/helix-controlplane/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.5
+version: 0.3.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/helix-controlplane/templates/deployment.yaml
+++ b/charts/helix-controlplane/templates/deployment.yaml
@@ -43,14 +43,14 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 8844
+              containerPort: 8080
               protocol: TCP
           envFrom:
             - configMapRef:
                 name: {{ include "helix-controlplane.fullname" . }}-config
           env:
             - name: SERVER_PORT
-              value: "8844"
+              value: "8080"
             - name: SERVER_URL
               value: {{ .Values.global.serverUrl }}
             - name: FILESTORE_LOCALFS_PATH

--- a/charts/helix-controlplane/templates/deployment.yaml
+++ b/charts/helix-controlplane/templates/deployment.yaml
@@ -60,8 +60,7 @@ spec:
             - name: RAG_INDEX_URL
               value: http://{{ include "helix-controlplane.fullname" . }}-llamaindex:5000/api/v1/rag/chunk
             - name: RAG_QUERY_URL
-              value: http://{{ include "helix-controlplane.fullname" .
-              }}-llamaindex:5000/api/v1/rag/query
+              value: http://{{ include "helix-controlplane.fullname" . }}-llamaindex:5000/api/v1/rag/query
             - name: RAG_TYPESENSE_URL
               value: http://{{ include "helix-controlplane.fullname" . }}-typesense:8108
             - name: RAG_TYPESENSE_API_KEY

--- a/charts/helix-controlplane/values.yaml
+++ b/charts/helix-controlplane/values.yaml
@@ -10,7 +10,7 @@ global:
   ##
   imagePullSecrets: []
   storageClass: ""
-  serverUrl: http://localhost:8844
+  serverUrl: http://localhost:8080
 
 image:
   repository: registry.helix.ml/helix/controlplane


### PR DESCRIPTION
fix issue on redirect from clicking on links in the filestore going to the internal 8844 port