### PR TITLE
Add /embed/task/:taskId route for iframe embedding

### DIFF
--- a/frontend/src/pages/EmbedTaskPage.tsx
+++ b/frontend/src/pages/EmbedTaskPage.tsx
@@ -1,0 +1,27 @@
+import React, { FC } from 'react'
+import { useRoute } from 'react-router5'
+import { Box, CircularProgress } from '@mui/material'
+import SpecTaskDetailContent from '../components/tasks/SpecTaskDetailContent'
+import { useSpecTask } from '../services/specTaskService'
+
+const EmbedTaskPage: FC = () => {
+  const { route } = useRoute()
+  const taskId = route.params.taskId as string
+  const { isLoading } = useSpecTask(taskId, { enabled: !!taskId })
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  return (
+    <Box sx={{ height: '100vh', overflow: 'hidden' }}>
+      <SpecTaskDetailContent taskId={taskId} />
+    </Box>
+  )
+}
+
+export default EmbedTaskPage

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -26,6 +26,7 @@ import SpecTasksPage from './pages/SpecTasksPage'
 import SpecTaskDetailPage from './pages/SpecTaskDetailPage'
 import SpecTaskReviewPage from './pages/SpecTaskReviewPage'
 import TeamDesktopPage from './pages/TeamDesktopPage'
+import EmbedTaskPage from './pages/EmbedTaskPage'
 import Projects from './pages/Projects'
 import { FilestoreContextProvider } from './contexts/filestore'
 import Files from './pages/Files'
@@ -442,6 +443,15 @@ const routes: IApplicationRoute[] = [
     title: 'Waitlist',
   },
   render: () => <Waitlist />,
+}, {
+  name: 'embed_task',
+  path: '/embed/task/:taskId',
+  meta: {
+    drawer: false,
+    fullscreen: true,
+    title: 'Task',
+  },
+  render: () => <EmbedTaskPage />,
 }, {
   name: 'login',
   path: '/login',


### PR DESCRIPTION
## Summary
Adds a fullscreen route for embedding the spec task detail view in external applications (like the Gatewaze newsletter editor). The route renders `SpecTaskDetailContent` without any navigation chrome — no sidebar, breadcrumbs, or drawer.

## Changes
- New `EmbedTaskPage.tsx` component — minimal wrapper around `SpecTaskDetailContent`
- New route `/embed/task/:taskId` with `fullscreen: true` meta (Layout strips all chrome)
- Enables embedding Helix task views in iframes, similar to embedding a YouTube video

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kk95f1seff98mbxhfa31qj81/tasks/spt_01kpx1cn84drg8mea69s6wbyvv)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001890_do-gateways-start-up/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001890_do-gateways-start-up/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001890_do-gateways-start-up/tasks.md)

🚀 Built with [Helix](https://helix.ml)