### PR TITLE
OpenAI-compat API: return response IDs and log them as session IDs

### DIFF
--- a/api/pkg/server/auth_utils.go
+++ b/api/pkg/server/auth_utils.go
@@ -117,16 +117,6 @@ func addCorsHeaders(w http.ResponseWriter) {
 Access Control
 -
 */
-// if any of the admin users IDs is "all" then we are in dev mode and every user is an admin
-// nolint:unused
-func isDevelopmentMode(adminUserIDs []string) bool {
-	for _, id := range adminUserIDs {
-		if id == types.AdminAllUsers {
-			return true
-		}
-	}
-	return false
-}
 
 func hasUser(user *types.User) bool {
 	return user.ID != ""

--- a/api/pkg/server/openai_chat_handlers.go
+++ b/api/pkg/server/openai_chat_handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/helixml/helix/api/pkg/controller"
 	"github.com/helixml/helix/api/pkg/model"
 	oai "github.com/helixml/helix/api/pkg/openai"
+	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/types"
 
 	"github.com/rs/zerolog/log"
@@ -83,9 +84,11 @@ func (s *HelixAPIServer) createChatCompletion(rw http.ResponseWriter, r *http.Re
 		ownerID = oai.RunnerID
 	}
 
+	responseID := system.GenerateOpenAIResponseID()
+
 	ctx := oai.SetContextValues(r.Context(), &oai.ContextValues{
 		OwnerID:         ownerID,
-		SessionID:       "n/a",
+		SessionID:       responseID,
 		InteractionID:   "n/a",
 		OriginalRequest: body,
 	})
@@ -186,6 +189,8 @@ func (s *HelixAPIServer) createChatCompletion(rw http.ResponseWriter, r *http.Re
 			return
 		}
 
+		resp.ID = responseID
+
 		err = json.NewEncoder(rw).Encode(resp)
 		if err != nil {
 			log.Error().Err(err).Msg("error writing response")
@@ -208,6 +213,7 @@ func (s *HelixAPIServer) createChatCompletion(rw http.ResponseWriter, r *http.Re
 	// Write the stream into the response
 	for {
 		response, err := stream.Recv()
+		response.ID = responseID
 		if errors.Is(err, io.EOF) {
 			break
 		}

--- a/api/pkg/server/openai_chat_handlers_test.go
+++ b/api/pkg/server/openai_chat_handlers_test.go
@@ -164,7 +164,7 @@ func (suite *OpenAIChatSuite) TestChatCompletions_Basic_Blocking() {
 			vals, ok := openai.GetContextValues(ctx)
 			suite.True(ok)
 			suite.Equal(ownerID, vals.OwnerID)
-			suite.Equal("n/a", vals.SessionID)
+			suite.True(strings.HasPrefix(vals.SessionID, "oai_"), "SessionID should start with 'oai_'")
 			suite.Equal("n/a", vals.InteractionID)
 
 			return oai.ChatCompletionResponse{
@@ -230,7 +230,7 @@ func (suite *OpenAIChatSuite) TestChatCompletions_Streaming() {
 			vals, ok := openai.GetContextValues(ctx)
 			suite.True(ok)
 			suite.Equal(ownerID, vals.OwnerID)
-			suite.Equal("n/a", vals.SessionID)
+			suite.True(strings.HasPrefix(vals.SessionID, "oai_"), "SessionID should start with 'oai_'")
 			suite.Equal("n/a", vals.InteractionID)
 
 			return stream, nil
@@ -399,7 +399,7 @@ func (suite *OpenAIChatSuite) TestChatCompletions_App_Blocking() {
 			vals, ok := openai.GetContextValues(ctx)
 			suite.True(ok)
 			suite.Equal(ownerID, vals.OwnerID)
-			suite.Equal("n/a", vals.SessionID)
+			suite.True(strings.HasPrefix(vals.SessionID, "oai_"), "SessionID should start with 'oai_'")
 			suite.Equal("n/a", vals.InteractionID)
 
 			return oai.ChatCompletionResponse{
@@ -490,7 +490,7 @@ func (suite *OpenAIChatSuite) TestChatCompletions_App_HelixModel() {
 			vals, ok := openai.GetContextValues(ctx)
 			suite.True(ok)
 			suite.Equal(ownerID, vals.OwnerID)
-			suite.Equal("n/a", vals.SessionID)
+			suite.True(strings.HasPrefix(vals.SessionID, "oai_"), "SessionID should start with 'oai_'")
 			suite.Equal("n/a", vals.InteractionID)
 
 			return oai.ChatCompletionResponse{
@@ -617,7 +617,7 @@ func (suite *OpenAIChatSuite) TestChatCompletions_AppRag_Blocking() {
 			vals, ok := openai.GetContextValues(ctx)
 			suite.True(ok)
 			suite.Equal(ownerID, vals.OwnerID)
-			suite.Equal("n/a", vals.SessionID)
+			suite.True(strings.HasPrefix(vals.SessionID, "oai_"), "SessionID should start with 'oai_'")
 			suite.Equal("n/a", vals.InteractionID)
 
 			suite.Contains(req.Messages[1].Content, "This is a test RAG source 1")
@@ -718,7 +718,7 @@ func (suite *OpenAIChatSuite) TestChatCompletions_AppFromAuth_Blocking() {
 			vals, ok := openai.GetContextValues(ctx)
 			suite.True(ok)
 			suite.Equal(ownerID, vals.OwnerID)
-			suite.Equal("n/a", vals.SessionID)
+			suite.True(strings.HasPrefix(vals.SessionID, "oai_"), "SessionID should start with 'oai_'")
 			suite.Equal("n/a", vals.InteractionID)
 
 			return oai.ChatCompletionResponse{
@@ -805,7 +805,7 @@ func (suite *OpenAIChatSuite) TestChatCompletions_App_Streaming() {
 			vals, ok := openai.GetContextValues(ctx)
 			suite.True(ok)
 			suite.Equal(ownerID, vals.OwnerID)
-			suite.Equal("n/a", vals.SessionID)
+			suite.True(strings.HasPrefix(vals.SessionID, "oai_"), "SessionID should start with 'oai_'")
 			suite.Equal("n/a", vals.InteractionID)
 
 			suite.Require().Equal(2, len(req.Messages))

--- a/api/pkg/server/websocket_server_gptscript_runner.go
+++ b/api/pkg/server/websocket_server_gptscript_runner.go
@@ -78,7 +78,7 @@ func (apiServer *HelixAPIServer) startGptScriptRunnerWebSocketServer(r *mux.Rout
 			if err != nil {
 				log.Error().Msgf("Error writing to GPTScript runner websocket: %s", err.Error())
 				if nakErr := msg.Nak(); nakErr != nil {
-					return fmt.Errorf("Error writing to GPTScript runner websocket: %v, failed to Nak the message: %v", err, nakErr)
+					return fmt.Errorf("error writing to GPTScript runner websocket: %v, failed to Nak the message: %v", err, nakErr)
 				}
 				return err
 			}

--- a/api/pkg/system/uuid.go
+++ b/api/pkg/system/uuid.go
@@ -21,6 +21,7 @@ const (
 	KnowledgeVersionPrefix    = "knov_"
 	SecretPrefix              = "sec_"
 	TestRunPrefix             = "testrun_"
+	OpenAIResponsePrefix      = "oai_"
 )
 
 func GenerateUUID() string {
@@ -84,4 +85,8 @@ func GenerateVersion() string {
 
 func GenerateTestRunID() string {
 	return fmt.Sprintf("%s%s", TestRunPrefix, newID())
+}
+
+func GenerateOpenAIResponseID() string {
+	return fmt.Sprintf("%s%s", OpenAIResponsePrefix, newID())
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2db9cf56-cdec-4d11-a441-040a3b965a1b)

You can now filter by the id returned by the OpenAI compatible API on apps in the LLM calls dashboard, to ease debugging.