### PR TITLE
fix: SharePoint citation links now open directly instead of 404

### DIFF
--- a/api/pkg/controller/knowledge/knowledge_extract.go
+++ b/api/pkg/controller/knowledge/knowledge_extract.go
@@ -564,6 +564,7 @@ func (r *Reconciler) extractDataFromSharePoint(ctx context.Context, k *types.Kno
 				"size":          downloadedFile.Size,
 				"last_modified": downloadedFile.LastModified,
 				"source":        "sharepoint",
+				"source_url":    downloadedFile.WebURL,
 			},
 		})
 	}


### PR DESCRIPTION
## Summary
- Fixed SharePoint document citations returning 404 errors in web UI
- Fixed raw `[DOC_ID:xxx]` markers appearing in Teams and Slack responses

## Changes

### SharePoint Citation Links (Web UI)
External URLs (SharePoint, web sources) are now stored directly without path manipulation, so clicking citations opens the document directly.

**Problem:** Citations were returning 404 because URLs were corrupted by `filepath.Join()` which normalized `https://` to `https:/`.

### Teams & Slack Citation Formatting
Added `shared.ConvertDocIDsToNumberedCitations()` to convert raw `[DOC_ID:xxx]` markers to readable numbered citations `[1]`, `[2]`, etc.

**Before (Teams/Slack):**
```
exits at Stairwell A [DOC_ID:357638e68b]. Evacuation required [DOC_ID:25c1dfb246].
```

**After:**
```
exits at Stairwell A [1]. Evacuation required [2].
```

## Test plan
- [ ] Create/refresh a SharePoint knowledge source
- [ ] **Web UI**: Start a session, ask a RAG question, verify citation links open SharePoint directly
- [ ] **Teams**: Send a message to a Teams bot with SharePoint knowledge, verify citations show as `[1]`, `[2]` not `[DOC_ID:xxx]`
- [ ] **Slack**: Send a message to a Slack bot with knowledge source, verify citations show as `[1]`, `[2]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)