### PR TITLE
When you join a session midway through, like you refresh ...

### DIFF
--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -2790,6 +2790,40 @@ func (apiServer *HelixAPIServer) publishEntryPatchesToFrontend(
 	return nil
 }
 
+// buildFullStatePatchEvent builds a serialized interaction_patch event containing the
+// full content of all entries (computed with no previous entries, so patch_offset=0
+// for each). Used to catch up a late-joining WebSocket client that missed earlier
+// streaming patches.
+func buildFullStatePatchEvent(sessionID, owner, interactionID string, entries []wsprotocol.ResponseEntry) ([]byte, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	event := &types.WebsocketEvent{
+		Type:          types.WebsocketEventInteractionPatch,
+		SessionID:     sessionID,
+		InteractionID: interactionID,
+		Owner:         owner,
+		EntryCount:    len(entries),
+	}
+	entryPatches := make([]types.EntryPatch, 0, len(entries))
+	for i, entry := range entries {
+		// previousContent="" → computePatch returns patchOffset=0, patch=full content
+		epOffset, epPatch, epTotalLen := computePatch("", entry.Content)
+		entryPatches = append(entryPatches, types.EntryPatch{
+			Index:       i,
+			MessageID:   entry.MessageID,
+			Type:        entry.Type,
+			Patch:       epPatch,
+			PatchOffset: epOffset,
+			TotalLength: epTotalLen,
+			ToolName:    entry.ToolName,
+			ToolStatus:  entry.ToolStatus,
+		})
+	}
+	event.EntryPatches = entryPatches
+	return json.Marshal(event)
+}
+
 // handleUserCreatedThread processes user-created thread event from Zed UI
 // Creates a new Helix session and maps it to the Zed thread
 func (apiServer *HelixAPIServer) handleUserCreatedThread(agentSessionID string, syncMsg *types.SyncMessage) error {

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/controller"
 	"github.com/helixml/helix/api/pkg/pubsub"
+	"github.com/helixml/helix/api/pkg/server/wsprotocol"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/suite"
@@ -1843,4 +1845,92 @@ func (s *WebSocketSyncSuite) TestStreamingPatch_PreviousEntriesTracked() {
 	s.Equal("**Tool Call: list_files**", sctx.previousEntries[1].Content)
 	s.Equal("tool_call", sctx.previousEntries[1].Type)
 	sctx.mu.Unlock()
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// buildFullStatePatchEvent tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+func (s *WebSocketSyncSuite) TestBuildFullStatePatchEvent_Empty() {
+	payload, err := buildFullStatePatchEvent("ses-1", "owner-1", "int-1", nil)
+	s.NoError(err)
+	s.Nil(payload, "empty entries should return nil payload")
+}
+
+func (s *WebSocketSyncSuite) TestBuildFullStatePatchEvent_FullState() {
+	entries := []wsprotocol.ResponseEntry{
+		{MessageID: "msg-1", Type: "text", Content: "Hello world"},
+		{MessageID: "msg-2", Type: "tool_call", Content: "ls -la", ToolName: "bash", ToolStatus: "complete"},
+	}
+
+	payload, err := buildFullStatePatchEvent("ses-1", "owner-1", "int-1", entries)
+	s.NoError(err)
+	s.NotNil(payload)
+
+	var event types.WebsocketEvent
+	s.Require().NoError(json.Unmarshal(payload, &event))
+
+	s.Equal(types.WebsocketEventInteractionPatch, event.Type)
+	s.Equal("ses-1", event.SessionID)
+	s.Equal("int-1", event.InteractionID)
+	s.Equal(2, event.EntryCount)
+	s.Require().Len(event.EntryPatches, 2)
+
+	// All patches must have offset=0 (full replace, no delta baseline)
+	for i, ep := range event.EntryPatches {
+		s.Equal(0, ep.PatchOffset, "entry %d: patch_offset must be 0 for full-state snapshot", i)
+		s.Equal(entries[i].Content, ep.Patch, "entry %d: patch must equal full content", i)
+		s.Equal(entries[i].Type, ep.Type, "entry %d: type preserved", i)
+		s.Equal(entries[i].MessageID, ep.MessageID, "entry %d: message_id preserved", i)
+	}
+
+	s.Equal("bash", event.EntryPatches[1].ToolName)
+	s.Equal("complete", event.EntryPatches[1].ToolStatus)
+}
+
+// TestLateJoinerCatchUp verifies that a streaming context present at WebSocket
+// connect time produces a full-state patch via buildFullStatePatchEvent.
+func (s *WebSocketSyncSuite) TestLateJoinerCatchUp_ActiveStreamingContext() {
+	acc := &wsprotocol.MessageAccumulator{}
+	acc.AddMessageWithType("msg-1", "I'll start by exploring", "text")
+	acc.AddMessageWithType("msg-2", "**Tool Call: list_files**", "tool_call")
+
+	s.server.streamingContextsMu.Lock()
+	s.server.streamingContexts["ses-lj"] = &streamingContext{
+		session:     &types.Session{ID: "ses-lj", Owner: "owner-lj"},
+		interaction: &types.Interaction{ID: "int-lj"},
+		accumulator: acc,
+	}
+	s.server.streamingContextsMu.Unlock()
+
+	// Simulate what websocket_server_user.go does on connect
+	s.server.streamingContextsMu.RLock()
+	sctx := s.server.streamingContexts["ses-lj"]
+	s.server.streamingContextsMu.RUnlock()
+
+	s.Require().NotNil(sctx)
+
+	sctx.mu.Lock()
+	entries := sctx.accumulator.Entries()
+	interactionID := sctx.interaction.ID
+	owner := sctx.session.Owner
+	sctx.mu.Unlock()
+
+	payload, err := buildFullStatePatchEvent("ses-lj", owner, interactionID, entries)
+	s.NoError(err)
+	s.Require().NotNil(payload)
+
+	var event types.WebsocketEvent
+	s.Require().NoError(json.Unmarshal(payload, &event))
+
+	s.Equal(types.WebsocketEventInteractionPatch, event.Type)
+	s.Require().Len(event.EntryPatches, 2)
+
+	s.Equal(0, event.EntryPatches[0].PatchOffset)
+	s.Equal("I'll start by exploring", event.EntryPatches[0].Patch)
+	s.Equal("text", event.EntryPatches[0].Type)
+
+	s.Equal(0, event.EntryPatches[1].PatchOffset)
+	s.Equal("**Tool Call: list_files**", event.EntryPatches[1].Patch)
+	s.Equal("tool_call", event.EntryPatches[1].Type)
 }

--- a/api/pkg/server/websocket_server_user.go
+++ b/api/pkg/server/websocket_server_user.go
@@ -112,6 +112,40 @@ func (apiServer *HelixAPIServer) startUserWebSocketServer(
 			}
 		}()
 
