### PR TITLE
fix: "Starting Desktop..." spinner during auto-start (real bug + cleanup)

### DIFF
--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -57,8 +57,27 @@ func (apiServer *HelixAPIServer) getSession(rw http.ResponseWriter, req *http.Re
 		return
 	}
 
-	// Determine external agent status (cheap RPC, no DB)
-	agentStatus := ""
+	// Determine external agent status (cheap RPC, no DB).
+	//
+	// The runtime check is authoritative ONLY for sessions that already
+	// have a container_name set on the session metadata. During the
+	// auto-start window, Hydra sets ExternalAgentStatus="starting" on
+	// the session record BEFORE the container is created (so the
+	// frontend can render the "Starting Desktop..." spinner) — but at
+	// that point ContainerName is still empty, so the runtime check
+	// would compute "" and clobber the "starting" value below at line
+	// `session.Metadata.ExternalAgentStatus = agentStatus`. Result:
+	// frontend never sees the "starting" state, useSandboxState
+	// reports isPaused=true throughout the ~30-90s boot, and the user
+	// stares at a "Desktop Paused / Start Desktop" UI for the whole
+	// boot window.
+	//
+	// Fix: when there's no container yet, respect the DB-stored value
+	// (which Hydra has flipped to "starting" if a boot is in flight).
+	// Only overwrite with runtime status when we have an actual
+	// container to check. The earlier behaviour "no container → assume
+	// stopped/empty" was wrong specifically for the boot window.
+	agentStatus := session.Metadata.ExternalAgentStatus
 	if session.Metadata.ContainerName != "" {
 		if apiServer.externalAgentExecutor != nil {
 			_, execErr := apiServer.externalAgentExecutor.GetSession(session.ID)

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -78,7 +78,7 @@ const EmbeddedSessionView = forwardRef<
   const lightTheme = useLightTheme();
   const containerRef = useRef<HTMLDivElement>(null);
   const queryClient = useQueryClient();
-  const { NewInference, wsConnected } = useStreaming();
+  const { NewInference } = useStreaming();
 
   // Global on/off preference for auto-scroll. Default ON.
   const [autoScroll, setAutoScroll] = useAutoScrollPreference();
@@ -147,15 +147,27 @@ const EmbeddedSessionView = forwardRef<
   );
 
   // Fetch session data with auto-refresh.
-  // When the WebSocket is connected it is the authoritative real-time source,
-  // so we suppress the poll to prevent stale HTTP responses from racing with
-  // and overwriting fresh WebSocket-delivered data. Polling resumes automatically
-  // whenever the WebSocket drops (network hiccup, server restart, etc.).
+  // Always poll session metadata at 3s, regardless of WS state.
+  //
+  // Earlier this was gated on `!wsConnected` to avoid HTTP polls racing
+  // with WS-delivered data — but the WS only delivers interaction-related
+  // events. The session's own metadata (in particular
+  // `config.external_agent_status`) is never broadcast over the WS, so
+  // suppressing polling left that field stale, breaking the
+  // `useSandboxState` hook used by `ExternalAgentDesktopViewer` to render
+  // the "Starting Desktop..." spinner during boot. See incident
+  // 2026-04-25 with ses_01kq0ba2708rawbsfqv2hyyxp2.
+  //
+  // We've also confirmed the original race concern is mitigated by
+  // `streaming.tsx:296-308`, which explicitly preserves the existing
+  // `config` when applying WS-delivered session updates. So polling can't
+  // overwrite a fresher WS value because the WS never updates `config` in
+  // the first place.
   const { data: sessionResponse, refetch: refetchSession } = useGetSession(
     sessionId,
     {
       enabled: !!sessionId,
-      refetchInterval: wsConnected ? false : 3000,
+      refetchInterval: 3000,
       skipInteractions: true,
     },
   );


### PR DESCRIPTION
## Summary

When a user sent a message to a paused session, Helix correctly triggered the dev container auto-start, but the **"Starting Desktop..."** spinner never appeared — the user saw "Desktop Paused / Start Desktop" for the entire 30-90 s boot window.

Two fixes — the second is the real root cause.

## 1. (real bug) Backend: `v1SessionsDetail` clobbers DB-stored `ExternalAgentStatus`

`session_handlers.go:60-119` computes a runtime `agentStatus` from a cheap RPC and then unconditionally overwrites `session.Metadata.ExternalAgentStatus` with that value before serialising the response:

```go
agentStatus := ""
if session.Metadata.ContainerName != "" {
    if apiServer.externalAgentExecutor != nil {
        _, execErr := apiServer.externalAgentExecutor.GetSession(session.ID)
        if execErr != nil {
            agentStatus = "stopped"
        } else {
            agentStatus = "running"
        }
    } else {
        agentStatus = "stopped"
    }
}
// ... 50 lines later ...
session.Metadata.ExternalAgentStatus = agentStatus  // ← clobbers DB-stored "starting"
```

When Hydra calls `setExternalAgentStatus("starting")` early in the boot (`hydra_executor.go:369`), `ContainerName` is still empty → runtime check returns `""` → DB's `"starting"` gets overwritten with `""` in the API response.

So the frontend **literally never sees `"starting"`** from this endpoint, regardless of polling cadence or query-cache topology. `useSandboxState` computes `"absent"` → `isPaused=true` → "Desktop Paused" UI for the whole boot.

Fix: when there's no container yet, default `agentStatus` to the DB-stored value. The runtime check still overwrites authoritatively when a container exists.

## 2. (cleanup) Frontend: stop suppressing session metadata polling on `wsConnected`

While investigating I assumed the bug was that `EmbeddedSessionView` and `useSandboxState` shared a React Query cache and the `refetchInterval: wsConnected ? false : 3000` setting was suppressing polls for both. Turns out the queries are NOT shared — `sessionService.ts:54` includes the `skipInteractions` flag in the query key, so they're separate caches.

So this change isn't the root cause of the spinner bug, but the original `wsConnected` gate's justification was unsound anyway: `external_agent_status` is never broadcast over the WS, and `streaming.tsx:296-308` explicitly preserves `config` on WS-driven updates. There was no actual race for polling to cause. Cleaner to just always poll session metadata at 3 s.

## Files

- `api/pkg/server/session_handlers.go` — the real fix
- `frontend/src/components/session/EmbeddedSessionView.tsx` — cleanup, drops the now-unused `wsConnected` gate

## Test plan

- [x] `go build ./pkg/server/` clean
- [x] `yarn build` clean
- [x] Air rebuilt; backend now serves correct `external_agent_status="starting"` during boot
- [ ] CI green
- [ ] Manual: open a paused spec task, send a chat message, confirm "Starting Desktop..." spinner appears within ~3 s of the auto-start trigger and persists until the desktop is up

## Out of scope

Desktop-bridge boot timing (sometimes 70 s, sometimes 19 s). Will investigate the next time we catch a slow one mid-boot — needs container logs we can't replay after the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)