### PR TITLE
fix: replace fragile sticky-scroll with simple auto-scroll toggle

### DIFF
--- a/design/2026-04-24-duplicate-claude-acp-spawn.md
+++ b/design/2026-04-24-duplicate-claude-acp-spawn.md
@@ -1,0 +1,107 @@
+# Duplicate `claude-agent-acp` spawn breaks chrome-devtools MCP
+
+## Symptom
+
+In a resumed spec task agent session (`spt_01kpx1cn84drg8mea69s6wbyvv`,
+session `f163a349-f8a3-447b-9789-d7a36e6fb66b`), the model says
+"No such tool available: mcp__chrome-devtools__navigate_page" for every
+chrome-devtools call. Other stdio MCPs (`github`, `drone-ci`) and HTTP MCPs
+(`helix-desktop`, `helix-session`) work fine. Zed's own UI shows
+chrome-devtools as connected with all tools listed — but those are Zed's
+context_server tools, not the agent's.
+
+The same session worked perfectly the day before (2026-04-23 11:30–17:02,
+dozens of chrome-devtools calls succeeded). The break appeared 16 minutes
+after the container was restarted today.
+
+## Root cause
+
+Two concurrent `claude` processes are running, both with
+`--resume f163a349-f8a3-447b-9789-d7a36e6fb66b`, each spawned by its own
+`npm exec @agentclientprotocol/claude-agent-acp@0.30.0` wrapper:
+
+```
+npm exec @agent(7966) → claude(8028)  children: github, drone-ci          ← active, broken
+npm exec @agent(7973) → claude(8041)  children: chrome-devtools, github, drone-ci
+```
+
+`claude` 8028 — the one the model is actually talking to — has no
+chrome-devtools-mcp child process at all. It successfully spawned `github`
+and `drone-ci` stdio MCPs but chrome-devtools never started (or crashed
+silently during init). The other claude (8041) has all three but is unused.
+
+A fresh `claude` spawned manually with the exact same `--mcp-config` JSON
+in the same container reports `chrome-devtools: connected` with 29 tools.
+So chrome-devtools-mcp 0.23.0, the stdio transport, and the SDK all work
+fine when there's only one claude per session.
+
+The chrome-devtools-mcp at PID 6781 visible in `ps` is owned by Zed itself
+(parent chain via PID 6315, `npm exec` directly under Zed's process tree),
+not by either claude. That's why Zed shows the tools.
+
+## Earlier dedup work, and why it isn't catching this case
+
+Prior fixes for related dedup races (all still in place):
+
+- zed `826d32faae` (Apr 2) — `THREAD_LOAD_IN_PROGRESS` lock in
+  `crates/external_websocket_sync/src/thread_service.rs` to prevent
+  workspace restore + `open_thread` from both spawning load tasks.
+- helix `d66bfd20e` (Mar 20) — `findSessionByZedThreadID` dedup in
+  `websocket_external_agent_sync.go` to stop creating multiple Helix
+  sessions for the same Zed thread.
+
+Six more zed-side commits between Apr 2 and now strengthened the load lock
+(`d470dac687`, `48de0cf877`, `f3a2622736`, `40a88fde39`, `48700037d0`,
+`22f94a8bbb`). The `48700037d0 Add logging to observe whether thread load
+guard fires in practice` commit is itself a tell — someone was already
+unsure the guard was catching duplicates.
+
+The current guard is a single mutex (post-`40a88fde39`), with a
+"wait then fast-path" branch when `open_thread` arrives during panel
+restoration. So duplicate load of the *same* `acp_thread_id` should be
+deduped.
+
+## Hypotheses for the regression
+
+1. **Two different `acp_thread_id`s targeting the same claude session.**
+   The lock dedups per thread ID, not per `--resume` session ID. If two
+   distinct Zed threads both pass `--resume f163a349-...` to claude, both
+   pass the lock independently and both spawn ACP wrappers.
+2. **A spawn path that bypasses the load lock entirely.** Some path
+   creates an `AgentConnection` (and therefore spawns
+   `claude-agent-acp`) without going through `open_existing_thread_sync`
+   or `load_agent_thread`.
+3. **Sequential, not concurrent, spawns.** Workspace restore acquires and
+   releases the lock; some later trigger (websocket reconnect, retry,
+   etc.) re-spawns after the lock is gone. Lock as written only catches
+   *concurrent* loads.
+
+## Next debug step
+
+Existing `[THREAD_SERVICE]` eprintln logs (added in `48700037d0`) are
+sufficient. After reproducing, look for either:
+
+- Two `🔒 Acquired thread load lock for <id>` lines with **different**
+  `acp_thread_id` values that resolve to the same `agent_id` — confirms
+  hypothesis 1.
+- An ACP wrapper spawn (visible in `ps -ef | grep claude-agent-acp`)
+  with **no** preceding `🔒 Acquired thread load lock` log line —
+  confirms hypothesis 2.
+- Two `🔒 Acquired` lines for the **same** `acp_thread_id` separated by
+  a `🔓 Released` — confirms hypothesis 3.
+
+## Workaround (until fixed)
+
+Restart the spec task agent. A fresh container gets a single claude /
+single ACP wrapper and chrome-devtools tools work normally.
+
+## Files of interest
+
+- `crates/external_websocket_sync/src/thread_service.rs` (zed) — load lock
+  implementation, lines 55–95 and 1575–1700.
+- `crates/external_websocket_sync/src/websocket_sync.rs` (zed) —
+  `handle_open_thread` at line 499.
+- `api/pkg/external-agent/zed_config.go` (helix) — MCP config that lists
+  `chrome-devtools` as a stdio MCP (line 246).
+- `api/pkg/server/websocket_external_agent_sync.go` (helix) —
+  `findSessionByZedThreadID` dedup, lines 755 / 1028 / 2145.

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -12,11 +12,16 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import CircularProgress from "@mui/material/CircularProgress";
 import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import VerticalAlignBottomIcon from "@mui/icons-material/VerticalAlignBottom";
+import KeyboardDoubleArrowDownIcon from "@mui/icons-material/KeyboardDoubleArrowDown";
 import { useQueryClient } from "@tanstack/react-query";
-
-// DEBUG: Set to true to show scroll debug overlay
-const DEBUG_SCROLL = false;
+import {
+  useAutoScrollPreference,
+  AUTO_SCROLL_NEAR_BOTTOM_PX,
+} from "../../hooks/useAutoScrollPreference";
 
 // Number of interactions to render initially (and per "load more" click).
 // Keep this low — long-running agent sessions can have interactions with
@@ -50,12 +55,19 @@ export interface EmbeddedSessionViewHandle {
 }
 
 /**
- * EmbeddedSessionView - A lightweight session message thread viewer
+ * EmbeddedSessionView - session message thread viewer.
  *
- * Simple sticky-scroll behavior:
- * - If you're at the bottom, stay at the bottom as content grows
- * - If you scroll up, stay where you are
- * - If you scroll back to bottom, resume auto-scroll
+ * Auto-scroll model (deliberately simple — see commit history for prior
+ * sticky-scroll attempts that were too race-prone to be reliable):
+ *
+ *   - A single global preference (`helix.autoScroll`, default ON) controls
+ *     whether new content auto-scrolls the chat to the bottom.
+ *   - When ON: every render where scrollHeight grew is followed by a scroll
+ *     to bottom. No "is the user at the bottom?" detection. No guards. No
+ *     wheel/touch listeners. The user opts out with the toggle button.
+ *   - When OFF: no auto-scroll. If new content lands below the viewport,
+ *     a "Jump to latest" pill appears; clicking it scrolls to bottom and
+ *     re-enables the preference.
  */
 const EmbeddedSessionView = forwardRef<
   EmbeddedSessionViewHandle,
@@ -68,9 +80,16 @@ const EmbeddedSessionView = forwardRef<
   const queryClient = useQueryClient();
   const { NewInference, wsConnected } = useStreaming();
 
-  // Simple scroll state: are we currently at the bottom?
-  // This is the ONLY state we need for sticky scroll behavior
-  const isAtBottomRef = useRef(true);
+  // Global on/off preference for auto-scroll. Default ON.
+  const [autoScroll, setAutoScroll] = useAutoScrollPreference();
+  const autoScrollRef = useRef(autoScroll);
+  useEffect(() => {
+    autoScrollRef.current = autoScroll;
+  }, [autoScroll]);
+
+  // True when auto-scroll is OFF and new content has landed below the viewport.
+  // Drives the "Jump to latest" pill.
+  const [hasNewBelow, setHasNewBelow] = useState(false);
 
   // Pagination state: track which page we've loaded up to (page 0 = newest)
   const [oldestPageLoaded, setOldestPageLoaded] = useState(0);
@@ -78,170 +97,45 @@ const EmbeddedSessionView = forwardRef<
   const [olderInteractions, setOlderInteractions] = useState<TypesInteraction[]>([]);
   // Loading state for fetching older interactions
   const [isLoadingOlder, setIsLoadingOlder] = useState(false);
-  // Guard: when true, scroll events are from programmatic scrollTo, not user interaction.
-  // Prevents the scroll handler from unsetting isAtBottom during auto-scroll.
-  const isProgrammaticScrollRef = useRef(false);
-  const SCROLL_THRESHOLD = 50;
 
-  // DEBUG: State for debug overlay
-  const [debugInfo, setDebugInfo] = useState({
-    isAtBottom: true,
-    scrollTop: 0,
-    scrollHeight: 0,
-    clientHeight: 0,
-    lastEvent: "init",
-    mutationCount: 0,
-    scrollCount: 0,
-  });
-
-  // Check if currently at bottom
-  const checkIsAtBottom = useCallback(() => {
+  // Returns true if the viewport is "near enough" the bottom that we treat
+  // it as caught up (used to hide the jump-to-latest pill).
+  const isNearBottom = useCallback(() => {
     const container = containerRef.current;
     if (!container) return true;
     const { scrollTop, scrollHeight, clientHeight } = container;
-    return scrollTop + clientHeight >= scrollHeight - SCROLL_THRESHOLD;
+    return scrollTop + clientHeight >= scrollHeight - AUTO_SCROLL_NEAR_BOTTOM_PX;
   }, []);
 
-  // Update isAtBottom on every scroll event
+  // Only used to clear the pill when the user scrolls back to the bottom.
+  // We deliberately do NOT track "is the user at the bottom" for auto-scroll
+  // decisions — auto-scroll is purely driven by the preference toggle.
   const handleScroll = useCallback(() => {
-    const container = containerRef.current;
-    if (!container) return;
+    if (autoScrollRef.current) return;
+    if (isNearBottom()) setHasNewBelow(false);
+  }, [isNearBottom]);
 
-    // Skip if this scroll was triggered by our own programmatic scrollTo
-    if (isProgrammaticScrollRef.current) return;
-
-    isAtBottomRef.current = checkIsAtBottom();
-
-    if (DEBUG_SCROLL) {
-      setDebugInfo((prev) => ({
-        ...prev,
-        isAtBottom: isAtBottomRef.current,
-        scrollTop: Math.round(container.scrollTop),
-        scrollHeight: container.scrollHeight,
-        clientHeight: container.clientHeight,
-        lastEvent: "scroll",
-        scrollCount: prev.scrollCount + 1,
-      }));
-    }
-  }, [checkIsAtBottom]);
-
-  // iOS Safari fix: Also track via native scroll event listener
-  // React's onScroll might not fire correctly on iOS
-  // Depends on session so it re-runs after the container is rendered
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) {
-      if (DEBUG_SCROLL) {
-        setDebugInfo((prev) => ({ ...prev, lastEvent: "NO CONTAINER REF" }));
-      }
-      return;
-    }
-
-    // Debug: mark that we attached the listener
-    if (DEBUG_SCROLL) {
-      setDebugInfo((prev) => ({ ...prev, lastEvent: "listener-attached" }));
-    }
-
-    const onNativeScroll = () => {
-      if (isProgrammaticScrollRef.current) return;
-      isAtBottomRef.current = checkIsAtBottom();
-
-      if (DEBUG_SCROLL) {
-        setDebugInfo((prev) => ({
-          ...prev,
-          isAtBottom: isAtBottomRef.current,
-          scrollTop: Math.round(container.scrollTop),
-          scrollHeight: container.scrollHeight,
-          clientHeight: container.clientHeight,
-          lastEvent: "native-scroll",
-          scrollCount: prev.scrollCount + 1,
-        }));
-      }
-    };
-
-    // Also listen for wheel events directly (Magic Keyboard trackpad)
-    const onWheel = () => {
-      // Small delay to let scroll position update
-      requestAnimationFrame(() => {
-        isAtBottomRef.current = checkIsAtBottom();
-        if (DEBUG_SCROLL) {
-          setDebugInfo((prev) => ({
-            ...prev,
-            isAtBottom: isAtBottomRef.current,
-            scrollTop: Math.round(container.scrollTop),
-            lastEvent: "wheel",
-            scrollCount: prev.scrollCount + 1,
-          }));
-        }
-      });
-    };
-
-    // Touch events for iOS - check if container is even receiving touch input
-    const onTouchMove = () => {
-      requestAnimationFrame(() => {
-        isAtBottomRef.current = checkIsAtBottom();
-        if (DEBUG_SCROLL) {
-          setDebugInfo((prev) => ({
-            ...prev,
-            isAtBottom: isAtBottomRef.current,
-            scrollTop: Math.round(container.scrollTop),
-            lastEvent: `touch(h=${container.scrollHeight},st=${Math.round(container.scrollTop)})`,
-            scrollCount: prev.scrollCount + 1,
-          }));
-        }
-      });
-    };
-
-    // Use passive: true for better scroll performance
-    container.addEventListener("scroll", onNativeScroll, { passive: true });
-    container.addEventListener("wheel", onWheel, { passive: true });
-    container.addEventListener("touchmove", onTouchMove, { passive: true });
-
-    return () => {
-      container.removeEventListener("scroll", onNativeScroll);
-      container.removeEventListener("wheel", onWheel);
-      container.removeEventListener("touchmove", onTouchMove);
-    };
-  }, [checkIsAtBottom]);
-
-  // Scroll to bottom - only scrolls if we're already at the bottom (sticky scroll)
-  // Pass force=true to scroll regardless of current position
+  // Scroll to bottom. Respects the auto-scroll preference unless `force` is set
+  // (force is only used for initial mount, session change, and the
+  // jump-to-latest pill click).
   const scrollToBottom = useCallback(
     (force = false) => {
       const container = containerRef.current;
       if (!container) return;
-
-      // Only scroll if we're already at the bottom (or forced)
-      // This implements "sticky scroll" - stay at bottom if you were there
-      if (!force && !isAtBottomRef.current) {
-        if (DEBUG_SCROLL) {
-          setDebugInfo((prev) => ({
-            ...prev,
-            lastEvent: `SCROLL_BLOCKED (not at bottom)`,
-          }));
-        }
-        return;
-      }
-
-      // DEBUG: Show what triggered the scroll
-      if (DEBUG_SCROLL) {
-        setDebugInfo((prev) => ({
-          ...prev,
-          lastEvent: `SCROLL_TO_BOTTOM (${force ? "forced" : "sticky"})`,
-        }));
-      }
-
-      isProgrammaticScrollRef.current = true;
+      if (!force && !autoScrollRef.current) return;
       container.scrollTop = container.scrollHeight;
-      isAtBottomRef.current = true;
-      // Clear the guard after the scroll event has fired
-      requestAnimationFrame(() => {
-        isProgrammaticScrollRef.current = false;
-      });
+      setHasNewBelow(false);
       onScrollToBottom?.();
     },
     [onScrollToBottom],
   );
