### PR TITLE
disable failing tests for now

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -406,270 +406,270 @@ steps:
     - failure
   depends_on: [oauth-outlook-integration-test]
 
-- name: oauth-google-calendar-integration-test
-  image: golang:1.24
-  volumes:
-  - name: oauth-google-calendar-test-results
-    path: /tmp/helix-oauth-test-results
-  - name: go-build-cache
-    path: /root/.cache/go-build
-  - name: go-mod-cache
-    path: /go/pkg/mod
-  environment:
-    # Google OAuth test credentials
-    GOOGLE_SKILL_TEST_OAUTH_CLIENT_ID:
-      from_secret: google_skill_test_oauth_client_id
-    GOOGLE_SKILL_TEST_OAUTH_CLIENT_SECRET:
-      from_secret: google_skill_test_oauth_client_secret
-    GOOGLE_SKILL_TEST_OAUTH_USERNAME:
-      from_secret: google_skill_test_oauth_username
-    GOOGLE_SKILL_TEST_OAUTH_PASSWORD:
-      from_secret: google_skill_test_oauth_password
-    # Gmail credentials for device verification
-    GMAIL_CREDENTIALS_BASE64:
-      from_secret: gmail_credentials_base64
-    # Database config (running in a sidecar)
-    POSTGRES_HOST: postgres
-    POSTGRES_PORT: "5432"
-    POSTGRES_USER: postgres
-    POSTGRES_PASSWORD: postgres
-    POSTGRES_DATABASE: postgres
-    TYPESENSE_URL: http://typesense:8108
-    TYPESENSE_API_KEY: typesense
-    TEXT_EXTRACTION_TIKA_URL: http://tika:9998
-    RAG_CRAWLER_LAUNCHER_URL: http://chrome:7317
-    KEYCLOAK_URL: http://keycloak:8080/auth
-    KEYCLOAK_FRONTEND_URL: http://keycloak:8080/auth/
-    KEYCLOAK_PASSWORD: REPLACE_ME
-    ORGANIZATIONS_CREATE_ENABLED_FOR_NON_ADMINS: "true"
-    # CI-specific configuration for OAuth test
-    WEB_SERVER_HOST: "localhost"
-    # API Keys for LLM providers
-    OPENAI_API_KEY:
-      from_secret: openai_api_key
-    ANTHROPIC_API_KEY:
-      from_secret: anthropic_api_key
-    # Agent configuration
-    REASONING_MODEL_PROVIDER: openai
-    REASONING_MODEL: o3-mini    
-    REASONING_MODEL_EFFORT: none
-    GENERATION_MODEL_PROVIDER: openai
-    GENERATION_MODEL: gpt-4o
-    SMALL_REASONING_MODEL_PROVIDER: openai
-    SMALL_REASONING_MODEL: o3-mini
-    SMALL_REASONING_MODEL_EFFORT: none
-    SMALL_GENERATION_MODEL_PROVIDER: openai
-    SMALL_GENERATION_MODEL: gpt-4o-mini
+# - name: oauth-google-calendar-integration-test
+#   image: golang:1.24
+#   volumes:
+#   - name: oauth-google-calendar-test-results
+#     path: /tmp/helix-oauth-test-results
+#   - name: go-build-cache
+#     path: /root/.cache/go-build
+#   - name: go-mod-cache
+#     path: /go/pkg/mod
+#   environment:
+#     # Google OAuth test credentials
+#     GOOGLE_SKILL_TEST_OAUTH_CLIENT_ID:
+#       from_secret: google_skill_test_oauth_client_id
+#     GOOGLE_SKILL_TEST_OAUTH_CLIENT_SECRET:
+#       from_secret: google_skill_test_oauth_client_secret
+#     GOOGLE_SKILL_TEST_OAUTH_USERNAME:
+#       from_secret: google_skill_test_oauth_username
+#     GOOGLE_SKILL_TEST_OAUTH_PASSWORD:
+#       from_secret: google_skill_test_oauth_password
+#     # Gmail credentials for device verification
+#     GMAIL_CREDENTIALS_BASE64:
+#       from_secret: gmail_credentials_base64
+#     # Database config (running in a sidecar)
+#     POSTGRES_HOST: postgres
+#     POSTGRES_PORT: "5432"
+#     POSTGRES_USER: postgres
+#     POSTGRES_PASSWORD: postgres
+#     POSTGRES_DATABASE: postgres
+#     TYPESENSE_URL: http://typesense:8108
+#     TYPESENSE_API_KEY: typesense
+#     TEXT_EXTRACTION_TIKA_URL: http://tika:9998
+#     RAG_CRAWLER_LAUNCHER_URL: http://chrome:7317
+#     KEYCLOAK_URL: http://keycloak:8080/auth
+#     KEYCLOAK_FRONTEND_URL: http://keycloak:8080/auth/
+#     KEYCLOAK_PASSWORD: REPLACE_ME
+#     ORGANIZATIONS_CREATE_ENABLED_FOR_NON_ADMINS: "true"
+#     # CI-specific configuration for OAuth test
+#     WEB_SERVER_HOST: "localhost"
+#     # API Keys for LLM providers
+#     OPENAI_API_KEY:
+#       from_secret: openai_api_key
+#     ANTHROPIC_API_KEY:
+#       from_secret: anthropic_api_key
+#     # Agent configuration
+#     REASONING_MODEL_PROVIDER: openai
+#     REASONING_MODEL: o3-mini    
+#     REASONING_MODEL_EFFORT: none
+#     GENERATION_MODEL_PROVIDER: openai
+#     GENERATION_MODEL: gpt-4o
+#     SMALL_REASONING_MODEL_PROVIDER: openai
+#     SMALL_REASONING_MODEL: o3-mini
+#     SMALL_REASONING_MODEL_EFFORT: none
+#     SMALL_GENERATION_MODEL_PROVIDER: openai
+#     SMALL_GENERATION_MODEL: gpt-4o-mini
 
