### PR TITLE
set zed://settings/text_rendering_mode to 'grayscale' in ...

### DIFF
--- a/api/cmd/settings-sync-daemon/main.go
+++ b/api/cmd/settings-sync-daemon/main.go
@@ -721,6 +721,9 @@ func (d *SettingsDaemon) syncFromHelix() error {
 
 	d.helixSettings = map[string]interface{}{
 		"context_servers": config.ContextServers,
+		// Use grayscale text rendering - subpixel antialiasing doesn't work well
+		// over video streaming since the client display's subpixel layout is unknown
+		"text_rendering_mode": "grayscale",
 		// Disable dev container suggestions - Helix runs Zed inside its own containers
 		"remote": map[string]interface{}{
 			"suggest_dev_container": false,


### PR DESCRIPTION
> **Helix**: set zed://settings/text_rendering_mode to 'grayscale' in the settings sync daemon, and the same equivalent in gnome settings
