### PR TITLE
fix: always use internal URL for Kodit repository registration

### DIFF
--- a/api/pkg/services/git_repository_service.go
+++ b/api/pkg/services/git_repository_service.go
@@ -242,19 +242,28 @@ func (s *GitRepositoryService) CreateRepository(ctx context.Context, request *ty
 
 	// Register with Kodit if kodit_indexing is enabled
 	if s.koditService != nil && request.KoditIndexing {
-		// Determine the clone URL for Kodit
-		// For external repos: use ExternalURL
-		// For local repos: use CloneURL with embedded API key auth
-		koditCloneURL := gitRepo.ExternalURL
-		if !isExternal {
-			if request.KoditAPIKey == "" {
-				log.Warn().
+		// For external repos, we need to clone the repo to disk first so Kodit can access it
+		// via the internal URL. The internal URL is always used so Kodit clones through Helix.
+		if isExternal {
+			if err := s.updateRepositoryFromGit(gitRepo); err != nil {
+				log.Error().
+					Err(err).
 					Str("repo_id", repoID).
-					Msg("Cannot register local repository with Kodit without API key - user must authenticate with API key")
-			} else {
-				// Build authenticated URL: http://api:APIKEY@host/git/repo_id
-				koditCloneURL = s.BuildAuthenticatedCloneURL(repoID, request.KoditAPIKey)
+					Msg("Failed to clone external repository for Kodit indexing")
+				// Don't fail repo creation, but skip Kodit registration
+				return gitRepo, nil
 			}
+		}
+
+		// Always use the internal URL - Kodit clones through Helix's git server
+		var koditCloneURL string
+		if request.KoditAPIKey == "" {
+			log.Warn().
+				Str("repo_id", repoID).
+				Msg("Cannot register repository with Kodit without API key - user must authenticate with API key")
+		} else {
+			// Build authenticated URL: http://api:APIKEY@host/git/repo_id
+			koditCloneURL = s.BuildAuthenticatedCloneURL(repoID, request.KoditAPIKey)
 		}
 
 		// Only register if we have a valid URL
@@ -562,16 +571,12 @@ func (s *GitRepositoryService) UpdateRepository(
 
 	// Register with Kodit if indexing was just enabled
 	if shouldRegisterKodit {
-		// Determine the clone URL for Kodit
-		// For external repos: use ExternalURL
-		// For local repos: use CloneURL with embedded API key auth
-		koditCloneURL := existing.ExternalURL
-		if !existing.IsExternal {
-			if koditAPIKey == "" {
-				return nil, fmt.Errorf("cannot register local repository with Kodit without API key")
-			}
-			koditCloneURL = s.BuildAuthenticatedCloneURL(repoID, koditAPIKey)
+		// Always use the internal URL - Kodit clones through Helix's git server
+		// GetRepository was called earlier, so external repos are already cloned to disk
+		if koditAPIKey == "" {
+			return nil, fmt.Errorf("cannot register repository with Kodit without API key")
 		}
+		koditCloneURL := s.BuildAuthenticatedCloneURL(repoID, koditAPIKey)
 
 		koditResp, err := s.koditService.RegisterRepository(ctx, koditCloneURL)
 		if err != nil {


### PR DESCRIPTION
Previously, external repos would register with Kodit using their ExternalURL directly. This change ensures all repos use the internal Helix git server URL, so Kodit always clones through Helix.

Changes:
- CreateRepository: Clone external repos to disk before Kodit registration
- UpdateRepository: Remove isExternal check, always use internal URL
- reRegisterWithKodit: Remove IsExternal check, always use internal URL

The race condition for CreateRepository is handled by explicitly cloning external repos before registration. For UpdateRepository and reRegisterWithKodit, GetRepository is called first which handles cloning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)