### PR TITLE
Fix TriggerSlack project channel field to update only on blur

### DIFF
--- a/frontend/src/components/app/TriggerSlack.tsx
+++ b/frontend/src/components/app/TriggerSlack.tsx
@@ -1,29 +1,29 @@
-import React, { FC, useState, useEffect } from 'react'
-import Box from '@mui/material/Box'
-import Typography from '@mui/material/Typography'
-import Switch from '@mui/material/Switch'
-import FormControlLabel from '@mui/material/FormControlLabel'
-import TextField from '@mui/material/TextField'
-import Alert from '@mui/material/Alert'
-import Circle from '@mui/icons-material/Circle'
-import Visibility from '@mui/icons-material/Visibility'
-import VisibilityOff from '@mui/icons-material/VisibilityOff'
-import IconButton from '@mui/material/IconButton'
-import InputAdornment from '@mui/material/InputAdornment'
-import Button from '@mui/material/Button'
-import { TypesTrigger } from '../../api/api'
-import { SlackLogo } from '../icons/ProviderIcons'
+import React, { FC, useState, useEffect } from "react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Switch from "@mui/material/Switch";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import TextField from "@mui/material/TextField";
+import Alert from "@mui/material/Alert";
+import Circle from "@mui/icons-material/Circle";
+import Visibility from "@mui/icons-material/Visibility";
+import VisibilityOff from "@mui/icons-material/VisibilityOff";
+import IconButton from "@mui/material/IconButton";
+import InputAdornment from "@mui/material/InputAdornment";
+import Button from "@mui/material/Button";
+import { TypesTrigger } from "../../api/api";
+import { SlackLogo } from "../icons/ProviderIcons";
 
