### PR TITLE
Force proportional windowed initial size for Zed; shrink Chrome MCP viewport

### DIFF
--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -245,12 +245,17 @@ func GenerateZedMCPConfig(
 	// See: https://developer.chrome.com/blog/chrome-devtools-mcp
 	config.ContextServers["chrome-devtools"] = ContextServerConfig{
 		Command: "npx",
+		// --viewport sets the rendered page size (Chrome window ends up viewport + ~80px
+		// of decorations). 1280x800 sits at the canonical desktop-vs-mobile breakpoint
+		// so sites still render in desktop mode, and the resulting Chrome window leaves
+		// a wide margin on a 1920x1080 monitor — staying below Mutter's auto-maximize
+		// threshold (the previous 1600x1080 value tripped it).
 		// Stealth flags: make Chrome less detectable as automation.
 		// Disables navigator.webdriver, suppresses "Chrome is being controlled" infobar,
 		// and prevents extension probing (e.g. LinkedIn bot detection).
 		Args: []string{
 			"chrome-devtools-mcp@latest",
-			"--viewport", "1600x1080",
+			"--viewport", "1280x800",
 			"--chrome-arg=--disable-blink-features=AutomationControlled",
 			"--chrome-arg=--no-first-run",
 			"--chrome-arg=--disable-infobars",

--- a/desktop/ubuntu-config/start-zed-helix.sh
+++ b/desktop/ubuntu-config/start-zed-helix.sh
@@ -27,6 +27,36 @@ launch_terminal() {
 }
 
 # =========================================
+# Initial window bounds — sidestep GNOME auto-maximize
+# =========================================
+#
+# Upstream Zed commit a0d0195ca9 (PR #52940, 2026-04-07, merged into Helix via
+# the 001864 Zed merge on 2026-04-24) bumped DEFAULT_WINDOW_SIZE from
+# 1536x864 to 1536x1095. On a 1920x1080 virtual monitor, default_bounds()
+# clips the new value to 1536x1080 — exactly the work-area height — which
+# trips Mutter's auto-maximize=true and the user sees a fullscreen Zed.
+#
+# ZED_WINDOW_SIZE / ZED_WINDOW_POSITION (workspace.rs:171-183, :8011-8017)
+# wrap the bounds as WindowBounds::Windowed and skip the auto-maximize path.
+# Sized to 80% of the logical work area with a 10% margin on each side, so
+# the proportions hold for 1920x1080, 4K, 5K and any HiDPI session.
+#
+# GDK_SCALE is exported by startup-app.sh when HELIX_ZOOM_LEVEL > 100;
+# unset at 100% zoom (hence :-1). HELIX_SCALE_FACTOR itself isn't exported.
+# At 1920x1080 / 100% the formula lands on 1536x864 — the exact size Zed
+# defaulted to before a0d0195ca9.
+ZED_SCALE=${GDK_SCALE:-1}
+ZED_LOGICAL_W=$(( ${GAMESCOPE_WIDTH:-1920} / ZED_SCALE ))
+ZED_LOGICAL_H=$(( ${GAMESCOPE_HEIGHT:-1080} / ZED_SCALE ))
+ZED_W=$(( ZED_LOGICAL_W * 80 / 100 ))
+ZED_H=$(( ZED_LOGICAL_H * 80 / 100 ))
+ZED_X=$(( ZED_LOGICAL_W * 10 / 100 ))
+ZED_Y=$(( ZED_LOGICAL_H * 10 / 100 ))
+export ZED_WINDOW_SIZE="${ZED_WINDOW_SIZE:-${ZED_W},${ZED_H}}"
+export ZED_WINDOW_POSITION="${ZED_WINDOW_POSITION:-${ZED_X},${ZED_Y}}"
+echo "Zed initial window: size=${ZED_WINDOW_SIZE} position=${ZED_WINDOW_POSITION} (GAMESCOPE=${GAMESCOPE_WIDTH:-1920}x${GAMESCOPE_HEIGHT:-1080}, GDK_SCALE=${ZED_SCALE})"
+
+# =========================================
 # Source shared core and run
 # =========================================
 


### PR DESCRIPTION
## Summary

Zed has been launching maximised in every new spectask on the Ubuntu/GNOME desktop, and unmaximising it leaves a window taller than the streamed viewport. Root cause: upstream Zed commit [`a0d0195ca9`](https://github.com/zed-industries/zed/pull/52940) ("Add onboarding for parallel agents", 2026-04-07) bumped `DEFAULT_WINDOW_SIZE` from `1536×864` to `1536×1095`. That commit landed in the Helix Zed fork via the 001864 merge on 2026-04-24. On a 1920×1080 virtual monitor `default_bounds()` clips the new value to `1536×1080` — exactly the work-area height — which trips Mutter's `auto-maximize=true` and the user sees a fullscreen Zed.

Coincidentally, the chrome-devtools MCP `--viewport 1600x1080` set in task 001532 produced a ~1600×1160 Chrome window that also tripped the same auto-maximise threshold; shrinking it is a one-line follow-on that gets Chrome out of the same trap.

## Changes

- **`desktop/ubuntu-config/start-zed-helix.sh`**: export `ZED_WINDOW_SIZE` and `ZED_WINDOW_POSITION` computed dynamically as 80% of `GAMESCOPE_WIDTH/HEIGHT` divided by `GDK_SCALE`, with a 10% margin on each side. Zed wraps env-var bounds as `WindowBounds::Windowed`, which skips the auto-maximise path entirely. Formula lands on `1536×864` at 1920×1080/100% — exactly the dimensions Zed defaulted to before `a0d0195ca9` — and scales proportionally to 4K (3072×1728), 5K (2048×1152 at 200% zoom), etc.
- **`api/pkg/external-agent/zed_config.go`**: shrink the chrome-devtools MCP viewport from `1600x1080` to `1280x800`. `1280` is the canonical desktop-vs-mobile breakpoint, so sites still render in desktop mode, and the resulting Chrome window leaves a wide margin on a 1920×1080 monitor.

The Sway desktop is untouched — its tiling behaviour is a different dynamic and out of scope for this task.

## Test plan

- [ ] Fresh spectask at default 1920×1080 / 100% zoom: Zed launches centred 1536×864 at origin (192, 108), not maximised
- [ ] Spectask with `GAMESCOPE_WIDTH=3840 GAMESCOPE_HEIGHT=2160`: Zed scales to ~3072×1728 centred
- [ ] Spectask with `HELIX_ZOOM_LEVEL=200`: Zed at the scaled logical size
- [ ] Chrome opened via chrome-devtools MCP: window ~1280×880, desktop sites render in desktop mode
- [ ] Stream in a small browser viewport (≈1280×720) on a 1920×1080 session: Zed not clipped at the bottom
- [ ] Sway sessions: no behaviour change

Spec: `helix-specs:001916_why-do-the-zed-windows`

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kq2bx9tw2mmhas4tnrrgawzm)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001916_why-do-the-zed-windows/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001916_why-do-the-zed-windows/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001916_why-do-the-zed-windows/tasks.md)

🚀 Built with [Helix](https://helix.ml)