### PR TITLE
fix: release-rollback step fails at pip3 install awscli

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2766,7 +2766,7 @@ trigger:
 
 steps:
   - name: rollback-release
-    image: google/cloud-sdk:slim
+    image: golang:1.25-bookworm
     environment:
       GITHUB_TOKEN:
         from_secret: github_token
@@ -2779,14 +2779,16 @@ steps:
       SLACK_WEBHOOK_URL:
         from_secret: JANITOR_SLACK_WEBHOOK_URL
     commands:
-      - apt-get update -qq && apt-get install -y -qq curl jq > /dev/null
-      # Install gh CLI
+      # Add gh CLI apt repo
       - curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
-      - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-      - apt-get update -qq && apt-get install -y -qq gh > /dev/null
-      # Install helm
-      - curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash > /dev/null 2>&1
-      # Install awscli
-      - pip3 install -q awscli 2>/dev/null
+      - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
+      # Add Google Cloud SDK apt repo (for gsutil used by the helm rollback path)
+      - curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+      - echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list
+      # Install tooling (awscli and jq from Debian, gh + gcloud from added repos)
+      - apt-get update -qq
+      - apt-get install -y -qq jq awscli gh google-cloud-cli > /dev/null
+      # Install helm (not packaged in Debian)
+      - curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash > /dev/null
       # Run rollback
       - scripts/release-rollback.sh "$DRONE_TAG"


### PR DESCRIPTION
## Summary

- `release-rollback` step silently failed at `pip3 install -q awscli 2>/dev/null` on [build 612](https://drone.lukemarsden.net/helixml/helix/612/19/2) (tag `2.9.27`). The base image `google/cloud-sdk:slim` is Debian bookworm, which enforces PEP 668 and blocks system-wide pip installs; `2>/dev/null` hid the error. `scripts/release-rollback.sh` never ran.
- Swap to `golang:1.25-bookworm` — same image already used 5× elsewhere in `.drone.yml`, so it's cached on the runners. Install `awscli`, `jq`, `gh`, and `google-cloud-cli` via apt (no pip). Add the Google Cloud SDK apt repo so `gsutil` remains available for the helm chart rollback path.
- Drop the `2>/dev/null` redirect on the helm install so future failures surface in the Drone log.

## Test plan

- [x] Install block verified locally in `golang:1.25-bookworm`: `jq 1.6`, `aws-cli 2.9.19`, `gh 2.89.0`, `gsutil 5.36`, `gcloud 565.0.0`, `helm 3.20.2` all install and report versions cleanly.
- [x] Full pipeline exercised with `drone exec --pipeline release-rollback --event tag --trusted`: exits 0, `scripts/release-rollback.sh 99.99.99-dryrun` reaches completion, all credential-gated branches (`GITHUB_TOKEN`, `GCS`, `R2`) warn-and-skip safely.
- [ ] End-to-end verification against real credentials is only possible on the next failed release; change is low-risk (swaps base image + installs the same tool surface the script already used).

🤖 Generated with [Claude Code](https://claude.com/claude-code)