### PR TITLE
fix: defer response_entries marshal to DB write

### DIFF
--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -1662,9 +1662,11 @@ func (s *WebSocketSyncSuite) TestStreamingThrottle_DBWriteAfterInterval() {
 	s.server.streamingContextsMu.RUnlock()
 	sctx.mu.Lock()
 	s.True(sctx.dirty, "should be dirty after throttled write")
-	s.Equal("Token 1 Token 2", sctx.interaction.ResponseMessage)
+	// ResponseMessage is deferred to DB write, so it may still hold the
+	// first token's value. The accumulator always has the latest content.
+	s.Equal("Token 1 Token 2", sctx.accumulator.Content)
 	// Artificially expire the throttle interval
-	sctx.lastDBWrite = time.Now().Add(-300 * time.Millisecond)
+	sctx.lastDBWrite = time.Now().Add(-10 * time.Second)
 	sctx.mu.Unlock()
 
 	// Now expect another DB write since interval expired


### PR DESCRIPTION
## Summary
- Move `json.Marshal(acc.Entries())` + `json.Unmarshal` from the hot path (every message) into the DB write throttle block (every 5s)
- For a 16 MB interaction with 211 entries, this avoids serializing 16 MB of JSON multiple times per second when no DB write is happening
- Also added marshal in `flushAndClearStreamingContext` to ensure the final flush has up-to-date entries
- Frontend streaming unaffected — `publishEntryPatchesToFrontend` uses `acc.Entries()` directly, not the interaction's `ResponseEntries` field

Companion to https://github.com/helixml/helix/pull/2200 — together they reduce streaming DB pressure ~25x and eliminate unnecessary CPU burn from JSON serialization.

## Test plan
- [x] `go build ./pkg/server/` passes
- [ ] Deploy and verify API CPU drops during active streaming
- [ ] Verify streaming updates still appear in real-time in frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)