### PR TITLE
fix: auto-approve all Claude Code tool calls in sandbox

### DIFF
--- a/Dockerfile.hyprland-helix
+++ b/Dockerfile.hyprland-helix
@@ -368,7 +368,7 @@ RUN mkdir -p /home/retro/.gemini && \
     echo '{"privacy":{"usageStatisticsEnabled":false},"general":{"disableAutoUpdate":true,"disableUpdateNag":true}}' > /home/retro/.gemini/settings.json
 
 RUN mkdir -p /home/retro/.claude && \
-    echo '{"env":{"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC":"1","DISABLE_TELEMETRY":"1","DISABLE_ERROR_REPORTING":"1","DISABLE_AUTOUPDATER":"1"}}' > /home/retro/.claude/settings.json
+    echo '{"permissions":{"allow":["*"]},"env":{"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC":"1","DISABLE_TELEMETRY":"1","DISABLE_ERROR_REPORTING":"1","DISABLE_AUTOUPDATER":"1"}}' > /home/retro/.claude/settings.json
 
 RUN mkdir -p /home/retro/.config/zed && \
     echo '{"telemetry":{"diagnostics":false,"metrics":false}}' > /home/retro/.config/zed/settings.json

--- a/Dockerfile.sway-helix
+++ b/Dockerfile.sway-helix
@@ -866,7 +866,7 @@ RUN mkdir -p /home/retro/.gemini && \
     echo '{"privacy":{"usageStatisticsEnabled":false},"general":{"disableAutoUpdate":true,"disableUpdateNag":true}}' > /home/retro/.gemini/settings.json
 
 RUN mkdir -p /home/retro/.claude && \
-    echo '{"env":{"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC":"1","DISABLE_TELEMETRY":"1","DISABLE_ERROR_REPORTING":"1","DISABLE_AUTOUPDATER":"1"}}' > /home/retro/.claude/settings.json
+    echo '{"permissions":{"allow":["*"]},"env":{"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC":"1","DISABLE_TELEMETRY":"1","DISABLE_ERROR_REPORTING":"1","DISABLE_AUTOUPDATER":"1"}}' > /home/retro/.claude/settings.json
 
 RUN mkdir -p /home/retro/.config/zed && \
     echo '{"telemetry":{"diagnostics":false,"metrics":false}}' > /home/retro/.config/zed/settings.json

--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -838,7 +838,7 @@ RUN mkdir -p /home/retro/.gemini && \
 RUN npm install -g @anthropic-ai/claude-code@latest
 
 RUN mkdir -p /home/retro/.claude && \
-    echo '{"env":{"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC":"1","DISABLE_TELEMETRY":"1","DISABLE_ERROR_REPORTING":"1","DISABLE_AUTOUPDATER":"1"}}' > /home/retro/.claude/settings.json
+    echo '{"permissions":{"allow":["*"]},"env":{"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC":"1","DISABLE_TELEMETRY":"1","DISABLE_ERROR_REPORTING":"1","DISABLE_AUTOUPDATER":"1"}}' > /home/retro/.claude/settings.json
 
 RUN mkdir -p /home/retro/.config/zed && \
     echo '{"theme":"Ayu Dark","telemetry":{"diagnostics":false,"metrics":false}}' > /home/retro/.config/zed/settings.json


### PR DESCRIPTION
## Summary

- Add `permissions.allow=["*"]` to Claude Code `settings.json` in all three desktop Dockerfiles (ubuntu, sway, hyprland)
- Claude Code runs inside a sandboxed container, so permission prompts just block autonomous operation with no security benefit

## Test plan

- [x] `build-ubuntu` passes
- [ ] Start a Claude Code ACP session and verify it doesn't prompt for tool permissions

Generated with [Claude Code](https://claude.com/claude-code)