### PR TITLE
Honor Keep Alive on PR-merge-triggered shutdown

### DIFF
--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -1004,6 +1004,7 @@ func (s *HelixAPIServer) updateSpecTask(w http.ResponseWriter, r *http.Request) 
 		task.PublicDesignDocs = *updateReq.PublicDesignDocs
 	}
 	// Update keep alive setting (pointer allows explicit false)
+	previousKeepAlive := task.KeepAlive
 	if updateReq.KeepAlive != nil {
 		task.KeepAlive = *updateReq.KeepAlive
 	}
@@ -1058,6 +1059,26 @@ func (s *HelixAPIServer) updateSpecTask(w http.ResponseWriter, r *http.Request) 
 		log.Error().Err(err).Str("task_id", taskID).Msg("Failed to update SpecTask")
 		http.Error(w, fmt.Sprintf("failed to update SpecTask: %v", err), http.StatusInternalServerError)
 		return
+	}
+
+	// If the user just turned KeepAlive off on a task that already reached Done,
+	// the orchestrator's handleDone() has already exited without stopping the
+	// desktop (because KeepAlive was true at the time). Release the desktop now
+	// so the user has an explicit way to free the resources after merge.
+	if previousKeepAlive && !task.KeepAlive && task.Status == types.TaskStatusDone && task.PlanningSessionID != "" {
+		stopErr := s.externalAgentExecutor.StopDesktop(ctx, task.PlanningSessionID)
+		if stopErr != nil {
+			log.Warn().
+				Err(stopErr).
+				Str("task_id", taskID).
+				Str("session_id", task.PlanningSessionID).
+				Msg("Failed to stop desktop after KeepAlive turned off on Done task (continuing)")
+		} else {
+			log.Info().
+				Str("task_id", taskID).
+				Str("session_id", task.PlanningSessionID).
+				Msg("Stopped desktop after KeepAlive turned off on Done task")
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/api/pkg/server/spec_driven_task_keep_alive_test.go
+++ b/api/pkg/server/spec_driven_task_keep_alive_test.go
@@ -1,0 +1,142 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/config"
+	external_agent "github.com/helixml/helix/api/pkg/external-agent"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+type SpecTaskKeepAliveSuite struct {
+	suite.Suite
+
+	ctrl     *gomock.Controller
+	store    *store.MockStore
+	executor *external_agent.MockExecutor
+	server   *HelixAPIServer
+
+	userID string
+	taskID string
+}
+
+func TestSpecTaskKeepAliveSuite(t *testing.T) {
+	suite.Run(t, new(SpecTaskKeepAliveSuite))
+}
+
+func (s *SpecTaskKeepAliveSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.store = store.NewMockStore(s.ctrl)
+	s.executor = external_agent.NewMockExecutor(s.ctrl)
+	s.server = &HelixAPIServer{
+		Cfg:                   &config.ServerConfig{},
+		Store:                 s.store,
+		externalAgentExecutor: s.executor,
+	}
+	s.userID = "user_keepalive_test"
+	s.taskID = "task_keepalive_test"
+}
+
+func (s *SpecTaskKeepAliveSuite) TearDownTest() {
+	s.ctrl.Finish()
+}
+
+func (s *SpecTaskKeepAliveSuite) makeUpdateRequest(body types.SpecTaskUpdateRequest) *http.Request {
+	buf, err := json.Marshal(body)
+	s.Require().NoError(err)
+	req := httptest.NewRequest("PUT", "/api/v1/spec-tasks/"+s.taskID, bytes.NewReader(buf))
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: s.userID}))
+	req = mux.SetURLVars(req, map[string]string{"taskId": s.taskID})
+	return req
+}
+
+// Verifies that turning KeepAlive off on a Done task triggers StopDesktop —
+// the user's explicit "release the desktop after merge" path.
+func (s *SpecTaskKeepAliveSuite) TestKeepAliveOff_OnDoneTask_StopsDesktop() {
+	existingTask := &types.SpecTask{
+		ID:                s.taskID,
+		ProjectID:         "project_keepalive",
+		Status:            types.TaskStatusDone,
+		PlanningSessionID: "session_keepalive",
+		KeepAlive:         true,
+	}
+	project := &types.Project{
+		ID:     "project_keepalive",
+		UserID: s.userID,
+	}
+
+	s.store.EXPECT().GetSpecTask(gomock.Any(), s.taskID).Return(existingTask, nil)
+	s.store.EXPECT().GetProject(gomock.Any(), "project_keepalive").Return(project, nil)
+	s.store.EXPECT().UpdateSpecTask(gomock.Any(), gomock.Any()).DoAndReturn(func(_ interface{}, t *types.SpecTask) error {
+		s.False(t.KeepAlive, "KeepAlive should be flipped to false")
+		return nil
+	})
+	s.executor.EXPECT().StopDesktop(gomock.Any(), "session_keepalive").Return(nil)
+
+	keepAliveOff := false
+	rr := httptest.NewRecorder()
+	s.server.updateSpecTask(rr, s.makeUpdateRequest(types.SpecTaskUpdateRequest{KeepAlive: &keepAliveOff}))
+
+	s.Equal(http.StatusOK, rr.Code)
+}
+
+// Verifies that turning KeepAlive ON does NOT call StopDesktop, even on a Done task.
+func (s *SpecTaskKeepAliveSuite) TestKeepAliveOn_OnDoneTask_DoesNotStopDesktop() {
+	existingTask := &types.SpecTask{
+		ID:                s.taskID,
+		ProjectID:         "project_keepalive",
+		Status:            types.TaskStatusDone,
+		PlanningSessionID: "session_keepalive",
+		KeepAlive:         false,
+	}
+	project := &types.Project{
+		ID:     "project_keepalive",
+		UserID: s.userID,
+	}
+
+	s.store.EXPECT().GetSpecTask(gomock.Any(), s.taskID).Return(existingTask, nil)
+	s.store.EXPECT().GetProject(gomock.Any(), "project_keepalive").Return(project, nil)
+	s.store.EXPECT().UpdateSpecTask(gomock.Any(), gomock.Any()).Return(nil)
+	// No executor expectation — gomock will fail the test if StopDesktop is called.
+
+	keepAliveOn := true
+	rr := httptest.NewRecorder()
+	s.server.updateSpecTask(rr, s.makeUpdateRequest(types.SpecTaskUpdateRequest{KeepAlive: &keepAliveOn}))
+
+	s.Equal(http.StatusOK, rr.Code)
+}
+
+// Verifies that turning KeepAlive off on a non-Done task does NOT call StopDesktop —
+// the existing idle-shutdown path will handle it normally.
+func (s *SpecTaskKeepAliveSuite) TestKeepAliveOff_OnRunningTask_DoesNotStopDesktop() {
+	existingTask := &types.SpecTask{
+		ID:                s.taskID,
+		ProjectID:         "project_keepalive",
+		Status:            types.TaskStatusImplementation,
+		PlanningSessionID: "session_keepalive",
+		KeepAlive:         true,
+	}
+	project := &types.Project{
+		ID:     "project_keepalive",
+		UserID: s.userID,
+	}
+
+	s.store.EXPECT().GetSpecTask(gomock.Any(), s.taskID).Return(existingTask, nil)
+	s.store.EXPECT().GetProject(gomock.Any(), "project_keepalive").Return(project, nil)
+	s.store.EXPECT().UpdateSpecTask(gomock.Any(), gomock.Any()).Return(nil)
+	// No executor expectation — gomock will fail the test if StopDesktop is called.
+
+	keepAliveOff := false
+	rr := httptest.NewRecorder()
+	s.server.updateSpecTask(rr, s.makeUpdateRequest(types.SpecTaskUpdateRequest{KeepAlive: &keepAliveOff}))
+
+	s.Equal(http.StatusOK, rr.Code)
+}

