### PR TITLE
fix: clean stale /helix contents before ZFS pool creation

### DIFF
--- a/for-mac/scripts/init-zfs-pool.sh
+++ b/for-mac/scripts/init-zfs-pool.sh
@@ -29,10 +29,12 @@ else
     echo "Creating ZFS pool on $DATA_DISK..."
     sudo mkdir -p /helix
     if [ "$(ls -A /helix 2>/dev/null)" ]; then
-        echo "ERROR: /helix exists and is not empty (stale golden image data?). Contents:"
+        # /helix may have stale data from the root disk (e.g. Docker creating
+        # /helix/container-docker before ZFS is mounted). This is ephemeral
+        # root disk data — safe to remove before ZFS pool creation.
+        echo "Cleaning stale /helix contents before pool creation:"
         ls -la /helix
-        echo "Remove manually: sudo rm -rf /helix/*"
-        exit 1
+        sudo rm -rf /helix/*
     fi
     sudo zpool create -f -m /helix helix "$DATA_DISK"
 fi


### PR DESCRIPTION
## Summary

On first boot or after root disk upgrade, Docker may autostart via systemd and create `/helix/container-docker` before the ZFS init script runs via SSH. The script then finds `/helix` non-empty and errors out, requiring manual `sudo rm -rf /helix/*`.

Now automatically cleans `/helix/*` before pool creation. This only runs in the first-boot path (no existing ZFS pool found), so the data is ephemeral root disk content that ZFS datasets will recreate.

## Test plan

- [ ] Fresh VM boot with new root disk -- ZFS pool should create without error
- [ ] Existing VM with ZFS pool -- no change (pool import path, doesn't hit this code)

Generated with [Claude Code](https://claude.com/claude-code)