+
+  // Click handler for the jump-to-latest pill: jump and re-enable auto-scroll.
+  const handleJumpToLatest = useCallback(() => {
+    setAutoScroll(true);
+    autoScrollRef.current = true;
+    scrollToBottom(true);
+  }, [scrollToBottom, setAutoScroll]);
 
   // Expose scrollToBottom via ref for parent components
   useImperativeHandle(
@@ -284,37 +178,25 @@ const EmbeddedSessionView = forwardRef<
     enabled: !!sessionId,
   });
 
-  // Track if we're streaming (last interaction is in waiting state)
-  // Use paginatedData for the most recent interaction state
-  const isStreaming = useMemo(() => {
-    const interactions = paginatedData?.interactions;
-    if (!interactions || interactions.length === 0) return false;
-    // paginatedData.interactions is newest-first, so [0] is the most recent
-    const lastInteraction = interactions[0];
-    return (
-      lastInteraction.state === TypesInteractionState.InteractionStateWaiting
-    );
-  }, [paginatedData?.interactions]);
-
-  // Scroll to bottom on initial load
+  // Track scrollHeight across renders so we know when content grew.
+  const prevScrollHeightRef = useRef(0);
+  // True until the first time we've forced an initial scroll-to-bottom for
+  // this session. Reset on session change.
   const hasInitiallyScrolled = useRef(false);
 
