### PR TITLE
fix sync stack: auto-wake gate quiescence, 60s threshold, qwen-only shell guidance, opus-4-7 thinking summaries

### DIFF
--- a/api/pkg/anthropic/thinking_retry.go
+++ b/api/pkg/anthropic/thinking_retry.go
@@ -119,9 +119,20 @@ func detectThinkingTypeMismatch(body []byte) string {
 }
 
 // swapThinkingType rewrites the request body's thinking.type to newType.
-// When switching to "enabled" it injects budget_tokens=4096 if missing and
-// removes the adaptive-only "display" field. When switching to "adaptive" it
-// removes budget_tokens (adaptive doesn't accept it).
+//
+// When switching to "enabled": injects budget_tokens=4096 if missing and
+// removes the adaptive-only "display" field.
+//
+// When switching to "adaptive": removes budget_tokens (adaptive rejects it)
+// and ensures top-level output_config.effort is set. The Vertex rejection
+// that triggers this swap explicitly says "Use thinking.type.adaptive and
+// output_config.effort to control thinking behavior" — the two fields work
+// as a pair. Without effort, adaptive runs at the model's implicit minimum,
+// which produces an empty thinking summary visible to the client (renders
+// as `<thinking></thinking>` with no content). We default to "medium",
+// which is the right trade-off between latency and useful summary depth
+// for the Helix spec-task workload. Caller can pre-set
+// output_config.effort to override.
 //
 // Returns (newBody, true) on success, (nil, false) if the body is not valid
 // JSON or has no thinking field.
@@ -148,6 +159,9 @@ func swapThinkingType(body []byte, newType string) ([]byte, bool) {
 		delete(thinking, "display")
 	case "adaptive":
 		delete(thinking, "budget_tokens")
+		if !ensureOutputConfigEffort(bodyMap, "medium") {
+			return nil, false
+		}
 	}
 
 	newThinking, err := json.Marshal(thinking)
@@ -161,4 +175,30 @@ func swapThinkingType(body []byte, newType string) ([]byte, bool) {
 		return nil, false
 	}
 	return newBody, true
+}
+
+// ensureOutputConfigEffort sets bodyMap["output_config"]["effort"] = effort
+// if not already set. Preserves any other fields under output_config.
+// Returns false on JSON malformedness.
+func ensureOutputConfigEffort(bodyMap map[string]json.RawMessage, effort string) bool {
+	outputConfig := map[string]json.RawMessage{}
+	if raw, ok := bodyMap["output_config"]; ok {
+		if err := json.Unmarshal(raw, &outputConfig); err != nil {
+			return false
+		}
+	}
+	if _, has := outputConfig["effort"]; has {
+		return true
+	}
+	effortRaw, err := json.Marshal(effort)
+	if err != nil {
+		return false
+	}
+	outputConfig["effort"] = effortRaw
+	newOutputConfig, err := json.Marshal(outputConfig)
+	if err != nil {
+		return false
+	}
+	bodyMap["output_config"] = newOutputConfig
+	return true
 }

