### PR TITLE
fix: timing helpers fail with set -e outside build-sandbox

### DIFF
--- a/stack
+++ b/stack
@@ -1110,7 +1110,7 @@ function build-desktop() {
   fi
 
   local DESKTOP_BUILD_START=$SECONDS
-  _dt_elapsed() { local msg="[⏱️  desktop-${DESKTOP_NAME} +$((SECONDS - DESKTOP_BUILD_START))s] $*"; echo "$msg"; [ -n "${BUILD_SANDBOX_TIMING_LOG:-}" ] && echo "$msg" >> "$BUILD_SANDBOX_TIMING_LOG"; }
+  _dt_elapsed() { local msg="[⏱️  desktop-${DESKTOP_NAME} +$((SECONDS - DESKTOP_BUILD_START))s] $*"; echo "$msg"; [ -n "${BUILD_SANDBOX_TIMING_LOG:-}" ] && echo "$msg" >> "$BUILD_SANDBOX_TIMING_LOG" || true; }
   _dt_elapsed "Starting build..."
 
   # Build Zed if binary doesn't exist
@@ -1262,7 +1262,7 @@ function transfer-desktop-to-sandbox() {
 
   # Use local registry for efficient layer-based transfer
   local TRANSFER_START=$SECONDS
-  _tx_elapsed() { local msg="[⏱️  transfer-${DESKTOP_NAME} +$((SECONDS - TRANSFER_START))s] $*"; echo "$msg"; [ -n "${BUILD_SANDBOX_TIMING_LOG:-}" ] && echo "$msg" >> "$BUILD_SANDBOX_TIMING_LOG"; }
+  _tx_elapsed() { local msg="[⏱️  transfer-${DESKTOP_NAME} +$((SECONDS - TRANSFER_START))s] $*"; echo "$msg"; [ -n "${BUILD_SANDBOX_TIMING_LOG:-}" ] && echo "$msg" >> "$BUILD_SANDBOX_TIMING_LOG" || true; }
   local REGISTRY_TAG="localhost:5000/${IMAGE_NAME}:${IMAGE_TAG}"
   local SANDBOX_REGISTRY_TAG="registry:5000/${IMAGE_NAME}:${IMAGE_TAG}"
 


### PR DESCRIPTION
## Summary
- `_dt_elapsed` and `_tx_elapsed` timing helpers use `[ -n "$VAR" ] && echo ...` which returns exit code 1 when `BUILD_SANDBOX_TIMING_LOG` is empty
- With `set -e` (errexit), this kills the script when `build-desktop`/`build-ubuntu` is called directly (not from `build-sandbox` which sets the variable)
- Fix: add `|| true` to prevent the `&&` short-circuit from propagating exit 1

## Test plan
- [x] `./stack build-ubuntu` no longer silently exits after "Starting build..."
- [x] `./stack build-sandbox` still works (timing log is written correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)