### PR TITLE
fix: smallest possible change to fix knowledge disappearing issue.

### DIFF
--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -47,11 +47,6 @@ const Layout: FC = ({
     return account.serverConfig.version !== account.serverConfig.latest_version
   }, [account.serverConfig?.version, account.serverConfig?.latest_version])
 
-  console.log('Layout:', {
-    deploymentId: account.serverConfig?.deployment_id,
-    serverConfig: account.serverConfig
-  });
-
   return (
     <>
       <Collapse in={showVersionBanner && hasNewVersion}>


### PR DESCRIPTION
When adding knowledge sources to an app, the unsaved sources would disappear from the UI after the backend polling cycle ran (every 2 seconds), before the user had a chance to save them.

The app initialization code was overwriting local knowledgeSources state with backend data whenever apps.data refreshed, causing unsaved changes to be lost.

Restructured app initialization into three separate effects with clear responsibilities:

1. App ID change effect: Resets initialization flags
2. App data loading effect: Only sets knowledge sources during initial load
3. New app initialization effect: Handles "new" app case separately

Modified the app data loading effect to only initialize knowledge sources once per app ID, while still updating the app state when backend data changes.