### PR TITLE
Fix controlplane crash when Kodit is enabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,8 @@ COPY --from=api-build-env /helix /helix
 COPY --from=ui-build-env /app/dist /www
 # Embedding model files for kodit code intelligence
 COPY --from=embedding-model /build/models/ /kodit-models/
+# ONNX Runtime library required by kodit's Hugot embedding provider (built with -tags ORT)
+COPY --from=tokenizers-lib /app/lib/libonnxruntime.so /usr/lib/
 
 ENV FRONTEND_URL=/www
 


### PR DESCRIPTION
## Summary
The production Docker image was missing `libonnxruntime.so`, causing a CrashLoopBackOff when `KODIT_ENABLED=true`. The binary is compiled with `-tags ORT` which requires this library at runtime, but the final image stage omitted the COPY from the `tokenizers-lib` build stage.

## Changes
- Added `COPY --from=tokenizers-lib /app/lib/libonnxruntime.so /usr/lib/` to the production image stage in `Dockerfile`

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01knwv6w4hr6whc9zqw9reys4e)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001758_controlplane-crash-on/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001758_controlplane-crash-on/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001758_controlplane-crash-on/tasks.md)

🚀 Built with [Helix](https://helix.ml)