### PR TITLE
fix: include kodit embedding models in api-dev-env Docker stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 # - Copy tokenizers library for CGo
 COPY --from=tokenizers-lib /app/lib/libtokenizers.a /usr/lib/
+# - Copy embedding models for kodit code intelligence
+COPY --from=embedding-model /build/models/ /kodit-models/
 # - Copy the files and run a build to make startup faster
 COPY api /app/api
 WORKDIR /app/api

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -108,7 +108,6 @@ services:
       - ./go.sum:/app/go.sum
       - ./api:/app/api
       - ./WORKDIR_README.md:/opt/helix/WORKDIR_README.md:ro
-      - ./kodit-models:/kodit-models:ro
       - ${FILESTORE_DATA:-helix-filestore}:/filestore
       - helix-socket:/socket
       # Go caches for faster air rebuilds (shared with runner config)


### PR DESCRIPTION
## Summary
- Add `COPY --from=embedding-model` to the `api-dev-env` Dockerfile stage so the ONNX embedding models are available at `/kodit-models/` in the dev API container
- Remove broken `./kodit-models:/kodit-models:ro` bind-mount from docker-compose.dev.yaml (the directory doesn't exist on the host — models should be baked into the image)

The production image already had this copy (line 111), but the dev stage was missing it, causing kodit to fail with "no code models" errors at runtime.

## Test plan
- [ ] `docker compose -f docker-compose.dev.yaml build api` succeeds
- [ ] API container starts without kodit model errors
- [ ] Kodit code indexing works in dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)