### PR TITLE
Gate spec approval on tab viewing and improve resolve button icon

### DIFF
--- a/frontend/src/components/spec-tasks/CommentLogSidebar.tsx
+++ b/frontend/src/components/spec-tasks/CommentLogSidebar.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Box, Typography, Paper, Chip, IconButton } from '@mui/material'
-import CloseIcon from '@mui/icons-material/Close'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import { MessageWithToolCalls, ResponseEntry } from '../session/InteractionInference'
 import { DesignReviewComment } from '../../services/designReviewService'
@@ -74,8 +73,8 @@ export default function CommentLogSidebar({
                     color={comment.quoted_text ? "primary" : "default"}
                   />
                   {!comment.resolved && (
-                    <IconButton size="small" onClick={() => onResolveComment(comment.id!)}>
-                      <CloseIcon fontSize="small" />
+                    <IconButton size="small" onClick={() => onResolveComment(comment.id!)} sx={{ color: 'success.main' }}>
+                      <CheckCircleIcon fontSize="small" />
                     </IconButton>
                   )}
                 </Box>

--- a/frontend/src/components/spec-tasks/DesignReviewContent.tsx
+++ b/frontend/src/components/spec-tasks/DesignReviewContent.tsx
@@ -126,6 +126,7 @@ export default function DesignReviewContent({
   const [viewedTabs, setViewedTabs] = useState<Set<DocumentType>>(
     new Set(["requirements"]),
   );
+  const viewedContentRef = useRef<Map<DocumentType, string>>(new Map());
   const [showRejectDialog, setShowRejectDialog] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
   const [shareLinkCopied, setShareLinkCopied] = useState(false);
@@ -248,6 +249,12 @@ export default function DesignReviewContent({
   );
   const unresolvedCount = getUnresolvedCount(allComments);
 
+  const ALL_TABS: DocumentType[] = ["requirements", "technical_design", "implementation_plan"];
+  const allTabsViewed = ALL_TABS.every((t) => viewedTabs.has(t));
+  const unviewedTabNames = ALL_TABS
+    .filter((t) => !viewedTabs.has(t))
+    .map((t) => DOCUMENT_LABELS[t]);
+
   // Memoize document content
   const documentContent = useMemo(() => {
     if (!review) return "";
@@ -272,10 +279,51 @@ export default function DesignReviewContent({
       .length;
   };
 
+  const getTabContent = (tab: DocumentType): string => {
+    if (!review) return "";
+    switch (tab) {
+      case "requirements":
+        return review.requirements_spec || "";
+      case "technical_design":
+        return review.technical_design || "";
+      case "implementation_plan":
+        return review.implementation_plan || "";
+    }
+  };
+
+  // Snapshot content on initial mount for the default tab
+  useEffect(() => {
+    if (review && !viewedContentRef.current.has("requirements")) {
+      viewedContentRef.current.set("requirements", getTabContent("requirements"));
+    }
+  }, [review]);
+
+  // Invalidate viewed tabs when content changes
+  useEffect(() => {
+    if (!review) return;
+    const tabs: DocumentType[] = ["requirements", "technical_design", "implementation_plan"];
+    const invalidated: DocumentType[] = [];
+    for (const tab of tabs) {
+      const snapshot = viewedContentRef.current.get(tab);
+      if (snapshot !== undefined && snapshot !== getTabContent(tab)) {
+        invalidated.push(tab);
+        viewedContentRef.current.delete(tab);
+      }
+    }
+    if (invalidated.length > 0) {
+      setViewedTabs((prev) => {
+        const next = new Set(prev);
+        for (const tab of invalidated) next.delete(tab);
+        return next;
+      });
+    }
+  }, [review?.requirements_spec, review?.technical_design, review?.implementation_plan]);
+
   // Handle tab change
   const handleTabChange = (newTab: DocumentType) => {
     setActiveTab(newTab);
     setViewedTabs((prev) => new Set(prev).add(newTab));
+    viewedContentRef.current.set(newTab, getTabContent(newTab));
     if (documentRef.current) {
       documentRef.current.scrollTop = 0;
     }
@@ -1090,69 +1138,41 @@ export default function DesignReviewContent({
                 },
               }}
             >
-              <Tab
-                label={
-                  <Box display="flex" alignItems="center" gap={0.5}>
-                    Requirements
-                    {getCommentCount("requirements") > 0 && (
-                      <Chip
-                        label={getCommentCount("requirements")}
-                        size="small"
-                        color="warning"
-                        sx={{
-                          height: 16,
-                          minWidth: 16,
-                          fontSize: "0.65rem",
-                          "& .MuiChip-label": { px: 0.5 },
-                        }}
-                      />
-                    )}
-                  </Box>
-                }
-                value="requirements"
-              />
-              <Tab
-                label={
-                  <Box display="flex" alignItems="center" gap={0.5}>
-                    Technical Design
-                    {getCommentCount("technical_design") > 0 && (
-                      <Chip
-                        label={getCommentCount("technical_design")}
-                        size="small"
-                        color="warning"
-                        sx={{
-                          height: 16,
-                          minWidth: 16,
-                          fontSize: "0.65rem",
-                          "& .MuiChip-label": { px: 0.5 },
-                        }}
-                      />
-                    )}
-                  </Box>
-                }
-                value="technical_design"
-              />
-              <Tab
-                label={
-                  <Box display="flex" alignItems="center" gap={0.5}>
-                    Implementation Plan
-                    {getCommentCount("implementation_plan") > 0 && (
-                      <Chip
-                        label={getCommentCount("implementation_plan")}
-                        size="small"
-                        color="warning"
-                        sx={{
-                          height: 16,
-                          minWidth: 16,
-                          fontSize: "0.65rem",
-                          "& .MuiChip-label": { px: 0.5 },
-                        }}
-                      />
-                    )}
-                  </Box>
-                }
-                value="implementation_plan"
-              />
+              {ALL_TABS.map((tab) => (
+                <Tab
+                  key={tab}
+                  label={
+                    <Box display="flex" alignItems="center" gap={0.5}>
+                      {DOCUMENT_LABELS[tab]}
+                      {!viewedTabs.has(tab) && (
+                        <Box
+                          sx={{
+                            width: 8,
+                            height: 8,
+                            borderRadius: "50%",
+                            bgcolor: "warning.main",
+                            flexShrink: 0,
+                          }}
+                        />
+                      )}
+                      {getCommentCount(tab) > 0 && (
+                        <Chip
+                          label={getCommentCount(tab)}
+                          size="small"
+                          color="warning"
+                          sx={{
+                            height: 16,
+                            minWidth: 16,
+                            fontSize: "0.65rem",
+                            "& .MuiChip-label": { px: 0.5 },
+                          }}
+                        />
+                      )}
+                    </Box>
+                  }
+                  value={tab}
+                />
+              ))}
             </Tabs>
 
             {/* Git info and actions on the right */}
@@ -1506,6 +1526,8 @@ export default function DesignReviewContent({
             setSubmitDecision("request_changes");
             setShowSubmitDialog(true);
           }}
+          allTabsViewed={allTabsViewed}
+          unviewedTabNames={unviewedTabNames}
           onReject={() => setShowRejectDialog(true)}
           onStartImplementation={handleStartImplementation}
         />

--- a/frontend/src/components/spec-tasks/InlineCommentBubble.tsx
+++ b/frontend/src/components/spec-tasks/InlineCommentBubble.tsx
@@ -8,7 +8,7 @@ import {
   CircularProgress,
   Button,
 } from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import { MessageWithToolCalls, ResponseEntry } from "../session/InteractionInference";
@@ -126,8 +126,8 @@ export default function InlineCommentBubble({
         mb={1}
       >
         <Chip label="Comment" size="small" color="primary" />
-        <IconButton size="small" onClick={() => onResolve(comment.id!)}>
-          <CloseIcon fontSize="small" />
+        <IconButton size="small" onClick={() => onResolve(comment.id!)} sx={{ color: "success.main" }}>
+          <CheckCircleIcon fontSize="small" />
         </IconButton>
       </Box>
 

--- a/frontend/src/components/spec-tasks/ReviewActionFooter.tsx
+++ b/frontend/src/components/spec-tasks/ReviewActionFooter.tsx
@@ -9,6 +9,8 @@ interface ReviewActionFooterProps {
   implementationStarted: boolean // True if task is already in implementation phase
   isBlockedByDependencies?: boolean
   blockedReason?: string
+  allTabsViewed?: boolean
+  unviewedTabNames?: string[]
   onApprove: () => void
   onRequestChanges: () => void
   onReject: () => void
@@ -22,6 +24,8 @@ export default function ReviewActionFooter({
   implementationStarted,
   isBlockedByDependencies = false,
   blockedReason = '',
+  allTabsViewed = true,
+  unviewedTabNames = [],
   onApprove,
   onRequestChanges,
   onReject,
@@ -89,14 +93,25 @@ export default function ReviewActionFooter({
           >
             Request Changes
           </Button>
-          <Button
-            variant="contained"
-            color="success"
-            onClick={onApprove}
-            disabled={unresolvedCount > 0}
+          <Tooltip
+            title={
+              !allTabsViewed
+                ? `Review all tabs before approving: ${unviewedTabNames.join(', ')}`
+                : ''
+            }
+            placement="top"
           >
-            Approve Design
-          </Button>
+            <span>
+              <Button
+                variant="contained"
+                color="success"
+                onClick={onApprove}
+                disabled={unresolvedCount > 0 || !allTabsViewed}
+              >
+                Approve Design
+              </Button>
+            </span>
+          </Tooltip>
         </>
       ) : (
         <Alert severity="info" sx={{ flex: 1 }}>


### PR DESCRIPTION
## Summary
Prevents users from approving a spec design until they've viewed all three tabs (Requirements, Technical Design, Implementation Plan). Also changes the comment resolve button from an ambiguous X icon to a green checkmark.

## Changes
- **ReviewActionFooter**: Disable "Approve Design" button when not all tabs viewed, with tooltip showing which tabs remain
- **DesignReviewContent**: Wire existing `viewedTabs` state to the footer; add content-change detection that invalidates viewed tabs when the agent revises content; add orange dot indicator on unviewed tab labels; refactor tab rendering to use `.map()`
- **InlineCommentBubble**: Replace `CloseIcon` with green `CheckCircleIcon` on resolve button
- **CommentLogSidebar**: Same resolve icon change; remove unused `CloseIcon` import

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kpx1t8sg1cwahrt6s6sfbw69)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001891_dont-let-the-user/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001891_dont-let-the-user/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001891_dont-let-the-user/tasks.md)

🚀 Built with [Helix](https://helix.ml)