### PR TITLE
Fix session container state detection for play/stop buttons

### DIFF
--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -100,6 +100,24 @@ func (apiServer *HelixAPIServer) getSession(_ http.ResponseWriter, req *http.Req
 	}
 	session.Interactions = interactions
 
+	// Check if the external agent (sandbox container) is actually running
+	// If not running, update status to "stopped"
+	if session.Metadata.ContainerName != "" {
+		if apiServer.externalAgentExecutor != nil {
+			_, err := apiServer.externalAgentExecutor.GetSession(session.ID)
+			if err != nil {
+				// External agent not running - mark as stopped
+				session.Metadata.ExternalAgentStatus = "stopped"
+			} else {
+				// External agent is running
+				session.Metadata.ExternalAgentStatus = "running"
+			}
+		} else {
+			// No external agent executor available - assume stopped
+			session.Metadata.ExternalAgentStatus = "stopped"
+		}
+	}
+
 	return session, nil
 }
 

--- a/frontend/src/components/external-agent/ExternalAgentDesktopViewer.tsx
+++ b/frontend/src/components/external-agent/ExternalAgentDesktopViewer.tsx
@@ -36,7 +36,10 @@ export const useSandboxState = (sessionId: string) => {
           const hasContainer = !!response.data.config?.container_name;
 
           // Map session metadata to sandbox state
-          if (status === 'running' || (hasContainer && desiredState === 'running')) {
+          // Check stopped status first - it takes priority from the backend check
+          if (status === 'stopped') {
+            setSandboxState('absent');
+          } else if (status === 'running' || (hasContainer && desiredState === 'running')) {
             setSandboxState('running');
           } else if (status === 'starting') {
             setSandboxState('starting');


### PR DESCRIPTION
## Summary
- Backend: Add actual container state check in `getSession` handler - now checks if container is running via `externalAgentExecutor.GetSession()` and sets `ExternalAgentStatus` to "stopped" when not running
- Frontend: Fix `useSandboxState` logic order - check `status === 'stopped'` first before the `hasContainer && desiredState` condition that was giving false positives

This fixes the issue where stopped containers incorrectly showed a stop button instead of a play button on the spec task details page.

## Test plan
- [ ] Stop a running desktop container
- [ ] Verify the play button shows (not stop button)
- [ ] Start the container again
- [ ] Verify the stop button shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)