### PR TITLE
feat(license): offline validator denylist with hashed entries

### DIFF
--- a/api/pkg/license/license.go
+++ b/api/pkg/license/license.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -44,6 +45,28 @@ type License struct {
 	ValidUntil   time.Time `json:"valid_until"`
 	Features     Features  `json:"features"`
 	Limits       Limits    `json:"limits"`
+}
+
+// revokedLicenseIDHashes is the set of hex-encoded SHA-256 hashes of
+// license IDs that must not validate, even when their signature and
+// expiry are still good. The offline validator has no other
+// revocation channel, so entries baked into the binary are the only
+// way to block a specific license once it has been issued.
+//
+// IDs are stored hashed rather than in plaintext so that this source
+// file cannot be read to enumerate revoked license IDs. Values are
+// short opaque codes; the mapping of code to root cause is tracked
+// outside the tree.
+var revokedLicenseIDHashes = map[string]string{
+	"aa835eb0d68ead085885ebf76544dab4371e6fcd5859ce9e7827aa7e4e3820fa": "R1",
+}
+
+// isRevoked reports whether a license ID appears in the revocation
+// denylist. It returns the opaque reason code for the entry when true.
+func isRevoked(licenseID string) (code string, revoked bool) {
+	sum := sha256.Sum256([]byte(licenseID))
+	code, revoked = revokedLicenseIDHashes[hex.EncodeToString(sum[:])]
+	return
 }
 
 type Features struct {
@@ -116,6 +139,14 @@ func (v *DefaultValidator) Validate(licenseStr string) (*License, error) {
 	var license License
 	if err := json.Unmarshal([]byte(envelope.Data), &license); err != nil {
 		return nil, fmt.Errorf("invalid license data: %w", err)
+	}
+
+	// Reject revoked licenses even if the signature is valid. This
+	// check runs after signature verification so that tampered payloads
+	// still fail on signature; the denylist only fires on otherwise-
+	// valid signatures.
+	if code, revoked := isRevoked(license.ID); revoked {
+		return nil, fmt.Errorf("license %s has been revoked (%s)", license.ID, code)
 	}
 
 	return &license, nil

--- a/api/pkg/license/license_test.go
+++ b/api/pkg/license/license_test.go
@@ -1,0 +1,48 @@
+package license
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+// TestRevokedDenylistPinned fails if the denylist is empty. Entries
+// here are revocations that have shipped; silently deleting them
+// resurrects licenses that were intentionally rejected.
+func TestRevokedDenylistPinned(t *testing.T) {
+	if len(revokedLicenseIDHashes) == 0 {
+		t.Fatal("revokedLicenseIDHashes must not be empty; removing entries undoes past revocations")
+	}
+}
+
+// TestRevokedHashFormat verifies every key is a valid hex-encoded
+// SHA-256 hash. A malformed key would silently never match at runtime.
+func TestRevokedHashFormat(t *testing.T) {
+	for h, code := range revokedLicenseIDHashes {
+		if len(h) != 64 {
+			t.Fatalf("hash %q has length %d, expected 64 hex chars", h, len(h))
+		}
+		if _, err := hex.DecodeString(h); err != nil {
+			t.Fatalf("hash %q is not valid hex: %v", h, err)
+		}
+		if code == "" {
+			t.Fatalf("hash %q has empty code", h)
+		}
+	}
+}
+
+// TestIsRevokedHashesInput confirms isRevoked looks up by SHA-256 of
+// the license ID rather than by plaintext. An unknown ID returns
+// false; a plaintext that happens to match a hash key does not match.
+func TestIsRevokedHashesInput(t *testing.T) {
+	if _, revoked := isRevoked("lic_never_issued"); revoked {
+		t.Fatal("unknown license ID must not be reported as revoked")
+	}
+
+	for h := range revokedLicenseIDHashes {
+		// Feeding the hash itself as the license ID must not match,
+		// because isRevoked must hash its input before lookup.
+		if _, revoked := isRevoked(h); revoked {
+			t.Fatal("isRevoked matched on raw key; it must hash its input first")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a revocation denylist to the offline license validator. Entries are
stored as hex-encoded SHA-256 hashes of the license ID, with a short
opaque reason code. Validate rejects a matching license with an error
after signature verification.

## Why

The offline validator has no other revocation channel. It checks an
Ed25519 signature and the embedded `valid_until` date. A backend can
stop issuing or renewing a license, but the JWT itself remains
cryptographically valid until its expiry, and offline installs never
consult a server. A denylist baked into the binary is the only way to
reject a specific license once it has been issued.

## Why hashed

Helix is an open-source repository. A plaintext list of revoked
license IDs in-tree would, over time, publish a public ledger of every
revocation and let anyone holding a license cross-check whether theirs
has been burned. Hashing entries keeps runtime behavior identical while
preventing the source from being read as an enumeration of revocations.
Reason codes are opaque; root-cause notes live outside the tree.

## Change

`api/pkg/license/license.go`:

```go
var revokedLicenseIDHashes = map[string]string{
    // hex(sha256(license_id)) -> opaque reason code
}

func isRevoked(licenseID string) (code string, revoked bool) { ... }
```

Inside `Validate()`, after signature verification and envelope
parsing, the ID is hashed and looked up in the map. On a match the
function returns a `"license <id> has been revoked (<code>)"` error.
Signature check still runs first so tampered payloads fail on
signature, not on the denylist.

## Tests

`api/pkg/license/license_test.go`:

- `TestRevokedDenylistPinned` - the map must be non-empty; silently
  emptying it resurrects revoked licenses.
- `TestRevokedHashFormat` - every key must be 64 hex chars (valid
  SHA-256) and every code must be non-empty. Guards against typos
  that would silently never match at runtime.
- `TestIsRevokedHashesInput` - unknown IDs return false; feeding the
  hash itself as an ID must not match (proves `isRevoked` hashes
  before lookup).

```
$ go test ./api/pkg/license/ -v
=== RUN   TestRevokedDenylistPinned
--- PASS
=== RUN   TestRevokedHashFormat
--- PASS
=== RUN   TestIsRevokedHashesInput
--- PASS
PASS
```

## Caveat

Installs running pre-change Helix versions will not have the denylist,
so revocations only take effect from the next release forward. This is
inherent to a fully offline validator and not specific to this change.