### PR TITLE
spec-tasks/design-docs: git fetch helix-specs before reading

### DIFF
--- a/api/pkg/server/spec_task_orchestrator_handlers.go
+++ b/api/pkg/server/spec_task_orchestrator_handlers.go
@@ -68,6 +68,25 @@ func (apiServer *HelixAPIServer) getSpecTaskDesignDocs(_ http.ResponseWriter, re
 
 // readDesignDocsFromGit reads design documents from the helix-specs branch
 func (apiServer *HelixAPIServer) readDesignDocsFromGit(repoPath string, taskID string) ([]DesignDocument, error) {
+	// Fetch from origin so writes pushed by agents (via raw `git push`,
+	// not the in-process write API) are visible. Best-effort — if the
+	// fetch fails (no network, no remote configured), fall through to
+	// reading whatever we have locally.
+	if fetchCmd := exec.Command("git", "fetch", "origin", "helix-specs", "--quiet"); true {
+		fetchCmd.Dir = repoPath
+		if fetchOut, fetchErr := fetchCmd.CombinedOutput(); fetchErr != nil {
+			log.Debug().Err(fetchErr).Str("output", string(fetchOut)).Str("repo_path", repoPath).Msg("design-docs: fetch helix-specs failed; reading local state")
+		}
+		// Move the local helix-specs ref to the freshly fetched origin tip.
+		// Using update-ref instead of merge avoids any working-tree state.
+		if updateCmd := exec.Command("git", "update-ref", "refs/heads/helix-specs", "refs/remotes/origin/helix-specs"); true {
+			updateCmd.Dir = repoPath
+			if updateOut, updateErr := updateCmd.CombinedOutput(); updateErr != nil {
+				log.Debug().Err(updateErr).Str("output", string(updateOut)).Str("repo_path", repoPath).Msg("design-docs: update-ref helix-specs failed")
+			}
+		}
+	}
+
 	// First, list all files in helix-specs branch to find task directory
 	// Format: design/tasks/{date}_{name}_{task_id}/
 	cmd := exec.Command("git", "ls-tree", "--name-only", "-r", "helix-specs")


### PR DESCRIPTION
## Summary

`readDesignDocsFromGit`'s comment claims "*agents write through the API, so the local repo always has the latest data*". That assumption holds for the agents that go through Helix's in-process write path, but it breaks for `just_do_it_mode` tasks where the agent does its own `git push origin helix-specs` from inside the sandbox — the push lands on origin (e.g. GitHub via the bridge), but the API server's local worktree never refreshes, so `/api/v1/spec-tasks/{id}/design-docs` returns an empty `documents` array even though the file exists upstream.

E2E test caught this end-to-end testing the Gatewaze newsletter → Helix research flow:
- Agent confirmed `git commit && git push origin helix-specs`
- GitHub shows the directory + file
- `/design-docs` returns `{"documents": []}`
- Newsletter sync function in turn never imports anything

## Fix

Best-effort `git fetch origin helix-specs --quiet` + `git update-ref refs/heads/helix-specs refs/remotes/origin/helix-specs` before the existing `ls-tree`. Both are no-ops if the remote is unreachable or the branch doesn't exist; the existing read path then returns whatever's local (or empty), preserving prior behaviour for offline cases. No working-tree state involved (uses `update-ref`, not `merge` or `pull`), so this is safe even with detached or modified checkouts.

## Performance

One network round-trip per call. If this becomes a hot path, drop in a small in-process TTL cache keyed on `(repoPath, branch)`. Not doing that now to keep the change minimal.

## Test plan
- [x] `go build ./api/pkg/server/` clean
- [ ] After deploy: a task with `output.html` pushed via `git push origin helix-specs` (i.e. the just_do_it_mode flow) shows up in `GET /api/v1/spec-tasks/{id}/design-docs`'s `documents` array on the next call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)