### PR TITLE
fix scheduler state consistency and eliminate silent failures

### DIFF
--- a/api/pkg/scheduler/gpu_allocation_distribution_test.go
+++ b/api/pkg/scheduler/gpu_allocation_distribution_test.go
@@ -153,12 +153,14 @@ func TestGPUAllocationDistribution(t *testing.T) {
 		t.Logf("This suggests the GPU allocation logic is not considering existing allocations")
 
 		// Debug information
-		allocatedMemory := runnerCtrl.calculateAllocatedMemoryPerGPU(testRunnerID)
+		allocatedMemory, err := runnerCtrl.calculateAllocatedMemoryPerGPU(testRunnerID)
+		require.NoError(t, err, "Should be able to calculate allocated memory per GPU")
 		t.Logf("Debug - Allocated memory per GPU: %+v", allocatedMemory)
 	}
 
 	// Additional verification: check that the allocation decisions make sense
-	allocatedMemoryPerGPU := runnerCtrl.calculateAllocatedMemoryPerGPU(testRunnerID)
+	allocatedMemoryPerGPU, err := runnerCtrl.calculateAllocatedMemoryPerGPU(testRunnerID)
+	require.NoError(t, err, "Should be able to calculate allocated memory per GPU")
 
 	gpu0Memory := allocatedMemoryPerGPU[0]
 	gpu1Memory := allocatedMemoryPerGPU[1]

--- a/api/pkg/scheduler/overscheduling_prevention_test.go
+++ b/api/pkg/scheduler/overscheduling_prevention_test.go
@@ -155,7 +155,8 @@ func TestOverSchedulingPrevention(t *testing.T) {
 		}
 
 		// Safety check: ensure we never over-allocate
