### PR TITLE
Fix GitHub repo browser to show public org repos and add org filter

### DIFF
--- a/api/pkg/agent/skill/github/client.go
+++ b/api/pkg/agent/skill/github/client.go
@@ -103,16 +103,18 @@ func NewClientWithGitHubApp(appID, installationID int64, privateKey, baseURL str
 }
 
 // ListRepositories lists all repositories accessible to the authenticated user
-// including personal repos, collaborator repos, and organization repos
+// including personal repos, collaborator repos, and organization repos (both public and private).
+//
+// GitHub's GET /user/repos with affiliation=organization_member may not return
+// public org repos, so we supplement with per-org repo listing.
 func (c *Client) ListRepositories(ctx context.Context) ([]*github.Repository, error) {
+	// Step 1: Get user repos (personal, collaborator, org-member)
 	var allRepos []*github.Repository
 	opt := &github.RepositoryListOptions{
 		ListOptions: github.ListOptions{PerPage: 100},
 		Sort:        "updated",
-		// Include all repos: owned, collaborator access, and organization membership
 		Affiliation: "owner,collaborator,organization_member",
-		// Include all visibility types (public, private, internal)
-		Visibility: "all",
+		Visibility:  "all",
 	}
 
 	for {
@@ -127,7 +129,82 @@ func (c *Client) ListRepositories(ctx context.Context) ([]*github.Repository, er
 		opt.Page = resp.NextPage
 	}
 
+	// Step 2: List user's organizations
+	orgs, err := c.listUserOrganizations(ctx)
+	if err != nil {
+		// Non-fatal: return what we have from Step 1
+		return allRepos, nil
+	}
+
+	// Step 3: For each org, list all visible repos (includes public ones)
+	for _, org := range orgs {
+		orgRepos, err := c.listOrgRepositories(ctx, org.GetLogin())
+		if err != nil {
+			continue // Skip orgs we can't list, return what we can
+		}
+		allRepos = append(allRepos, orgRepos...)
+	}
+
+	// Step 4: Deduplicate by repo ID
+	return deduplicateRepos(allRepos), nil
+}
+
+// listUserOrganizations returns all organizations the authenticated user belongs to.
+func (c *Client) listUserOrganizations(ctx context.Context) ([]*github.Organization, error) {
+	var allOrgs []*github.Organization
+	opt := &github.ListOptions{PerPage: 100}
+
+	for {
+		orgs, resp, err := c.client.Organizations.List(ctx, "", opt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list organizations: %w", err)
+		}
+		allOrgs = append(allOrgs, orgs...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
+	}
+
+	return allOrgs, nil
+}
+
+// listOrgRepositories returns all repositories in an organization visible to the authenticated user.
+func (c *Client) listOrgRepositories(ctx context.Context, orgLogin string) ([]*github.Repository, error) {
+	var allRepos []*github.Repository
+	opt := &github.RepositoryListByOrgOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
+		Sort:        "updated",
+		Type:        "all",
+	}
+
+	for {
+		repos, resp, err := c.client.Repositories.ListByOrg(ctx, orgLogin, opt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list org repositories for %s: %w", orgLogin, err)
+		}
+		allRepos = append(allRepos, repos...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opt.Page = resp.NextPage
+	}
+
 	return allRepos, nil
+}
+
+// deduplicateRepos removes duplicate repositories by ID.
+func deduplicateRepos(repos []*github.Repository) []*github.Repository {
+	seen := make(map[int64]bool)
+	var result []*github.Repository
+	for _, repo := range repos {
+		id := repo.GetID()
+		if !seen[id] {
+			seen[id] = true
+			result = append(result, repo)
+		}
+	}
+	return result
 }
 
 // CreatePullRequest creates a new pull request

--- a/frontend/src/components/project/BrowseProvidersDialog.tsx
+++ b/frontend/src/components/project/BrowseProvidersDialog.tsx
@@ -24,6 +24,9 @@ import {
   InputAdornment,
   FormControlLabel,
   Switch,
+  Select,
+  MenuItem,
+  FormControl,
 } from "@mui/material";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import {
@@ -155,6 +158,7 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
     string | null
   >(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const [orgFilter, setOrgFilter] = useState("all");
   const [koditIndexing, setKoditIndexing] = useState(true);
   const [selectedRepo, setSelectedRepo] = useState<TypesRepositoryInfo | null>(
     null,
@@ -216,6 +220,7 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
       setSelectedConnectionId(null);
       setSelectedPatConnectionId(null);
       setSearchQuery("");
+      setOrgFilter("all");
       setSelectedRepo(null);
       setKoditIndexing(true);
       setPat("");
@@ -566,6 +571,7 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
       setSelectedConnectionId(null);
       setSelectedPatConnectionId(null);
       setSearchQuery("");
+      setOrgFilter("all");
       setSelectedRepo(null);
       setPatRepos([]);
       setPatReposError(null);
@@ -589,6 +595,7 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
       setSelectedConnectionId(null);
       setSelectedPatConnectionId(null);
       setSearchQuery("");
+      setOrgFilter("all");
       setSelectedRepo(null);
       setPat("");
       setOrgUrl("");
@@ -616,8 +623,26 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
           ? "Failed to load repositories"
           : null;
 
-  // Filter repositories by search query
+  // Extract unique owners/orgs from repo full_name for the filter dropdown
+  const availableOrgs = React.useMemo(() => {
+    const owners = new Set<string>();
+    currentRepos.forEach((repo) => {
+      if (repo.full_name) {
+        const owner = repo.full_name.split("/")[0];
+        if (owner) owners.add(owner);
+      }
+    });
+    return Array.from(owners).sort();
+  }, [currentRepos]);
+
+  // Filter repositories by org and search query
   const filteredRepos = currentRepos.filter((repo) => {
+    // Apply org filter
+    if (orgFilter !== "all") {
+      const owner = repo.full_name?.split("/")[0];
+      if (owner !== orgFilter) return false;
+    }
+    // Apply search filter
     if (!searchQuery) return true;
     const query = searchQuery.toLowerCase();
     return (
@@ -1099,6 +1124,20 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
       </DialogTitle>
       <DialogContent>
         <Box sx={{ mb: 2, display: 'flex', gap: 1, alignItems: 'center' }}>
+          {availableOrgs.length > 1 && (
+            <FormControl size="small" sx={{ minWidth: 140 }}>
+              <Select
+                value={orgFilter}
+                onChange={(e) => setOrgFilter(e.target.value)}
+                displayEmpty
+              >
+                <MenuItem value="all">All orgs</MenuItem>
+                {availableOrgs.map((org) => (
+                  <MenuItem key={org} value={org}>{org}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
           <TextField
             fullWidth
             size="small"
@@ -1138,8 +1177,8 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
         ) : filteredRepos.length === 0 ? (
           <Box sx={{ textAlign: "center", py: 4 }}>
             <Typography color="text.secondary">
-              {searchQuery
-                ? "No repositories match your search"
+              {searchQuery || orgFilter !== "all"
+                ? "No repositories match your filters"
                 : "No repositories found"}
             </Typography>
           </Box>


### PR DESCRIPTION
## Summary
The GitHub repository browser only showed private repos from organizations. This was because the `GET /user/repos` API with `affiliation=organization_member` doesn't reliably return public org repos. Fixed by supplementing with per-org repo listing and deduplicating results. Also added an org filter dropdown to the browser UI for easier navigation.

## Changes
- **Backend** (`api/pkg/agent/skill/github/client.go`): `ListRepositories()` now also fetches the user's orgs via `GET /user/orgs` and lists each org's repos via `GET /orgs/{org}/repos`, then deduplicates by repo ID
- **Frontend** (`frontend/src/components/project/BrowseProvidersDialog.tsx`): Added an org/owner filter dropdown (derived from `full_name`) alongside the existing search field, with proper state reset on navigation

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01knhy82f65398wprgry76nc25)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001725_how-come-i-can-only/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001725_how-come-i-can-only/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001725_how-come-i-can-only/tasks.md)

🚀 Built with [Helix](https://helix.ml)