### PR TITLE
Force pushing on a spec task branch doesn't work. It fail...

### DIFF
--- a/api/pkg/services/git_http_server.go
+++ b/api/pkg/services/git_http_server.go
@@ -689,7 +689,11 @@ func (s *GitHTTPServer) detectChangedBranches(repoPath string, before, after map
 			if existed && oldHash != "" {
 				// Check if old commit is ancestor of new commit (fast-forward)
 				// If NOT ancestor, this is a force push
-				if !IsAncestor(context.Background(), repoPath, oldHash, newHash) {
+				_, _, err := gitcmd.NewCommand("merge-base", "--is-ancestor").
+					AddDynamicArguments(oldHash, newHash).
+					RunStdString(context.Background(), &gitcmd.RunOpts{Dir: repoPath})
+				if err != nil {
+					// merge-base --is-ancestor returns non-zero if not ancestor
 					isForce = true
 					log.Info().
 						Str("branch", branch).

--- a/api/pkg/services/gitea_git_helpers.go
+++ b/api/pkg/services/gitea_git_helpers.go
@@ -27,8 +27,8 @@ func IsErrEmptyRepository(err error) bool {
 // Note: Git error messages can vary by version and locale. These patterns
 // cover common English git outputs from versions 2.x+.
 var gitErrorPatterns = struct {
-	AlreadyUpToDate     []string // Not really an error, just informational
-	EmptyRepository     []string // Remote has no refs (empty repo)
+	AlreadyUpToDate   []string // Not really an error, just informational
+	EmptyRepository   []string // Remote has no refs (empty repo)
 	RemoteAlreadyExists []string
 }{
 	AlreadyUpToDate: []string{
@@ -57,14 +57,14 @@ func matchesAnyPattern(text string, patterns []string) bool {
 
 // FetchOptions contains options for git fetch operations
 type FetchOptions struct {
-	Remote   string        // Remote name (e.g., "origin")
-	Branch   string        // Specific branch to fetch (empty for all)
-	Force    bool          // Force fetch (overwrite local refs)
-	Prune    bool          // Remove remote-tracking refs that no longer exist
-	Depth    int           // Shallow fetch with depth limit (0 for full)
-	Env      []string      // Environment variables (for auth)
-	Timeout  time.Duration // Command timeout
-	RefSpecs []string      // Explicit refspecs (optional)
+	Remote    string        // Remote name (e.g., "origin")
+	Branch    string        // Specific branch to fetch (empty for all)
+	Force     bool          // Force fetch (overwrite local refs)
+	Prune     bool          // Remove remote-tracking refs that no longer exist
+	Depth     int           // Shallow fetch with depth limit (0 for full)
+	Env       []string      // Environment variables (for auth)
+	Timeout   time.Duration // Command timeout
+	RefSpecs  []string      // Explicit refspecs (optional)
 }
 
 // Fetch fetches from a remote repository using native git
@@ -363,17 +363,6 @@ func ShortHash(hash string) string {
 		return hash
 	}
 	return hash[:8]
-}
-
-// IsAncestor checks if ancestorCommit is an ancestor of descendantCommit.
-// Returns true if ancestorCommit is reachable from descendantCommit's history.
-// This is useful for detecting force pushes (old commit not ancestor of new = force push).
-func IsAncestor(ctx context.Context, repoPath, ancestorCommit, descendantCommit string) bool {
-	_, _, err := gitcmd.NewCommand("merge-base", "--is-ancestor").
-		AddDynamicArguments(ancestorCommit, descendantCommit).
-		RunStdString(ctx, &gitcmd.RunOpts{Dir: repoPath})
-	// merge-base --is-ancestor returns 0 if ancestor, non-zero otherwise
-	return err == nil
 }
 
 // PreReceiveHookVersion is incremented when the hook logic changes.


### PR DESCRIPTION
> **Helix**: Force pushing on a spec task branch doesn't work. It fails with the following error in the Helix API server, but agents should be able to force push on their branches, I think. 

uhoh force push failed with api-1  | 2026-02-17T07:33:45Z ERR pkg/services/git_repository_service_push.go:98 > [GitPush] FAILED to push to external repository error="PushOu
tOfDate Error: exit status 1 - To https://github.com/helixml/helix\n ! [rejected]            feature/001036-we-badly-need-to -> feature/001036-w
e-badly-need-to (non-fast-forward)\nerror: failed to push some refs to 'https://github.com/helixml/helix'\nhint: Updates were rejected because a
 pushed branch tip is behind its remote\nhint: counterpart. If you want to integrate the remote changes, use 'git pull'\nhint: before pushing ag
ain.\nhint: See the 'Note about fast-forwards' in 'git push --help' for details.\n - To https://github.com/helixml/helix\n ! [rejected]
   feature/001036-we-badly-need-to -> feature/001036-we-badly-need-to (non-fast-forward)\nerror: failed to push some refs to 'https://github.com
/helixml/helix'\nhint: Updates were rejected because a pushed branch tip is behind its remote\nhint: counterpart. If you want to integrate the r
emote changes, use 'git pull'\nhint: before pushing again.\nhint: See the 'Note about fast-forwards' in 'git push --help' for details.\n: To htt
ps://github.com/helixml/helix\n ! [rejected]            feature/001036-we-badly-need-to -> feature/001036-we-badly-need-to (non-fast-forward)\ne
rror: failed to push some refs to 'https://github.com/helixml/helix'\nhint: Updates were rejected because a pushed branch tip is behind its remo
te\nhint: counterpart. If you want to integrate the remote changes, use 'git pull'\nhint: before pushing again.\nhint: See the 'Note about fast-
forwards' in 'git push --help' for details.\n\n" auth_type=basic:x-access-token branch=feature/001036-we-badly-need-to external_url=https://gith
ub.com/helixml/helix push_duration=299.292469 repo_id=prj_01kg02vqqyg178c1n2ydscn5fb-helix-4 total_elapsed=312.103003
api-1  | 2026-02-17T07:33:45Z ERR pkg/services/git_http_server.go:610 > Failed to push branch to upstream - rolling back error="failed to push t
o external repository: PushOutOfDate Error: exit status 1 - To https://github.com/helixml/helix\n ! [rejected]            feature/001036-we-badl
y-need-to -> feature/001036-we-badly-need-to (non-fast-forward)\nerror: failed to push some refs to 'https://github.com/helixml/helix'\nhint: Up
dates were rejected because a pushed branch tip is behind its remote\nhint: counterpart. If you want to integrate the remote changes, use 'git p
ull'\nhint: before pushing again.\nhint: See the 'Note about fast-forwards' in 'git push --help' for details.\n - To https://github.com/helixml/
helix\n ! [rejected]            feature/001036-we-badly-need-to -> feature/001036-we-badly-need-to (non-fast-forward)\nerror: failed to push som
e refs to 'https://github.com/helixml/helix'\nhint: Updates were rejected because a pushed branch tip is behind its remote\nhint: counterpart. I
f you want to integrate the remote changes, use 'git pull'\nhint: before pushing again.\nhint: See the 'Note about fast-forwards' in 'git push -
-help' for details.\n: To https://github.com/helixml/helix\n ! [rejected]            feature/001036-we-badly-need-to -> feature/001036-we-badly-
need-to (non-fast-forward)\nerror: failed to push some refs to 'https://github.com/helixml/helix'\nhint: Updates were rejected because a pushed
branch tip is behind its remote\nhint: counterpart. If you want to integrate the remote changes, use 'git pull'\nhint: before pushing again.\nhi
nt: See the 'Note about fast-forwards' in 'git push --help' for details.\n\n" branch=feature/001036-we-badly-need-to repo_id=prj_01kg02vqqyg178c
1n2ydscn5fb-helix-4
