### PR TITLE
fix(frontend): show user-friendly error when session ends

### DIFF
--- a/frontend/src/components/external-agent/ScreenshotViewer.tsx
+++ b/frontend/src/components/external-agent/ScreenshotViewer.tsx
@@ -43,6 +43,7 @@ const ScreenshotViewer: React.FC<ScreenshotViewerProps> = ({
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [streamingMode, setStreamingMode] = useState<'screenshot' | 'stream'>('screenshot');
+  const [sessionUnavailable, setSessionUnavailable] = useState(false); // Stop polling when session ends
   const containerRef = React.useRef<HTMLDivElement>(null);
   const mountTimeRef = React.useRef<Date>(new Date());
   const [isInitialLoading, setIsInitialLoading] = useState(true);
@@ -71,7 +72,10 @@ const ScreenshotViewer: React.FC<ScreenshotViewerProps> = ({
       });
 
       if (!response.ok) {
-        throw new Error(`Failed to fetch screenshot: ${response.status} ${response.statusText}`);
+        // Create error with status code accessible
+        const error = new Error(`Failed to fetch screenshot: ${response.status} ${response.statusText}`);
+        (error as any).status = response.status;
+        throw error;
       }
 
       const blob = await response.blob();
@@ -106,6 +110,7 @@ const ScreenshotViewer: React.FC<ScreenshotViewerProps> = ({
       img.src = newUrl;
     } catch (err: any) {
       const errorMsg = err.message || 'Failed to fetch screenshot';
+      const statusCode = err.status;
 
       // During initial loading (first 60 seconds), suppress errors
       // Container takes time to start and screenshot server to initialize
@@ -113,9 +118,17 @@ const ScreenshotViewer: React.FC<ScreenshotViewerProps> = ({
         // Keep loading state, don't show error yet
         setIsLoading(true);
       } else {
-        // After grace period, show actual errors
-        setError(errorMsg);
-        onError?.(errorMsg);
+        // After grace period, show user-friendly errors based on status code
+        let displayError = errorMsg;
+        if (statusCode === 503) {
+          displayError = 'Session ended - desktop is no longer available';
+          setSessionUnavailable(true); // Stop polling
+        } else if (statusCode === 404) {
+          displayError = 'Session not found';
+          setSessionUnavailable(true); // Stop polling
+        }
+        setError(displayError);
+        onError?.(errorMsg); // Pass original error to callback for debugging
         setIsLoading(false);
       }
     }
@@ -128,7 +141,8 @@ const ScreenshotViewer: React.FC<ScreenshotViewerProps> = ({
 
   // Auto-refresh screenshot with RAF for higher priority
   useEffect(() => {
-    if (!autoRefresh || streamingMode !== 'screenshot') return;
+    // Don't poll if auto-refresh disabled, not in screenshot mode, or session is unavailable
+    if (!autoRefresh || streamingMode !== 'screenshot' || sessionUnavailable) return;
 
     let timeoutId: NodeJS.Timeout;
     let rafId: number;
@@ -147,7 +161,7 @@ const ScreenshotViewer: React.FC<ScreenshotViewerProps> = ({
       clearTimeout(timeoutId);
       if (rafId) cancelAnimationFrame(rafId);
     };
-  }, [autoRefresh, refreshInterval, streamingMode]);
+  }, [autoRefresh, refreshInterval, streamingMode, sessionUnavailable]);
 
   // Initial fetch
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Shows "Session ended - desktop is no longer available" for 503 errors instead of raw HTTP status
- Shows "Session not found" for 404 errors
- Checks HTTP status codes directly instead of parsing error message strings

## Test plan

- [ ] Start an external agent session
- [ ] Stop the sandbox container
- [ ] Verify the error message shows "Session ended - desktop is no longer available"

🤖 Generated with [Claude Code](https://claude.com/claude-code)