### PR TITLE
invalid request format to Anthropic's API: prompt is too ...

### DIFF
--- a/zed.diff
+++ b/zed.diff
@@ -1,0 +1,420 @@
+commit 170b32056eb6ff577e7eadb773e9e6562a36cb13
+Author: Luke Marsden <luke@helix.ml>
+Date:   Wed Jan 28 11:16:19 2026 +0000
+
+    Restore token counting fix lost in merge (PR #44943)
+    
+    Re-apply the Anthropic token counting improvements from commit d16619a654
+    that were accidentally lost during merge 28b927bce5.
+    
+    Changes:
+    - Add CountTokensRequest, CountTokensResponse, and count_tokens() to anthropic crate
+    - Add into_anthropic_count_tokens_request() to convert requests for token counting API
+    - Rename count_anthropic_tokens to count_anthropic_tokens_with_tiktoken as fallback
+    - Update AnthropicModel::count_tokens to use Anthropic API first, tiktoken fallback
+    
+    This fixes 'prompt is too long' errors caused by inaccurate client-side token
+    estimation using GPT-4's tiktoken tokenizer instead of Anthropic's actual counts.
+    
+    Spec-Ref: helix-specs@1428a938e:001049_invalid-request-format
+
+diff --git a/crates/anthropic/src/anthropic.rs b/crates/anthropic/src/anthropic.rs
+index 16bd7c816f..b76c0f8576 100644
+--- a/crates/anthropic/src/anthropic.rs
++++ b/crates/anthropic/src/anthropic.rs
+@@ -1046,6 +1046,71 @@ pub fn parse_prompt_too_long(message: &str) -> Option<u64> {
+         .ok()
+ }
+ 
++/// Request body for the token counting API.
++/// Similar to `Request` but without `max_tokens` since it's not needed for counting.
++#[derive(Debug, Serialize)]
++pub struct CountTokensRequest {
++    pub model: String,
++    pub messages: Vec<Message>,
++    #[serde(default, skip_serializing_if = "Option::is_none")]
++    pub system: Option<StringOrContents>,
++    #[serde(default, skip_serializing_if = "Vec::is_empty")]
++    pub tools: Vec<Tool>,
++    #[serde(default, skip_serializing_if = "Option::is_none")]
++    pub thinking: Option<Thinking>,
++    #[serde(default, skip_serializing_if = "Option::is_none")]
++    pub tool_choice: Option<ToolChoice>,
++}
++
++/// Response from the token counting API.
++#[derive(Debug, Deserialize)]
++pub struct CountTokensResponse {
++    pub input_tokens: u64,
++}
++
++/// Count the number of tokens in a message without creating it.
++pub async fn count_tokens(
++    client: &dyn HttpClient,
++    api_url: &str,
++    api_key: &str,
++    request: CountTokensRequest,
++) -> Result<CountTokensResponse, AnthropicError> {
++    let uri = format!("{api_url}/v1/messages/count_tokens");
++
++    let request_builder = HttpRequest::builder()
++        .method(Method::POST)
++        .uri(uri)
++        .header("Anthropic-Version", "2023-06-01")
++        .header("X-Api-Key", api_key.trim())
++        .header("Content-Type", "application/json");
++
++    let serialized_request =
++        serde_json::to_string(&request).map_err(AnthropicError::SerializeRequest)?;
++    let http_request = request_builder
++        .body(AsyncBody::from(serialized_request))
++        .map_err(AnthropicError::BuildRequestBody)?;
++
++    let mut response = client
++        .send(http_request)
++        .await
++        .map_err(AnthropicError::HttpSend)?;
++
++    let rate_limits = RateLimitInfo::from_headers(response.headers());
++
++    if response.status().is_success() {
++        let mut body = String::new();
++        response
++            .body_mut()
++            .read_to_string(&mut body)
++            .await
++            .map_err(AnthropicError::ReadResponse)?;
++
++        serde_json::from_str(&body).map_err(AnthropicError::DeserializeResponse)
++    } else {
++        Err(handle_error_response(response, rate_limits).await)
++    }
++}
++
+ #[test]
+ fn test_match_window_exceeded() {
+     let error = ApiError {
+diff --git a/crates/language_models/src/provider/anthropic.rs b/crates/language_models/src/provider/anthropic.rs
+index 1affe38a08..2c34a897f8 100644
+--- a/crates/language_models/src/provider/anthropic.rs
++++ b/crates/language_models/src/provider/anthropic.rs
+@@ -1,6 +1,6 @@
+ use anthropic::{
+-    ANTHROPIC_API_URL, AnthropicError, AnthropicModelMode, ContentDelta, Event, ResponseContent,
+-    ToolResultContent, ToolResultPart, Usage,
++    ANTHROPIC_API_URL, AnthropicError, AnthropicModelMode, ContentDelta, CountTokensRequest, Event,
++    ResponseContent, ToolResultContent, ToolResultPart, Usage,
+ };
+ use anyhow::{Result, anyhow};
+ use collections::{BTreeMap, HashMap};
+@@ -231,68 +231,215 @@ pub struct AnthropicModel {
+     request_limiter: RateLimiter,
+ }
+ 
+-pub fn count_anthropic_tokens(
++/// Convert a LanguageModelRequest to an Anthropic CountTokensRequest.
++pub fn into_anthropic_count_tokens_request(
+     request: LanguageModelRequest,
+-    cx: &App,
+-) -> BoxFuture<'static, Result<u64>> {
+-    cx.background_spawn(async move {
+-        let messages = request.messages;
+-        let mut tokens_from_images = 0;
+-        let mut string_messages = Vec::with_capacity(messages.len());
+-
+-        for message in messages {
+-            use language_model::MessageContent;
+-
+-            let mut string_contents = String::new();
+-
+-            for content in message.content {
+-                match content {
+-                    MessageContent::Text(text) => {
+-                        string_contents.push_str(&text);
+-                    }
+-                    MessageContent::Thinking { .. } => {
+-                        // Thinking blocks are not included in the input token count.
+-                    }
+-                    MessageContent::RedactedThinking(_) => {
+-                        // Thinking blocks are not included in the input token count.
+-                    }
+-                    MessageContent::Image(image) => {
+-                        tokens_from_images += image.estimate_tokens();
+-                    }
+-                    MessageContent::ToolUse(_tool_use) => {
+-                        // TODO: Estimate token usage from tool uses.
+-                    }
+-                    MessageContent::ToolResult(tool_result) => match &tool_result.content {
+-                        LanguageModelToolResultContent::Text(text) => {
+-                            string_contents.push_str(text);
++    model: String,
++    mode: AnthropicModelMode,
++) -> CountTokensRequest {
++    let mut new_messages: Vec<anthropic::Message> = Vec::new();
++    let mut system_message = String::new();
++
++    for message in request.messages {
++        if message.contents_empty() {
++            continue;
++        }
++
++        match message.role {
++            Role::User | Role::Assistant => {
++                let anthropic_message_content: Vec<anthropic::RequestContent> = message
++                    .content
++                    .into_iter()
++                    .filter_map(|content| match content {
++                        MessageContent::Text(text) => {
++                            let text = if text.chars().last().is_some_and(|c| c.is_whitespace()) {
++                                text.trim_end().to_string()
++                            } else {
++                                text
++                            };
++                            if !text.is_empty() {
++                                Some(anthropic::RequestContent::Text {
++                                    text,
++                                    cache_control: None,
++                                })
++                            } else {
++                                None
++                            }
++                        }
++                        MessageContent::Thinking {
++                            text: thinking,
++                            signature,
++                        } => {
++                            if !thinking.is_empty() {
++                                Some(anthropic::RequestContent::Thinking {
++                                    thinking,
++                                    signature: signature.unwrap_or_default(),
++                                    cache_control: None,
++                                })
++                            } else {
++                                None
++                            }
++                        }
++                        MessageContent::RedactedThinking(data) => {
++                            if !data.is_empty() {
++                                Some(anthropic::RequestContent::RedactedThinking { data })
++                            } else {
++                                None
++                            }
+                         }
+-                        LanguageModelToolResultContent::Image(image) => {
+-                            tokens_from_images += image.estimate_tokens();
++                        MessageContent::Image(image) => Some(anthropic::RequestContent::Image {
++                            source: anthropic::ImageSource {
++                                source_type: "base64".to_string(),
++                                media_type: "image/png".to_string(),
++                                data: image.source.to_string(),
++                            },
++                            cache_control: None,
++                        }),
++                        MessageContent::ToolUse(tool_use) => {
++                            Some(anthropic::RequestContent::ToolUse {
++                                id: tool_use.id.to_string(),
++                                name: tool_use.name.to_string(),
++                                input: tool_use.input,
++                                cache_control: None,
++                            })
++                        }
++                        MessageContent::ToolResult(tool_result) => {
++                            Some(anthropic::RequestContent::ToolResult {
++                                tool_use_id: tool_result.tool_use_id.to_string(),
++                                is_error: tool_result.is_error,
++                                content: match tool_result.content {
++                                    LanguageModelToolResultContent::Text(text) => {
++                                        ToolResultContent::Plain(text.to_string())
++                                    }
++                                    LanguageModelToolResultContent::Image(image) => {
++                                        ToolResultContent::Multipart(vec![ToolResultPart::Image {
++                                            source: anthropic::ImageSource {
++                                                source_type: "base64".to_string(),
++                                                media_type: "image/png".to_string(),
++                                                data: image.source.to_string(),
++                                            },
++                                        }])
++                                    }
++                                },
++                                cache_control: None,
++                            })
+                         }
+-                    },
++                    })
++                    .collect();
++                let anthropic_role = match message.role {
++                    Role::User => anthropic::Role::User,
++                    Role::Assistant => anthropic::Role::Assistant,
++                    Role::System => unreachable!("System role should never occur here"),
++                };
++                if let Some(last_message) = new_messages.last_mut()
++                    && last_message.role == anthropic_role
++                {
++                    last_message.content.extend(anthropic_message_content);
++                    continue;
+                 }
+-            }
+ 
+-            if !string_contents.is_empty() {
+-                string_messages.push(tiktoken_rs::ChatCompletionRequestMessage {
+-                    role: match message.role {
+-                        Role::User => "user".into(),
+-                        Role::Assistant => "assistant".into(),
+-                        Role::System => "system".into(),
+-                    },
+-                    content: Some(string_contents),
+-                    name: None,
+-                    function_call: None,
++                new_messages.push(anthropic::Message {
++                    role: anthropic_role,
++                    content: anthropic_message_content,
+                 });
+             }
++            Role::System => {
++                if !system_message.is_empty() {
++                    system_message.push_str("\n\n");
++                }
++                system_message.push_str(&message.string_contents());
++            }
++        }
++    }
++
++    CountTokensRequest {
++        model,
++        messages: new_messages,
++        system: if system_message.is_empty() {
++            None
++        } else {
++            Some(anthropic::StringOrContents::String(system_message))
++        },
++        thinking: if request.thinking_allowed
++            && let AnthropicModelMode::Thinking { budget_tokens } = mode
++        {
++            Some(anthropic::Thinking::Enabled { budget_tokens })
++        } else {
++            None
++        },
++        tools: request
++            .tools
++            .into_iter()
++            .map(|tool| anthropic::Tool {
++                name: tool.name,
++                description: tool.description,
++                input_schema: tool.input_schema,
++            })
++            .collect(),
++        tool_choice: request.tool_choice.map(|choice| match choice {
++            LanguageModelToolChoice::Auto => anthropic::ToolChoice::Auto,
++            LanguageModelToolChoice::Any => anthropic::ToolChoice::Any,
++            LanguageModelToolChoice::None => anthropic::ToolChoice::None,
++        }),
++    }
++}
++
++/// Estimate tokens using tiktoken. Used as a fallback when the API is unavailable,
++/// or by providers (like Zed Cloud) that don't have direct Anthropic API access.
++pub fn count_anthropic_tokens_with_tiktoken(request: LanguageModelRequest) -> Result<u64> {
++    let messages = request.messages;
++    let mut tokens_from_images = 0;
++    let mut string_messages = Vec::with_capacity(messages.len());
++
++    for message in messages {
++        let mut string_contents = String::new();
++
++        for content in message.content {
++            match content {
++                MessageContent::Text(text) => {
++                    string_contents.push_str(&text);
++                }
++                MessageContent::Thinking { .. } => {
++                    // Thinking blocks are not included in the input token count.
++                }
++                MessageContent::RedactedThinking(_) => {
++                    // Thinking blocks are not included in the input token count.
++                }
++                MessageContent::Image(image) => {
++                    tokens_from_images += image.estimate_tokens();
++                }
++                MessageContent::ToolUse(_tool_use) => {
++                    // TODO: Estimate token usage from tool uses.
++                }
++                MessageContent::ToolResult(tool_result) => match &tool_result.content {
++                    LanguageModelToolResultContent::Text(text) => {
++                        string_contents.push_str(text);
++                    }
++                    LanguageModelToolResultContent::Image(image) => {
++                        tokens_from_images += image.estimate_tokens();
++                    }
++                },
++            }
++        }
++
++        if !string_contents.is_empty() {
++            string_messages.push(tiktoken_rs::ChatCompletionRequestMessage {
++                role: match message.role {
++                    Role::User => "user".into(),
++                    Role::Assistant => "assistant".into(),
++                    Role::System => "system".into(),
++                },
++                content: Some(string_contents),
++                name: None,
++                function_call: None,
++            });
+         }
++    }
+ 
+-        // Tiktoken doesn't yet support these models, so we manually use the
+-        // same tokenizer as GPT-4.
+-        tiktoken_rs::num_tokens_from_messages("gpt-4", &string_messages)
+-            .map(|tokens| (tokens + tokens_from_images) as u64)
+-    })
+-    .boxed()
++    // Tiktoken doesn't yet support these models, so we manually use the
++    // same tokenizer as GPT-4.
++    tiktoken_rs::num_tokens_from_messages("gpt-4", &string_messages)
++        .map(|tokens| (tokens + tokens_from_images) as u64)
+ }
+ 
+ impl AnthropicModel {
+@@ -394,7 +541,40 @@ impl LanguageModel for AnthropicModel {
+         request: LanguageModelRequest,
+         cx: &App,
+     ) -> BoxFuture<'static, Result<u64>> {
+-        count_anthropic_tokens(request, cx)
++        let http_client = self.http_client.clone();
++        let model_id = self.model.request_id().to_string();
++        let mode = self.model.mode();
++
++        let (api_key, api_url) = self.state.read_with(cx, |state, cx| {
++            let api_url = AnthropicLanguageModelProvider::api_url(cx);
++            (
++                state.api_key_state.key(&api_url).map(|k| k.to_string()),
++                api_url.to_string(),
++            )
++        });
++
++        async move {
++            // If no API key, fall back to tiktoken estimation
++            let Some(api_key) = api_key else {
++                return count_anthropic_tokens_with_tiktoken(request);
++            };
++
++            let count_request =
++                into_anthropic_count_tokens_request(request.clone(), model_id, mode);
++
++            match anthropic::count_tokens(http_client.as_ref(), &api_url, &api_key, count_request)
++                .await
++            {
++                Ok(response) => Ok(response.input_tokens),
++                Err(err) => {
++                    log::error!(
++                        "Anthropic count_tokens API failed, falling back to tiktoken: {err:?}"
++                    );
++                    count_anthropic_tokens_with_tiktoken(request)
++                }
++            }
++        }
++        .boxed()
+     }
+ 
+     fn stream_completion(


### PR DESCRIPTION
> **Helix**: invalid request format to Anthropic's API: prompt is too long: 205507 tokens > 200000 maximum <- Is this a known issue in the Zed editor, and are there any GitHub issues? Maybe it was fixed in a newer version than the one I'm running. I'm running a custom fork. It's quite expensive to fully update the latest upstream.
Yes, this is a known issue within the Zed editor's AI ecosystem. The "prompt is too long" error (e.g., 205,507 tokens > 200,000 maximum) typically stems from how Zed manages context windows and calculates tokens before sending requests to Anthropic's API. 
Several relevant Zed GitHub issues and discussions address this:
Issue #31854: AI: Zed shows context limit as 200K, but in reality it's 120K. Users reported that Zed incorrectly displays the context window as 200k when the effective limit (or hard server cap for certain tiers) is actually much lower.
Issue #34486: Generate commit message exceeding token limit. This specifically highlights errors when Zed includes large files or massive diffs in the prompt, exceeding the 128k–200k limits without automatic truncation.
Issue #38533 & PR #44943: Improve token count accuracy using Anthropic's API. This fix, merged in December 2025, improved how Zed calculates token usage client-side to prevent sending requests that the API would reject for being over-limit.
Discussion #32150: "Thread reached the token limit". Contributors confirmed that if the conversation history (thread) exceeds the model's capacity, Zed currently lacks a robust "auto-compaction" feature, leading to these 400 errors. 
Why your custom fork might be failing:
Legacy Tokenizer: Older versions of Zed used fallback estimators that could be off by 15–30%. If your fork predates PR #44943, Zed may be "underestimating" the tokens and sending a payload that Anthropic sees as >200k.
Hard-coded Caps: Earlier versions had hard-coded limits for specific models that didn't sync with Anthropic's dynamic context windows. 
Potential Workaround: Instead of a full upstream update, try cherry-picking the changes from Zed PR #44943 into your fork to gain the improved Anthropic token counting.
Would you like me to look for the specific commit hash for that token counting fix to make cherry-picking easier?
