### PR TITLE
Fix/app edit access

### DIFF
--- a/api/pkg/client/app_access_grants.go
+++ b/api/pkg/client/app_access_grants.go
@@ -45,3 +45,12 @@ func (c *HelixClient) DeleteAppAccessGrant(ctx context.Context, appID string, gr
 	}
 	return nil
 }
+
+func (c *HelixClient) GetAppUserAccess(ctx context.Context, appID string) (*types.UserAppAccessResponse, error) {
+	var response types.UserAppAccessResponse
+	err := c.makeRequest(ctx, http.MethodGet, fmt.Sprintf("/apps/%s/user-access", appID), nil, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}

--- a/api/pkg/client/client.go
+++ b/api/pkg/client/client.go
@@ -67,6 +67,9 @@ type Client interface {
 	ListAppAccessGrants(ctx context.Context, f *AppAccessGrantsFilter) ([]*types.AccessGrant, error)
 	CreateAppAccessGrant(ctx context.Context, appID string, grant *types.CreateAccessGrantRequest) (*types.AccessGrant, error)
 	DeleteAppAccessGrant(ctx context.Context, appID, grantID string) error
+
+	// Get current user's access level for an app
+	GetAppUserAccess(ctx context.Context, appID string) (*types.UserAppAccessResponse, error)
 }
 
 type SessionFilter struct {

--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -1084,11 +1084,11 @@ func (s *HelixAPIServer) getAppUserAccess(_ http.ResponseWriter, r *http.Request
 	readErr := s.authorizeUserToResource(r.Context(), user, app.OrganizationID, app.ID, types.ResourceApplication, types.ActionGet)
 	writeErr := s.authorizeUserToResource(r.Context(), user, app.OrganizationID, app.ID, types.ResourceApplication, types.ActionUpdate)
 
-	if readErr != nil {
-		response.CanRead = false
+	if readErr == nil {
+		response.CanRead = true
 	}
-	if writeErr != nil {
-		response.CanWrite = false
+	if writeErr == nil {
+		response.CanWrite = true
 	}
 
 	// Always return the response, even if the user has no access

--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -1005,22 +1005,15 @@ func (s *HelixAPIServer) appRunAPIAction(_ http.ResponseWriter, r *http.Request)
 	return response, nil
 }
 
-// Response for the user access endpoint
-type UserAppAccessResponse struct {
-	CanRead  bool `json:"can_read"`
-	CanWrite bool `json:"can_write"`
-	IsAdmin  bool `json:"is_admin"`
-}
-
 // getAppUserAccess godoc
 // @Summary Get current user's access level for an app
 // @Description Returns the access rights the current user has for this app
 // @Tags    apps
-// @Success 200 {object} UserAppAccessResponse
+// @Success 200 {object} types.UserAppAccessResponse
 // @Param id path string true "App ID"
 // @Router /api/v1/apps/{id}/user-access [get]
 // @Security BearerAuth
-func (s *HelixAPIServer) getAppUserAccess(_ http.ResponseWriter, r *http.Request) (*UserAppAccessResponse, *system.HTTPError) {
+func (s *HelixAPIServer) getAppUserAccess(_ http.ResponseWriter, r *http.Request) (*types.UserAppAccessResponse, *system.HTTPError) {
 	// Get current user and app ID
 	user := getRequestUser(r)
 	id := getID(r)
@@ -1035,7 +1028,7 @@ func (s *HelixAPIServer) getAppUserAccess(_ http.ResponseWriter, r *http.Request
 	}
 
 	// Initialize response with no permissions
-	response := &UserAppAccessResponse{
+	response := &types.UserAppAccessResponse{
 		CanRead:  false,
 		CanWrite: false,
 		IsAdmin:  false,

--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -835,6 +835,7 @@ func (s *HelixAPIServer) getAppOAuthTokenEnv(ctx context.Context, user *types.Us
 // @Accept json
 // @Produce json
 // @Param request body types.GptScriptRequest true "Request"
+// @Router /api/v1/apps/{id}/gptscript [post]
 // @Success 200 {object} types.GptScriptResponse
 // @Failure 400 {object} system.HTTPError
 // @Failure 404 {object} system.HTTPError
@@ -947,6 +948,7 @@ func (s *HelixAPIServer) appRunScript(_ http.ResponseWriter, r *http.Request) (*
 // @Accept json
 // @Produce json
 // @Param request body types.RunAPIActionRequest true "Request"
+// @Router /api/v1/apps/{id}/api-actions [post]
 // @Success 200 {object} types.RunAPIActionResponse
 // @Failure 400 {object} system.HTTPError
 // @Failure 404 {object} system.HTTPError

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -381,7 +381,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/server.UserAppAccessResponse"
+                            "$ref": "#/definitions/types.UserAppAccessResponse"
                         }
                     }
                 }
@@ -2244,20 +2244,6 @@ const docTemplate = `{
             "properties": {
                 "license_key": {
                     "type": "string"
-                }
-            }
-        },
-        "server.UserAppAccessResponse": {
-            "type": "object",
-            "properties": {
-                "can_read": {
-                    "type": "boolean"
-                },
-                "can_write": {
-                    "type": "boolean"
-                },
-                "is_admin": {
-                    "type": "boolean"
                 }
             }
         },
@@ -4848,6 +4834,20 @@ const docTemplate = `{
                 },
                 "username": {
                     "type": "string"
+                }
+            }
+        },
+        "types.UserAppAccessResponse": {
+            "type": "object",
+            "properties": {
+                "can_read": {
+                    "type": "boolean"
+                },
+                "can_write": {
+                    "type": "boolean"
+                },
+                "is_admin": {
+                    "type": "boolean"
                 }
             }
         },

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -255,9 +255,17 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
+                "description": "Runs an API action for an app",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Run an API action",
                 "parameters": [
                     {
-                        "description": "Request body with API action name and parameters.",
+                        "description": "Request",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -272,6 +280,24 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/types.RunAPIActionResponse"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
                     }
                 }
             }
@@ -283,9 +309,17 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
+                "description": "Runs a gptscript for an app",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Run a GptScript",
                 "parameters": [
                     {
-                        "description": "Request body with script configuration.",
+                        "description": "Request",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -299,6 +333,55 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/types.GptScriptResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/apps/{id}/user-access": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the access rights the current user has for this app",
+                "tags": [
+                    "apps"
+                ],
+                "summary": "Get current user's access level for an app",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "App ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.UserAppAccessResponse"
                         }
                     }
                 }
@@ -2164,6 +2247,31 @@ const docTemplate = `{
                 }
             }
         },
+        "server.UserAppAccessResponse": {
+            "type": "object",
+            "properties": {
+                "can_read": {
+                    "type": "boolean"
+                },
+                "can_write": {
+                    "type": "boolean"
+                },
+                "is_admin": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "system.HTTPError": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "statusCode": {
+                    "type": "integer"
+                }
+            }
+        },
         "types.AccessGrant": {
             "type": "object",
             "properties": {
@@ -2180,14 +2288,6 @@ const docTemplate = `{
                 "resource_id": {
                     "description": "App ID, Knowledge ID, etc",
                     "type": "string"
-                },
-                "resource_type": {
-                    "description": "Kind of resource (app, knowledge, provider endpoint, etc)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.Resource"
-                        }
-                    ]
                 },
                 "roles": {
                     "type": "array",
@@ -2419,6 +2519,20 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
+                },
+                "oauth_provider": {
+                    "description": "OAuth configuration",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.OAuthProviderType"
+                        }
+                    ]
+                },
+                "oauth_scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "query": {
                     "type": "object",
