### PR TITLE
fix: large session performance — API truncation, skipInteractions, structured restore

### DIFF
--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -33,6 +33,7 @@ import (
 // @Tags    sessions
 // @Success 200 {object} types.Session
 // @Param id path string true "Session ID"
+// @Param skipInteractions query string false "Set to '1' to omit interactions from the response"
 // @Router /api/v1/sessions/{id} [get]
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) getSession(rw http.ResponseWriter, req *http.Request) {
@@ -100,32 +101,21 @@ func (apiServer *HelixAPIServer) getSession(rw http.ResponseWriter, req *http.Re
 		return
 	}
 
-	// Cache miss — load full interactions
-	interactions, _, err := apiServer.Store.ListInteractions(ctx, &types.ListInteractionsQuery{
-		SessionID:    id,
-		GenerationID: session.GenerationID,
-		PerPage:      1000,
-	})
-	if err != nil {
-		http.Error(rw, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	// Cap response_entries and strip redundant response_message to avoid
-	// sending multi-MB payloads. Same truncation as listInteractions.
-	const maxEntriesPerInteraction = 50
-	for _, interaction := range interactions {
-		if interaction.ResponseEntries != nil {
-			interaction.ResponseMessage = ""
-			var entries []json.RawMessage
-			if err := json.Unmarshal(interaction.ResponseEntries, &entries); err == nil && len(entries) > maxEntriesPerInteraction {
-				truncated := entries[len(entries)-maxEntriesPerInteraction:]
-				if truncatedJSON, err := json.Marshal(truncated); err == nil {
-					interaction.ResponseEntries = truncatedJSON
-				}
-			}
+	// Cache miss — load interactions unless caller opts out.
+	// EmbeddedSessionView passes skipInteractions=1 and fetches interactions
+	// separately via the paginated interactions endpoint.
+	if req.URL.Query().Get("skipInteractions") != "1" {
+		interactions, _, err := apiServer.Store.ListInteractions(ctx, &types.ListInteractionsQuery{
+			SessionID:    id,
+			GenerationID: session.GenerationID,
+			PerPage:      1000,
+		})
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
 		}
+		session.Interactions = interactions
 	}
-	session.Interactions = interactions
 	session.Metadata.ExternalAgentStatus = agentStatus
 
 	rw.Header().Set("Content-Type", "application/json")

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -110,6 +110,21 @@ func (apiServer *HelixAPIServer) getSession(rw http.ResponseWriter, req *http.Re
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	// Cap response_entries and strip redundant response_message to avoid
+	// sending multi-MB payloads. Same truncation as listInteractions.
+	const maxEntriesPerInteraction = 50
+	for _, interaction := range interactions {
+		if interaction.ResponseEntries != nil {
+			interaction.ResponseMessage = ""
+			var entries []json.RawMessage
+			if err := json.Unmarshal(interaction.ResponseEntries, &entries); err == nil && len(entries) > maxEntriesPerInteraction {
+				truncated := entries[len(entries)-maxEntriesPerInteraction:]
+				if truncatedJSON, err := json.Marshal(truncated); err == nil {
+					interaction.ResponseEntries = truncatedJSON
+				}
+			}
+		}
+	}
 	session.Interactions = interactions
 	session.Metadata.ExternalAgentStatus = agentStatus
 

--- a/api/pkg/server/session_interaction_handlers.go
+++ b/api/pkg/server/session_interaction_handlers.go
@@ -64,6 +64,27 @@ func (s *HelixAPIServer) listInteractions(_ http.ResponseWriter, req *http.Reque
 		return nil, system.NewHTTPError500(fmt.Sprintf("failed to get interactions for session %s, error: %s", id, err))
 	}
 
+	// Cap response_entries to the last 50 per interaction and strip the
+	// redundant flat response_message when entries exist. Long-running agent
+	// sessions can have 600+ entries per interaction (20+ MB of JSON).
+	// The frontend renders from response_entries and reconstructs the flat
+	// text for copy-to-clipboard from entries client-side.
+	const maxEntries = 50
+	for _, interaction := range interactions {
+		if interaction.ResponseEntries != nil {
+			// Strip the redundant flat string — frontend uses entries
+			interaction.ResponseMessage = ""
+
+			var entries []json.RawMessage
+			if err := json.Unmarshal(interaction.ResponseEntries, &entries); err == nil && len(entries) > maxEntries {
+				truncated := entries[len(entries)-maxEntries:]
+				if truncatedJSON, err := json.Marshal(truncated); err == nil {
+					interaction.ResponseEntries = truncatedJSON
+				}
+			}
+		}
+	}
+
 	totalPages := int(totalCount) / perPage
 	if int(totalCount)%perPage > 0 {
 		totalPages++

--- a/api/pkg/server/session_interaction_handlers.go
+++ b/api/pkg/server/session_interaction_handlers.go
@@ -82,7 +82,7 @@ func (s *HelixAPIServer) listInteractions(_ http.ResponseWriter, req *http.Reque
 				}
 				for i, entry := range entries {
 					if content, ok := entry["content"].(string); ok && len(content) > maxEntryContentLen {
-						entries[i]["content"] = content[len(content)-maxEntryContentLen:]
+						entries[i]["content"] = content[:maxEntryContentLen] + "\n\n[content truncated]"
 					}
 				}
 				if truncatedJSON, err := json.Marshal(entries); err == nil {

--- a/api/pkg/server/session_interaction_handlers.go
+++ b/api/pkg/server/session_interaction_handlers.go
@@ -64,21 +64,28 @@ func (s *HelixAPIServer) listInteractions(_ http.ResponseWriter, req *http.Reque
 		return nil, system.NewHTTPError500(fmt.Sprintf("failed to get interactions for session %s, error: %s", id, err))
 	}
 
-	// Cap response_entries to the last 50 per interaction and strip the
-	// redundant flat response_message when entries exist. Long-running agent
-	// sessions can have 600+ entries per interaction (20+ MB of JSON).
-	// The frontend renders from response_entries and reconstructs the flat
-	// text for copy-to-clipboard from entries client-side.
+	// Cap response_entries to avoid sending multi-MB payloads.
+	// - Strip redundant response_message when entries exist
+	// - Keep only the last 50 entries
+	// - Truncate individual entry content to 100 KB (a single 2.5 MB text
+	//   entry will kill the browser's markdown renderer)
 	const maxEntries = 50
+	const maxEntryContentLen = 100_000
 	for _, interaction := range interactions {
 		if interaction.ResponseEntries != nil {
-			// Strip the redundant flat string — frontend uses entries
 			interaction.ResponseMessage = ""
 
-			var entries []json.RawMessage
-			if err := json.Unmarshal(interaction.ResponseEntries, &entries); err == nil && len(entries) > maxEntries {
-				truncated := entries[len(entries)-maxEntries:]
-				if truncatedJSON, err := json.Marshal(truncated); err == nil {
+			var entries []map[string]interface{}
+			if err := json.Unmarshal(interaction.ResponseEntries, &entries); err == nil {
+				if len(entries) > maxEntries {
+					entries = entries[len(entries)-maxEntries:]
+				}
+				for i, entry := range entries {
+					if content, ok := entry["content"].(string); ok && len(content) > maxEntryContentLen {
+						entries[i]["content"] = content[len(content)-maxEntryContentLen:]
+					}
+				}
+				if truncatedJSON, err := json.Marshal(entries); err == nil {
 					interaction.ResponseEntries = truncatedJSON
 				}
 			}

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -1137,11 +1137,12 @@ func (apiServer *HelixAPIServer) handleMessageAdded(sessionID string, syncMsg *t
 			// Creating a new accumulator per call would lose this mapping because
 			// the DB only stores the joined Content string + LastMessageID/Offset.
 			if sctx.accumulator == nil {
-				sctx.accumulator = &wsprotocol.MessageAccumulator{
-					Content:       targetInteraction.ResponseMessage,
-					LastMessageID: targetInteraction.LastZedMessageID,
-					Offset:        targetInteraction.LastZedMessageOffset,
-				}
+				sctx.accumulator = wsprotocol.RestoreAccumulator(
+					targetInteraction.ResponseMessage,
+					targetInteraction.LastZedMessageID,
+					targetInteraction.LastZedMessageOffset,
+					targetInteraction.ResponseEntries,
+				)
 			}
 			acc := sctx.accumulator
 			prevMessageID := acc.LastMessageID

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -407,7 +407,7 @@ func (s *WebSocketSyncSuite) TestMessageAdded_AssistantNewMessageID_MultiEntry()
 	}
 	s.store.EXPECT().GetSession(gomock.Any(), "ses_3").Return(session, nil)
 
-	// Interaction already has content from msg-A
+	// Interaction already has content from msg-A (with structured entries)
 	existingInteraction := &types.Interaction{
 		ID:                   "int-3",
 		SessionID:            "ses_3",
@@ -415,6 +415,7 @@ func (s *WebSocketSyncSuite) TestMessageAdded_AssistantNewMessageID_MultiEntry()
 		ResponseMessage:      "First message",
 		LastZedMessageID:     "msg-A",
 		LastZedMessageOffset: 0,
+		ResponseEntries:      []byte(`[{"type":"text","content":"First message","message_id":"msg-A"}]`),
 	}
 	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
 		[]*types.Interaction{existingInteraction}, int64(1), nil,

--- a/api/pkg/server/wsprotocol/accumulator.go
+++ b/api/pkg/server/wsprotocol/accumulator.go
@@ -50,8 +50,7 @@ func RestoreAccumulator(content string, lastMessageID string, offset int, respon
 		}
 	}
 
-	// No structured entries — start fresh. The old flat Content is discarded
-	// rather than creating a __prefix__ blob that loses type information.
+	// No structured entries — start fresh.
 	return &MessageAccumulator{}
 }
 

--- a/api/pkg/server/wsprotocol/accumulator.go
+++ b/api/pkg/server/wsprotocol/accumulator.go
@@ -1,10 +1,59 @@
 package wsprotocol
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/helixml/helix/api/pkg/util/sanitize"
+	"gorm.io/datatypes"
 )
+
+// RestoreAccumulator rebuilds an accumulator from persisted DB state.
+// If structured response_entries are available, it restores the full
+// message_id→content map with correct types. Otherwise falls back to
+// the legacy Content/LastMessageID/Offset restore which loses structure.
+func RestoreAccumulator(content string, lastMessageID string, offset int, responseEntries datatypes.JSON) *MessageAccumulator {
+	// Try structured restore from response_entries
+	if len(responseEntries) > 0 {
+		var entries []ResponseEntry
+		if err := json.Unmarshal(responseEntries, &entries); err == nil && len(entries) > 0 {
+			acc := &MessageAccumulator{
+				Content:        content,
+				LastMessageID:  lastMessageID,
+				Offset:         offset,
+				contentDirty:   false,
+				messageOrder:   make([]string, 0, len(entries)),
+				messageContent: make(map[string]string, len(entries)),
+				messageType:    make(map[string]string, len(entries)),
+				messageToolName:   make(map[string]string),
+				messageToolStatus: make(map[string]string),
+			}
+			for _, entry := range entries {
+				id := entry.MessageID
+				if id == "" {
+					continue
+				}
+				acc.messageOrder = append(acc.messageOrder, id)
+				acc.messageContent[id] = entry.Content
+				acc.messageType[id] = entry.Type
+				if entry.ToolName != "" {
+					acc.messageToolName[id] = entry.ToolName
+				}
+				if entry.ToolStatus != "" {
+					acc.messageToolStatus[id] = entry.ToolStatus
+				}
+			}
+			if lastMessageID == "" && len(acc.messageOrder) > 0 {
+				acc.LastMessageID = acc.messageOrder[len(acc.messageOrder)-1]
+			}
+			return acc
+		}
+	}
+
+	// No structured entries — start fresh. The old flat Content is discarded
+	// rather than creating a __prefix__ blob that loses type information.
+	return &MessageAccumulator{}
+}
 
 // ResponseEntry represents a single typed entry in the response.
 // Used to preserve the structural boundary between assistant text and tool calls.
@@ -89,23 +138,6 @@ func (a *MessageAccumulator) AddMessageWithToolInfo(messageID, content, entryTyp
 	}
 	if a.messageToolStatus == nil {
 		a.messageToolStatus = make(map[string]string)
-	}
-
-	// Migrate legacy state: if we have Content but no messageOrder, this
-	// accumulator was restored from DB (only LastMessageID/Offset persisted).
-	// Treat the existing Content as belonging to LastMessageID so we don't
-	// lose it. This only runs once on first AddMessage after restore.
-	if len(a.messageOrder) == 0 && a.Content != "" && a.LastMessageID != "" {
-		a.messageOrder = []string{a.LastMessageID}
-		a.messageContent[a.LastMessageID] = a.Content[a.Offset:]
-		if a.Offset > 2 {
-			// There was a prefix before this message. We can't recover individual
-			// message_ids for the prefix, so store it under a synthetic key that
-			// sorts before any real message_id.
-			const prefixKey = "\x00__prefix__"
-			a.messageOrder = append([]string{prefixKey}, a.messageOrder...)
-			a.messageContent[prefixKey] = a.Content[:a.Offset-2] // subtract "\n\n"
-		}
 	}
 
 	if _, exists := a.messageContent[messageID]; exists {

--- a/api/pkg/server/wsprotocol/accumulator_test.go
+++ b/api/pkg/server/wsprotocol/accumulator_test.go
@@ -316,19 +316,21 @@ func TestEntriesStreamingGrowth(t *testing.T) {
 }
 
 func TestResumeFromPersistedState(t *testing.T) {
-	// Simulate restoring state from DB after API restart
-	a := &MessageAccumulator{
-		Content:       "Previous message\n\nStreaming...",
-		LastMessageID: "msg-2",
-		Offset:        len("Previous message") + 2,
-	}
+	// Simulate restoring state from DB after API restart using structured entries
+	entries := []byte(`[{"type":"text","content":"Previous message","message_id":"msg-1"},{"type":"text","content":"Streaming...","message_id":"msg-2"}]`)
+	a := RestoreAccumulator(
+		"Previous message\n\nStreaming...",
+		"msg-2",
+		len("Previous message")+2,
+		entries,
+	)
 
 	// Continue streaming msg-2
 	a.AddMessage("msg-2", "Streaming complete")
 
 	expected := "Previous message\n\nStreaming complete"
 	a.Rebuild()
-	if a.Content !=expected {
+	if a.Content != expected {
 		t.Errorf("expected %q, got %q", expected, a.Content)
 	}
 
@@ -337,7 +339,7 @@ func TestResumeFromPersistedState(t *testing.T) {
 
 	expected = "Previous message\n\nStreaming complete\n\nFinal"
 	a.Rebuild()
-	if a.Content !=expected {
+	if a.Content != expected {
 		t.Errorf("expected %q, got %q", expected, a.Content)
 	}
 }

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1035,6 +1035,7 @@ export interface ServerKoditFileResultDTO {
   language?: string;
   lines?: string;
   links?: Record<string, string>;
+  page?: number;
   path?: string;
   preview?: string;
   score?: number;
@@ -8700,6 +8701,34 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
+     * @description Rasterizes a document page (PDF, etc.) and returns it as a PNG image
+     *
+     * @tags git-repositories
+     * @name V1GitRepositoriesPageImageDetail
+     * @summary Render document page image
+     * @request GET:/api/v1/git/repositories/{id}/page-image
+     * @secure
+     */
+    v1GitRepositoriesPageImageDetail: (
+      id: string,
+      query: {
+        /** File path within the repository */
+        path: string;
+        /** 1-based page number */
+        page: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<File, TypesAPIError>({
+        path: `/api/v1/git/repositories/${id}/page-image`,
+        method: "GET",
+        query: query,
+        secure: true,
+        format: "blob",
+        ...params,
+      }),
+
+    /**
      * @description Pulls latest commits from remote repository
      *
      * @tags git-repositories
@@ -8922,6 +8951,34 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     ) =>
       this.request<TypesGitRepositoryTreeResponse, TypesAPIError>({
         path: `/api/v1/git/repositories/${id}/tree`,
+        method: "GET",
+        query: query,
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Search document pages (PDFs, etc.) using cross-modal visual similarity
+     *
+     * @tags git-repositories
+     * @name V1GitRepositoriesVisualSearchDetail
+     * @summary Visual search repository
+     * @request GET:/api/v1/git/repositories/{id}/visual-search
+     * @secure
+     */
+    v1GitRepositoriesVisualSearchDetail: (
+      id: string,
+      query: {
+        /** Natural language search query */
+        query: string;
+        /** Maximum results (default 10, max 100) */
+        limit?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<ServerKoditSearchResponse, TypesAPIError>({
+        path: `/api/v1/git/repositories/${id}/visual-search`,
         method: "GET",
         query: query,
         secure: true,
@@ -11840,10 +11897,18 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @request GET:/api/v1/sessions/{id}
      * @secure
      */
-    v1SessionsDetail: (id: string, params: RequestParams = {}) =>
+    v1SessionsDetail: (
+      id: string,
+      query?: {
+        /** Set to '1' to omit interactions from the response */
+        skipInteractions?: string;
+      },
+      params: RequestParams = {},
+    ) =>
       this.request<TypesSession, any>({
         path: `/api/v1/sessions/${id}`,
         method: "GET",
+        query: query,
         secure: true,
         ...params,
       }),

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -18,8 +18,10 @@ import { useQueryClient } from "@tanstack/react-query";
 // DEBUG: Set to true to show scroll debug overlay
 const DEBUG_SCROLL = false;
 
-// Number of interactions to render initially (and per "load more" click)
-const INTERACTIONS_TO_RENDER = 20;
+// Number of interactions to render initially (and per "load more" click).
+// Keep this low — long-running agent sessions can have interactions with
+// hundreds of entries, each rendered as a Markdown component.
+const INTERACTIONS_TO_RENDER = 5;
 
 import Interaction from "./Interaction";
 import InteractionLiveStream from "./InteractionLiveStream";

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -262,6 +262,7 @@ const EmbeddedSessionView = forwardRef<
     {
       enabled: !!sessionId,
       refetchInterval: wsConnected ? false : 3000,
+      skipInteractions: true,
     },
   );
 

--- a/frontend/src/components/session/Interaction.tsx
+++ b/frontend/src/components/session/Interaction.tsx
@@ -130,9 +130,17 @@ export const Interaction: FC<InteractionProps> = ({
       }
     }
 
-    // Extract assistant response from response_message
+    // Extract assistant response from response_message, or derive from
+    // response_entries when the API strips the redundant flat string.
     if (interaction?.response_message) {
       assistantMessage = interaction.response_message;
+    } else if ((interaction as any)?.response_entries?.length > 0) {
+      // Reconstruct flat text from entries for display guards and copy
+      const entries = (interaction as any).response_entries as Array<{ type: string; content: string }>;
+      assistantMessage = entries
+        .filter((e) => e.type === "text")
+        .map((e) => e.content)
+        .join("\n\n");
     }
 
     // Check for images in content

--- a/frontend/src/components/session/Interaction.tsx
+++ b/frontend/src/components/session/Interaction.tsx
@@ -130,17 +130,9 @@ export const Interaction: FC<InteractionProps> = ({
       }
     }
 
-    // Extract assistant response from response_message, or derive from
-    // response_entries when the API strips the redundant flat string.
+    // Extract assistant response from response_message
     if (interaction?.response_message) {
       assistantMessage = interaction.response_message;
-    } else if ((interaction as any)?.response_entries?.length > 0) {
-      // Reconstruct flat text from entries for display guards and copy
-      const entries = (interaction as any).response_entries as Array<{ type: string; content: string }>;
-      assistantMessage = entries
-        .filter((e) => e.type === "text")
-        .map((e) => e.content)
-        .join("\n\n");
     }
 
     // Check for images in content
@@ -275,7 +267,7 @@ export const Interaction: FC<InteractionProps> = ({
       )}
 
       {/* Assistant Response Container */}
-      {(assistantMessage || isLive) && (
+      {(assistantMessage || (interaction as any)?.response_entries?.length > 0 || isLive) && (
         <Box
           sx={{
             display: "flex",

--- a/frontend/src/components/session/InteractionInference.tsx
+++ b/frontend/src/components/session/InteractionInference.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useEffect } from "react";
+import React, { FC, useState, useEffect, useMemo } from "react";
 import { styled } from "@mui/system";
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
@@ -267,6 +267,18 @@ export const InteractionInference: FC<{
       },
     }));
 
+  // Derive copy text from response_entries when response_message is empty
+  // (the API strips it to save bandwidth when entries exist)
+  const copyText = useMemo(() => {
+    if (message) return message;
+    const entries = (interaction as any)?.response_entries as ResponseEntry[] | undefined;
+    if (!entries || entries.length === 0) return "";
+    return entries
+      .filter((e: ResponseEntry) => e.type === "text")
+      .map((e: ResponseEntry) => e.content)
+      .join("\n\n");
+  }, [message, interaction]);
+
   if (!serverConfig || !serverConfig.filestore_prefix) return null;
   if (!interaction) return null;
 
@@ -416,7 +428,7 @@ export const InteractionInference: FC<{
                       </Tooltip>
 
                       <CopyButtonWithCheck
-                        text={message || ""}
+                        text={copyText}
                         alwaysVisible={isLastInteraction}
                       />
 

--- a/frontend/src/components/session/InteractionInference.tsx
+++ b/frontend/src/components/session/InteractionInference.tsx
@@ -318,7 +318,7 @@ export const InteractionInference: FC<{
       {toolSteps.length > 0 && isFromAssistant && (
         <ToolStepsWidget steps={toolSteps} />
       )}
-      {message && (
+      {(message || (interaction as any)?.response_entries?.length > 0) && (
         <Box
           sx={{
             my: 0.5,

--- a/frontend/src/services/sessionService.ts
+++ b/frontend/src/services/sessionService.ts
@@ -45,13 +45,17 @@ export function useListSessionSteps(sessionId: string, options?: { enabled?: boo
   })
 }
 
-export function useGetSession(sessionId: string, options?: { enabled?: boolean; refetchInterval?: number | false }) {
+export function useGetSession(sessionId: string, options?: { enabled?: boolean; refetchInterval?: number | false; skipInteractions?: boolean }) {
   const api = useApi()
   const apiClient = api.getApiClient()
+  const skipInteractions = options?.skipInteractions ?? false
 
   return useQuery({
-    queryKey: GET_SESSION_QUERY_KEY(sessionId),
-    queryFn: () => apiClient.v1SessionsDetail(sessionId),
+    queryKey: [...GET_SESSION_QUERY_KEY(sessionId), skipInteractions ? 'skip' : 'full'],
+    queryFn: () => apiClient.v1SessionsDetail(
+      sessionId,
+      skipInteractions ? { skipInteractions: '1' } : undefined,
+    ),
     enabled: options?.enabled ?? true,
     refetchInterval: options?.refetchInterval,
     // Prevent immediate refetches when multiple consumers share this query.


### PR DESCRIPTION
## Summary
Fixes browser hang and massive API payloads for long-running agent sessions (500+ entries, 20+ MB interactions).

**API changes:**
- Add `skipInteractions` query param to `GET /api/v1/sessions/{id}` — skips loading interactions entirely (50 MB → ~5 KB)
- Cap `response_entries` to last 50 per interaction in list endpoint
- Truncate individual entry content to 100 KB (single 2.5 MB thinking blocks were killing the markdown renderer)
- Strip redundant `response_message` when `response_entries` exists (42 MB → 427 KB)

**Frontend changes:**
- `EmbeddedSessionView` uses `skipInteractions=1` and fetches interactions via paginated endpoint
- Reduce initial interactions from 20 to 5
- Fix display guards to check `response_entries` length when `response_message` is stripped
- Fix copy button to reconstruct text from entries

**Accumulator changes:**
- Restore from structured `response_entries` instead of flat `response_message` string
- Remove legacy `__prefix__` migration that corrupted tool call rendering after API restarts

## Test plan
- [x] `go build ./pkg/server/` passes
- [x] All `TestWebSocketSyncSuite` tests pass (46/46)
- [x] All accumulator tests pass (18/18)
- [x] `yarn build` passes
- [ ] Load large session in browser — should render instantly instead of hanging
- [ ] Verify tool calls render correctly after API restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)