### PR TITLE
fix: UpdateSession must bump Updated timestamp to prevent idle kills

### DIFF
--- a/api/pkg/store/memorystore/memorystore.go
+++ b/api/pkg/store/memorystore/memorystore.go
@@ -103,6 +103,7 @@ func (m *MemoryStore) CreateSession(_ context.Context, session types.Session) (*
 func (m *MemoryStore) UpdateSession(_ context.Context, session types.Session) (*types.Session, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	session.Updated = time.Now()
 	cp := session
 	m.sessions[session.ID] = &cp
 	return &cp, nil

--- a/api/pkg/store/store_desktop_idle_test.go
+++ b/api/pkg/store/store_desktop_idle_test.go
@@ -157,3 +157,58 @@ func (suite *PostgresStoreTestSuite) TestPostgresStore_ListIdleDesktops_SkipsRec
 		suite.NotEqual(session.ID, s.ID, "recently created desktop with no interactions must not be returned")
 	}
 }
+
+// TestPostgresStore_ListIdleDesktops_SkipsRestartedSessionWithOldInteractions
+// verifies that restarting a stopped session (via UpdateSession) bumps the
+// Updated timestamp, preventing the idle checker from killing it immediately.
+// This is the exact scenario from the bug: a session with stale interactions
+// gets restarted → UpdateSession must bump s.updated so GREATEST picks the
+// fresh timestamp.
+func (suite *PostgresStoreTestSuite) TestPostgresStore_ListIdleDesktops_SkipsRestartedSessionWithOldInteractions() {
+	ctx := context.Background()
+	containerID := "container-restarted-" + system.GenerateUUID()
+
+	// Session created and last updated 3 hours ago (idle)
+	oldTime := time.Now().Add(-3 * time.Hour)
+	session := types.Session{
+		ID:      system.GenerateSessionID(),
+		Owner:   "user_id",
+		Created: oldTime,
+		Updated: oldTime,
+		Metadata: types.SessionMetadata{
+			ExternalAgentStatus: "stopped",
+			DevContainerID:      containerID,
+		},
+	}
+	_, err := suite.db.CreateSession(ctx, session)
+	suite.NoError(err)
+	suite.T().Cleanup(func() { _, _ = suite.db.DeleteSession(ctx, session.ID) })
+
+	// Old interaction from 3 hours ago
+	interaction := &types.Interaction{
+		ID:           system.GenerateInteractionID(),
+		SessionID:    session.ID,
+		GenerationID: 1,
+		UserID:       "user_id",
+		Created:      oldTime,
+		Updated:      oldTime,
+	}
+	_, err = suite.db.CreateInteraction(ctx, interaction)
+	suite.NoError(err)
+
+	// Simulate restart: read-modify-write via UpdateSession (like StartDesktop does)
+	dbSession, err := suite.db.GetSession(ctx, session.ID)
+	suite.NoError(err)
+	dbSession.Metadata.ExternalAgentStatus = "running"
+	_, err = suite.db.UpdateSession(ctx, *dbSession)
+	suite.NoError(err)
+
+	// The session was just restarted — it must NOT be considered idle
+	idleSince := time.Now().Add(-1 * time.Hour)
+	results, err := suite.db.ListIdleDesktops(ctx, idleSince)
+	suite.NoError(err)
+
+	for _, s := range results {
+		suite.NotEqual(session.ID, s.ID, "just-restarted desktop must not be returned as idle")
+	}
+}

--- a/api/pkg/store/store_sessions.go
+++ b/api/pkg/store/store_sessions.go
@@ -171,6 +171,13 @@ func (s *PostgresStore) UpdateSession(ctx context.Context, session types.Session
 		session.Name = string([]rune(session.Name)[:255])
 	}
 
+	// Always bump the updated timestamp. The field is named "Updated" (not
+	// "UpdatedAt") so GORM doesn't auto-update it. Without this, callers
+	// that read-modify-write a session (e.g. StartDesktop) silently
+	// preserve the old timestamp, which causes the idle checker to
+	// immediately kill just-restarted sessions.
+	session.Updated = time.Now()
+
 	// Log session metadata before update
 	ragResultsCount := 0
 	if session.Metadata.SessionRAGResults != nil {


### PR DESCRIPTION
## Summary

- PR #2179 fixed the idle checker SQL to use `GREATEST(interaction, session)` timestamps, but the fix relied on `s.updated` being bumped when a session is restarted — it isn't
- `Session.Updated` is named `Updated` (not `UpdatedAt`), so GORM has no auto-update behavior
- `StartDesktop` does read-modify-write (`GetSession` → modify metadata → `Save`), which writes back the **original** `Updated` value from the DB
- Result: a session last updated 3 hours ago gets restarted, `Updated` stays 3 hours ago, idle checker kills it on the next tick

## Fix

- `UpdateSession` now always sets `session.Updated = time.Now()` before `Save`
- Same fix applied to the in-memory store (used in E2E tests)
- New test covers the exact restart-with-old-interactions scenario

## Test plan

- [ ] New test `TestPostgresStore_ListIdleDesktops_SkipsRestartedSessionWithOldInteractions` passes in CI
- [ ] Existing idle checker tests still pass
- [ ] Manual: restart a stopped session, verify it survives the idle checker for the full timeout period

🤖 Generated with [Claude Code](https://claude.com/claude-code)