### PR TITLE
feat: smart --load skips image export when unchanged

### DIFF
--- a/desktop/shared/docker-buildx-wrapper.sh
+++ b/desktop/shared/docker-buildx-wrapper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Docker wrapper that transparently routes 'docker build' through buildx
-# and adds --load for remote builders.
+# and uses smart --load for remote builders (skips export when image unchanged).
 #
 # Problem: Docker 29.x's 'docker build' ignores the default buildx builder
 # and always uses the local daemon's built-in BuildKit. When a shared remote
@@ -8,8 +8,10 @@
 # entirely — defeating cross-session cache sharing.
 #
 # Solution: This wrapper rewrites 'docker build' to 'docker buildx build'
-# (which honors the default builder) and adds --load when a remote builder
-# is active so images are loaded into the local daemon.
+# (which honors the default builder) and uses smart --load for remote builders:
+# builds without --load first (~5s) to check if the image changed, then only
+# does the expensive --load (~655s for 7.7GB images) when something actually
+# changed. This makes cached rebuilds near-instant.
 #
 # Installed at /usr/local/bin/docker (ahead of /usr/bin/docker in PATH).
 
@@ -36,21 +38,81 @@ fi
 # Remove 'build' from args — we'll use 'buildx build' instead
 shift
 
-if [ "$_DOCKER_WRAPPER_DRIVER" = "remote" ]; then
-    # Remote builder: check if --load is needed
-    has_tag=false
-    has_output=false
-    for arg in "$@"; do
-        case "$arg" in
-            -t|--tag) has_tag=true ;;
-            --output|--output=*|--load|--push) has_output=true ;;
-        esac
-    done
-
-    if $has_tag && ! $has_output; then
-        exec "$REAL_DOCKER" buildx build "$@" --load
-    fi
+if [ "$_DOCKER_WRAPPER_DRIVER" != "remote" ]; then
+    # Non-remote builder: just use buildx build directly
+    exec "$REAL_DOCKER" buildx build "$@"
 fi
 
-# Use 'buildx build' to honor the default builder
-exec "$REAL_DOCKER" buildx build "$@"
+# Remote builder: extract tags and check for explicit output flags
+has_tag=false
+has_output=false
+tags=()
+next_is_tag=false
+for arg in "$@"; do
+    if $next_is_tag; then
+        tags+=("$arg")
+        next_is_tag=false
+        continue
+    fi
+    case "$arg" in
+        -t|--tag) has_tag=true; next_is_tag=true ;;
+        --output|--output=*|--load|--push) has_output=true ;;
+    esac
+done
+
+# If user specified explicit output or no tag, pass through
+if $has_output || ! $has_tag; then
+    exec "$REAL_DOCKER" buildx build "$@"
+fi
+
+# Check if all tagged images exist in local daemon
+all_local=true
+for tag in "${tags[@]}"; do
+    if [ -z "$("$REAL_DOCKER" images -q "$tag" 2>/dev/null)" ]; then
+        all_local=false
+        break
+    fi
+done
+
+if ! $all_local; then
+    # Image not in local daemon — must build with --load
+    exec "$REAL_DOCKER" buildx build "$@" --load
+fi
+
+# Image exists locally. Quick build WITHOUT --load to check if anything changed.
+# BuildKit runs the full build (all cached = ~5s) and writes the image digest
+# to iidfile WITHOUT the expensive export step (~655s for large images).
+iid_file=$(mktemp /tmp/buildx-iid-XXXXXX)
+"$REAL_DOCKER" buildx build "$@" --iidfile "$iid_file"
+rc=$?
+if [ $rc -ne 0 ]; then
+    rm -f "$iid_file"
+    exit $rc
+fi
+
+new_id=""
+[ -f "$iid_file" ] && new_id=$(cat "$iid_file")
+rm -f "$iid_file"
+
+if [ -z "$new_id" ]; then
+    # Couldn't determine digest — fall back to --load
+    exec "$REAL_DOCKER" buildx build "$@" --load
+fi
+
+# Compare buildx digest with local daemon's image ID
+need_load=false
+for tag in "${tags[@]}"; do
+    local_id=$("$REAL_DOCKER" images --no-trunc -q "$tag" 2>/dev/null | head -1)
+    if [ "$new_id" != "$local_id" ]; then
+        need_load=true
+        break
+    fi
+done
+
+if $need_load; then
+    echo "[docker-wrapper] Image changed (new: ${new_id:0:19}), loading into daemon..."
+    exec "$REAL_DOCKER" buildx build "$@" --load
+fi
+
+echo "[docker-wrapper] Image unchanged (${new_id:0:19}), skipping load"
+exit 0

--- a/stack
+++ b/stack
@@ -18,8 +18,12 @@ export COMPOSE_PROFILES=${COMPOSE_PROFILES:=""}
 # the default buildx builder and always uses the local daemon's built-in
 # BuildKit. Only 'docker buildx build' routes through the configured builder.
 #
