### PR TITLE
update the prompting in planning and implementation promp...

### DIFF
--- a/api/pkg/services/agent_instruction_service.go
+++ b/api/pkg/services/agent_instruction_service.go
@@ -158,6 +158,34 @@ You have access to **Kodit**, an MCP server for code intelligence. Use it during
 
 When you find useful patterns via Kodit, document them in design.md so future cloned tasks benefit.
 
+## Visual Testing & Screenshots (For UI/Frontend Tasks)
+
+You can test your UI changes and capture screenshots as proof of work:
+
+**Browser automation:** ` + "`chrome-devtools`" + ` MCP server
+- Navigate pages, click elements, fill forms, run the app
+
+**Screenshots:** ` + "`helix-desktop`" + ` MCP server
+- ` + "`list_windows`" + ` - Find browser window ID
+- ` + "`focus_window`" + ` - Bring window to front (REQUIRED before screenshot)
+- ` + "`save_screenshot`" + ` - Save to file
+
+**Screenshot workflow:**
+1. Run the app / open in browser
+2. Navigate to the page you changed
+3. ` + "`list_windows`" + ` → find browser window ID
+4. ` + "`focus_window`" + ` → bring to front (window must be visible!)
+5. ` + "`save_screenshot`" + ` with path: ` + "`/home/retro/work/helix-specs/design/tasks/{{.TaskDirName}}/screenshots/01-description.png`" + `
+
+**Naming convention:** ` + "`01-feature-before.png`" + `, ` + "`02-feature-after.png`" + `, ` + "`03-error-state.png`" + `
+
+**After taking screenshots:**
+- Reference them in design.md or create screenshots.md
+- Mention them in your PR description
+- They serve as visual proof that your implementation works
+
+Screenshots are optional but valuable for UI work - they help reviewers see what changed.
+
 ## Don't Over-Engineer
 
 - "Start a container" → docker-compose.yaml, NOT a Python wrapper

--- a/api/pkg/services/spec_task_prompts.go
+++ b/api/pkg/services/spec_task_prompts.go
@@ -93,6 +93,29 @@ in other repositories and libraries within the organization:
 This helps you design solutions that are consistent with existing patterns rather than
 reinventing approaches that already exist.
 
+## Visual Testing (Optional - For UI/Frontend Tasks)
+
+You have tools to explore and screenshot the application during planning:
+
+**Browser automation:** ` + "`chrome-devtools`" + ` MCP server
+- Navigate pages, click elements, fill forms
+- Useful for understanding current UI behavior
+
+**Screenshots:** ` + "`helix-desktop`" + ` MCP server
+- ` + "`list_windows`" + ` - Find browser window ID
+- ` + "`focus_window`" + ` - Bring window to front (REQUIRED before screenshot)
+- ` + "`save_screenshot`" + ` - Save to file
+
+**When to use:** Understanding existing UI, documenting current state, exploring edge cases.
+
+**Screenshot workflow:**
+1. Open the app in browser (if applicable)
+2. ` + "`list_windows`" + ` → find browser window ID
+3. ` + "`focus_window`" + ` → bring to front
+4. ` + "`save_screenshot`" + ` with path: ` + "`/home/retro/work/helix-specs/design/tasks/{{.TaskDirName}}/screenshots/01-description.png`" + `
+
+Screenshots are optional but valuable for UI tasks - save them in your task's screenshots/ folder.
+
 ## Document Your Learnings
 
 **Your design docs may be cloned to similar projects.** Write down what you discover:


### PR DESCRIPTION
> **Helix**: update the prompting in planning and implementation prompt to tell agent it can and should test changes itself using chrome mcp and take screenshots and store them in the spec-tasks folder nicely named and referenced in the final spec and pull request text (i'm not sure how we'll take screenshots - i think there's a helix desktop mcp for that, but will need to make sure window is visible when screenshot is taken)
