### PR TITLE
Rename "Just Do It" to "Skip spec" and add toggle to backlog cards

### DIFF
--- a/frontend/src/components/tasks/NewSpecTaskForm.tsx
+++ b/frontend/src/components/tasks/NewSpecTaskForm.tsx
@@ -565,12 +565,12 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
             }}
             placeholder={
               justDoItMode
-                ? "Describe what you want the agent to do. It will start immediately without planning."
+                ? "Describe what you want the agent to do. It will start immediately without spec generation."
                 : "Describe the task - the AI will generate specs from this."
             }
             helperText={
               justDoItMode
-                ? "Agent will start working immediately"
+                ? "Spec generation will be skipped — agent starts implementation immediately"
                 : "Planning agent extracts task name, description, and generates specifications"
             }
             inputRef={taskPromptRef}
@@ -887,10 +887,10 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
             )}
           </Box>
 
-          {/* Just Do It Mode Checkbox */}
+          {/* Skip Spec Checkbox */}
           <FormControl fullWidth>
             <Tooltip
-              title={`Skip writing a spec and just get the agent to immediately start doing what you ask (${navigator.platform.includes("Mac") ? "⌘J" : "Ctrl+J"})`}
+              title={`Skip spec generation and go straight to implementation (${navigator.platform.includes("Mac") ? "⌘J" : "Ctrl+J"})`}
               placement="top"
             >
               <FormControlLabel
@@ -905,7 +905,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
                   <Box>
                     <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                       <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                        Just Do It
+                        Skip spec
                       </Typography>
                       <Box
                         component="span"
@@ -923,8 +923,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
                       </Box>
                     </Box>
                     <Typography variant="caption" color="text.secondary">
-                      Skip spec planning — useful for tasks that don't require
-                      planning code changes
+                      Skip spec generation — go straight to implementation
                     </Typography>
                   </Box>
                 }

--- a/frontend/src/components/tasks/NewSpecTaskForm.tsx
+++ b/frontend/src/components/tasks/NewSpecTaskForm.tsx
@@ -565,12 +565,12 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
             }}
             placeholder={
               justDoItMode
-                ? "Describe what you want the agent to do. It will start immediately without spec generation."
+                ? "Describe what you want the agent to do. It will start immediately without planning."
                 : "Describe the task - the AI will generate specs from this."
             }
             helperText={
               justDoItMode
-                ? "Spec generation will be skipped — agent starts implementation immediately"
+                ? "Planning will be skipped — agent starts implementation immediately"
                 : "Planning agent extracts task name, description, and generates specifications"
             }
             inputRef={taskPromptRef}
@@ -890,7 +890,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
           {/* Skip Spec Checkbox */}
           <FormControl fullWidth>
             <Tooltip
-              title={`Skip spec generation and go straight to implementation (${navigator.platform.includes("Mac") ? "⌘J" : "Ctrl+J"})`}
+              title={`Skip planning and go straight to implementation (${navigator.platform.includes("Mac") ? "⌘J" : "Ctrl+J"})`}
               placement="top"
             >
               <FormControlLabel
@@ -905,7 +905,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
                   <Box>
                     <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                       <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                        Skip spec
+                        Skip planning
                       </Typography>
                       <Box
                         component="span"
@@ -923,7 +923,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
                       </Box>
                     </Box>
                     <Typography variant="caption" color="text.secondary">
-                      Skip spec generation — go straight to implementation
+                      Skip planning — go straight to implementation
                     </Typography>
                   </Box>
                 }

