### PR TITLE
Embed auth follow-ups: prefer Bearer over cookie, fix /auth/authenticated

### DIFF
--- a/api/pkg/server/auth.go
+++ b/api/pkg/server/auth.go
@@ -965,6 +965,17 @@ func (s *HelixAPIServer) authenticated(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// If the auth middleware already resolved a user from any source
+	// (Bearer token / API key / OIDC token / cookie), trust that. This
+	// is what allows embed pages to authenticate via ?access_token=...
+	// in the URL even when no session cookie is present.
+	if user := getRequestUser(r); hasUser(user) {
+		writeResponse(w, types.AuthenticatedResponse{
+			Authenticated: true,
+		}, http.StatusOK)
+		return
+	}
+
 	// BFF pattern: Check for session cookie first
 	if s.sessionManager != nil {
 		session, err := s.sessionManager.GetSessionFromRequest(ctx, r)

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -78,13 +78,22 @@ if (embedToken) {
   const authValue = `Bearer ${embedToken}`
   axios.defaults.headers.common['Authorization'] = authValue
   apiClientSingleton.instance.defaults.headers.common['Authorization'] = authValue
+  // Disable cookie sending so the server's auth middleware falls through
+  // to Bearer-token auth. Otherwise an existing helix_session cookie (e.g.
+  // because the user is also logged into Helix in the same browser) would
+  // win and we'd authenticate as that user, not as the API key owner.
+  axios.defaults.withCredentials = false
+  apiClientSingleton.instance.defaults.withCredentials = false
 }
 
 // Add interceptors to the Api client's axios instance
 apiClientSingleton.instance.interceptors.request.use(csrfInterceptor)
 
-// Configure axios to send cookies with requests (same-origin)
-axios.defaults.withCredentials = true
+// Configure axios to send cookies with requests (same-origin).
+// Skip when an embed token is in play — see embed-auth block above.
+if (!embedToken) {
+  axios.defaults.withCredentials = true
+}
 
 // Add interceptors for direct axios usage
 axios.interceptors.request.use(csrfInterceptor)


### PR DESCRIPTION
## Summary

Two follow-up fixes to PR #2287 (the embed `?access_token=` work) found by E2E testing the Gatewaze newsletter → Helix iframe flow.

### 1. `EmbedTaskPage`: disable cookies when access_token is in URL (`fde04cb`)

The auth middleware (`auth_middleware.go:354`) tries the BFF cookie session **before** the Bearer token. So when a user is logged into Helix in the same browser as the embedder, the cookie wins and the API key in the embed URL is silently ignored — they get authenticated as themselves and hit project-level auth failures.

Fix: when an embed `access_token` is in the URL, disable cookie sending in both axios and the `apiClientSingleton`. Server then falls through to Bearer auth.

### 2. `/auth/authenticated`: trust Bearer tokens (`2b0df79`)

`/auth/authenticated` only checked the BFF session cookie and the legacy `access_token` cookie — not the Bearer / API key that `extractMiddleware` already resolves.

Result: with `?access_token=` in the URL, `/api/v1/spec-tasks/...` works fine (Bearer accepted), but `/auth/authenticated` returns `{"authenticated":false}`. The React app sees this and redirects to `/login`.

Fix: at the top of the handler, if the auth middleware already resolved a user from any source, return `authenticated=true`. Cookie fallback paths kept as-is for callers that hit this endpoint without going through `extractMiddleware`.

## Test plan

- [x] Verified locally: with both fixes, `meta.helix.ml/embed/task/{id}?access_token={api_key}` will authenticate via the API key without redirecting to `/login`, even when no cookie session exists.
- [ ] After merge + deploy: rerun the Gatewaze newsletter → "Research with Helix" → iframe flow end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)