### PR TITLE
fix: persist synthesized SpecApproval in atomic transition path

### DIFF
--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -1242,6 +1243,18 @@ func (s *SpecDrivenTaskService) ApproveSpecs(ctx context.Context, task *types.Sp
 		}
 		if task.HelixAppID != "" {
 			extraFields["helix_app_id"] = task.HelixAppID
+		}
+		// Persist the synthesized SpecApproval struct (only set when the
+		// caller arrived with task.SpecApproval == nil). The pre-PR2260
+		// implementation persisted this implicitly via UpdateSpecTask saving
+		// the whole struct; the atomic-update path only writes columns we
+		// list here.
+		if task.SpecApproval != nil {
+			specApprovalJSON, marshalErr := json.Marshal(task.SpecApproval)
+			if marshalErr != nil {
+				return fmt.Errorf("failed to marshal SpecApproval: %w", marshalErr)
+			}
+			extraFields["spec_approval"] = string(specApprovalJSON)
 		}
 		transitioned, err := s.store.TransitionSpecTaskStatus(
 			ctx,

--- a/api/pkg/services/spec_driven_task_service_test.go
+++ b/api/pkg/services/spec_driven_task_service_test.go
@@ -306,12 +306,20 @@ func TestSpecDrivenTaskService_ApproveSpecs_SynthesizesNilSpecApproval(t *testin
 		gomock.Any(),
 		types.TaskStatusImplementation,
 		gomock.Any(),
-	).Return(true, nil)
+	).DoAndReturn(func(_ context.Context, _ string, _ []types.SpecTaskStatus, _ types.SpecTaskStatus, extraFields map[string]any) (bool, error) {
+		// Synthesized SpecApproval must be persisted in the same atomic UPDATE,
+		// otherwise the in-memory synthesis is lost on the next re-fetch.
+		raw, ok := extraFields["spec_approval"]
+		require.True(t, ok, "spec_approval field must be in extraFields when SpecApproval was synthesized")
+		jsonStr, ok := raw.(string)
+		require.True(t, ok, "spec_approval must be marshalled to a JSON string")
+		assert.Contains(t, jsonStr, "task-stuck")
+		assert.Contains(t, jsonStr, "user-1")
+		return true, nil
+	})
 
 	err := service.ApproveSpecs(ctx, &types.SpecTask{ID: "task-stuck"})
 	require.NoError(t, err)
-	// SpecApproval is synthesized in-memory; verifying via mock callback would require
-	// re-fetching after the transition, which TransitionSpecTaskStatus doesn't expose.
 	_ = approvedAt
 }
 


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/helixml/helix/pull/2260. While investigating an unrelated streaming bug I noticed that PR2260 silently dropped persistence of `SpecApproval` when the in-memory synthesis path runs.

## Root cause

Pre-PR2260, `ApproveSpecs` ended in `s.store.UpdateSpecTask(ctx, task)` which calls `tx.Save(task)` — that persists every field on the struct, including the `SpecApproval` synthesized at lines 1139-1150 when the caller arrives with `task.SpecApproval == nil`.

PR2260 replaced that with `TransitionSpecTaskStatus(...)`, which only writes the columns explicitly named in `extraFields`. `spec_approval` was not in the list. Result: when a task hits `ApproveSpecs` with `SpecApproval==nil`, the synthesis runs but the JSONB column is never updated.

The existing tests (`TestSpecDrivenTaskService_ApproveSpecs_SynthesizesNilSpecApproval` and `TestSpecDrivenTaskService_ApproveSpecs_NilSpecApprovalAndNilApprovedAt`) didn't catch this — they only asserted the mock call was made, not that the synthesized struct was passed through.

## Fix

- Marshal `task.SpecApproval` to JSON and add it to `extraFields` when non-nil.
- Update `TestSpecDrivenTaskService_ApproveSpecs_SynthesizesNilSpecApproval` to use `DoAndReturn` and assert the `spec_approval` field is present in the UPDATE.

## Files

- `api/pkg/services/spec_driven_task_service.go` — add `spec_approval` to extraFields, add `encoding/json` import
- `api/pkg/services/spec_driven_task_service_test.go` — assertion that `spec_approval` is included

## Test plan

- [x] `go test -v -run TestSpecDrivenTaskService_ApproveSpecs ./pkg/services/ -count=1` passes (3/3)
- [x] `go build ./pkg/services/` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)