### PR TITLE
fix: stop rewriting ports.ubuntu.com — Oxford mirror lacks arm64 packages

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -32,7 +32,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # Pin to specific digest for stable layer caching.
 # Update digest when intentionally upgrading Ubuntu version.
 FROM ubuntu:25.04 AS sandbox
-RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://ports.ubuntu.com/ubuntu-ports|http://mirror.ox.ac.uk/sites/archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 
 # Configure default user and set env (from GOW base)
 ENV \

--- a/Dockerfile.sway-helix
+++ b/Dockerfile.sway-helix
@@ -17,7 +17,7 @@
 # Ubuntu's grim package is compiled without libjpeg, so we build from source
 # to enable JPEG output for smaller screenshots (100KB JPEG vs 300KB PNG)
 FROM ubuntu:25.10 AS grim-build
-RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://ports.ubuntu.com/ubuntu-ports|http://mirror.ox.ac.uk/sites/archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 RUN apt-get update && apt-get install -y \
     meson ninja-build pkg-config git \
     libwayland-dev libcairo-dev libjpeg-turbo8-dev libpng-dev \
@@ -75,7 +75,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # On macOS ARM64 VMs: CUDA not used, encoding happens on host via VideoToolbox
 # Enable with HELIX_VIDEO_MODE=zerocopy
 FROM ubuntu:25.10 AS rust-build-env
-RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://ports.ubuntu.com/ubuntu-ports|http://mirror.ox.ac.uk/sites/archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 WORKDIR /build
 
 ARG TARGETARCH
@@ -138,7 +138,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 #
 # Required for ext-image-copy-capture-v1 protocol (Sway 1.11 needs wlroots 0.19)
 FROM ubuntu:25.10 AS wlroots-build
-RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://ports.ubuntu.com/ubuntu-ports|http://mirror.ox.ac.uk/sites/archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /build
@@ -194,7 +194,7 @@ RUN cd wlroots && \
 # Build Sway 1.11 from source against wlroots 0.19.0
 # Required for ext-image-copy-capture-v1 protocol support
 FROM ubuntu:25.10 AS sway-build
-RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://ports.ubuntu.com/ubuntu-ports|http://mirror.ox.ac.uk/sites/archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /build
@@ -267,7 +267,7 @@ RUN if [ "${TARGETARCH}" = "arm64" ]; then LIB_TRIPLE="aarch64-linux-gnu"; else 
 # Sway Desktop - Ubuntu 25.10 base with minimal GOW
 # ====================================================================
 FROM ubuntu:25.10
-RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://ports.ubuntu.com/ubuntu-ports|http://mirror.ox.ac.uk/sites/archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 
 # Configure default user and set env (from GOW base-app)
 ENV \

--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -74,7 +74,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # Uses TARGETARCH to build the right plugins for the current platform.
 # No --platform directive, so this works on any CI runner architecture.
 FROM ubuntu:25.10 AS rust-build-env
-RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://ports.ubuntu.com/ubuntu-ports|http://mirror.ox.ac.uk/sites/archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 ARG TARGETARCH
 WORKDIR /build
 
@@ -183,7 +183,7 @@ RUN if [ -f /usr/local/cuda/lib64/libnvrtc.so.12 ]; then \
 # The headless bridge uses GStreamer's pipewiresrc + waylandsink for
 # zero-copy DMA-BUF transfer from GNOME screen-cast to Wolf.
 FROM ubuntu:25.10
-RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://ports.ubuntu.com/ubuntu-ports|http://mirror.ox.ac.uk/sites/archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 
 # Configure default user and set env (from GOW base-app)
 ENV \

--- a/Dockerfile.zed-build
+++ b/Dockerfile.zed-build
@@ -13,7 +13,7 @@
 
 # --- Stage 1: Build environment (deps + rustup, no source or compilation) ---
 FROM ubuntu:25.10 AS builder-env
-RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://ports.ubuntu.com/ubuntu-ports|http://mirror.ox.ac.uk/sites/archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
+RUN sed -i 's|http://archive.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g; s|http://security.ubuntu.com|http://mirror.ox.ac.uk/sites/archive.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Summary
- Oxford's `archive.ubuntu.com` mirror has `InRelease` metadata for arm64 but **not the actual `Packages` files**, causing `apt-get update` to fail on arm64 CI runners (see build 625 step 16/6)
- The canonical `ports.ubuntu.com` is working fine — only `archive.ubuntu.com` and `security.ubuntu.com` need the Oxford redirect
- Removes the `ports.ubuntu.com` → Oxford rewrite from all 9 sed commands across 4 Dockerfiles

## Test plan
- [ ] arm64 sandbox build (`Dockerfile.sandbox`) passes `apt-get update`
- [ ] amd64 builds still use Oxford mirror successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)