### PR TITLE
fix(hydra): use `zfs destroy -r` in CleanupSessionZvol so manual snapshots don't block GC

### DIFF
--- a/api/pkg/hydra/golden_zvol.go
+++ b/api/pkg/hydra/golden_zvol.go
@@ -488,6 +488,16 @@ func SetupGoldenClone(projectID, sessionID string) (string, error) {
 }
 
 // CleanupSessionZvol unmounts and destroys a session's cloned zvol.
+//
+// Uses `zfs destroy -r` so any descendant snapshots (e.g. ones an operator
+// created out-of-band like `@pre-repo-cleanup-...`) are torn down with the
+// zvol. Without `-r`, ZFS refuses to destroy a dataset that has children and
+// the orphan accumulates forever, polluting GC logs.
+//
+// Note: `-r` (lowercase) does NOT cascade into clones of those snapshots —
+// if someone has manually cloned a child snapshot into another dataset, the
+// destroy still fails with "dataset is busy", which is the right answer (we
+// don't silently nuke unrelated work). The caller's GC loop logs and moves on.
 func CleanupSessionZvol(sessionID string) error {
 	cloneName := sessionZvolName(sessionID)
 	mountPath := sessionZvolMountPath(sessionID)
@@ -506,8 +516,8 @@ func CleanupSessionZvol(sessionID string) error {
 		}
 	}
 
