### PR TITLE
fix: use proper RBAC authorization for git repository handlers

### DIFF
--- a/api/pkg/server/git_repository_handlers.go
+++ b/api/pkg/server/git_repository_handlers.go
@@ -113,16 +113,8 @@ func (s *HelixAPIServer) getGitRepository(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if repository.OrganizationID != "" {
-		_, err := s.authorizeOrgMember(r.Context(), user, repository.OrganizationID)
-		if err != nil {
-			writeErrResponse(w, err, http.StatusForbidden)
-			return
-		}
-	}
-
-	if repository.OwnerID != user.ID {
-		writeErrResponse(w, system.NewHTTPError403("unauthorized"), http.StatusForbidden)
+	if err := s.authorizeUserToRepository(r.Context(), user, repository, types.ActionGet); err != nil {
+		writeErrResponse(w, err, http.StatusForbidden)
 		return
 	}
 
@@ -168,16 +160,8 @@ func (s *HelixAPIServer) updateGitRepository(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if existing.OrganizationID != "" {
-		_, err := s.authorizeOrgMember(r.Context(), user, existing.OrganizationID)
-		if err != nil {
-			writeErrResponse(w, err, http.StatusForbidden)
-			return
-		}
-	}
-
-	if existing.OwnerID != user.ID {
-		writeErrResponse(w, system.NewHTTPError403("unauthorized"), http.StatusForbidden)
+	if err := s.authorizeUserToRepository(r.Context(), user, existing, types.ActionUpdate); err != nil {
+		writeErrResponse(w, err, http.StatusForbidden)
 		return
 	}
 
@@ -220,16 +204,8 @@ func (s *HelixAPIServer) deleteGitRepository(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if existing.OrganizationID != "" {
-		_, err := s.authorizeOrgMember(r.Context(), user, existing.OrganizationID)
-		if err != nil {
-			writeErrResponse(w, err, http.StatusForbidden)
-			return
-		}
-	}
-
-	if existing.OwnerID != user.ID {
-		writeErrResponse(w, system.NewHTTPError403("unauthorized"), http.StatusForbidden)
+	if err := s.authorizeUserToRepository(r.Context(), user, existing, types.ActionDelete); err != nil {
+		writeErrResponse(w, err, http.StatusForbidden)
 		return
 	}
 
@@ -819,16 +795,8 @@ func (s *HelixAPIServer) createOrUpdateGitRepositoryFileContents(w http.Response
 		return
 	}
 
-	if existing.OrganizationID != "" {
-		_, err := s.authorizeOrgMember(r.Context(), user, existing.OrganizationID)
-		if err != nil {
-			writeErrResponse(w, err, http.StatusForbidden)
-			return
-		}
-	}
-
-	if existing.OwnerID != user.ID {
-		writeErrResponse(w, system.NewHTTPError403("unauthorized"), http.StatusForbidden)
+	if err := s.authorizeUserToRepository(r.Context(), user, existing, types.ActionUpdate); err != nil {
+		writeErrResponse(w, err, http.StatusForbidden)
 		return
 	}
 
@@ -926,16 +894,8 @@ func (s *HelixAPIServer) pushPullGitRepository(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if existing.OrganizationID != "" {
-		_, err := s.authorizeOrgMember(r.Context(), user, existing.OrganizationID)
-		if err != nil {
-			writeErrResponse(w, err, http.StatusForbidden)
-			return
-		}
-	}
-
-	if existing.OwnerID != user.ID {
-		writeErrResponse(w, system.NewHTTPError403("unauthorized"), http.StatusForbidden)
+	if err := s.authorizeUserToRepository(r.Context(), user, existing, types.ActionUpdate); err != nil {
+		writeErrResponse(w, err, http.StatusForbidden)
 		return
 	}
 
@@ -1010,16 +970,8 @@ func (s *HelixAPIServer) listGitRepositoryCommits(w http.ResponseWriter, r *http
 		return
 	}
 
-	if repository.OrganizationID != "" {
-		_, err := s.authorizeOrgMember(r.Context(), user, repository.OrganizationID)
-		if err != nil {
-			writeErrResponse(w, err, http.StatusForbidden)
-			return
-		}
-	}
-
-	if repository.OwnerID != user.ID {
-		writeErrResponse(w, system.NewHTTPError403("unauthorized"), http.StatusForbidden)
+	if err := s.authorizeUserToRepository(r.Context(), user, repository, types.ActionGet); err != nil {
+		writeErrResponse(w, err, http.StatusForbidden)
 		return
 	}
 
@@ -1093,16 +1045,8 @@ func (s *HelixAPIServer) createGitRepositoryBranch(w http.ResponseWriter, r *htt
 		return
 	}
 
-	if repository.OrganizationID != "" {
-		_, err := s.authorizeOrgMember(r.Context(), user, repository.OrganizationID)
-		if err != nil {
-			writeErrResponse(w, err, http.StatusForbidden)
-			return
-		}
-	}
-
-	if repository.OwnerID != user.ID {
-		writeErrResponse(w, system.NewHTTPError403("unauthorized"), http.StatusForbidden)
+	if err := s.authorizeUserToRepository(r.Context(), user, repository, types.ActionUpdate); err != nil {
+		writeErrResponse(w, err, http.StatusForbidden)
 		return
 	}
 
@@ -1173,16 +1117,8 @@ func (s *HelixAPIServer) listGitRepositoryPullRequests(w http.ResponseWriter, r 
 		return
 	}
 
-	if repository.OrganizationID != "" {
-		_, err := s.authorizeOrgMember(r.Context(), user, repository.OrganizationID)
-		if err != nil {
-			writeErrResponse(w, err, http.StatusForbidden)
-			return
-		}
-	}
-
-	if repository.OwnerID != user.ID {
-		writeErrResponse(w, system.NewHTTPError403("unauthorized"), http.StatusForbidden)
+	if err := s.authorizeUserToRepository(r.Context(), user, repository, types.ActionGet); err != nil {
+		writeErrResponse(w, err, http.StatusForbidden)
 		return
 	}
 
@@ -1229,16 +1165,8 @@ func (s *HelixAPIServer) createGitRepositoryPullRequest(w http.ResponseWriter, r
 		return
 	}
 
-	if repository.OrganizationID != "" {
-		_, err := s.authorizeOrgMember(r.Context(), user, repository.OrganizationID)
-		if err != nil {
-			writeErrResponse(w, err, http.StatusForbidden)
-			return
-		}
-	}
-
-	if repository.OwnerID != user.ID {
-		writeErrResponse(w, system.NewHTTPError403("unauthorized"), http.StatusForbidden)
+	if err := s.authorizeUserToRepository(r.Context(), user, repository, types.ActionUpdate); err != nil {
+		writeErrResponse(w, err, http.StatusForbidden)
 		return
 	}
 


### PR DESCRIPTION
Added authorizeUserToRepository function that properly handles:
- Personal repos: owner check only
- Org repos: requires org membership + owner/org-owner/RBAC check

Fixed 9 handlers that had broken authorization logic where org members who passed the membership check would still fail the owner check:
- getGitRepository
- updateGitRepository
- deleteGitRepository
- createOrUpdateGitRepositoryFileContents
- pushPullGitRepository
- listGitRepositoryCommits
- createGitRepositoryBranch
- listGitRepositoryPullRequests
- createGitRepositoryPullRequest

🤖 Generated with [Claude Code](https://claude.com/claude-code)