### PR TITLE
fix: git clone CWD issue in flock subshells (sandbox pipelines)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1738,11 +1738,9 @@ steps:
             echo 'Cloning Zed at commit $${ZED_COMMIT}...'
             cd /
             rm -rf /drone/src/cache/zed-source
-            mkdir -p /drone/src/cache/zed-source
-            cd /drone/src/cache/zed-source
-            git init
-            git fetch --depth 1 https://github.com/helixml/zed.git $${ZED_COMMIT}
-            git checkout FETCH_HEAD
+            git init /drone/src/cache/zed-source
+            git -C /drone/src/cache/zed-source fetch --depth 1 https://github.com/helixml/zed.git $${ZED_COMMIT}
+            git -C /drone/src/cache/zed-source checkout FETCH_HEAD
           fi
         "
       # Clone qwen-code only if not cached (flock prevents concurrent clone race)
@@ -1756,11 +1754,9 @@ steps:
             echo 'Cloning qwen-code at commit $${QWEN_COMMIT}...'
             cd /
             rm -rf /drone/src/cache/qwen-source
-            mkdir -p /drone/src/cache/qwen-source
-            cd /drone/src/cache/qwen-source
-            git init
-            git fetch --depth 1 https://github.com/helixml/qwen-code.git $${QWEN_COMMIT}
-            git checkout FETCH_HEAD
+            git init /drone/src/cache/qwen-source
+            git -C /drone/src/cache/qwen-source fetch --depth 1 https://github.com/helixml/qwen-code.git $${QWEN_COMMIT}
+            git -C /drone/src/cache/qwen-source checkout FETCH_HEAD
           fi
         "
       - echo "=== Dependency versions ==="
@@ -2149,11 +2145,9 @@ steps:
             echo 'Cloning Zed at commit $${ZED_COMMIT}...'
             cd /
             rm -rf /drone/src/cache/zed-source
-            mkdir -p /drone/src/cache/zed-source
-            cd /drone/src/cache/zed-source
-            git init
-            git fetch --depth 1 https://github.com/helixml/zed.git $${ZED_COMMIT}
-            git checkout FETCH_HEAD
+            git init /drone/src/cache/zed-source
+            git -C /drone/src/cache/zed-source fetch --depth 1 https://github.com/helixml/zed.git $${ZED_COMMIT}
+            git -C /drone/src/cache/zed-source checkout FETCH_HEAD
           fi
         "
       - |
@@ -2166,11 +2160,9 @@ steps:
             echo 'Cloning qwen-code at commit $${QWEN_COMMIT}...'
             cd /
             rm -rf /drone/src/cache/qwen-source
-            mkdir -p /drone/src/cache/qwen-source
-            cd /drone/src/cache/qwen-source
-            git init
-            git fetch --depth 1 https://github.com/helixml/qwen-code.git $${QWEN_COMMIT}
-            git checkout FETCH_HEAD
+            git init /drone/src/cache/qwen-source
+            git -C /drone/src/cache/qwen-source fetch --depth 1 https://github.com/helixml/qwen-code.git $${QWEN_COMMIT}
+            git -C /drone/src/cache/qwen-source checkout FETCH_HEAD
           fi
         "
       - echo "=== Dependency versions ==="


### PR DESCRIPTION
## Summary

- Replace `mkdir -p` + `cd` + `git init` with `git init <dir>` + `git -C <dir>` in all 4 flock subshells (Zed + qwen-code clone, amd64 + arm64 pipelines)
- The old pattern fails on Docker Desktop virtiofs (arm64 runner) — `git init` gets "unable to get current working directory" after `mkdir`+`cd` inside a flock subshell
- `git init <dir>` creates the directory and initializes the repo in one step; `git -C` operates without depending on the shell's CWD

Fixes build #18070 `clone-dependencies` failure on `build-sandbox-arm64`.

## Test plan

- [ ] Push triggers sandbox arm64 build — verify `clone-dependencies` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)