### PR TITLE
Replace Bitnami PostgreSQL with official postgres in Helm chart

### DIFF
--- a/charts/helix-controlplane/CHANGELOG.md
+++ b/charts/helix-controlplane/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.4.0] - 2026-03-13
+
+### Changed
+- **BREAKING: Replaced Bitnami PostgreSQL with official postgres image**. See [UPGRADE.md](UPGRADE.md) for migration instructions.
+  - Removed Bitnami `postgresql` and `common` chart dependencies
+  - PostgreSQL now uses `postgres:17-alpine` via a self-managed Deployment
+  - Service name changed from `{release}-postgresql` to `{release}-helix-controlplane-postgres`
+  - PVC name changed from `data-{release}-postgresql-0` to `{release}-helix-controlplane-postgres-pvc`
+  - Removed `postgresql.image.registry`, `postgresql.auth.postgresPassword`, `postgresql.architecture` values
+  - Added `postgresql.persistence.*` values (previously managed by Bitnami subchart)
+- Changed pgvector deployment strategy from `RollingUpdate` to `Recreate` to prevent deadlocks with ReadWriteOnce PVCs
+
+### Added
+- Migration script (`scripts/migrate-from-bitnami.sh`) for preserving data during upgrade
+- PostgreSQL readiness probe using `pg_isready`
+- `helix-controlplane.tplvalues.render` and `helix-controlplane.storage.class` template helpers (replacing Bitnami common library)
+
+### Removed
+- Keycloak installation from `kind_helm_install.sh`
+
 ## [Unreleased]
 
 ### Added

--- a/charts/helix-controlplane/CHANGELOG.md
+++ b/charts/helix-controlplane/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.4.0] - 2026-03-13
+## [2.9.0] - 2026-03-13
 
 ### Changed
 - **BREAKING: Replaced Bitnami PostgreSQL with official postgres image**. See [UPGRADE.md](UPGRADE.md) for migration instructions.

--- a/charts/helix-controlplane/CHANGELOG.md
+++ b/charts/helix-controlplane/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [2.9.0] - 2026-03-13
 
 ### Changed
@@ -10,19 +12,14 @@
   - PVC name changed from `data-{release}-postgresql-0` to `{release}-helix-controlplane-postgres-pvc`
   - Removed `postgresql.image.registry`, `postgresql.auth.postgresPassword`, `postgresql.architecture` values
   - Added `postgresql.persistence.*` values (previously managed by Bitnami subchart)
-- Changed pgvector deployment strategy from `RollingUpdate` to `Recreate` to prevent deadlocks with ReadWriteOnce PVCs
+  - Added `postgresql.resources` to configure requests/limits on the bundled PostgreSQL container
+- Updated `values-example.yaml` to document the new structured license key configuration
+- Deprecated using `secretEnvVars` for common configurations like LICENSE_KEY in favor of structured configuration
 
 ### Added
 - Migration script (`scripts/migrate-from-bitnami.sh`) for preserving data during upgrade
 - PostgreSQL readiness probe using `pg_isready`
-- `helix-controlplane.tplvalues.render` and `helix-controlplane.storage.class` template helpers (replacing Bitnami common library)
-
-### Removed
-- Keycloak installation from `kind_helm_install.sh`
-
-## [Unreleased]
-
-### Added
+- `helix-controlplane.tplvalues.render`, `helix-controlplane.storage.class`, and `helix-controlplane.postgres-image` template helpers (replacing Bitnami common library)
 - **Structured License Key Configuration**: Added explicit structured configuration parameters for the Helix license key in the controlplane helm chart
   - `controlplane.licenseKey`: Direct license key value
   - `controlplane.licenseKeyExistingSecret`: Reference to existing Kubernetes secret containing the license key
@@ -30,6 +27,5 @@
   - This replaces the need to use `secretEnvVars` for license key configuration
   - Follows the same pattern as other credentials (runner token, Keycloak, provider API keys)
 
-### Changed
-- Updated `values-example.yaml` to document the new structured license key configuration
-- Deprecated using `secretEnvVars` for common configurations like LICENSE_KEY in favor of structured configuration 
+### Removed
+- Keycloak installation from `kind_helm_install.sh`

--- a/charts/helix-controlplane/Chart.lock
+++ b/charts/helix-controlplane/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 14.3.3
-- name: common
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.31.4
-digest: sha256:79ec534bf681c98d8e0a36cbcf641b99edadcbb1a301f5bbca719fc854623bfe
-generated: "2025-12-18T13:14:04.05599575+01:00"

--- a/charts/helix-controlplane/Chart.yaml
+++ b/charts/helix-controlplane/Chart.yaml
@@ -16,11 +16,11 @@ icon: https://helix.ml/logo.png
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 2.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.7.10"
+appVersion: "2.9.0"
 

--- a/charts/helix-controlplane/Chart.yaml
+++ b/charts/helix-controlplane/Chart.yaml
@@ -16,7 +16,7 @@ icon: https://helix.ml/logo.png
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.39
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,13 +24,3 @@ version: 0.3.39
 # It is recommended to use it with quotes.
 appVersion: "2.7.10"
 
-dependencies:
-  - condition: postgresql.enabled
-    name: postgresql
-    repository: oci://registry-1.docker.io/bitnamicharts
-    version: 14.x.x
-  - name: common
-    repository: oci://registry-1.docker.io/bitnamicharts
-    tags:
-      - bitnami-common
-    version: 2.x.x

--- a/charts/helix-controlplane/UPGRADE.md
+++ b/charts/helix-controlplane/UPGRADE.md
@@ -1,8 +1,8 @@
 # Upgrade Guide
 
-## Upgrading to 0.4.0
+## Upgrading to 2.9.0
 
-Chart version 0.4.0 replaces the Bitnami PostgreSQL subchart with the official `postgres:17-alpine` image. This is a **breaking change** for existing installations.
+Chart version 2.9.0 replaces the Bitnami PostgreSQL subchart with the official `postgres:17-alpine` image. This is a **breaking change** for existing installations.
 
 ### What changed
 
