### PR TITLE
fix(docker): use golang:1.25-bookworm instead of non-existent bullseye

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -24,7 +24,7 @@ FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
 
 ### BUILD
 
-FROM golang:1.25-bullseye AS go-build-env
+FROM golang:1.25-bookworm AS go-build-env
 WORKDIR /workspace/helix
 
 # <- COPY go.mod and go.sum files to the workspace


### PR DESCRIPTION
## Summary
- Fix CI build failure caused by non-existent `golang:1.25-bullseye` Docker image
- Go 1.25 images are based on Debian bookworm, not bullseye

## Test plan
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)