### PR TITLE
Update keycloak-bitnami to use bitnamilegacy registry

### DIFF
--- a/Dockerfile.keycloak-bitnami
+++ b/Dockerfile.keycloak-bitnami
@@ -1,5 +1,5 @@
 # Use Bitnami Keycloak as base instead of official Keycloak
-FROM bitnami/keycloak:23.0.7
+FROM bitnamilegacy/keycloak:23.0.7
 
 # Switch to root to install custom theme
 USER root


### PR DESCRIPTION
Bitnami has moved legacy images to bitnamilegacy/ registry. Update FROM bitnami/keycloak to FROM bitnamilegacy/keycloak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)