### PR TITLE
dynamic providers env

### DIFF
--- a/api/cmd/helix/serve.go
+++ b/api/cmd/helix/serve.go
@@ -218,6 +218,13 @@ func serve(cmd *cobra.Command, cfg *config.ServerConfig) error {
 		return err
 	}
 
+	// Initialize dynamic providers from environment variable
+	err = postgresStore.InitializeDynamicProviders(ctx, cfg.Providers.DynamicProviders)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to initialize dynamic providers, continuing with startup")
+		// Don't fail the entire startup if dynamic providers fail to initialize
+	}
+
 	// Reset any running executions
 	err = postgresStore.ResetRunningExecutions(ctx)
 	if err != nil {

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -72,7 +72,8 @@ type Providers struct {
 	Anthropic                 Anthropic
 	Helix                     Helix
 	VLLM                      VLLM
-	EnableCustomUserProviders bool `envconfig:"ENABLE_CUSTOM_USER_PROVIDERS" default:"false"` // Allow users to configure their own providers, if "false" then only admins can add them
+	EnableCustomUserProviders bool   `envconfig:"ENABLE_CUSTOM_USER_PROVIDERS" default:"false"` // Allow users to configure their own providers, if "false" then only admins can add them
+	DynamicProviders          string `envconfig:"DYNAMIC_PROVIDERS"`                            // Format: "provider1:api_key1:base_url1,provider2:api_key2:base_url2"
 }
 
 type OpenAI struct {

--- a/api/pkg/store/dynamic_providers.go
+++ b/api/pkg/store/dynamic_providers.go
@@ -148,25 +148,25 @@ func (s *PostgresStore) InitializeDynamicProviders(ctx context.Context, dynamicP
 				Str("provider_name", config.Name).
 				Msg("Provider already exists in database, skipping to avoid overwriting existing configuration")
 			continue
-		} else {
-			// Create new endpoint
-			log.Info().
-				Str("provider_name", config.Name).
-				Msg("Creating new dynamic provider endpoint")
-
-			_, err := s.CreateProviderEndpoint(ctx, endpoint)
-			if err != nil {
-				log.Error().
-					Err(err).
-					Str("provider_name", config.Name).
-					Msg("Failed to create dynamic provider endpoint")
-				continue
-			}
-
-			log.Info().
-				Str("provider_name", config.Name).
-				Msg("Successfully created dynamic provider endpoint")
 		}
+
+		// Create new endpoint
+		log.Info().
+			Str("provider_name", config.Name).
+			Msg("Creating new dynamic provider endpoint")
+
+		_, err := s.CreateProviderEndpoint(ctx, endpoint)
+		if err != nil {
+			log.Error().
+				Err(err).
+				Str("provider_name", config.Name).
+				Msg("Failed to create dynamic provider endpoint")
+			continue
+		}
+
+		log.Info().
+			Str("provider_name", config.Name).
+			Msg("Successfully created dynamic provider endpoint")
 	}
 
 	log.Info().

--- a/api/pkg/store/dynamic_providers.go
+++ b/api/pkg/store/dynamic_providers.go
@@ -1,0 +1,177 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// DynamicProviderConfig represents a single dynamic provider configuration
+type DynamicProviderConfig struct {
+	Name    string
+	APIKey  string
+	BaseURL string
+}
+
+// ParseDynamicProviders parses the DYNAMIC_PROVIDERS environment variable
+// Expected format: "provider1:api_key1:base_url1,provider2:api_key2:base_url2"
+// Returns a slice of DynamicProviderConfig structs
+func ParseDynamicProviders(dynamicProviders string) ([]DynamicProviderConfig, error) {
+	if dynamicProviders == "" {
+		return nil, nil
+	}
+
+	var configs []DynamicProviderConfig
+
+	// Split by comma to get individual provider configurations
+	providerSpecs := strings.Split(dynamicProviders, ",")
+
+	for _, spec := range providerSpecs {
+		spec = strings.TrimSpace(spec)
+		if spec == "" {
+			continue
+		}
+
+		// Split by colon to get name:key:url
+		// We need to be careful with URLs that contain colons (like https://)
+		// So we'll only split on the first two colons to separate name:key from the rest
+		firstColon := strings.Index(spec, ":")
+		if firstColon == -1 {
+			return nil, fmt.Errorf("invalid provider specification '%s': expected format 'name:api_key' or 'name:api_key:base_url'", spec)
+		}
+
+		name := strings.TrimSpace(spec[:firstColon])
+		remainder := strings.TrimSpace(spec[firstColon+1:])
+
+		if name == "" {
+			return nil, fmt.Errorf("provider name cannot be empty in specification '%s'", spec)
+		}
+
+		// Find the second colon for the API key
+		secondColon := strings.Index(remainder, ":")
+		var apiKey, baseURL string
+
+		if secondColon == -1 {
+			// No base URL provided, just name:api_key
+			apiKey = remainder
+		} else {
+			// Base URL provided, name:api_key:base_url
+			apiKey = strings.TrimSpace(remainder[:secondColon])
+			baseURL = strings.TrimSpace(remainder[secondColon+1:])
+		}
+
+		if apiKey == "" {
+			return nil, fmt.Errorf("API key cannot be empty for provider '%s'", name)
+		}
+
+		config := DynamicProviderConfig{
+			Name:    name,
+			APIKey:  apiKey,
+			BaseURL: baseURL,
+		}
+
+		configs = append(configs, config)
+	}
+
+	return configs, nil
+}
+
+// ToProviderEndpoint converts a DynamicProviderConfig to a ProviderEndpoint
+func (d *DynamicProviderConfig) ToProviderEndpoint() *types.ProviderEndpoint {
+	return &types.ProviderEndpoint{
+		Name:         d.Name,
+		Description:  fmt.Sprintf("Dynamic provider: %s", d.Name),
+		BaseURL:      d.BaseURL,
+		APIKey:       d.APIKey,
+		EndpointType: types.ProviderEndpointTypeGlobal,
+		Owner:        string(types.OwnerTypeSystem),
+		OwnerType:    types.OwnerTypeSystem,
+	}
+}
+
+// InitializeDynamicProviders creates new provider endpoints from the DYNAMIC_PROVIDERS environment variable.
+// It will only create providers that don't already exist in the database to avoid overwriting manual configurations.
+func (s *PostgresStore) InitializeDynamicProviders(ctx context.Context, dynamicProviders string) error {
+	if dynamicProviders == "" {
+		log.Debug().Msg("No dynamic providers configured")
+		return nil
+	}
+
+	log.Info().
+		Str("dynamic_providers", dynamicProviders).
+		Msg("Initializing dynamic providers")
+
+	// Parse the dynamic providers string
+	configs, err := ParseDynamicProviders(dynamicProviders)
+	if err != nil {
+		return fmt.Errorf("failed to parse dynamic providers: %w", err)
+	}
+
+	log.Info().
+		Int("provider_count", len(configs)).
+		Msg("Parsed dynamic provider configurations")
+
+	// Get existing provider endpoints to check for duplicates
+	existingEndpoints, err := s.ListProviderEndpoints(ctx, &ListProviderEndpointsQuery{
+		WithGlobal: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list existing provider endpoints: %w", err)
+	}
+
+	// Create a map of existing provider names for quick lookup
+	existingNames := make(map[string]*types.ProviderEndpoint)
+	for _, endpoint := range existingEndpoints {
+		// Only consider system-owned global endpoints for dynamic provider updates
+		if endpoint.OwnerType == types.OwnerTypeSystem && endpoint.EndpointType == types.ProviderEndpointTypeGlobal {
+			existingNames[endpoint.Name] = endpoint
+		}
+	}
+
+	// Process each dynamic provider configuration
+	for _, config := range configs {
+		log.Info().
+			Str("provider_name", config.Name).
+			Str("base_url", config.BaseURL).
+			Msg("Processing dynamic provider")
+
+		endpoint := config.ToProviderEndpoint()
+
+		// Check if provider already exists
+		if _, exists := existingNames[config.Name]; exists {
+			// Skip existing providers to avoid overwriting manual configurations
+			log.Info().
+				Str("provider_name", config.Name).
+				Msg("Provider already exists in database, skipping to avoid overwriting existing configuration")
+			continue
+		} else {
+			// Create new endpoint
+			log.Info().
+				Str("provider_name", config.Name).
+				Msg("Creating new dynamic provider endpoint")
+
+			_, err := s.CreateProviderEndpoint(ctx, endpoint)
+			if err != nil {
+				log.Error().
+					Err(err).
+					Str("provider_name", config.Name).
+					Msg("Failed to create dynamic provider endpoint")
+				continue
+			}
+
+			log.Info().
+				Str("provider_name", config.Name).
+				Msg("Successfully created dynamic provider endpoint")
+		}
+	}
+
+	log.Info().
+		Int("total_configured", len(configs)).
+		Msg("Finished processing dynamic providers (existing providers were skipped)")
+
+	return nil
+}

--- a/api/pkg/store/dynamic_providers_test.go
+++ b/api/pkg/store/dynamic_providers_test.go
@@ -1,0 +1,151 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+func TestParseDynamicProviders(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []DynamicProviderConfig
+		wantErr  bool
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name:  "single provider with base URL",
+			input: "groq:gsk_xxxx:https://api.groq.com/openai/v1",
+			expected: []DynamicProviderConfig{
+				{
+					Name:    "groq",
+					APIKey:  "gsk_xxxx",
+					BaseURL: "https://api.groq.com/openai/v1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "single provider without base URL",
+			input: "openai:sk_xxxx",
+			expected: []DynamicProviderConfig{
+				{
+					Name:    "openai",
+					APIKey:  "sk_xxxx",
+					BaseURL: "",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "multiple providers",
+			input: "groq:gsk_xxxx:https://api.groq.com/openai/v1,cerebras:csk_yyyy:https://api.cerebras.ai/v1,openai:sk_zzzz",
+			expected: []DynamicProviderConfig{
+				{
+					Name:    "groq",
+					APIKey:  "gsk_xxxx",
+					BaseURL: "https://api.groq.com/openai/v1",
+				},
+				{
+					Name:    "cerebras",
+					APIKey:  "csk_yyyy",
+					BaseURL: "https://api.cerebras.ai/v1",
+				},
+				{
+					Name:    "openai",
+					APIKey:  "sk_zzzz",
+					BaseURL: "",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:     "invalid format - missing API key",
+			input:    "provider1",
+			expected: nil,
+			wantErr:  true,
+		},
+		{
+			name:  "URL with colons",
+			input: "provider1:key:url:extra",
+			expected: []DynamicProviderConfig{
+				{
+					Name:    "provider1",
+					APIKey:  "key",
+					BaseURL: "url:extra",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:     "invalid format - empty provider name",
+			input:    ":key:url",
+			expected: nil,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid format - empty API key",
+			input:    "provider1::url",
+			expected: nil,
+			wantErr:  true,
+		},
+		{
+			name:  "whitespace handling",
+			input: " groq : gsk_xxxx : https://api.groq.com/openai/v1 , cerebras : csk_yyyy : https://api.cerebras.ai/v1 ",
+			expected: []DynamicProviderConfig{
+				{
+					Name:    "groq",
+					APIKey:  "gsk_xxxx",
+					BaseURL: "https://api.groq.com/openai/v1",
+				},
+				{
+					Name:    "cerebras",
+					APIKey:  "csk_yyyy",
+					BaseURL: "https://api.cerebras.ai/v1",
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseDynamicProviders(tt.input)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestToProviderEndpoint(t *testing.T) {
+	config := DynamicProviderConfig{
+		Name:    "test-provider",
+		APIKey:  "test-key",
+		BaseURL: "https://api.test.com/v1",
+	}
+
+	endpoint := config.ToProviderEndpoint()
+
+	assert.Equal(t, "test-provider", endpoint.Name)
+	assert.Equal(t, "Dynamic provider: test-provider", endpoint.Description)
+	assert.Equal(t, "https://api.test.com/v1", endpoint.BaseURL)
+	assert.Equal(t, "test-key", endpoint.APIKey)
+	assert.Equal(t, types.ProviderEndpointTypeGlobal, endpoint.EndpointType)
+	assert.Equal(t, string(types.OwnerTypeSystem), endpoint.Owner)
+	assert.Equal(t, types.OwnerTypeSystem, endpoint.OwnerType)
+}

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -84,6 +84,8 @@ services:
       # URL in the compose stack (rather than localhost in the pod which is default for k8s)
       - RAG_HAYSTACK_URL=http://haystack:8000
       - RAG_PGVECTOR_PROVIDER=helix
+      # Dynamic providers: format is "provider1:api_key1:base_url1,provider2:api_key2:base_url2"
+      - DYNAMIC_PROVIDERS=${DYNAMIC_PROVIDERS:-}
     volumes:
       - ./go.mod:/app/go.mod
       - ./go.sum:/app/go.sum

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,6 +43,10 @@ services:
       - RAG_HAYSTACK_URL=http://haystack:8000
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      # Dynamic providers: format is "provider1:api_key1:base_url1,provider2:api_key2:base_url2"
+      # Only creates providers that don't already exist (won't overwrite existing ones)
+      # Example: DYNAMIC_PROVIDERS=groq:gsk_xxxx:https://api.groq.com/openai/v1,cerebras:csk_xxxx:https://api.cerebras.ai/v1
+      - DYNAMIC_PROVIDERS=${DYNAMIC_PROVIDERS:-}
     volumes:
       - ${FILESTORE_DATA:-helix-filestore}:/filestore
       - helix-socket:/socket

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ PROXY=https://get.helixml.tech
 EXTRA_OLLAMA_MODELS=""
 HELIX_VERSION=""
 CLI_INSTALL_PATH="/usr/local/bin/helix"
-RAG_PGVECTOR_PROVIDER=""
+EMBEDDINGS_PROVIDER="helix"
 
 # Determine OS and architecture
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -94,7 +94,7 @@ Options:
   --openai-api-key <key>   Specify the OpenAI API key for any OpenAI compatible API
   --openai-base-url <url>  Specify the base URL for the OpenAI API
   --anthropic-api-key <key> Specify the Anthropic API key for Claude models
-  --rag-pgvector-provider <provider> Specify the provider for PGVector embeddings (openai, togetherai, vllm, helix)
+  --embeddings-provider <provider> Specify the provider for embeddings (openai, togetherai, vllm, helix, default: helix)
   --older-gpu              Disable axolotl and sdxl models (which don't work on older GPUs) on the runner
   --hf-token <token>       Specify the Hugging Face token for downloading models
   -y                       Auto approve the installation
@@ -128,8 +128,8 @@ Examples:
 8. Install CLI and controlplane with OpenAI-compatible API key and base URL:
    ./install.sh --cli --controlplane --openai-api-key YOUR_OPENAI_API_KEY --openai-base-url YOUR_OPENAI_BASE_URL
 
-9. Install CLI and controlplane with custom RAG embeddings provider:
-   ./install.sh --cli --controlplane --rag-pgvector-provider helix
+9. Install CLI and controlplane with custom embeddings provider:
+   ./install.sh --cli --controlplane --embeddings-provider openai
 
 EOF
 }
@@ -216,12 +216,12 @@ while [[ $# -gt 0 ]]; do
             ANTHROPIC_API_KEY="$2"
             shift 2
             ;;
-        --rag-pgvector-provider=*)
-            RAG_PGVECTOR_PROVIDER="${1#*=}"
+        --embeddings-provider=*)
+            EMBEDDINGS_PROVIDER="${1#*=}"
             shift
             ;;
-        --rag-pgvector-provider)
-            RAG_PGVECTOR_PROVIDER="$2"
+        --embeddings-provider)
+            EMBEDDINGS_PROVIDER="$2"
             shift 2
             ;;
         --older-gpu)
@@ -717,12 +717,10 @@ ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
 EOF
     fi
 
-    # Add RAG PGVector provider configuration if specified
-    if [ -n "$RAG_PGVECTOR_PROVIDER" ]; then
-        cat << EOF >> "$ENV_FILE"
-RAG_PGVECTOR_PROVIDER=$RAG_PGVECTOR_PROVIDER
+    # Add embeddings provider configuration
+    cat << EOF >> "$ENV_FILE"
+RAG_PGVECTOR_PROVIDER=$EMBEDDINGS_PROVIDER
 EOF
-    fi
 
     # Set default FINETUNING_PROVIDER to helix if neither OpenAI nor TogetherAI are specified
     if [ -z "$OPENAI_API_KEY" ] && [ -z "$TOGETHER_API_KEY" ] && [ "$AUTODETECTED_LLM" = false ]; then

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,7 @@ PROXY=https://get.helixml.tech
 EXTRA_OLLAMA_MODELS=""
 HELIX_VERSION=""
 CLI_INSTALL_PATH="/usr/local/bin/helix"
+RAG_PGVECTOR_PROVIDER=""
 
 # Determine OS and architecture
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -93,6 +94,7 @@ Options:
   --openai-api-key <key>   Specify the OpenAI API key for any OpenAI compatible API
   --openai-base-url <url>  Specify the base URL for the OpenAI API
   --anthropic-api-key <key> Specify the Anthropic API key for Claude models
+  --rag-pgvector-provider <provider> Specify the provider for PGVector embeddings (openai, togetherai, vllm, helix)
   --older-gpu              Disable axolotl and sdxl models (which don't work on older GPUs) on the runner
   --hf-token <token>       Specify the Hugging Face token for downloading models
   -y                       Auto approve the installation
@@ -125,6 +127,9 @@ Examples:
 
 8. Install CLI and controlplane with OpenAI-compatible API key and base URL:
    ./install.sh --cli --controlplane --openai-api-key YOUR_OPENAI_API_KEY --openai-base-url YOUR_OPENAI_BASE_URL
+
+9. Install CLI and controlplane with custom RAG embeddings provider:
+   ./install.sh --cli --controlplane --rag-pgvector-provider helix
 
 EOF
 }
@@ -209,6 +214,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         --anthropic-api-key)
             ANTHROPIC_API_KEY="$2"
+            shift 2
+            ;;
+        --rag-pgvector-provider=*)
+            RAG_PGVECTOR_PROVIDER="${1#*=}"
+            shift
+            ;;
+        --rag-pgvector-provider)
+            RAG_PGVECTOR_PROVIDER="$2"
             shift 2
             ;;
         --older-gpu)
@@ -701,6 +714,13 @@ EOF
     if [ -n "$ANTHROPIC_API_KEY" ]; then
         cat << EOF >> "$ENV_FILE"
 ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
+EOF
+    fi
+
+    # Add RAG PGVector provider configuration if specified
+    if [ -n "$RAG_PGVECTOR_PROVIDER" ]; then
+        cat << EOF >> "$ENV_FILE"
+RAG_PGVECTOR_PROVIDER=$RAG_PGVECTOR_PROVIDER
 EOF
     fi
 


### PR DESCRIPTION
support --dynamic-providers and DYNAMIC_PROVIDERS env var (and --embeddings-provider) to seed inference providers in the db via env var

this is so that i can configure the launchpad trial vms to use relaxAI as the embeddings provider since they now helpfully support our vision embedding model in their vllm cluster