-  commands:
-    - chmod +x scripts/run-oauth-integration-test.sh
-    - ./scripts/run-oauth-integration-test.sh google-calendar TestGoogleCalendarOAuthSkillsE2E
-  when:
-    event:
-    - push
-  # depends_on: [unit-test]
+#   commands:
+#     - chmod +x scripts/run-oauth-integration-test.sh
+#     - ./scripts/run-oauth-integration-test.sh google-calendar TestGoogleCalendarOAuthSkillsE2E
+#   when:
+#     event:
+#     - push
+#   # depends_on: [unit-test]
 
-- name: upload-oauth-google-calendar-test-artifacts
-  image: golang:1.24
-  volumes:
-  - name: oauth-google-calendar-test-results
-    path: /tmp/helix-oauth-test-results
-  environment:
-    LAUNCHPAD_URL: "https://deploy.helix.ml"
-    CI_SHARED_SECRET:
-      from_secret: ci_shared_secret
-  commands:
-    - chmod +x scripts/upload-oauth-test-artifacts.sh
-    - ./scripts/upload-oauth-test-artifacts.sh google-calendar
-  when:
-    event:
-    - push
-    status:
-    - success
-    - failure
-  depends_on: [oauth-google-calendar-integration-test]
+# - name: upload-oauth-google-calendar-test-artifacts
+#   image: golang:1.24
+#   volumes:
+#   - name: oauth-google-calendar-test-results
+#     path: /tmp/helix-oauth-test-results
+#   environment:
+#     LAUNCHPAD_URL: "https://deploy.helix.ml"
+#     CI_SHARED_SECRET:
+#       from_secret: ci_shared_secret
+#   commands:
+#     - chmod +x scripts/upload-oauth-test-artifacts.sh
+#     - ./scripts/upload-oauth-test-artifacts.sh google-calendar
+#   when:
+#     event:
+#     - push
+#     status:
+#     - success
+#     - failure
+#   depends_on: [oauth-google-calendar-integration-test]
 