--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -277,7 +277,7 @@ export default function SpecTaskActionButtons({
               : "Start Planning";
 
     const skipSpecToggle = (
-      <Tooltip title="Skip spec generation and go straight to implementation" placement="top">
+      <Tooltip title="Skip planning and go straight to implementation" placement="top">
         <FormControlLabel
           control={
             <Switch
@@ -295,7 +295,7 @@ export default function SpecTaskActionButtons({
           }
           label={
             <Typography variant="caption" sx={{ whiteSpace: "nowrap" }}>
-              Skip spec
+              Skip planning
             </Typography>
           }
           sx={{ mr: 0 }}
@@ -376,7 +376,7 @@ export default function SpecTaskActionButtons({
           width: isInline ? "auto" : "100%",
         }}
       >
-        <Tooltip title={isArchived ? "Task is archived" : "Skip spec generation and start implementation"}>
+        <Tooltip title={isArchived ? "Task is archived" : "Skip planning and start implementation"}>
           <span>
             <Button
               variant="outlined"
@@ -397,7 +397,7 @@ export default function SpecTaskActionButtons({
               fullWidth={!isInline}
               sx={buttonSx}
             >
-              {isSkipping ? "Skipping..." : "Skip Spec"}
+              {isSkipping ? "Skipping..." : "Skip Planning"}
             </Button>
           </span>
         </Tooltip>

--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -4,9 +4,11 @@ import {
   Box,
   Button,
   CircularProgress,
+  FormControlLabel,
   Menu,
   MenuItem,
   ListItemText,
+  Switch,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -25,6 +27,7 @@ import {
   useSkipSpec,
   useReopenTask,
 } from "../../services/specTaskWorkflowService";
+import { useUpdateSpecTask } from "../../services/specTaskService";
 import { useListOAuthProviders, useListOAuthConnections } from "../../services/oauthProvidersService";
 import { findOAuthProviderForType, findOAuthConnectionForProvider, hasRequiredScopes } from "../../utils/oauthProviders";
 import { useOAuthFlow } from "../../hooks/useOAuthFlow";
@@ -185,6 +188,7 @@ export default function SpecTaskActionButtons({
   const stopAgentMutation = useStopAgent(task.id);
   const skipSpecMutation = useSkipSpec(task.id);
   const reopenTaskMutation = useReopenTask(task.id);
+  const updateSpecTaskMutation = useUpdateSpecTask();
   const [isReviewingSpec, setIsReviewingSpec] = useState(false);
   const [prMenuAnchor, setPrMenuAnchor] = useState<null | HTMLElement>(null);
   const [showOAuthPrompt, setShowOAuthPrompt] = useState(false);
@@ -266,15 +270,44 @@ export default function SpecTaskActionButtons({
           ? "Queue Planning"
           : task.metadata?.error
             ? task.just_do_it_mode
-              ? "Retry"
+              ? "Retry Implementation"
               : "Retry Planning"
             : task.just_do_it_mode
-              ? "Just Do It"
+              ? "Start Implementation"
               : "Start Planning";
+
+    const skipSpecToggle = (
+      <Tooltip title="Skip spec generation and go straight to implementation" placement="top">
+        <FormControlLabel
+          control={
+            <Switch
+              size="small"
+              checked={!!task.just_do_it_mode}
+              onChange={(e) => {
+                e.stopPropagation();
+                updateSpecTaskMutation.mutate({
+                  taskId: task.id,
+                  updates: { just_do_it_mode: e.target.checked },
+                });
+              }}
+              disabled={isArchived || updateSpecTaskMutation.isPending}
+            />
+          }
+          label={
+            <Typography variant="caption" sx={{ whiteSpace: "nowrap" }}>
+              Skip spec
+            </Typography>
+          }
+          sx={{ mr: 0 }}
+          onClick={(e) => e.stopPropagation()}
+        />
+      </Tooltip>
+    );
 
     if (isInline) {
       return (
-        <Box sx={{ display: "flex", gap: 1 }}>
+        <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+          {skipSpecToggle}
           <CompactActionButton
             tooltip={startTooltip}
             color={task.just_do_it_mode ? "success" : "warning"}
@@ -297,9 +330,9 @@ export default function SpecTaskActionButtons({
     }
 
     return (
-      <Box sx={isInline ? { display: "flex", gap: 1 } : { mt: 1.5 }}>
+      <Box sx={{ mt: 1.5 }}>
         <Tooltip title={startTooltip} placement="top">
-          <span style={{ width: isInline ? "auto" : "100%" }}>
+          <span style={{ width: "100%" }}>
             <Button
               ref={startPlanningButtonRef}
               size={buttonSize}
@@ -317,13 +350,16 @@ export default function SpecTaskActionButtons({
                 onStartPlanning?.();
               }}
               disabled={isStartDisabled}
-              fullWidth={!isInline}
+              fullWidth
               sx={buttonSx}
             >
               {startLabel}
             </Button>
           </span>
         </Tooltip>
+        <Box sx={{ mt: 0.5, display: "flex", justifyContent: "center" }}>
+          {skipSpecToggle}
+        </Box>
       </Box>
     );
   }

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -1311,7 +1311,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                 size="small"
               />
             }
-            label="Skip spec (go straight to implementation)"
+            label="Skip planning (go straight to implementation)"
           />
         </Box>
       )}

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -1311,7 +1311,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                 size="small"
               />
             }
-            label="Skip planning (go straight to implementation)"
+            label="Skip spec (go straight to implementation)"
           />
         </Box>
       )}

--- a/frontend/src/services/specTaskWorkflowService.ts
+++ b/frontend/src/services/specTaskWorkflowService.ts
@@ -132,13 +132,13 @@ export function useSkipSpec(specTaskId: string) {
       return response.data;
     },
     onSuccess: () => {
-      snackbar.success("Skipped spec - task moved to implementation");
+      snackbar.success("Skipped planning - task moved to implementation");
       queryClient.invalidateQueries({ queryKey: ["spec-tasks", specTaskId] });
       queryClient.invalidateQueries({ queryKey: ["spec-tasks"] });
     },
     onError: (error: any) => {
       snackbar.error(
-        error?.response?.data?.message || "Failed to skip spec",
+        error?.response?.data?.message || "Failed to skip planning",
       );
     },
   });


### PR DESCRIPTION
## Summary
The "Just do it" terminology was confusing to users. This renames it to "Skip spec" everywhere and adds a toggle directly on backlog task cards so users can enable/disable it without opening edit mode.

## Changes
- **SpecTaskActionButtons.tsx**: Renamed backlog button from "Just Do It" → "Start Implementation" and "Retry" → "Retry Implementation". Added a "Skip spec" Switch toggle next to the action button that calls the update API to flip `just_do_it_mode`.
- **NewSpecTaskForm.tsx**: Renamed the creation form checkbox from "Just Do It" to "Skip spec". Updated placeholder and helper text to describe skipping spec generation.
- **SpecTaskDetailContent.tsx**: Updated the edit-mode checkbox label from "Skip planning" to "Skip spec" for consistency.

## Screenshots

### Backlog card with "Skip spec" ON → shows "Start Implementation"
![Skip spec ON](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001848_the-button-just-do-it/screenshots/02-backlog-skip-spec-on.png)

### Backlog card with "Skip spec" OFF → shows "Start Planning"
![Skip spec OFF](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001848_the-button-just-do-it/screenshots/03-backlog-skip-spec-off.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kpdgjbfesret986an42h800t)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001848_the-button-just-do-it/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001848_the-button-just-do-it/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001848_the-button-just-do-it/tasks.md)

🚀 Built with [Helix](https://helix.ml)