--- a/api/pkg/anthropic/thinking_retry_test.go
+++ b/api/pkg/anthropic/thinking_retry_test.go
@@ -126,6 +126,24 @@ func TestThinkingRetryTransport_EnabledRejectedSwapsToAdaptive(t *testing.T) {
 	assert.Equal(t, "adaptive", thinking["type"])
 	_, hasBudget := thinking["budget_tokens"]
 	assert.False(t, hasBudget, "budget_tokens should be stripped when switching to adaptive")
+
+	var outputConfig map[string]interface{}
+	require.NoError(t, json.Unmarshal(retryBody["output_config"], &outputConfig))
+	assert.Equal(t, "medium", outputConfig["effort"], "should default output_config.effort to medium when swapping to adaptive (otherwise the model produces an empty thinking summary)")
+}
+
+func TestSwapThinkingType_AdaptivePreservesExistingOutputConfigEffort(t *testing.T) {
+	// If the caller already specified an effort, swapThinkingType must not
+	// clobber it — they may have a deliberate reason for high or low.
+	body := []byte(`{"thinking":{"type":"enabled","budget_tokens":4096},"output_config":{"effort":"high","other_field":"keep_me"}}`)
+	out, ok := swapThinkingType(body, "adaptive")
+	require.True(t, ok)
+
+	var bodyMap map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &bodyMap))
+	outputConfig, _ := bodyMap["output_config"].(map[string]interface{})
+	assert.Equal(t, "high", outputConfig["effort"], "pre-set effort must not be overwritten")
+	assert.Equal(t, "keep_me", outputConfig["other_field"], "sibling fields under output_config must be preserved")
 }
 
 func TestThinkingRetryTransport_NonThinking400PassesThrough(t *testing.T) {

--- a/api/pkg/server/auto_wake_stuck_interactions.go
+++ b/api/pkg/server/auto_wake_stuck_interactions.go
@@ -140,31 +140,24 @@ const (
 	// defaultAutoWakeStuckThreshold is the minimum age of a
 	// `state=waiting` interaction before we consider it stuck.
 	//
-	// 120 s is deliberately conservative. Picking too low produces
-	// false positives when the Anthropic API itself is slow (load,
-	// cold cache, large prompts taking time before the first chunk).
-	// A false positive re-sends the user's prompt while the agent is
-	// mid-something — for idempotent prompts that's a cosmetic
-	// duplicate response, for destructive ones (`rm`, `git push`)
-	// it's a real risk.
+	// 60 s targets the dominant failure mode: agent emits a few early
+	// chunks (tool_call, thinking) then goes silent for minutes while
+	// claude-agent-acp buffers the rest of the turn on its outbound
+	// channel. The streaming-context gate below now requires
+	// `lastPublish` to be older than this same threshold before
+	// considering the session quiescent, so we don't false-positive on
+	// genuinely-still-streaming turns.
 	//
-	// What this DOES NOT need to cover: extended-thinking silence.
-	// Claude's thinking surfaces as `AgentThoughtChunk` ACP session
-	// notifications, which produce `MessageAdded` events to Helix,
-	// which create entries in `apiServer.streamingContexts`. The
-	// streaming-context gate in maybeAutoWake catches the thinking
-	// case directly — we don't need the threshold to be long enough
-	// to wait it out. Same goes for tool-heavy starts: every
-	// `tool_call` entry creates a streaming context.
-	//
-	// What's left for the threshold: the genuinely-blank window
-	// between the user's `session/prompt` and the wrapper's first
-	// outbound notification of any kind. On a healthy session that's
-	// usually 2-10 s; under load or for huge prompts it can stretch.
-	// 120 s is well past observed normal ceilings.
+	// False-positive cost: if the Anthropic API takes >60 s before the
+	// first chunk on a slow turn, we re-send the user's prompt. For
+	// idempotent prompts that's a cosmetic duplicate. For destructive
+	// ones (`rm`, `git push`) it's a real risk — but the auto-wake
+	// re-sends the *same prompt* the user already authorised, so worst
+	// case the agent runs the destructive op twice on its own work
+	// directory. Bounded by autoWakeMaxRetries.
 	//
 	// Override at runtime with HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS.
-	defaultAutoWakeStuckThreshold = 120 * time.Second
+	defaultAutoWakeStuckThreshold = 60 * time.Second
 
 	// autoWakeMaxRetries caps how many wake-ups we attempt for a single
 	// stuck interaction before giving up and marking it state=error.
@@ -282,27 +275,36 @@ func (apiServer *HelixAPIServer) maybeAutoWake(ctx context.Context, stuck *types
 		return
 	}
 
-	// Gate 1b — active streaming context.
+	// Gate 1b — quiescence-aware streaming-context check.
 	//
-	// If the wrapper has dispatched ANY content-bearing event for this
-	// session's current turn, `getOrCreateStreamingContext` will have
-	// created a `streamingContext` entry. That happens for:
+	// `getOrCreateStreamingContext` creates an entry on the first
+	// content-bearing event of a turn (text chunk, thinking, tool_call)
+	// and `flushAndClearStreamingContext` only removes it on
+	// `message_completed` or a fresh WS reconnect. So an active context
+	// is *not* proof of recent activity — when the wrapper buffers the
+	// tail of a turn (the bug this worker exists to mitigate) the
+	// context lives on for minutes after the last visible chunk, with
+	// no `message_completed` ever arriving. Skipping unconditionally on
+	// "context exists" defeats the whole worker for the dominant
+	// failure mode.
 	//
-	//   - text chunks (`agent_message_chunk`)
-	//   - thinking entries (`agent_thought_chunk` — Claude's extended
-	//     thinking is NOT silent at the protocol level)
-	//   - tool calls (`tool_call`, `tool_call_update`)
-	//   - any other session_update with content
-	//
-	// If the context exists, skip — the agent is demonstrably alive on
-	// this session, even if the row in the DB still looks blank to
-	// ListStuckWaitingInteractions (throttled DB writes can lag the
-	// in-memory streaming state by tens of seconds).
+	// Instead: skip only if the context exists AND its `lastPublish`
+	// (the most recent time we forwarded a chunk to the frontend) is
+	// within `threshold`. After `threshold` of in-context silence we
+	// treat the session as quiescent for wake-up purposes, which is
+	// what we want — tool-call cascades and thinking bursts touch
+	// `lastPublish` on every event, so an actively-streaming session
+	// will reliably stay above the threshold.
 	apiServer.streamingContextsMu.RLock()
-	_, hasStreamingCtx := apiServer.streamingContexts[stuck.SessionID]
+	sctx := apiServer.streamingContexts[stuck.SessionID]
 	apiServer.streamingContextsMu.RUnlock()
-	if hasStreamingCtx {
-		return
+	if sctx != nil {
+		sctx.mu.Lock()
+		lastPublish := sctx.lastPublish
+		sctx.mu.Unlock()
+		if time.Since(lastPublish) < threshold {
+			return
+		}
 	}
 
 	// Same threshold, computed against interaction age now that we know

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -895,6 +895,17 @@ Follow these guidelines when making changes:
 	// Build repository section listing local + Kodit repos for the agent
 	repoSection := s.buildRepositorySectionForTask(ctx, task, project)
 
+	// qwen-code's Shell tool requires `is_background` on every call (see
+	// qwen-code/packages/core/src/tools/shell.test.ts). Other runtimes use a
+	// different parameter name (Claude Code: `run_in_background`, Codex: none),
+	// and forcing `is_background` on those tools triggers
+	// `InputValidationError: An unexpected parameter "is_background" was provided`
+	// on the agent's first Bash call, burning a tool slot before any real work.
+	shellCommandsGuidance := ""
+	if codeAgentRuntimeJDI == types.CodeAgentRuntimeQwenCode {
+		shellCommandsGuidance = "**Shell commands:** Specify is_background (true or false) on all shell commands - it's required. Use true for long-running operations (builds, servers, installs).\n\n"
+	}
+
 	promptWithBranch := fmt.Sprintf(`%s
 %s
 ---
@@ -903,12 +914,10 @@ Follow these guidelines when making changes:
 
 **Primary Project Directory:** /home/retro/work/%s/
 %s
-**Shell commands:** Specify is_background (true or false) on all shell commands - it's required. Use true for long-running operations (builds, servers, installs).
-
-%s
+%s%s
 
 **For persistent installs:** Add commands to /home/retro/work/helix-specs/.helix/startup.sh (runs at sandbox startup, must be idempotent). Push directly to helix-specs branch.
-`, userPrompt, guidelinesSection, primaryRepoName, repoSection, gitInstructions)
+`, userPrompt, guidelinesSection, primaryRepoName, repoSection, shellCommandsGuidance, gitInstructions)
 
 	interaction := &types.Interaction{
 		ID:            system.GenerateInteractionID(),


### PR DESCRIPTION
## Summary

Four fixes for the recurring "agent went silent" pattern on spec-task sessions, all triggered by investigating one hung session this morning (`spt_01kq58ebrtmm0ar8s86vzhmh1v`). Each is a small surface, but they cluster around the same user-visible symptom and reinforce each other — landing as one PR so the diagnosis is reviewable as a unit.

## What changed

**1. Auto-wake streaming-context gate is now quiescence-aware (`api/pkg/server/auto_wake_stuck_interactions.go`)**

The old gate skipped on *existence* of a `streamingContext` entry for the session. But that entry's lifecycle is created-on-first-chunk → cleared-on-message_completed-or-WS-reconnect — and the bug we're trying to mitigate (`claude-agent-acp` buffering tail-of-turn events on its outbound channel) means `message_completed` never arrives. So the streaming context lingers for minutes after the last visible chunk, and the gate skipped every 10s tick, defeating the worker for the dominant failure mode it exists to handle.

The new gate reads `sctx.lastPublish` (under `sctx.mu`) and skips only if a chunk landed within the threshold. Tool calls, thinking bursts, and message chunks all touch `lastPublish` on every event, so an actively-streaming turn keeps refreshing the timestamp; a buffered/stuck turn doesn't.

**2. Threshold lowered from 120s → 60s (same file)**

With the gate now correctly tracking activity (rather than rolling presence), 60s of *true* silence after the agent has clearly started working is rare enough to use as a stuck signal. Comment block updated to reflect the new rationale and the false-positive analysis (`HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS` env override unchanged).

**3. Just-Do-It system prompt's `is_background` shell guidance is now qwen-only (`api/pkg/services/spec_driven_task_service.go`)**

The prompt unconditionally told the agent to "Specify is_background (true or false) on all shell commands - it's required". `is_background` is qwen-code's Shell-tool parameter (`qwen-code/packages/core/src/tools/shell.test.ts`). Claude Code (default for most spec tasks) uses `run_in_background`; passing `is_background` returns `InputValidationError: An unexpected parameter "is_background" was provided` and burns the agent's first Bash call on a guaranteed-failing schema before any real work starts. Now gated on `CodeAgentRuntime == CodeAgentRuntimeQwenCode`.

**4. Anthropic proxy now injects `output_config.effort=medium` when swapping `thinking.type` to `adaptive` (`api/pkg/anthropic/thinking_retry.go`)**

The Vertex rejection that triggers the swap to `adaptive` literally tells us:

> *"thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.*

…and we were doing only the first half. The retry produced a body with `{"thinking": {"type": "adaptive"}}` and no top-level `output_config`, which runs the model at its implicit minimum effort. At minimum effort the model produces little enough thinking that the visible summary is empty — exactly the `<thinking></thinking>` blocks we see in every opus-4-7 response on this box. So "adaptive thinking is summarised by Anthropic and they hide the content" was a wrong diagnosis in chat earlier; the right diagnosis is "we forgot to tell the model how hard to think."

Fix: when swapping to adaptive, also set `output_config.effort` to `medium` if the caller hasn't already set one. Existing `output_config` siblings preserved, caller-supplied effort respected. New tests cover both the default-injection and the preserve-existing-effort paths.

## Why these go together

All four contribute to the same user-visible symptom: agent does some early work, then either hits a wall (the InputValidationError schema mismatch, the buffered-turn bug) or goes silent in a way that *looks* like a hang (empty thinking summaries during a long thinking burst). Helix's recovery worker would then silently no-op at the gate. Fixing one without the others leaves the symptom partially unaddressed.

## Background

`design/2026-04-25-zed-claude-async-event-flush-on-user-input.md` covers the upstream ACP off-by-one buffering bug and the rationale for the auto-wake worker's existence in detail. This PR is the next iteration — the original worker landed without the activity check on the streaming-context gate, which we now know was the wrong call.

## Test plan

- [ ] CI green
- [ ] Reproduce the 4+ minute hang scenario by starting a fresh spec task and confirming the worker now fires after 60s of in-context silence (look for `🔔 [AUTO_WAKE] Re-sending stuck interaction's prompt`)
- [ ] Confirm a normally-streaming turn (lots of tool calls, thinking) does NOT trigger auto-wake — `lastPublish` should keep refreshing
- [ ] Start a spec task with a Claude Code app and confirm the agent's first Bash call no longer fails with `InputValidationError`
- [ ] Start a spec task with a qwen-code app (if any exist) and confirm the `is_background` guidance is still emitted
- [ ] Watch an opus-4-7 turn and confirm visible thinking summaries now arrive (non-empty `<thinking>...</thinking>` content during reasoning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)