### PR TITLE
responses from the agent streaming into the response to a...

### DIFF
--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -27,6 +27,8 @@ import (
 type streamingContext struct {
 	session     *types.Session
 	interaction *types.Interaction
+	// Request ID for commenter notification (design review comments)
+	requestID string
 	// DB write throttling
 	lastDBWrite time.Time
 	dirty       bool // true if interaction has been updated since last DB write
@@ -954,6 +956,10 @@ func (apiServer *HelixAPIServer) handleMessageAdded(sessionID string, syncMsg *t
 	}
 
 	if role == "assistant" {
+		// Extract request_id for commenter notification (design review comments)
+		// This is set when sendMessageToSpecTaskAgent sends a comment to the agent
+		requestID, _ := syncMsg.Data["request_id"].(string)
+
 		// PERFORMANCE OPTIMIZATION: Use streaming context cache to avoid
 		// redundant DB queries during token streaming. GetSession and
 		// ListInteractions are called once on the first token, then cached
@@ -965,6 +971,16 @@ func (apiServer *HelixAPIServer) handleMessageAdded(sessionID string, syncMsg *t
 
 		sctx.mu.Lock()
 		defer sctx.mu.Unlock()
+
+		// Store requestID in streaming context for commenter notification
+		// Only set if not already set (first message_added for this streaming context)
+		if sctx.requestID == "" && requestID != "" {
+			sctx.requestID = requestID
+			log.Debug().
+				Str("session_id", helixSessionID).
+				Str("request_id", requestID).
+				Msg("📝 [HELIX] Stored requestID in streaming context for commenter notification")
+		}
 
 		helixSession := sctx.session
 		targetInteraction := sctx.interaction
@@ -1022,7 +1038,7 @@ func (apiServer *HelixAPIServer) handleMessageAdded(sessionID string, syncMsg *t
 			// THROTTLED FRONTEND PUBLISH: Only publish if enough time has passed.
 			// Uses patch-based delta to reduce wire traffic from O(N) to O(delta).
 			if now.Sub(sctx.lastPublish) >= publishInterval {
-				err := apiServer.publishInteractionPatchToFrontend(helixSessionID, helixSession.Owner, targetInteraction, sctx.previousContent)
+				err := apiServer.publishInteractionPatchToFrontend(helixSessionID, helixSession.Owner, targetInteraction, sctx.previousContent, sctx.requestID)
 				if err != nil {
 					log.Error().Err(err).
 						Str("session_id", helixSessionID).
@@ -2544,10 +2560,12 @@ func computePatch(previousContent, newContent string) (patchOffset int, patch st
 // publishInteractionPatchToFrontend sends a delta patch instead of the full interaction.
 // This reduces per-update wire traffic from O(N) to O(delta). The frontend applies the
 // patch to reconstruct the full content: content = content[:patchOffset] + patch.
+// If requestID is provided, also publishes to the commenter's queue (for design review comments).
 func (apiServer *HelixAPIServer) publishInteractionPatchToFrontend(
 	sessionID, owner string,
 	interaction *types.Interaction,
 	previousContent string,
+	requestID ...string,
 ) (err error) {
 	patchOffset, patch, totalLength := computePatch(previousContent, interaction.ResponseMessage)
 
@@ -2580,10 +2598,27 @@ func (apiServer *HelixAPIServer) publishInteractionPatchToFrontend(
 		Int("full_content_len", len(interaction.ResponseMessage)).
 		Msg("📤 [HELIX] Published interaction patch to frontend")
 
-	// Also publish to commenter if applicable
-	if apiServer.requestToCommenterMapping != nil {
-		// We don't have requestID here, so we skip commenter publishing for patches.
-		// Commenters will get the full interaction on completion.
+	// Also publish to commenter if applicable (for design review comments)
+	if len(requestID) > 0 && requestID[0] != "" {
+		if apiServer.requestToCommenterMapping != nil {
+			if commenterID, exists := apiServer.requestToCommenterMapping[requestID[0]]; exists && commenterID != owner {
+				// Publish to commenter's queue as well
+				err = apiServer.pubsub.Publish(context.Background(), pubsub.GetSessionQueue(commenterID, sessionID), messageBytes)
+				if err != nil {
+					log.Warn().
+						Err(err).
+						Str("session_id", sessionID).
+						Str("commenter_id", commenterID).
+						Msg("Failed to publish interaction patch to commenter")
+				} else {
+					log.Debug().
+						Str("session_id", sessionID).
+						Str("interaction_id", interaction.ID).
+						Str("commenter_id", commenterID).
+						Msg("📤 [HELIX] Published interaction patch to commenter")
+				}
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
> **Helix**: responses from the agent streaming into the response to a comment in the spec comment UI seem to have stopped working in the last ~week or so, review recent commits for what might have stopped it working and fix it, being careful not to regress anything that said commits might have been trying to fix
