### PR TITLE
fix(tasks): sanitize newlines from task names and branch paths

### DIFF
--- a/api/pkg/services/design_docs_helpers.go
+++ b/api/pkg/services/design_docs_helpers.go
@@ -25,8 +25,12 @@ func sanitizeForBranchName(taskName string) string {
 	// Convert to lowercase
 	name := strings.ToLower(taskName)
 
-	// Remove special characters except hyphens and alphanumeric
-	reg := regexp.MustCompile(`[^a-z0-9-\s]`)
+	// Replace all whitespace (including newlines, tabs) with spaces first
+	reg := regexp.MustCompile(`\s+`)
+	name = reg.ReplaceAllString(name, " ")
+
+	// Remove special characters except hyphens, spaces, and alphanumeric
+	reg = regexp.MustCompile(`[^a-z0-9- ]`)
 	name = reg.ReplaceAllString(name, "")
 
 	// Replace spaces with hyphens

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -1288,10 +1289,21 @@ func generateTaskID() string {
 }
 
 func generateTaskNameFromPrompt(prompt string) string {
-	if len(prompt) > 60 {
-		return prompt[:57] + "..."
+	// Replace newlines and other whitespace with spaces to create clean task names
+	// (prompts can contain newlines from multi-line input)
+	name := strings.ReplaceAll(prompt, "\n", " ")
+	name = strings.ReplaceAll(name, "\r", " ")
+	name = strings.ReplaceAll(name, "\t", " ")
+	// Collapse multiple spaces into one
+	for strings.Contains(name, "  ") {
+		name = strings.ReplaceAll(name, "  ", " ")
 	}
-	return prompt
+	name = strings.TrimSpace(name)
+
+	if len(name) > 60 {
+		return name[:57] + "..."
+	}
+	return name
 }
 
 // isTaskInactive returns true if the task is in a terminal/inactive state

--- a/api/pkg/services/spec_task_orchestrator_test.go
+++ b/api/pkg/services/spec_task_orchestrator_test.go
@@ -143,6 +143,9 @@ func TestSanitizeForBranchName(t *testing.T) {
 		{"UPPERCASE TEXT", "uppercase-text"},
 		{"Multiple   Spaces", "multiple-spaces"},
 		{"Special!@#$%Characters", "specialcharacters"},
+		{"Task with\nnewline", "task-with-newline"},                          // Newlines become hyphens
+		{"Task with\ttab", "task-with-tab"},                                  // Tabs become hyphens
+		{"Connect to Azure DevOps\n^ in dialog", "connect-to-azure-devops"}, // Regression test
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Task names derived from user prompts can contain newlines from multi-line input
- These newlines were propagating into `design_doc_path` and branch names
- This caused lookup failures when the git receive-pack handler tried to match pushed files to spec tasks
- Fixes issue where spec tasks weren't transitioning to `spec_review` status after design docs were pushed

## Changes
- `generateTaskNameFromPrompt`: Replace `\n`, `\r`, `\t` with spaces and collapse multiple spaces before truncating
- `sanitizeForBranchName`: Convert all whitespace (including newlines) to spaces first, then replace with hyphens
- Added regression tests for newline and tab handling

## Test plan
- [x] Existing `TestSanitizeForBranchName` tests pass
- [x] New test cases for newlines, tabs, and the specific regression case pass
- [ ] Create a new spec task with a multi-line prompt and verify the task name is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)