### PR TITLE
fix: switch desktop/session server to Streamable HTTP so it works with zed ootb

### DIFF
--- a/api/pkg/desktop/mcp_server.go
+++ b/api/pkg/desktop/mcp_server.go
@@ -22,14 +22,14 @@ import (
 // It exposes screenshot, clipboard, and input tools to AI agents.
 type MCPServer struct {
 	mcpServer     *server.MCPServer
-	sseServer     *server.SSEServer
+	httpServer    *server.StreamableHTTPServer
 	screenshotURL string // URL to the local screenshot HTTP endpoint
 	logger        *slog.Logger
 }
 
 // MCPConfig holds configuration for the MCP server
 type MCPConfig struct {
-	// Port for the MCP SSE server (default: 9877)
+	// Port for the MCP server (default: 9877)
 	Port string
 	// ScreenshotURL is the local screenshot endpoint (default: http://localhost:9876/screenshot)
 	ScreenshotURL string
@@ -203,9 +203,9 @@ func NewMCPServer(cfg MCPConfig, logger *slog.Logger) *MCPServer {
 	)
 	m.mcpServer.AddTool(getWorkspacesTool, m.handleGetWorkspaces)
 
-	// Create SSE server
-	m.sseServer = server.NewSSEServer(m.mcpServer,
-		server.WithBasePath("/mcp"),
+	// Create Streamable HTTP server for direct POST support (compatible with Zed's HttpTransport)
+	m.httpServer = server.NewStreamableHTTPServer(m.mcpServer,
+		server.WithStateLess(true),
 	)
 
 	return m
@@ -1072,10 +1072,10 @@ func formatSwayWorkspaces(data []byte) string {
 
 // ServeHTTP serves MCP requests
 func (m *MCPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	m.sseServer.ServeHTTP(w, r)
+	m.httpServer.ServeHTTP(w, r)
 }
 
-// Run starts the MCP SSE server
+// Run starts the MCP server
 func (m *MCPServer) Run(ctx context.Context, port string) error {
 	if port == "" {
 		port = "9877"
@@ -1083,7 +1083,7 @@ func (m *MCPServer) Run(ctx context.Context, port string) error {
 
 	httpServer := &http.Server{
 		Addr:    ":" + port,
-		Handler: m.sseServer,
+		Handler: m.httpServer,
 	}
 
 	m.logger.Info("MCP server starting", "port", port)

--- a/api/pkg/desktop/mcp_server_test.go
+++ b/api/pkg/desktop/mcp_server_test.go
@@ -1,6 +1,12 @@
 package desktop
 
 import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -180,6 +186,118 @@ func TestFormatSwayWorkspaces(t *testing.T) {
 				t.Errorf("formatSwayWorkspaces() = %q, want %q", result, tt.expected)
 			}
 		})
+	}
+}
+
+// TestMCPServer_StreamableHTTP verifies the server responds to Streamable HTTP
+// protocol (POST with JSON-RPC body), which is what Zed's HttpTransport uses.
+func TestMCPServer_StreamableHTTP(t *testing.T) {
+	logger := slog.Default()
+	srv := NewMCPServer(MCPConfig{}, logger)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Send a JSON-RPC initialize request as POST to /mcp, the way Zed does it
+	initPayload := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	resp, err := http.Post(ts.URL+"/mcp", "application/json", strings.NewReader(initPayload))
+	if err != nil {
+		t.Fatalf("POST /mcp failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("response is not valid JSON: %v\nbody: %s", err, string(body))
+	}
+
+	// Verify it's a JSON-RPC response with server info
+	resultField, ok := result["result"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected result field in response, got: %s", string(body))
+	}
+	serverInfo, ok := resultField["serverInfo"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected serverInfo in result, got: %+v", resultField)
+	}
+	if serverInfo["name"] != "Helix Desktop" {
+		t.Errorf("expected server name 'Helix Desktop', got %q", serverInfo["name"])
+	}
+}
+
+// TestMCPServer_ToolsList verifies tools/list works over Streamable HTTP.
+func TestMCPServer_ToolsList(t *testing.T) {
+	logger := slog.Default()
+	srv := NewMCPServer(MCPConfig{}, logger)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Initialize first
+	initPayload := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	resp, err := http.Post(ts.URL+"/mcp", "application/json", strings.NewReader(initPayload))
+	if err != nil {
+		t.Fatalf("initialize failed: %v", err)
+	}
+	// Extract session ID from Mcp-Session header if present
+	sessionID := resp.Header.Get("Mcp-Session")
+	resp.Body.Close()
+
+	// Now list tools
+	listPayload := `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`
+	req, _ := http.NewRequest("POST", ts.URL+"/mcp", strings.NewReader(listPayload))
+	req.Header.Set("Content-Type", "application/json")
+	if sessionID != "" {
+		req.Header.Set("Mcp-Session", sessionID)
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("tools/list failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("response is not valid JSON: %v\nbody: %s", err, string(body))
+	}
+
+	resultField, ok := result["result"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected result field, got: %s", string(body))
+	}
+
+	tools, ok := resultField["tools"].([]interface{})
+	if !ok {
+		t.Fatalf("expected tools array, got: %+v", resultField)
+	}
+
+	// Verify we have the expected desktop tools
+	toolNames := make(map[string]bool)
+	for _, tool := range tools {
+		toolMap := tool.(map[string]interface{})
+		toolNames[toolMap["name"].(string)] = true
+	}
+
+	expectedTools := []string{"take_screenshot", "type_text", "mouse_click", "list_windows", "get_clipboard", "set_clipboard"}
+	for _, name := range expectedTools {
+		if !toolNames[name] {
+			t.Errorf("expected tool %q not found in tools list", name)
+		}
 	}
 }
 

--- a/api/pkg/session/mcp_server.go
+++ b/api/pkg/session/mcp_server.go
@@ -24,7 +24,7 @@ import (
 // is useful for all agents, not just desktop environments.
 type MCPServer struct {
 	mcpServer     *server.MCPServer
-	sseServer     *server.SSEServer
+	httpServer    *server.StreamableHTTPServer
 	helixAPIURL   string // Helix API URL for session endpoints
 	helixAPIToken string // Helix API token for authentication
 	sessionID     string // Current session ID (most likely to be relevant)
@@ -33,7 +33,7 @@ type MCPServer struct {
 
 // MCPConfig holds configuration for the session MCP server
 type MCPConfig struct {
-	// Port for the MCP SSE server (default: 9878)
+	// Port for the MCP server (default: 9878)
 	Port string
 	// HelixAPIURL is the Helix API endpoint (from HELIX_API_URL env)
 	HelixAPIURL string
@@ -225,9 +225,9 @@ Use this when you have an interaction ID (e.g., from title_history) and want to 
 	)
 	m.mcpServer.AddTool(getInteractionTool, m.handleGetInteraction)
 
-	// Create SSE server
-	m.sseServer = server.NewSSEServer(m.mcpServer,
-		server.WithBasePath("/mcp"),
+	// Create Streamable HTTP server for direct POST support (compatible with Zed's HttpTransport)
+	m.httpServer = server.NewStreamableHTTPServer(m.mcpServer,
+		server.WithStateLess(true),
 	)
 
 	return m
@@ -235,10 +235,10 @@ Use this when you have an interaction ID (e.g., from title_history) and want to 
 
 // ServeHTTP serves MCP requests
 func (m *MCPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	m.sseServer.ServeHTTP(w, r)
+	m.httpServer.ServeHTTP(w, r)
 }
 
-// Run starts the MCP SSE server
+// Run starts the MCP server
 func (m *MCPServer) Run(ctx context.Context, port string) error {
 	if port == "" {
 		port = "9878"
@@ -246,7 +246,7 @@ func (m *MCPServer) Run(ctx context.Context, port string) error {
 
 	httpServer := &http.Server{
 		Addr:    ":" + port,
-		Handler: m.sseServer,
+		Handler: m.httpServer,
 	}
 
 	m.logger.Info("Session MCP server starting", "port", port)

--- a/api/pkg/session/mcp_server_test.go
+++ b/api/pkg/session/mcp_server_test.go
@@ -1,0 +1,130 @@
+package session
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestMCPServer_StreamableHTTP verifies the server responds to Streamable HTTP
+// protocol (POST with JSON-RPC body), which is what Zed's HttpTransport uses.
+func TestMCPServer_StreamableHTTP(t *testing.T) {
+	logger := slog.Default()
+	srv := NewMCPServer(MCPConfig{
+		HelixAPIURL:   "http://localhost:8080",
+		HelixAPIToken: "test-token",
+		SessionID:     "test-session",
+	}, logger)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Send a JSON-RPC initialize request as POST to /mcp, the way Zed does it
+	initPayload := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	resp, err := http.Post(ts.URL+"/mcp", "application/json", strings.NewReader(initPayload))
+	if err != nil {
+		t.Fatalf("POST /mcp failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("response is not valid JSON: %v\nbody: %s", err, string(body))
+	}
+
+	// Verify it's a JSON-RPC response with server info
+	resultField, ok := result["result"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected result field in response, got: %s", string(body))
+	}
+	serverInfo, ok := resultField["serverInfo"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected serverInfo in result, got: %+v", resultField)
+	}
+	if serverInfo["name"] != "Helix Session" {
+		t.Errorf("expected server name 'Helix Session', got %q", serverInfo["name"])
+	}
+}
+
+// TestMCPServer_ToolsList verifies tools/list works over Streamable HTTP.
+func TestMCPServer_ToolsList(t *testing.T) {
+	logger := slog.Default()
+	srv := NewMCPServer(MCPConfig{
+		HelixAPIURL:   "http://localhost:8080",
+		HelixAPIToken: "test-token",
+		SessionID:     "test-session",
+	}, logger)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Initialize first
+	initPayload := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	resp, err := http.Post(ts.URL+"/mcp", "application/json", strings.NewReader(initPayload))
+	if err != nil {
+		t.Fatalf("initialize failed: %v", err)
+	}
+	sessionID := resp.Header.Get("Mcp-Session")
+	resp.Body.Close()
+
+	// Now list tools
+	listPayload := `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`
+	req, _ := http.NewRequest("POST", ts.URL+"/mcp", strings.NewReader(listPayload))
+	req.Header.Set("Content-Type", "application/json")
+	if sessionID != "" {
+		req.Header.Set("Mcp-Session", sessionID)
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("tools/list failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("response is not valid JSON: %v\nbody: %s", err, string(body))
+	}
+
+	resultField, ok := result["result"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected result field, got: %s", string(body))
+	}
+
+	tools, ok := resultField["tools"].([]interface{})
+	if !ok {
+		t.Fatalf("expected tools array, got: %+v", resultField)
+	}
+
+	// Verify we have the expected session tools
+	toolNames := make(map[string]bool)
+	for _, tool := range tools {
+		toolMap := tool.(map[string]interface{})
+		toolNames[toolMap["name"].(string)] = true
+	}
+
+	expectedTools := []string{"current_session", "session_toc", "get_turn", "search_session", "list_sessions"}
+	for _, name := range expectedTools {
+		if !toolNames[name] {
+			t.Errorf("expected tool %q not found in tools list", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Migrates desktop MCP server (`api/pkg/desktop/mcp_server.go`) from `SSEServer` to `StreamableHTTPServer`
- Migrates session MCP server (`api/pkg/session/mcp_server.go`) from `SSEServer` to `StreamableHTTPServer`
- Adds transport-level tests for both servers verifying JSON-RPC initialize and tools/list over Streamable HTTP

## Problem
Zed's `HttpTransport` sends `POST /mcp` with JSON-RPC payloads (Streamable HTTP protocol). The desktop-bridge and session MCP servers used `server.SSEServer`, which expects `GET /mcp/sse` + `POST /mcp/message` — a completely different wire protocol. This mismatch caused 60-second "Context server request timeout" errors in Zed.

The server-side backends (`mcp_backend_session`, `mcp_backend_external`) were already migrated to `StreamableHTTPServer`. The local desktop and session servers were the remaining holdouts.

## Test plan
- [x] RED: Tests POST JSON-RPC `initialize` to `/mcp` → got 404 (SSEServer doesn't serve that path)
- [x] GREEN: Swapped to `StreamableHTTPServer` → tests pass with proper JSON-RPC response
- [x] `go test ./api/pkg/desktop/ ./api/pkg/session/` — all pass
- [x] `go build ./api/pkg/desktop/ ./api/pkg/session/ ./api/pkg/server/` — clean
- [x] Deploy and verify Zed connects to desktop-bridge without timeout

Assisted by AI. Co-Authored-By: Helix <noreply@helix.ml>