### PR TITLE
fix(security): change ADMIN_USER_IDS default from "all" to empty

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,8 +25,8 @@ services:
       - TOGETHER_API_KEY=${TOGETHER_API_KEY:-}
       - RUNNER_TOKEN=${RUNNER_TOKEN-oh-hallo-insecure-token}
       - SERVER_URL=${SERVER_URL:-http://localhost:8080}
-      # lock down dashboard in production
-      - ADMIN_USER_IDS=${ADMIN_USER_IDS-all}
+      # Comma-separated list of user IDs who should be admins (leave empty for no admins, set to "all" for everyone)
+      - ADMIN_USER_IDS=${ADMIN_USER_IDS:-}
       - ADMIN_USER_SOURCE=${ADMIN_USER_SOURCE-env}
       - EVAL_USER_ID=${EVAL_USER_ID:-}
       - FILESTORE_LOCALFS_PATH=/filestore


### PR DESCRIPTION
## Summary
- Change `ADMIN_USER_IDS` default from `all` to empty in production `docker-compose.yaml`
- Previously all registered users became admins by default, which is a security risk
- Development files (`docker-compose.dev.yaml`, `docker-compose.oidc.yaml`) retain `all` default for convenience

## Test plan
- [ ] Deploy with empty `ADMIN_USER_IDS` - verify no users are admins
- [ ] Deploy with `ADMIN_USER_IDS=all` - verify all users are admins
- [ ] Deploy with `ADMIN_USER_IDS=user-123,user-456` - verify only specified users are admins

🤖 Generated with [Claude Code](https://claude.com/claude-code)