### PR TITLE
Layout: include CssBaseline in fullscreen routes

### DIFF
--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -452,10 +452,14 @@ const Layout: FC<{
     }
   }
 
-  // Fullscreen mode: render children without any chrome (sidebar, drawer, banners)
+  // Fullscreen mode: render children without any chrome (sidebar, drawer, banners).
+  // Still include CssBaseline so MUI's typography + body styles apply — without it,
+  // embed pages get browser defaults (Times New Roman, undefined text color → black
+  // on whatever bg the page paints).
   if (router.meta.fullscreen) {
     return (
       <>
+        <CssBaseline />
         {children}
         <Snackbar />
         <GlobalLoading />


### PR DESCRIPTION
## Summary

Routes with `meta.fullscreen` (e.g. `/embed/task/:taskId`) skipped `CssBaseline` because it only lived in the chrome'd Layout branch.

E2E test caught the symptom: the embedded view rendered in Times New Roman with black text on the dark theme background — invisible. Root cause: no `CssBaseline` → no body font, no default text color, fall through to browser defaults.

## Fix

Render `CssBaseline` in the fullscreen branch too. The chrome'd branch keeps its own (unchanged).

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] After deploy: `meta.helix.ml/embed/task/{id}?access_token={key}` renders with the platform font (IBM Plex Sans) and theme text color, on the dark theme bg. No more Times New Roman.

🤖 Generated with [Claude Code](https://claude.com/claude-code)