### PR TITLE
Remove host port exposure from VectorChord in production compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -121,8 +121,6 @@ services:
       - POSTGRES_PASSWORD=${PGVECTOR_PASSWORD-pgvector}
     volumes:
       - ${VECTORCHORD_DATA:-helix-vectorchord-kodit}:/var/lib/postgresql/data
-    ports:
-      - "5432"
     restart: unless-stopped
 
   # NOTE: Sandbox services are NOT defined here - they are configured by install.sh


### PR DESCRIPTION
## Summary
The `vectorchord-kodit` service in `docker-compose.yaml` exposed PostgreSQL port 5432 on a random host port via `ports: - "5432"`. This is unnecessary since the only consumer (`helix` service) connects via Docker internal DNS (`vectorchord-kodit:5432`). Removing the port mapping eliminates an unneeded attack surface.

## Changes
- Removed `ports:` block from `vectorchord-kodit` service in `docker-compose.yaml`

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kpzk5wsdr111n6bndh4mw47y)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001897_the-production-docker/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001897_the-production-docker/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001897_the-production-docker/tasks.md)

🚀 Built with [Helix](https://helix.ml)