### PR TITLE
fix: bypass HTTP proxy for internal Chrome browser connections

### DIFF
--- a/api/cmd/helix/serve.go
+++ b/api/cmd/helix/serve.go
@@ -203,6 +203,11 @@ func getFilestore(ctx context.Context, cfg *config.ServerConfig) (filestore.File
 }
 
 func serve(cmd *cobra.Command, cfg *config.ServerConfig) error {
+	// Ensure internal browser service hosts bypass any configured HTTP proxy.
+	// This covers go-rod's internal http.Get() calls which use http.DefaultClient.
+	// The non-launcher code path uses a dedicated no-proxy HTTP client instead.
+	browser.EnsureNoProxyForBrowserHosts(cfg)
+
 	// Validate license key if provided
 	var userLicense *license.License
 	if cfg.LicenseKey != "" {

--- a/api/pkg/controller/knowledge/browser/browser.go
+++ b/api/pkg/controller/knowledge/browser/browser.go
@@ -2,11 +2,13 @@ package browser
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/go-rod/rod"
@@ -34,6 +36,80 @@ type Browser struct {
 	browser *rod.Browser
 
 	pagePool rod.Pool[rod.Page]
+}
+
+// EnsureNoProxyForBrowserHosts adds the Chrome and launcher service hostnames
+// to the NO_PROXY environment variable so that internal service connections
+// bypass any configured HTTP proxy. This must be called before any HTTP requests
+// are made (including by third-party libraries like go-rod) to ensure Go's
+// cached proxy configuration includes these hosts.
+func EnsureNoProxyForBrowserHosts(cfg *config.ServerConfig) {
+	// Only relevant if a proxy is configured
+	if os.Getenv("HTTP_PROXY") == "" && os.Getenv("http_proxy") == "" &&
+		os.Getenv("HTTPS_PROXY") == "" && os.Getenv("https_proxy") == "" {
+		return
+	}
+
+	seen := make(map[string]bool)
+	var bypassHosts []string
+	for _, rawURL := range []string{cfg.RAG.Crawler.ChromeURL, cfg.RAG.Crawler.LauncherURL} {
+		if rawURL == "" {
+			continue
+		}
+		parsed, err := url.Parse(rawURL)
+		if err != nil {
+			log.Warn().Err(err).Str("url", rawURL).Msg("Failed to parse browser service URL for NO_PROXY configuration")
+			continue
+		}
+		host := strings.ToLower(parsed.Hostname())
+		if host != "" && !seen[host] {
+			seen[host] = true
+			bypassHosts = append(bypassHosts, host)
+		}
+	}
+
+	if len(bypassHosts) == 0 {
+		return
+	}
+
+	// Read existing NO_PROXY value (check both cases)
+	noProxy := os.Getenv("NO_PROXY")
+	if noProxy == "" {
+		noProxy = os.Getenv("no_proxy")
+	}
+
+	var toAdd []string
+	for _, host := range bypassHosts {
+		found := false
+		for _, existing := range strings.Split(strings.ToLower(noProxy), ",") {
+			if strings.TrimSpace(existing) == host {
+				found = true
+				break
+			}
+		}
+		if !found {
+			toAdd = append(toAdd, host)
+		}
+	}
+
+	if len(toAdd) == 0 {
+		return
+	}
+
+	newNoProxy := noProxy
+	if newNoProxy != "" {
+		newNoProxy += ","
+	}
+	newNoProxy += strings.Join(toAdd, ",")
+
+	// Set both cases so Go's httpproxy.FromEnvironment() picks it up
+	os.Setenv("NO_PROXY", newNoProxy)
+	os.Setenv("no_proxy", newNoProxy)
+
+	log.Info().
+		Strs("hosts", toAdd).
+		Str("NO_PROXY", newNoProxy).
+		Msg("Added browser service hosts to NO_PROXY to bypass HTTP proxy")
 }
 
 func New(cfg *config.ServerConfig) (*Browser, error) {
@@ -189,6 +265,22 @@ func (b *Browser) PutBrowser(browser *rod.Browser) error {
 	return nil
 }
 
+// noProxyHTTPClient returns an HTTP client that bypasses any configured proxy.
+// This is used for internal service communication (e.g., Chrome browser) where
+// requests should never go through an external HTTP proxy.
+func noProxyHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy: nil, // explicitly bypass proxy
+		},
+	}
+}
+
+// chromeVersionResponse is the JSON structure returned by Chrome's /json/version endpoint.
+type chromeVersionResponse struct {
+	WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+}
+
 func (b *Browser) getChromeURL() (string, error) {
 	chromeURL := b.cfg.RAG.Crawler.ChromeURL
 
@@ -215,31 +307,53 @@ func (b *Browser) getChromeURL() (string, error) {
 	// Replace the hostname with the IP address in the original URL
 	resolvedURL := strings.Replace(chromeURL, parsedURL.Hostname(), ip, 1)
 
-	// Use the resolved URL for the request
+	// Use a no-proxy HTTP client for internal Chrome service communication.
+	// This also replaces the previous launcher.ResolveURL() call which used
+	// http.Get() (affected by HTTP_PROXY) and made a redundant second request
+	// to the same /json/version endpoint.
 	req, err := http.NewRequest("GET", resolvedURL+"/json/version", nil)
 	if err != nil {
 		return "", fmt.Errorf("error creating request for Chrome URL (%s): %w", resolvedURL, err)
 	}
 	req.Header.Set("Host", parsedURL.Hostname()) // Set the original hostname in the Host header
 
-	resp, err := http.DefaultClient.Do(req)
+	client := noProxyHTTPClient()
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("error checking Chrome URL (%s): %w", resolvedURL, err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		bts, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return "", fmt.Errorf("error reading Chrome URL (%s) response: %w", resolvedURL, err)
-		}
-		return "", fmt.Errorf("error checking Chrome URL (%s): %s", resolvedURL, string(bts))
-	}
-
-	u, err := launcher.ResolveURL(resolvedURL)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("error resolving Chrome URL (%s): %w", resolvedURL, err)
+		return "", fmt.Errorf("error reading Chrome URL (%s) response: %w", resolvedURL, err)
 	}
 
