### PR TITLE
feat(haystack): vision RAG pipeline

### DIFF
--- a/api/pkg/controller/inference.go
+++ b/api/pkg/controller/inference.go
@@ -556,6 +556,10 @@ func (c *Controller) evaluateRAG(ctx context.Context, user *types.User, req open
 
 	log.Trace().Interface("documentIDs", filterDocumentIDs).Msg("document IDs")
 
+	pipeline := types.TextPipeline
+	if entity.Config.RAGSettings.EnableVision {
+		pipeline = types.VisionPipeline
+	}
 	ragResults, err := c.Options.RAG.Query(ctx, &types.SessionRAGQuery{
 		Prompt:            prompt,
 		DataEntityID:      entity.ID,
@@ -563,6 +567,7 @@ func (c *Controller) evaluateRAG(ctx context.Context, user *types.User, req open
 		DistanceFunction:  entity.Config.RAGSettings.DistanceFunction,
 		MaxResults:        entity.Config.RAGSettings.ResultsCount,
 		DocumentIDList:    filterDocumentIDs,
+		Pipeline:          pipeline,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error querying RAG: %w", err)
@@ -632,6 +637,10 @@ func (c *Controller) evaluateKnowledge(
 			}
 			log.Trace().Interface("inference filterDocumentIDs", filterDocumentIDs).Msg("filterDocumentIDs")
 
+			pipeline := types.TextPipeline
+			if knowledge.RAGSettings.EnableVision {
+				pipeline = types.VisionPipeline
+			}
 			ragResults, err := ragClient.Query(ctx, &types.SessionRAGQuery{
 				Prompt:            prompt,
 				DataEntityID:      knowledge.GetDataEntityID(),
@@ -639,6 +648,7 @@ func (c *Controller) evaluateKnowledge(
 				DistanceFunction:  knowledge.RAGSettings.DistanceFunction,
 				MaxResults:        knowledge.RAGSettings.ResultsCount,
 				DocumentIDList:    filterDocumentIDs,
+				Pipeline:          pipeline,
 			})
 			if err != nil {
 				return nil, nil, fmt.Errorf("error querying RAG: %w", err)

--- a/api/pkg/controller/knowledge/knowledge_indexer.go
+++ b/api/pkg/controller/knowledge/knowledge_indexer.go
@@ -322,6 +322,9 @@ func (r *Reconciler) indexData(ctx context.Context, k *types.Knowledge, version 
 }
 
 func (r *Reconciler) indexDataDirectly(ctx context.Context, k *types.Knowledge, version string, data []*indexerData, startedAt time.Time) error {
+	if k == nil {
+		return fmt.Errorf("knowledge is nil")
+	}
 	ragClient := r.getRagClient(k)
 
 	log.Info().
@@ -348,7 +351,7 @@ func (r *Reconciler) indexDataDirectly(ctx context.Context, k *types.Knowledge, 
 		})
 
 		pipeline := types.TextPipeline
-		if k != nil && k.RAGSettings.EnableVision {
+		if k.RAGSettings.EnableVision {
 			pipeline = types.VisionPipeline
 		}
 

--- a/api/pkg/controller/knowledge/knowledge_indexer.go
+++ b/api/pkg/controller/knowledge/knowledge_indexer.go
@@ -347,6 +347,11 @@ func (r *Reconciler) indexDataDirectly(ctx context.Context, k *types.Knowledge, 
 			StartedAt:      startedAt,
 		})
 
+		pipeline := types.TextPipeline
+		if k != nil && k.RAGSettings.EnableVision {
+			pipeline = types.VisionPipeline
+		}
+
 		err := ragClient.Index(ctx, &types.SessionRAGIndexChunk{
 			DataEntityID:    types.GetDataEntityID(k.ID, version),
 			Filename:        d.Source,
@@ -356,6 +361,7 @@ func (r *Reconciler) indexDataDirectly(ctx context.Context, k *types.Knowledge, 
 			ContentOffset:   0,
 			Content:         string(d.Data),
 			Metadata:        convertMetadataToStringMap(d.Metadata),
+			Pipeline:        pipeline,
 		})
 		if err != nil {
 			// return fmt.Errorf("failed to index data from source %s, error: %w", d.Source, err)
@@ -472,6 +478,11 @@ func convertChunksIntoBatches(chunks []*text.DataPrepTextSplitterChunk, batchSiz
 func (r *Reconciler) convertTextSplitterChunks(ctx context.Context, k *types.Knowledge, version string, chunks []*text.DataPrepTextSplitterChunk) []*types.SessionRAGIndexChunk {
 	indexChunks := make([]*types.SessionRAGIndexChunk, 0, len(chunks))
 
+	pipeline := types.TextPipeline
+	if k != nil && k.RAGSettings.EnableVision {
+		pipeline = types.VisionPipeline
+	}
+
 	// Keep a cache of metadata for files
 	metadataCache := make(map[string]map[string]string)
 
@@ -553,6 +564,7 @@ func (r *Reconciler) convertTextSplitterChunks(ctx context.Context, k *types.Kno
 			ContentOffset:   chunk.Index,
 			Content:         chunk.Text,
 			Metadata:        metadata,
+			Pipeline:        pipeline,
 		})
 	}
 

--- a/api/pkg/controller/knowledge/query/query.go
+++ b/api/pkg/controller/knowledge/query/query.go
@@ -106,12 +106,17 @@ func (q *Query) getDocuments(ctx context.Context, prompt string, knowledges []*t
 				return nil, fmt.Errorf("error getting RAG client: %w", err)
 			}
 
+			pipeline := types.TextPipeline
+			if knowledge.RAGSettings.EnableVision {
+				pipeline = types.VisionPipeline
+			}
 			ragResults, err := ragClient.Query(ctx, &types.SessionRAGQuery{
 				Prompt:            prompt,
 				DataEntityID:      knowledge.GetDataEntityID(),
 				DistanceThreshold: knowledge.RAGSettings.Threshold,
 				DistanceFunction:  knowledge.RAGSettings.DistanceFunction,
 				MaxResults:        knowledge.RAGSettings.ResultsCount,
+				Pipeline:          pipeline,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("error querying RAG: %w", err)

--- a/api/pkg/rag/rag_haystack.go
+++ b/api/pkg/rag/rag_haystack.go
@@ -153,7 +153,11 @@ func (h *HaystackRAG) Index(ctx context.Context, chunks ...*types.SessionRAGInde
 		w.Close()
 
 		// Create the request
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.endpoint+"/process", &b)
+		endpoint := h.endpoint + "/process"
+		if chunk.Pipeline == types.VisionPipeline {
+			endpoint = h.endpoint + "/process-vision"
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &b)
 		if err != nil {
 			return fmt.Errorf("creating request: %w", err)
 		}
@@ -249,7 +253,11 @@ func (h *HaystackRAG) Query(ctx context.Context, q *types.SessionRAGQuery) ([]*t
 	}
 
 	// Create request
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.endpoint+"/query", bytes.NewReader(bts))
+	endpoint := h.endpoint + "/query"
+	if q.Pipeline == types.VisionPipeline {
+		endpoint = h.endpoint + "/query-vision"
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(bts))
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}

--- a/api/pkg/server/knowledge_search_handlers.go
+++ b/api/pkg/server/knowledge_search_handlers.go
@@ -83,6 +83,10 @@ func (s *HelixAPIServer) knowledgeSearch(_ http.ResponseWriter, r *http.Request)
 				filterDocumentIDs = append(filterDocumentIDs, rag.ParseDocID(filterAction))
 			}
 			log.Trace().Interface("filterDocumentIDs", filterDocumentIDs).Msg("filterDocumentIDs")
+			pipeline := types.TextPipeline
+			if knowledge.RAGSettings.EnableVision {
+				pipeline = types.VisionPipeline
+			}
 			resp, err := client.Query(ctx, &types.SessionRAGQuery{
 				Prompt:            prompt,
 				DataEntityID:      knowledge.GetDataEntityID(),
@@ -90,6 +94,7 @@ func (s *HelixAPIServer) knowledgeSearch(_ http.ResponseWriter, r *http.Request)
 				DistanceFunction:  knowledge.RAGSettings.DistanceFunction,
 				MaxResults:        knowledge.RAGSettings.ResultsCount,
 				DocumentIDList:    filterDocumentIDs,
+				Pipeline:          pipeline,
 			})
 			if err != nil {
 				log.Error().Err(err).Msgf("error querying RAG for knowledge %s", knowledge.ID)

--- a/api/pkg/server/openai_chat_handlers_test.go
+++ b/api/pkg/server/openai_chat_handlers_test.go
@@ -898,6 +898,7 @@ func (suite *OpenAIChatSuite) TestChatCompletions_AppRag_Blocking() {
 		DistanceFunction:  "cosine",
 		MaxResults:        2,
 		DocumentIDList:    []string{},
+		Pipeline:          types.TextPipeline,
 	}).Return([]*types.SessionRAGResult{
 		{
 			Content: "This is a test RAG source 1",

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -105,6 +105,7 @@ type RAGSettings struct {
 	DisableChunking    bool             `json:"disable_chunking" yaml:"disable_chunking"`       // if true, we will not chunk the text and send the entire file to the RAG indexing endpoint
 	DisableDownloading bool             `json:"disable_downloading" yaml:"disable_downloading"` // if true, we will not download the file and send the URL to the RAG indexing endpoint
 	PromptTemplate     string           `json:"prompt_template" yaml:"prompt_template"`         // the prompt template to use for the RAG query
+	EnableVision       bool             `json:"enable_vision" yaml:"enable_vision"`             // if true, we will use the vision pipeline -- Future - might want to specify different pipelines
 
 	// RAG endpoint configuration if used with a custom RAG service
 	IndexURL  string `json:"index_url" yaml:"index_url"`   // the URL of the index endpoint (defaults to Helix RAG_INDEX_URL env var)
@@ -140,6 +141,13 @@ func (RAGSettings) GormDataType() string {
 	return "json"
 }
 
+type RAGPipeline string
+
+var (
+	TextPipeline   RAGPipeline = "text_pipeline"
+	VisionPipeline RAGPipeline = "vision_pipeline"
+)
+
 // the data we send off to rag implementations to be indexed
 type SessionRAGIndexChunk struct {
 	DataEntityID    string            `json:"data_entity_id"`
@@ -150,18 +158,20 @@ type SessionRAGIndexChunk struct {
 	ContentOffset   int               `json:"content_offset"`
 	Content         string            `json:"content"`
 	Metadata        map[string]string `json:"metadata"`
+	Pipeline        RAGPipeline       `json:"pipeline"` // RAG providers can have different pipelines
 }
 
 // the query we post to llamaindex to get results back from a user
 // prompt against a rag enabled session
 type SessionRAGQuery struct {
-	Prompt            string   `json:"prompt"`
-	DataEntityID      string   `json:"data_entity_id"`
-	DistanceThreshold float64  `json:"distance_threshold"`
-	DistanceFunction  string   `json:"distance_function"`
-	MaxResults        int      `json:"max_results"`
-	ExhaustiveSearch  bool     `json:"exhaustive_search"`
-	DocumentIDList    []string `json:"document_id_list"` // TODO(Phil): I can see this getting out of hand, should make it more generic to handle any kind of metadata filter
+	Prompt            string      `json:"prompt"`
+	DataEntityID      string      `json:"data_entity_id"`
+	DistanceThreshold float64     `json:"distance_threshold"`
+	DistanceFunction  string      `json:"distance_function"`
+	MaxResults        int         `json:"max_results"`
+	ExhaustiveSearch  bool        `json:"exhaustive_search"`
+	DocumentIDList    []string    `json:"document_id_list"` // TODO(Phil): I can see this getting out of hand, should make it more generic to handle any kind of metadata filter
+	Pipeline          RAGPipeline `json:"pipeline"`         // RAG providers can have different pipelines
 }
 
 type DeleteIndexRequest struct {

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -276,6 +276,14 @@ services:
       - RAG_HAYSTACK_CHUNK_OVERLAP=${RAG_HAYSTACK_CHUNK_OVERLAP:-50}
       # Socket configuration for api communication
       - HELIX_EMBEDDINGS_SOCKET=/socket/embeddings.sock
+      # Vision RAG Settings
+      - RAG_VISION_ENABLED=${RAG_VISION_ENABLED:-false}
+      - RAG_VISION_BASE_URL=${RAG_VISION_BASE_URL:-}
+      - RAG_VISION_API_KEY=${RAG_VISION_API_KEY:-}
+      - RAG_VISION_EMBEDDINGS_MODEL=${RAG_VISION_EMBEDDINGS_MODEL:-"MrLight/dse-qwen2-2b-mrl-v1"}
+      - RAG_VISION_EMBEDDINGS_DIM=${RAG_VISION_EMBEDDINGS_DIM:-1536}
+      - RAG_VISION_EMBEDDINGS_SOCKET=${RAG_VISION_EMBEDDINGS_SOCKET:-}
+      - RAG_VISION_PGVECTOR_TABLE=${RAG_VISION_PGVECTOR_TABLE:-haystack_documents_vision}
     volumes:
       - ./haystack_service:/app
       - helix-socket:/socket

--- a/frontend/src/components/app/AddKnowledgeDialog.tsx
+++ b/frontend/src/components/app/AddKnowledgeDialog.tsx
@@ -55,16 +55,16 @@ const AddKnowledgeDialog: React.FC<AddKnowledgeDialogProps> = ({
       source: sourceType === 'filestore'
         ? { filestore: { path: knowledgePath } }
         : {
-            web: {
-              urls: [url],
-              crawler: {
-                enabled: true,
-                max_depth: 1,
-                max_pages: 5,
-                readability: true
-              }
+          web: {
+            urls: [url],
+            crawler: {
+              enabled: true,
+              max_depth: 1,
+              max_pages: 5,
+              readability: true
             }
-          },
+          }
+        },
       refresh_schedule: '',
       version: '',
       state: '',
@@ -72,11 +72,12 @@ const AddKnowledgeDialog: React.FC<AddKnowledgeDialogProps> = ({
         results_count: 0,
         chunk_size: 0,
         chunk_overflow: 0,
+        enable_vision: false,
       },
     };
 
     onAdd(newSource);
-    
+
     // Adding a small delay to show the loading indicator
     // The parent component should handle closing this dialog after processing is complete
     setTimeout(() => {
@@ -108,7 +109,7 @@ const AddKnowledgeDialog: React.FC<AddKnowledgeDialogProps> = ({
             <FormControlLabel value="filestore" control={<Radio />} label="Files" />
           </RadioGroup>
         </FormControl>
-        
+
         {sourceType === 'web' && (
           <TextField
             fullWidth
@@ -140,9 +141,9 @@ const AddKnowledgeDialog: React.FC<AddKnowledgeDialogProps> = ({
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose} disabled={isLoading}>Cancel</Button>
-        <Button 
-          onClick={handleSubmit} 
-          variant="contained" 
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
           disabled={isLoading}
           startIcon={isLoading ? <CircularProgress size={20} /> : null}
         >

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -629,6 +629,7 @@ export interface IKnowledgeSource {
     results_count: number;
     chunk_size: number;
     chunk_overflow: number;
+    enable_vision: boolean;
   };
   state: string;
   message?: string;

--- a/haystack_service/app/api.py
+++ b/haystack_service/app/api.py
@@ -84,9 +84,8 @@ async def get_image_service():
     return service
 
 
-# TODO(Phil): bad name. vision.
-@app.post("/process-image", response_model=ProcessResponse)
-async def process_image(
+@app.post("/process-vision", response_model=ProcessResponse)
+async def process_vision(
     file: UploadFile = File(...),
     metadata: Optional[str] = Form(None),
     service: HaystackImageService = Depends(get_image_service),

--- a/haystack_service/app/config.py
+++ b/haystack_service/app/config.py
@@ -34,7 +34,11 @@ class Settings:
     VISION_EMBEDDINGS_MODEL: str = os.getenv(
         "RAG_VISION_EMBEDDINGS_MODEL", "MrLight/dse-qwen2-2b-mrl-v1"
     )
-
+    VISION_EMBEDDINGS_SOCKET: Optional[str] = os.getenv(
+        "RAG_VISION_EMBEDDINGS_SOCKET", None
+    )
+    VISION_BASE_URL: Optional[str] = os.getenv("RAG_VISION_BASE_URL", None)
+    VISION_API_KEY: Optional[str] = os.getenv("RAG_VISION_API_KEY", None)
     VISION_PGVECTOR_TABLE: str = os.getenv(
         "RAG_VISION_PGVECTOR_TABLE", "haystack_documents_vision"
     )

--- a/haystack_service/app/converters.py
+++ b/haystack_service/app/converters.py
@@ -122,8 +122,8 @@ class PDFToImagesConverter:
     def __init__(
         self,
         output_dir: str = "./pdf_images",
-        dpi: int = 90,
-        format: str = "png",
+        dpi: int = 75,
+        format: str = "jpg",
         prefix: str = "page_",
     ):
         """

--- a/haystack_service/app/service.py
+++ b/haystack_service/app/service.py
@@ -1,33 +1,37 @@
 import logging
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from haystack import Pipeline
-from haystack.components.joiners import DocumentJoiner
-from haystack.components.preprocessors import DocumentSplitter, DocumentCleaner
-from haystack.components.writers import DocumentWriter
-from haystack.dataclasses import Document
-from haystack.utils.auth import Secret
-from haystack.document_stores.types import DuplicatePolicy
-
 from haystack.components.embedders import OpenAIDocumentEmbedder, OpenAITextEmbedder
-from .unix_socket_embedders import UnixSocketOpenAIDocumentEmbedder, UnixSocketOpenAITextEmbedder
-from .converters import LocalUnstructuredConverter
-
-from .vectorchord.document_store import VectorchordDocumentStore
-from .vectorchord.components import VectorchordEmbeddingRetriever, VectorchordBM25Retriever
+from haystack.components.joiners import DocumentJoiner
+from haystack.components.preprocessors import DocumentCleaner, DocumentSplitter
+from haystack.components.writers import DocumentWriter
+from haystack.document_stores.types import DuplicatePolicy
+from haystack.utils.auth import Secret
 
 from .config import settings
+from .converters import LocalUnstructuredConverter
+from .unix_socket_embedders import (
+    UnixSocketOpenAIDocumentEmbedder,
+    UnixSocketOpenAITextEmbedder,
+)
+from .vectorchord.components import (
+    VectorchordBM25Retriever,
+    VectorchordEmbeddingRetriever,
+)
+from .vectorchord.document_store import VectorchordDocumentStore
 
 logger = logging.getLogger(__name__)
 
+
 class HaystackService:
     """Main service class for Haystack RAG operations"""
-    
+
     def __init__(self):
         """Initialize the Haystack service"""
         logger.info("Initializing HaystackService")
-        
+
         # Initialize document stores
         try:
             # VectorChord store for both dense embeddings and BM25
@@ -37,277 +41,306 @@ class HaystackService:
                 embedding_dimension=settings.EMBEDDING_DIM,
                 table_name=settings.PGVECTOR_TABLE,
                 vector_function="cosine_similarity",
-                search_strategy="vchordrq", # Enable for faster vector search
-                recreate_table=False
+                search_strategy="vchordrq",  # Enable for faster vector search
+                recreate_table=False,
             )
-            logger.info(f"Connected to VectorchordDocumentStore: {settings.PGVECTOR_TABLE}")
-            
+            logger.info(
+                f"Connected to VectorchordDocumentStore: {settings.PGVECTOR_TABLE}"
+            )
+
             # We'll use VectorChord for BM25 as well, so no need for a separate in-memory store
             # Keep a reference for compatibility with existing code
             self.bm25_document_store = self.document_store
-            
+
         except Exception as e:
             logger.error(f"Failed to connect to document stores: {str(e)}")
             raise
-        
+
         # Initialize pipelines
         self._init_indexing_pipeline()
         self._init_query_pipeline()
-        
+
         logger.info("HaystackService initialization complete")
 
     def _init_indexing_pipeline(self):
         """Initialize the document indexing pipeline"""
         self.indexing_pipeline = Pipeline()
-        
+
         # Create components for indexing pipeline
         if settings.EMBEDDINGS_SOCKET:
-            logger.info(f"Using UNIX socket for document embeddings: {settings.EMBEDDINGS_SOCKET}")
+            logger.info(
+                f"Using UNIX socket for document embeddings: {settings.EMBEDDINGS_SOCKET}"
+            )
             embedder = UnixSocketOpenAIDocumentEmbedder(
                 socket_path=settings.EMBEDDINGS_SOCKET,
                 model=settings.EMBEDDINGS_MODEL,
-                dimensions=settings.EMBEDDING_DIM
+                dimensions=settings.EMBEDDING_DIM,
             )
         else:
+            logger.info(f"Using API for document embeddings: {settings.VLLM_BASE_URL}")
             embedder = OpenAIDocumentEmbedder(
                 api_key=Secret.from_token(settings.VLLM_API_KEY),
                 api_base_url=settings.VLLM_BASE_URL,
                 model=settings.EMBEDDINGS_MODEL,
-                dimensions=settings.EMBEDDING_DIM
+                dimensions=settings.EMBEDDING_DIM,
             )
-        
+
         converter = LocalUnstructuredConverter()
-        
+
         cleaner = DocumentCleaner(
             remove_empty_lines=False,
             remove_extra_whitespaces=False,
-            remove_regex=r'\.{5,}'  # Remove runs of 5 or more dots
+            remove_regex=r"\.{5,}",  # Remove runs of 5 or more dots
         )
-        
+
         splitter = DocumentSplitter(
             split_length=settings.CHUNK_SIZE,
             split_overlap=settings.CHUNK_OVERLAP,
             split_by=settings.CHUNK_UNIT,
-            respect_sentence_boundary=True
+            respect_sentence_boundary=True,
         )
         splitter.warm_up()
-        
+
         # Writer for the vector store (which now handles both embeddings and BM25)
         # NUL bytes are filtered out in VectorchordDocumentStore.write_documents method
         vector_writer = DocumentWriter(
             document_store=self.document_store,
-            policy=DuplicatePolicy.OVERWRITE  # Use overwrite policy to handle duplicate documents
+            policy=DuplicatePolicy.OVERWRITE,  # Use overwrite policy to handle duplicate documents
         )
-        
+
         # Add components
         self.indexing_pipeline.add_component("converter", converter)
         self.indexing_pipeline.add_component("cleaner", cleaner)
         self.indexing_pipeline.add_component("splitter", splitter)
         self.indexing_pipeline.add_component("embedder", embedder)
         self.indexing_pipeline.add_component("vector_writer", vector_writer)
-        
+
         # Connect components
         self.indexing_pipeline.connect("converter", "cleaner")
         self.indexing_pipeline.connect("cleaner", "splitter")
         self.indexing_pipeline.connect("splitter", "embedder")
         self.indexing_pipeline.connect("embedder", "vector_writer")
-        
+
         # Save converter instance for text extraction
         self.converter = converter
-        
-        logger.info(f"Initialized indexing pipeline with chunk_size={settings.CHUNK_SIZE}, overlap={settings.CHUNK_OVERLAP}")
+
+        logger.info(
+            f"Initialized indexing pipeline with chunk_size={settings.CHUNK_SIZE}, overlap={settings.CHUNK_OVERLAP}"
+        )
 
     def _init_query_pipeline(self):
         """Initialize the query pipeline"""
         self.query_pipeline = Pipeline()
-        
+
         # Create components for query pipeline
         if settings.EMBEDDINGS_SOCKET:
-            logger.info(f"Using UNIX socket for text embeddings: {settings.EMBEDDINGS_SOCKET}")
+            logger.info(
+                f"Using UNIX socket for text embeddings: {settings.EMBEDDINGS_SOCKET}"
+            )
             embedder = UnixSocketOpenAITextEmbedder(
                 socket_path=settings.EMBEDDINGS_SOCKET,
                 model=settings.EMBEDDINGS_MODEL,
-                dimensions=settings.EMBEDDING_DIM
+                dimensions=settings.EMBEDDING_DIM,
             )
         else:
+            logger.info(f"Using API for text embeddings: {settings.VLLM_BASE_URL}")
             embedder = OpenAITextEmbedder(
                 api_key=Secret.from_token(settings.VLLM_API_KEY),
                 api_base_url=settings.VLLM_BASE_URL,
                 model=settings.EMBEDDINGS_MODEL,
-                dimensions=settings.EMBEDDING_DIM
+                dimensions=settings.EMBEDDING_DIM,
             )
-        
+
         # Dense vector retriever using VectorChord
         vector_retriever = VectorchordEmbeddingRetriever(
-            document_store=self.document_store,
-            filters=None,
-            top_k=5
+            document_store=self.document_store, filters=None, top_k=5
         )
-        
+
         # BM25 retriever using VectorChord-bm25
         bm25_retriever = VectorchordBM25Retriever(
-            document_store=self.document_store,
-            filters=None,
-            top_k=5
+            document_store=self.document_store, filters=None, top_k=5
         )
-        
+
         # Document joiner to combine results from both retrievers
-        document_joiner = DocumentJoiner(
-            join_mode="reciprocal_rank_fusion",
-            top_k=5
-        )
-        
+        document_joiner = DocumentJoiner(join_mode="reciprocal_rank_fusion", top_k=5)
+
         # Add components
         self.query_pipeline.add_component("embedder", embedder)
         self.query_pipeline.add_component("vector_retriever", vector_retriever)
         self.query_pipeline.add_component("bm25_retriever", bm25_retriever)
         self.query_pipeline.add_component("document_joiner", document_joiner)
-        
+
         # Connect components
         # Vector retrieval - need to be explicit about field connections
-        self.query_pipeline.connect("embedder.embedding", "vector_retriever.query_embedding")
-        
+        self.query_pipeline.connect(
+            "embedder.embedding", "vector_retriever.query_embedding"
+        )
+
         # Join documents from both retrievers - these are already correct
         self.query_pipeline.connect("vector_retriever", "document_joiner")
         self.query_pipeline.connect("bm25_retriever", "document_joiner")
-        
+
         # Save retrievers for parameter updates
         self.vector_retriever = vector_retriever
         self.bm25_retriever = bm25_retriever
         self.document_joiner = document_joiner
-        
+
         logger.info("Initialized query pipeline")
 
     async def extract_text(self, file_path: str) -> str:
         """
         Extract text from a file using the converter
-        
+
         Args:
             file_path: Path to the file to extract text from
-            
+
         Returns:
             Extracted text content
         """
         logger.info(f"Extracting text from {os.path.basename(file_path)}")
-        
+
         # Use the converter to extract text
         try:
             documents = self.converter.run(paths=[file_path])
         except Exception as e:
             logger.error(f"Error extracting text: {str(e)}")
             raise
-        
+
         # Return the concatenated text from all documents
         return "\n\n".join([doc.content for doc in documents.get("documents", [])])
-    
+
     def _analyze_scores(self, vector_docs, bm25_docs):
         """
         Analyze the score distributions from both retrievers to identify potential normalization issues.
-        
+
         Args:
             vector_docs: List of documents from the vector retriever
             bm25_docs: List of documents from the BM25 retriever
-            
+
         Returns:
             Dictionary with score analysis information
         """
         # Initialize score collections - filter out None values
         vector_scores = [getattr(doc, "score", 0.0) for doc in vector_docs]
         vector_scores = [score for score in vector_scores if score is not None]
-        
+
         bm25_scores = [getattr(doc, "score", 0.0) for doc in bm25_docs]
         bm25_scores = [score for score in bm25_scores if score is not None]
-        
+
         # Skip empty score lists
         if not vector_scores and not bm25_scores:
             logger.warning("No valid scores available for analysis")
             return {}
-            
+
         # Compute statistics
         stats = {
             "vector": {
                 "count": len(vector_scores),
                 "min": min(vector_scores) if vector_scores else None,
                 "max": max(vector_scores) if vector_scores else None,
-                "mean": sum(vector_scores) / len(vector_scores) if vector_scores else None,
-                "range": max(vector_scores) - min(vector_scores) if vector_scores else None,
+                "mean": sum(vector_scores) / len(vector_scores)
+                if vector_scores
+                else None,
+                "range": max(vector_scores) - min(vector_scores)
+                if vector_scores
+                else None,
             },
             "bm25": {
                 "count": len(bm25_scores),
                 "min": min(bm25_scores) if bm25_scores else None,
-                "max": max(bm25_scores) if bm25_scores else None, 
+                "max": max(bm25_scores) if bm25_scores else None,
                 "mean": sum(bm25_scores) / len(bm25_scores) if bm25_scores else None,
                 "range": max(bm25_scores) - min(bm25_scores) if bm25_scores else None,
-            }
+            },
         }
-        
+
         # Log findings
-        logger.info(f"Score analysis - Vector scores: count={stats['vector']['count']}, "
-                   f"min={stats['vector']['min']}, max={stats['vector']['max']}, "
-                   f"mean={stats['vector']['mean']}, range={stats['vector']['range']}")
-        logger.info(f"Score analysis - BM25 scores: count={stats['bm25']['count']}, "
-                   f"min={stats['bm25']['min']}, max={stats['bm25']['max']}, "
-                   f"mean={stats['bm25']['mean']}, range={stats['bm25']['range']}")
-        
+        logger.info(
+            f"Score analysis - Vector scores: count={stats['vector']['count']}, "
+            f"min={stats['vector']['min']}, max={stats['vector']['max']}, "
+            f"mean={stats['vector']['mean']}, range={stats['vector']['range']}"
+        )
+        logger.info(
+            f"Score analysis - BM25 scores: count={stats['bm25']['count']}, "
+            f"min={stats['bm25']['min']}, max={stats['bm25']['max']}, "
+            f"mean={stats['bm25']['mean']}, range={stats['bm25']['range']}"
+        )
+
         # Analyze potential issues
         if vector_scores and bm25_scores:
-            vector_range = stats['vector']['range']
-            bm25_range = stats['bm25']['range']
-            
+            vector_range = stats["vector"]["range"]
+            bm25_range = stats["bm25"]["range"]
+
             # Check if one retriever has much larger score range than the other
             if vector_range and bm25_range and vector_range > 5 * bm25_range:
-                logger.warning("Vector score range is much larger than BM25 score range - "
-                              "this could lead to vector results dominating the ranking")
+                logger.warning(
+                    "Vector score range is much larger than BM25 score range - "
+                    "this could lead to vector results dominating the ranking"
+                )
             elif bm25_range and vector_range and bm25_range > 5 * vector_range:
-                logger.warning("BM25 score range is much larger than vector score range - "
-                              "this could lead to BM25 results dominating the ranking")
-                
+                logger.warning(
+                    "BM25 score range is much larger than vector score range - "
+                    "this could lead to BM25 results dominating the ranking"
+                )
+
             # Check if the mean scores are very different
-            if stats['vector']['mean'] and stats['bm25']['mean']:
-                if stats['vector']['mean'] > 5 * stats['bm25']['mean']:
-                    logger.warning("Vector mean score is much higher than BM25 mean score - "
-                                  "this could lead to vector results dominating the ranking")
-                elif stats['bm25']['mean'] > 5 * stats['vector']['mean']:
-                    logger.warning("BM25 mean score is much higher than vector mean score - "
-                                  "this could lead to BM25 results dominating the ranking")
-        
+            if stats["vector"]["mean"] and stats["bm25"]["mean"]:
+                if stats["vector"]["mean"] > 5 * stats["bm25"]["mean"]:
+                    logger.warning(
+                        "Vector mean score is much higher than BM25 mean score - "
+                        "this could lead to vector results dominating the ranking"
+                    )
+                elif stats["bm25"]["mean"] > 5 * stats["vector"]["mean"]:
+                    logger.warning(
+                        "BM25 mean score is much higher than vector mean score - "
+                        "this could lead to BM25 results dominating the ranking"
+                    )
+
         return stats
-    
-    async def process_and_index(self, file_path: str, metadata: Dict[str, Any] = None) -> Dict[str, Any]:
+
+    async def process_and_index(
+        self, file_path: str, metadata: Dict[str, Any] = None
+    ) -> Dict[str, Any]:
         """
         Process a document file and index it
-        
+
         Args:
             file_path: Path to the file to process
             metadata: Optional metadata to attach to the document chunks
-            
+
         Returns:
             Dict containing processing stats
         """
         if metadata is None:
             metadata = {}
-        
+
         # Get the original filename from metadata
         original_filename = metadata.get("filename")
         if not original_filename:
-            raise ValueError("Original filename must be provided in metadata for process_and_index")
-        
-        logger.info(f"Processing and indexing {original_filename} with metadata: {metadata}")
-        
+            raise ValueError(
+                "Original filename must be provided in metadata for process_and_index"
+            )
+
+        logger.info(
+            f"Processing and indexing {original_filename} with metadata: {metadata}"
+        )
+
         # Use the original filename as the source, never the temp path
         metadata["source"] = original_filename
-        
+
         # Set up the parameters for the indexing pipeline
         params = {
             "converter": {"paths": [file_path], "meta": metadata},
         }
-        
+
         try:
             output = self.indexing_pipeline.run(params)
-            
+
             # Get the number of chunks created by looking at vector_writer output
-            num_chunks = len(output.get("vector_writer", {}).get("written_documents", []))
-            
+            num_chunks = len(
+                output.get("vector_writer", {}).get("written_documents", [])
+            )
+
             # Return stats
             return {
                 "filename": original_filename,
@@ -315,20 +348,22 @@ class HaystackService:
                 "chunks": num_chunks,
                 "metadata": metadata,
             }
-            
+
         except Exception as e:
             logger.error(f"Error processing document: {str(e)}")
             raise
-    
-    async def query(self, query_text: str, filters: Dict[str, Any] = None, top_k: int = 5) -> List[Dict[str, Any]]:
+
+    async def query(
+        self, query_text: str, filters: Dict[str, Any] = None, top_k: int = 5
+    ) -> List[Dict[str, Any]]:
         """
         Query the document store for relevant passages
-        
+
         Args:
             query_text: The query text to search for
             filters: Optional filters to apply to the search
             top_k: Number of results to return
-            
+
         Returns:
             List of dictionaries with document data
         """
@@ -336,91 +371,106 @@ class HaystackService:
         if "\x00" in query_text:
             logger.warning("Query contained NUL bytes that will be removed")
             query_text = query_text.replace("\x00", "")
-        
+
         # Validate query text after sanitizing
         if not query_text or query_text.strip() == "":
             logger.error("Empty query text received or contained only NUL bytes")
             raise ValueError("Query text cannot be empty")
-            
-        logger.info(f"Querying with: '{query_text}', filters: {filters}, top_k: {top_k}")
-        
+
+        logger.info(
+            f"Querying with: '{query_text}', filters: {filters}, top_k: {top_k}"
+        )
+
         # Format filters correctly if they're provided
         formatted_filters = None
         if filters:
             try:
                 # Simple filters might just be key-value pairs like {"data_entity_id": "some_id"}
                 # We need to convert them to the format expected by Haystack with operator and conditions
-                if not any(key in filters for key in ["operator", "conditions", "field"]):
+                if not any(
+                    key in filters for key in ["operator", "conditions", "field"]
+                ):
                     # Simple key-value filters need to be converted to proper format
                     conditions = []
                     for key, value in filters.items():
-                        conditions.append({
-                            "field": f"meta.{key}",
-                            "operator": "==",
-                            "value": value
-                        })
-                    
-                    formatted_filters = {
-                        "operator": "AND",
-                        "conditions": conditions
-                    }
+                        conditions.append(
+                            {"field": f"meta.{key}", "operator": "==", "value": value}
+                        )
+
+                    formatted_filters = {"operator": "AND", "conditions": conditions}
                 else:
                     # Filters are already in the correct format
                     formatted_filters = filters
-                    
+
                 logger.info(f"Using formatted filters: {formatted_filters}")
             except Exception as e:
-                logger.warning(f"Failed to format filters: {str(e)}. Continuing without filters.")
-        
+                logger.warning(
+                    f"Failed to format filters: {str(e)}. Continuing without filters."
+                )
+
         # Update retriever parameters
         self.vector_retriever.top_k = top_k
         self.vector_retriever.filters = formatted_filters
-        
+
         self.bm25_retriever.top_k = top_k
         self.bm25_retriever.filters = formatted_filters
         # At this point there are 2*top_k results from the retrievers
 
-        logger.info(f"Chopping joined results in half to meet the request for top_k: {top_k}")
+        logger.info(
+            f"Chopping joined results in half to meet the request for top_k: {top_k}"
+        )
         self.document_joiner.top_k = top_k
-        
+
         # Set up the parameters for the query pipeline
         params = {
             "embedder": {"text": query_text},
             "bm25_retriever": {"query": query_text},
         }
-        
+
         try:
             # Debug individual retriever operation first
             # Test BM25 retriever directly to see results before joining
             logger.info("DEBUG: Testing BM25 retriever directly")
             try:
-                bm25_results = self.bm25_retriever.run(query=query_text, filters=formatted_filters, top_k=top_k)
-                logger.info(f"DEBUG: BM25 retriever returned {len(bm25_results.get('documents', []))} documents")
-                for i, doc in enumerate(bm25_results.get('documents', [])):
-                    logger.info(f"DEBUG: BM25 result {i+1}: id={doc.id}, score={doc.score}")
+                bm25_results = self.bm25_retriever.run(
+                    query=query_text, filters=formatted_filters, top_k=top_k
+                )
+                logger.info(
+                    f"DEBUG: BM25 retriever returned {len(bm25_results.get('documents', []))} documents"
+                )
+                for i, doc in enumerate(bm25_results.get("documents", [])):
+                    logger.info(
+                        f"DEBUG: BM25 result {i + 1}: id={doc.id}, score={doc.score}"
+                    )
             except Exception as e:
                 logger.error(f"DEBUG: BM25 retriever error: {str(e)}")
-            
+
             # Test the vector retriever directly
             logger.info("DEBUG: Testing vector retriever directly")
             try:
                 # Get the query embedding
-                embeddings = self.query_pipeline.get_component("embedder").run(text=query_text)
+                embeddings = self.query_pipeline.get_component("embedder").run(
+                    text=query_text
+                )
                 query_embedding = embeddings["embedding"]
-                
+
                 # Call the retriever directly - use the component interface
                 vector_results = self.vector_retriever.run(
-                    query_embedding=query_embedding, 
-                    filters=formatted_filters, 
-                    top_k=top_k
+                    query_embedding=query_embedding,
+                    filters=formatted_filters,
+                    top_k=top_k,
                 )
-                
+
                 # Extract documents from the result dictionary
                 vector_docs = vector_results.get("documents", [])
-                logger.info(f"DEBUG: Vector retriever returned {len(vector_docs)} documents")
+                logger.info(
+                    f"DEBUG: Vector retriever returned {len(vector_docs)} documents"
+                )
                 for vector_doc in vector_docs:
-                    logger.info(f"DEBUG: Vector result: id={getattr(vector_doc, 'id', 'unknown')}, "
-                             f"score={getattr(vector_doc, 'score', 'unknown')}")
+                    logger.info(
+                        f"DEBUG: Vector result: id={getattr(vector_doc, 'id', 'unknown')}, "
+                        f"score={getattr(vector_doc, 'score', 'unknown')}"
+                    )
             except Exception as e:
                 logger.error(f"DEBUG: Vector retriever error: {str(e)}")
                 # Initialize with empty results so subsequent code doesn't fail
@@ -429,125 +479,177 @@ class HaystackService:
             # Special debug: analyze score distributions
             logger.info("DEBUG: Analyzing score distributions from both retrievers")
             try:
-                bm25_docs = bm25_results.get('documents', [])
-                vector_docs = vector_results.get('documents', [])
-                
+                bm25_docs = bm25_results.get("documents", [])
+                vector_docs = vector_results.get("documents", [])
+
                 # Analyze the scores
                 score_analysis = self._analyze_scores(vector_docs, bm25_docs)
-                
+
                 # Check for potential modifications to improve ranking
                 if score_analysis:
-                    logger.info("DEBUG: Consider these potential improvements based on score analysis:")
-                    
+                    logger.info(
+                        "DEBUG: Consider these potential improvements based on score analysis:"
+                    )
+
                     # Check if score normalization might help
-                    if (score_analysis.get('vector', {}).get('range') and 
-                        score_analysis.get('bm25', {}).get('range')):
-                        
-                        logger.info("DEBUG: One potential fix is to normalize scores before joining:")
-                        logger.info("DEBUG: For vector scores: score_norm = (score - min_score) / score_range")
-                        logger.info("DEBUG: For BM25 scores: score_norm = (score - min_score) / score_range")
-                        logger.info("DEBUG: This would make both retrievers contribute more equally to ranking")
+                    if score_analysis.get("vector", {}).get(
+                        "range"
+                    ) and score_analysis.get("bm25", {}).get("range"):
+                        logger.info(
+                            "DEBUG: One potential fix is to normalize scores before joining:"
+                        )
+                        logger.info(
+                            "DEBUG: For vector scores: score_norm = (score - min_score) / score_range"
+                        )
+                        logger.info(
+                            "DEBUG: For BM25 scores: score_norm = (score - min_score) / score_range"
+                        )
+                        logger.info(
+                            "DEBUG: This would make both retrievers contribute more equally to ranking"
+                        )
             except Exception as e:
                 logger.error(f"DEBUG: Score analysis failed: {str(e)}")
                 logger.exception("Score analysis error details:")
 
             # Special debug: manually simulate the reciprocal rank fusion to understand how the DocumentJoiner works
-            logger.info("DEBUG: Manually simulating reciprocal rank fusion to understand document joiner behavior")
+            logger.info(
+                "DEBUG: Manually simulating reciprocal rank fusion to understand document joiner behavior"
+            )
             try:
                 # Get documents from both retrievers
-                bm25_docs = bm25_results.get('documents', [])
-                vector_docs = vector_results.get('documents', [])
-                
+                bm25_docs = bm25_results.get("documents", [])
+                vector_docs = vector_results.get("documents", [])
+
                 # Combine all unique document IDs
-                all_doc_ids = set(doc.id for doc in bm25_docs if hasattr(doc, 'id'))
-                all_doc_ids.update(doc.id for doc in vector_docs if hasattr(doc, 'id'))
-                logger.info(f"DEBUG: Found {len(all_doc_ids)} unique document IDs across both retrievers")
-                
+                all_doc_ids = set(doc.id for doc in bm25_docs if hasattr(doc, "id"))
+                all_doc_ids.update(doc.id for doc in vector_docs if hasattr(doc, "id"))
+                logger.info(
+                    f"DEBUG: Found {len(all_doc_ids)} unique document IDs across both retrievers"
+                )
+
                 # Track rankings in each result list
-                bm25_ranks = {doc.id: i+1 for i, doc in enumerate(bm25_docs) if hasattr(doc, 'id')}
-                vector_ranks = {doc.id: i+1 for i, doc in enumerate(vector_docs) if hasattr(doc, 'id')}
-                
+                bm25_ranks = {
+                    doc.id: i + 1
+                    for i, doc in enumerate(bm25_docs)
+                    if hasattr(doc, "id")
+                }
+                vector_ranks = {
+                    doc.id: i + 1
+                    for i, doc in enumerate(vector_docs)
+                    if hasattr(doc, "id")
+                }
+
                 # Default constant k for RRF formula
                 k = 60  # Standard value used in RRF
-                
+
                 # Calculate RRF scores
                 rrf_scores = {}
                 for doc_id in all_doc_ids:
                     # For documents not in a result set, rank is considered "infinity"
                     # which effectively means their contribution from that source is 0
-                    bm25_rank = bm25_ranks.get(doc_id, float('inf')) 
-                    vector_rank = vector_ranks.get(doc_id, float('inf'))
-                    
+                    bm25_rank = bm25_ranks.get(doc_id, float("inf"))
+                    vector_rank = vector_ranks.get(doc_id, float("inf"))
+
                     # RRF formula: score = sum of 1/(k + rank) across all sources
                     rrf_score = 0
-                    if bm25_rank != float('inf'):
+                    if bm25_rank != float("inf"):
                         rrf_score += 1 / (k + bm25_rank)
-                    if vector_rank != float('inf'):
+                    if vector_rank != float("inf"):
                         rrf_score += 1 / (k + vector_rank)
-                    
+
                     rrf_scores[doc_id] = rrf_score
-                
+
                 # Sort documents by RRF score (higher is better)
-                sorted_doc_ids = sorted(rrf_scores.keys(), key=lambda doc_id: rrf_scores[doc_id], reverse=True)
-                
+                sorted_doc_ids = sorted(
+                    rrf_scores.keys(),
+                    key=lambda doc_id: rrf_scores[doc_id],
+                    reverse=True,
+                )
+
                 # Log the top results and their source ranks
                 logger.info("DEBUG: Top documents after RRF fusion:")
-                for i, doc_id in enumerate(sorted_doc_ids[:min(10, len(sorted_doc_ids))], 1):
-                    buzzwang = any(doc.content and "SmartBuzz" in doc.content for doc in bm25_docs + vector_docs if doc.id == doc_id)
-                    logger.info(f"DEBUG: Rank {i}: doc_id={doc_id}, "
-                              f"RRF score={rrf_scores[doc_id]:.6f}, "
-                              f"BM25 rank={bm25_ranks.get(doc_id, 'not in results')}, "
-                              f"Vector rank={vector_ranks.get(doc_id, 'not in results')}, "
-                              f"buzzwang={buzzwang}")
+                for i, doc_id in enumerate(
+                    sorted_doc_ids[: min(10, len(sorted_doc_ids))], 1
+                ):
+                    buzzwang = any(
+                        doc.content and "SmartBuzz" in doc.content
+                        for doc in bm25_docs + vector_docs
+                        if doc.id == doc_id
+                    )
+                    logger.info(
+                        f"DEBUG: Rank {i}: doc_id={doc_id}, "
+                        f"RRF score={rrf_scores[doc_id]:.6f}, "
+                        f"BM25 rank={bm25_ranks.get(doc_id, 'not in results')}, "
+                        f"Vector rank={vector_ranks.get(doc_id, 'not in results')}, "
+                        f"buzzwang={buzzwang}"
+                    )
             except Exception as e:
                 logger.error(f"DEBUG: Manual RRF simulation failed: {str(e)}")
                 logger.exception("RRF simulation error details:")
 
             # Log comparison with actual pipeline results
-            result = self.query_pipeline.run({
-                "bm25_retriever": {"query": query_text, "filters": formatted_filters, "top_k": top_k},
-                "embedder": {"text": query_text},
-                "vector_retriever": {"filters": formatted_filters, "top_k": top_k}
-            })
+            result = self.query_pipeline.run(
+                {
+                    "bm25_retriever": {
+                        "query": query_text,
+                        "filters": formatted_filters,
+                        "top_k": top_k,
+                    },
+                    "embedder": {"text": query_text},
+                    "vector_retriever": {"filters": formatted_filters, "top_k": top_k},
+                }
+            )
             documents = result.get("document_joiner", {}).get("documents", [])
             logger.info(f"DEBUG: Query pipeline returned {len(documents)} documents")
-            
+
             # Compare with our manual RRF
             if documents:
-                logger.info("DEBUG: Comparing pipeline results with manual RRF calculation:")
-                for i, doc in enumerate(documents[:min(len(documents), top_k)]):
-                    if hasattr(doc, 'id') and doc.id in rrf_scores:
+                logger.info(
+                    "DEBUG: Comparing pipeline results with manual RRF calculation:"
+                )
+                for i, doc in enumerate(documents[: min(len(documents), top_k)]):
+                    if hasattr(doc, "id") and doc.id in rrf_scores:
                         # Find this document's position in our sorted RRF results
-                        manual_rank = sorted_doc_ids.index(doc.id) + 1 if doc.id in sorted_doc_ids else "not found"
+                        manual_rank = (
+                            sorted_doc_ids.index(doc.id) + 1
+                            if doc.id in sorted_doc_ids
+                            else "not found"
+                        )
                         logger.info(
-                            f"DEBUG: Document {doc.id} - actual joiner rank: {i+1}, "
+                            f"DEBUG: Document {doc.id} - actual joiner rank: {i + 1}, "
                             f"manual RRF rank: {manual_rank}, "
                             f"actual joiner score: {getattr(doc, 'score', 'unknown')}, "
                             f"manual RRF score: {rrf_scores.get(doc.id, 'unknown')}"
                         )
                     else:
-                        logger.info(f"DEBUG: Document at position {i+1} has no ID or wasn't in manual results")
+                        logger.info(
+                            f"DEBUG: Document at position {i + 1} has no ID or wasn't in manual results"
+                        )
 
             # Run the query pipeline
             logger.info("Running full query pipeline with document joining")
             try:
                 # Run the pipeline
                 output = self.query_pipeline.run(params)
-                
+
                 # Get the results from the document joiner
                 documents = output.get("document_joiner", {}).get("documents", [])
                 logger.info(f"Document joiner returned {len(documents)} documents")
-                
+
                 # Filter out NUL bytes from document content
                 for doc in documents:
-                    if doc.content and '\x00' in doc.content:
-                        logger.warning(f"Filtering NUL bytes from retrieval result document: {doc.id}")
-                        doc.content = doc.content.replace('\x00', '')
-                
+                    if doc.content and "\x00" in doc.content:
+                        logger.warning(
+                            f"Filtering NUL bytes from retrieval result document: {doc.id}"
+                        )
+                        doc.content = doc.content.replace("\x00", "")
+
                 # Debug the joined results
                 for i, doc in enumerate(documents):
-                    logger.info(f"DEBUG: Final joined result {i+1}: id={getattr(doc, 'id', 'unknown')}, "
-                             f"score={getattr(doc, 'score', 'unknown')}")
+                    logger.info(
+                        f"DEBUG: Final joined result {i + 1}: id={getattr(doc, 'id', 'unknown')}, "
+                        f"score={getattr(doc, 'score', 'unknown')}"
+                    )
             except Exception as e:
                 logger.error(f"Error running query pipeline: {str(e)}")
                 logger.exception("Query pipeline error details:")
@@ -556,50 +658,51 @@ class HaystackService:
             # Convert to dictionaries
             results = []
             for i, doc in enumerate(documents):
-                results.append({
-                    "id": doc.id,
-                    "content": doc.content,
-                    "score": float(doc.score) if hasattr(doc, "score") and doc.score is not None else 0.0,
-                    "metadata": doc.meta,
-                    "rank": i + 1
-                })
-                
+                results.append(
+                    {
+                        "id": doc.id,
+                        "content": doc.content,
+                        "score": float(doc.score)
+                        if hasattr(doc, "score") and doc.score is not None
+                        else 0.0,
+                        "metadata": doc.meta,
+                        "rank": i + 1,
+                    }
+                )
+
             return results
-            
+
         except Exception as e:
             logger.error(f"Error querying document store: {str(e)}")
             raise
-    
+
     async def delete(self, filters: Dict[str, Any]) -> Dict[str, Any]:
         """
         Delete documents from the store that match the given filters
-        
+
         Args:
             filters: Filters to identify documents to delete
-            
+
         Returns:
             Dict with deletion status
         """
         logger.info(f"Deleting documents with filters: {filters}")
-        
+
         try:
             # Get documents that match filters
             matching_docs = self.document_store.filter_documents(filters=filters)
-            
+
             if not matching_docs:
                 return {"status": "success", "documents_deleted": 0}
-            
+
             # Get IDs of matching documents
             doc_ids = [doc.id for doc in matching_docs]
-            
+
             # Delete from the document store
             self.document_store.delete_documents(doc_ids)
-            
-            return {
-                "status": "success",
-                "documents_deleted": len(doc_ids)
-            }
-            
+
+            return {"status": "success", "documents_deleted": len(doc_ids)}
+
         except Exception as e:
             logger.error(f"Error deleting documents: {str(e)}")
-            raise 
+            raise

--- a/haystack_service/app/service_image.py
+++ b/haystack_service/app/service_image.py
@@ -102,26 +102,26 @@ class HaystackImageService:
         self, for_documents: bool = True
     ) -> Union[MultimodalDocumentEmbedder, MultimodalTextEmbedder]:
         """Get the appropriate embedder based on configuration"""
-        if settings.EMBEDDINGS_SOCKET:
+        if settings.VISION_EMBEDDINGS_SOCKET:
             logger.info(
-                f"Using UNIX socket for embeddings: {settings.EMBEDDINGS_SOCKET}"
+                f"Using UNIX socket for vision embeddings: {settings.VISION_EMBEDDINGS_SOCKET}"
             )
             return (
                 UnixSocketOpenAIDocumentEmbedder
                 if for_documents
                 else UnixSocketOpenAITextEmbedder
             )(
-                socket_path=settings.EMBEDDINGS_SOCKET,
+                socket_path=settings.VISION_EMBEDDINGS_SOCKET,
                 model=settings.VISION_EMBEDDINGS_MODEL,
                 batch_size=1 if for_documents else None,
             )
 
-        logger.info(f"Using API for embeddings: {settings.VLLM_BASE_URL}")
+        logger.info(f"Using API for vision embeddings: {settings.VISION_BASE_URL}")
         return (
             MultimodalDocumentEmbedder if for_documents else MultimodalTextEmbedder
         )(
-            api_key=Secret.from_token(settings.VLLM_API_KEY),
-            api_base_url=settings.VLLM_BASE_URL,
+            api_key=Secret.from_token(settings.VISION_API_KEY),
+            api_base_url=settings.VISION_BASE_URL,
             model=settings.VISION_EMBEDDINGS_MODEL,
         )
 

--- a/haystack_service/app/splitters.py
+++ b/haystack_service/app/splitters.py
@@ -50,20 +50,27 @@ class ImageSplitter:
                         image_data = image_file.read()
                         base64_image_data = base64.b64encode(image_data).decode("utf-8")
 
+                    mime_type = (
+                        "image/png"
+                        if image_path.lower().endswith(".png")
+                        else "image/jpeg"
+                        if image_path.lower().endswith((".jpg", ".jpeg"))
+                        else "application/octet-stream"
+                    )
+
+                    # Add the correct base64 header to the image data
+                    base64_image_data = f"data:{mime_type};base64,{base64_image_data}"
+
                     # Create byte stream with proper mime type detection
                     byte_stream = ByteStream(
                         data=image_data,
                         meta={},
-                        mime_type="image/png"
-                        if image_path.lower().endswith(".png")
-                        else "image/jpeg"
-                        if image_path.lower().endswith((".jpg", ".jpeg"))
-                        else "application/octet-stream",
+                        mime_type=mime_type,
                     )
 
                     # Create a haystack Document with proper ByteStream
                     page_doc = Document(
-                        content=base64_image_data,  # Must set this as well because the OpenAI Embedding code only works with the content field
+                        content=base64_image_data,  # Must set this as well because the Helix API expects there to be content
                         blob=byte_stream,
                         meta={
                             **doc.meta,

--- a/haystack_service/app/vectorchord/document_store/document_store.py
+++ b/haystack_service/app/vectorchord/document_store/document_store.py
@@ -472,23 +472,6 @@ class VectorchordDocumentStore:
     def _create_bm25_index_if_not_exists(self):
         """Create the BM25 index if it doesn't exist and update content_bm25vector column."""
         try:
-            # First, update all existing documents to have their content tokenized
-            # Use 'Bert' as the default tokenizer
-            tokenizer = "Bert"
-            query = SQL("""
-                UPDATE {schema_name}.{table_name}
-                SET content_bm25vector = tokenize(content, %s)
-                WHERE content IS NOT NULL AND content_bm25vector IS NULL
-            """).format(
-                schema_name=Identifier(self.schema_name),
-                table_name=Identifier(self.table_name),
-            )
-            self._execute_sql(
-                query,
-                params=(tokenizer,),
-                error_msg=f"Failed to update content_bm25vector for {self.schema_name}.{self.table_name}",
-            )
-
             # Then create the index
             index_name = (
                 SQL("{table_name}_bm25_idx")

--- a/haystack_service/app/vectorchord/document_store/document_store.py
+++ b/haystack_service/app/vectorchord/document_store/document_store.py
@@ -766,7 +766,11 @@ class VectorchordDocumentStore:
                     raise
 
             # Get the IDs of documents we just inserted with content
-            doc_ids = [doc["id"] for doc in pg_documents if doc["content"]]
+            doc_ids = [
+                doc["id"]
+                for doc in pg_documents
+                if doc["content"] and not doc["blob_data"]
+            ]
 
             if doc_ids:
                 # Convert list of IDs to a comma-separated string of quoted IDs
@@ -848,10 +852,6 @@ class VectorchordDocumentStore:
                 blob_data = blob.data
                 blob_meta = blob.meta
                 blob_mime_type = blob.mime_type
-
-                # This is a hack to avoid saving the image data to the database as text
-                # But content is required for the OpenAI Embedding API to work.
-                content = None
 
             # Return a dict with PostgreSQL compatible keys and values
             pg_document = {


### PR DESCRIPTION
Introducing a new way to do RAG with vision models. New features include:

- a new haystack vision embedding pipeline to embed and store images of PDFs
- addition to the App UI to enable vision mode
- improved haystack codebase, reduced tech tebt
- tested with openai and vllm

As usual, expect some rough edges, this is cutting edge. Better documentation and improve resilience to follow.