### PR TITLE
fix: use proper project authorization for spec task workflow handlers

### DIFF
--- a/api/pkg/server/spec_task_implementation_handlers.go
+++ b/api/pkg/server/spec_task_implementation_handlers.go
@@ -44,8 +44,13 @@ func (s *HelixAPIServer) startImplementation(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Check authorization
-	if err := s.authorizeUserToResource(ctx, user, "", specTask.ProjectID, types.ResourceProject, "update"); err != nil {
+	// Check authorization using project-level auth (handles personal + org projects)
+	if err := s.authorizeUserToProjectByID(ctx, user, specTask.ProjectID, types.ActionUpdate); err != nil {
+		log.Warn().
+			Err(err).
+			Str("user_id", user.ID).
+			Str("project_id", specTask.ProjectID).
+			Msg("User not authorized to start implementation")
 		http.Error(w, "Not authorized", http.StatusForbidden)
 		return
 	}

--- a/api/pkg/server/spec_task_workflow_handlers.go
+++ b/api/pkg/server/spec_task_workflow_handlers.go
@@ -47,23 +47,14 @@ func (s *HelixAPIServer) approveImplementation(w http.ResponseWriter, r *http.Re
 	}
 
 	// Authorize - check if user has access to this project
-	// For personal projects (no organization), check if user is the project owner
-	if project.OrganizationID == "" {
-		if user.ID != project.UserID {
-			log.Warn().
-				Str("user_id", user.ID).
-				Str("project_owner", project.UserID).
-				Str("project_id", project.ID).
-				Msg("User is not the owner of this personal project")
-			http.Error(w, "Not authorized", http.StatusForbidden)
-			return
-		}
-	} else {
-		// Organization project - use RBAC
-		if err := s.authorizeUserToResource(ctx, user, project.OrganizationID, specTask.ProjectID, types.ResourceProject, types.ActionUpdate); err != nil {
-			http.Error(w, "Not authorized", http.StatusForbidden)
-			return
-		}
+	if err := s.authorizeUserToProject(ctx, user, project, types.ActionUpdate); err != nil {
+		log.Warn().
+			Err(err).
+			Str("user_id", user.ID).
+			Str("project_id", project.ID).
+			Msg("User not authorized to approve implementation")
+		http.Error(w, "Not authorized", http.StatusForbidden)
+		return
 	}
 
 	// Verify status - allow approval from implementation or implementation_review
@@ -152,23 +143,14 @@ func (s *HelixAPIServer) stopAgentSession(w http.ResponseWriter, r *http.Request
 	}
 
 	// Authorize - check if user has access to this project
-	// For personal projects (no organization), check if user is the project owner
-	if project.OrganizationID == "" {
-		if user.ID != project.UserID {
-			log.Warn().
-				Str("user_id", user.ID).
-				Str("project_owner", project.UserID).
-				Str("project_id", project.ID).
-				Msg("User is not the owner of this personal project")
-			http.Error(w, "Not authorized", http.StatusForbidden)
-			return
-		}
-	} else {
-		// Organization project - use RBAC
-		if err := s.authorizeUserToResource(ctx, user, project.OrganizationID, specTask.ProjectID, types.ResourceProject, types.ActionUpdate); err != nil {
-			http.Error(w, "Not authorized", http.StatusForbidden)
-			return
-		}
+	if err := s.authorizeUserToProject(ctx, user, project, types.ActionUpdate); err != nil {
+		log.Warn().
+			Err(err).
+			Str("user_id", user.ID).
+			Str("project_id", project.ID).
+			Msg("User not authorized to stop agent session")
+		http.Error(w, "Not authorized", http.StatusForbidden)
+		return
 	}
 
 	// Stop external agent if exists


### PR DESCRIPTION
The approveImplementation, stopAgentSession, and startImplementation handlers were calling authorizeUserToResource directly, bypassing the ownership and org-owner checks in authorizeUserToProject. This caused 403 Forbidden errors for org members trying to approve implementations.

- approveImplementation: use authorizeUserToProject instead of manual ownership check + authorizeUserToResource
- stopAgentSession: same fix
- startImplementation: was passing empty string for orgID which meant RBAC checks would never find access grants; now uses authorizeUserToProjectByID

🤖 Generated with [Claude Code](https://claude.com/claude-code)