### PR TITLE
perf(hydra): create zvols with volblocksize=8K to reduce write amplification

### DIFF
--- a/api/pkg/hydra/golden_zvol.go
+++ b/api/pkg/hydra/golden_zvol.go
@@ -32,6 +32,14 @@ const (
 	// so only used space is allocated. 500G is generous ceiling.
 	zvolDefaultSize = "500G"
 
+	// zvolBlockSize is the volblocksize for new zvols. The inner XFS uses
+	// 4K blocks; the ZFS default of 16K means each XFS metadata write
+	// triggers a 4K → 16K read-modify-write at the zvol layer (4× write
+	// amplification). 8K halves that amplification while keeping lz4
+	// compression effective. Immutable after zvol creation, so this only
+	// affects newly-created zvols.
+	zvolBlockSize = "8K"
+
 	// zvolMountBase is where cloned zvols are mounted.
 	zvolMountBase = "/container-docker/zvol-mounts"
 )
@@ -667,6 +675,7 @@ func CreateGoldenZvol(projectID string) (string, error) {
 	// Create thin-provisioned zvol with dedup=off. Block sharing comes from
 	// ZFS clones (free, no DDT involvement), so dedup adds only overhead here.
 	if err := runCmd("zfs", "create", "-V", zvolDefaultSize, "-s",
+		"-o", "volblocksize="+zvolBlockSize,
 		"-o", "dedup=off", "-o", "compression=lz4",
 		zvolName); err != nil {
 		return "", fmt.Errorf("zfs create %s failed: %w", zvolName, err)
@@ -721,6 +730,7 @@ func CreateSessionZvol(sessionID string) (string, error) {
 
 	// Create thin-provisioned zvol with dedup=off (same rationale as golden zvols).
 	if err := runCmd("zfs", "create", "-V", zvolDefaultSize, "-s",
+		"-o", "volblocksize="+zvolBlockSize,
 		"-o", "dedup=off", "-o", "compression=lz4",
 		zvolName); err != nil {
 		return "", fmt.Errorf("zfs create %s failed: %w", zvolName, err)
@@ -919,6 +929,7 @@ func MigrateGoldenToZvol(projectID string) error {
 	}
 
 	if err := runCmd("zfs", "create", "-V", zvolDefaultSize, "-s",
+		"-o", "volblocksize="+zvolBlockSize,
 		"-o", "dedup=off", "-o", "compression=lz4",
 		goldenName); err != nil {
 		return fmt.Errorf("zfs create %s failed: %w", goldenName, err)


### PR DESCRIPTION
## Summary

- Session and golden zvols are formatted with XFS (4K blocks). The ZFS default `volblocksize=16K` makes every XFS metadata write a 4K → 16K read-modify-write at the zvol layer — **4× write amplification** on the metadata-heavy ops (chowns, package installs, build artifacts) that dominate session cold-start I/O.
- Set `volblocksize=8K` at zvol-create time. Halves amplification while keeping lz4 compression effective. Considered 4K (full match) but it mostly defeats compression and increases per-record overhead — 8K is the better Pareto point for this workload.
- Single constant `zvolBlockSize` so future tuning is one edit.

## Why not match the other direction (XFS block size up to 16K)

Possible on this kernel (≥6.12 has LBS XFS), but adds 30–50% internal fragmentation on small-file workloads (source trees, `node_modules`, `.cache`). On a pool that's already 2.82T / 825G free with `prod/helix-workspaces` propped up by 3.48× dedup, that's not affordable.

## Scope

`volblocksize` is immutable after zvol creation. Affects only **new** zvols. Existing session and golden zvols stay at 16K until they're destroyed and recreated, which happens naturally as sessions cycle. The host's `/var/lib/docker` (zd16, ext4 on a 16K zvol) and `/prod/container-docker` (zd0) are out of scope — those are big in-place migrations for a separate maintenance window.

Three call sites updated in `api/pkg/hydra/golden_zvol.go`:
- `CreateGoldenZvol`
- `CreateSessionZvol`
- `MigrateGoldenToZvol`

## Test plan

- [x] `go build ./api/pkg/hydra/`
- [ ] On a deploy: start a fresh session, check the new zvol's volblocksize: `zfs get volblocksize prod/helix-zvols/ses-<sid>` → should report `8K  local`
- [ ] Sanity-check that the freshly-formatted XFS still mounts and the session starts normally
- [ ] Watch `/proc/pressure/io` during a few concurrent cold starts and compare to the pre-merge baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)