### PR TITLE
fix(desktop): drop recursive chown on /home/retro at container start

### DIFF
--- a/Dockerfile.sway-helix
+++ b/Dockerfile.sway-helix
@@ -462,7 +462,11 @@ echo "Setting default user uid=$(id -u ${UNAME}) gid=$(id -g ${UNAME})"
 echo "Setting umask to ${UMASK}"
 umask "${UMASK}"
 echo "Ensure ${UNAME} home directory is writable"
-chown -R "${UNAME}:${UNAME}" "/home/${UNAME}" 2>/dev/null || true
+# Non-recursive: image is built with retro:retro and the persistent home volume is
+# initialized with retro:retro. A recursive chown over a populated home dir at every
+# container start was producing huge metadata-write storms through the ext4-on-zvol +
+# dedup'd ZFS workspace stack (PSI io.full ~67% during cold starts).
+chown "${UNAME}:${UNAME}" "/home/${UNAME}" 2>/dev/null || true
 echo "Ensure XDG_RUNTIME_DIR is writable"
 mkdir -p "${XDG_RUNTIME_DIR:-/run/user/1000}"
 chown -R "${UNAME}:${UNAME}" "${XDG_RUNTIME_DIR:-/run/user/1000}" 2>/dev/null || true

--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -467,7 +467,11 @@ echo "Setting default user uid=$(id -u ${UNAME}) gid=$(id -g ${UNAME})"
 echo "Setting umask to ${UMASK}"
 umask "${UMASK}"
 echo "Ensure ${UNAME} home directory is writable"
-chown -R "${UNAME}:${UNAME}" "/home/${UNAME}" 2>/dev/null || true
+# Non-recursive: image is built with retro:retro and the persistent home volume is
+# initialized with retro:retro. A recursive chown over a populated home dir at every
+# container start was producing huge metadata-write storms through the ext4-on-zvol +
+# dedup'd ZFS workspace stack (PSI io.full ~67% during cold starts).
+chown "${UNAME}:${UNAME}" "/home/${UNAME}" 2>/dev/null || true
 echo "Ensure XDG_RUNTIME_DIR is writable"
 mkdir -p "${XDG_RUNTIME_DIR:-/run/user/1000}"
 chown -R "${UNAME}:${UNAME}" "${XDG_RUNTIME_DIR:-/run/user/1000}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- The cont-init.d script from the upstream games-on-whales base ran `chown -R retro:retro /home/retro` on every container start — boilerplate defending against a runtime-UID-override case Helix never uses.
- On a populated session home this produced a metadata-write storm: PSI `io.full` ~67% over 10s, load average 20+ with no CPU/memory pressure during concurrent cold starts.
- Replace the `-R` chown with a non-recursive one so the original "ensure top-level dir is owned by retro" intent is preserved at zero cost. Same patch applied to both `Dockerfile.ubuntu-helix` and `Dockerfile.sway-helix`.

## Why it hurts so much

The recursive walk crosses two storage paths in roughly equal proportion (measured ~123k inodes outside `work/`, ~107k inside):

1. **`/home/retro` (rootfs)** → overlay → ext4 → 16K-volblocksize zvol → ZFS. Each metadata op = ext4 journal commit + 4K → 16K read-modify-write amplification on the zvol.
2. **`/home/retro/work`** → bind mount from `prod/helix-workspaces` (ZFS direct, but with `dedup=on`). Each metadata write costs a DDT lookup + update against a 17.6 GB DDT that's competing with the 32 GB ARC.

Both costs are paid for every inode in `/home/retro` at every container start, even though ownership never changed.

## Test plan

- [ ] `./stack build-ubuntu` and confirm the desktop image still builds clean
- [ ] Start a fresh spectask session against the rebuilt image; confirm container starts and `/home/retro` is usable as `retro`
- [ ] Watch `cat /proc/pressure/io` during 2–3 concurrent session cold starts and confirm the spike is gone
- [ ] Sanity-check that existing sessions still come back up correctly when their image is updated (the home dir is already retro-owned, so the non-recursive chown should be a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)