### PR TITLE
refactor(smoke): remove individual test timeouts

### DIFF
--- a/integration-test/smoke/app_integration_test.go
+++ b/integration-test/smoke/app_integration_test.go
@@ -5,7 +5,6 @@ package smoke
 
 import (
 	"testing"
-	"time"
 
 	"github.com/go-rod/rod/lib/devices"
 	"github.com/helixml/helix/integration-test/smoke/helper"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestCreateIntegrationApp(t *testing.T) {
-	ctx := helper.SetTestTimeout(t, 60*time.Second)
+	ctx := helper.CreateContext(t)
 
 	browser := createBrowser(ctx)
 	defer browser.MustClose()

--- a/integration-test/smoke/app_knowledge_test.go
+++ b/integration-test/smoke/app_knowledge_test.go
@@ -5,7 +5,6 @@ package smoke
 
 import (
 	"testing"
-	"time"
 
 	"github.com/go-rod/rod/lib/devices"
 	"github.com/helixml/helix/integration-test/smoke/helper"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestCreateRagApp(t *testing.T) {
-	ctx := helper.SetTestTimeout(t, 120*time.Second)
+	ctx := helper.CreateContext(t)
 
 	browser := createBrowser(ctx)
 	defer browser.MustClose()

--- a/integration-test/smoke/chat_test.go
+++ b/integration-test/smoke/chat_test.go
@@ -5,14 +5,13 @@ package smoke
 
 import (
 	"testing"
-	"time"
 
 	"github.com/helixml/helix/integration-test/smoke/helper"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStartNewSession(t *testing.T) {
-	ctx := helper.SetTestTimeout(t, 30*time.Second)
+	ctx := helper.CreateContext(t)
 
 	browser := createBrowser(ctx)
 	defer browser.MustClose()

--- a/integration-test/smoke/helix_cli_apply_test.go
+++ b/integration-test/smoke/helix_cli_apply_test.go
@@ -11,14 +11,13 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/helixml/helix/integration-test/smoke/helper"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHelixCLIApply(t *testing.T) {
-	ctx := helper.SetTestTimeout(t, 120*time.Second)
+	ctx := helper.CreateContext(t)
 
 	browser := createBrowser(ctx)
 	defer browser.MustClose()

--- a/integration-test/smoke/helix_cli_test.go
+++ b/integration-test/smoke/helix_cli_test.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/helixml/helix/integration-test/smoke/helper"
 	"github.com/stretchr/testify/require"
@@ -85,7 +84,7 @@ func TestHelixCLIInstall(t *testing.T) {
 }
 
 func TestHelixCLITest(t *testing.T) {
-	ctx := helper.SetTestTimeout(t, 30*time.Second)
+	ctx := helper.CreateContext(t)
 
 	browser := createBrowser(ctx)
 	defer browser.MustClose()

--- a/integration-test/smoke/helper/util.go
+++ b/integration-test/smoke/helper/util.go
@@ -143,8 +143,8 @@ func StartNewImageSession(t *testing.T, page *rod.Page) error {
 	return nil
 }
 
-func SetTestTimeout(t *testing.T, timeout time.Duration) context.Context {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+func CreateContext(t *testing.T) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel) // Register the cancel function to be called when the test finishes
 	go func() {
 		<-ctx.Done()

--- a/integration-test/smoke/inference_image_test.go
+++ b/integration-test/smoke/inference_image_test.go
@@ -5,14 +5,13 @@ package smoke
 
 import (
 	"testing"
-	"time"
 
 	"github.com/helixml/helix/integration-test/smoke/helper"
 	"github.com/stretchr/testify/require"
 )
 
 func TestImageInference(t *testing.T) {
-	ctx := helper.SetTestTimeout(t, 90*time.Second)
+	ctx := helper.CreateContext(t)
 
 	browser := createBrowser(ctx)
 	defer browser.MustClose()


### PR DESCRIPTION
Rely on the global go test -timeout instead. Because in reality if one times out, then the whole test is a failure. So I only really need one timeout. And I think that 120s might sometimes be too low.