### PR TITLE
fix: idle checker kills just-restarted sessions immediately

### DIFF
--- a/api/pkg/store/store_desktop_idle_test.go
+++ b/api/pkg/store/store_desktop_idle_test.go
@@ -14,11 +14,13 @@ func (suite *PostgresStoreTestSuite) TestPostgresStore_ListIdleDesktops_ReturnsI
 	ctx := context.Background()
 	containerID := "container-idle-" + system.GenerateUUID()
 
+	// Both session and interaction must be older than the idle threshold
+	oldTime := time.Now().Add(-2 * time.Hour)
 	session := types.Session{
 		ID:      system.GenerateSessionID(),
 		Owner:   "user_id",
-		Created: time.Now(),
-		Updated: time.Now(),
+		Created: oldTime,
+		Updated: oldTime,
 		Metadata: types.SessionMetadata{
 			ExternalAgentStatus: "running",
 			DevContainerID:      containerID,
@@ -29,7 +31,6 @@ func (suite *PostgresStoreTestSuite) TestPostgresStore_ListIdleDesktops_ReturnsI
 	suite.T().Cleanup(func() { _, _ = suite.db.DeleteSession(ctx, session.ID) })
 
 	// Interaction updated 2 hours ago — outside the 1-hour threshold
-	oldTime := time.Now().Add(-2 * time.Hour)
 	interaction := &types.Interaction{
 		ID:           system.GenerateInteractionID(),
 		SessionID:    session.ID,

--- a/api/pkg/store/store_sessions.go
+++ b/api/pkg/store/store_sessions.go
@@ -353,7 +353,7 @@ func (s *PostgresStore) ListIdleDesktops(ctx context.Context, idleSince time.Tim
 WITH desktop_last_activity AS (
     SELECT
         s.config->>'dev_container_id' AS container_id,
-        COALESCE(MAX(i.updated), MAX(s.updated)) AS last_activity
+        GREATEST(COALESCE(MAX(i.updated), '1970-01-01'::timestamptz), MAX(s.updated)) AS last_activity
     FROM sessions s
     LEFT JOIN interactions i ON i.session_id = s.id
     WHERE s.deleted_at IS NULL


### PR DESCRIPTION
## Summary

- Restarting a stopped session gets immediately killed by the idle checker
- `ListIdleDesktops` used `COALESCE(MAX(i.updated), MAX(s.updated))` which only falls back to `s.updated` when there are zero interactions
- For sessions with old interactions, restarting updates `s.updated` but the query ignores it in favor of the stale `i.updated`

## Fix

`GREATEST(COALESCE(MAX(i.updated), '1970-01-01'), MAX(s.updated))` — whichever is more recent (last interaction or last session update) determines idleness. Starting a session gives a full idle window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)