### PR TITLE
fix: use ${HELIX_VERSION:-latest} in docker-compose.yaml image tags

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -758,7 +758,6 @@ steps:
       - curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
       - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
       - apt-get update && apt-get install -y gh
-      - sed -i "s/:latest/:$DRONE_TAG/g" docker-compose.yaml
       - sed -i "s/\${HELIX_VERSION:-latest}/$DRONE_TAG/g" docker-compose.yaml
       - |
         if [ -n "$DRONE_TAG" ]; then

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,9 @@
-# Production docker-compose.yaml for HelixML :latest
+# Production docker-compose.yaml for HelixML
 # See https://docs.helixml.tech/helix/private-deployment/controlplane/
 
 services:
   api:
-    image: registry.helixml.tech/helix/controlplane:latest
+    image: registry.helixml.tech/helix/controlplane:${HELIX_VERSION:-latest}
     # If you want to run the API on a different port, set the
     # API_PORT environment variable and also updated env variables
     # connect to Helix
@@ -116,7 +116,7 @@ services:
       - UWSGI_WORKERS=4
       - UWSGI_THREADS=4
   typesense:
-    image: registry.helixml.tech/helix/typesense:latest
+    image: registry.helixml.tech/helix/typesense:${HELIX_VERSION:-latest}
     restart: always
     command: ["--data-dir", "/data", "--api-key", "typesense"]
     # ports:
@@ -132,7 +132,7 @@ services:
     #   - 7317:7317
   haystack:
     profiles: [haystack]
-    image: registry.helixml.tech/helix/haystack:latest
+    image: registry.helixml.tech/helix/haystack:${HELIX_VERSION:-latest}
     restart: always
     environment:
       - PGVECTOR_DSN=postgresql://postgres:${PGVECTOR_PASSWORD-pgvector}@pgvector:5432/postgres

--- a/for-mac/scripts/provision-vm-light.sh
+++ b/for-mac/scripts/provision-vm-light.sh
@@ -556,8 +556,7 @@ if ! step_done "run_install_sh"; then
         log "docker-compose.yaml is missing or empty — copying from local repo checkout..."
         scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
             -P "$SSH_PORT" "$REPO_ROOT/docker-compose.yaml" "${VM_USER}@localhost:/opt/HelixML/docker-compose.yaml"
-        # Apply version substitutions (same as release-backend does)
-        run_ssh "cd /opt/HelixML && sed -i 's/:latest/:${HELIX_VERSION}/g' docker-compose.yaml"
+        # Replace ${HELIX_VERSION:-latest} with the actual version (same as release-backend does)
         run_ssh "cd /opt/HelixML && sed -i 's/\${HELIX_VERSION:-latest}/${HELIX_VERSION}/g' docker-compose.yaml"
         COMPOSE_SIZE=$(run_ssh "wc -c < /opt/HelixML/docker-compose.yaml 2>/dev/null || echo 0")
         if [ "${COMPOSE_SIZE:-0}" -lt 100 ]; then


### PR DESCRIPTION
## Summary

- **docker-compose.yaml**: Changed controlplane, typesense, and haystack image tags from hardcoded `:latest` to `${HELIX_VERSION:-latest}` so that `HELIX_VERSION` in `.env` actually controls the version pulled
- **`.drone.yml`**: Removed redundant `sed -i "s/:latest/:$DRONE_TAG/g"` — the existing `${HELIX_VERSION:-latest}` substitution handles it
- **`provision-vm-light.sh`**: Same cleanup of redundant sed line

## Problem

Setting `HELIX_VERSION=x.y.z` in `.env` and running `docker compose pull` had no effect — images were always pulled as `:latest` because the compose file hardcoded that tag. This affected SaaS and self-hosted deployments that use `git pull` to get the compose file.

## Why this is safe

The CI `release-backend` step already has `sed -i "s/\${HELIX_VERSION:-latest}/$DRONE_TAG/g"` which matches the new pattern, so released artifacts (downloaded by `install.sh`) continue to have hardcoded version tags. Without `HELIX_VERSION` in `.env`, the default is `latest` — same as before.

## Test plan

- [ ] Verify `docker compose config` shows correct image tags when `HELIX_VERSION` is set in `.env`
- [ ] Verify `docker compose config` shows `:latest` when `HELIX_VERSION` is unset
- [ ] Next tagged release: confirm released `docker-compose.yaml` has hardcoded version tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)