### PR TITLE
fix: use clean EFI vars template instead of downloading from R2

### DIFF
--- a/for-mac/download.go
+++ b/for-mac/download.go
@@ -151,6 +151,14 @@ func (d *VMDownloader) CheckFilesExist() (allExist bool, missing []VMManifestFil
 
 	vmDir := filepath.Join(getHelixDataDir(), "vm", "helix-desktop")
 	for _, f := range d.manifest.Files {
+		// Skip efi_vars.fd — we always use the clean template from the app
+		// bundle instead. Downloaded EFI vars encode partition GUIDs from the
+		// build machine which may not match the disk image, causing UEFI to
+		// fail to find the bootloader.
+		if f.Name == "efi_vars.fd" {
+			continue
+		}
+
 		// For compressed files, check the decompressed output
 		checkName := f.Name
 		checkSize := f.Size
@@ -221,6 +229,11 @@ func (d *VMDownloader) DownloadAll(ctx interface{ EventsEmit(string, ...interfac
 	const maxFileRetries = 3
 
 	for _, f := range missing {
+		// Skip efi_vars.fd — use clean template from app bundle instead
+		if f.Name == "efi_vars.fd" {
+			continue
+		}
+
 		select {
 		case <-d.cancel:
 			return fmt.Errorf("download cancelled")


### PR DESCRIPTION
## Summary
- The `efi_vars.fd` uploaded to R2 during provisioning encodes UEFI boot entries with partition GUIDs from the build machine
- When users download this file, the GUIDs don't match their disk image, causing UEFI to fail finding the bootloader (`shimaa64.efi: Not Found`) and the VM hangs silently
- Fix: skip downloading `efi_vars.fd` from R2. The app already falls back to the clean `edk2-arm-vars.fd` template from the bundle, and UEFI auto-discovers the bootloader correctly

## Root cause
```
BdsDxe: failed to load Boot0004 "Ubuntu" from HD(15,GPT,8E4FD553-...)/\EFI\ubuntu\shimaa64.efi: Not Found
```
The EFI vars pointed to partition UUID `8E4FD553-...` but the actual EFI System Partition had UUID `632F3EBD-...`.

## Test plan
- [x] Verified fresh EFI vars boot the VM successfully (kernel output visible)
- [x] Verified `vm.go` fallback copies `edk2-arm-vars.fd` when `efi_vars.fd` is missing
- [ ] Delete `~/Library/Application Support/Helix/vm/helix-desktop` and relaunch app — VM should boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)