### PR TITLE
Fix "Invalid nickname" error during user registration

### DIFF
--- a/frontend/src/contexts/account.tsx
+++ b/frontend/src/contexts/account.tsx
@@ -348,7 +348,9 @@ export const useAccountContext = (): IAccountContext => {
 
         if (win.$crisp) {
           win.$crisp.push(['set', 'user:email', user?.email])
-          win.$crisp.push(['set', 'user:nickname', user?.name])
+          if (user?.name) {
+            win.$crisp.push(['set', 'user:nickname', user?.name])
+          }
         }
 
         setUser(user)


### PR DESCRIPTION
Newly registered users don't have a FullName set, causing Crisp chat widget to throw "Invalid nickname" error when trying to set undefined as nickname. Only set nickname if user.name exists to prevent registration flow errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Only set Crisp `user:nickname` when `user.name` exists to prevent invalid nickname errors during registration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37630426c0eaa0e810a77ef86b5b6647a2920082. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->