+		// Late-joiner catch-up: if the agent is currently streaming for this session,
+		// send a full-state snapshot so the client has a correct baseline for subsequent
+		// delta patches. The subscription is established first (above) to avoid missing
+		// any patches published between reading the snapshot and starting the read loop.
+		apiServer.streamingContextsMu.RLock()
+		sctx := apiServer.streamingContexts[sessionID]
+		apiServer.streamingContextsMu.RUnlock()
+
+		if sctx != nil {
+			sctx.mu.Lock()
+			var catchUpPayload []byte
+			if sctx.accumulator != nil {
+				entries := sctx.accumulator.Entries()
+				interactionID := sctx.interaction.ID
+				owner := sctx.session.Owner
+				sctx.mu.Unlock()
+				var buildErr error
+				catchUpPayload, buildErr = buildFullStatePatchEvent(sessionID, owner, interactionID, entries)
+				if buildErr != nil {
+					log.Warn().Err(buildErr).Str("session_id", sessionID).Msg("Failed to build late-joiner catch-up event")
+				}
+			} else {
+				sctx.mu.Unlock()
+			}
+			if len(catchUpPayload) > 0 {
+				wsMu.Lock()
+				if writeErr := conn.WriteMessage(websocket.TextMessage, catchUpPayload); writeErr != nil {
+					log.Warn().Err(writeErr).Str("session_id", sessionID).Msg("Failed to send late-joiner catch-up event")
+				}
+				wsMu.Unlock()
+				log.Debug().Str("session_id", sessionID).Msg("Sent late-joiner catch-up snapshot")
+			}
+		}
+
 		log.Trace().
 			Str("user_id", user.ID).
 			Str("session_id", sessionID).


### PR DESCRIPTION
> **Helix**: When you join a session midway through, like you refresh the page and the agent is currently streaming, then you only get the new patches. You do not get the entire original set of entries. This is related to the large change that we made in https://github.com/helixml/helix/pull/1898

---
[Created by Helix](https://helix.ml)
