### PR TITLE
Fix spec tasks stuck in infinite spec_approved processing loop

### DIFF
--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -411,6 +411,23 @@ func (s *HelixAPIServer) approveSpecs(w http.ResponseWriter, r *http.Request) {
 		s.auditLogService.LogTaskApproved(ctx, existingTask, user.ID, user.Email)
 	}
 
+	// Keep DesignReview record in sync — callers of this endpoint bypass
+	// submitDesignReview, so the review record would otherwise stay "pending"
+	// while the task advances to implementation.
+	if req.Approved {
+		reviews, listErr := s.Store.ListSpecTaskDesignReviews(ctx, taskID)
+		if listErr == nil && len(reviews) > 0 {
+			latest := &reviews[len(reviews)-1]
+			if latest.Status != types.SpecTaskDesignReviewStatusApproved {
+				latest.Status = types.SpecTaskDesignReviewStatusApproved
+				latest.ApprovedAt = existingTask.SpecApprovedAt
+				if updateErr := s.Store.UpdateSpecTaskDesignReview(ctx, latest); updateErr != nil {
+					log.Warn().Err(updateErr).Str("review_id", latest.ID).Msg("Failed to sync design review status (continuing)")
+				}
+			}
+		}
+	}
+
 	// Process approval immediately in goroutine (don't wait for orchestrator polling)
 	// This sends the implementation instruction to the agent right away
 	s.wg.Add(1)

--- a/api/pkg/server/spec_task_design_review_handlers.go
+++ b/api/pkg/server/spec_task_design_review_handlers.go
@@ -286,6 +286,38 @@ func (s *HelixAPIServer) submitDesignReview(w http.ResponseWriter, r *http.Reque
 		review.ApprovedAt = &now
 		review.OverallComment = req.OverallComment
 
+		specTask.Status = types.TaskStatusSpecApproved
+		specTask.SpecApprovedBy = user.ID
+		specTask.SpecApprovedAt = &now
+		specTask.StatusUpdatedAt = &now
+		specTask.SpecApproval = &types.SpecApprovalResponse{
+			Approved:   true,
+			ApprovedBy: user.ID,
+			ApprovedAt: now,
+			Comments:   req.OverallComment,
+		}
+
+		if err := s.Store.UpdateSpecTask(ctx, specTask); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if s.auditLogService != nil {
+			s.auditLogService.LogTaskApproved(ctx, specTask, user.ID, user.Email)
+		}
+
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			if err := s.specDrivenTaskService.ApproveSpecs(context.Background(), specTask); err != nil {
+				log.Error().
+					Err(err).
+					Str("spec_task_id", specTask.ID).
+					Str("review_id", review.ID).
+					Msg("[DesignReview] Failed to process spec approval (orchestrator will retry)")
+			}
+		}()
+
 	case "request_changes":
 		review.Status = types.SpecTaskDesignReviewStatusChangesRequested
 		now := time.Now()

