### PR TITLE
Fix Unix socket authentication by implementing X-Helix-User-ID header

### DIFF
--- a/api/pkg/server/auth_utils.go
+++ b/api/pkg/server/auth_utils.go
@@ -100,7 +100,16 @@ func setRequestUser(ctx context.Context, user types.User) context.Context {
 func getRequestUser(req *http.Request) *types.User {
 	// Check if this is a socket request by looking at the underlying connection type
 	if h, ok := req.Context().Value(http.LocalAddrContextKey).(*net.UnixAddr); ok && h != nil {
-		// TODO: get X-Helix-User-ID header and set it
+		// Socket requests are trusted - get user ID from header
+		userID := req.Header.Get("X-Helix-User-ID")
+		if userID == "" {
+			userID = "socket"
+		}
+		return &types.User{
+			ID:        userID,
+			Type:      types.OwnerTypeSocket,
+			TokenType: types.TokenTypeSocket,
+		}
 	}
 	userIntf := req.Context().Value(userKey)
 	if userIntf == nil {


### PR DESCRIPTION
## Summary

Restores Unix socket authentication that was broken in commit 790bad9f1. Socket requests now properly return a trusted user object instead of nil, fixing "unauthorized" errors for internal API calls.

## Root Cause

Commit 790bad9f1 removed the socket user implementation and left a TODO comment. This caused all internal API calls via Unix socket (like `/v1/chat/completions` from Haystack/internal services) to fail with "unauthorized" errors because `getRequestUser()` returned `nil` for socket requests.

## Changes

- Implement `X-Helix-User-ID` header support for Unix socket requests
- Falls back to "socket" as user ID if header is not provided
- Returns user with `OwnerTypeSocket` and `TokenTypeSocket` for trusted internal communication
- Maintains backward compatibility with default "socket" user