@@ -3440,6 +3554,29 @@ const docTemplate = `{
             ],
             "x-enum-varnames": [
                 "MessageContentTypeText"
+            ]
+        },
+        "types.OAuthProviderType": {
+            "type": "string",
+            "enum": [
+                "",
+                "atlassian",
+                "google",
+                "microsoft",
+                "github",
+                "slack",
+                "linkedin",
+                "custom"
+            ],
+            "x-enum-varnames": [
+                "OAuthProviderTypeUnknown",
+                "OAuthProviderTypeAtlassian",
+                "OAuthProviderTypeGoogle",
+                "OAuthProviderTypeMicrosoft",
+                "OAuthProviderTypeGitHub",
+                "OAuthProviderTypeSlack",
+                "OAuthProviderTypeLinkedIn",
+                "OAuthProviderTypeCustom"
             ]
         },
         "types.OpenAIMessage": {
@@ -4516,6 +4653,21 @@ const docTemplate = `{
                 },
                 "model": {
                     "type": "string"
+                },
+                "oauth_provider": {
+                    "description": "OAuth configuration",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.OAuthProviderType"
+                        }
+                    ]
+                },
+                "oauth_scopes": {
+                    "description": "Required OAuth scopes for this API",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "query": {
                     "description": "Query parameters that will be always set",

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -410,6 +410,7 @@ func (apiServer *HelixAPIServer) registerRoutes(_ context.Context) (*mux.Router,
 	authRouter.HandleFunc("/apps/{id}", system.Wrapper(apiServer.deleteApp)).Methods(http.MethodDelete)
 	authRouter.HandleFunc("/apps/{id}/llm-calls", system.Wrapper(apiServer.listAppLLMCalls)).Methods(http.MethodGet)
 	authRouter.HandleFunc("/apps/{id}/api-actions", system.Wrapper(apiServer.appRunAPIAction)).Methods(http.MethodPost)
+	authRouter.HandleFunc("/apps/{id}/user-access", system.Wrapper(apiServer.getAppUserAccess)).Methods(http.MethodGet)
 	authRouter.HandleFunc("/apps/{id}/access-grants", apiServer.listAppAccessGrants).Methods(http.MethodGet)
 	authRouter.HandleFunc("/apps/{id}/access-grants", apiServer.createAppAccessGrant).Methods(http.MethodPost)
 	authRouter.HandleFunc("/apps/{id}/access-grants/{grant_id}", apiServer.deleteAppAccessGrant).Methods(http.MethodDelete)

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -251,9 +251,17 @@
                         "BearerAuth": []
                     }
                 ],
+                "description": "Runs an API action for an app",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Run an API action",
                 "parameters": [
                     {
-                        "description": "Request body with API action name and parameters.",
+                        "description": "Request",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -268,6 +276,24 @@
                         "schema": {
                             "$ref": "#/definitions/types.RunAPIActionResponse"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
                     }
                 }
             }
@@ -279,9 +305,17 @@
                         "BearerAuth": []
                     }
                 ],
