### PR TITLE
fix: reject approve-implementation if no commits have been pushed

### DIFF
--- a/api/pkg/server/spec_task_workflow_handlers.go
+++ b/api/pkg/server/spec_task_workflow_handlers.go
@@ -104,6 +104,16 @@ func (s *HelixAPIServer) approveImplementation(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// Reject approval if the agent has not pushed any commits to the feature
+	// branch. Without this guard, approve-implementation would open an empty PR
+	// (external repos) or merge a zero-commit diff (internal repos). The UI
+	// disables the button in this state; this check is the defense-in-depth
+	// for direct API callers.
+	if specTask.LastPushAt == nil {
+		http.Error(w, "Agent has not pushed any commits yet", http.StatusConflict)
+		return
+	}
+
 	if project.DefaultRepoID == "" {
 		http.Error(w, "Default repository not set for project", http.StatusBadRequest)
 		return


### PR DESCRIPTION
## Summary

- Adds a server-side guard in `approveImplementation` (`api/pkg/server/spec_task_workflow_handlers.go`) that returns `409 Conflict` when `specTask.LastPushAt == nil`. Without this, the handler would open an empty PR (external repos) or merge a zero-commit diff (internal repos).
- Complements https://github.com/helixml/helix/pull/2220 which disables the Accept/Reject buttons in the same state in the UI. This PR closes the gap for direct API callers (CLI, curl, programmatic integrations) — the two changes are independent and can merge in either order.

## Placement

Guard runs right after the task-status switch, before the OAuth validation and merge logic. It only applies to `TaskStatusImplementation` / `TaskStatusImplementationReview` because the spec-phase auto-approve branch above it early-returns.

## Test plan

- [x] `go build ./pkg/server/` passes.
- [ ] Existing integration tests (CI) — this handler has no unit tests today, which is noted but left out of scope to avoid piling test infrastructure onto a 10-line fix.
- [ ] Manual: hit `POST /api/v1/spec-tasks/{id}/approve-implementation` on a task in implementation phase where the agent hasn't pushed; expect `409 Conflict` with body `Agent has not pushed any commits yet`. After the agent pushes (`LastPushAt` populated by `git_http_server.go:964`), the same call should proceed normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)