### PR TITLE
fix(helm): make GPU resource key configurable for AMD/ROCm

### DIFF
--- a/charts/helix-runner/README.md
+++ b/charts/helix-runner/README.md
@@ -48,6 +48,20 @@ helm upgrade --install helix-runner helix/helix-runner \
 
 The runner will automatically detect and use all GPUs allocated to it by Kubernetes. VLLM and Ollama will handle model loading across multiple GPUs on the same runner.
 
+## AMD GPUs (ROCm)
+
+By default the chart requests `nvidia.com/gpu`. On AMD clusters using the ROCm device plugin, override the resource key:
+
+```bash
+helm upgrade --install helix-runner helix/helix-runner \
+  --set runner.host="<host>" \
+  --set runner.token="<token>" \
+  --set gpuResourceKey="amd.com/gpu" \
+  --set gpuCount=1
+```
+
+The runner pod will request `amd.com/gpu: "1"` instead of `nvidia.com/gpu: "1"`. No other changes to `resources:` are needed — that block is only for non-GPU resources (CPU, memory, hugepages, etc.).
+
 ## Troubleshooting
 
 ### GPU Upgrade Deadlocks

--- a/charts/helix-runner/templates/deployment.yaml
+++ b/charts/helix-runner/templates/deployment.yaml
@@ -104,32 +104,33 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
+            {{- $gpuKey := .Values.gpuResourceKey | default "nvidia.com/gpu" }}
             {{- if hasKey .Values "gpuCount" }}
               {{- if gt (.Values.gpuCount | int) 0 }}
             limits:
-              nvidia.com/gpu: {{ .Values.gpuCount | quote }}
+              {{ $gpuKey }}: {{ .Values.gpuCount | quote }}
               {{- range $key, $value := .Values.resources.limits }}
-              {{- if ne $key "nvidia.com/gpu" }}
+              {{- if ne $key $gpuKey }}
               {{ $key }}: {{ $value }}
               {{- end }}
               {{- end }}
             requests:
-              nvidia.com/gpu: {{ .Values.gpuCount | quote }}
+              {{ $gpuKey }}: {{ .Values.gpuCount | quote }}
               {{- range $key, $value := .Values.resources.requests }}
-              {{- if ne $key "nvidia.com/gpu" }}
+              {{- if ne $key $gpuKey }}
               {{ $key }}: {{ $value }}
               {{- end }}
               {{- end }}
               {{- else }}
             limits:
               {{- range $key, $value := .Values.resources.limits }}
-              {{- if ne $key "nvidia.com/gpu" }}
+              {{- if ne $key $gpuKey }}
               {{ $key }}: {{ $value }}
               {{- end }}
               {{- end }}
             requests:
               {{- range $key, $value := .Values.resources.requests }}
-              {{- if ne $key "nvidia.com/gpu" }}
+              {{- if ne $key $gpuKey }}
               {{ $key }}: {{ $value }}
               {{- end }}
               {{- end }}

--- a/charts/helix-runner/values.yaml
+++ b/charts/helix-runner/values.yaml
@@ -56,18 +56,23 @@ runner:
 # The runner will automatically detect and use all allocated GPUs
 gpuCount: 1
 
+# Kubernetes resource key used to request GPUs. Defaults to NVIDIA; set to
+# "amd.com/gpu" for AMD/ROCm clusters. Other device-plugin keys are supported
+# as long as the upstream device plugin is installed.
+gpuResourceKey: "nvidia.com/gpu"
+
 # GKE-specific setup for GPU containers
 # Enables NVIDIA library path registration with ldconfig so that
 # Ollama and vLLM can find libcuda.so on GKE nodes
 # Set to true when running on Google Kubernetes Engine
 gkeSetup: false
 
-# Both node selectors and resources need to target
+# Extra pod resource requests/limits (CPU, memory, hugepages, etc.).
+# GPU requests are driven by gpuResourceKey + gpuCount above; you do NOT
+# need to set a GPU key here.
 resources:
-  limits:
-    nvidia.com/gpu: '1'
-  requests:
-    nvidia.com/gpu: '1'
+  limits: {}
+  requests: {}
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/helix-sandbox/templates/deployment.yaml
+++ b/charts/helix-sandbox/templates/deployment.yaml
@@ -206,7 +206,8 @@ spec:
             {{- /* Add GPU resources based on vendor */ -}}
             {{- if eq $gpuVendor "nvidia" }}
             {{- if .Values.gpu.nvidia.enabled }}
-            {{- $gpuLimit := dict "nvidia.com/gpu" (.Values.gpu.nvidia.count | default 1) }}
+            {{- $nvidiaKey := .Values.gpu.nvidia.resourceName | default "nvidia.com/gpu" }}
+            {{- $gpuLimit := dict $nvidiaKey (.Values.gpu.nvidia.count | default 1) }}
             {{- if $resources.limits }}
             {{- $resources = merge $resources (dict "limits" (merge $resources.limits $gpuLimit)) }}
             {{- else }}

