### PR TITLE
Fix: pin PostgreSQL to v17, move off deprecated bitnamilegacy

### DIFF
--- a/charts/helix-controlplane/values.yaml
+++ b/charts/helix-controlplane/values.yaml
@@ -253,8 +253,8 @@ postgresql:
   enabled: true
   image:
     registry: docker.io
-    repository: bitnamilegacy/postgresql
-    tag: "latest"
+    repository: bitnami/postgresql
+    tag: "17"
     pullPolicy: IfNotPresent
   auth:
     postgresPassword: ""


### PR DESCRIPTION
## Summary
- Pin bundled PostgreSQL image from `bitnamilegacy/postgresql:latest` to `bitnami/postgresql:17`
- `bitnamilegacy` repo is deprecated and no longer updated — `latest` silently resolved to PG18
- PG18 breaks upgrades from existing PG17 data directories (`FATAL: database files are incompatible with server`)
- Reported by NTT customer after re-deploying with updated quick start guide

## Test plan
- [ ] Fresh install on kind — verify PostgreSQL starts with PG17 image
- [ ] Upgrade from existing PG17 install — verify no version mismatch error

🤖 Generated with [Claude Code](https://claude.com/claude-code)