### PR TITLE
fix: restore console password after VM root disk upgrade

### DIFF
--- a/for-mac/scripts/provision-vm.sh
+++ b/for-mac/scripts/provision-vm.sh
@@ -551,7 +551,7 @@ write_files:
           "max-file": "3"
         }
       }
-  - path: /etc/ssh/sshd_config.d/helix.conf
+  - path: /etc/ssh/sshd_config.d/50-helix.conf
     content: |
       PasswordAuthentication yes
       PubkeyAuthentication yes
@@ -670,6 +670,26 @@ write_files:
           mkdir -p /home/ubuntu/helix
           cp /helix/config/env.vm /home/ubuntu/helix/.env.vm
           chown ubuntu:ubuntu /home/ubuntu/helix/.env.vm
+      fi
+
+      # Restore console password from ZFS config (set by injectDesktopSecret)
+      if [ -f /helix/config/console_password ]; then
+          PASS=\$(cat /helix/config/console_password 2>/dev/null)
+          if [ -n "\$PASS" ]; then
+              echo "ubuntu:\$PASS" | chpasswd
+              log "Restored console password from /helix/config/console_password"
+          fi
+      fi
+
+      # Fix sshd config ordering: 50-helix.conf must sort before 60-cloudimg-settings.conf
+      # so PasswordAuthentication yes takes effect (sshd uses first-match-wins)
+      if [ -f /etc/ssh/sshd_config.d/helix.conf ]; then
+          mv /etc/ssh/sshd_config.d/helix.conf /etc/ssh/sshd_config.d/50-helix.conf
+          log "Renamed helix.conf -> 50-helix.conf for sshd ordering"
+      fi
+      if [ -f /etc/ssh/sshd_config.d/60-cloudimg-settings.conf ]; then
+          sed -i '/^PasswordAuthentication/d' /etc/ssh/sshd_config.d/60-cloudimg-settings.conf
+          log "Removed PasswordAuthentication override from 60-cloudimg-settings.conf"
       fi
 
       # Docker starts automatically via systemd ordering (Before=docker.service).


### PR DESCRIPTION
## Summary
- **sshd config ordering**: Rename `helix.conf` → `50-helix.conf` so it sorts before cloud-init's `60-cloudimg-settings.conf` (`PasswordAuthentication no`). sshd uses first-match-wins on `sshd_config.d/`.
- **Password restore on boot**: `helix-storage-init.sh` and `init-zfs-pool.sh` now restore the console password from `/helix/config/console_password` (persisted by `injectDesktopSecret`) via `chpasswd` at boot time.
- **Migration for existing VMs**: Boot scripts rename old `helix.conf` → `50-helix.conf` and strip the `PasswordAuthentication` override from `60-cloudimg-settings.conf`.

## Root cause
After a root disk upgrade (e.g. 2.7.2 → 2.7.3), the fresh root disk has cloud-init's default password and sshd config. `injectDesktopSecret` sets the correct password later via SSH, but between boot and that point the console login was broken because:
1. `PasswordAuthentication no` in `60-cloudimg-settings.conf` won sshd first-match over `helix.conf`
2. The stored password was never applied to the fresh root disk at boot

## Test plan
- [ ] SSH into VM after upgrade, verify: `sudo sshd -T | grep passwordauthentication` → `yes`
- [ ] Verify: `ls /etc/ssh/sshd_config.d/` → `50-helix.conf`, not `helix.conf`
- [ ] Test console login with password shown in UI
- [ ] `go build ./for-mac/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)