### PR TITLE
fix(install): sandbox.sh auto-detects local controlplane

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2398,6 +2398,12 @@ TURN_PUBLIC_IP="${TURN_PUBLIC_IP}"
 TURN_PASSWORD="${TURN_PASSWORD}"
 HELIX_HOSTNAME="${HELIX_HOSTNAME}"
 PRIVILEGED_DOCKER="${PRIVILEGED_DOCKER}"
+
+# Check if controlplane container is running locally - if so, use Docker network hostname
+if docker ps --format '{{.Image}}' | grep -q 'registry.helixml.tech/helix/controlplane'; then
+    HELIX_API_URL="http://api:8080"
+    echo "Detected controlplane container running. Setting HELIX_API_URL to ${HELIX_API_URL}"
+fi
 EOF
 
     # Conditionally append network check based on whether controlplane is co-located


### PR DESCRIPTION
## Summary
- Add runtime detection to sandbox.sh that checks if the controlplane container is running locally
- If detected, automatically override `HELIX_API_URL` to `http://api:8080` (Docker network hostname)
- Matches the existing behavior in runner.sh

## Problem
When a user installs sandbox with `--api-host http://localhost:8080` on a machine that also runs the controlplane, the sandbox container tries to connect to `localhost:8080` - which inside the container refers to the container itself, not the host.

## Solution
At runtime, sandbox.sh now checks if the controlplane container is running and automatically uses `http://api:8080` instead.

## Test plan
- [ ] Install sandbox on machine with controlplane: `./install.sh --sandbox --api-host http://localhost:8080 --runner-token TOKEN`
- [ ] Verify sandbox.sh detects controlplane and uses `http://api:8080`
- [ ] Verify sandbox connects successfully to controlplane

🤖 Generated with [Claude Code](https://claude.com/claude-code)