### PR TITLE
Reduce embedding log noise

### DIFF
--- a/api/pkg/openai/logger/openai_logger.go
+++ b/api/pkg/openai/logger/openai_logger.go
@@ -456,7 +456,7 @@ func (m *LoggingMiddleware) CreateEmbeddings(ctx context.Context, request openai
 	startTime := time.Now()
 
 	// Log the request
-	log.Info().
+	log.Debug().
 		Str("component", "openai_logger").
 		Str("provider", string(m.provider)).
 		Str("operation", "embedding").
@@ -482,7 +482,7 @@ func (m *LoggingMiddleware) CreateEmbeddings(ctx context.Context, request openai
 			Msg("❌ Embedding failed")
 	} else {
 		// Build the log entry
-		logEntry := log.Info().
+		logEntry := log.Debug().
 			Str("component", "openai_logger").
 			Str("provider", string(m.provider)).
 			Str("operation", "embedding").
@@ -507,7 +507,7 @@ func (m *LoggingMiddleware) CreateFlexibleEmbeddings(ctx context.Context, reques
 	startTime := time.Now()
 
 	// Log the request
-	logEntry := log.Info().
+	logEntry := log.Debug().
 		Str("component", "openai_logger").
 		Str("provider", string(m.provider)).
 		Str("operation", "flexible_embedding").
@@ -541,7 +541,7 @@ func (m *LoggingMiddleware) CreateFlexibleEmbeddings(ctx context.Context, reques
 			Msg("❌ Flexible embedding failed")
 	} else {
 		// Build the log entry
-		logEntry := log.Info().
+		logEntry := log.Debug().
 			Str("component", "openai_logger").
 			Str("provider", string(m.provider)).
 			Str("operation", "flexible_embedding").

--- a/api/pkg/openai/manager/provider_manager.go
+++ b/api/pkg/openai/manager/provider_manager.go
@@ -394,7 +394,7 @@ func (m *MultiClientManager) initializeClient(endpoint *types.ProviderEndpoint) 
 
 	// Log TLS configuration for database-configured providers (user/org endpoints)
 	// This helps debug enterprise TLS issues with providers configured via web UI
-	log.Info().
+	log.Debug().
 		Str("provider_id", endpoint.ID).
 		Str("provider_name", endpoint.Name).
 		Str("base_url", endpoint.BaseURL).


### PR DESCRIPTION
## Summary
Embedding operations generated 3 INFO-level log lines per chunk (request, completion, provider init), flooding production logs. Changed these to DEBUG level so they're hidden by default but available when needed.

## Changes
- Changed 4 embedding log statements in `api/pkg/openai/logger/openai_logger.go` from `log.Info()` to `log.Debug()` (request/completion for both standard and flexible embeddings)
- Changed 1 provider initialization log in `api/pkg/openai/manager/provider_manager.go` from `log.Info()` to `log.Debug()`
- Error logs for embedding failures remain at `log.Error()` level

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kpdbcgvgm3sybdvhy53nt49d)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001846_please-reduce-the-log/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001846_please-reduce-the-log/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001846_please-reduce-the-log/tasks.md)

🚀 Built with [Helix](https://helix.ml)