### PR TITLE
fix(spectask): restore session with correct workspace and repository …

### DIFF
--- a/api/pkg/external-agent/wolf_executor.go
+++ b/api/pkg/external-agent/wolf_executor.go
@@ -259,12 +259,18 @@ func (w *WolfExecutor) createSwayWolfApp(config SwayWolfAppConfig) *wolf.App {
 	// Add SSH keys mount if user has SSH keys
 	// The SSH key directory is created by the API when keys are created
 	// Mount as read-only for security
-	sshKeyDir := fmt.Sprintf("/opt/helix/filestore/ssh-keys/%s", config.UserID)
-	if _, err := os.Stat(sshKeyDir); err == nil {
-		mounts = append(mounts, fmt.Sprintf("%s:/home/retro/.ssh:ro", sshKeyDir))
+	// CRITICAL: Use /filestore/ prefix for translateToHostPath compatibility
+	// - Check existence with API container path (/filestore/...)
+	// - Mount with HOST path (translated for Wolf)
+	sshKeyDirAPI := fmt.Sprintf("/filestore/ssh-keys/%s", config.UserID)
+	if _, err := os.Stat(sshKeyDirAPI); err == nil {
+		// Translate to host path for Wolf mount
+		sshKeyDirHost := w.translateToHostPath(sshKeyDirAPI)
+		mounts = append(mounts, fmt.Sprintf("%s:/home/retro/.ssh:ro", sshKeyDirHost))
 		log.Info().
 			Str("user_id", config.UserID).
-			Str("ssh_key_dir", sshKeyDir).
+			Str("ssh_key_dir_api", sshKeyDirAPI).
+			Str("ssh_key_dir_host", sshKeyDirHost).
 			Msg("Mounting SSH keys for git access")
 	}
 

--- a/api/pkg/server/ssh_key_handlers.go
+++ b/api/pkg/server/ssh_key_handlers.go
@@ -301,7 +301,8 @@ func (apiServer *HelixAPIServer) deleteSSHKey(_ http.ResponseWriter, req *http.R
 // writeSSHKeyToFilesystem writes SSH key files to the host filesystem
 func (apiServer *HelixAPIServer) writeSSHKeyToFilesystem(userID, keyID, privateKey, publicKey string) error {
 	// Create user SSH key directory
-	sshKeyDir := filepath.Join("/opt/helix/filestore/ssh-keys", userID)
+	// Use /filestore/ prefix (API container mount) - translateToHostPath handles Wolf mounts
+	sshKeyDir := filepath.Join("/filestore/ssh-keys", userID)
 	if err := os.MkdirAll(sshKeyDir, 0700); err != nil {
 		return fmt.Errorf("failed to create SSH key directory: %w", err)
 	}
@@ -342,7 +343,8 @@ func (apiServer *HelixAPIServer) writeSSHKeyToFilesystem(userID, keyID, privateK
 
 // deleteSSHKeyFromFilesystem deletes SSH key files from the host filesystem
 func (apiServer *HelixAPIServer) deleteSSHKeyFromFilesystem(userID, keyID string) error {
-	sshKeyDir := filepath.Join("/opt/helix/filestore/ssh-keys", userID)
+	// Use /filestore/ prefix (API container mount) - translateToHostPath handles Wolf mounts
+	sshKeyDir := filepath.Join("/filestore/ssh-keys", userID)
 
 	// Delete private key
 	privateKeyPath := filepath.Join(sshKeyDir, keyID+".key")

--- a/api/pkg/services/spec_task_orchestrator.go
+++ b/api/pkg/services/spec_task_orchestrator.go
@@ -688,7 +688,10 @@ func (o *SpecTaskOrchestrator) getOrCreateExternalAgent(ctx context.Context, tas
 
 	// Create new external agent
 	agentID := fmt.Sprintf("zed-spectask-%s", task.ID)
-	workspaceDir := fmt.Sprintf("/opt/helix/filestore/workspaces/spectasks/%s", task.ID)
+	// CRITICAL: Use /filestore/ prefix (not /opt/helix/filestore/) so translateToHostPath works
+	// wolf_executor.go:translateToHostPath expects paths starting with /filestore/
+	// Also use "spec-tasks" (with hyphen) for consistency with wolf_executor.go
+	workspaceDir := fmt.Sprintf("/filestore/workspaces/spec-tasks/%s", task.ID)
 
 	log.Info().
 		Str("agent_id", agentID).


### PR DESCRIPTION
…info

When restoring a SpecTask external agent session (clicking "Start Desktop" after the lobby was stopped), the restore code was missing critical fields that creation includes:

- SpecTaskID: needed for workspace path computation in StartZedAgent
- RepositoryIDs: needed for Zed startup arguments (which repos to open)
- PrimaryRepositoryID: needed for design docs path

Also fixes path consistency to use /filestore/ prefix (API container path) instead of /opt/helix/filestore/ (host path), which is required for translateToHostPath() to work correctly when mounting into Wolf sandboxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)