### PR TITLE
fix: smart --load uses --output type=image for digest check

### DIFF
--- a/stack
+++ b/stack
@@ -81,12 +81,14 @@ function docker_build_load() {
     return $?
   fi
 
-  # Image exists locally. Quick build WITHOUT --load to check if anything changed.
-  # This runs the full build in BuildKit (all cached = ~5s) and writes the image
-  # digest to iidfile WITHOUT the expensive export step.
+  # Image exists locally. Quick build with --output type=image to check if anything
+  # changed. This exports the manifest to BuildKit's internal store (fast, no tarball
+  # transfer) and writes the config digest to iidfile. --provenance=false ensures
+  # the iidfile contains the config digest (not a manifest list), matching what
+  # 'docker images --no-trunc -q' returns for loaded images.
   local iid_file
   iid_file=$(mktemp /tmp/buildx-iid-XXXXXX)
-  docker buildx build "${args[@]}" --iidfile "$iid_file"
+  docker buildx build "${args[@]}" --output type=image --provenance=false --iidfile "$iid_file"
   local rc=$?
   if [ $rc -ne 0 ]; then
     rm -f "$iid_file"


### PR DESCRIPTION
## Summary
- Fixes the smart `--load` optimization that was broken because `--iidfile` is empty with remote BuildKit when no output mode is specified
- Uses `--output type=image --provenance=false` for the check build: exports manifest to BuildKit's internal store (~0s, no tarball transfer), returns config digest that matches `docker images --no-trunc -q`
- Tested in spectask container: unchanged images skip `--load` in ~0.4s, changed images correctly detected and loaded

## Details
Remote BuildKit (the `helix-shared` builder) doesn't compute the image config digest unless it exports something. Without an output mode, `--iidfile` is written but empty, causing the smart --load to always fall back to `--load`.

The fix uses `--output type=image` which exports the manifest to BuildKit's internal image store (fast, ~0s for cached builds, no tarball transfer) and `--provenance=false` to ensure `--iidfile` returns the config digest (not a manifest list digest).

## Test plan
- [x] Verified in spectask container: `docker build -t test:v1 ...` on second run shows "Image unchanged, skipping load"
- [x] Verified changed Dockerfile correctly detects change: "Image changed, loading into daemon..."
- [x] Image is correctly available in local daemon after both paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)