### PR TITLE
fix(auto-wake): bump threshold to 120s, gate on streaming context, env-tunable

### DIFF
--- a/api/pkg/server/auto_wake_stuck_interactions.go
+++ b/api/pkg/server/auto_wake_stuck_interactions.go
@@ -122,6 +122,8 @@ package server
 
 import (
 	"context"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/helixml/helix/api/pkg/system"
@@ -135,17 +137,45 @@ const (
 	// leaves the user staring at a frozen chat for longer than needed.
 	autoWakeScanInterval = 10 * time.Second
 
-	// autoWakeStuckThreshold is the minimum age of a `state=waiting`
-	// interaction before we consider it stuck. Set well above the
-	// observed normal time-to-first-token for any agent (Claude usually
-	// streams the first token in under 5 s; a 30 s gap is a strong
-	// signal the wrapper has buffered something).
-	autoWakeStuckThreshold = 30 * time.Second
+	// defaultAutoWakeStuckThreshold is the minimum age of a
+	// `state=waiting` interaction before we consider it stuck.
+	//
+	// 120 s is deliberately conservative. Picking too low produces
+	// false positives on legitimately-slow prompts:
+	//   - Claude with extended thinking enabled can think silently for
+	//     minutes before emitting any tokens
+	//   - Tool-heavy starts may run several MCP/Read/Bash tools before
+	//     producing user-visible text
+	//   - Anthropic API can be slow under load or on a cold cache
+	//
+	// A false positive here means re-sending the user's prompt while
+	// the agent is mid-think. For idempotent prompts that's a cosmetic
+	// duplicate response; for destructive prompts it's a real risk
+	// (the agent may execute the same tool call twice). We also gate
+	// on the presence of a streaming context (see maybeAutoWake) which
+	// catches most of the tool-heavy case, but not silent thinking
+	// before the first emit.
+	//
+	// Override at runtime with HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS.
+	defaultAutoWakeStuckThreshold = 120 * time.Second
 
 	// autoWakeMaxRetries caps how many wake-ups we attempt for a single
 	// stuck interaction before giving up and marking it state=error.
 	autoWakeMaxRetries = 2
 )
+
+// autoWakeStuckThreshold returns the configured stuck threshold.
+// Reads HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS once per call so
+// operators can tune live without redeploying (the worker reads it
+// every scan tick, ~10 s).
+func autoWakeStuckThreshold() time.Duration {
+	if raw := os.Getenv("HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS"); raw != "" {
+		if seconds, err := strconv.Atoi(raw); err == nil && seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+	}
+	return defaultAutoWakeStuckThreshold
+}
 
 // startAutoWakeStuckInteractionsWorker launches the periodic scanner.
 // Idempotent in spirit but the API server only calls it once at init.
@@ -156,7 +186,7 @@ func (apiServer *HelixAPIServer) startAutoWakeStuckInteractionsWorker(ctx contex
 
 		log.Info().
 			Dur("scan_interval", autoWakeScanInterval).
-			Dur("stuck_threshold", autoWakeStuckThreshold).
+			Dur("stuck_threshold", autoWakeStuckThreshold()).
 			Int("max_retries", autoWakeMaxRetries).
 			Msg("🚀 [AUTO_WAKE] Started auto-wake worker for stuck waiting interactions")
 
@@ -174,7 +204,7 @@ func (apiServer *HelixAPIServer) startAutoWakeStuckInteractionsWorker(ctx contex
 
 // scanAndAutoWakeStuckInteractions runs one detection pass.
 func (apiServer *HelixAPIServer) scanAndAutoWakeStuckInteractions(ctx context.Context) {
-	cutoff := time.Now().Add(-autoWakeStuckThreshold)
+	cutoff := time.Now().Add(-autoWakeStuckThreshold())
 
 	stuck, err := apiServer.Store.ListStuckWaitingInteractions(ctx, cutoff, 50)
 	if err != nil {
@@ -208,7 +238,47 @@ func (apiServer *HelixAPIServer) maybeAutoWake(ctx context.Context, stuck *types
 	if !connected || conn == nil {
 		return
 	}
-	if time.Since(conn.ConnectedAt) < autoWakeStuckThreshold {
+	threshold := autoWakeStuckThreshold()
+	if time.Since(conn.ConnectedAt) < threshold {
+		return
+	}
+
+	// Gate 1b — active streaming context.
+	//
+	// If the wrapper has dispatched at least one `added message` event
+	// for this session's current turn, getOrCreateStreamingContext
+	// will have created a streamingContext entry. That happens for
+	// text chunks, tool calls, thought-style step_info events, and any
+	// other content-bearing notification — i.e. anything that proves
+	// the agent is actively producing output for this turn even if no
+	// text has reached interaction.response_message yet (which is the
+	// usual tool-heavy-start case).
+	//
+	// If a context exists, skip — the agent is working, even if the
+	// row in the DB still looks blank to ListStuckWaitingInteractions
+	// because of throttled DB writes.
+	//
+	// Note: this does NOT cover the "silent extended thinking before
+	// first emit" case — Claude can think for 60-120 s without any
+	// session_update arriving, in which case no streaming context
+	// exists and we'd flag this as stuck. We accept that false-positive
+	// risk in exchange for the conservative threshold; if it becomes a
+	// problem in practice we can lengthen the threshold further or
+	// expose a per-session opt-out.
+	apiServer.streamingContextsMu.RLock()
+	_, hasStreamingCtx := apiServer.streamingContexts[stuck.SessionID]
+	apiServer.streamingContextsMu.RUnlock()
+	if hasStreamingCtx {
+		return
+	}
+
+	// Same threshold, computed against interaction age now that we know
+	// the connection has been live long enough and there's no active
+	// streaming on the session. Caller has already filtered on
+	// `created < now - autoWakeStuckThreshold` at the SQL level using
+	// the previous threshold value, but recheck here defensively in
+	// case the env var was bumped UP between the SQL filter and now.
+	if time.Since(stuck.Created) < threshold {
 		return
 	}
 

--- a/api/pkg/server/auto_wake_stuck_interactions.go
+++ b/api/pkg/server/auto_wake_stuck_interactions.go
@@ -141,20 +141,27 @@ const (
 	// `state=waiting` interaction before we consider it stuck.
 	//
 	// 120 s is deliberately conservative. Picking too low produces
-	// false positives on legitimately-slow prompts:
-	//   - Claude with extended thinking enabled can think silently for
-	//     minutes before emitting any tokens
-	//   - Tool-heavy starts may run several MCP/Read/Bash tools before
-	//     producing user-visible text
-	//   - Anthropic API can be slow under load or on a cold cache
+	// false positives when the Anthropic API itself is slow (load,
+	// cold cache, large prompts taking time before the first chunk).
+	// A false positive re-sends the user's prompt while the agent is
+	// mid-something — for idempotent prompts that's a cosmetic
+	// duplicate response, for destructive ones (`rm`, `git push`)
+	// it's a real risk.
 	//
-	// A false positive here means re-sending the user's prompt while
-	// the agent is mid-think. For idempotent prompts that's a cosmetic
-	// duplicate response; for destructive prompts it's a real risk
-	// (the agent may execute the same tool call twice). We also gate
-	// on the presence of a streaming context (see maybeAutoWake) which
-	// catches most of the tool-heavy case, but not silent thinking
-	// before the first emit.
+	// What this DOES NOT need to cover: extended-thinking silence.
+	// Claude's thinking surfaces as `AgentThoughtChunk` ACP session
+	// notifications, which produce `MessageAdded` events to Helix,
+	// which create entries in `apiServer.streamingContexts`. The
+	// streaming-context gate in maybeAutoWake catches the thinking
+	// case directly — we don't need the threshold to be long enough
+	// to wait it out. Same goes for tool-heavy starts: every
+	// `tool_call` entry creates a streaming context.
+	//
+	// What's left for the threshold: the genuinely-blank window
+	// between the user's `session/prompt` and the wrapper's first
+	// outbound notification of any kind. On a healthy session that's
+	// usually 2-10 s; under load or for huge prompts it can stretch.
+	// 120 s is well past observed normal ceilings.
 	//
 	// Override at runtime with HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS.
 	defaultAutoWakeStuckThreshold = 120 * time.Second
@@ -239,32 +246,58 @@ func (apiServer *HelixAPIServer) maybeAutoWake(ctx context.Context, stuck *types
 		return
 	}
 	threshold := autoWakeStuckThreshold()
-	if time.Since(conn.ConnectedAt) < threshold {
+
+	// The "stuck enough to wake" clock should anchor on the most
+	// recent of:
+	//   - When the WebSocket connected (agent only able to receive
+	//     prompts after this)
+	//   - When the session last had activity (a chat_message went out,
+	//     a message_completed came back — both call TouchSession and
+	//     bump session.updated)
+	//
+	// This handles three failure modes the connection-only gate misses:
+	//
+	//   - User sends a follow-up message while X is stuck: session.updated
+	//     refreshes; we shouldn't wake X immediately because the user is
+	//     already manually doing what we'd do.
+	//   - A previous turn completed recently (message_completed bumps
+	//     session.updated): the agent was demonstrably alive
+	//     `threshold` seconds ago; X probably isn't stuck yet, just
+	//     queued behind that completion's flush.
+	//   - WS reconnected long ago but the agent has been chatty since
+	//     (each turn touches session.updated): no need to wake on age
+	//     of a single old-but-still-processing prompt.
+	session, err := apiServer.Store.GetSession(ctx, stuck.SessionID)
+	if err != nil {
+		log.Warn().Err(err).
+			Str("interaction_id", stuck.ID).
+			Msg("[AUTO_WAKE] Failed to load session for activity anchor; skipping")
+		return
+	}
+	anchor := conn.ConnectedAt
+	if session.Updated.After(anchor) {
+		anchor = session.Updated
+	}
+	if time.Since(anchor) < threshold {
 		return
 	}
 
 	// Gate 1b — active streaming context.
 	//
-	// If the wrapper has dispatched at least one `added message` event
-	// for this session's current turn, getOrCreateStreamingContext
-	// will have created a streamingContext entry. That happens for
-	// text chunks, tool calls, thought-style step_info events, and any
-	// other content-bearing notification — i.e. anything that proves
-	// the agent is actively producing output for this turn even if no
-	// text has reached interaction.response_message yet (which is the
-	// usual tool-heavy-start case).
+	// If the wrapper has dispatched ANY content-bearing event for this
+	// session's current turn, `getOrCreateStreamingContext` will have
+	// created a `streamingContext` entry. That happens for:
 	//
-	// If a context exists, skip — the agent is working, even if the
-	// row in the DB still looks blank to ListStuckWaitingInteractions
-	// because of throttled DB writes.
+	//   - text chunks (`agent_message_chunk`)
+	//   - thinking entries (`agent_thought_chunk` — Claude's extended
+	//     thinking is NOT silent at the protocol level)
+	//   - tool calls (`tool_call`, `tool_call_update`)
+	//   - any other session_update with content
 	//
-	// Note: this does NOT cover the "silent extended thinking before
-	// first emit" case — Claude can think for 60-120 s without any
-	// session_update arriving, in which case no streaming context
-	// exists and we'd flag this as stuck. We accept that false-positive
-	// risk in exchange for the conservative threshold; if it becomes a
-	// problem in practice we can lengthen the threshold further or
-	// expose a per-session opt-out.
+	// If the context exists, skip — the agent is demonstrably alive on
+	// this session, even if the row in the DB still looks blank to
+	// ListStuckWaitingInteractions (throttled DB writes can lag the
+	// in-memory streaming state by tens of seconds).
 	apiServer.streamingContextsMu.RLock()
 	_, hasStreamingCtx := apiServer.streamingContexts[stuck.SessionID]
 	apiServer.streamingContextsMu.RUnlock()
@@ -303,14 +336,7 @@ func (apiServer *HelixAPIServer) maybeAutoWake(ctx context.Context, stuck *types
 		return
 	}
 
-	// Need session metadata for the WS command.
-	session, err := apiServer.Store.GetSession(ctx, stuck.SessionID)
-	if err != nil {
-		log.Warn().Err(err).
-			Str("interaction_id", stuck.ID).
-			Msg("[AUTO_WAKE] Failed to load session; skipping")
-		return
-	}
+	// (`session` already loaded above for the activity-anchor check.)
 
 	// Skip if the stuck interaction has no prompt content to re-send.
 	// Pathological case (synthetic interactions, bad data) — don't try


### PR DESCRIPTION
## Summary

Tighten the auto-wake worker's false-positive surface, motivated by the question: *"What if it just takes longer than 30 seconds for the LLM to process the request and start sending response tokens?"*

A false positive re-sends the user's prompt while the agent is mid-something. For an idempotent prompt that's a cosmetic duplicate response; for a destructive one (`rm`, `git push --force`) it's a real risk. The original 30 s threshold + connection-only gate left several plausible legitimate-slow scenarios in the false-positive window.

## Changes

### 1. Threshold bumped from 30 s → 120 s

Conservative default. Still catches the multi-minute / multi-hour stuck cases users actually complain about; gives slow-but-working prompts plenty of room.

What this does NOT need to cover: extended thinking. `AgentThoughtChunk` is an ACP `session_update` that surfaces to Helix as a `MessageAdded` → creates a `streamingContext` entry on our side → caught by the existing streaming-context gate. Same goes for tool-heavy starts — every `tool_call` entry creates a streaming context. Confirmed by inspecting `acp_thread.rs:1471`.

What's left for the threshold: the genuinely-blank window between the user's `session/prompt` and the wrapper's first outbound notification of any kind. On a healthy session that's 2-10 s; under load or for huge prompts it can stretch. 120 s is well past observed normal ceilings.

### 2. Env-tunable via `HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS`

Read once per scan tick (~10 s) so operators can adjust live without redeploying. Falls back to 120 s if unset or unparseable.

### 3. New gate: skip if `apiServer.streamingContexts[sessionID]` exists

The wrapper creates this entry on the first content-bearing event for the current turn — text chunks, tool calls, thinking entries, anything that goes through `getOrCreateStreamingContext`. If it's there, the agent is producing output even if no text has reached `response_message` yet (throttled DB writes can lag the in-memory streaming state by tens of seconds). Skip the wake-up.

### 4. Activity-anchored threshold (commit `baac1c825`)

The "stuck enough to wake" clock now anchors on `max(conn.ConnectedAt, session.Updated)` rather than just `ConnectedAt`. `session.Updated` is touched on every `TouchSession` call — `sendChatMessageToExternalAgent`, `handleMessageCompleted`, etc. — so it represents "time since last turn-level activity on this session".

Handles three failure modes the connection-only gate missed:

- **User sends a follow-up while X is stuck** → `session.Updated` refreshes → don't wake X immediately (the user is already manually doing what we'd do).
- **Previous turn completed recently** → agent demonstrably alive `threshold` seconds ago → X is probably queued behind that flush, not stuck.
- **WS reconnected long ago and the agent has been chatty** → `session.Updated` stays fresh as turns happen → no wake on the age of one slow prompt in an otherwise healthy session.

## Honest limitation

If the wrapper ever emits NO `session_update` for a long time (no thoughts, no tool calls, no chunks) AND no other interaction in the session is moving AND the WS has been live > threshold AND `session.Updated` is > threshold ago — we'll wake. That's the false-positive remainder. In practice this only happens for the worst load/queue scenarios on the Anthropic API. The 120 s threshold + retry cap of 2 + env override give us tuning headroom if production data shows this needs to widen.

## Files

- `api/pkg/server/auto_wake_stuck_interactions.go` only

## Test plan

- [x] `go build ./pkg/server/` clean
- [x] Air rebuilt; new threshold confirmed live: `🚀 [AUTO_WAKE] Started auto-wake worker for stuck waiting interactions max_retries=2 scan_interval=10000 stuck_threshold=120000`
- [ ] CI green
- [ ] Manual: kick off a tool-heavy spec task; observe NO wake-up fires while tools are running (`hasStreamingCtx` gate)
- [ ] Manual: send a follow-up while a previous prompt is processing; observe NO wake-up fires for the older interaction (`session.Updated` anchor)
- [ ] Manual: bump `HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS=60` in `.env`, restart, confirm log shows new threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)