### PR TITLE
fix: treat terminated_idle as absent in listTasks sandbox state

### DIFF
--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -294,7 +294,7 @@ func (s *HelixAPIServer) listTasks(w http.ResponseWriter, r *http.Request) {
 					status := cfg.ExternalAgentStatus
 					hasContainer := cfg.ContainerName != ""
 					switch {
-					case status == "stopped":
+					case status == "stopped" || status == "terminated_idle":
 						task.SandboxState = "absent"
 					case status == "starting":
 						task.SandboxState = "starting"


### PR DESCRIPTION
## Summary
- The `listTasks` handler's switch statement didn't handle the `terminated_idle` status set by the idle checker, causing it to fall through to the `hasContainer` case and incorrectly report the sandbox as `"running"`
- Meanwhile the `getSession` handler does a fresh executor check and correctly returns `"stopped"`, so clicking into a task showed "Desktop Paused" while the Kanban card showed live screenshots
- Fix: treat `terminated_idle` the same as `stopped` → maps to `"absent"` sandbox state

## Test plan
- [x] Verified via API: `sandbox_state` for task `spt_01knr22cw8fx9pncdyfcg6w7aa` changed from `"running"` to `"absent"` after the fix
- [x] `go build ./api/pkg/server/` compiles cleanly
- [ ] Verify in browser: Kanban cards for idle-terminated tasks no longer show screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)