### PR TITLE
Bump chart versions and auto-stamp from release tags

### DIFF
--- a/charts/helix-controlplane/Chart.yaml
+++ b/charts/helix-controlplane/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.38
+version: 0.3.39
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/helix-runner/Chart.yaml
+++ b/charts/helix-runner/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.8
+version: 0.3.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/helix-sandbox/Chart.yaml
+++ b/charts/helix-sandbox/Chart.yaml
@@ -8,7 +8,7 @@ description: |
 type: application
 
 # Chart version - increment on changes to chart templates
-version: 0.2.0
+version: 0.2.1
 
 # Application version - matches helix-sandbox container version
 appVersion: "2.7.10"

--- a/scripts/gen_packages.sh
+++ b/scripts/gen_packages.sh
@@ -11,12 +11,22 @@ curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scrip
 chmod 700 get_helm.sh
 ./get_helm.sh
 
-# Stamp appVersion from release tag if available
+# Stamp version and appVersion from release tag if available
 # Supports Drone CI (DRONE_TAG) and Google Cloud Build (TAG_NAME)
+# This aligns chart version with app version (like cert-manager) so releases
+# automatically publish new chart versions without manual bumps.
 RELEASE_TAG="${DRONE_TAG:-${TAG_NAME:-}}"
+# Strip leading 'v' if present (e.g. v2.7.11 -> 2.7.11)
+RELEASE_TAG="${RELEASE_TAG#v}"
 if [ -n "${RELEASE_TAG}" ]; then
-  echo "Stamping appVersion=${RELEASE_TAG} into all Chart.yaml files"
+  # Helm chart version field requires valid semver
+  if ! echo "${RELEASE_TAG}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+    echo "ERROR: RELEASE_TAG '${RELEASE_TAG}' is not valid semver for chart version"
+    exit 1
+  fi
+  echo "Stamping version=${RELEASE_TAG} and appVersion=${RELEASE_TAG} into all Chart.yaml files"
   for chart in charts/*/Chart.yaml; do
+    sed -i "s/^version:.*/version: ${RELEASE_TAG}/" "$chart"
     sed -i "s/^appVersion:.*/appVersion: \"${RELEASE_TAG}\"/" "$chart"
   done
 fi

--- a/scripts/repo_sync.sh
+++ b/scripts/repo_sync.sh
@@ -5,11 +5,21 @@ set -e
 REPO_URL="https://charts.helixml.tech"
 
 function gen_packages() {
-  # Stamp appVersion from release tag if available
+  # Stamp version and appVersion from release tag if available
+  # This aligns chart version with app version (like cert-manager) so releases
+  # automatically publish new chart versions without manual bumps.
   RELEASE_TAG="${DRONE_TAG:-${TAG_NAME:-}}"
+  # Strip leading 'v' if present (e.g. v2.7.11 -> 2.7.11)
+  RELEASE_TAG="${RELEASE_TAG#v}"
   if [ -n "${RELEASE_TAG}" ]; then
-    echo "Stamping appVersion=${RELEASE_TAG} into all Chart.yaml files"
+    # Helm chart version field requires valid semver
+    if ! echo "${RELEASE_TAG}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+      echo "ERROR: RELEASE_TAG '${RELEASE_TAG}' is not valid semver for chart version"
+      exit 1
+    fi
+    echo "Stamping version=${RELEASE_TAG} and appVersion=${RELEASE_TAG} into all Chart.yaml files"
     for chart in charts/*/Chart.yaml; do
+      sed -i "s/^version:.*/version: ${RELEASE_TAG}/" "$chart"
       sed -i "s/^appVersion:.*/appVersion: \"${RELEASE_TAG}\"/" "$chart"
     done
   fi


### PR DESCRIPTION
## Summary
- Bumps chart versions (controlplane 0.3.39, sandbox 0.2.1, runner 0.3.9) to publish the appVersion/tag fixes from PR #1806
- Stamps chart `version` field (not just `appVersion`) from release tags in CI packaging scripts — aligns chart version with app version (like cert-manager) so future releases auto-publish new charts without manual bumps
- Adds semver validation and `v`-prefix stripping to prevent malformed tags breaking `helm package`

## Context
PR #1806 changed all charts from `tag: "latest"` to `tag: ""` with `appVersion` fallback, but the chart versions weren't bumped so the changes were never published. This fixes that and ensures it never happens again.

## Test plan
- [ ] Verify charts publish to charts.helixml.tech after merge
- [ ] On next release tag, verify both `version` and `appVersion` are stamped correctly
- [ ] `helm repo update helix && helm search repo helix/` shows new versions with correct appVersion

🤖 Generated with [Claude Code](https://claude.com/claude-code)