### PR TITLE
fix: In progress session still has button to 'start implementation'

### DIFF
--- a/frontend/src/components/spec-tasks/DesignReviewViewer.tsx
+++ b/frontend/src/components/spec-tasks/DesignReviewViewer.tsx
@@ -1412,6 +1412,7 @@ export default function DesignReviewViewer({
             unresolvedCount={unresolvedCount}
             startingImplementation={startingImplementation}
             implementationStarted={
+              task?.status === TypesSpecTaskStatus.TaskStatusSpecApproved ||
               task?.status === TypesSpecTaskStatus.TaskStatusImplementation ||
               task?.status === TypesSpecTaskStatus.TaskStatusImplementationQueued ||
               task?.status === TypesSpecTaskStatus.TaskStatusImplementationReview ||


### PR DESCRIPTION
## Summary
This PR fixes #1433

When a task's spec is approved (status becomes `spec_approved`), the task is already in the implementation phase. The "Start Implementation" button should not be visible since implementation has already begun or is about to begin.

## Changes
- Added `TaskStatusSpecApproved` status to the `implementationStarted` check in `DesignReviewViewer.tsx`
- This ensures the "Start Implementation" button is hidden when the spec has been approved