-  // Reset scroll state and clear stale cache when sessionId changes
+  // Reset state and clear stale cache when sessionId changes.
   const prevSessionIdRef = useRef(sessionId);
   useEffect(() => {
     if (sessionId !== prevSessionIdRef.current) {
       const oldSessionId = prevSessionIdRef.current;
       prevSessionIdRef.current = sessionId;
 
-      // Reset scroll tracking so the new session scrolls to bottom on load
       hasInitiallyScrolled.current = false;
-      isAtBottomRef.current = true;
       prevScrollHeightRef.current = 0;
-      // Reset pagination state for new session
+      setHasNewBelow(false);
       setOldestPageLoaded(0);
       setOlderInteractions([]);
 
-      // Remove old session's React Query cache to prevent flash of stale content
       if (oldSessionId) {
         queryClient.removeQueries({
           queryKey: GET_SESSION_QUERY_KEY(oldSessionId),
@@ -326,6 +208,9 @@ const EmbeddedSessionView = forwardRef<
     }
   }, [sessionId, queryClient]);
 
+  // Force-scroll to the bottom on first content render for a session, even if
+  // auto-scroll is OFF — opening a session should land you on the latest
+  // message.
   useEffect(() => {
     if (
       paginatedData?.interactions &&
@@ -333,67 +218,40 @@ const EmbeddedSessionView = forwardRef<
       !hasInitiallyScrolled.current
     ) {
       hasInitiallyScrolled.current = true;
-      // Use setTimeout to ensure content is fully rendered (RAF may be too early)
-      setTimeout(() => {
-        scrollToBottom(true); // Force scroll on initial load
-      }, 100);
-    }
-  }, [paginatedData?.interactions?.length, scrollToBottom]);
-
-  // Track previous streaming state to detect when streaming ends
-  const prevIsStreamingRef = useRef(isStreaming);
-
-  // Scroll to bottom when streaming ends - critical for reliable scroll behavior
-  useEffect(() => {
-    const wasStreaming = prevIsStreamingRef.current;
-    prevIsStreamingRef.current = isStreaming;
-
-    // When streaming transitions from true to false, scroll to show final content
-    if (wasStreaming && !isStreaming) {
-      // Wait for final content to render before scrolling
+      // setTimeout (vs RAF) gives markdown / code highlighting time to render
+      // so the scroll lands on truly-final content.
       setTimeout(() => {
         scrollToBottom(true);
       }, 100);
     }
-  }, [isStreaming, scrollToBottom]);
+  }, [paginatedData?.interactions?.length, scrollToBottom]);
 
-  // Maintain sticky scroll when session data updates (e.g., from polling or WebSocket)
-  // Use useLayoutEffect to run synchronously after DOM mutations but before browser paint
-  // This ensures we scroll before any scroll events could fire from layout reflow
-  const prevScrollHeightRef = useRef(0);
-
+  // After every render: if scrollHeight grew, either auto-scroll (when ON) or
+  // surface the jump-to-latest pill (when OFF and the new content is below
+  // the viewport). useLayoutEffect runs after DOM mutations but before paint,
+  // so the user never sees a flash of off-bottom content when auto-scroll is on.
   useLayoutEffect(() => {
     const container = containerRef.current;
     if (!container || !session) return;
 
     const prevScrollHeight = prevScrollHeightRef.current;
     const currentScrollHeight = container.scrollHeight;
+    prevScrollHeightRef.current = currentScrollHeight;
 
-    // If content height changed and we were at bottom, scroll to bottom
-    if (currentScrollHeight !== prevScrollHeight && prevScrollHeight > 0) {
-      // Check isAtBottomRef BEFORE the scroll - this is the value from before the DOM update
-      if (isAtBottomRef.current) {
-        isProgrammaticScrollRef.current = true;
-        container.scrollTop = currentScrollHeight;
-        requestAnimationFrame(() => {
-          isProgrammaticScrollRef.current = false;
-        });
-      }
+    if (currentScrollHeight === prevScrollHeight || prevScrollHeight === 0) {
+      return;
     }
 
-    prevScrollHeightRef.current = currentScrollHeight;
-  });
+    if (autoScroll) {
+      container.scrollTop = currentScrollHeight;
+      return;
+    }
 
-  // DISABLED: MutationObserver was causing constant scroll jumps
-  // because scroll events weren't being detected on iOS Safari,
-  // so isAtBottomRef stayed true and every mutation scrolled to bottom.
-  //
-  // Instead, we only scroll on:
-  // 1. Initial load
-  // 2. When interaction count increases (new message)
-  // 3. When InteractionLiveStream calls onMessageUpdate during streaming
-  //
-  // This is less "smooth" for streaming but more reliable.
+    // Auto-scroll OFF: show the pill if the new bottom is now below the viewport.
+    if (!isNearBottom()) {
+      setHasNewBelow(true);
+    }
+  });
 
   // Reload session handler
   const handleReloadSession = useCallback(async () => {
@@ -521,122 +379,158 @@ const EmbeddedSessionView = forwardRef<
 
   return (
     <Box
-      ref={containerRef}
-      onScroll={handleScroll}
       sx={{
-        // Use height: 0 + flex: 1 to force this to be the scrollable container
-        // Without height: 0, the container may expand to fit content on iOS
-        height: 0,
         flex: 1,
-        overflow: "auto",
-        display: "flex",
-        flexDirection: "column",
         minHeight: 0,
         position: "relative",
-        // Enable momentum scrolling on iOS
-        WebkitOverflowScrolling: "touch",
-        ...lightTheme.scrollbar,
+        display: "flex",
+        flexDirection: "column",
       }}
     >
-      {/* DEBUG OVERLAY */}
-      {DEBUG_SCROLL && (
-        <Box
-          sx={{
-            position: "sticky",
-            top: 0,
-            left: 0,
-            right: 0,
-            zIndex: 9999,
-            backgroundColor: "rgba(0, 0, 0, 0.85)",
-            color: "#0f0",
-            fontFamily: "monospace",
-            fontSize: "11px",
-            padding: "4px 8px",
-            pointerEvents: "none",
-          }}
-        >
-          <div>
-            atBottom: {debugInfo.isAtBottom ? "YES" : "NO"} | scrollTop:{" "}
-            {debugInfo.scrollTop}
-          </div>
-          <div>
-            scrollH: {debugInfo.scrollHeight} | clientH:{" "}
-            {debugInfo.clientHeight}
-          </div>
-          <div>last: {debugInfo.lastEvent}</div>
-          <div>
-            mutations: {debugInfo.mutationCount} | scrolls:{" "}
-            {debugInfo.scrollCount}
-          </div>
-        </Box>
-      )}
       <Box
+        ref={containerRef}
+        onScroll={handleScroll}
         sx={{
-          width: "100%",
-          maxWidth: 700,
-          mx: "auto",
-          px: 2,
-          py: 2,
+          // Use height: 0 + flex: 1 to force this to be the scrollable container
+          // Without height: 0, the container may expand to fit content on iOS
+          height: 0,
+          flex: 1,
+          overflow: "auto",
           display: "flex",
           flexDirection: "column",
-          gap: 2,
-          // Ensure content can shrink on narrow screens
-          minWidth: 0,
-          boxSizing: "border-box",
+          minHeight: 0,
+          position: "relative",
+          // Enable momentum scrolling on iOS
+          WebkitOverflowScrolling: "touch",
+          ...lightTheme.scrollbar,
         }}
       >
-        {/* Show "Load older" button when there are more interactions */}
-        {hasOlderInteractions && (
-          <Button
-            variant="text"
-            size="small"
-            startIcon={isLoadingOlder ? <CircularProgress size={16} /> : <ExpandLessIcon />}
-            onClick={handleLoadOlder}
-            disabled={isLoadingOlder}
-            sx={{
-              alignSelf: "center",
-              color: "text.secondary",
-              textTransform: "none",
-              mb: 1,
-            }}
-          >
-            {isLoadingOlder ? 'Loading...' : `Show ${remainingOlderCount} older messages`}
-          </Button>
-        )}
-        {visibleInteractions.map((interaction, index) => {
-          const isLastInteraction = index === totalInteractions - 1;
-          const isLive =
-            isLastInteraction &&
-            interaction.state === TypesInteractionState.InteractionStateWaiting;
-          return (
-            <Interaction
-              key={interaction.id}
-              serverConfig={account.serverConfig}
-              interaction={interaction}
-              session={session}
-              highlightAllFiles={false}
-              onReloadSession={handleReloadSession}
-              onRegenerate={handleRegenerate}
-              isLastInteraction={isLastInteraction}
-              isOwner={isOwner}
-              isAdmin={account.admin}
-              scrollToBottom={scrollToBottom}
-              session_id={sessionId}
-              sessionSteps={sessionSteps?.data || []}
+        <Box
+          sx={{
+            width: "100%",
+            maxWidth: 700,
+            mx: "auto",
+            px: 2,
+            py: 2,
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+            // Ensure content can shrink on narrow screens
+            minWidth: 0,
+            boxSizing: "border-box",
+          }}
+        >
+          {hasOlderInteractions && (
+            <Button
+              variant="text"
+              size="small"
+              startIcon={isLoadingOlder ? <CircularProgress size={16} /> : <ExpandLessIcon />}
+              onClick={handleLoadOlder}
+              disabled={isLoadingOlder}
+              sx={{
+                alignSelf: "center",
+                color: "text.secondary",
+                textTransform: "none",
+                mb: 1,
+              }}
             >
-              {isLive && (isOwner || account.admin) && (
-                <InteractionLiveStream
-                  session_id={sessionId}
-                  interaction={interaction}
-                  session={session}
-                  serverConfig={account.serverConfig}
-                  onMessageUpdate={scrollToBottom}
-                />
-              )}
-            </Interaction>
-          );
-        })}
+              {isLoadingOlder ? "Loading..." : `Show ${remainingOlderCount} older messages`}
+            </Button>
+          )}
+          {visibleInteractions.map((interaction, index) => {
+            const isLastInteraction = index === totalInteractions - 1;
+            const isLive =
+              isLastInteraction &&
+              interaction.state === TypesInteractionState.InteractionStateWaiting;
+            return (
+              <Interaction
+                key={interaction.id}
+                serverConfig={account.serverConfig}
+                interaction={interaction}
+                session={session}
+                highlightAllFiles={false}
+                onReloadSession={handleReloadSession}
+                onRegenerate={handleRegenerate}
+                isLastInteraction={isLastInteraction}
+                isOwner={isOwner}
+                isAdmin={account.admin}
+                scrollToBottom={scrollToBottom}
+                session_id={sessionId}
+                sessionSteps={sessionSteps?.data || []}
+              >
+                {isLive && (isOwner || account.admin) && (
+                  <InteractionLiveStream
+                    session_id={sessionId}
+                    interaction={interaction}
+                    session={session}
+                    serverConfig={account.serverConfig}
+                    onMessageUpdate={scrollToBottom}
+                  />
+                )}
+              </Interaction>
+            );
+          })}
+        </Box>
       </Box>
+
+      {/* Auto-scroll toggle (bottom-right) */}
+      <Tooltip
+        title={
+          autoScroll
+            ? "Auto-scroll to latest is on. Click to turn off."
+            : "Auto-scroll to latest is off. Click to turn on."
+        }
+        placement="left"
+      >
+        <IconButton
+          size="small"
+          onClick={() => {
+            const next = !autoScroll;
+            setAutoScroll(next);
+            autoScrollRef.current = next;
+            if (next) scrollToBottom(true);
+          }}
+          aria-label={autoScroll ? "Disable auto-scroll" : "Enable auto-scroll"}
+          sx={{
+            position: "absolute",
+            bottom: 8,
+            right: 12,
+            zIndex: 2,
+            backgroundColor: "background.paper",
+            border: 1,
+            borderColor: "divider",
+            color: autoScroll ? "primary.main" : "text.disabled",
+            "&:hover": {
+              backgroundColor: "action.hover",
+            },
+          }}
+        >
+          <VerticalAlignBottomIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+
+      {/* Jump-to-latest pill (bottom-center, only when auto-scroll OFF and
+          new content has arrived below the viewport) */}
+      {!autoScroll && hasNewBelow && (
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={<KeyboardDoubleArrowDownIcon />}
+          onClick={handleJumpToLatest}
+          sx={{
+            position: "absolute",
+            bottom: 12,
+            left: "50%",
+            transform: "translateX(-50%)",
+            zIndex: 3,
+            textTransform: "none",
+            borderRadius: 999,
+            boxShadow: 3,
+          }}
+        >
+          Jump to latest
+        </Button>
+      )}
     </Box>
   );
 });

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -1,6 +1,5 @@
 import React, {
   useEffect,
-  useLayoutEffect,
   useRef,
   useMemo,
   useCallback,
@@ -17,6 +16,7 @@ import Tooltip from "@mui/material/Tooltip";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import VerticalAlignBottomIcon from "@mui/icons-material/VerticalAlignBottom";
 import KeyboardDoubleArrowDownIcon from "@mui/icons-material/KeyboardDoubleArrowDown";
+import PauseIcon from "@mui/icons-material/Pause";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   useAutoScrollPreference,
@@ -178,10 +178,13 @@ const EmbeddedSessionView = forwardRef<
     enabled: !!sessionId,
   });
 
