### PR TITLE
Fix golden build UI stuck after API restart and reduce cache bloat

### DIFF
--- a/api/pkg/hydra/golden.go
+++ b/api/pkg/hydra/golden.go
@@ -458,6 +458,13 @@ func PurgeContainersFromGolden(projectID string) error {
 	// Remove buildx state — not needed, sessions use shared buildkit
 	os.RemoveAll(filepath.Join(golden, "buildx"))
 
+	// Remove volumes — stale named/anonymous volumes from build steps
+	// (node_modules, Go module cache, etc). Sessions create their own.
+	// This is a safety net; the in-container cleanup (workspace-setup.sh)
+	// runs `docker volume prune` before dockerd stops, but if that was
+	// skipped or incomplete, this catches it at the filesystem level.
+	os.RemoveAll(filepath.Join(golden, "volumes"))
+
 	// Remove the golden build result marker. If this file is left in the golden
 	// cache, monitorGoldenBuild() on subsequent golden builds will find it
 	// immediately after SetupGoldenCopy and promote prematurely — before the
@@ -471,7 +478,7 @@ func PurgeContainersFromGolden(projectID string) error {
 	log.Info().
 		Str("project_id", projectID).
 		Str("golden", golden).
-		Msg("Purged container/network/containerd/buildx/result state from golden cache")
+		Msg("Purged container/network/containerd/buildx/volumes/result state from golden cache")
 
 	return nil
 }

--- a/api/pkg/server/project_handlers.go
+++ b/api/pkg/server/project_handlers.go
@@ -145,6 +145,44 @@ func (s *HelixAPIServer) getProject(_ http.ResponseWriter, r *http.Request) (*ty
 		}
 	}
 
+	// Recover stale "building" golden build states (lazy recovery on read).
+	// After an API restart, the monitoring goroutine is dead but DB still says
+	// "building". If the build isn't tracked in memory AND the container isn't
+	// running, reset the status so the UI doesn't get stuck.
+	if project.Metadata.DockerCacheStatus != nil {
+		staleRecovered := false
+		for sbID, sbState := range project.Metadata.DockerCacheStatus.Sandboxes {
+			if sbState.Status != "building" || sbState.BuildSessionID == "" {
+				continue
+			}
+			// Two conditions must BOTH be false for recovery:
+			// 1. Monitoring goroutine alive (in-memory tracking)
+			// 2. Container still running on sandbox
+			// During normal operation, condition 1 is true → no recovery.
+			// After API restart, both are false → recovery triggers.
+			if s.goldenBuildService.IsTracking(project.ID, sbID) {
+				continue
+			}
+			if s.externalAgentExecutor.HasRunningContainer(r.Context(), sbState.BuildSessionID) {
+				continue
+			}
+			log.Info().
+				Str("project_id", projectID).
+				Str("sandbox_id", sbID).
+				Str("session_id", sbState.BuildSessionID).
+				Msg("Recovering stale golden build: monitoring goroutine dead and container not running")
+			sbState.Status = "none"
+			sbState.BuildSessionID = ""
+			sbState.Error = ""
+			staleRecovered = true
+		}
+		if staleRecovered {
+			if updateErr := s.Store.UpdateProject(r.Context(), project); updateErr != nil {
+				log.Warn().Err(updateErr).Str("project_id", projectID).Msg("Failed to reset stale golden build status")
+			}
+		}
+	}
+
 	// Load startup script from helix-specs branch in primary repo.
 	// Sync from upstream first — helix-specs can be modified outside Helix
 	// (e.g., direct git pushes), so we need the latest version.

--- a/api/pkg/services/golden_build_service.go
+++ b/api/pkg/services/golden_build_service.go
@@ -49,6 +49,18 @@ func buildKey(projectID, sandboxID string) string {
 	return projectID + "/" + sandboxID
 }
 
