### PR TITLE
Revive vol2

### DIFF
--- a/api/pkg/cli/secret/create.go
+++ b/api/pkg/cli/secret/create.go
@@ -23,7 +23,7 @@ var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new secret",
 	Long:  `Create a new secret with a name and value.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		name, _ := cmd.Flags().GetString("name")
 		value, _ := cmd.Flags().GetString("value")
 		appID, _ := cmd.Flags().GetString("app-id")

--- a/api/pkg/cli/secret/list.go
+++ b/api/pkg/cli/secret/list.go
@@ -19,7 +19,7 @@ var listCmd = &cobra.Command{
 	Aliases: []string{"ls"},
 	Short:   "List helix secrets",
 	Long:    ``,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		apiClient, err := client.NewClientFromEnv()
 		if err != nil {
 			return err

--- a/api/pkg/cli/secret/update.go
+++ b/api/pkg/cli/secret/update.go
@@ -23,7 +23,7 @@ var updateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update a secret value",
 	Long:  `Update an existing secret by providing its name and updating its value.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		name, _ := cmd.Flags().GetString("name")
 		value, _ := cmd.Flags().GetString("value")
 

--- a/api/pkg/client/fs.go
+++ b/api/pkg/client/fs.go
@@ -24,7 +24,7 @@ func (c *HelixClient) FilestoreList(ctx context.Context, path string) ([]filesto
 	query.Add("path", path)
 	url.RawQuery = query.Encode()
 
-	err := c.makeRequest("GET", url.String(), nil, &resp)
+	err := c.makeRequest(http.MethodGet, url.String(), nil, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +37,7 @@ func (c *HelixClient) FilestoreDelete(ctx context.Context, path string) error {
 		return fmt.Errorf("path is required")
 	}
 
-	err := c.makeRequest("DELETE", "/filestore/delete?path="+path, nil, nil)
+	err := c.makeRequest(http.MethodDelete, "/filestore/delete?path="+path, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func (c *HelixClient) FilestoreUpload(ctx context.Context, path string, file io.
 	query.Add("path", path)
 	url.RawQuery = query.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, "POST", c.url+url.String(), body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url+url.String(), body)
 	if err != nil {
 		return err
 	}

--- a/api/pkg/controller/dataprep.go
+++ b/api/pkg/controller/dataprep.go
@@ -119,10 +119,10 @@ func (c *Controller) convertDocumentsToText(session *types.Session) (*types.Sess
 
 	// converting to text is quite fast but we don't have a scaling strategy for llamaindex right now
 	// so let's just have some control over large numbers of files in one session
-	err = system.ForEachConcurrently[string](
+	err = system.ForEachConcurrently(
 		filesToConvert,
 		5,
-		func(file string, i int) error {
+		func(file string, _ int) error {
 			fileURL := ""
 			filenameParts := strings.Split(file, ".")
 			originalFile := file

--- a/api/pkg/controller/filestore.go
+++ b/api/pkg/controller/filestore.go
@@ -67,7 +67,7 @@ func (c *Controller) GetFilestoreInteractionInputsPath(ctx types.OwnerContext, s
 	return c.GetFilestoreUserPath(ctx, GetInteractionInputsFolder(sessionID, interactionID))
 }
 
-func (c *Controller) GetFilestoreResultsPath(ctx types.OwnerContext, sessionID string, interactionID string) (string, error) {
+func (c *Controller) GetFilestoreResultsPath(ctx types.OwnerContext, sessionID string, _ string) (string, error) {
 	return c.GetFilestoreUserPath(ctx, GetSessionResultsFolder(sessionID))
 }
 

--- a/api/pkg/controller/handlers.go
+++ b/api/pkg/controller/handlers.go
@@ -73,18 +73,18 @@ func (c *Controller) GetAPIKeys(ctx context.Context, user *types.User) ([]*types
 }
 
 func (c *Controller) DeleteAPIKey(ctx context.Context, user *types.User, apiKey string) error {
-	fetchedApiKey, err := c.Options.Store.GetAPIKey(ctx, apiKey)
+	fetchedAPIKey, err := c.Options.Store.GetAPIKey(ctx, apiKey)
 	if err != nil {
 		return err
 	}
-	if fetchedApiKey == nil {
+	if fetchedAPIKey == nil {
 		return errors.New("no such key")
 	}
 	// only the owner of an api key can delete it
-	if fetchedApiKey.Owner != user.ID || fetchedApiKey.OwnerType != user.Type {
+	if fetchedAPIKey.Owner != user.ID || fetchedAPIKey.OwnerType != user.Type {
 		return errors.New("unauthorized")
 	}
-	err = c.Options.Store.DeleteAPIKey(ctx, fetchedApiKey.Key)
+	err = c.Options.Store.DeleteAPIKey(ctx, fetchedAPIKey.Key)
 	if err != nil {
 		return err
 	}
@@ -118,14 +118,14 @@ func (c *Controller) cleanOldRunnerMetrics(_ context.Context) error {
 	return nil
 }
 
-func (c *Controller) AddRunnerMetrics(ctx context.Context, metrics *types.RunnerState) (*types.RunnerState, error) {
+func (c *Controller) AddRunnerMetrics(_ context.Context, metrics *types.RunnerState) (*types.RunnerState, error) {
 	c.activeRunners.Store(metrics.ID, metrics)
 	return metrics, nil
 }
 
-func (c *Controller) GetDashboardData(ctx context.Context) (*types.DashboardData, error) {
+func (c *Controller) GetDashboardData(_ context.Context) (*types.DashboardData, error) {
 	runners := []*types.RunnerState{}
-	c.activeRunners.Range(func(i string, metrics *types.RunnerState) bool {
+	c.activeRunners.Range(func(_ string, metrics *types.RunnerState) bool {
 		runners = append(runners, metrics)
 		return true
 	})

--- a/api/pkg/controller/inference.go
+++ b/api/pkg/controller/inference.go
@@ -468,7 +468,7 @@ func (c *Controller) enrichPromptWithKnowledge(ctx context.Context, user *types.
 		return fmt.Errorf("failed to load RAG: %w", err)
 	}
 
-	knowledgeResults, knowledge, err := c.evaluateKnowledge(ctx, user, *req, assistant, opts)
+	knowledgeResults, knowledge, err := c.evaluateKnowledge(ctx, *req, assistant, opts)
 	if err != nil {
 		return fmt.Errorf("failed to load knowledge: %w", err)
 	}
@@ -520,7 +520,11 @@ func (c *Controller) evaluateRAG(ctx context.Context, user *types.User, req open
 	return ragContent, nil
 }
 
-func (c *Controller) evaluateKnowledge(ctx context.Context, user *types.User, req openai.ChatCompletionRequest, assistant *types.AssistantConfig, opts *ChatCompletionOptions) ([]*prompts.BackgroundKnowledge, *types.Knowledge, error) {
+func (c *Controller) evaluateKnowledge(
+	ctx context.Context,
+	req openai.ChatCompletionRequest,
+	assistant *types.AssistantConfig,
+	opts *ChatCompletionOptions) ([]*prompts.BackgroundKnowledge, *types.Knowledge, error) {
 	var (
 		backgroundKnowledge []*prompts.BackgroundKnowledge
 		usedKnowledge       *types.Knowledge
@@ -684,7 +688,7 @@ func setSystemPrompt(req *openai.ChatCompletionRequest, systemPrompt string) ope
 	return *req
 }
 
-func (c *Controller) GetRagClient(ctx context.Context, knowledge *types.Knowledge) (rag.RAG, error) {
+func (c *Controller) GetRagClient(_ context.Context, knowledge *types.Knowledge) (rag.RAG, error) {
 	if knowledge.RAGSettings.IndexURL != "" && knowledge.RAGSettings.QueryURL != "" {
 		return rag.NewLlamaindex(&knowledge.RAGSettings), nil
 	}

--- a/api/pkg/controller/knowledge/cron_test.go
+++ b/api/pkg/controller/knowledge/cron_test.go
@@ -56,11 +56,11 @@ func (suite *CronSuite) SetupTest() {
 	suite.reconciler, err = New(suite.cfg, suite.store, suite.filestore, suite.extractor, suite.rag, b)
 	suite.Require().NoError(err)
 
-	suite.reconciler.newRagClient = func(settings *types.RAGSettings) rag.RAG {
+	suite.reconciler.newRagClient = func(_ *types.RAGSettings) rag.RAG {
 		return suite.rag
 	}
 
-	suite.reconciler.newCrawler = func(k *types.Knowledge) (crawler.Crawler, error) {
+	suite.reconciler.newCrawler = func(_ *types.Knowledge) (crawler.Crawler, error) {
 		return suite.crawler, nil
 	}
 }

--- a/api/pkg/controller/knowledge/knowledge_extract_test.go
+++ b/api/pkg/controller/knowledge/knowledge_extract_test.go
@@ -57,11 +57,11 @@ func (suite *ExtractorSuite) SetupTest() {
 
 	suite.reconciler, err = New(suite.cfg, suite.store, suite.filestore, suite.extractor, suite.rag, b)
 	suite.Require().NoError(err)
-	suite.reconciler.newRagClient = func(settings *types.RAGSettings) rag.RAG {
+	suite.reconciler.newRagClient = func(_ *types.RAGSettings) rag.RAG {
 		return suite.rag
 	}
 
-	suite.reconciler.newCrawler = func(k *types.Knowledge) (crawler.Crawler, error) {
+	suite.reconciler.newCrawler = func(_ *types.Knowledge) (crawler.Crawler, error) {
 		return suite.crawler, nil
 	}
 }

--- a/api/pkg/controller/knowledge/knowledge_indexer_test.go
+++ b/api/pkg/controller/knowledge/knowledge_indexer_test.go
@@ -60,11 +60,11 @@ func (suite *IndexerSuite) SetupTest() {
 	suite.reconciler, err = New(suite.cfg, suite.store, suite.filestore, suite.extractor, suite.rag, b)
 	suite.Require().NoError(err)
 
-	suite.reconciler.newRagClient = func(settings *types.RAGSettings) rag.RAG {
+	suite.reconciler.newRagClient = func(_ *types.RAGSettings) rag.RAG {
 		return suite.rag
 	}
 
-	suite.reconciler.newCrawler = func(k *types.Knowledge) (crawler.Crawler, error) {
+	suite.reconciler.newCrawler = func(_ *types.Knowledge) (crawler.Crawler, error) {
 		return suite.crawler, nil
 	}
 }

--- a/api/pkg/controller/knowledge/query/query_test.go
+++ b/api/pkg/controller/knowledge/query/query_test.go
@@ -71,7 +71,7 @@ func (suite *QuerySuite) SetupTest() {
 	suite.query = New(&QueryConfig{
 		store:     suite.store,
 		apiClient: apiClient,
-		getRAGClient: func(ctx context.Context, knowledge *types.Knowledge) (rag.RAG, error) {
+		getRAGClient: func(_ context.Context, _ *types.Knowledge) (rag.RAG, error) {
 			return suite.rag, nil
 		},
 		model: model,

--- a/api/pkg/controller/knowledge/readability/readability.go
+++ b/api/pkg/controller/knowledge/readability/readability.go
@@ -29,7 +29,7 @@ type DefaultParser struct {
 	parser *readability.Parser
 }
 
-func (p *DefaultParser) Parse(ctx context.Context, content, u string) (*Article, error) {
+func (p *DefaultParser) Parse(_ context.Context, content, u string) (*Article, error) {
 	parsedURL, err := url.Parse(u)
 	if err != nil {
 		return nil, err

--- a/api/pkg/controller/queue.go
+++ b/api/pkg/controller/queue.go
@@ -14,7 +14,7 @@ import (
 )
 
 // TODO: remove
-func (c *Controller) ShiftSessionQueue(ctx context.Context, filter types.SessionFilter, runnerID string) (*types.Session, error) {
+func (c *Controller) ShiftSessionQueue(_ context.Context, filter types.SessionFilter, runnerID string) (*types.Session, error) {
 	// Default to requesting warm work
 	newWorkOnly := false
 

--- a/api/pkg/dataprep/text/dynamic.go
+++ b/api/pkg/dataprep/text/dynamic.go
@@ -24,6 +24,7 @@ func NewDynamicDataPrep(client openai.Client, model string, prompts ...string) *
 	if err != nil {
 		panic(err)
 	}
+	allPrompts = append(allPrompts, prompts...)
 
 	// use sensible defaults
 	return &DynamicDataPrep{
@@ -48,7 +49,7 @@ func (d *DynamicDataPrep) ExpandChunks(chunks []*DataPrepTextSplitterChunk) (
 }
 
 func (d *DynamicDataPrep) ConvertChunk(
-	ownerID, sessionID, chunk string, index int, documentID, documentGroupID, promptName string,
+	ownerID, sessionID, chunk string, _ int, documentID, documentGroupID, promptName string,
 ) ([]types.DataPrepTextQuestion, error) {
 	prompt, err := qapairs.FindPrompt(promptName)
 	if err != nil {

--- a/api/pkg/dataprep/text/types.go
+++ b/api/pkg/dataprep/text/types.go
@@ -6,6 +6,7 @@ import (
 
 type DataPrepTextQuestionGenerator interface {
 	ExpandChunks(chunks []*DataPrepTextSplitterChunk) ([]*DataPrepTextSplitterChunk, error)
+	// TODO: consider dropping index, as it's not being used anywhere at the moment
 	ConvertChunk(ownerID, sessionID, chunk string, index int, documentID, documentGroupID, promptName string) ([]types.DataPrepTextQuestion, error)
 	GetConcurrency() int
 	GetChunkSize() int

--- a/api/pkg/filestore/fs.go
+++ b/api/pkg/filestore/fs.go
@@ -12,6 +12,9 @@ import (
 	"github.com/helixml/helix/api/pkg/system"
 )
 
+// Compile-time interface check:
+var _ FileStore = (*FileSystemStorage)(nil)
+
 type FileSystemStorage struct {
 	basePath string
 	baseURL  string
@@ -26,7 +29,7 @@ func NewFileSystemStorage(basePath string, baseURL, secret string) *FileSystemSt
 	}
 }
 
-func (s *FileSystemStorage) List(ctx context.Context, prefix string) ([]FileStoreItem, error) {
+func (s *FileSystemStorage) List(_ context.Context, prefix string) ([]FileStoreItem, error) {
 	fullPath := filepath.Join(s.basePath, prefix)
 	files, err := os.ReadDir(fullPath)
 	if err != nil {
@@ -53,7 +56,7 @@ func (s *FileSystemStorage) List(ctx context.Context, prefix string) ([]FileStor
 	return items, nil
 }
 
-func (s *FileSystemStorage) Get(ctx context.Context, path string) (FileStoreItem, error) {
+func (s *FileSystemStorage) Get(_ context.Context, path string) (FileStoreItem, error) {
 	fullPath := filepath.Join(s.basePath, path)
 	info, err := os.Stat(fullPath)
 	if err != nil {
@@ -69,7 +72,7 @@ func (s *FileSystemStorage) Get(ctx context.Context, path string) (FileStoreItem
 	}, nil
 }
 
-func (s *FileSystemStorage) SignedURL(ctx context.Context, path string) (string, error) {
+func (s *FileSystemStorage) SignedURL(_ context.Context, path string) (string, error) {
 	return PresignURL(s.baseURL, "/"+path, s.secret, 20*time.Minute), nil
 }
 
@@ -94,7 +97,7 @@ func (s *FileSystemStorage) WriteFile(ctx context.Context, path string, r io.Rea
 	return s.Get(ctx, path)
 }
 
-func (s *FileSystemStorage) OpenFile(ctx context.Context, path string) (io.ReadCloser, error) {
+func (s *FileSystemStorage) OpenFile(_ context.Context, path string) (io.ReadCloser, error) {
 	fullPath := filepath.Join(s.basePath, path)
 
 	file, err := os.Open(fullPath)
@@ -105,13 +108,13 @@ func (s *FileSystemStorage) OpenFile(ctx context.Context, path string) (io.ReadC
 	return file, nil
 }
 
-func (s *FileSystemStorage) DownloadFolder(ctx context.Context, path string) (io.Reader, error) {
+func (s *FileSystemStorage) DownloadFolder(_ context.Context, path string) (io.Reader, error) {
 	fullPath := filepath.Join(s.basePath, path)
 	return system.GetTarStream(fullPath)
 }
 
 // UploadFolder uploads a folder from a tarball in the io.Reader to the specified path.
-func (s *FileSystemStorage) UploadFolder(ctx context.Context, path string, r io.Reader) error {
+func (s *FileSystemStorage) UploadFolder(_ context.Context, path string, r io.Reader) error {
 	// Determine the full path to the destination folder
 	fullPath := filepath.Join(s.basePath, path)
 
@@ -171,7 +174,7 @@ func (s *FileSystemStorage) Rename(ctx context.Context, path string, newPath str
 	return s.Get(ctx, newPath)
 }
 
-func (s *FileSystemStorage) Delete(ctx context.Context, path string) error {
+func (s *FileSystemStorage) Delete(_ context.Context, path string) error {
 	fullPath := filepath.Join(s.basePath, path)
 
 	if err := os.RemoveAll(fullPath); err != nil {
@@ -191,7 +194,7 @@ func (s *FileSystemStorage) CreateFolder(ctx context.Context, path string) (File
 	return s.Get(ctx, path)
 }
 
-func (s *FileSystemStorage) CopyFile(ctx context.Context, fromPath string, toPath string) error {
+func (s *FileSystemStorage) CopyFile(_ context.Context, fromPath string, toPath string) error {
 	fullFromPath := filepath.Join(s.basePath, fromPath)
 	fullToPath := filepath.Join(s.basePath, toPath)
 
@@ -220,6 +223,3 @@ func (s *FileSystemStorage) CopyFile(ctx context.Context, fromPath string, toPat
 
 	return nil
 }
-
-// Compile-time interface check:
-var _ FileStore = (*FileSystemStorage)(nil)

--- a/api/pkg/gptscript/testfaster_runner.go
+++ b/api/pkg/gptscript/testfaster_runner.go
@@ -198,7 +198,13 @@ func (e *TestFasterExecutor) runGPTScriptTestfaster(ctx context.Context, script 
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	resp, err := http.Post(fmt.Sprintf("%s/api/v1/run/script", cluster.URL), "application/json", bytes.NewBuffer(reqBytes))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/api/v1/run/script", cluster.URL), bytes.NewBuffer(reqBytes))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send HTTP request: %w", err)
 	}
@@ -242,7 +248,13 @@ func (e *TestFasterExecutor) runGPTAppTestfaster(ctx context.Context, app *types
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	resp, err := http.Post(fmt.Sprintf("%s/api/v1/run/app", cluster.URL), "application/json", bytes.NewBuffer(reqBytes))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/api/v1/run/app", cluster.URL), bytes.NewBuffer(reqBytes))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send HTTP request: %w", err)
 	}

--- a/api/pkg/janitor/janitor.go
+++ b/api/pkg/janitor/janitor.go
@@ -42,7 +42,7 @@ func (j *Janitor) Initialize() error {
 			TracesSampleRate: 1.0,
 		})
 		if err != nil {
-			return fmt.Errorf("Sentry initialization failed: %v\n", err)
+			return fmt.Errorf("Sentry initialization failed: %v", err)
 		}
 		system.SetHTTPErrorHandler(func(err *system.HTTPError, req *http.Request) {
 			reportErrorWithRequest(err, req, map[string]interface{}{})
@@ -117,7 +117,8 @@ func (j *Janitor) WriteSubscriptionEvent(eventType types.SubscriptionEventType, 
 	message := func() string {
 		j.recentlyCreatedSubscriptionMutex.Lock()
 		defer j.recentlyCreatedSubscriptionMutex.Unlock()
-		if eventType == types.SubscriptionEventTypeCreated {
+		switch eventType {
+		case types.SubscriptionEventTypeCreated:
 			j.recentlyCreatedSubscriptionMap[user.Email] = true
 			go func() {
 				time.Sleep(10 * time.Second)
@@ -126,15 +127,15 @@ func (j *Janitor) WriteSubscriptionEvent(eventType types.SubscriptionEventType, 
 				delete(j.recentlyCreatedSubscriptionMap, user.Email)
 			}()
 			return fmt.Sprintf("💰 %s created a NEW subscription %s", user.Email, user.SubscriptionURL)
-		} else if eventType == types.SubscriptionEventTypeUpdated {
+		case types.SubscriptionEventTypeUpdated:
 			_, ok := j.recentlyCreatedSubscriptionMap[user.Email]
 			if ok {
 				return ""
 			}
 			return fmt.Sprintf("🎉 %s UPDATED their subscription %s", user.Email, user.SubscriptionURL)
-		} else if eventType == types.SubscriptionEventTypeDeleted {
+		case types.SubscriptionEventTypeDeleted:
 			return fmt.Sprintf("🛑 %s CANCELLED their subscription %s", user.Email, user.SubscriptionURL)
-		} else {
+		default:
 			return ""
 		}
 	}()

--- a/api/pkg/model/diffusers_generic.go
+++ b/api/pkg/model/diffusers_generic.go
@@ -18,7 +18,7 @@ type DiffusersGenericImage struct {
 	Hide        bool
 }
 
-func (i *DiffusersGenericImage) GetMemoryRequirements(mode types.SessionMode) uint64 {
+func (i *DiffusersGenericImage) GetMemoryRequirements(_ types.SessionMode) uint64 {
 	return i.Memory
 }
 
@@ -34,7 +34,7 @@ func (i *DiffusersGenericImage) ModelName() ModelName {
 	return NewModel(i.Id)
 }
 
-func (i *DiffusersGenericImage) GetTask(session *types.Session, fileManager ModelSessionFileManager) (*types.RunnerTask, error) {
+func (i *DiffusersGenericImage) GetTask(session *types.Session, _ ModelSessionFileManager) (*types.RunnerTask, error) {
 	task, err := getGenericTask(session)
 	if err != nil {
 		return nil, err
@@ -43,15 +43,15 @@ func (i *DiffusersGenericImage) GetTask(session *types.Session, fileManager Mode
 	return task, nil
 }
 
-func (i *DiffusersGenericImage) GetCommand(ctx context.Context, sessionFilter types.SessionFilter, config types.RunnerProcessConfig) (*exec.Cmd, error) {
+func (i *DiffusersGenericImage) GetCommand(_ context.Context, _ types.SessionFilter, _ types.RunnerProcessConfig) (*exec.Cmd, error) {
 	return nil, fmt.Errorf("not implemented 1")
 }
 
-func (i *DiffusersGenericImage) GetTextStreams(mode types.SessionMode, eventHandler WorkerEventHandler) (*TextStream, *TextStream, error) {
+func (i *DiffusersGenericImage) GetTextStreams(_ types.SessionMode, _ WorkerEventHandler) (*TextStream, *TextStream, error) {
 	return nil, nil, fmt.Errorf("not implemented 2")
 }
 
-func (i *DiffusersGenericImage) PrepareFiles(session *types.Session, isInitialSession bool, fileManager ModelSessionFileManager) (*types.Session, error) {
+func (i *DiffusersGenericImage) PrepareFiles(_ *types.Session, _ bool, _ ModelSessionFileManager) (*types.Session, error) {
 	return nil, fmt.Errorf("not implemented 3")
 }
 

--- a/api/pkg/model/ollama_generic.go
+++ b/api/pkg/model/ollama_generic.go
@@ -17,7 +17,7 @@ type OllamaGenericText struct {
 	Hide          bool
 }
 
-func (i *OllamaGenericText) GetMemoryRequirements(mode types.SessionMode) uint64 {
+func (i *OllamaGenericText) GetMemoryRequirements(_ types.SessionMode) uint64 {
 	return i.Memory
 }
 
@@ -38,7 +38,7 @@ func (i *OllamaGenericText) ModelName() ModelName {
 }
 
 // TODO(rusenask): probably noop
-func (i *OllamaGenericText) GetTask(session *types.Session, fileManager ModelSessionFileManager) (*types.RunnerTask, error) {
+func (i *OllamaGenericText) GetTask(session *types.Session, _ ModelSessionFileManager) (*types.RunnerTask, error) {
 	task, err := getGenericTask(session)
 	if err != nil {
 		return nil, err
@@ -47,15 +47,15 @@ func (i *OllamaGenericText) GetTask(session *types.Session, fileManager ModelSes
 	return task, nil
 }
 
-func (i *OllamaGenericText) GetCommand(ctx context.Context, sessionFilter types.SessionFilter, config types.RunnerProcessConfig) (*exec.Cmd, error) {
+func (i *OllamaGenericText) GetCommand(_ context.Context, _ types.SessionFilter, _ types.RunnerProcessConfig) (*exec.Cmd, error) {
 	return nil, fmt.Errorf("not implemented 1")
 }
 
-func (i *OllamaGenericText) GetTextStreams(mode types.SessionMode, eventHandler WorkerEventHandler) (*TextStream, *TextStream, error) {
+func (i *OllamaGenericText) GetTextStreams(_ types.SessionMode, _ WorkerEventHandler) (*TextStream, *TextStream, error) {
 	return nil, nil, fmt.Errorf("not implemented 2")
 }
 
-func (i *OllamaGenericText) PrepareFiles(session *types.Session, isInitialSession bool, fileManager ModelSessionFileManager) (*types.Session, error) {
+func (i *OllamaGenericText) PrepareFiles(_ *types.Session, _ bool, _ ModelSessionFileManager) (*types.Session, error) {
 	return nil, fmt.Errorf("not implemented 3")
 }
 

--- a/api/pkg/openai/helix_openai_client.go
+++ b/api/pkg/openai/helix_openai_client.go
@@ -25,7 +25,7 @@ var _ HelixClient = &InternalHelixServer{}
 
 var chatCompletionTimeout = 180 * time.Second
 
-func ListModels(ctx context.Context) ([]model.OpenAIModel, error) {
+func ListModels(_ context.Context) ([]model.OpenAIModel, error) {
 	ollamaModels, err := model.GetDefaultOllamaModels()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Ollama models: %w", err)

--- a/api/pkg/openai/openai_client_test.go
+++ b/api/pkg/openai/openai_client_test.go
@@ -14,7 +14,7 @@ import (
 func TestRetry(t *testing.T) {
 	called := 0
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		called++
 
 		if called > 2 {
@@ -51,7 +51,7 @@ func TestDoNotRetryOnAuthFailures(t *testing.T) {
 func TestDoNotRetryOnAuthFailures_TestServer(t *testing.T) {
 	called := 0
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		called++
 
 		w.WriteHeader(http.StatusUnauthorized)

--- a/api/pkg/pubsub/nats.go
+++ b/api/pkg/pubsub/nats.go
@@ -177,7 +177,7 @@ func (n *Nats) Request(ctx context.Context, _, subject string, payload []byte, h
 	}
 }
 
-func (n *Nats) QueueSubscribe(_ context.Context, queue, subject string, conc int, handler func(msg *Message) error) (Subscription, error) {
+func (n *Nats) QueueSubscribe(_ context.Context, queue, subject string, handler func(msg *Message) error) (Subscription, error) {
 	sub, err := n.conn.QueueSubscribe(subject, queue, func(msg *nats.Msg) {
 		err := handler(&Message{
 			Reply:  msg.Header.Get(helixNatsReplyHeader),
@@ -267,7 +267,7 @@ func (n *Nats) StreamRequest(ctx context.Context, stream, subject string, payloa
 
 // QueueSubscribe is similar to Subscribe, but it will only deliver a message to one subscriber in the group. This way you can
 // have multiple subscribers to the same subject, but only one gets it.
-func (n *Nats) StreamConsume(ctx context.Context, stream, subject string, conc int, handler func(msg *Message) error) (Subscription, error) {
+func (n *Nats) StreamConsume(ctx context.Context, stream, subject string, handler func(msg *Message) error) (Subscription, error) {
 	n.consumerMu.Lock()
 	defer n.consumerMu.Unlock()
 

--- a/api/pkg/pubsub/nats_test.go
+++ b/api/pkg/pubsub/nats_test.go
@@ -140,7 +140,7 @@ func TestQueueMultipleSubs(t *testing.T) {
 		worker2 int
 	)
 
-	sub1, err := pubsub.QueueSubscribe(ctx, ScriptRunnerStream, AppQueue, 10, func(msg *Message) error {
+	sub1, err := pubsub.QueueSubscribe(ctx, ScriptRunnerStream, AppQueue, func(msg *Message) error {
 		err := pubsub.Publish(ctx, msg.Reply, []byte("world"))
 		require.NoError(t, err)
 
@@ -159,7 +159,7 @@ func TestQueueMultipleSubs(t *testing.T) {
 		}
 	}()
 
-	sub2, err := pubsub.QueueSubscribe(ctx, ScriptRunnerStream, AppQueue, 10, func(msg *Message) error {
+	sub2, err := pubsub.QueueSubscribe(ctx, ScriptRunnerStream, AppQueue, func(msg *Message) error {
 		err := pubsub.Publish(ctx, msg.Reply, []byte("world"))
 		require.NoError(t, err)
 		if ackErr := msg.Ack(); ackErr != nil {
@@ -223,7 +223,7 @@ func TestNatsStreaming(t *testing.T) {
 		// Wait a bit before starting the work
 		time.Sleep(1 * time.Second)
 
-		sub, err := pubsub.StreamConsume(ctx, ScriptRunnerStream, AppQueue, 10, func(msg *Message) error {
+		sub, err := pubsub.StreamConsume(ctx, ScriptRunnerStream, AppQueue, func(msg *Message) error {
 			err := pubsub.Publish(ctx, msg.Reply, []byte("world"))
 			require.NoError(t, err)
 
@@ -238,7 +238,7 @@ func TestNatsStreaming(t *testing.T) {
 			}
 		}()
 
-		sub2, err := pubsub.StreamConsume(ctx, ScriptRunnerStream, AppQueue, 10, func(msg *Message) error {
+		sub2, err := pubsub.StreamConsume(ctx, ScriptRunnerStream, AppQueue, func(msg *Message) error {
 			err := pubsub.Publish(ctx, msg.Reply, []byte("world"))
 			require.NoError(t, err)
 
@@ -303,7 +303,7 @@ func TestStreamRetries(t *testing.T) {
 
 	var nacks int
 
-	sub, err := pubsub.StreamConsume(ctx, ScriptRunnerStream, AppQueue, 10, func(msg *Message) error {
+	sub, err := pubsub.StreamConsume(ctx, ScriptRunnerStream, AppQueue, func(msg *Message) error {
 		t.Log("consume", string(msg.Data))
 		// Nack 5 messages and don't reply anything, they should be retried
 		if nacks < 5 {
@@ -373,7 +373,7 @@ func TestStreamMultipleSubs(t *testing.T) {
 		worker2 int
 	)
 
-	sub1, err := pubsub.StreamConsume(ctx, ScriptRunnerStream, AppQueue, 10, func(msg *Message) error {
+	sub1, err := pubsub.StreamConsume(ctx, ScriptRunnerStream, AppQueue, func(msg *Message) error {
 		err := pubsub.Publish(ctx, msg.Reply, []byte("world"))
 		require.NoError(t, err)
 
@@ -392,7 +392,7 @@ func TestStreamMultipleSubs(t *testing.T) {
 		}
 	}()
 
-	sub2, err := pubsub.StreamConsume(ctx, ScriptRunnerStream, AppQueue, 10, func(msg *Message) error {
+	sub2, err := pubsub.StreamConsume(ctx, ScriptRunnerStream, AppQueue, func(msg *Message) error {
 		err := pubsub.Publish(ctx, msg.Reply, []byte("world"))
 		require.NoError(t, err)
 
@@ -468,7 +468,7 @@ func TestStreamAfterDelay(t *testing.T) {
 		nacksMu sync.Mutex
 	)
 
-	sub, err := pubsub.StreamConsume(ctx, ScriptRunnerStream, AppQueue, 10, func(msg *Message) error {
+	sub, err := pubsub.StreamConsume(ctx, ScriptRunnerStream, AppQueue, func(msg *Message) error {
 		nacksMu.Lock()
 		defer nacksMu.Unlock()
 
@@ -552,7 +552,7 @@ func TestStreamFailOne(t *testing.T) {
 		wg.Wait()
 	}()
 
-	sub, err := pubsub.StreamConsume(ctx, ScriptRunnerStream, AppQueue, 10, func(msg *Message) error {
+	sub, err := pubsub.StreamConsume(ctx, ScriptRunnerStream, AppQueue, func(msg *Message) error {
 		if string(msg.Data) == "work-0" {
 			// Don't ack or nack
 			t.Log("will not process this message")

--- a/api/pkg/pubsub/pubsub.go
+++ b/api/pkg/pubsub/pubsub.go
@@ -20,10 +20,10 @@ type PubSub interface {
 	Request(ctx context.Context, stream, sub string, payload []byte, header map[string]string, timeout time.Duration) ([]byte, error)
 	// QueueSubscribe subscribes to a topic with a queue group. Should be used for fast workloads, failed
 	// messages will not be redelivered. Slow consumers will block the queue group.
-	QueueSubscribe(ctx context.Context, stream, sub string, conc int, handler func(msg *Message) error) (Subscription, error)
+	QueueSubscribe(ctx context.Context, stream, sub string, handler func(msg *Message) error) (Subscription, error)
 
 	StreamRequest(ctx context.Context, stream, sub string, payload []byte, header map[string]string, timeout time.Duration) ([]byte, error)
-	StreamConsume(ctx context.Context, stream, sub string, conc int, handler func(msg *Message) error) (Subscription, error)
+	StreamConsume(ctx context.Context, stream, sub string, handler func(msg *Message) error) (Subscription, error)
 }
 
 type Message struct {

--- a/api/pkg/scheduler/scheduler.go
+++ b/api/pkg/scheduler/scheduler.go
@@ -121,7 +121,7 @@ func newSchedulerWithoutGoroutines(cfg *config.ServerConfig, onSchedulingErr fun
 
 // NewTimeoutFunc returns a function to check if a runner has been idle for a specified timeout duration.
 func NewTimeoutFunc(timeout time.Duration) TimeoutFunc {
-	return func(runnerID string, lastActivity time.Time) bool {
+	return func(_ string, lastActivity time.Time) bool {
 		// Check if the model has been unused for more than the specified timeout duration.
 		return time.Since(lastActivity) > timeout
 	}

--- a/api/pkg/scheduler/scheduler_test.go
+++ b/api/pkg/scheduler/scheduler_test.go
@@ -24,7 +24,7 @@ func TestScheduler_TimeoutRunner(t *testing.T) {
 	scheduler := NewScheduler(context.Background(), &config, nil)
 
 	// Monkeypatch the scheduler's cluster
-	timeoutRunner1Func := func(id string, t time.Time) bool {
+	timeoutRunner1Func := func(id string, _ time.Time) bool {
 		return id == "test-runner-1"
 	}
 	cluster := NewCluster(timeoutRunner1Func)

--- a/api/pkg/scheduler/strategy_test.go
+++ b/api/pkg/scheduler/strategy_test.go
@@ -15,7 +15,7 @@ const (
 )
 
 var (
-	dummyTimeout = func(runnerID string, lastActivityTime time.Time) bool {
+	dummyTimeout = func(_ string, _ time.Time) bool {
 		return false
 	}
 	testModel, _ = model.GetModel(testModelStr)

--- a/api/pkg/server/websocket_server_gptscript_runner.go
+++ b/api/pkg/server/websocket_server_gptscript_runner.go
@@ -59,7 +59,7 @@ func (apiServer *HelixAPIServer) startGptScriptRunnerWebSocketServer(r *mux.Rout
 			Int("concurrency", concurrency).
 			Msgf("connected runner websocket: %s\n", runnerID)
 
-		appSub, err := apiServer.pubsub.StreamConsume(ctx, pubsub.ScriptRunnerStream, pubsub.AppQueue, concurrency, func(msg *pubsub.Message) error {
+		appSub, err := apiServer.pubsub.StreamConsume(ctx, pubsub.ScriptRunnerStream, pubsub.AppQueue, func(msg *pubsub.Message) error {
 			var messageType types.RunnerEventRequestType
 
 			switch msg.Header.Get("kind") {

--- a/api/pkg/store/postgres.go
+++ b/api/pkg/store/postgres.go
@@ -282,7 +282,7 @@ func (s *PostgresStore) GetUserMeta(
 	if userID == "" {
 		return nil, fmt.Errorf("userID cannot be empty")
 	}
-	row := s.pgDb.QueryRow(fmt.Sprintf(`
+	row := s.pgDb.QueryRowContext(ctx, fmt.Sprintf(`
 		SELECT %s
 		FROM usermeta WHERE id = $1
 	`, UsermetaFieldsString), userID)
@@ -298,7 +298,7 @@ func (s *PostgresStore) CreateUserMeta(
 	if err != nil {
 		return nil, err
 	}
-	_, err = s.pgDb.Exec(fmt.Sprintf(`
+	_, err = s.pgDb.ExecContext(ctx, fmt.Sprintf(`
 		INSERT INTO usermeta (
 			%s
 		) VALUES (
@@ -323,7 +323,7 @@ func (s *PostgresStore) UpdateUserMeta(
 	// prepend the ID to the values
 	values = append([]interface{}{user.ID}, values...)
 
-	_, err = s.pgDb.Exec(fmt.Sprintf(`
+	_, err = s.pgDb.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE usermeta SET
 			%s
 		WHERE id = $1
@@ -336,23 +336,23 @@ func (s *PostgresStore) UpdateUserMeta(
 	return &user, nil
 }
 
-func (d *PostgresStore) EnsureUserMeta(
+func (s *PostgresStore) EnsureUserMeta(
 	ctx context.Context,
 	user types.UserMeta,
 ) (*types.UserMeta, error) {
-	existing, err := d.GetUserMeta(ctx, user.ID)
+	existing, err := s.GetUserMeta(ctx, user.ID)
 	if err != nil || existing == nil {
-		return d.CreateUserMeta(ctx, user)
+		return s.CreateUserMeta(ctx, user)
 	}
-	return d.UpdateUserMeta(ctx, user)
+	return s.UpdateUserMeta(ctx, user)
 }
 
-func (d *PostgresStore) UpdateSessionMeta(
+func (s *PostgresStore) UpdateSessionMeta(
 	ctx context.Context,
 	data types.SessionMetaUpdate,
 ) (*types.Session, error) {
 	if data.Owner != "" {
-		_, err := d.pgDb.Exec(`
+		_, err := s.pgDb.Exec(`
 		UPDATE session SET
 			name = $2,
 			owner = $3,
@@ -363,7 +363,7 @@ func (d *PostgresStore) UpdateSessionMeta(
 			return nil, err
 		}
 	} else {
-		_, err := d.pgDb.Exec(`
+		_, err := s.pgDb.Exec(`
 		UPDATE session SET
 			name = $2
 		WHERE id = $1
@@ -373,7 +373,7 @@ func (d *PostgresStore) UpdateSessionMeta(
 		}
 	}
 
-	return d.GetSession(ctx, data.ID)
+	return s.GetSession(ctx, data.ID)
 }
 
 // Compile-time interface check:

--- a/api/pkg/store/postgres.go
+++ b/api/pkg/store/postgres.go
@@ -234,12 +234,14 @@ func getKeyValueIndexes(fields []string, offset int) string {
 	return strings.Join(parts, ", ")
 }
 
-var USERMETA_FIELDS = []string{
-	"id",
-	"config",
-}
+var (
+	UsermetaFields = []string{
+		"id",
+		"config",
+	}
 
-var USERMETA_FIELDS_STRING = strings.Join(USERMETA_FIELDS, ", ")
+	UsermetaFieldsString = strings.Join(UsermetaFields, ", ")
+)
 
 func scanUserMetaRow(row Scanner) (*types.UserMeta, error) {
 	user := &types.UserMeta{}
@@ -273,22 +275,22 @@ func getUserMetaValues(user *types.UserMeta) ([]interface{}, error) {
 	}, nil
 }
 
-func (d *PostgresStore) GetUserMeta(
+func (s *PostgresStore) GetUserMeta(
 	ctx context.Context,
 	userID string,
 ) (*types.UserMeta, error) {
 	if userID == "" {
 		return nil, fmt.Errorf("userID cannot be empty")
 	}
-	row := d.pgDb.QueryRow(fmt.Sprintf(`
+	row := s.pgDb.QueryRow(fmt.Sprintf(`
 		SELECT %s
 		FROM usermeta WHERE id = $1
-	`, USERMETA_FIELDS_STRING), userID)
+	`, UsermetaFieldsString), userID)
 
 	return scanUserMetaRow(row)
 }
 
-func (d *PostgresStore) CreateUserMeta(
+func (s *PostgresStore) CreateUserMeta(
 	ctx context.Context,
 	user types.UserMeta,
 ) (*types.UserMeta, error) {
@@ -296,13 +298,13 @@ func (d *PostgresStore) CreateUserMeta(
 	if err != nil {
 		return nil, err
 	}
-	_, err = d.pgDb.Exec(fmt.Sprintf(`
+	_, err = s.pgDb.Exec(fmt.Sprintf(`
 		INSERT INTO usermeta (
 			%s
 		) VALUES (
 			%s
 		)
-	`, USERMETA_FIELDS_STRING, getValueIndexes(USERMETA_FIELDS)), values...)
+	`, UsermetaFieldsString, getValueIndexes(UsermetaFields)), values...)
 
 	if err != nil {
 		return nil, err
@@ -310,7 +312,7 @@ func (d *PostgresStore) CreateUserMeta(
 	return &user, nil
 }
 
-func (d *PostgresStore) UpdateUserMeta(
+func (s *PostgresStore) UpdateUserMeta(
 	ctx context.Context,
 	user types.UserMeta,
 ) (*types.UserMeta, error) {
@@ -321,11 +323,11 @@ func (d *PostgresStore) UpdateUserMeta(
 	// prepend the ID to the values
 	values = append([]interface{}{user.ID}, values...)
 
-	_, err = d.pgDb.Exec(fmt.Sprintf(`
+	_, err = s.pgDb.Exec(fmt.Sprintf(`
 		UPDATE usermeta SET
 			%s
 		WHERE id = $1
-	`, getKeyValueIndexes(USERMETA_FIELDS, 1)), values...)
+	`, getKeyValueIndexes(UsermetaFields, 1)), values...)
 
 	if err != nil {
 		return nil, err
@@ -341,9 +343,8 @@ func (d *PostgresStore) EnsureUserMeta(
 	existing, err := d.GetUserMeta(ctx, user.ID)
 	if err != nil || existing == nil {
 		return d.CreateUserMeta(ctx, user)
-	} else {
-		return d.UpdateUserMeta(ctx, user)
 	}
+	return d.UpdateUserMeta(ctx, user)
 }
 
 func (d *PostgresStore) UpdateSessionMeta(
@@ -378,8 +379,8 @@ func (d *PostgresStore) UpdateSessionMeta(
 // Compile-time interface check:
 var _ Store = (*PostgresStore)(nil)
 
-func (d *PostgresStore) MigrateUp() error {
-	migrations, err := d.GetMigrations()
+func (s *PostgresStore) MigrateUp() error {
+	migrations, err := s.GetMigrations()
 	if err != nil {
 		return err
 	}
@@ -390,8 +391,8 @@ func (d *PostgresStore) MigrateUp() error {
 	return nil
 }
 
-func (d *PostgresStore) MigrateDown() error {
-	migrations, err := d.GetMigrations()
+func (s *PostgresStore) MigrateDown() error {
+	migrations, err := s.GetMigrations()
 	if err != nil {
 		return err
 	}
@@ -405,7 +406,7 @@ func (d *PostgresStore) MigrateDown() error {
 //go:embed migrations/*.sql
 var fs embed.FS
 
-func (d *PostgresStore) GetMigrations() (*migrate.Migrate, error) {
+func (s *PostgresStore) GetMigrations() (*migrate.Migrate, error) {
 	files, err := iofs.New(fs, "migrations")
 	if err != nil {
 		return nil, err
@@ -413,7 +414,7 @@ func (d *PostgresStore) GetMigrations() (*migrate.Migrate, error) {
 	migrations, err := migrate.NewWithSourceInstance(
 		"iofs",
 		files,
-		fmt.Sprintf("%s&&x-migrations-table=helix_schema_migrations", d.connectionString),
+		fmt.Sprintf("%s&&x-migrations-table=helix_schema_migrations", s.connectionString),
 	)
 	if err != nil {
 		return nil, err

--- a/api/pkg/system/http.go
+++ b/api/pkg/system/http.go
@@ -314,7 +314,7 @@ func PostRequestBuffer[ResultType any](
 ) (ResultType, error) {
 	var result ResultType
 	client := NewRetryClient(3)
-	req, err := retryablehttp.NewRequest("POST", URL(options, path), data)
+	req, err := retryablehttp.NewRequest(http.MethodPost, URL(options, path), data)
 	if err != nil {
 		return result, err
 	}
@@ -352,11 +352,11 @@ func PostRequestBuffer[ResultType any](
 
 func NewRetryClient(retryMax int) *retryablehttp.Client {
 	retryClient := retryablehttp.NewClient()
-	retryClient.RetryMax = 5
+	retryClient.RetryMax = retryMax
 	retryClient.Logger = stdlog.New(io.Discard, "", stdlog.LstdFlags)
 	retryClient.RequestLogHook = func(_ retryablehttp.Logger, req *http.Request, attempt int) {
 		switch {
-		case req.Method == "POST":
+		case req.Method == http.MethodPost:
 			log.Trace().
 				Str(req.Method, req.URL.String()).
 				Int("attempt", attempt).
@@ -369,7 +369,7 @@ func NewRetryClient(retryMax int) *retryablehttp.Client {
 				Msgf("")
 		}
 	}
-	retryClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	retryClient.CheckRetry = func(_ context.Context, resp *http.Response, err error) (bool, error) {
 		if resp == nil {
 			return true, err
 		}

--- a/api/pkg/testfaster_client/api.go
+++ b/api/pkg/testfaster_client/api.go
@@ -127,7 +127,7 @@ func getLeaseLoader(apiHandler HttpApiHandler, poolId, leaseId string) func() (s
 			return "", "", err
 		}
 		if lease.State == "error" {
-			return "", lease.Status, fmt.Errorf("wait failed, state was error\n")
+			return "", lease.Status, fmt.Errorf("wait failed, state was error")
 		}
 		return lease.State, lease.Status, nil
 	}
@@ -138,10 +138,10 @@ func getLeaseProcessor() func(envelope WebsocketEnvelope) (string, error) {
 		lease := &Lease{}
 		err := json.Unmarshal([]byte(envelope.Body), lease)
 		if err != nil {
-			return "", fmt.Errorf("Error decoding JSON body %s\n\n%s\n", err.Error(), envelope.Body)
+			return "", fmt.Errorf("Error decoding JSON body %s\n\n%s", err.Error(), envelope.Body)
 		}
 		if lease.State == "error" {
-			return "", fmt.Errorf("wait failed, state was error\n")
+			return "", fmt.Errorf("wait failed, state: %s", lease.State)
 		}
 		return lease.State, nil
 	}
@@ -310,7 +310,7 @@ func getPoolLoader(apiHandler HttpApiHandler, id string) func() (string, string,
 			return "", "", err
 		}
 		if pool.State == "error" {
-			return "", pool.Status, fmt.Errorf("wait failed, state was error\n")
+			return "", pool.Status, fmt.Errorf("wait failed, state was error")
 		}
 		return pool.State, pool.Status, nil
 	}
@@ -321,10 +321,10 @@ func getPoolProcessor() func(envelope WebsocketEnvelope) (string, error) {
 		pool := &Pool{}
 		err := json.Unmarshal([]byte(envelope.Body), pool)
 		if err != nil {
-			return "", fmt.Errorf("Error decoding JSON body %s\n\n%s\n", err.Error(), envelope.Body)
+			return "", fmt.Errorf("Error decoding JSON body %s\n\n%s", err.Error(), envelope.Body)
 		}
 		if pool.State == "error" {
-			return "", fmt.Errorf("wait failed, state was error\n")
+			return "", fmt.Errorf("wait failed, state was error")
 		}
 		return pool.State, nil
 	}
@@ -340,7 +340,7 @@ func waitForPool(apiHandler HttpApiHandler, poolSubscription *WebsocketSubscript
 		if state != "error" {
 			return nil
 		}
-		return fmt.Errorf("wait failed, state was: %s\n", state)
+		return fmt.Errorf("wait failed, state was: %s", state)
 	}
 
 	waiter := NewEntityWaiter(
@@ -468,7 +468,7 @@ func (handler *HttpApiHandler) Request(method string, path string, body interfac
 	var err error
 	var resp *http.Response
 
-	hasBody := body != nil && (method == "POST" || method == "PUT")
+	hasBody := body != nil && (method == http.MethodPost || method == http.MethodPut)
 
 	var reader io.Reader
 
@@ -538,7 +538,7 @@ func (handler *HttpApiHandler) Request(method string, path string, body interfac
 
 func (handler *HttpApiHandler) PingBackend() (*Backend, error) {
 	backend := &Backend{}
-	err := handler.Request("PUT", "/api/v1/backend/ping", nil, &backend)
+	err := handler.Request(http.MethodPut, "/api/v1/backend/ping", nil, &backend)
 	if err != nil {
 		log.Printf("Error checking access token: %s\n", err)
 		return nil, err
@@ -548,7 +548,7 @@ func (handler *HttpApiHandler) PingBackend() (*Backend, error) {
 
 func (handler *HttpApiHandler) GetPools() ([]*Pool, error) {
 	poolArray := []*Pool{}
-	err := handler.Request("GET", "/api/v1/pools", nil, &poolArray)
+	err := handler.Request(http.MethodGet, "/api/v1/pools", nil, &poolArray)
 	if err != nil {
 		return nil, err
 	}
@@ -557,7 +557,7 @@ func (handler *HttpApiHandler) GetPools() ([]*Pool, error) {
 
 func (handler *HttpApiHandler) CreatePool(request *PoolRequest) (*Pool, error) {
 	pool := &Pool{}
-	err := handler.Request("POST", "/api/v1/pools", request, pool)
+	err := handler.Request(http.MethodPost, "/api/v1/pools", request, pool)
 	if err != nil {
 		return nil, err
 	}
@@ -566,7 +566,7 @@ func (handler *HttpApiHandler) CreatePool(request *PoolRequest) (*Pool, error) {
 
 func (handler *HttpApiHandler) GetPool(id string) (*Pool, error) {
 	pool := Pool{}
-	err := handler.Request("GET", fmt.Sprintf("/api/v1/pools/%s", id), nil, &pool)
+	err := handler.Request(http.MethodGet, fmt.Sprintf("/api/v1/pools/%s", id), nil, &pool)
 	if err != nil {
 		return nil, err
 	}
@@ -575,7 +575,7 @@ func (handler *HttpApiHandler) GetPool(id string) (*Pool, error) {
 
 func (handler *HttpApiHandler) UpdatePool(update PoolState) (*Pool, error) {
 	updatedPool := &Pool{}
-	err := handler.Request("PUT", fmt.Sprintf("/api/v1/pools/%s/state", update.PoolId), update, &updatedPool)
+	err := handler.Request(http.MethodPut, fmt.Sprintf("/api/v1/pools/%s/state", update.PoolId), update, &updatedPool)
 	if err != nil {
 		return nil, err
 	}
@@ -584,7 +584,7 @@ func (handler *HttpApiHandler) UpdatePool(update PoolState) (*Pool, error) {
 
 func (handler *HttpApiHandler) UpdatePoolMeta(update PoolState) (*Pool, error) {
 	updatedPool := &Pool{}
-	err := handler.Request("PUT", fmt.Sprintf("/api/v1/pools/%s/meta", update.PoolId), update, &updatedPool)
+	err := handler.Request(http.MethodPut, fmt.Sprintf("/api/v1/pools/%s/meta", update.PoolId), update, &updatedPool)
 	if err != nil {
 		return nil, err
 	}
@@ -593,7 +593,7 @@ func (handler *HttpApiHandler) UpdatePoolMeta(update PoolState) (*Pool, error) {
 
 func (handler *HttpApiHandler) CreateVm(vm *Vm) (*Vm, error) {
 	createdVm := &Vm{}
-	err := handler.Request("POST", fmt.Sprintf("/api/v1/pools/%s/vms", vm.Pool), vm, &createdVm)
+	err := handler.Request(http.MethodPost, fmt.Sprintf("/api/v1/pools/%s/vms", vm.Pool), vm, &createdVm)
 	if err != nil {
 		return nil, err
 	}
@@ -603,7 +603,7 @@ func (handler *HttpApiHandler) CreateVm(vm *Vm) (*Vm, error) {
 func (handler *HttpApiHandler) UpdateVm(update VmState) (*Vm, error) {
 	log.Printf("[UpdateVm] updating with %+v", update)
 	updatedVm := &Vm{}
-	err := handler.Request("PUT", fmt.Sprintf("/api/v1/pools/%s/vms/%s/state", update.PoolId, update.VmId), update, &updatedVm)
+	err := handler.Request(http.MethodPut, fmt.Sprintf("/api/v1/pools/%s/vms/%s/state", update.PoolId, update.VmId), update, &updatedVm)
 	if err != nil {
 		return nil, err
 	}
@@ -611,12 +611,12 @@ func (handler *HttpApiHandler) UpdateVm(update VmState) (*Vm, error) {
 }
 
 func (handler *HttpApiHandler) DeleteVm(poolId, vmId string) error {
-	return handler.Request("DELETE", fmt.Sprintf("/api/v1/pools/%s/vms/%s", poolId, vmId), nil, nil)
+	return handler.Request(http.MethodDelete, fmt.Sprintf("/api/v1/pools/%s/vms/%s", poolId, vmId), nil, nil)
 }
 
 func (handler *HttpApiHandler) GetLease(poolId, leaseId string) (*Lease, error) {
 	lease := Lease{}
-	err := handler.Request("GET", fmt.Sprintf("/api/v1/pools/%s/leases/%s", poolId, leaseId), nil, &lease)
+	err := handler.Request(http.MethodGet, fmt.Sprintf("/api/v1/pools/%s/leases/%s", poolId, leaseId), nil, &lease)
 	if err != nil {
 		return nil, err
 	}
@@ -625,7 +625,7 @@ func (handler *HttpApiHandler) GetLease(poolId, leaseId string) (*Lease, error) 
 
 func (handler *HttpApiHandler) CreateLease(lease *Lease) (*Lease, error) {
 	createdLease := &Lease{}
-	err := handler.Request("POST", fmt.Sprintf("/api/v1/pools/%s/leases", lease.Pool), lease, &createdLease)
+	err := handler.Request(http.MethodPost, fmt.Sprintf("/api/v1/pools/%s/leases", lease.Pool), lease, &createdLease)
 	if err != nil {
 		return nil, err
 	}
@@ -634,7 +634,7 @@ func (handler *HttpApiHandler) CreateLease(lease *Lease) (*Lease, error) {
 
 func (handler *HttpApiHandler) UpdateLease(update LeaseState) (*Lease, error) {
 	updatedLease := &Lease{}
-	err := handler.Request("PUT", fmt.Sprintf("/api/v1/pools/%s/leases/%s/state", update.PoolId, update.LeaseId), update, &updatedLease)
+	err := handler.Request(http.MethodPut, fmt.Sprintf("/api/v1/pools/%s/leases/%s/state", update.PoolId, update.LeaseId), update, &updatedLease)
 	if err != nil {
 		return nil, err
 	}
@@ -642,7 +642,7 @@ func (handler *HttpApiHandler) UpdateLease(update LeaseState) (*Lease, error) {
 }
 
 func (handler *HttpApiHandler) DeleteLease(poolID string, leaseID string) error {
-	err := handler.Request("DELETE", fmt.Sprintf("/api/v1/pools/%s/leases/%s", poolID, leaseID), "", "")
+	err := handler.Request(http.MethodDelete, fmt.Sprintf("/api/v1/pools/%s/leases/%s", poolID, leaseID), "", "")
 	if err != nil {
 		return err
 	}
@@ -651,7 +651,7 @@ func (handler *HttpApiHandler) DeleteLease(poolID string, leaseID string) error 
 
 func (handler *HttpApiHandler) PostData(url string, data interface{}) error {
 	return handler.Request(
-		"POST",
+		http.MethodPost,
 		url,
 		data,
 		nil,

--- a/api/pkg/testfaster_client/get.go
+++ b/api/pkg/testfaster_client/get.go
@@ -189,7 +189,7 @@ func (apiHandler *HttpApiHandler) Get(request *PoolRequest) (*Lease, error) {
 			Meta:  meta,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("Error posting lease: %s\n", err)
+			return nil, fmt.Errorf("Error posting lease: %s", err)
 		}
 		fmt.Printf("Lease created (%s)\n", lease.Id)
 	} else {
@@ -204,12 +204,12 @@ func (apiHandler *HttpApiHandler) Get(request *PoolRequest) (*Lease, error) {
 
 	leaseSubscription, err := socket.Subscribe(lease.GetSubscriptionChannel())
 	if err != nil {
-		return nil, fmt.Errorf("Error subscribing for lease updates: %s\n", err)
+		return nil, fmt.Errorf("Error subscribing for lease updates: %s", err)
 	}
 
 	leaseState, err := waitForLeaseAssigned(*apiHandler, leaseSubscription, pool.Id, lease.Id)
 	if err != nil {
-		return nil, fmt.Errorf("Error waiting for lease to be assigned: %s\n", err)
+		return nil, fmt.Errorf("Error waiting for lease to be assigned: %s", err)
 	}
 
 	tempKubeconfig := `# Testfaster intermediate kubeconfig (recording lease info before VM is
@@ -220,7 +220,7 @@ func (apiHandler *HttpApiHandler) Get(request *PoolRequest) (*Lease, error) {
 
 	err = os.WriteFile("kubeconfig", []byte(tempKubeconfig), 0644)
 	if err != nil {
-		return nil, fmt.Errorf("Error: could not write temp kubeconfig: %s\n", err)
+		return nil, fmt.Errorf("Error: could not write temp kubeconfig: %s", err)
 	}
 
 	fmt.Printf("\nNote: If you want to abort building the VM, you can now safely press ^C\n")
@@ -232,17 +232,17 @@ func (apiHandler *HttpApiHandler) Get(request *PoolRequest) (*Lease, error) {
 		fmt.Printf("Waiting for lease to be ready...\n")
 		lease, err = apiHandler.GetLease(pool.Id, lease.Id)
 		if err != nil {
-			return nil, fmt.Errorf("Error getting lease state: %s\n", err)
+			return nil, fmt.Errorf("Error getting lease state: %s", err)
 		}
 		stopLogsChan, err := streamVmLogs(socket, pool.Id, lease.Vm)
 		if err != nil {
-			return nil, fmt.Errorf("Error getting logs channel for lease: %s\n", err)
+			return nil, fmt.Errorf("Error getting logs channel for lease: %s", err)
 		}
 		_, err = waitForLeaseReady(*apiHandler, leaseSubscription, pool.Id, lease.Id)
 		stopLogsChan <- true
 		if err != nil {
 			lease, _ = apiHandler.GetLease(pool.Id, lease.Id)
-			return nil, fmt.Errorf("Error waiting for lease: %s\n%+v\n", err, lease)
+			return nil, fmt.Errorf("Error waiting for lease: %s\n%+v", err, lease)
 		}
 	}
 
@@ -251,18 +251,18 @@ func (apiHandler *HttpApiHandler) Get(request *PoolRequest) (*Lease, error) {
 	err = socket.Unsubscribe(pool.GetSubscriptionChannel())
 
 	if err != nil {
-		return nil, fmt.Errorf("Error unsubscribing to pool events: %s\n", err)
+		return nil, fmt.Errorf("Error unsubscribing to pool events: %s", err)
 	}
 
 	lease, err = apiHandler.GetLease(pool.Id, lease.Id)
 
 	if err != nil {
-		return nil, fmt.Errorf("Error getting lease state: %s\n", err)
+		return nil, fmt.Errorf("Error getting lease state: %s", err)
 	}
 
 	err = os.WriteFile("kubeconfig", []byte(lease.Kubeconfig), 0644)
 	if err != nil {
-		return nil, fmt.Errorf("Error: could not write to kubeconfig: %s\n", err)
+		return nil, fmt.Errorf("Error: could not write to kubeconfig: %s", err)
 	}
 	fmt.Printf("Cluster acquired, now run:\n\n    export KUBECONFIG=$(pwd)/kubeconfig\n    kubectl get pods --all-namespaces\n\nConsider adding kubeconfig to .gitignore\n")
 

--- a/api/pkg/tools/tools_api_response.go
+++ b/api/pkg/tools/tools_api_response.go
@@ -23,10 +23,10 @@ func (c *ChainStrategy) interpretResponse(ctx context.Context, sessionID, intera
 		return c.handleErrorResponse(ctx, sessionID, interactionID, tool, resp.StatusCode, bts)
 	}
 
-	return c.handleSuccessResponse(ctx, sessionID, interactionID, tool, history, resp.StatusCode, bts)
+	return c.handleSuccessResponse(ctx, sessionID, interactionID, tool, history, bts)
 }
 
-func (c *ChainStrategy) handleSuccessResponse(ctx context.Context, sessionID, interactionID string, tool *types.Tool, history []*types.ToolHistoryMessage, statusCode int, body []byte) (*RunActionResponse, error) {
+func (c *ChainStrategy) handleSuccessResponse(ctx context.Context, sessionID, interactionID string, tool *types.Tool, history []*types.ToolHistoryMessage, body []byte) (*RunActionResponse, error) {
 	messages := c.prepareSuccessMessages(tool, history, body)
 	req := c.prepareChatCompletionRequest(messages, false, tool.Config.API.Model)
 
@@ -47,7 +47,7 @@ func (c *ChainStrategy) handleSuccessResponse(ctx context.Context, sessionID, in
 	}, nil
 }
 
-func (c *ChainStrategy) handleSuccessResponseStream(ctx context.Context, sessionID, interactionID string, tool *types.Tool, history []*types.ToolHistoryMessage, statusCode int, body []byte) (*openai.ChatCompletionStream, error) {
+func (c *ChainStrategy) handleSuccessResponseStream(ctx context.Context, sessionID, interactionID string, tool *types.Tool, history []*types.ToolHistoryMessage, body []byte) (*openai.ChatCompletionStream, error) {
 	messages := c.prepareSuccessMessages(tool, history, body)
 	req := c.prepareChatCompletionRequest(messages, true, tool.Config.API.Model)
 
@@ -124,10 +124,10 @@ func (c *ChainStrategy) interpretResponseStream(ctx context.Context, sessionID, 
 	}
 
 	if resp.StatusCode >= 400 {
-		return c.handleSuccessResponseStream(ctx, sessionID, interactionID, tool, history, resp.StatusCode, bts)
+		return c.handleSuccessResponseStream(ctx, sessionID, interactionID, tool, history, bts)
 	}
 
-	return c.handleSuccessResponseStream(ctx, sessionID, interactionID, tool, history, resp.StatusCode, bts)
+	return c.handleSuccessResponseStream(ctx, sessionID, interactionID, tool, history, bts)
 }
 
 func (c *ChainStrategy) prepareSuccessMessages(tool *types.Tool, history []*types.ToolHistoryMessage, body []byte) []openai.ChatCompletionMessage {

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -1116,7 +1116,7 @@ func (t Trigger) Value() (driver.Value, error) {
 func (t *Trigger) Scan(src interface{}) error {
 	source, ok := src.([]byte)
 	if !ok {
-		return errors.New("type assertion .([]byte) failed.")
+		return errors.New("type assertion .([]byte) failed")
 	}
 	var result Trigger
 	if err := json.Unmarshal(source, &result); err != nil {


### PR DESCRIPTION
This is a brand new batch of changes that will lead to our enabling of the https://golangci-lint.run/usage/linters/#revive linter

* no logic has changed
* consistent naming of receivers
* removed unused vars/func params
* some var/func names have been Go-ified (camel cased, etc.)

More to follow!