-- name: oauth-jira-integration-test
-  image: golang:1.24
-  volumes:
-  - name: oauth-jira-test-results
-    path: /tmp/helix-oauth-test-results
-  - name: go-build-cache
-    path: /root/.cache/go-build
-  - name: go-mod-cache
-    path: /go/pkg/mod
-  environment:
-    # Atlassian OAuth test credentials
-    ATLASSIAN_SKILL_TEST_OAUTH_CLIENT_ID:
-      from_secret: atlassian_skill_test_oauth_client_id
-    ATLASSIAN_SKILL_TEST_OAUTH_CLIENT_SECRET:
-      from_secret: atlassian_skill_test_oauth_client_secret
-    ATLASSIAN_SKILL_TEST_OAUTH_USERNAME:
-      from_secret: atlassian_skill_test_oauth_username
-    ATLASSIAN_SKILL_TEST_OAUTH_PASSWORD:
-      from_secret: atlassian_skill_test_oauth_password
-    ATLASSIAN_SKILL_TEST_JIRA_CLOUD_ID:
-      from_secret: atlassian_skill_test_jira_cloud_id
-    # Gmail credentials for MFA handling
-    GMAIL_CREDENTIALS_BASE64:
-      from_secret: gmail_credentials_base64
-    # Database config (running in a sidecar)
-    POSTGRES_HOST: postgres
-    POSTGRES_PORT: "5432"
-    POSTGRES_USER: postgres
-    POSTGRES_PASSWORD: postgres
-    POSTGRES_DATABASE: postgres
-    TYPESENSE_URL: http://typesense:8108
-    TYPESENSE_API_KEY: typesense
-    TEXT_EXTRACTION_TIKA_URL: http://tika:9998
-    RAG_CRAWLER_LAUNCHER_URL: http://chrome:7317
-    KEYCLOAK_URL: http://keycloak:8080/auth
-    KEYCLOAK_FRONTEND_URL: http://keycloak:8080/auth/
-    KEYCLOAK_PASSWORD: REPLACE_ME
-    ORGANIZATIONS_CREATE_ENABLED_FOR_NON_ADMINS: "true"
-    # CI-specific configuration for OAuth test
-    WEB_SERVER_HOST: "localhost"
-    # API Keys for LLM providers
-    OPENAI_API_KEY:
-      from_secret: openai_api_key
-    ANTHROPIC_API_KEY:
-      from_secret: anthropic_api_key
-    # Agent configuration
-    REASONING_MODEL_PROVIDER: openai
-    REASONING_MODEL: o3-mini    
-    REASONING_MODEL_EFFORT: none
-    GENERATION_MODEL_PROVIDER: openai
-    GENERATION_MODEL: gpt-4o
-    SMALL_REASONING_MODEL_PROVIDER: openai
-    SMALL_REASONING_MODEL: o3-mini
-    SMALL_REASONING_MODEL_EFFORT: none
-    SMALL_GENERATION_MODEL_PROVIDER: openai
-    SMALL_GENERATION_MODEL: gpt-4o-mini
+# - name: oauth-jira-integration-test
+#   image: golang:1.24
+#   volumes:
+#   - name: oauth-jira-test-results
+#     path: /tmp/helix-oauth-test-results
+#   - name: go-build-cache
+#     path: /root/.cache/go-build
+#   - name: go-mod-cache
+#     path: /go/pkg/mod
+#   environment:
+#     # Atlassian OAuth test credentials
+#     ATLASSIAN_SKILL_TEST_OAUTH_CLIENT_ID:
+#       from_secret: atlassian_skill_test_oauth_client_id
+#     ATLASSIAN_SKILL_TEST_OAUTH_CLIENT_SECRET:
+#       from_secret: atlassian_skill_test_oauth_client_secret
+#     ATLASSIAN_SKILL_TEST_OAUTH_USERNAME:
+#       from_secret: atlassian_skill_test_oauth_username
+#     ATLASSIAN_SKILL_TEST_OAUTH_PASSWORD:
+#       from_secret: atlassian_skill_test_oauth_password
+#     ATLASSIAN_SKILL_TEST_JIRA_CLOUD_ID:
+#       from_secret: atlassian_skill_test_jira_cloud_id
+#     # Gmail credentials for MFA handling
+#     GMAIL_CREDENTIALS_BASE64:
+#       from_secret: gmail_credentials_base64
+#     # Database config (running in a sidecar)
+#     POSTGRES_HOST: postgres
+#     POSTGRES_PORT: "5432"
+#     POSTGRES_USER: postgres
+#     POSTGRES_PASSWORD: postgres
+#     POSTGRES_DATABASE: postgres
+#     TYPESENSE_URL: http://typesense:8108
+#     TYPESENSE_API_KEY: typesense
+#     TEXT_EXTRACTION_TIKA_URL: http://tika:9998
+#     RAG_CRAWLER_LAUNCHER_URL: http://chrome:7317
+#     KEYCLOAK_URL: http://keycloak:8080/auth
+#     KEYCLOAK_FRONTEND_URL: http://keycloak:8080/auth/
+#     KEYCLOAK_PASSWORD: REPLACE_ME
+#     ORGANIZATIONS_CREATE_ENABLED_FOR_NON_ADMINS: "true"
+#     # CI-specific configuration for OAuth test
+#     WEB_SERVER_HOST: "localhost"
+#     # API Keys for LLM providers
+#     OPENAI_API_KEY:
+#       from_secret: openai_api_key
+#     ANTHROPIC_API_KEY:
+#       from_secret: anthropic_api_key
+#     # Agent configuration
+#     REASONING_MODEL_PROVIDER: openai
+#     REASONING_MODEL: o3-mini    
+#     REASONING_MODEL_EFFORT: none
+#     GENERATION_MODEL_PROVIDER: openai
+#     GENERATION_MODEL: gpt-4o
+#     SMALL_REASONING_MODEL_PROVIDER: openai
+#     SMALL_REASONING_MODEL: o3-mini
+#     SMALL_REASONING_MODEL_EFFORT: none
+#     SMALL_GENERATION_MODEL_PROVIDER: openai
+#     SMALL_GENERATION_MODEL: gpt-4o-mini
 
