### PR TITLE
Fix GitHub repo picker: require read:org scope for org repo listing

### DIFF
--- a/api/pkg/agent/skill/github/client.go
+++ b/api/pkg/agent/skill/github/client.go
@@ -130,6 +130,8 @@ func (c *Client) ListRepositories(ctx context.Context) ([]*github.Repository, er
 		opt.Page = resp.NextPage
 	}
 
+	log.Info().Int("user_repos_count", len(allRepos)).Msg("Step 1: fetched user repos")
+
 	// Step 2: List user's organizations
 	orgs, err := c.listUserOrganizations(ctx)
 	if err != nil {
@@ -137,17 +139,27 @@ func (c *Client) ListRepositories(ctx context.Context) ([]*github.Repository, er
 		return allRepos, nil
 	}
 
+	orgNames := make([]string, len(orgs))
+	for i, org := range orgs {
+		orgNames[i] = org.GetLogin()
+	}
+	log.Info().Strs("orgs", orgNames).Int("org_count", len(orgs)).Msg("Step 2: listed user organizations")
+
 	// Step 3: For each org, list all visible repos (includes public ones)
 	for _, org := range orgs {
 		orgRepos, err := c.listOrgRepositories(ctx, org.GetLogin())
 		if err != nil {
-			continue // Skip orgs we can't list, return what we can
+			log.Warn().Err(err).Str("org", org.GetLogin()).Msg("Step 3: failed to list org repos, skipping")
+			continue
 		}
+		log.Info().Str("org", org.GetLogin()).Int("repo_count", len(orgRepos)).Msg("Step 3: fetched org repos")
 		allRepos = append(allRepos, orgRepos...)
 	}
 
 	// Step 4: Deduplicate by repo ID
-	return deduplicateRepos(allRepos), nil
+	deduped := deduplicateRepos(allRepos)
+	log.Info().Int("total_before_dedup", len(allRepos)).Int("total_after_dedup", len(deduped)).Msg("Step 4: deduplicated repos")
+	return deduped, nil
 }
 
 // listUserOrganizations returns all organizations the authenticated user belongs to.

--- a/api/pkg/agent/skill/github/client.go
+++ b/api/pkg/agent/skill/github/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v57/github"
+	"github.com/rs/zerolog/log"
 	"golang.org/x/oauth2"
 )
 
@@ -132,7 +133,7 @@ func (c *Client) ListRepositories(ctx context.Context) ([]*github.Repository, er
 	// Step 2: List user's organizations
 	orgs, err := c.listUserOrganizations(ctx)
 	if err != nil {
-		// Non-fatal: return what we have from Step 1
+		log.Warn().Err(err).Msg("Failed to list user organizations (needs read:org scope) — org-level repo listing will be skipped")
 		return allRepos, nil
 	}
 

--- a/api/pkg/server/git_repository_handlers.go
+++ b/api/pkg/server/git_repository_handlers.go
@@ -1719,6 +1719,17 @@ func (s *HelixAPIServer) browseRemoteRepositories(w http.ResponseWriter, r *http
 			return
 		}
 
+		hasReadOrg := false
+		for _, s := range scopes {
+			if s == "read:org" {
+				hasReadOrg = true
+				break
+			}
+		}
+		if !hasReadOrg {
+			log.Warn().Strs("scopes", scopes).Msg("GitHub PAT missing 'read:org' scope — organization repo listing may be incomplete")
+		}
+
 		ghRepos, err := ghClient.ListRepositories(ctx)
 		if err != nil {
 			if isAuthenticationError(err) {

--- a/frontend/src/components/project/BrowseProvidersDialog.tsx
+++ b/frontend/src/components/project/BrowseProvidersDialog.tsx
@@ -71,7 +71,7 @@ import {
 } from "../../utils/oauthProviders";
 
 // Scopes required for GitHub repo browsing (including workflow file support)
-const GITHUB_REQUIRED_SCOPES = ["repo", "workflow"];
+const GITHUB_REQUIRED_SCOPES = ["repo", "workflow", "read:org"];
 
 interface BrowseProvidersDialogProps {
   open: boolean;
@@ -787,7 +787,7 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
 
           {needsScopeUpgrade && (
             <Alert severity="warning" sx={{ mb: 2 }}>
-              Your GitHub connection needs the <strong>workflow</strong> scope to push changes to <code>.github/workflows/</code>. Click &ldquo;Connect via OAuth&rdquo; below to reconnect with the required permissions.
+              Your GitHub connection is missing required permissions. Click &ldquo;Connect via OAuth&rdquo; below to reconnect with the required scopes (<code>repo</code>, <code>workflow</code>, <code>read:org</code>).
             </Alert>
           )}
 
@@ -1062,7 +1062,7 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
               }}
               helperText={
                 selectedProvider === "github"
-                  ? "Create a token at GitHub → Settings → Developer settings → Personal access tokens"
+                  ? "Create a classic token with 'repo' and 'read:org' scopes at GitHub → Settings → Developer settings → Personal access tokens"
                   : selectedProvider === "gitlab"
                     ? "Create a token at GitLab → Preferences → Access Tokens"
                     : selectedProvider === "bitbucket"

--- a/frontend/src/components/project/BrowseProvidersDialog.tsx
+++ b/frontend/src/components/project/BrowseProvidersDialog.tsx
@@ -635,7 +635,7 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
     return Array.from(owners).sort();
   }, [currentRepos]);
 
-  // Filter repositories by org and search query
+  // Filter repositories by org and search query, then sort alphabetically
   const filteredRepos = currentRepos.filter((repo) => {
     // Apply org filter
     if (orgFilter !== "all") {
@@ -650,7 +650,7 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
       repo.full_name?.toLowerCase().includes(query) ||
       repo.description?.toLowerCase().includes(query)
     );
-  });
+  }).sort((a, b) => (a.full_name || a.name || "").localeCompare(b.full_name || b.name || ""));
 
   const currentProvider = PROVIDERS.find((p) => p.id === selectedProvider);
 
