### PR TITLE
ci: Build sandbox on all branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1355,10 +1355,9 @@ type: docker
 name: build-sandbox
 
 trigger:
-  ref:
-    include:
-      - refs/heads/main
-      - refs/tags/*
+  event:
+    - push
+    - tag
 
 volumes:
   - name: dockersocket
@@ -1648,7 +1647,7 @@ steps:
     depends_on:
       - build-desktops
 
-  # Step 6: Push to registry (only on tag or main branch)
+  # Step 6: Push to registry
   - name: push-sandbox
     image: docker:cli
     environment:
@@ -1681,10 +1680,5 @@ steps:
     volumes:
       - name: dockersocket
         path: /var/run/docker.sock
-    when:
-      ref:
-        include:
-          - refs/heads/main
-          - refs/tags/*
     depends_on:
       - build-sandbox


### PR DESCRIPTION
## Summary
- Remove ref restrictions from `build-sandbox` pipeline trigger
- Remove ref restrictions from `push-sandbox` step
- Now builds and pushes sandbox images on every branch push, not just main/tags
- Non-release builds use commit SHA for version tags

## Test plan
- [ ] Push to feature branch and verify Drone triggers build-sandbox pipeline
- [ ] Verify image is pushed to registry with commit SHA tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)