### PR TITLE
Introduce ADMIN_USER_SOURCE for checking admin users

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/helixml/helix/api/pkg/types"
@@ -257,8 +258,11 @@ type WebServer struct {
 
 	RunnerToken string `envconfig:"RUNNER_TOKEN" description:"The token for runner auth."`
 	// a list of keycloak ids that are considered admins
-	// if the string '*' is included it means ALL users
+	// if the string 'all' is included it means ALL users
 	AdminIDs []string `envconfig:"ADMIN_USER_IDS" description:"Keycloak admin IDs."`
+	// Specifies the source of the Admin user IDs.
+	// By default AdminSrc is set to env.
+	AdminSrc AdminSrcType `envconfig:"ADMIN_USER_SOURCE" default:"env" description:"Source of admin IDs"`
 	// if this is specified then we provide the option to clone entire
 	// sessions into this user without having to logout and login
 	EvalUserID string `envconfig:"EVAL_USER_ID" description:""`
@@ -269,6 +273,27 @@ type WebServer struct {
 	// (this is so helix nodes can see files)
 	// later, we might add a token to the URLs
 	LocalFilestorePath string
+}
+
+// AdminSrcType is an enum specifyin the type of Admin ID source.
+// It currently supports only two sources:
+// * env: ADMIN_USER_IDS env var
+// * jwt: admin JWT token claim
+type AdminSrcType string
+
+const (
+	AdminSrcTypeEnv AdminSrcType = "env"
+	AdminSrcTypeJWT AdminSrcType = "jwt"
+)
+
+// Decode implements envconfig.Decoder for value validation.
+func (a *AdminSrcType) Decode(value string) error {
+	switch value {
+	case string(AdminSrcTypeEnv), string(AdminSrcTypeJWT):
+		return nil
+	default:
+		return fmt.Errorf("invalid source of admin IDs: %q", value)
+	}
 }
 
 type SubscriptionQuotas struct {

--- a/api/pkg/server/auth_utils.go
+++ b/api/pkg/server/auth_utils.go
@@ -117,7 +117,8 @@ func addCorsHeaders(w http.ResponseWriter) {
 Access Control
 -
 */
-// if any of the admin users IDs is "*" then we are in dev mode and every user is an admin
+// if any of the admin users IDs is "all" then we are in dev mode and every user is an admin
+// nolint:unused
 func isDevelopmentMode(adminUserIDs []string) bool {
 	for _, id := range adminUserIDs {
 		if id == types.AdminAllUsers {

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -113,6 +113,7 @@ func NewServer(
 			store,
 			authMiddlewareConfig{
 				adminUserIDs: cfg.WebServer.AdminIDs,
+				adminUserSrc: cfg.WebServer.AdminSrc,
 				runnerToken:  cfg.WebServer.RunnerToken,
 			},
 		),

--- a/charts/helix-controlplane/values-example.yaml
+++ b/charts/helix-controlplane/values-example.yaml
@@ -36,6 +36,7 @@ envVariables:
   KEYCLOAK_PASSWORD: "oh-hallo-insecure-password"
   # Dashboard
   ADMIN_USER_IDS: "all"
+  ADMIN_USER_SOURCE: "env"
   # Evals
   EVAL_USER_ID: ""
   HELIX_API_KEY: "helix_api_key"

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -35,6 +35,7 @@ services:
       - KEYCLOAK_FRONTEND_URL=${KEYCLOAK_FRONTEND_URL:-http://localhost:8080/auth/}
       # lock down dashboard in production
       - ADMIN_USER_IDS=${ADMIN_USER_IDS-all}
+      - ADMIN_USER_SOURCE=${ADMIN_USER_SOURCE-env}
       - TEXT_EXTRACTION_URL=http://llamaindex:5000/api/v1/extract
       - RAG_INDEX_URL=http://llamaindex:5000/api/v1/rag/chunk
       - RAG_QUERY_URL=http://llamaindex:5000/api/v1/rag/query

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,6 +32,7 @@ services:
       - KEYCLOAK_FRONTEND_URL=${KEYCLOAK_FRONTEND_URL:-http://localhost:8080/auth/}
       # lock down dashboard in production
       - ADMIN_USER_IDS=${ADMIN_USER_IDS-all}
+      - ADMIN_USER_SOURCE=${ADMIN_USER_SOURCE-env}
       - TEXT_EXTRACTION_URL=http://llamaindex:5000/api/v1/extract
       - RAG_INDEX_URL=http://llamaindex:5000/api/v1/rag/chunk
       - RAG_QUERY_URL=http://llamaindex:5000/api/v1/rag/query

--- a/scripts/kind_helm_install.sh
+++ b/scripts/kind_helm_install.sh
@@ -124,6 +124,7 @@ for env_var in \
     KEYCLOAK_USER \
     KEYCLOAK_PASSWORD \
     ADMIN_USER_IDS \
+    ADMIN_USER_SOURCE \
     EVAL_USER_ID \
     HELIX_API_KEY; do
     eval value=\${$env_var:-}


### PR DESCRIPTION
> [!IMPORTANT]
> `admin` claims in the JWT token assume `admin` boolean key **TBD**

The new `ADMIN_USER_SOURCE` env var allows to specify the source of the admin user check.

There are currently two possible admin user sources:
* `env`: admin user IDs are read from the `ADMIN_USER_IDS` env var
* `jwt`: admin JWT token claim is checked

By default, the "env" source is set. If the "jwt" source is required it must be
explicitly overridden by setting ADMIN_USER_SOURCE env var accordingly.

There was a lot of code duplication throughout so we've done a bit of boyscouting:
* auth middleware groups config in a dedicated config field
* remove the `development` field - there is no need for it (the check is
  being done inside the for loop
* introduced account type which helps with dealing with different types of
  admin account decisions and keeps code just a bit more type-safe