### PR TITLE
Add gptscript_runner service to helix stack

### DIFF
--- a/charts/helix-controlplane/templates/deployment_gptscript_runner.yaml
+++ b/charts/helix-controlplane/templates/deployment_gptscript_runner.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: script-runner
     {{- include "helix-controlplane.labels" . | nindent 4 }}
-spec:  
+spec:
   replicas: {{ .Values.gptscript.replicas }}
   strategy:
     type: RollingUpdate
@@ -38,7 +38,7 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.gptscript.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}          
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - configMapRef:
                 name: {{ include "helix-controlplane.fullname" . }}-config
@@ -53,3 +53,5 @@ spec:
               value: "{{ .Values.gptscript.concurrency }}"
             - name: MAX_TASKS
               value: "{{ .Values.gptscript.maxTasks }}"
+            - name: GPTSCRIPT_PROVIDER_{{ include "helix-controlplane.fullname" . | replace "." "_" | replace "-" "_" | upper }}_API_KEY
+              value: "{{ .Values.envVariables.HELIX_API_KEY }}"

--- a/charts/helix-controlplane/values-example.yaml
+++ b/charts/helix-controlplane/values-example.yaml
@@ -31,5 +31,6 @@ envVariables:
   KEYCLOAK_PASSWORD: "oh-hallo-insecure-password"
   # Dashboard
   ADMIN_USER_IDS: "all"
-  # Evals 
+  # Evals
   EVAL_USER_ID: ""
+  HELIX_API_KEY: "helix_api_key"

--- a/charts/helix-controlplane/values.yaml
+++ b/charts/helix-controlplane/values.yaml
@@ -199,7 +199,7 @@ readinessProbe:
   periodSeconds: 10
   timeoutSeconds: 10
   failureThreshold: 6
-  
+
 # Volumes is mounted to the controlplane for persistence. All user
 # uploads and generated images, finetunes and models are stored here.
 volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -104,9 +104,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=${POSTGRES_ADMIN_PASSWORD-postgres}
   gptscript_runner:
-    build:
-      context: .
-      dockerfile: Dockerfile.gptscript
+    image: registry.helix.ml/helix/gptscript-runner:latest
     restart: always
     env_file:
       - .env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -103,6 +103,22 @@ services:
       - POSTGRES_DATABASE=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=${POSTGRES_ADMIN_PASSWORD-postgres}
+  gptscript_runner:
+    build:
+      context: .
+      dockerfile: Dockerfile.gptscript
+    restart: always
+    env_file:
+      - .env
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - API_HOST=http://api:80
+      - API_TOKEN=${RUNNER_TOKEN-oh-hallo-insecure-token}
+      - GPTSCRIPT_PROVIDER_API_API_KEY=${HELIX_API_KEY:-}
+      - CONCURRENCY=20 # number of tasks to run concurrently
+      - MAX_TASKS=0  # max number of tasks to run before exiting. Set to 0 to run forever
+    depends_on:
+      - api
   tika:
     image: apache/tika:2.9.2.1
     ports:


### PR DESCRIPTION
This adds a new service, `gptscript_runner`, to the Helix stack. It is aimed to make the `gptscript` talking to locally run LLM models via OpenAI compatible API provided by helix API service. The Helix API key required by `gptscript` to communicate with Helix must be specified via the `HELIX_API_KEY` env var: you can make it available via the .env file.