### PR TITLE
fix: show provider icons on onboarding

### DIFF
--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -806,7 +806,7 @@ export default function Onboarding() {
                     gap: 1.5,
                   }}
                 >
-                  <Box sx={{ width: 28, height: 28, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                  <Box sx={{ width: 28, height: 28, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, color: '#fff' }}>
                     <AnthropicLogo style={{ width: 24, height: 24 }} />
                   </Box>
                   <Box sx={{ flex: 1, minWidth: 0 }}>
@@ -877,9 +877,9 @@ export default function Onboarding() {
                         gap: 1.5,
                       }}
                     >
-                      <Box sx={{ width: 28, height: 28, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                      <Box sx={{ width: 28, height: 28, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, color: '#fff' }}>
                         {typeof Logo === 'string' ? (
-                          <img src={Logo} alt="" style={{ width: 24, height: 24 }} />
+                          <img src={Logo} alt="" style={{ width: 24, height: 24, background: '#fff', borderRadius: 4 }} />
                         ) : (
                           <Logo style={{ width: 24, height: 24 }} />
                         )}


### PR DESCRIPTION
## Summary
- Simple change to show the provider icons on onboarding
- SVG icons (OpenAI, Anthropic, Groq, etc.) were invisible on the dark background because they use `currentColor` which inherited a dark color
- PNG icons with transparent backgrounds (TogetherAI) showed as just a blue dot because the gray circles blended into the dark UI

## Test plan
- [ ] Open onboarding screen and verify all provider icons are visible
- [ ] Check TogetherAI shows 4-circle logo on white background
- [ ] Check SVG-based logos (OpenAI, Anthropic, Groq, AWS, Cerebras) render in white

🤖 Generated with [Claude Code](https://claude.com/claude-code)