### PR TITLE
Add Slack notifications for beta waitlist signups

### DIFF
--- a/api/pkg/notification/admin_alerts_test.go
+++ b/api/pkg/notification/admin_alerts_test.go
@@ -1,0 +1,86 @@
+package notification
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSlackSender records calls to SendMessage
+type mockSlackSender struct {
+	calls []slackCall
+	err   error // if set, SendMessage returns this error
+}
+
+type slackCall struct {
+	userEmail string
+	message   string
+}
+
+func (m *mockSlackSender) SendMessage(userEmail string, message string) error {
+	m.calls = append(m.calls, slackCall{userEmail: userEmail, message: message})
+	return m.err
+}
+
+func TestSendWaitlistSignupAlert_WithEmailAndName(t *testing.T) {
+	slack := &mockSlackSender{}
+	alerter := &AdminAlerter{slack: slack}
+
+	user := &types.User{
+		Email:    "test@example.com",
+		FullName: "Test User",
+	}
+
+	alerter.sendWaitlistSignupAlert(user)
+
+	require.Len(t, slack.calls, 1)
+	assert.Equal(t, "", slack.calls[0].userEmail)
+	assert.Contains(t, slack.calls[0].message, "test@example.com")
+	assert.Contains(t, slack.calls[0].message, "Test User")
+	assert.Contains(t, slack.calls[0].message, "waiting for approval")
+}
+
+func TestSendWaitlistSignupAlert_WithEmailOnly(t *testing.T) {
+	slack := &mockSlackSender{}
+	alerter := &AdminAlerter{slack: slack}
+
+	user := &types.User{
+		Email: "noname@example.com",
+	}
+
+	alerter.sendWaitlistSignupAlert(user)
+
+	require.Len(t, slack.calls, 1)
+	assert.Contains(t, slack.calls[0].message, "noname@example.com")
+	assert.NotContains(t, slack.calls[0].message, "()")
+	assert.Contains(t, slack.calls[0].message, "waiting for approval")
+}
+
+func TestSendWaitlistSignupAlert_NilSlack(t *testing.T) {
+	alerter := &AdminAlerter{slack: nil}
+
+	user := &types.User{
+		Email: "test@example.com",
+	}
+
+	// Should not panic
+	alerter.sendWaitlistSignupAlert(user)
+}
+
+func TestSendWaitlistSignupAlert_SlackError(t *testing.T) {
+	slack := &mockSlackSender{err: errors.New("webhook failed")}
+	alerter := &AdminAlerter{slack: slack}
+
+	user := &types.User{
+		Email:    "test@example.com",
+		FullName: "Test User",
+	}
+
+	// Should not panic — errors are logged, not returned
+	alerter.sendWaitlistSignupAlert(user)
+
+	require.Len(t, slack.calls, 1)
+}

--- a/api/pkg/server/auth.go
+++ b/api/pkg/server/auth.go
@@ -213,6 +213,11 @@ func (s *HelixAPIServer) register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Notify admins about new waitlisted signup
+	if createdUser.Waitlisted && s.adminAlerter != nil {
+		s.adminAlerter.SendWaitlistSignupAlert(createdUser)
+	}
+
 	token, err := s.authenticator.GenerateUserToken(ctx, createdUser)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate user token")


### PR DESCRIPTION
## Summary
- Send a Slack message to #helix-support when a new user signs up and is waitlisted
- Covers both direct registration and OIDC/SSO signup paths
- Reuses existing `JANITOR_SLACK_WEBHOOK_URL` — no new config needed
- No-ops silently when Slack webhook isn't configured

## Test plan
- [x] Unit tests for `SendWaitlistSignupAlert` (email+name, email-only, nil slack, error handling)
- [x] Unit tests for OIDC path (new waitlisted user triggers callback, existing user doesn't, non-waitlisted doesn't)
- [x] All existing tests pass (`go test ./api/pkg/notification/ ./api/pkg/auth/ ./api/pkg/server/`)
- [ ] Deploy to app.helix.ml, create test account, verify Slack message in #helix-support

🤖 Generated with [Claude Code](https://claude.com/claude-code)