### PR TITLE
feat(helm): add GKE ManagedCertificate support for automatic TLS

### DIFF
--- a/charts/helix-controlplane/Chart.yaml
+++ b/charts/helix-controlplane/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.35
+version: 0.3.36
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/helix-controlplane/templates/gke_managed_certificate.yaml
+++ b/charts/helix-controlplane/templates/gke_managed_certificate.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.ingress.enabled .Values.ingress.gke .Values.ingress.gke.managedCertificate .Values.ingress.gke.managedCertificate.enabled }}
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: {{ include "helix-controlplane.fullname" . }}-managed-cert
+  labels:
+    {{- include "helix-controlplane.labels" . | nindent 4 }}
+spec:
+  domains:
+    {{- if .Values.ingress.gke.managedCertificate.domains }}
+    {{- range .Values.ingress.gke.managedCertificate.domains }}
+    - {{ . | quote }}
+    {{- end }}
+    {{- else }}
+    {{- range .Values.ingress.hosts }}
+    - {{ .host | quote }}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/helix-controlplane/values.yaml
+++ b/charts/helix-controlplane/values.yaml
@@ -201,6 +201,13 @@ ingress:
         - path: /
           pathType: ImplementationSpecific
   tls: []
+  # GKE-specific configuration
+  gke:
+    managedCertificate:
+      # Enable to automatically create a Google-managed TLS certificate
+      enabled: false
+      # Optional: specify domains explicitly. If empty, uses ingress.hosts[].host
+      domains: []
 
 resources: {}
 


### PR DESCRIPTION
## Summary
- Adds optional support for Google-managed TLS certificates on GKE deployments
- When enabled, the Helm chart automatically creates a ManagedCertificate resource
- Eliminates the need for manual certificate setup when deploying to GKE with a custom domain

## Usage

In values.yaml:
```yaml
ingress:
  enabled: true
  className: "gce"
  annotations:
    kubernetes.io/ingress.global-static-ip-name: "helix-ip"
    networking.gke.io/managed-certificates: "my-helix-controlplane-managed-cert"
  hosts:
    - host: helix.example.com
      paths:
        - path: /
          pathType: Prefix
  gke:
    managedCertificate:
      enabled: true
```

## Test plan
- [ ] Deploy to GKE with `ingress.gke.managedCertificate.enabled: true`
- [ ] Verify ManagedCertificate resource is created
- [ ] Verify certificate provisions successfully (takes 10-15 min)
- [ ] Verify HTTPS works on the domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)