### PR TITLE
Fix YAML parsing for VLLM models with runtime_args

### DIFF
--- a/api/pkg/cli/model/apply_test.go
+++ b/api/pkg/cli/model/apply_test.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -131,4 +133,29 @@ func TestValidKinds(t *testing.T) {
 		}
 		assert.False(t, isValid, "Kind %s should be invalid", invalidKind)
 	})
+}
+
+func TestParseModelConfigFile_VLLMWithRuntimeArgs(t *testing.T) {
+	yamlContent := `apiVersion: helix.ml/v1alpha1
+kind: Model
+metadata:
+  name: qwen-3-coder-30b-a3b-instruct
+spec:
+  id: Qwen/Qwen3-Coder-30B-A3B-Instruct
+  type: chat
+  runtime: vllm
+  memory: 39000000000
+  runtime_args:
+    args:
+      - "--trust-remote-code"
+      - "--max-model-len"
+      - "32768"
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.yml")
+	require.NoError(t, os.WriteFile(tmpFile, []byte(yamlContent), 0644))
+
+	_, err := parseModelConfigFile(tmpFile)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary
Fixes YAML parsing error when applying Model CRDs with nested `runtime_args` configuration for VLLM models.

## Problem
When applying a Model CRD with nested runtime_args from YAML:
```yaml
runtime_args:
  args:
    - "--trust-remote-code"
    - "--max-model-len"
    - "32768"
```

The command failed with:
```
failed to marshal spec: json: unsupported type: map[interface {}]interface {}
```

## Root Cause
The `gopkg.in/yaml.v2` package unmarshals nested maps as `map[interface{}]interface{}`, but JSON marshaling requires `map[string]interface{}`. The existing code at `apply.go:172-179` only converted the top-level map, not nested structures.

## Solution
Added recursive conversion functions:
- `convertYAMLMapToStringMap()` - Converts the entire map structure
- `convertYAMLValue()` - Recursively handles maps, arrays, and primitives

## Testing
- Added test `TestParseModelConfigFile_VLLMWithRuntimeArgs` that verifies the exact YAML that previously failed now works
- All existing tests pass

## Test plan
- [x] Unit tests pass
- [ ] Manual test: Apply VLLM model YAML with runtime_args

🤖 Generated with [Claude Code](https://claude.com/claude-code)