### PR TITLE
Add SERVE_PROD_FRONTEND_IN_DEV option for production frontend in dev

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -417,8 +417,8 @@ type WebServer struct {
 	URL  string `envconfig:"SERVER_URL" description:"The URL the api server is listening on."`
 	Host string `envconfig:"SERVER_HOST" default:"0.0.0.0" description:"The host to bind the api server to."`
 	Port int    `envconfig:"SERVER_PORT" default:"80" description:""`
-	// Can either be a URL to frontend or a path to static files
-	FrontendURL string `envconfig:"FRONTEND_URL" default:"http://frontend:8081" description:""`
+	// ServeProdFrontendInDev enables serving the production frontend build instead of the dev server
+	ServeProdFrontendInDev bool `envconfig:"SERVE_PROD_FRONTEND_IN_DEV" default:"false" description:"Serve production frontend build instead of dev server"`
 
 	RunnerToken string `envconfig:"RUNNER_TOKEN" description:"The token for runner auth."`
 	// Comma-separated list of user IDs that should be admins, or "all" for dev mode.

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -56,7 +56,6 @@ services:
       - STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY:-}
       - STRIPE_WEBHOOK_SIGNING_SECRET=${STRIPE_WEBHOOK_SIGNING_SECRET:-}
       - STRIPE_PRICE_LOOKUP_KEY=${STRIPE_PRICE_LOOKUP_KEY:-}
-      - FRONTEND_URL=http://frontend:8081
       # lock down dashboard in production
       - ADMIN_USER_IDS=${ADMIN_USER_IDS-all}
       - EVAL_USER_ID=${EVAL_USER_ID:-}
@@ -112,6 +111,8 @@ services:
       # Go caches for faster air rebuilds (shared with runner config)
       - go-pkg-mod:/go/pkg/mod
       - go-build-cache:/root/.cache/go-build
+      # Production frontend build (used when SERVE_PROD_FRONTEND_IN_DEV=true)
+      - ./frontend/dist:/www:ro
     depends_on:
       - postgres
       - postgres-mcp


### PR DESCRIPTION
## Summary
- Add `SERVE_PROD_FRONTEND_IN_DEV` env var (default: `false`)
- When `true`, serves production build from `/www`
- When `false` (default), proxies to Vite dev server at `http://frontend:8081`
- Remove redundant `FRONTEND_URL` from docker-compose
- Mount `frontend/dist` as `/www`

## Usage

```bash
# Build frontend
cd frontend && yarn build && cd ..

# Enable production frontend
echo "SERVE_PROD_FRONTEND_IN_DEV=true" >> .env
docker compose -f docker-compose.dev.yaml up -d api

# Switch back to dev mode
sed -i '/^SERVE_PROD_FRONTEND_IN_DEV=/d' .env
docker compose -f docker-compose.dev.yaml up -d api
```

## Test plan
- [ ] Default behavior still proxies to Vite dev server
- [ ] Setting `SERVE_PROD_FRONTEND_IN_DEV=true` serves production build
- [ ] Cache headers work (no-cache for index.html, immutable for assets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)