### PR TITLE
Fix: Pass WIP limits from project metadata to Kanban board

### DIFF
--- a/frontend/src/pages/SpecTasksPage.tsx
+++ b/frontend/src/pages/SpecTasksPage.tsx
@@ -1131,6 +1131,7 @@ const SpecTasksPage: FC = () => {
               <SpecTaskKanbanBoard
                 userId={account.user?.id}
                 projectId={projectId}
+                wipLimits={project?.metadata?.board_settings?.wip_limits}
                 onCreateTask={handleOpenCreateDialog}
                 onTaskClick={(task) => {
                   // Navigate to task detail page


### PR DESCRIPTION
## Summary

- Kanban board was ignoring project's WIP limit settings
- `SpecTasksPage.tsx` was not passing `wipLimits` prop to `SpecTaskKanbanBoard`
- Board always used defaults (planning: 3, review: 2, implementation: 5)
- Now passes `project.metadata?.board_settings?.wip_limits` to respect project settings

## Test plan

- [x] Set custom WIP limits in project settings (e.g., planning: 6)
- [x] Verify Kanban board respects the configured limit


🤖 Generated with [Claude Code](https://claude.com/claude-code)