### PR TITLE
Validate Claude Code setup tokens and reject Anthropic API keys

### DIFF
--- a/api/pkg/server/claude_subscription_handlers.go
+++ b/api/pkg/server/claude_subscription_handlers.go
@@ -72,7 +72,7 @@ func (apiServer *HelixAPIServer) createClaudeSubscription(_ http.ResponseWriter,
 				"This is an Anthropic API key, not a Claude Code setup token. " +
 					"Run 'claude setup-token' in your terminal to generate the correct token.")
 		}
-		if !strings.HasPrefix(token, "sk-ant-oat01-") {
+		if !strings.HasPrefix(token, "sk-ant-oat") {
 			return nil, system.NewHTTPError400(
 				"Invalid setup token format. " +
 					"Run 'claude setup-token' to generate a valid token.")

--- a/api/pkg/server/claude_subscription_handlers.go
+++ b/api/pkg/server/claude_subscription_handlers.go
@@ -66,7 +66,19 @@ func (apiServer *HelixAPIServer) createClaudeSubscription(_ http.ResponseWriter,
 
 	if createReq.SetupToken != "" {
 		// Setup token flow: token from `claude setup-token`
-		credJSON, err := json.Marshal(types.ClaudeSetupTokenCredentials{SetupToken: strings.TrimSpace(createReq.SetupToken)})
+		token := strings.TrimSpace(createReq.SetupToken)
+		if strings.HasPrefix(token, "sk-ant-api") {
+			return nil, system.NewHTTPError400(
+				"This is an Anthropic API key, not a Claude Code setup token. " +
+					"Run 'claude setup-token' in your terminal to generate the correct token.")
+		}
+		if !strings.HasPrefix(token, "sk-ant-oat01-") {
+			return nil, system.NewHTTPError400(
+				"Invalid setup token format. " +
+					"Run 'claude setup-token' to generate a valid token.")
+		}
+
+		credJSON, err := json.Marshal(types.ClaudeSetupTokenCredentials{SetupToken: token})
 		if err != nil {
 			return nil, system.NewHTTPError500("failed to marshal credentials")
 		}

--- a/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
+++ b/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
@@ -63,6 +63,25 @@ interface ClaudeSubscriptionConnectProps {
 
 const SETUP_TOKEN_COMMAND = 'claude setup-token'
 
+function validateSetupToken(token: string): string | null {
+  const trimmed = token.trim()
+  if (!trimmed) return null
+
+  if (trimmed.startsWith('sk-ant-api')) {
+    return 'This looks like an Anthropic API key, not a Claude Code setup token. Run `claude setup-token` in your terminal to generate the correct token.'
+  }
+
+  if (!trimmed.startsWith('sk-ant-oat01-')) {
+    return "This doesn't look like a valid Claude Code setup token. Run `claude setup-token` to generate one."
+  }
+
+  if (trimmed.length < 50) {
+    return 'This token appears to be incomplete. Make sure you copied the full token.'
+  }
+
+  return null
+}
+
 const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
   variant = 'button',
   onConnected,
@@ -156,6 +175,8 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
     }
   }
 
+  const tokenValidationError = validateSetupToken(tokenValue)
+
   const firstSub = subscriptions?.[0]
   const isSetupToken = firstSub?.credential_type === 'setup_token'
   const expiry = firstSub && !isSetupToken ? getTokenExpiryStatus(firstSub.access_token_expires_at) : null
@@ -192,8 +213,8 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
           autoFocus
           fullWidth
           type="password"
-          label="Your Token"
-          placeholder="Paste your token here..."
+          label="Claude Code Setup Token"
+          placeholder="Paste your Claude Code setup token here..."
           value={tokenValue}
           onChange={(e) => setTokenValue(e.target.value)}
           variant="outlined"
@@ -202,6 +223,12 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
           }}
           sx={{ mb: 1 }}
         />
+
+        {tokenValidationError && (
+          <Alert severity="error" sx={{ mb: 1 }}>
+            {tokenValidationError}
+          </Alert>
+        )}
 
         {submitError && (
           <Alert severity="error" sx={{ mb: 1 }}>
@@ -223,7 +250,7 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
         <Button
           onClick={handleSubmitToken}
           variant="contained"
-          disabled={submitting || !tokenValue.trim()}
+          disabled={submitting || !tokenValue.trim() || !!tokenValidationError}
         >
           {submitting ? <><CircularProgress size={14} sx={{ mr: 0.5 }} /> Connecting...</> : 'Connect'}
         </Button>

--- a/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
+++ b/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
@@ -71,7 +71,7 @@ function validateSetupToken(token: string): string | null {
     return 'This looks like an Anthropic API key, not a Claude Code setup token. Run `claude setup-token` in your terminal to generate the correct token.'
   }
 
-  if (!trimmed.startsWith('sk-ant-oat01-')) {
+  if (!trimmed.startsWith('sk-ant-oat')) {
     return "This doesn't look like a valid Claude Code setup token. Run `claude setup-token` to generate one."
   }
 


### PR DESCRIPTION
## Summary
Users frequently paste their Anthropic API key (`sk-ant-api03-...`) into the Claude Code setup token dialog, which silently accepts it and shows a misleading green "Connected" status. The token only fails later at runtime. This adds frontend and backend validation to catch wrong credential types immediately with helpful error messages.

## Changes
- Add `validateSetupToken()` in `ClaudeSubscriptionConnect.tsx` — checks token prefix and shows specific errors for API keys vs random text
- Disable "Connect" button when validation fails
- Rename text field label from "Your Token" to "Claude Code Setup Token" for clarity
- Add backend validation in `createClaudeSubscription` handler to reject `sk-ant-api*` tokens (HTTP 400) and tokens without the `sk-ant-oat01-` prefix

## Screenshots

**Anthropic API key pasted — specific error shown:**
![API key error](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001866_users-are-confused-about/screenshots/02-api-key-error-visible.png)

**Random text pasted — generic error shown:**
![Random text error](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001866_users-are-confused-about/screenshots/03-random-text-error.png)

**Valid setup token — accepted, Connect enabled:**
![Valid token accepted](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001866_users-are-confused-about/screenshots/04-valid-token-accepted.png)

**After connecting — green Connected status:**
![Connected status](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001866_users-are-confused-about/screenshots/05-valid-token-connected.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kpnjczy3qerrt95fyh8q2b8j)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001866_users-are-confused-about/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001866_users-are-confused-about/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001866_users-are-confused-about/tasks.md)

🚀 Built with [Helix](https://helix.ml)