### PR TITLE
fix: define log() before use in create-dmg.sh

### DIFF
--- a/for-mac/scripts/create-dmg.sh
+++ b/for-mac/scripts/create-dmg.sh
@@ -51,7 +51,7 @@ while [[ $# -gt 0 ]]; do
         --build-dir) BUILD_DIR="$2"; shift 2 ;;
         --notarize) NOTARIZE=true; shift ;;
         --upload) UPLOAD=true; shift ;;
-        --skip-styling) log "WARNING: --skip-styling is deprecated (template approach doesn't need it)"; shift ;;
+        --skip-styling) echo "WARNING: --skip-styling is deprecated (template approach doesn't need it)"; shift ;;
         --rebuild-template) REBUILD_TEMPLATE=true; shift ;;
         --version) VERSION="$2"; shift 2 ;;
         --r2-bucket) R2_BUCKET="$2"; shift 2 ;;


### PR DESCRIPTION
## Summary
- The `--skip-styling` deprecation warning called `log()` before the function was defined (line 54 vs line 73), causing macOS to invoke `/usr/bin/log` instead and fail the CI DMG build.

## Test plan
- [ ] Verify `build-macos-dmg` pipeline passes on next tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)