### PR TITLE
fix: sign qemu-img with disable-library-validation entitlement

### DIFF
--- a/for-mac/scripts/build-helix-app.sh
+++ b/for-mac/scripts/build-helix-app.sh
@@ -385,6 +385,7 @@ codesign --force --sign - --timestamp=none \
     "$MACOS_DIR/qemu-system-aarch64" 2>/dev/null || true
 if [ -f "$MACOS_DIR/qemu-img" ]; then
     codesign --force --sign - --timestamp=none \
+        --entitlements "$APP_ENTITLEMENTS" \
         "$MACOS_DIR/qemu-img" 2>/dev/null || true
 fi
 

--- a/for-mac/scripts/sign-app.sh
+++ b/for-mac/scripts/sign-app.sh
@@ -138,8 +138,8 @@ fi
 
 QEMU_IMG="${MACOS_DIR}/qemu-img"
 if [ -f "$QEMU_IMG" ]; then
-    codesign "${SIGN_OPTS[@]}" "$QEMU_IMG"
-    log "  Signed qemu-img"
+    codesign "${SIGN_OPTS[@]}" --entitlements "$APP_ENTITLEMENTS" "$QEMU_IMG"
+    log "  Signed qemu-img (with app entitlements)"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary
qemu-img was re-signed after `--deep` without entitlements, stripping the `disable-library-validation` that `--deep` had applied. This caused macOS to prompt **"Helix would like to access data from other apps"** when qemu-img loaded bundled frameworks (zstd, glib).

Fix: sign qemu-img with `APP_ENTITLEMENTS` (which contains `disable-library-validation`) in both `build-helix-app.sh` and `sign-app.sh`.

## Root cause
`build-helix-app.sh` Step 7:
1. `--deep` signs everything with app entitlements (including qemu-img) 
2. qemu-system-aarch64 + dylib are re-signed with QEMU entitlements (hypervisor, JIT)
3. qemu-img was re-signed with **no entitlements** — stripping `disable-library-validation`

Without `disable-library-validation`, macOS treats loading bundled frameworks as accessing another app's data.

## Test plan
- [ ] Build app, launch on clean machine — no TCC prompt when VM boots
- [ ] Verify: `codesign -d --entitlements - Helix.app/Contents/MacOS/qemu-img` shows `disable-library-validation`

Generated with [Claude Code](https://claude.com/claude-code)