### PR TITLE
default admin source to env

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -268,7 +268,7 @@ type WebServer struct {
 	AdminIDs []string `envconfig:"ADMIN_USER_IDS" description:"Keycloak admin IDs."`
 	// Specifies the source of the Admin user IDs.
 	// By default AdminSrc is set to env.
-	AdminSrc AdminSrcType `envconfig:"ADMIN_USER_SOURCE" default:"env" description:"Source of admin IDs"`
+	AdminSrc AdminSrcType `envconfig:"ADMIN_USER_SOURCE" default:"env" description:"Source of admin IDs (env or jwt)"`
 	// if this is specified then we provide the option to clone entire
 	// sessions into this user without having to logout and login
 	EvalUserID string `envconfig:"EVAL_USER_ID" description:""`
@@ -299,6 +299,10 @@ func (a AdminSrcType) String() string {
 
 // Decode implements envconfig.Decoder for value validation.
 func (a *AdminSrcType) Decode(value string) error {
+	if value == "" {
+		*a = AdminSrcTypeEnv
+		return nil
+	}
 	switch value {
 	case string(AdminSrcTypeEnv), string(AdminSrcTypeJWT):
 		*a = AdminSrcType(value)


### PR DESCRIPTION
so it's not necessary to specify it in the .env