### PR TITLE
fix: remove amd64-only digest pins from qwen Dockerfiles

### DIFF
--- a/Dockerfile.qwen-build
+++ b/Dockerfile.qwen-build
@@ -9,7 +9,7 @@
 #   packages/     — workspace packages (if present)
 #   package.json, package-lock.json
 
-FROM node:20-slim@sha256:7129e1780341f8dff603243d2b0cb9179c1716291ff6a86706946b629d3c544a AS builder
+FROM node:20-slim AS builder
 
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.qwen-code-build
+++ b/Dockerfile.qwen-code-build
@@ -9,7 +9,7 @@
 #
 # Usage: ./stack build-qwen-code
 # ====================================================================
-FROM node:20-slim@sha256:7129e1780341f8dff603243d2b0cb9179c1716291ff6a86706946b629d3c544a AS builder
+FROM node:20-slim AS builder
 
 # Install git (required for simple-git dependency)
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- `Dockerfile.qwen-build` and `Dockerfile.qwen-code-build` still pin `node:20-slim@sha256:7129e178...`, which is the amd64-only manifest. Missed by `3de1e5dec` ("Remove amd64-only SHA digest pins from all Dockerfiles").
- On arm64 build nodes, Docker pulls the amd64 image and runs it under qemu. `apt-get update` then fails with `At least one invalid signature was encountered` — a known qemu/gpgv interaction.
- Broke release build https://drone.lukemarsden.net/helixml/helix/697 (tag 2.9.31), stage `build-sandbox-arm64` / `build-qwen-code`. Will recur on every tagged release until fixed.

## Fix
Drop the digest pin, use the multi-arch tag. Docker resolves to native platform per builder. Matches what `3de1e5dec` did for every other Dockerfile in the repo.

## Test plan
- [ ] CI passes on both amd64 and arm64 sandbox stages
- [ ] Verify the `InvalidBaseImagePlatform` warning is gone from arm64 build logs
- [ ] Tag a test release after merge to confirm the release pipeline is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)