### PR TITLE
UI nits

### DIFF
--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -16,11 +16,13 @@ import {
   CheckCircle as ApproveIcon,
   Close as CloseIcon,
   RocketLaunch as LaunchIcon,
+  SkipNext as SkipIcon,
   Replay as ReopenIcon,
 } from "@mui/icons-material";
 import {
   useApproveImplementation,
   useStopAgent,
+  useSkipSpec,
   useReopenTask,
 } from "../../services/specTaskWorkflowService";
 import { useUpdateSpecTask } from "../../services/specTaskService";
@@ -182,6 +184,7 @@ export default function SpecTaskActionButtons({
 }: SpecTaskActionButtonsProps) {
   const approveImplementationMutation = useApproveImplementation(task.id);
   const stopAgentMutation = useStopAgent(task.id);
+  const skipSpecMutation = useSkipSpec(task.id);
   const reopenTaskMutation = useReopenTask(task.id);
   const updateSpecTaskMutation = useUpdateSpecTask();
   const [isReviewingSpec, setIsReviewingSpec] = useState(false);
@@ -264,12 +267,14 @@ export default function SpecTaskActionButtons({
         : isBlockedByDependencies
           ? "Queue Planning"
           : task.metadata?.error
-            ? "Retry Planning"
-            : "Start Planning";
+            ? task.just_do_it_mode
+              ? "Retry Implementation"
+              : "Retry Planning"
+            : task.just_do_it_mode
+              ? "Start Implementation"
+              : "Start Planning";
 
-    const skipLabel = task.metadata?.error
-      ? "or retry as implementation"
-      : "or skip to implementation";
+    const skipLabel = "or skip to implementation";
 
     const handleSkipToImplementation = async (e: React.MouseEvent) => {
       e.stopPropagation();
@@ -279,6 +284,29 @@ export default function SpecTaskActionButtons({
       });
       onStartPlanning?.();
     };
+
+    const skipDisabled =
+      isStartDisabled || updateSpecTaskMutation.isPending || !!task.just_do_it_mode;
+
+    const skipLink = (
+      <Typography
+        variant="caption"
+        onClick={skipDisabled ? undefined : handleSkipToImplementation}
+        sx={{
+          whiteSpace: "nowrap",
+          cursor: skipDisabled ? "default" : "pointer",
+          color: skipDisabled ? "text.disabled" : "text.secondary",
+          "&:hover": skipDisabled
+            ? {}
+            : {
+                color: "primary.main",
+                textDecoration: "underline",
+              },
+        }}
+      >
+        {updateSpecTaskMutation.isPending ? "Starting..." : skipLabel}
+      </Typography>
+    );
 
     if (isInline) {
       return (
@@ -300,6 +328,7 @@ export default function SpecTaskActionButtons({
             }}
             disabled={isStartDisabled}
           />
+          {!task.just_do_it_mode && skipLink}
         </Box>
       );
     }
@@ -332,25 +361,48 @@ export default function SpecTaskActionButtons({
             </Button>
           </span>
         </Tooltip>
-        <Box sx={{ mt: 0.5, display: "flex", justifyContent: "center" }}>
-          <Tooltip title="Skip planning and go straight to implementation" placement="top">
-            <Typography
-              variant="caption"
-              onClick={handleSkipToImplementation}
-              sx={{
-                cursor: isStartDisabled || updateSpecTaskMutation.isPending ? "default" : "pointer",
-                color: isStartDisabled || updateSpecTaskMutation.isPending ? "text.disabled" : "text.secondary",
-                "&:hover": isStartDisabled || updateSpecTaskMutation.isPending ? {} : {
-                  color: "primary.main",
-                  textDecoration: "underline",
-                },
-                pointerEvents: isStartDisabled || updateSpecTaskMutation.isPending ? "none" : "auto",
+        {!task.just_do_it_mode && (
+          <Box sx={{ mt: 0.5, display: "flex", justifyContent: "center" }}>
+            {skipLink}
+          </Box>
+        )}
+      </Box>
+    );
+  }
+
+  // Spec generation phase: recovery Skip Planning button for stuck tasks.
+  // Only shown in the detail page (inline variant) to keep kanban cards uncluttered.
+  if (task.status === "spec_generation" && isInline) {
+    const isSkipping = skipSpecMutation.isPending;
+    return (
+      <Box sx={{ display: "flex", gap: 1 }}>
+        <Tooltip
+          title={isArchived ? "Task is archived" : "Skip planning and start implementation"}
+          placement="top"
+        >
+          <span>
+            <Button
+              variant="outlined"
+              size="small"
+              color="warning"
+              startIcon={
+                isSkipping ? (
+                  <CircularProgress size={18} color="inherit" />
+                ) : (
+                  <SkipIcon sx={{ fontSize: 18 }} />
+                )
+              }
+              onClick={(e) => {
+                e.stopPropagation();
+                skipSpecMutation.mutate();
               }}
+              disabled={isArchived || isSkipping}
+              sx={buttonSx}
             >
-              {updateSpecTaskMutation.isPending ? "Starting..." : skipLabel}
-            </Typography>
-          </Tooltip>
-        </Box>
+              {isSkipping ? "Skipping..." : "Skip Planning"}
+            </Button>
+          </span>
+        </Tooltip>
       </Box>
     );
   }

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -87,6 +87,7 @@ import {
   useGetProjectRepositories,
 } from "../../services/projectService";
 import { useMoveToBacklog } from "../../services/specTaskWorkflowService";
+import { getUserById } from "../../services/userService";
 import CloneTaskDialog from "../specTask/CloneTaskDialog";
 import AgentDropdown from "../agent/AgentDropdown";
 import CloneGroupProgressFull from "../specTask/CloneGroupProgress";
@@ -165,6 +166,13 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
     withDependsOn: true,
     enabled: !!task?.project_id,
   });
+
+  const { data: taskAuthor } = getUserById(task?.created_by || "", !!task?.created_by);
+  const authorDisplay =
+    taskAuthor?.full_name ||
+    taskAuthor?.username ||
+    taskAuthor?.email ||
+    task?.created_by;
 
   // Label state
   const { data: projectLabels = [] } = useProjectLabels(
@@ -1332,7 +1340,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
       <Box sx={{ mt: 3 }}>
         {task?.created_by && (
           <Typography variant="caption" color="text.secondary" display="block">
-            Author: {task.created_by}
+            Author: {authorDisplay}
           </Typography>
         )}
         <Typography variant="caption" color="text.secondary" display="block">

--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -738,7 +738,7 @@ function TaskCardInner({
           />
         </Tooltip>
       )}
-      <CardContent sx={{ p: 2, "&:last-child": { pb: 2 } }}>
+      <CardContent sx={{ p: 2, "&:last-child": { pb: 4 } }}>
         {/* Task name */}
         <Box
           sx={{


### PR DESCRIPTION
## Summary
Follow-ups on https://github.com/helixml/helix/pull/2253 plus a couple of adjacent fixes noticed during review.

- `SpecTaskActionButtons`
  - Start / Retry button label now reflects `just_do_it_mode` (reads "Start Implementation" / "Retry Implementation" when yolo is already on, so the label matches what the backend will actually do)
  - Skip link kept on kanban backlog card AND added to the task detail page header (previous inline variant had no skip affordance)
  - Recovery "Skip Planning" button restored for stuck `spec_generation` tasks, detail page only (kept off kanban cards to avoid noise)
  - Dropped the tooltip on the skip link — it was redundant with the link text and rendered on top of the Start Planning button above it
- `SpecTaskDetailContent` — Author resolves via `getUserById` to `full_name → username → email → id` instead of showing the raw `usr_xxx` id
- `TaskCard` — bumped `CardContent` `pb` from 2 → 4 so the task-number badge no longer collides with bottom action buttons (Stop Agent etc.)

## Test plan
- [x] `yarn build` passes
- [ ] Kanban backlog card: "Start Planning" button + "or skip to implementation" link beneath
- [ ] Task detail header: same button + link layout; skip link hidden when `just_do_it_mode` is already true
- [ ] Backlog task with `just_do_it_mode: true` (API-created or cloned) shows "Start Implementation" label
- [ ] Stuck `spec_generation` task: outlined "Skip Planning" recovery button visible on detail page
- [ ] Task detail Author line shows a human name, not `usr_...`
- [ ] Task number `#000001` no longer overlaps the Stop Agent button on implementation-review cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)