### PR TITLE
fix: transparent docker wrapper for shared BuildKit

### DIFF
--- a/Dockerfile.sway-helix
+++ b/Dockerfile.sway-helix
@@ -732,9 +732,11 @@ RUN chmod 755 /etc/cont-init.d/15-setup-gpu-permissions.sh
 ADD desktop/shared/17-start-dockerd.sh /etc/cont-init.d/17-start-dockerd.sh
 RUN chmod 755 /etc/cont-init.d/17-start-dockerd.sh
 
-# Workspace README
+# Workspace README and docker wrapper for transparent shared BuildKit
 RUN mkdir -p /opt/helix
 ADD WORKDIR_README.md /opt/helix/WORKDIR_README.md
+ADD desktop/shared/docker-buildx-wrapper.sh /opt/helix/docker-buildx-wrapper.sh
+RUN chmod 755 /opt/helix/docker-buildx-wrapper.sh
 
 # ====================================================================
 # GStreamer zero-copy plugin and CUDA libs (amd64 only)

--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -838,9 +838,11 @@ ENV CHROME_DEVTOOLS_MCP_HEADLESS=true \
 ADD desktop/shared/17-start-dockerd.sh /etc/cont-init.d/17-start-dockerd.sh
 RUN chmod 755 /etc/cont-init.d/17-start-dockerd.sh
 
-# Workspace README
+# Workspace README and docker wrapper for transparent shared BuildKit
 RUN mkdir -p /opt/helix
 ADD WORKDIR_README.md /opt/helix/WORKDIR_README.md
+ADD desktop/shared/docker-buildx-wrapper.sh /opt/helix/docker-buildx-wrapper.sh
+RUN chmod 755 /opt/helix/docker-buildx-wrapper.sh
 
 # ====================================================================
 # GStreamer zero-copy plugin and CUDA libs (amd64 only)

--- a/design/2026-02-21-shared-buildkit-cache.md
+++ b/design/2026-02-21-shared-buildkit-cache.md
@@ -1,0 +1,38 @@
+# Shared BuildKit Cache Across Spectask Sessions
+
+**Date**: 2026-02-21
+**PR**: #1705 (core fix), follow-up commit (transparent user wrapper)
+
+## Problem
+
+Docker build cache was not shared between spectask sessions. Each desktop container ran its own local BuildKit instance, so the cache was lost when the container was destroyed. Building helix-in-helix (which compiles Rust/Zed from source) took ~43 minutes every time.
+
+## Root Cause
+
+The sandbox already ran a shared BuildKit container (`helix-buildkit`) with a persistent volume, and desktop containers configured a `helix-shared` remote buildx builder pointing to it. However, **Docker 29.x's `docker build` ignores the default buildx builder** and uses the local daemon's built-in BuildKit. Only `docker buildx build` or the `BUILDX_BUILDER` env var forces the remote builder.
+
+## Fix
+
+Two-part solution:
+
+1. **`BUILDX_BUILDER=helix-shared` set globally** in `/etc/environment`, `/etc/profile.d/`, and `~/.bashrc` so all `docker build` commands route through the shared BuildKit. (`17-start-dockerd.sh`, `stack`)
+
+2. **Transparent `docker` wrapper** at `/usr/local/bin/docker` that adds `--load` when a remote builder is active and `-t` is used. Without this, `docker build -t foo .` builds remotely but doesn't load the image into the local daemon. (`docker-buildx-wrapper.sh`)
+
+## Results
+
+| Phase | Cold Cache | Hot Cache | Speedup |
+|-------|-----------|-----------|---------|
+| `./stack build` | ~3 min | ~15 sec | ~12x |
+| `./stack build-zed release` | ~11 min | ~45 sec | ~15x |
+| `./stack build-sandbox` | ~29 min | ~20 min* | ~1.5x |
+| **Total startup** | **~43 min** | **~21 min** | **~2x** |
+
+*`build-sandbox` is mostly limited by Docker image layer push/pull, not compilation.
+
+## Files Changed
+
+- `stack` — `docker_build_load()` helper replaces raw `docker build` calls
+- `desktop/shared/17-start-dockerd.sh` — sets `BUILDX_BUILDER` globally, installs wrapper
+- `desktop/shared/docker-buildx-wrapper.sh` — transparent `--load` injection for users
+- `Dockerfile.ubuntu-helix`, `Dockerfile.sway-helix` — bundle the wrapper script