--- a/api/pkg/services/spec_task_orchestrator.go
+++ b/api/pkg/services/spec_task_orchestrator.go
@@ -1210,7 +1210,13 @@ func (o *SpecTaskOrchestrator) buildPlanningPrompt(task *types.SpecTask, app *ty
 }
 
 func (o *SpecTaskOrchestrator) handleDone(ctx context.Context, task *types.SpecTask) error {
-	// Terminate the desktop
+	if task.KeepAlive {
+		log.Info().
+			Str("task_id", task.ID).
+			Msg("Task in done status but keep_alive is set - leaving desktop running")
+		return nil
+	}
+
 	err := o.containerExecutor.StopDesktop(ctx, task.PlanningSessionID)
 	if err != nil {
 		return fmt.Errorf("failed to stop desktop: %w", err)

--- a/api/pkg/services/spec_task_orchestrator_test.go
+++ b/api/pkg/services/spec_task_orchestrator_test.go
@@ -54,6 +54,20 @@ func (s *SpecTaskOrchestratorTestSuite) TestHandleDone_StopsDesktop() {
 	s.Require().NoError(err)
 }
 
+func (s *SpecTaskOrchestratorTestSuite) TestHandleDone_KeepAliveSkipsStop() {
+	ctx := context.Background()
+	task := &types.SpecTask{
+		ID:                "task-keep-alive",
+		PlanningSessionID: "session-keep-alive",
+		Status:            types.TaskStatusDone,
+		KeepAlive:         true,
+	}
+
+	// No StopDesktop expectation — gomock will fail the test if it gets called.
+	err := s.orchestrator.handleDone(ctx, task)
+	s.Require().NoError(err)
+}
+
 func (s *SpecTaskOrchestratorTestSuite) TestHandleBacklog_SkipsWhenStaleEvent() {
 	ctx := context.Background()
 	eventTask := &types.SpecTask{


### PR DESCRIPTION
## Summary

When a spec task's PR was merged, the orchestrator transitioned the task to Done and **always** stopped the desktop — bypassing the Keep Alive toggle (green lock icon), which only protected against idle-based shutdown. This made the lock icon misleading: a user who explicitly turned it green would still lose their session as soon as the PR landed, exactly when they may want to keep iterating.

This PR gates the desktop stop in `handleDone()` on `task.KeepAlive`. The merge is still recorded (status, `MergedAt`, `CompletedAt`, golden-build trigger, attention events all unchanged), but the desktop is left running. The user releases it explicitly by toggling Keep Alive off — handled in the keep-alive update endpoint by calling `StopDesktop` when the flag transitions `true → false` on a Done task.

## Changes

- `api/pkg/services/spec_task_orchestrator.go`: gate `StopDesktop` call in `handleDone()` on `task.KeepAlive`.
- `api/pkg/server/spec_driven_task_handlers.go`: capture previous KeepAlive value; after a successful update, if the user just turned KeepAlive off on a Done task, call `s.externalAgentExecutor.StopDesktop()` to release the desktop.
- `api/pkg/services/spec_task_orchestrator_test.go`: add `TestHandleDone_KeepAliveSkipsStop` (asserts `StopDesktop` is NOT called when KeepAlive=true).
- `api/pkg/server/spec_driven_task_keep_alive_test.go`: new test suite covering all three handler paths — toggle-off-on-Done (StopDesktop called), toggle-on (not called), toggle-off on a non-Done task (not called).

## Why gate in `handleDone()`

There are four merge-detection paths in `spec_task_orchestrator.go` (PR poll "all merged", branch-merged-to-main fallback, external PR detection, no-PR fallback). All four set `task.Status = TaskStatusDone` and rely on the state machine to dispatch `handleDone()`. One gate downstream of all four — instead of duplicating `if task.KeepAlive` checks at each site — keeps the change small and avoids breaking the PR-tracking UI (which depends on the status transition).

## Test plan

- [x] Unit tests pass (`TestSpecTaskOrchestratorTestSuite/TestHandleDone_*`, `TestSpecTaskKeepAliveSuite/*`).
- [x] `go build ./pkg/server/ ./pkg/services/ ./pkg/store/ ./pkg/types/` passes.
- [x] `cd frontend && yarn build` passes (no FE changes).
- [ ] **Not manually validated end-to-end** — requires a real GitHub repo + PR-merge cycle. Behavior is covered by the unit tests above. To validate manually: enable Keep Alive on a task with an open PR, merge the PR on GitHub, verify the desktop stays alive and the lock icon remains visible. Then toggle Keep Alive off and verify the desktop stops.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kq4x0m8vg4dd4eefvkam0d4c)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001926_if-auto-sleep-is/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001926_if-auto-sleep-is/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001926_if-auto-sleep-is/tasks.md)

🚀 Built with [Helix](https://helix.ml)