### PR TITLE
fix: recover interrupted interactions on Zed reconnect

### DIFF
--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -1447,6 +1447,29 @@ func (apiServer *HelixAPIServer) getOrCreateStreamingContext(ctx context.Context
 			}
 		}
 	}
+	// After an API restart, the most recent interaction may have been marked as
+	// "error"/"Interrupted" by ResetRunningInteractions. If Zed reconnects and
+	// resumes sending messages, recover by reusing that interaction — reset its
+	// state back to Waiting so it can continue accumulating responses.
+	if targetInteraction == nil && len(interactions) > 0 {
+		last := interactions[len(interactions)-1]
+		if last.State == types.InteractionStateError && last.Error == "Interrupted" {
+			last.State = types.InteractionStateWaiting
+			last.Error = ""
+			last.Completed = time.Time{}
+			if _, err := apiServer.Controller.Options.Store.UpdateInteraction(ctx, last); err != nil {
+				log.Error().Err(err).
+					Str("interaction_id", last.ID).
+					Msg("Failed to recover interrupted interaction")
+			} else {
+				log.Info().
+					Str("interaction_id", last.ID).
+					Str("session_id", helixSessionID).
+					Msg("🔄 [HELIX] Recovered interrupted interaction after API restart")
+			}
+			targetInteraction = last
+		}
+	}
 
 	// Set interactionID for tracking transitions
 	var newInteractionID string


### PR DESCRIPTION
## Summary
- When the API restarts, `ResetRunningInteractions` marks all `Waiting` interactions as `error`/`Interrupted`
- When Zed reconnects and resumes sending messages, `getOrCreateStreamingContext` couldn't find a `Waiting` interaction, so all messages were silently dropped
- Fix: if the most recent interaction was specifically marked "Interrupted" (not a real error), recover it by resetting state back to `Waiting` so Zed can continue writing to it

## Test plan
- [x] `go build ./pkg/server/` passes
- [ ] Verify on live system by restarting API while a session is active — the session should recover instead of showing "Error: Interrupted"

🤖 Generated with [Claude Code](https://claude.com/claude-code)