### PR TITLE
fix: prevent Finder windows during CI DMG builds

### DIFF
--- a/for-mac/scripts/create-dmg.sh
+++ b/for-mac/scripts/create-dmg.sh
@@ -248,8 +248,8 @@ osascript <<APPLESCRIPT || log "WARNING: Finder styling failed (no GUI session?)
             set arrangement of viewOptions to not arranged
             set icon size of viewOptions to 128
             set background picture of viewOptions to file ".background:background.png"
-            set position of item "${APP_BUNDLE_NAME}.app" of container window to {490, 175}
-            set position of item "Applications" of container window to {170, 175}
+            set position of item "${APP_BUNDLE_NAME}.app" of container window to {170, 175}
+            set position of item "Applications" of container window to {490, 175}
             close
             open
             delay 2


### PR DESCRIPTION
## Summary
- Add `-nobrowse` to `hdiutil attach` calls so mounted volumes don't appear in Finder sidebar/desktop during CI builds
- Keep AppleScript styling (needed because template `.DS_Store` is often ignored by Finder after app bundle swap) but make it invisible: hide Finder before, close all windows after, restore visibility
- CI runner doubles as a dev machine, so Finder windows were popping up and disrupting work

## Test plan
- [ ] Run `./scripts/create-dmg.sh` on the CI/dev machine — verify no Finder windows appear
- [ ] Open the resulting DMG on a Mac — verify background image, icon positions, and window size are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)