### PR TITLE
Add global.extraEnv to controlplane chart for proxy support

### DIFF
--- a/charts/helix-controlplane/templates/chrome_deployment.yaml
+++ b/charts/helix-controlplane/templates/chrome_deployment.yaml
@@ -43,6 +43,15 @@ spec:
             - name: http
               containerPort: 7317
               protocol: TCP
+          {{- if or .Values.global.extraEnv .Values.chrome.extraEnv }}
+          env:
+            {{- with .Values.global.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.chrome.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/helix-controlplane/templates/deployment.yaml
+++ b/charts/helix-controlplane/templates/deployment.yaml
@@ -352,6 +352,9 @@ spec:
             - name: KODIT_ENABLED
               value: "false"
             {{- end }}
+            {{- with .Values.global.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .Values.controlplane.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -497,6 +500,9 @@ spec:
             - name: PGVECTOR_DSN
               value: "postgresql://{{ .Values.pgvector.auth.username | default "postgres" }}:{{ .Values.pgvector.auth.password | default "pgvector" }}@{{ include "helix-controlplane.fullname" . }}-pgvector:5432/{{ .Values.pgvector.auth.database | default "postgres" }}"
             {{- end }}
+            {{- end }}
+            {{- with .Values.global.extraEnv }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- with .Values.controlplane.haystack.env }}
             {{- toYaml . | nindent 12 }}

--- a/charts/helix-controlplane/templates/searxng_deployment.yaml
+++ b/charts/helix-controlplane/templates/searxng_deployment.yaml
@@ -53,6 +53,9 @@ spec:
               value: "4"
             - name: UWSGI_THREADS
               value: "4"
+            {{- with .Values.global.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: searxng-config
               mountPath: /etc/searxng/settings.yml

--- a/charts/helix-controlplane/values.yaml
+++ b/charts/helix-controlplane/values.yaml
@@ -7,6 +7,17 @@ global:
   imagePullSecrets: []
   storageClass: ""
   serverUrl: http://localhost:8080
+  # Extra environment variables applied to all components (controlplane, chrome, searxng, haystack).
+  # Useful for proxy configuration in environments where all outbound traffic must go through a proxy.
+  # Example:
+  #   extraEnv:
+  #     - name: HTTPS_PROXY
+  #       value: "http://proxy:8080"
+  #     - name: HTTP_PROXY
+  #       value: "http://proxy:8080"
+  #     - name: NO_PROXY
+  #       value: "localhost,127.0.0.1,.svc,.cluster.local"
+  extraEnv: []
 
 image:
   repository: registry.helixml.tech/helix/controlplane
@@ -31,6 +42,8 @@ chrome:
   image:
     repository: ghcr.io/go-rod/rod
     tag: "v0.115.0"
+  # Extra environment variables for the Chrome container (in addition to global.extraEnv)
+  extraEnv: []
 
 typesense:
   enabled: false


### PR DESCRIPTION
## Summary
- Adds `global.extraEnv` to the controlplane Helm chart that propagates env vars to **all** sub-deployments: controlplane, Chrome (headless Chromium for web crawling), SearXNG (web search), and Haystack sidecar
- Adds `chrome.extraEnv` for Chrome-specific env vars
- Enables customers behind corporate proxies to set `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` once in values and have it apply to all components

## Context
NTT customer behind a corporate proxy could not use web knowledge sources — the Chrome pod (which does the actual web fetching) and SearXNG (web search) had no way to receive proxy configuration via Helm values.

## Usage
```yaml
global:
  extraEnv:
    - name: HTTPS_PROXY
      value: "http://proxy:8080"
    - name: HTTP_PROXY
      value: "http://proxy:8080"
    - name: NO_PROXY
      value: "localhost,127.0.0.1,.svc,.cluster.local"
```

## Test plan
- [ ] `helm template` with empty `global.extraEnv` renders no extra env blocks
- [ ] `helm template` with populated `global.extraEnv` renders env vars in controlplane, chrome, searxng, and haystack containers
- [ ] `chrome.extraEnv` renders after `global.extraEnv` in chrome container
- [ ] `controlplane.extraEnv` renders after `global.extraEnv` in controlplane container
- [ ] Verify proxy env vars work for web knowledge source crawling (Chrome + SearXNG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)