### PR TITLE
fix: poll license status on interval and add Discord links

### DIFF
--- a/for-mac/frontend/src/App.tsx
+++ b/for-mac/frontend/src/App.tsx
@@ -238,6 +238,10 @@ export function App() {
         const status = await GetVMStatus();
         setVmStatus(status);
 
+        // Poll license status so UI reacts to trial expiry mid-session
+        const license = await GetLicenseStatus();
+        setLicenseStatus(license);
+
         if (status.state === "running") {
           const [zfs, quota] = await Promise.all([
             GetZFSStats(),
@@ -402,6 +406,17 @@ export function App() {
         )}
 
         <div className="titlebar-spacer" />
+
+        <button
+          className="discord-link"
+          onDoubleClick={(e) => e.stopPropagation()}
+          onClick={() => BrowserOpenURL("https://discord.gg/VJftd844GE")}
+          title="Chat with us on Discord"
+        >
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+            <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 00-.041-.106 13.107 13.107 0 01-1.872-.892.077.077 0 01-.008-.128 10.2 10.2 0 00.372-.292.074.074 0 01.077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 01.078.01c.12.098.246.198.373.292a.077.077 0 01-.006.127 12.299 12.299 0 01-1.873.892.077.077 0 00-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.839 19.839 0 006.002-3.03.077.077 0 00.032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+          </svg>
+        </button>
 
         {licenseStatus.state === "trial_active" && (() => {
           const remaining = getTrialRemaining(licenseStatus.trial_ends_at);

--- a/for-mac/frontend/src/components/LicenseCard.tsx
+++ b/for-mac/frontend/src/components/LicenseCard.tsx
@@ -126,6 +126,17 @@ export function LicenseCard({ licenseStatus: ls, onLicenseUpdated, showToast }: 
             >
               Get a license at helix.ml
             </a>
+            <span className="license-links-sep">&middot;</span>
+            <a
+              href="#"
+              className="license-link"
+              onClick={(e) => {
+                e.preventDefault();
+                BrowserOpenURL('https://discord.gg/VJftd844GE');
+              }}
+            >
+              Chat to us on Discord
+            </a>
           </div>
           {licenseError && (
             <div className="error-msg" style={{ marginTop: 8 }}>
@@ -196,6 +207,18 @@ export function LicenseCard({ licenseStatus: ls, onLicenseUpdated, showToast }: 
               {startingTrial ? 'Starting trial...' : 'Start 24-Hour Free Trial'}
             </button>
           </div>
+        </div>
+        <div className="license-links" style={{ marginTop: 12 }}>
+          <a
+            href="#"
+            className="license-link"
+            onClick={(e) => {
+              e.preventDefault();
+              BrowserOpenURL('https://discord.gg/VJftd844GE');
+            }}
+          >
+            Chat to us on Discord
+          </a>
         </div>
         {licenseError && (
           <div className="error-msg" style={{ marginTop: 8 }}>

--- a/for-mac/frontend/src/style.css
+++ b/for-mac/frontend/src/style.css
@@ -184,6 +184,30 @@ body {
     font-size: 12px;
 }
 
+/* ---- Discord Link (titlebar) ---- */
+
+.discord-link {
+    --wails-draggable: no-drag;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all var(--transition-fast);
+    flex-shrink: 0;
+}
+
+.discord-link:hover {
+    border-color: rgba(88, 101, 242, 0.5);
+    background: rgba(88, 101, 242, 0.12);
+    color: #7289da;
+}
+
 /* ---- Trial Badge (titlebar) ---- */
 
 .trial-badge-titlebar {
@@ -925,6 +949,11 @@ body {
 .license-link:hover {
     color: var(--text-primary);
     text-decoration: underline;
+}
+
+.license-links-sep {
+    color: var(--text-faded);
+    margin: 0 6px;
 }
 
 /* ---- Settings Panel (slide-over) ---- */


### PR DESCRIPTION
## Summary
- **Poll license status every 3s** so the UI reacts when a trial expires mid-session (previously only fetched on init)
- **Add Discord link to titlebar** — always-visible icon button that opens the Helix Discord invite
- **Add "Chat to us on Discord" links** to the `trial_expired` and `no_trial` license card states

## Test plan
- [ ] Build frontend: `cd for-mac/frontend && npm run build`
- [ ] Start app, verify Discord icon appears in titlebar next to lozenges
- [ ] Verify clicking Discord icon opens https://discord.gg/VJftd844GE
- [ ] Verify trial expiry: license status updates in UI without app restart
- [ ] Verify Discord links appear in trial_expired and no_trial license cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)