### PR TITLE
fix(helm): GKE ingress annotation + bump chart to 0.3.37

### DIFF
--- a/charts/helix-controlplane/Chart.yaml
+++ b/charts/helix-controlplane/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.36
+version: 0.3.37
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/helix-controlplane/templates/ingress.yaml
+++ b/charts/helix-controlplane/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "helix-controlplane.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+{{- if .Values.ingress.className }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
   {{- end }}


### PR DESCRIPTION
## Summary
- Always add `kubernetes.io/ingress.class` annotation when `ingress.className` is set, not just for K8s < 1.18
- Bump chart version from 0.3.36 to 0.3.37 to publish the IngressClass template that was merged but never released

## Problem
On GKE 1.34+, the GCE ingress controller only watches for the `kubernetes.io/ingress.class: gce` **annotation** — it ignores the `ingressClassName: gce` spec field. Without the annotation, the controller never processes the Ingress, no load balancer is created, and the site is unreachable.

The ingress template previously only added the annotation for K8s < 1.18 (backward compatibility), but GKE needs it regardless of version.

Additionally, the `ingressclass.yaml` template (merged in e88e9c65c) was never published because the chart version was not bumped.

## Changes
- `charts/helix-controlplane/templates/ingress.yaml`: Remove K8s version check from annotation logic
- `charts/helix-controlplane/Chart.yaml`: Bump version to 0.3.37

## Test plan
- [x] Tested on GKE 1.34.3 cluster in europe-west2
- [x] After applying annotation, load balancer controller immediately picked up the Ingress
- [x] Load balancer created with static IP 34.54.226.145
- [x] Backend health check: HEALTHY
- [ ] Verify `helm template` produces both IngressClass and annotation for GKE config

🤖 Generated with [Claude Code](https://claude.com/claude-code)