### PR TITLE
Make Go code Go code again: revive linter checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,6 @@ linters:
     #- revive
 
 issues:
-  deadline: 2m
+  deadline: 5m
   exlude-dirs:
     - vendor

--- a/api/cmd/helix/runner.go
+++ b/api/cmd/helix/runner.go
@@ -254,8 +254,8 @@ func runnerCLI(cmd *cobra.Command, options *RunnerOptions) error {
 
 	// global state - expedient hack (TODO remove this when we switch cog away
 	// from downloading lora weights via http from the filestore)
-	model.API_HOST = options.Runner.ApiHost
-	model.API_TOKEN = options.Runner.ApiToken
+	model.APIHost = options.Runner.ApiHost
+	model.APIToken = options.Runner.ApiToken
 
 	if !options.Runner.MockRunner {
 		// Axolotl runtime warmup

--- a/api/pkg/gptscript/runner.go
+++ b/api/pkg/gptscript/runner.go
@@ -150,7 +150,7 @@ func (d *Runner) dial(ctx context.Context) (*websocket.Conn, error) {
 
 	apiHost = fmt.Sprintf("%s%s?access_token=%s&concurrency=%d&runnerid=%s",
 		apiHost,
-		system.GetApiPath("/ws/gptscript-runner"),
+		system.GetAPIPath("/ws/gptscript-runner"),
 		url.QueryEscape(d.cfg.APIToken), // Runner auth token to connect to the control plane
 		d.cfg.Concurrency,               // Concurrency is the number of tasks the runner can handle concurrently
 		d.cfg.RunnerID,                  // Runner ID is a unique identifier for the runner

--- a/api/pkg/model/axolotl_mistral7b.go
+++ b/api/pkg/model/axolotl_mistral7b.go
@@ -26,9 +26,8 @@ type Mistral7bInstruct01 struct {
 func (l *Mistral7bInstruct01) GetMemoryRequirements(mode types.SessionMode) uint64 {
 	if mode == types.SessionModeFinetune {
 		return GB * 24
-	} else {
-		return GB * 2
 	}
+	return GB * 2
 }
 
 func (l *Mistral7bInstruct01) GetType() types.SessionType {

--- a/api/pkg/model/cog_sdxl.go
+++ b/api/pkg/model/cog_sdxl.go
@@ -18,8 +18,10 @@ import (
 
 // get hackily written to at process startup
 // TODO: remove this when we rip out cog downloading its weights over http
-var API_HOST string
-var API_TOKEN string
+var (
+	APIHost  string
+	APIToken string
+)
 
 /*
 
@@ -35,9 +37,8 @@ type CogSDXL struct {
 func (l *CogSDXL) GetMemoryRequirements(mode types.SessionMode) uint64 {
 	if mode == types.SessionModeFinetune {
 		return GB * 24
-	} else {
-		return MB * 19334
 	}
+	return MB * 19334
 }
 
 func (l *CogSDXL) GetType() types.SessionType {
@@ -199,9 +200,9 @@ func (l *CogSDXL) GetCommand(ctx context.Context, sessionFilter types.SessionFil
 		// Set the log level, which is a name, but must be uppercased
 		fmt.Sprintf("LOG_LEVEL=%s", strings.ToUpper(os.Getenv("LOG_LEVEL"))),
 		// cog likes to download LoRA from a URL, so we construct one for it
-		fmt.Sprintf("API_HOST=%s", API_HOST),
+		fmt.Sprintf("API_HOST=%s", APIHost),
 		// one day it will need to auth to the API server to download LoRAs
-		fmt.Sprintf("API_TOKEN=%s", API_TOKEN),
+		fmt.Sprintf("API_TOKEN=%s", APIToken),
 	)
 
 	return cmd, nil

--- a/api/pkg/model/utils.go
+++ b/api/pkg/model/utils.go
@@ -27,12 +27,14 @@ func getGenericTask(session *types.Session) (*types.RunnerTask, error) {
 	if lastInteraction == nil {
 		return nil, fmt.Errorf("session has no user messages")
 	}
-	if session.Mode == types.SessionModeInference {
+
+	switch session.Mode {
+	case types.SessionModeInference:
 		return &types.RunnerTask{
 			Prompt:  lastInteraction.Message,
 			LoraDir: session.LoraDir,
 		}, nil
-	} else if session.Mode == types.SessionModeFinetune {
+	case types.SessionModeFinetune:
 		if len(lastInteraction.Files) == 0 {
 			return nil, fmt.Errorf("session has no files")
 		}
@@ -43,7 +45,7 @@ func getGenericTask(session *types.Session) (*types.RunnerTask, error) {
 		return &types.RunnerTask{
 			DatasetDir: path.Dir(lastInteraction.Files[0]),
 		}, nil
-	} else {
+	default:
 		return nil, fmt.Errorf("invalid session mode")
 	}
 }

--- a/api/pkg/runner/controller.go
+++ b/api/pkg/runner/controller.go
@@ -151,12 +151,12 @@ func NewRunner(
 func (r *Runner) Initialize(ctx context.Context) error {
 	// connect to the runner websocket server on the api
 	// when we write events down the channel - write them to the websocket
-	parsedURL, err := url.Parse(system.WSURL(r.httpClientOptions, system.GetApiPath("/ws/runner")))
+	parsedURL, err := url.Parse(system.WSURL(r.httpClientOptions, system.GetAPIPath("/ws/runner")))
 	if err != nil {
 		return err
 	}
 
-	fmt.Println("Connecting to controlplane", system.WSURL(r.httpClientOptions, system.GetApiPath("/ws/runner")))
+	fmt.Println("Connecting to controlplane", system.WSURL(r.httpClientOptions, system.GetAPIPath("/ws/runner")))
 
 	queryParams := url.Values{}
 	queryParams.Add("runnerid", r.Options.ID)
@@ -309,7 +309,7 @@ func (r *Runner) pollSlots(_ context.Context) error {
 }
 
 func (r *Runner) getSlots() (*types.GetDesiredRunnerSlotsResponse, error) {
-	parsedURL, err := url.Parse(system.URL(r.httpClientOptions, system.GetApiPath(fmt.Sprintf("/runner/%s/slots", r.Options.ID))))
+	parsedURL, err := url.Parse(system.URL(r.httpClientOptions, system.GetAPIPath(fmt.Sprintf("/runner/%s/slots", r.Options.ID))))
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (r *Runner) reportStateLoop(_ context.Context) error {
 	log.Trace().Msgf("🟠 Sending runner state %s %+v", r.Options.ID, state)
 	_, err = system.PostRequest[*types.RunnerState, *types.RunnerState](
 		r.httpClientOptions,
-		system.GetApiPath(fmt.Sprintf("/runner/%s/state", r.Options.ID)),
+		system.GetAPIPath(fmt.Sprintf("/runner/%s/state", r.Options.ID)),
 		state,
 	)
 	if err != nil {
@@ -392,7 +392,7 @@ func GiB(bytes int64) float32 {
 // yet.
 // nolint:unused
 func (r *Runner) getNextApiSession(_ context.Context, queryParams url.Values) (*types.Session, error) {
-	parsedURL, err := url.Parse(system.URL(r.httpClientOptions, system.GetApiPath(fmt.Sprintf("/runner/%s/nextsession", r.Options.ID))))
+	parsedURL, err := url.Parse(system.URL(r.httpClientOptions, system.GetAPIPath(fmt.Sprintf("/runner/%s/nextsession", r.Options.ID))))
 	if err != nil {
 		return nil, err
 	}
@@ -500,7 +500,7 @@ func (r *Runner) postWorkerResponseToApi(res *types.RunnerTaskResponse) error {
 	// and the api server is just appending to the session
 	_, err := system.PostRequest[*types.RunnerTaskResponse, *types.RunnerTaskResponse](
 		r.httpClientOptions,
-		system.GetApiPath(fmt.Sprintf("/runner/%s/response", r.Options.ID)),
+		system.GetAPIPath(fmt.Sprintf("/runner/%s/response", r.Options.ID)),
 		res,
 	)
 	if err != nil {

--- a/api/pkg/runner/files.go
+++ b/api/pkg/runner/files.go
@@ -102,7 +102,7 @@ func (handler *FileHandler) downloadFile(sessionID string, remotePath string, lo
 		return nil
 	}
 
-	url := system.URL(handler.httpClientOptions, system.GetApiPath(fmt.Sprintf("/runner/%s/session/%s/download/file", handler.runnerID, sessionID)))
+	url := system.URL(handler.httpClientOptions, system.GetAPIPath(fmt.Sprintf("/runner/%s/session/%s/download/file", handler.runnerID, sessionID)))
 	urlValues := urllib.Values{}
 	urlValues.Add("path", remotePath)
 
@@ -156,7 +156,7 @@ func (handler *FileHandler) downloadFolder(sessionID string, remotePath string, 
 	if err := os.MkdirAll(localPath, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to create folder: %w", err)
 	}
-	url := system.URL(handler.httpClientOptions, system.GetApiPath(fmt.Sprintf("/runner/%s/session/%s/download/folder", handler.runnerID, sessionID)))
+	url := system.URL(handler.httpClientOptions, system.GetAPIPath(fmt.Sprintf("/runner/%s/session/%s/download/folder", handler.runnerID, sessionID)))
 	urlValues := urllib.Values{}
 	urlValues.Add("path", remotePath)
 	fullURL := fmt.Sprintf("%s?%s", url, urlValues.Encode())
@@ -239,7 +239,7 @@ func (handler *FileHandler) uploadFiles(sessionID string, localFiles []string, r
 		return nil, err
 	}
 
-	url := system.URL(handler.httpClientOptions, system.GetApiPath(fmt.Sprintf("/runner/%s/session/%s/upload/files", handler.runnerID, sessionID)))
+	url := system.URL(handler.httpClientOptions, system.GetAPIPath(fmt.Sprintf("/runner/%s/session/%s/upload/files", handler.runnerID, sessionID)))
 	urlValues := urllib.Values{}
 	urlValues.Add("path", remoteFolder)
 	fullURL := fmt.Sprintf("%s?%s", url, urlValues.Encode())
@@ -368,7 +368,7 @@ func (handler *FileHandler) uploadFolder(sessionID string, localPath string, rem
 		},
 	}
 
-	url := system.URL(handler.httpClientOptions, system.GetApiPath(fmt.Sprintf("/runner/%s/session/%s/upload/folder", handler.runnerID, sessionID)))
+	url := system.URL(handler.httpClientOptions, system.GetAPIPath(fmt.Sprintf("/runner/%s/session/%s/upload/folder", handler.runnerID, sessionID)))
 	urlValues := urllib.Values{}
 	urlValues.Add("path", remoteFolder)
 	fullURL := fmt.Sprintf("%s?%s", url, urlValues.Encode())

--- a/api/pkg/runner/utils.go
+++ b/api/pkg/runner/utils.go
@@ -25,12 +25,10 @@ func getChildPids(pid int) ([]int, error) {
 			if exitCode == 1 {
 				// this CAN mean pgrep just found no matches, this just means no children
 				return []int{}, nil
-			} else {
-				return nil, fmt.Errorf("error calling pgrep -P %d: %s, %s", pid, err, out)
 			}
-		} else {
 			return nil, fmt.Errorf("error calling pgrep -P %d: %s, %s", pid, err, out)
 		}
+		return nil, fmt.Errorf("error calling pgrep -P %d: %s, %s", pid, err, out)
 	}
 
 	var pids []int

--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -173,7 +173,7 @@ func (s *HelixAPIServer) createApp(_ http.ResponseWriter, r *http.Request) (*typ
 		if err != nil {
 			return nil, system.NewHTTPError500(err.Error())
 		}
-		githubApp, err := apps.NewGithubApp(apps.GithubAppOptions{
+		githubApp, err := apps.NewGithubApp(apps.AppOptions{
 			GithubConfig: s.Cfg.GitHub,
 			Client:       client,
 			App:          created,
@@ -508,7 +508,7 @@ func (s *HelixAPIServer) updateGithubApp(_ http.ResponseWriter, r *http.Request)
 		if err != nil {
 			return nil, system.NewHTTPError500(err.Error())
 		}
-		githubApp, err := apps.NewGithubApp(apps.GithubAppOptions{
+		githubApp, err := apps.NewGithubApp(apps.AppOptions{
 			GithubConfig: s.Cfg.GitHub,
 			Client:       client,
 			App:          existing,

--- a/api/pkg/system/http.go
+++ b/api/pkg/system/http.go
@@ -16,7 +16,7 @@ import (
 )
 
 // the sub path any API's are served over
-const API_SUB_PATH = "/api/v1"
+const APISubPath = "/api/v1"
 
 type ClientOptions struct {
 	Host  string
@@ -27,8 +27,8 @@ func URL(options ClientOptions, path string) string {
 	return fmt.Sprintf("%s%s", options.Host, path)
 }
 
-func GetApiPath(path string) string {
-	return fmt.Sprintf("%s%s", API_SUB_PATH, path)
+func GetAPIPath(path string) string {
+	return fmt.Sprintf("%s%s", APISubPath, path)
 }
 
 func WSURL(options ClientOptions, path string) string {
@@ -37,9 +37,8 @@ func WSURL(options ClientOptions, path string) string {
 	// and https:// with wss://
 	if strings.HasPrefix(url, "http://") {
 		return "ws" + url[4:]
-	} else {
-		return "wss" + url[5:]
 	}
+	return "wss" + url[5:]
 }
 
 type HTTPError struct {
@@ -141,14 +140,13 @@ func WrapperWithConfig[T any](handler httpWrapper[T], config WrapperConfig) func
 			}
 			http.Error(res, err.Error(), statusCode)
 			return
-		} else {
-			res.Header().Set("Content-Type", "application/json")
-			jsonError := json.NewEncoder(res).Encode(data)
-			if jsonError != nil {
-				log.Ctx(req.Context()).Error().Msgf("error for json encoding: %s", err.Error())
-				http.Error(res, jsonError.Error(), http.StatusInternalServerError)
-				return
-			}
+		}
+		res.Header().Set("Content-Type", "application/json")
+		jsonError := json.NewEncoder(res).Encode(data)
+		if jsonError != nil {
+			log.Ctx(req.Context()).Error().Msgf("error for json encoding: %s", err.Error())
+			http.Error(res, jsonError.Error(), http.StatusInternalServerError)
+			return
 		}
 	}
 	return ret
@@ -183,14 +181,13 @@ func DefaultWrapperWithConfig[T any](handler defaultWrapper[T], config WrapperCo
 			}
 			http.Error(res, err.Error(), http.StatusInternalServerError)
 			return
-		} else {
-			res.Header().Set("Content-Type", "application/json")
-			jsonError := json.NewEncoder(res).Encode(data)
-			if jsonError != nil {
-				log.Ctx(req.Context()).Error().Msgf("error for json encoding: %s", jsonError.Error())
-				http.Error(res, jsonError.Error(), http.StatusInternalServerError)
-				return
-			}
+		}
+		res.Header().Set("Content-Type", "application/json")
+		jsonError := json.NewEncoder(res).Encode(data)
+		if jsonError != nil {
+			log.Ctx(req.Context()).Error().Msgf("error for json encoding: %s", jsonError.Error())
+			http.Error(res, jsonError.Error(), http.StatusInternalServerError)
+			return
 		}
 	}
 	return ret

--- a/api/pkg/testfaster_client/api.go
+++ b/api/pkg/testfaster_client/api.go
@@ -128,9 +128,8 @@ func getLeaseLoader(apiHandler HttpApiHandler, poolId, leaseId string) func() (s
 		}
 		if lease.State == "error" {
 			return "", lease.Status, fmt.Errorf("wait failed, state was error\n")
-		} else {
-			return lease.State, lease.Status, nil
 		}
+		return lease.State, lease.Status, nil
 	}
 }
 
@@ -143,9 +142,8 @@ func getLeaseProcessor() func(envelope WebsocketEnvelope) (string, error) {
 		}
 		if lease.State == "error" {
 			return "", fmt.Errorf("wait failed, state was error\n")
-		} else {
-			return lease.State, nil
 		}
+		return lease.State, nil
 	}
 }
 
@@ -154,9 +152,8 @@ func waitForLease(apiHandler HttpApiHandler, poolSubscription *WebsocketSubscrip
 	getError := func(state string) error {
 		if state == "error" || state == "complete" || state == "timeout" {
 			return fmt.Errorf("wait failed, state was %s", state)
-		} else {
-			return nil
 		}
+		return nil
 	}
 
 	waiter := NewEntityWaiter(
@@ -314,9 +311,8 @@ func getPoolLoader(apiHandler HttpApiHandler, id string) func() (string, string,
 		}
 		if pool.State == "error" {
 			return "", pool.Status, fmt.Errorf("wait failed, state was error\n")
-		} else {
-			return pool.State, pool.Status, nil
 		}
+		return pool.State, pool.Status, nil
 	}
 }
 
@@ -329,9 +325,8 @@ func getPoolProcessor() func(envelope WebsocketEnvelope) (string, error) {
 		}
 		if pool.State == "error" {
 			return "", fmt.Errorf("wait failed, state was error\n")
-		} else {
-			return pool.State, nil
 		}
+		return pool.State, nil
 	}
 }
 
@@ -521,9 +516,8 @@ func (handler *HttpApiHandler) Request(method string, path string, body interfac
 		err = json.Unmarshal(respBody, &errorBody)
 		if err == nil {
 			return fmt.Errorf("%d %s", resp.StatusCode, errorBody.Error)
-		} else {
-			return fmt.Errorf("bad status code %d", resp.StatusCode)
 		}
+		return fmt.Errorf("bad status code %d", resp.StatusCode)
 	}
 
 	if os.Getenv("DEBUG_HTTP_ALL") != "" || (hasBody && os.Getenv("DEBUG_HTTP") != "") {

--- a/api/pkg/types/knowledge.go
+++ b/api/pkg/types/knowledge.go
@@ -128,21 +128,21 @@ type KnowledgeSource struct {
 	Content   *string                        `json:"text"`
 }
 
-func (m KnowledgeSource) Value() (driver.Value, error) {
-	j, err := json.Marshal(m)
+func (k KnowledgeSource) Value() (driver.Value, error) {
+	j, err := json.Marshal(k)
 	return j, err
 }
 
-func (t *KnowledgeSource) Scan(src interface{}) error {
+func (k *KnowledgeSource) Scan(src interface{}) error {
 	source, ok := src.([]byte)
 	if !ok {
-		return errors.New("type assertion .([]byte) failed.")
+		return errors.New("type assertion .([]byte) failed")
 	}
 	var result KnowledgeSource
 	if err := json.Unmarshal(source, &result); err != nil {
 		return err
 	}
-	*t = result
+	*k = result
 	return nil
 }
 
@@ -225,21 +225,21 @@ type CrawledSources struct {
 	// TODO: files?
 }
 
-func (m CrawledSources) Value() (driver.Value, error) {
-	j, err := json.Marshal(m)
+func (c CrawledSources) Value() (driver.Value, error) {
+	j, err := json.Marshal(c)
 	return j, err
 }
 
-func (t *CrawledSources) Scan(src interface{}) error {
+func (c *CrawledSources) Scan(src interface{}) error {
 	source, ok := src.([]byte)
 	if !ok {
-		return errors.New("type assertion .([]byte) failed.")
+		return errors.New("type assertion .([]byte) failed")
 	}
 	var result CrawledSources
 	if err := json.Unmarshal(source, &result); err != nil {
 		return err
 	}
-	*t = result
+	*c = result
 	return nil
 }
 

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -118,21 +118,21 @@ type RAGSettings struct {
 	} `json:"typesense" yaml:"typesense"`
 }
 
-func (m RAGSettings) Value() (driver.Value, error) {
-	j, err := json.Marshal(m)
+func (r RAGSettings) Value() (driver.Value, error) {
+	j, err := json.Marshal(r)
 	return j, err
 }
 
-func (t *RAGSettings) Scan(src interface{}) error {
+func (r *RAGSettings) Scan(src interface{}) error {
 	source, ok := src.([]byte)
 	if !ok {
-		return errors.New("type assertion .([]byte) failed.")
+		return errors.New("type assertion .([]byte) failed")
 	}
 	var result RAGSettings
 	if err := json.Unmarshal(source, &result); err != nil {
 		return err
 	}
-	*t = result
+	*r = result
 	return nil
 }
 
@@ -196,7 +196,7 @@ type SessionMetadata struct {
 	Stream                  bool              `json:"stream"`
 	// Evals are cool. Scores are strings of floats so we can distinguish ""
 	// (not rated) from "0.0"
-	EvalRunId               string   `json:"eval_run_id"`
+	EvalRunID               string   `json:"eval_run_id"`
 	EvalUserScore           string   `json:"eval_user_score"`
 	EvalUserReason          string   `json:"eval_user_reason"`
 	EvalManualScore         string   `json:"eval_manual_score"`
@@ -397,16 +397,16 @@ func (m Interactions) Value() (driver.Value, error) {
 	return j, err
 }
 
-func (t *Interactions) Scan(src interface{}) error {
+func (m *Interactions) Scan(src interface{}) error {
 	source, ok := src.([]byte)
 	if !ok {
-		return errors.New("type assertion .([]byte) failed.")
+		return errors.New("type assertion .([]byte) failed")
 	}
 	var result Interactions
 	if err := json.Unmarshal(source, &result); err != nil {
 		return err
 	}
-	*t = result
+	*m = result
 	return nil
 }
 
@@ -419,16 +419,16 @@ func (m SessionMetadata) Value() (driver.Value, error) {
 	return j, err
 }
 
-func (t *SessionMetadata) Scan(src interface{}) error {
+func (m *SessionMetadata) Scan(src interface{}) error {
 	source, ok := src.([]byte)
 	if !ok {
-		return errors.New("type assertion .([]byte) failed.")
+		return errors.New("type assertion .([]byte) failed")
 	}
 	var result SessionMetadata
 	if err := json.Unmarshal(source, &result); err != nil {
 		return err
 	}
-	*t = result
+	*m = result
 	return nil
 }
 
@@ -891,15 +891,15 @@ type ToolConfig struct {
 	Zapier    *ToolZapierConfig    `json:"zapier"`
 }
 
-func (m ToolConfig) Value() (driver.Value, error) {
-	j, err := json.Marshal(m)
+func (t ToolConfig) Value() (driver.Value, error) {
+	j, err := json.Marshal(t)
 	return j, err
 }
 
 func (t *ToolConfig) Scan(src interface{}) error {
 	source, ok := src.([]byte)
 	if !ok {
-		return errors.New("type assertion .([]byte) failed.")
+		return errors.New("type assertion .([]byte) failed")
 	}
 	var result ToolConfig
 	if err := json.Unmarshal(source, &result); err != nil {
@@ -1072,21 +1072,21 @@ type AppConfig struct {
 	Github         *AppGithubConfig  `json:"github"`
 }
 
-func (m AppConfig) Value() (driver.Value, error) {
-	j, err := json.Marshal(m)
+func (c AppConfig) Value() (driver.Value, error) {
+	j, err := json.Marshal(c)
 	return j, err
 }
 
-func (t *AppConfig) Scan(src interface{}) error {
+func (c *AppConfig) Scan(src interface{}) error {
 	source, ok := src.([]byte)
 	if !ok {
-		return errors.New("type assertion .([]byte) failed.")
+		return errors.New("type assertion .([]byte) failed")
 	}
 	var result AppConfig
 	if err := json.Unmarshal(source, &result); err != nil {
 		return err
 	}
-	*t = result
+	*c = result
 	return nil
 }
 
@@ -1108,8 +1108,8 @@ type Trigger struct {
 	Cron    *CronTrigger    `json:"cron,omitempty"`
 }
 
-func (m Trigger) Value() (driver.Value, error) {
-	j, err := json.Marshal(m)
+func (t Trigger) Value() (driver.Value, error) {
+	j, err := json.Marshal(t)
 	return j, err
 }
 
@@ -1132,15 +1132,15 @@ func (Trigger) GormDataType() string {
 
 type Triggers []Trigger
 
-func (m Triggers) Value() (driver.Value, error) {
-	j, err := json.Marshal(m)
+func (t Triggers) Value() (driver.Value, error) {
+	j, err := json.Marshal(t)
 	return j, err
 }
 
 func (t *Triggers) Scan(src interface{}) error {
 	source, ok := src.([]byte)
 	if !ok {
-		return errors.New("type assertion .([]byte) failed.")
+		return errors.New("type assertion .([]byte) failed")
 	}
 	var result []Trigger
 	if err := json.Unmarshal(source, &result); err != nil {
@@ -1212,21 +1212,21 @@ type GptScriptResponse struct {
 	Retries int    `json:"retries"`
 }
 
-func (m GptScriptResponse) Value() (driver.Value, error) {
-	j, err := json.Marshal(m)
+func (g GptScriptResponse) Value() (driver.Value, error) {
+	j, err := json.Marshal(g)
 	return j, err
 }
 
-func (t *GptScriptResponse) Scan(src interface{}) error {
+func (g *GptScriptResponse) Scan(src interface{}) error {
 	source, ok := src.([]byte)
 	if !ok {
-		return errors.New("type assertion .([]byte) failed.")
+		return errors.New("type assertion .([]byte) failed")
 	}
 	var result GptScriptResponse
 	if err := json.Unmarshal(source, &result); err != nil {
 		return err
 	}
-	*t = result
+	*g = result
 	return nil
 }
 
@@ -1239,21 +1239,21 @@ type DataEntityConfig struct {
 	RAGSettings   RAGSettings `json:"rag_settings"`
 }
 
-func (m DataEntityConfig) Value() (driver.Value, error) {
-	j, err := json.Marshal(m)
+func (d DataEntityConfig) Value() (driver.Value, error) {
+	j, err := json.Marshal(d)
 	return j, err
 }
 
-func (t *DataEntityConfig) Scan(src interface{}) error {
+func (d *DataEntityConfig) Scan(src interface{}) error {
 	source, ok := src.([]byte)
 	if !ok {
-		return errors.New("type assertion .([]byte) failed.")
+		return errors.New("type assertion .([]byte) failed")
 	}
 	var result DataEntityConfig
 	if err := json.Unmarshal(source, &result); err != nil {
 		return err
 	}
-	*t = result
+	*d = result
 	return nil
 }
 
@@ -1317,21 +1317,21 @@ type GptScriptRunnerRequest struct {
 	GithubApp *GptScriptGithubApp `json:"github_app"`
 }
 
-func (m GptScriptRunnerRequest) Value() (driver.Value, error) {
-	j, err := json.Marshal(m)
+func (r GptScriptRunnerRequest) Value() (driver.Value, error) {
+	j, err := json.Marshal(r)
 	return j, err
 }
 
-func (t *GptScriptRunnerRequest) Scan(src interface{}) error {
+func (r *GptScriptRunnerRequest) Scan(src interface{}) error {
 	source, ok := src.([]byte)
 	if !ok {
-		return errors.New("type assertion .([]byte) failed.")
+		return errors.New("type assertion .([]byte) failed")
 	}
 	var result GptScriptRunnerRequest
 	if err := json.Unmarshal(source, &result); err != nil {
 		return err
 	}
-	*t = result
+	*r = result
 	return nil
 }
 

--- a/api/pkg/util/copydir/copy_dir.go
+++ b/api/pkg/util/copydir/copy_dir.go
@@ -47,9 +47,8 @@ func CopyDir(dst, src string) error {
 			// Skip any dot files
 			if info.IsDir() {
 				return filepath.SkipDir
-			} else {
-				return nil
 			}
+			return nil
 		}
 
 		// The "path" has the src prefixed to it. We need to join our


### PR DESCRIPTION
This commit is a first batch of revive linter
(https://golangci-lint.run/usage/linters/#revive) warnings that actually attempts to make Go code follow Go idioms and best practices:

* be consistent with receiver names! Dont just pick one for one method, and then a different name for another method - it creates confusion
* do not name variables such that the beginning of their name is the same as the name of the package i.e. no var in github package should start with GitHub - it stutters and frankly makes no sense.
* do not put `"."` at the end of errors you return; same with `"\"`
* avoid redundant `else` statements when all the `else` clause does is a `return` Just return!

Some unused code has been removed, too.

I'm also bumping the linter timeout. 