-import { useGetAppTriggerStatus } from '../../services/appService'
-import { IAppFlatState } from '../../types'
-import TriggerSlackSetup from './TriggerSlackSetup'
+import { useGetAppTriggerStatus } from "../../services/appService";
+import { IAppFlatState } from "../../types";
+import TriggerSlackSetup from "./TriggerSlackSetup";
 
 interface TriggerSlackProps {
-  app: IAppFlatState
-  appId: string
-  triggers?: TypesTrigger[]
-  onUpdate: (triggers: TypesTrigger[]) => void
-  readOnly?: boolean
+  app: IAppFlatState;
+  appId: string;
+  triggers?: TypesTrigger[];
+  onUpdate: (triggers: TypesTrigger[]) => void;
+  readOnly?: boolean;
 }
 
 const TriggerSlack: FC<TriggerSlackProps> = ({
@@ -31,47 +31,61 @@ const TriggerSlack: FC<TriggerSlackProps> = ({
   appId,
   triggers = [],
   onUpdate,
-  readOnly = false
+  readOnly = false,
 }) => {
-  const hasSlackTrigger = triggers.some(t => t.slack && t.slack.enabled === true)
-  const slackTrigger = triggers.find(t => t.slack)?.slack
+  const hasSlackTrigger = triggers.some(
+    (t) => t.slack && t.slack.enabled === true,
+  );
+  const slackTrigger = triggers.find((t) => t.slack)?.slack;
 
   // State for Slack configuration
-  const [appToken, setAppToken] = useState<string>(slackTrigger?.app_token || '')
-  const [botToken, setBotToken] = useState<string>(slackTrigger?.bot_token || '')
-  const [projectUpdates, setProjectUpdates] = useState<boolean>(slackTrigger?.project_updates || false)
-  const [projectChannel, setProjectChannel] = useState<string>(slackTrigger?.project_channel || '')
-  const [showAppToken, setShowAppToken] = useState<boolean>(false)
-  const [showBotToken, setShowBotToken] = useState<boolean>(false)
-  const [showSetupDialog, setShowSetupDialog] = useState<boolean>(false)
-  const isProjectManagerEnabled = app.projectManagerTool?.enabled === true
-  const hasProjectManagerProjectId = Boolean(app.projectManagerTool?.project_id)
-  const showProjectManagerWarning = projectUpdates && (!isProjectManagerEnabled || !hasProjectManagerProjectId)
+  const [appToken, setAppToken] = useState<string>(
+    slackTrigger?.app_token || "",
+  );
+  const [botToken, setBotToken] = useState<string>(
+    slackTrigger?.bot_token || "",
+  );
+  const [projectUpdates, setProjectUpdates] = useState<boolean>(
+    slackTrigger?.project_updates || false,
+  );
+  const [projectChannel, setProjectChannel] = useState<string>(
+    slackTrigger?.project_channel || "",
+  );
+  const [showAppToken, setShowAppToken] = useState<boolean>(false);
+  const [showBotToken, setShowBotToken] = useState<boolean>(false);
+  const [showSetupDialog, setShowSetupDialog] = useState<boolean>(false);
+  const isProjectManagerEnabled = app.projectManagerTool?.enabled === true;
+  const hasProjectManagerProjectId = Boolean(
+    app.projectManagerTool?.project_id,
+  );
+  const showProjectManagerWarning =
+    projectUpdates && (!isProjectManagerEnabled || !hasProjectManagerProjectId);
 
   // If slack is configured, we need to get the status of the bot
-  const { data: slackStatus, isLoading: isLoadingSlackStatus } = useGetAppTriggerStatus(appId, 'slack', {
-    enabled: hasSlackTrigger,
-    refetchInterval: 1500
-  })
+  const { data: slackStatus, isLoading: isLoadingSlackStatus } =
+    useGetAppTriggerStatus(appId, "slack", {
+      enabled: hasSlackTrigger,
+      refetchInterval: 1500,
+    });
 
   // Update state when triggers change
   useEffect(() => {
     if (slackTrigger) {
-      setAppToken(slackTrigger.app_token || '')
-      setBotToken(slackTrigger.bot_token || '')
-      setProjectUpdates(slackTrigger.project_updates || false)
-      setProjectChannel(slackTrigger.project_channel || '')
+      setAppToken(slackTrigger.app_token || "");
+      setBotToken(slackTrigger.bot_token || "");
+      setProjectUpdates(slackTrigger.project_updates || false);
+      setProjectChannel(slackTrigger.project_channel || "");
     }
-  }, [slackTrigger])
+  }, [slackTrigger]);
 
   const buildSlackTrigger = (
     enabled: boolean,
     appTokenValue: string,
     botTokenValue: string,
     projectUpdatesValue: boolean,
-    projectChannelValue: string
+    projectChannelValue: string,
   ) => {
-    const currentSlackTrigger = triggers.find(t => t.slack)?.slack
+    const currentSlackTrigger = triggers.find((t) => t.slack)?.slack;
 
     return {
       enabled,
@@ -79,61 +93,101 @@ const TriggerSlack: FC<TriggerSlackProps> = ({
       bot_token: botTokenValue,
       channels: currentSlackTrigger?.channels || [],
       project_updates: projectUpdatesValue,
-      project_channel: projectChannelValue
-    }
-  }
+      project_channel: projectChannelValue,
+    };
+  };
 
   const handleSlackToggle = (enabled: boolean) => {
     if (enabled) {
-      const newTriggers = [...triggers.filter(t => !t.slack), {
-        slack: buildSlackTrigger(true, appToken, botToken, projectUpdates, projectChannel)
-      }]
-      onUpdate(newTriggers)
+      const newTriggers = [
+        ...triggers.filter((t) => !t.slack),
+        {
+          slack: buildSlackTrigger(
+            true,
+            appToken,
+            botToken,
+            projectUpdates,
+            projectChannel,
+          ),
+        },
+      ];
+      onUpdate(newTriggers);
     } else {
-      const updatedTriggers = [...triggers.filter(t => !t.slack), {
-        slack: buildSlackTrigger(false, appToken, botToken, projectUpdates, projectChannel)
-      }]
-      onUpdate(updatedTriggers)
+      const updatedTriggers = [
+        ...triggers.filter((t) => !t.slack),
+        {
+          slack: buildSlackTrigger(
+            false,
+            appToken,
+            botToken,
+            projectUpdates,
+            projectChannel,
+          ),
+        },
+      ];
+      onUpdate(updatedTriggers);
     }
-  }
+  };
 
   const handleAppTokenChange = (token: string) => {
-    setAppToken(token)
-    updateSlackTrigger(token, botToken, projectUpdates, projectChannel)
-  }
+    setAppToken(token);
+    updateSlackTrigger(token, botToken, projectUpdates, projectChannel);
+  };
 
   const handleBotTokenChange = (token: string) => {
-    setBotToken(token)
-    updateSlackTrigger(appToken, token, projectUpdates, projectChannel)
-  }
+    setBotToken(token);
+    updateSlackTrigger(appToken, token, projectUpdates, projectChannel);
+  };
 
   const handleProjectUpdatesChange = (enabled: boolean) => {
-    setProjectUpdates(enabled)
-    updateSlackTrigger(appToken, botToken, enabled, projectChannel)
-  }
+    setProjectUpdates(enabled);
+    updateSlackTrigger(appToken, botToken, enabled, projectChannel);
+  };
 
