### PR TITLE
fix: stop bundling/copying efi_vars.fd from build machine

### DIFF
--- a/for-mac/scripts/build-helix-app.sh
+++ b/for-mac/scripts/build-helix-app.sh
@@ -298,11 +298,10 @@ else
 MANIFEST_EOF
 fi
 
-# Bundle EFI vars (64MB — small enough to include in the app)
-if [ -f "${VM_DIR}/efi_vars.fd" ]; then
-    cp "${VM_DIR}/efi_vars.fd" "${VM_BUNDLE_DIR}/efi_vars.fd"
-    log "  Bundled EFI vars ($(du -h "${VM_BUNDLE_DIR}/efi_vars.fd" | awk '{print $1}'))"
-fi
+# NOTE: Do NOT bundle efi_vars.fd from provisioning. It encodes partition
+# GUIDs from the build machine that don't match user disk images, causing
+# UEFI to fail to find the bootloader. The app copies the clean
+# edk2-arm-vars.fd template at boot time instead.
 
 # =============================================================================
 # Step 6: Fix dylib paths (install_name_tool)


### PR DESCRIPTION
## Summary
- Stop bundling `efi_vars.fd` in the `.app` during build (encodes build machine partition GUIDs)
- Stop copying `efi_vars.fd` from bundle to VM dir on fresh install and in dev mode
- The existing fallback in `runVM()` already copies the clean `edk2-arm-vars.fd` template when `efi_vars.fd` doesn't exist

## Test plan
- [ ] Fresh install: verify VM boots with clean EFI vars template (no bundled efi_vars.fd)
- [ ] Verify `efi_vars.fd` is NOT present in app bundle after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)