### PR TITLE
chore: remove unused keycloak installation from kind_helm_install.sh

### DIFF
--- a/scripts/kind_helm_install.sh
+++ b/scripts/kind_helm_install.sh
@@ -9,7 +9,7 @@ USE_LOCAL_HELM_CHART=${USE_LOCAL_HELM_CHART:-""}
 # USE_EXTERNAL_POSTGRES=1 
 # This option is used to test the chart when using an external postgres instance.
 # The script will install an independent postgres instance using the official helm chart.
-# Both keycloak and helix will be configured to use the external postgres instance.
+# Helix will be configured to use the external postgres instance.
 USE_EXTERNAL_POSTGRES=${USE_EXTERNAL_POSTGRES:-""}
 
 # Function to check if a command is installed
@@ -103,41 +103,6 @@ EOF
   wait_for_pod_ready_with_label "cnpg.io/cluster=helix-external-postgres"
 fi
 
-
-HELM_VALUES_KEYCLOAK=()
-HELM_VALUES_KEYCLOAK+=("--set" "auth.adminUser=admin")
-HELM_VALUES_KEYCLOAK+=("--set" "auth.adminPassword=oh-hallo-insecure-password")
-HELM_VALUES_KEYCLOAK+=("--set" "httpRelativePath=/auth/")
-if [ -n "$USE_EXTERNAL_POSTGRES" ] && [ "$USE_EXTERNAL_POSTGRES" != "false" ] && [ "$USE_EXTERNAL_POSTGRES" != "" ]; then
-  HELM_VALUES_KEYCLOAK+=("--set" "postgresql.enabled=false")
-  HELM_VALUES_KEYCLOAK+=("--set" "externalDatabase.existingSecret=helix-external-postgres-app")
-  HELM_VALUES_KEYCLOAK+=("--set" "externalDatabase.existingSecretHostKey=host")
-  HELM_VALUES_KEYCLOAK+=("--set" "externalDatabase.existingSecretPortKey=port")
-  HELM_VALUES_KEYCLOAK+=("--set" "externalDatabase.existingSecretUserKey=user")
-  HELM_VALUES_KEYCLOAK+=("--set" "externalDatabase.existingSecretDatabaseKey=dbname")
-  HELM_VALUES_KEYCLOAK+=("--set" "externalDatabase.existingSecretPasswordKey=password")
-fi
-
-# Install Keycloak using Helm with official image
-helm upgrade --install keycloak oci://registry-1.docker.io/bitnamicharts/keycloak \
-  --version "24.3.1" \
-  "${HELM_VALUES_KEYCLOAK[@]}"
-
-# # TODO: This is OOMKilled on my machine. Likely best fix is to update the base image.
-# # Install Keycloak using Helm with custom Helix image
-# export KEYCLOAK_VERSION=${HELIX_VERSION:-$(curl -s https://get.helixml.tech/latest.txt)}
-# helm upgrade --install keycloak oci://registry-1.docker.io/bitnamicharts/keycloak \
-#   --set global.security.allowInsecureImages=true \
-#   --version "24.3.1" \
-#   --set auth.adminUser=admin \
-#   --set auth.adminPassword=oh-hallo-insecure-password \
-#   --set image.registry=ghcr.io \
-#   --set image.repository=helix/keycloak-bitnami \
-#   --set image.tag="${KEYCLOAK_VERSION}" \
-#   --set httpRelativePath="/auth/"
-
-wait_for_pod_ready_with_label "app.kubernetes.io/name=keycloak"
-
 if [ -n "$USE_LOCAL_HELM_CHART" ] && [ "$USE_LOCAL_HELM_CHART" != "false" ] && [ "$USE_LOCAL_HELM_CHART" != "" ]; then
   echo "Using local Helm chart..."
 
@@ -175,8 +140,6 @@ HELM_VALUES=()
 # Add base values
 HELM_VALUES+=("-f" "$DIR/values-example.yaml")
 HELM_VALUES+=("--set" "image.tag=${HELIX_VERSION}")
-HELM_VALUES+=("--set" "controlplane.keycloak.user=admin")
-HELM_VALUES+=("--set" "controlplane.keycloak.password=oh-hallo-insecure-password")
 
 if [ -n "$USE_EXTERNAL_POSTGRES" ] && [ "$USE_EXTERNAL_POSTGRES" != "false" ] && [ "$USE_EXTERNAL_POSTGRES" != "" ]; then
   HELM_VALUES+=("--set" "postgresql.enabled=false")


### PR DESCRIPTION
## Summary

Removed dead code from `scripts/kind_helm_install.sh` that was installing Keycloak but never actually using it. The helix-controlplane chart defaults to `authProvider: "regular"` and `keycloak.enabled: false`, so the keycloak helm install block and `--set controlplane.keycloak.user/password` flags were unnecessary.

- Removed keycloak helm install block (~40 lines)
- Removed `HELM_VALUES_KEYCLOAK` array and conditional logic
- Removed `wait_for_pod_ready_with_label keycloak` call
- Removed unused `--set controlplane.keycloak.user/password` flags
- Updated comment to reflect keycloak removal

## Testing

✅ Validated end-to-end: Fresh kind cluster install with edited script:
- No keycloak pods deployed
- All 6 helix pods reach Running (controlplane 2/2)
- Zero restarts
- Controlplane initialized successfully with kodit enabled
- Port-forward accessible at localhost:8090

Confirmed the libonnxruntime.so Dockerfile fix (from #2181) is working correctly in Kubernetes mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)