### PR TITLE
fix: use user's Git identity for sandbox commits (Azure DevOps support)

### DIFF
--- a/api/pkg/scripts/zed_startup.sh
+++ b/api/pkg/scripts/zed_startup.sh
@@ -75,10 +75,21 @@ write_project_files() {
 # Function to initialize git repository
 init_git_repo() {
     log "Initializing git repository..."
-    
+
+    # Validate required environment variables
+    if [ -z "$GIT_USER_EMAIL" ]; then
+        log "FATAL: GIT_USER_EMAIL environment variable is required but not set"
+        exit 1
+    fi
+    if [ -z "$GIT_USER_NAME" ]; then
+        log "FATAL: GIT_USER_NAME environment variable is required but not set"
+        exit 1
+    fi
+
     git init
-    git config user.email "zed-agent@helixml.ai"
-    git config user.name "Zed Agent"
+    git config user.email "$GIT_USER_EMAIL"
+    git config user.name "$GIT_USER_NAME"
+    log "Git config: $GIT_USER_NAME <$GIT_USER_EMAIL>"
     
     # Add all files to git
     git add .
@@ -151,9 +162,21 @@ main() {
         create_feature_branch
     else
         log "Failed to fetch project code, initializing empty git repo..."
+
+        # Validate required environment variables
+        if [ -z "$GIT_USER_EMAIL" ]; then
+            log "FATAL: GIT_USER_EMAIL environment variable is required but not set"
+            exit 1
+        fi
+        if [ -z "$GIT_USER_NAME" ]; then
+            log "FATAL: GIT_USER_NAME environment variable is required but not set"
+            exit 1
+        fi
+
         git init
-        git config user.email "zed-agent@helixml.ai"
-        git config user.name "Zed Agent"
+        git config user.email "$GIT_USER_EMAIL"
+        git config user.name "$GIT_USER_NAME"
+        log "Git config: $GIT_USER_NAME <$GIT_USER_EMAIL>"
         
         # Create a basic README
         echo "# Project Workspace" > README.md

--- a/wolf/sway-config/start-zed-helix.sh
+++ b/wolf/sway-config/start-zed-helix.sh
@@ -121,22 +121,20 @@ echo "========================================="
 echo "Configuring Git..."
 echo "========================================="
 
-# Configure git user identity (required for commits)
-if [ -n "$GIT_USER_NAME" ]; then
-    git config --global user.name "$GIT_USER_NAME"
-    echo "✅ Git user.name: $GIT_USER_NAME"
-else
-    git config --global user.name "Helix Agent"
-    echo "✅ Git user.name: Helix Agent (default)"
+# Configure git user identity (required for commits to enterprise Git systems like Azure DevOps)
+if [ -z "$GIT_USER_NAME" ]; then
+    echo "❌ FATAL: GIT_USER_NAME environment variable is required but not set"
+    exit 1
+fi
+if [ -z "$GIT_USER_EMAIL" ]; then
+    echo "❌ FATAL: GIT_USER_EMAIL environment variable is required but not set"
+    exit 1
 fi
 
-if [ -n "$GIT_USER_EMAIL" ]; then
-    git config --global user.email "$GIT_USER_EMAIL"
-    echo "✅ Git user.email: $GIT_USER_EMAIL"
-else
-    git config --global user.email "agent@helix.ml"
-    echo "✅ Git user.email: agent@helix.ml (default)"
-fi
+git config --global user.name "$GIT_USER_NAME"
+echo "✅ Git user.name: $GIT_USER_NAME"
+git config --global user.email "$GIT_USER_EMAIL"
+echo "✅ Git user.email: $GIT_USER_EMAIL"
 
 # Configure git to use merge commits (not rebase) for concurrent agent work
 git config --global pull.rebase false


### PR DESCRIPTION
Enterprise Git systems like Azure DevOps reject commits from generic Helix email addresses. This change:

- Looks up user's name and email when starting Zed agent sessions
- Passes GIT_USER_NAME and GIT_USER_EMAIL as environment variables
- Makes missing Git identity a fatal error (no fallbacks)
- Updates startup scripts to require these env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)