### PR TITLE
Fix multi-word search in Kanban board and backlog table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,7 @@ func (s *MySuite) SetupTest() { /* init ctrl, store, server */ }
 - **Routing**: `useRouter()` with `router.navigate('name', { params })` — NOT `<Link>` or `<a href>` (react-router5)
 - Invalidate queries after mutations, don't use `setQueryData`
 - Use ContextSidebar pattern (see `ProjectsSidebar.tsx`)
+- **Search/filter**: use `matchesAllTokens()` from `utils/searchUtils.ts` — splits on whitespace, requires all tokens to match (AND logic). NEVER use raw `.includes(query)` for search boxes — it fails on multi-word queries
 
 ## Architecture
 - **ACP**: `LLM ←(OpenAI API)→ Qwen Code Agent ←(ACP)→ Zed IDE`

--- a/frontend/src/components/tasks/BacklogTableView.tsx
+++ b/frontend/src/components/tasks/BacklogTableView.tsx
@@ -26,6 +26,7 @@ import useSnackbar from "../../hooks/useSnackbar";
 import { TypesSpecTaskPriority } from "../../api/api";
 import { SpecTask, useUpdateSpecTask } from "../../services/specTaskService";
 import BacklogFilterBar from "./BacklogFilterBar";
+import { matchesAllTokens } from "../../utils/searchUtils";
 
 // Priority order for sorting (critical at top)
 const PRIORITY_ORDER: Record<string, number> = {
@@ -85,9 +86,8 @@ const BacklogTableView: React.FC<BacklogTableViewProps> = ({
 
     // Apply search filter
     if (search) {
-      const searchLower = search.toLowerCase();
       result = result.filter((task) =>
-        (task.original_prompt || "").toLowerCase().includes(searchLower),
+        matchesAllTokens(search, task.original_prompt),
       );
     }
 

--- a/frontend/src/components/tasks/SpecTaskKanbanBoard.tsx
+++ b/frontend/src/components/tasks/SpecTaskKanbanBoard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from "react";
+import { matchesAllTokens } from "../../utils/searchUtils";
 import {
   Box,
   Typography,
@@ -829,20 +830,21 @@ const SpecTaskKanbanBoard: React.FC<SpecTaskKanbanBoardProps> = ({
     filter: string,
   ): BoardTask[] => {
     if (!filter.trim()) return taskList;
-    const lowerFilter = filter.toLowerCase();
-    // Check if filter is purely numeric (e.g., "1412") for task_number matching
     const trimmedFilter = filter.trim();
     const numericFilter = /^\d+$/.test(trimmedFilter)
       ? parseInt(trimmedFilter, 10)
       : null;
 
-    return taskList.filter(
-      (task) =>
-        task.name?.toLowerCase().includes(lowerFilter) ||
-        task.description?.toLowerCase().includes(lowerFilter) ||
-        task.implementation_plan?.toLowerCase().includes(lowerFilter) ||
-        (numericFilter !== null && task.task_number === numericFilter),
-    );
+    return taskList.filter((task) => {
+      if (numericFilter !== null && task.task_number === numericFilter)
+        return true;
+      return matchesAllTokens(
+        filter,
+        task.name,
+        task.description,
+        task.implementation_plan,
+      );
+    });
   };
 
   // Derive available labels from all loaded tasks

--- a/frontend/src/utils/searchUtils.ts
+++ b/frontend/src/utils/searchUtils.ts
@@ -1,0 +1,10 @@
+export function matchesAllTokens(
+  query: string,
+  ...fields: (string | undefined | null)[]
+): boolean {
+  const trimmed = query.trim();
+  if (!trimmed) return true;
+  const tokens = trimmed.toLowerCase().split(/\s+/);
+  const searchableText = fields.filter(Boolean).join(" ").toLowerCase();
+  return tokens.every((token) => searchableText.includes(token));
+}


### PR DESCRIPTION
## Summary
Multi-word searches like "github public" now match tasks containing all search terms anywhere in the text, instead of requiring the exact substring. Previously, the search treated the entire input as a literal substring match, which failed when the words appeared in different parts of the text.

## Changes
- Add shared `matchesAllTokens()` utility in `frontend/src/utils/searchUtils.ts` that splits queries on whitespace and requires all tokens to match (AND logic)
- Update `SpecTaskKanbanBoard.tsx` `filterTasks` to use `matchesAllTokens` instead of `.includes()`
- Update `BacklogTableView.tsx` search filter to use `matchesAllTokens` instead of `.includes()`

## Test results (browser console verification)
| Query | Expected | Result |
|-------|----------|--------|
| `"github public"` | true | true |
| `"GitHub public"` | true | true |
| `"public"` | true | true |
| `"private repos"` | true | true |
| `"nonexistent word"` | false | false |
| `""` (empty) | true | true |
| `"github   public"` (extra spaces) | true | true |

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kp8rm9x96g7akx17sqkz6pej)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001816_how-come-the-search/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001816_how-come-the-search/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001816_how-come-the-search/tasks.md)

🚀 Built with [Helix](https://helix.ml)