### PR TITLE
fix: restore docker PATH in macOS CI cleanup cron

### DIFF
--- a/scripts/cleanup-docker-mac-ci.sh
+++ b/scripts/cleanup-docker-mac-ci.sh
@@ -30,8 +30,20 @@
 
 set -uo pipefail
 
+# macOS cron runs with a minimal PATH that doesn't include Docker Desktop's
+# binary location. Without this, every `docker` call silently failed for days
+# and the script reported `removed=0 errors=0` despite doing nothing.
+export PATH="/usr/local/bin:/opt/homebrew/bin:$PATH"
+
 LOG_FILE="/tmp/docker-ci-cleanup.log"
 DRY_RUN="${1:-}"
+
+# Fail fast if docker is still not reachable — silent failure was the bug we
+# just fixed; don't let the script pretend to succeed again.
+if ! command -v docker >/dev/null 2>&1; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [docker-mac-cleanup] FATAL: docker not found in PATH" >&2
+    exit 1
+fi
 
 log() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') [docker-mac-cleanup] $*"


### PR DESCRIPTION
## Summary

- macOS cron runs with a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that omits Docker Desktop's install locations.
- Every `docker` invocation in `cleanup-docker-mac-ci.sh` has been silently failing for at least 5 days on the arm64 build node, while the script logged `Cleanup complete: removed=0 errors=0` and exited 0.
- The Docker Desktop VM filled to 100% (1.9 TB of 2 TB) as a result.
- That disk-full state caused `apt-key`/`gpgv` to fail with `mktemp: No space left on device` inside build containers, which apt surfaces generically as `At least one invalid signature was encountered`.
- This was the actual root cause of the arm64 release build failures in https://drone.lukemarsden.net/helixml/helix/697 (stage 3 controlplane) and https://drone.lukemarsden.net/helixml/helix/709 (stage 16 qwen-code).

### Evidence from `/tmp/docker-ci-cleanup.log` on flight

```
2026-04-21 03:00:01 [docker-mac-cleanup] --- Phase 1: Old helix images (keep newest per repo) ---
/Users/luke/pm/helix/scripts/cleanup-docker-mac-ci.sh: line 43: docker: command not found
/Users/luke/pm/helix/scripts/cleanup-docker-mac-ci.sh: line 47: docker: command not found
...
2026-04-21 03:00:01 [docker-mac-cleanup] Cleanup complete: removed=0 errors=0
```

## Changes

1. `export PATH="/usr/local/bin:/opt/homebrew/bin:$PATH"` — covers Docker Desktop on Intel (`/usr/local/bin/docker`) and Apple Silicon (`/opt/homebrew/bin/docker`).
2. `command -v docker` guard that exits non-zero if docker still isn't reachable — so silent failure can't recur. Not `set -e` because the script has several expected non-zero docker filter returns.

## Operational note

Flight's `pm/helix` clone is at a stale HEAD (`26abc8450`) that predates the script being checked in (`cb6786190`). I've already scp'd the fixed script into place so the next cron tick picks it up. When flight's clone is eventually updated, a `git pull` will reconcile.

## Test plan
- [ ] Verify tomorrow's 3am cron run logs `Removed N images` (not `removed=0`)
- [ ] `docker system df` on flight shows reclaimed space
- [ ] Re-trigger a release build and confirm arm64 stages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)