### PR TITLE
fix: create Zed themes dir to stop settings.json being parsed as theme

### DIFF
--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -930,7 +930,7 @@ RUN npm install -g @anthropic-ai/claude-code@latest
 # Claude Code settings (bypassPermissions etc.) are written at runtime by
 # helix-workspace-setup.sh after symlinking ~/.claude to persistent storage.
 
-RUN mkdir -p /home/retro/.config/zed && \
+RUN mkdir -p /home/retro/.config/zed/themes && \
     echo '{"theme":"Ayu Dark","telemetry":{"diagnostics":false,"metrics":false}}' > /home/retro/.config/zed/settings.json
 
 ENV GEMINI_TELEMETRY_ENABLED=false \

--- a/api/cmd/settings-sync-daemon/main.go
+++ b/api/cmd/settings-sync-daemon/main.go
@@ -887,6 +887,14 @@ func (d *SettingsDaemon) startWatcher() error {
 		return fmt.Errorf("failed to create settings directory: %w", err)
 	}
 
+	// Ensure themes directory exists. Zed's theme watcher watches this path;
+	// if it doesn't exist, the watcher falls back to the parent config dir
+	// and ends up trying to parse settings.json as a theme file on every write.
+	themesDir := filepath.Join(settingsDir, "themes")
+	if err := os.MkdirAll(themesDir, 0755); err != nil {
+		log.Printf("Warning: failed to create themes directory: %v", err)
+	}
+
 	// Create empty settings file if it doesn't exist
 	if _, err := os.Stat(SettingsPath); os.IsNotExist(err) {
 		if err := os.WriteFile(SettingsPath, []byte("{}"), 0644); err != nil {


### PR DESCRIPTION
## Summary

- Creates `~/.config/zed/themes/` directory in both the Dockerfile and settings-sync-daemon startup
- Fixes `ERROR [crates/zed/src/main.rs:1484] missing field 'name' at line 67 column 1` that repeats every 30 seconds in ACP container logs

## Root cause

Zed's `watch_themes()` calls `fs.watch("~/.config/zed/themes/")`. On Linux, `fs.watch()` uses inotify in `NonRecursive` mode. When the target path **doesn't exist**, it falls back to watching the parent directory (`~/.config/zed/`). The settings-sync-daemon writes `settings.json` every 30s, which triggers the parent-dir watcher. The theme watcher then calls `load_user_theme("settings.json")`, parsing it as `ThemeFamilyContent` (which requires a `name` field) — and fails.

Creating the themes directory ensures inotify scopes to the correct directory and settings.json events are filtered out by the `starts_with(root_path)` check in `FsWatcher`.

## Test plan

- [ ] `go build ./api/cmd/settings-sync-daemon/` passes
- [ ] `build-ubuntu` and start a new session
- [ ] Verify `~/.config/zed/themes/` exists in the container
- [ ] Check Zed.log no longer shows `missing field 'name'` errors every 30s

WARNING: NOT tested on a live container yet.

Closes Trello #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)