### PR TITLE
fix: orgNavigate stale closure causes intermittent broken card clicks

### DIFF
--- a/frontend/src/contexts/account.tsx
+++ b/frontend/src/contexts/account.tsx
@@ -91,6 +91,11 @@ export const useAccountContext = (): IAccountContext => {
   const loading = useLoading()
   const router = useRouter()
   const organizationTools = useOrganizations()
+  // Keep a ref to organizationTools so that orgNavigate always reads the latest
+  // state, even when called from stale closures (e.g. React.memo'd components
+  // that captured an old onTaskClick → old orgNavigate).
+  const organizationToolsRef = useRef(organizationTools)
+  organizationToolsRef.current = organizationTools
   const [ admin, setAdmin ] = useState(false)
   const [ mobileMenuOpen, setMobileMenuOpen ] = useState(false)
   const [ showLoginWindow, setShowLoginWindow ] = useState(false)
@@ -390,7 +395,7 @@ export const useAccountContext = (): IAccountContext => {
       targetRouteName = `org_${routeName}`
     }
 
-    const useOrgID = params.org_id || organizationTools.organization?.name
+    const useOrgID = params.org_id || organizationToolsRef.current.organization?.name
     const targetParams = {
       ...params,
       org_id: useOrgID,


### PR DESCRIPTION
## Summary
- `orgNavigate` reads `organizationTools.organization?.name` from a closure
- `TaskCard`'s `React.memo` custom comparator doesn't check `onTaskClick`, so the card retains `orgNavigate` from its first render
- If `organization` hadn't finished its async load chain (4+ sequential API calls) at first render, `organization?.name` is permanently `undefined` in that closure
- This causes `router.navigate` to throw `Cannot build path: requires missing parameters { org_id }`
- Uses a ref so `orgNavigate` always reads the latest `organizationTools` state at call time, immune to stale closures

## Test plan
- [x] Verified clicking spec task cards navigates correctly on https://meta.helix.ml
- [x] `yarn build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)