### PR TITLE
feat(desktop): allow HELIX_ENCODER=vaapi to force VA-API on AMD

### DIFF
--- a/api/pkg/desktop/ws_stream.go
+++ b/api/pkg/desktop/ws_stream.go
@@ -469,13 +469,13 @@ func (v *VideoStreamer) startScanoutMode(ctx context.Context) error {
 //    On AMD, VA-API is skipped in auto-detect due to a historical radeonsi+gst-va
 //    runtime crash. To opt in (newer mesa/gst-va releases have fixed it), set
 //    HELIX_ENCODER=vaapi (or vaapi-legacy for gst-vaapi plugin).
-// 1. NVIDIA NVENC (nvh264enc) - fastest, lowest latency
-// 2. Intel QSV (qsvh264enc) - Intel Quick Sync Video
-// 3. VA-API (vah264enc) - Intel VA-API (skipped on AMD by default — historical crash)
-// 4. VA-API Legacy (vaapih264enc) - older VA-API plugin (skipped on AMD by default)
-// 5. VA-API LP (vah264lpenc) - Intel VA-API Low Power mode (skipped on AMD)
-// 6. OpenH264 (openh264enc) - Cisco's software encoder (AMD default)
-// 7. x264 (x264enc) - software fallback (requires gst-plugins-ugly)
+// 1. NVIDIA NVENC (nvh264enc): fastest, lowest latency
+// 2. Intel QSV (qsvh264enc): Intel Quick Sync Video
+// 3. VA-API (vah264enc): Intel VA-API (skipped on AMD by default due to historical crash)
+// 4. VA-API Legacy (vaapih264enc): older VA-API plugin (skipped on AMD by default)
+// 5. VA-API LP (vah264lpenc): Intel VA-API Low Power mode (skipped on AMD)
+// 6. OpenH264 (openh264enc): Cisco's software encoder (AMD default)
+// 7. x264 (x264enc): software fallback (requires gst-plugins-ugly)
 func (v *VideoStreamer) selectEncoder() string {
 	// Check for explicit encoder override via environment variable
 	if override := os.Getenv("HELIX_ENCODER"); override != "" {
@@ -493,10 +493,18 @@ func (v *VideoStreamer) selectEncoder() string {
 			v.logger.Info("using NVIDIA NVENC encoder (forced via HELIX_ENCODER)")
 			return "nvenc"
 		case "vaapi":
-			v.logger.Info("using VA-API encoder (forced via HELIX_ENCODER — bypasses AMD skip)")
+			if !checkGstElement("vah264enc") {
+				v.logger.Warn("HELIX_ENCODER=vaapi requested but vah264enc element not available, using auto-detect")
+				break
+			}
+			v.logger.Info("using VA-API encoder (forced via HELIX_ENCODER)")
 			return "vaapi"
 		case "vaapi-legacy":
-			v.logger.Info("using VA-API legacy encoder (forced via HELIX_ENCODER — bypasses AMD skip)")
+			if !checkGstElement("vaapih264enc") {
+				v.logger.Warn("HELIX_ENCODER=vaapi-legacy requested but vaapih264enc element not available, using auto-detect")
+				break
+			}
+			v.logger.Info("using VA-API legacy encoder (forced via HELIX_ENCODER)")
 			return "vaapi-legacy"
 		default:
 			v.logger.Warn("unknown HELIX_ENCODER value, using auto-detect", "value", override)
@@ -563,9 +571,11 @@ func (v *VideoStreamer) selectEncoder() string {
 	return "openh264"
 }
 
-// checkGstElement checks if a GStreamer element is available.
-// Uses go-gst bindings to query the element factory.
-func checkGstElement(element string) bool {
+// checkGstElement reports whether a GStreamer element is available.
+// It is a package-level var (not a function) so selectEncoder tests can
+// substitute a deterministic stub without needing a real gstreamer
+// installation on the build host.
+var checkGstElement = func(element string) bool {
 	InitGStreamer()
 	return CheckGstElement(element)
 }

--- a/api/pkg/desktop/ws_stream.go
+++ b/api/pkg/desktop/ws_stream.go
@@ -465,11 +465,14 @@ func (v *VideoStreamer) startScanoutMode(ctx context.Context) error {
 
 // selectEncoder chooses the best available encoder
 // Priority order:
-// 0. HELIX_ENCODER env var override (for testing/benchmarking)
+// 0. HELIX_ENCODER env var override (vsock|openh264|x264|nvenc|vaapi|vaapi-legacy).
+//    On AMD, VA-API is skipped in auto-detect due to a historical radeonsi+gst-va
+//    runtime crash. To opt in (newer mesa/gst-va releases have fixed it), set
+//    HELIX_ENCODER=vaapi (or vaapi-legacy for gst-vaapi plugin).
 // 1. NVIDIA NVENC (nvh264enc) - fastest, lowest latency
 // 2. Intel QSV (qsvh264enc) - Intel Quick Sync Video
-// 3. VA-API (vah264enc) - Intel VA-API (skipped on AMD — runtime crash)
-// 4. VA-API Legacy (vaapih264enc) - older VA-API plugin (skipped on AMD)
+// 3. VA-API (vah264enc) - Intel VA-API (skipped on AMD by default — historical crash)
+// 4. VA-API Legacy (vaapih264enc) - older VA-API plugin (skipped on AMD by default)
 // 5. VA-API LP (vah264lpenc) - Intel VA-API Low Power mode (skipped on AMD)
 // 6. OpenH264 (openh264enc) - Cisco's software encoder (AMD default)
 // 7. x264 (x264enc) - software fallback (requires gst-plugins-ugly)
@@ -489,6 +492,12 @@ func (v *VideoStreamer) selectEncoder() string {
 		case "nvenc":
 			v.logger.Info("using NVIDIA NVENC encoder (forced via HELIX_ENCODER)")
 			return "nvenc"
+		case "vaapi":
+			v.logger.Info("using VA-API encoder (forced via HELIX_ENCODER — bypasses AMD skip)")
+			return "vaapi"
+		case "vaapi-legacy":
+			v.logger.Info("using VA-API legacy encoder (forced via HELIX_ENCODER — bypasses AMD skip)")
+			return "vaapi-legacy"
 		default:
 			v.logger.Warn("unknown HELIX_ENCODER value, using auto-detect", "value", override)
 		}

--- a/api/pkg/desktop/ws_stream_select_encoder_test.go
+++ b/api/pkg/desktop/ws_stream_select_encoder_test.go
@@ -1,0 +1,118 @@
+package desktop
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// withStubbedGstElements installs a stub for checkGstElement for the
+// duration of the test. The stub reports true only for elements in
+// `present` and false otherwise, letting us pin the selector's
+// auto-detect behaviour without needing a real GStreamer install.
+func withStubbedGstElements(t *testing.T, present ...string) {
+	t.Helper()
+	set := map[string]bool{}
+	for _, e := range present {
+		set[e] = true
+	}
+	original := checkGstElement
+	checkGstElement = func(element string) bool { return set[element] }
+	t.Cleanup(func() { checkGstElement = original })
+}
+
+// newStreamerForSelectEncoder produces a minimally-populated
+// VideoStreamer suitable for calling selectEncoder(). Only the logger
+// is read along that path; everything else is zero-value.
+func newStreamerForSelectEncoder() *VideoStreamer {
+	return &VideoStreamer{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+func TestSelectEncoder_HelixEncoderOverrides(t *testing.T) {
+	cases := []struct {
+		name      string
+		override  string
+		available []string
+		want      string
+	}{
+		{"vsock override", "vsock", nil, "vsock"},
+		{"openh264 override", "openh264", nil, "openh264"},
+		{"x264 override", "x264", nil, "x264"},
+		{"nvenc override", "nvenc", nil, "nvenc"},
+		{"vaapi override with element available", "vaapi", []string{"vah264enc"}, "vaapi"},
+		{"vaapi-legacy override with element available", "vaapi-legacy", []string{"vaapih264enc"}, "vaapi-legacy"},
+		{"uppercase value is normalised", "VAAPI", []string{"vah264enc"}, "vaapi"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HELIX_ENCODER", tc.override)
+			t.Setenv("LIBVA_DRIVER_NAME", "")
+			withStubbedGstElements(t, tc.available...)
+			got := newStreamerForSelectEncoder().selectEncoder()
+			if got != tc.want {
+				t.Fatalf("HELIX_ENCODER=%q: got %q, want %q", tc.override, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSelectEncoder_VaapiOverrideFallsBackWhenElementMissing(t *testing.T) {
+	// If the operator asks for VA-API but the element isn't installed,
+	// the override should fail open to auto-detect rather than returning
+	// a string the pipeline builder can't satisfy.
+	t.Setenv("HELIX_ENCODER", "vaapi")
+	t.Setenv("LIBVA_DRIVER_NAME", "")
+	withStubbedGstElements(t, "openh264enc")
+
+	got := newStreamerForSelectEncoder().selectEncoder()
+	if got != "openh264" {
+		t.Fatalf("expected fallback to openh264 when vah264enc missing, got %q", got)
+	}
+}
+
+func TestSelectEncoder_VaapiLegacyOverrideFallsBackWhenElementMissing(t *testing.T) {
+	t.Setenv("HELIX_ENCODER", "vaapi-legacy")
+	t.Setenv("LIBVA_DRIVER_NAME", "")
+	withStubbedGstElements(t, "openh264enc")
+
+	got := newStreamerForSelectEncoder().selectEncoder()
+	if got != "openh264" {
+		t.Fatalf("expected fallback to openh264 when vaapih264enc missing, got %q", got)
+	}
+}
+
+func TestSelectEncoder_UnknownOverrideFallsThrough(t *testing.T) {
+	t.Setenv("HELIX_ENCODER", "banana")
+	t.Setenv("LIBVA_DRIVER_NAME", "")
+	withStubbedGstElements(t, "nvh264enc")
+
+	got := newStreamerForSelectEncoder().selectEncoder()
+	if got != "nvenc" {
+		t.Fatalf("expected auto-detect to pick nvenc, got %q", got)
+	}
+}
+
+func TestSelectEncoder_AutoDetectSkipsVaapiOnAMD(t *testing.T) {
+	// LIBVA_DRIVER_NAME=radeonsi marks AMD; VA-API must be skipped in
+	// auto-detect. OpenH264 is the expected fallback.
+	t.Setenv("HELIX_ENCODER", "")
+	t.Setenv("LIBVA_DRIVER_NAME", "radeonsi")
+	withStubbedGstElements(t, "vah264enc", "vaapih264enc", "openh264enc")
+
+	got := newStreamerForSelectEncoder().selectEncoder()
+	if got != "openh264" {
+		t.Fatalf("expected AMD auto-detect to fall through to openh264, got %q", got)
+	}
+}
+
+func TestSelectEncoder_AutoDetectPicksVaapiOnIntel(t *testing.T) {
+	// On non-AMD the VA-API path is allowed.
+	t.Setenv("HELIX_ENCODER", "")
+	t.Setenv("LIBVA_DRIVER_NAME", "iHD")
+	withStubbedGstElements(t, "vah264enc", "openh264enc")
+
+	got := newStreamerForSelectEncoder().selectEncoder()
+	if got != "vaapi" {
+		t.Fatalf("expected Intel auto-detect to pick vaapi, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `HELIX_ENCODER=vaapi` and `HELIX_ENCODER=vaapi-legacy` as recognised values in the existing encoder override, letting AMD deployments opt into hardware H.264 encoding.

## Why

Commit `df18c9195` (2026-03-16) hard-coded a skip of VA-API encoders when `LIBVA_DRIVER_NAME=radeonsi`, because the gst-va plugin crashed at runtime on AMD with:

```
gst_buffer_insert_memory: assertion 'mem != NULL' failed
```

Retested today inside the actual production image `ghcr.io/helixml/helix-ubuntu:2.9.31-linux-amd64` on an Azure `Standard_NV8ads_V710_v5` (AMD Radeon Pro V710 MxGPU):

- OS: Ubuntu 25.10
- GStreamer: 1.26.6
- Mesa: 25.2.8-0ubuntu0.25.10.1
- libva: 2.22.0-3ubuntu3
- Driver: Mesa Gallium 25.2.8 for AMD Radeon Pro V710 MxGPU (radeonsi, navi32)

`vainfo` advertises `VAEntrypointEncSlice` on H264 baseline/main/high plus HEVC and AV1 encode. Both `vah264enc` (gst-va) and `vaapih264enc` (gst-vaapi legacy) encode cleanly:

```
$ gst-launch-1.0 -q videotestsrc num-buffers=120 \
    ! video/x-raw,width=1920,height=1080,framerate=60/1 \
    ! vah264enc bitrate=8294 ! h264parse ! fakesink
# EXIT=0, no crash

$ gst-launch-1.0 -q videotestsrc num-buffers=120 \
    ! video/x-raw,width=1920,height=1080,framerate=60/1 \
    ! vaapih264enc bitrate=8294 ! h264parse ! fakesink
# EXIT=0, no crash
```

Motivation: on AKS with V710, the desktop-bridge currently falls back to OpenH264 (software) for stream encoding. On smaller GPU nodes this contends with desktop + inner inference processes for CPU, so the spec-task experience feels sluggish even though the GPU sits idle for encoding.

## Approach

Minimal and BC-safe: auto-detect still skips VA-API on AMD (preserves behaviour for users on older helix-ubuntu images where the crash was real). Ops can opt in per-deployment via `HELIX_ENCODER=vaapi` in the sandbox chart values. Once this has some operational bake, a follow-up can flip the default.

## Test plan
- [ ] Rebuild helix-ubuntu with this change
- [ ] Deploy to existing AKS test cluster (`helix-test-20260421` in `rg-helix-test-20260421`) with `sandbox.extraEnv.HELIX_ENCODER=vaapi`
- [ ] Confirm `desktop-bridge` log shows `using VA-API encoder (forced via HELIX_ENCODER ...)`
- [ ] Confirm frames encode cleanly for ≥5 min (no `gst_buffer_insert_memory` assertion)
- [ ] Verify CPU usage on the sandbox pod drops vs OpenH264 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)