+                "description": "Runs a gptscript for an app",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Run a GptScript",
                 "parameters": [
                     {
-                        "description": "Request body with script configuration.",
+                        "description": "Request",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -295,6 +329,55 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/types.GptScriptResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/apps/{id}/user-access": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the access rights the current user has for this app",
+                "tags": [
+                    "apps"
+                ],
+                "summary": "Get current user's access level for an app",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "App ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.UserAppAccessResponse"
                         }
                     }
                 }
@@ -2160,6 +2243,31 @@
                 }
             }
         },
+        "server.UserAppAccessResponse": {
+            "type": "object",
+            "properties": {
+                "can_read": {
+                    "type": "boolean"
+                },
+                "can_write": {
+                    "type": "boolean"
+                },
+                "is_admin": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "system.HTTPError": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "statusCode": {
+                    "type": "integer"
+                }
+            }
+        },
         "types.AccessGrant": {
             "type": "object",
             "properties": {
@@ -2176,14 +2284,6 @@
                 "resource_id": {
                     "description": "App ID, Knowledge ID, etc",
                     "type": "string"
-                },
-                "resource_type": {
-                    "description": "Kind of resource (app, knowledge, provider endpoint, etc)",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.Resource"
-                        }
-                    ]
                 },
                 "roles": {
                     "type": "array",
@@ -2415,6 +2515,20 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "oauth_provider": {
+                    "description": "OAuth configuration",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.OAuthProviderType"
+                        }
+                    ]
+                },
+                "oauth_scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "query": {
                     "type": "object",
@@ -3436,6 +3550,29 @@
             ],
             "x-enum-varnames": [
                 "MessageContentTypeText"
+            ]
+        },
+        "types.OAuthProviderType": {
+            "type": "string",
+            "enum": [
+                "",
+                "atlassian",
+                "google",
+                "microsoft",
+                "github",
+                "slack",
+                "linkedin",
+                "custom"
+            ],
+            "x-enum-varnames": [
+                "OAuthProviderTypeUnknown",
+                "OAuthProviderTypeAtlassian",
+                "OAuthProviderTypeGoogle",
+                "OAuthProviderTypeMicrosoft",
+                "OAuthProviderTypeGitHub",
+                "OAuthProviderTypeSlack",
+                "OAuthProviderTypeLinkedIn",
+                "OAuthProviderTypeCustom"
             ]
         },
         "types.OpenAIMessage": {
@@ -4512,6 +4649,21 @@
                 },
                 "model": {
                     "type": "string"
+                },
+                "oauth_provider": {
+                    "description": "OAuth configuration",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.OAuthProviderType"
+                        }
+                    ]
+                },
+                "oauth_scopes": {
+                    "description": "Required OAuth scopes for this API",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "query": {
                     "description": "Query parameters that will be always set",

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -377,7 +377,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/server.UserAppAccessResponse"
+                            "$ref": "#/definitions/types.UserAppAccessResponse"
                         }
                     }
                 }
@@ -2240,20 +2240,6 @@
             "properties": {
                 "license_key": {
                     "type": "string"
-                }
-            }
-        },
-        "server.UserAppAccessResponse": {
-            "type": "object",
-            "properties": {
-                "can_read": {
-                    "type": "boolean"
-                },
-                "can_write": {
-                    "type": "boolean"
-                },
-                "is_admin": {
-                    "type": "boolean"
                 }
             }
         },
@@ -4844,6 +4830,20 @@
                 },
                 "username": {
                     "type": "string"
+                }
+            }
+        },
+        "types.UserAppAccessResponse": {
+            "type": "object",
+            "properties": {
+                "can_read": {
+                    "type": "boolean"
+                },
+                "can_write": {
+                    "type": "boolean"
+                },
+                "is_admin": {
+                    "type": "boolean"
                 }
             }
         },

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -491,15 +491,6 @@ definitions:
       license_key:
         type: string
     type: object
-  server.UserAppAccessResponse:
-    properties:
-      can_read:
-        type: boolean
-      can_write:
-        type: boolean
-      is_admin:
-        type: boolean
-    type: object
   system.HTTPError:
     properties:
       message:
@@ -2321,6 +2312,15 @@ definitions:
       username:
         type: string
     type: object
+  types.UserAppAccessResponse:
+    properties:
+      can_read:
+        type: boolean
+      can_write:
+        type: boolean
+      is_admin:
+        type: boolean
+    type: object
   types.UserResponse:
     properties:
       email:
@@ -2570,7 +2570,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/server.UserAppAccessResponse'
+            $ref: '#/definitions/types.UserAppAccessResponse'
       security:
       - BearerAuth: []
       summary: Get current user's access level for an app

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -491,6 +491,22 @@ definitions:
       license_key:
         type: string
     type: object
