### PR TITLE
fix: add EnvironmentFile to helix-drm-manager systemd unit in CI golden image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@
 - Be a skeptical staff engineer — no sycophancy, challenge bad assumptions, focus on facts
 - If uncertain, investigate rather than confirming beliefs
 - **Current year: 2026** — include "2026" in web searches for current info
+- If you find yourself adding hacks or workarounds, **stop** — take a step back, root cause the issue, understand the wider context, and fix it properly. Don't always take the path of least resistance — we need maintainable code.
 - See also: `.cursor/rules/*.mdc`
 
 ## FORBIDDEN ACTIONS

--- a/for-mac/scripts/provision-vm-light.sh
+++ b/for-mac/scripts/provision-vm-light.sh
@@ -519,6 +519,7 @@ Wants=systemd-udev-settle.service
 
 [Service]
 Type=simple
+EnvironmentFile=-/etc/helix-drm-manager.env
 ExecStart=/usr/local/bin/helix-drm-manager
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
## Summary
- Adds `EnvironmentFile=-/etc/helix-drm-manager.env` to the helix-drm-manager systemd unit in `provision-vm-light.sh` (used by CI golden image builds)
- Without this, the DRM manager ignores `/etc/helix-drm-manager.env` and uses the hardcoded default port (15937) instead of the configured port (41937), causing desktop containers to fail to connect to QEMU's frame export server

## Root cause
`provision-vm-light.sh` (CI) was missing the `EnvironmentFile` directive that `provision-vm.sh` (local dev) already had. The DRM manager binary defaults to port 15937, but the macOS app writes `QEMU_ADDR=10.0.2.2:41937` to `/etc/helix-drm-manager.env`. Without the systemd directive, that env file is never loaded.

## Test plan
- [ ] CI builds a new golden image with the fix
- [ ] Desktop session connects successfully (DRM manager uses port 41937)
