### PR TITLE
fix: show correct status during VM update decompression

### DIFF
--- a/for-mac/frontend/src/components/SettingsPanel.tsx
+++ b/for-mac/frontend/src/components/SettingsPanel.tsx
@@ -339,7 +339,9 @@ export function SettingsPanel({
             {vmUpdateProgress && !combinedUpdateProgress && (
               <div style={{ marginBottom: 12 }}>
                 <div style={{ fontSize: 12, color: 'var(--text-secondary)', marginBottom: 6 }}>
-                  Downloading system update...
+                  {vmUpdateProgress.phase === 'decompressing_vm' ? 'Unpacking system update...' :
+                   vmUpdateProgress.phase === 'verifying_vm' ? 'Verifying system update...' :
+                   'Downloading system update...'}
                 </div>
                 <div className="progress-bar">
                   <div

--- a/for-mac/updater.go
+++ b/for-mac/updater.go
@@ -663,8 +663,14 @@ func (e *updateEmitter) EventsEmit(eventName string, data ...interface{}) {
 	// emits "download:progress" events which we translate.
 	if len(data) > 0 {
 		if p, ok := data[0].(DownloadProgress); ok {
+			phase := "downloading_vm"
+			if p.Status == "decompressing" {
+				phase = "decompressing_vm"
+			} else if p.Status == "verifying" {
+				phase = "verifying_vm"
+			}
 			e.emitFn(UpdateProgress{
-				Phase:      "downloading_vm",
+				Phase:      phase,
 				BytesDone:  p.BytesDone,
 				BytesTotal: p.BytesTotal,
 				Percent:    p.Percent,


### PR DESCRIPTION
## Summary

The `updateEmitter` adapter in `updater.go` hardcoded `Phase: "downloading_vm"` even when the decompressor was emitting `Status: "decompressing"` or `"verifying"`. The settings panel then showed "Downloading system update..." during unpacking.

Now passes through the actual status. Settings panel shows "Unpacking system update..." or "Verifying system update..." during those phases.

## Test plan

- [ ] Trigger a VM update that includes a .zst compressed file
- [ ] Verify settings panel shows "Unpacking..." during decompression phase

Generated with [Claude Code](https://claude.com/claude-code)