### PR TITLE
fix(ci): use rollout status and show init container logs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1560,10 +1560,9 @@ platform:
 trigger:
   event:
     - cron
-    - push
-  branch:
-    - main
-    - fix/helm-upgrade-*
+  cron:
+    - helm-upgrade-nightly
+    - developer
 
 steps:
   - name: helm-upgrade-test


### PR DESCRIPTION
kubectl wait matches old terminating pods during upgrade, causing false positives then timeout. Switch to kubectl rollout status which properly tracks new deployment rollouts. Also show init container (wait-for-postgres) logs and pod describe in diagnostics.