-# Adds --load when a remote builder is active so images are available locally
-# for 'docker compose up', 'docker run', etc.
+# For remote builders: uses smart --load that skips the expensive image export
+# when the image hasn't changed. The export (--load) transfers the entire image
+# as a tarball from the remote builder to the local daemon — ~655s for a 7.7GB
+# image even when fully cached. By building without --load first (~5s) and
+# comparing the image digest with the local daemon's copy, we skip the export
+# when nothing changed.
 function docker_build_load() {
   local args=("$@")
 
@@ -33,30 +37,98 @@ function docker_build_load() {
     driver=$(docker buildx inspect 2>/dev/null | grep -m1 "^Driver:" | awk '{print $2}')
   fi
 
-  if [ "${driver:-}" = "remote" ]; then
-    # Remote builder: add --load so the image is loaded into the local daemon
-    local has_tag=false
-    local has_output=false
-    for arg in "${args[@]}"; do
-      case "$arg" in
-        -t) has_tag=true ;;
-        --output|--output=*|--load|--push) has_output=true ;;
-      esac
-    done
-    if $has_tag && ! $has_output; then
-      args+=("--load")
-    fi
+  if [ "${driver:-}" != "remote" ]; then
+    # Non-remote builder: buildx build directly (no --load needed)
+    docker buildx build "${args[@]}"
+    return $?
   fi
 
-  # Use 'docker buildx build' to honor the default builder
-  docker buildx build "${args[@]}"
+  # Remote builder: extract tags and check for explicit output flags
+  local has_tag=false
+  local has_output=false
+  local tags=()
+  local next_is_tag=false
+  for arg in "${args[@]}"; do
+    if $next_is_tag; then
+      tags+=("$arg")
+      next_is_tag=false
+      continue
+    fi
+    case "$arg" in
+      -t|--tag) has_tag=true; next_is_tag=true ;;
+      --output|--output=*|--load|--push) has_output=true ;;
+    esac
+  done
+
+  # If user specified explicit output or no tag, pass through
+  if $has_output || ! $has_tag; then
+    docker buildx build "${args[@]}"
+    return $?
+  fi
+
+  # Check if all tagged images exist in local daemon
+  local all_local=true
+  for tag in "${tags[@]}"; do
+    if [ -z "$(docker images -q "$tag" 2>/dev/null)" ]; then
+      all_local=false
+      break
+    fi
+  done
+
+  if ! $all_local; then
+    # Image not in local daemon — must build with --load
+    docker buildx build "${args[@]}" --load
+    return $?
+  fi
+
+  # Image exists locally. Quick build WITHOUT --load to check if anything changed.
+  # This runs the full build in BuildKit (all cached = ~5s) and writes the image
+  # digest to iidfile WITHOUT the expensive export step.
+  local iid_file
+  iid_file=$(mktemp /tmp/buildx-iid-XXXXXX)
+  docker buildx build "${args[@]}" --iidfile "$iid_file"
+  local rc=$?
+  if [ $rc -ne 0 ]; then
+    rm -f "$iid_file"
+    return $rc
+  fi
+
+  local new_id=""
+  [ -f "$iid_file" ] && new_id=$(cat "$iid_file")
+  rm -f "$iid_file"
+
+  if [ -z "$new_id" ]; then
+    # Couldn't determine digest — fall back to --load
+    docker buildx build "${args[@]}" --load
+    return $?
+  fi
+
+  # Compare buildx digest with local daemon's image ID
+  local need_load=false
+  for tag in "${tags[@]}"; do
+    local local_id
+    local_id=$(docker images --no-trunc -q "$tag" 2>/dev/null | head -1)
+    if [ "$new_id" != "$local_id" ]; then
+      need_load=true
+      break
+    fi
+  done
+
+  if $need_load; then
+    echo "[build] Image changed (new: ${new_id:0:19}), loading into daemon..."
+    docker buildx build "${args[@]}" --load
+    return $?
+  fi
+
+  echo "[build] Image unchanged (${new_id:0:19}), skipping load"
+  return 0
 }
 
 # Desktop categories for build-sandbox
 # Production desktops are always built; experimental require opt-in via EXPERIMENTAL_DESKTOPS
 # Note: Using arrays because IFS is set to '\n\t' (no space splitting)
-PRODUCTION_DESKTOPS=(sway ubuntu)
-AVAILABLE_EXPERIMENTAL_DESKTOPS=(zorin xfce kde)
+PRODUCTION_DESKTOPS=(ubuntu)
+AVAILABLE_EXPERIMENTAL_DESKTOPS=(sway zorin xfce kde)
 # EXPERIMENTAL_DESKTOPS can be set as space-separated string, converted to array below
 
 # Configure host networking for Docker-in-Docker support


### PR DESCRIPTION
## Summary
- **Smart `--load`**: Both `docker_build_load()` and the docker wrapper now build WITHOUT `--load` first (~5s for cached builds), compare the image digest via `--iidfile` with the local daemon's image ID, and skip `--load` entirely when the image hasn't changed. Saves ~655s per 7.7GB image on cached rebuilds.
- **Sway → experimental**: Moved sway from `PRODUCTION_DESKTOPS` to `AVAILABLE_EXPERIMENTAL_DESKTOPS`. Spectasks only use ubuntu, saving build+transfer of the 5.2GB sway image.
- **Design doc**: Updated with smart --load architecture, timing data, and remaining bottleneck analysis.

## How smart --load works
1. Is the builder remote? NO → just `docker buildx build` (no --load needed)
2. Does local daemon already have the image? NO → build with `--load` (first build)
3. Build WITHOUT `--load`, WITH `--iidfile` (~5s for cached builds)
4. Compare iidfile digest with `docker images --no-trunc -q`:
   - **MATCH**: skip `--load` → "Image unchanged, skipping load"
   - **DIFFER**: build with `--load` → "Image changed, loading into daemon..."

## Test plan
- [ ] Verify smart --load works on host (local docker driver — should pass through without --load)
- [ ] Build ubuntu desktop image with updated wrapper
- [ ] Deploy to running spectask container and verify smart --load works with remote builder
- [ ] Start fresh spectask to measure end-to-end startup time
- [ ] Verify image changes still trigger --load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)