### PR TITLE
fix: reduce streaming DB write interval from 200ms to 5s

### DIFF
--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -51,7 +51,11 @@ const (
 	// Intermediate content is buffered in the streamingContext.
 	// Risk: up to dbWriteInterval of content lost on crash. Acceptable because
 	// message_completed always writes the final state, and Zed has the full content.
-	dbWriteInterval = 200 * time.Millisecond
+	// Note: long-running agent sessions can accumulate 10+ MB of response_entries.
+	// Each DB write replaces the entire JSONB blob (TOAST rewrite), so frequent
+	// writes cause massive autovacuum pressure. 5s keeps crash-loss minimal while
+	// reducing TOAST churn ~25x vs the previous 200ms interval.
+	dbWriteInterval = 5 * time.Second
 
 	// publishInterval is the minimum time between frontend pubsub events during streaming.
 	// Frontend batches to requestAnimationFrame (~16ms), so faster is wasted work.


### PR DESCRIPTION
## Summary
- Bump `dbWriteInterval` from 200ms to 5s to reduce PostgreSQL TOAST churn during streaming
- Long-running agent sessions accumulate 10+ MB of `response_entries` JSONB — each DB write replaces the entire blob, causing TOAST rewrites that generate millions of dead tuples
- On the current system: autovacuum was burning 100-200% CPU cleaning up 1.63M dead TOAST tuples in a 9 GB TOAST table, all from a single 12 MB interaction being written every 200ms
- Frontend is unaffected — it already receives real-time updates via WebSocket entry patches (50ms interval), not from DB polling
- Crash recovery impact: at most 5s of streamed content lost vs 200ms, and `message_completed` always writes the final state

## Test plan
- [x] `go build ./pkg/server/` passes
- [ ] Deploy and monitor Postgres CPU during active streaming session
- [ ] Verify frontend streaming is still smooth (should be identical — uses WebSocket patches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)