### PR TITLE
Delete Kodit repositories when Helix repos are deleted

### DIFF
--- a/api/pkg/server/kodit_handlers_test.go
+++ b/api/pkg/server/kodit_handlers_test.go
@@ -52,6 +52,7 @@ func (f *fakeKoditService) GetRepositoryStatus(_ context.Context, _ int64) (trac
 	return f.status, f.err
 }
 func (f *fakeKoditService) RescanCommit(_ context.Context, _ int64, _ string) error { return f.err }
+func (f *fakeKoditService) DeleteRepository(_ context.Context, _ int64) error              { return f.err }
 
 type fakeGitRepositoryStore struct {
 	store.Store

--- a/api/pkg/services/git_repository_service.go
+++ b/api/pkg/services/git_repository_service.go
@@ -897,18 +897,32 @@ func (s *GitRepositoryService) UpdateRepository(
 	return existing, nil
 }
 
-// DeleteRepository deletes a repository
+// DeleteRepository deletes a repository from the filesystem, database, and Kodit.
 func (s *GitRepositoryService) DeleteRepository(ctx context.Context, repoID string) error {
-	repoPath := filepath.Join(s.gitRepoBase, repoID)
-
-	// Delete repository directory
-	if err := os.RemoveAll(repoPath); err != nil {
-		log.Warn().Err(err).Str("repo_id", repoID).Msg("failed to delete repository directory")
-		// Continue to delete metadata even if filesystem deletion fails
+	// Fetch the repo first so we can read kodit metadata before deleting.
+	repo, err := s.store.GetGitRepository(ctx, repoID)
+	if err != nil {
+		log.Warn().Err(err).Str("repo_id", repoID).Msg("failed to fetch repository before deletion")
+		// Continue — we still want to clean up the filesystem and DB record.
 	}
 
-	err := s.store.DeleteGitRepository(ctx, repoID)
-	if err != nil {
+	// Delete from Kodit if the repo was indexed there.
+	if repo != nil && s.koditService != nil && s.koditService.IsEnabled() {
+		koditRepoID := koditRepoIDFromMetadata(repo.Metadata)
+		if koditRepoID != 0 {
+			if err := s.koditService.DeleteRepository(ctx, koditRepoID); err != nil {
+				log.Warn().Err(err).Str("repo_id", repoID).Int64("kodit_repo_id", koditRepoID).Msg("failed to delete repository from Kodit")
+			}
+		}
+	}
+
+	// Delete repository directory
+	repoPath := filepath.Join(s.gitRepoBase, repoID)
+	if err := os.RemoveAll(repoPath); err != nil {
+		log.Warn().Err(err).Str("repo_id", repoID).Msg("failed to delete repository directory")
+	}
+
+	if err := s.store.DeleteGitRepository(ctx, repoID); err != nil {
 		log.Warn().Err(err).Str("repo_id", repoID).Msg("failed to delete repository metadata")
 	}
 
@@ -917,6 +931,34 @@ func (s *GitRepositoryService) DeleteRepository(ctx context.Context, repoID stri
 		Msg("deleted git repository")
 
 	return nil
+}
+
+// koditRepoIDFromMetadata extracts the kodit_repo_id from repository metadata,
+// handling int64, float64 (JSON), int, and string formats.
+func koditRepoIDFromMetadata(metadata map[string]any) int64 {
+	if metadata == nil {
+		return 0
+	}
+	raw, ok := metadata["kodit_repo_id"]
+	if !ok {
+		return 0
+	}
+	switch v := raw.(type) {
+	case int64:
+		return v
+	case float64:
+		return int64(v)
+	case int:
+		return int64(v)
+	case string:
+		id, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return 0
+		}
+		return id
+	default:
+		return 0
+	}
 }
 
 // incrementRepositoryName intelligently increments a repository name suffix

--- a/api/pkg/services/git_repository_service_test.go
+++ b/api/pkg/services/git_repository_service_test.go
@@ -1,10 +1,137 @@
 package services
 
 import (
+	"context"
 	"testing"
 
+	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
+	"github.com/helixml/kodit/domain/enrichment"
+	"github.com/helixml/kodit/domain/repository"
+	"github.com/helixml/kodit/domain/tracking"
 )
+
+// fakeStore embeds store.Store and overrides only the methods we need.
+type fakeStore struct {
+	store.Store
+	repo    *types.GitRepository
+	deleted bool
+}
+
+func (f *fakeStore) GetGitRepository(_ context.Context, _ string) (*types.GitRepository, error) {
+	if f.repo == nil {
+		return nil, store.ErrNotFound
+	}
+	return f.repo, nil
+}
+
+func (f *fakeStore) DeleteGitRepository(_ context.Context, _ string) error {
+	f.deleted = true
+	return nil
+}
+
+// fakeKodit records calls for verification.
+type fakeKodit struct {
+	enabled          bool
+	deletedRepoID    int64
+	deleteRepoCalled bool
+	err              error
+}
+
+func (f *fakeKodit) IsEnabled() bool { return f.enabled }
+func (f *fakeKodit) RegisterRepository(_ context.Context, _ string) (int64, bool, error) {
+	return 0, false, f.err
+}
+func (f *fakeKodit) DeleteRepository(_ context.Context, id int64) error {
+	f.deleteRepoCalled = true
+	f.deletedRepoID = id
+	return f.err
+}
+func (f *fakeKodit) GetRepositoryEnrichments(_ context.Context, _ int64, _, _ string) ([]enrichment.Enrichment, error) {
+	return nil, f.err
+}
+func (f *fakeKodit) GetEnrichment(_ context.Context, _ string) (enrichment.Enrichment, error) {
+	return enrichment.Enrichment{}, f.err
+}
+func (f *fakeKodit) GetRepositoryCommits(_ context.Context, _ int64, _ int) ([]repository.Commit, error) {
+	return nil, f.err
+}
+func (f *fakeKodit) SearchSnippets(_ context.Context, _ int64, _ string, _ int) ([]enrichment.Enrichment, error) {
+	return nil, f.err
+}
+func (f *fakeKodit) GetRepositoryStatus(_ context.Context, _ int64) (tracking.RepositoryStatusSummary, error) {
+	return tracking.RepositoryStatusSummary{}, f.err
+}
+func (f *fakeKodit) RescanCommit(_ context.Context, _ int64, _ string) error { return f.err }
+
+func TestDeleteRepository_DeletesFromKodit(t *testing.T) {
+	kodit := &fakeKodit{enabled: true}
+	st := &fakeStore{
+		repo: &types.GitRepository{
+			ID:            "repo-1",
+			KoditIndexing: true,
+			Metadata:      map[string]any{"kodit_repo_id": int64(42)},
+		},
+	}
+	svc := NewGitRepositoryService(st, t.TempDir(), "http://localhost:8080", "test", "test@test.com")
+	svc.SetKoditService(kodit)
+
+	if err := svc.DeleteRepository(t.Context(), "repo-1"); err != nil {
+		t.Fatalf("DeleteRepository() error: %v", err)
+	}
+
+	if !kodit.deleteRepoCalled {
+		t.Error("expected kodit DeleteRepository to be called")
+	}
+	if kodit.deletedRepoID != 42 {
+		t.Errorf("expected kodit repo ID 42, got %d", kodit.deletedRepoID)
+	}
+	if !st.deleted {
+		t.Error("expected store DeleteGitRepository to be called")
+	}
+}
+
+func TestDeleteRepository_SkipsKoditWhenNoRepoID(t *testing.T) {
+	kodit := &fakeKodit{enabled: true}
+	st := &fakeStore{
+		repo: &types.GitRepository{
+			ID:            "repo-2",
+			KoditIndexing: true,
+			Metadata:      map[string]any{},
+		},
+	}
+	svc := NewGitRepositoryService(st, t.TempDir(), "http://localhost:8080", "test", "test@test.com")
+	svc.SetKoditService(kodit)
+
+	if err := svc.DeleteRepository(t.Context(), "repo-2"); err != nil {
+		t.Fatalf("DeleteRepository() error: %v", err)
+	}
+
+	if kodit.deleteRepoCalled {
+		t.Error("expected kodit DeleteRepository NOT to be called when no kodit_repo_id")
+	}
+}
+
+func TestDeleteRepository_SkipsKoditWhenDisabled(t *testing.T) {
+	kodit := &fakeKodit{enabled: false}
+	st := &fakeStore{
+		repo: &types.GitRepository{
+			ID:            "repo-3",
+			KoditIndexing: true,
+			Metadata:      map[string]any{"kodit_repo_id": int64(42)},
+		},
+	}
+	svc := NewGitRepositoryService(st, t.TempDir(), "http://localhost:8080", "test", "test@test.com")
+	svc.SetKoditService(kodit)
+
+	if err := svc.DeleteRepository(t.Context(), "repo-3"); err != nil {
+		t.Fatalf("DeleteRepository() error: %v", err)
+	}
+
+	if kodit.deleteRepoCalled {
+		t.Error("expected kodit DeleteRepository NOT to be called when kodit is disabled")
+	}
+}
 
 func TestGetPullRequestURL(t *testing.T) {
 	tests := []struct {

--- a/api/pkg/services/kodit_service.go
+++ b/api/pkg/services/kodit_service.go
@@ -221,6 +221,20 @@ func (s *KoditService) GetRepositoryStatus(ctx context.Context, koditRepoID int6
 	return summary, nil
 }
 
+// DeleteRepository removes a repository from Kodit.
+func (s *KoditService) DeleteRepository(ctx context.Context, koditRepoID int64) error {
+	if !s.enabled {
+		return fmt.Errorf("kodit service not enabled")
+	}
+
+	if err := s.client.Repositories.Delete(ctx, koditRepoID); err != nil {
+		return fmt.Errorf("failed to delete repository from kodit: %w", err)
+	}
+
+	log.Info().Int64("kodit_repo_id", koditRepoID).Msg("Deleted repository from Kodit")
+	return nil
+}
+
 // RescanCommit triggers a rescan of a specific commit in Kodit
 func (s *KoditService) RescanCommit(ctx context.Context, koditRepoID int64, commitSHA string) error {
 	if !s.enabled {

--- a/api/pkg/services/kodit_service_test.go
+++ b/api/pkg/services/kodit_service_test.go
@@ -40,6 +40,7 @@ func TestDisabledServiceMethods(t *testing.T) {
 		{"SearchSnippets", func() error { _, e := svc.SearchSnippets(ctx, 1, "test", 10); return e }},
 		{"GetRepositoryStatus", func() error { _, e := svc.GetRepositoryStatus(ctx, 1); return e }},
 		{"RescanCommit", func() error { return svc.RescanCommit(ctx, 1, "abc123") }},
+		{"DeleteRepository", func() error { return svc.DeleteRepository(ctx, 1) }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.fn() == nil {

--- a/api/pkg/services/kodit_servicer.go
+++ b/api/pkg/services/kodit_servicer.go
@@ -24,6 +24,7 @@ type KoditServicer interface {
 	SearchSnippets(ctx context.Context, koditRepoID int64, query string, limit int) ([]enrichment.Enrichment, error)
 	GetRepositoryStatus(ctx context.Context, koditRepoID int64) (tracking.RepositoryStatusSummary, error)
 	RescanCommit(ctx context.Context, koditRepoID int64, commitSHA string) error
+	DeleteRepository(ctx context.Context, koditRepoID int64) error
 }
 
 // disabledKoditService is a KoditServicer that is always disabled.
@@ -49,6 +50,9 @@ func (d *disabledKoditService) GetRepositoryStatus(context.Context, int64) (trac
 	return tracking.RepositoryStatusSummary{}, errors.New("kodit service not enabled")
 }
 func (d *disabledKoditService) RescanCommit(context.Context, int64, string) error {
+	return errors.New("kodit service not enabled")
+}
+func (d *disabledKoditService) DeleteRepository(context.Context, int64) error {
 	return errors.New("kodit service not enabled")
 }
 


### PR DESCRIPTION
## Summary
- When a Helix repository is deleted, the corresponding Kodit repository is now also deleted
- Previously only the filesystem directory and DB record were cleaned up, leaving orphaned data in Kodit
- Adds `DeleteRepository` to `KoditServicer` interface, backed by kodit's async delete queue

## Test plan
- [x] `TestDeleteRepository_DeletesFromKodit` — verifies kodit delete is called with correct ID
- [x] `TestDeleteRepository_SkipsKoditWhenNoRepoID` — no call when metadata lacks kodit ID
- [x] `TestDeleteRepository_SkipsKoditWhenDisabled` — no call when kodit is disabled
- [x] All existing kodit handler and service tests pass

Assisted by AI. Co-Authored-By: Helix <noreply@helix.ml>