### PR TITLE
Fix sandbox UI blank page caused by crypto.randomUUID in HTTP context

### DIFF
--- a/frontend/src/components/external-agent/DesktopStreamViewer.tsx
+++ b/frontend/src/components/external-agent/DesktopStreamViewer.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState, useCallback } from "react";
+import { v4 as uuidv4 } from "uuid";
 import {
   Box,
   Typography,
@@ -112,7 +113,7 @@ function getOrCreateStreamUUID(sessionId: string): string {
   const storageKey = `helix-stream-uuid-${sessionId}`;
   let id = sessionStorage.getItem(storageKey);
   if (!id) {
-    id = crypto.randomUUID();
+    id = uuidv4();
     sessionStorage.setItem(storageKey, id);
   }
   return id;


### PR DESCRIPTION
## Summary
Replace `crypto.randomUUID()` with `uuidv4()` from the `uuid` npm package in `DesktopStreamViewer.tsx`. The Web Crypto API's `randomUUID()` only works in secure contexts (HTTPS or localhost), so accessing the sandbox over plain HTTP throws `Uncaught TypeError: crypto.randomUUID is not a function`, crashing the React tree to a blank page.

## Changes
- Added `import { v4 as uuidv4 } from 'uuid'` to `DesktopStreamViewer.tsx`
- Replaced `crypto.randomUUID()` with `uuidv4()` in `getOrCreateStreamUUID()`
- No new dependencies — `uuid` v11.0.5 is already in `package.json` and used in 4 other files

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01knwv7cpa9fwsjek2nt644k36)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001759_sandbox-ui-renders-a/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001759_sandbox-ui-renders-a/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001759_sandbox-ui-renders-a/tasks.md)

🚀 Built with [Helix](https://helix.ml)