### PR TITLE
gah claude subscription + claude code mode is back to ask...

### DIFF
--- a/api/cmd/settings-sync-daemon/main.go
+++ b/api/cmd/settings-sync-daemon/main.go
@@ -186,7 +186,7 @@ func (d *SettingsDaemon) generateAgentServerConfig() map[string]interface{} {
 		// The raw `claude` CLI does NOT support --experimental-acp.
 		return map[string]interface{}{
 			"claude": map[string]interface{}{
-				"default": "bypassPermissions",
+				"default_mode": "bypassPermissions",
 				"env":          env,
 			},
 		}


### PR DESCRIPTION
> **Helix**: gah claude subscription + claude code mode is back to asking permission all the bloody time. we had put in a setting to always bypass permissions in zed + helix but we changed some stuff to do with that just yesterday (check zed and helix commit history) - see if you can fix the regression
