### PR TITLE
Fix PR merge issues: hide stale error on completed tasks, prevent duplicate PR creation

### DIFF
--- a/api/pkg/server/spec_task_workflow_handlers.go
+++ b/api/pkg/server/spec_task_workflow_handlers.go
@@ -511,6 +511,15 @@ func (s *HelixAPIServer) ensurePullRequestForRepo(ctx context.Context, repo *typ
 		return nil, nil
 	}
 
+	// If we already track a PR for this repo, return it — don't create a duplicate.
+	// This prevents re-creation when a PR is closed/deleted and ListPullRequests
+	// (which only returns open PRs) can no longer see it.
+	for _, existing := range task.RepoPullRequests {
+		if existing.RepositoryID == repo.ID && existing.PRID != "" {
+			return &existing, nil
+		}
+	}
+
 	branch := task.BranchName
 
 	// Check if the branch exists in this repo before trying to push

--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -1065,7 +1065,7 @@ function TaskCardInner({
         )}
 
         {/* Show task error prominently and avoid desktop viewer when errored */}
-        {taskError && (
+        {taskError && task.phase !== "completed" && (
           <Box
             sx={{
               mb: 1,


### PR DESCRIPTION
## Summary
Two bugs in the spec task PR workflow:
1. When a PR gets merged, the task card shows a stale error banner ("Pull request could not be created...") alongside the green "Task finished" message
2. When a PR is closed/deleted on GitHub, Helix creates a duplicate PR for the same branch

## Changes
- `frontend/src/components/tasks/TaskCard.tsx`: Hide error banner when task phase is "completed" (error preserved in metadata for debugging)
- `api/pkg/server/spec_task_workflow_handlers.go`: Add early return in `ensurePullRequestForRepo()` when the task already tracks a PR for the repo, preventing duplicate creation when the GitHub API (which only returns open PRs) can't see closed ones

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kpdmszzq5p7qgrh6h8nc15v2)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001849_fix-pr-merge-issues-when/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001849_fix-pr-merge-issues-when/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001849_fix-pr-merge-issues-when/tasks.md)

🚀 Built with [Helix](https://helix.ml)