### PR TITLE
Pull Request: Add screenshot attachments to task creation

### DIFF
--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -21919,6 +21919,13 @@ const docTemplate = `{
                     "description": "Optional: Helix agent to use for spec generation",
                     "type": "string"
                 },
+                "attachment_paths": {
+                    "description": "Image attachments (filestore paths uploaded by the user)",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "base_branch": {
                     "description": "For new mode: branch to create from (defaults to repo default)",
                     "type": "string"
@@ -27986,6 +27993,13 @@ const docTemplate = `{
                     "description": "Team member assigned to work on this task",
                     "type": "string"
                 },
+                "attachment_paths": {
+                    "description": "Filestore paths of user-uploaded screenshots",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "base_branch": {
                     "description": "The base branch this was created from",
                     "type": "string"
@@ -28700,6 +28714,13 @@ const docTemplate = `{
                 "assignee_id": {
                     "description": "Team member assigned to work on this task",
                     "type": "string"
+                },
+                "attachment_paths": {
+                    "description": "Filestore paths of user-uploaded screenshots",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "base_branch": {
                     "description": "The base branch this was created from",

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -486,6 +486,8 @@ func NewServer(
 	apiServer.specDrivenTaskService.SendMessageToAgent = apiServer.sendMessageToSpecTaskAgent
 	// Set the project secrets callback for injecting secrets as env vars into desktop containers
 	apiServer.specDrivenTaskService.GetProjectSecrets = apiServer.GetProjectSecretsAsEnvVars
+	// Set the filestore for reading uploaded image attachments
+	apiServer.specDrivenTaskService.SetFileStore(appController.Options.Filestore)
 
 	// Initialize Attention Service for human-needed event notifications
 	apiServer.attentionService = services.NewAttentionService(store, cfg)

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -21915,6 +21915,13 @@
                     "description": "Optional: Helix agent to use for spec generation",
                     "type": "string"
                 },
+                "attachment_paths": {
+                    "description": "Image attachments (filestore paths uploaded by the user)",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "base_branch": {
                     "description": "For new mode: branch to create from (defaults to repo default)",
                     "type": "string"
@@ -27982,6 +27989,13 @@
                     "description": "Team member assigned to work on this task",
                     "type": "string"
                 },
+                "attachment_paths": {
+                    "description": "Filestore paths of user-uploaded screenshots",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "base_branch": {
                     "description": "The base branch this was created from",
                     "type": "string"
@@ -28696,6 +28710,13 @@
                 "assignee_id": {
                     "description": "Team member assigned to work on this task",
                     "type": "string"
+                },
+                "attachment_paths": {
+                    "description": "Filestore paths of user-uploaded screenshots",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "base_branch": {
                     "description": "The base branch this was created from",

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -3884,6 +3884,11 @@ definitions:
       app_id:
         description: 'Optional: Helix agent to use for spec generation'
         type: string
+      attachment_paths:
+        description: Image attachments (filestore paths uploaded by the user)
+        items:
+          type: string
+        type: array
       base_branch:
         description: 'For new mode: branch to create from (defaults to repo default)'
         type: string
@@ -8168,6 +8173,11 @@ definitions:
       assignee_id:
         description: Team member assigned to work on this task
         type: string
+      attachment_paths:
+        description: Filestore paths of user-uploaded screenshots
+        items:
+          type: string
+        type: array
       base_branch:
         description: The base branch this was created from
         type: string
@@ -8701,6 +8711,11 @@ definitions:
       assignee_id:
         description: Team member assigned to work on this task
         type: string
+      attachment_paths:
+        description: Filestore paths of user-uploaded screenshots
+        items:
+          type: string
+        type: array
       base_branch:
         description: The base branch this was created from
         type: string

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -2,12 +2,17 @@ package services
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"io"
+	"mime"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	external_agent "github.com/helixml/helix/api/pkg/external-agent"
+	"github.com/helixml/helix/api/pkg/filestore"
 	"github.com/helixml/helix/api/pkg/notification"
 	"github.com/helixml/helix/api/pkg/pubsub"
 	"github.com/helixml/helix/api/pkg/store"
@@ -49,6 +54,7 @@ type SpecDrivenTaskService struct {
 	auditLogService          *AuditLogService          // Service for audit logging
 	koditService             KoditServicer             // Kodit code intelligence (for MCP documentation in prompts)
 	GetProjectSecrets        ProjectSecretsGetter      // Callback to get project secrets as env vars
+	fileStore                filestore.FileStore       // For reading uploaded image attachments
 	wg                       sync.WaitGroup
 }
 
@@ -92,6 +98,11 @@ func NewSpecDrivenTaskService(
 	)
 
 	return service
+}
+
+// SetFileStore sets the filestore for reading uploaded image attachments.
+func (s *SpecDrivenTaskService) SetFileStore(fs filestore.FileStore) {
+	s.fileStore = fs
 }
 
 // SetKoditService replaces the kodit service after late initialization.
@@ -185,8 +196,9 @@ func (s *SpecDrivenTaskService) CreateTaskFromPrompt(ctx context.Context, req *t
 		BranchPrefix: req.BranchPrefix,  // User-specified prefix for new branches
 		BranchName:   req.WorkingBranch, // For existing mode, this is the branch to continue on
 		// Repositories inherited from parent project - no task-level repo configuration
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		AttachmentPaths: req.AttachmentPaths, // User-uploaded screenshots
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
 	}
 	if req.DependsOn != nil {
 		task.DependsOn = make([]types.SpecTask, 0, len(req.DependsOn))
@@ -437,16 +449,23 @@ func (s *SpecDrivenTaskService) StartSpecGeneration(ctx context.Context, task *t
 	}
 
 	interaction := &types.Interaction{
-		ID:            system.GenerateInteractionID(),
-		Created:       time.Now(),
-		Updated:       time.Now(),
-		Scheduled:     time.Now(),
-		SessionID:     session.ID,
-		UserID:        task.CreatedBy,
-		Mode:          types.SessionModeInference,
-		SystemPrompt:  "", // Don't override agent's system prompt
-		PromptMessage: fullMessage,
-		State:         types.InteractionStateWaiting,
+		ID:           system.GenerateInteractionID(),
+		Created:      time.Now(),
+		Updated:      time.Now(),
+		Scheduled:    time.Now(),
+		SessionID:    session.ID,
+		UserID:       task.CreatedBy,
+		Mode:         types.SessionModeInference,
+		SystemPrompt: "", // Don't override agent's system prompt
+		State:        types.InteractionStateWaiting,
+	}
+
+	// If the task has image attachments and we have a filestore, build a multimodal prompt
+	// so the LLM can actually "see" the screenshots
+	if len(task.AttachmentPaths) > 0 && s.fileStore != nil {
+		interaction.PromptMessageContent = s.buildMultimodalPrompt(ctx, fullMessage, task.AttachmentPaths)
+	} else {
+		interaction.PromptMessage = fullMessage
 	}
 
 	log.Debug().Str("task_id", task.ID).Msg("DEBUG: About to create initial interaction")
@@ -1369,6 +1388,47 @@ func (s *SpecDrivenTaskService) selectZedAgent() string {
 		return ""
 	}
 	return s.zedAgentPool[0]
+}
+
+// buildMultimodalPrompt creates a MessageContent with text and base64-encoded images
+// so the LLM can see screenshots attached to the task.
+func (s *SpecDrivenTaskService) buildMultimodalPrompt(ctx context.Context, textMessage string, attachmentPaths []string) types.MessageContent {
+	parts := []any{textMessage}
+
+	for _, path := range attachmentPaths {
+		reader, err := s.fileStore.OpenFile(ctx, path)
+		if err != nil {
+			log.Warn().Err(err).Str("path", path).Msg("Failed to open attachment, skipping")
+			continue
+		}
+
+		data, err := io.ReadAll(reader)
+		reader.Close()
+		if err != nil {
+			log.Warn().Err(err).Str("path", path).Msg("Failed to read attachment, skipping")
+			continue
+		}
+
+		// Determine MIME type from extension
+		mimeType := mime.TypeByExtension(filepath.Ext(path))
+		if mimeType == "" {
+			mimeType = "image/png" // fallback
+		}
+
+		dataURI := "data:" + mimeType + ";base64," + base64.StdEncoding.EncodeToString(data)
+
+		parts = append(parts, types.ImageURLPart{
+			Type: "image_url",
+			ImageURL: types.ImageURLData{
+				URL: dataURI,
+			},
+		})
+	}
+
+	return types.MessageContent{
+		ContentType: types.MessageContentTypeText,
+		Parts:       parts,
+	}
 }
 
 func (s *SpecDrivenTaskService) markTaskFailed(ctx context.Context, task *types.SpecTask, errorMessage string) {

--- a/api/pkg/types/simple_spec_task.go
+++ b/api/pkg/types/simple_spec_task.go
@@ -87,6 +87,9 @@ type CreateTaskRequest struct {
 	BranchPrefix  string     `json:"branch_prefix,omitempty"`  // For new mode: user-specified prefix (task# appended)
 	WorkingBranch string     `json:"working_branch,omitempty"` // For existing mode: branch to continue working on
 
+	// Image attachments (filestore paths uploaded by the user)
+	AttachmentPaths []string `json:"attachment_paths,omitempty"` // Filestore paths of uploaded screenshots
+
 	// Git repositories are now managed at the project level - no task-level repo selection needed
 }
 
@@ -188,8 +191,9 @@ type SpecTask struct {
 	CreatedAt time.Time              `json:"created_at"`
 	UpdatedAt time.Time              `json:"updated_at"`
 	Archived  bool                   `json:"archived" gorm:"default:false;index"` // Archive to hide from main view
-	Labels    []string               `json:"labels" gorm:"type:jsonb;serializer:json"`
-	Metadata  map[string]interface{} `json:"metadata,omitempty" gorm:"type:jsonb;serializer:json"`
+	Labels          []string               `json:"labels" gorm:"type:jsonb;serializer:json"`
+	Metadata        map[string]interface{} `json:"metadata,omitempty" gorm:"type:jsonb;serializer:json"`
+	AttachmentPaths []string               `json:"attachment_paths,omitempty" gorm:"type:jsonb;serializer:json"` // Filestore paths of user-uploaded screenshots
 
 	// Public sharing
 	PublicDesignDocs bool `json:"public_design_docs" gorm:"default:false"` // Allow viewing design docs without login

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -2382,6 +2382,8 @@ export interface TypesCreateSecretRequest {
 export interface TypesCreateTaskRequest {
   /** Optional: Helix agent to use for spec generation */
   app_id?: string;
+  /** Image attachments (filestore paths uploaded by the user) */
+  attachment_paths?: string[];
   /** For new mode: branch to create from (defaults to repo default) */
   base_branch?: string;
   /** Branch configuration */
@@ -4947,6 +4949,8 @@ export interface TypesSpecTask {
   archived?: boolean;
   /** Team member assigned to work on this task */
   assignee_id?: string;
+  /** Filestore paths of user-uploaded screenshots */
+  attachment_paths?: string[];
   /** The base branch this was created from */
   base_branch?: string;
   /** "new" or "existing" */
@@ -5245,6 +5249,8 @@ export interface TypesSpecTaskWithProject {
   archived?: boolean;
   /** Team member assigned to work on this task */
   assignee_id?: string;
+  /** Filestore paths of user-uploaded screenshots */
+  attachment_paths?: string[];
   /** The base branch this was created from */
   base_branch?: string;
   /** "new" or "existing" */

--- a/frontend/src/components/tasks/ImageAttachments.tsx
+++ b/frontend/src/components/tasks/ImageAttachments.tsx
@@ -1,0 +1,388 @@
+import React, { useState, useEffect, useCallback, useRef } from "react";
+import { useDropzone } from "react-dropzone";
+import {
+  Box,
+  Typography,
+  IconButton,
+  CircularProgress,
+  Alert,
+} from "@mui/material";
+import { Close as CloseIcon, Image as ImageIcon } from "@mui/icons-material";
+import { useUploadFilestoreFiles, useDeleteFilestoreItem, useFilestoreConfig, getFilestoreViewerUrl } from "../../services/filestoreService";
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const ACCEPTED_TYPES: Record<string, string[]> = {
+  "image/png": [".png"],
+  "image/jpeg": [".jpg", ".jpeg"],
+  "image/gif": [".gif"],
+  "image/webp": [".webp"],
+};
+
+export interface UploadedImage {
+  id: string;
+  filename: string;
+  previewUrl: string;
+  viewerUrl: string;
+  filestorePath: string;
+}
+
+interface ImageAttachmentsProps {
+  /** Called whenever the list of successfully uploaded images changes */
+  onImagesChange: (images: UploadedImage[]) => void;
+  /** Filestore path prefix for uploads (e.g. "task-attachments/{sessionId}") */
+  uploadPath: string;
+  /** Ref to a container element to listen for paste events on */
+  pasteTargetRef?: React.RefObject<HTMLElement | null>;
+}
+
+interface PendingUpload {
+  id: string;
+  filename: string;
+  previewUrl: string;
+  uploading: boolean;
+  error?: string;
+}
+
+const ImageAttachments: React.FC<ImageAttachmentsProps> = ({
+  onImagesChange,
+  uploadPath,
+  pasteTargetRef,
+}) => {
+  const [images, setImages] = useState<UploadedImage[]>([]);
+  const [pending, setPending] = useState<PendingUpload[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const uploadMutation = useUploadFilestoreFiles();
+  const deleteMutation = useDeleteFilestoreItem();
+  const { data: filestoreConfig } = useFilestoreConfig();
+
+  // Notify parent when images change
+  const imagesRef = useRef(images);
+  useEffect(() => {
+    imagesRef.current = images;
+    onImagesChange(images);
+  }, [images]);
+
+  const processFiles = useCallback(
+    async (files: File[]) => {
+      setError(null);
+
+      // Validate files
+      const validFiles: File[] = [];
+      for (const file of files) {
+        if (file.size > MAX_FILE_SIZE) {
+          setError(`"${file.name}" exceeds 10MB limit`);
+          continue;
+        }
+        if (!Object.keys(ACCEPTED_TYPES).includes(file.type)) {
+          setError(`"${file.name}" is not a supported image format (PNG, JPEG, GIF, WebP)`);
+          continue;
+        }
+        validFiles.push(file);
+      }
+
+      if (validFiles.length === 0) return;
+
+      // Create pending entries with previews
+      const newPending: PendingUpload[] = validFiles.map((file) => ({
+        id: crypto.randomUUID(),
+        filename: file.name,
+        previewUrl: URL.createObjectURL(file),
+        uploading: true,
+      }));
+      setPending((prev) => [...prev, ...newPending]);
+
+      // Upload each file
+      for (let i = 0; i < validFiles.length; i++) {
+        const file = validFiles[i];
+        const pendingEntry = newPending[i];
+
+        try {
+          await uploadMutation.mutateAsync({
+            path: uploadPath,
+            files: [file],
+            config: filestoreConfig || undefined,
+          });
+
+          // Build the filestore path for this file
+          const userPrefix = filestoreConfig?.user_prefix || "";
+          const fullPath = userPrefix
+            ? `${userPrefix}/${uploadPath}/${file.name}`
+            : `${uploadPath}/${file.name}`;
+          const viewerUrl = getFilestoreViewerUrl(fullPath);
+
+          const uploadedImage: UploadedImage = {
+            id: pendingEntry.id,
+            filename: file.name,
+            previewUrl: pendingEntry.previewUrl,
+            viewerUrl,
+            filestorePath: fullPath,
+          };
+
+          setImages((prev) => [...prev, uploadedImage]);
+          setPending((prev) => prev.filter((p) => p.id !== pendingEntry.id));
+        } catch (err) {
+          console.error(`Failed to upload ${file.name}:`, err);
+          setPending((prev) =>
+            prev.map((p) =>
+              p.id === pendingEntry.id
+                ? { ...p, uploading: false, error: "Upload failed" }
+                : p,
+            ),
+          );
+        }
+      }
+    },
+    [uploadPath, filestoreConfig],
+  );
+
+  // Drag-and-drop
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    accept: ACCEPTED_TYPES,
+    maxSize: MAX_FILE_SIZE,
+    onDrop: processFiles,
+    noClick: images.length > 0 || pending.length > 0, // Only clickable when empty
+  });
+
+  // Clipboard paste handler
+  useEffect(() => {
+    const target = pasteTargetRef?.current;
+    if (!target) return;
+
+    const handlePaste = (e: Event) => {
+      const clipboardEvent = e as ClipboardEvent;
+      const items = clipboardEvent.clipboardData?.items;
+      if (!items) return;
+
+      const imageFiles: File[] = [];
+      for (const item of Array.from(items)) {
+        if (item.type.startsWith("image/")) {
+          const file = item.getAsFile();
+          if (file) {
+            // Generate a meaningful filename for pasted images
+            const ext = file.type.split("/")[1] || "png";
+            const pastedFile = new File(
+              [file],
+              `screenshot-${Date.now()}.${ext}`,
+              { type: file.type },
+            );
+            imageFiles.push(pastedFile);
+          }
+        }
+      }
+
+      if (imageFiles.length > 0) {
+        e.preventDefault();
+        processFiles(imageFiles);
+      }
+    };
+
+    target.addEventListener("paste", handlePaste);
+    return () => target.removeEventListener("paste", handlePaste);
+  }, [pasteTargetRef?.current, processFiles]);
+
+  const handleRemove = useCallback(
+    async (image: UploadedImage) => {
+      // Remove from UI immediately
+      setImages((prev) => prev.filter((img) => img.id !== image.id));
+      URL.revokeObjectURL(image.previewUrl);
+
+      // Delete from filestore (best-effort, don't block UI)
+      try {
+        await deleteMutation.mutateAsync(image.filestorePath);
+      } catch (err) {
+        console.error("Failed to delete file from filestore:", err);
+      }
+    },
+    [],
+  );
+
+  const handleRemovePending = useCallback((id: string) => {
+    setPending((prev) => {
+      const entry = prev.find((p) => p.id === id);
+      if (entry) URL.revokeObjectURL(entry.previewUrl);
+      return prev.filter((p) => p.id !== id);
+    });
+  }, []);
+
+  const hasItems = images.length > 0 || pending.length > 0;
+
+  return (
+    <Box>
+      {/* Drop zone */}
+      <Box
+        {...getRootProps()}
+        sx={{
+          border: "1px dashed",
+          borderColor: isDragActive ? "primary.main" : "divider",
+          borderRadius: 1,
+          p: hasItems ? 1 : 2,
+          cursor: "pointer",
+          bgcolor: isDragActive ? "action.hover" : "transparent",
+          transition: "all 0.2s",
+          "&:hover": { borderColor: "text.secondary" },
+        }}
+      >
+        <input {...getInputProps()} />
+
+        {!hasItems && (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 1,
+            }}
+          >
+            <ImageIcon sx={{ fontSize: 20, color: "text.secondary" }} />
+            <Typography variant="caption" color="text.secondary">
+              Drop screenshots here, paste from clipboard, or click to browse
+            </Typography>
+          </Box>
+        )}
+
+        {/* Thumbnail grid */}
+        {hasItems && (
+          <Box
+            sx={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 1,
+            }}
+          >
+            {images.map((img) => (
+              <Box
+                key={img.id}
+                sx={{
+                  position: "relative",
+                  width: 80,
+                  height: 80,
+                  borderRadius: 1,
+                  overflow: "hidden",
+                  border: 1,
+                  borderColor: "divider",
+                }}
+              >
+                <Box
+                  component="img"
+                  src={img.previewUrl}
+                  alt={img.filename}
+                  sx={{
+                    width: "100%",
+                    height: "100%",
+                    objectFit: "cover",
+                  }}
+                />
+                <IconButton
+                  size="small"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleRemove(img);
+                  }}
+                  sx={{
+                    position: "absolute",
+                    top: 0,
+                    right: 0,
+                    bgcolor: "rgba(0,0,0,0.6)",
+                    color: "white",
+                    p: 0.25,
+                    "&:hover": { bgcolor: "rgba(0,0,0,0.8)" },
+                  }}
+                >
+                  <CloseIcon sx={{ fontSize: 14 }} />
+                </IconButton>
+              </Box>
+            ))}
+
+            {pending.map((p) => (
+              <Box
+                key={p.id}
+                sx={{
+                  position: "relative",
+                  width: 80,
+                  height: 80,
+                  borderRadius: 1,
+                  overflow: "hidden",
+                  border: 1,
+                  borderColor: p.error ? "error.main" : "divider",
+                  opacity: p.uploading ? 0.6 : 1,
+                }}
+              >
+                <Box
+                  component="img"
+                  src={p.previewUrl}
+                  alt={p.filename}
+                  sx={{
+                    width: "100%",
+                    height: "100%",
+                    objectFit: "cover",
+                  }}
+                />
+                {p.uploading && (
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      inset: 0,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      bgcolor: "rgba(0,0,0,0.4)",
+                    }}
+                  >
+                    <CircularProgress size={20} sx={{ color: "white" }} />
+                  </Box>
+                )}
+                {p.error && (
+                  <IconButton
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRemovePending(p.id);
+                    }}
+                    sx={{
+                      position: "absolute",
+                      top: 0,
+                      right: 0,
+                      bgcolor: "rgba(0,0,0,0.6)",
+                      color: "white",
+                      p: 0.25,
+                      "&:hover": { bgcolor: "rgba(0,0,0,0.8)" },
+                    }}
+                  >
+                    <CloseIcon sx={{ fontSize: 14 }} />
+                  </IconButton>
+                )}
+              </Box>
+            ))}
+
+            {/* Add more button */}
+            <Box
+              sx={{
+                width: 80,
+                height: 80,
+                borderRadius: 1,
+                border: "1px dashed",
+                borderColor: "divider",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                cursor: "pointer",
+                "&:hover": { borderColor: "text.secondary" },
+              }}
+            >
+              <ImageIcon sx={{ fontSize: 20, color: "text.secondary" }} />
+            </Box>
+          </Box>
+        )}
+      </Box>
+
+      {error && (
+        <Alert severity="warning" sx={{ mt: 1 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+    </Box>
+  );
+};
+
+export default ImageAttachments;

--- a/frontend/src/components/tasks/NewSpecTaskForm.tsx
+++ b/frontend/src/components/tasks/NewSpecTaskForm.tsx
@@ -4,6 +4,7 @@ import React, {
   useRef,
   useMemo,
   useCallback,
+  useId,
 } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -46,6 +47,8 @@ import useSnackbar from "../../hooks/useSnackbar";
 import useApps from "../../hooks/useApps";
 import { useGetProject, useGetProjectRepositories } from "../../services";
 import { useSpecTasks, useProjectLabels, useAddLabel } from "../../services/specTaskService";
+import ImageAttachments, { UploadedImage } from "./ImageAttachments";
+import { getFilestoreViewerUrl } from "../../services/filestoreService";
 
 const LAST_LABELS_KEY = "helix_last_task_labels";
 const DRAFT_KEY_PREFIX = "helix_new_spectask_draft_";
@@ -189,6 +192,10 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
   const codingAgentFormRef = useRef<CodingAgentFormHandle>(null);
   // Ref for task prompt text field
   const taskPromptRef = useRef<HTMLTextAreaElement>(null);
+  // Image attachments
+  const [uploadSessionId] = useState(() => crypto.randomUUID());
+  const [attachedImages, setAttachedImages] = useState<UploadedImage[]>([]);
+  const formContainerRef = useRef<HTMLDivElement>(null);
 
   // Sort apps: project default first, then zed_external, then others
   const sortedApps = useMemo(() => {
@@ -324,8 +331,20 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
         agentId = createdAgent.id;
       }
 
+      // Append image references to prompt if any images are attached
+      let finalPrompt = taskPrompt;
+      if (attachedImages.length > 0) {
+        const imageRefs = attachedImages
+          .map((img, i) => `![screenshot-${i + 1}](${img.viewerUrl})`)
+          .join("\n");
+        finalPrompt = taskPrompt + "\n\n" + imageRefs;
+      }
+
       const createTaskRequest = {
-        prompt: taskPrompt,
+        prompt: finalPrompt,
+        attachment_paths: attachedImages.length > 0
+          ? attachedImages.map((img) => img.filestorePath)
+          : undefined,
         priority: taskPriority as TypesSpecTaskPriority,
         project_id: projectId,
         app_id: agentId || undefined,
@@ -442,7 +461,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
       )}
 
       {/* Content */}
-      <Box sx={{ flex: 1, overflow: "auto", p: 2 }}>
+      <Box ref={formContainerRef} sx={{ flex: 1, overflow: "auto", p: 2 }}>
         <Stack spacing={2}>
           {/* Priority Selector */}
           <FormControl fullWidth size="small">
@@ -575,6 +594,13 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
             }
             inputRef={taskPromptRef}
             size="small"
+          />
+
+          {/* Screenshot Attachments */}
+          <ImageAttachments
+            onImagesChange={setAttachedImages}
+            uploadPath={`task-attachments/${uploadSessionId}`}
+            pasteTargetRef={formContainerRef}
           />
 
           <Autocomplete

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -3884,6 +3884,11 @@ definitions:
       app_id:
         description: 'Optional: Helix agent to use for spec generation'
         type: string
+      attachment_paths:
+        description: Image attachments (filestore paths uploaded by the user)
+        items:
+          type: string
+        type: array
       base_branch:
         description: 'For new mode: branch to create from (defaults to repo default)'
         type: string
@@ -8168,6 +8173,11 @@ definitions:
       assignee_id:
         description: Team member assigned to work on this task
         type: string
+      attachment_paths:
+        description: Filestore paths of user-uploaded screenshots
+        items:
+          type: string
+        type: array
       base_branch:
         description: The base branch this was created from
         type: string
@@ -8701,6 +8711,11 @@ definitions:
       assignee_id:
         description: Team member assigned to work on this task
         type: string
+      attachment_paths:
+        description: Filestore paths of user-uploaded screenshots
+        items:
+          type: string
+        type: array
       base_branch:
         description: The base branch this was created from
         type: string

--- a/openapi.json
+++ b/openapi.json
@@ -25418,6 +25418,13 @@
                         "description": "Optional: Helix agent to use for spec generation",
                         "type": "string"
                     },
+                    "attachment_paths": {
+                        "description": "Image attachments (filestore paths uploaded by the user)",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "base_branch": {
                         "description": "For new mode: branch to create from (defaults to repo default)",
                         "type": "string"
@@ -31485,6 +31492,13 @@
                         "description": "Team member assigned to work on this task",
                         "type": "string"
                     },
+                    "attachment_paths": {
+                        "description": "Filestore paths of user-uploaded screenshots",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "base_branch": {
                         "description": "The base branch this was created from",
                         "type": "string"
@@ -32199,6 +32213,13 @@
                     "assignee_id": {
                         "description": "Team member assigned to work on this task",
                         "type": "string"
+                    },
+                    "attachment_paths": {
+                        "description": "Filestore paths of user-uploaded screenshots",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "base_branch": {
                         "description": "The base branch this was created from",

--- a/swagger.json
+++ b/swagger.json
@@ -21915,6 +21915,13 @@
                     "description": "Optional: Helix agent to use for spec generation",
                     "type": "string"
                 },
+                "attachment_paths": {
+                    "description": "Image attachments (filestore paths uploaded by the user)",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "base_branch": {
                     "description": "For new mode: branch to create from (defaults to repo default)",
                     "type": "string"
@@ -27982,6 +27989,13 @@
                     "description": "Team member assigned to work on this task",
                     "type": "string"
                 },
+                "attachment_paths": {
+                    "description": "Filestore paths of user-uploaded screenshots",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "base_branch": {
                     "description": "The base branch this was created from",
                     "type": "string"
@@ -28696,6 +28710,13 @@
                 "assignee_id": {
                     "description": "Team member assigned to work on this task",
                     "type": "string"
+                },
+                "attachment_paths": {
+                    "description": "Filestore paths of user-uploaded screenshots",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "base_branch": {
                     "description": "The base branch this was created from",


### PR DESCRIPTION
**Branch:** `feature/001736-i-would-like-to-be-able`

## Summary

Allow users to attach screenshots when creating a new SpecTask so the AI agent has visual context (error messages, UI mockups, current state) to understand what needs to be done.

## Changes

### Frontend
- **New `ImageAttachments.tsx` component** with drag-and-drop (react-dropzone), clipboard paste (Ctrl+V), thumbnail preview grid with per-image remove button, upload progress, file size validation (10MB max), and file type filtering (PNG, JPEG, GIF, WebP)
- **Modified `NewSpecTaskForm.tsx`** to integrate the image attachments component, send `attachment_paths` in the create request, and append markdown image references to the prompt text

### Backend
- **Modified `simple_spec_task.go`** — added `AttachmentPaths []string` field to both `CreateTaskRequest` and `SpecTask` model (JSONB storage)
- **Modified `spec_driven_task_service.go`** — added `buildMultimodalPrompt()` method that reads images from filestore, base64-encodes them, and creates `PromptMessageContent` with `ImageURLPart` entries so external LLM providers receive the images inline
- **Modified `server.go`** — wired filestore into `SpecDrivenTaskService`
- **Regenerated OpenAPI spec and TypeScript client** to include the new `attachment_paths` field

## Testing

- Verified image upload appears as thumbnail in the form
- Verified remove button deletes image from UI and filestore
- TypeScript compilation passes (`npx tsc --noEmit`)

## Screenshots

See `screenshots/` directory:
- `01-new-task-form-with-image-upload.png` — form with uploaded image showing remove button
- `02-after-image-removed.png` — form after clicking remove, showing empty drop zone

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01knmnpkcdnct4jwvp6mf6qfp0)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001736_i-would-like-to-be-able/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001736_i-would-like-to-be-able/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001736_i-would-like-to-be-able/tasks.md)

🚀 Built with [Helix](https://helix.ml)