### PR TITLE
Fix silent Slack webhook errors

### DIFF
--- a/api/pkg/janitor/utils.go
+++ b/api/pkg/janitor/utils.go
@@ -3,6 +3,7 @@ package janitor
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 )
 
@@ -37,7 +38,7 @@ func sendSlackNotification(webhookURL string, message string) error {
 		return err
 	}
 	if buf.String() != "ok" {
-		return err
+		return fmt.Errorf("slack webhook returned %d: %s", resp.StatusCode, buf.String())
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- `sendSlackNotification` was silently swallowing Slack API errors (returning nil instead of an error)
- When Slack returns a non-"ok" response (e.g. `no_service` for a dead webhook), the function now returns a proper error with the HTTP status code and response body
- This was masking a dead webhook URL on SaaS — the API logs showed "notification sent" but nothing actually reached Slack

## Test plan
- [x] `go build ./api/pkg/janitor/`
- [ ] Deploy and verify error logs appear when webhook URL is invalid
- [ ] Update `JANITOR_SLACK_WEBHOOK_URL` with a new webhook and verify notifications arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)