### PR TITLE
Disable Open PR and Reject buttons until agent has pushed code

### DIFF
--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -49,6 +49,7 @@ export interface SpecTaskForActions {
   planning_session_id?: string;
   metadata?: { error?: string };
   repo_pull_requests?: RepoPR[];
+  last_push_at?: string;
 }
 
 interface SpecTaskActionButtonsProps {
@@ -236,6 +237,8 @@ export default function SpecTaskActionButtons({
   // Determine if this is a direct-push scenario (branch same as base) vs PR workflow
   const isDirectPush =
     !hasExternalRepo || task.base_branch === task.branch_name;
+
+  const hasPushed = !!task.last_push_at;
 
   // Button size based on variant
   const buttonSize = "small";
@@ -494,10 +497,10 @@ export default function SpecTaskActionButtons({
       return (
         <Box sx={{ display: "flex", gap: 1 }}>
           <CompactActionButton
-            tooltip={isArchived ? "Task is archived" : ""}
+            tooltip={isArchived ? "Task is archived" : !hasPushed ? "Waiting for agent to push code..." : ""}
             variant="outlined"
             color="error"
-            disabled={isArchived || isArchiving}
+            disabled={isArchived || isArchiving || !hasPushed}
             icon={
               isArchiving ? (
                 <CircularProgress size={16} color="inherit" />
@@ -512,10 +515,10 @@ export default function SpecTaskActionButtons({
             }}
           />
           <CompactActionButton
-            tooltip={isArchived ? "Task is archived" : ""}
+            tooltip={isArchived ? "Task is archived" : !hasPushed ? "Waiting for agent to push code..." : ""}
             variant="contained"
             color="success"
-            disabled={isArchived || approveImplementationMutation.isPending}
+            disabled={isArchived || approveImplementationMutation.isPending || !hasPushed}
             icon={
               approveImplementationMutation.isPending ? (
                 <CircularProgress size={16} color="inherit" />
@@ -562,13 +565,13 @@ export default function SpecTaskActionButtons({
         }
       >
         <Box sx={{ display: "flex", gap: 1 }}>
-          <Tooltip title={isArchived ? "Task is archived" : ""} placement="top">
+          <Tooltip title={isArchived ? "Task is archived" : !hasPushed ? "Waiting for agent to push code..." : ""} placement="top">
             <span style={{ flex: 1 }}>
               <Button
                 size={buttonSize}
                 variant="outlined"
                 color="error"
-                disabled={isArchived || isArchiving}
+                disabled={isArchived || isArchiving || !hasPushed}
                 startIcon={
                   isArchiving ? (
                     <CircularProgress size={14} color="inherit" />
@@ -588,7 +591,7 @@ export default function SpecTaskActionButtons({
             </span>
           </Tooltip>
 
-          <Tooltip title={isArchived ? "Task is archived" : ""} placement="top">
+          <Tooltip title={isArchived ? "Task is archived" : !hasPushed ? "Waiting for agent to push code..." : ""} placement="top">
             <span style={{ flex: 1 }}>
               <Button
                 size={buttonSize}
@@ -602,7 +605,7 @@ export default function SpecTaskActionButtons({
                   )
                 }
                 onClick={handleOpenPR}
-                disabled={isArchived || approveImplementationMutation.isPending}
+                disabled={isArchived || approveImplementationMutation.isPending || !hasPushed}
                 fullWidth
                 sx={buttonSx}
               >

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -2030,6 +2030,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                       just_do_it_mode: justDoItMode,
                       planning_session_id: task.planning_session_id,
                       metadata: task.metadata as { error?: string },
+                      last_push_at: task.last_push_at,
                     }}
                     variant="inline"
                     onStartPlanning={handleStartPlanning}
@@ -2440,6 +2441,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                   just_do_it_mode: justDoItMode,
                   planning_session_id: task.planning_session_id,
                   metadata: task.metadata as { error?: string },
+                  last_push_at: task.last_push_at,
                 }}
                 variant="inline"
                 onStartPlanning={handleStartPlanning}

--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -146,6 +146,7 @@ export interface SpecTaskWithExtras {
   assignee_id?: string;
   labels?: string[];
   updated_at?: string;
+  last_push_at?: string;
 }
 
 export interface TaskDependency {

--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -1289,6 +1289,7 @@ function TaskCardInner({
               base_branch: task.base_branch,
               branch_name: task.branch_name,
               archived: task.archived,
+              last_push_at: task.last_push_at,
             }}
             variant="stacked"
             onReject={(shiftKey) => {


### PR DESCRIPTION
## Summary
The "Open PR" / "Accept" and "Reject" buttons in the implementation phase now stay disabled until the agent has pushed at least one commit to the feature branch. A tooltip ("Waiting for agent to push code...") explains the wait. This prevents users from triggering empty PRs or rejecting work that hasn't started yet.

## Changes
- Added `last_push_at` to `SpecTaskForActions` interface and derived `hasPushed` boolean
- Disabled both Reject and Open PR/Accept buttons when `!hasPushed` (inline + stacked variants)
- Updated all 3 call sites (TaskCard, SpecTaskDetailContent x2) to pass `last_push_at`

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01km3gr2td5zqkppg9vbqekc1e)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001599_open-pr-button-shouldnt/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001599_open-pr-button-shouldnt/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001599_open-pr-button-shouldnt/tasks.md)

🚀 Built with [Helix](https://helix.ml)