### PR TITLE
(refactor): Client context plumbing

### DIFF
--- a/api/cmd/helix/test.go
+++ b/api/cmd/helix/test.go
@@ -820,7 +820,7 @@ func deployApp(namespacedAppName string, yamlFile string) (string, error) {
 		},
 	}
 
-	createdApp, err := apiClient.CreateApp(app)
+	createdApp, err := apiClient.CreateApp(context.Background(), app)
 	if err != nil {
 		return "", fmt.Errorf("failed to create app: %w", err)
 	}
@@ -834,8 +834,10 @@ func deleteApp(namespacedAppName string) error {
 		return fmt.Errorf("failed to create API client: %w", err)
 	}
 
+	ctx := context.Background()
+
 	// First, we need to look up the app by name
-	existingApps, err := apiClient.ListApps(&client.AppFilter{})
+	existingApps, err := apiClient.ListApps(ctx, &client.AppFilter{})
 	if err != nil {
 		return fmt.Errorf("failed to list apps: %w", err)
 	}
@@ -853,7 +855,7 @@ func deleteApp(namespacedAppName string) error {
 	}
 
 	// Delete the app
-	if err := apiClient.DeleteApp(appID, true); err != nil {
+	if err := apiClient.DeleteApp(ctx, appID, true); err != nil {
 		return fmt.Errorf("failed to delete app: %w", err)
 	}
 

--- a/api/pkg/cli/app/cmd.go
+++ b/api/pkg/cli/app/cmd.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/helixml/helix/api/pkg/client"
@@ -22,8 +23,8 @@ func New() *cobra.Command {
 	return rootCmd
 }
 
-func lookupApp(apiClient *client.HelixClient, ref string) (*types.App, error) {
-	apps, err := apiClient.ListApps(&client.AppFilter{})
+func lookupApp(ctx context.Context, apiClient *client.HelixClient, ref string) (*types.App, error) {
+	apps, err := apiClient.ListApps(ctx, &client.AppFilter{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list apps: %w", err)
 	}

--- a/api/pkg/cli/app/inspect.go
+++ b/api/pkg/cli/app/inspect.go
@@ -27,7 +27,7 @@ var inspectCmd = &cobra.Command{
 			return err
 		}
 
-		app, err := lookupApp(apiClient, args[0])
+		app, err := lookupApp(cmd.Context(), apiClient, args[0])
 		if err != nil {
 			return fmt.Errorf("failed to lookup app: %w", err)
 		}

--- a/api/pkg/cli/app/list.go
+++ b/api/pkg/cli/app/list.go
@@ -36,7 +36,7 @@ var listCmd = &cobra.Command{
 			return err
 		}
 
-		apps, err := apiClient.ListApps(&client.AppFilter{})
+		apps, err := apiClient.ListApps(cmd.Context(), &client.AppFilter{})
 		if err != nil {
 			return fmt.Errorf("failed to list apps: %w", err)
 		}

--- a/api/pkg/cli/app/remove.go
+++ b/api/pkg/cli/app/remove.go
@@ -33,13 +33,13 @@ var removeCmd = &cobra.Command{
 			return err
 		}
 
-		app, err := lookupApp(apiClient, args[0])
+		app, err := lookupApp(cmd.Context(), apiClient, args[0])
 		if err != nil {
 			return fmt.Errorf("failed to lookup app: %w", err)
 		}
 
 		// Delete the app
-		if err := apiClient.DeleteApp(app.ID, knowledge); err != nil {
+		if err := apiClient.DeleteApp(cmd.Context(), app.ID, knowledge); err != nil {
 			return fmt.Errorf("failed to delete app: %w", err)
 		}
 

--- a/api/pkg/cli/knowledge/cmd.go
+++ b/api/pkg/cli/knowledge/cmd.go
@@ -1,6 +1,7 @@
 package knowledge
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/helixml/helix/api/pkg/client"
@@ -22,8 +23,8 @@ func New() *cobra.Command {
 	return rootCmd
 }
 
-func lookupKnowledge(apiClient *client.HelixClient, ref string) (*types.Knowledge, error) {
-	knowledge, err := apiClient.ListKnowledge(&client.KnowledgeFilter{})
+func lookupKnowledge(ctx context.Context, apiClient *client.HelixClient, ref string) (*types.Knowledge, error) {
+	knowledge, err := apiClient.ListKnowledge(ctx, &client.KnowledgeFilter{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list apps: %w", err)
 	}

--- a/api/pkg/cli/knowledge/inspect.go
+++ b/api/pkg/cli/knowledge/inspect.go
@@ -23,7 +23,7 @@ var inspectCmd = &cobra.Command{
 			return err
 		}
 
-		knowledge, err := apiClient.GetKnowledge(args[0])
+		knowledge, err := apiClient.GetKnowledge(cmd.Context(), args[0])
 		if err != nil {
 			return fmt.Errorf("failed to get knowledge: %w", err)
 		}

--- a/api/pkg/cli/knowledge/list.go
+++ b/api/pkg/cli/knowledge/list.go
@@ -28,7 +28,7 @@ var listCmd = &cobra.Command{
 			return err
 		}
 
-		knowledge, err := apiClient.ListKnowledge(&client.KnowledgeFilter{})
+		knowledge, err := apiClient.ListKnowledge(cmd.Context(), &client.KnowledgeFilter{})
 		if err != nil {
 			return fmt.Errorf("failed to list knowledge: %w", err)
 		}

--- a/api/pkg/cli/knowledge/remove.go
+++ b/api/pkg/cli/knowledge/remove.go
@@ -27,7 +27,7 @@ var removeCmd = &cobra.Command{
 			return err
 		}
 
-		knowledges, err := apiClient.ListKnowledge(&client.KnowledgeFilter{})
+		knowledges, err := apiClient.ListKnowledge(cmd.Context(), &client.KnowledgeFilter{})
 		if err != nil {
 			return fmt.Errorf("failed to list knowledge: %w", err)
 		}
@@ -46,7 +46,7 @@ var removeCmd = &cobra.Command{
 		}
 
 		// Delete the knowledge
-		if err := apiClient.DeleteKnowledge(knowledge.ID); err != nil {
+		if err := apiClient.DeleteKnowledge(cmd.Context(), knowledge.ID); err != nil {
 			return fmt.Errorf("failed to delete knowledge: %w", err)
 		}
 

--- a/api/pkg/cli/knowledge/versions_list.go
+++ b/api/pkg/cli/knowledge/versions_list.go
@@ -27,12 +27,12 @@ var versionsListCmd = &cobra.Command{
 			return err
 		}
 
-		knowledge, err := lookupKnowledge(apiClient, args[0])
+		knowledge, err := lookupKnowledge(cmd.Context(), apiClient, args[0])
 		if err != nil {
 			return fmt.Errorf("failed to lookup knowledge: %w", err)
 		}
 
-		versions, err := apiClient.ListKnowledgeVersions(&client.KnowledgeVersionsFilter{
+		versions, err := apiClient.ListKnowledgeVersions(cmd.Context(), &client.KnowledgeVersionsFilter{
 			KnowledgeID: knowledge.ID,
 		})
 		if err != nil {

--- a/api/pkg/cli/secret/create.go
+++ b/api/pkg/cli/secret/create.go
@@ -49,7 +49,7 @@ var createCmd = &cobra.Command{
 			AppID: appID,
 		}
 
-		_, err = apiClient.CreateSecret(secret)
+		_, err = apiClient.CreateSecret(cmd.Context(), secret)
 		if err != nil {
 			return fmt.Errorf("failed to create secret: %w", err)
 		}

--- a/api/pkg/cli/secret/delete.go
+++ b/api/pkg/cli/secret/delete.go
@@ -39,7 +39,7 @@ var deleteCmd = &cobra.Command{
 		}
 
 		// Fetch the list of secrets
-		secrets, err := apiClient.ListSecrets()
+		secrets, err := apiClient.ListSecrets(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("failed to fetch secrets: %w", err)
 		}
@@ -58,7 +58,7 @@ var deleteCmd = &cobra.Command{
 		}
 
 		// Delete the secret
-		err = apiClient.DeleteSecret(secretID)
+		err = apiClient.DeleteSecret(cmd.Context(), secretID)
 		if err != nil {
 			return fmt.Errorf("failed to delete secret: %w", err)
 		}

--- a/api/pkg/cli/secret/list.go
+++ b/api/pkg/cli/secret/list.go
@@ -25,7 +25,7 @@ var listCmd = &cobra.Command{
 			return err
 		}
 
-		secrets, err := apiClient.ListSecrets()
+		secrets, err := apiClient.ListSecrets(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("failed to list secrets: %w", err)
 		}

--- a/api/pkg/cli/secret/update.go
+++ b/api/pkg/cli/secret/update.go
@@ -55,7 +55,7 @@ var updateCmd = &cobra.Command{
 		var existingSecret types.Secret
 
 		// Fetch the existing secret
-		secrets, err := apiClient.ListSecrets()
+		secrets, err := apiClient.ListSecrets(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("failed to fetch existing secret: %w", err)
 		}
@@ -74,7 +74,7 @@ var updateCmd = &cobra.Command{
 		// Update the secret fields if provided
 		existingSecret.Value = []byte(value)
 
-		_, err = apiClient.UpdateSecret(existingSecret.ID, &existingSecret)
+		_, err = apiClient.UpdateSecret(cmd.Context(), existingSecret.ID, &existingSecret)
 		if err != nil {
 			return fmt.Errorf("failed to update secret: %w", err)
 		}

--- a/api/pkg/client/app.go
+++ b/api/pkg/client/app.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -15,46 +16,46 @@ import (
 type AppFilter struct {
 }
 
-func (c *HelixClient) ListApps(f *AppFilter) ([]*types.App, error) {
+func (c *HelixClient) ListApps(ctx context.Context, f *AppFilter) ([]*types.App, error) {
 	var apps []*types.App
-	err := c.makeRequest(http.MethodGet, "/apps", nil, &apps)
+	err := c.makeRequest(ctx, http.MethodGet, "/apps", nil, &apps)
 	if err != nil {
 		return nil, err
 	}
 	return apps, nil
 }
 
-func (c *HelixClient) GetApp(appID string) (*types.App, error) {
+func (c *HelixClient) GetApp(ctx context.Context, appID string) (*types.App, error) {
 	var app types.App
-	err := c.makeRequest(http.MethodGet, "/apps/"+appID, nil, &app)
+	err := c.makeRequest(ctx, http.MethodGet, "/apps/"+appID, nil, &app)
 	if err != nil {
 		return nil, err
 	}
 	return &app, nil
 }
 
-func (c *HelixClient) CreateApp(app *types.App) (*types.App, error) {
+func (c *HelixClient) CreateApp(ctx context.Context, app *types.App) (*types.App, error) {
 	bts, err := json.Marshal(app)
 	if err != nil {
 		return nil, err
 	}
 
 	var createdApp types.App
-	err = c.makeRequest(http.MethodPost, "/apps", bytes.NewBuffer(bts), &createdApp)
+	err = c.makeRequest(ctx, http.MethodPost, "/apps", bytes.NewBuffer(bts), &createdApp)
 	if err != nil {
 		return nil, err
 	}
 	return &createdApp, nil
 }
 
-func (c *HelixClient) UpdateApp(app *types.App) (*types.App, error) {
+func (c *HelixClient) UpdateApp(ctx context.Context, app *types.App) (*types.App, error) {
 	bts, err := json.Marshal(app)
 	if err != nil {
 		return nil, err
 	}
 
 	var updatedApp types.App
-	err = c.makeRequest(http.MethodPut, "/apps/"+app.ID, bytes.NewBuffer(bts), &updatedApp)
+	err = c.makeRequest(ctx, http.MethodPut, "/apps/"+app.ID, bytes.NewBuffer(bts), &updatedApp)
 	if err != nil {
 		return nil, err
 	}
@@ -62,13 +63,13 @@ func (c *HelixClient) UpdateApp(app *types.App) (*types.App, error) {
 	return &updatedApp, nil
 }
 
-func (c *HelixClient) DeleteApp(appID string, deleteKnowledge bool) error {
+func (c *HelixClient) DeleteApp(ctx context.Context, appID string, deleteKnowledge bool) error {
 	query := url.Values{}
 	query.Add("knowledge", strconv.FormatBool(deleteKnowledge))
 
 	url := "/apps/" + appID + "?" + query.Encode()
 
-	err := c.makeRequest(http.MethodDelete, url, nil, nil)
+	err := c.makeRequest(ctx, http.MethodDelete, url, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -77,10 +78,10 @@ func (c *HelixClient) DeleteApp(appID string, deleteKnowledge bool) error {
 }
 
 // TODO: optimize this to not list all apps and instead use a server side filter
-func (c *HelixClient) GetAppByName(name string) (*types.App, error) {
+func (c *HelixClient) GetAppByName(ctx context.Context, name string) (*types.App, error) {
 	log.Debug().Str("name", name).Msg("getting app by name")
 
-	apps, err := c.ListApps(nil)
+	apps, err := c.ListApps(ctx, nil)
 	if err != nil {
 		log.Error().Err(err).Str("name", name).Msg("failed to list apps")
 		return nil, err

--- a/api/pkg/client/client.go
+++ b/api/pkg/client/client.go
@@ -17,23 +17,23 @@ import (
 )
 
 type Client interface {
-	CreateApp(app *types.App) (*types.App, error)
-	GetApp(appID string) (*types.App, error)
-	UpdateApp(app *types.App) (*types.App, error)
-	DeleteApp(appID string, deleteKnowledge bool) error
-	ListApps(f *AppFilter) ([]*types.App, error)
+	CreateApp(ctx context.Context, app *types.App) (*types.App, error)
+	GetApp(ctx context.Context, appID string) (*types.App, error)
+	UpdateApp(ctx context.Context, app *types.App) (*types.App, error)
+	DeleteApp(ctx context.Context, appID string, deleteKnowledge bool) error
+	ListApps(ctx context.Context, f *AppFilter) ([]*types.App, error)
 
-	ListKnowledge(f *KnowledgeFilter) ([]*types.Knowledge, error)
-	GetKnowledge(id string) (*types.Knowledge, error)
-	DeleteKnowledge(id string) error
-	RefreshKnowledge(id string) error
+	ListKnowledge(ctx context.Context, f *KnowledgeFilter) ([]*types.Knowledge, error)
+	GetKnowledge(ctx context.Context, id string) (*types.Knowledge, error)
+	DeleteKnowledge(ctx context.Context, id string) error
+	RefreshKnowledge(ctx context.Context, id string) error
 
-	ListSecrets() ([]*types.Secret, error)
-	CreateSecret(secret *types.CreateSecretRequest) (*types.Secret, error)
-	UpdateSecret(id string, secret *types.Secret) (*types.Secret, error)
-	DeleteSecret(id string) error
+	ListSecrets(ctx context.Context) ([]*types.Secret, error)
+	CreateSecret(ctx context.Context, secret *types.CreateSecretRequest) (*types.Secret, error)
+	UpdateSecret(ctx context.Context, id string, secret *types.Secret) (*types.Secret, error)
+	DeleteSecret(ctx context.Context, id string) error
 
-	ListKnowledgeVersions(f *KnowledgeVersionsFilter) ([]*types.KnowledgeVersion, error)
+	ListKnowledgeVersions(ctx context.Context, f *KnowledgeVersionsFilter) ([]*types.KnowledgeVersion, error)
 
 	FilestoreList(ctx context.Context, path string) ([]filestore.FileStoreItem, error)
 	FilestoreUpload(ctx context.Context, path string, file io.Reader) error
@@ -81,8 +81,8 @@ func NewClient(url, apiKey string) (*HelixClient, error) {
 	}, nil
 }
 
-func (c *HelixClient) makeRequest(method, path string, body io.Reader, v interface{}) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+func (c *HelixClient) makeRequest(ctx context.Context, method, path string, body io.Reader, v interface{}) error {
+	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	fullURL := c.url + path
@@ -102,7 +102,7 @@ func (c *HelixClient) makeRequest(method, path string, body io.Reader, v interfa
 		body = strings.NewReader(string(bodyBytes))
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, body)
+	req, err := http.NewRequestWithContext(reqCtx, method, fullURL, body)
 	if err != nil {
 		return err
 	}

--- a/api/pkg/client/fs.go
+++ b/api/pkg/client/fs.go
@@ -24,7 +24,7 @@ func (c *HelixClient) FilestoreList(ctx context.Context, path string) ([]filesto
 	query.Add("path", path)
 	url.RawQuery = query.Encode()
 
-	err := c.makeRequest(http.MethodGet, url.String(), nil, &resp)
+	err := c.makeRequest(ctx, http.MethodGet, url.String(), nil, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +37,7 @@ func (c *HelixClient) FilestoreDelete(ctx context.Context, path string) error {
 		return fmt.Errorf("path is required")
 	}
 
-	err := c.makeRequest(http.MethodDelete, "/filestore/delete?path="+path, nil, nil)
+	err := c.makeRequest(ctx, http.MethodDelete, "/filestore/delete?path="+path, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/api/pkg/client/knowledge.go
+++ b/api/pkg/client/knowledge.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -11,7 +12,7 @@ type KnowledgeFilter struct {
 	AppID string
 }
 
-func (c *HelixClient) ListKnowledge(f *KnowledgeFilter) ([]*types.Knowledge, error) {
+func (c *HelixClient) ListKnowledge(ctx context.Context, f *KnowledgeFilter) ([]*types.Knowledge, error) {
 	path := "/knowledge"
 	if f.AppID != "" {
 		path += "?app_id=" + f.AppID
@@ -19,7 +20,7 @@ func (c *HelixClient) ListKnowledge(f *KnowledgeFilter) ([]*types.Knowledge, err
 
 	var knowledge []*types.Knowledge
 
-	err := c.makeRequest(http.MethodGet, path, nil, &knowledge)
+	err := c.makeRequest(ctx, http.MethodGet, path, nil, &knowledge)
 	if err != nil {
 		return nil, err
 	}
@@ -27,11 +28,11 @@ func (c *HelixClient) ListKnowledge(f *KnowledgeFilter) ([]*types.Knowledge, err
 	return knowledge, nil
 }
 
-func (c *HelixClient) GetKnowledge(id string) (*types.Knowledge, error) {
+func (c *HelixClient) GetKnowledge(ctx context.Context, id string) (*types.Knowledge, error) {
 	path := "/knowledge/" + id
 
 	var knowledge *types.Knowledge
-	err := c.makeRequest(http.MethodGet, path, nil, &knowledge)
+	err := c.makeRequest(ctx, http.MethodGet, path, nil, &knowledge)
 	if err != nil {
 		return nil, err
 	}
@@ -39,16 +40,16 @@ func (c *HelixClient) GetKnowledge(id string) (*types.Knowledge, error) {
 	return knowledge, nil
 }
 
-func (c *HelixClient) DeleteKnowledge(id string) error {
-	err := c.makeRequest(http.MethodDelete, "/knowledge/"+id, nil, nil)
+func (c *HelixClient) DeleteKnowledge(ctx context.Context, id string) error {
+	err := c.makeRequest(ctx, http.MethodDelete, "/knowledge/"+id, nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to delete knowledge, %w", err)
 	}
 	return nil
 }
 
-func (c *HelixClient) RefreshKnowledge(id string) error {
-	err := c.makeRequest(http.MethodPost, "/knowledge/"+id+"/refresh", nil, nil)
+func (c *HelixClient) RefreshKnowledge(ctx context.Context, id string) error {
+	err := c.makeRequest(ctx, http.MethodPost, "/knowledge/"+id+"/refresh", nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to refresh knowledge, %w", err)
 	}
@@ -60,9 +61,9 @@ type KnowledgeVersionsFilter struct {
 	KnowledgeID string
 }
 
-func (c *HelixClient) ListKnowledgeVersions(f *KnowledgeVersionsFilter) ([]*types.KnowledgeVersion, error) {
+func (c *HelixClient) ListKnowledgeVersions(ctx context.Context, f *KnowledgeVersionsFilter) ([]*types.KnowledgeVersion, error) {
 	var knowledge []*types.KnowledgeVersion
-	err := c.makeRequest(http.MethodGet, fmt.Sprintf("/knowledge/%s/versions", f.KnowledgeID), nil, &knowledge)
+	err := c.makeRequest(ctx, http.MethodGet, fmt.Sprintf("/knowledge/%s/versions", f.KnowledgeID), nil, &knowledge)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/client/secret.go
+++ b/api/pkg/client/secret.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -10,9 +11,9 @@ import (
 )
 
 // ListSecrets retrieves a list of secrets
-func (c *HelixClient) ListSecrets() ([]*types.Secret, error) {
+func (c *HelixClient) ListSecrets(ctx context.Context) ([]*types.Secret, error) {
 	var secrets []*types.Secret
-	err := c.makeRequest(http.MethodGet, "/secrets", nil, &secrets)
+	err := c.makeRequest(ctx, http.MethodGet, "/secrets", nil, &secrets)
 	if err != nil {
 		return nil, err
 	}
@@ -20,7 +21,7 @@ func (c *HelixClient) ListSecrets() ([]*types.Secret, error) {
 }
 
 // CreateSecret creates a new secret
-func (c *HelixClient) CreateSecret(secret *types.CreateSecretRequest) (*types.Secret, error) {
+func (c *HelixClient) CreateSecret(ctx context.Context, secret *types.CreateSecretRequest) (*types.Secret, error) {
 	var createdSecret types.Secret
 
 	bts, err := json.Marshal(secret)
@@ -28,7 +29,7 @@ func (c *HelixClient) CreateSecret(secret *types.CreateSecretRequest) (*types.Se
 		return nil, fmt.Errorf("failed to marshal secret: %w", err)
 	}
 
-	err = c.makeRequest(http.MethodPost, "/secrets", bytes.NewBuffer(bts), &createdSecret)
+	err = c.makeRequest(ctx, http.MethodPost, "/secrets", bytes.NewBuffer(bts), &createdSecret)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +37,7 @@ func (c *HelixClient) CreateSecret(secret *types.CreateSecretRequest) (*types.Se
 }
 
 // UpdateSecret updates an existing secret
-func (c *HelixClient) UpdateSecret(id string, secret *types.Secret) (*types.Secret, error) {
+func (c *HelixClient) UpdateSecret(ctx context.Context, id string, secret *types.Secret) (*types.Secret, error) {
 	var updatedSecret types.Secret
 
 	bts, err := json.Marshal(secret)
@@ -44,7 +45,7 @@ func (c *HelixClient) UpdateSecret(id string, secret *types.Secret) (*types.Secr
 		return nil, fmt.Errorf("failed to marshal secret: %w", err)
 	}
 
-	err = c.makeRequest(http.MethodPut, fmt.Sprintf("/secrets/%s", id), bytes.NewBuffer(bts), &updatedSecret)
+	err = c.makeRequest(ctx, http.MethodPut, fmt.Sprintf("/secrets/%s", id), bytes.NewBuffer(bts), &updatedSecret)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +53,8 @@ func (c *HelixClient) UpdateSecret(id string, secret *types.Secret) (*types.Secr
 }
 
 // DeleteSecret deletes a secret by ID
-func (c *HelixClient) DeleteSecret(id string) error {
-	err := c.makeRequest(http.MethodDelete, fmt.Sprintf("/secrets/%s", id), nil, nil)
+func (c *HelixClient) DeleteSecret(ctx context.Context, id string) error {
+	err := c.makeRequest(ctx, http.MethodDelete, fmt.Sprintf("/secrets/%s", id), nil, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR refactors helix API and implements proper `context` plumbing.

The API client methods now accept `context` which is passed down to it from a callsite.

In some helix commands we do this e.g. https://github.com/helixml/helix/blob/790bc12e6a4b01f60d9a29ab6b13f805c1f1b506/api/pkg/cli/fs/remove.go#L32

But in others we dont. This is a terrible inconsistency that might prevent adding some functionality in the future (say, cli canellations, etc.)

We're now also passing context to `makeRequest` which then wraps it in the request timeout.