### PR TITLE
Fix controlplane CrashLoopBackOff when Kodit is enabled (missing ORT library)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # - Copy tokenizers library for CGo
 COPY --from=tokenizers-lib /app/lib/libtokenizers.a /usr/lib/
 COPY --from=tokenizers-lib /app/lib/libonnxruntime.so /usr/lib/
+# Tell kodit where to find the ORT library (see production stage comment for details)
+ENV ORT_LIB_DIR=/usr/lib
 # - Copy embedding models for kodit code intelligence
 COPY --from=embedding-model /build/models/ /kodit-models/
 # - Copy the files and run a build to make startup faster
@@ -124,6 +126,10 @@ COPY --from=ui-build-env /app/dist /www
 COPY --from=embedding-model /build/models/ /kodit-models/
 # ONNX Runtime library required by kodit's Hugot embedding provider (built with -tags ORT)
 COPY --from=tokenizers-lib /app/lib/libonnxruntime.so /usr/lib/
+# Tell kodit where to find the ORT library. Without this, kodit's auto-detection
+# resolves to /lib (because the binary is at /helix → filepath.Dir = /) which
+# may fail depending on usrmerge symlink state and library availability.
+ENV ORT_LIB_DIR=/usr/lib
 
 ENV FRONTEND_URL=/www
 

--- a/api/pkg/server/kodit_init.go
+++ b/api/pkg/server/kodit_init.go
@@ -5,6 +5,7 @@ package server
 import (
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 
 	"github.com/helixml/helix/api/pkg/config"
@@ -76,6 +77,17 @@ func InitKodit(cfg *config.ServerConfig, gitRepoService *services.GitRepositoryS
 
 	// Pass helix's zerolog logger to kodit so log output is consistent.
 	koditOpts = append(koditOpts, kodit.WithLogger(log.Logger))
+
+	// Pre-flight: verify the ONNX Runtime shared library is present before
+	// attempting to create the kodit client. The hugot error is cryptic;
+	// this gives operators a clear, actionable message.
+	ortLibDir := os.Getenv("ORT_LIB_DIR")
+	if ortLibDir != "" {
+		ortPath := filepath.Join(ortLibDir, "libonnxruntime.so")
+		if _, err := os.Stat(ortPath); os.IsNotExist(err) {
+			return nil, fmt.Errorf("kodit is enabled but %s not found — ensure the container image was built with the ORT build stage (see Dockerfile)", ortPath)
+		}
+	}
 
 	koditClient, err := kodit.New(koditOpts...)
 	if err != nil {


### PR DESCRIPTION
## Summary
A fresh Helix deployment with `KODIT_ENABLED=true` crashes during startup because kodit's ORT library auto-detection resolves to `/lib/libonnxruntime.so` instead of `/usr/lib/libonnxruntime.so`. This happens because the binary sits at `/helix`, making `filepath.Dir("/helix")` = `/`, so the candidate path `/lib` is tried first. Setting `ORT_LIB_DIR=/usr/lib` explicitly bypasses this fragile auto-detection.

## Changes
- **Dockerfile**: Added `ENV ORT_LIB_DIR=/usr/lib` to both dev and production stages, ensuring kodit finds the ORT library at the canonical path where it's installed
- **api/pkg/server/kodit_init.go**: Added a pre-flight check that verifies the ORT library exists before attempting to initialize kodit, producing a clear actionable error message instead of the cryptic hugot error

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01knxvkcrb3xgv7e2x4gdh5yhh)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001762_a-fresh-helix-2923/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001762_a-fresh-helix-2923/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001762_a-fresh-helix-2923/tasks.md)

🚀 Built with [Helix](https://helix.ml)