### PR TITLE
Fix tooltip flicker on usage display

### DIFF
--- a/frontend/src/components/app/AppUsage.tsx
+++ b/frontend/src/components/app/AppUsage.tsx
@@ -742,7 +742,7 @@ const InteractionDetails: FC<InteractionDetailsProps> = ({
                   </TableCell>
                   <TableCell>
                     <Tooltip
-                      placement='right'
+                      placement='top'
                       enterDelay={50}
                       enterNextDelay={50}
                       title={
@@ -767,7 +767,7 @@ const InteractionDetails: FC<InteractionDetailsProps> = ({
                   </TableCell>
                   <TableCell>
                     <Tooltip 
-                      placement='right'
+                      placement='top'
                       enterDelay={50}
                       enterNextDelay={50}
                       title={


### PR DESCRIPTION
Change tooltip placement from 'right' to 'top' in `AppUsage.tsx` to fix flickering in the usage display.

The flickering occurred because 'right' placed tooltips would extend beyond the viewport when positioned too far right, causing the browser to continuously attempt repositioning, leading to a visible flicker. Changing to 'top' prevents this conflict.

---
[Slack Thread](https://mlops-community.slack.com/archives/C0675EX9V2Q/p1754986113007859?thread_ts=1754986113.007859&cid=C0675EX9V2Q)

<a href="https://cursor.com/background-agent?bcId=bc-b51b1388-fb75-4020-bc09-d4730f32b053">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b51b1388-fb75-4020-bc09-d4730f32b053">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

