### PR TITLE
Promote code intelligence tabs to top-level with progress tracking

### DIFF
--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -18070,6 +18070,21 @@ const docTemplate = `{
                 "status": {
                     "type": "string"
                 },
+                "tasks_active": {
+                    "type": "integer"
+                },
+                "tasks_completed": {
+                    "type": "integer"
+                },
+                "tasks_failed": {
+                    "type": "integer"
+                },
+                "tasks_pending": {
+                    "type": "integer"
+                },
+                "tasks_total": {
+                    "type": "integer"
+                },
                 "updated_at": {
                     "type": "string"
                 }

--- a/api/pkg/server/kodit_handlers.go
+++ b/api/pkg/server/kodit_handlers.go
@@ -14,6 +14,8 @@ import (
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/helixml/kodit/domain/enrichment"
 	"github.com/helixml/kodit/domain/repository"
+	"github.com/helixml/kodit/domain/snippet"
+	"github.com/helixml/kodit/domain/task"
 	"github.com/helixml/kodit/domain/tracking"
 	"github.com/rs/zerolog/log"
 )
@@ -67,9 +69,14 @@ type KoditIndexingStatusData struct {
 
 // KoditIndexingStatusAttributes holds the indexing status fields.
 type KoditIndexingStatusAttributes struct {
-	Status    string    `json:"status"`
-	Message   string    `json:"message"`
-	UpdatedAt time.Time `json:"updated_at"`
+	Status         string    `json:"status"`
+	Message        string    `json:"message"`
+	UpdatedAt      time.Time `json:"updated_at"`
+	TasksTotal     int       `json:"tasks_total"`
+	TasksCompleted int       `json:"tasks_completed"`
+	TasksActive    int       `json:"tasks_active"`
+	TasksPending   int       `json:"tasks_pending"`
+	TasksFailed    int       `json:"tasks_failed"`
 }
 
 // KoditCommitDTO is the JSON representation of a commit.
@@ -719,8 +726,38 @@ func (apiServer *HelixAPIServer) getRepositoryIndexingStatus(w http.ResponseWrit
 		return
 	}
 
+	dto := indexingStatusToDTO(summary)
+
+	// Enrich with task progress when actively indexing
+	summaryStatus := summary.Status()
+	if summaryStatus != snippet.IndexStatusCompleted && summaryStatus != snippet.IndexStatusCompletedWithErrors && summaryStatus != snippet.IndexStatusFailed {
+		tasks, err := apiServer.koditService.RepositoryTasks(r.Context(), koditRepoID)
+		if err == nil {
+			completed := 0
+			active := 0
+			failed := 0
+			for _, ts := range tasks.Statuses {
+				state := task.ReportingState(ts.State)
+				switch {
+				case state == task.ReportingStateCompleted || state == task.ReportingStateSkipped:
+					completed++
+				case state == task.ReportingStateStarted || state == task.ReportingStateInProgress:
+					active++
+				case state == task.ReportingStateFailed:
+					failed++
+				}
+			}
+			total := completed + active + failed + len(tasks.PendingTasks)
+			dto.Data.Attributes.TasksTotal = total
+			dto.Data.Attributes.TasksCompleted = completed
+			dto.Data.Attributes.TasksActive = active
+			dto.Data.Attributes.TasksPending = len(tasks.PendingTasks)
+			dto.Data.Attributes.TasksFailed = failed
+		}
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(indexingStatusToDTO(summary))
+	json.NewEncoder(w).Encode(dto)
 }
 
 // getRepositoryWikiTree returns the wiki navigation tree for a repository

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -18066,6 +18066,21 @@
                 "status": {
                     "type": "string"
                 },
+                "tasks_active": {
+                    "type": "integer"
+                },
+                "tasks_completed": {
+                    "type": "integer"
+                },
+                "tasks_failed": {
+                    "type": "integer"
+                },
+                "tasks_pending": {
+                    "type": "integer"
+                },
+                "tasks_total": {
+                    "type": "integer"
+                },
                 "updated_at": {
                     "type": "string"
                 }

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -1682,6 +1682,16 @@ definitions:
         type: string
       status:
         type: string
+      tasks_active:
+        type: integer
+      tasks_completed:
+        type: integer
+      tasks_failed:
+        type: integer
+      tasks_pending:
+        type: integer
+      tasks_total:
+        type: integer
       updated_at:
         type: string
     type: object

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1058,6 +1058,11 @@ export interface ServerKoditGrepResultDTO {
 export interface ServerKoditIndexingStatusAttributes {
   message?: string;
   status?: string;
+  tasks_active?: number;
+  tasks_completed?: number;
+  tasks_failed?: number;
+  tasks_pending?: number;
+  tasks_total?: number;
   updated_at?: string;
 }
 

--- a/frontend/src/components/git/CodeIntelligenceTab.tsx
+++ b/frontend/src/components/git/CodeIntelligenceTab.tsx
@@ -1212,3 +1212,4 @@ const CodeIntelligenceTab: FC<CodeIntelligenceTabProps> = ({ repository, enrichm
 }
 
 export default CodeIntelligenceTab
+export { WikiSubTab, SearchSubTab, ChangelogSubTab, ConnectSubTab }

--- a/frontend/src/components/git/CodeTab.tsx
+++ b/frontend/src/components/git/CodeTab.tsx
@@ -228,7 +228,7 @@ const CodeTab: FC<CodeTabProps> = ({
   const diagramsLoading = diagramEnrichmentQueries.some(q => q.isLoading) && diagramEnrichmentIds.length > 0
 
   const handleNavigateToCodeIntelligence = () => {
-    router.mergeParams({ tab: 'code-intelligence' })
+    router.mergeParams({ tab: 'wiki' })
   }
 
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)

--- a/frontend/src/components/git/KoditStatusPill.tsx
+++ b/frontend/src/components/git/KoditStatusPill.tsx
@@ -155,9 +155,19 @@ const KoditStatusPill: FC<KoditStatusPillProps> = ({
   }
 
   if (status === 'indexing' || status === 'in_progress') {
+    const tasksTotal = attrs?.tasks_total || 0
+    const tasksCompleted = attrs?.tasks_completed || 0
+    const tasksPending = attrs?.tasks_pending || 0
+    const progressLabel = tasksTotal > 0
+      ? `Indexing ${tasksCompleted}/${tasksTotal}`
+      : 'Indexing...'
+    const tooltipDetail = tasksTotal > 0
+      ? `${tasksCompleted} of ${tasksTotal} tasks completed${tasksPending > 0 ? `, ${tasksPending} queued` : ''}`
+      : (message || 'Repository is being indexed...')
+
     return (
       <Box sx={{ display: 'flex', alignItems: 'center' }}>
-        <Tooltip title={message || 'Repository is being indexed...'} arrow placement="top">
+        <Tooltip title={tooltipDetail} arrow placement="top">
           <Chip
             icon={
               <Box
@@ -174,7 +184,7 @@ const KoditStatusPill: FC<KoditStatusPillProps> = ({
                 <RefreshCw size={14} />
               </Box>
             }
-            label="Indexing..."
+            label={progressLabel}
             size="small"
             color="warning"
             sx={{
@@ -190,12 +200,15 @@ const KoditStatusPill: FC<KoditStatusPillProps> = ({
   }
 
   if (status === 'queued' || status === 'pending') {
+    const tasksPending = attrs?.tasks_pending || 0
+    const pendingLabel = tasksPending > 0 ? `Queued (${tasksPending} tasks)` : 'Queued'
+
     return (
       <Box sx={{ display: 'flex', alignItems: 'center' }}>
         <Tooltip title={message || 'Repository is queued for indexing'} arrow placement="top">
           <Chip
             icon={<Clock size={14} />}
-            label="Queued"
+            label={pendingLabel}
             size="small"
             color="info"
             sx={{

--- a/frontend/src/pages/GitRepoDetail.tsx
+++ b/frontend/src/pages/GitRepoDetail.tsx
@@ -45,6 +45,9 @@ import {
   GitPullRequest,
   Kanban,
   Plus,
+  BookOpen,
+  Search as SearchIcon,
+  Plug,
 } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 
@@ -80,14 +83,15 @@ import {
 } from '../services/koditService'
 import MonacoEditor from '../components/widgets/MonacoEditor'
 import CodeTab from '../components/git/CodeTab'
-import CodeIntelligenceTab from '../components/git/CodeIntelligenceTab'
+import CodeIntelligenceTab, { WikiSubTab, SearchSubTab, ChangelogSubTab, ConnectSubTab } from '../components/git/CodeIntelligenceTab'
+import KoditStatusPill from '../components/git/KoditStatusPill'
 import CommitsTab from '../components/git/CommitsTab'
 import SettingsTab from '../components/git/SettingsTab'
 import PullRequests from '../components/git/PullRequests'
 import CreateProjectDialog from '../components/project/CreateProjectDialog'
 import { TypesExternalRepositoryType, TypesAzureDevOps, TypesGitRepository } from '../api/api'
 
-const TAB_NAMES = ['code', 'code-intelligence', 'settings', 'access', 'commits', 'pull-requests'] as const
+const TAB_NAMES = ['code', 'wiki', 'search', 'changelog', 'connect', 'settings', 'access', 'commits', 'pull-requests'] as const
 type TabName = typeof TAB_NAMES[number]
 
 const getTabName = (name: string | undefined): TabName => {
@@ -162,9 +166,10 @@ const GitRepoDetail: FC = () => {
 
   // Kodit code intelligence status and enrichments
   // Get indexing status to determine polling frequency
-  const { data: koditStatus } = useKoditStatus(repoId || '', {
+  const { data: koditStatusData, isLoading: koditStatusLoading, error: koditStatusError } = useKoditStatus(repoId || '', {
     enabled: !isLoading && repository !== undefined && repository !== null && repository?.kodit_indexing
   })
+  const koditStatus = koditStatusData
 
   // Poll more frequently (3s) when actively indexing to show enrichments flowing in
   // Otherwise use default (30s for latest, no polling for specific commits)
@@ -413,7 +418,7 @@ const GitRepoDetail: FC = () => {
   }
 
   const handleViewEnrichments = (commitSha: string) => {
-    router.mergeParams({ tab: 'code-intelligence', commit: commitSha })
+    router.mergeParams({ tab: 'changelog', commit: commitSha })
   }
 
   const handlePushPull = async (force = false) => {
@@ -711,18 +716,12 @@ const GitRepoDetail: FC = () => {
                   />
                 )}
                 {repository.kodit_indexing && (
-                  <Chip
-                    icon={<Brain size={12} />}
-                    label="Code Intelligence"
-                    size="small"
-                    color="success"
+                  <KoditStatusPill
+                    data={koditStatusData}
+                    isLoading={koditStatusLoading}
+                    error={koditStatusError}
                   />
                 )}
-                <Chip
-                  label={repository.repo_type || 'project'}
-                  size="small"
-                  variant="outlined"
-                />
               </Box>
             </Box>
 
@@ -770,24 +769,17 @@ const GitRepoDetail: FC = () => {
           </Box>
 
           {/* Navigation tabs */}
-          <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+          <Box sx={{ borderBottom: 1, borderColor: 'divider', display: 'flex', alignItems: 'stretch' }}>
             <Tabs value={currentTab} onChange={(_, newValue) => {
               const tabName = newValue as TabName
               setCurrentTab(tabName)
               router.mergeParams({ tab: tabName })
-            }}>              
+            }}>
               <Tab
                 value="code"
                 icon={<CodeIcon size={16} />}
                 iconPosition="start"
                 label="Code"
-                sx={{ textTransform: 'none', minHeight: 48 }}
-              />
-              <Tab
-                value="code-intelligence"
-                icon={<Brain size={16} />}
-                iconPosition="start"
-                label="Code Intelligence"
                 sx={{ textTransform: 'none', minHeight: 48 }}
               />
               <Tab
@@ -818,20 +810,89 @@ const GitRepoDetail: FC = () => {
                 label="Access"
                 sx={{ textTransform: 'none', minHeight: 48 }}
               />
+              {repository.kodit_indexing && (
+                <Tab
+                  disabled
+                  title="Helix Code Intelligence"
+                  icon={<Brain size={14} />}
+                  sx={{
+                    minHeight: 48,
+                    minWidth: 'auto',
+                    px: 1,
+                    ml: 1,
+                    opacity: 0.5,
+                    cursor: 'default',
+                    '&.Mui-disabled': { opacity: 0.5 },
+                    borderLeft: '1px solid',
+                    borderColor: 'divider',
+                  }}
+                  aria-hidden="true"
+                />
+              )}
+              {repository.kodit_indexing && (
+                <Tab
+                  value="wiki"
+                  title="Auto-generated documentation"
+                  icon={<BookOpen size={16} />}
+                  iconPosition="start"
+                  label="Wiki"
+                  sx={{ textTransform: 'none', minHeight: 48 }}
+                />
+              )}
+              {repository.kodit_indexing && (
+                <Tab
+                  value="search"
+                  title="Semantic and keyword code search"
+                  icon={<SearchIcon size={16} />}
+                  iconPosition="start"
+                  label="Search"
+                  sx={{ textTransform: 'none', minHeight: 48 }}
+                />
+              )}
+              {repository.kodit_indexing && (
+                <Tab
+                  value="changelog"
+                  title="AI-generated commit descriptions"
+                  icon={<GitCommit size={16} />}
+                  iconPosition="start"
+                  label="Changelog"
+                  sx={{ textTransform: 'none', minHeight: 48 }}
+                />
+              )}
+              {repository.kodit_indexing && (
+                <Tab
+                  value="connect"
+                  title="Connect external MCP clients"
+                  icon={<Plug size={16} />}
+                  iconPosition="start"
+                  label="Connect"
+                  sx={{ textTransform: 'none', minHeight: 48 }}
+                />
+              )}
             </Tabs>
           </Box>
         </Box>
 
         {/* Tab panels */}
         <Box sx={{ mt: 3 }}>
-          {/* Code Intelligence Tab */}
-          {currentTab === 'code-intelligence' && (
-            <CodeIntelligenceTab
-              repository={repository}
-              enrichments={enrichments}
-              repoId={repoId || ''}
-              commitSha={commitFromQuery}
-            />
+          {/* Wiki Tab */}
+          {currentTab === 'wiki' && repository.kodit_indexing && (
+            <WikiSubTab repoId={repoId || ''} enabled={!!repoId && repository.kodit_indexing} />
+          )}
+
+          {/* Search Tab */}
+          {currentTab === 'search' && repository.kodit_indexing && (
+            <SearchSubTab repoId={repoId || ''} enabled={!!repoId && repository.kodit_indexing} />
+          )}
+
+          {/* Changelog Tab */}
+          {currentTab === 'changelog' && repository.kodit_indexing && (
+            <ChangelogSubTab enrichments={enrichments} />
+          )}
+
+          {/* Connect Tab */}
+          {currentTab === 'connect' && repository.kodit_indexing && (
+            <ConnectSubTab />
           )}
 
           {/* Code Tab */}

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -1682,6 +1682,16 @@ definitions:
         type: string
       status:
         type: string
+      tasks_active:
+        type: integer
+      tasks_completed:
+        type: integer
+      tasks_failed:
+        type: integer
+      tasks_pending:
+        type: integer
+      tasks_total:
+        type: integer
       updated_at:
         type: string
     type: object

--- a/openapi.json
+++ b/openapi.json
@@ -21389,6 +21389,21 @@
                     "status": {
                         "type": "string"
                     },
+                    "tasks_active": {
+                        "type": "integer"
+                    },
+                    "tasks_completed": {
+                        "type": "integer"
+                    },
+                    "tasks_failed": {
+                        "type": "integer"
+                    },
+                    "tasks_pending": {
+                        "type": "integer"
+                    },
+                    "tasks_total": {
+                        "type": "integer"
+                    },
                     "updated_at": {
                         "type": "string"
                     }

--- a/swagger.json
+++ b/swagger.json
@@ -18066,6 +18066,21 @@
                 "status": {
                     "type": "string"
                 },
+                "tasks_active": {
+                    "type": "integer"
+                },
+                "tasks_completed": {
+                    "type": "integer"
+                },
+                "tasks_failed": {
+                    "type": "integer"
+                },
+                "tasks_pending": {
+                    "type": "integer"
+                },
+                "tasks_total": {
+                    "type": "integer"
+                },
                 "updated_at": {
                     "type": "string"
                 }


### PR DESCRIPTION
## Summary
- Split the monolithic "Code Intelligence" tab into individual top-level tabs (Wiki, Search, Changelog, Connect) with a brain icon divider to signal they are Helix Code Intelligence features
- Replace static "Code Intelligence" chip with dynamic KoditStatusPill showing live sync status and indexing progress (e.g. "Indexing 3/7")
- Add task progress fields to the indexing status API endpoint for real-time progress tracking
- Remove unused repo_type chip, add hover tooltips to all code intelligence tabs

## Test plan
- [x] Verified all tabs render correctly and switch between them
- [x] Verified brain icon divider appears with tooltip "Helix Code Intelligence"
- [x] Verified tabs only appear when code intelligence is enabled
- [x] Verified old `code-intelligence` URL falls back gracefully to Code tab
- [x] Verified search functionality works within the new tab layout
- [x] Verified zero console errors/warnings
- [x] Verified Go backend builds cleanly
- [x] WARNING: indexing progress display not tested with actively indexing repo (completed before testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)