### PR TITLE
chore: upgrade kodit to v1.1.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/go-retryablehttp v0.7.8
-	github.com/helixml/kodit v1.1.5
+	github.com/helixml/kodit v1.1.6
 	github.com/infracloudio/msbotbuilder-go v0.2.5
 	github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf
 	github.com/jfrog/froggit-go v1.20.1

--- a/go.sum
+++ b/go.sum
@@ -536,10 +536,8 @@ github.com/hashicorp/go-version v1.8.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/helixml/kodit v1.1.3 h1:RY8DbhpXV0YCGVR3tCGcIehU2onwKJ4pkpc1jzVxmkE=
-github.com/helixml/kodit v1.1.3/go.mod h1:4HMeBt3mHHn6fdJoJtxExa9dn36xFd/vZRieM3DYwN8=
-github.com/helixml/kodit v1.1.5 h1:1THSYo4/zIO2KV9KnMsQcv1AjE2O8xzcXVk3UiX/E5E=
-github.com/helixml/kodit v1.1.5/go.mod h1:4HMeBt3mHHn6fdJoJtxExa9dn36xFd/vZRieM3DYwN8=
+github.com/helixml/kodit v1.1.6 h1:uu59hU7ljCVuH693d+Fcbteli2O82cUfDAJsrkK1Vxw=
+github.com/helixml/kodit v1.1.6/go.mod h1:4HMeBt3mHHn6fdJoJtxExa9dn36xFd/vZRieM3DYwN8=
 github.com/helixml/langchaingo v0.1.15 h1:6cEwRQgEri4aDrvDnSESmsMY9H35UUoWuOEukSP3lJw=
 github.com/helixml/langchaingo v0.1.15/go.mod h1:EeervIv/DNYhSfQSMaql20wMFvhgF7lDaVaatp8lVPw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=


### PR DESCRIPTION
## Summary
- Upgrades `github.com/helixml/kodit` from v1.1.5 to v1.1.6

## Test plan
- [ ] CI passes
- [ ] Kodit code intelligence features work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)