### PR TITLE
Add extraEnv and ollamaEnabled toggle to runner Helm chart

### DIFF
--- a/charts/helix-runner/templates/deployment.yaml
+++ b/charts/helix-runner/templates/deployment.yaml
@@ -99,7 +99,10 @@ spec:
               value: {{ .Values.runner.huggingfaceToken | quote }}
             {{- end }}
             - name: RUNTIME_OLLAMA_ENABLED
-              value: "true"
+              value: {{ ne (.Values.runner.ollamaEnabled | toString) "false" | quote }}
+            {{- with .Values.runner.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- if hasKey .Values "gpuCount" }}
               {{- if gt (.Values.gpuCount | int) 0 }}

--- a/charts/helix-runner/values.yaml
+++ b/charts/helix-runner/values.yaml
@@ -33,7 +33,22 @@ runner:
   huggingfaceToken: ""
   # Alternative: read Hugging Face token from a Kubernetes secret (leave huggingfaceToken empty when using this)
   huggingfaceTokenExistingSecret: ""
-  huggingfaceTokenExistingSecretKey: ""  # defaults to "token" if not specified 
+  huggingfaceTokenExistingSecretKey: ""  # defaults to "token" if not specified
+  # Enable/disable the embedded Ollama runtime on the runner
+  # Set to false if using an external LLM provider and don't need local model pulling
+  ollamaEnabled: true
+  # Additional environment variables to set on the runner container
+  # Useful for proxy configuration, custom CA certs, etc.
+  # Note: cannot override env vars already defined in the template (API_TOKEN, HF_TOKEN, RUNTIME_OLLAMA_ENABLED)
+  # Example:
+  #   extraEnv:
+  #     - name: HTTPS_PROXY
+  #       value: "http://proxy:8080"
+  #     - name: HTTP_PROXY
+  #       value: "http://proxy:8080"
+  #     - name: NO_PROXY
+  #       value: "localhost,127.0.0.1,10.0.0.0/8"
+  extraEnv: []
 
 # GPU configuration
 # Number of GPUs this runner should manage


### PR DESCRIPTION
## Summary
- Adds `runner.extraEnv` to the runner Helm chart, allowing customers to pass arbitrary environment variables (e.g. `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) without forking the chart
- Adds `runner.ollamaEnabled` toggle to control the `RUNTIME_OLLAMA_ENABLED` env var (defaults to `true`)
- Triggered by a customer behind a corporate proxy whose runner's embedded Ollama couldn't reach `registry.ollama.ai`

## Test plan
- [ ] `helm template` with default values renders `RUNTIME_OLLAMA_ENABLED: "true"` and no extra env
- [ ] `helm template` with `runner.ollamaEnabled=false` renders `RUNTIME_OLLAMA_ENABLED: "false"`
- [ ] `helm template` with `runner.extraEnv` renders additional env vars at correct indentation
- [ ] Verify proxy env vars are forwarded to Ollama subprocess (already wired in `ollama_runtime.go:583-584`)
- [ ] Note: `RUNTIME_OLLAMA_ENABLED` is parsed by Go config but not yet enforced in runner code — separate PR needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)