### PR TITLE
fix: bump minimum VM RAM from 4GB to 6GB, require 8GB system RAM

### DIFF
--- a/for-mac/settings.go
+++ b/for-mac/settings.go
@@ -74,8 +74,8 @@ func DefaultSettings() AppSettings {
 	memoryMB := 8192 // fallback
 	if totalMem := getSystemMemoryMB(); totalMem > 0 {
 		memoryMB = totalMem / 2
-		if memoryMB < 4096 {
-			memoryMB = 4096
+		if memoryMB < 6144 {
+			memoryMB = 6144
 		}
 	}
 

--- a/for-mac/vm.go
+++ b/for-mac/vm.go
@@ -548,8 +548,8 @@ func checkSystemRequirements() error {
 	}
 
 	memMB := getSystemMemoryMB()
-	if memMB > 0 && memMB < 4*1024 {
-		return fmt.Errorf("Helix requires at least 4 GB of RAM. This machine has %d MB.", memMB)
+	if memMB > 0 && memMB < 8*1024 {
+		return fmt.Errorf("Helix requires at least 8 GB of RAM. This machine has %d MB.", memMB)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

4GB VM RAM is not enough on 8GB machines. On 8GB system: `8192/2 = 4096`, clamped to 4096. That leaves insufficient headroom for Docker + GNOME + Zed + containers.

- Bump minimum VM RAM from 4096MB to 6144MB
- System requirements check now enforces 8GB minimum system RAM

## Test plan

- [ ] 8GB machine: VM gets 6GB RAM, boots and runs containers
- [ ] 16GB machine: VM gets 8GB RAM (16384/2), unchanged behavior

Generated with [Claude Code](https://claude.com/claude-code)