### PR TITLE
fix: prevent provision-vm from racing release-backend for docker-compose.yaml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2491,8 +2491,9 @@ platform:
   os: darwin
   arch: arm64
 
-# Wait for ARM64 Docker images to be built before provisioning the VM
+# Wait for ARM64 Docker images and release artifacts before provisioning the VM
 depends_on:
+  - default
   - build-controlplane-arm64
   - build-haystack-arm64
   - build-typesense-arm64


### PR DESCRIPTION
## Summary

- **Added `default` pipeline dependency** to `build-macos-dmg` in `.drone.yml` so `provision-vm` waits for `release-backend` to upload `docker-compose.yaml` to the GitHub release before trying to download it.
- **Replaced remote curl fallback** in `provision-vm-light.sh` with a local `scp` from `$REPO_ROOT/docker-compose.yaml` — the Drone checkout always has the correct file for the tag, eliminating the network dependency entirely.

## Test plan

- [ ] Verify `build-macos-dmg` `depends_on` includes `default` in `.drone.yml`
- [ ] Tag a test release and confirm `provision-vm` completes without 404 errors on `docker-compose.yaml`
- [ ] Confirm the local-copy fallback applies `:latest` → `:${HELIX_VERSION}` substitutions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)