### PR TITLE
Pass BuildKit endpoint to dev containers via BUILDKIT_HOST env var

### DIFF
--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -438,6 +439,15 @@ func (dm *DevContainerManager) buildEnv(req *CreateDevContainerRequest) []string
 		if !hasDriverCaps {
 			env = append(env, "NVIDIA_DRIVER_CAPABILITIES=all")
 		}
+	}
+
+	// Add BUILDKIT_HOST for shared BuildKit cache support
+	// Dev containers mount their per-session Docker socket, but helix-buildkit runs
+	// on the sandbox's main dockerd. Pass the BuildKit endpoint directly so docker-shim
+	// can create the buildx builder without looking up the container.
+	if buildkitHost := getBuildKitHost(); buildkitHost != "" {
+		env = append(env, fmt.Sprintf("BUILDKIT_HOST=%s", buildkitHost))
+		log.Debug().Str("buildkit_host", buildkitHost).Msg("Added BUILDKIT_HOST to dev container env")
 	}
 
 	// Override API URLs with sandbox's own HELIX_API_URL
@@ -994,4 +1004,29 @@ func (dm *DevContainerManager) streamContainerLogs(ctx context.Context, containe
 	}
 
 	log.Debug().Str("container", containerName).Msg("Stopped streaming container logs")
+}
+
+// getBuildKitHost returns the BuildKit endpoint URL (e.g., "tcp://172.17.0.5:1234")
+// by querying the helix-buildkit container's IP address on the sandbox's main dockerd.
+// Returns empty string if BuildKit is not available.
+func getBuildKitHost() string {
+	// Query helix-buildkit container IP using the sandbox's main Docker socket
+	// (not the per-session socket that dev containers use)
+	cmd := exec.Command("docker", "-H", "unix:///var/run/docker.sock",
+		"inspect", "-f", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
+		SharedBuildKitContainerName)
+	output, err := cmd.Output()
+	if err != nil {
+		log.Debug().Err(err).Msg("BuildKit container not found or not running")
+		return ""
+	}
+
+	ip := strings.TrimSpace(string(output))
+	if ip == "" {
+		log.Debug().Msg("BuildKit container has no IP address")
+		return ""
+	}
+
+	// BuildKit listens on TCP port 1234 (configured in setupSharedBuildKit)
+	return fmt.Sprintf("tcp://%s:1234", ip)
 }


### PR DESCRIPTION
## Summary
- Hydra now queries helix-buildkit container IP from the main dockerd and passes it to dev containers as `BUILDKIT_HOST` env var
- docker-shim uses `BUILDKIT_HOST` directly to create the buildx builder instead of looking up the container
- Falls back to container lookup if `BUILDKIT_HOST` is not set (for backwards compatibility)

## Problem
Dev containers mount a per-session isolated Docker socket for user commands, but helix-buildkit runs on the sandbox's main dockerd. This caused docker-shim to fail finding helix-buildkit because it was looking on the wrong Docker daemon.

## Solution
Pass the BuildKit TCP endpoint directly to dev containers so docker-shim can create the buildx builder without container discovery.

## Test plan
- [ ] Build helix-ubuntu with the docker-shim changes
- [ ] Start a new Helix dev container session
- [ ] Verify `BUILDKIT_HOST` is set in the container environment
- [ ] Run `docker build` inside the dev container and verify it uses the shared cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)