### PR TITLE
fix: Prevent stale content from previous interaction showing in chat

### DIFF
--- a/frontend/src/contexts/streaming.tsx
+++ b/frontend/src/contexts/streaming.tsx
@@ -200,15 +200,23 @@ export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ ch
             // IMPORTANT: Only fall back to current values if the interaction ID matches
             // Otherwise we'd show stale content from a previous interaction
             const isSameInteraction = current.id === lastInteraction.id;
-            const updatedInteraction: Partial<TypesInteraction> = {
-              ...current,
-              id: lastInteraction.id,
-              state: lastInteraction.state,
-              // Copy all important fields from the interaction
-              // Only use fallback if it's the same interaction (streaming update)
-              prompt_message: lastInteraction.prompt_message || (isSameInteraction ? current.prompt_message : undefined),
-              response_message: lastInteraction.response_message || (isSameInteraction ? current.response_message : undefined),
-            };
+
+            // When it's a different interaction, start fresh - don't spread current
+            const updatedInteraction: Partial<TypesInteraction> = isSameInteraction
+              ? {
+                  ...current,
+                  id: lastInteraction.id,
+                  state: lastInteraction.state,
+                  prompt_message: lastInteraction.prompt_message || current.prompt_message,
+                  response_message: lastInteraction.response_message || current.response_message,
+                }
+              : {
+                  // New interaction - start with clean slate, only use server data
+                  id: lastInteraction.id,
+                  state: lastInteraction.state,
+                  prompt_message: lastInteraction.prompt_message,
+                  response_message: lastInteraction.response_message,
+                };
 
             const newMap = new Map(prev).set(currentSessionId, updatedInteraction);
             return newMap;
@@ -253,13 +261,23 @@ export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({ ch
             // IMPORTANT: Only fall back to current values if the interaction ID matches
             // Otherwise we'd show stale content from a previous interaction
             const isSameInteraction = current.id === updatedInteraction.id;
-            const updated: Partial<TypesInteraction> = {
-              ...current,
-              id: updatedInteraction.id,
-              state: updatedInteraction.state,
-              prompt_message: updatedInteraction.prompt_message || (isSameInteraction ? current.prompt_message : undefined),
-              response_message: updatedInteraction.response_message || (isSameInteraction ? current.response_message : undefined),
-            };
+
+            // When it's a different interaction, start fresh - don't spread current
+            const updated: Partial<TypesInteraction> = isSameInteraction
+              ? {
+                  ...current,
+                  id: updatedInteraction.id,
+                  state: updatedInteraction.state,
+                  prompt_message: updatedInteraction.prompt_message || current.prompt_message,
+                  response_message: updatedInteraction.response_message || current.response_message,
+                }
+              : {
+                  // New interaction - start with clean slate
+                  id: updatedInteraction.id,
+                  state: updatedInteraction.state,
+                  prompt_message: updatedInteraction.prompt_message,
+                  response_message: updatedInteraction.response_message,
+                };
 
             const newMap = new Map(prev).set(currentSessionId, updated);
             return newMap;


### PR DESCRIPTION
## Summary
- Fixed issue where switching between interactions in the same session briefly showed content from the previous interaction
- Root cause: `currentResponses` map is keyed by sessionId (not interactionId), so new interactions would pick up stale data
- Added interaction ID validation in multiple places to ensure data matches the current interaction

## Test plan
- [x] Send multiple messages in a Zed session
- [x] Verify that when a new interaction starts, it shows "thinking" dots instead of the previous response
- [x] Verify streaming still works correctly for ongoing interactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)