### PR TITLE
Embed auth fix #3: validate token in /auth/{authenticated,user} directly

### DIFF
--- a/api/pkg/server/auth.go
+++ b/api/pkg/server/auth.go
@@ -730,6 +730,31 @@ func (s *HelixAPIServer) user(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Bearer / API key / access_token query param. Same reason as in
+	// authenticated() above — this endpoint isn't behind extractMiddleware,
+	// so we resolve the token ourselves to support embed pages.
+	if s.authMiddleware != nil {
+		if token := getRequestToken(r); token != "" {
+			user, err := s.authMiddleware.getUserFromToken(ctx, token)
+			if err == nil && hasUser(user) {
+				dbUser, err := s.Store.GetUser(ctx, &store.GetUserQuery{ID: user.ID})
+				if err == nil && dbUser != nil {
+					response := types.UserResponse{
+						ID:                  dbUser.ID,
+						Email:               dbUser.Email,
+						Token:               "",
+						Name:                dbUser.FullName,
+						Admin:               dbUser.Admin,
+						OnboardingCompleted: dbUser.OnboardingCompleted,
+						Waitlisted:          dbUser.Waitlisted,
+					}
+					writeResponse(w, response, http.StatusOK)
+					return
+				}
+			}
+		}
+	}
+
 	// BFF pattern: Check for session cookie first
 	if s.sessionManager != nil {
 		session, err := s.sessionManager.GetSessionFromRequest(ctx, r)
@@ -965,15 +990,20 @@ func (s *HelixAPIServer) authenticated(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If the auth middleware already resolved a user from any source
-	// (Bearer token / API key / OIDC token / cookie), trust that. This
-	// is what allows embed pages to authenticate via ?access_token=...
-	// in the URL even when no session cookie is present.
-	if user := getRequestUser(r); hasUser(user) {
-		writeResponse(w, types.AuthenticatedResponse{
-			Authenticated: true,
-		}, http.StatusOK)
-		return
+	// Bearer / API key / access_token query param. This endpoint lives on
+	// the insecureRouter (no extractMiddleware), so we have to validate
+	// the token ourselves. Lets embed pages authenticate via
+	// ?access_token=... in the URL when no session cookie is present.
+	if s.authMiddleware != nil {
+		if token := getRequestToken(r); token != "" {
+			user, err := s.authMiddleware.getUserFromToken(ctx, token)
+			if err == nil && hasUser(user) {
+				writeResponse(w, types.AuthenticatedResponse{
+					Authenticated: true,
+				}, http.StatusOK)
+				return
+			}
+		}
 	}
 
 	// BFF pattern: Check for session cookie first


### PR DESCRIPTION
## Summary

PR #2289's `/auth/authenticated` fix didn't actually work because I missed that the endpoint is on `insecureRouter` — a separate subRouter that doesn't have `extractMiddleware`. So `getRequestUser(r)` always returned nil at the top of the handler.

E2E test confirmed: with the deployed code, `curl -H "Authorization: Bearer hl-..." https://meta.helix.ml/api/v1/auth/authenticated` still returns `{"authenticated":false}` even though the same Bearer token works fine on `/api/v1/spec-tasks/...`.

## Fix

In both `/auth/authenticated` and `/auth/user` handlers, resolve the token ourselves via `s.authMiddleware.getUserFromToken()`. That covers `Authorization: Bearer`, `?access_token=`, and `x-api-key` callers.

Existing cookie / BFF session paths kept exactly as they were — this is purely an additional branch at the top of each handler.

## Why two endpoints

The React app's account context loads the user in two steps:
1. `/auth/authenticated` → `{authenticated: true}` to skip the login redirect
2. `/auth/user` → user object to populate state

Both need to recognize the embed token, otherwise the app either redirects to `/login` (step 1 fails) or never finishes initialization (step 2 fails).

## Test plan

- [x] `go build ./api/pkg/server/` clean
- [ ] After deploy: `curl -H "Authorization: Bearer ${HELIX_API_KEY}" https://meta.helix.ml/api/v1/auth/authenticated` returns `{"authenticated":true}`
- [ ] Embed iframe `meta.helix.ml/embed/task/{id}?access_token={key}` renders the task content (not the login redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)