-  // Track scrollHeight across renders so we know when content grew.
-  const prevScrollHeightRef = useRef(0);
-  // True until the first time we've forced an initial scroll-to-bottom for
-  // this session. Reset on session change.
+  // Ref to the inner content Box; observed by ResizeObserver so we only
+  // react to *actual* content size changes, not every React re-render.
+  const contentRef = useRef<HTMLDivElement>(null);
+  // Last observed content height. 0 until the first ResizeObserver callback.
+  const lastContentHeightRef = useRef(0);
+  // True once we've forced an initial scroll-to-bottom for this session.
+  // Reset on session change.
   const hasInitiallyScrolled = useRef(false);
 
   // Reset state and clear stale cache when sessionId changes.
@@ -192,7 +195,7 @@ const EmbeddedSessionView = forwardRef<
       prevSessionIdRef.current = sessionId;
 
       hasInitiallyScrolled.current = false;
-      prevScrollHeightRef.current = 0;
+      lastContentHeightRef.current = 0;
       setHasNewBelow(false);
       setOldestPageLoaded(0);
       setOlderInteractions([]);
@@ -226,32 +229,37 @@ const EmbeddedSessionView = forwardRef<
     }
   }, [paginatedData?.interactions?.length, scrollToBottom]);
 
-  // After every render: if scrollHeight grew, either auto-scroll (when ON) or
-  // surface the jump-to-latest pill (when OFF and the new content is below
-  // the viewport). useLayoutEffect runs after DOM mutations but before paint,
-  // so the user never sees a flash of off-bottom content when auto-scroll is on.
-  useLayoutEffect(() => {
+  // ResizeObserver-driven auto-scroll: only fires when the content's actual
+  // size changes. Renders that don't grow content (e.g., the 3s React Query
+  // poll returning identical data) do no scroll work at all.
+  useEffect(() => {
     const container = containerRef.current;
-    if (!container || !session) return;
+    const content = contentRef.current;
+    if (!container || !content) return;
 
-    const prevScrollHeight = prevScrollHeightRef.current;
-    const currentScrollHeight = container.scrollHeight;
-    prevScrollHeightRef.current = currentScrollHeight;
+    const observer = new ResizeObserver((entries) => {
+      const newHeight = entries[0]?.contentRect.height ?? 0;
+      const prevHeight = lastContentHeightRef.current;
+      lastContentHeightRef.current = newHeight;
 
-    if (currentScrollHeight === prevScrollHeight || prevScrollHeight === 0) {
-      return;
-    }
+      // First measurement after mount/session-reset: just record it. The
+      // initial-scroll effect handles getting us to the bottom.
+      if (prevHeight === 0) return;
+      // Only react to growth; shrinking (e.g., a tool call collapsing) shouldn't
+      // yank the viewport.
+      if (newHeight <= prevHeight) return;
 
-    if (autoScroll) {
-      container.scrollTop = currentScrollHeight;
-      return;
-    }
+      if (autoScrollRef.current) {
+        container.scrollTop = container.scrollHeight;
+        setHasNewBelow(false);
+      } else if (!isNearBottom()) {
+        setHasNewBelow(true);
+      }
+    });
 
-    // Auto-scroll OFF: show the pill if the new bottom is now below the viewport.
-    if (!isNearBottom()) {
-      setHasNewBelow(true);
-    }
-  });
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [isNearBottom]);
 
   // Reload session handler
   const handleReloadSession = useCallback(async () => {
@@ -406,6 +414,7 @@ const EmbeddedSessionView = forwardRef<
         }}
       >
         <Box
+          ref={contentRef}
           sx={{
             width: "100%",
             maxWidth: 700,
@@ -473,12 +482,13 @@ const EmbeddedSessionView = forwardRef<
         </Box>
       </Box>
 
-      {/* Auto-scroll toggle (bottom-right) */}
+      {/* Auto-scroll toggle (bottom-right) — stark filled/outlined treatment
+          so the on/off state is visible at a glance. */}
       <Tooltip
         title={
           autoScroll
-            ? "Auto-scroll to latest is on. Click to turn off."
-            : "Auto-scroll to latest is off. Click to turn on."
+            ? "Auto-scroll is on. Click to pause."
+            : "Auto-scroll is paused. Click to resume."
         }
         placement="left"
       >
@@ -490,22 +500,45 @@ const EmbeddedSessionView = forwardRef<
             autoScrollRef.current = next;
             if (next) scrollToBottom(true);
           }}
-          aria-label={autoScroll ? "Disable auto-scroll" : "Enable auto-scroll"}
+          aria-label={autoScroll ? "Pause auto-scroll" : "Resume auto-scroll"}
+          aria-pressed={autoScroll}
           sx={{
             position: "absolute",
             bottom: 8,
             right: 12,
             zIndex: 2,
-            backgroundColor: "background.paper",
-            border: 1,
-            borderColor: "divider",
-            color: autoScroll ? "primary.main" : "text.disabled",
-            "&:hover": {
-              backgroundColor: "action.hover",
-            },
+            transition: "background-color 0.15s, color 0.15s, box-shadow 0.15s, opacity 0.15s",
+            ...(autoScroll
+              ? {
+                  // ON: filled, primary, prominent
+                  backgroundColor: "primary.main",
+                  color: "primary.contrastText",
+                  boxShadow: 2,
+                  border: "none",
+                  "&:hover": {
+                    backgroundColor: "primary.dark",
+                  },
+                }
+              : {
+                  // OFF: outlined ghost, dimmed
+                  backgroundColor: "background.paper",
+                  color: "text.secondary",
+                  border: 1,
+                  borderColor: "divider",
+                  boxShadow: "none",
+                  opacity: 0.65,
+                  "&:hover": {
+                    backgroundColor: "action.hover",
+                    opacity: 1,
+                  },
+                }),
           }}
         >
-          <VerticalAlignBottomIcon fontSize="small" />
+          {autoScroll ? (
+            <VerticalAlignBottomIcon fontSize="small" />
+          ) : (
+            <PauseIcon fontSize="small" />
+          )}
         </IconButton>
       </Tooltip>
 

--- a/frontend/src/hooks/useAutoScrollPreference.ts
+++ b/frontend/src/hooks/useAutoScrollPreference.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "helix.autoScroll";
+
+// How close to the bottom (in px) is "at bottom enough" to hide the
+// jump-to-latest pill. Only used when auto-scroll is OFF.
+export const AUTO_SCROLL_NEAR_BOTTOM_PX = 80;
+
+const readStored = (): boolean => {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    if (v === null) return true;
+    return v === "true";
+  } catch {
+    return true;
+  }
+};
+
+const writeStored = (value: boolean) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(value));
+  } catch {
+    // ignore
+  }
+};
+
+// Single global preference, shared across all EmbeddedSessionView instances
+// in the page. Each subscriber re-renders when the value changes (whether
+// the change came from this hook or another instance via the storage event).
+const subscribers = new Set<(value: boolean) => void>();
+
+const broadcast = (value: boolean) => {
+  for (const fn of subscribers) fn(value);
+};
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (e) => {
+    if (e.key === STORAGE_KEY) broadcast(readStored());
+  });
+}
+
+export const useAutoScrollPreference = (): [boolean, (next: boolean) => void] => {
+  const [value, setValue] = useState<boolean>(readStored);
+
+  useEffect(() => {
+    subscribers.add(setValue);
+    return () => {
+      subscribers.delete(setValue);
+    };
+  }, []);
+
+  const setPreference = useCallback((next: boolean) => {
+    writeStored(next);
+    broadcast(next);
+  }, []);
+
+  return [value, setPreference];
+};


