### PR TITLE
docs: never squash merge PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@
 ### Git
 - **NEVER** `git checkout -- .`, `git reset --hard`, `git checkout -f` — destroys uncommitted work
 - **NEVER** `git stash drop/pop` — use `git stash apply` (keeps backup)
+- **NEVER** squash merge — always use regular merge commits (`gh pr merge --merge`)
 - **NEVER** push to main, amend commits on main, delete source files, delete `.git/index.lock`
 - **NEVER** `rm -rf *` or `rm -rf .*` in a git repo
 - **NEVER** `git checkout --orphan` then clear files — use a separate temp directory instead


### PR DESCRIPTION
## Summary
- Add rule to CLAUDE.md forbidding squash merges — always use regular merge commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)