### PR TITLE
fix: clear lifecycle fields when moving task back to backlog

### DIFF
--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -741,6 +741,35 @@ func (s *HelixAPIServer) updateSpecTask(w http.ResponseWriter, r *http.Request) 
 		// Update StatusUpdatedAt so task appears at top of new column in Kanban
 		now := time.Now()
 		task.StatusUpdatedAt = &now
+
+		// When moving back to backlog, clear lifecycle fields so the task
+		// starts fresh. Without this, the orchestrator sees old specs and
+		// immediately transitions to spec_review without generating new ones.
+		if updateReq.Status == types.TaskStatusBacklog {
+			task.RequirementsSpec = ""
+			task.TechnicalDesign = ""
+			task.ImplementationPlan = ""
+			task.DesignDocsPushedAt = nil
+			task.DesignDocPath = ""
+			task.SpecApprovedBy = ""
+			task.SpecApprovedAt = nil
+			task.SpecApproval = nil
+			task.SpecRevisionCount = 0
+			task.ImplementationApprovedBy = ""
+			task.ImplementationApprovedAt = nil
+			task.PlanningSessionID = ""
+			task.ExternalAgentID = ""
+			task.ZedInstanceID = ""
+			task.LastPushCommitHash = ""
+			task.LastPushAt = nil
+			task.StartedAt = nil
+			task.CompletedAt = nil
+			task.PlanningStartedAt = nil
+			task.MergedToMain = false
+			task.MergedAt = nil
+			task.MergeCommitHash = ""
+			task.PullRequestID = ""
+		}
 	}
 	if updateReq.Priority != "" {
 		task.Priority = updateReq.Priority


### PR DESCRIPTION
## Summary
- When a task was sent back to backlog via "Move to Backlog", only the status field was updated — old specs, approvals, timestamps, and session data remained
- The orchestrator then saw populated specs and immediately transitioned the task to `spec_review` without regenerating, leaving it stuck
- Now clears all lifecycle fields (specs, approvals, sessions, timestamps, PR data) when transitioning to backlog so the task starts fresh
- Branch name and task number are preserved as identity fields

## Test plan
- [x] `go build ./pkg/server/ ./pkg/types/` passes
- [ ] Move a completed/in-progress task to backlog, verify it shows as clean backlog task
- [ ] Verify auto-start picks it up and runs spec generation from scratch

🤖 Generated with [Claude Code](https://claude.com/claude-code)