-  commands:
-    - chmod +x scripts/run-oauth-integration-test.sh
-    - echo "=== Environment Variable Check ==="
-    - echo "GMAIL_CREDENTIALS_BASE64 length:" $(echo -n "${GMAIL_CREDENTIALS_BASE64}" | wc -c)
-    - echo "ATLASSIAN_SKILL_TEST_OAUTH_CLIENT_ID is set:" $(test -n "${ATLASSIAN_SKILL_TEST_OAUTH_CLIENT_ID}" && echo "YES" || echo "NO")
-    - echo "ATLASSIAN_SKILL_TEST_OAUTH_USERNAME is set:" $(test -n "${ATLASSIAN_SKILL_TEST_OAUTH_USERNAME}" && echo "YES" || echo "NO")
-    - echo "ATLASSIAN_SKILL_TEST_JIRA_CLOUD_ID is set:" $(test -n "${ATLASSIAN_SKILL_TEST_JIRA_CLOUD_ID}" && echo "YES" || echo "NO")
-    - echo "=== Starting Jira OAuth Test ==="
-    - ./scripts/run-oauth-integration-test.sh jira TestJiraOAuthSkillsE2E
-  when:
-    event:
-    - push
-  # depends_on: [unit-test]
+#   commands:
+#     - chmod +x scripts/run-oauth-integration-test.sh
+#     - echo "=== Environment Variable Check ==="
+#     - echo "GMAIL_CREDENTIALS_BASE64 length:" $(echo -n "${GMAIL_CREDENTIALS_BASE64}" | wc -c)
+#     - echo "ATLASSIAN_SKILL_TEST_OAUTH_CLIENT_ID is set:" $(test -n "${ATLASSIAN_SKILL_TEST_OAUTH_CLIENT_ID}" && echo "YES" || echo "NO")
+#     - echo "ATLASSIAN_SKILL_TEST_OAUTH_USERNAME is set:" $(test -n "${ATLASSIAN_SKILL_TEST_OAUTH_USERNAME}" && echo "YES" || echo "NO")
+#     - echo "ATLASSIAN_SKILL_TEST_JIRA_CLOUD_ID is set:" $(test -n "${ATLASSIAN_SKILL_TEST_JIRA_CLOUD_ID}" && echo "YES" || echo "NO")
+#     - echo "=== Starting Jira OAuth Test ==="
+#     - ./scripts/run-oauth-integration-test.sh jira TestJiraOAuthSkillsE2E
+#   when:
+#     event:
+#     - push
+#   # depends_on: [unit-test]
 
