### PR TITLE
fix: expose kodit port 8632 for nginx proxy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -158,8 +158,8 @@ services:
       - "host.docker.internal:host-gateway"
   kodit:
     image: registry.helixml.tech/helix/kodit:0.5.16
-    # ports:
-    #   - 8632:8632
+    ports:
+      - 8632:8632
     command: ["serve", "--host", "0.0.0.0", "--port", "8632"]
     restart: always
     depends_on:


### PR DESCRIPTION
## Summary
- Uncomments the kodit port mapping (8632:8632) in docker-compose.yaml

## Problem
The kodit service port mapping was commented out, causing nginx to return 502 Bad Gateway for `kodit.helix.ml`. nginx proxies to `localhost:8632` but kodit wasn't exposing that port to the host.

## Test plan
- [x] Verified `sudo ss -tlnp | grep 8632` shows kodit listening
- [x] Verified https://kodit.helix.ml/ returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)