+// IsTracking returns true if the golden build service is actively monitoring
+// a build for this project+sandbox pair (i.e., the monitoring goroutine is alive).
+// After an API restart, all tracking is lost — this method returns false for
+// everything, which signals that the DB status may be stale.
+func (g *GoldenBuildService) IsTracking(projectID, sandboxID string) bool {
+	key := buildKey(projectID, sandboxID)
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	_, ok := g.building[key]
+	return ok
+}
+
 // updateSandboxCacheStatus updates the per-sandbox DockerCacheState in project metadata.
 func (g *GoldenBuildService) updateSandboxCacheStatus(ctx context.Context, projectID, sandboxID string, update func(*types.SandboxCacheState)) {
 	g.mu.Lock()

--- a/desktop/shared/helix-workspace-setup.sh
+++ b/desktop/shared/helix-workspace-setup.sh
@@ -674,6 +674,38 @@ if [ "${HELIX_GOLDEN_BUILD:-}" = "true" ]; then
         echo ""
         echo "✅ Golden build: startup script completed successfully"
 
+        # Clean up Docker artifacts that inflate the golden cache.
+        # Sessions only need the final built images — these intermediates
+        # are push/build artifacts that accumulate across golden builds:
+        #   - Registry-tagged images (10.x.x.x:5000/buildcache/...) from
+        #     the docker wrapper's push-to-registry optimization
+        #   - Dangling (untagged) images from intermediate build steps
+        #   - Unused volumes (build caches, node_modules from build steps)
+        echo "Cleaning Docker build artifacts before golden promotion..."
+
+        # Show before state
+        echo "  Before cleanup:"
+        docker system df 2>/dev/null | sed 's/^/    /' || true
+
+        # Remove images tagged with registry IPs (e.g. 10.213.0.2:5000/buildcache/...)
+        # These are push artifacts — the built images are already tagged locally
+        REGISTRY_IMAGES=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep -E '^\d+\.\d+\.\d+\.\d+:' || true)
+        if [ -n "$REGISTRY_IMAGES" ]; then
+            echo "$REGISTRY_IMAGES" | xargs docker rmi 2>/dev/null || true
+            echo "  Removed registry-tagged images"
+        fi
+
+        # Remove dangling images (intermediate build layers with <none> tag)
+        docker image prune -f 2>/dev/null || true
+
+        # Remove unused volumes (build step caches that won't carry forward)
+        docker volume prune -f 2>/dev/null || true
+
+        # Show after state
+        echo "  After cleanup:"
+        docker system df 2>/dev/null | sed 's/^/    /' || true
+        echo "✅ Docker cleanup complete"
+
         echo "Stopping dockerd for clean shutdown..."
         # Stop dockerd cleanly so Docker data on disk is consistent
         # (the data will be promoted to golden cache by Hydra)


### PR DESCRIPTION
## Summary

- **Stale golden build recovery**: After API restart, the monitoring goroutine dies but the DB still says `status="building"`, leaving the UI stuck showing a build that no longer exists. Adds lazy recovery in the `getProject` handler — when a project is polled and a sandbox shows "building", checks if the goroutine is alive (`IsTracking`) AND the container is running (`HasRunningContainer`). If neither is true, resets to "none". No false positives during normal operation because the goroutine check passes.

- **Golden cache size reduction**: Docker artifacts (registry-tagged push images, dangling intermediates, unused volumes) accumulate across golden builds (~29 GB reclaimable out of 59 GB observed). Adds cleanup in `workspace-setup.sh` before dockerd stops (requires `build-ubuntu`), and removes `volumes/` in `PurgeContainersFromGolden` as a filesystem-level safety net.

## Test plan

- [ ] Restart API while golden build status shows "building" → verify UI recovers on next project poll
- [ ] Trigger golden build → verify it completes normally (no false recovery during active build)
- [ ] After `build-ubuntu`: run golden build → verify `docker system df` before/after cleanup in container logs
- [ ] Verify golden cache size is reduced (~30 GB instead of ~59 GB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)