### PR TITLE
fix: gate Claude Code startup on credentials file existence

### DIFF
--- a/api/cmd/settings-sync-daemon/main.go
+++ b/api/cmd/settings-sync-daemon/main.go
@@ -164,6 +164,9 @@ func (d *SettingsDaemon) generateAgentServerConfig() map[string]interface{} {
 				log.Printf("Claude credentials file not yet available, deferring claude_code agent_servers: %v", err)
 				return nil
 			}
+			// Write marker so start-zed-core.sh knows to wait for credentials
+			// before launching Zed (belt-and-suspenders with the os.Stat gate above).
+			_ = os.WriteFile(ClaudeSubscriptionMarkerPath, []byte("1"), 0644)
 			// IMPORTANT: Hydra sets ANTHROPIC_BASE_URL on ALL containers, which
 			// leaks into Claude Code's process via env inheritance. We must
 			// explicitly override it to the real Anthropic API so Claude Code
@@ -353,7 +356,8 @@ func (d *SettingsDaemon) injectKoditAuth() {
 }
 
 const (
-	ClaudeCredentialsPath = "/home/retro/.claude/.credentials.json"
+	ClaudeCredentialsPath          = "/home/retro/.claude/.credentials.json"
+	ClaudeSubscriptionMarkerPath   = "/tmp/helix-claude-subscription-mode"
 )
 
 // syncClaudeCredentials fetches Claude OAuth credentials from the Helix API


### PR DESCRIPTION
## Summary

- Don't emit `agent_servers` config for Claude Code subscription mode until `~/.claude/.credentials.json` exists
- Claude Code's credential reader is memoized — if it starts before credentials are written, it caches null permanently
- If credentials aren't ready yet, `generateAgentServerConfig()` returns nil, so Zed won't start Claude Code
- On the next poll cycle, the file will exist and Claude Code starts with both access and refresh tokens

This is the proper fix for the race condition that the `CLAUDE_CODE_OAUTH_TOKEN` env var was papering over.

## Test plan

- [ ] Start a Claude Code ACP session with subscription mode
- [ ] Verify Claude Code doesn't start until credentials file is written
- [ ] Verify Claude Code authenticates and can refresh tokens

Generated with [Claude Code](https://claude.com/claude-code)