### PR TITLE
fix: use docker buildx build to honor default builder

### DIFF
--- a/desktop/shared/docker-buildx-wrapper.sh
+++ b/desktop/shared/docker-buildx-wrapper.sh
@@ -1,44 +1,56 @@
 #!/bin/bash
-# Docker wrapper that transparently adds --load for remote buildx builders.
+# Docker wrapper that transparently routes 'docker build' through buildx
+# and adds --load for remote builders.
 #
-# Problem: When BUILDX_BUILDER points to a remote builder, 'docker build -t'
-# builds the image remotely but doesn't load it into the local daemon.
-# Users expect 'docker build -t foo .' to make 'foo' available locally.
+# Problem: Docker 29.x's 'docker build' ignores the default buildx builder
+# and always uses the local daemon's built-in BuildKit. When a shared remote
+# BuildKit is configured as the default builder, 'docker build' bypasses it
+# entirely — defeating cross-session cache sharing.
 #
-# Solution: This wrapper detects 'docker build' with -t and no explicit output,
-# and adds --load automatically when a remote builder is active.
+# Solution: This wrapper rewrites 'docker build' to 'docker buildx build'
+# (which honors the default builder) and adds --load when a remote builder
+# is active so images are loaded into the local daemon.
 #
 # Installed at /usr/local/bin/docker (ahead of /usr/bin/docker in PATH).
 
 REAL_DOCKER=/usr/bin/docker
 
 # Fast path: only intercept 'build' subcommand
-if [ "${1:-}" != "build" ] || [ -z "${BUILDX_BUILDER:-}" ]; then
+if [ "${1:-}" != "build" ]; then
     exec "$REAL_DOCKER" "$@"
 fi
 
-# Check if builder is remote (cache result for performance)
-if [ -z "${_DOCKER_WRAPPER_IS_REMOTE:-}" ]; then
-    _DOCKER_WRAPPER_IS_REMOTE=$("$REAL_DOCKER" buildx inspect "$BUILDX_BUILDER" 2>/dev/null | grep -cm1 "^Driver:.*remote" || echo "0")
-    export _DOCKER_WRAPPER_IS_REMOTE
+# Determine the active builder's driver (remote vs docker)
+# Check explicit BUILDX_BUILDER first, then fall back to default builder
+if [ -z "${_DOCKER_WRAPPER_DRIVER:-}" ]; then
+    if [ -n "${BUILDX_BUILDER:-}" ]; then
+        _DOCKER_WRAPPER_DRIVER=$("$REAL_DOCKER" buildx inspect "$BUILDX_BUILDER" 2>/dev/null | grep -m1 "^Driver:" | awk '{print $2}')
+    else
+        # Inspect the default builder (marked with * in buildx ls)
+        _DOCKER_WRAPPER_DRIVER=$("$REAL_DOCKER" buildx inspect 2>/dev/null | grep -m1 "^Driver:" | awk '{print $2}')
+    fi
+    _DOCKER_WRAPPER_DRIVER="${_DOCKER_WRAPPER_DRIVER:-docker}"
+    export _DOCKER_WRAPPER_DRIVER
 fi
 
-if [ "$_DOCKER_WRAPPER_IS_REMOTE" != "1" ]; then
-    exec "$REAL_DOCKER" "$@"
+# Remove 'build' from args — we'll use 'buildx build' instead
+shift
+
+if [ "$_DOCKER_WRAPPER_DRIVER" = "remote" ]; then
+    # Remote builder: check if --load is needed
+    has_tag=false
+    has_output=false
+    for arg in "$@"; do
+        case "$arg" in
+            -t|--tag) has_tag=true ;;
+            --output|--output=*|--load|--push) has_output=true ;;
+        esac
+    done
+
+    if $has_tag && ! $has_output; then
+        exec "$REAL_DOCKER" buildx build "$@" --load
+    fi
 fi
 
-# Parse args to check for -t and --output/--load/--push
-has_tag=false
-has_output=false
-for arg in "$@"; do
-    case "$arg" in
-        -t|--tag) has_tag=true ;;
-        --output|--output=*|--load|--push) has_output=true ;;
-    esac
-done
-
-if $has_tag && ! $has_output; then
-    exec "$REAL_DOCKER" "$@" --load
-else
-    exec "$REAL_DOCKER" "$@"
-fi
+# Use 'buildx build' to honor the default builder
+exec "$REAL_DOCKER" buildx build "$@"

