### PR TITLE
docs: update blog post with final benchmark numbers

### DIFF
--- a/design/2026-02-21-smart-load-blog.md
+++ b/design/2026-02-21-smart-load-blog.md
@@ -19,6 +19,8 @@ Host Machine
 └── sandbox-nvidia (Docker-in-Docker host)
     ├── helix-buildkit (shared BuildKit instance)
     │   └── buildkit_state volume (persistent cache)
+    ├── helix-registry (shared Docker registry)
+    │   └── registry_data volume (layer-level transfer cache)
     ├── agent-session-A (desktop container)
     │   └── local dockerd → builds route to shared BuildKit
     ├── agent-session-B (desktop container)
@@ -32,24 +34,24 @@ The key insight: when Agent B builds the same Dockerfile that Agent A already bu
 
 ## The `--load` Bottleneck
 
-Shared BuildKit got us halfway there. Builds were fast (5 seconds for fully cached images), but there was a catch: **the image still needed to be loaded into the local Docker daemon**.
+Shared BuildKit got us halfway there. Builds were fast (~0.5 seconds for fully cached images), but there was a catch: **the image still needed to be loaded into the local Docker daemon**.
 
 When using a remote BuildKit builder, `docker buildx build --load` exports the built image as a tarball, streams it over gRPC to the client, and imports it into the local daemon. This happens even when every layer is cached and the image hasn't changed at all.
 
-For a 7.7GB image (our desktop base image with GNOME, IDE, and dev tools):
+For a 7.73GB image (our desktop base image with GNOME, IDE, and dev tools):
 
 | Operation | Time |
 |-----------|------|
-| `docker buildx build` (cached, no --load) | 5s |
-| `docker buildx build --load` (cached) | **655s** |
+| `docker buildx build` (cached, no --load) | 0.5s |
+| `docker buildx build --load` (cached) | **~10s** |
 
-That's 11 minutes to transfer an image that didn't change. The `--load` flag serializes the entire image into a Docker-format tarball, streams it over gRPC, and the receiving daemon deserializes and imports every layer — even layers it already has. There's no layer-level deduplication in the tarball transfer path. It's essentially `docker save | docker load` over a network connection.
+That's 10 seconds to transfer an image that didn't change. The `--load` flag serializes the entire image into a Docker-format tarball, streams it over gRPC, and the receiving daemon deserializes and imports every layer — even layers it already has. There's no layer-level deduplication in the tarball transfer path.
 
-Why is it so slow? The tarball format is sequential and uncompressed-then-recompressed. BuildKit exports each layer as a tar archive, concatenates them into the image tarball, streams it over gRPC (with flow control overhead), and the daemon re-extracts each layer to its content store. At ~12 MB/s effective throughput for 7.7GB, that's the 655 seconds.
+This adds up: building Helix involves 6+ images. Even with a hot BuildKit cache, the `--load` overhead per image turns a sub-second build into a 10-second wait, and the full stack build takes ~23 seconds of mostly `--load` transfers.
 
 ## Smart `--load`
 
-The fix is conceptually simple: **don't load the image if it hasn't changed**.
+The first optimization: **don't load the image if it hasn't changed**.
 
 ```
 docker build -t myapp:latest .
@@ -61,7 +63,7 @@ docker build -t myapp:latest .
       2. Compare iidfile digest with local daemon's image ID
          → docker images --no-trunc -q myapp:latest
       3. Match? → Skip --load. "Image unchanged, skipping load"
-         Differ? → Run full --load. "Image changed, loading..."
+         Differ? → Use registry push/pull for layer-level transfer
 ```
 
 A transparent wrapper at `/usr/local/bin/docker` intercepts both `docker build` and `docker buildx build`, applying this logic automatically. No code changes needed in build scripts, Makefiles, or CI pipelines.
@@ -80,9 +82,35 @@ With default provenance, BuildKit wraps the image manifest in a **manifest list*
 
 Docker 29.x's `docker build` ignores the default buildx builder entirely — it always uses the local daemon's built-in BuildKit. Only `docker buildx build` honors the configured builder. The wrapper rewrites `docker build` to `docker buildx build` (to use the shared cache) and applies smart --load (to avoid the tarball transfer).
 
+## Registry-Accelerated Loading
+
+Smart --load eliminates the transfer when nothing changed. But when code *does* change, even a one-line change in the top layer of a 7.73GB image still triggers a full tarball `--load` (~10s). The tarball format doesn't support layer-level deduplication — it's all or nothing.
+
+We solved this with a **shared Docker registry** running alongside BuildKit on the sandbox network. When the wrapper detects an image has changed, instead of `--load`:
+
+1. **Push** to the registry — BuildKit pushes only the changed layers (~0.1s)
+2. **Pull** from the registry — the local daemon checks which layers it already has, downloads only the new ones (~0.5s)
+
+The Docker registry protocol does layer-level dedup natively. For a 7.73GB image with 95 base layers and 1 changed layer, the pull shows 95 "Already exists" and downloads only the single new layer.
+
+### Benchmarks: 1-line change in top layer of 7.73GB image
+
+Measured E2E inside a real desktop container, 3 runs each:
+
+| Approach | Time | Speedup |
+|----------|------|---------|
+| Tarball `--load` (before) | **9,973ms** | 1x baseline |
+| Registry push/pull (after) | **871ms** | **11.5x** |
+| Unchanged image (smart skip) | **314ms** | **31.7x** |
+
+The three paths compose naturally:
+1. **Image unchanged** → skip load entirely (314ms)
+2. **Image changed, registry available** → push/pull via registry (871ms)
+3. **Image changed, no registry** → fall back to tarball `--load` (10s)
+
 ## Results
 
