### PR TITLE
Surface outside-collaborator org repos; mark read-only repos in picker

### DIFF
--- a/api/pkg/agent/skill/github/client.go
+++ b/api/pkg/agent/skill/github/client.go
@@ -107,7 +107,13 @@ func NewClientWithGitHubApp(appID, installationID int64, privateKey, baseURL str
 // including personal repos, collaborator repos, and organization repos (both public and private).
 //
 // GitHub's GET /user/repos with affiliation=organization_member may not return
-// public org repos, so we supplement with per-org repo listing.
+// public org repos, so we supplement with per-org repo listing. We discover orgs
+// from two sources because each misses cases the other catches:
+//   - GET /user/orgs returns orgs the user is a *member* of, but not orgs where
+//     the user is only an outside collaborator on individual repos.
+//   - The owners of repos returned by /user/repos surface those collaborator orgs,
+//     but only if the user has access to at least one repo in them.
+// Unioning both gives us every org we can plausibly enumerate public repos for.
 func (c *Client) ListRepositories(ctx context.Context) ([]*github.Repository, error) {
 	// Step 1: Get user repos (personal, collaborator, org-member)
 	var allRepos []*github.Repository
@@ -132,27 +138,59 @@ func (c *Client) ListRepositories(ctx context.Context) ([]*github.Repository, er
 
 	log.Info().Int("user_repos_count", len(allRepos)).Msg("Step 1: fetched user repos")
 
-	// Step 2: List user's organizations
-	orgs, err := c.listUserOrganizations(ctx)
-	if err != nil {
-		log.Warn().Err(err).Msg("Failed to list user organizations (needs read:org scope) — org-level repo listing will be skipped")
-		return allRepos, nil
-	}
-
-	orgNames := make([]string, len(orgs))
-	for i, org := range orgs {
-		orgNames[i] = org.GetLogin()
-	}
-	log.Info().Strs("orgs", orgNames).Int("org_count", len(orgs)).Msg("Step 2: listed user organizations")
-
-	// Step 3: For each org, list all visible repos (includes public ones)
-	for _, org := range orgs {
-		orgRepos, err := c.listOrgRepositories(ctx, org.GetLogin())
-		if err != nil {
-			log.Warn().Err(err).Str("org", org.GetLogin()).Msg("Step 3: failed to list org repos, skipping")
+	// Collect orgs from owners of org-owned repos in Step 1. This catches orgs
+	// where the user is an outside collaborator and so doesn't appear in /user/orgs.
+	orgsFromRepos := make(map[string]bool)
+	for _, repo := range allRepos {
+		owner := repo.GetOwner()
+		if owner == nil {
 			continue
 		}
-		log.Info().Str("org", org.GetLogin()).Int("repo_count", len(orgRepos)).Msg("Step 3: fetched org repos")
+		if owner.GetType() == "Organization" {
+			orgsFromRepos[owner.GetLogin()] = true
+		}
+	}
+
+	// Step 2: List user's organizations (orgs the user is a member of).
+	// May fail if read:org scope is missing — in that case we still proceed
+	// using only the orgs derived from Step 1.
+	memberOrgs, err := c.listUserOrganizations(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to list user organizations (needs read:org scope) — falling back to orgs derived from user repos")
+	}
+
+	allOrgs := make(map[string]bool, len(orgsFromRepos)+len(memberOrgs))
+	for org := range orgsFromRepos {
+		allOrgs[org] = true
+	}
+	for _, org := range memberOrgs {
+		allOrgs[org.GetLogin()] = true
+	}
+
+	memberOrgNames := make([]string, len(memberOrgs))
+	for i, org := range memberOrgs {
+		memberOrgNames[i] = org.GetLogin()
+	}
+	collaboratorOnlyOrgs := make([]string, 0)
+	for org := range orgsFromRepos {
+		if _, isMember := lookupOrgInList(memberOrgs, org); !isMember {
+			collaboratorOnlyOrgs = append(collaboratorOnlyOrgs, org)
+		}
+	}
+	log.Info().
+		Strs("member_orgs", memberOrgNames).
+		Strs("collaborator_only_orgs", collaboratorOnlyOrgs).
+		Int("total_orgs_to_query", len(allOrgs)).
+		Msg("Step 2: assembled org list (members + collaborator-only)")
+
+	// Step 3: For each org, list all visible repos (includes public ones)
+	for orgLogin := range allOrgs {
+		orgRepos, err := c.listOrgRepositories(ctx, orgLogin)
+		if err != nil {
+			log.Warn().Err(err).Str("org", orgLogin).Msg("Step 3: failed to list org repos, skipping")
+			continue
+		}
+		log.Info().Str("org", orgLogin).Int("repo_count", len(orgRepos)).Msg("Step 3: fetched org repos")
 		allRepos = append(allRepos, orgRepos...)
 	}
 
@@ -160,6 +198,28 @@ func (c *Client) ListRepositories(ctx context.Context) ([]*github.Repository, er
 	deduped := deduplicateRepos(allRepos)
 	log.Info().Int("total_before_dedup", len(allRepos)).Int("total_after_dedup", len(deduped)).Msg("Step 4: deduplicated repos")
 	return deduped, nil
+}
+
+// HasWriteAccess returns true when the authenticated user can push to the repo.
+// GitHub populates Permissions on /user/repos and /orgs/{org}/repos for authenticated
+// requests, so a missing map is unusual; we treat it as write access to avoid
+// over-blocking the link UI in edge cases (e.g. GitHub App contexts).
+func HasWriteAccess(repo *github.Repository) bool {
+	perms := repo.GetPermissions()
+	if perms == nil {
+		return true
+	}
+	return perms["admin"] || perms["maintain"] || perms["push"]
+}
+
+// lookupOrgInList returns the matching org and true if login appears in orgs.
+func lookupOrgInList(orgs []*github.Organization, login string) (*github.Organization, bool) {
+	for _, o := range orgs {
+		if o.GetLogin() == login {
+			return o, true
+		}
+	}
+	return nil, false
 }
 
 // listUserOrganizations returns all organizations the authenticated user belongs to.

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -27161,6 +27161,10 @@ const docTemplate = `{
         "types.RepositoryInfo": {
             "type": "object",
             "properties": {
+                "can_write": {
+                    "description": "CanWrite is true when the authenticated user has push or admin access to the repo.\nHelix needs write access to push branches and open pull requests, so read-only\nrepos can be listed but cannot be linked as a project repo.",
+                    "type": "boolean"
+                },
                 "clone_url": {
                     "description": "HTTPS clone URL",
                     "type": "string"

--- a/api/pkg/server/git_provider_connection_handlers.go
+++ b/api/pkg/server/git_provider_connection_handlers.go
@@ -407,6 +407,7 @@ func (s *HelixAPIServer) fetchRepositoriesWithPAT(ctx context.Context, req types
 				Description:   repo.GetDescription(),
 				Private:       repo.GetPrivate(),
 				DefaultBranch: repo.GetDefaultBranch(),
+				CanWrite:      github.HasWriteAccess(repo),
 			})
 		}
 
@@ -428,6 +429,7 @@ func (s *HelixAPIServer) fetchRepositoriesWithPAT(ctx context.Context, req types
 				Description:   project.Description,
 				Private:       project.Visibility != "public",
 				DefaultBranch: project.DefaultBranch,
+				CanWrite:      true, // GitLab permission introspection not yet wired up; preserve prior behaviour
 			})
 		}
 
@@ -466,6 +468,7 @@ func (s *HelixAPIServer) fetchRepositoriesWithPAT(ctx context.Context, req types
 				HTMLURL:       htmlURL,
 				Private:       true,
 				DefaultBranch: defaultBranch,
+				CanWrite:      true, // ADO permission introspection not yet wired up; preserve prior behaviour
 			})
 		}
 
@@ -487,6 +490,7 @@ func (s *HelixAPIServer) fetchRepositoriesWithPAT(ctx context.Context, req types
 				Description:   repo.Description,
 				Private:       repo.IsPrivate,
 				DefaultBranch: repo.MainBranch,
+				CanWrite:      true, // Bitbucket permission introspection not yet wired up; preserve prior behaviour
 			})
 		}
 

--- a/api/pkg/server/git_repository_handlers.go
+++ b/api/pkg/server/git_repository_handlers.go
@@ -1750,6 +1750,7 @@ func (s *HelixAPIServer) browseRemoteRepositories(w http.ResponseWriter, r *http
 				Description:   repo.GetDescription(),
 				Private:       repo.GetPrivate(),
 				DefaultBranch: repo.GetDefaultBranch(),
+				CanWrite:      github.HasWriteAccess(repo),
 			})
 		}
 
@@ -1785,6 +1786,7 @@ func (s *HelixAPIServer) browseRemoteRepositories(w http.ResponseWriter, r *http
 				Description:   project.Description,
 				Private:       project.Visibility != "public",
 				DefaultBranch: project.DefaultBranch,
+				CanWrite:      true, // GitLab permission introspection not yet wired up; preserve prior behaviour
 			})
 		}
 
@@ -1838,6 +1840,7 @@ func (s *HelixAPIServer) browseRemoteRepositories(w http.ResponseWriter, r *http
 				Description:   "",   // ADO repos don't have description in the basic response
 				Private:       true, // ADO repos are private by default
 				DefaultBranch: defaultBranch,
+				CanWrite:      true, // ADO permission introspection not yet wired up; preserve prior behaviour
 			})
 		}
 

--- a/api/pkg/server/oauth.go
+++ b/api/pkg/server/oauth.go
@@ -1093,6 +1093,7 @@ func (s *HelixAPIServer) handleListOAuthConnectionRepositories(_ http.ResponseWr
 				Description:   repo.GetDescription(),
 				Private:       repo.GetPrivate(),
 				DefaultBranch: repo.GetDefaultBranch(),
+				CanWrite:      github.HasWriteAccess(repo),
 			})
 		}
 
@@ -1124,6 +1125,7 @@ func (s *HelixAPIServer) handleListOAuthConnectionRepositories(_ http.ResponseWr
 				Description:   project.Description,
 				Private:       project.Visibility != "public",
 				DefaultBranch: project.DefaultBranch,
+				CanWrite:      true, // GitLab/ADO permission introspection not yet wired up; preserve prior behaviour
 			})
 		}
 
@@ -1192,6 +1194,7 @@ func (s *HelixAPIServer) handleListOAuthConnectionRepositories(_ http.ResponseWr
 				Description:   "", // ADO repos don't have description in the basic response
 				Private:       true, // ADO repos are private by default
 				DefaultBranch: defaultBranch,
+				CanWrite:      true, // ADO permission introspection not yet wired up; preserve prior behaviour
 			})
 		}
 

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -27157,6 +27157,10 @@
         "types.RepositoryInfo": {
             "type": "object",
             "properties": {
+                "can_write": {
+                    "description": "CanWrite is true when the authenticated user has push or admin access to the repo.\nHelix needs write access to push branches and open pull requests, so read-only\nrepos can be listed but cannot be linked as a project repo.",
+                    "type": "boolean"
+                },
                 "clone_url": {
                     "description": "HTTPS clone URL",
                     "type": "string"

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -7127,6 +7127,12 @@ definitions:
     type: object
   types.RepositoryInfo:
     properties:
+      can_write:
+        description: |-
+          CanWrite is true when the authenticated user has push or admin access to the repo.
+          Helix needs write access to push branches and open pull requests, so read-only
+          repos can be listed but cannot be linked as a project repo.
+        type: boolean
       clone_url:
         description: HTTPS clone URL
         type: string

--- a/api/pkg/types/external_repositories.go
+++ b/api/pkg/types/external_repositories.go
@@ -10,6 +10,10 @@ type RepositoryInfo struct {
 	Description string `json:"description"`
 	Private     bool   `json:"private"`
 	DefaultBranch string `json:"default_branch,omitempty"`
+	// CanWrite is true when the authenticated user has push or admin access to the repo.
+	// Helix needs write access to push branches and open pull requests, so read-only
+	// repos can be listed but cannot be linked as a project repo.
+	CanWrite bool `json:"can_write"`
 }
 
 // ListOAuthRepositoriesResponse is the response for listing repositories from an OAuth connection

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -4328,6 +4328,12 @@ export interface TypesRepositoryAccessCheck {
 }
 
 export interface TypesRepositoryInfo {
+  /**
+   * CanWrite is true when the authenticated user has push or admin access to the repo.
+   * Helix needs write access to push branches and open pull requests, so read-only
+   * repos can be listed but cannot be linked as a project repo.
+   */
+  can_write?: boolean;
   /** HTTPS clone URL */
   clone_url?: string;
   default_branch?: string;

--- a/frontend/src/components/project/BrowseProvidersDialog.tsx
+++ b/frontend/src/components/project/BrowseProvidersDialog.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
   CircularProgress,
   Alert,
+  Link,
   List,
   ListItem,
   ListItemButton,
@@ -1173,9 +1174,16 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
             <Alert severity="info" sx={{ mb: 2 }}>
               Not seeing repos from all your organizations? Organizations can restrict OAuth app access.
               Check your{" "}
-              <a href={settingsUrl} target="_blank" rel="noopener noreferrer">
+              <Link
+                href={settingsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                color="inherit"
+                underline="always"
+                sx={{ fontWeight: 600 }}
+              >
                 GitHub application settings
-              </a>{" "}
+              </Link>{" "}
               and grant access for each organization.
             </Alert>
           );

--- a/frontend/src/components/project/BrowseProvidersDialog.tsx
+++ b/frontend/src/components/project/BrowseProvidersDialog.tsx
@@ -1223,6 +1223,17 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
                       secondary={repo.description || "No description"}
                       secondaryTypographyProps={{ noWrap: true }}
                     />
+                    {repo.can_write === false && (
+                      <Tooltip title="You only have read access. Helix can't push branches or open PRs against this repo. Fork it to your account to contribute.">
+                        <Chip
+                          label="Read-only"
+                          size="small"
+                          color="warning"
+                          variant="outlined"
+                          sx={{ ml: 1 }}
+                        />
+                      </Tooltip>
+                    )}
                     {repo.private && (
                       <Chip
                         label="Private"
@@ -1261,6 +1272,13 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
                 </Box>
               }
             />
+            {selectedRepo.can_write === false && (
+              <Alert severity="warning" sx={{ mt: 2 }}>
+                You only have read access to this repo. Helix needs push access to commit changes
+                and open pull requests, so it can&apos;t be linked to a project. To contribute,
+                fork it to your own account or organization first.
+              </Alert>
+            )}
             {organizationName && (
               <Alert severity="info" sx={{ mt: 2 }}>
                 This repository will be accessible to all members of{" "}
@@ -1273,14 +1291,28 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
       <DialogActions>
         <Button onClick={handleBack}>Back</Button>
         <Button onClick={onClose}>Cancel</Button>
-        <Button
-          variant="contained"
-          color="secondary"
-          onClick={handleSelectRepo}
-          disabled={!selectedRepo || isLinking}
+        <Tooltip
+          title={
+            selectedRepo?.can_write === false
+              ? "Read-only repos can't be linked — fork it first"
+              : ""
+          }
         >
-          {isLinking ? <CircularProgress size={20} /> : "Link Repository"}
-        </Button>
+          <span>
+            <Button
+              variant="contained"
+              color="secondary"
+              onClick={handleSelectRepo}
+              disabled={
+                !selectedRepo ||
+                isLinking ||
+                selectedRepo.can_write === false
+              }
+            >
+              {isLinking ? <CircularProgress size={20} /> : "Link Repository"}
+            </Button>
+          </span>
+        </Tooltip>
       </DialogActions>
     </Dialog>
   );

--- a/frontend/src/contexts/theme.tsx
+++ b/frontend/src/contexts/theme.tsx
@@ -130,19 +130,19 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
               transition: 'all 0.2s ease-in-out',
             },
             root: {
-              zIndex: 100002, // Above floating windows (z-index 9999) and tooltips (100001)
+              zIndex: 100002, // Above floating windows (z-index 9999); tooltips (100004) render above
               transition: 'all 0.2s ease-in-out',
             },
           },
         },
-        // Ensure tooltips appear above floating windows (z-index 9999) and modals
+        // Tooltips must sit above dialogs (100002), popovers and select menus (100003)
+        // so they remain visible when triggered from elements inside a modal.
         MuiTooltip: {
           defaultProps: {
-            // Higher z-index ensures tooltips appear above floating windows
             slotProps: {
               popper: {
                 sx: {
-                  zIndex: 100001,
+                  zIndex: 100004,
                 },
               },
             },

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -7127,6 +7127,12 @@ definitions:
     type: object
   types.RepositoryInfo:
     properties:
+      can_write:
+        description: |-
+          CanWrite is true when the authenticated user has push or admin access to the repo.
+          Helix needs write access to push branches and open pull requests, so read-only
+          repos can be listed but cannot be linked as a project repo.
+        type: boolean
       clone_url:
         description: HTTPS clone URL
         type: string

--- a/openapi.json
+++ b/openapi.json
@@ -30815,6 +30815,10 @@
             "types.RepositoryInfo": {
                 "type": "object",
                 "properties": {
+                    "can_write": {
+                        "description": "CanWrite is true when the authenticated user has push or admin access to the repo.\nHelix needs write access to push branches and open pull requests, so read-only\nrepos can be listed but cannot be linked as a project repo.",
+                        "type": "boolean"
+                    },
                     "clone_url": {
                         "description": "HTTPS clone URL",
                         "type": "string"

--- a/swagger.json
+++ b/swagger.json
@@ -27157,6 +27157,10 @@
         "types.RepositoryInfo": {
             "type": "object",
             "properties": {
+                "can_write": {
+                    "description": "CanWrite is true when the authenticated user has push or admin access to the repo.\nHelix needs write access to push branches and open pull requests, so read-only\nrepos can be listed but cannot be linked as a project repo.",
+                    "type": "boolean"
+                },
                 "clone_url": {
                     "description": "HTTPS clone URL",
                     "type": "string"


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/helixml/helix/pull/2251. That PR added `read:org` to requested scopes, but a separate edge case kept public org repos hidden when the user is an **outside collaborator** rather than an org member.

When you're an outside collaborator on private repos in an org (e.g. Luke on `gatewaze/lf-gatewaze-agents`), GitHub's `GET /user/orgs` does **not** return that org — `read:org` doesn't help, because you're not a member. As a result, the existing flow never queried `/orgs/gatewaze/repos`, so the 3 public repos in that org stayed invisible.

This PR also addresses what to do once those repos surface: outside-collaborator access on public repos is typically pull-only, so we now mark them and prevent them being linked as a Helix project repo (Helix needs push to commit changes and open PRs).

## Changes

**Discovery fix** — `api/pkg/agent/skill/github/client.go`
- `ListRepositories()` unions `/user/orgs` results with the unique organization owners of repos already returned by `/user/repos`. The collaborator-only case is observable from those repos, no extra permissions or user input needed.
- New `HasWriteAccess()` helper reads `repo.GetPermissions()` (`admin || maintain || push`).

**Read-only UX**
- `types.RepositoryInfo` gains `CanWrite bool`, populated from GitHub permissions at all 3 conversion sites (`oauth.go`, `git_repository_handlers.go`, `git_provider_connection_handlers.go`). Non-GitHub providers default to `true` pending equivalent permission introspection.
- `BrowseProvidersDialog.tsx` — yellow `Read-only` chip on read-only repos; warning Alert when one is selected; Link Repository button disabled with tooltip suggesting to fork.

**Unrelated tooltip-under-modal bug** — `frontend/src/contexts/theme.tsx`
- `MuiTooltip` was at z-index `100001` while `MuiDialog` was at `100002`, so tooltips inside dialogs (including the new tooltip on the disabled Link button above) were hidden by the modal. Bumped tooltip to `100004` so it sits above dialogs (`100002`) and popovers/selects (`100003`).

## Verification

Confirmed against the live OAuth connection at meta.helix.ml — the 3 public gatewaze repos (`gatewaze/gatewaze`, `gatewaze/gatewaze-modules`, `gatewaze/lf-gatewaze-modules`) now appear in the picker with the `Read-only` badge, and the Link button is disabled when one is selected. The 2 private repos (`gatewaze/lf-gatewaze-agents`, `gatewaze/premium-gatewaze-modules`) where the user has admin remain linkable.

## Test plan

- [ ] Browse Repositories → GitHub → confirm previously invisible public org repos now appear when you're an outside collaborator
- [ ] Confirm `Read-only` chip shows on repos with pull-only permissions
- [ ] Confirm Link Repository button is disabled with tooltip when a read-only repo is selected
- [ ] Confirm tooltip on disabled button now renders **above** the modal (was hidden under it before)
- [ ] Confirm regular org-member repos (where the user has push) still link normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)