-	return u, nil
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("error checking Chrome URL (%s): %s", resolvedURL, string(body))
+	}
+
+	// Extract the WebSocket debugger URL from the /json/version response
+	var versionInfo chromeVersionResponse
+	if err := json.Unmarshal(body, &versionInfo); err != nil {
+		return "", fmt.Errorf("error parsing Chrome version response from %s: %w", resolvedURL, err)
+	}
+
+	if versionInfo.WebSocketDebuggerURL == "" {
+		return "", fmt.Errorf("Chrome at %s returned empty webSocketDebuggerUrl", resolvedURL)
+	}
+
+	// Replace the host in the WebSocket URL with our resolved host
+	wsURL, err := url.Parse(versionInfo.WebSocketDebuggerURL)
+	if err != nil {
+		return "", fmt.Errorf("error parsing webSocketDebuggerUrl (%s): %w", versionInfo.WebSocketDebuggerURL, err)
+	}
+
+	resolvedParsed, err := url.Parse(resolvedURL)
+	if err != nil {
+		return "", fmt.Errorf("error parsing resolved URL (%s): %w", resolvedURL, err)
+	}
+	wsURL.Host = resolvedParsed.Host
+
+	return wsURL.String(), nil
 }

--- a/api/pkg/controller/knowledge/browser/noproxy_test.go
+++ b/api/pkg/controller/knowledge/browser/noproxy_test.go
@@ -1,0 +1,119 @@
+package browser
+
+import (
+	"os"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnsureNoProxyForBrowserHosts(t *testing.T) {
+	tests := []struct {
+		name            string
+		httpProxy       string
+		httpsProxy      string
+		existingNoProxy string
+		chromeURL       string
+		launcherURL     string
+		expectedNoProxy string
+		expectChange    bool
+	}{
+		{
+			name:            "no proxy configured, does nothing",
+			httpProxy:       "",
+			httpsProxy:      "",
+			existingNoProxy: "",
+			chromeURL:       "http://chrome:9222",
+			launcherURL:     "http://chrome:7317",
+			expectedNoProxy: "",
+			expectChange:    false,
+		},
+		{
+			name:            "proxy configured, adds chrome host",
+			httpProxy:       "http://proxy:8080",
+			existingNoProxy: "localhost,127.0.0.1",
+			chromeURL:       "http://chrome:9222",
+			launcherURL:     "http://chrome:7317",
+			expectedNoProxy: "localhost,127.0.0.1,chrome",
+			expectChange:    true,
+		},
+		{
+			name:            "proxy configured, chrome already in NO_PROXY",
+			httpProxy:       "http://proxy:8080",
+			existingNoProxy: "localhost,127.0.0.1,chrome",
+			chromeURL:       "http://chrome:9222",
+			launcherURL:     "http://chrome:7317",
+			expectedNoProxy: "localhost,127.0.0.1,chrome",
+			expectChange:    false,
+		},
+		{
+			name:            "proxy configured, different chrome and launcher hosts",
+			httpProxy:       "http://proxy:8080",
+			existingNoProxy: "localhost",
+			chromeURL:       "http://my-chrome:9222",
+			launcherURL:     "http://my-launcher:7317",
+			expectedNoProxy: "localhost,my-chrome,my-launcher",
+			expectChange:    true,
+		},
+		{
+			name:            "HTTPS_PROXY only",
+			httpsProxy:      "http://proxy:8080",
+			existingNoProxy: "",
+			chromeURL:       "http://chrome:9222",
+			launcherURL:     "http://chrome:7317",
+			expectedNoProxy: "chrome",
+			expectChange:    true,
+		},
+		{
+			name:            "IP-based chrome URL",
+			httpProxy:       "http://proxy:8080",
+			existingNoProxy: "localhost",
+			chromeURL:       "http://192.168.1.10:9222",
+			launcherURL:     "http://192.168.1.10:7317",
+			expectedNoProxy: "localhost,192.168.1.10",
+			expectChange:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore env vars that EnsureNoProxyForBrowserHosts reads/writes.
+			// We can't use t.Setenv because we need to handle Unsetenv for lowercase variants.
+			origHTTP := os.Getenv("HTTP_PROXY")
+			origHTTPS := os.Getenv("HTTPS_PROXY")
+			origNoProxy := os.Getenv("NO_PROXY")
+			origNoProxyLower := os.Getenv("no_proxy")
+			defer func() {
+				os.Setenv("HTTP_PROXY", origHTTP)
+				os.Setenv("HTTPS_PROXY", origHTTPS)
+				os.Setenv("NO_PROXY", origNoProxy)
+				os.Setenv("no_proxy", origNoProxyLower)
+				os.Unsetenv("http_proxy")
+				os.Unsetenv("https_proxy")
+			}()
+
+			// Set test env
+			os.Setenv("HTTP_PROXY", tt.httpProxy)
+			os.Setenv("HTTPS_PROXY", tt.httpsProxy)
+			os.Setenv("NO_PROXY", tt.existingNoProxy)
+			os.Setenv("no_proxy", "")
+			os.Unsetenv("http_proxy")
+			os.Unsetenv("https_proxy")
+
+			cfg := &config.ServerConfig{}
+			cfg.RAG.Crawler.ChromeURL = tt.chromeURL
+			cfg.RAG.Crawler.LauncherURL = tt.launcherURL
+
+			EnsureNoProxyForBrowserHosts(cfg)
+
+			result := os.Getenv("NO_PROXY")
+			assert.Equal(t, tt.expectedNoProxy, result)
+
+			// Verify both cases are set when changed
+			if tt.expectChange {
+				assert.Equal(t, os.Getenv("NO_PROXY"), os.Getenv("no_proxy"))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- When `HTTP_PROXY`/`HTTPS_PROXY` env vars are set, internal requests to the Chrome browser service (`chrome:7317`/`chrome:9222`) were routed through the proxy, causing `invalid character '<' looking for beginning of value` errors on startup
- Adds Chrome/launcher hostnames to `NO_PROXY` env var at startup to cover go-rod's internal `http.Get()` calls
- Uses a dedicated no-proxy HTTP client for `getChromeURL()` and inlines the `ResolveURL` logic (also eliminates a redundant duplicate `/json/version` request)

## Test plan
- [ ] Deploy to k8s cluster with `HTTP_PROXY`/`HTTPS_PROXY` set and verify controlplane starts without browser pool errors
- [ ] Verify RAG/knowledge crawling still works with proxy configured
- [x] Unit tests pass: `go test -v -run TestEnsureNoProxyForBrowserHosts ./api/pkg/controller/knowledge/browser/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)