### PR TITLE
Fix WebRTC port ranges for production to match dev configuration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -313,7 +313,7 @@ services:
     command: bash -c "/app/server/init-moonlight-config.sh"
     ports:
       - "8081:8080"  # Web interface
-      - "40000-40010:40000-40010/udp"  # WebRTC UDP ports
+      - "40000-40100:40000-40100/udp"  # WebRTC UDP ports (expanded for multiple concurrent sessions)
     networks:
       - default
     environment:

--- a/install.sh
+++ b/install.sh
@@ -1523,7 +1523,7 @@ EOF
   ],
   "webrtc_port_range": {
     "min": 40000,
-    "max": 40010
+    "max": 40100
   },
   "webrtc_network_types": [
     "udp4",
@@ -2001,7 +2001,7 @@ EOF"
         echo "│"
         echo "│ ⚠️  Additional ports for desktop streaming (Helix Code):"
         echo "│   - UDP 3478: TURN server for WebRTC NAT traversal"
-        echo "│   - UDP 40000-40010: WebRTC media ports"
+        echo "│   - UDP 40000-40100: WebRTC media ports"
     fi
     echo "│"
     echo "│ Start the Helix services by running:"


### PR DESCRIPTION
Updated WebRTC port ranges from 40000-40010 to 40000-40100 (101 ports) to support multiple concurrent streaming sessions. This aligns production docker-compose.yaml and install.sh with the dev configuration.

Changes:
- docker-compose.yaml: Updated moonlight-web UDP port range
- install.sh: Updated webrtc_port_range max in config.json template
- install.sh: Updated port documentation for Helix Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands WebRTC UDP port range from 40000-40010 to 40000-40100 across docker-compose and installer config/docs to support multiple concurrent streams.
> 
> - **WebRTC/Moonlight Web**
>   - `docker-compose.yaml`: update `moonlight-web` UDP mapping to `40000-40100:40000-40100/udp`.
>   - `install.sh`:
>     - Set `webrtc_port_range.max` to `40100` in generated `moonlight-web-config/config.json`.
>     - Adjust firewall guidance to `UDP 40000-40100`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b38bb2ee76174c2b528247b564554ea3c30ab56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->