### PR TITLE
fix: stopped sessions show as running on kanban

### DIFF
--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -278,7 +278,10 @@ func (s *HelixAPIServer) listTasks(w http.ResponseWriter, r *http.Request) {
 					// but RevDial hasn't connected yet, causing ScreenshotViewer 503 errors.
 					cfg := session.Metadata
 					if cfg.ContainerName != "" && s.externalAgentExecutor != nil {
-						if cfg.ExternalAgentStatus == "running" {
+						// Live-check the executor for "running" and "" (stopped-but-not-yet-labelled)
+						// sessions. Skip "starting" (RevDial not yet connected — upgrading it to
+						// "running" causes ScreenshotViewer 503s) and "stopped" (already terminal).
+						if cfg.ExternalAgentStatus == "running" || cfg.ExternalAgentStatus == "" {
 							_, err := s.externalAgentExecutor.GetSession(session.ID)
 							if err != nil {
 								cfg.ExternalAgentStatus = "stopped"


### PR DESCRIPTION
## Summary

- Stopped sessions were showing as "running" on the kanban board
- Root cause: `hydra_executor` clears `ExternalAgentStatus` to `""` (not `"stopped"`) when stopping, but leaves `ContainerName` set
- PR #2168 narrowed the live executor check to only fire when `ExternalAgentStatus == "running"`, so stopped sessions (status=`""`) skipped the check, fell through to `case hasContainer:` → `SandboxState = "running"`
- Detail page was correct because it reads session data directly, not via the `listTasks` path

## Fix

Also run the live-check when `ExternalAgentStatus == ""`. The executor detects the container is gone → sets status to `"stopped"` → kanban shows `"absent"`. `"starting"` continues to be excluded to avoid the RevDial-not-connected issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)