### PR TITLE
Rename vars so they follow idiomatic Go

### DIFF
--- a/api/cmd/helix/runner.go
+++ b/api/cmd/helix/runner.go
@@ -26,8 +26,8 @@ func NewRunnerOptions() *RunnerOptions {
 	return &RunnerOptions{
 		Runner: runner.RunnerOptions{
 			ID:                           getDefaultServeOptionString("RUNNER_ID", ""),
-			ApiHost:                      getDefaultServeOptionString("API_HOST", ""),
-			ApiToken:                     getDefaultServeOptionString("API_TOKEN", ""),
+			APIHost:                      getDefaultServeOptionString("API_HOST", ""),
+			APIToken:                     getDefaultServeOptionString("API_TOKEN", ""),
 			MemoryBytes:                  uint64(getDefaultServeOptionInt("MEMORY_BYTES", 0)),
 			MemoryString:                 getDefaultServeOptionString("MEMORY_STRING", ""),
 			GetTaskDelayMilliseconds:     getDefaultServeOptionInt("GET_TASK_DELAY_MILLISECONDS", 100),
@@ -77,12 +77,12 @@ func newRunnerCmd() *cobra.Command {
 	)
 
 	runnerCmd.PersistentFlags().StringVar(
-		&allOptions.Runner.ApiHost, "api-host", allOptions.Runner.ApiHost,
+		&allOptions.Runner.APIHost, "api-host", allOptions.Runner.APIHost,
 		`The base URL of the api - e.g. http://1.2.3.4:8080`,
 	)
 
 	runnerCmd.PersistentFlags().StringVar(
-		&allOptions.Runner.ApiToken, "api-token", allOptions.Runner.ApiToken,
+		&allOptions.Runner.APIToken, "api-token", allOptions.Runner.APIToken,
 		`The auth token for this runner`,
 	)
 
@@ -180,7 +180,7 @@ var WarmupSession_Model_Mistral7b = types.Session{
 	Updated:      time.Now(),
 	Mode:         "inference",
 	Type:         types.SessionTypeText,
-	ModelName:    model.Model_Axolotl_Mistral7b,
+	ModelName:    model.ModelAxolotlMistral7b,
 	LoraDir:      "",
 	Interactions: []*types.Interaction{ITX_A, ITX_B},
 	Owner:        "warmup-user",
@@ -208,7 +208,7 @@ var WarmupSession_Model_SDXL = types.Session{
 	Updated:      time.Now(),
 	Mode:         "inference",
 	Type:         types.SessionTypeImage,
-	ModelName:    model.Model_Cog_SDXL,
+	ModelName:    model.ModelCogSdxl,
 	LoraDir:      "",
 	Interactions: []*types.Interaction{ITX_A, ITX_B},
 	Owner:        "warmup-user",
@@ -218,7 +218,7 @@ var WarmupSession_Model_SDXL = types.Session{
 func runnerCLI(cmd *cobra.Command, options *RunnerOptions) error {
 	system.SetupLogging()
 
-	if options.Runner.ApiToken == "" {
+	if options.Runner.APIToken == "" {
 		return fmt.Errorf("api token is required")
 	}
 
@@ -254,17 +254,17 @@ func runnerCLI(cmd *cobra.Command, options *RunnerOptions) error {
 
 	// global state - expedient hack (TODO remove this when we switch cog away
 	// from downloading lora weights via http from the filestore)
-	model.APIHost = options.Runner.ApiHost
-	model.APIToken = options.Runner.ApiToken
+	model.APIHost = options.Runner.APIHost
+	model.APIToken = options.Runner.APIToken
 
 	if !options.Runner.MockRunner {
 		// Axolotl runtime warmup
 		if options.Runner.Config.Runtimes.Axolotl.Enabled {
 			for _, modelName := range options.Runner.Config.Runtimes.Axolotl.WarmupModels {
 				switch modelName {
-				case model.Model_Axolotl_Mistral7b:
+				case model.ModelAxolotlMistral7b:
 					log.Info().Msgf("Adding warmup session for model %s", modelName)
-				case model.Model_Cog_SDXL:
+				case model.ModelCogSdxl:
 					log.Info().Msgf("Adding warmup session for model %s", modelName)
 				default:
 					log.Error().Msgf("Unknown warmup model %s", modelName)
@@ -276,7 +276,7 @@ func runnerCLI(cmd *cobra.Command, options *RunnerOptions) error {
 		if options.Runner.Config.Runtimes.Ollama.Enabled && !options.Runner.Config.Runtimes.V2Engine {
 			for _, modelName := range options.Runner.Config.Runtimes.Ollama.WarmupModels {
 				switch modelName {
-				case model.Model_Ollama_Llama3_8b:
+				case model.ModelOllamaLlama38b:
 					log.Info().Msgf("Adding warmup session for model %s", modelName)
 				}
 			}

--- a/api/pkg/controller/handlers.go
+++ b/api/pkg/controller/handlers.go
@@ -41,12 +41,12 @@ func (c *Controller) CreateAPIKey(ctx context.Context, user *types.User, apiKey 
 }
 
 func (c *Controller) GetAPIKeys(ctx context.Context, user *types.User) ([]*types.APIKey, error) {
-	apiKeys, err := c.Options.Store.ListAPIKeys(ctx, &store.ListApiKeysQuery{
+	apiKeys, err := c.Options.Store.ListAPIKeys(ctx, &store.ListAPIKeysQuery{
 		Owner:     user.ID,
 		OwnerType: user.Type,
 		// filter by APIKeyType_API when deciding whether to auto-create user
 		// API keys
-		Type: types.APIKeyType_API,
+		Type: types.APIkeytypeAPI,
 	})
 	if err != nil {
 		return nil, err
@@ -54,7 +54,7 @@ func (c *Controller) GetAPIKeys(ctx context.Context, user *types.User) ([]*types
 	if len(apiKeys) == 0 {
 		_, err := c.CreateAPIKey(ctx, user, &types.APIKey{
 			Name: "default",
-			Type: types.APIKeyType_API,
+			Type: types.APIkeytypeAPI,
 		})
 		if err != nil {
 			return nil, err
@@ -62,7 +62,7 @@ func (c *Controller) GetAPIKeys(ctx context.Context, user *types.User) ([]*types
 		return c.GetAPIKeys(ctx, user)
 	}
 	// return all api key types
-	apiKeys, err = c.Options.Store.ListAPIKeys(ctx, &store.ListApiKeysQuery{
+	apiKeys, err = c.Options.Store.ListAPIKeys(ctx, &store.ListAPIKeysQuery{
 		Owner:     user.ID,
 		OwnerType: user.Type,
 	})

--- a/api/pkg/controller/inference.go
+++ b/api/pkg/controller/inference.go
@@ -199,7 +199,7 @@ func (c *Controller) evaluateToolUsage(ctx context.Context, user *types.User, re
 		return nil, false, fmt.Errorf("failed to emit run action step info: %w", err)
 	}
 
-	resp, err := c.ToolsPlanner.RunAction(ctx, vals.SessionID, vals.InteractionID, selectedTool, history, isActionable.Api)
+	resp, err := c.ToolsPlanner.RunAction(ctx, vals.SessionID, vals.InteractionID, selectedTool, history, isActionable.API)
 	if err != nil {
 		if emitErr := c.emitStepInfo(ctx, &types.StepInfo{
 			Name:    selectedTool.Name,
@@ -256,12 +256,12 @@ func (c *Controller) evaluateToolUsageStream(ctx context.Context, user *types.Us
 		return nil, false, fmt.Errorf("failed to emit step info: %w", err)
 	}
 
-	stream, err := c.ToolsPlanner.RunActionStream(ctx, vals.SessionID, vals.InteractionID, selectedTool, history, isActionable.Api)
+	stream, err := c.ToolsPlanner.RunActionStream(ctx, vals.SessionID, vals.InteractionID, selectedTool, history, isActionable.API)
 	if err != nil {
 		log.Warn().
 			Err(err).
 			Str("tool", selectedTool.Name).
-			Str("action", isActionable.Api).
+			Str("action", isActionable.API).
 			Msg("failed to perform action")
 
 		if emitErr := c.emitStepInfo(ctx, &types.StepInfo{
@@ -346,9 +346,9 @@ func (c *Controller) selectAndConfigureTool(ctx context.Context, user *types.Use
 		return nil, nil, false, nil
 	}
 
-	selectedTool, ok := getToolFromAction(assistant.Tools, isActionable.Api)
+	selectedTool, ok := getToolFromAction(assistant.Tools, isActionable.API)
 	if !ok {
-		return nil, nil, false, fmt.Errorf("tool not found for action: %s", isActionable.Api)
+		return nil, nil, false, fmt.Errorf("tool not found for action: %s", isActionable.API)
 	}
 
 	// If assistant has configured a model, give the hint to the tool that it should use that model too

--- a/api/pkg/controller/knowledge/crawler/firecrawl.go
+++ b/api/pkg/controller/knowledge/crawler/firecrawl.go
@@ -18,10 +18,10 @@ func NewFirecrawl(k *types.Knowledge) (*Firecrawl, error) {
 
 	var (
 		apiKey = k.Source.Web.Crawler.Firecrawl.APIKey
-		apiUrl = k.Source.Web.Crawler.Firecrawl.APIURL
+		apiURL = k.Source.Web.Crawler.Firecrawl.APIURL
 	)
 
-	app, err := firecrawl.NewFirecrawlApp(apiKey, apiUrl)
+	app, err := firecrawl.NewFirecrawlApp(apiKey, apiURL)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/controller/sessions.go
+++ b/api/pkg/controller/sessions.go
@@ -661,7 +661,7 @@ func (c *Controller) checkForActions(session *types.Session) (*types.Session, er
 	}
 
 	log.Info().
-		Str("api", isActionable.Api).
+		Str("api", isActionable.API).
 		Str("actionable", isActionable.NeedsTool).
 		Str("justification", isActionable.Justification).
 		Str("history", fmt.Sprintf("%+v", messageHistory)).
@@ -674,12 +674,12 @@ func (c *Controller) checkForActions(session *types.Session) (*types.Session, er
 	lastInteraction.Mode = types.SessionModeAction
 
 	lastInteraction.Mode = types.SessionModeAction
-	lastInteraction.Metadata["tool_action"] = isActionable.Api
+	lastInteraction.Metadata["tool_action"] = isActionable.API
 	lastInteraction.Metadata["tool_action_justification"] = isActionable.Justification
 
-	actionTool, ok := getToolFromAction(activeTools, isActionable.Api)
+	actionTool, ok := getToolFromAction(activeTools, isActionable.API)
 	if !ok {
-		return nil, fmt.Errorf("tool not found for action: %s", isActionable.Api)
+		return nil, fmt.Errorf("tool not found for action: %s", isActionable.API)
 	}
 
 	lastInteraction.Metadata["tool_id"] = actionTool.ID
@@ -1042,14 +1042,14 @@ func (c *Controller) CloneUntilInteraction(
 		return nil, err
 	}
 
-	newDocumentIds := map[string]string{}
+	newDocumentIDs := map[string]string{}
 
 	for filename, documentID := range newSession.Metadata.DocumentIDs {
 		newFile := strings.Replace(filename, oldPrefix, newPrefix, 1)
-		newDocumentIds[newFile] = documentID
+		newDocumentIDs[newFile] = documentID
 	}
 
-	newSession.Metadata.DocumentIDs = newDocumentIds
+	newSession.Metadata.DocumentIDs = newDocumentIDs
 
 	copyFile := func(filePath string) (string, error) {
 		newFile := strings.Replace(filePath, oldPrefix, newPrefix, 1)
@@ -1088,7 +1088,7 @@ func (c *Controller) CloneUntilInteraction(
 		}
 
 		for _, file := range interaction.Files {
-			if path.Base(file) == types.TEXT_DATA_PREP_QUESTIONS_FILE && req.Mode == types.CloneInteractionModeJustData && interaction.ID == userInteraction.ID {
+			if path.Base(file) == types.TextDataPrepQuestionsFile && req.Mode == types.CloneInteractionModeJustData && interaction.ID == userInteraction.ID {
 				// this means we are only copying the data and we've just come across the questions file
 				// in the last user interaction so we don't copy it
 				continue

--- a/api/pkg/controller/utils.go
+++ b/api/pkg/controller/utils.go
@@ -188,7 +188,7 @@ func appendQuestionsToFile(
 // for the moment, we append question pairs to the same file
 // eventually we will append questions to a JSONL file per source file
 func getQuestionsFilename(sourceFilename string) string {
-	return path.Join(path.Dir(sourceFilename), types.TEXT_DATA_PREP_QUESTIONS_FILE)
+	return path.Join(path.Dir(sourceFilename), types.TextDataPrepQuestionsFile)
 	// return fmt.Sprintf("%s%s", sourceFilename, types.TEXT_DATA_PREP_QUESTIONS_FILE_SUFFIX)
 }
 

--- a/api/pkg/data/utils.go
+++ b/api/pkg/data/utils.go
@@ -45,7 +45,7 @@ func GetInteractionFinetuneFile(session *types.Session, interactionID string) (s
 	}
 	foundFile := ""
 	for _, filepath := range interaction.Files {
-		if path.Base(filepath) == types.TEXT_DATA_PREP_QUESTIONS_FILE {
+		if path.Base(filepath) == types.TextDataPrepQuestionsFile {
 			foundFile = filepath
 			break
 		}

--- a/api/pkg/model/axolotl_mistral7b.go
+++ b/api/pkg/model/axolotl_mistral7b.go
@@ -34,7 +34,7 @@ func (l *Mistral7bInstruct01) GetType() types.SessionType {
 	return types.SessionTypeText
 }
 
-func (l *Mistral7bInstruct01) GetTask(session *types.Session, fileManager ModelSessionFileManager) (*types.RunnerTask, error) {
+func (l *Mistral7bInstruct01) GetTask(session *types.Session, fileManager SessionFileManager) (*types.RunnerTask, error) {
 	task, err := getGenericTask(session)
 	if err != nil {
 		return nil, err
@@ -120,7 +120,7 @@ func (l *Mistral7bInstruct01) GetTextStreams(mode types.SessionMode, eventHandle
 	return nil, nil, nil
 }
 
-func (l *Mistral7bInstruct01) PrepareFiles(session *types.Session, isInitialSession bool, fileManager ModelSessionFileManager) (*types.Session, error) {
+func (l *Mistral7bInstruct01) PrepareFiles(session *types.Session, isInitialSession bool, fileManager SessionFileManager) (*types.Session, error) {
 	var err error
 	if isInitialSession && session.Mode == types.SessionModeInference && session.LoraDir != "" {
 		session, err = downloadLoraDir(session, fileManager)
@@ -137,7 +137,7 @@ func (l *Mistral7bInstruct01) PrepareFiles(session *types.Session, isInitialSess
 		jsonLFiles := []string{}
 		for _, interaction := range finetuneInteractions {
 			for _, file := range interaction.Files {
-				if path.Base(file) == types.TEXT_DATA_PREP_QUESTIONS_FILE {
+				if path.Base(file) == types.TextDataPrepQuestionsFile {
 					localFilename := fmt.Sprintf("%s.jsonl", interaction.ID)
 					localPath := path.Join(fileManager.GetFolder(), localFilename)
 					err := fileManager.DownloadFile(file, localPath)
@@ -149,7 +149,7 @@ func (l *Mistral7bInstruct01) PrepareFiles(session *types.Session, isInitialSess
 			}
 		}
 
-		combinedFile := path.Join(fileManager.GetFolder(), types.TEXT_DATA_PREP_QUESTIONS_FILE)
+		combinedFile := path.Join(fileManager.GetFolder(), types.TextDataPrepQuestionsFile)
 		err = system.ConcatenateFiles(combinedFile, jsonLFiles, "\n")
 		if err != nil {
 			return nil, err

--- a/api/pkg/model/cog_sdxl.go
+++ b/api/pkg/model/cog_sdxl.go
@@ -45,7 +45,7 @@ func (l *CogSDXL) GetType() types.SessionType {
 	return types.SessionTypeImage
 }
 
-func (l *CogSDXL) GetTask(session *types.Session, fileManager ModelSessionFileManager) (*types.RunnerTask, error) {
+func (l *CogSDXL) GetTask(session *types.Session, fileManager SessionFileManager) (*types.RunnerTask, error) {
 	task, err := getGenericTask(session)
 	if err != nil {
 		return nil, err
@@ -125,7 +125,7 @@ func (l *CogSDXL) getMockCommand(ctx context.Context, sessionFilter types.Sessio
 	return cmd, nil
 }
 
-func (l *CogSDXL) PrepareFiles(session *types.Session, isInitialSession bool, fileManager ModelSessionFileManager) (*types.Session, error) {
+func (l *CogSDXL) PrepareFiles(session *types.Session, isInitialSession bool, fileManager SessionFileManager) (*types.Session, error) {
 	var err error
 	if isInitialSession && session.Mode == types.SessionModeInference && session.LoraDir != "" {
 		session, err = downloadLoraDir(session, fileManager)

--- a/api/pkg/model/diffusers_generic.go
+++ b/api/pkg/model/diffusers_generic.go
@@ -11,7 +11,7 @@ import (
 var _ Model = &DiffusersGenericImage{}
 
 type DiffusersGenericImage struct {
-	Id          string // e.g. "stabilityai/stable-diffusion-3.5-medium"
+	ID          string // e.g. "stabilityai/stable-diffusion-3.5-medium"
 	Name        string // e.g. "Stable Diffusion 3.5 Medium"
 	Memory      uint64
 	Description string
@@ -27,14 +27,14 @@ func (i *DiffusersGenericImage) GetType() types.SessionType {
 }
 
 func (i *DiffusersGenericImage) GetID() string {
-	return i.Id
+	return i.ID
 }
 
 func (i *DiffusersGenericImage) ModelName() ModelName {
-	return NewModel(i.Id)
+	return NewModel(i.ID)
 }
 
-func (i *DiffusersGenericImage) GetTask(session *types.Session, _ ModelSessionFileManager) (*types.RunnerTask, error) {
+func (i *DiffusersGenericImage) GetTask(session *types.Session, _ SessionFileManager) (*types.RunnerTask, error) {
 	task, err := getGenericTask(session)
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func (i *DiffusersGenericImage) GetTextStreams(_ types.SessionMode, _ WorkerEven
 	return nil, nil, fmt.Errorf("not implemented 2")
 }
 
-func (i *DiffusersGenericImage) PrepareFiles(_ *types.Session, _ bool, _ ModelSessionFileManager) (*types.Session, error) {
+func (i *DiffusersGenericImage) PrepareFiles(_ *types.Session, _ bool, _ SessionFileManager) (*types.Session, error) {
 	return nil, fmt.Errorf("not implemented 3")
 }
 

--- a/api/pkg/model/files.go
+++ b/api/pkg/model/files.go
@@ -9,7 +9,7 @@ import (
 // a generic lora dir downloader for a session
 func downloadLoraDir(
 	session *types.Session,
-	fileManager ModelSessionFileManager,
+	fileManager SessionFileManager,
 ) (*types.Session, error) {
 	if session.LoraDir == "" {
 		return session, nil

--- a/api/pkg/model/models.go
+++ b/api/pkg/model/models.go
@@ -50,7 +50,7 @@ func (m ModelName) InferenceRuntime() types.InferenceRuntime {
 	if strings.Contains(m.String(), ":") {
 		return types.InferenceRuntimeOllama
 	}
-	if m.String() == Model_Cog_SDXL {
+	if m.String() == ModelCogSdxl {
 		return types.InferenceRuntimeCog
 	}
 	diffusersModels, err := GetDefaultDiffusersModels()
@@ -58,7 +58,7 @@ func (m ModelName) InferenceRuntime() types.InferenceRuntime {
 		return types.InferenceRuntimeAxolotl
 	}
 	for _, model := range diffusersModels {
-		if m.String() == model.Id {
+		if m.String() == model.ID {
 			return types.InferenceRuntimeDiffusers
 		}
 	}
@@ -85,7 +85,7 @@ func ProcessModelName(
 	case types.SessionTypeText:
 		if sessionType == types.SessionTypeText && !ragEnabled && (sessionMode == types.SessionModeFinetune || hasFinetune) {
 			// fine tuning doesn't work with ollama yet
-			return Model_Axolotl_Mistral7b, nil
+			return ModelAxolotlMistral7b, nil
 		}
 
 		switch provider {
@@ -101,19 +101,19 @@ func ProcessModelName(
 		// TODO: we plan to retire the helix-* model names, but we are keeping for now for backwards compatibility
 		switch modelName {
 		case "helix-4":
-			return Model_Ollama_Llama3_70b, nil
+			return ModelOllamaLlama370b, nil
 		case "helix-3.5":
-			return Model_Ollama_Llama3_8b, nil
+			return ModelOllamaLlama38b, nil
 		case "helix-mixtral":
-			return Model_Ollama_Mixtral, nil
+			return ModelOllamaMixtral, nil
 		case "helix-json":
-			return Model_Ollama_NousHermes2ThetaLlama3, nil
+			return ModelOllamaNoushermes2thetallama3, nil
 		case "helix-small":
-			return Model_Ollama_Phi3, nil
+			return ModelOllamaPhi3, nil
 		default:
 			if modelName == "" {
 				// default text model for non-finetune inference
-				return Model_Ollama_Llama3_8b, nil
+				return ModelOllamaLlama38b, nil
 
 			} else {
 				// allow user-provided model name (e.g. assume API users
@@ -124,7 +124,7 @@ func ProcessModelName(
 	case types.SessionTypeImage:
 		if modelName == "" {
 			// default image model for image inference
-			return Model_Diffusers_SDTurbo, nil
+			return ModelDiffusersSdturbo, nil
 		}
 		// allow user-provided model name (e.g. assume API users
 		// know what they're doing).
@@ -140,45 +140,45 @@ func ProcessModelName(
 // this gives us an in memory cache of model instances we can quickly lookup from
 func GetModels() (map[string]Model, error) {
 	models := map[string]Model{}
-	models[Model_Axolotl_Mistral7b] = &Mistral7bInstruct01{}
-	models[Model_Cog_SDXL] = &CogSDXL{}
+	models[ModelAxolotlMistral7b] = &Mistral7bInstruct01{}
+	models[ModelCogSdxl] = &CogSDXL{}
 	ollamaModels, err := GetDefaultOllamaModels()
 	if err != nil {
 		return nil, err
 	}
 	for _, model := range ollamaModels {
-		models[model.Id] = model
+		models[model.ID] = model
 	}
 	diffusersModels, err := GetDefaultDiffusersModels()
 	if err != nil {
 		return nil, err
 	}
 	for _, model := range diffusersModels {
-		models[model.Id] = model
+		models[model.ID] = model
 	}
 	return models, nil
 }
 
 const (
-	Model_Axolotl_Mistral7b string = "mistralai/Mistral-7B-Instruct-v0.1"
-	Model_Cog_SDXL          string = "stabilityai/stable-diffusion-xl-base-1.0"
-	Model_Diffusers_SD35    string = "stabilityai/stable-diffusion-3.5-medium"
-	Model_Diffusers_SDTurbo string = "stabilityai/sd-turbo"
-	Model_Diffusers_FluxDev string = "black-forest-labs/FLUX.1-dev"
+	ModelAxolotlMistral7b string = "mistralai/Mistral-7B-Instruct-v0.1"
+	ModelCogSdxl          string = "stabilityai/stable-diffusion-xl-base-1.0"
+	ModelDiffusersSd35    string = "stabilityai/stable-diffusion-3.5-medium"
+	ModelDiffusersSdturbo string = "stabilityai/sd-turbo"
+	ModelDiffusersFluxdev string = "black-forest-labs/FLUX.1-dev"
 
 	// We only need constants for _some_ ollama models that are hardcoded in
 	// various places (backward compat). Other ones can be added dynamically now.
-	Model_Ollama_Llama3_8b              string = "llama3:instruct"
-	Model_Ollama_Mixtral                string = "mixtral:instruct"
-	Model_Ollama_NousHermes2ThetaLlama3 string = "adrienbrault/nous-hermes2theta-llama3-8b:q8_0"
-	Model_Ollama_Llama3_70b             string = "llama3:70b"
-	Model_Ollama_Phi3                   string = "phi3:instruct"
+	ModelOllamaLlama38b               string = "llama3:instruct"
+	ModelOllamaMixtral                string = "mixtral:instruct"
+	ModelOllamaNoushermes2thetallama3 string = "adrienbrault/nous-hermes2theta-llama3-8b:q8_0"
+	ModelOllamaLlama370b              string = "llama3:70b"
+	ModelOllamaPhi3                   string = "phi3:instruct"
 )
 
 func GetDefaultDiffusersModels() ([]*DiffusersGenericImage, error) {
 	return []*DiffusersGenericImage{
 		{
-			Id:          Model_Diffusers_FluxDev,
+			ID:          ModelDiffusersFluxdev,
 			Name:        "FLUX.1-dev",
 			Memory:      GB * 39,
 			Description: "High quality image model, from Black Forest Labs",
@@ -192,7 +192,7 @@ func GetDefaultOllamaModels() ([]*OllamaGenericText, error) {
 	models := []*OllamaGenericText{
 		// Latest models, Dec 2024 updates
 		{
-			Id:            "llama3.1:8b-instruct-q8_0", // https://ollama.com/library/llama3.1:8b-instruct-q8_0
+			ID:            "llama3.1:8b-instruct-q8_0", // https://ollama.com/library/llama3.1:8b-instruct-q8_0
 			Name:          "Llama 3.1 8B",
 			Memory:        GB * 15,
 			ContextLength: 32768, // goes up to 128k, but then uses 35GB
@@ -200,7 +200,7 @@ func GetDefaultOllamaModels() ([]*OllamaGenericText, error) {
 			Hide:          false,
 		},
 		{
-			Id:            "llama3.3:70b-instruct-q4_K_M", // https://ollama.com/library/llama3.1:70b-instruct-q4_K_M
+			ID:            "llama3.3:70b-instruct-q4_K_M", // https://ollama.com/library/llama3.1:70b-instruct-q4_K_M
 			Name:          "Llama 3.3 70B",
 			Memory:        GB * 48,
 			ContextLength: 16384,
@@ -208,7 +208,7 @@ func GetDefaultOllamaModels() ([]*OllamaGenericText, error) {
 			Hide:          false,
 		},
 		{
-			Id:            "llama3.2:1b-instruct-q8_0", // https://ollama.com/library/llama3.2:1b-instruct-q8_0
+			ID:            "llama3.2:1b-instruct-q8_0", // https://ollama.com/library/llama3.2:1b-instruct-q8_0
 			Name:          "Llama 3.2 1B",
 			Memory:        GB * 15,
 			ContextLength: 131072,
@@ -216,7 +216,7 @@ func GetDefaultOllamaModels() ([]*OllamaGenericText, error) {
 			Hide:          false,
 		},
 		{
-			Id:            "llama3.2:3b-instruct-q8_0", // https://ollama.com/library/llama3.2:3b-instruct-q8_0
+			ID:            "llama3.2:3b-instruct-q8_0", // https://ollama.com/library/llama3.2:3b-instruct-q8_0
 			Name:          "Llama 3.2 3B",
 			Memory:        GB * 26,
 			ContextLength: 131072,
@@ -224,7 +224,7 @@ func GetDefaultOllamaModels() ([]*OllamaGenericText, error) {
 			Hide:          false,
 		},
 		{
-			Id:            "phi3.5:3.8b-mini-instruct-q8_0", // https://ollama.com/library/phi3.5:3.8b-mini-instruct-q8_0
+			ID:            "phi3.5:3.8b-mini-instruct-q8_0", // https://ollama.com/library/phi3.5:3.8b-mini-instruct-q8_0
 			Name:          "Phi 3.5 3.8B",
 			Memory:        GB * 35,
 			ContextLength: 65536,
@@ -232,7 +232,7 @@ func GetDefaultOllamaModels() ([]*OllamaGenericText, error) {
 			Hide:          false,
 		},
 		{
-			Id:            "qwen2.5:7b-instruct-q8_0", // https://ollama.com/library/qwen2.5:7b-instruct-q8_0
+			ID:            "qwen2.5:7b-instruct-q8_0", // https://ollama.com/library/qwen2.5:7b-instruct-q8_0
 			Name:          "Qwen 2.5 7B",
 			Memory:        GB * 12,
 			ContextLength: 32768,
@@ -240,7 +240,7 @@ func GetDefaultOllamaModels() ([]*OllamaGenericText, error) {
 			Hide:          false,
 		},
 		{
-			Id:            "aya:8b-23-q8_0", // https://ollama.com/library/aya:8b-23-q8_0
+			ID:            "aya:8b-23-q8_0", // https://ollama.com/library/aya:8b-23-q8_0
 			Name:          "Aya 8B",
 			Memory:        GB * 11,
 			ContextLength: 8192,
@@ -248,7 +248,7 @@ func GetDefaultOllamaModels() ([]*OllamaGenericText, error) {
 			Hide:          false,
 		},
 		{
-			Id:            "aya:35b-23-q4_0", // https://ollama.com/library/aya:35b-23-q4_0
+			ID:            "aya:35b-23-q4_0", // https://ollama.com/library/aya:35b-23-q4_0
 			Name:          "Aya 35B",
 			Memory:        GB * 32,
 			ContextLength: 8192,
@@ -258,7 +258,7 @@ func GetDefaultOllamaModels() ([]*OllamaGenericText, error) {
 		// Old llama3:instruct and ph3:instruct, leaving in here because the id
 		// is in lots of our examples and tests
 		{
-			Id:            "llama3:instruct", // https://ollama.com/library/llama3:instruct
+			ID:            "llama3:instruct", // https://ollama.com/library/llama3:instruct
 			Name:          "Llama 3 8B",
 			Memory:        MB * 6390,
 			ContextLength: 8192,
@@ -266,7 +266,7 @@ func GetDefaultOllamaModels() ([]*OllamaGenericText, error) {
 			Hide:          true,
 		},
 		{
-			Id:            "phi3:instruct", // https://ollama.com/library/phi3:instruct
+			ID:            "phi3:instruct", // https://ollama.com/library/phi3:instruct
 			Name:          "Phi-3",
 			Memory:        MB * 2300,
 			ContextLength: 131072,
@@ -274,7 +274,7 @@ func GetDefaultOllamaModels() ([]*OllamaGenericText, error) {
 			Hide:          true,
 		},
 		{
-			Id:            "llama3:70b", // https://ollama.com/library/llama3:70b
+			ID:            "llama3:70b", // https://ollama.com/library/llama3:70b
 			Name:          "Llama 3 70B",
 			Memory:        GB * 40,
 			ContextLength: 8192,
@@ -282,7 +282,7 @@ func GetDefaultOllamaModels() ([]*OllamaGenericText, error) {
 			Hide:          true,
 		},
 		{
-			Id:            "gemma2:2b-instruct-q8_0", // https://ollama.com/library/gemma2:2b-instruct-q8_0
+			ID:            "gemma2:2b-instruct-q8_0", // https://ollama.com/library/gemma2:2b-instruct-q8_0
 			Name:          "Gemma 2 2B",
 			Memory:        MB * 4916,
 			ContextLength: 8192,

--- a/api/pkg/model/models_test.go
+++ b/api/pkg/model/models_test.go
@@ -43,7 +43,7 @@ func TestProcessModelName(t *testing.T) {
 				hasFinetune: false,
 				ragEnabled:  true,
 			},
-			want: NewModel(Model_Ollama_Llama3_8b),
+			want: NewModel(ModelOllamaLlama38b),
 		},
 		{
 			name: "empty model, finetune, no rag",
@@ -55,7 +55,7 @@ func TestProcessModelName(t *testing.T) {
 				hasFinetune: true,
 				ragEnabled:  false,
 			},
-			want: NewModel(Model_Axolotl_Mistral7b),
+			want: NewModel(ModelAxolotlMistral7b),
 		},
 		{
 			name: "normal inference",
@@ -67,7 +67,7 @@ func TestProcessModelName(t *testing.T) {
 				hasFinetune: false,
 				ragEnabled:  false,
 			},
-			want: NewModel(Model_Ollama_Llama3_8b),
+			want: NewModel(ModelOllamaLlama38b),
 		},
 		{
 			name: "normal inference, model set helix-4",
@@ -79,7 +79,7 @@ func TestProcessModelName(t *testing.T) {
 				hasFinetune: false,
 				ragEnabled:  false,
 			},
-			want: NewModel(Model_Ollama_Llama3_70b),
+			want: NewModel(ModelOllamaLlama370b),
 		},
 		{
 			name: "normal inference, model set helix-mixtral",
@@ -91,7 +91,7 @@ func TestProcessModelName(t *testing.T) {
 				hasFinetune: false,
 				ragEnabled:  false,
 			},
-			want: NewModel(Model_Ollama_Mixtral),
+			want: NewModel(ModelOllamaMixtral),
 		},
 	}
 	for _, tt := range tests {

--- a/api/pkg/model/ollama_generic.go
+++ b/api/pkg/model/ollama_generic.go
@@ -9,7 +9,7 @@ import (
 )
 
 type OllamaGenericText struct {
-	Id            string // e.g. "phi3.5:3.8b-mini-instruct-q8_0"
+	ID            string // e.g. "phi3.5:3.8b-mini-instruct-q8_0"
 	Name          string // e.g. "Phi 3.5"
 	Memory        uint64
 	ContextLength int64
@@ -30,15 +30,15 @@ func (i *OllamaGenericText) GetType() types.SessionType {
 }
 
 func (i *OllamaGenericText) GetID() string {
-	return i.Id
+	return i.ID
 }
 
 func (i *OllamaGenericText) ModelName() ModelName {
-	return NewModel(i.Id)
+	return NewModel(i.ID)
 }
 
 // TODO(rusenask): probably noop
-func (i *OllamaGenericText) GetTask(session *types.Session, _ ModelSessionFileManager) (*types.RunnerTask, error) {
+func (i *OllamaGenericText) GetTask(session *types.Session, _ SessionFileManager) (*types.RunnerTask, error) {
 	task, err := getGenericTask(session)
 	if err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func (i *OllamaGenericText) GetTextStreams(_ types.SessionMode, _ WorkerEventHan
 	return nil, nil, fmt.Errorf("not implemented 2")
 }
 
-func (i *OllamaGenericText) PrepareFiles(_ *types.Session, _ bool, _ ModelSessionFileManager) (*types.Session, error) {
+func (i *OllamaGenericText) PrepareFiles(_ *types.Session, _ bool, _ SessionFileManager) (*types.Session, error) {
 	return nil, fmt.Errorf("not implemented 3")
 }
 

--- a/api/pkg/model/types.go
+++ b/api/pkg/model/types.go
@@ -85,23 +85,23 @@ type Model interface {
 	// GetTask will be called on the session return from this function
 	// so PrepareFiles and GetTask very much work in tandem
 	// TODO: add the same for uploading files - i.e. the model shold have control over what happens
-	PrepareFiles(session *types.Session, isInitialSession bool, fileManager ModelSessionFileManager) (*types.Session, error)
+	PrepareFiles(session *types.Session, isInitialSession bool, fileManager SessionFileManager) (*types.Session, error)
 
 	// convert a session (which has an active mode i.e. inference or finetune) into a task
 	// this primarily means constructing the prompt
 	// and downloading files from the filestore
 	// we don't need to fill in the SessionID and Session fields
 	// the runner controller will do that for us
-	GetTask(session *types.Session, fileManager ModelSessionFileManager) (*types.RunnerTask, error)
+	GetTask(session *types.Session, fileManager SessionFileManager) (*types.RunnerTask, error)
 }
 
 // an interface that allows models to be opinionated about how they manage
 // a sessions files
 // for example, for text fine tuning - we want to download all JSONL files
 // across interactions and then concatenate them into one file
-// a ModelSessionFileManager implmentation will be per session and so have
+// a SessionFileManager implmentation will be per session and so have
 // allocated a folder for each session
-type ModelSessionFileManager interface {
+type SessionFileManager interface {
 	// tell the model what folder we are saving local files to
 	GetFolder() string
 	// given remote filestore path and local path

--- a/api/pkg/model/types_mocks.go
+++ b/api/pkg/model/types_mocks.go
@@ -72,7 +72,7 @@ func (mr *MockModelMockRecorder) GetMemoryRequirements(mode any) *gomock.Call {
 }
 
 // GetTask mocks base method.
-func (m *MockModel) GetTask(session *types.Session, fileManager ModelSessionFileManager) (*types.RunnerTask, error) {
+func (m *MockModel) GetTask(session *types.Session, fileManager SessionFileManager) (*types.RunnerTask, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTask", session, fileManager)
 	ret0, _ := ret[0].(*types.RunnerTask)
@@ -117,7 +117,7 @@ func (mr *MockModelMockRecorder) GetType() *gomock.Call {
 }
 
 // PrepareFiles mocks base method.
-func (m *MockModel) PrepareFiles(session *types.Session, isInitialSession bool, fileManager ModelSessionFileManager) (*types.Session, error) {
+func (m *MockModel) PrepareFiles(session *types.Session, isInitialSession bool, fileManager SessionFileManager) (*types.Session, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareFiles", session, isInitialSession, fileManager)
 	ret0, _ := ret[0].(*types.Session)

--- a/api/pkg/openai/helix_openai_client_test.go
+++ b/api/pkg/openai/helix_openai_client_test.go
@@ -93,7 +93,7 @@ func (suite *HelixClientTestSuite) Test_CreateChatCompletion_Response() {
 	})
 
 	resp, err := suite.srv.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
-		Model:    model.Model_Ollama_Llama3_8b,
+		Model:    model.ModelOllamaLlama38b,
 		Stream:   false,
 		Messages: []openai.ChatCompletionMessage{},
 	})
@@ -126,7 +126,7 @@ func (suite *HelixClientTestSuite) Test_CreateChatCompletion_ErrorResponse() {
 	})
 
 	_, err := suite.srv.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
-		Model:    model.Model_Ollama_Llama3_8b,
+		Model:    model.ModelOllamaLlama38b,
 		Stream:   false,
 		Messages: []openai.ChatCompletionMessage{},
 	})
@@ -195,7 +195,7 @@ func (suite *HelixClientTestSuite) Test_CreateChatCompletion_StreamingResponse()
 	})
 
 	stream, err := suite.srv.CreateChatCompletionStream(ctx, openai.ChatCompletionRequest{
-		Model:    model.Model_Ollama_Llama3_8b,
+		Model:    model.ModelOllamaLlama38b,
 		Stream:   true,
 		Messages: []openai.ChatCompletionMessage{},
 	})

--- a/api/pkg/openai/helix_openai_server_test.go
+++ b/api/pkg/openai/helix_openai_server_test.go
@@ -52,8 +52,8 @@ func (suite *HelixOpenAiServerTestSuite) SetupTest() {
 }
 
 func (suite *HelixOpenAiServerTestSuite) Test_GetNextLLMInferenceRequest() {
-	suite.Assert().NoError(enqueueTestLLMWorkload(suite.srv.scheduler, "req-1", model.Model_Ollama_Llama3_70b))
-	suite.Assert().NoError(enqueueTestLLMWorkload(suite.srv.scheduler, "req-2", model.Model_Ollama_Llama3_8b))
+	suite.Assert().NoError(enqueueTestLLMWorkload(suite.srv.scheduler, "req-1", model.ModelOllamaLlama370b))
+	suite.Assert().NoError(enqueueTestLLMWorkload(suite.srv.scheduler, "req-2", model.ModelOllamaLlama38b))
 
 	// Enough time for the internal goroutine to process the queue. No way of getting access to this
 	// outside of the scheduler.

--- a/api/pkg/runner/axolotl_model_instance.go
+++ b/api/pkg/runner/axolotl_model_instance.go
@@ -148,8 +148,8 @@ func NewAxolotlModelInstance(ctx context.Context, cfg *ModelInstanceConfig) (*Ax
 	id := system.GenerateUUID()
 
 	httpClientOptions := system.ClientOptions{
-		Host:  cfg.RunnerOptions.ApiHost,
-		Token: cfg.RunnerOptions.ApiToken,
+		Host:  cfg.RunnerOptions.APIHost,
+		Token: cfg.RunnerOptions.APIToken,
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -568,7 +568,7 @@ func (i *AxolotlModelInstance) processInteraction(session *types.Session) error 
 		jsonLFiles := []string{}
 		for _, interaction := range finetuneInteractions {
 			for _, file := range interaction.Files {
-				if path.Base(file) == types.TEXT_DATA_PREP_QUESTIONS_FILE {
+				if path.Base(file) == types.TextDataPrepQuestionsFile {
 					localFilename := fmt.Sprintf("%s.jsonl", interaction.ID)
 					localPath := path.Join(fileManager.GetFolder(), localFilename)
 					err := fileManager.DownloadFile(file, localPath)
@@ -580,7 +580,7 @@ func (i *AxolotlModelInstance) processInteraction(session *types.Session) error 
 			}
 		}
 
-		combinedFile := path.Join(fileManager.GetFolder(), types.TEXT_DATA_PREP_QUESTIONS_FILE)
+		combinedFile := path.Join(fileManager.GetFolder(), types.TextDataPrepQuestionsFile)
 		err := system.ConcatenateFiles(combinedFile, jsonLFiles, "\n")
 		if err != nil {
 			return err

--- a/api/pkg/runner/cog_model_instance.go
+++ b/api/pkg/runner/cog_model_instance.go
@@ -129,8 +129,8 @@ func NewCogModelInstance(ctx context.Context, cfg *ModelInstanceConfig) (*CogMod
 	id := system.GenerateUUID()
 
 	httpClientOptions := system.ClientOptions{
-		Host:  cfg.RunnerOptions.ApiHost,
-		Token: cfg.RunnerOptions.ApiToken,
+		Host:  cfg.RunnerOptions.APIHost,
+		Token: cfg.RunnerOptions.APIToken,
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/api/pkg/runner/controller.go
+++ b/api/pkg/runner/controller.go
@@ -26,8 +26,8 @@ import (
 
 type RunnerOptions struct {
 	ID       string
-	ApiHost  string
-	ApiToken string
+	APIHost  string
+	APIToken string
 
 	CacheDir string
 
@@ -109,10 +109,10 @@ func NewRunner(
 	if options.ID == "" {
 		return nil, fmt.Errorf("id is required")
 	}
-	if options.ApiHost == "" {
+	if options.APIHost == "" {
 		return nil, fmt.Errorf("api host required")
 	}
-	if options.ApiToken == "" {
+	if options.APIToken == "" {
 		return nil, fmt.Errorf("api token is required")
 	}
 	if options.RuntimeFactory == nil {
@@ -120,7 +120,7 @@ func NewRunner(
 	}
 
 	// Remove trailing slash from ApiHost if present
-	options.ApiHost = strings.TrimSuffix(options.ApiHost, "/")
+	options.APIHost = strings.TrimSuffix(options.APIHost, "/")
 
 	if options.MemoryString != "" {
 		bytes, err := bytesize.Parse(options.MemoryString)
@@ -137,8 +137,8 @@ func NewRunner(
 		Ctx:     ctx,
 		Options: options,
 		httpClientOptions: system.ClientOptions{
-			Host:  options.ApiHost,
-			Token: options.ApiToken,
+			Host:  options.APIHost,
+			Token: options.APIToken,
 		},
 		activeModelInstances:  xsync.NewMapOf[string, ModelInstance](),
 		websocketEventChannel: make(chan *types.WebsocketEvent),
@@ -160,7 +160,7 @@ func (r *Runner) Initialize(ctx context.Context) error {
 
 	queryParams := url.Values{}
 	queryParams.Add("runnerid", r.Options.ID)
-	queryParams.Add("access_token", r.Options.ApiToken)
+	queryParams.Add("access_token", r.Options.APIToken)
 	parsedURL.RawQuery = queryParams.Encode()
 
 	go server.ConnectRunnerWebSocketClient(

--- a/api/pkg/runner/controller_inference.go
+++ b/api/pkg/runner/controller_inference.go
@@ -27,7 +27,7 @@ func (r *Runner) warmupInference(ctx context.Context) error {
 		},
 		&types.RunnerLLMInferenceRequest{
 			Request: &openai.ChatCompletionRequest{
-				Model: model.Model_Ollama_Llama3_8b,
+				Model: model.ModelOllamaLlama38b,
 			},
 		},
 	)

--- a/api/pkg/runner/controller_test.go
+++ b/api/pkg/runner/controller_test.go
@@ -44,9 +44,9 @@ func TestController_GetSlots(t *testing.T) {
 
 	// Create a new controller with the server URL
 	runner, err := NewRunner(context.Background(), RunnerOptions{
-		ApiHost:     server.URL,
+		APIHost:     server.URL,
 		ID:          "test",
-		ApiToken:    "test",
+		APIToken:    "test",
 		MemoryBytes: 1,
 		RuntimeFactory: &mockRuntimeFactory{
 			getRuntimeFunc: func() *Slot {
@@ -86,9 +86,9 @@ func TestController_SlotLifecycle(t *testing.T) {
 	m.EXPECT().Stop().Times(1)
 	mockLLMWorkChan := make(chan *types.RunnerLLMInferenceRequest, 1)
 	runner, err := NewRunner(ctx, RunnerOptions{
-		ApiHost:     server.URL,
+		APIHost:     server.URL,
 		ID:          "test",
-		ApiToken:    "test",
+		APIToken:    "test",
 		MemoryBytes: 1,
 		RuntimeFactory: &mockRuntimeFactory{
 			getRuntimeFunc: func() *Slot {
@@ -115,7 +115,7 @@ func TestController_SlotLifecycle(t *testing.T) {
 						LLMInferenceRequest: &types.RunnerLLMInferenceRequest{
 							RequestID: "test",
 							Request: &openai.ChatCompletionRequest{
-								Model: model.Model_Ollama_Llama3_8b,
+								Model: model.ModelOllamaLlama38b,
 							},
 						},
 					},
@@ -161,7 +161,7 @@ func TestController_SlotLifecycle(t *testing.T) {
 						LLMInferenceRequest: &types.RunnerLLMInferenceRequest{
 							RequestID: "test-1",
 							Request: &openai.ChatCompletionRequest{
-								Model: model.Model_Ollama_Llama3_8b,
+								Model: model.ModelOllamaLlama38b,
 							},
 						},
 					},
@@ -174,7 +174,7 @@ func TestController_SlotLifecycle(t *testing.T) {
 						LLMInferenceRequest: &types.RunnerLLMInferenceRequest{
 							RequestID: "test-2",
 							Request: &openai.ChatCompletionRequest{
-								Model: model.Model_Ollama_Llama3_8b,
+								Model: model.ModelOllamaLlama38b,
 							},
 						},
 					},

--- a/api/pkg/runner/diffusers_model_instance.go
+++ b/api/pkg/runner/diffusers_model_instance.go
@@ -133,8 +133,8 @@ func NewDiffusersModelInstance(ctx context.Context, cfg *ModelInstanceConfig) (*
 	id := system.GenerateUUID()
 
 	httpClientOptions := system.ClientOptions{
-		Host:  cfg.RunnerOptions.ApiHost,
-		Token: cfg.RunnerOptions.ApiToken,
+		Host:  cfg.RunnerOptions.APIHost,
+		Token: cfg.RunnerOptions.APIToken,
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/api/pkg/runner/files.go
+++ b/api/pkg/runner/files.go
@@ -42,7 +42,7 @@ func (handler *SessionFileHandler) DownloadFolder(remotePath string, localPath s
 }
 
 // Compile-time interface check:
-var _ model.ModelSessionFileManager = (*SessionFileHandler)(nil)
+var _ model.SessionFileManager = (*SessionFileHandler)(nil)
 
 type FileHandler struct {
 	runnerID          string
@@ -67,7 +67,7 @@ func (handler *FileHandler) uploadWorkerResponse(res *types.RunnerTaskResponse) 
 		Msgf("🟢 upload worker response: %+v", res)
 
 	if len(res.Files) > 0 {
-		uploadedFiles, err := handler.uploadFiles(res.SessionID, res.Files, types.FILESTORE_RESULTS_DIR)
+		uploadedFiles, err := handler.uploadFiles(res.SessionID, res.Files, types.FilestoreResultsDir)
 		if err != nil {
 			return nil, err
 		}
@@ -81,7 +81,7 @@ func (handler *FileHandler) uploadWorkerResponse(res *types.RunnerTaskResponse) 
 		// we keep a history of re-trainings and can always go back to a previous step
 		// (because the previous lora dir is still there)
 		// the api server will "hoist" this folder to the session.LoraDir which is the "live" LoraDir
-		uploadedLoraDir, err := handler.uploadFolder(res.SessionID, res.LoraDir, path.Join(types.FILESTORE_LORA_DIR, res.InteractionID))
+		uploadedLoraDir, err := handler.uploadFolder(res.SessionID, res.LoraDir, path.Join(types.FilestoreLoraDir, res.InteractionID))
 		if err != nil {
 			return nil, err
 		}

--- a/api/pkg/runner/llm_ollama_model_instance.go
+++ b/api/pkg/runner/llm_ollama_model_instance.go
@@ -554,7 +554,7 @@ func (i *OllamaInferenceModelInstance) processInteraction(inferenceReq *types.Ru
 	// Look up the context length for the current model
 	maxTokens := defaultMaxTokens
 	for _, m := range defaultModels {
-		if m.Id == inferenceReq.Request.Model {
+		if m.ID == inferenceReq.Request.Model {
 			log.Info().Msgf("using context length %d for model %s", m.ContextLength, inferenceReq.Request.Model)
 			maxTokens = int(m.ContextLength)
 			break

--- a/api/pkg/runner/slot.go
+++ b/api/pkg/runner/slot.go
@@ -151,13 +151,13 @@ func (f *runtimeFactory) NewSlot(ctx context.Context,
 		if runnerOptions.MockRunner {
 			if initialSession.Type == types.SessionTypeText {
 				runtimeName = types.InferenceRuntimeAxolotl
-				initialSession.ModelName = model.Model_Axolotl_Mistral7b
+				initialSession.ModelName = model.ModelAxolotlMistral7b
 			} else if initialSession.Type == types.SessionTypeImage {
 				// I know - this looks odd, but "InferenceRuntimeAxolotl" should actually be called
 				// "InferenceRuntimeDefault" - i.e. it's the original "run a python program" version
 				// that does both axolotl and sdxl
 				runtimeName = types.InferenceRuntimeAxolotl
-				initialSession.ModelName = model.Model_Cog_SDXL
+				initialSession.ModelName = model.ModelCogSdxl
 			}
 		}
 

--- a/api/pkg/scheduler/scheduler.go
+++ b/api/pkg/scheduler/scheduler.go
@@ -96,10 +96,10 @@ func newSchedulerWithoutGoroutines(cfg *config.ServerConfig, onSchedulingErr fun
 
 	schedStratFunc := MaxSpreadStrategy
 	switch SchedulingStrategy(cfg.Providers.Helix.SchedulingStrategy) {
-	case SchedulingStrategy_MaxUtilization:
+	case SchedulingstrategyMaxutilization:
 		log.Info().Str("strategy", cfg.Providers.Helix.SchedulingStrategy).Msg("scheduling strategy with spread work across all runners")
 		schedStratFunc = MaxUtilizationStrategy
-	case SchedulingStrategy_MaxSpread:
+	case SchedulingstrategyMaxspread:
 		log.Info().Str("strategy", cfg.Providers.Helix.SchedulingStrategy).Msg("scheduling strategy will maximize utilization on individual runners")
 		schedStratFunc = MaxSpreadStrategy
 	default:

--- a/api/pkg/scheduler/scheduler_test.go
+++ b/api/pkg/scheduler/scheduler_test.go
@@ -15,7 +15,7 @@ import (
 func TestScheduler_NoRunnersAvailable(t *testing.T) {
 	config, _ := config.LoadServerConfig()
 	scheduler := NewScheduler(context.Background(), &config, nil)
-	err := scheduleTestLLMWorkload(scheduler, "test-request-1", model.Model_Ollama_Llama3_8b)
+	err := scheduleTestLLMWorkload(scheduler, "test-request-1", model.ModelOllamaLlama38b)
 	assert.ErrorContains(t, err, "no runners available")
 }
 
@@ -30,14 +30,14 @@ func TestScheduler_TimeoutRunner(t *testing.T) {
 	cluster := NewCluster(timeoutRunner1Func)
 	scheduler.cluster = cluster
 
-	m, _ := model.GetModel(model.Model_Ollama_Llama3_8b)
+	m, _ := model.GetModel(model.ModelOllamaLlama38b)
 	scheduler.UpdateRunner(&types.RunnerState{
 		ID:          "test-runner-1",
 		TotalMemory: m.GetMemoryRequirements(types.SessionModeInference) * 2,
 	})
 
 	// Schedule a job
-	err := scheduleTestLLMWorkload(scheduler, "test-request-1", model.Model_Ollama_Llama3_8b)
+	err := scheduleTestLLMWorkload(scheduler, "test-request-1", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 
 	scheduler.UpdateRunner(&types.RunnerState{
@@ -48,7 +48,7 @@ func TestScheduler_TimeoutRunner(t *testing.T) {
 	// Allow the background goroutine to run
 	var work *Workload
 	waitFor(t, func() bool {
-		work, err = scheduler.WorkForRunner("test-runner-2", WorkloadTypeLLMInferenceRequest, false, model.Model_Ollama_Llama3_8b)
+		work, err = scheduler.WorkForRunner("test-runner-2", WorkloadTypeLLMInferenceRequest, false, model.ModelOllamaLlama38b)
 		return work != nil
 	}, 2*time.Second)
 
@@ -62,38 +62,38 @@ func TestScheduler_TimeoutRunner(t *testing.T) {
 func TestScheduler_ThreeJobsOnSingleRunnerThatCanFitTwo(t *testing.T) {
 	config, _ := config.LoadServerConfig()
 	scheduler := NewScheduler(context.Background(), &config, nil)
-	m, _ := model.GetModel(model.Model_Ollama_Llama3_8b)
+	m, _ := model.GetModel(model.ModelOllamaLlama38b)
 	scheduler.UpdateRunner(&types.RunnerState{
 		ID:          "test-runner",
 		TotalMemory: m.GetMemoryRequirements(types.SessionModeInference) * 2,
 	})
 
 	// Test requests
-	err := scheduleTestLLMWorkload(scheduler, "test-request-1", model.Model_Ollama_Llama3_8b)
+	err := scheduleTestLLMWorkload(scheduler, "test-request-1", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 
-	err = scheduleTestLLMWorkload(scheduler, "test-request-2", model.Model_Ollama_Llama3_8b)
+	err = scheduleTestLLMWorkload(scheduler, "test-request-2", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 
-	err = scheduleTestLLMWorkload(scheduler, "test-request-3", model.Model_Ollama_Llama3_8b)
+	err = scheduleTestLLMWorkload(scheduler, "test-request-3", model.ModelOllamaLlama38b)
 	assert.ErrorContains(t, err, "full")
 }
 
 func TestScheduler_TestWarmSlot(t *testing.T) {
 	config, _ := config.LoadServerConfig()
 	scheduler := NewScheduler(context.Background(), &config, nil)
-	m, _ := model.GetModel(model.Model_Ollama_Llama3_8b)
+	m, _ := model.GetModel(model.ModelOllamaLlama38b)
 	scheduler.UpdateRunner(&types.RunnerState{
 		ID:          "test-runner",
 		TotalMemory: m.GetMemoryRequirements(types.SessionModeInference) * 2,
 	})
 
 	// Test request
-	err := scheduleTestLLMWorkload(scheduler, "test-request-1", model.Model_Ollama_Llama3_8b)
+	err := scheduleTestLLMWorkload(scheduler, "test-request-1", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 
 	// Simulate the runner starting the work
-	_, err = scheduler.WorkForRunner("test-runner", WorkloadTypeLLMInferenceRequest, false, model.Model_Ollama_Llama3_8b)
+	_, err = scheduler.WorkForRunner("test-runner", WorkloadTypeLLMInferenceRequest, false, model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 
 	// Simulate the runner finishing the work
@@ -101,7 +101,7 @@ func TestScheduler_TestWarmSlot(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Start request-2
-	err = scheduleTestLLMWorkload(scheduler, "test-request-2", model.Model_Ollama_Llama3_8b)
+	err = scheduleTestLLMWorkload(scheduler, "test-request-2", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 
 	// Make sure there's only one slot
@@ -112,24 +112,24 @@ func TestScheduler_TestRemoveStaleSlots(t *testing.T) {
 	config, _ := config.LoadServerConfig()
 	config.Providers.Helix.ModelTTL = 1 * time.Microsecond
 	scheduler := NewScheduler(context.Background(), &config, nil)
-	m, _ := model.GetModel(model.Model_Ollama_Llama3_8b)
+	m, _ := model.GetModel(model.ModelOllamaLlama38b)
 	scheduler.UpdateRunner(&types.RunnerState{
 		ID:          "test-runner",
 		TotalMemory: 2 * m.GetMemoryRequirements(types.SessionModeInference),
 	})
 
 	// Test request
-	err := scheduleTestLLMWorkload(scheduler, "test-request-1", model.Model_Ollama_Llama3_8b)
+	err := scheduleTestLLMWorkload(scheduler, "test-request-1", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 
 	// Test request 2
-	err = scheduleTestLLMWorkload(scheduler, "test-request-2", model.Model_Ollama_Llama3_8b)
+	err = scheduleTestLLMWorkload(scheduler, "test-request-2", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 
 	// Simulate the runner starting the work
-	_, err = scheduler.WorkForRunner("test-runner", WorkloadTypeLLMInferenceRequest, false, model.Model_Ollama_Llama3_8b)
+	_, err = scheduler.WorkForRunner("test-runner", WorkloadTypeLLMInferenceRequest, false, model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
-	_, err = scheduler.WorkForRunner("test-runner", WorkloadTypeLLMInferenceRequest, false, model.Model_Ollama_Llama3_8b)
+	_, err = scheduler.WorkForRunner("test-runner", WorkloadTypeLLMInferenceRequest, false, model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 	// Simulate the runner finishing the work
 	err = scheduler.Release("test-request-1")
@@ -138,11 +138,11 @@ func TestScheduler_TestRemoveStaleSlots(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Start request-3, a new model type
-	err = scheduleTestLLMWorkload(scheduler, "test-request-3", model.Model_Ollama_Phi3)
+	err = scheduleTestLLMWorkload(scheduler, "test-request-3", model.ModelOllamaPhi3)
 	assert.NoError(t, err)
 
 	// Simulate the runner starting the work
-	_, err = scheduler.WorkForRunner("test-runner", WorkloadTypeLLMInferenceRequest, false, model.Model_Ollama_Phi3)
+	_, err = scheduler.WorkForRunner("test-runner", WorkloadTypeLLMInferenceRequest, false, model.ModelOllamaPhi3)
 	assert.NoError(t, err)
 
 	// Simulate runner updating control plane with removed models
@@ -151,10 +151,10 @@ func TestScheduler_TestRemoveStaleSlots(t *testing.T) {
 		TotalMemory: m.GetMemoryRequirements(types.SessionModeInference),
 		ModelInstances: []*types.ModelInstanceState{
 			{
-				ModelName: model.Model_Ollama_Llama3_8b,
+				ModelName: model.ModelOllamaLlama38b,
 				Mode:      types.SessionModeInference,
 			}, {
-				ModelName: model.Model_Ollama_Phi3,
+				ModelName: model.ModelOllamaPhi3,
 				Mode:      types.SessionModeInference,
 			},
 		},
@@ -166,18 +166,18 @@ func TestScheduler_TestRemoveStaleSlots(t *testing.T) {
 func TestScheduler_FullWhenJobsWarm(t *testing.T) {
 	config, _ := config.LoadServerConfig()
 	scheduler := NewScheduler(context.Background(), &config, nil)
-	m, _ := model.GetModel(model.Model_Ollama_Llama3_8b)
+	m, _ := model.GetModel(model.ModelOllamaLlama38b)
 	scheduler.UpdateRunner(&types.RunnerState{
 		ID:          "test-runner",
 		TotalMemory: m.GetMemoryRequirements(types.SessionModeInference),
 	})
 
 	// Test request
-	err := scheduleTestLLMWorkload(scheduler, "test-request-1", model.Model_Ollama_Llama3_8b)
+	err := scheduleTestLLMWorkload(scheduler, "test-request-1", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 
 	// Simulate runner doing work
-	_, err = scheduler.WorkForRunner("test-runner", WorkloadTypeLLMInferenceRequest, false, model.Model_Ollama_Llama3_8b)
+	_, err = scheduler.WorkForRunner("test-runner", WorkloadTypeLLMInferenceRequest, false, model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 
 	err = scheduler.Release("test-request-1")
@@ -185,22 +185,22 @@ func TestScheduler_FullWhenJobsWarm(t *testing.T) {
 
 	// Even though the work has finished, the slot is still warm, so it should report full when a
 	// new model is requested
-	err = scheduleTestLLMWorkload(scheduler, "test-request-2", model.Model_Ollama_Phi3)
+	err = scheduleTestLLMWorkload(scheduler, "test-request-2", model.ModelOllamaPhi3)
 	assert.ErrorContains(t, err, "full")
 }
 
 func TestScheduler_MaximiseUtilization(t *testing.T) {
 	config, _ := config.LoadServerConfig()
-	config.Providers.Helix.SchedulingStrategy = string(SchedulingStrategy_MaxUtilization)
+	config.Providers.Helix.SchedulingStrategy = string(SchedulingstrategyMaxutilization)
 	scheduler := NewScheduler(context.Background(), &config, nil)
-	m, _ := model.GetModel(model.Model_Ollama_Llama3_8b)
+	m, _ := model.GetModel(model.ModelOllamaLlama38b)
 	scheduler.UpdateRunner(&types.RunnerState{
 		ID:          "test-runner-1",
 		TotalMemory: 2 * m.GetMemoryRequirements(types.SessionModeInference),
 	})
 
 	// Add one request
-	err := scheduleTestLLMWorkload(scheduler, "test-request-1", model.Model_Ollama_Llama3_8b)
+	err := scheduleTestLLMWorkload(scheduler, "test-request-1", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 
 	// Add a second runner
@@ -211,11 +211,11 @@ func TestScheduler_MaximiseUtilization(t *testing.T) {
 	assert.NoError(t, err)
 
 	// When scheduling a second request, it should fill the first runner, not the second
-	err = scheduleTestLLMWorkload(scheduler, "test-request-2", model.Model_Ollama_Llama3_8b)
+	err = scheduleTestLLMWorkload(scheduler, "test-request-2", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 
 	// Check that NO work has been scheduler's cluster
-	work, err := scheduler.WorkForRunner("test-runner-2", WorkloadTypeLLMInferenceRequest, false, model.Model_Ollama_Llama3_8b)
+	work, err := scheduler.WorkForRunner("test-runner-2", WorkloadTypeLLMInferenceRequest, false, model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 	if work != nil {
 		t.Error("second runner should have no work because we're maximizing utilization (represented by nil)")
@@ -227,51 +227,51 @@ func TestScheduler_TestSessionScheduler(t *testing.T) {
 	config, _ := config.LoadServerConfig()
 	config.Providers.Helix.ModelTTL = 1 * time.Microsecond
 	scheduler := NewScheduler(context.Background(), &config, nil)
-	m, _ := model.GetModel(model.Model_Ollama_Llama3_8b)
+	m, _ := model.GetModel(model.ModelOllamaLlama38b)
 	scheduler.UpdateRunner(&types.RunnerState{
 		ID:          "test-runner",
 		TotalMemory: m.GetMemoryRequirements(types.SessionModeInference) * 2,
 	})
 
 	// Test request
-	err := createTestSession(scheduler, "test-request-1", model.Model_Ollama_Llama3_8b, "")
+	err := createTestSession(scheduler, "test-request-1", model.ModelOllamaLlama38b, "")
 	assert.NoError(t, err)
-	err = createTestSession(scheduler, "test-request-2", model.Model_Ollama_Llama3_8b, "")
+	err = createTestSession(scheduler, "test-request-2", model.ModelOllamaLlama38b, "")
 	assert.NoError(t, err)
-	err = createTestSession(scheduler, "test-request-3", model.Model_Ollama_Phi3, "")
+	err = createTestSession(scheduler, "test-request-3", model.ModelOllamaPhi3, "")
 	assert.ErrorContains(t, err, "full")
 
 	// Simulate runner taking and finishing work
-	_, err = scheduler.WorkForRunner("test-runner", WorkloadTypeSession, false, model.Model_Ollama_Llama3_8b)
+	_, err = scheduler.WorkForRunner("test-runner", WorkloadTypeSession, false, model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 	err = scheduler.Release("test-request-1")
 	assert.NoError(t, err)
 
-	_, err = scheduler.WorkForRunner("test-runner", WorkloadTypeSession, false, model.Model_Ollama_Llama3_8b)
+	_, err = scheduler.WorkForRunner("test-runner", WorkloadTypeSession, false, model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 	err = scheduler.Release("test-request-2")
 	assert.NoError(t, err)
 
 	// Now work should fit, since the test is always stale
-	err = scheduleTestLLMWorkload(scheduler, "test-request-4", model.Model_Ollama_Phi3)
+	err = scheduleTestLLMWorkload(scheduler, "test-request-4", model.ModelOllamaPhi3)
 	assert.NoError(t, err)
 }
 
 func TestScheduler_LoraDirSession(t *testing.T) {
 	config, _ := config.LoadServerConfig()
 	scheduler := NewScheduler(context.Background(), &config, nil)
-	m, _ := model.GetModel(model.Model_Axolotl_Mistral7b)
+	m, _ := model.GetModel(model.ModelAxolotlMistral7b)
 	scheduler.UpdateRunner(&types.RunnerState{
 		ID:          "test-runner-1",
 		TotalMemory: m.GetMemoryRequirements(types.SessionModeInference),
 	})
 
 	// Test request
-	err := createTestSession(scheduler, "test-request-1", model.Model_Axolotl_Mistral7b, "test")
+	err := createTestSession(scheduler, "test-request-1", model.ModelAxolotlMistral7b, "test")
 	assert.NoError(t, err)
 
 	// Simulate runner taking and finishing work
-	_, err = scheduler.WorkForRunner("test-runner-1", WorkloadTypeSession, false, model.Model_Axolotl_Mistral7b)
+	_, err = scheduler.WorkForRunner("test-runner-1", WorkloadTypeSession, false, model.ModelAxolotlMistral7b)
 	assert.NoError(t, err)
 	err = scheduler.Release("test-request-1")
 	assert.NoError(t, err)
@@ -283,20 +283,20 @@ func TestScheduler_LoraDirSession(t *testing.T) {
 	})
 
 	// Reschedule lora work, must always scheduler's cluster
-	err = createTestSession(scheduler, "test-request-2", model.Model_Axolotl_Mistral7b, "test")
+	err = createTestSession(scheduler, "test-request-2", model.ModelAxolotlMistral7b, "test")
 	assert.NoError(t, err)
 
 	// Check that NO work has been scheduler's cluster
-	work, err := scheduler.WorkForRunner("test-runner-2", WorkloadTypeSession, false, model.Model_Axolotl_Mistral7b)
+	work, err := scheduler.WorkForRunner("test-runner-2", WorkloadTypeSession, false, model.ModelAxolotlMistral7b)
 	assert.NoError(t, err)
 	if work != nil {
 		t.Error("second runner should have no work because of the warm lora dir")
 	}
 
 	// Schedule a second lora dir, must scheduler's cluster
-	err = createTestSession(scheduler, "test-request-3", model.Model_Axolotl_Mistral7b, "new")
+	err = createTestSession(scheduler, "test-request-3", model.ModelAxolotlMistral7b, "new")
 	assert.NoError(t, err)
-	work, err = scheduler.WorkForRunner("test-runner-2", WorkloadTypeSession, false, model.Model_Axolotl_Mistral7b)
+	work, err = scheduler.WorkForRunner("test-runner-2", WorkloadTypeSession, false, model.ModelAxolotlMistral7b)
 	assert.NoError(t, err)
 	if work == nil {
 		t.Error("second runner should have work because of the new lora dir")
@@ -307,20 +307,20 @@ func TestScheduler_RunnerWithWrongModel(t *testing.T) {
 	config, _ := config.LoadServerConfig()
 	config.Providers.Helix.ModelTTL = 1 * time.Microsecond
 	scheduler := NewScheduler(context.Background(), &config, nil)
-	m, _ := model.GetModel(model.Model_Ollama_Llama3_8b)
+	m, _ := model.GetModel(model.ModelOllamaLlama38b)
 	scheduler.UpdateRunner(&types.RunnerState{
 		ID:          "test-runner",
 		TotalMemory: m.GetMemoryRequirements(types.SessionModeInference) * 2,
 	})
 
 	// Test request
-	err := createTestSession(scheduler, "test-request-1", model.Model_Ollama_Llama3_8b, "")
+	err := createTestSession(scheduler, "test-request-1", model.ModelOllamaLlama38b, "")
 	assert.NoError(t, err)
 	err = createTestSession(scheduler, "test-request-2", "gemma2:2b-instruct-q8_0", "")
 	assert.NoError(t, err)
 
 	// Simulate runner taking and finishing work
-	w, err := scheduler.WorkForRunner("test-runner", WorkloadTypeSession, false, model.Model_Ollama_Llama3_8b)
+	w, err := scheduler.WorkForRunner("test-runner", WorkloadTypeSession, false, model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 	assert.Equal(t, w.ID(), "test-request-1")
 	err = scheduler.Release("test-request-1")
@@ -333,7 +333,7 @@ func TestScheduler_RunnerWithWrongModel(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test any work will do
-	err = createTestSession(scheduler, "test-request-1", model.Model_Ollama_Llama3_8b, "")
+	err = createTestSession(scheduler, "test-request-1", model.ModelOllamaLlama38b, "")
 	assert.NoError(t, err)
 	w, err = scheduler.WorkForRunner("test-runner", WorkloadTypeSession, false, "")
 	assert.NoError(t, err)
@@ -352,21 +352,21 @@ func TestScheduler_SlotTimeoutTest(t *testing.T) {
 	config.Providers.Helix.SlotTTL = 1 * time.Microsecond
 	config.Providers.Helix.ModelTTL = 1 * time.Microsecond
 	scheduler := NewScheduler(context.Background(), &config, nil)
-	m, _ := model.GetModel(model.Model_Ollama_Llama3_8b)
+	m, _ := model.GetModel(model.ModelOllamaLlama38b)
 	scheduler.UpdateRunner(&types.RunnerState{
 		ID:          "test-runner",
 		TotalMemory: m.GetMemoryRequirements(types.SessionModeInference) * 1,
 	})
 
 	// Test request
-	err := createTestSession(scheduler, "test-request-1", model.Model_Ollama_Llama3_8b, "")
+	err := createTestSession(scheduler, "test-request-1", model.ModelOllamaLlama38b, "")
 	assert.NoError(t, err)
 
 	// Wait for the model to timeout
 	time.Sleep(2 * time.Millisecond)
 
 	// Since the model has timed out, the slot should be stale
-	err = createTestSession(scheduler, "test-request-2", model.Model_Ollama_Llama3_8b, "")
+	err = createTestSession(scheduler, "test-request-2", model.ModelOllamaLlama38b, "")
 	assert.NoError(t, err)
 }
 
@@ -380,26 +380,26 @@ func TestScheduler_EnqueueLLMRequest(t *testing.T) {
 	}
 
 	// Add a runner, otherwise we will get an error saying no runners available
-	m, _ := model.GetModel(model.Model_Ollama_Llama3_8b)
+	m, _ := model.GetModel(model.ModelOllamaLlama38b)
 	scheduler.UpdateRunner(&types.RunnerState{
 		ID:          "test-runner",
 		TotalMemory: m.GetMemoryRequirements(types.SessionModeInference) * 1,
 	})
 
 	// Start some work on the runner, so that subsequent requests must queue
-	err := enqueueTestLLMWorkload(scheduler, "request-1", model.Model_Ollama_Llama3_8b)
+	err := enqueueTestLLMWorkload(scheduler, "request-1", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 	waitFor(t, emptyQueueFunc, time.Second) // This waits for the queue to be processed
 	err = scheduler.Begin("request-1")      // This marks the slot as started
 	assert.NoError(t, err)
 
 	// Now runners are busy, add work to queue
-	err = enqueueTestLLMWorkload(scheduler, "request-2", model.Model_Ollama_Llama3_8b)
+	err = enqueueTestLLMWorkload(scheduler, "request-2", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 	assert.Len(t, scheduler.queue, 1)
 
 	// Can't requeue work already in queue
-	err = enqueueTestLLMWorkload(scheduler, "request-2", model.Model_Ollama_Llama3_8b)
+	err = enqueueTestLLMWorkload(scheduler, "request-2", model.ModelOllamaLlama38b)
 	assert.Error(t, err)
 	assert.Len(t, scheduler.queue, 1)
 
@@ -410,9 +410,9 @@ func TestScheduler_EnqueueLLMRequest(t *testing.T) {
 	assert.Len(t, scheduler.queue, 0)
 
 	// Now add too many things to the queue
-	err = enqueueTestLLMWorkload(scheduler, "request-3", model.Model_Ollama_Llama3_8b)
+	err = enqueueTestLLMWorkload(scheduler, "request-3", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
-	err = enqueueTestLLMWorkload(scheduler, "request-4", model.Model_Ollama_Llama3_8b)
+	err = enqueueTestLLMWorkload(scheduler, "request-4", model.ModelOllamaLlama38b)
 	assert.Error(t, err)
 }
 
@@ -426,25 +426,25 @@ func TestScheduler_EnqueueSessionRequest(t *testing.T) {
 	}
 
 	// Add a runner, otherwise we will get an error saying no runners available
-	m, _ := model.GetModel(model.Model_Ollama_Llama3_8b)
+	m, _ := model.GetModel(model.ModelOllamaLlama38b)
 	scheduler.UpdateRunner(&types.RunnerState{
 		ID:          "test-runner",
 		TotalMemory: m.GetMemoryRequirements(types.SessionModeInference) * 1,
 	})
 
 	// Start some work on the runner, so that subsequent requests must queue
-	err := enqueueTestLLMWorkload(scheduler, "request-1", model.Model_Ollama_Llama3_8b)
+	err := enqueueTestLLMWorkload(scheduler, "request-1", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 	waitFor(t, emptyQueueFunc, time.Second) // This waits for the queue to be processed
 	err = scheduler.Begin("request-1")      // This marks the slot as started
 	assert.NoError(t, err)
 
 	// Test Priority item entering the queue after a non-priority item
-	err = enqueueTestSession(scheduler, "request-2", model.Model_Ollama_Llama3_8b, "", false)
+	err = enqueueTestSession(scheduler, "request-2", model.ModelOllamaLlama38b, "", false)
 	assert.NoError(t, err)
 	assert.Len(t, scheduler.queue, 1)
 
-	err = enqueueTestSession(scheduler, "request-3", model.Model_Ollama_Llama3_8b, "", true)
+	err = enqueueTestSession(scheduler, "request-3", model.ModelOllamaLlama38b, "", true)
 	assert.NoError(t, err)
 	assert.Len(t, scheduler.queue, 2)
 
@@ -460,7 +460,7 @@ func TestScheduler_RunnerLifecycle(t *testing.T) {
 	}
 
 	// Runner shows up
-	m, _ := model.GetModel(model.Model_Ollama_Llama3_8b)
+	m, _ := model.GetModel(model.ModelOllamaLlama38b)
 	scheduler.UpdateRunner(&types.RunnerState{
 		ID:          "test-runner",
 		TotalMemory: m.GetMemoryRequirements(types.SessionModeInference) * 1,
@@ -471,7 +471,7 @@ func TestScheduler_RunnerLifecycle(t *testing.T) {
 	assert.Len(t, slots, 0)
 
 	// Enqueue and schedule some work
-	err := enqueueTestLLMWorkload(scheduler, "request-1", model.Model_Ollama_Llama3_8b)
+	err := enqueueTestLLMWorkload(scheduler, "request-1", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 	waitFor(t, emptyQueueFunc, time.Second) // This waits for the queue to be processed
 
@@ -491,7 +491,7 @@ func TestScheduler_ProcessQueue(t *testing.T) {
 	scheduler := newSchedulerWithoutGoroutines(&config, errorFunc)
 
 	// Without a runner, adding to the queue and processing should result in an error on the work
-	err := enqueueTestLLMWorkload(scheduler, "request-1", model.Model_Ollama_Llama3_8b)
+	err := enqueueTestLLMWorkload(scheduler, "request-1", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 	assert.Len(t, scheduler.queue, 1)
 
@@ -503,23 +503,23 @@ func TestScheduler_ProcessQueue(t *testing.T) {
 	assert.True(t, hasErr)
 
 	// Add a two runner, one big one small
-	m, _ := model.GetModel(model.Model_Ollama_Llama3_8b)
+	m, _ := model.GetModel(model.ModelOllamaLlama38b)
 	scheduler.UpdateRunner(&types.RunnerState{
 		ID:          "runner-1",
 		TotalMemory: m.GetMemoryRequirements(types.SessionModeInference) * 1,
 	})
-	m, _ = model.GetModel(model.Model_Ollama_Phi3)
+	m, _ = model.GetModel(model.ModelOllamaPhi3)
 	scheduler.UpdateRunner(&types.RunnerState{
 		ID:          "runner-2",
 		TotalMemory: m.GetMemoryRequirements(types.SessionModeInference) * 1,
 	})
 
 	// Now enqueue work. Fill up the big runner.
-	err = enqueueTestLLMWorkload(scheduler, "request-1", model.Model_Ollama_Llama3_8b)
+	err = enqueueTestLLMWorkload(scheduler, "request-1", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
-	err = enqueueTestLLMWorkload(scheduler, "request-2", model.Model_Ollama_Llama3_8b)
+	err = enqueueTestLLMWorkload(scheduler, "request-2", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
-	err = enqueueTestLLMWorkload(scheduler, "request-3", model.Model_Ollama_Phi3)
+	err = enqueueTestLLMWorkload(scheduler, "request-3", model.ModelOllamaPhi3)
 	assert.NoError(t, err)
 
 	ctx, cancel = context.WithTimeout(context.Background(), time.Millisecond)
@@ -541,14 +541,14 @@ func TestScheduler_ChangingRunnerName(t *testing.T) {
 	scheduler := newSchedulerWithoutGoroutines(&config, func(*Workload, error) {})
 
 	// Add a runner
-	m, _ := model.GetModel(model.Model_Ollama_Llama3_8b)
+	m, _ := model.GetModel(model.ModelOllamaLlama38b)
 	scheduler.UpdateRunner(&types.RunnerState{
 		ID:          "test-runner",
 		TotalMemory: m.GetMemoryRequirements(types.SessionModeInference) * 1,
 	})
 
 	// Schedule some work
-	err := enqueueTestLLMWorkload(scheduler, "request-1", model.Model_Ollama_Llama3_8b)
+	err := enqueueTestLLMWorkload(scheduler, "request-1", model.ModelOllamaLlama38b)
 	assert.NoError(t, err)
 
 	// Manually process the queue

--- a/api/pkg/scheduler/strategy.go
+++ b/api/pkg/scheduler/strategy.go
@@ -12,9 +12,9 @@ import (
 type SchedulingStrategy string
 
 const (
-	SchedulingStrategy_None           SchedulingStrategy = ""
-	SchedulingStrategy_MaxUtilization SchedulingStrategy = "max_utilization"
-	SchedulingStrategy_MaxSpread      SchedulingStrategy = "max_spread"
+	SchedulingstrategyNone           SchedulingStrategy = ""
+	SchedulingstrategyMaxutilization SchedulingStrategy = "max_utilization"
+	SchedulingstrategyMaxspread      SchedulingStrategy = "max_spread"
 )
 
 type SchedulingStrategyFunc func(Cluster, WorkloadAllocator, *Workload) (string, error)

--- a/api/pkg/scheduler/strategy_test.go
+++ b/api/pkg/scheduler/strategy_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	testModelStr = model.Model_Ollama_Llama3_8b
+	testModelStr = model.ModelOllamaLlama38b
 )
 
 var (

--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -212,7 +212,7 @@ func (s *HelixAPIServer) createApp(_ http.ResponseWriter, r *http.Request) (*typ
 
 	_, err = s.Controller.CreateAPIKey(ctx, user, &types.APIKey{
 		Name:  "api key 1",
-		Type:  types.APIKeyType_App,
+		Type:  types.APIkeytypeApp,
 		AppID: &sql.NullString{String: created.ID, Valid: true},
 	})
 	if err != nil {

--- a/api/pkg/server/auth_middleware.go
+++ b/api/pkg/server/auth_middleware.go
@@ -81,7 +81,7 @@ func (auth *authMiddleware) getUserFromToken(ctx context.Context, token string) 
 		}, nil
 	}
 
-	if strings.HasPrefix(token, types.API_KEY_PREIX) {
+	if strings.HasPrefix(token, types.APIKeyPrefix) {
 		// we have an API key - we should load it from the database and construct our user that way
 		apiKey, err := auth.store.GetAPIKey(ctx, token)
 		if err != nil {

--- a/api/pkg/server/auth_utils.go
+++ b/api/pkg/server/auth_utils.go
@@ -120,7 +120,7 @@ Access Control
 // if any of the admin users IDs is "*" then we are in dev mode and every user is an admin
 func isDevelopmentMode(adminUserIDs []string) bool {
 	for _, id := range adminUserIDs {
-		if id == types.ADMIN_ALL_USERS {
+		if id == types.AdminAllUsers {
 			return true
 		}
 	}

--- a/api/pkg/server/github_handlers.go
+++ b/api/pkg/server/github_handlers.go
@@ -151,7 +151,7 @@ func (apiServer *HelixAPIServer) githubWebhook(w http.ResponseWriter, r *http.Re
 
 // do we already have the github token as an api key in the database?
 func (apiServer *HelixAPIServer) getGithubDatabaseToken(ctx context.Context, user *types.User) (string, error) {
-	apiKeys, err := apiServer.Store.ListAPIKeys(ctx, &store.ListApiKeysQuery{
+	apiKeys, err := apiServer.Store.ListAPIKeys(ctx, &store.ListAPIKeysQuery{
 		Owner:     user.ID,
 		OwnerType: user.Type,
 	})
@@ -159,7 +159,7 @@ func (apiServer *HelixAPIServer) getGithubDatabaseToken(ctx context.Context, use
 		return "", err
 	}
 	for _, apiKey := range apiKeys {
-		if apiKey.Type == types.APIKeyType_Github {
+		if apiKey.Type == types.APIkeytypeGithub {
 			return apiKey.Key, nil
 		}
 	}
@@ -167,7 +167,7 @@ func (apiServer *HelixAPIServer) getGithubDatabaseToken(ctx context.Context, use
 }
 
 func (apiServer *HelixAPIServer) setGithubDatabaseToken(ctx context.Context, user *types.User, token string) error {
-	apiKeys, err := apiServer.Store.ListAPIKeys(ctx, &store.ListApiKeysQuery{
+	apiKeys, err := apiServer.Store.ListAPIKeys(ctx, &store.ListAPIKeysQuery{
 		Owner:     user.ID,
 		OwnerType: user.Type,
 	})
@@ -175,7 +175,7 @@ func (apiServer *HelixAPIServer) setGithubDatabaseToken(ctx context.Context, use
 		return err
 	}
 	for _, apiKey := range apiKeys {
-		if apiKey.Type == types.APIKeyType_Github {
+		if apiKey.Type == types.APIkeytypeGithub {
 			err = apiServer.Store.DeleteAPIKey(ctx, apiKey.Key)
 			if err != nil {
 				return err
@@ -187,7 +187,7 @@ func (apiServer *HelixAPIServer) setGithubDatabaseToken(ctx context.Context, use
 		OwnerType: user.Type,
 		Name:      "github-oauth",
 		Key:       token,
-		Type:      types.APIKeyType_Github,
+		Type:      types.APIkeytypeGithub,
 	})
 
 	if err != nil {

--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -684,7 +684,7 @@ func (apiServer *HelixAPIServer) createAPIKey(_ http.ResponseWriter, req *http.R
 	if name != "" {
 		// if we are using the query string route then don't try to deode the body
 		newAPIKey.Name = name
-		newAPIKey.Type = types.APIKeyType_API
+		newAPIKey.Type = types.APIkeytypeAPI
 	} else {
 		// For now we need to manually unmarshal the body because of the sql.NullString
 		body, err := io.ReadAll(req.Body)

--- a/api/pkg/server/openai_chat_handlers_test.go
+++ b/api/pkg/server/openai_chat_handlers_test.go
@@ -1035,7 +1035,7 @@ func (suite *OpenAIChatSuite) TestChatCompletions_App_CustomQueryParams() {
 	isActionableResponse := tools.IsActionableResponse{
 		NeedsTool:     tools.NeedsToolYes,
 		Justification: "Test reason",
-		Api:           "custom",
+		API:           "custom",
 	}
 	isActionableResponseBts, _ := json.Marshal(isActionableResponse)
 

--- a/api/pkg/store/migration_scripts.go
+++ b/api/pkg/store/migration_scripts.go
@@ -23,6 +23,6 @@ func helloWorld(*gorm.DB) error {
 	return nil
 }
 
-var MIGRATION_SCRIPTS map[string]func(*gorm.DB) error = map[string]func(*gorm.DB) error{
+var MigrationScripts map[string]func(*gorm.DB) error = map[string]func(*gorm.DB) error{
 	"01_hello_world": helloWorld,
 }

--- a/api/pkg/store/postgres.go
+++ b/api/pkg/store/postgres.go
@@ -49,7 +49,7 @@ func NewPostgresStore(
 
 	// Read SSL setting from environment
 	sslSettings := "sslmode=disable"
-	if os.Getenv(ENV_POSTGRES_SSL) == "true" {
+	if os.Getenv(EnvPostgresSSL) == "true" {
 		sslSettings = "sslmode=require"
 	}
 
@@ -131,7 +131,7 @@ func (s *PostgresStore) autoMigrate() error {
 		log.Err(err).Msg("failed to add DB FK")
 	}
 
-	return s.runMigrationScripts(MIGRATION_SCRIPTS)
+	return s.runMigrationScripts(MigrationScripts)
 }
 
 // loop over each migration script and run it only if it's not already been run
@@ -425,7 +425,7 @@ func (s *PostgresStore) GetMigrations() (*migrate.Migrate, error) {
 // Available DB types
 const (
 	DatabaseTypePostgres = "postgres"
-	ENV_POSTGRES_SSL     = "HELIX_POSTGRES_SSL"
+	EnvPostgresSSL       = "HELIX_POSTGRES_SSL"
 )
 
 func connect(ctx context.Context, cfg config.Store) (*gorm.DB, error) {
@@ -442,7 +442,7 @@ func connect(ctx context.Context, cfg config.Store) (*gorm.DB, error) {
 
 			// Read SSL setting from environment
 			sslSettings := "sslmode=disable"
-			if os.Getenv(ENV_POSTGRES_SSL) == "true" {
+			if os.Getenv(EnvPostgresSSL) == "true" {
 				sslSettings = "sslmode=require"
 			}
 

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -25,7 +25,7 @@ type GetSessionsQuery struct {
 	Limit         int             `json:"limit"`
 }
 
-type ListApiKeysQuery struct {
+type ListAPIKeysQuery struct {
 	Owner     string           `json:"owner"`
 	OwnerType types.OwnerType  `json:"owner_type"`
 	Type      types.APIKeyType `json:"type"`
@@ -76,7 +76,7 @@ type Store interface {
 	// api keys
 	CreateAPIKey(ctx context.Context, apiKey *types.APIKey) (*types.APIKey, error)
 	GetAPIKey(ctx context.Context, apiKey string) (*types.APIKey, error)
-	ListAPIKeys(ctx context.Context, query *ListApiKeysQuery) ([]*types.APIKey, error)
+	ListAPIKeys(ctx context.Context, query *ListAPIKeysQuery) ([]*types.APIKey, error)
 	DeleteAPIKey(ctx context.Context, apiKey string) error
 
 	// tools

--- a/api/pkg/store/store_apikeys.go
+++ b/api/pkg/store/store_apikeys.go
@@ -41,7 +41,7 @@ func (s *PostgresStore) GetAPIKey(ctx context.Context, key string) (*types.APIKe
 	return &apiKey, nil
 }
 
-func (s *PostgresStore) ListAPIKeys(ctx context.Context, q *ListApiKeysQuery) ([]*types.APIKey, error) {
+func (s *PostgresStore) ListAPIKeys(ctx context.Context, q *ListAPIKeysQuery) ([]*types.APIKey, error) {
 	var apiKeys []*types.APIKey
 	queryAPIKey := &types.APIKey{
 		Owner:     q.Owner,

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -557,7 +557,7 @@ func (mr *MockStoreMockRecorder) GetUserMeta(ctx, id any) *gomock.Call {
 }
 
 // ListAPIKeys mocks base method.
-func (m *MockStore) ListAPIKeys(ctx context.Context, query *ListApiKeysQuery) ([]*types.APIKey, error) {
+func (m *MockStore) ListAPIKeys(ctx context.Context, query *ListAPIKeysQuery) ([]*types.APIKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAPIKeys", ctx, query)
 	ret0, _ := ret[0].([]*types.APIKey)

--- a/api/pkg/system/apikey.go
+++ b/api/pkg/system/apikey.go
@@ -19,7 +19,7 @@ func GenerateAPIKey() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return types.API_KEY_PREIX + base64.URLEncoding.EncodeToString(key), nil
+	return types.APIKeyPrefix + base64.URLEncoding.EncodeToString(key), nil
 }
 
 func GenerateEcdsaKeypair() (*types.KeyPair, error) {

--- a/api/pkg/system/http.go
+++ b/api/pkg/system/http.go
@@ -96,8 +96,8 @@ func NewHTTPError500(message string) *HTTPError {
 type httpErrorHandler func(err *HTTPError, req *http.Request)
 type errorHandler func(err error, req *http.Request)
 
-var HTTP_ERROR_HANDLER httpErrorHandler
-var ERROR_HANDLER errorHandler
+var HTTPErrorHandler httpErrorHandler
+var ErrorHandler errorHandler
 
 // functions that understand they need to return a http error
 type httpWrapper[T any] func(res http.ResponseWriter, req *http.Request) (T, *HTTPError)
@@ -111,25 +111,25 @@ type WrapperConfig struct {
 }
 
 func SetHTTPErrorHandler(handler httpErrorHandler) {
-	HTTP_ERROR_HANDLER = handler
+	HTTPErrorHandler = handler
 }
 
 func SetErrorHandler(handler errorHandler) {
-	ERROR_HANDLER = handler
+	ErrorHandler = handler
 }
 
 // wrap a http handler with some error handling
 // so if it returns an error we handle it
 func Wrapper[T any](handler httpWrapper[T]) func(res http.ResponseWriter, req *http.Request) {
-	return WrapperWithConfig[T](handler, WrapperConfig{})
+	return WrapperWithConfig(handler, WrapperConfig{})
 }
 
 func WrapperWithConfig[T any](handler httpWrapper[T], config WrapperConfig) func(res http.ResponseWriter, req *http.Request) {
 	ret := func(res http.ResponseWriter, req *http.Request) {
 		data, err := handler(res, req)
 		if err != nil {
-			if HTTP_ERROR_HANDLER != nil {
-				HTTP_ERROR_HANDLER(err, req)
+			if HTTPErrorHandler != nil {
+				HTTPErrorHandler(err, req)
 			}
 			if !config.SilenceErrors {
 				log.Error().Msgf("error for route: %s", err.Error())
@@ -173,8 +173,8 @@ func DefaultWrapperWithConfig[T any](handler defaultWrapper[T], config WrapperCo
 	ret := func(res http.ResponseWriter, req *http.Request) {
 		data, err := handler(res, req)
 		if err != nil {
-			if ERROR_HANDLER != nil {
-				ERROR_HANDLER(err, req)
+			if ErrorHandler != nil {
+				ErrorHandler(err, req)
 			}
 			if !config.SilenceErrors {
 				log.Error().Msgf("error for route: %s", err.Error())

--- a/api/pkg/tools/informative_or_actionable.go
+++ b/api/pkg/tools/informative_or_actionable.go
@@ -22,7 +22,7 @@ const (
 
 type IsActionableResponse struct {
 	NeedsTool     string `json:"needs_tool"`
-	Api           string `json:"api"`
+	API           string `json:"api"`
 	Justification string `json:"justification"`
 }
 
@@ -165,7 +165,7 @@ func (c *ChainStrategy) isActionable(ctx context.Context, sessionID, interaction
 		Str("history", fmt.Sprintf("%+v", history)).
 		Str("justification", actionableResponse.Justification).
 		Str("needs_tool", actionableResponse.NeedsTool).
-		Str("chosen_tool", actionableResponse.Api).
+		Str("chosen_tool", actionableResponse.API).
 		Dur("time_taken", time.Since(started)).
 		Msg("is_actionable")
 

--- a/api/pkg/tools/informative_or_actionable_test.go
+++ b/api/pkg/tools/informative_or_actionable_test.go
@@ -108,7 +108,7 @@ func (suite *ActionTestSuite) TestIsActionable_Yes() {
 	suite.strategy.wg.Wait()
 
 	suite.Equal("yes", resp.NeedsTool)
-	suite.Equal("getWeather", resp.Api)
+	suite.Equal("getWeather", resp.API)
 }
 
 func (suite *ActionTestSuite) TestIsActionable_Retryable() {
@@ -181,7 +181,7 @@ func (suite *ActionTestSuite) TestIsActionable_Retryable() {
 	suite.strategy.wg.Wait()
 
 	suite.Equal("yes", resp.NeedsTool)
-	suite.Equal("getWeather", resp.Api)
+	suite.Equal("getWeather", resp.API)
 }
 
 func (suite *ActionTestSuite) TestIsActionable_NotActionable() {
@@ -229,5 +229,5 @@ func (suite *ActionTestSuite) TestIsActionable_NotActionable() {
 	suite.strategy.wg.Wait()
 
 	suite.Equal("no", resp.NeedsTool)
-	suite.Equal("", resp.Api)
+	suite.Equal("", resp.API)
 }

--- a/api/pkg/types/enums.go
+++ b/api/pkg/types/enums.go
@@ -161,23 +161,24 @@ const (
 	SessionEventTypeDeleted SessionEventType = "deleted"
 )
 
-const FILESTORE_RESULTS_DIR = "results"
-const FILESTORE_LORA_DIR = "lora"
+const (
+	FilestoreResultsDir = "results"
+	FilestoreLoraDir    = "lora"
+	LoraDirNone         = "none"
 
-const LORA_DIR_NONE = "none"
+	// in the interaction metadata we keep track of which chunks
+	// have been turned into questions - we use the following format
+	// qa_<filename>
+	// the value will be a comma separated list of chunk indexes
+	// e.g. qa_file.txt = 0,1,2,3,4
+	TextDataPrepFilesConvertedPrefix = "qa_"
 
-// in the interaction metadata we keep track of which chunks
-// have been turned into questions - we use the following format
-// qa_<filename>
-// the value will be a comma separated list of chunk indexes
-// e.g. qa_file.txt = 0,1,2,3,4
-const TEXT_DATA_PREP_FILES_CONVERTED_PREFIX = "qa_"
+	// what we append on the end of the files to turn them into the qa files
+	TextDataPrepQuestionsFileSuffix = ".qa.jsonl"
 
-// what we append on the end of the files to turn them into the qa files
-const TEXT_DATA_PREP_QUESTIONS_FILE_SUFFIX = ".qa.jsonl"
-
-// let's write to the same file for now
-const TEXT_DATA_PREP_QUESTIONS_FILE = "finetune_dataset.jsonl"
+	// let's write to the same file for now
+	TextDataPrepQuestionsFile = "finetune_dataset.jsonl"
+)
 
 type TextDataPrepStage string
 
@@ -192,11 +193,11 @@ const (
 	TextDataPrepStageComplete          TextDataPrepStage = "complete"
 )
 
-const API_KEY_PREIX = "hl-"
+const APIKeyPrefix = "hl-"
 
 // what will activate all users being admin users
 // this is a dev setting and should be applied to ADMIN_USER_IDS
-const ADMIN_ALL_USERS = "all"
+const AdminAllUsers = "all"
 
 type InferenceRuntime string
 
@@ -231,28 +232,28 @@ var (
 type DataPrepModule string
 
 const (
-	DataPrepModule_None         DataPrepModule = ""
-	DataPrepModule_GPT3Point5   DataPrepModule = "gpt3.5"
-	DataPrepModule_GPT4         DataPrepModule = "gpt4"
-	DataPrepModule_HelixMistral DataPrepModule = "helix_mistral"
-	DataPrepModule_Dynamic      DataPrepModule = "dynamic"
+	DataprepmoduleNone         DataPrepModule = ""
+	DataprepmoduleGpt3point5   DataPrepModule = "gpt3.5"
+	DataPrepModule_GPT4        DataPrepModule = "gpt4"
+	DataprepmoduleHelixmistral DataPrepModule = "helix_mistral"
+	DataprepmoduleDynamic      DataPrepModule = "dynamic"
 )
 
 func ValidateDataPrepModule(moduleName string, acceptEmpty bool) (DataPrepModule, error) {
 	switch moduleName {
-	case string(DataPrepModule_GPT3Point5):
-		return DataPrepModule_GPT3Point5, nil
+	case string(DataprepmoduleGpt3point5):
+		return DataprepmoduleGpt3point5, nil
 	case string(DataPrepModule_GPT4):
 		return DataPrepModule_GPT4, nil
-	case string(DataPrepModule_HelixMistral):
-		return DataPrepModule_HelixMistral, nil
-	case string(DataPrepModule_Dynamic):
-		return DataPrepModule_Dynamic, nil
+	case string(DataprepmoduleHelixmistral):
+		return DataprepmoduleHelixmistral, nil
+	case string(DataprepmoduleDynamic):
+		return DataprepmoduleDynamic, nil
 	default:
-		if acceptEmpty && moduleName == string(DataPrepModule_None) {
-			return DataPrepModule_None, nil
+		if acceptEmpty && moduleName == string(DataprepmoduleNone) {
+			return DataprepmoduleNone, nil
 		} else {
-			return DataPrepModule_None, fmt.Errorf("invalid data prep module name: %s", moduleName)
+			return DataprepmoduleNone, fmt.Errorf("invalid data prep module name: %s", moduleName)
 		}
 	}
 }
@@ -267,13 +268,13 @@ const (
 type APIKeyType string
 
 const (
-	APIKeyType_None APIKeyType = ""
+	APIkeytypeNone APIKeyType = ""
 	// generic access token for a user
-	APIKeyType_API APIKeyType = "api"
+	APIkeytypeAPI APIKeyType = "api"
 	// a github oauth token
-	APIKeyType_Github APIKeyType = "github"
+	APIkeytypeGithub APIKeyType = "github"
 	// a helix access token for a specific app
-	APIKeyType_App APIKeyType = "app"
+	APIkeytypeApp APIKeyType = "app"
 )
 
 type DataEntityType string


### PR DESCRIPTION
> [!IMPORTANT]
> No business logic has changed in this PR

This is the first commit of many that will rename identifiers in the codebase so they follow idiomatic Go:
* CamelCase
* Select keywords uppercase e.g. HTTP, API, ID, etc.