### PR TITLE
fix: prevent stale config/js caching after deployments

### DIFF
--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -142,6 +142,10 @@ func (apiServer *HelixAPIServer) configJS(res http.ResponseWriter, req *http.Req
 		return
 	}
 	res.Header().Set("Content-Type", "application/javascript")
+	// Never cache config - contains version and deployment-specific values
+	res.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	res.Header().Set("Pragma", "no-cache")
+	res.Header().Set("Expires", "0")
 	content := fmt.Sprintf(`
 window.DISABLE_LLM_CALL_LOGGING = %t
 window.HELIX_SENTRY_DSN = "%s"


### PR DESCRIPTION
## Summary
- Add `Cache-Control: no-cache, no-store, must-revalidate` headers to the `/api/v1/config/js` endpoint
- This endpoint serves `window.HELIX_VERSION` and other deployment-specific config via a `<script>` tag in `index.html`
- Without explicit cache headers, browsers/CDNs used default heuristic caching, causing users to see stale version numbers after deployments (e.g., seeing 2.7.19 when the server was already on 2.7.22RC1)

## Test plan
- [ ] Deploy and verify version number updates immediately without needing hard refresh
- [ ] Confirm no perceptible page load slowdown (response is ~300 bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)