### PR TITLE
fix: add missing 'name' field in Zed agent_servers config

### DIFF
--- a/api/cmd/settings-sync-daemon/main.go
+++ b/api/cmd/settings-sync-daemon/main.go
@@ -103,6 +103,7 @@ func (d *SettingsDaemon) generateAgentServerConfig() map[string]interface{} {
 
 		return map[string]interface{}{
 			"qwen": map[string]interface{}{
+				"name":    "qwen", // Required: Zed expects a name field for agent_servers
 				"type":    "custom", // Required: Zed deserializes agent_servers using tagged enum
 				"command": "qwen",
 				"args": []string{


### PR DESCRIPTION
## Summary

Fixes the error `missing field 'name' at line 70 column 1` that appears in Zed logs every 30 seconds when settings-sync updates settings.json.

Zed expects a `name` field in custom agent_server configurations. The settings-sync daemon was generating the config without this field.

## Test plan

- [ ] Start an external agent session with qwen_code runtime
- [ ] Check Zed logs - should no longer see "missing field 'name'" errors
- [ ] Verify qwen agent still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)