### PR TITLE
fix: use FAT12 seed disk for cloud-init instead of ISO9660

### DIFF
--- a/for-mac/scripts/build-helix-app.sh
+++ b/for-mac/scripts/build-helix-app.sh
@@ -298,11 +298,10 @@ else
 MANIFEST_EOF
 fi
 
-# Bundle EFI vars (64MB — small enough to include in the app)
-if [ -f "${VM_DIR}/efi_vars.fd" ]; then
-    cp "${VM_DIR}/efi_vars.fd" "${VM_BUNDLE_DIR}/efi_vars.fd"
-    log "  Bundled EFI vars ($(du -h "${VM_BUNDLE_DIR}/efi_vars.fd" | awk '{print $1}'))"
-fi
+# NOTE: Do NOT bundle efi_vars.fd from provisioning. It encodes partition
+# GUIDs from the build machine that don't match user disk images, causing
+# UEFI to fail to find the bootloader. The app copies the clean
+# edk2-arm-vars.fd template at boot time instead.
 
 # =============================================================================
 # Step 6: Fix dylib paths (install_name_tool)

--- a/for-mac/scripts/provision-vm-light.sh
+++ b/for-mac/scripts/provision-vm-light.sh
@@ -838,6 +838,9 @@ if ! step_done "cleanup"; then
     run_ssh "sudo rm -rf /tmp/* /var/tmp/*" || true
     # Cloud-init logs and seed data
     run_ssh "sudo rm -rf /var/lib/cloud/instances /var/log/cloud-init*" || true
+    # Ensure UEFI fallback bootloader exists — clean EFI vars have no boot
+    # entries, so UEFI auto-discovers \EFI\BOOT\BOOTAA64.EFI on first boot.
+    run_ssh "sudo mkdir -p /boot/efi/EFI/BOOT && sudo cp /boot/efi/EFI/ubuntu/shimaa64.efi /boot/efi/EFI/BOOT/BOOTAA64.EFI" || true
     mark_step "cleanup"
 fi
 

--- a/for-mac/scripts/provision-vm.sh
+++ b/for-mac/scripts/provision-vm.sh
@@ -1017,6 +1017,9 @@ if ! step_done "cleanup"; then
     run_ssh "sudo rm -rf /tmp/* /var/tmp/*" || true
     # Cloud-init logs and seed data (no longer needed)
     run_ssh "sudo rm -rf /var/lib/cloud/instances /var/log/cloud-init*" || true
+    # Ensure UEFI fallback bootloader exists — clean EFI vars have no boot
+    # entries, so UEFI auto-discovers \EFI\BOOT\BOOTAA64.EFI on first boot.
+    run_ssh "sudo mkdir -p /boot/efi/EFI/BOOT && sudo cp /boot/efi/EFI/ubuntu/shimaa64.efi /boot/efi/EFI/BOOT/BOOTAA64.EFI" || true
     mark_step "cleanup"
 fi
 


### PR DESCRIPTION
## Summary
- **Root cause**: macOS app boot times out because cloud-init never injects SSH keys. `ensureCloudInitSeed()` created an ISO9660 image, but UEFI (EDK II) has no ISO9660 driver — cloud-init can't read the NoCloud datasource.
- Replace ISO creation with pure-Go FAT12 image builder with VFAT long filename support (`user-data`/`meta-data` exceed 8.3 limit)
- Stop bundling/copying `efi_vars.fd` from app bundle (encodes build machine partition GUIDs)
- Add UEFI fallback bootloader (`BOOTAA64.EFI`) during provisioning for clean EFI vars compatibility

## Test plan
- [ ] Build macOS app from this branch
- [ ] Delete existing `seed.iso` and `.seed-pubkey` from `~/Library/Application Support/Helix/vm/helix-desktop/`
- [ ] Start VM — verify cloud-init injects SSH key and boot completes within ~2 minutes
- [ ] Verify `file seed.iso` shows FAT12 (not ISO9660)
- [ ] Verify `user-data` and `meta-data` files are readable on the seed disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)