### PR TITLE
add a filter to the specs page (kanban board) so you can ...

### DIFF
--- a/frontend/src/components/tasks/SpecTaskKanbanBoard.tsx
+++ b/frontend/src/components/tasks/SpecTaskKanbanBoard.tsx
@@ -26,6 +26,7 @@ import {
   FormControl,
   InputLabel,
   Avatar,
+  InputAdornment,
 } from "@mui/material";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
@@ -55,6 +56,8 @@ import {
   RocketLaunch as LaunchIcon,
   InfoOutlined as InfoIcon,
   PlayArrowRounded as AutoPlayIcon,
+  Search as SearchIcon,
+  Clear as ClearIcon,
 } from "@mui/icons-material";
 // Removed drag-and-drop imports to prevent infinite loops
 import { useTheme } from "@mui/material/styles";
@@ -588,7 +591,7 @@ const SpecTaskKanbanBoard: React.FC<SpecTaskKanbanBoardProps> = ({
   showArchived: showArchivedProp = false,
   showMetrics: showMetricsProp,
   showMerged: showMergedProp = true,
-  searchFilter = "",
+  searchFilter: searchFilterProp = "",
 }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
@@ -615,6 +618,9 @@ const SpecTaskKanbanBoard: React.FC<SpecTaskKanbanBoardProps> = ({
   const [highlightedDependencyTaskIds, setHighlightedDependencyTaskIds] =
     useState<string[] | null>(null);
   const [archivingTaskId, setArchivingTaskId] = useState<string | null>(null);
+
+  // Local search filter state (use prop as initial value, but manage locally)
+  const [searchFilter, setSearchFilter] = useState(searchFilterProp);
 
   // Backlog table view state
   const [backlogExpanded, setBacklogExpanded] = useState(false);
@@ -1306,6 +1312,37 @@ const SpecTaskKanbanBoard: React.FC<SpecTaskKanbanBoardProps> = ({
               </Button>
             </Tooltip>
           )}
+          {/* Search filter */}
+          <TextField
+            size="small"
+            placeholder="Search tasks..."
+            value={searchFilter}
+            onChange={(e) => setSearchFilter(e.target.value)}
+            sx={{
+              width: 200,
+              "& .MuiOutlinedInput-root": {
+                height: 36,
+              },
+            }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon sx={{ fontSize: 18, color: "text.secondary" }} />
+                </InputAdornment>
+              ),
+              endAdornment: searchFilter && (
+                <InputAdornment position="end">
+                  <IconButton
+                    size="small"
+                    onClick={() => setSearchFilter("")}
+                    sx={{ padding: 0.25 }}
+                  >
+                    <ClearIcon sx={{ fontSize: 16 }} />
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          />
         </Box>
       </Box>
 

--- a/frontend/src/pages/SpecTasksPage.tsx
+++ b/frontend/src/pages/SpecTasksPage.tsx
@@ -12,8 +12,6 @@ import {
   Tooltip,
   useMediaQuery,
   useTheme,
-  TextField,
-  InputAdornment,
 } from "@mui/material";
 import {
   Add as AddIcon,
@@ -26,8 +24,6 @@ import {
   Archive as ArchiveIcon,
   BarChart as MetricsIcon,
   Visibility as ViewIcon,
-  Search as SearchIcon,
-  Clear as ClearIcon,
 } from "@mui/icons-material";
 import {
   Plus,
@@ -195,7 +191,6 @@ const SpecTasksPage: FC = () => {
   const METRICS_STORAGE_KEY = "helix-kanban-show-metrics";
   const MERGED_STORAGE_KEY = "helix-kanban-show-merged";
   const [showArchived, setShowArchived] = useState(false);
-  const [searchFilter, setSearchFilter] = useState("");
   const [showMetrics, setShowMetrics] = useState(() => {
     const stored = localStorage.getItem(METRICS_STORAGE_KEY);
     return stored !== null ? stored === "true" : true;
@@ -694,39 +689,6 @@ const SpecTasksPage: FC = () => {
             />
           </Box>
 
-          {/* Search filter for kanban board */}
-          <TextField
-            size="small"
-            placeholder="Search tasks..."
-            value={searchFilter}
-            onChange={(e) => setSearchFilter(e.target.value)}
-            sx={{
-              width: 200,
-              display: { xs: "none", md: "flex" },
-              "& .MuiOutlinedInput-root": {
-                height: 32,
-              },
-            }}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <SearchIcon sx={{ fontSize: 18, color: "text.secondary" }} />
-                </InputAdornment>
-              ),
-              endAdornment: searchFilter && (
-                <InputAdornment position="end">
-                  <IconButton
-                    size="small"
-                    onClick={() => setSearchFilter("")}
-                    sx={{ padding: 0.25 }}
-                  >
-                    <ClearIcon sx={{ fontSize: 16 }} />
-                  </IconButton>
-                </InputAdornment>
-              ),
-            }}
-          />
-
           {/* View mode toggle: Board vs Workspace vs Audit Trail */}
           <Stack direction="row" spacing={0.5} sx={{ borderRadius: 1, p: 0.5 }}>
             <Tooltip
@@ -1182,7 +1144,6 @@ const SpecTasksPage: FC = () => {
                 showArchived={showArchived}
                 showMetrics={showMetrics}
                 showMerged={showMerged}
-                searchFilter={searchFilter}
               />
             )}
             {viewMode === "workspace" && (


### PR DESCRIPTION
> **Helix**: add a filter to the specs page (kanban board) so you can search across title, description, and maybe even tasks - could be a frontend side filter probably because we already have that info in the frontend