--- a/api/pkg/server/spec_task_design_review_handlers.go
+++ b/api/pkg/server/spec_task_design_review_handlers.go
@@ -281,42 +281,57 @@ func (s *HelixAPIServer) submitDesignReview(w http.ResponseWriter, r *http.Reque
 
 	switch req.Decision {
 	case "approve":
+		if review.Status == types.SpecTaskDesignReviewStatusApproved {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(review)
+			return
+		}
+
 		review.Status = types.SpecTaskDesignReviewStatusApproved
 		now := time.Now()
 		review.ApprovedAt = &now
 		review.OverallComment = req.OverallComment
 
-		specTask.Status = types.TaskStatusSpecApproved
-		specTask.SpecApprovedBy = user.ID
-		specTask.SpecApprovedAt = &now
-		specTask.StatusUpdatedAt = &now
-		specTask.SpecApproval = &types.SpecApprovalResponse{
-			Approved:   true,
-			ApprovedBy: user.ID,
-			ApprovedAt: now,
-			Comments:   req.OverallComment,
-		}
-
-		if err := s.Store.UpdateSpecTask(ctx, specTask); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		if s.auditLogService != nil {
-			s.auditLogService.LogTaskApproved(ctx, specTask, user.ID, user.Email)
-		}
-
-		s.wg.Add(1)
-		go func() {
-			defer s.wg.Done()
-			if err := s.specDrivenTaskService.ApproveSpecs(context.Background(), specTask); err != nil {
-				log.Error().
-					Err(err).
-					Str("spec_task_id", specTask.ID).
-					Str("review_id", review.ID).
-					Msg("[DesignReview] Failed to process spec approval (orchestrator will retry)")
+		switch specTask.Status {
+		case types.TaskStatusSpecReview, types.TaskStatusSpecRevision, types.TaskStatusSpecGeneration:
+			specTask.Status = types.TaskStatusSpecApproved
+			specTask.SpecApprovedBy = user.ID
+			specTask.SpecApprovedAt = &now
+			specTask.StatusUpdatedAt = &now
+			specTask.SpecApproval = &types.SpecApprovalResponse{
+				TaskID:     specTask.ID,
+				Approved:   true,
+				ApprovedBy: user.ID,
+				ApprovedAt: now,
+				Comments:   req.OverallComment,
 			}
-		}()
+
+			if err := s.Store.UpdateSpecTask(ctx, specTask); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			if s.auditLogService != nil {
+				s.auditLogService.LogTaskApproved(ctx, specTask, user.ID, user.Email)
+			}
+
+			s.wg.Add(1)
+			go func() {
+				defer s.wg.Done()
+				if err := s.specDrivenTaskService.ApproveSpecs(context.Background(), specTask); err != nil {
+					log.Error().
+						Err(err).
+						Str("spec_task_id", specTask.ID).
+						Str("review_id", review.ID).
+						Msg("[DesignReview] Failed to process spec approval (orchestrator will retry)")
+				}
+			}()
+		default:
+			log.Info().
+				Str("spec_task_id", specTask.ID).
+				Str("status", string(specTask.Status)).
+				Msg("[DesignReview] Task already past spec phase, updating review only")
+		}
 
 	case "request_changes":
 		review.Status = types.SpecTaskDesignReviewStatusChangesRequested

--- a/api/pkg/server/spec_task_workflow_handlers.go
+++ b/api/pkg/server/spec_task_workflow_handlers.go
@@ -83,6 +83,11 @@ func (s *HelixAPIServer) approveImplementation(w http.ResponseWriter, r *http.Re
 		specTask.SpecApprovedBy = user.ID
 		specTask.SpecApprovedAt = &now
 		specTask.StatusUpdatedAt = &now
+		specTask.SpecApproval = &types.SpecApprovalResponse{
+			Approved:   true,
+			ApprovedBy: user.ID,
+			ApprovedAt: now,
+		}
 		if err := s.Store.UpdateSpecTask(ctx, specTask); err != nil {
 			http.Error(w, fmt.Sprintf("Failed to auto-approve specs: %v", err), http.StatusInternalServerError)
 			return

--- a/api/pkg/server/spec_task_workflow_handlers.go
+++ b/api/pkg/server/spec_task_workflow_handlers.go
@@ -84,6 +84,7 @@ func (s *HelixAPIServer) approveImplementation(w http.ResponseWriter, r *http.Re
 		specTask.SpecApprovedAt = &now
 		specTask.StatusUpdatedAt = &now
 		specTask.SpecApproval = &types.SpecApprovalResponse{
+			TaskID:     specTaskID,
 			Approved:   true,
 			ApprovedBy: user.ID,
 			ApprovedAt: now,

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -1137,11 +1137,12 @@ func (s *SpecDrivenTaskService) ApproveSpecs(ctx context.Context, task *types.Sp
 	}
 
 	if task.SpecApproval == nil {
-		approvedAt := time.Time{}
+		approvedAt := time.Now()
 		if task.SpecApprovedAt != nil {
 			approvedAt = *task.SpecApprovedAt
 		}
 		task.SpecApproval = &types.SpecApprovalResponse{
+			TaskID:     task.ID,
 			Approved:   true,
 			ApprovedBy: task.SpecApprovedBy,
 			ApprovedAt: approvedAt,

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -1137,7 +1137,15 @@ func (s *SpecDrivenTaskService) ApproveSpecs(ctx context.Context, task *types.Sp
 	}
 
 	if task.SpecApproval == nil {
-		return fmt.Errorf("spec approval not found")
+		approvedAt := time.Time{}
+		if task.SpecApprovedAt != nil {
+			approvedAt = *task.SpecApprovedAt
+		}
+		task.SpecApproval = &types.SpecApprovalResponse{
+			Approved:   true,
+			ApprovedBy: task.SpecApprovedBy,
+			ApprovedAt: approvedAt,
+		}
 	}
 
 	if task.SpecApproval.Approved {

--- a/api/pkg/services/spec_driven_task_service_test.go
+++ b/api/pkg/services/spec_driven_task_service_test.go
@@ -304,6 +304,7 @@ func TestSpecDrivenTaskService_ApproveSpecs_SynthesizesNilSpecApproval(t *testin
 		func(_ context.Context, task *types.SpecTask) error {
 			assert.Equal(t, types.TaskStatusImplementation, task.Status)
 			assert.NotNil(t, task.SpecApproval, "SpecApproval should have been synthesized")
+			assert.Equal(t, "task-stuck", task.SpecApproval.TaskID)
 			assert.True(t, task.SpecApproval.Approved)
 			assert.Equal(t, "user-1", task.SpecApproval.ApprovedBy)
 			assert.Equal(t, approvedAt, task.SpecApproval.ApprovedAt)
@@ -361,7 +362,7 @@ func TestSpecDrivenTaskService_ApproveSpecs_NilSpecApprovalAndNilApprovedAt(t *t
 			assert.NotNil(t, task.SpecApproval)
 			assert.True(t, task.SpecApproval.Approved)
 			assert.Equal(t, "user-1", task.SpecApproval.ApprovedBy)
-			assert.True(t, task.SpecApproval.ApprovedAt.IsZero(), "ApprovedAt should be zero time when SpecApprovedAt is nil")
+			assert.False(t, task.SpecApproval.ApprovedAt.IsZero(), "ApprovedAt should fall back to time.Now() when SpecApprovedAt is nil")
 			return nil
 		},
 	)

--- a/api/pkg/services/spec_driven_task_service_test.go
+++ b/api/pkg/services/spec_driven_task_service_test.go
@@ -257,6 +257,119 @@ func isValidUTF8(s string) bool {
 	return true
 }
 
+func TestSpecDrivenTaskService_ApproveSpecs_SynthesizesNilSpecApproval(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	var mockPubsub pubsub.PubSub = nil
+
+	service := NewSpecDrivenTaskService(
+		mockStore,
+		nil,
+		"test-helix-agent",
+		[]string{"test-zed-agent"},
+		mockPubsub,
+		nil, nil, nil,
+		NewDisabledKoditService(),
+	)
+	service.SetTestMode(true)
+
+	ctx := context.Background()
+	approvedAt := time.Now()
+
+	// Task has SpecApprovedBy/SpecApprovedAt set but SpecApproval is nil —
+	// this is the broken state from the approveImplementation fallback bug.
+	taskInDB := &types.SpecTask{
+		ID:            "task-stuck",
+		ProjectID:     "project-1",
+		Status:        types.TaskStatusSpecApproved,
+		SpecApprovedBy: "user-1",
+		SpecApprovedAt: &approvedAt,
+		SpecApproval:  nil, // <-- the bug: this was never set
+		TaskNumber:    42,
+		Name:          "stuck-task",
+	}
+
+	mockStore.EXPECT().GetSpecTask(ctx, "task-stuck").Return(taskInDB, nil)
+	mockStore.EXPECT().GetProject(ctx, "project-1").Return(&types.Project{
+		ID:            "project-1",
+		DefaultRepoID: "repo-1",
+	}, nil)
+	mockStore.EXPECT().GetGitRepository(ctx, "repo-1").Return(&types.GitRepository{
+		ID:            "repo-1",
+		DefaultBranch: "main",
+	}, nil)
+	mockStore.EXPECT().UpdateSpecTask(ctx, gomock.Any()).DoAndReturn(
+		func(_ context.Context, task *types.SpecTask) error {
+			assert.Equal(t, types.TaskStatusImplementation, task.Status)
+			assert.NotNil(t, task.SpecApproval, "SpecApproval should have been synthesized")
+			assert.True(t, task.SpecApproval.Approved)
+			assert.Equal(t, "user-1", task.SpecApproval.ApprovedBy)
+			assert.Equal(t, approvedAt, task.SpecApproval.ApprovedAt)
+			return nil
+		},
+	)
+
+	err := service.ApproveSpecs(ctx, &types.SpecTask{ID: "task-stuck"})
+	require.NoError(t, err)
+}
+
+func TestSpecDrivenTaskService_ApproveSpecs_NilSpecApprovalAndNilApprovedAt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	var mockPubsub pubsub.PubSub = nil
+
+	service := NewSpecDrivenTaskService(
+		mockStore,
+		nil,
+		"test-helix-agent",
+		[]string{"test-zed-agent"},
+		mockPubsub,
+		nil, nil, nil,
+		NewDisabledKoditService(),
+	)
+	service.SetTestMode(true)
+
+	ctx := context.Background()
+
+	// Both SpecApproval and SpecApprovedAt are nil — worst case scenario.
+	taskInDB := &types.SpecTask{
+		ID:            "task-worst-case",
+		ProjectID:     "project-1",
+		Status:        types.TaskStatusSpecApproved,
+		SpecApprovedBy: "user-1",
+		SpecApprovedAt: nil,
+		SpecApproval:  nil,
+		TaskNumber:    43,
+		Name:          "worst-case-task",
+	}
+
+	mockStore.EXPECT().GetSpecTask(ctx, "task-worst-case").Return(taskInDB, nil)
+	mockStore.EXPECT().GetProject(ctx, "project-1").Return(&types.Project{
+		ID:            "project-1",
+		DefaultRepoID: "repo-1",
+	}, nil)
+	mockStore.EXPECT().GetGitRepository(ctx, "repo-1").Return(&types.GitRepository{
+		ID:            "repo-1",
+		DefaultBranch: "main",
+	}, nil)
+	mockStore.EXPECT().UpdateSpecTask(ctx, gomock.Any()).DoAndReturn(
+		func(_ context.Context, task *types.SpecTask) error {
+			assert.NotNil(t, task.SpecApproval)
+			assert.True(t, task.SpecApproval.Approved)
+			assert.Equal(t, "user-1", task.SpecApproval.ApprovedBy)
+			assert.True(t, task.SpecApproval.ApprovedAt.IsZero(), "ApprovedAt should be zero time when SpecApprovedAt is nil")
+			return nil
+		},
+	)
+
+	err := service.ApproveSpecs(ctx, &types.SpecTask{ID: "task-worst-case"})
+	require.NoError(t, err)
+}
+
 func TestSpecDrivenTaskService_SelectZedAgent(t *testing.T) {
 	// Test with agents available
 	service := NewSpecDrivenTaskService(nil, nil, "test-helix-agent", []string{"agent1", "agent2"}, nil, nil, nil, nil, NewDisabledKoditService())

--- a/api/pkg/services/spec_task_orchestrator.go
+++ b/api/pkg/services/spec_task_orchestrator.go
@@ -248,7 +248,7 @@ func (o *SpecTaskOrchestrator) processTasks(ctx context.Context) {
 		err := o.processTask(ctx, task)
 		if err != nil {
 			// Tasks with deleted projects are expected - don't spam logs
-			if strings.Contains(err.Error(), "record not found") || strings.Contains(err.Error(), "not found") {
+			if strings.Contains(err.Error(), "record not found") {
 				log.Trace().
 					Err(err).
 					Str("task_id", task.ID).

--- a/api/pkg/services/spec_task_orchestrator.go
+++ b/api/pkg/services/spec_task_orchestrator.go
@@ -15,6 +15,13 @@ import (
 
 //go:generate mockgen -source $GOFILE -destination spec_task_orchestrator_mocks.go -package $GOPACKAGE
 
+// isDeletedProjectError returns true for GORM "record not found" errors that
+// indicate a task references a deleted project. Used to suppress expected noise
+// in orchestrator loops. Must NOT match domain errors like "spec approval not found".
+func isDeletedProjectError(err error) bool {
+	return strings.Contains(err.Error(), "record not found")
+}
+
 // SpecTaskOrchestrator orchestrates SpecTasks through the complete workflow
 // Pushes agents through design → approval → implementation
 // Manages agent lifecycle and reuses sessions across Helix interactions
@@ -248,7 +255,7 @@ func (o *SpecTaskOrchestrator) processTasks(ctx context.Context) {
 		err := o.processTask(ctx, task)
 		if err != nil {
 			// Tasks with deleted projects are expected - don't spam logs
-			if strings.Contains(err.Error(), "record not found") {
+			if isDeletedProjectError(err) {
 				log.Trace().
 					Err(err).
 					Str("task_id", task.ID).
@@ -895,7 +902,7 @@ func (o *SpecTaskOrchestrator) pollPullRequests(ctx context.Context) {
 		err := o.handlePullRequest(ctx, task)
 		if err != nil {
 			// Tasks with deleted projects are expected - don't spam logs
-			if strings.Contains(err.Error(), "record not found") || strings.Contains(err.Error(), "not found") {
+			if isDeletedProjectError(err) {
 				log.Trace().
 					Err(err).
 					Str("task_id", task.ID).
@@ -958,7 +965,7 @@ func (o *SpecTaskOrchestrator) detectExternalPRActivity(ctx context.Context) {
 		err := o.checkTaskForExternalPRActivity(ctx, task)
 		if err != nil {
 			// Don't spam logs for deleted projects
-			if strings.Contains(err.Error(), "record not found") || strings.Contains(err.Error(), "not found") {
+			if isDeletedProjectError(err) {
 				log.Trace().
 					Err(err).
 					Str("task_id", task.ID).

--- a/api/pkg/services/spec_task_orchestrator_test.go
+++ b/api/pkg/services/spec_task_orchestrator_test.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
@@ -413,4 +415,95 @@ func TestSanitizeForBranchName(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func (s *SpecTaskOrchestratorTestSuite) TestHandleSpecApproved_SelfHealsNilSpecApproval() {
+	ctx := context.Background()
+	approvedAt := time.Now()
+
+	// Simulate the broken state: spec_approved status but SpecApproval is nil
+	task := &types.SpecTask{
+		ID:             "task-stuck",
+		ProjectID:      "project-1",
+		Status:         types.TaskStatusSpecApproved,
+		SpecApprovedBy: "user-1",
+		SpecApprovedAt: &approvedAt,
+		SpecApproval:   nil,
+		TaskNumber:     42,
+		Name:           "stuck-task",
+	}
+
+	// Set up the specTaskService on the orchestrator
+	service := NewSpecDrivenTaskService(
+		s.store, nil, "test-helix-agent", []string{"test-zed-agent"},
+		nil, nil, nil, nil, NewDisabledKoditService(),
+	)
+	service.SetTestMode(true)
+	s.orchestrator.specTaskService = service
+
+	// ApproveSpecs re-reads the task from store
+	s.store.EXPECT().GetSpecTask(ctx, "task-stuck").Return(task, nil)
+	s.store.EXPECT().GetProject(ctx, "project-1").Return(&types.Project{
+		ID:            "project-1",
+		DefaultRepoID: "repo-1",
+	}, nil)
+	s.store.EXPECT().GetGitRepository(ctx, "repo-1").Return(&types.GitRepository{
+		ID:            "repo-1",
+		DefaultBranch: "main",
+	}, nil)
+	s.store.EXPECT().UpdateSpecTask(ctx, gomock.Any()).DoAndReturn(
+		func(_ context.Context, t *types.SpecTask) error {
+			s.Equal(types.TaskStatusImplementation, t.Status)
+			s.NotNil(t.SpecApproval, "SpecApproval should have been synthesized")
+			s.True(t.SpecApproval.Approved)
+			s.Equal("user-1", t.SpecApproval.ApprovedBy)
+			return nil
+		},
+	)
+
+	err := s.orchestrator.handleSpecApproved(ctx, task)
+	s.Require().NoError(err)
+}
+
+func (s *SpecTaskOrchestratorTestSuite) TestProcessTask_ErrorFilterDistinguishesNotFoundTypes() {
+	ctx := context.Background()
+
+	// "record not found" (GORM) should match the deleted-project filter
+	gormErr := "failed to get project: record not found"
+	assert.True(s.T(), strings.Contains(gormErr, "record not found"),
+		"GORM 'record not found' should match the filter")
+
+	// "spec approval not found" should NOT match the tightened filter
+	specErr := "failed to approve specs: spec approval not found"
+	assert.False(s.T(), strings.Contains(specErr, "record not found"),
+		"'spec approval not found' should NOT match 'record not found' filter")
+
+	// Verify processTask dispatches to handleSpecApproved
+	task := &types.SpecTask{
+		ID:         "task-test",
+		ProjectID:  "project-1",
+		Status:     types.TaskStatusSpecApproved,
+		TaskNumber: 99,
+		Name:       "test-task",
+	}
+
+	service := NewSpecDrivenTaskService(
+		s.store, nil, "test-helix-agent", []string{},
+		nil, nil, nil, nil, NewDisabledKoditService(),
+	)
+	service.SetTestMode(true)
+	s.orchestrator.specTaskService = service
+
+	// GetSpecTask returns a task where ApproveSpecs will hit GetProject and fail
+	s.store.EXPECT().GetSpecTask(ctx, "task-test").Return(task, nil)
+	s.store.EXPECT().GetProject(ctx, "project-1").Return(&types.Project{
+		ID:            "project-1",
+		DefaultRepoID: "",
+	}, nil)
+
+	err := s.orchestrator.processTask(ctx, task)
+	s.Require().Error(err)
+	// The error should contain "not found" in a domain-specific way, not "record not found"
+	assert.Contains(s.T(), err.Error(), "default repository not set")
+	assert.False(s.T(), strings.Contains(err.Error(), "record not found"))
 }

--- a/api/pkg/services/spec_task_orchestrator_test.go
+++ b/api/pkg/services/spec_task_orchestrator_test.go
@@ -2,7 +2,7 @@ package services
 
 import (
 	"context"
-	"strings"
+	"fmt"
 	"testing"
 	"time"
 
@@ -465,18 +465,20 @@ func (s *SpecTaskOrchestratorTestSuite) TestHandleSpecApproved_SelfHealsNilSpecA
 	s.Require().NoError(err)
 }
 
+func (s *SpecTaskOrchestratorTestSuite) TestIsDeletedProjectError() {
+	// GORM "record not found" errors should match
+	assert.True(s.T(), isDeletedProjectError(fmt.Errorf("failed to get project: record not found")))
+	assert.True(s.T(), isDeletedProjectError(fmt.Errorf("record not found")))
+
+	// Domain errors containing "not found" but NOT "record not found" should NOT match
+	assert.False(s.T(), isDeletedProjectError(fmt.Errorf("spec approval not found")))
+	assert.False(s.T(), isDeletedProjectError(fmt.Errorf("failed to approve specs: spec approval not found")))
+	assert.False(s.T(), isDeletedProjectError(fmt.Errorf("default repository not set for project")))
+	assert.False(s.T(), isDeletedProjectError(fmt.Errorf("branch not found")))
+}
+
 func (s *SpecTaskOrchestratorTestSuite) TestProcessTask_ErrorFilterDistinguishesNotFoundTypes() {
 	ctx := context.Background()
-
-	// "record not found" (GORM) should match the deleted-project filter
-	gormErr := "failed to get project: record not found"
-	assert.True(s.T(), strings.Contains(gormErr, "record not found"),
-		"GORM 'record not found' should match the filter")
-
-	// "spec approval not found" should NOT match the tightened filter
-	specErr := "failed to approve specs: spec approval not found"
-	assert.False(s.T(), strings.Contains(specErr, "record not found"),
-		"'spec approval not found' should NOT match 'record not found' filter")
 
 	// Verify processTask dispatches to handleSpecApproved
 	task := &types.SpecTask{
@@ -505,5 +507,5 @@ func (s *SpecTaskOrchestratorTestSuite) TestProcessTask_ErrorFilterDistinguishes
 	s.Require().Error(err)
 	// The error should contain "not found" in a domain-specific way, not "record not found"
 	assert.Contains(s.T(), err.Error(), "default repository not set")
-	assert.False(s.T(), strings.Contains(err.Error(), "record not found"))
+	assert.False(s.T(), isDeletedProjectError(err))
 }

--- a/frontend/src/components/spec-tasks/DesignReviewContent.tsx
+++ b/frontend/src/components/spec-tasks/DesignReviewContent.tsx
@@ -910,12 +910,6 @@ export default function DesignReviewContent({
       });
 
       if (submitDecision === "approve") {
-        const apiClient = api.getApiClient();
-        await apiClient.v1SpecTasksApproveSpecsCreate(specTaskId, {
-          approved: true,
-          comments: overallComment || "Design approved",
-        });
-
         snackbar.success("Design approved! Agent starting implementation...");
         setShowSubmitDialog(false);
 


### PR DESCRIPTION
## Summary
When a user clicks "Approve Implementation" while a task is still in `spec_review`, the handler's fallback path sets status to `spec_approved` but forgets to populate the `SpecApproval` JSONB field. This causes `ApproveSpecs()` to fail with "spec approval not found", leaving the task permanently stuck while the orchestrator retries every 10 seconds.

## Changes
- **spec_task_workflow_handlers.go**: Populate `specTask.SpecApproval` in the `approveImplementation` fallback path, matching what the normal spec approval handler does
- **spec_driven_task_service.go**: Instead of returning an error when `SpecApproval` is nil, synthesize one from the task's `SpecApprovedBy`/`SpecApprovedAt` fields — this self-heals tasks already stuck in the DB
- **spec_task_orchestrator.go**: Tighten the error filter from `"not found"` to `"record not found"` so that `"spec approval not found"` errors are logged at ERROR level instead of being silently swallowed at TRACE

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kprbewxc3psbtfsvssghdmks)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001869_bug-report-spec-tasks/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001869_bug-report-spec-tasks/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001869_bug-report-spec-tasks/tasks.md)

🚀 Built with [Helix](https://helix.ml)