### PR TITLE
fix(ci): add flock locking and fix qwen tiktoken in sandbox build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1415,7 +1415,6 @@ trigger:
     - push
   branch:
     - main
-    - feature/sway-ubuntu-25.10
     - fix/ci-sandbox-build-concurrency
 
 volumes:
@@ -1754,7 +1753,6 @@ steps:
         - push
       branch:
         - main
-        - feature/sway-ubuntu-25.10
         - fix/ci-sandbox-build-concurrency
     depends_on:
       - build-sandbox


### PR DESCRIPTION
- Add flock-based locking to prevent race conditions when multiple builds access shared cache concurrently
- Fix qwen-code build to copy node_modules (tiktoken has native bindings)
- Add persistent cargo target directory for Zed incremental builds
- Fix shell variable escaping in flock commands (was using \$$ instead of $$)

Affected steps:
- clone-dependencies: flock on zed-source.lock, qwen-source.lock
- build-qwen-code: flock on qwen-build.lock
- build-zed: flock on zed-build.lock, persistent /var/cache/drone/cargo/zed-target