### PR TITLE
Fix operator CI: add go mod tidy before build and lint

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -789,7 +789,7 @@ steps:
       GITHUB_TOKEN:
         from_secret: github_token
     commands:
-      - cd operator && go build ./...
+      - cd operator && go mod tidy && go build ./...
     depends_on: []
 
   - name: run-linter-operator
@@ -800,7 +800,7 @@ steps:
       - name: go-mod-cache
         path: /go/pkg/mod
     commands:
-      - cd operator && golangci-lint run ./...
+      - cd operator && go mod tidy && golangci-lint run ./...
     when:
       event:
         - push


### PR DESCRIPTION
## Summary
- Operator CI steps (`build-operator`, `run-linter-operator`) fail with `go: updates to go.mod needed; to update it: go mod tidy`
- Same root cause as #1808 — the `replace` directive + Go version mismatch triggers staleness check
- Fix: add `go mod tidy` before `go build` and `golangci-lint`

## Test plan
- [ ] CI `build-operator` step passes
- [ ] CI `run-linter-operator` step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)