### PR TITLE
fix: Vertex AI proxy model name format and URL scheme handling

### DIFF
--- a/api/pkg/anthropic/anthropic_proxy.go
+++ b/api/pkg/anthropic/anthropic_proxy.go
@@ -146,8 +146,10 @@ func (s *Proxy) anthropicAPIProxyDirector(r *http.Request) {
 	r.Header.Del("api-key")
 
 	// Vertex AI mode: if the endpoint has a VertexProjectID, transform the request
-	// for Vertex's rawPredict/streamRawPredict API format
-	if endpoint.VertexProjectID != "" {
+	// for Vertex's rawPredict/streamRawPredict API format.
+	// Exception: /v1/models goes to the direct Anthropic API since Vertex has no
+	// model listing endpoint. This requires an API key to be configured alongside Vertex.
+	if endpoint.VertexProjectID != "" && r.URL.Path != "/v1/models" {
 		tokenSource, err := s.getVertexTokenSource(r.Context(), endpoint.VertexCredentialsJSON, endpoint.VertexCredentialsFile)
 		if err != nil {
 			log.Error().Err(err).

--- a/api/pkg/anthropic/vertex.go
+++ b/api/pkg/anthropic/vertex.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/rs/zerolog/log"
@@ -146,6 +147,16 @@ func vertexTransformRequest(r *http.Request, projectID, region string, tokenSour
 	r.Header.Del("api-key")
 	r.Header.Set("Authorization", "Bearer "+token.AccessToken)
 
+	// Always set the Vertex host/scheme so we never end up with an empty URL
+	baseURL := VertexBaseURL(region)
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse Vertex base URL %q: %w", baseURL, err)
+	}
+	r.URL.Host = u.Host
+	r.URL.Scheme = u.Scheme
+	r.Host = u.Host
+
 	// Read the body if present (POST requests for /v1/messages)
 	if r.Body == nil {
 		return nil
@@ -182,6 +193,10 @@ func vertexTransformRequest(r *http.Request, projectID, region string, tokenSour
 		if err := json.Unmarshal(modelRaw, &modelName); err == nil && modelName != "" {
 			// Remove model from body — Vertex puts it in the URL
 			delete(bodyMap, "model")
+			// Convert Anthropic model ID format to Vertex format:
+			// claude-sonnet-4-20250514 → claude-sonnet-4@20250514
+			// Vertex requires @ between model name and date version
+			modelName = convertModelNameToVertex(modelName)
 		}
 	}
 
@@ -219,15 +234,31 @@ func vertexTransformRequest(r *http.Request, projectID, region string, tokenSour
 		return io.NopCloser(bytes.NewReader(newBody)), nil
 	}
 
-	// Update the host to Vertex
-	baseURL := VertexBaseURL(region)
-	u, err := url.Parse(baseURL)
-	if err != nil {
-		return fmt.Errorf("failed to parse Vertex base URL %q: %w", baseURL, err)
-	}
-	r.URL.Host = u.Host
-	r.URL.Scheme = u.Scheme
-	r.Host = u.Host
-
 	return nil
+}
+
+// convertModelNameToVertex converts Anthropic API model IDs to Vertex AI format.
+// Anthropic uses dashes (claude-sonnet-4-20250514), Vertex uses @ (claude-sonnet-4@20250514).
+// If the model name already contains @, it's returned as-is.
+func convertModelNameToVertex(modelName string) string {
+	if strings.Contains(modelName, "@") {
+		return modelName
+	}
+	parts := strings.Split(modelName, "-")
+	if len(parts) >= 2 {
+		lastPart := parts[len(parts)-1]
+		if len(lastPart) == 8 && isAllDigits(lastPart) {
+			return strings.Join(parts[:len(parts)-1], "-") + "@" + lastPart
+		}
+	}
+	return modelName
+}
+
+func isAllDigits(s string) bool {
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/api/pkg/anthropic/vertex_test.go
+++ b/api/pkg/anthropic/vertex_test.go
@@ -77,8 +77,8 @@ func TestVertexTransformRequest_NonStreaming(t *testing.T) {
 	err = vertexTransformRequest(req, "helixml", "global", ts)
 	require.NoError(t, err)
 
-	// Check URL was rewritten to rawPredict (non-streaming)
-	assert.Equal(t, "/v1/projects/helixml/locations/global/publishers/anthropic/models/claude-sonnet-4-20250514:rawPredict", req.URL.Path)
+	// Check URL was rewritten to rawPredict (non-streaming), model name uses @ format for Vertex
+	assert.Equal(t, "/v1/projects/helixml/locations/global/publishers/anthropic/models/claude-sonnet-4@20250514:rawPredict", req.URL.Path)
 	assert.Equal(t, "aiplatform.googleapis.com", req.URL.Host)
 	assert.Equal(t, "https", req.URL.Scheme)
 
@@ -130,8 +130,8 @@ func TestVertexTransformRequest_Streaming(t *testing.T) {
 	err = vertexTransformRequest(req, "helixml", "us-east5", ts)
 	require.NoError(t, err)
 
-	// Check URL uses streamRawPredict for streaming
-	assert.Equal(t, "/v1/projects/helixml/locations/us-east5/publishers/anthropic/models/claude-sonnet-4-20250514:streamRawPredict", req.URL.Path)
+	// Check URL uses streamRawPredict for streaming, model name uses @ format
+	assert.Equal(t, "/v1/projects/helixml/locations/us-east5/publishers/anthropic/models/claude-sonnet-4@20250514:streamRawPredict", req.URL.Path)
 	assert.Equal(t, "us-east5-aiplatform.googleapis.com", req.URL.Host)
 }
 
@@ -155,7 +155,7 @@ func TestVertexTransformRequest_GlobalRegion(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "aiplatform.googleapis.com", req.URL.Host)
-	assert.Equal(t, "/v1/projects/my-project/locations/global/publishers/anthropic/models/claude-opus-4-20250514:rawPredict", req.URL.Path)
+	assert.Equal(t, "/v1/projects/my-project/locations/global/publishers/anthropic/models/claude-opus-4@20250514:rawPredict", req.URL.Path)
 }
 
 func TestVertexTransformRequest_PreservesExistingAnthropicVersion(t *testing.T) {
@@ -224,6 +224,10 @@ func TestVertexTransformRequest_NilBody(t *testing.T) {
 	// Auth should still be set even with nil body
 	assert.Equal(t, "Bearer vertex-tok", req.Header.Get("Authorization"))
 	assert.Empty(t, req.Header.Get("x-api-key"))
+
+	// URL host/scheme should be set even with nil body
+	assert.Equal(t, "aiplatform.googleapis.com", req.URL.Host)
+	assert.Equal(t, "https", req.URL.Scheme)
 }
 
 func TestVertexTransformRequest_ContentLengthUpdated(t *testing.T) {
@@ -313,4 +317,23 @@ func TestTokenSourceCacheKey(t *testing.T) {
 	key3 := tokenSourceCacheKey(`{"type":"service_account","project_id":"a"}`, "")
 	key4 := tokenSourceCacheKey(`{"type":"service_account","project_id":"b"}`, "")
 	assert.NotEqual(t, key3, key4, "different JSON should produce different cache keys")
+}
+
+func TestConvertModelNameToVertex(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"claude-sonnet-4-20250514", "claude-sonnet-4@20250514"},
+		{"claude-opus-4-5-20251101", "claude-opus-4-5@20251101"},
+		{"claude-haiku-3-5-20241022", "claude-haiku-3-5@20241022"},
+		{"claude-sonnet-4@20250514", "claude-sonnet-4@20250514"}, // already @ format
+		{"claude-sonnet-4", "claude-sonnet-4"},                   // no date suffix
+		{"claude-3-opus", "claude-3-opus"},                       // no date suffix
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, convertModelNameToVertex(tt.input))
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- Convert Anthropic model IDs to Vertex format (`claude-sonnet-4-20250514` → `claude-sonnet-4@20250514`) — Vertex requires `@` between model name and date version
- Set URL host/scheme before early returns so nil-body requests (GET `/v1/models`) don't 502 with `unsupported protocol scheme ""`
- Route `/v1/models` to direct Anthropic API since Vertex has no model listing endpoint

## Test plan
- [x] Unit tests for `convertModelNameToVertex` covering all model name formats
- [x] Updated existing Vertex transform tests to expect `@` format
- [x] Verified locally: requests route through Vertex (`streamRawPredict`) and return successfully
- [x] Verified `/v1/models` falls through to direct Anthropic API

🤖 Generated with [Claude Code](https://claude.com/claude-code)