### PR TITLE
security: stop exposing postgres port in dev compose

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -122,8 +122,8 @@ services:
   postgres:
     image: postgres:12.13-alpine
     restart: always
-    ports:
-     - 5432:5432  # SECURITY: Never expose postgres externally - attackers scan for this
+    # ports:
+    #  - 5432:5432  # SECURITY: Never expose postgres externally - attackers scan for this
     volumes:
       - ${POSTGRES_DATA:-helix-postgres-db}:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
## Summary
- Port 5432 was re-exposed in 4400df325 (quota api) which allows anyone with network access to connect with the default password and wipe the database
- This has already caused data loss on dev instances with public IPs
- Commenting the port back out (matching the original security intent)

## Test plan
- [x] Verified `docker port helix-postgres-1` returns empty after restart
- [x] Verified `ss -tlnp | grep 5432` shows no listener

🤖 Generated with [Claude Code](https://claude.com/claude-code)