### PR TITLE
Allow RUNNER_TOKEN to perform chat completions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -35,6 +35,10 @@ steps:
       from_secret: openai_base_url
     # Database config (running in a sidecar)
     POSTGRES_HOST: postgres
+    POSTGRES_PORT: "5432"
+    POSTGRES_USER: postgres
+    POSTGRES_PASSWORD: postgres
+    POSTGRES_DATABASE: postgres
     TYPESENSE_URL: http://typesense:8108
     TYPESENSE_API_KEY: typesense
     TEXT_EXTRACTION_TIKA_URL: http://tika:9998

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ instructions.txt
 build-errors.log
 .DS_Store
 vendor
+*/**/out.md

--- a/api/pkg/openai/context.go
+++ b/api/pkg/openai/context.go
@@ -18,6 +18,14 @@ var (
 	stepKey          stepKeyType
 )
 
+const (
+	// TODO: this needs to be removed and replaced
+	// with actual RunnerID that needs to be passed
+	// to the request handlers.
+	RunnerID = "runner"
+	SystemID = "system"
+)
+
 type Step struct {
 	Step types.LLMCallStep
 }

--- a/api/pkg/server/auth_utils.go
+++ b/api/pkg/server/auth_utils.go
@@ -131,6 +131,10 @@ func hasUser(user *types.User) bool {
 	return user.ID != ""
 }
 
+func hasUserOrRunner(user *types.User) bool {
+	return hasUser(user) || isRunner(user)
+}
+
 func isAdmin(user *types.User) bool {
 	return hasUser(user) && user.Admin
 }

