### PR TITLE
Fix container state reconciliation after API restart

### DIFF
--- a/api/pkg/external-agent/executor.go
+++ b/api/pkg/external-agent/executor.go
@@ -28,6 +28,9 @@ type Executor interface {
 
 	// Reconciliation support
 	HasRunningContainer(ctx context.Context, sessionID string) bool
+
+	// Container discovery from sandbox
+	DiscoverContainersFromSandbox(ctx context.Context, sandboxID string) error
 }
 
 // Shared types used by all executor implementations

--- a/api/pkg/external-agent/executor_mocks.go
+++ b/api/pkg/external-agent/executor_mocks.go
@@ -68,6 +68,20 @@ func (mr *MockExecutorMockRecorder) CreateZedThread(ctx, instanceID, threadID, c
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateZedThread", reflect.TypeOf((*MockExecutor)(nil).CreateZedThread), ctx, instanceID, threadID, config)
 }
 
+// DiscoverContainersFromSandbox mocks base method.
+func (m *MockExecutor) DiscoverContainersFromSandbox(ctx context.Context, sandboxID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DiscoverContainersFromSandbox", ctx, sandboxID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DiscoverContainersFromSandbox indicates an expected call of DiscoverContainersFromSandbox.
+func (mr *MockExecutorMockRecorder) DiscoverContainersFromSandbox(ctx, sandboxID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiscoverContainersFromSandbox", reflect.TypeOf((*MockExecutor)(nil).DiscoverContainersFromSandbox), ctx, sandboxID)
+}
+
 // FindContainerBySessionID mocks base method.
 func (m *MockExecutor) FindContainerBySessionID(ctx context.Context, helixSessionID string) (string, error) {
 	m.ctrl.T.Helper()

--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -1033,3 +1033,153 @@ func (h *HydraExecutor) checkDesktopBridgeHealth(ctx context.Context, runnerID, 
 
 	return resp.StatusCode == http.StatusOK
 }
+
+// DiscoverContainersFromSandbox queries a sandbox for running dev containers and
+// reconciles them with the in-memory sessions map and database state.
+// This is called when a sandbox connects (via heartbeat) to recover state after
+// API restart or when containers were started but the API didn't record them.
+func (h *HydraExecutor) DiscoverContainersFromSandbox(ctx context.Context, sandboxID string) error {
+	if h.connman == nil {
+		return fmt.Errorf("connection manager not available")
+	}
+
+	// Hydra runner ID follows the pattern: hydra-{SANDBOX_INSTANCE_ID}
+	hydraRunnerID := "hydra-" + sandboxID
+
+	// Create RevDial client to query Hydra
+	hydraClient := hydra.NewRevDialClient(h.connman, hydraRunnerID)
+
+	// Query for running containers
+	containerList, err := hydraClient.ListDevContainers(ctx)
+	if err != nil {
+		// Don't fail on connection errors - sandbox might not be ready yet
+		log.Debug().Err(err).
+			Str("sandbox_id", sandboxID).
+			Msg("Failed to query containers from sandbox (may not be ready)")
+		return nil
+	}
+
+	if len(containerList.Containers) == 0 {
+		return nil
+	}
+
+	log.Info().
+		Str("sandbox_id", sandboxID).
+		Int("container_count", len(containerList.Containers)).
+		Msg("Discovered running containers from sandbox")
+
+	// Collect containers that need to be added to our map
+	// We do this in two phases to avoid holding the lock during DB operations
+	type containerToAdd struct {
+		sessionID     string
+		containerID   string
+		containerName string
+		containerIP   string
+		containerType string
+	}
+	var containersToAdd []containerToAdd
+
+	// Phase 1: Check which containers we don't have tracked (short lock)
+	h.mutex.RLock()
+	for _, container := range containerList.Containers {
+		sessionID := container.SessionID
+		if _, exists := h.sessions[sessionID]; !exists {
+			containerType := "sway"
+			if strings.Contains(container.ContainerName, "ubuntu") {
+				containerType = "ubuntu"
+			}
+			containersToAdd = append(containersToAdd, containerToAdd{
+				sessionID:     sessionID,
+				containerID:   container.ContainerID,
+				containerName: container.ContainerName,
+				containerIP:   container.IPAddress,
+				containerType: containerType,
+			})
+		}
+	}
+	h.mutex.RUnlock()
+
+	if len(containersToAdd) == 0 {
+		return nil
+	}
+
+	// Phase 2: For each container, acquire per-session lock, update DB, then update map
+	for _, container := range containersToAdd {
+		sessionID := container.sessionID
+
+		// Acquire per-session creation lock to prevent race with StartDesktop
+		h.creationLocksMutex.Lock()
+		sessionLock, exists := h.creationLocks[sessionID]
+		if !exists {
+			sessionLock = &sync.Mutex{}
+			h.creationLocks[sessionID] = sessionLock
+		}
+		h.creationLocksMutex.Unlock()
+
+		sessionLock.Lock()
+
+		// Double-check we still need to add this (StartDesktop may have run)
+		h.mutex.RLock()
+		_, alreadyTracked := h.sessions[sessionID]
+		h.mutex.RUnlock()
+
+		if alreadyTracked {
+			sessionLock.Unlock()
+			continue
+		}
+
+		// Check if session exists in database
+		dbSession, err := h.store.GetSession(ctx, sessionID)
+		if err != nil {
+			log.Debug().Err(err).
+				Str("session_id", sessionID).
+				Msg("Session not found in database during discovery (may have been deleted)")
+			// TODO: Consider stopping orphaned container here
+			sessionLock.Unlock()
+			continue
+		}
+
+		// Update database session metadata (outside of sessions map lock)
+		if dbSession.Metadata.ContainerName != container.containerName ||
+			dbSession.Metadata.ExternalAgentStatus != "running" {
+			dbSession.Metadata.ContainerName = container.containerName
+			dbSession.Metadata.ContainerID = container.containerID
+			dbSession.Metadata.ContainerIP = container.containerIP
+			dbSession.Metadata.ExternalAgentStatus = "running"
+			dbSession.Metadata.ExecutorMode = "hydra"
+			dbSession.SandboxID = sandboxID
+
+			if _, err := h.store.UpdateSession(ctx, *dbSession); err != nil {
+				log.Warn().Err(err).
+					Str("session_id", sessionID).
+					Msg("Failed to update session metadata after container discovery")
+				sessionLock.Unlock()
+				continue
+			}
+		}
+
+		// Add to in-memory sessions map
+		h.mutex.Lock()
+		h.sessions[sessionID] = &ZedSession{
+			SessionID:     sessionID,
+			ContainerID:   container.containerID,
+			ContainerName: container.containerName,
+			Status:        "running",
+			ContainerIP:   container.containerIP,
+			LastAccess:    time.Now(),
+		}
+		h.mutex.Unlock()
+
+		log.Info().
+			Str("session_id", sessionID).
+			Str("container_id", container.containerID).
+			Str("container_name", container.containerName).
+			Str("container_type", container.containerType).
+			Str("sandbox_id", sandboxID).
+			Msg("Recovered container from sandbox discovery")
+
+		sessionLock.Unlock()
+	}
+
+	return nil
+}

--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -175,6 +175,121 @@ func (dm *DevContainerManager) CreateDevContainer(ctx context.Context, req *Crea
 		}
 	}
 
+	// Check if container with this name already exists
+	// This handles cases where:
+	// 1. API restarted but container is still running
+	// 2. Previous start request failed after container creation but before DB update
+	existingContainer, err := dockerClient.ContainerInspect(ctx, req.ContainerName)
+	if err == nil {
+		// Container exists - check its state
+		if existingContainer.State.Running {
+			// Container is already running - return success
+			log.Info().
+				Str("session_id", req.SessionID).
+				Str("container_id", existingContainer.ID).
+				Str("container_name", req.ContainerName).
+				Msg("Container already running, returning existing container")
+
+			// Get IP address
+			var ipAddress string
+			if existingContainer.HostConfig.NetworkMode.IsHost() {
+				ipAddress = "host"
+			} else {
+				for _, network := range existingContainer.NetworkSettings.Networks {
+					if network.IPAddress != "" {
+						ipAddress = network.IPAddress
+						break
+					}
+				}
+				if ipAddress == "" {
+					ipAddress = existingContainer.NetworkSettings.IPAddress
+				}
+			}
+			if ipAddress == "" {
+				ipAddress = "host"
+			}
+
+			// Track container in our map
+			dm.mu.Lock()
+			dm.containers[req.SessionID] = &DevContainer{
+				SessionID:     req.SessionID,
+				ContainerID:   existingContainer.ID,
+				ContainerName: req.ContainerName,
+				IPAddress:     ipAddress,
+			}
+			dm.mu.Unlock()
+
+			return &DevContainerResponse{
+				ContainerID:   existingContainer.ID,
+				ContainerName: req.ContainerName,
+				IPAddress:     ipAddress,
+			}, nil
+		}
+
+		// Container exists but is stopped - start it
+		log.Info().
+			Str("session_id", req.SessionID).
+			Str("container_id", existingContainer.ID).
+			Str("container_name", req.ContainerName).
+			Str("state", existingContainer.State.Status).
+			Msg("Container exists but stopped, starting it")
+
+		if err := dockerClient.ContainerStart(ctx, existingContainer.ID, container.StartOptions{}); err != nil {
+			// Failed to start - remove and create new
+			log.Warn().Err(err).
+				Str("container_id", existingContainer.ID).
+				Msg("Failed to start existing container, removing and creating new")
+			dockerClient.ContainerRemove(ctx, existingContainer.ID, container.RemoveOptions{Force: true})
+		} else {
+			// Started successfully - get updated info and return
+			inspect, err := dockerClient.ContainerInspect(ctx, existingContainer.ID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to inspect started container: %w", err)
+			}
+
+			var ipAddress string
+			if inspect.HostConfig.NetworkMode.IsHost() {
+				ipAddress = "host"
+			} else {
+				for _, network := range inspect.NetworkSettings.Networks {
+					if network.IPAddress != "" {
+						ipAddress = network.IPAddress
+						break
+					}
+				}
+				if ipAddress == "" {
+					ipAddress = inspect.NetworkSettings.IPAddress
+				}
+			}
+			if ipAddress == "" {
+				ipAddress = "host"
+			}
+
+			// Track container
+			dm.mu.Lock()
+			dm.containers[req.SessionID] = &DevContainer{
+				SessionID:     req.SessionID,
+				ContainerID:   existingContainer.ID,
+				ContainerName: req.ContainerName,
+				IPAddress:     ipAddress,
+			}
+			dm.mu.Unlock()
+
+			log.Info().
+				Str("session_id", req.SessionID).
+				Str("container_id", existingContainer.ID).
+				Str("container_name", req.ContainerName).
+				Msg("Existing container started successfully")
+
+			return &DevContainerResponse{
+				ContainerID:   existingContainer.ID,
+				ContainerName: req.ContainerName,
+				IPAddress:     ipAddress,
+			}, nil
+		}
+	}
+	// Container doesn't exist (or was removed above) - create new one
+
 	// Create container
 	resp, err := dockerClient.ContainerCreate(ctx, containerConfig, hostConfig, networkConfig, nil, req.ContainerName)
 	if err != nil {


### PR DESCRIPTION
This commit fixes several issues with container state management:

1. Hydra CreateDevContainer: Check if container already exists before creating. If running, return existing container info. If stopped, start it instead of failing with "name already in use" error.

2. API HydraExecutor: Add DiscoverContainersFromSandbox method that queries a sandbox for running containers and reconciles them with the API's in-memory sessions map and database state.

3. Sandbox registration: Call container discovery when a sandbox registers with the API. This recovers container state after API restart when containers are still running on the sandbox.

Race condition fixes in discovery:
- Two-phase locking: short read lock to identify containers to add, then per-session locks for individual updates
- Uses existing per-session creation locks to prevent race with StartDesktop
- Double-check pattern after acquiring lock
- DB operations done outside of sessions map lock

The fix handles these scenarios:
- API restarts but containers keep running on sandbox
- Container was started but API didn't record it properly
- Multiple attempts to start the same container
- Discovery running concurrently with container creation

Known limitations (future work):
- Container crash detection relies on in-memory state, not Docker
- Orphaned containers (session deleted) not cleaned up automatically
- Sandbox offline doesn't trigger cleanup