### PR TITLE
Fix: disable caching on helm index.yaml after chart upload

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,3 +22,8 @@ steps:
 - name: gcr.io/cloud-builders/gsutil
   args: ['rsync', 'temp/', 'gs://charts.helixml.tech']
   id: 'upload_charts'
+
+# Disable caching on index.yaml so helm clients see updates immediately
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['setmeta', '-h', 'Cache-Control:no-cache,no-store,max-age=0', 'gs://charts.helixml.tech/index.yaml']
+  id: 'disable_index_cache'


### PR DESCRIPTION
## Summary
- Add a post-upload step to `cloudbuild.yaml` that sets `Cache-Control: no-cache` on `index.yaml`
- Without this, GCS/Cloudflare serve stale index and `helm repo update` doesn't see new chart versions until cache expires

## Test plan
- [ ] Next release tag triggers Cloud Build and index.yaml has `no-cache` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)