--- a/charts/helix-sandbox/templates/statefulset.yaml
+++ b/charts/helix-sandbox/templates/statefulset.yaml
@@ -193,7 +193,8 @@ spec:
             {{- /* Add GPU resources based on vendor */ -}}
             {{- if eq $gpuVendor "nvidia" }}
             {{- if .Values.gpu.nvidia.enabled }}
-            {{- $gpuLimit := dict "nvidia.com/gpu" (.Values.gpu.nvidia.count | default 1) }}
+            {{- $nvidiaKey := .Values.gpu.nvidia.resourceName | default "nvidia.com/gpu" }}
+            {{- $gpuLimit := dict $nvidiaKey (.Values.gpu.nvidia.count | default 1) }}
             {{- if $resources.limits }}
             {{- $resources = merge $resources (dict "limits" (merge $resources.limits $gpuLimit)) }}
             {{- else }}

--- a/charts/helix-sandbox/values.yaml
+++ b/charts/helix-sandbox/values.yaml
@@ -120,6 +120,10 @@ gpu:
     # Runtime class name for OpenShift/Kubernetes
     # OpenShift typically uses "nvidia" or custom runtime class
     runtimeClassName: ""
+    # GPU resource name for Kubernetes device plugin.
+    # Override if you use a non-standard NVIDIA device plugin that advertises
+    # a different resource key.
+    resourceName: "nvidia.com/gpu"
     # GKE-specific setup for nested GPU containers
     # Enables library path configuration and cgroup fixes for Docker-in-Docker
     # Set to true when running on Google Kubernetes Engine


### PR DESCRIPTION
## Summary
- **helix-runner**: `nvidia.com/gpu` was hardcoded in both `values.yaml` and `templates/deployment.yaml`. The template's dedup loop forced `nvidia.com/gpu` back into `limits`/`requests` even when operators overrode `resources:` in their values, so AMD/ROCm users had to manually patch the rendered YAML after every `helm upgrade`. Added a top-level `gpuResourceKey` value (default `"nvidia.com/gpu"`) and replaced all hardcoded references — including the dedup filter — with the configurable key. Removed the redundant `nvidia.com/gpu` entries from the default `resources` block (they were always deduped, rendering unchanged).
- **helix-sandbox**: Already dispatched per-vendor via `gpu.vendor`, with `amd`/`intel` branches reading `.resourceName` from values, but the `nvidia` branch had a hardcoded `"nvidia.com/gpu"`. Added `gpu.nvidia.resourceName` for symmetry and to support non-standard NVIDIA device plugins (e.g. MIG, shared GPUs).
- **README**: added an "AMD GPUs (ROCm)" section to `charts/helix-runner/README.md` with a one-flag override example.
- **Chart versions** are not bumped here — repo convention per prior commit `8599955f0 "Bump chart versions and auto-stamp from release tags"` is that versions are stamped at release time, not in PRs.

## AMD user migration
```yaml
# helix-runner values — replaces any manual resources: patch
gpuResourceKey: "amd.com/gpu"
gpuCount: 1

# helix-sandbox values — unchanged, the existing vendor dispatch already handled AMD
gpu:
  vendor: "amd"
  nvidia:
    enabled: false
  amd:
    enabled: true
    resourceName: "amd.com/gpu"
```

## Render verification (`helm template`)
| Scenario | Rendered resources |
|---|---|
| helix-runner, default (NVIDIA) | `nvidia.com/gpu: "1"` only — unchanged |
| helix-runner, `--set gpuResourceKey=amd.com/gpu` | `amd.com/gpu: "1"` only, no NVIDIA leak |
| helix-runner, `gpuResourceKey=amd.com/gpu` + CPU/memory override | `amd.com/gpu: "1"`, `cpu: 4`, `memory: 8Gi` |
| helix-runner, `gpuCount=0` | empty `limits`/`requests` — unchanged |
| helix-sandbox, default (NVIDIA) | `nvidia.com/gpu: 1` — unchanged |
| helix-sandbox, `--set gpu.nvidia.resourceName=nvidia.com/gpu-shared` | `nvidia.com/gpu-shared: 1` |
| helix-sandbox, AMD enabled | `amd.com/gpu: 1`, no NVIDIA leak |

`helm lint` passes clean on both charts.

## Test plan
- [ ] CI chart lint / template tests pass
- [ ] Deploy to an AMD/ROCm cluster with `gpuResourceKey: "amd.com/gpu"` and confirm pod spec shows `amd.com/gpu: "1"` with no NVIDIA leak
- [ ] Deploy to an NVIDIA cluster with default values and confirm no regression (pod spec unchanged)
- [ ] Verify existing values files that still specify `resources.limits.nvidia.com/gpu: '1'` continue to work (dedup still strips it when `gpuResourceKey=nvidia.com/gpu`)

## Follow-ups (out of scope)
- `helix-sandbox` `amd`/`intel` branches read `.resourceName` without a `| default` fallback — my new nvidia branch does, so siblings are now less defensive. Small consistency fix.
- `helix-runner`'s `gkeSetup` is NVIDIA-only (runs `ldconfig` against `/usr/local/nvidia/lib64`). No AMD/ROCm equivalent today; worth revisiting if AMD on GKE becomes a use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)