-- name: upload-oauth-jira-test-artifacts
-  image: golang:1.24
-  volumes:
-  - name: oauth-jira-test-results
-    path: /tmp/helix-oauth-test-results
-  environment:
-    LAUNCHPAD_URL: "https://deploy.helix.ml"
-    CI_SHARED_SECRET:
-      from_secret: ci_shared_secret
-  commands:
-    - chmod +x scripts/upload-oauth-test-artifacts.sh
-    - ./scripts/upload-oauth-test-artifacts.sh jira
-  when:
-    event:
-    - push
-    status:
-    - success
-    - failure
-  depends_on: [oauth-jira-integration-test]
+# - name: upload-oauth-jira-test-artifacts
+#   image: golang:1.24
+#   volumes:
+#   - name: oauth-jira-test-results
+#     path: /tmp/helix-oauth-test-results
+#   environment:
+#     LAUNCHPAD_URL: "https://deploy.helix.ml"
+#     CI_SHARED_SECRET:
+#       from_secret: ci_shared_secret
+#   commands:
+#     - chmod +x scripts/upload-oauth-test-artifacts.sh
+#     - ./scripts/upload-oauth-test-artifacts.sh jira
+#   when:
+#     event:
+#     - push
+#     status:
+#     - success
+#     - failure
+#   depends_on: [oauth-jira-integration-test]
 
