### PR TITLE
Fix onboarding dismiss loop for non-admin users

### DIFF
--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -642,10 +642,15 @@ export default function Onboarding() {
     }
   }, [taskPrompt, createdProjectId, createdAgentId, api, markComplete, snackbar, handleComplete])
 
-  const handleDismiss = useCallback(() => {
+  const handleDismiss = useCallback(async () => {
     account.dismissOnboarding()
+    try {
+      await api.getApiClient().v1UsersMeOnboardingCreate()
+    } catch (err) {
+      console.error('Failed to mark onboarding complete on dismiss:', err)
+    }
     router.navigateReplace('projects')
-  }, [router])
+  }, [api, router])
 
   const userName = account.user?.name?.split(' ')[0] || account.user?.email?.split('@')[0] || 'there'
 


### PR DESCRIPTION
## Summary
- Dismissing onboarding (X button) now calls the onboarding complete API, marking `onboarding_completed=true` server-side
- Previously, dismiss only set an in-memory ref which was insufficient to break the redirect loop for non-admin users with no orgs

## Test plan
- [ ] Register a new non-admin user (with `ADMIN_USER_IDS` not set to `all`)
- [ ] Verify onboarding screen appears
- [ ] Click the X (dismiss) button
- [ ] Verify you land on the projects page and are NOT redirected back to onboarding
- [ ] Refresh the page — should stay on projects, not return to onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)