### PR TITLE
Issue with onboarding on the SaaS (app.helix.ml) two thin...

### DIFF
--- a/frontend/src/components/agent/CodingAgentForm.tsx
+++ b/frontend/src/components/agent/CodingAgentForm.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, useImperativeHandle, useState } from 'react'
+import { useCodingAgentProviderState } from './useCodingAgentProviderState'
 import { Alert, Box, Button, CircularProgress, FormControl, FormControlLabel, MenuItem, Radio, RadioGroup, Select, TextField, Typography } from '@mui/material'
 import { SxProps, Theme } from '@mui/material/styles'
 
@@ -25,8 +26,6 @@ interface CodingAgentFormProps {
   value: CodingAgentFormValue
   onChange: (value: CodingAgentFormValue) => void
   disabled?: boolean
-  hasClaudeSubscription?: boolean
-  hasAnthropicProvider?: boolean
   recommendedModels: string[]
   modelPickerHint?: string
   modelPickerDisplayMode?: 'short' | 'full'
@@ -70,8 +69,6 @@ const CodingAgentForm = forwardRef<CodingAgentFormHandle, CodingAgentFormProps>(
   value,
   onChange,
   disabled = false,
-  hasClaudeSubscription = false,
-  hasAnthropicProvider = false,
   recommendedModels,
   modelPickerHint = 'Choose a capable model for agentic coding.',
   modelPickerDisplayMode = 'short',
@@ -107,6 +104,7 @@ const CodingAgentForm = forwardRef<CodingAgentFormHandle, CodingAgentFormProps>(
   const apps = useApps()
   const [createError, setCreateError] = useState('')
   const [isCreating, setIsCreating] = useState(false)
+  const { hasAnthropicProvider, hasClaudeSubscription } = useCodingAgentProviderState(value, onChange)
   const showModelPicker = value.codeAgentRuntime !== 'claude_code' || value.claudeCodeMode === 'api_key'
   const isClaudeCodeSubscription = value.codeAgentRuntime === 'claude_code' && value.claudeCodeMode === 'subscription'
 

--- a/frontend/src/components/agent/useCodingAgentProviderState.ts
+++ b/frontend/src/components/agent/useCodingAgentProviderState.ts
@@ -1,0 +1,45 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { useClaudeSubscriptions } from '../account/ClaudeSubscriptionConnect'
+import { useListProviders } from '../../services/providersService'
+import { CodingAgentFormValue } from './CodingAgentForm'
+
+/**
+ * Fetches provider and subscription state for CodingAgentForm, and auto-selects
+ * the correct runtime/mode once when data first loads.
+ *
+ * Called internally by CodingAgentForm — parents no longer need to compute or
+ * pass hasAnthropicProvider / hasClaudeSubscription.
+ */
+export function useCodingAgentProviderState(
+  value: CodingAgentFormValue,
+  onChange: (value: CodingAgentFormValue) => void,
+) {
+  const { data: providerEndpoints } = useListProviders({ loadModels: false })
+  const { data: claudeSubscriptions } = useClaudeSubscriptions()
+
+  const hasAnthropicProvider = useMemo(() => {
+    if (!providerEndpoints) return false
+    return providerEndpoints.some(p => p.name === 'anthropic')
+  }, [providerEndpoints])
+
+  const hasClaudeSubscription = (claudeSubscriptions?.length ?? 0) > 0
+
+  // Use a primitive so we stay within the "only primitives in deps" rule.
+  const providerEndpointsLoaded = providerEndpoints !== undefined
+
+  // Auto-select the correct runtime/mode once, when provider data first resolves.
+  // The ref guard ensures this never overrides an explicit user selection.
+  const hasAutoSelected = useRef(false)
+  useEffect(() => {
+    if (hasAutoSelected.current) return
+    if (!providerEndpointsLoaded) return
+    hasAutoSelected.current = true
+    if (hasAnthropicProvider) {
+      onChange({ ...value, codeAgentRuntime: 'claude_code', claudeCodeMode: 'api_key' })
+    } else if (hasClaudeSubscription) {
+      onChange({ ...value, codeAgentRuntime: 'claude_code', claudeCodeMode: 'subscription' })
+    }
+  }, [hasAnthropicProvider, hasClaudeSubscription, providerEndpointsLoaded])
+
+  return { hasAnthropicProvider, hasClaudeSubscription }
+}

--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -283,9 +283,7 @@ const AppSettings: FC<AppSettingsProps> = ({
   })
   const { data: claudeSubscriptions } = useClaudeSubscriptions()
   const hasClaudeSubscription = (claudeSubscriptions?.length ?? 0) > 0
-  const hasAnthropicProvider = providerEndpoints.some(
-    ep => ep.endpoint_type === 'user' && ep.name === 'anthropic'
-  )
+  const hasAnthropicProvider = providerEndpoints.some(ep => ep.name === 'anthropic')
 
   // Advanced settings state
   const [contextLimit, setContextLimit] = useState(app.context_limit || 0)

--- a/frontend/src/components/project/AgentSelectionModal.tsx
+++ b/frontend/src/components/project/AgentSelectionModal.tsx
@@ -28,10 +28,7 @@ import useAccount from '../../hooks/useAccount'
 
 import { AppsContext, CodeAgentRuntime, generateAgentName } from '../../contexts/apps'
 import { IApp, AGENT_TYPE_ZED_EXTERNAL } from '../../types'
-import { useClaudeSubscriptions } from '../account/ClaudeSubscriptionConnect'
-import { useListProviders } from '../../services/providersService'
 import { RECOMMENDED_CODING_MODELS } from '../../constants/models'
-import { TypesProviderEndpointType } from '../../api/api'
 import CodingAgentForm, { CodingAgentFormHandle } from '../agent/CodingAgentForm'
 
 
@@ -56,19 +53,6 @@ const AgentSelectionModal: FC<AgentSelectionModalProps> = ({
   const [isLoading, setIsLoading] = useState(false)
   const [showCreateForm, setShowCreateForm] = useState(false)
   const codingAgentFormRef = useRef<CodingAgentFormHandle>(null)
-
-  // Claude subscription + provider state
-  const { data: claudeSubscriptions } = useClaudeSubscriptions()
-  const hasClaudeSubscription = (claudeSubscriptions?.length ?? 0) > 0
-  const { data: providerEndpoints } = useListProviders({ loadModels: false })
-  const hasAnthropicProvider = useMemo(() => {
-    if (!providerEndpoints) return false
-    return providerEndpoints.some(p => p.name === 'anthropic')
-  }, [providerEndpoints])
-  const userProviderCount = useMemo(() => {
-    if (!providerEndpoints) return 0
-    return providerEndpoints.filter(p => p.endpoint_type === TypesProviderEndpointType.ProviderEndpointTypeUser).length
-  }, [providerEndpoints])
 
   // Create agent form state
   const [codeAgentRuntime, setCodeAgentRuntime] = useState<CodeAgentRuntime>('zed_agent')
@@ -129,14 +113,6 @@ const AgentSelectionModal: FC<AgentSelectionModalProps> = ({
       setShowCreateForm(true)
     }
   }, [open, apps])
-
-  // Auto-default to Claude Code when it's the only available AI provider
-  useEffect(() => {
-    if (hasClaudeSubscription && !hasAnthropicProvider && userProviderCount === 0) {
-      setCodeAgentRuntime('claude_code')
-      setClaudeCodeMode('subscription')
-    }
-  }, [hasClaudeSubscription, hasAnthropicProvider, userProviderCount])
 
   const handleSelect = () => {
     if (selectedAgentId) {
@@ -272,8 +248,6 @@ const AgentSelectionModal: FC<AgentSelectionModalProps> = ({
                 setNewAgentName(nextValue.agentName)
               }}
               disabled={isCreating}
-              hasClaudeSubscription={hasClaudeSubscription}
-              hasAnthropicProvider={hasAnthropicProvider}
               recommendedModels={RECOMMENDED_CODING_MODELS}
               createAgentDescription="Code development agent for spec tasks"
               onCreateStateChange={setIsCreating}

--- a/frontend/src/components/project/CreateProjectDialog.tsx
+++ b/frontend/src/components/project/CreateProjectDialog.tsx
@@ -48,9 +48,6 @@ import useApi from '../../hooks/useApi'
 import { AppsContext, CodeAgentRuntime, generateAgentName } from '../../contexts/apps'
 import { IApp, AGENT_TYPE_ZED_EXTERNAL } from '../../types'
 import { findOAuthConnectionForProvider, findOAuthProviderForType, hasRequiredScopes, PROVIDER_TYPES } from '../../utils/oauthProviders'
-import { useClaudeSubscriptions } from '../account/ClaudeSubscriptionConnect'
-import { useListProviders } from '../../services/providersService'
-import { TypesProviderEndpointType } from '../../api/api'
 import { RECOMMENDED_CODING_MODELS } from '../../constants/models'
 import CodingAgentForm from '../agent/CodingAgentForm'
 import type { CodingAgentFormHandle } from '../agent/CodingAgentForm'
@@ -90,19 +87,6 @@ const CreateProjectDialog: FC<CreateProjectDialogProps> = ({
   const queryClient = useQueryClient()
   const { apps, loadApps } = useContext(AppsContext)
   const createProjectMutation = useCreateProject()
-
-  // Claude subscription + provider state
-  const { data: claudeSubscriptions } = useClaudeSubscriptions()
-  const hasClaudeSubscription = (claudeSubscriptions?.length ?? 0) > 0
-  const { data: providerEndpoints } = useListProviders({ loadModels: false })
-  const hasAnthropicProvider = useMemo(() => {
-    if (!providerEndpoints) return false
-    return providerEndpoints.some(p => p.name === 'anthropic')
-  }, [providerEndpoints])
-  const userProviderCount = useMemo(() => {
-    if (!providerEndpoints) return 0
-    return providerEndpoints.filter(p => p.endpoint_type === TypesProviderEndpointType.ProviderEndpointTypeUser).length
-  }, [providerEndpoints])
 
   // OAuth connections for GitHub browse
   const { data: oauthConnections } = useListOAuthConnections()
@@ -320,14 +304,6 @@ const CreateProjectDialog: FC<CreateProjectDialogProps> = ({
       }
     }
   }, [open, apps, sortedApps, selectedAgentId])
-
-  // Auto-default to Claude Code when a claude subscription or anthropic provider is available
-  useEffect(() => {
-    if (hasClaudeSubscription || hasAnthropicProvider) {
-      setCodeAgentRuntime('claude_code')
-      setClaudeCodeMode(hasAnthropicProvider ? 'api_key' : 'subscription')
-    }
-  }, [hasClaudeSubscription, hasAnthropicProvider])
 
   // Detect OAuth popup closure and refresh connections
   useEffect(() => {
@@ -1088,8 +1064,6 @@ const CreateProjectDialog: FC<CreateProjectDialogProps> = ({
                   setNewAgentName(nextValue.agentName)
                 }}
                 disabled={creatingAgent || createProjectMutation.isPending || creatingRepo}
-                hasClaudeSubscription={hasClaudeSubscription}
-                hasAnthropicProvider={hasAnthropicProvider}
                 recommendedModels={RECOMMENDED_CODING_MODELS}
                 createAgentDescription="Code development agent for spec tasks"
                 onCreateStateChange={setCreatingAgent}

--- a/frontend/src/components/tasks/NewSpecTaskForm.tsx
+++ b/frontend/src/components/tasks/NewSpecTaskForm.tsx
@@ -40,10 +40,6 @@ import AgentDropdown from "../agent/AgentDropdown";
 import CodingAgentForm, {
   CodingAgentFormHandle,
 } from "../agent/CodingAgentForm";
-import { useClaudeSubscriptions } from "../account/ClaudeSubscriptionConnect";
-import { useListProviders } from "../../services/providersService";
-import { TypesProviderEndpointType } from "../../api/api";
-
 import useAccount from "../../hooks/useAccount";
 import useApi from "../../hooks/useApi";
 import useSnackbar from "../../hooks/useSnackbar";
@@ -166,21 +162,6 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
   const [userModifiedName, setUserModifiedName] = useState(false);
   const [creatingAgent, setCreatingAgent] = useState(false);
   const codingAgentFormRef = useRef<CodingAgentFormHandle>(null);
-  const { data: claudeSubscriptions } = useClaudeSubscriptions();
-  const hasClaudeSubscription = (claudeSubscriptions?.length ?? 0) > 0;
-  const { data: providerEndpoints } = useListProviders({ loadModels: false });
-  const hasAnthropicProvider = useMemo(() => {
-    if (!providerEndpoints) return false;
-    return providerEndpoints.some((p) => p.name === "anthropic");
-  }, [providerEndpoints]);
-  const userProviderCount = useMemo(() => {
-    if (!providerEndpoints) return 0;
-    return providerEndpoints.filter(
-      (p) =>
-        p.endpoint_type === TypesProviderEndpointType.ProviderEndpointTypeUser,
-    ).length;
-  }, [providerEndpoints]);
-
   // Ref for task prompt text field
   const taskPromptRef = useRef<HTMLTextAreaElement>(null);
 
@@ -230,13 +211,6 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
       setNewAgentName(generateAgentName(selectedModel, codeAgentRuntime));
     }
   }, [selectedModel, codeAgentRuntime, userModifiedName, showCreateAgentForm]);
-
-  useEffect(() => {
-    if (hasClaudeSubscription || hasAnthropicProvider) {
-      setCodeAgentRuntime("claude_code");
-      setClaudeCodeMode(hasAnthropicProvider ? "api_key" : "subscription");
-    }
-  }, [hasClaudeSubscription, hasAnthropicProvider]);
 
   // Load apps on mount
   useEffect(() => {
@@ -753,8 +727,6 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
                     setNewAgentName(nextValue.agentName);
                   }}
                   disabled={creatingAgent || isCreating}
-                  hasClaudeSubscription={hasClaudeSubscription}
-                  hasAnthropicProvider={hasAnthropicProvider}
                   recommendedModels={RECOMMENDED_CODING_MODELS}
                   createAgentDescription="Code development agent for spec tasks"
                   onCreateStateChange={setCreatingAgent}

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -309,7 +309,6 @@ export default function Onboarding() {
     });
     return map;
   }, []);
-  const hasAnthropicProvider = connectedProviderIds.has("anthropic");
   // Consider Claude subscription as a valid provider for the "Continue" button
   const hasUserProviders =
     connectedProviderIds.size > 0 || hasClaudeSubscription;
@@ -541,18 +540,6 @@ export default function Onboarding() {
     isLoadingProviders,
     providers,
   ]);
-
-  // Auto-default to Claude Code when it's the only available AI provider
-  useEffect(() => {
-    if (
-      hasClaudeSubscription &&
-      !hasAnthropicProvider &&
-      connectedProviderIds.size === 0
-    ) {
-      setCodeAgentRuntime("claude_code");
-      setClaudeCodeMode("subscription");
-    }
-  }, [hasClaudeSubscription, hasAnthropicProvider, connectedProviderIds.size]);
 
   // Auto-generate agent name when model or runtime changes
   useEffect(() => {
@@ -2092,8 +2079,6 @@ export default function Onboarding() {
                       setNewAgentName(nextValue.agentName);
                     }}
                     disabled={creatingAgent}
-                    hasClaudeSubscription={hasClaudeSubscription}
-                    hasAnthropicProvider={hasAnthropicProvider}
                     recommendedModels={RECOMMENDED_CODING_MODELS}
                     createAgentDescription="Code development agent"
                     createAgentOrganizationId={createdOrg?.id}

--- a/frontend/src/pages/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings.tsx
@@ -87,10 +87,6 @@ import {
   useGetProjectGuidelinesHistory,
 } from "../services";
 import { useGitRepositories } from "../services/gitRepositoryService";
-import { useClaudeSubscriptions } from "../components/account/ClaudeSubscriptionConnect";
-import { useListProviders } from "../services/providersService";
-import { TypesProviderEndpointType } from "../api/api";
-
 const ProjectSettings: FC = () => {
   const account = useAccount();
   const { params, navigate } = useRouter();
@@ -503,22 +499,6 @@ const ProjectSettings: FC = () => {
   const [userModifiedName, setUserModifiedName] = useState(false);
   const [creatingAgent, setCreatingAgent] = useState(false);
   const codingAgentFormRef = useRef<CodingAgentFormHandle>(null);
-  const { data: claudeSubscriptions } = useClaudeSubscriptions();
-  const hasClaudeSubscription = (claudeSubscriptions?.length ?? 0) > 0;
-  const { data: providerEndpoints } = useListProviders({ loadModels: false });
-  const hasAnthropicProvider = useMemo(() => {
-    if (!providerEndpoints) return false;
-    return providerEndpoints.some((p) => p.name === "anthropic");
-  }, [providerEndpoints]);
-  const userProviderCount = useMemo(() => {
-    if (!providerEndpoints) return 0;
-    return providerEndpoints.filter(
-      (p) =>
-        p.endpoint_type ===
-        TypesProviderEndpointType.ProviderEndpointTypeUser,
-    ).length;
-  }, [providerEndpoints]);
-
   // Sort apps: zed_external first, then others
   const sortedApps = useMemo(() => {
     if (!apps) return [];
@@ -559,12 +539,6 @@ const ProjectSettings: FC = () => {
     }
   }, [selectedModel, codeAgentRuntime, userModifiedName, showCreateAgentForm]);
 
-  useEffect(() => {
-    if (hasClaudeSubscription && !hasAnthropicProvider && userProviderCount === 0) {
-      setCodeAgentRuntime("claude_code");
-      setClaudeCodeMode("subscription");
-    }
-  }, [hasClaudeSubscription, hasAnthropicProvider, userProviderCount]);
 
   // Initialize form from server data
   // This runs when project loads or refetches (standard React Query pattern)
@@ -1390,8 +1364,6 @@ const ProjectSettings: FC = () => {
                       setNewAgentName(nextValue.agentName);
                     }}
                     disabled={creatingAgent}
-                    hasClaudeSubscription={hasClaudeSubscription}
-                    hasAnthropicProvider={hasAnthropicProvider}
                     recommendedModels={RECOMMENDED_CODING_MODELS}
                     createAgentDescription="Code development agent for spec tasks"
                     onCreateStateChange={setCreatingAgent}


### PR DESCRIPTION
> **Helix**: Issue with onboarding on the SaaS (app.helix.ml) two things:
1. when anthropic provider is available as system provider, claude code isn't auto-suggested as the model
2. when you select claude code, it shows "Anthropic API Key (not configured)" even though it is as a global one

I thought we fixed this today in a recent PR, but maybe there's duplicate code between where we fixed it and the onboarding UI?! I also noticed the same errant behaviour in the "Create New Agent" flow inside project settings

---
[Created by Helix](https://helix.ml)