+  server.UserAppAccessResponse:
+    properties:
+      can_read:
+        type: boolean
+      can_write:
+        type: boolean
+      is_admin:
+        type: boolean
+    type: object
+  system.HTTPError:
+    properties:
+      message:
+        type: string
+      statusCode:
+        type: integer
+    type: object
   types.AccessGrant:
     properties:
       created_at:
@@ -503,10 +519,6 @@ definitions:
       resource_id:
         description: App ID, Knowledge ID, etc
         type: string
-      resource_type:
-        allOf:
-        - $ref: '#/definitions/types.Resource'
-        description: Kind of resource (app, knowledge, provider endpoint, etc)
       roles:
         items:
           $ref: '#/definitions/types.Role'
@@ -660,6 +672,14 @@ definitions:
         type: object
       name:
         type: string
+      oauth_provider:
+        allOf:
+        - $ref: '#/definitions/types.OAuthProviderType'
+        description: OAuth configuration
+      oauth_scopes:
+        items:
+          type: string
+        type: array
       query:
         additionalProperties:
           type: string
@@ -1382,6 +1402,26 @@ definitions:
     type: string
     x-enum-varnames:
     - MessageContentTypeText
+  types.OAuthProviderType:
+    enum:
+    - ""
+    - atlassian
+    - google
+    - microsoft
+    - github
+    - slack
+    - linkedin
+    - custom
+    type: string
+    x-enum-varnames:
+    - OAuthProviderTypeUnknown
+    - OAuthProviderTypeAtlassian
+    - OAuthProviderTypeGoogle
+    - OAuthProviderTypeMicrosoft
+    - OAuthProviderTypeGitHub
+    - OAuthProviderTypeSlack
+    - OAuthProviderTypeLinkedIn
+    - OAuthProviderTypeCustom
   types.OpenAIMessage:
     properties:
       content:
@@ -2151,6 +2191,15 @@ definitions:
         type: object
       model:
         type: string
+      oauth_provider:
+        allOf:
+        - $ref: '#/definitions/types.OAuthProviderType'
+        description: OAuth configuration
+      oauth_scopes:
+        description: Required OAuth scopes for this API
+        items:
+          type: string
+        type: array
       query:
         additionalProperties:
           type: string
@@ -2442,36 +2491,91 @@ paths:
       - apps
   /api/v1/apps/{id}/api-actions:
     post:
+      consumes:
+      - application/json
+      description: Runs an API action for an app
       parameters:
-      - description: Request body with API action name and parameters.
+      - description: Request
         in: body
         name: request
         required: true
         schema:
           $ref: '#/definitions/types.RunAPIActionRequest'
+      produces:
+      - application/json
       responses:
         "200":
           description: OK
           schema:
             $ref: '#/definitions/types.RunAPIActionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
       security:
       - BearerAuth: []
+      summary: Run an API action
   /api/v1/apps/{id}/gptscript:
     post:
+      consumes:
+      - application/json
+      description: Runs a gptscript for an app
       parameters:
-      - description: Request body with script configuration.
+      - description: Request
         in: body
         name: request
         required: true
         schema:
           $ref: '#/definitions/types.GptScriptRequest'
+      produces:
+      - application/json
       responses:
         "200":
           description: OK
           schema:
             $ref: '#/definitions/types.GptScriptResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
       security:
       - BearerAuth: []
+      summary: Run a GptScript
+  /api/v1/apps/{id}/user-access:
+    get:
+      description: Returns the access rights the current user has for this app
+      parameters:
+      - description: App ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.UserAppAccessResponse'
+      security:
+      - BearerAuth: []
+      summary: Get current user's access level for an app
+      tags:
+      - apps
   /api/v1/apps/github/{id}:
     put:
       parameters:

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -1551,3 +1551,10 @@ type ContextMenuAction struct {
 	Label       string `json:"label"`        // The label that will be shown in the UI
 	Value       string `json:"value"`        // The value written to the text area when the action is selected
 }
+
+// Response for the user access endpoint
+type UserAppAccessResponse struct {
+	CanRead  bool `json:"can_read"`
+	CanWrite bool `json:"can_write"`
+	IsAdmin  bool `json:"is_admin"`
+}

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -329,12 +329,6 @@ export interface ServerLicenseKeyRequest {
   license_key?: string;
 }
 