--- a/stack
+++ b/stack
@@ -13,33 +13,43 @@ export STOP_PGVECTOR=${STOP_PGVECTOR:=""}
 export WIPE_SLOTS=${WIPE_SLOTS:="0"}
 export COMPOSE_PROFILES=${COMPOSE_PROFILES:=""}
 
-# When BUILDX_BUILDER is set to a remote builder (e.g., helix-shared), plain
-# 'docker build -t' doesn't load images into the local daemon automatically.
-# This helper detects a remote builder and adds --load so images are available
-# locally for 'docker compose up', 'docker run', etc.
+# Uses 'docker buildx build' instead of plain 'docker build' to ensure
+# the default buildx builder is honored. Docker 29.x's 'docker build' ignores
+# the default buildx builder and always uses the local daemon's built-in
+# BuildKit. Only 'docker buildx build' routes through the configured builder.
+#
+# Adds --load when a remote builder is active so images are available locally
+# for 'docker compose up', 'docker run', etc.
 function docker_build_load() {
   local args=("$@")
-  if [ -n "${BUILDX_BUILDER:-}" ]; then
-    # Check if the builder uses the remote driver (needs --load for local images)
-    local driver
-    driver=$(docker buildx inspect "$BUILDX_BUILDER" 2>/dev/null | grep -m1 "^Driver:" | awk '{print $2}')
-    if [ "$driver" = "remote" ]; then
-      # Only add --load if the command uses -t (tags an image) and doesn't
-      # already have --output or --load or --push
-      local has_tag=false
-      local has_output=false
-      for arg in "${args[@]}"; do
-        case "$arg" in
-          -t) has_tag=true ;;
-          --output|--output=*|--load|--push) has_output=true ;;
-        esac
-      done
-      if $has_tag && ! $has_output; then
-        args+=("--load")
-      fi
+
+  # Check if the active builder (explicit or default) uses the remote driver
+  local builder="${BUILDX_BUILDER:-}"
+  local driver
+  if [ -n "$builder" ]; then
+    driver=$(docker buildx inspect "$builder" 2>/dev/null | grep -m1 "^Driver:" | awk '{print $2}')
+  else
+    # No explicit builder — check the default builder (marked with * in buildx ls)
+    driver=$(docker buildx inspect 2>/dev/null | grep -m1 "^Driver:" | awk '{print $2}')
+  fi
+
+  if [ "${driver:-}" = "remote" ]; then
+    # Remote builder: add --load so the image is loaded into the local daemon
+    local has_tag=false
+    local has_output=false
+    for arg in "${args[@]}"; do
+      case "$arg" in
+        -t) has_tag=true ;;
+        --output|--output=*|--load|--push) has_output=true ;;
+      esac
+    done
+    if $has_tag && ! $has_output; then
+      args+=("--load")
     fi
   fi
-  docker build "${args[@]}"
+
+  # Use 'docker buildx build' to honor the default builder
+  docker buildx build "${args[@]}"
 }
 
 # Desktop categories for build-sandbox


### PR DESCRIPTION
## Summary
- Docker 29.x's `docker build` ignores the default buildx builder and always uses the local daemon's built-in BuildKit
- In helix-in-helix spectasks, `BUILDX_BUILDER` was set in `/etc/profile.d/` and `~/.bashrc` (login/interactive shells only), but the startup script runs via the container init system which doesn't source those files
- This meant ALL docker builds in the startup script (`./stack build-zed`, `./stack build-sandbox`) used the per-container local BuildKit instead of the shared remote one — defeating cross-session cache sharing entirely
- **Fix**: Changed `docker_build_load()` and the docker wrapper to:
  1. Use `docker buildx build` instead of `docker build` (which honors the default builder)
  2. Auto-detect the builder driver via `docker buildx inspect` instead of requiring `BUILDX_BUILDER` env var

## Test plan
- [ ] Start a helix-in-helix spectask, verify startup builds use shared BuildKit
- [ ] Start a second spectask, verify docker builds are cached from the first
- [ ] Verify `docker build -t foo .` still works in interactive shells

🤖 Generated with [Claude Code](https://claude.com/claude-code)