### PR TITLE
fixes pdf parsing

### DIFF
--- a/api/pkg/extract/tika_extractor.go
+++ b/api/pkg/extract/tika_extractor.go
@@ -90,7 +90,7 @@ func (e *TikaExtractor) extract(ctx context.Context, extractReq *ExtractRequest)
 	client := tika.NewClient(e.httpClient, e.extractorURL)
 
 	hdr := http.Header{}
-	hdr.Set("Accept", "text/plain")
+	hdr.Set("Accept", "*/*")
 
 	parsed, err := client.ParseWithHeader(ctx, bytes.NewReader(extractReq.Content), hdr)
 	if err != nil {


### PR DESCRIPTION
Fixes an error
```
Dec 16, 2024 5:20:58 PM org.apache.cxf.jaxrs.impl.WebApplicationExceptionMapper toResponse
WARNING: javax.ws.rs.ClientErrorException: HTTP 406 Not Acceptable
	at org.apache.cxf.jaxrs.utils.SpecExceptions.toHttpException(SpecExceptions.java:117)
	at org.apache.cxf.jaxrs.utils.ExceptionUtils.toHttpException(ExceptionUtils.java:168)
```

Tested on the patched kubernetes deployment