### PR TITLE
fix: readable credentials text on onboarding

### DIFF
--- a/frontend/src/components/agent/CodingAgentForm.tsx
+++ b/frontend/src/components/agent/CodingAgentForm.tsx
@@ -268,7 +268,7 @@ const CodingAgentForm = forwardRef<CodingAgentFormHandle, CodingAgentFormProps>(
                 control={<Radio size="small" sx={claudeRadioSx} />}
                 disabled={!hasClaudeSubscription}
                 label={
-                  <Typography variant="body2">
+                  <Typography variant="body2" color="inherit">
                     Claude Subscription{hasClaudeSubscription ? ' (connected)' : ' (not connected)'}
                   </Typography>
                 }
@@ -278,7 +278,7 @@ const CodingAgentForm = forwardRef<CodingAgentFormHandle, CodingAgentFormProps>(
                 control={<Radio size="small" sx={claudeRadioSx} />}
                 disabled={!hasAnthropicProvider}
                 label={
-                  <Typography variant="body2">
+                  <Typography variant="body2" color="inherit">
                     Anthropic API Key{hasAnthropicProvider ? ' (configured)' : ' (not configured)'}
                   </Typography>
                 }

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -1722,6 +1722,7 @@ export default function Onboarding() {
                       borderRadius: 1.5,
                       border: "1px solid rgba(255,255,255,0.06)",
                       bgcolor: "rgba(255,255,255,0.02)",
+                      color: "#fff",
                     }}
                     claudeRadioSx={{
                       color: "rgba(255,255,255,0.3)",


### PR DESCRIPTION
## Summary
- Credentials radio labels ("Claude Subscription", "Anthropic API Key") were black text on dark blue background in onboarding — unreadable
- Set `color="inherit"` on radio label Typography so they pick up container color
- Added `color: "#fff"` to the credentials box sx in onboarding

## Test plan
- [ ] Open onboarding flow, verify credentials text is white/readable on dark background
- [ ] Verify credentials box still looks correct on the normal (non-onboarding) agent form

🤖 Generated with [Claude Code](https://claude.com/claude-code)