### PR TITLE
fix(rag): use full kodit enrichment content instead of 300-char preview

### DIFF
--- a/api/pkg/rag/rag_kodit.go
+++ b/api/pkg/rag/rag_kodit.go
@@ -153,7 +153,7 @@ func (k *KoditRAG) Query(ctx context.Context, q *types.SessionRAGQuery) ([]*type
 	ragResults := make([]*types.SessionRAGResult, 0, len(results))
 	for _, r := range results {
 		result := &types.SessionRAGResult{
-			Content:  r.Preview,
+			Content:  r.Content,
 			Source:   r.Path,
 			Filename: r.Path,
 			Distance: 1.0 - r.Score, // kodit uses similarity scores (0-1); RAG uses distance

--- a/api/pkg/services/kodit_service.go
+++ b/api/pkg/services/kodit_service.go
@@ -877,7 +877,8 @@ func (s *KoditService) resolveFileResults(ctx context.Context, enrichments []enr
 			lines = fmt.Sprintf("L%d-L%d", lr.StartLine(), lr.EndLine())
 		}
 
-		preview := e.Content()
+		fullContent := e.Content()
+		preview := fullContent
 		runes := []rune(preview)
 		if len(runes) > 300 {
 			preview = string(runes[:300]) + "..."
@@ -889,6 +890,7 @@ func (s *KoditService) resolveFileResults(ctx context.Context, enrichments []enr
 			Lines:    lines,
 			Score:    scores[idStr],
 			Preview:  preview,
+			Content:  fullContent,
 		})
 	}
 

--- a/api/pkg/services/kodit_servicer.go
+++ b/api/pkg/services/kodit_servicer.go
@@ -32,6 +32,7 @@ type KoditFileResult struct {
 	Lines    string  `json:"lines,omitempty"`
 	Score    float64 `json:"score"`
 	Preview  string  `json:"preview"`
+	Content  string  `json:"content"` // Full enrichment content (not truncated)
 }
 
 // KoditGrepResult represents a grep match grouped by file.


### PR DESCRIPTION
## Summary

Previously the RAG query returned only the first 300 characters of enriched chunks (via `r.Preview`), ignoring the configured chunk_size setting entirely. This meant that even if you set chunk_size to 5000, the LLM would only ever see ~200 tokens.

Now we:
- Store both **full content** (for RAG) and **truncated preview** (for UI display)
- RAG pipeline uses the full enrichment content
- Handlers/MCP/UI continue using the preview for display efficiency

Fixes the issue where RAG chunks were hard-capped at 300 characters regardless of configuration.

## Changes
- `kodit_servicer.go`: Add `Content` field to `KoditFileResult`
- `kodit_service.go`: Populate full content and truncated preview separately
- `rag_kodit.go`: Use full `r.Content` instead of `r.Preview`