### PR TITLE
Last revive fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters:
     - bodyclose
     - tparallel
     - errcheck
-    #- revive
+    - revive
 
 issues:
   exlude-dirs:

--- a/api/pkg/scheduler/cluster.go
+++ b/api/pkg/scheduler/cluster.go
@@ -20,6 +20,11 @@ type cluster struct {
 	runnerTimeoutFunc TimeoutFunc                   // Function to check if runners have timed out.
 }
 
+var _ Cluster = &cluster{}
+
+// NOTE(milosgajdos): we really should make sure we return exported types.
+// If we want the type fields to be inaccessible we should make them unexported.
+// nolint:revive
 func NewCluster(runnerTimeoutFunc TimeoutFunc) *cluster {
 	return &cluster{
 		runners:           xsync.NewMapOf[string, *runner](),

--- a/api/pkg/scheduler/scheduler.go
+++ b/api/pkg/scheduler/scheduler.go
@@ -50,6 +50,10 @@ var _ Scheduler = &scheduler{}
 
 // NewScheduler creates a new scheduler with a workload allocator.
 // This also starts a goroutine to process the queue in the background.
+//
+// NOTE(milosgajdos): we really should make sure we return exported types.
+// If we want the type fields to be inaccessible we should make them unexported.
+// nolint:revive
 func NewScheduler(ctx context.Context, cfg *config.ServerConfig, onSchedulingErr func(work *Workload, err error)) *scheduler {
 	scheduler := newSchedulerWithoutGoroutines(cfg, onSchedulingErr)
 


### PR DESCRIPTION
See: https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported

As an aside we really should make sure we always return exported types. UNexported are really terrible to work with: you can not switch type/type assert them - this is good for things like if we are very anal about interface breakage, but in the grand scheme of things it makes dealing with some code pretty painful at times.