### PR TITLE
feat: discoverable git repo options and clone instructions

### DIFF
--- a/frontend/src/components/project/CreateProjectDialog.tsx
+++ b/frontend/src/components/project/CreateProjectDialog.tsx
@@ -14,14 +14,10 @@ import {
   Typography,
   Divider,
   Alert,
-  ToggleButtonGroup,
-  ToggleButton,
   CircularProgress,
   IconButton,
   Tooltip,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
+  Paper,
   List,
   ListItem,
   ListItemButton,
@@ -31,7 +27,6 @@ import {
   Chip,
   InputAdornment,
 } from '@mui/material'
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import GitHubIcon from '@mui/icons-material/GitHub'
 import LockIcon from '@mui/icons-material/Lock'
 import { FolderGit2, Link as LinkIcon, Plus, Bot, RefreshCw, Search } from 'lucide-react'
@@ -54,7 +49,7 @@ import type { CodingAgentFormHandle } from '../agent/CodingAgentForm'
 
 
 
-type RepoMode = 'auto' | 'select' | 'create' | 'link'
+type RepoMode = 'select' | 'create' | 'link'
 
 interface CreateProjectDialogProps {
   open: boolean
@@ -97,8 +92,7 @@ const CreateProjectDialog: FC<CreateProjectDialogProps> = ({
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
   const [selectedRepoId, setSelectedRepoId] = useState('')
-  const [repoMode, setRepoMode] = useState<RepoMode>('auto')
-  const [advancedExpanded, setAdvancedExpanded] = useState(false)
+  const [repoMode, setRepoMode] = useState<RepoMode>('create')
 
   // New repo creation fields
   const [newRepoName, setNewRepoName] = useState('')
@@ -245,8 +239,7 @@ const CreateProjectDialog: FC<CreateProjectDialogProps> = ({
       setName('')
       setDescription('')
       setSelectedRepoId('')
-      setRepoMode('auto')
-      setAdvancedExpanded(false)
+      setRepoMode('create')
       setNewRepoName('')
       setNewRepoDescription('')
       setUserModifiedRepoName(false)
@@ -275,7 +268,6 @@ const CreateProjectDialog: FC<CreateProjectDialogProps> = ({
       // When opening with a preselected repo, switch to select mode
       setRepoMode('select')
       setSelectedRepoId(preselectedRepoId)
-      setAdvancedExpanded(true)
     }
   }, [open, preselectedRepoId])
 
@@ -329,34 +321,7 @@ const CreateProjectDialog: FC<CreateProjectDialogProps> = ({
     let repoIdToUse = ''
     setRepoError('')
 
-    if (repoMode === 'auto') {
-      // Auto mode: create a repo with the same name as the project
-      if (!onCreateRepo) {
-        setRepoError('Repository creation not available')
-        return
-      }
-
-      const autoRepoName = toRepoName(name)
-      if (!autoRepoName) {
-        setRepoError('Please enter a valid project name')
-        return
-      }
-
-      setCreatingRepo(true)
-      try {
-        const newRepo = await onCreateRepo(autoRepoName, description || `Files for ${name}`)
-        if (!newRepo?.id) {
-          setRepoError('Failed to create repository')
-          return
-        }
-        repoIdToUse = newRepo.id
-      } catch (err) {
-        setRepoError(err instanceof Error ? err.message : 'Failed to create repository')
-        return
-      } finally {
-        setCreatingRepo(false)
-      }
-    } else if (repoMode === 'select') {
+    if (repoMode === 'select') {
       if (!selectedRepoId) {
         setRepoError('Please select a repository')
         return
@@ -492,7 +457,6 @@ const CreateProjectDialog: FC<CreateProjectDialogProps> = ({
     : !!selectedAgentId
 
   const isSubmitDisabled = createProjectMutation.isPending || creatingRepo || creatingAgent || !name.trim() || !agentValid || (
-    repoMode === 'auto' ? false : // Auto mode only needs project name
     repoMode === 'select' ? !selectedRepoId :
     repoMode === 'create' ? !newRepoName.trim() :
     !externalUrl.trim() || (externalType === TypesExternalRepositoryType.ExternalRepositoryTypeADO && (!externalOrgUrl.trim() || !externalToken.trim()))
@@ -532,71 +496,84 @@ const CreateProjectDialog: FC<CreateProjectDialogProps> = ({
             placeholder="What is this project about?"
           />
 
-          {/* Advanced: Git Repository Options */}
-          <Accordion
-            expanded={advancedExpanded || !!preselectedRepoId}
-            onChange={(_, expanded) => {
-              if (!preselectedRepoId) {
-                setAdvancedExpanded(expanded)
-                // When expanding, default to 'create' mode if currently 'auto'
-                if (expanded && repoMode === 'auto') {
-                  setRepoMode('create')
-                }
-                // When collapsing, reset to 'auto' mode
-                if (!expanded) {
-                  setRepoMode('auto')
-                }
-              }
-            }}
-            sx={{
-              boxShadow: 'none',
-              border: (theme) => `1px solid ${theme.palette.divider}`,
-              '&:before': { display: 'none' },
-              borderRadius: 1,
-            }}
-          >
-            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <FolderGit2 size={18} />
-                <Typography variant="body2">
-                  {advancedExpanded || preselectedRepoId
-                    ? 'Git Repository'
-                    : 'Connect a Git repository (optional)'}
-                </Typography>
-              </Box>
-            </AccordionSummary>
-            <AccordionDetails>
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                <Typography variant="body2" color="text.secondary">
-                  Connect an existing Git repository or create a new one with a custom name.
-                  {!advancedExpanded && ' Leave collapsed to auto-create storage for your project.'}
-                </Typography>
+          {/* Git Repository picker */}
+          <Box>
+            <Typography variant="subtitle2" sx={{ mb: 0.25 }}>
+              Git Repository
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+              Every project needs a repo. Pick one.
+            </Typography>
 
-                <ToggleButtonGroup
-                  value={repoMode}
-                  exclusive
-                  onChange={(_, v) => {
-                    if (v && !preselectedRepoId && v !== 'auto') {
-                      setRepoMode(v)
-                    }
-                  }}
-                  size="small"
-                  fullWidth
-                  disabled={!!preselectedRepoId}
-                >
-                  <ToggleButton value="create">
-                    <Plus size={16} style={{ marginRight: 4 }} />
-                    New
-                  </ToggleButton>
-                  <ToggleButton value="select">
-                    <FolderGit2 size={16} style={{ marginRight: 4 }} />
-                    Existing
-                  </ToggleButton>
-                  <ToggleButton value="link">
-                    <LinkIcon size={16} style={{ marginRight: 4 }} />
-                    External
-                  </ToggleButton>
-                </ToggleButtonGroup>
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(3, 1fr)',
+                gap: 1,
+                mb: 2,
+              }}
+            >
+              {([
+                {
+                  mode: 'create' as const,
+                  icon: <Plus size={18} />,
+                  title: 'New Helix repo',
+                  desc: "We'll create and host a fresh repo for you.",
+                },
+                {
+                  mode: 'select' as const,
+                  icon: <FolderGit2 size={18} />,
+                  title: 'Use existing',
+                  desc: 'Reuse a repo already in this organisation.',
+                },
+                {
+                  mode: 'link' as const,
+                  icon: <LinkIcon size={18} />,
+                  title: 'Link external',
+                  desc: 'Connect GitHub, GitLab, or Azure DevOps.',
+                },
+              ]).map((tile) => {
+                const isSelected = repoMode === tile.mode
+                const isDisabled = !!preselectedRepoId && tile.mode !== 'select'
+                return (
+                  <Paper
+                    key={tile.mode}
+                    variant="outlined"
+                    onClick={() => {
+                      if (!preselectedRepoId) setRepoMode(tile.mode)
+                    }}
+                    sx={(theme) => ({
+                      p: 1.5,
+                      cursor: preselectedRepoId ? 'default' : 'pointer',
+                      borderColor: isSelected ? theme.palette.secondary.main : theme.palette.divider,
+                      borderWidth: isSelected ? 2 : 1,
+                      bgcolor: isSelected ? 'action.selected' : 'transparent',
+                      opacity: isDisabled ? 0.5 : 1,
+                      transition: 'border-color 0.15s, background-color 0.15s',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 0.5,
+                      minHeight: 104,
+                      '&:hover': preselectedRepoId
+                        ? {}
+                        : { borderColor: isSelected ? theme.palette.secondary.main : theme.palette.text.secondary },
+                    })}
+                  >
+                    <Box sx={{ color: isSelected ? 'secondary.main' : 'text.secondary' }}>
+                      {tile.icon}
+                    </Box>
+                    <Typography variant="body2" fontWeight={600}>
+                      {tile.title}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.35 }}>
+                      {tile.desc}
+                    </Typography>
+                  </Paper>
+                )
+              })}
+            </Box>
+
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
 
                 {repoMode === 'select' && (
                   <FormControl fullWidth size="small">
@@ -980,9 +957,8 @@ const CreateProjectDialog: FC<CreateProjectDialogProps> = ({
                     )}
                   </Box>
                 )}
-              </Box>
-            </AccordionDetails>
-          </Accordion>
+            </Box>
+          </Box>
 
           {repoError && (
             <Alert severity="error" sx={{ mt: 1 }}>

--- a/frontend/src/pages/GitRepoDetail.tsx
+++ b/frontend/src/pages/GitRepoDetail.tsx
@@ -708,6 +708,16 @@ const GitRepoDetail: FC = () => {
 
               {/* Chips and Sync Button */}
               <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>
+                {!isExternal && (
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    startIcon={<Copy size={14} />}
+                    onClick={() => setCloneDialogOpen(true)}
+                  >
+                    Clone
+                  </Button>
+                )}
                 {isExternal && (
                   <Chip
                     icon={<Link size={12} />}
@@ -1045,70 +1055,60 @@ const GitRepoDetail: FC = () => {
           <DialogTitle>Clone Repository</DialogTitle>
           <DialogContent>
             <Stack spacing={2} sx={{ mt: 1 }}>
-              {isExternal && repository.metadata?.external_url ? (
-                <>
-                  <Typography variant="body2" color="text.secondary">
-                    This is an external repository. Use the URL below to clone it:
-                  </Typography>
-                  <Box sx={{ display: 'flex', gap: 1 }}>
-                    <TextField
-                      fullWidth
-                      value={repository.metadata?.external_url || ''}
-                      InputProps={{
-                        readOnly: true,
-                        sx: { fontFamily: 'monospace', fontSize: '0.875rem' }
-                      }}
-                    />
-                    <Tooltip title={copiedClone ? 'Copied!' : 'Copy'}>
-                      <IconButton
-                        onClick={() => handleCopyCloneCommand(repository.metadata?.external_url || '')}
-                        color={copiedClone ? 'success' : 'default'}
-                      >
-                        <Copy size={18} />
-                      </IconButton>
-                    </Tooltip>
-                  </Box>
-                  <Button
-                    variant="outlined"
-                    fullWidth
-                    startIcon={<ExternalLink size={16} />}
-                    onClick={() => window.open(repository.metadata?.external_url || '', '_blank')}
+              <Typography variant="body2" color="text.secondary">
+                Run this command on your machine to clone the repository:
+              </Typography>
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <TextField
+                  fullWidth
+                  value={`git clone ${cloneUrl}`}
+                  InputProps={{
+                    readOnly: true,
+                    sx: { fontFamily: 'monospace', fontSize: '0.875rem' }
+                  }}
+                />
+                <Tooltip title={copiedClone ? 'Copied!' : 'Copy'}>
+                  <IconButton
+                    onClick={() => handleCopyCloneCommand(`git clone ${cloneUrl}`)}
+                    color={copiedClone ? 'success' : 'default'}
                   >
-                    Open in {repository.metadata?.external_type || 'Browser'}
-                  </Button>
-                </>
-              ) : isExternal ? (
-                <Alert severity="warning">
-                  This external repository does not have a clone URL configured.
-                </Alert>
-              ) : (
-                <>
-                  <Alert severity="info">
-                    This is a Helix-hosted repository. It is automatically cloned by agents when working on spec tasks.
-                  </Alert>
-                  <Typography variant="body2" color="text.secondary">
-                    Clone command (for reference):
-                  </Typography>
-                  <Box sx={{ display: 'flex', gap: 1 }}>
-                    <TextField
-                      fullWidth
-                      value={cloneUrl}
-                      InputProps={{
-                        readOnly: true,
-                        sx: { fontFamily: 'monospace', fontSize: '0.875rem' }
-                      }}
-                    />
-                    <Tooltip title={copiedClone ? 'Copied!' : 'Copy'}>
-                      <IconButton
-                        onClick={() => handleCopyCloneCommand(cloneUrl)}
-                        color={copiedClone ? 'success' : 'default'}
-                      >
-                        <Copy size={18} />
-                      </IconButton>
-                    </Tooltip>
+                    <Copy size={18} />
+                  </IconButton>
+                </Tooltip>
+              </Box>
+
+              <Box>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                  When prompted, authenticate with:
+                </Typography>
+                <Paper variant="outlined" sx={{ p: 1.5 }}>
+                  <Box sx={{ display: 'grid', gridTemplateColumns: 'auto 1fr', columnGap: 2, rowGap: 0.5, alignItems: 'center' }}>
+                    <Typography variant="body2" color="text.secondary">Username</Typography>
+                    <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>helix</Typography>
+                    <Typography variant="body2" color="text.secondary">Password</Typography>
+                    <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>your API key</Typography>
                   </Box>
-                </>
-              )}
+                </Paper>
+              </Box>
+
+              <Alert
+                severity="info"
+                action={
+                  account.organizationTools.organization?.id ? (
+                    <Button
+                      size="small"
+                      onClick={() => {
+                        setCloneDialogOpen(false)
+                        account.orgNavigate('org_api_keys')
+                      }}
+                    >
+                      Manage keys
+                    </Button>
+                  ) : undefined
+                }
+              >
+                Need an API key? Create one under Organization Settings → API Keys.
+              </Alert>
             </Stack>
           </DialogContent>
           <DialogActions>


### PR DESCRIPTION
## Summary
- Replace the collapsed "Git Repository (optional)" accordion in the create-project dialog with three always-visible tiles: **New Helix repo**, **Use existing**, **Link external**. External repos (GitHub / GitLab / Azure DevOps) are now a first-class option instead of being buried.
- On the repo detail page, add a **Clone** button (internal repos only) that opens a rewritten dialog with a copyable `git clone` command, auth instructions (username `helix`, API key as password), and a link to the API keys page. The dialog was already implemented but unreachable — `setCloneDialogOpen(true)` was never called.
- External repos do not show the Clone button because they're cloned from their origin (GitHub etc.), not through Helix auth.

## Test plan
- [ ] Open the create-project dialog in an organisation — three tiles are visible by default, "New Helix repo" is selected, repo name auto-populates from project name
- [ ] Click "Use existing" — existing repos dropdown appears
- [ ] Click "Link external" — provider selector appears; with a GitHub OAuth connection, the inline repo browser works
- [ ] Open a project's internal repo detail page — Clone button is visible next to chips; clicking it opens the dialog with the `git clone <url>` command, `Username: helix`, `Password: your API key`
- [ ] Open an external repo detail page — no Clone button is shown
- [ ] Click "Manage keys" in the info alert — navigates to Organization → API Keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)