### PR TITLE
fix: close race window that sends duplicate implementation instructions

### DIFF
--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -1221,6 +1221,22 @@ func (s *SpecDrivenTaskService) ApproveSpecs(ctx context.Context, task *types.Sp
 			}
 		}
 
+		// Set status to implementation BEFORE sending the instruction.
+		// This closes the race window between the HTTP handler's goroutine
+		// and the orchestrator polling loop: both re-read the task from DB,
+		// and if the status is still spec_approved when the second caller
+		// reads it, the idempotency guard (above) won't catch it.
+		now := time.Now()
+		task.Status = types.TaskStatusImplementation
+		task.StatusUpdatedAt = &now
+		task.BranchName = branchName
+		task.StartedAt = &now
+
+		err = s.store.UpdateSpecTask(ctx, task)
+		if err != nil {
+			return fmt.Errorf("failed to update task approval: %w", err)
+		}
+
 		// Send instruction to existing agent session (reuse planning session)
 		sessionID := task.PlanningSessionID
 
@@ -1255,17 +1271,6 @@ func (s *SpecDrivenTaskService) ApproveSpecs(ctx context.Context, task *types.Sp
 			log.Warn().
 				Str("task_id", task.ID).
 				Msg("No planning session ID found - agent will not receive implementation instruction")
-		}
-
-		now := time.Now()
-		task.Status = types.TaskStatusImplementation
-		task.StatusUpdatedAt = &now
-		task.BranchName = branchName
-		task.StartedAt = &now
-
-		err = s.store.UpdateSpecTask(ctx, task)
-		if err != nil {
-			return fmt.Errorf("failed to update task approval: %w", err)
 		}
 
 	} else {


### PR DESCRIPTION
## Summary
- Moves the `UpdateSpecTask` (status → `implementation`) to **before** `SendApprovalInstruction`, closing the race window between the HTTP handler's goroutine and the orchestrator polling loop
- Both callers re-read the task from DB; if the status is still `spec_approved` when the second one reads it, the existing idempotency guard doesn't fire, creating a duplicate interaction with an empty response
- The duplicate empty interaction is what the frontend displays, making it look like the agent response isn't streaming

## Root cause
Observed on `spt_01kpra9hz8a02ser2v2ghzavcj`: two `IMPLEMENTATION` interactions were created 1 second apart (15:37:31Z and 15:37:32Z). The agent responded to the first one (15KB+ of content), but the second one had 0 bytes of response. The frontend showed the latest (empty) interaction.

## Test plan
- [x] `go build ./api/pkg/services/ ./api/pkg/server/` compiles cleanly
- [ ] Approve a spec task and verify only one implementation interaction is created
- [ ] Verify the agent response streams correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)