### PR TITLE
fix: increase postgres max_connections from 50 to 200

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -132,9 +132,9 @@ services:
      - 127.0.0.1:5432:5432
     command: >
       postgres
-      -c shared_buffers=32MB
-      -c work_mem=2MB
-      -c max_connections=50
+      -c shared_buffers=128MB
+      -c work_mem=4MB
+      -c max_connections=200
       -c max_worker_processes=2
       -c maintenance_work_mem=32MB
       -c effective_cache_size=256MB

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,9 +70,9 @@ services:
     #   - 5432:5432
     command: >
       postgres
-      -c shared_buffers=32MB
-      -c work_mem=2MB
-      -c max_connections=50
+      -c shared_buffers=128MB
+      -c work_mem=4MB
+      -c max_connections=200
       -c max_worker_processes=2
       -c maintenance_work_mem=32MB
       -c effective_cache_size=256MB


### PR DESCRIPTION
## Summary
- Postgres `max_connections` was set to 50, but the Go API server alone defaults to a pool of 50 — leaving zero headroom for `postgres-mcp`, `psql`, or any other client
- This was causing `FATAL: sorry, too many clients already` errors under load (observed in API logs during spectask operations)
- Bumped `max_connections` to 200, `shared_buffers` to 128MB, `work_mem` to 4MB in both `docker-compose.yaml` and `docker-compose.dev.yaml`

## Test plan
- [ ] Restart postgres container and verify it starts with new settings: `docker exec helix-postgres-1 psql -U postgres -c "SHOW max_connections"`
- [ ] Run under load and confirm no more "too many clients" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)