@@ -1163,6 +1163,23 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
             </IconButton>
           </Tooltip>
         </Box>
+
+        {viewMode === "browse-repos" && selectedProvider === "github" && (() => {
+          const ghProvider = providers?.find((p) => matchesProviderType(p.type, p.name, "github"));
+          const settingsUrl = ghProvider?.client_id
+            ? `https://github.com/settings/connections/applications/${ghProvider.client_id}`
+            : "https://github.com/settings/applications";
+          return (
+            <Alert severity="info" sx={{ mb: 2 }}>
+              Not seeing repos from all your organizations? Organizations can restrict OAuth app access.
+              Check your{" "}
+              <a href={settingsUrl} target="_blank" rel="noopener noreferrer">
+                GitHub application settings
+              </a>{" "}
+              and grant access for each organization.
+            </Alert>
+          );
+        })()}
 
         {currentError && (
           <Alert severity="error" sx={{ mb: 2 }}>


### PR DESCRIPTION
## Summary

Task 1725 added a 4-step `ListRepositories()` to fetch public org repos, but Step 2 (`GET /user/orgs`) silently fails without `read:org` scope — returning 403 per GitHub API docs. This meant Steps 2-3 never ran, so public org repos were still missing.

Additionally, GitHub OAuth App org-level access restrictions can silently prevent org data from being returned even with correct scopes. The UI now explains this and links to the settings page.

## Changes

- Add `read:org` to `GITHUB_REQUIRED_SCOPES` — existing OAuth connections without it now trigger scope upgrade banner
- Update scope upgrade warning to list all required scopes (`repo`, `workflow`, `read:org`)
- Update PAT helper text to mention `read:org` scope requirement
- Add server-side warning log when PAT is missing `read:org`
- Add warning log when `listUserOrganizations()` fails (was silent fallback)
- Sort repo list alphabetically by full_name in browse view
- Add info Alert explaining GitHub OAuth App org access restrictions with link to `https://github.com/settings/connections/applications/{client_id}`

## Root Cause

Two issues:

1. **Missing scope**: GitHub's `GET /user/orgs` endpoint requires `read:org` or `user` scope. Without it, the call returns 403, which was caught and silently swallowed. The OAuth auth URL already requests `read:org`, but existing connections created before that change didn't have it, and `GITHUB_REQUIRED_SCOPES` only checked for `["repo", "workflow"]`.

2. **Org access restrictions**: GitHub allows organizations to restrict which OAuth apps can access their data. Even with correct scopes, restricted orgs are invisible to the API. Users need to grant access at the GitHub settings page. The UI now explains this clearly.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kpra9hz8a02ser2v2ghzavcj)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001868_we-just-merged-and/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001868_we-just-merged-and/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001868_we-just-merged-and/tasks.md)

🚀 Built with [Helix](https://helix.ml)