### PR TITLE
fix sync stack: interrupt prompts skip busy guard + always inject output_config.effort for adaptive thinking

### DIFF
--- a/api/pkg/anthropic/thinking_retry.go
+++ b/api/pkg/anthropic/thinking_retry.go
@@ -46,6 +46,29 @@ func (t *thinkingRetryTransport) RoundTrip(req *http.Request) (*http.Response, e
 	if err != nil {
 		return nil, err
 	}
+
+	// Upfront mutation: if the request has thinking.type=adaptive but no
+	// top-level output_config.effort, inject medium effort *before* sending.
+	//
+	// Why this matters: claude-agent-acp sends adaptive directly for opus-4-7
+	// (which Vertex requires), so the swap-from-enabled retry path below
+	// never fires. Without this upfront injection the model runs at its
+	// implicit minimum effort, producing empty thinking summaries — visible
+	// to the user as `<thinking></thinking>` blocks with no content.
+	// The Vertex error message we parse on the retry path explicitly says
+	// to set both fields together; this just applies the same rule before
+	// we even see a 400. ensureOutputConfigEffort respects any caller-set
+	// effort and preserves other output_config fields.
+	if mutatedBody, didMutate := ensureAdaptiveEffort(origBody, "medium"); didMutate {
+		log.Info().
+			Int("orig_len", len(origBody)).
+			Int("new_len", len(mutatedBody)).
+			Msg("injecting output_config.effort=medium for adaptive-thinking request (otherwise summary is empty)")
+		origBody = mutatedBody
+		req.ContentLength = int64(len(origBody))
+		req.Header.Del("Content-Length")
+	}
+
 	req.Body = io.NopCloser(bytes.NewReader(origBody))
 	// Repopulate GetBody too in case the underlying transport wants to retry on
 	// a transport-level redirect.
@@ -170,6 +193,55 @@ func swapThinkingType(body []byte, newType string) ([]byte, bool) {
 	}
 	bodyMap["thinking"] = newThinking
 
+	newBody, err := json.Marshal(bodyMap)
+	if err != nil {
+		return nil, false
+	}
+	return newBody, true
+}
+
+// ensureAdaptiveEffort inspects body and, if it has thinking.type=adaptive
+// without a top-level output_config.effort, injects effort. Returns
+// (newBody, true) when a mutation happened, (nil, false) otherwise — including
+// when the body has no thinking field, isn't adaptive, already has effort,
+// or isn't valid JSON. Callers should fall through to the unmutated body
+// in the false case rather than treating it as an error.
+func ensureAdaptiveEffort(body []byte, effort string) ([]byte, bool) {
+	var bodyMap map[string]json.RawMessage
+	if err := json.Unmarshal(body, &bodyMap); err != nil {
+		return nil, false
+	}
+	thinkingRaw, ok := bodyMap["thinking"]
+	if !ok {
+		return nil, false
+	}
+	var thinking map[string]json.RawMessage
+	if err := json.Unmarshal(thinkingRaw, &thinking); err != nil {
+		return nil, false
+	}
+	typeRaw, ok := thinking["type"]
+	if !ok {
+		return nil, false
+	}
+	var typeStr string
+	if err := json.Unmarshal(typeRaw, &typeStr); err != nil {
+		return nil, false
+	}
+	if typeStr != "adaptive" {
+		return nil, false
+	}
+	// Already has output_config.effort? Don't touch it.
+	if raw, ok := bodyMap["output_config"]; ok {
+		var outputConfig map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &outputConfig); err == nil {
+			if _, has := outputConfig["effort"]; has {
+				return nil, false
+			}
+		}
+	}
+	if !ensureOutputConfigEffort(bodyMap, effort) {
+		return nil, false
+	}
 	newBody, err := json.Marshal(bodyMap)
 	if err != nil {
 		return nil, false

--- a/api/pkg/anthropic/thinking_retry_test.go
+++ b/api/pkg/anthropic/thinking_retry_test.go
@@ -132,6 +132,94 @@ func TestThinkingRetryTransport_EnabledRejectedSwapsToAdaptive(t *testing.T) {
 	assert.Equal(t, "medium", outputConfig["effort"], "should default output_config.effort to medium when swapping to adaptive (otherwise the model produces an empty thinking summary)")
 }
 
+func TestThinkingRetryTransport_AdaptiveUpfrontInjectsEffort(t *testing.T) {
+	// claude-agent-acp sends adaptive directly for opus-4-7. The 400-retry
+	// path never fires, so output_config.effort must be injected upfront —
+	// otherwise the model runs at minimum effort and the thinking summary
+	// is empty.
+	success := `{"id":"msg_x","type":"message","content":[]}`
+
+	rt := &fakeRoundTripper{
+		responses: []*http.Response{newJSONResponse(http.StatusOK, success)},
+	}
+	transport := &thinkingRetryTransport{base: rt}
+
+	req := newRequestWithThinking(t, map[string]interface{}{
+		"type": "adaptive",
+	})
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int32(1), rt.receivedCalls.Load(), "should not retry — upstream returned 200")
+
+	var sentBody map[string]interface{}
+	require.NoError(t, json.Unmarshal(rt.receivedBody[0], &sentBody))
+	outputConfig, ok := sentBody["output_config"].(map[string]interface{})
+	require.True(t, ok, "output_config must have been injected at top level")
+	assert.Equal(t, "medium", outputConfig["effort"], "effort must default to medium for adaptive without caller-set effort")
+}
+
+func TestThinkingRetryTransport_AdaptiveUpfrontRespectsCallerEffort(t *testing.T) {
+	// If the caller already set output_config.effort, leave it alone.
+	success := `{"id":"msg_y","type":"message","content":[]}`
+
+	rt := &fakeRoundTripper{
+		responses: []*http.Response{newJSONResponse(http.StatusOK, success)},
+	}
+	transport := &thinkingRetryTransport{base: rt}
+
+	body := map[string]interface{}{
+		"model":      "claude-opus-4-7",
+		"max_tokens": 1024,
+		"messages":   []map[string]string{{"role": "user", "content": "hi"}},
+		"thinking":   map[string]interface{}{"type": "adaptive"},
+		"output_config": map[string]interface{}{
+			"effort":    "high",
+			"keep_this": "yes",
+		},
+	}
+	bs, err := json.Marshal(body)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/messages", bytes.NewReader(bs))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	var sentBody map[string]interface{}
+	require.NoError(t, json.Unmarshal(rt.receivedBody[0], &sentBody))
+	outputConfig, _ := sentBody["output_config"].(map[string]interface{})
+	assert.Equal(t, "high", outputConfig["effort"], "caller-set effort must not be overridden")
+	assert.Equal(t, "yes", outputConfig["keep_this"], "sibling fields under output_config must be preserved")
+}
+
+func TestThinkingRetryTransport_NonAdaptiveUpfrontDoesNotInject(t *testing.T) {
+	// thinking.type=enabled requests must NOT have output_config.effort
+	// injected — that field is adaptive-specific and would itself trigger
+	// a 400 from the older Vertex pods.
+	success := `{"id":"msg_z","type":"message","content":[]}`
+
+	rt := &fakeRoundTripper{
+		responses: []*http.Response{newJSONResponse(http.StatusOK, success)},
+	}
+	transport := &thinkingRetryTransport{base: rt}
+
+	req := newRequestWithThinking(t, map[string]interface{}{
+		"type":          "enabled",
+		"budget_tokens": 4096,
+	})
+
+	_, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	var sentBody map[string]interface{}
+	require.NoError(t, json.Unmarshal(rt.receivedBody[0], &sentBody))
+	_, hasOutputConfig := sentBody["output_config"]
+	assert.False(t, hasOutputConfig, "must not inject output_config for non-adaptive thinking")
+}
+
 func TestSwapThinkingType_AdaptivePreservesExistingOutputConfigEffort(t *testing.T) {
 	// If the caller already specified an effort, swapThinkingType must not
 	// clobber it — they may have a deliberate reason for high or low.

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -2755,14 +2755,28 @@ func (apiServer *HelixAPIServer) sendQueuedPromptToSession(ctx context.Context, 
 	// ListInteractions defaults to id ASC (oldest first) — without the explicit
 	// order, we would get the very first interaction in the session (always
 	// Complete) and the busy check would never fire.
-	latestInteractions, _, recheckErr := apiServer.Store.ListInteractions(ctx, &types.ListInteractionsQuery{
-		SessionID:    sessionID,
-		GenerationID: session.GenerationID,
-		PerPage:      1,
-		Order:        "id DESC",
-	})
-	if recheckErr == nil && len(latestInteractions) > 0 && latestInteractions[0].State == types.InteractionStateWaiting {
-		return fmt.Errorf("session %s became busy (interaction %s is Waiting), deferring queue prompt", sessionID, latestInteractions[0].ID)
+	//
+	// Interrupt prompts (Cmd/Ctrl+Enter on the spec-task chat) are exempt:
+	// their entire purpose is to land while the agent is mid-turn. The Zed
+	// e2e Phase 8 test (zed/crates/external_websocket_sync/e2e-test/
+	// helix-ws-test-server/main.go:780) covers exactly this — sends the
+	// interrupt the moment the first assistant token arrives and asserts
+	// the cancelled turn's message_completed AND the interrupt's
+	// message_completed both arrive. If we defer here the interrupt
+	// silently fails, the frontend marks it as failed, and the user has
+	// to manually retry. Pre-2026-04-26 the guard was latent because of
+	// the ASC/DESC ListInteractions ordering bug fixed in 853492e14;
+	// fixing the ordering exposed this missing branch.
+	if !prompt.Interrupt {
+		latestInteractions, _, recheckErr := apiServer.Store.ListInteractions(ctx, &types.ListInteractionsQuery{
+			SessionID:    sessionID,
+			GenerationID: session.GenerationID,
+			PerPage:      1,
+			Order:        "id DESC",
+		})
+		if recheckErr == nil && len(latestInteractions) > 0 && latestInteractions[0].State == types.InteractionStateWaiting {
+			return fmt.Errorf("session %s became busy (interaction %s is Waiting), deferring queue prompt", sessionID, latestInteractions[0].ID)
+		}
 	}
 
 	// CRITICAL: Create an interaction BEFORE sending the message


### PR DESCRIPTION
## Summary

Two follow-ups to the auto-wake / shell-guidance / proxy PR (#2299) that landed earlier today. Both surfaced from live testing on `meta.helix.ml` immediately after #2299 merged. Independent fixes, kept in one PR for the same reviewer pass; commits are individually revertable.

## Fix A — interrupt prompts must skip the busy guard (`api/pkg/server/websocket_external_agent_sync.go`)

`sendQueuedPromptToSession` is called from both `processPromptQueue` (queue-mode) and `processInterruptPrompt` (interrupt-mode). The "session became busy, deferring" guard at the top of the function is correct for queue prompts — their entire point is to land when the agent is idle — but defeats the entire point of an interrupt prompt, which exists to cancel an in-flight turn.

The guard was added 2026-04-16 in `5d1e6bae2` for a real Zed-user-message race, but didn't fire on long-lived sessions because of the ASC/DESC `ListInteractions` ordering bug fixed today in `853492e14`. Now that the busy check actually works, it correctly identifies the session as busy — and silently fails every interrupt the user sends with Cmd/Ctrl+Enter, marking the prompt as `failed` in the UI.

**Live evidence** (session `ses_01kpx1d2n1bn7d85byv28s36g7`):

```
16:50:47  Failed to create research task     (queue, sent OK)
16:51:06  no, main-CLXIOyg3.js:48...         (INTERRUPT, failed)
          error: "session ses_... became busy (interaction
                  int_01kq5b6ryzdka9p7ykytm2hvde is Waiting),
                  deferring queue prompt"
16:51:22  retry of the same interrupt        (failed again)
```

Phase 8 of the Zed e2e test (`zed/crates/external_websocket_sync/e2e-test/helix-ws-test-server/main.go:780-1199`) covers exactly this contract: send an interrupt the moment the first assistant token arrives, and both the cancelled turn's `message_completed` AND the interrupt's `message_completed` must arrive. We were silently failing the interrupt before it could even reach the wrapper.

Fix: gate the busy-defer on `!prompt.Interrupt`. Interrupts proceed through to interaction creation and the wrapper as designed.

## Fix B — always inject `output_config.effort=medium` for adaptive thinking, not just on retry (`api/pkg/anthropic/thinking_retry.go`)

PR #2299's proxy change only injected `output_config.effort` on the swap-from-`enabled` retry path. But `claude-agent-acp` sends `thinking.type=adaptive` directly for opus-4-7 (Vertex requires adaptive on that model), so the 400 retry never fires and the injection never happens. Result: every opus-4-7 turn runs at the model's implicit minimum effort, the model produces little enough thinking that the visible summary is empty, and the user still sees `<thinking></thinking>` blocks with no content.

**Live evidence**: `spt_01kq2bx9tw2mmhas4tnrrgawzm` interaction `int_01kq5bgaycvnkymbqn1zg2yj0a`, created at `2026-04-26 16:56 UTC` — 14 minutes after #2299 landed and Air rebuilt — still rendered with empty thinking blocks across all 9 text entries. Zero `retrying Anthropic` log lines for the session, confirming the 400/swap path was never entered.

Fix: at the top of the transport's `RoundTrip`, before sending, inspect the outgoing body. If it has `thinking.type=adaptive` but no top-level `output_config.effort`, inject `medium`. Behaviour:

- Caller-set effort is respected (e.g. if `claude-agent-acp` ever starts setting `low`/`high` itself, we don't override).
- Sibling fields under `output_config` are preserved.
- Non-adaptive requests (`type=enabled` / `type=disabled`) are left alone — `output_config.effort` is an adaptive-only field, and injecting it on the older schema would itself trigger a 400 from the pods that don't speak adaptive.

Three new tests cover the upfront-inject, respect-caller-effort, and non-adaptive-untouched cases. Existing tests still pass.

## Test plan

- [ ] CI green
- [ ] Send a Cmd+Enter interrupt mid-turn on a spec task — confirm the interrupt's interaction is created and the agent actually cancels its current work (Zed e2e Phase 8 contract)
- [ ] Watch an opus-4-7 turn — confirm the visible thinking block now contains a non-empty summary
- [ ] Confirm the proxy log shows `injecting output_config.effort=medium for adaptive-thinking request` on outgoing requests
- [ ] Confirm normal queue-mode prompts (plain Enter) still respect the busy-defer guard and don't race with Zed user messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)