-  const handleProjectChannelChange = (channel: string) => {
-    setProjectChannel(channel)
-    updateSlackTrigger(appToken, botToken, projectUpdates, channel)
-  }
+  const handleProjectChannelBlur = () => {
+    updateSlackTrigger(appToken, botToken, projectUpdates, projectChannel);
+  };
 
   const updateSlackTrigger = (
     appTokenValue: string,
     botTokenValue: string,
     projectUpdatesValue: boolean,
-    projectChannelValue: string
+    projectChannelValue: string,
   ) => {
-    const newTriggers = [...triggers.filter(t => !t.slack), {
-      slack: buildSlackTrigger(true, appTokenValue, botTokenValue, projectUpdatesValue, projectChannelValue)
-    }]
-    onUpdate(newTriggers)
-  }
+    const newTriggers = [
+      ...triggers.filter((t) => !t.slack),
+      {
+        slack: buildSlackTrigger(
+          true,
+          appTokenValue,
+          botTokenValue,
+          projectUpdatesValue,
+          projectChannelValue,
+        ),
+      },
+    ];
+    onUpdate(newTriggers);
+  };
 
   return (
-    <Box sx={{ p: 2, borderRadius: 1, border: '1px solid', borderColor: 'divider' }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center' }}>
-          <SlackLogo sx={{ mr: 2, fontSize: 24, color: 'primary.main' }} />
+    <Box
+      sx={{
+        p: 2,
+        borderRadius: 1,
+        border: "1px solid",
+        borderColor: "divider",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          mb: 2,
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <SlackLogo sx={{ mr: 2, fontSize: 24, color: "primary.main" }} />
           <Box>
             <Typography gutterBottom>Slack</Typography>
             <Typography variant="body2" color="text.secondary">
@@ -153,17 +207,30 @@ const TriggerSlack: FC<TriggerSlackProps> = ({
         />
       </Box>
 
-      {(hasSlackTrigger) && (
-        <Box sx={{ mt: 2, p: 2, borderRadius: 1, opacity: hasSlackTrigger ? 1 : 0.6 }}>
+      {hasSlackTrigger && (
+        <Box
+          sx={{
+            mt: 2,
+            p: 2,
+            borderRadius: 1,
+            opacity: hasSlackTrigger ? 1 : 0.6,
+          }}
+        >
           {!hasSlackTrigger && slackTrigger && (
             <Alert severity="info" sx={{ mb: 2 }}>
-              Trigger is disabled. Enable it above to activate Slack integration.
+              Trigger is disabled. Enable it above to activate Slack
+              integration.
             </Alert>
           )}
-          
+
           {/* App Token */}
           <Box sx={{ mb: 2 }}>
-            <Typography variant="body2" color="text.secondary" gutterBottom sx={{ mb: 2 }}>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              gutterBottom
+              sx={{ mb: 2 }}
+            >
               App Token
             </Typography>
             <TextField
@@ -174,7 +241,7 @@ const TriggerSlack: FC<TriggerSlackProps> = ({
               onChange={(e) => handleAppTokenChange(e.target.value)}
               disabled={readOnly || !hasSlackTrigger}
               helperText="Your Slack app token (starts with xapp-)"
-              type={showAppToken ? 'text' : 'password'}
+              type={showAppToken ? "text" : "password"}
               autoComplete="new-bot-app-token-password"
               InputProps={{
                 endAdornment: (
@@ -195,7 +262,12 @@ const TriggerSlack: FC<TriggerSlackProps> = ({
 
           {/* Bot Token */}
           <Box sx={{ mb: 2 }}>
-            <Typography variant="body2" color="text.secondary" gutterBottom sx={{ mb: 2 }}>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              gutterBottom
+              sx={{ mb: 2 }}
+            >
               Bot Token
             </Typography>
             <TextField
@@ -206,7 +278,7 @@ const TriggerSlack: FC<TriggerSlackProps> = ({
               onChange={(e) => handleBotTokenChange(e.target.value)}
               disabled={readOnly || !hasSlackTrigger}
               helperText="Your Slack bot token (starts with xoxb-)"
-              type={showBotToken ? 'text' : 'password'}
+              type={showBotToken ? "text" : "password"}
               autoComplete="new-password"
               InputProps={{
                 endAdornment: (
@@ -237,17 +309,25 @@ const TriggerSlack: FC<TriggerSlackProps> = ({
               label="Project updates"
             />
             <Typography variant="body2" color="text.secondary">
-              This works together with the Project Manager skill to send updates to the provided channel when spec tasks are updated in Helix Projects.
+              This works together with the Project Manager skill to send updates
+              to the provided channel when spec tasks are updated in Helix
+              Projects.
             </Typography>
             {showProjectManagerWarning && (
               <Alert severity="warning" sx={{ mt: 1.5 }}>
-                Project updates require Project Manager skill to be enabled and a project ID to be selected there.
+                Project updates require Project Manager skill to be enabled and
+                a project ID to be selected there.
               </Alert>
             )}
           </Box>
 
           <Box sx={{ mb: 2 }}>
-            <Typography variant="body2" color="text.secondary" gutterBottom sx={{ mb: 2 }}>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              gutterBottom
+              sx={{ mb: 2 }}
+            >
               Project channel
             </Typography>
             <TextField
@@ -255,85 +335,96 @@ const TriggerSlack: FC<TriggerSlackProps> = ({
               size="small"
               placeholder="#project-updates"
               value={projectChannel}
-              onChange={(e) => handleProjectChannelChange(e.target.value)}
+              onChange={(e) => setProjectChannel(e.target.value)}
+              onBlur={handleProjectChannelBlur}
               disabled={readOnly || !hasSlackTrigger || !projectUpdates}
               helperText="This is where the spec task updates will go."
             />
           </Box>
 
           {/* Configuration summary */}
-          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
               {(() => {
                 // If Slack trigger is disabled
                 if (!slackTrigger?.enabled) {
                   return (
                     <>
-                      <Circle sx={{ fontSize: 12, color: 'grey.400' }} />
+                      <Circle sx={{ fontSize: 12, color: "grey.400" }} />
                       <Typography variant="body2" color="text.secondary">
                         <strong>Status:</strong> Slack integration disabled
                       </Typography>
                     </>
-                  )
+                  );
                 }
 
                 // If no tokens are configured, show grey circle with existing message
                 if (slackTrigger?.enabled && (!appToken || !botToken)) {
                   return (
                     <>
-                      <Circle sx={{ fontSize: 12, color: 'grey.400' }} />
+                      <Circle sx={{ fontSize: 12, color: "grey.400" }} />
                       <Typography variant="body2" color="text.secondary">
-                        <strong>Status:</strong> Slack integration {appToken && botToken ? 'configured' : 'needs tokens'}
+                        <strong>Status:</strong> Slack integration{" "}
+                        {appToken && botToken ? "configured" : "needs tokens"}
                       </Typography>
                     </>
-                  )
+                  );
                 }
-                
+
                 // If we have tokens but no trigger status yet, show grey circle
                 if (!slackStatus?.data && !isLoadingSlackStatus) {
                   return (
                     <>
-                      <Circle sx={{ fontSize: 12, color: 'grey.400' }} />
+                      <Circle sx={{ fontSize: 12, color: "grey.400" }} />
                       <Typography variant="body2" color="text.secondary">
                         <strong>Status:</strong> Slack integration configured
                       </Typography>
                     </>
-                  )
+                  );
                 }
-                
+
                 // If trigger status is OK, show green circle with status message
                 if (slackStatus?.data?.ok === true) {
                   return (
                     <>
-                      <Circle sx={{ fontSize: 12, color: 'success.main' }} />
+                      <Circle sx={{ fontSize: 12, color: "success.main" }} />
                       <Typography variant="body2" color="text.secondary">
-                        <strong>Status:</strong> {slackStatus.data.message || 'Slack integration active'}
+                        <strong>Status:</strong>{" "}
+                        {slackStatus.data.message || "Slack integration active"}
                       </Typography>
                     </>
-                  )
+                  );
                 }
-                
+
                 // If trigger status is not OK, show red circle with error message
                 if (slackStatus?.data?.ok === false) {
                   return (
                     <>
-                      <Circle sx={{ fontSize: 12, color: 'error.main' }} />
+                      <Circle sx={{ fontSize: 12, color: "error.main" }} />
                       <Typography variant="body2" color="text.secondary">
-                        <strong>Status:</strong> {slackStatus.data.message || 'Slack integration error'}
+                        <strong>Status:</strong>{" "}
+                        {slackStatus.data.message || "Slack integration error"}
                       </Typography>
                     </>
-                  )
+                  );
                 }
-                
+
                 // Loading state
                 return (
                   <>
-                    <Circle sx={{ fontSize: 12, color: 'grey.400' }} />
+                    <Circle sx={{ fontSize: 12, color: "grey.400" }} />
                     <Typography variant="body2" color="text.secondary">
-                      <strong>Status:</strong> Checking Slack integration status...
+                      <strong>Status:</strong> Checking Slack integration
+                      status...
                     </Typography>
                   </>
-                )
+                );
               })()}
             </Box>
             <Button
@@ -359,7 +450,7 @@ const TriggerSlack: FC<TriggerSlackProps> = ({
         onBotTokenChange={handleBotTokenChange}
       />
     </Box>
-  )
-}
+  );
+};
 
-export default TriggerSlack
+export default TriggerSlack;


### PR DESCRIPTION
> **Helix**: ## Bug

The "Project channel" `TextField` in `frontend/src/components/app/TriggerSlack.tsx` fires `handleProjectChannelChange` → `updateSlackTrigger` → `onUpdate` on **every keystroke** via its `onChange` handler. This triggers an underlying data update with each character typed, which is inconsistent with how other forms in the app behave.

**Why:**
This causes unnecessary update calls on every keystroke, potentially triggering unwanted API calls or state churn. The correct behaviour is to commit the value only when the user leaves the field (`onBlur`), matching the pattern used elsewhere in the codebase.

**Where:**
- `frontend/src/components/app/TriggerSlack.tsx` — specifically the "Project channel" `TextField` (~line 247)

**Fix:**
1. Change the `onChange` handler on the "Project channel" `TextField` to **only** call `setProjectChannel(e.target.value)` (local state update, so the input remains controlled and responsive).
2. Add an `onBlur` handler that calls `updateSlackTrigger(appToken, botToken, projectUpdates, projectChannel)` to propagate the final value upstream — mirroring the pattern used in other forms.
3. Remove `handleProjectChannelChange` (or reduce it to just the local `setProjectChannel` call) since it no longer needs to call `updateSlackTrigger` directly.

**Acceptance criteria:**
- Typing into the "Project channel" field updates only local component state on each keystroke (no `onUpdate` call fired mid-typing).
- When focus leaves the field (`onBlur`), the updated channel value is propagated via `onUpdate`.
- All other fields (`appToken`, `botToken`, `projectUpdates` switch) retain their existing behaviour unchanged.
- No visual/UX regression in the field (it remains controlled, placeholder and helperText intact).
