### PR TITLE
Remove redundant http.Flush when writing chunks

### DIFF
--- a/api/pkg/server/openai_chat_handlers.go
+++ b/api/pkg/server/openai_chat_handlers.go
@@ -226,13 +226,6 @@ func (s *HelixAPIServer) createChatCompletion(rw http.ResponseWriter, r *http.Re
 		if err := writeChunk(rw, bts); err != nil {
 			log.Error().Msgf("failed to write completion chunk: %v", err)
 		}
-
-		// Flush the stream to ensure the client receives the data immediately
-		if flusher, ok := rw.(http.Flusher); ok {
-			flusher.Flush()
-		} else {
-			log.Warn().Msg("ResponseWriter does not support Flusher interface")
-		}
 	}
 }
 

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -523,13 +523,6 @@ func (s *HelixAPIServer) handleStreamingSession(ctx context.Context, user *types
 		log.Error().Err(err).Msg("failed to write chunk")
 	}
 
-	// Flush the stream to ensure the client receives the data immediately
-	if flusher, ok := rw.(http.Flusher); ok {
-		flusher.Flush()
-	} else {
-		log.Warn().Msg("ResponseWriter does not support Flusher interface")
-	}
-
 	// Call the LLM
 	stream, _, err := s.Controller.ChatCompletionStream(ctx, user, chatCompletionRequest, options)
 	if err != nil {

--- a/api/pkg/server/session_legacy_handlers.go
+++ b/api/pkg/server/session_legacy_handlers.go
@@ -377,13 +377,6 @@ func (apiServer *HelixAPIServer) handleStreamingResponse(res http.ResponseWriter
 					return err
 				}
 
-				// Flush the stream to ensure the client receives the data immediately
-				if flusher, ok := res.(http.Flusher); ok {
-					flusher.Flush()
-				} else {
-					log.Warn().Msg("ResponseWriter does not support Flusher interface")
-				}
-
 				// Close connection
 				close(doneCh)
 				return nil
@@ -405,13 +398,6 @@ func (apiServer *HelixAPIServer) handleStreamingResponse(res http.ResponseWriter
 			err = writeChunk(res, respData)
 			if err != nil {
 				return err
-			}
-
-			// Flush the stream to ensure the client receives the data immediately
-			if flusher, ok := res.(http.Flusher); ok {
-				flusher.Flush()
-			} else {
-				log.Warn().Msg("ResponseWriter does not support Flusher interface")
 			}
 
 			// Close connection
@@ -523,6 +509,8 @@ func writeChunk(w io.Writer, chunk []byte) error {
 	// Flush the ResponseWriter buffer to send the chunk immediately
 	if flusher, ok := w.(http.Flusher); ok {
 		flusher.Flush()
+	} else {
+		log.Warn().Msg("ResponseWriter does not support Flusher interface")
 	}
 
 	return nil


### PR DESCRIPTION
`writeChunk` is already doing `http.Flusher` assertion

https://github.com/helixml/helix/blob/9d2bf5164750f9dc2a4442617fcae76af5ff4306/api/pkg/server/session_legacy_handlers.go#L524-L526

There is no need to do that again at the callsite.