### PR TITLE
fix: set MACOSX_DEPLOYMENT_TARGET=14.0 in QEMU build scripts

### DIFF
--- a/for-mac/qemu-helix/build-qemu-only.sh
+++ b/for-mac/qemu-helix/build-qemu-only.sh
@@ -27,6 +27,8 @@ fi
 # Add Homebrew tools to PATH
 export PATH="/opt/homebrew/opt/bison/bin:/opt/homebrew/bin:$PATH"
 export PKG_CONFIG_PATH="$SYSROOT/lib/pkgconfig"
+# Target macOS 14.0 so the binary runs on older macOS versions.
+export MACOSX_DEPLOYMENT_TARGET="14.0"
 
 BUILD_DIR="$QEMU_SRC/build"
 

--- a/for-mac/qemu-helix/build-qemu-standalone.sh
+++ b/for-mac/qemu-helix/build-qemu-standalone.sh
@@ -51,8 +51,13 @@ echo "📝 Setting up build environment..."
 export PKG_CONFIG="$SYSROOT/host/bin/pkg-config"
 export PKG_CONFIG_PATH="$SYSROOT/lib/pkgconfig"
 export PATH="$SYSROOT/host/bin:$PATH"
+# Target macOS 14.0 (Sonoma) so the binary runs on older macOS versions.
+# APIs from newer SDKs (e.g. hv_vm_config_set_ipa_granule in macOS 26) are
+# weak-linked and guarded by __builtin_available() runtime checks in the code.
+export MACOSX_DEPLOYMENT_TARGET="14.0"
 echo "   PKG_CONFIG: $PKG_CONFIG"
 echo "   PKG_CONFIG_PATH: $PKG_CONFIG_PATH"
+echo "   MACOSX_DEPLOYMENT_TARGET: $MACOSX_DEPLOYMENT_TARGET"
 echo ""
 
 # Step 2: Run configure script


### PR DESCRIPTION
## Summary

- Building QEMU on macOS 26.3 without an explicit deployment target tags the dylib as `macOS 26.0`, hard-linking `hv_vm_config_set_ipa_granule` (new in macOS 26). This causes `dyld: Symbol not found` on macOS 15.x (Sequoia), e.g. Scaleway M1 Mac Minis.
- The QEMU code already has `__builtin_available(macOS 26, *)` runtime guards and a `dlsym` fallback for older macOS. Setting the deployment target to 14.0 makes the linker weak-link these symbols so the binary loads on older macOS.
- Sets `MACOSX_DEPLOYMENT_TARGET=14.0` in both `build-qemu-standalone.sh` and `build-qemu-only.sh`.

## Test plan

- [ ] Rebuild QEMU with `cd for-mac && make rebuild-qemu`
- [ ] Verify dylib deployment target: `otool -l libqemu-aarch64-softmmu.dylib | grep -A2 VERSION_MIN`
- [ ] Test on macOS 15.x (Scaleway M1) -- should no longer crash with dyld symbol error
- [ ] Test on macOS 26.x -- should still work (runtime check calls the API directly)

Generated with [Claude Code](https://claude.com/claude-code)