### PR TITLE
fix: prevent branch restore after PR merge

### DIFF
--- a/api/pkg/services/git_http_server.go
+++ b/api/pkg/services/git_http_server.go
@@ -1174,6 +1174,25 @@ func (s *GitHTTPServer) ensurePullRequest(ctx context.Context, repo *types.GitRe
 
 	log.Info().Str("repo_id", repo.ID).Str("branch", branch).Msg("Ensuring pull request")
 
+	// If we already track a PR for this repo, return without pushing or
+	// re-creating. Pushing would recreate a branch that GitHub auto-deleted
+	// after merge, or re-open a branch the user closed intentionally.
+	// ListPullRequests (open-only) can't see merged/closed PRs, so without
+	// this guard we'd fall through to CreatePullRequest and duplicate.
+	// Mirrors the guard added to ensurePullRequestForRepo in PR #2225.
+	for i := range task.RepoPullRequests {
+		existing := &task.RepoPullRequests[i]
+		if existing.RepositoryID == repo.ID && existing.PRID != "" {
+			log.Info().
+				Str("pr_id", existing.PRID).
+				Str("pr_state", existing.PRState).
+				Str("repo_id", repo.ID).
+				Str("branch", branch).
+				Msg("Task already tracks a PR for this repo, skipping ensurePullRequest")
+			return nil
+		}
+	}
+
 	// Acquire repo lock for push operation to prevent race conditions.
 	// Use the approver's OAuth token when available.
 	if err := s.gitRepoService.WithRepoLock(repo.ID, func() error {


### PR DESCRIPTION
## Summary

Reproduced on PR https://github.com/helixml/helix/pull/2225 itself — after the PR was merged and GitHub auto-deleted the branch, Helix immediately restored it. PR #2225 fixed the same bug in `ensurePullRequestForRepo` (in `spec_task_workflow_handlers.go`) but missed the **sibling function** `ensurePullRequest` in `git_http_server.go`, which has the same unconditional push pattern.

## Race condition

1. User merges PR on GitHub → branch is auto-deleted.
2. `task.Status` is still `pull_request` (merge-detection polling hasn't transitioned it yet).
3. Any push to Helix's internal git HTTP server arrives (agent cleanup push, or any push at all).
4. `handleFeatureBranchPush` (`git_http_server.go:970`) matches the task by status and fires `ensurePullRequest` in a goroutine.
5. `ensurePullRequest` calls `PushBranchToRemote` unconditionally at line 1180 — **branch recreated on GitHub**.
6. Then `ListPullRequests` (open-only) doesn't see the merged PR, so the flow would have fallen through to `CreatePullRequest` (duplicate-creation mode), which typically fails with "commits already merged" but the branch restoration has already happened.

## Fix

Mirror PR #2225's guard: if `task.RepoPullRequests` already has a record for this repo with a non-empty `PRID`, early-return before the push. No push, no list, no create.

Uses the idiomatic `for i := range ... &slice[i]` pattern (matches `GetFirstOpenPR` in the types file — the nit I called out during the PR #2225 review).

## Test plan

- [x] `go build ./pkg/services/` passes.
- [ ] Manual repro: create a spec task, get to `pull_request` status, merge on GitHub with auto-delete-branch enabled, trigger another push to Helix (any event that causes `handleFeatureBranchPush` to fire with `task.Status == pull_request`). Before: branch reappears on GitHub. After: branch stays deleted, no new PR attempted.
- [ ] Existing integration tests (CI).

## Notes

- This fix doesn't address the underlying race (merge detection can lag); it just prevents the lag window from causing user-visible damage.
- `task.RepoPullRequests[repo.ID].PRState` may remain stale (`open` when actually `merged`) until the merge-detection poller catches up — separate, lower-severity issue.
- No new test added. Function has no existing test coverage; extending is out of scope for a 19-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)