### PR TITLE
Remove noisy per-request auth debug logs

### DIFF
--- a/api/pkg/auth/session_manager.go
+++ b/api/pkg/auth/session_manager.go
@@ -107,8 +107,6 @@ func (sm *SessionManager) GetSessionFromRequest(ctx context.Context, r *http.Req
 		return nil, ErrSessionNotFound
 	}
 
-	log.Debug().Str("session_id", sessionID).Str("path", r.URL.Path).Msg("Looking up session from request")
-
 	session, err := sm.store.GetUserSession(ctx, sessionID)
 	if err != nil {
 		log.Debug().Err(err).Str("session_id", sessionID).Str("path", r.URL.Path).Msg("Session lookup failed in store")

--- a/api/pkg/server/auth_middleware.go
+++ b/api/pkg/server/auth_middleware.go
@@ -293,12 +293,6 @@ func (auth *authMiddleware) getUserFromSession(ctx context.Context, r *http.Requ
 
 	dbUser.Admin = auth.isAdminWithContext(ctx, dbUser.ID)
 
-	log.Debug().
-		Str("session_id", session.ID).
-		Str("user_id", dbUser.ID).
-		Str("auth_provider", string(session.AuthProvider)).
-		Msg("Authenticated user via BFF session")
-
 	return dbUser, nil
 }
 


### PR DESCRIPTION
## Summary
- Remove debug log "Looking up session from request" that fires on every authenticated request
- Remove debug log "Authenticated user via BFF session" that fires on every authenticated request

Error cases are still logged separately.

## Test plan
- [x] API hot-reloads via Air
- [ ] Verify logs are less noisy

🤖 Generated with [Claude Code](https://claude.com/claude-code)