### PR TITLE
Add linter step into CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ workspace:
 
 steps:
 - name: build-backend
-  image: golang:1.23.4-alpine3.20
+  image: golang:1.23.4-alpine3.21
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -24,8 +24,17 @@ steps:
     - yarn build
   depends_on: []
 
+- name: run-linter
+  image: golangci/golangci-lint:v1.62-alpine
+  commands:
+    - golangci-lint run
+  when:
+    event:
+    - push
+  depends_on: []
+
 - name: unit-test
-  image: golang:1.23.4-alpine3.20
+  image: golang:1.23.4-alpine3.21
   environment:
     OPENAI_API_KEY:
       from_secret: openai_tools

--- a/Dockerfile.lint
+++ b/Dockerfile.lint
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+
+ARG GO_VERSION=1.23
+ARG GOLANGCI_LINT_VERSION=v1.62
+ARG ALPINE_VERSION=3.21
+
+FROM golangci/golangci-lint:${GOLANGCI_LINT_VERSION}-alpine AS golangci-lint
+
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS base
+RUN apk add --no-cache gcc musl-dev git
+WORKDIR /src
+
+FROM base
+RUN --mount=type=bind,target=. \
+  --mount=type=cache,target=/root/.cache \
+  --mount=from=golangci-lint,source=/usr/bin/golangci-lint,target=/usr/bin/golangci-lint \
+  golangci-lint run

--- a/local-development.md
+++ b/local-development.md
@@ -202,13 +202,23 @@ If you're familiar with [tmux](https://github.com/tmux/tmux/wiki) you will find 
 
 Both the frontend and the api have hot-reloads when in development mode. Rebuilds should only be required when adding libraries.
 
-### 5. Running tests
+### 5. Running linter
+
+> [!IMPORTANT]
+> You must install [golangci-lint](https://golangci-lint.run/)
+> See [here](https://golangci-lint.run/welcome/install/) for installation options.
+
+```
+./stack lint
+```
+
+### 6. Running tests
 
 ```
 ./stack test
 ```
 
-### 6. Tear down the Helix stack
+### 7. Tear down the Helix stack
 
 Bring down the stack
 
@@ -238,6 +248,7 @@ Bring down the stack
 
    - Format all code with standard language formatters.
    - Follow the project's coding guidelines for the frontend.
+   - Run [Go linter](https://golangci-lint.run/)
 
 3. **Commit Messages**
 

--- a/stack
+++ b/stack
@@ -154,6 +154,10 @@ function update_openapi() {
 	-o api/pkg/server
 }
 
+function lint() {
+        golangci-lint run .
+}
+
 function test() {
   # Ingest env variables from .env file
   set -a


### PR DESCRIPTION
We've added golangci-linter config into our codebase and now it's time to add the linter step into CI so we guarantee at least some quality of the code, such as uncompromisingly rejecting the code that does not handler errors, properly, etc.

We are also adding `Dockerfile.lint` Dockerfile for local development if you prefer that.