### PR TITLE
fix: use ephemeral EFI vars instead of persistent file

### DIFF
--- a/for-mac/README.md
+++ b/for-mac/README.md
@@ -103,7 +103,7 @@ That's it. Here's what each step does:
 
 **`--upload`** pushes the DMG and VM images to Cloudflare R2:
 - `s3://helix-releases/desktop/{version}/Helix-for-Mac.dmg`
-- `s3://helix-releases/vm/{version}/disk.qcow2`, `zfs-data.qcow2`, `efi_vars.fd`
+- `s3://helix-releases/vm/{version}/disk.qcow2`, `zfs-data.qcow2`
 - `s3://helix-releases/vm/{version}/manifest.json`
 - `s3://helix-releases/desktop/latest.json`
 
@@ -205,9 +205,8 @@ helix-for-mac.app/
         edk2-arm-vars.fd
       vulkan/icd.d/                         # Vulkan driver config
         kosmickrisp_mesa_icd.json
-      vm/                                   # VM manifest + EFI vars
+      vm/                                   # VM manifest
         vm-manifest.json                    # CDN download manifest (SHA256, sizes, URLs)
-        efi_vars.fd                         # EFI variables (64MB)
       NOTICES.md                            # Open-source license notices
 ```
 
@@ -246,7 +245,6 @@ go run virgl_probe.go        # Probe virglrenderer availability
 | `download.go` | VM image CDN downloader with HTTP Range resume + SHA256 |
 | `license.go` | 24h trial + ECDSA license validation (offline) |
 | `settings.go` | Persistent settings (~/Library/Application Support/Helix/settings.json) |
-| `utm.go` | UTM integration (dev mode fallback) |
 | `encoder.go` | Software video encoder |
 | `vsock.go` | Virtio-vsock for host-guest frame transfer |
 | `scripts/build-helix-app.sh` | Build .app with embedded QEMU + VM manifest |

--- a/for-mac/download.go
+++ b/for-mac/download.go
@@ -151,14 +151,6 @@ func (d *VMDownloader) CheckFilesExist() (allExist bool, missing []VMManifestFil
 
 	vmDir := filepath.Join(getHelixDataDir(), "vm", "helix-desktop")
 	for _, f := range d.manifest.Files {
-		// Skip efi_vars.fd — we always use the clean template from the app
-		// bundle instead. Downloaded EFI vars encode partition GUIDs from the
-		// build machine which may not match the disk image, causing UEFI to
-		// fail to find the bootloader.
-		if f.Name == "efi_vars.fd" {
-			continue
-		}
-
 		// For compressed files, check the decompressed output
 		checkName := f.Name
 		checkSize := f.Size
@@ -229,11 +221,6 @@ func (d *VMDownloader) DownloadAll(ctx interface{ EventsEmit(string, ...interfac
 	const maxFileRetries = 3
 
 	for _, f := range missing {
-		// Skip efi_vars.fd — use clean template from app bundle instead
-		if f.Name == "efi_vars.fd" {
-			continue
-		}
-
 		select {
 		case <-d.cancel:
 			return fmt.Errorf("download cancelled")

--- a/for-mac/scripts/build-helix-app.sh
+++ b/for-mac/scripts/build-helix-app.sh
@@ -298,11 +298,6 @@ else
 MANIFEST_EOF
 fi
 
-# NOTE: Do NOT bundle efi_vars.fd from provisioning. It encodes partition
-# GUIDs from the build machine that don't match user disk images, causing
-# UEFI to fail to find the bootloader. The app copies the clean
-# edk2-arm-vars.fd template at boot time instead.
-
 # =============================================================================
 # Step 6: Fix dylib paths (install_name_tool)
 # =============================================================================

--- a/for-mac/scripts/create-dmg.sh
+++ b/for-mac/scripts/create-dmg.sh
@@ -352,10 +352,6 @@ if [ "$UPLOAD" = true ]; then
         log "  WARNING: zfs-data.qcow2 not found at ${VM_DIR}, skipping"
     fi
 
-    if [ -f "${VM_DIR}/efi_vars.fd" ]; then
-        upload_file "${VM_DIR}/efi_vars.fd" "vm/${VERSION}/efi_vars.fd"
-    fi
-
     # 3. Upload manifest from app bundle
     MANIFEST="${APP_BUNDLE}/Contents/Resources/vm/vm-manifest.json"
     if [ -f "$MANIFEST" ]; then

--- a/for-mac/scripts/provision-vm-light.sh
+++ b/for-mac/scripts/provision-vm-light.sh
@@ -125,7 +125,7 @@ boot_provisioning_vm() {
         -smp "$CPUS"
         -m "$MEMORY_MB"
         -drive if=pflash,format=raw,file="$EFI_CODE",readonly=on
-        -drive if=pflash,format=raw,file="${VM_DIR}/efi_vars.fd"
+        -drive if=pflash,format=raw,snapshot=on,file="$EFI_VARS_TEMPLATE"
         -drive file="${VM_DIR}/disk.qcow2",format=qcow2,if=virtio
         -device virtio-net-pci,netdev=net0
         -netdev user,id=net0,hostfwd=tcp::${SSH_PORT}-:22
@@ -188,9 +188,6 @@ if ! step_done "disk"; then
     cp "${VM_DIR}/${UBUNTU_IMG}" "${VM_DIR}/disk.qcow2.tmp"
     qemu-img resize "${VM_DIR}/disk.qcow2.tmp" "$DISK_SIZE"
     mv "${VM_DIR}/disk.qcow2.tmp" "${VM_DIR}/disk.qcow2"
-
-    # Copy EFI vars template
-    cp "$EFI_VARS_TEMPLATE" "${VM_DIR}/efi_vars.fd"
 
     mark_step "disk"
 fi

--- a/for-mac/vm-manifest.json
+++ b/for-mac/vm-manifest.json
@@ -9,7 +9,6 @@
       "compression": "zstd",
       "decompressed_name": "disk.qcow2",
       "decompressed_size": 19857211392
-    },
-    {"name": "efi_vars.fd", "size": 67108864, "sha256": "b0e3fdf5b4db9db59432830daa7a36896aa817d7ddc0351fbb47d4db56b1de4d"}
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Use QEMU `snapshot=on` for the EFI vars pflash drive, eliminating persistent `efi_vars.fd` entirely
- Remove all `efi_vars.fd` management: bundling, uploading, downloading, copying, deleting
- Remove UTM bundle creation step from provisioning (no longer used)
- Provisioning scripts also use `snapshot=on` for ephemeral EFI vars

## Problem

We've had a series of bugs around stale EFI vars:
- #1671 — build-machine partition GUIDs baked into `efi_vars.fd` don't match after upgrades
- #1696 — old `efi_vars.fd` persists across disk upgrades, boot entries reference wrong GUIDs
- #1698 — stop bundling/copying `efi_vars.fd` from build machine

Each fix added more conditional logic. The root cause is that **persistent UEFI NVRAM is unnecessary for an appliance VM**.

## Fix

QEMU's `snapshot=on` flag creates an in-memory overlay — UEFI gets a clean NVRAM every boot, writes are discarded on shutdown. Point it directly at the `edk2-arm-vars.fd` template:

```
-drive if=pflash,format=raw,snapshot=on,file=edk2-arm-vars.fd
```

GRUB's config lives on the filesystem (`grub.cfg`), not in NVRAM. UEFI auto-discovers `EFI/BOOT/BOOTAA64.EFI` via the standard fallback path every time. No state to go stale.

### Removed across 10 files (-320 lines):

- `efi_vars.fd` from `vm-manifest.json` (no longer downloaded)
- Skip-efi_vars logic from `download.go` and `updater.go`
- File copy/create/delete logic from `vm.go`
- Upload of `efi_vars.fd` to R2 in `upload-vm-images.sh` and `create-dmg.sh`
- "Do not bundle" comment from `build-helix-app.sh`
- `efi_vars.fd` creation in `provision-vm.sh` and `provision-vm-light.sh`
- Entire UTM bundle step (~200 lines of plist generation) from `provision-vm.sh`
- Stale `utm.go` reference from `README.md`

## Test plan

- [ ] Fresh install: VM boots without `efi_vars.fd` on disk
- [ ] Upgrade from previous version: stale files cleaned up, VM boots fine
- [ ] Reboot: VM boots cleanly each time (no UEFI shell, no systemd-boot assertion)
- [ ] Provisioning: `provision-vm.sh` and `provision-vm-light.sh` work with ephemeral EFI vars
- [ ] WARNING: NOT tested yet — need to verify on a real VM boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