-		finalAllocatedPerGPU := runnerCtrl.calculateAllocatedMemoryPerGPU(testRunnerID)
+		finalAllocatedPerGPU, err := runnerCtrl.calculateAllocatedMemoryPerGPU(testRunnerID)
+		require.NoError(t, err, "Should be able to calculate allocated memory per GPU")
 		for gpuIndex, allocatedOnGPU := range finalAllocatedPerGPU {
 			assert.LessOrEqual(t, allocatedOnGPU, gpuMemoryBytes,
 				"GPU %d should never exceed capacity during scheduling attempt %d", gpuIndex, attempt)
@@ -178,7 +179,8 @@ func TestOverSchedulingPrevention(t *testing.T) {
 	t.Logf("\n=== FINAL ANALYSIS ===")
 
 	finalQueueSize := len(scheduler.queue.Queue())
-	finalAllocatedPerGPU := runnerCtrl.calculateAllocatedMemoryPerGPU(testRunnerID)
+	finalAllocatedPerGPU, err := runnerCtrl.calculateAllocatedMemoryPerGPU(testRunnerID)
+	require.NoError(t, err, "Should be able to calculate final allocated memory per GPU")
 	_, finalAllocated, finalFree, err := scheduler.calculateRunnerMemory(testRunnerID)
 	require.NoError(t, err, "Should be able to calculate final runner memory")
 

--- a/api/pkg/scheduler/runner.go
+++ b/api/pkg/scheduler/runner.go
@@ -38,11 +38,11 @@ type RunnerController struct {
 	slotsCache          *LockingRunnerMap[types.ListRunnerSlotsResponse]
 	statusCache         *LockingRunnerMap[types.RunnerStatus]
 	store               store.Store
-	onRunnerConnectedFn func(runnerID string)       // Callback for when a new runner connects
-	getModelMemoryFn    func(modelID string) uint64 // Callback to get authoritative model memory from scheduler
-	getSchedulerSlotsFn func() map[uuid.UUID]*Slot  // Callback to get scheduler's desired state slots
-	healthChecker       HealthChecker               // Interface for health checking, allows mocking in tests
-	runnerClient        RunnerClient                // Interface for runner requests, allows mocking in tests
+	onRunnerConnectedFn func(runnerID string)                // Callback for when a new runner connects
+	getModelMemoryFn    func(modelID string) (uint64, error) // Callback to get authoritative model memory from scheduler
+	getSchedulerSlotsFn func() map[uuid.UUID]*Slot           // Callback to get scheduler's desired state slots
+	healthChecker       HealthChecker                        // Interface for health checking, allows mocking in tests
+	runnerClient        RunnerClient                         // Interface for runner requests, allows mocking in tests
 }
 
 // HealthChecker interface allows for mocking health checks in tests
@@ -234,10 +234,10 @@ type RunnerControllerConfig struct {
 	PubSub              pubsub.PubSub
 	FS                  filestore.FileStore
 	Store               store.Store
-	OnRunnerConnectedFn func(runnerID string)       // Optional callback for when a new runner connects
-	GetModelMemoryFn    func(modelID string) uint64 // Optional callback to get authoritative model memory
-	HealthChecker       HealthChecker               // Optional: for testing, defaults to NATS-based implementation
-	RunnerClient        RunnerClient                // Optional: for testing, defaults to NATS-based implementation
+	OnRunnerConnectedFn func(runnerID string)                // Optional callback for when a new runner connects
+	GetModelMemoryFn    func(modelID string) (uint64, error) // Optional callback to get authoritative model memory
+	HealthChecker       HealthChecker                        // Optional: for testing, defaults to NATS-based implementation
+	RunnerClient        RunnerClient                         // Optional: for testing, defaults to NATS-based implementation
 }
 
 func NewRunnerController(ctx context.Context, cfg *RunnerControllerConfig) (*RunnerController, error) {
@@ -308,7 +308,7 @@ func (c *RunnerController) SetOnRunnerConnectedCallback(fn func(runnerID string)
 }
 
 // setModelMemoryCallback sets the callback function to get authoritative model memory from scheduler
-func (c *RunnerController) setModelMemoryCallback(fn func(modelID string) uint64) {
+func (c *RunnerController) setModelMemoryCallback(fn func(modelID string) (uint64, error)) {
 	c.callbackMu.Lock()
 	defer c.callbackMu.Unlock()
 	c.getModelMemoryFn = fn
@@ -730,19 +730,41 @@ func (c *RunnerController) calculateAllocatedMemoryPerGPU(runnerID string) (map[
 		// Get authoritative model memory from the scheduler
 		var modelMemory uint64
 		if c.getModelMemoryFn != nil {
-			modelMemory = c.getModelMemoryFn(slot.InitialWork().ModelName().String())
-		}
-
-		// If we still can't determine model memory, this is a critical error
-		if modelMemory == 0 {
-			err := fmt.Errorf("cannot determine model memory requirements for slot %s with model %s on runner %s",
+			var err error
+			modelMemory, err = c.getModelMemoryFn(slot.InitialWork().ModelName().String())
+			if err != nil {
+				err = fmt.Errorf("failed to get model memory for slot %s with model %s on runner %s: %w",
+					slotID.String(), slot.InitialWork().ModelName().String(), runnerID, err)
+				log.Error().
+					Str("runner_id", runnerID).
+					Str("slot_id", slotID.String()).
+					Str("model", slot.InitialWork().ModelName().String()).
+					Err(err).
+					Msg("CRITICAL: Failed to get model memory requirements - this could lead to over-scheduling")
+				return allocatedMemoryPerGPU, err
+			}
+		} else {
+			err := fmt.Errorf("no model memory callback available for slot %s with model %s on runner %s",
 				slotID.String(), slot.InitialWork().ModelName().String(), runnerID)
 			log.Error().
 				Str("runner_id", runnerID).
 				Str("slot_id", slotID.String()).
 				Str("model", slot.InitialWork().ModelName().String()).
 				Err(err).
-				Msg("CRITICAL: Cannot determine model memory requirements - this could lead to over-scheduling")
+				Msg("CRITICAL: No model memory callback available - this is a programming error")
+			return allocatedMemoryPerGPU, err
+		}
+
+		// Verify we got valid memory value
+		if modelMemory == 0 {
+			err := fmt.Errorf("model memory callback returned zero for slot %s with model %s on runner %s",
+				slotID.String(), slot.InitialWork().ModelName().String(), runnerID)
+			log.Error().
+				Str("runner_id", runnerID).
+				Str("slot_id", slotID.String()).
+				Str("model", slot.InitialWork().ModelName().String()).
+				Err(err).
+				Msg("CRITICAL: Model memory callback returned zero - this could lead to over-scheduling")
 			return allocatedMemoryPerGPU, err
 		}
 

--- a/api/pkg/scheduler/tensor_parallelism_test.go
+++ b/api/pkg/scheduler/tensor_parallelism_test.go
@@ -409,7 +409,8 @@ func TestFragmentationPrevention(t *testing.T) {
 		t.Logf("⚠️  Large model was not scheduled - checking if this is due to fragmentation or insufficient memory")
 
 		// Check memory state
-		allocatedMemPerGPU := runnerCtrl.calculateAllocatedMemoryPerGPU(testRunnerID)
+		allocatedMemPerGPU, err := runnerCtrl.calculateAllocatedMemoryPerGPU(testRunnerID)
+		require.NoError(t, err, "Should be able to calculate allocated memory per GPU")
 		for gpuIndex := 0; gpuIndex < gpuCount; gpuIndex++ {
 			allocated := allocatedMemPerGPU[gpuIndex]
 			free := gpuMemoryBytes - allocated
@@ -437,7 +438,8 @@ func TestFragmentationPrevention(t *testing.T) {
 	// Test Case 4: Verify no over-allocation occurred
 	t.Logf("\n=== TEST CASE 4: Verify no GPU over-allocation ===")
 
-	finalAllocatedMemPerGPU := runnerCtrl.calculateAllocatedMemoryPerGPU(testRunnerID)
+	finalAllocatedMemPerGPU, err := runnerCtrl.calculateAllocatedMemoryPerGPU(testRunnerID)
+	require.NoError(t, err, "Should be able to calculate final allocated memory per GPU")
 	for gpuIndex := 0; gpuIndex < gpuCount; gpuIndex++ {
 		allocated := finalAllocatedMemPerGPU[gpuIndex]
 		t.Logf("  Final GPU %d: %d GB allocated out of %d GB capacity",
@@ -619,7 +621,8 @@ func TestOptimalTensorParallelismScheduling(t *testing.T) {
 	// Test Case 3: Analyze final allocation efficiency
 	t.Logf("\n=== TEST CASE 3: Analyze final memory utilization ===")
 
-	finalAllocatedMemPerGPU := runnerCtrl.calculateAllocatedMemoryPerGPU(testRunnerID)
+	finalAllocatedMemPerGPU, err := runnerCtrl.calculateAllocatedMemoryPerGPU(testRunnerID)
+	require.NoError(t, err, "Should be able to calculate final allocated memory per GPU")
 	totalAllocated := uint64(0)
 	totalCapacity := gpuMemoryBytes * uint64(gpuCount)
 


### PR DESCRIPTION
fixed major consistency bugs where scheduler memory calculations and scheduling decisions were using different sources of truth, leading to potential over-scheduling. now everything uses local state for the hot path and explicit error handling everywhere.

- use local state (s.slots) for all memory calculations instead of mixing local/remote state  
- make getModelMemory() and calculateAllocatedMemoryPerGPU() return errors instead of silently failing with 0
- fix analyzeGlobalModelDistribution() to use same local state as scheduling decisions
- add comprehensive state source documentation explaining when to use local vs remote state
- all tests updated to handle new error returns and still pass