### PR TITLE
Fix socket auth precedence to prioritize middleware-set user

### DIFF
--- a/api/pkg/server/auth_utils.go
+++ b/api/pkg/server/auth_utils.go
@@ -98,6 +98,13 @@ func setRequestUser(ctx context.Context, user types.User) context.Context {
 }
 
 func getRequestUser(req *http.Request) *types.User {
+	// First check if user was set in context (e.g., by socket middleware)
+	userIntf := req.Context().Value(userKey)
+	if userIntf != nil {
+		user := userIntf.(types.User)
+		return &user
+	}
+
 	// Check if this is a socket request by looking at the underlying connection type
 	if h, ok := req.Context().Value(http.LocalAddrContextKey).(*net.UnixAddr); ok && h != nil {
 		// Socket requests are trusted - get user ID from header
@@ -111,13 +118,8 @@ func getRequestUser(req *http.Request) *types.User {
 			TokenType: types.TokenTypeSocket,
 		}
 	}
-	userIntf := req.Context().Value(userKey)
-	if userIntf == nil {
-		return nil
-	}
-	user := userIntf.(types.User)
 
-	return &user
+	return nil
 }
 
 func getOwnerContext(req *http.Request) types.OwnerContext {


### PR DESCRIPTION
## Summary

Fixes "failed to get wallet: not found" errors by ensuring the middleware-set user (loaded from database with wallet) takes precedence over synthetic socket user.

## Root Cause

The `getRequestUser()` function had the wrong order of checks:
1. ❌ First checked for socket connection → created synthetic user with only ID
2. ❌ Then checked context for middleware-set user (never reached)

This meant PR #1347's middleware that loads the full user from the database was being completely ignored! The synthetic socket user (with no wallet) was always used instead.

## The Fix

Reorder the checks in `getRequestUser()`:
1. ✅ First check context for middleware-set user (full user data + wallet)
2. ✅ Then check for socket connection as fallback
3. ✅ Finally return nil if neither found

## Flow After Fix

When socket request comes in:
1. Middleware runs and sets full user in context via `setRequestUser()` (from `HELIX_EMBEDDINGS_SOCKET_USER_ID`)
2. Handler calls `getRequestUser()`
3. `getRequestUser()` checks context FIRST, finds the middleware-set user
4. Returns full user object with wallet
5. Balance check succeeds ✅

## Why This Matters

Without this fix, even with PR #1347's middleware:
- Middleware loads user from database ✅
- Middleware sets user in context ✅  
- `getRequestUser()` ignores context, creates synthetic user ❌
- Wallet lookup fails because synthetic user has no wallet ❌

With this fix:
- Middleware loads user from database ✅
- Middleware sets user in context ✅
- `getRequestUser()` reads from context ✅
- Returns full user with wallet ✅

## Relationship to Previous PRs

- **PR #1346**: Added X-Helix-User-ID header support (but created synthetic user)
- **PR #1347**: Added middleware to load full user from database (but was ignored)
- **This PR**: Makes middleware user take precedence (fixes the wallet issue)

All three PRs work together:
1. Middleware loads full user → sets in context
2. `getRequestUser()` prioritizes context → uses full user
3. Header fallback provides flexibility when middleware not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)