### PR TITLE
fix: strip null bytes from prompt in createTaskFromPrompt

### DIFF
--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -57,6 +57,9 @@ func (s *HelixAPIServer) createTaskFromPrompt(w http.ResponseWriter, r *http.Req
 	req.UserID = user.ID
 	req.UserEmail = user.Email
 
+	// Strip null bytes that Postgres rejects (SQLSTATE 22021)
+	req.Prompt = strings.ReplaceAll(req.Prompt, "\x00", "")
+
 	// Validate request
 	if req.Prompt == "" {
 		http.Error(w, "prompt is required", http.StatusBadRequest)


### PR DESCRIPTION
## Summary

- Strips `\x00` null bytes from the prompt in `createTaskFromPrompt` before any DB write
- Postgres rejects strings containing null bytes with SQLSTATE 22021

A sibling fix (SQLSTATE 22P05) already landed for interaction fields — this covers the task creation endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)