### PR TITLE
fix(spec-tasks): use correct PR URL format for GitHub repos

### DIFF
--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -120,13 +120,13 @@ func (s *HelixAPIServer) getTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Compute PullRequestURL for tasks with PullRequestID (external repos like ADO)
+	// Compute PullRequestURL for tasks with PullRequestID (external repos)
 	if task.PullRequestID != "" && task.PullRequestURL == "" {
 		project, err := s.Store.GetProject(ctx, task.ProjectID)
 		if err == nil && project.DefaultRepoID != "" {
 			repo, err := s.Store.GetGitRepository(ctx, project.DefaultRepoID)
 			if err == nil && repo.ExternalURL != "" {
-				task.PullRequestURL = fmt.Sprintf("%s/pullrequest/%s", repo.ExternalURL, task.PullRequestID)
+				task.PullRequestURL = services.GetPullRequestURL(repo, task.PullRequestID)
 			}
 		}
 	}
@@ -204,7 +204,7 @@ func (s *HelixAPIServer) listTasks(w http.ResponseWriter, r *http.Request) {
 		tasks = []*types.SpecTask{}
 	}
 
-	// Compute PullRequestURL for tasks with PullRequestID (external repos like ADO)
+	// Compute PullRequestURL for tasks with PullRequestID (external repos)
 	if projectID != "" {
 		project, err := s.Store.GetProject(ctx, projectID)
 		if err == nil && project.DefaultRepoID != "" {
@@ -212,7 +212,7 @@ func (s *HelixAPIServer) listTasks(w http.ResponseWriter, r *http.Request) {
 			if err == nil && repo.ExternalURL != "" {
 				for _, task := range tasks {
 					if task.PullRequestID != "" && task.PullRequestURL == "" {
-						task.PullRequestURL = fmt.Sprintf("%s/pullrequest/%s", repo.ExternalURL, task.PullRequestID)
+						task.PullRequestURL = services.GetPullRequestURL(repo, task.PullRequestID)
 					}
 				}
 			}

--- a/api/pkg/services/git_repository_service_test.go
+++ b/api/pkg/services/git_repository_service_test.go
@@ -1,1 +1,71 @@
 package services
+
+import (
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+func TestGetPullRequestURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		repo          *types.GitRepository
+		pullRequestID string
+		expected      string
+	}{
+		{
+			name: "GitHub repo without .git suffix",
+			repo: &types.GitRepository{
+				ExternalURL:  "https://github.com/chocobar/demo-recipes",
+				ExternalType: types.ExternalRepositoryTypeGitHub,
+			},
+			pullRequestID: "1",
+			expected:      "https://github.com/chocobar/demo-recipes/pull/1",
+		},
+		{
+			name: "GitHub repo with .git suffix",
+			repo: &types.GitRepository{
+				ExternalURL:  "https://github.com/chocobar/demo-recipes.git",
+				ExternalType: types.ExternalRepositoryTypeGitHub,
+			},
+			pullRequestID: "1",
+			expected:      "https://github.com/chocobar/demo-recipes/pull/1",
+		},
+		{
+			name: "Azure DevOps repo",
+			repo: &types.GitRepository{
+				ExternalURL:  "https://dev.azure.com/org/project/_git/repo",
+				ExternalType: types.ExternalRepositoryTypeADO,
+			},
+			pullRequestID: "42",
+			expected:      "https://dev.azure.com/org/project/_git/repo/pullrequest/42",
+		},
+		{
+			name: "GitLab repo",
+			repo: &types.GitRepository{
+				ExternalURL:  "https://gitlab.com/org/repo",
+				ExternalType: types.ExternalRepositoryTypeGitLab,
+			},
+			pullRequestID: "123",
+			expected:      "https://gitlab.com/org/repo/merge_requests/123",
+		},
+		{
+			name: "Bitbucket repo",
+			repo: &types.GitRepository{
+				ExternalURL:  "https://bitbucket.org/org/repo",
+				ExternalType: types.ExternalRepositoryTypeBitbucket,
+			},
+			pullRequestID: "99",
+			expected:      "https://bitbucket.org/org/repo/pull-requests/99",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetPullRequestURL(tt.repo, tt.pullRequestID)
+			if result != tt.expected {
+				t.Errorf("GetPullRequestURL() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fixed PR URL generation that was using Azure DevOps format (`/pullrequest/`) for all repository types
- GitHub repos were getting incorrect URLs like `https://github.com/org/repo.git/pullrequest/1`
- Now correctly generates `https://github.com/org/repo/pull/1` for GitHub

## Changes
- Use existing `services.GetPullRequestURL()` which handles GitHub, ADO, GitLab, Bitbucket correctly
- Added tests for `GetPullRequestURL` covering all repository types

## Test plan
- [x] Unit tests pass for all repo types
- [ ] Verify PR link works in UI for GitHub repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)