### PR TITLE
Fix buildkit cache directory permissions for non-root containers

### DIFF
--- a/api/pkg/hydra/manager.go
+++ b/api/pkg/hydra/manager.go
@@ -144,9 +144,14 @@ func (m *Manager) Start(ctx context.Context) error {
 
 	// Create shared BuildKit cache directory for all sessions
 	// This allows docker build cache to be shared across dockerd instances
+	// Use 0777 permissions so dev containers running as non-root can create subdirectories
 	buildkitCacheDir := filepath.Join(m.dataDir, SharedBuildKitCacheDir)
-	if err := os.MkdirAll(buildkitCacheDir, 0755); err != nil {
+	if err := os.MkdirAll(buildkitCacheDir, 0777); err != nil {
 		return fmt.Errorf("failed to create buildkit cache directory: %w", err)
+	}
+	// Ensure permissions are correct even if directory already existed
+	if err := os.Chmod(buildkitCacheDir, 0777); err != nil {
+		log.Warn().Err(err).Str("dir", buildkitCacheDir).Msg("Failed to set buildkit cache directory permissions")
 	}
 
 	// Setup shared BuildKit container and builder for cache sharing


### PR DESCRIPTION
## Summary

- The shared BuildKit cache directory was created with 0755 permissions
- Dev containers run as non-root users and couldn't create subdirectories like `helix-sway`
- This caused "permission denied" warnings when trying to use the shared cache

## Changes

- Use 0777 permissions when creating the buildkit-cache directory
- Add explicit chmod to fix permissions on existing directories

## Error before fix
```
{"level":"warn","error":"mkdir /buildkit-cache/helix-sway: permission denied","dir":"/buildkit-cache/helix-sway"...}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)