### PR TITLE
Fix approve-specs handler setting approval fields on rejections

### DIFF
--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -292,11 +292,16 @@ func (s *HelixAPIServer) approveSpecs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := time.Now()
-	existingTask.SpecApprovedBy = user.ID
-	existingTask.SpecApprovedAt = &now
-	existingTask.Status = types.TaskStatusSpecApproved
-	existingTask.StatusUpdatedAt = &now
 	existingTask.SpecApproval = &req
+	existingTask.StatusUpdatedAt = &now
+	if req.Approved {
+		existingTask.SpecApprovedBy = user.ID
+		existingTask.SpecApprovedAt = &now
+		existingTask.Status = types.TaskStatusSpecApproved
+	} else {
+		// Rejection — don't set approval tracking fields, go straight to revision
+		existingTask.Status = types.TaskStatusSpecRevision
+	}
 
 	err = s.Store.UpdateSpecTask(ctx, existingTask)
 	if err != nil {


### PR DESCRIPTION
When approved=false (or omitted, defaulting to false), the handler was setting SpecApprovedBy and SpecApprovedAt which is misleading, and transitioning through spec_approved → spec_revision → spec_generation via the orchestrator. Now rejections go directly to spec_revision and only set approval tracking fields when actually approved.