### PR TITLE
enable helix models by default

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -297,7 +297,7 @@ steps:
       # Runner with no baked models = empty
       # See https://github.com/helixml/base-images
       # and https://github.com/helixml/base-images/releases
-      - TAG=2025-01-27a-empty
+      - TAG=2025-04-29a-empty
       - APP_VERSION=${DRONE_TAG:-${DRONE_COMMIT_SHA:-latest}}
     username: admin
     password:
@@ -339,7 +339,7 @@ steps:
       # Runner with small models = small
       # See https://github.com/helixml/base-images
       # and https://github.com/helixml/base-images/releases
-      - TAG=2025-01-27a-small
+      - TAG=2025-04-29a-small
       - APP_VERSION=${DRONE_TAG:-${DRONE_COMMIT_SHA:-latest}}
     username: admin
     password:
@@ -365,7 +365,7 @@ steps:
       # Runner with small models = small
       # See https://github.com/helixml/base-images
       # and https://github.com/helixml/base-images/releases
-      - TAG=2025-01-27a-small
+      - TAG=2025-04-29a-small
       - APP_VERSION=${DRONE_TAG:-${DRONE_COMMIT_SHA:-latest}}
     username: admin
     password:
@@ -410,7 +410,7 @@ steps:
       # Runner with large models = large
       # See https://github.com/helixml/base-images
       # and https://github.com/helixml/base-images/releases
-      - TAG=2025-01-27a-large
+      - TAG=2025-04-29a-large
       - APP_VERSION=${DRONE_TAG:-${DRONE_COMMIT_SHA:-latest}}
     username: admin
     password:
@@ -436,7 +436,7 @@ steps:
       # Runner with large models = large
       # See https://github.com/helixml/base-images
       # and https://github.com/helixml/base-images/releases
-      - TAG=2025-01-27a-large
+      - TAG=2025-04-29a-large
       - APP_VERSION=${DRONE_TAG:-${DRONE_COMMIT_SHA:-latest}}
     username: admin
     password:

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -52,7 +52,7 @@ FROM registry.helixml.tech/helix/runner-base:${TAG}
 
 # Pass the CPU flag through to this stage
 ARG DEVELOPMENT_CPU_ONLY=""
-# Pass the vLLM version 
+# Pass the vLLM version
 ARG VLLM_VERSION
 
 # Install ollama

--- a/api/pkg/openai/helix_openai_client.go
+++ b/api/pkg/openai/helix_openai_client.go
@@ -46,6 +46,7 @@ func ListModels(_ context.Context) ([]types.OpenAIModel, error) {
 			Hide:          m.GetHidden(),
 			Type:          "chat",
 			ContextLength: int(m.GetContextLength()),
+			Enabled:       true,
 		})
 	}
 
@@ -62,6 +63,7 @@ func ListModels(_ context.Context) ([]types.OpenAIModel, error) {
 			Description: m.GetDescription(),
 			Hide:        m.GetHidden(),
 			Type:        "image",
+			Enabled:     true,
 		})
 	}
 
@@ -80,6 +82,7 @@ func ListModels(_ context.Context) ([]types.OpenAIModel, error) {
 			Hide:          m.GetHidden(),
 			Type:          "chat",
 			ContextLength: int(m.GetContextLength()),
+			Enabled:       true,
 		})
 	}
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -214,7 +214,7 @@ services:
       context: .
       dockerfile: Dockerfile.runner
       args:
-        TAG: 2024-12-07a-empty
+        TAG: 2025-04-29a-small
         # Builds vllm in CPU-only mode per https://github.com/vllm-project/vllm/discussions/8090
         DEVELOPMENT_CPU_ONLY: "true"
     environment:
@@ -234,7 +234,7 @@ services:
       context: .
       dockerfile: Dockerfile.runner
       args:
-        TAG: 2024-12-07a-empty
+        TAG: 2025-04-29a-small
     environment:
       # Prevent toolchain downloads
       - GOTOOLCHAIN=local 

--- a/stack
+++ b/stack
@@ -9,18 +9,26 @@ export WITH_DEMOS=${WITH_DEMOS:=""}
 
 # Helper function to check for NVIDIA GPU and set appropriate variables
 function setup_runner_profile() {
-  if command -v nvidia-smi &> /dev/null && nvidia-smi &> /dev/null; then
+  export FORCE_CPU=${FORCE_CPU:=""}
+  
+  if [[ -n "$FORCE_CPU" ]] || ! (command -v nvidia-smi &> /dev/null && nvidia-smi &> /dev/null); then
+    # CPU mode
+    if [[ -n "$FORCE_CPU" ]]; then
+      echo "FORCE_CPU is set, forcing CPU mode regardless of GPU detection"
+    else
+      echo "No NVIDIA GPU detected, running without GPU support"
+    fi
+    export RUNNER_CONTAINER="runner"
+    export RUNNER_PROFILE="--profile runner"
+    export DEV_CPU_ONLY_CMD="DEVELOPMENT_CPU_ONLY=true"
+    export VLLM_ENV_VARS="VLLM_DEVICE=cpu VLLM_LOGGING_LEVEL=DEBUG"
+  else
+    # GPU mode
     echo "NVIDIA GPU detected, using GPU support"
     export RUNNER_CONTAINER="runner_gpu"
     export RUNNER_PROFILE="--profile runner_gpu"
     export DEV_CPU_ONLY_CMD=""
     export VLLM_ENV_VARS=""
-  else
-    echo "No NVIDIA GPU detected, running without GPU support"
-    export RUNNER_CONTAINER="runner"
-    export RUNNER_PROFILE="--profile runner"
-    export DEV_CPU_ONLY_CMD="DEVELOPMENT_CPU_ONLY=true"
-    export VLLM_ENV_VARS="VLLM_DEVICE=cpu VLLM_LOGGING_LEVEL=DEBUG"
   fi
 }
 


### PR DESCRIPTION
* as well as providing a new FORCE_CPU option for testing CPU vLLM on dev nodes that do have a GPU
* and bumping the base image to one with the correct version of go installed (to stop errors in development)