### PR TITLE
fix: switch Ubuntu mirrors to GB mirrors in all Dockerfiles

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -32,6 +32,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # Pin to specific digest for stable layer caching.
 # Update digest when intentionally upgrading Ubuntu version.
 FROM ubuntu:25.04 AS sandbox
+RUN sed -i 's|http://archive.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://security.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://ports.ubuntu.com|http://gb.ports.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 
 # Configure default user and set env (from GOW base)
 ENV \

--- a/Dockerfile.sway-helix
+++ b/Dockerfile.sway-helix
@@ -17,6 +17,7 @@
 # Ubuntu's grim package is compiled without libjpeg, so we build from source
 # to enable JPEG output for smaller screenshots (100KB JPEG vs 300KB PNG)
 FROM ubuntu:25.10 AS grim-build
+RUN sed -i 's|http://archive.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://security.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://ports.ubuntu.com|http://gb.ports.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 RUN apt-get update && apt-get install -y \
     meson ninja-build pkg-config git \
     libwayland-dev libcairo-dev libjpeg-turbo8-dev libpng-dev \
@@ -74,6 +75,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # On macOS ARM64 VMs: CUDA not used, encoding happens on host via VideoToolbox
 # Enable with HELIX_VIDEO_MODE=zerocopy
 FROM ubuntu:25.10 AS rust-build-env
+RUN sed -i 's|http://archive.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://security.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://ports.ubuntu.com|http://gb.ports.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 WORKDIR /build
 
 ARG TARGETARCH
@@ -136,6 +138,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 #
 # Required for ext-image-copy-capture-v1 protocol (Sway 1.11 needs wlroots 0.19)
 FROM ubuntu:25.10 AS wlroots-build
+RUN sed -i 's|http://archive.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://security.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://ports.ubuntu.com|http://gb.ports.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /build
@@ -191,6 +194,7 @@ RUN cd wlroots && \
 # Build Sway 1.11 from source against wlroots 0.19.0
 # Required for ext-image-copy-capture-v1 protocol support
 FROM ubuntu:25.10 AS sway-build
+RUN sed -i 's|http://archive.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://security.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://ports.ubuntu.com|http://gb.ports.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /build
@@ -263,6 +267,7 @@ RUN if [ "${TARGETARCH}" = "arm64" ]; then LIB_TRIPLE="aarch64-linux-gnu"; else 
 # Sway Desktop - Ubuntu 25.10 base with minimal GOW
 # ====================================================================
 FROM ubuntu:25.10
+RUN sed -i 's|http://archive.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://security.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://ports.ubuntu.com|http://gb.ports.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 
 # Configure default user and set env (from GOW base-app)
 ENV \

--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -74,6 +74,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # Uses TARGETARCH to build the right plugins for the current platform.
 # No --platform directive, so this works on any CI runner architecture.
 FROM ubuntu:25.10 AS rust-build-env
+RUN sed -i 's|http://archive.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://security.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://ports.ubuntu.com|http://gb.ports.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 ARG TARGETARCH
 WORKDIR /build
 
@@ -182,6 +183,7 @@ RUN if [ -f /usr/local/cuda/lib64/libnvrtc.so.12 ]; then \
 # The headless bridge uses GStreamer's pipewiresrc + waylandsink for
 # zero-copy DMA-BUF transfer from GNOME screen-cast to Wolf.
 FROM ubuntu:25.10
+RUN sed -i 's|http://archive.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://security.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://ports.ubuntu.com|http://gb.ports.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 
 # Configure default user and set env (from GOW base-app)
 ENV \

--- a/Dockerfile.zed-build
+++ b/Dockerfile.zed-build
@@ -13,6 +13,7 @@
 
 # --- Stage 1: Build environment (deps + rustup, no source or compilation) ---
 FROM ubuntu:25.10 AS builder-env
+RUN sed -i 's|http://archive.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://security.ubuntu.com|http://gb.archive.ubuntu.com|g; s|http://ports.ubuntu.com|http://gb.ports.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Summary
- Default Ubuntu mirrors (archive.ubuntu.com, security.ubuntu.com, ports.ubuntu.com) are broken/unreliable
- Switch all 9 Ubuntu-based build stages across 4 Dockerfiles to GB mirrors (gb.archive.ubuntu.com, gb.ports.ubuntu.com)
- Affects: Dockerfile.ubuntu-helix (2 stages), Dockerfile.sway-helix (5 stages), Dockerfile.zed-build (1 stage), Dockerfile.sandbox (1 stage)
- Debian-based images (main API Dockerfile, runner, haystack) are unaffected — they use deb.debian.org

## Test plan
- [ ] `./stack build-ubuntu` completes without apt-get 404 errors
- [ ] `./stack build-sandbox` completes without apt-get 404 errors
- [ ] `./stack build-zed` completes without apt-get 404 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)