@@ -87,7 +87,7 @@ The local dump file is preserved at `/tmp/helix-pg-migration-{release}.sql` as a
 
 If your values file referenced Bitnami-specific fields, update it:
 
-**Before (0.3.x):**
+**Before (2.8.x):**
 ```yaml
 postgresql:
   enabled: true
@@ -103,7 +103,7 @@ postgresql:
   architecture: standalone
 ```
 
-**After (0.4.0):**
+**After (2.9.0):**
 ```yaml
 postgresql:
   enabled: true

--- a/charts/helix-controlplane/UPGRADE.md
+++ b/charts/helix-controlplane/UPGRADE.md
@@ -1,0 +1,146 @@
+# Upgrade Guide
+
+## Upgrading to 0.4.0
+
+Chart version 0.4.0 replaces the Bitnami PostgreSQL subchart with the official `postgres:17-alpine` image. This is a **breaking change** for existing installations.
+
+### What changed
+
+- The Bitnami `postgresql` and `common` chart dependencies have been removed
+- PostgreSQL is now deployed as a simple Deployment + Service using the official Docker image
+- The service name changed from `{release}-postgresql` to `{release}-helix-controlplane-postgres`
+- The PVC name changed from `data-{release}-postgresql-0` to `{release}-helix-controlplane-postgres-pvc`
+- Several `values.yaml` fields were removed (see below)
+
+### Removed values.yaml fields
+
+The following fields no longer have any effect and can be removed from your values overrides:
+
+| Removed field | Notes |
+|---|---|
+| `postgresql.image.registry` | Use `global.imageRegistry` for private registries |
+| `postgresql.auth.postgresPassword` | No separate superuser password — `auth.password` is used |
+| `postgresql.auth.postgresPasswordKey` | Removed with `postgresPassword` |
+| `postgresql.architecture` | Always `standalone` (single replica) |
+
+### New values.yaml fields
+
+| New field | Default | Notes |
+|---|---|---|
+| `postgresql.persistence.enabled` | `true` | Previously managed internally by Bitnami |
+| `postgresql.persistence.size` | `8Gi` | |
+| `postgresql.persistence.storageClass` | `""` | |
+| `postgresql.persistence.accessModes` | `[ReadWriteOnce]` | |
+| `postgresql.persistence.existingClaim` | `""` | Use to attach a pre-existing PVC |
+
+### Option A: Fresh install (recommended for most users)
+
+If you can afford to lose your database and start fresh:
+
+```bash
+# 1. Delete the old Bitnami PostgreSQL PVC
+kubectl delete pvc data-{release}-postgresql-0 -n {namespace}
+
+# 2. Upgrade the chart
+helm upgrade {release} helix/helix-controlplane \
+  -n {namespace} \
+  -f your-values.yaml
+
+# 3. The controlplane will create a fresh database on startup
+```
+
+### Option B: Preserve existing data
+
+If you need to keep your data, use the migration script included with the chart.
+
+**Prerequisites:**
+- `kubectl` configured with access to your cluster
+- The old chart version still running (do **not** upgrade first)
+
+**Steps:**
+
+```bash
+# 1. Download the migration script
+curl -O https://raw.githubusercontent.com/helixml/helix/main/charts/helix-controlplane/scripts/migrate-from-bitnami.sh
+chmod +x migrate-from-bitnami.sh
+
+# 2. Run the script — it will:
+#    - Dump your database from the old Bitnami pod
+#    - Pause and prompt you to run helm upgrade
+#    - Restore the dump into the new postgres pod
+#    - Verify the migration
+./migrate-from-bitnami.sh --release {release} --namespace {namespace}
+```
+
+The script is interactive — it will pause after the dump and tell you when to run `helm upgrade`. Follow the on-screen instructions.
+
+**After successful migration:**
+
+```bash
+# Delete the old Bitnami PVC (the data is now in the new PVC)
+kubectl delete pvc data-{release}-postgresql-0 -n {namespace}
+```
+
+The local dump file is preserved at `/tmp/helix-pg-migration-{release}.sql` as a backup.
+
+### Updating your values.yaml
+
+If your values file referenced Bitnami-specific fields, update it:
+
+**Before (0.3.x):**
+```yaml
+postgresql:
+  enabled: true
+  image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
+    tag: "17"
+  auth:
+    postgresPassword: "admin-password"
+    username: helix
+    password: "my-password"
+    database: helix
+  architecture: standalone
+```
+
+**After (0.4.0):**
+```yaml
+postgresql:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "17-alpine"
+  auth:
+    username: helix
+    password: "my-password"
+    database: helix
+  persistence:
+    enabled: true
+    size: 8Gi
+```
+
+### Using a private registry
+
+If you were using `postgresql.image.registry` to pull from a private registry, use `global.imageRegistry` instead:
+
+**Before:**
+```yaml
+postgresql:
+  image:
+    registry: my-registry.example.com
+    repository: bitnamilegacy/postgresql
+```
+
+**After:**
+```yaml
+global:
+  imageRegistry: my-registry.example.com
+postgresql:
+  image:
+    repository: postgres
+    tag: "17-alpine"
+```
+
+### External PostgreSQL (no change)
+
+If you use an external PostgreSQL instance (`postgresql.enabled: false`), no action is required. The `postgresql.external.*` configuration is unchanged.

--- a/charts/helix-controlplane/scripts/migrate-from-bitnami.sh
+++ b/charts/helix-controlplane/scripts/migrate-from-bitnami.sh
@@ -85,10 +85,26 @@ POSTGRES_DB=$(kubectl get deploy ${NS_FLAG} "${RELEASE}-helix-controlplane" -o j
   kubectl get deploy ${NS_FLAG} "${RELEASE}" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="POSTGRES_DATABASE")].value}' 2>/dev/null || \
   echo "helix")
 
+# Get the password from the Bitnami secret ({release}-postgresql)
+BITNAMI_SECRET="${RELEASE}-postgresql"
+echo "Reading password from secret ${BITNAMI_SECRET}..."
+POSTGRES_PASSWORD=$(kubectl get secret ${NS_FLAG} "${BITNAMI_SECRET}" -o jsonpath='{.data.password}' 2>/dev/null | base64 -d || \
+  echo "")
+if [ -z "${POSTGRES_PASSWORD}" ]; then
+  echo "WARNING: Could not read password from secret ${BITNAMI_SECRET}."
+  echo "Trying to read from controlplane deployment env..."
+  POSTGRES_PASSWORD=$(kubectl get deploy ${NS_FLAG} "${RELEASE}-helix-controlplane" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="POSTGRES_PASSWORD")].value}' 2>/dev/null || \
+    echo "")
+fi
+if [ -z "${POSTGRES_PASSWORD}" ]; then
+  echo "ERROR: Could not determine PostgreSQL password."
+  exit 1
+fi
+
 echo "User: ${POSTGRES_USER}, Database: ${POSTGRES_DB}"
 
-echo "Running pg_dumpall from ${OLD_POD}..."
-kubectl exec ${NS_FLAG} "${OLD_POD}" -- pg_dumpall -U "${POSTGRES_USER}" > "${DUMP_FILE}"
+echo "Running pg_dump from ${OLD_POD} (database: ${POSTGRES_DB})..."
+kubectl exec ${NS_FLAG} "${OLD_POD}" -- env PGPASSWORD="${POSTGRES_PASSWORD}" pg_dump -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" > "${DUMP_FILE}"
 
 DUMP_SIZE=$(wc -c < "${DUMP_FILE}" | tr -d ' ')
 echo "Dump complete: ${DUMP_FILE} (${DUMP_SIZE} bytes)"
@@ -139,9 +155,16 @@ echo "New postgres pod: ${NEW_POD}"
 echo "Copying dump file to new pod..."
 kubectl cp ${NS_FLAG} "${DUMP_FILE}" "${NEW_POD}:/tmp/helix-migration.sql"
 
+# Get the new postgres password from the new deployment's env
+echo "Reading new postgres credentials..."
+NEW_PASSWORD=$(kubectl get deploy ${NS_FLAG} \
+  -l "app.kubernetes.io/component=postgres,app.kubernetes.io/instance=${RELEASE}" \
+  -o jsonpath='{.items[0].spec.template.spec.containers[0].env[?(@.name=="POSTGRES_PASSWORD")].value}' 2>/dev/null || \
+  echo "${POSTGRES_PASSWORD}")
+
 echo "Restoring database..."
 kubectl exec ${NS_FLAG} "${NEW_POD}" -- \
-  psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -f /tmp/helix-migration.sql
+  env PGPASSWORD="${NEW_PASSWORD}" psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -f /tmp/helix-migration.sql
 
 echo "Cleaning up dump file from pod..."
 kubectl exec ${NS_FLAG} "${NEW_POD}" -- rm -f /tmp/helix-migration.sql
@@ -153,7 +176,7 @@ echo ""
 echo "--- Phase 4: Verify ---"
 
 TABLE_COUNT=$(kubectl exec ${NS_FLAG} "${NEW_POD}" -- \
-  psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -t -c \
+  env PGPASSWORD="${NEW_PASSWORD}" psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -t -c \
   "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';" | tr -d ' ')
 
 echo "Tables in public schema: ${TABLE_COUNT}"

--- a/charts/helix-controlplane/scripts/migrate-from-bitnami.sh
+++ b/charts/helix-controlplane/scripts/migrate-from-bitnami.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # and data directory layouts are incompatible, so a dump/restore is required.
 #
 # Usage:
-#   ./migrate-from-bitnami.sh <release-name> [namespace]
+#   ./migrate-from-bitnami.sh --release <name> [--namespace <ns>]
 #
 # Prerequisites:
 #   - kubectl configured with access to the cluster
@@ -23,16 +23,36 @@ set -euo pipefail
 #   Phase 2 (user action):  prompts you to run helm upgrade
 #   Phase 3 (post-upgrade): pg_restore into the new official postgres pod
 
-RELEASE=${1:-}
-NAMESPACE=${2:-default}
-DUMP_FILE="/tmp/helix-pg-migration-${RELEASE}.sql"
+usage() {
+  echo "Usage: $0 --release <name> [--namespace <ns>]"
+  echo ""
+  echo "Options:"
+  echo "  --release    Helm release name (required)"
+  echo "  --namespace  Kubernetes namespace (default: default)"
+  echo ""
+  echo "Example: $0 --release my-helix --namespace production"
+  exit 1
+}
+
+RELEASE=""
+NAMESPACE="default"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --release)    RELEASE="$2"; shift 2 ;;
+    --namespace)  NAMESPACE="$2"; shift 2 ;;
+    -h|--help)    usage ;;
+    *)            echo "Unknown option: $1"; usage ;;
+  esac
+done
 
 if [ -z "$RELEASE" ]; then
-  echo "Usage: $0 <release-name> [namespace]"
+  echo "ERROR: --release is required"
   echo ""
-  echo "Example: $0 my-helix default"
-  exit 1
+  usage
 fi
+
+DUMP_FILE="/tmp/helix-pg-migration-${RELEASE}.sql"
 
 NS_FLAG="-n ${NAMESPACE}"
 

--- a/charts/helix-controlplane/scripts/migrate-from-bitnami.sh
+++ b/charts/helix-controlplane/scripts/migrate-from-bitnami.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+set -euo pipefail
+
+# Migration script: Bitnami PostgreSQL → Official PostgreSQL
+#
+# For customers upgrading helix-controlplane chart from <0.4.0 to >=0.4.0
+# who want to preserve their database.
+#
+# The chart moved from the Bitnami PostgreSQL subchart (StatefulSet) to
+# an official postgres:17-alpine Deployment. PVC names, service names,
+# and data directory layouts are incompatible, so a dump/restore is required.
+#
+# Usage:
+#   ./migrate-from-bitnami.sh <release-name> [namespace]
+#
+# Prerequisites:
+#   - kubectl configured with access to the cluster
+#   - helm v3
+#   - The old chart version still running (pre-0.4.0)
+#
+# What this script does:
+#   Phase 1 (pre-upgrade):  pg_dump from the old Bitnami postgres pod
+#   Phase 2 (user action):  prompts you to run helm upgrade
+#   Phase 3 (post-upgrade): pg_restore into the new official postgres pod
+
+RELEASE=${1:-}
+NAMESPACE=${2:-default}
+DUMP_FILE="/tmp/helix-pg-migration-${RELEASE}.sql"
+
+if [ -z "$RELEASE" ]; then
+  echo "Usage: $0 <release-name> [namespace]"
+  echo ""
+  echo "Example: $0 my-helix default"
+  exit 1
+fi
+
+NS_FLAG="-n ${NAMESPACE}"
+
+echo "=== Helix PostgreSQL Migration: Bitnami → Official ==="
+echo "Release:   ${RELEASE}"
+echo "Namespace: ${NAMESPACE}"
+echo ""
+
+# -------------------------------------------------------
+# Phase 1: Dump from old Bitnami postgres
+# -------------------------------------------------------
+echo "--- Phase 1: Dump existing database ---"
+
+# Bitnami subchart creates a StatefulSet named {release}-postgresql
+OLD_POD="${RELEASE}-postgresql-0"
+
+echo "Checking old Bitnami pod ${OLD_POD}..."
+if ! kubectl get pod ${NS_FLAG} "${OLD_POD}" &>/dev/null; then
+  echo "ERROR: Pod ${OLD_POD} not found in namespace ${NAMESPACE}."
+  echo "Make sure the old chart version is still running before migrating."
+  exit 1
+fi
+
+# Get credentials from the old controlplane deployment
+echo "Reading database credentials from controlplane deployment..."
+POSTGRES_USER=$(kubectl get deploy ${NS_FLAG} "${RELEASE}-helix-controlplane" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="POSTGRES_USER")].value}' 2>/dev/null || \
+  kubectl get deploy ${NS_FLAG} "${RELEASE}" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="POSTGRES_USER")].value}' 2>/dev/null || \
+  echo "helix")
+POSTGRES_DB=$(kubectl get deploy ${NS_FLAG} "${RELEASE}-helix-controlplane" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="POSTGRES_DATABASE")].value}' 2>/dev/null || \
+  kubectl get deploy ${NS_FLAG} "${RELEASE}" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="POSTGRES_DATABASE")].value}' 2>/dev/null || \
+  echo "helix")
+
+echo "User: ${POSTGRES_USER}, Database: ${POSTGRES_DB}"
+
+echo "Running pg_dumpall from ${OLD_POD}..."
+kubectl exec ${NS_FLAG} "${OLD_POD}" -- pg_dumpall -U "${POSTGRES_USER}" > "${DUMP_FILE}"
+
+DUMP_SIZE=$(wc -c < "${DUMP_FILE}" | tr -d ' ')
+echo "Dump complete: ${DUMP_FILE} (${DUMP_SIZE} bytes)"
+
+if [ "${DUMP_SIZE}" -lt 100 ]; then
+  echo "WARNING: Dump file is suspiciously small. Check for errors above."
+  echo "Contents:"
+  cat "${DUMP_FILE}"
+  exit 1
+fi
+
+# -------------------------------------------------------
+# Phase 2: User upgrades the chart
+# -------------------------------------------------------
+echo ""
+echo "--- Phase 2: Upgrade the Helm chart ---"
+echo ""
+echo "The database has been dumped to: ${DUMP_FILE}"
+echo ""
+echo "Now upgrade the chart to >=0.4.0. For example:"
+echo ""
+echo "  helm upgrade ${RELEASE} helix/helix-controlplane \\"
+echo "    -n ${NAMESPACE} \\"
+echo "    -f your-values.yaml \\"
+echo "    --version 0.4.0"
+echo ""
+echo "After the upgrade completes and the new postgres pod is running,"
+echo "press Enter to continue with the restore..."
+read -r
+
+# -------------------------------------------------------
+# Phase 3: Restore into new official postgres
+# -------------------------------------------------------
+echo "--- Phase 3: Restore database ---"
+
+# The new deployment creates a pod with label app.kubernetes.io/component=postgres
+echo "Waiting for new postgres pod to be ready..."
+kubectl wait ${NS_FLAG} --for=condition=ready pod \
+  -l "app.kubernetes.io/component=postgres,app.kubernetes.io/instance=${RELEASE}" \
+  --timeout=120s
+
+NEW_POD=$(kubectl get pod ${NS_FLAG} \
+  -l "app.kubernetes.io/component=postgres,app.kubernetes.io/instance=${RELEASE}" \
+  -o jsonpath='{.items[0].metadata.name}')
+
+echo "New postgres pod: ${NEW_POD}"
+
+echo "Copying dump file to new pod..."
+kubectl cp ${NS_FLAG} "${DUMP_FILE}" "${NEW_POD}:/tmp/helix-migration.sql"
+
+echo "Restoring database..."
+kubectl exec ${NS_FLAG} "${NEW_POD}" -- \
+  psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -f /tmp/helix-migration.sql
+
+echo "Cleaning up dump file from pod..."
+kubectl exec ${NS_FLAG} "${NEW_POD}" -- rm -f /tmp/helix-migration.sql
+
+# -------------------------------------------------------
+# Phase 4: Verify
+# -------------------------------------------------------
+echo ""
+echo "--- Phase 4: Verify ---"
+
+TABLE_COUNT=$(kubectl exec ${NS_FLAG} "${NEW_POD}" -- \
+  psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -t -c \
+  "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';" | tr -d ' ')
+
+echo "Tables in public schema: ${TABLE_COUNT}"
+
+if [ "${TABLE_COUNT}" -gt 0 ]; then
+  echo ""
+  echo "=== Migration successful ==="
+  echo ""
+  echo "Restart the controlplane to reconnect:"
+  echo "  kubectl rollout restart deploy ${NS_FLAG} -l app.kubernetes.io/component=controlplane,app.kubernetes.io/instance=${RELEASE}"
+  echo ""
+  echo "Once verified, you can delete the old Bitnami PVC:"
+  echo "  kubectl delete pvc ${NS_FLAG} data-${RELEASE}-postgresql-0"
+  echo ""
+  echo "Local dump file preserved at: ${DUMP_FILE}"
+else
+  echo ""
+  echo "WARNING: No tables found after restore. Check the output above for errors."
+  echo "The dump file is preserved at: ${DUMP_FILE}"
+  exit 1
+fi

--- a/charts/helix-controlplane/scripts/migrate-from-bitnami.sh
+++ b/charts/helix-controlplane/scripts/migrate-from-bitnami.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-# Migration script: Bitnami PostgreSQL → Official PostgreSQL
+# Migration script: Bitnami PostgreSQL -> Official PostgreSQL
 #
-# For customers upgrading helix-controlplane chart from <0.4.0 to >=0.4.0
-# who want to preserve their database.
+# For customers upgrading helix-controlplane chart across the Bitnami
+# removal release who want to preserve their database.
 #
 # The chart moved from the Bitnami PostgreSQL subchart (StatefulSet) to
 # an official postgres:17-alpine Deployment. PVC names, service names,
@@ -16,7 +16,7 @@ set -euo pipefail
 # Prerequisites:
 #   - kubectl configured with access to the cluster
 #   - helm v3
-#   - The old chart version still running (pre-0.4.0)
+#   - The old chart version (with Bitnami PostgreSQL) still running
 #
 # What this script does:
 #   Phase 1 (pre-upgrade):  pg_dump from the old Bitnami postgres pod
@@ -76,14 +76,35 @@ if ! kubectl get pod ${NS_FLAG} "${OLD_POD}" &>/dev/null; then
   exit 1
 fi
 
-# Get credentials from the old controlplane deployment
+# Get credentials from the old controlplane deployment.
+# We deliberately do NOT fall back to a guessed default here — a wrong
+# user/database name would produce a valid-looking but empty dump.
 echo "Reading database credentials from controlplane deployment..."
-POSTGRES_USER=$(kubectl get deploy ${NS_FLAG} "${RELEASE}-helix-controlplane" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="POSTGRES_USER")].value}' 2>/dev/null || \
-  kubectl get deploy ${NS_FLAG} "${RELEASE}" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="POSTGRES_USER")].value}' 2>/dev/null || \
-  echo "helix")
-POSTGRES_DB=$(kubectl get deploy ${NS_FLAG} "${RELEASE}-helix-controlplane" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="POSTGRES_DATABASE")].value}' 2>/dev/null || \
-  kubectl get deploy ${NS_FLAG} "${RELEASE}" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="POSTGRES_DATABASE")].value}' 2>/dev/null || \
-  echo "helix")
+CP_DEPLOY=""
+for name in "${RELEASE}-helix-controlplane" "${RELEASE}"; do
+  if kubectl get deploy ${NS_FLAG} "$name" &>/dev/null; then
+    CP_DEPLOY="$name"
+    break
+  fi
+done
+if [ -z "${CP_DEPLOY}" ]; then
+  echo "ERROR: Could not find controlplane deployment (tried ${RELEASE}-helix-controlplane and ${RELEASE})."
+  exit 1
+fi
+
+POSTGRES_USER=$(kubectl get deploy ${NS_FLAG} "${CP_DEPLOY}" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="POSTGRES_USER")].value}')
+POSTGRES_DB=$(kubectl get deploy ${NS_FLAG} "${CP_DEPLOY}" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="POSTGRES_DATABASE")].value}')
+
+if [ -z "${POSTGRES_USER}" ]; then
+  echo "ERROR: POSTGRES_USER is empty on deployment ${CP_DEPLOY}."
+  echo "If credentials come from a Secret, set POSTGRES_USER via the environment before running this script."
+  exit 1
+fi
+if [ -z "${POSTGRES_DB}" ]; then
+  echo "ERROR: POSTGRES_DATABASE is empty on deployment ${CP_DEPLOY}."
+  echo "If credentials come from a Secret, set POSTGRES_DB via the environment before running this script."
+  exit 1
+fi
 
 # Get the password from the Bitnami secret ({release}-postgresql)
 BITNAMI_SECRET="${RELEASE}-postgresql"
@@ -124,12 +145,12 @@ echo "--- Phase 2: Upgrade the Helm chart ---"
 echo ""
 echo "The database has been dumped to: ${DUMP_FILE}"
 echo ""
-echo "Now upgrade the chart to >=0.4.0. For example:"
+echo "Now upgrade the chart to the new version that replaces Bitnami PostgreSQL."
+echo "For example:"
 echo ""
 echo "  helm upgrade ${RELEASE} helix/helix-controlplane \\"
 echo "    -n ${NAMESPACE} \\"
-echo "    -f your-values.yaml \\"
-echo "    --version 0.4.0"
+echo "    -f your-values.yaml"
 echo ""
 echo "After the upgrade completes and the new postgres pod is running,"
 echo "press Enter to continue with the restore..."
@@ -164,7 +185,7 @@ NEW_PASSWORD=$(kubectl get deploy ${NS_FLAG} \
 
 echo "Restoring database..."
 kubectl exec ${NS_FLAG} "${NEW_POD}" -- \
-  env PGPASSWORD="${NEW_PASSWORD}" psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -f /tmp/helix-migration.sql
+  env PGPASSWORD="${NEW_PASSWORD}" psql -v ON_ERROR_STOP=1 -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -f /tmp/helix-migration.sql
 
 echo "Cleaning up dump file from pod..."
 kubectl exec ${NS_FLAG} "${NEW_POD}" -- rm -f /tmp/helix-migration.sql

--- a/charts/helix-controlplane/templates/_helpers.tpl
+++ b/charts/helix-controlplane/templates/_helpers.tpl
@@ -62,13 +62,50 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Renders a value that contains a template.
+Replaces Bitnami common.tplvalues.render.
+Usage: {{ include "helix-controlplane.tplvalues.render" (dict "value" .Values.some.value "context" $) }}
+*/}}
+{{- define "helix-controlplane.tplvalues.render" -}}
+{{- if typeIs "string" .value }}
+{{- tpl .value .context }}
+{{- else }}
+{{- tpl (.value | toYaml) .context }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Return the appropriate storageClass for a PVC.
+Replaces Bitnami common.storage.class.
+Usage: {{ include "helix-controlplane.storage.class" (dict "persistence" .Values.some.persistence "global" .Values.global) }}
+*/}}
+{{- define "helix-controlplane.storage.class" -}}
+{{- $storageClass := "" -}}
+{{- if .global -}}
+{{- if .global.storageClass -}}
+{{- $storageClass = .global.storageClass -}}
+{{- end -}}
+{{- end -}}
+{{- if .persistence.storageClass -}}
+{{- $storageClass = .persistence.storageClass -}}
+{{- end -}}
+{{- if $storageClass -}}
+{{- if (eq "-" $storageClass) }}
+storageClassName: ""
+{{- else }}
+storageClassName: {{ $storageClass | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 PostgreSQL connection environment variables.
 Used by both the init container and main controlplane container.
 */}}
 {{- define "helix-controlplane.postgres-env" -}}
 {{- if .Values.postgresql.enabled }}
 - name: POSTGRES_HOST
-  value: {{ .Release.Name }}-postgresql
+  value: {{ include "helix-controlplane.fullname" . }}-postgres
 - name: POSTGRES_PORT
   value: "5432"
 {{- if .Values.postgresql.auth.existingSecret }}

--- a/charts/helix-controlplane/templates/_helpers.tpl
+++ b/charts/helix-controlplane/templates/_helpers.tpl
@@ -99,6 +99,18 @@ storageClassName: {{ $storageClass | quote }}
 {{- end -}}
 
 {{/*
+PostgreSQL image reference, honoring global.imageRegistry.
+Usage: image: {{ include "helix-controlplane.postgres-image" . | quote }}
+*/}}
+{{- define "helix-controlplane.postgres-image" -}}
+{{- if .Values.global.imageRegistry -}}
+{{ .Values.global.imageRegistry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
+{{- else -}}
+{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 PostgreSQL connection environment variables.
 Used by both the init container and main controlplane container.
 */}}

--- a/charts/helix-controlplane/templates/controlplane_pvc.yaml
+++ b/charts/helix-controlplane/templates/controlplane_pvc.yaml
@@ -14,10 +14,10 @@ spec:
     requests:
       storage: {{ .Values.persistence.size | quote }}
   {{- if .Values.persistence.selector }}
-  selector: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.selector "context" $) | nindent 4 }}
+  selector: {{- include "helix-controlplane.tplvalues.render" (dict "value" .Values.persistence.selector "context" $) | nindent 4 }}
   {{- end }}
   {{- if .Values.persistence.dataSource }}
-  dataSource: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.dataSource "context" $) | nindent 4 }}
+  dataSource: {{- include "helix-controlplane.tplvalues.render" (dict "value" .Values.persistence.dataSource "context" $) | nindent 4 }}
   {{- end }}
-  {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 2 }}
+  {{- include "helix-controlplane.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 2 }}
 {{- end -}}

--- a/charts/helix-controlplane/templates/deployment.yaml
+++ b/charts/helix-controlplane/templates/deployment.yaml
@@ -40,7 +40,11 @@ spec:
       {{- if ne (.Values.controlplane.waitForPostgres | toString) "false" }}
       initContainers:
         - name: wait-for-postgres
-          image: "{{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          {{- if .Values.global.imageRegistry }}
+          image: "{{ .Values.global.imageRegistry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          {{- else }}
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy | default "IfNotPresent" }}
           command: ['sh', '-c', 'timeout {{ .Values.controlplane.waitForPostgresTimeout | default 300 }} sh -c ''until PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER -d $POSTGRES_DATABASE -c "SELECT 1" > /dev/null 2>&1; do echo "Waiting for PostgreSQL ($POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DATABASE)..."; sleep 2; done''']
           env:

--- a/charts/helix-controlplane/templates/deployment.yaml
+++ b/charts/helix-controlplane/templates/deployment.yaml
@@ -40,11 +40,7 @@ spec:
       {{- if ne (.Values.controlplane.waitForPostgres | toString) "false" }}
       initContainers:
         - name: wait-for-postgres
-          {{- if .Values.global.imageRegistry }}
-          image: "{{ .Values.global.imageRegistry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
-          {{- else }}
-          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
-          {{- end }}
+          image: {{ include "helix-controlplane.postgres-image" . | quote }}
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy | default "IfNotPresent" }}
           command: ['sh', '-c', 'timeout {{ .Values.controlplane.waitForPostgresTimeout | default 300 }} sh -c ''until PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER -d $POSTGRES_DATABASE -c "SELECT 1" > /dev/null 2>&1; do echo "Waiting for PostgreSQL ($POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DATABASE)..."; sleep 2; done''']
           env:

--- a/charts/helix-controlplane/templates/deployment_postgres.yaml
+++ b/charts/helix-controlplane/templates/deployment_postgres.yaml
@@ -1,0 +1,126 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "helix-controlplane.fullname" . }}-postgres
+  labels:
+    {{- include "helix-controlplane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP
+      name: postgres
+  selector:
+    app.kubernetes.io/component: postgres
+    {{- include "helix-controlplane.selectorLabels" . | nindent 4 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "helix-controlplane.fullname" . }}-postgres
+  labels:
+    app.kubernetes.io/component: postgres
+    {{- include "helix-controlplane.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: postgres
+      {{- include "helix-controlplane.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/component: postgres
+        {{- include "helix-controlplane.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "helix-controlplane.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: postgres
+          {{- if .Values.global.imageRegistry }}
+          image: "{{ .Values.global.imageRegistry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          {{- else }}
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy | default "IfNotPresent" }}
+          ports:
+            - name: tcp-postgres
+              containerPort: 5432
+              protocol: TCP
+          env:
+            # Setting PGDATA to a subdirectory avoids issues with lost+found on ext4 PVCs
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+            - name: POSTGRES_DB
+              {{- if .Values.postgresql.auth.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.auth.existingSecret }}
+                  key: {{ .Values.postgresql.auth.databaseKey | default "database" }}
+              {{- else }}
+              value: {{ .Values.postgresql.auth.database | default "helix" }}
+              {{- end }}
+            - name: POSTGRES_USER
+              {{- if .Values.postgresql.auth.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.auth.existingSecret }}
+                  key: {{ .Values.postgresql.auth.usernameKey | default "username" }}
+              {{- else }}
+              value: {{ .Values.postgresql.auth.username | default "helix" }}
+              {{- end }}
+            - name: POSTGRES_PASSWORD
+              {{- if .Values.postgresql.auth.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.auth.existingSecret }}
+                  key: {{ .Values.postgresql.auth.passwordKey | default "password" }}
+              {{- else }}
+              value: {{ .Values.postgresql.auth.password | default "oh-hallo-insecure-password" }}
+              {{- end }}
+          readinessProbe:
+            exec:
+              command: ['pg_isready', '-U', '$(POSTGRES_USER)', '-d', '$(POSTGRES_DB)']
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          {{- if .Values.postgresql.persistence.enabled }}
+          volumeMounts:
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data
+          {{- end }}
+      {{- if .Values.postgresql.persistence.enabled }}
+      volumes:
+        - name: postgres-storage
+          persistentVolumeClaim:
+            claimName: {{ .Values.postgresql.persistence.existingClaim | default (printf "%s-postgres-pvc" (include "helix-controlplane.fullname" .)) }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/helix-controlplane/templates/deployment_postgres.yaml
+++ b/charts/helix-controlplane/templates/deployment_postgres.yaml
@@ -40,7 +40,7 @@ spec:
       {{- end }}
       labels:
         app.kubernetes.io/component: postgres
-        {{- include "helix-controlplane.labels" . | nindent 8 }}
+        {{- include "helix-controlplane.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -54,11 +54,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: postgres
-          {{- if .Values.global.imageRegistry }}
-          image: "{{ .Values.global.imageRegistry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
-          {{- else }}
-          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
-          {{- end }}
+          image: {{ include "helix-controlplane.postgres-image" . | quote }}
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy | default "IfNotPresent" }}
           ports:
             - name: tcp-postgres
@@ -100,6 +96,10 @@ spec:
               command: ['sh', '-c', 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"']
             initialDelaySeconds: 5
             periodSeconds: 10
+          {{- with .Values.postgresql.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.postgresql.persistence.enabled }}
           volumeMounts:
             - name: postgres-storage

--- a/charts/helix-controlplane/templates/deployment_postgres.yaml
+++ b/charts/helix-controlplane/templates/deployment_postgres.yaml
@@ -97,7 +97,7 @@ spec:
               {{- end }}
           readinessProbe:
             exec:
-              command: ['pg_isready', '-U', '$(POSTGRES_USER)', '-d', '$(POSTGRES_DB)']
+              command: ['sh', '-c', 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"']
             initialDelaySeconds: 5
             periodSeconds: 10
           {{- if .Values.postgresql.persistence.enabled }}

--- a/charts/helix-controlplane/templates/kodit_vectorchord_pvc.yaml
+++ b/charts/helix-controlplane/templates/kodit_vectorchord_pvc.yaml
@@ -19,10 +19,10 @@ spec:
     requests:
       storage: {{ .Values.kodit.vectorchord.persistence.size | quote }}
   {{- if .Values.kodit.vectorchord.persistence.selector }}
-  selector: {{- include "common.tplvalues.render" (dict "value" .Values.kodit.vectorchord.persistence.selector "context" $) | nindent 4 }}
+  selector: {{- include "helix-controlplane.tplvalues.render" (dict "value" .Values.kodit.vectorchord.persistence.selector "context" $) | nindent 4 }}
   {{- end }}
   {{- if .Values.kodit.vectorchord.persistence.dataSource }}
-  dataSource: {{- include "common.tplvalues.render" (dict "value" .Values.kodit.vectorchord.persistence.dataSource "context" $) | nindent 4 }}
+  dataSource: {{- include "helix-controlplane.tplvalues.render" (dict "value" .Values.kodit.vectorchord.persistence.dataSource "context" $) | nindent 4 }}
   {{- end }}
-  {{- include "common.storage.class" (dict "persistence" .Values.kodit.vectorchord.persistence "global" .Values.global) | nindent 2 }}
+  {{- include "helix-controlplane.storage.class" (dict "persistence" .Values.kodit.vectorchord.persistence "global" .Values.global) | nindent 2 }}
 {{- end -}}

--- a/charts/helix-controlplane/templates/postgres_pvc.yaml
+++ b/charts/helix-controlplane/templates/postgres_pvc.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.postgresql.enabled .Values.postgresql.persistence.enabled (not .Values.postgresql.persistence.existingClaim) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "helix-controlplane.fullname" . }}-postgres-pvc
+  labels:
+    {{- include "helix-controlplane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+  {{- with .Values.postgresql.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+  {{- range .Values.postgresql.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.postgresql.persistence.size | quote }}
+  {{- if .Values.postgresql.persistence.selector }}
+  selector: {{- include "helix-controlplane.tplvalues.render" (dict "value" .Values.postgresql.persistence.selector "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.postgresql.persistence.dataSource }}
+  dataSource: {{- include "helix-controlplane.tplvalues.render" (dict "value" .Values.postgresql.persistence.dataSource "context" $) | nindent 4 }}
+  {{- end }}
+  {{- include "helix-controlplane.storage.class" (dict "persistence" .Values.postgresql.persistence "global" .Values.global) | nindent 2 }}
+{{- end -}}

--- a/charts/helix-controlplane/values-example.yaml
+++ b/charts/helix-controlplane/values-example.yaml
@@ -333,6 +333,15 @@ postgresql:
     # storageClass: ""
     # existingClaim: ""
 
+  # Resource requests and limits for the bundled PostgreSQL container.
+  # Set these for production; empty by default.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+
   # For external PostgreSQL configuration (when enabled=false):
   # external:
   #   host: "my-external-postgresql.example.com"

--- a/charts/helix-controlplane/values-example.yaml
+++ b/charts/helix-controlplane/values-example.yaml
@@ -310,29 +310,28 @@ postgresql:
 
   # PostgreSQL image configuration
   image:
-    registry: docker.io
-    repository: bitnamilegacy/postgresql
-    tag: "17"
+    repository: postgres
+    tag: "17-alpine"
     pullPolicy: IfNotPresent
 
   # For bundled PostgreSQL auth configuration (when enabled=true):
   auth:
-    # Password for the "postgres" admin user
-    postgresPassword: "secure-postgres-admin-password"
-    # Custom user credentials
     username: helix
     password: "secure-helix-db-password"
     database: helix
 
     # Option: Use existing secret for all auth credentials
     # existingSecret: "postgresql-auth-secret"
-    # postgresPasswordKey: "postgres-password"  # defaults to "postgres-password"
     # usernameKey: "username"                   # defaults to "username"
     # passwordKey: "password"                   # defaults to "password"
     # databaseKey: "database"                   # defaults to "database"
 
-  # PostgreSQL architecture
-  architecture: standalone
+  # Persistence configuration
+  persistence:
+    enabled: true
+    size: 8Gi
+    # storageClass: ""
+    # existingClaim: ""
 
   # For external PostgreSQL configuration (when enabled=false):
   # external:

--- a/charts/helix-controlplane/values.yaml
+++ b/charts/helix-controlplane/values.yaml
@@ -233,6 +233,14 @@ postgresql:
     existingClaim: ""
     selector: {}
     dataSource: {}
+  # Resource requests and limits for the bundled PostgreSQL container.
+  # Empty by default; set this for production use.
+  resources: {}
+  #   requests:
+  #     cpu: 100m
+  #     memory: 256Mi
+  #   limits:
+  #     memory: 1Gi
   external:
     host: ""
     port: 5432

--- a/charts/helix-controlplane/values.yaml
+++ b/charts/helix-controlplane/values.yaml
@@ -212,21 +212,27 @@ affinity: {}
 postgresql:
   enabled: true
   image:
-    registry: docker.io
-    repository: bitnamilegacy/postgresql
-    tag: "17"
+    repository: postgres
+    tag: "17-alpine"
     pullPolicy: IfNotPresent
   auth:
-    postgresPassword: ""
     username: helix
     password: "oh-hallo-insecure-password"
     database: helix
     existingSecret: ""
-    postgresPasswordKey: "postgres-password"
     usernameKey: ""
     passwordKey: ""
     databaseKey: ""
-  architecture: standalone
+  persistence:
+    enabled: true
+    size: 8Gi
+    storageClass: ""
+    annotations: {}
+    accessModes:
+      - ReadWriteOnce
+    existingClaim: ""
+    selector: {}
+    dataSource: {}
   external:
     host: ""
     port: 5432
@@ -239,7 +245,6 @@ postgresql:
     existingSecretUserKey: ""
     existingSecretDatabaseKey: ""
     existingSecretPasswordKey: ""
-    annotations: {}
 
 # Kodit configuration - Code indexing service
 # Kodit provides code search and analysis capabilities for Helix

--- a/scripts/gen_packages.sh
+++ b/scripts/gen_packages.sh
@@ -41,17 +41,9 @@ do
     # Will generate a helm package per chart in a folder
     echo "$d"
 
-    # Fetch Helm chart dependencies from OCI registries before packaging
-    # This is required for charts that reference remote dependencies (e.g., bitnami charts)
-    # without bundled .tgz files in the charts/ subdirectory.
-    #
-    # The helix-controlplane chart declares dependencies like:
-    #   - postgresql: oci://registry-1.docker.io/bitnamicharts
-    #   - common: oci://registry-1.docker.io/bitnamicharts
-    #
-    # Running `helm dependency update` downloads these from the remote registry
-    # and creates them in the chart's charts/ directory so they can be packaged
-    # together with the main chart.
+    # Fetch any Helm chart dependencies before packaging.
+    # Running `helm dependency update` downloads dependencies declared in Chart.yaml
+    # and places them in the chart's charts/ directory for packaging.
     helm dependency update "$d" || true
 
     helm package "$d"

--- a/scripts/kind_helm_install.sh
+++ b/scripts/kind_helm_install.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # the official one from the helixml/helix repository.
 USE_LOCAL_HELM_CHART=${USE_LOCAL_HELM_CHART:-""}
 
-# USE_EXTERNAL_POSTGRES=1 
+# USE_EXTERNAL_POSTGRES=1
 # This option is used to test the chart when using an external postgres instance.
 # The script will install an independent postgres instance using the official helm chart.
 # Helix will be configured to use the external postgres instance.


### PR DESCRIPTION
## Summary

- **Remove Bitnami PostgreSQL subchart and common library** from the helix-controlplane Helm chart, replacing with a self-managed Deployment using the official `postgres:17-alpine` image
- **Fix pgvector deployment strategy** from RollingUpdate to Recreate (RollingUpdate deadlocks on single-replica RWO PVCs)
- **Add migration script** (`charts/helix-controlplane/scripts/migrate-from-bitnami.sh`) for customers who need to preserve data during upgrade
- **Remove keycloak** from kind_helm_install.sh
- **Bump chart version** to 0.4.0

## Breaking changes

- Service name changes from `{release}-postgresql` to `{release}-{fullname}-postgres`
- PVC name changes — old Bitnami PVC (`data-{release}-postgresql-0`) is not reused
- `postgresql.image.registry`, `postgresql.auth.postgresPassword`, `postgresql.architecture` values removed
- Customers must either delete their PostgreSQL PVC and reinstall, or run the migration script

## Migration

Customers who want to preserve data:
```bash
./charts/helix-controlplane/scripts/migrate-from-bitnami.sh --release my-helix --namespace production
```

Customers who can start fresh: delete the old PVC and `helm upgrade`.

## Test plan

- [x] `helm template test .` renders all resources correctly
- [x] `helm template test . --set postgresql.enabled=false --set postgresql.external.host=ext-db` renders external DB mode correctly
- [ ] Deploy to a kind cluster and verify controlplane connects to new postgres
- [ ] Test migration script against a running pre-0.4.0 installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)