### PR TITLE
Switching endpoint type from user → global doesn't work -...

### DIFF
--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -515,6 +515,19 @@ func (s *HelixAPIServer) updateProviderEndpoint(rw http.ResponseWriter, r *http.
 		return
 	}
 
+	// Apply endpoint type change and update ownership accordingly
+	if updatedEndpoint.EndpointType != "" && updatedEndpoint.EndpointType != existingEndpoint.EndpointType {
+		existingEndpoint.EndpointType = updatedEndpoint.EndpointType
+		switch updatedEndpoint.EndpointType {
+		case types.ProviderEndpointTypeGlobal:
+			existingEndpoint.Owner = string(types.OwnerTypeSystem)
+			existingEndpoint.OwnerType = types.OwnerTypeSystem
+		case types.ProviderEndpointTypeUser:
+			existingEndpoint.Owner = user.ID
+			existingEndpoint.OwnerType = types.OwnerTypeUser
+		}
+	}
+
 	// Preserve ID and ownership information
 	// Update name if provided and different from existing
 	if updatedEndpoint.Name != "" && updatedEndpoint.Name != existingEndpoint.Name {

--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -517,14 +517,14 @@ func (s *HelixAPIServer) updateProviderEndpoint(rw http.ResponseWriter, r *http.
 
 	// Apply endpoint type change and update ownership accordingly
 	if updatedEndpoint.EndpointType != "" && updatedEndpoint.EndpointType != existingEndpoint.EndpointType {
-		existingEndpoint.EndpointType = updatedEndpoint.EndpointType
 		switch updatedEndpoint.EndpointType {
 		case types.ProviderEndpointTypeGlobal:
+			existingEndpoint.EndpointType = updatedEndpoint.EndpointType
 			existingEndpoint.Owner = string(types.OwnerTypeSystem)
 			existingEndpoint.OwnerType = types.OwnerTypeSystem
-		case types.ProviderEndpointTypeUser:
-			existingEndpoint.Owner = user.ID
-			existingEndpoint.OwnerType = types.OwnerTypeUser
+		default:
+			http.Error(rw, fmt.Sprintf("Unsupported endpoint type switch to %q", updatedEndpoint.EndpointType), http.StatusBadRequest)
+			return
 		}
 	}
 

--- a/api/pkg/server/provider_handlers_test.go
+++ b/api/pkg/server/provider_handlers_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/ristretto/v2"
+	"github.com/gorilla/mux"
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/model"
 	"github.com/helixml/helix/api/pkg/openai"
@@ -350,4 +351,134 @@ func (s *ProviderHandlersSuite) TestCreateProviderEndpoint_WarmsCacheAndMasksAPI
 	case <-time.After(5 * time.Second):
 		s.Fail("cache warm goroutine did not complete in time")
 	}
+}
+
+func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_SwitchUserToGlobal() {
+	s.server.Cfg.Providers.EnableCustomUserProviders = true
+	endpointID := "ep_123"
+
+	adminCtx := setRequestUser(context.Background(), types.User{
+		ID:    "admin_id",
+		Admin: true,
+	})
+
+	existing := &types.ProviderEndpoint{
+		ID:           endpointID,
+		Name:         "my-endpoint",
+		BaseURL:      "http://localhost:11434",
+		Owner:        "admin_id",
+		OwnerType:    types.OwnerTypeUser,
+		EndpointType: types.ProviderEndpointTypeUser,
+	}
+
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{
+		ProvidersManagementEnabled: true,
+	}, nil)
+	s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{
+		ID: endpointID,
+	}).Return(existing, nil)
+	s.store.EXPECT().UpdateProviderEndpoint(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, ep *types.ProviderEndpoint) (*types.ProviderEndpoint, error) {
+			s.Equal(types.ProviderEndpointTypeGlobal, ep.EndpointType)
+			s.Equal(string(types.OwnerTypeSystem), ep.Owner)
+			s.Equal(types.OwnerTypeSystem, ep.OwnerType)
+			return ep, nil
+		})
+
+	update := types.UpdateProviderEndpoint{
+		Name:         "my-endpoint",
+		EndpointType: types.ProviderEndpointTypeGlobal,
+		BaseURL:      "http://localhost:11434",
+	}
+	body, _ := json.Marshal(update)
+
+	req := httptest.NewRequest(http.MethodPut, "/v1/provider-endpoints/"+endpointID, bytes.NewReader(body))
+	req = req.WithContext(adminCtx)
+	req = mux.SetURLVars(req, map[string]string{"id": endpointID})
+
+	rr := httptest.NewRecorder()
+	s.server.updateProviderEndpoint(rr, req)
+
+	s.Equal(http.StatusOK, rr.Code)
+}
+
+func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_NonAdminCannotSwitchToGlobal() {
+	s.server.Cfg.Providers.EnableCustomUserProviders = true
+	endpointID := "ep_123"
+
+	existing := &types.ProviderEndpoint{
+		ID:           endpointID,
+		Name:         "my-endpoint",
+		BaseURL:      "http://localhost:11434",
+		Owner:        "user_id",
+		OwnerType:    types.OwnerTypeUser,
+		EndpointType: types.ProviderEndpointTypeUser,
+	}
+
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{
+		ProvidersManagementEnabled: true,
+	}, nil)
+	s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{
+		ID: endpointID,
+	}).Return(existing, nil)
+
+	update := types.UpdateProviderEndpoint{
+		Name:         "my-endpoint",
+		EndpointType: types.ProviderEndpointTypeGlobal,
+		BaseURL:      "http://localhost:11434",
+	}
+	body, _ := json.Marshal(update)
+
+	req := httptest.NewRequest(http.MethodPut, "/v1/provider-endpoints/"+endpointID, bytes.NewReader(body))
+	req = req.WithContext(s.authCtx)
+	req = mux.SetURLVars(req, map[string]string{"id": endpointID})
+
+	rr := httptest.NewRecorder()
+	s.server.updateProviderEndpoint(rr, req)
+
+	s.Equal(http.StatusForbidden, rr.Code)
+	s.Contains(rr.Body.String(), "Only admins can update global endpoints")
+}
+
+func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_SwitchToOrgRejected() {
+	s.server.Cfg.Providers.EnableCustomUserProviders = true
+	endpointID := "ep_123"
+
+	adminCtx := setRequestUser(context.Background(), types.User{
+		ID:    "admin_id",
+		Admin: true,
+	})
+
+	existing := &types.ProviderEndpoint{
+		ID:           endpointID,
+		Name:         "my-endpoint",
+		BaseURL:      "http://localhost:11434",
+		Owner:        "admin_id",
+		OwnerType:    types.OwnerTypeUser,
+		EndpointType: types.ProviderEndpointTypeUser,
+	}
+
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{
+		ProvidersManagementEnabled: true,
+	}, nil)
+	s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{
+		ID: endpointID,
+	}).Return(existing, nil)
+
+	update := types.UpdateProviderEndpoint{
+		Name:         "my-endpoint",
+		EndpointType: types.ProviderEndpointTypeOrg,
+		BaseURL:      "http://localhost:11434",
+	}
+	body, _ := json.Marshal(update)
+
+	req := httptest.NewRequest(http.MethodPut, "/v1/provider-endpoints/"+endpointID, bytes.NewReader(body))
+	req = req.WithContext(adminCtx)
+	req = mux.SetURLVars(req, map[string]string{"id": endpointID})
+
+	rr := httptest.NewRecorder()
+	s.server.updateProviderEndpoint(rr, req)
+
+	s.Equal(http.StatusBadRequest, rr.Code)
+	s.Contains(rr.Body.String(), "Unsupported endpoint type switch")
 }


### PR DESCRIPTION
Switching endpoint type from user → global doesn't work
  - The owner stays as the user ID, so the system query still misses it
  - Needs to also update owner to system when changing to global, or the refresh needs to include all providers regardless

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kmn5zy5tcs8hd2ydh5p44e19)

🚀 Built with [Helix](https://helix.ml)