-- name: oauth-confluence-integration-test
-  image: golang:1.24
-  volumes:
-  - name: oauth-confluence-test-results
-    path: /tmp/helix-oauth-test-results
-  - name: go-build-cache
-    path: /root/.cache/go-build
-  - name: go-mod-cache
-    path: /go/pkg/mod
-  environment:
-    # Atlassian OAuth test credentials
-    ATLASSIAN_SKILL_TEST_OAUTH_CLIENT_ID:
-      from_secret: atlassian_skill_test_oauth_client_id
-    ATLASSIAN_SKILL_TEST_OAUTH_CLIENT_SECRET:
-      from_secret: atlassian_skill_test_oauth_client_secret
-    ATLASSIAN_SKILL_TEST_OAUTH_USERNAME:
-      from_secret: atlassian_skill_test_oauth_username
-    ATLASSIAN_SKILL_TEST_OAUTH_PASSWORD:
-      from_secret: atlassian_skill_test_oauth_password
-    ATLASSIAN_SKILL_TEST_CONFLUENCE_CLOUD_ID:
-      from_secret: atlassian_skill_test_confluence_cloud_id
-    # Gmail credentials for MFA handling
-    GMAIL_CREDENTIALS_BASE64:
-      from_secret: gmail_credentials_base64
-    # Database config (running in a sidecar)
-    POSTGRES_HOST: postgres
-    POSTGRES_PORT: "5432"
-    POSTGRES_USER: postgres
-    POSTGRES_PASSWORD: postgres
-    POSTGRES_DATABASE: postgres
-    TYPESENSE_URL: http://typesense:8108
-    TYPESENSE_API_KEY: typesense
-    TEXT_EXTRACTION_TIKA_URL: http://tika:9998
-    RAG_CRAWLER_LAUNCHER_URL: http://chrome:7317
-    KEYCLOAK_URL: http://keycloak:8080/auth
-    KEYCLOAK_FRONTEND_URL: http://keycloak:8080/auth/
-    KEYCLOAK_PASSWORD: REPLACE_ME
-    ORGANIZATIONS_CREATE_ENABLED_FOR_NON_ADMINS: "true"
-    # CI-specific configuration for OAuth test
-    WEB_SERVER_HOST: "localhost"
-    # API Keys for LLM providers
-    OPENAI_API_KEY:
-      from_secret: openai_api_key
-    ANTHROPIC_API_KEY:
-      from_secret: anthropic_api_key
-    # Agent configuration
-    REASONING_MODEL_PROVIDER: openai
-    REASONING_MODEL: o3-mini    
-    REASONING_MODEL_EFFORT: none
-    GENERATION_MODEL_PROVIDER: openai
-    GENERATION_MODEL: gpt-4o
-    SMALL_REASONING_MODEL_PROVIDER: openai
-    SMALL_REASONING_MODEL: o3-mini
-    SMALL_REASONING_MODEL_EFFORT: none
-    SMALL_GENERATION_MODEL_PROVIDER: openai
-    SMALL_GENERATION_MODEL: gpt-4o-mini
+# - name: oauth-confluence-integration-test
+#   image: golang:1.24
+#   volumes:
+#   - name: oauth-confluence-test-results
+#     path: /tmp/helix-oauth-test-results
+#   - name: go-build-cache
+#     path: /root/.cache/go-build
+#   - name: go-mod-cache
+#     path: /go/pkg/mod
+#   environment:
+#     # Atlassian OAuth test credentials
+#     ATLASSIAN_SKILL_TEST_OAUTH_CLIENT_ID:
+#       from_secret: atlassian_skill_test_oauth_client_id
+#     ATLASSIAN_SKILL_TEST_OAUTH_CLIENT_SECRET:
+#       from_secret: atlassian_skill_test_oauth_client_secret
+#     ATLASSIAN_SKILL_TEST_OAUTH_USERNAME:
+#       from_secret: atlassian_skill_test_oauth_username
+#     ATLASSIAN_SKILL_TEST_OAUTH_PASSWORD:
+#       from_secret: atlassian_skill_test_oauth_password
+#     ATLASSIAN_SKILL_TEST_CONFLUENCE_CLOUD_ID:
+#       from_secret: atlassian_skill_test_confluence_cloud_id
+#     # Gmail credentials for MFA handling
+#     GMAIL_CREDENTIALS_BASE64:
+#       from_secret: gmail_credentials_base64
+#     # Database config (running in a sidecar)
+#     POSTGRES_HOST: postgres
+#     POSTGRES_PORT: "5432"
+#     POSTGRES_USER: postgres
+#     POSTGRES_PASSWORD: postgres
+#     POSTGRES_DATABASE: postgres
+#     TYPESENSE_URL: http://typesense:8108
+#     TYPESENSE_API_KEY: typesense
+#     TEXT_EXTRACTION_TIKA_URL: http://tika:9998
+#     RAG_CRAWLER_LAUNCHER_URL: http://chrome:7317
+#     KEYCLOAK_URL: http://keycloak:8080/auth
+#     KEYCLOAK_FRONTEND_URL: http://keycloak:8080/auth/
+#     KEYCLOAK_PASSWORD: REPLACE_ME
+#     ORGANIZATIONS_CREATE_ENABLED_FOR_NON_ADMINS: "true"
+#     # CI-specific configuration for OAuth test
+#     WEB_SERVER_HOST: "localhost"
+#     # API Keys for LLM providers
+#     OPENAI_API_KEY:
+#       from_secret: openai_api_key
+#     ANTHROPIC_API_KEY:
+#       from_secret: anthropic_api_key
+#     # Agent configuration
+#     REASONING_MODEL_PROVIDER: openai
+#     REASONING_MODEL: o3-mini    
+#     REASONING_MODEL_EFFORT: none
+#     GENERATION_MODEL_PROVIDER: openai
+#     GENERATION_MODEL: gpt-4o
+#     SMALL_REASONING_MODEL_PROVIDER: openai
+#     SMALL_REASONING_MODEL: o3-mini
+#     SMALL_REASONING_MODEL_EFFORT: none
+#     SMALL_GENERATION_MODEL_PROVIDER: openai
+#     SMALL_GENERATION_MODEL: gpt-4o-mini
 
