### PR TITLE
Fix cloudbuild.yaml: pass TAG_NAME env to gen_packages.sh

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,6 +2,8 @@ steps:
 
 # Generate Helm packages
 - name: 'ubuntu'
+  env:
+  - 'TAG_NAME=$TAG_NAME'
   args: ['bash', './scripts/gen_packages.sh']
   id: 'gen_packages'
 


### PR DESCRIPTION
Cloud Build substitutions ($TAG_NAME) are only expanded in args/env fields, not automatically available as shell environment variables. The gen_packages.sh script reads TAG_NAME from the environment to stamp chart versions, so it must be explicitly passed.