### PR TITLE
fix: write build-sandbox timing markers to separate log file

### DIFF
--- a/stack
+++ b/stack
@@ -1026,7 +1026,8 @@ function build-desktop() {
   fi
 
   local DESKTOP_BUILD_START=$SECONDS
-  echo "[⏱️  desktop-${DESKTOP_NAME}] Starting build..."
+  _dt_elapsed() { local msg="[⏱️  desktop-${DESKTOP_NAME} +$((SECONDS - DESKTOP_BUILD_START))s] $*"; echo "$msg"; [ -n "${BUILD_SANDBOX_TIMING_LOG:-}" ] && echo "$msg" >> "$BUILD_SANDBOX_TIMING_LOG"; }
+  _dt_elapsed "Starting build..."
 
   # Build Zed if binary doesn't exist
   if [ ! -f "./zed-build/zed" ]; then
@@ -1041,7 +1042,7 @@ function build-desktop() {
 
   # Build qwen-code using containerized build (avoids husky/prepare script issues)
   # This is used by ALL desktop images (sway, zorin, ubuntu, xfce)
-  echo "[⏱️  desktop-${DESKTOP_NAME} +$((SECONDS - DESKTOP_BUILD_START))s] Building qwen-code..."
+  _dt_elapsed "Building qwen-code..."
   if ! build-qwen-code; then
     echo "❌ Failed to build qwen-code"
     exit 1
@@ -1054,7 +1055,7 @@ function build-desktop() {
   # Use --provenance=false to get stable image IDs when layers are cached
   # (BuildKit attestation manifests change each build, causing ID changes)
   # Docker automatically detects Go code changes via COPY layers
-  echo "[⏱️  desktop-${DESKTOP_NAME} +$((SECONDS - DESKTOP_BUILD_START))s] 🔨 Building ${IMAGE_NAME}:latest..."
+  _dt_elapsed "🔨 Building ${IMAGE_NAME}:latest..."
 
   docker_build_load --provenance=false -f "$DOCKERFILE" \
     -t "${IMAGE_NAME}:latest" \
@@ -1073,7 +1074,7 @@ function build-desktop() {
   # Use first 6 chars as tag - avoids Docker showing just hash when tag matches image ID
   local IMAGE_TAG="${IMAGE_HASH_FULL:0:6}"
 
-  echo "[⏱️  desktop-${DESKTOP_NAME} +$((SECONDS - DESKTOP_BUILD_START))s] ✅ ${DESKTOP_NAME} container built successfully"
+  _dt_elapsed "✅ ${DESKTOP_NAME} container built successfully"
   echo "📦 Image hash: ${IMAGE_HASH_FULL} (tag: ${IMAGE_TAG})"
 
   # Always write version file (even if image unchanged, fixes stale version files)
@@ -1177,6 +1178,7 @@ function transfer-desktop-to-sandbox() {
 
   # Use local registry for efficient layer-based transfer
   local TRANSFER_START=$SECONDS
+  _tx_elapsed() { local msg="[⏱️  transfer-${DESKTOP_NAME} +$((SECONDS - TRANSFER_START))s] $*"; echo "$msg"; [ -n "${BUILD_SANDBOX_TIMING_LOG:-}" ] && echo "$msg" >> "$BUILD_SANDBOX_TIMING_LOG"; }
   local REGISTRY_TAG="localhost:5000/${IMAGE_NAME}:${IMAGE_TAG}"
   local SANDBOX_REGISTRY_TAG="registry:5000/${IMAGE_NAME}:${IMAGE_TAG}"
 
@@ -1188,14 +1190,14 @@ function transfer-desktop-to-sandbox() {
   echo "🏷️  Tagging ${IMAGE_NAME}:latest as ${REGISTRY_TAG}..."
   docker tag "${IMAGE_NAME}:latest" "$REGISTRY_TAG"
 
-  echo "[⏱️  transfer-${DESKTOP_NAME} +$((SECONDS - TRANSFER_START))s] 📤 Pushing to local registry..."
+  _tx_elapsed "📤 Pushing to local registry..."
   if ! docker push "$REGISTRY_TAG" 2>&1 | grep -v "^$"; then
     echo "❌ Failed to push to local registry"
     return 1
   fi
 
   # Pull from registry inside sandbox
-  echo "[⏱️  transfer-${DESKTOP_NAME} +$((SECONDS - TRANSFER_START))s] 📥 Sandbox pulling from registry..."
+  _tx_elapsed "📥 Sandbox pulling from registry..."
   if ! sandbox_docker exec "$SANDBOX_CONTAINER_NAME" docker pull "$SANDBOX_REGISTRY_TAG" 2>&1 | grep -v "^$"; then
     echo "❌ Failed to pull from registry inside sandbox"
     return 1
@@ -1209,7 +1211,7 @@ function transfer-desktop-to-sandbox() {
   # (layers are shared, so this just removes the tag, not the data)
   sandbox_docker exec "$SANDBOX_CONTAINER_NAME" docker rmi "$SANDBOX_REGISTRY_TAG" 2>/dev/null || true
 
-  echo "[⏱️  transfer-${DESKTOP_NAME} +$((SECONDS - TRANSFER_START))s] ✅ ${IMAGE_NAME}:${IMAGE_TAG} transferred via registry"
+  _tx_elapsed "✅ ${IMAGE_NAME}:${IMAGE_TAG} transferred via registry"
 
   # Version files are bind-mounted from host (updated by build-desktop)
   if [ -f "sandbox-images/${IMAGE_NAME}.version" ]; then
@@ -1363,7 +1365,9 @@ function verify-desktop-build() {
 
 function build-sandbox() {
   local BUILD_START_TIME=$SECONDS
-  _bs_elapsed() { echo "[⏱️  +$((SECONDS - BUILD_START_TIME))s]"; }
+  export BUILD_SANDBOX_TIMING_LOG="/tmp/build-sandbox-timing-$(date +%s).log"
+  _bs_elapsed() { local msg="[⏱️  +$((SECONDS - BUILD_START_TIME))s] $*"; echo "$msg"; echo "$msg" >> "$BUILD_SANDBOX_TIMING_LOG"; }
+  echo "Timing log: $BUILD_SANDBOX_TIMING_LOG"
 
   echo "📦 Building Helix Sandbox container (DinD + Hydra + RevDial)..."
   echo ""
@@ -1393,7 +1397,7 @@ function build-sandbox() {
 
   # Step 1: Build Zed if needed (required for helix-sway and helix-zorin)
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "$(_bs_elapsed) 📝 [1/6] Checking Zed binary..."
+  _bs_elapsed "📝 [1/6] Checking Zed binary..."
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   if [ ! -f "./zed-build/zed" ]; then
     echo "Building Zed in release mode..."
@@ -1411,7 +1415,7 @@ function build-sandbox() {
   local STEP_NUM=2
   for desktop in "${PRODUCTION_DESKTOPS[@]}"; do
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo "$(_bs_elapsed) 📦 Building production desktop: helix-${desktop}..."
+    _bs_elapsed "📦 Building production desktop: helix-${desktop}..."
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     if ! SKIP_DESKTOP_TRANSFER=1 build-desktop "$desktop"; then
       echo "❌ Failed to build helix-${desktop}"
@@ -1443,7 +1447,7 @@ function build-sandbox() {
 
   # Build sandbox container
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "$(_bs_elapsed) 📦 Building helix-sandbox container..."
+  _bs_elapsed "📦 Building helix-sandbox container..."
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
   docker_build_load -f Dockerfile.sandbox -t helix-sandbox:latest .
@@ -1458,7 +1462,7 @@ function build-sandbox() {
 
   # Step 6: Start sandbox and transfer desktop images
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  echo "$(_bs_elapsed) 📝 [6/6] Starting sandbox and transferring desktop images..."
+  _bs_elapsed "📝 [6/6] Starting sandbox and transferring desktop images..."
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
   # Load sandbox service name from .env
@@ -1488,11 +1492,11 @@ function build-sandbox() {
 
   # Transfer all production desktop images to sandbox
   echo ""
-  echo "$(_bs_elapsed) 📦 Transferring desktop images to sandbox..."
+  _bs_elapsed "📦 Transferring desktop images to sandbox..."
   for desktop in "${PRODUCTION_DESKTOPS[@]}"; do
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo "$(_bs_elapsed) 📤 Transferring helix-${desktop} to sandbox..."
+    _bs_elapsed "📤 Transferring helix-${desktop} to sandbox..."
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     if ! transfer-desktop-to-sandbox "$desktop"; then
       echo "⚠️  Failed to transfer helix-${desktop} - continuing anyway"
@@ -1536,7 +1540,10 @@ function build-sandbox() {
   echo "  • 70-start-hydra.sh - starts Hydra daemon"
   echo "  • startup-app.sh - keeps container running"
   echo ""
-  echo "$(_bs_elapsed) 🎉 Sandbox build completed successfully! (total: $((SECONDS - BUILD_START_TIME))s)"
+  _bs_elapsed "🎉 Sandbox build completed successfully! (total: $((SECONDS - BUILD_START_TIME))s)"
+  echo ""
+  echo "📊 Timing log saved to: $BUILD_SANDBOX_TIMING_LOG"
+  cat "$BUILD_SANDBOX_TIMING_LOG"
 }
 
 


### PR DESCRIPTION
## Summary
- Timing markers from `build-sandbox` were lost because `docker build --load 2>&1 | tee` causes block buffering, swallowing interleaved echo statements
- All timing functions (`_bs_elapsed`, `_dt_elapsed`, `_tx_elapsed`) now write to a dedicated log file (`$BUILD_SANDBOX_TIMING_LOG`) in addition to stdout
- Full timing summary is printed at the end of the build
- Sub-step timers in `build-desktop()` and `transfer-desktop-to-sandbox()` also log to the same file when called from `build-sandbox`

## Test plan
- [ ] Run `./stack build-sandbox` and verify timing log is created and printed at end
- [ ] Verify timing markers appear in the log file even when docker build output is buffered

🤖 Generated with [Claude Code](https://claude.com/claude-code)