-  commands:
-    - chmod +x scripts/run-oauth-integration-test.sh
-    - echo "=== Environment Variable Check ==="
-    - echo "GMAIL_CREDENTIALS_BASE64 length:" $(echo -n "${GMAIL_CREDENTIALS_BASE64}" | wc -c)
-    - echo "ATLASSIAN_SKILL_TEST_OAUTH_CLIENT_ID is set:" $(test -n "${ATLASSIAN_SKILL_TEST_OAUTH_CLIENT_ID}" && echo "YES" || echo "NO")
-    - echo "ATLASSIAN_SKILL_TEST_OAUTH_USERNAME is set:" $(test -n "${ATLASSIAN_SKILL_TEST_OAUTH_USERNAME}" && echo "YES" || echo "NO")
-    - echo "ATLASSIAN_SKILL_TEST_CONFLUENCE_CLOUD_ID is set:" $(test -n "${ATLASSIAN_SKILL_TEST_CONFLUENCE_CLOUD_ID}" && echo "YES" || echo "NO")
-    - echo "=== Starting Confluence OAuth Test ==="
-    - ./scripts/run-oauth-integration-test.sh confluence TestConfluenceOAuthSkillsE2E
-  when:
-    event:
-    - push
-  # depends_on: [unit-test]
+#   commands:
+#     - chmod +x scripts/run-oauth-integration-test.sh
+#     - echo "=== Environment Variable Check ==="
+#     - echo "GMAIL_CREDENTIALS_BASE64 length:" $(echo -n "${GMAIL_CREDENTIALS_BASE64}" | wc -c)
+#     - echo "ATLASSIAN_SKILL_TEST_OAUTH_CLIENT_ID is set:" $(test -n "${ATLASSIAN_SKILL_TEST_OAUTH_CLIENT_ID}" && echo "YES" || echo "NO")
+#     - echo "ATLASSIAN_SKILL_TEST_OAUTH_USERNAME is set:" $(test -n "${ATLASSIAN_SKILL_TEST_OAUTH_USERNAME}" && echo "YES" || echo "NO")
+#     - echo "ATLASSIAN_SKILL_TEST_CONFLUENCE_CLOUD_ID is set:" $(test -n "${ATLASSIAN_SKILL_TEST_CONFLUENCE_CLOUD_ID}" && echo "YES" || echo "NO")
+#     - echo "=== Starting Confluence OAuth Test ==="
+#     - ./scripts/run-oauth-integration-test.sh confluence TestConfluenceOAuthSkillsE2E
+#   when:
+#     event:
+#     - push
+#   # depends_on: [unit-test]
 
-- name: upload-oauth-confluence-test-artifacts
-  image: golang:1.24
-  volumes:
-  - name: oauth-confluence-test-results
-    path: /tmp/helix-oauth-test-results
-  environment:
-    LAUNCHPAD_URL: "https://deploy.helix.ml"
-    CI_SHARED_SECRET:
-      from_secret: ci_shared_secret
-  commands:
-    - chmod +x scripts/upload-oauth-test-artifacts.sh
-    - ./scripts/upload-oauth-test-artifacts.sh confluence
-  when:
-    event:
-    - push
-    status:
-    - success
-    - failure
-  depends_on: [oauth-confluence-integration-test]
+# - name: upload-oauth-confluence-test-artifacts
+#   image: golang:1.24
+#   volumes:
+#   - name: oauth-confluence-test-results
+#     path: /tmp/helix-oauth-test-results
+#   environment:
+#     LAUNCHPAD_URL: "https://deploy.helix.ml"
+#     CI_SHARED_SECRET:
+#       from_secret: ci_shared_secret
+#   commands:
+#     - chmod +x scripts/upload-oauth-test-artifacts.sh
+#     - ./scripts/upload-oauth-test-artifacts.sh confluence
+#   when:
+#     event:
+#     - push
+#     status:
+#     - success
+#     - failure
+#   depends_on: [oauth-confluence-integration-test]
 
 - name: release-backend
   image: golang:1.24-bullseye


### PR DESCRIPTION
* google tests don't work when you run two concurrently because one of them gets a 'choose your account' screen which we haven't accounted for
* jira and confluence tests both now show a 'please enable 2fa' screen with a skip button we are not clicking