### PR TITLE
fix: drop CLAUDE_CODE_OAUTH_TOKEN env var, rely on credentials file

### DIFF
--- a/api/cmd/settings-sync-daemon/main.go
+++ b/api/cmd/settings-sync-daemon/main.go
@@ -41,10 +41,6 @@ type SettingsDaemon struct {
 	// Whether user has a Claude subscription available for credential sync
 	claudeSubscriptionAvailable bool
 
-	// Cached Claude OAuth access token (from last syncClaudeCredentials call)
-	// Used to pass via CLAUDE_CODE_OAUTH_TOKEN env var to the ACP wrapper
-	claudeAccessToken string
-
 	// Current state
 	helixSettings map[string]interface{}
 	userOverrides map[string]interface{}
@@ -156,22 +152,15 @@ func (d *SettingsDaemon) generateAgentServerConfig() map[string]interface{} {
 			}
 			log.Printf("Using claude_code runtime (API key mode): base_url=%s", baseURL)
 		} else {
-			// Subscription mode: Claude Code uses OAuth credentials.
+			// Subscription mode: Claude Code reads OAuth credentials
+			// (including refresh token) from ~/.claude/.credentials.json,
+			// which is written by syncClaudeCredentials() before Zed starts.
 			// IMPORTANT: Hydra sets ANTHROPIC_BASE_URL on ALL containers, which
 			// leaks into Claude Code's process via env inheritance. We must
 			// explicitly override it to the real Anthropic API so Claude Code
 			// talks directly to Anthropic with OAuth credentials.
 			env["ANTHROPIC_BASE_URL"] = "https://api.anthropic.com"
-			// Pass the OAuth access token via env var. The ACP wrapper spawns
-			// Claude Code via the SDK, and the credential reader inside Claude
-			// Code is memoized — if the file read fails or returns null on the
-			// first call, it's cached forever. CLAUDE_CODE_OAUTH_TOKEN is
-			// checked FIRST (before file read), so it's the most reliable way
-			// to provide credentials.
-			if d.claudeAccessToken != "" {
-				env["CLAUDE_CODE_OAUTH_TOKEN"] = d.claudeAccessToken
-			}
-			log.Printf("Using claude_code runtime (subscription mode, token_set=%v)", d.claudeAccessToken != "")
+			log.Printf("Using claude_code runtime (subscription mode)")
 		}
 
 		// Only set env — no command/args. Zed uses its built-in
@@ -403,9 +392,6 @@ func (d *SettingsDaemon) syncClaudeCredentials() {
 		log.Printf("Failed to parse Claude credentials: %v", err)
 		return
 	}
-
-	// Cache the access token for use in env vars
-	d.claudeAccessToken = creds.AccessToken
 
 	// Build the credentials file in Claude's expected format
 	credFile := map[string]interface{}{


### PR DESCRIPTION
## Summary

- Remove `CLAUDE_CODE_OAUTH_TOKEN` env var from settings-sync-daemon agent server config
- Claude Code now reads credentials solely from `~/.claude/.credentials.json` (written by `syncClaudeCredentials()` before Zed settings)
- The credentials file contains both access and refresh tokens, enabling native token refresh

The env var only passed the access token with no refresh token, so Claude Code couldn't refresh expired tokens.

## Test plan

- [ ] Start a Claude Code ACP session with subscription mode
- [ ] Verify Claude Code authenticates via credentials file
- [ ] Verify token refresh works when access token expires

Generated with [Claude Code](https://claude.com/claude-code)