-With shared BuildKit + smart `--load`, the full build sequence for Helix-in-Helix:
+With shared BuildKit + smart `--load` + registry acceleration, the full build sequence for Helix-in-Helix:
 
 | Phase | Before | After | Speedup |
 |-------|--------|-------|---------|
@@ -93,7 +121,7 @@ With shared BuildKit + smart `--load`, the full build sequence for Helix-in-Heli
 
 The first agent to build a project pays the full cold build cost. Every subsequent agent (building the same source) gets a **23-second startup** — just enough time for Docker to verify the cache hits and confirm the images haven't changed.
 
-When code actually changes, the build is still fast: BuildKit only recompiles changed layers (incremental), and `--load` only fires when the final image digest differs. A one-line Go change might rebuild only the final compilation layer (~30s) instead of the entire 43-minute pipeline.
+When code actually changes, the build is still fast: BuildKit only recompiles changed layers (incremental), and the registry-based load only transfers changed layers. A one-line Go change might rebuild only the final compilation layer (~30s) and transfer only that layer via the registry (~1s) instead of the entire 43-minute pipeline.
 
 ### What the 23 seconds actually does
 
@@ -102,38 +130,17 @@ The 23 seconds breaks down as:
 - **1.2s** — `./stack build-zed release` checks the Zed builder image via smart --load. Image unchanged → skip the 300MB binary export.
 - **12s** — `./stack build-sandbox` builds the sandbox Dockerfile (~4s), restarts the inner sandbox, and verifies desktop images via smart --load. No registry push/pull needed when images match.
 
-The images DO need to exist in the local daemon (for `docker run` / `docker compose up`). The first time, `--load` transfers them. After that, smart --load skips the transfer as long as the source hasn't changed.
-
-### What about single-layer changes?
-
-When only one layer changes in a 7.7GB image, `--load` still transfers the **entire image** as a tarball (~10s). The tarball format doesn't support layer-level deduplication — it's all or nothing.
-
-We solved this with a **shared Docker registry** running alongside BuildKit. When the wrapper detects an image has changed, it pushes to the registry (which only transfers changed layers) and pulls locally. The Docker pull protocol does layer-level dedup — it checks which layers the local daemon already has and only downloads the new ones.
-
-Benchmarked on a 7.73GB image with a 1-line change in the top layer:
-
-| Approach | Time | vs tarball |
-|----------|------|-----------|
-| Tarball `--load` (old) | **9,973ms** | 1x baseline |
-| Registry push/pull (new) | **871ms** | 11.5x faster |
-| Unchanged image (smart skip) | **314ms** | 31.7x faster |
-
-The registry push shows `pushing layers 0.1s done` (one tiny layer). The pull shows 95 layers as "Already exists" and downloads only the single changed layer. Layer-level dedup turns a 10-second full-image transfer into a sub-second delta.
-
-The three paths compose naturally:
-1. **Image unchanged** → skip load entirely (314ms)
-2. **Image changed, registry available** → push/pull via registry (871ms)
-3. **Image changed, no registry** → fall back to tarball `--load` (10s)
+The images DO need to exist in the local daemon (for `docker run` / `docker compose up`). The first time, the registry-based load transfers them layer by layer. After that, smart --load skips the transfer as long as the source hasn't changed.
 
 ## Implementation
 
 The solution has three components:
 
-1. **Docker wrapper** (`desktop/shared/docker-buildx-wrapper.sh`) — installed at `/usr/local/bin/docker` in each desktop container. Intercepts `docker build` and `docker buildx build`, routes through shared BuildKit, applies smart --load with registry acceleration.
+1. **Docker wrapper** (`desktop/shared/docker-buildx-wrapper.sh`) — installed at `/usr/local/bin/docker` in each desktop container. Intercepts `docker build` and `docker buildx build`, routes through shared BuildKit, applies smart --load with registry acceleration. Falls back to tarball `--load` if registry is unavailable.
 
-2. **Shared BuildKit + Registry** (`api/pkg/hydra/manager.go`) — the Hydra manager starts a `helix-buildkit` container (shared cache) and a `helix-registry` container (layer-level transfer) at the sandbox level. Both are on the same Docker network as desktop containers.
+2. **Shared BuildKit + Registry** (`api/pkg/hydra/manager.go`) — the Hydra manager starts a `helix-buildkit` container (shared build cache) and a `helix-registry` container (layer-level transfer) at the sandbox level. Both are on the same Docker network as desktop containers. BuildKit is configured to trust the insecure registry for push operations.
 
-3. **Init script** (`desktop/shared/17-start-dockerd.sh`) — configures the desktop container's dockerd to trust the insecure registry and exports `HELIX_REGISTRY` globally so the wrapper knows where to push/pull.
+3. **Init script** (`desktop/shared/17-start-dockerd.sh`) — configures the desktop container's dockerd to trust the insecure registry (`insecure-registries` in `daemon.json`) and exports `HELIX_REGISTRY` and `BUILDX_BUILDER` globally so the wrapper knows where to push/pull and which builder to use.
 
 The wrapper is generic — it works for any `docker build` workload, not just Helix. It auto-detects whether the active builder is remote, and only applies smart --load when it is. On a standard local Docker setup, it's a transparent passthrough.
 


### PR DESCRIPTION
## Summary
- Replace estimated 655s --load figure with actual measured ~10s
- Add registry-accelerated loading section with E2E benchmarks (871ms vs 9,973ms)
- Update architecture diagram to include helix-registry
- Restructure to show the three-tier optimization: skip → registry → tarball fallback

## Test plan
- [x] No code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)