--- a/api/pkg/server/openai_chat_handlers.go
+++ b/api/pkg/server/openai_chat_handlers.go
@@ -36,13 +36,13 @@ const (
 // @externalDocs.url https://platform.openai.com/docs/api-reference/chat/create
 func (s *HelixAPIServer) createChatCompletion(rw http.ResponseWriter, r *http.Request) {
 	addCorsHeaders(rw)
-	if r.Method == "OPTIONS" {
+	if r.Method == http.MethodOptions {
 		return
 	}
 
 	user := getRequestUser(r)
 
-	if !hasUser(user) {
+	if !hasUserOrRunner(user) {
 		http.Error(rw, "unauthorized", http.StatusUnauthorized)
 		log.Error().Msg("unauthorized")
 		return
@@ -63,7 +63,14 @@ func (s *HelixAPIServer) createChatCompletion(rw http.ResponseWriter, r *http.Re
 		return
 	}
 
-	modelName, err := model.ProcessModelName(string(s.Cfg.Inference.Provider), chatCompletionRequest.Model, types.SessionModeInference, types.SessionTypeText, false, false)
+	modelName, err := model.ProcessModelName(
+		string(s.Cfg.Inference.Provider),
+		chatCompletionRequest.Model,
+		types.SessionModeInference,
+		types.SessionTypeText,
+		false,
+		false,
+	)
 	if err != nil {
 		log.Error().Err(err).Msg("error processing model name")
 		http.Error(rw, "invalid model name: "+err.Error(), http.StatusBadRequest)

--- a/api/pkg/server/openai_chat_handlers.go
+++ b/api/pkg/server/openai_chat_handlers.go
@@ -78,9 +78,13 @@ func (s *HelixAPIServer) createChatCompletion(rw http.ResponseWriter, r *http.Re
 	}
 
 	chatCompletionRequest.Model = modelName
+	ownerID := user.ID
+	if user.TokenType == types.TokenTypeRunner {
+		ownerID = oai.RunnerID
+	}
 
 	ctx := oai.SetContextValues(r.Context(), &oai.ContextValues{
-		OwnerID:         user.ID,
+		OwnerID:         ownerID,
 		SessionID:       "n/a",
 		InteractionID:   "n/a",
 		OriginalRequest: body,
@@ -230,7 +234,6 @@ func (s *HelixAPIServer) createChatCompletion(rw http.ResponseWriter, r *http.Re
 			log.Warn().Msg("ResponseWriter does not support Flusher interface")
 		}
 	}
-
 }
 
 func (s *HelixAPIServer) getAppLoraAssistant(ctx context.Context, appID string) (*types.AssistantConfig, error) {

--- a/api/pkg/server/openai_chat_handlers_test.go
+++ b/api/pkg/server/openai_chat_handlers_test.go
@@ -32,7 +32,29 @@ import (
 )
 
 func TestOpenAIChatSuite(t *testing.T) {
-	suite.Run(t, new(OpenAIChatSuite))
+	// NOTE: we want to make sure that both the users and
+	// the runners can successfully trigger chat completions.
+	suitCfgs := []struct {
+		userID  string
+		authCtx context.Context
+	}{
+		{"user_id", setRequestUser(context.Background(), types.User{
+			ID:       "user_id",
+			Email:    "foo@email.com",
+			FullName: "Foo Bar",
+		})},
+		{"", setRequestUser(context.Background(), types.User{
+			Token:     "runner_token",
+			TokenType: types.TokenTypeRunner,
+		})},
+	}
+	for _, cfg := range suitCfgs {
+		testSuite := &OpenAIChatSuite{
+			userID:  cfg.userID,
+			authCtx: cfg.authCtx,
+		}
+		suite.Run(t, testSuite)
+	}
 }
 
 type OpenAIChatSuite struct {

--- a/api/pkg/server/openai_chat_handlers_test.go
+++ b/api/pkg/server/openai_chat_handlers_test.go
@@ -85,13 +85,6 @@ func (suite *OpenAIChatSuite) SetupTest() {
 	extractorMock := extract.NewMockExtractor(ctrl)
 	suite.rag = rag.NewMockRAG(ctrl)
 
-	suite.userID = "user_id"
-	suite.authCtx = setRequestUser(context.Background(), types.User{
-		ID:       suite.userID,
-		Email:    "foo@email.com",
-		FullName: "Foo Bar",
-	})
-
 	cfg := &config.ServerConfig{}
 	cfg.Tools.Enabled = false
 	cfg.Inference.Provider = types.ProviderTogetherAI
@@ -120,6 +113,20 @@ func (suite *OpenAIChatSuite) SetupTest() {
 	}
 }
 
+func getTestOwnerID(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	user, ok := ctx.Value(userKey).(types.User)
+	if !ok {
+		return "", !ok
+	}
+	if user.TokenType == types.TokenTypeRunner {
+		return openai.RunnerID, ok
+	}
+	return user.ID, ok
+}
+
 func (suite *OpenAIChatSuite) TestChatCompletions_Basic_Blocking() {
 
 	req, err := http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(`{
@@ -138,6 +145,9 @@ func (suite *OpenAIChatSuite) TestChatCompletions_Basic_Blocking() {
 	}`))
 	suite.NoError(err)
 
+	ownerID, ok := getTestOwnerID(suite.authCtx)
+	suite.Require().True(ok)
+
 	req = req.WithContext(suite.authCtx)
 
 	rec := httptest.NewRecorder()
@@ -153,7 +163,7 @@ func (suite *OpenAIChatSuite) TestChatCompletions_Basic_Blocking() {
 
 			vals, ok := openai.GetContextValues(ctx)
 			suite.True(ok)
-			suite.Equal("user_id", vals.OwnerID)
+			suite.Equal(ownerID, vals.OwnerID)
 			suite.Equal("n/a", vals.SessionID)
 			suite.Equal("n/a", vals.InteractionID)
 
@@ -205,6 +215,9 @@ func (suite *OpenAIChatSuite) TestChatCompletions_Streaming() {
 	}`))
 	suite.NoError(err)
 
+	ownerID, ok := getTestOwnerID(suite.authCtx)
+	suite.Require().True(ok)
+
 	req = req.WithContext(suite.authCtx)
 
 	rec := httptest.NewRecorder()
@@ -216,7 +229,7 @@ func (suite *OpenAIChatSuite) TestChatCompletions_Streaming() {
 		DoAndReturn(func(ctx context.Context, req oai.ChatCompletionRequest) (*oai.ChatCompletionStream, error) {
 			vals, ok := openai.GetContextValues(ctx)
 			suite.True(ok)
-			suite.Equal("user_id", vals.OwnerID)
+			suite.Equal(ownerID, vals.OwnerID)
 			suite.Equal("n/a", vals.SessionID)
 			suite.Equal("n/a", vals.InteractionID)
 
@@ -365,6 +378,9 @@ func (suite *OpenAIChatSuite) TestChatCompletions_App_Blocking() {
 	}`))
 	suite.NoError(err)
 
+	ownerID, ok := getTestOwnerID(suite.authCtx)
+	suite.Require().True(ok)
+
 	req = req.WithContext(suite.authCtx)
 
 	rec := httptest.NewRecorder()
@@ -382,7 +398,7 @@ func (suite *OpenAIChatSuite) TestChatCompletions_App_Blocking() {
 
 			vals, ok := openai.GetContextValues(ctx)
 			suite.True(ok)
-			suite.Equal("user_id", vals.OwnerID)
+			suite.Equal(ownerID, vals.OwnerID)
 			suite.Equal("n/a", vals.SessionID)
 			suite.Equal("n/a", vals.InteractionID)
 
@@ -453,6 +469,9 @@ func (suite *OpenAIChatSuite) TestChatCompletions_App_HelixModel() {
 	}`))
 	suite.NoError(err)
 
+	ownerID, ok := getTestOwnerID(suite.authCtx)
+	suite.Require().True(ok)
+
 	req = req.WithContext(suite.authCtx)
 
 	rec := httptest.NewRecorder()
@@ -470,7 +489,7 @@ func (suite *OpenAIChatSuite) TestChatCompletions_App_HelixModel() {
 
 			vals, ok := openai.GetContextValues(ctx)
 			suite.True(ok)
-			suite.Equal("user_id", vals.OwnerID)
+			suite.Equal(ownerID, vals.OwnerID)
 			suite.Equal("n/a", vals.SessionID)
 			suite.Equal("n/a", vals.InteractionID)
 
@@ -572,6 +591,9 @@ func (suite *OpenAIChatSuite) TestChatCompletions_AppRag_Blocking() {
 	}`))
 	suite.NoError(err)
 
+	ownerID, ok := getTestOwnerID(suite.authCtx)
+	suite.Require().True(ok)
+
 	req = req.WithContext(suite.authCtx)
 
 	rec := httptest.NewRecorder()
@@ -594,7 +616,7 @@ func (suite *OpenAIChatSuite) TestChatCompletions_AppRag_Blocking() {
 
 			vals, ok := openai.GetContextValues(ctx)
 			suite.True(ok)
-			suite.Equal("user_id", vals.OwnerID)
+			suite.Equal(ownerID, vals.OwnerID)
 			suite.Equal("n/a", vals.SessionID)
 			suite.Equal("n/a", vals.InteractionID)
 
@@ -654,27 +676,29 @@ func (suite *OpenAIChatSuite) TestChatCompletions_AppFromAuth_Blocking() {
 	}).Return([]*types.Secret{}, nil)
 
 	req, err := http.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(`{
-		"model": "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-		"stream": false,
-		"messages": [
-			{
-				"role": "system",
-				"content": "You are a helpful assistant."
-			},
-			{
-				"role": "user",
-				"content": "tell me about oceans!"
-			}
-		]
-	}`))
+ 		"model": "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+ 		"stream": false,
+ 		"messages": [
+ 			{
+ 				"role": "system",
+ 				"content": "You are a helpful assistant."
+ 			},
+ 			{
+ 				"role": "user",
+ 				"content": "tell me about oceans!"
+ 			}
+ 		]
+ 	}`))
 	suite.NoError(err)
 
-	authCtx := setRequestUser(context.Background(), types.User{
-		ID:       suite.userID,
-		Email:    "foo@email.com",
-		FullName: "Foo Bar",
-		AppID:    "app123",
-	})
+	// Let's pack AppID into the auth context
+	user := suite.authCtx.Value(userKey).(types.User)
+	user.AppID = "app123"
+
+	authCtx := setRequestUser(context.Background(), user)
+
+	ownerID, ok := getTestOwnerID(authCtx)
+	suite.Require().True(ok)
 
 	req = req.WithContext(authCtx)
 
@@ -693,7 +717,7 @@ func (suite *OpenAIChatSuite) TestChatCompletions_AppFromAuth_Blocking() {
 
 			vals, ok := openai.GetContextValues(ctx)
 			suite.True(ok)
-			suite.Equal("user_id", vals.OwnerID)
+			suite.Equal(ownerID, vals.OwnerID)
 			suite.Equal("n/a", vals.SessionID)
 			suite.Equal("n/a", vals.InteractionID)
 
@@ -764,6 +788,9 @@ func (suite *OpenAIChatSuite) TestChatCompletions_App_Streaming() {
 	}`))
 	suite.NoError(err)
 
+	ownerID, ok := getTestOwnerID(suite.authCtx)
+	suite.Require().True(ok)
+
 	req = req.WithContext(suite.authCtx)
 
 	rec := httptest.NewRecorder()
@@ -777,7 +804,7 @@ func (suite *OpenAIChatSuite) TestChatCompletions_App_Streaming() {
 
 			vals, ok := openai.GetContextValues(ctx)
 			suite.True(ok)
-			suite.Equal("user_id", vals.OwnerID)
+			suite.Equal(ownerID, vals.OwnerID)
 			suite.Equal("n/a", vals.SessionID)
 			suite.Equal("n/a", vals.InteractionID)
 

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -237,8 +237,13 @@ func (s *HelixAPIServer) startChatSessionHandler(rw http.ResponseWriter, req *ht
 		}()
 	}
 
+	ownerID := user.ID
+	if user.TokenType == types.TokenTypeRunner {
+		ownerID = oai.RunnerID
+	}
+
 	ctx = oai.SetContextValues(ctx, &oai.ContextValues{
-		OwnerID:         user.ID,
+		OwnerID:         ownerID,
 		SessionID:       session.ID,
 		InteractionID:   session.Interactions[0].ID,
 		OriginalRequest: body,
@@ -352,9 +357,14 @@ func (s *HelixAPIServer) restartChatSessionHandler(rw http.ResponseWriter, req *
 
 	ctx = oai.SetContextAppID(ctx, session.ParentApp)
 
+	ownerID := user.ID
+	if user.TokenType == types.TokenTypeRunner {
+		ownerID = oai.RunnerID
+	}
+
 	// Set required context values
 	ctx = oai.SetContextValues(ctx, &oai.ContextValues{
-		OwnerID:       user.ID,
+		OwnerID:       ownerID,
 		SessionID:     session.ID,
 		InteractionID: session.Interactions[len(session.Interactions)-1].ID,
 	})
@@ -397,8 +407,13 @@ func (s *HelixAPIServer) generateSessionName(user *types.User, sessionID, model,
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	ownerID := user.ID
+	if user.TokenType == types.TokenTypeRunner {
+		ownerID = oai.RunnerID
+	}
+
 	ctx = oai.SetContextValues(ctx, &oai.ContextValues{
-		OwnerID:       user.ID,
+		OwnerID:       ownerID,
 		SessionID:     sessionID,
 		InteractionID: "n/a",
 	})

--- a/api/pkg/store/store_test.go
+++ b/api/pkg/store/store_test.go
@@ -2,10 +2,10 @@ package store
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/helixml/helix/api/pkg/config"
+	"github.com/kelseyhightower/envconfig"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -22,20 +22,12 @@ type PostgresStoreTestSuite struct {
 func (suite *PostgresStoreTestSuite) SetupTest() {
 	suite.ctx = context.Background()
 
-	// TODO: move server options to envconfig
-	host := os.Getenv("POSTGRES_HOST")
-	if host == "" {
-		host = "localhost"
-	}
+	var storeCfg config.Store
 
-	store, err := NewPostgresStore(config.Store{
-		Host:        host,
-		Port:        5432,
-		Username:    "postgres",
-		Password:    "postgres",
-		Database:    "postgres",
-		AutoMigrate: true,
-	})
+	err := envconfig.Process("", &storeCfg)
+	suite.NoError(err)
+
+	store, err := NewPostgresStore(storeCfg)
 	suite.NoError(err)
 
 	suite.db = store

--- a/api/pkg/tools/informative_or_actionable.go
+++ b/api/pkg/tools/informative_or_actionable.go
@@ -135,7 +135,7 @@ func (c *ChainStrategy) isActionable(ctx context.Context, sessionID, interaction
 
 	// Required for the correct openai context to be set
 	ctx = oai.SetContextValues(ctx, &oai.ContextValues{
-		OwnerID:       "system",
+		OwnerID:       oai.SystemID,
 		SessionID:     sessionID,
 		InteractionID: interactionID,
 	})

--- a/api/pkg/tools/tools_api.go
+++ b/api/pkg/tools/tools_api.go
@@ -147,7 +147,7 @@ func (c *ChainStrategy) getAPIRequestParameters(ctx context.Context, sessionID, 
 	}
 
 	ctx = oai.SetContextValues(ctx, &oai.ContextValues{
-		OwnerID:       "system",
+		OwnerID:       oai.SystemID,
 		SessionID:     sessionID,
 		InteractionID: interactionID,
 	})

--- a/api/pkg/tools/tools_api_response.go
+++ b/api/pkg/tools/tools_api_response.go
@@ -93,7 +93,7 @@ func (c *ChainStrategy) handleErrorResponse(ctx context.Context, sessionID, inte
 	}
 
 	ctx = oai.SetContextValues(ctx, &oai.ContextValues{
-		OwnerID:       "system",
+		OwnerID:       oai.SystemID,
 		SessionID:     sessionID,
 		InteractionID: interactionID,
 	})
@@ -180,7 +180,7 @@ func (c *ChainStrategy) prepareChatCompletionRequest(messages []openai.ChatCompl
 
 func (c *ChainStrategy) setContextAndStep(ctx context.Context, sessionID, interactionID string, step types.LLMCallStep) context.Context {
 	ctx = oai.SetContextValues(ctx, &oai.ContextValues{
-		OwnerID:       "system",
+		OwnerID:       oai.SystemID,
 		SessionID:     sessionID,
 		InteractionID: interactionID,
 	})
@@ -209,5 +209,5 @@ Include relevant details, references, and links if present. Format the summary i
 Make sure to NEVER mention technical terms like "APIs, JSON, Request, etc..." and use first person pronoun (say it as if you performed the action)`
 
 const errorResponsePrompt = `As an ai chat assistant, your job is to help the user understand and resolve API error messages.
-When offering solutions, You will clarify without going into unnecessary detail. You must respond in less than 100 words. 
+When offering solutions, You will clarify without going into unnecessary detail. You must respond in less than 100 words.
 You should commence by saying "An error occurred while trying to process your request ..." also, if you think it's auth error, ask the user to read this doc https://docs.helix.ml/helix/develop/helix-tools/ (format as markdown)`

--- a/api/pkg/types/enums.go
+++ b/api/pkg/types/enums.go
@@ -105,6 +105,7 @@ type OwnerType string
 
 const (
 	OwnerTypeUser   OwnerType = "user"
+	OwnerTypeRunner OwnerType = "runner"
 	OwnerTypeSystem OwnerType = "system"
 )
 


### PR DESCRIPTION
We've modified the authorization check to allow runners to do chat completions. This will make integrating different types of runners eeasier at the cost of slight "security" tradeoff which we've accepted for the time being.