### PR TITLE
Fix zed-e2e-test CI: add go mod tidy after replace path rewrite

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1928,6 +1928,7 @@ steps:
         WORKDIR /app
         RUN apk add --no-cache gcc g++ musl-dev && \
             sed -i 's|../../../../../helix|/helix|g' go.mod && \
+            go mod tidy && \
             CGO_ENABLED=1 go build -ldflags '-extldflags "-static"' -o /helix-ws-test-server .
 
         # Stage 2: Runtime


### PR DESCRIPTION
## Summary
- The `zed-e2e-test` CI step rewrites the `replace` directive path in the test server's `go.mod` using `sed`, which invalidates the module graph
- Go then refuses to build with `go: updates to go.mod needed; to update it: go mod tidy`
- Fix: add `go mod tidy` between the `sed` rewrite and `go build`

## Test plan
- [ ] CI `zed-e2e-test` step passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)