### PR TITLE
fix: deduplicate message_completed to fix ZE2E phase 8 isolation violation

### DIFF
--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -105,6 +105,7 @@ type HelixAPIServer struct {
 	contextMappingsMutex        sync.RWMutex        // Mutex for contextMappings (and related mappings below)
 	requestToSessionMapping     map[string]string // request_id -> Helix session_id mapping (for chat_message routing)
 	requestToInteractionMapping map[string]string // request_id -> interaction_id (for routing message_added/completed to correct interaction)
+	completedRequestIDs         map[string]bool   // request_ids already processed by handleMessageCompleted (dedup guard)
 	externalAgentSessionMapping map[string]string   // External agent session_id -> Helix session_id mapping
 	externalAgentUserMapping    map[string]string   // External agent session_id -> user_id mapping
 	// Comment processing timeouts - uses database for queue state (QueuedAt/RequestID fields)

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -2110,6 +2110,27 @@ func (apiServer *HelixAPIServer) handleMessageCompleted(sessionID string, syncMs
 	var targetInteractionID string
 	apiServer.contextMappingsMutex.Lock()
 
+	// Deduplicate: Zed (Claude Code) can send two message_completed events for the
+	// same request_id when an interrupt races with the cancelled turn's completion.
+	// The second duplicate has no requestToInteractionMapping entry (deleted by the
+	// first), falls through to the DB fallback, finds the interrupt's waiting
+	// interaction, and incorrectly marks it complete — causing the isolation
+	// violation and leaving the interrupt's message_completed unmatched.
+	if messageRequestID != "" {
+		if apiServer.completedRequestIDs == nil {
+			apiServer.completedRequestIDs = make(map[string]bool)
+		}
+		if apiServer.completedRequestIDs[messageRequestID] {
+			apiServer.contextMappingsMutex.Unlock()
+			log.Warn().
+				Str("helix_session_id", helixSessionID).
+				Str("request_id", messageRequestID).
+				Msg("⚠️ [HELIX] Duplicate message_completed for already-processed request_id — ignoring")
+			return nil
+		}
+		apiServer.completedRequestIDs[messageRequestID] = true
+	}
+
 	// Try to find the interaction via request_id → interaction_id mapping
 	if messageRequestID != "" {
 		if mappedID, ok := apiServer.requestToInteractionMapping[messageRequestID]; ok {


### PR DESCRIPTION
## Summary

The ZE2E test (`zed-e2e-test` on amd64) was failing intermittently with two errors for the `claude` agent:

1. **FAIL: Phase 8: No message_completed for req-phase8-interrupt-claude**
2. **ISOLATION VIOLATION: Interaction X contains message_id "1" which belongs to earlier interaction Y**

## Root cause

Claude Code (via the Anthropic API) occasionally sends **two `message_completed` events** for the same `request_id` when an interrupt races with the cancelled turn's completion in phase 8 (mid-stream interrupt).

The second duplicate arrives after `requestToInteractionMapping[req-phase8-initial-claude]` has already been deleted by the first pass. It falls through to the DB fallback, finds the interrupt's **waiting** interaction (`int_01kntapc`), and incorrectly marks it complete — writing the initial turn's `response_entries` (containing `message_id "1"`) onto the interrupt's interaction. This is the isolation violation.

With `int_01kntapc` already marked complete, the real `message_completed` for `req-phase8-interrupt-claude` finds no waiting interaction and is skipped — hence "No message_completed for req-phase8-interrupt-claude".

The test was consistently passing for `zed-agent` (which doesn't double-fire) and intermittently failing for `claude`.

## Fix

Add a `completedRequestIDs` set (guarded by the existing `contextMappingsMutex`) and return early with a warning if a `request_id` has already been processed by `handleMessageCompleted`. No Zed binary change needed.

## Test plan
- [ ] ZE2E test passes for both `zed-agent` and `claude` agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)