### PR TITLE
fix: provider endpoints menu actions not opening dialogs

### DIFF
--- a/frontend/src/components/dashboard/ProviderEndpointsTable.tsx
+++ b/frontend/src/components/dashboard/ProviderEndpointsTable.tsx
@@ -108,7 +108,8 @@ const ProviderEndpointsTable: FC = () => {
 
   const handleMenuClose = () => {
     setAnchorEl(null);
-    setSelectedEndpoint(null);
+    // Don't clear selectedEndpoint here - it's needed by dialogs that open from menu items.
+    // The endpoint is cleared when dialogs close (handleDeleteDialogClose, handleEditDialogClose, etc.)
   };
 
   const handleDeleteClick = () => {


### PR DESCRIPTION
## Summary
- Fixed Edit/Delete menu actions in the admin Provider Endpoints table not opening their dialogs
- Root cause: `handleMenuClose()` was clearing `selectedEndpoint` when MUI Menu auto-closed after clicking a menu item, before the dialog could render
- Fix: Don't clear `selectedEndpoint` in `handleMenuClose` - it's properly cleared when dialogs close via their respective close handlers

## Test plan
- [ ] Go to Admin Dashboard → Provider Endpoints tab
- [ ] Click the three-dot menu on a non-system provider endpoint
- [ ] Click "Edit Details" → Dialog should open
- [ ] Click "Delete" → Confirmation dialog should open

🤖 Generated with [Claude Code](https://claude.com/claude-code)