-export interface ServerUserAppAccessResponse {
-  can_read?: boolean;
-  can_write?: boolean;
-  is_admin?: boolean;
-}
-
 export interface SystemHTTPError {
   message?: string;
   statusCode?: number;
@@ -1430,6 +1424,12 @@ export interface TypesUser {
   username?: string;
 }
 
+export interface TypesUserAppAccessResponse {
+  can_read?: boolean;
+  can_write?: boolean;
+  is_admin?: boolean;
+}
+
 export interface TypesUserResponse {
   email?: string;
   id?: string;
@@ -1767,7 +1767,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     v1AppsUserAccessDetail: (id: string, params: RequestParams = {}) =>
-      this.request<ServerUserAppAccessResponse, any>({
+      this.request<TypesUserAppAccessResponse, any>({
         path: `/api/v1/apps/${id}/user-access`,
         method: "GET",
         secure: true,

--- a/frontend/src/hooks/useUserAppAccess.ts
+++ b/frontend/src/hooks/useUserAppAccess.ts
@@ -1,0 +1,90 @@
+import { useState, useEffect } from 'react'
+import useApi from './useApi'
+import { IUserAppAccess, IUserAppAccessState } from '../types'
+import useAccount from './useAccount'
+
+const DEFAULT_ACCESS: IUserAppAccess = {
+  can_read: false,
+  can_write: false,
+  is_admin: false
+}
+
+/**
+ * Hook to get the current user's access rights for a specific app
+ * @param appId - The ID of the app to check access for
+ * @returns Object containing access rights and loading state
+ */
+export const useUserAppAccess = (appId: string | null): IUserAppAccessState => {
+  const api = useApi()
+  const account = useAccount()
+  const [loading, setLoading] = useState<boolean>(false)
+  const [error, setError] = useState<string | null>(null)
+  const [access, setAccess] = useState<IUserAppAccess>(DEFAULT_ACCESS)
+
+  /**
+   * Fetch user access rights for the specified app
+   */
+  const fetchUserAccess = async () => {
+    // Don't attempt to fetch if appId is null or empty
+    if (!appId) {
+      setAccess(DEFAULT_ACCESS)
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    
+    try {
+      // Call the new API endpoint to get user access rights
+      const response = await api.get<IUserAppAccess>(
+        `/api/v1/apps/${appId}/user-access`,
+        undefined,
+        { snackbar: false } // Suppress snackbar errors
+      )
+      
+      if (response) {
+        setAccess(response)
+      } else {
+        // If response is null, default to no access
+        setAccess({
+          can_read: false,
+          can_write: false,
+          is_admin: false
+        })
+        setError('Failed to get access rights')
+      }
+    } catch (err) {
+      console.error('Error fetching user access:', err)
+      setAccess({
+        can_read: false,
+        can_write: false,
+        is_admin: false
+      })
+      setError(err instanceof Error ? err.message : 'Unknown error')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Fetch access rights when appId changes
+  useEffect(() => {
+    if(!appId || !account.user) return
+    fetchUserAccess()
+  }, [
+    appId,
+    account.user,
+  ])
+
+  // Return access state, loading state, and a function to manually refresh
+  return {
+    loading,
+    error,
+    access,
+    refresh: fetchUserAccess,
+    isAdmin: access?.is_admin || false,
+    canWrite: access?.can_write || false,
+    canRead: access?.can_read || false
+  }
+}
+
+export default useUserAppAccess 

--- a/frontend/src/hooks/useUserAppAccess.ts
+++ b/frontend/src/hooks/useUserAppAccess.ts
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react'
 import useApi from './useApi'
-import { IUserAppAccess, IUserAppAccessState } from '../types'
+import { IUserAppAccessState } from '../types'
 import useAccount from './useAccount'
+import { TypesUserAppAccessResponse } from '../api/api'
 
-const DEFAULT_ACCESS: IUserAppAccess = {
+const DEFAULT_ACCESS: TypesUserAppAccessResponse = {
   can_read: false,
   can_write: false,
   is_admin: false
@@ -19,7 +20,7 @@ export const useUserAppAccess = (appId: string | null): IUserAppAccessState => {
   const account = useAccount()
   const [loading, setLoading] = useState<boolean>(false)
   const [error, setError] = useState<string | null>(null)
-  const [access, setAccess] = useState<IUserAppAccess>(DEFAULT_ACCESS)
+  const [access, setAccess] = useState<TypesUserAppAccessResponse>(DEFAULT_ACCESS)
 
   /**
    * Fetch user access rights for the specified app
@@ -36,30 +37,18 @@ export const useUserAppAccess = (appId: string | null): IUserAppAccessState => {
     
     try {
       // Call the new API endpoint to get user access rights
-      const response = await api.get<IUserAppAccess>(
-        `/api/v1/apps/${appId}/user-access`,
-        undefined,
-        { snackbar: false } // Suppress snackbar errors
-      )
-      
-      if (response) {
-        setAccess(response)
+      const accessResponse = await api.getApiClient().v1AppsUserAccessDetail(appId)
+          
+      if (accessResponse.data) {
+        setAccess(accessResponse.data)
       } else {
         // If response is null, default to no access
-        setAccess({
-          can_read: false,
-          can_write: false,
-          is_admin: false
-        })
+        setAccess(DEFAULT_ACCESS)
         setError('Failed to get access rights')
       }
     } catch (err) {
       console.error('Error fetching user access:', err)
-      setAccess({
-        can_read: false,
-        can_write: false,
-        is_admin: false
-      })
+      setAccess(DEFAULT_ACCESS)
       setError(err instanceof Error ? err.message : 'Unknown error')
     } finally {
       setLoading(false)

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -48,6 +48,8 @@ const App: FC = () => {
   } = useRouter()
 
   const appTools = useApp(params.app_id)
+  // Get user access information from appTools
+  const { userAccess } = appTools
 
   const [deletingAPIKey, setDeletingAPIKey] = useState('')
   const [isAccessDenied, setIsAccessDenied] = useState(false)
@@ -115,6 +117,8 @@ const App: FC = () => {
   if (isAccessDenied) return <AccessDenied />
   if (!appTools.app) return null
 
+  const isReadOnly = appTools.isReadOnly
+
   return (
     <Page
       showDrawerButton={false}
@@ -137,7 +141,7 @@ const App: FC = () => {
             variant="outlined"
             onClick={appTools.handleCopyEmbedCode}
             startIcon={<ContentCopyIcon />}
-            disabled={account.apiKeys.length === 0 || appTools.isReadOnly}
+            disabled={account.apiKeys.length === 0 || isReadOnly}
           >
             Embed
           </Button>
@@ -170,7 +174,8 @@ const App: FC = () => {
               <Tab label="IDE" value="ide" />
               <Tab label="Logs" value="logs" />
               {
-                appTools.app?.organization_id && (
+                // Only show Access tab if user is an admin and app has an organization_id
+                appTools.app?.organization_id && userAccess.isAdmin && (
                   <Tab label="Access" value="access" />
                 )
               }
@@ -190,7 +195,7 @@ const App: FC = () => {
                       id={appTools.id}
                       app={appTools.flatApp}
                       onUpdate={appTools.saveFlatApp}
-                      readOnly={appTools.isReadOnly}
+                      readOnly={isReadOnly}
                       showErrors={appTools.showErrors}
                       isAdmin={account.admin}
                       providerEndpoints={endpointProviders.data}
@@ -203,7 +208,7 @@ const App: FC = () => {
                         appId={appTools.id}
                         accessGrants={appTools.accessGrants}
                         isLoading={false}
-                        isReadOnly={false}
+                        isReadOnly={isReadOnly}
                         onCreateGrant={appTools.createAccessGrant}
                         onDeleteGrant={appTools.deleteAccessGrant}
                       />
@@ -217,7 +222,7 @@ const App: FC = () => {
                       </Typography>
                       <KnowledgeEditor
                         appId={appTools.id}
-                        disabled={appTools.isReadOnly}
+                        disabled={isReadOnly}
                         saveKnowledgeToApp={async (knowledge) => {
                           // the knowledge has changed so we need to keep the app hook
                           // in sync so it knows about the knowledge IDs then we
@@ -247,14 +252,14 @@ const App: FC = () => {
                         tools={appTools.apiToolsFromTools}
                         onSaveApiTool={appTools.onSaveApiTool}
                         onDeleteApiTool={appTools.onDeleteApiTool}
-                        isReadOnly={appTools.isReadOnly}
+                        isReadOnly={isReadOnly}
                       />
 
                       <ZapierIntegrations
                         zapier={appTools.zapierTools}
                         onSaveZapierTool={appTools.onSaveZapierTool}
                         onDeleteZapierTool={appTools.onDeleteZapierTool}
-                        isReadOnly={appTools.isReadOnly}
+                        isReadOnly={isReadOnly}
                       />
                     </>
                   )}
@@ -274,7 +279,7 @@ const App: FC = () => {
                       }}
                       onEdit={(tool, index) => appTools.setEditingGptScript({ tool, index })}
                       onDeleteGptScript={appTools.onDeleteGptScript}
-                      isReadOnly={appTools.isReadOnly}
+                      isReadOnly={isReadOnly}
                       isGithubApp={appTools.isGithubApp}
                     />
                   )}
@@ -286,7 +291,7 @@ const App: FC = () => {
                       onDeleteKey={(key) => setDeletingAPIKey(key)}
                       allowedDomains={appTools.flatApp?.allowedDomains || []}
                       setAllowedDomains={(allowedDomains) => appTools.saveFlatApp({ allowedDomains })}
-                      isReadOnly={appTools.isReadOnly}
+                      isReadOnly={isReadOnly}
                     />
                   )}
 
@@ -375,7 +380,7 @@ const App: FC = () => {
         setEditingGptScript={appTools.setEditingGptScript}
         onSaveGptScript={appTools.onSaveGptScript}
         showErrors={appTools.showErrors}
-        isReadOnly={appTools.isReadOnly}
+        isReadOnly={isReadOnly}
       />
 
     </Page>

--- a/frontend/src/pages/Create.tsx
+++ b/frontend/src/pages/Create.tsx
@@ -33,6 +33,7 @@ import useRouter from '../hooks/useRouter'
 import useSessions from '../hooks/useSessions'
 import useSnackbar from '../hooks/useSnackbar'
 import useTracking from '../hooks/useTracking'
+import useUserAppAccess from '../hooks/useUserAppAccess'
 import { useStreaming } from '../contexts/streaming'
 
 import {
@@ -94,6 +95,8 @@ const Create: FC = () => {
   const appID = router.params.app_id || ''
   const model = router.params.model || ''
 
+  const userAppAccess = useUserAppAccess(appID)
+
   const activeAssistantID = router.params.assistant_id || '0'
   const activeAssistant = apps.app && getAssistant(apps.app, activeAssistantID)
 
@@ -107,9 +110,8 @@ const Create: FC = () => {
   // Then, in the Create component, we'll add a check to see if the current user owns the app
   // This should be added near the top of the component, after the existing useEffect hooks
   const userOwnsApp = useMemo(() => {
-    if (!apps.app || !account.user) return false
-    return apps.app.owner === account.user.id
-  }, [apps.app, account.user])
+    return userAppAccess.canRead
+  }, [userAppAccess.canRead])
 
   /*
    *

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -997,3 +997,20 @@ export interface CreateAccessGrantRequest {
   team_id?: string;        // Team ID
   roles: string[];         // Role names
 }
+
+// User app access types
+export interface IUserAppAccess {
+  can_read: boolean
+  can_write: boolean
+  is_admin: boolean
+}
+
+export interface IUserAppAccessState {
+  loading: boolean
+  error: string | null
+  access: IUserAppAccess | null
+  refresh: () => Promise<void>
+  isAdmin: boolean
+  canWrite: boolean
+  canRead: boolean
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,3 +1,5 @@
+import { TypesUserAppAccessResponse } from './api/api'
+
 export type ISessionCreator = 'system' | 'user' | 'assistant'
 // SYSTEM means the system prompt, NOT an assistant message (as it previously
 // did). At time of writing, it's unused in the frontend because the frontend
@@ -998,17 +1000,10 @@ export interface CreateAccessGrantRequest {
   roles: string[];         // Role names
 }
 
-// User app access types
-export interface IUserAppAccess {
-  can_read: boolean
-  can_write: boolean
-  is_admin: boolean
-}
-
 export interface IUserAppAccessState {
   loading: boolean
   error: string | null
-  access: IUserAppAccess | null
+  access: TypesUserAppAccessResponse | null
   refresh: () => Promise<void>
   isAdmin: boolean
   canWrite: boolean

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -491,15 +491,6 @@ definitions:
       license_key:
         type: string
     type: object
-  server.UserAppAccessResponse:
-    properties:
-      can_read:
-        type: boolean
-      can_write:
-        type: boolean
-      is_admin:
-        type: boolean
-    type: object
   system.HTTPError:
     properties:
       message:
@@ -2321,6 +2312,15 @@ definitions:
       username:
         type: string
     type: object
+  types.UserAppAccessResponse:
+    properties:
+      can_read:
+        type: boolean
+      can_write:
+        type: boolean
+      is_admin:
+        type: boolean
+    type: object
   types.UserResponse:
     properties:
       email:
@@ -2570,7 +2570,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/server.UserAppAccessResponse'
+            $ref: '#/definitions/types.UserAppAccessResponse'
       security:
       - BearerAuth: []
       summary: Get current user's access level for an app

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -491,6 +491,22 @@ definitions:
       license_key:
         type: string
     type: object
+  server.UserAppAccessResponse:
+    properties:
+      can_read:
+        type: boolean
+      can_write:
+        type: boolean
+      is_admin:
+        type: boolean
+    type: object
+  system.HTTPError:
+    properties:
+      message:
+        type: string
+      statusCode:
+        type: integer
+    type: object
   types.AccessGrant:
     properties:
       created_at:
@@ -503,10 +519,6 @@ definitions:
       resource_id:
         description: App ID, Knowledge ID, etc
         type: string
-      resource_type:
-        allOf:
-        - $ref: '#/definitions/types.Resource'
-        description: Kind of resource (app, knowledge, provider endpoint, etc)
       roles:
         items:
           $ref: '#/definitions/types.Role'
@@ -660,6 +672,14 @@ definitions:
         type: object
       name:
         type: string
+      oauth_provider:
+        allOf:
+        - $ref: '#/definitions/types.OAuthProviderType'
+        description: OAuth configuration
+      oauth_scopes:
+        items:
+          type: string
+        type: array
       query:
         additionalProperties:
           type: string
@@ -1382,6 +1402,26 @@ definitions:
     type: string
     x-enum-varnames:
     - MessageContentTypeText
+  types.OAuthProviderType:
+    enum:
+    - ""
+    - atlassian
+    - google
+    - microsoft
+    - github
+    - slack
+    - linkedin
+    - custom
+    type: string
+    x-enum-varnames:
+    - OAuthProviderTypeUnknown
+    - OAuthProviderTypeAtlassian
+    - OAuthProviderTypeGoogle
+    - OAuthProviderTypeMicrosoft
+    - OAuthProviderTypeGitHub
+    - OAuthProviderTypeSlack
+    - OAuthProviderTypeLinkedIn
+    - OAuthProviderTypeCustom
   types.OpenAIMessage:
     properties:
       content:
@@ -2151,6 +2191,15 @@ definitions:
         type: object
       model:
         type: string
+      oauth_provider:
+        allOf:
+        - $ref: '#/definitions/types.OAuthProviderType'
+        description: OAuth configuration
+      oauth_scopes:
+        description: Required OAuth scopes for this API
+        items:
+          type: string
+        type: array
       query:
         additionalProperties:
           type: string
@@ -2442,36 +2491,91 @@ paths:
       - apps
   /api/v1/apps/{id}/api-actions:
     post:
+      consumes:
+      - application/json
+      description: Runs an API action for an app
       parameters:
-      - description: Request body with API action name and parameters.
+      - description: Request
         in: body
         name: request
         required: true
         schema:
           $ref: '#/definitions/types.RunAPIActionRequest'
+      produces:
+      - application/json
       responses:
         "200":
           description: OK
           schema:
             $ref: '#/definitions/types.RunAPIActionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
       security:
       - BearerAuth: []
+      summary: Run an API action
   /api/v1/apps/{id}/gptscript:
     post:
+      consumes:
+      - application/json
+      description: Runs a gptscript for an app
       parameters:
-      - description: Request body with script configuration.
+      - description: Request
         in: body
         name: request
         required: true
         schema:
           $ref: '#/definitions/types.GptScriptRequest'
+      produces:
+      - application/json
       responses:
         "200":
           description: OK
           schema:
             $ref: '#/definitions/types.GptScriptResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
       security:
       - BearerAuth: []
+      summary: Run a GptScript
+  /api/v1/apps/{id}/user-access:
+    get:
+      description: Returns the access rights the current user has for this app
+      parameters:
+      - description: App ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.UserAppAccessResponse'
+      security:
+      - BearerAuth: []
+      summary: Get current user's access level for an app
+      tags:
+      - apps
   /api/v1/apps/github/{id}:
     put:
       parameters:

--- a/integration-test/api/organizations_rbac_test.go
+++ b/integration-test/api/organizations_rbac_test.go
@@ -488,6 +488,18 @@ func (suite *OrganizationsRBACTestSuite) TestAppUpdate_SingleUser() {
 		suite.True(access.CanRead, "userMember2 should be able to read from the app")
 		suite.False(access.IsAdmin, "userMember2 should not be an admin of the app")
 	})
+
+	suite.T().Run("UserAccessEndpoint_NotOwner_NoAccess", func(_ *testing.T) {
+		userMember3Client, err := getAPIClient(suite.userMember3APIKey)
+		suite.Require().NoError(err)
+
+		access, err := userMember3Client.GetAppUserAccess(suite.ctx, app.ID)
+		suite.Require().NoError(err)
+
+		suite.False(access.CanWrite, "userMember3 should not be able to write to the app")
+		suite.False(access.CanRead, "userMember3 should not be able to read from the app")
+		suite.False(access.IsAdmin, "userMember3 should not be an admin of the app")
+	})
 }
 
 func (suite *OrganizationsRBACTestSuite) TestAppUpdate_Team() {

--- a/integration-test/api/organizations_rbac_test.go
+++ b/integration-test/api/organizations_rbac_test.go
@@ -464,6 +464,30 @@ func (suite *OrganizationsRBACTestSuite) TestAppUpdate_SingleUser() {
 	userMember3Client, err := getAPIClient(suite.userMember3APIKey)
 	suite.Require().NoError(err)
 	suite.Error(assertAppWriteAccess(userMember3Client, app.ID), "userMember3 should not be able to update the app")
+
+	suite.T().Run("UserAccessEndpoint_Owner", func(_ *testing.T) {
+		userMember1Client, err := getAPIClient(suite.userMember1APIKey)
+		suite.Require().NoError(err)
+
+		access, err := userMember1Client.GetAppUserAccess(suite.ctx, app.ID)
+		suite.Require().NoError(err)
+
+		suite.True(access.CanWrite, "userMember1 should be able to write to the app")
+		suite.True(access.CanRead, "userMember1 should be able to read from the app")
+		suite.True(access.IsAdmin, "userMember1 should be an admin of the app")
+	})
+
+	suite.T().Run("UserAccessEndpoint_NotOwner_ButWithAccess", func(_ *testing.T) {
+		userMember2Client, err := getAPIClient(suite.userMember2APIKey)
+		suite.Require().NoError(err)
+
+		access, err := userMember2Client.GetAppUserAccess(suite.ctx, app.ID)
+		suite.Require().NoError(err)
+
+		suite.True(access.CanWrite, "userMember2 should be able to write to the app")
+		suite.True(access.CanRead, "userMember2 should be able to read from the app")
+		suite.False(access.IsAdmin, "userMember2 should not be an admin of the app")
+	})
 }
 
 func (suite *OrganizationsRBACTestSuite) TestAppUpdate_Team() {

--- a/stack
+++ b/stack
@@ -154,7 +154,7 @@ function update_openapi() {
 	-o api/pkg/server
 	# Copy the generated files to the frontend
 	cp -r api/pkg/server/swagger.yaml frontend/swagger/
-	npx swagger-typescript-api -p ./frontend/swagger/swagger.yaml -o ./frontend/src/api --axios -n api.ts
+	npx swagger-typescript-api@13.0.23 -p ./frontend/swagger/swagger.yaml -o ./frontend/src/api --axios -n api.ts
 }
 
 function lint() {


### PR DESCRIPTION
Implement a new backend handler that just gives us the current user's access level over an app without revealing any information about the access grants.

This can then be used to show or hide the access tab as well as show or hide the edit app button based on the level of access the user has. This is to account for a scenario where a user is read only on an app, but therefore shouldn't really see the details of other access grants to the app, but they do want to be able to see the app, we need to know that they can or they can't.