### PR TITLE
Fix: use bitnamilegacy/postgresql:17 (bitnami/postgresql:17 doesn't exist)

### DIFF
--- a/charts/helix-controlplane/values-example.yaml
+++ b/charts/helix-controlplane/values-example.yaml
@@ -415,9 +415,9 @@ postgresql:
   # PostgreSQL image configuration
   image:
     registry: docker.io
-    repository: bitnami/postgresql
-    tag: latest
-    pullPolicy: Always
+    repository: bitnamilegacy/postgresql
+    tag: "17"
+    pullPolicy: IfNotPresent
 
   # For bundled PostgreSQL auth configuration (when enabled=true):
   auth:

--- a/charts/helix-controlplane/values.yaml
+++ b/charts/helix-controlplane/values.yaml
@@ -253,7 +253,7 @@ postgresql:
   enabled: true
   image:
     registry: docker.io
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     tag: "17"
     pullPolicy: IfNotPresent
   auth:


### PR DESCRIPTION
## Summary
- `bitnami/postgresql:17` doesn't exist on Docker Hub — Bitnami moved versioned tags to `bitnamilegacy`
- Changes both `values.yaml` and `values-example.yaml` to use `bitnamilegacy/postgresql:17`
- Fixes ImagePullBackOff on fresh installs with chart 2.7.16

## Test plan
- [x] Fresh kind install — PostgreSQL pod pulls `bitnamilegacy/postgresql:17` successfully
- [x] Upgrade from existing install — no PG version mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)