--- a/desktop/shared/17-start-dockerd.sh
+++ b/desktop/shared/17-start-dockerd.sh
@@ -167,6 +167,15 @@ export BUILDX_BUILDER=helix-shared
 PROFILE_EOF
     echo "[dockerd] Set BUILDX_BUILDER=helix-shared globally (via /etc/environment and /etc/profile.d/)"
 
+    # Install docker wrapper that transparently adds --load for remote builders.
+    # This makes user 'docker build -t foo .' work seamlessly — the image builds
+    # on the shared BuildKit and automatically loads into the local daemon.
+    if [ -f /opt/helix/docker-buildx-wrapper.sh ]; then
+        cp /opt/helix/docker-buildx-wrapper.sh /usr/local/bin/docker
+        chmod +x /usr/local/bin/docker
+        echo "[dockerd] Installed docker wrapper at /usr/local/bin/docker (auto --load for remote builders)"
+    fi
+
     # Fix ownership of .docker directory for retro user
     # (buildx commands above run as root and create ~/.docker owned by root)
     if id -u retro >/dev/null 2>&1; then

--- a/desktop/shared/docker-buildx-wrapper.sh
+++ b/desktop/shared/docker-buildx-wrapper.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Docker wrapper that transparently adds --load for remote buildx builders.
+#
+# Problem: When BUILDX_BUILDER points to a remote builder, 'docker build -t'
+# builds the image remotely but doesn't load it into the local daemon.
+# Users expect 'docker build -t foo .' to make 'foo' available locally.
+#
+# Solution: This wrapper detects 'docker build' with -t and no explicit output,
+# and adds --load automatically when a remote builder is active.
+#
+# Installed at /usr/local/bin/docker (ahead of /usr/bin/docker in PATH).
+
+REAL_DOCKER=/usr/bin/docker
+
+# Fast path: only intercept 'build' subcommand
+if [ "${1:-}" != "build" ] || [ -z "${BUILDX_BUILDER:-}" ]; then
+    exec "$REAL_DOCKER" "$@"
+fi
+
+# Check if builder is remote (cache result for performance)
+if [ -z "${_DOCKER_WRAPPER_IS_REMOTE:-}" ]; then
+    _DOCKER_WRAPPER_IS_REMOTE=$("$REAL_DOCKER" buildx inspect "$BUILDX_BUILDER" 2>/dev/null | grep -cm1 "^Driver:.*remote" || echo "0")
+    export _DOCKER_WRAPPER_IS_REMOTE
+fi
+
+if [ "$_DOCKER_WRAPPER_IS_REMOTE" != "1" ]; then
+    exec "$REAL_DOCKER" "$@"
+fi
+
+# Parse args to check for -t and --output/--load/--push
+has_tag=false
+has_output=false
+for arg in "$@"; do
+    case "$arg" in
+        -t|--tag) has_tag=true ;;
+        --output|--output=*|--load|--push) has_output=true ;;
+    esac
+done
+
+if $has_tag && ! $has_output; then
+    exec "$REAL_DOCKER" "$@" --load
+else
+    exec "$REAL_DOCKER" "$@"
+fi


### PR DESCRIPTION
## Summary
- Adds a transparent `docker` wrapper script that auto-adds `--load` when building with a remote BuildKit builder, so `docker build -t foo .` works seamlessly for users
- Installs the wrapper at `/usr/local/bin/docker` during desktop container init (`17-start-dockerd.sh`)
- Bundles the wrapper in both ubuntu and sway desktop images
- Adds design doc for the shared BuildKit cache architecture

Follow-up to #1705 which set `BUILDX_BUILDER=helix-shared` globally.

## Test plan
- [ ] Build desktop image with `./stack build-ubuntu`
- [ ] Start a spectask, run `docker build -t test .` inside it
- [ ] Verify build uses shared BuildKit (check `helix-buildkit` container CPU)
- [ ] Verify image is available locally after build (`docker images test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)