### PR TITLE
fix(runner): detect Ollama subprocess crashes via stderr parsing

### DIFF
--- a/api/pkg/runner/slot.go
+++ b/api/pkg/runner/slot.go
@@ -287,9 +287,8 @@ func (s *Slot) Create(ctx context.Context) (err error) {
 			Msg("🔍 TRACING: Final runtimeParams.NumParallel being passed to NewOllamaRuntime")
 
 		// Set up crash callback to handle unexpected Ollama crashes (e.g., CUDA errors)
-		runtimeParams.OnCrash = func(exitCode int, stderr string) {
+		runtimeParams.OnCrash = func(stderr string) {
 			log.Error().
-				Int("exit_code", exitCode).
 				Str("slot_id", s.ID.String()).
 				Str("model", s.Model).
 				Str("stderr_preview", func() string {


### PR DESCRIPTION
## Summary

Fixes the issue where Ollama subprocess crashes (e.g., CUDA errors) were not being detected and cleaned up, causing slots to remain in a zombie state indefinitely.

## Root Cause

Ollama uses a **two-process architecture**:
1. **Main server process** (`ollama serve`) - handles API requests, stays alive
2. **Runner subprocess** (`ollama runner`) - runs the model, crashes with CUDA errors

The previous `monitorProcess()` approach used `cmd.Wait()` to monitor the main process, which never exited even when the subprocess crashed. This meant:
- Crash callbacks never fired
- Slots were never cleaned up
- Logs showed the crash but no cleanup happened

## Changes

- ✅ Replace process exit monitoring with **stderr parsing**
- ✅ Scan stderr for `"llama runner terminated"` + `"exit status"` messages
- ✅ Trigger crash callback immediately when subprocess crash detected  
- ✅ Remove ineffective `monitorProcess()` function
- ✅ Simplify crash callback signature (removed exit code parameter)

## Evidence

From production logs showing the issue:
```
19:08:48 - "llama runner terminated" error="exit status 2"  ← subprocess crashed
19:16:50 - "gpu VRAM usage didn't recover" (8 minutes later) ← main process still alive
```

The main process kept running for 8+ minutes after the crash, never triggering cleanup.

## Test Plan

- [ ] Deploy to staging
- [ ] Trigger a CUDA error (e.g., OOM)
- [ ] Verify crash is detected in logs immediately
- [ ] Verify slot cleanup happens automatically
- [ ] Verify no zombie processes remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)