### PR TITLE
docker-shim: fail fast when shared BuildKit builder unavailable

### DIFF
--- a/desktop/docker-shim/docker.go
+++ b/desktop/docker-shim/docker.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,7 +14,12 @@ import (
 // runDocker handles docker CLI commands with path translation and cache injection
 func runDocker(args []string) int {
 	// Process arguments
-	newArgs := processDockerArgs(args)
+	newArgs, err := processDockerArgs(args)
+	if err != nil {
+		// Fail fast: print error and exit with non-zero code
+		fmt.Fprintf(os.Stderr, "docker-shim: build failed: %v\n", err)
+		return 1
+	}
 
 	log.Debug().
 		Strs("original", args).
@@ -25,7 +31,8 @@ func runDocker(args []string) int {
 }
 
 // processDockerArgs processes docker arguments for path translation and cache injection
-func processDockerArgs(args []string) []string {
+// Returns error if a required component (like shared builder) is unavailable
+func processDockerArgs(args []string) ([]string, error) {
 	result := make([]string, 0, len(args)+4) // Extra space for cache flags
 
 	// First pass: translate paths in volume/mount arguments
@@ -66,9 +73,13 @@ func processDockerArgs(args []string) []string {
 	}
 
 	// Second pass: inject BuildKit cache flags for build commands
-	result = injectBuildCacheFlags(result)
+	// This may fail if the shared builder is unavailable
+	result, err := injectBuildCacheFlags(result)
+	if err != nil {
+		return nil, err
+	}
 
-	return result
+	return result, nil
 }
 
 // isBuildCommand checks if the args represent a docker build command
@@ -173,13 +184,21 @@ const SharedBuilderName = "helix-shared"
 const SharedBuildKitContainerName = "helix-buildkit"
 
 // ensureSharedBuilder checks if the helix-shared builder exists, creates it if not
-// Returns true if the builder is available, false if it couldn't be set up
-func ensureSharedBuilder() bool {
+// Returns nil if the builder is available, error with details if it couldn't be set up
+func ensureSharedBuilder() error {
 	// Check if builder already exists
 	checkCmd := exec.Command(DockerRealPath, "buildx", "inspect", SharedBuilderName)
 	if err := checkCmd.Run(); err == nil {
 		log.Debug().Str("builder", SharedBuilderName).Msg("Shared builder already exists")
-		return true
+		return nil
+	}
+
+	// Check if BuildKit container exists
+	checkContainerCmd := exec.Command(DockerRealPath, "inspect", SharedBuildKitContainerName)
+	if err := checkContainerCmd.Run(); err != nil {
+		return fmt.Errorf("shared BuildKit container '%s' not found. "+
+			"This container should be started by Hydra. Check that Hydra is running and has set up the BuildKit container. "+
+			"Error: %w", SharedBuildKitContainerName, err)
 	}
 
 	// Get buildkit container IP
@@ -188,13 +207,14 @@ func ensureSharedBuilder() bool {
 		SharedBuildKitContainerName)
 	ipOutput, err := ipCmd.Output()
 	if err != nil {
-		log.Debug().Err(err).Msg("Could not get BuildKit container IP, shared builder not available")
-		return false
+		return fmt.Errorf("could not get IP for BuildKit container '%s': %w",
+			SharedBuildKitContainerName, err)
 	}
 	buildkitIP := strings.TrimSpace(string(ipOutput))
 	if buildkitIP == "" {
-		log.Debug().Msg("BuildKit container has no IP, shared builder not available")
-		return false
+		return fmt.Errorf("BuildKit container '%s' has no IP address. "+
+			"The container may not be connected to a network properly",
+			SharedBuildKitContainerName)
 	}
 
 	// Create the builder
@@ -209,11 +229,11 @@ func ensureSharedBuilder() bool {
 		"tcp://"+buildkitIP+":1234",
 	)
 	if output, err := createCmd.CombinedOutput(); err != nil {
-		log.Warn().Err(err).Str("output", string(output)).Msg("Failed to create shared builder")
-		return false
+		return fmt.Errorf("failed to create shared builder '%s': %s: %w",
+			SharedBuilderName, strings.TrimSpace(string(output)), err)
 	}
 
-	return true
+	return nil
 }
 
 // hasBuilderFlag checks if --builder flag is already present
@@ -227,22 +247,24 @@ func hasBuilderFlag(args []string) bool {
 }
 
 // injectBuildCacheFlags adds BuildKit cache flags and builder to build commands
-func injectBuildCacheFlags(args []string) []string {
+// Returns the modified args and an error if the shared builder can't be set up
+// Fail-fast: if cache directory exists, builder MUST be available
+func injectBuildCacheFlags(args []string) ([]string, error) {
 	// Only process build commands
 	if !isBuildCommand(args) {
-		return args
+		return args, nil
 	}
 
-	// Check if cache directory exists
+	// Check if cache directory exists - if it does, we REQUIRE the builder
 	if _, err := os.Stat(BuildKitCacheDir); os.IsNotExist(err) {
 		log.Debug().Msg("BuildKit cache directory not found, skipping cache injection")
-		return args
+		return args, nil
 	}
 
 	// Don't inject if user already specified cache flags
 	if hasCacheFlags(args) {
 		log.Debug().Msg("Cache flags already present, skipping injection")
-		return args
+		return args, nil
 	}
 
 	// Extract image name for cache key
@@ -256,8 +278,7 @@ func injectBuildCacheFlags(args []string) []string {
 
 	// Ensure cache subdirectory exists
 	if err := os.MkdirAll(cacheDir, 0755); err != nil {
-		log.Warn().Err(err).Str("dir", cacheDir).Msg("Failed to create cache directory")
-		return args
+		return nil, fmt.Errorf("failed to create cache directory '%s': %w", cacheDir, err)
 	}
 
 	// Find where to insert flags (after "build" or "buildx build")
@@ -270,7 +291,17 @@ func injectBuildCacheFlags(args []string) []string {
 	}
 
 	if insertIdx == -1 || insertIdx > len(args) {
-		return args
+		return args, nil
+	}
+
+	// FAIL FAST: Shared builder is REQUIRED when cache directory exists
+	// This ensures builds always use the shared cache for consistency
+	if !hasBuilderFlag(args) {
+		if err := ensureSharedBuilder(); err != nil {
+			return nil, fmt.Errorf("shared BuildKit builder required for cached builds: %w\n\n"+
+				"The /buildkit-cache directory exists, which means cached builds are expected.\n"+
+				"Ensure Hydra has started the helix-buildkit container.", err)
+		}
 	}
 
 	// Build new args with builder and cache flags
@@ -280,8 +311,8 @@ func injectBuildCacheFlags(args []string) []string {
 	result := make([]string, 0, len(args)+4)
 	result = append(result, args[:insertIdx]...)
 
-	// Add --builder flag if shared builder is available and not already specified
-	if !hasBuilderFlag(args) && ensureSharedBuilder() {
+	// Add --builder flag if not already specified
+	if !hasBuilderFlag(args) {
 		result = append(result, "--builder="+SharedBuilderName)
 		// With remote builder, we need --load to get image into local docker
 		// Check if --load or --push already specified
@@ -305,7 +336,7 @@ func injectBuildCacheFlags(args []string) []string {
 		Str("image", imageName).
 		Msg("Injected BuildKit cache flags")
 
-	return result
+	return result, nil
 }
 
 // execReal executes the real binary, replacing the current process

--- a/desktop/docker-shim/docker_test.go
+++ b/desktop/docker-shim/docker_test.go
@@ -209,7 +209,10 @@ func TestInjectBuildCacheFlags(t *testing.T) {
 
 	t.Run("no cache dir - no injection", func(t *testing.T) {
 		args := []string{"build", "-t", "myimage", "."}
-		got := injectBuildCacheFlags(args)
+		got, err := injectBuildCacheFlags(args)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
 		if !reflect.DeepEqual(got, args) {
 			t.Errorf("Expected no change when cache dir doesn't exist, got %v", got)
 		}
@@ -217,7 +220,10 @@ func TestInjectBuildCacheFlags(t *testing.T) {
 
 	t.Run("non-build command - no injection", func(t *testing.T) {
 		args := []string{"run", "-it", "ubuntu"}
-		got := injectBuildCacheFlags(args)
+		got, err := injectBuildCacheFlags(args)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
 		if !reflect.DeepEqual(got, args) {
 			t.Errorf("Expected no change for non-build command, got %v", got)
 		}
@@ -225,7 +231,10 @@ func TestInjectBuildCacheFlags(t *testing.T) {
 
 	t.Run("already has cache flags - no injection", func(t *testing.T) {
 		args := []string{"build", "--cache-from=type=local,src=/other", "-t", "myimage", "."}
-		got := injectBuildCacheFlags(args)
+		got, err := injectBuildCacheFlags(args)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
 		if !reflect.DeepEqual(got, args) {
 			t.Errorf("Expected no change when cache flags present, got %v", got)
 		}
@@ -278,7 +287,10 @@ func TestProcessDockerArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := processDockerArgs(tt.args)
+			got, err := processDockerArgs(tt.args)
+			if err != nil {
+				t.Fatalf("processDockerArgs(%v) returned error: %v", tt.args, err)
+			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("processDockerArgs(%v) = %v, want %v", tt.args, got, tt.want)
 			}

--- a/desktop/docker-shim/integration_test.go
+++ b/desktop/docker-shim/integration_test.go
@@ -167,7 +167,10 @@ func TestIntegration_DockerBuildNoCacheDir(t *testing.T) {
 	args := []string{"build", "-t", "test:nocache", "."}
 
 	// Save original and use non-existent cache dir
-	processed := injectBuildCacheFlags(args)
+	processed, err := injectBuildCacheFlags(args)
+	if err != nil {
+		t.Fatalf("injectBuildCacheFlags returned error: %v", err)
+	}
 
 	// Should be unchanged since /buildkit-cache doesn't exist
 	if len(processed) != len(args) {


### PR DESCRIPTION
## Summary

When `/buildkit-cache` exists, the shared BuildKit builder is REQUIRED for docker builds. Previously, the shim would inject cache flags even when the builder wasn't available, causing "Cache export is not supported for the docker driver" errors.

## Changes

**Fail-fast behavior:** The shim now fails immediately with a clear error when:
- `/buildkit-cache` directory exists (expecting cached builds)
- The `helix-buildkit` container is missing or unreachable
- The `helix-shared` buildx builder cannot be created

**Error message example:**
```
docker-shim: build failed: shared BuildKit builder required for cached builds:
shared BuildKit container 'helix-buildkit' not found. This container should be
started by Hydra. Check that Hydra is running and has set up the BuildKit container.

The /buildkit-cache directory exists, which means cached builds are expected.
Ensure Hydra has started the helix-buildkit container.
```

## Error before fix
```
🔨 Building helix-sway:latest...
[+] Building 0.0s (0/0)                                  docker:default
ERROR: failed to build: Cache export is not supported for the docker driver.
```

This error was confusing because it didn't explain what was wrong or how to fix it.

## Principle

Follows the fail-fast principle: builds fail immediately with actionable error messages rather than proceeding with broken cache configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)