-	// Destroy the clone
-	if err := runCmd("zfs", "destroy", cloneName); err != nil {
+	// Destroy the clone (recursive: takes any descendant snapshots with it)
+	if err := runCmd("zfs", "destroy", "-r", cloneName); err != nil {
 		return fmt.Errorf("failed to destroy clone %s: %w", cloneName, err)
 	}
 

--- a/api/pkg/hydra/golden_zvol_test.go
+++ b/api/pkg/hydra/golden_zvol_test.go
@@ -579,7 +579,26 @@ func (s *GoldenZvolSuite) TestCleanupSessionZvol_Success() {
 	require.NoError(s.T(), err)
 
 	assert.True(s.T(), s.mock.hasCommand("umount /container-docker/zvol-mounts/ses_001"))
-	assert.True(s.T(), s.mock.hasCommand("zfs destroy prod/helix-zvols/ses-ses_001"))
+	assert.True(s.T(), s.mock.hasCommand("zfs destroy -r prod/helix-zvols/ses-ses_001"))
+	assert.False(s.T(), s.mock.datasets["prod/helix-zvols/ses-ses_001"])
+}
+
+// TestCleanupSessionZvol_WithChildSnapshot covers the bug from spec task 001911:
+// an operator manually ran `zfs snapshot ses-XXX@pre-repo-cleanup-...`, which
+// blocked GC because plain `zfs destroy` refuses datasets that have children.
+// The fix is to pass `-r` so descendant snapshots are torn down with the zvol.
+func (s *GoldenZvolSuite) TestCleanupSessionZvol_WithChildSnapshot() {
+	zfsParentDataset = "prod/helix-zvols"
+	s.mock.addDataset("prod/helix-zvols/ses-ses_001")
+	s.mock.addSnapshot("prod/helix-zvols/ses-ses_001", "pre-repo-cleanup-2026-03-31")
+	s.mock.setMounted("/container-docker/zvol-mounts/ses_001")
+
+	err := CleanupSessionZvol("ses_001")
+	require.NoError(s.T(), err)
+
+	// Must use -r so the descendant snapshot doesn't block the destroy.
+	assert.True(s.T(), s.mock.hasCommand("zfs destroy -r prod/helix-zvols/ses-ses_001"),
+		"expected `zfs destroy -r` so the manually-created child snapshot is taken down with the zvol")
 	assert.False(s.T(), s.mock.datasets["prod/helix-zvols/ses-ses_001"])
 }
 
@@ -604,8 +623,8 @@ func (s *GoldenZvolSuite) TestCleanupSessionZvol_NotMounted() {
 
 	// Should NOT have tried to unmount
 	assert.False(s.T(), s.mock.hasCommand("umount"))
-	// Should still destroy
-	assert.True(s.T(), s.mock.hasCommand("zfs destroy prod/helix-zvols/ses-ses_001"))
+	// Should still destroy (recursive — see CleanupSessionZvol doc-comment)
+	assert.True(s.T(), s.mock.hasCommand("zfs destroy -r prod/helix-zvols/ses-ses_001"))
 }
 
 func (s *GoldenZvolSuite) TestCleanupSessionZvol_LazyUnmount() {
@@ -836,10 +855,10 @@ func (s *GoldenZvolSuite) TestGCOrphanedZvols_CleansOrphans() {
 	require.NoError(s.T(), err)
 	assert.Equal(s.T(), 1, cleaned)
 
-	// Orphan should be destroyed
-	assert.True(s.T(), s.mock.hasCommand("zfs destroy prod/helix-zvols/ses-ses_orphan"))
+	// Orphan should be destroyed (recursive — see CleanupSessionZvol doc-comment)
+	assert.True(s.T(), s.mock.hasCommand("zfs destroy -r prod/helix-zvols/ses-ses_orphan"))
 	// Active should NOT be destroyed
-	assert.False(s.T(), s.mock.hasCommand("zfs destroy prod/helix-zvols/ses-ses_active"))
+	assert.False(s.T(), s.mock.hasCommand("zfs destroy -r prod/helix-zvols/ses-ses_active"))
 	// Golden should NOT be destroyed
 	assert.False(s.T(), s.mock.hasCommand("zfs destroy prod/helix-zvols/golden-prj_abc"))
 }
@@ -887,7 +906,7 @@ func (s *GoldenZvolSuite) TestGCOrphanedZvols_CleansNoMarker() {
 	cleaned, err := GCOrphanedZvols(active)
 	require.NoError(s.T(), err)
 	assert.Equal(s.T(), 1, cleaned)
-	assert.True(s.T(), s.mock.hasCommand("zfs destroy prod/helix-zvols/ses-ses_no_marker"))
+	assert.True(s.T(), s.mock.hasCommand("zfs destroy -r prod/helix-zvols/ses-ses_no_marker"))
 }
 
 // -----------------------------------------------------------------------
@@ -1404,7 +1423,7 @@ func (s *GoldenZvolSuite) TestCleanup_ZvolSessionUsesZvolCleanup() {
 	err := CleanupSessionZvol("ses_001")
 	require.NoError(s.T(), err)
 
-	assert.True(s.T(), s.mock.hasCommand("zfs destroy prod/helix-zvols/ses-ses_001"))
+	assert.True(s.T(), s.mock.hasCommand("zfs destroy -r prod/helix-zvols/ses-ses_001"))
 }
 
 func (s *GoldenZvolSuite) TestCleanup_NonZvolSessionSkipsZvolCleanup() {


### PR DESCRIPTION
## Summary

`GCOrphanedZvols` was failing to clean up session zvols whenever an operator had created a snapshot on the zvol out of band (e.g. `@pre-repo-cleanup-2026-03-31`). ZFS refuses plain `zfs destroy` on a dataset with children, so those orphans accumulated forever and the warning repeated every GC cycle:

```
sandbox-nvidia-1  | [HYDRA] 8:14AM WRN Failed to GC orphaned zvol
  error="failed to destroy clone prod/helix-zvols/ses-ses_01kmqtedcrk20w85qqfnwbqvj9:
  zfs destroy ...: exit status 1
  (output: cannot destroy '...': volume has children
   use '-r' to destroy the following datasets:
   prod/helix-zvols/ses-ses_01kmqtedcrk20w85qqfnwbqvj9@pre-repo-cleanup-2026-03-31)"
  session_id=ses_01kmqtedcrk20w85qqfnwbqvj9
```

Fix: pass `-r` to `zfs destroy` in `CleanupSessionZvol`.

## Changes

- `api/pkg/hydra/golden_zvol.go` — one-line change: `runCmd("zfs", "destroy", cloneName)` → `runCmd("zfs", "destroy", "-r", cloneName)`. Doc-comment expanded to explain the `-r` choice and the `-R` alternative we explicitly rejected.
- `api/pkg/hydra/golden_zvol_test.go` — new `TestCleanupSessionZvol_WithChildSnapshot` covers the bug; existing assertions updated to expect the `-r` form (5 sites).

## Why `-r` and not `-R`

| Flag | Behaviour |
|------|-----------|
| `-r` | Destroy + descendant snapshots. Fails if a snapshot has a *clone* outside the dataset. |
| `-R` | Also destroys those clones. Could silently nuke an unrelated session zvol that happens to be cloned from one of these snapshots. |

By the time `CleanupSessionZvol` runs the session is already known to be gone (GC: >7 days inactive; failed-build path: build just failed; golden deletion: project is being torn down), so taking incidental snapshots with it is correct. But silently nuking *clones* of those snapshots would be a footgun — if `-r` fails because of a dependent clone, the existing fail-soft behaviour in `GCOrphanedZvols` logs and moves on, and the operator deals with the dependent clone explicitly. Same pattern already used at `golden_zvol.go:593` for the post-promote old-golden cleanup.

## Test plan

- [x] `cd api && go build ./pkg/hydra/ ./pkg/store/ ./pkg/types/` — clean.
- [x] `cd api && go test -v -run TestGoldenZvolSuite ./pkg/hydra/ -count=1` — 53/53 pass, including the new `TestCleanupSessionZvol_WithChildSnapshot`.
- [ ] After deploy: confirm "Failed to GC orphaned zvol ... volume has children" warnings stop appearing in `docker compose logs sandbox-nvidia` for the listed `ses_01kmqtedcrk2...`, `ses_01kmyhx3xw5kx...`, etc.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kq1rdf4ppfq9zrq2q6cf963q)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001911_gc-is-failing-when-there/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001911_gc-is-failing-when-there/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001911_gc-is-failing-when-there/tasks.md)

🚀 Built with [Helix](https://helix.ml)