### PR DESCRIPTION
## Summary

The sticky-scroll on spec task detail pages (embedded in Session View) has been "almost-but-not-quite" working through multiple attempted fixes. Investigation found three persistent race-condition surfaces feeding a single `isAtBottomRef` boolean:

1. **Content reflow above the viewport** — image loads, code highlighting, polling+WebSocket double-updates can grow `scrollHeight` faster than scroll-anchoring catches up. A scroll event fires, `handleScroll` runs (guard is false because the change wasn't from our `scrollTop=` call), `checkIsAtBottom()` returns false, and sticky breaks — without the user touching anything.
2. **RAF guard is too short** — `isProgrammaticScrollRef` cleared in `requestAnimationFrame` works most of the time, but Chromium coalesces scroll events across frames and iOS Safari momentum scrolling has unreliable timing. A delayed scroll event lands after the guard cleared and registers as user input.
3. **Multiple uncoordinated triggers** — `useLayoutEffect` (no deps), throttled `onMessageUpdate` from streaming, and `RobustPromptInput.onHeightChange` can each set/clear the guard inside overlapping windows.

Each previous fix (`d1a60baa1`, `14df1bb61`, `e5bf25c9d`) addressed a single symptom. Continuing to add guards keeps shifting which race surfaces.

**Pivoted** to a model the user controls explicitly:

- Single global preference (`helix.autoScroll`, default ON) in `localStorage`
- **When ON:** every render where `scrollHeight` grows scrolls to bottom. No "is the user at bottom?" detection. No guards. No wheel/touch listeners.
- **When OFF:** no auto-scroll. A "Jump to latest" pill appears when new content lands below the viewport; clicking it jumps to the bottom *and* re-enables the preference.
- Pinned toggle button bottom-right (primary color when on, dim when off, with explanatory tooltip).
- Initial-load force-scroll preserved so opening a session always lands on the latest message regardless of preference.

Removes ~150 lines of race-prone scroll-tracking machinery (`isAtBottomRef`, `isProgrammaticScrollRef`, `SCROLL_THRESHOLD`, `checkIsAtBottom`, the wheel/touch/native-scroll `useEffect`, the streaming-end scroll effect, the debug overlay, and the unused `isStreaming` memo).

**Trade-off:** read-history-without-jumping requires one toggle click. In return, sticky behavior becomes reliable in a way the prior design couldn't deliver.

Also bundles an unrelated design note (`design/2026-04-24-duplicate-claude-acp-spawn.md`) from a parallel investigation into duplicate `claude-agent-acp` spawn breaking the chrome-devtools MCP.

## Test plan

- [ ] Open a streaming spec task — verify chat auto-scrolls to bottom by default
- [ ] Click the bottom-right pin → goes dim, scrolling stops as content streams
- [ ] Watch new content arrive past the viewport → "Jump to latest" pill appears
- [ ] Click pill → jumps to bottom, pin re-lights, sticky behavior resumes
- [ ] Reload the page → toggle state persists (`localStorage`)
- [ ] Open a different session with toggle off → still lands at the latest message (initial-load force)
- [ ] Open the same task in two browser tabs, toggle in one → other tab updates via `storage` event
- [ ] Type a long message that grows the input → chat shifts to keep latest visible (auto-scroll on); chat doesn't yank when reading old messages (auto-scroll off)
- [ ] `cd frontend && yarn build` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)