### PR TITLE
fix: prime cache spinner, ZFS tree visibility, and Vertex thinking retry

### DIFF
--- a/api/pkg/anthropic/thinking_retry.go
+++ b/api/pkg/anthropic/thinking_retry.go
@@ -28,11 +28,22 @@ import (
 //	 Use "thinking.type.adaptive" and "output_config.effort" to control
 //	 thinking behavior.`
 //
-// We can't predict which pod the LB will pick. Instead, on a 400 that matches
-// either pattern, swap the thinking.type and retry once.
+// We can't predict which pod the LB will pick. On a 400 that matches either
+// pattern, swap the thinking.type and retry. If the retry hits a pod with
+// the OPPOSITE constraint (e.g. opus-4-7 traffic that gets routed to a new
+// pod requiring adaptive after we just swapped to enabled), we keep flipping
+// and retrying up to maxThinkingRetries total attempts. With ~50/50 LB
+// distribution this drives the failure probability below 1% within a few
+// retries while bounding latency.
 type thinkingRetryTransport struct {
 	base http.RoundTripper
 }
+
+// maxThinkingRetries is the total number of attempts (initial + retries) we'll
+// make against Vertex when chasing schema-mismatch 400s. Each retry alternates
+// thinking.type based on the latest pod's complaint, so an even number of
+// retries explores both forms equally.
+const maxThinkingRetries = 5
 
 func (t *thinkingRetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Skip non-POST or anything without a body — only Anthropic /v1/messages
@@ -69,59 +80,76 @@ func (t *thinkingRetryTransport) RoundTrip(req *http.Request) (*http.Response, e
 		req.Header.Del("Content-Length")
 	}
 
-	req.Body = io.NopCloser(bytes.NewReader(origBody))
-	// Repopulate GetBody too in case the underlying transport wants to retry on
-	// a transport-level redirect.
-	req.GetBody = func() (io.ReadCloser, error) {
-		return io.NopCloser(bytes.NewReader(origBody)), nil
+	body := origBody
+	var resp *http.Response
+	var respBody []byte
+
+	for attempt := 0; attempt < maxThinkingRetries; attempt++ {
+		attemptReq := req
+		if attempt > 0 {
+			attemptReq = req.Clone(req.Context())
+		}
+		// Capture the current body in a per-iteration variable so the
+		// GetBody closure doesn't observe a later reassignment.
+		attemptBody := body
+		attemptReq.Body = io.NopCloser(bytes.NewReader(attemptBody))
+		attemptReq.ContentLength = int64(len(attemptBody))
+		attemptReq.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(attemptBody)), nil
+		}
+		// Drop any precomputed Content-Length header so the transport rewrites it.
+		attemptReq.Header.Del("Content-Length")
+
+		var rtErr error
+		resp, rtErr = t.base.RoundTrip(attemptReq)
+		if rtErr != nil || resp == nil || resp.StatusCode != http.StatusBadRequest {
+			return resp, rtErr
+		}
+
+		// Buffer the response body so we can inspect it. If it's not a thinking
+		// schema mismatch we replay it back to the caller unchanged.
+		var readErr error
+		respBody, readErr = io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+
+		altType := detectThinkingTypeMismatch(respBody)
+		if altType == "" {
+			resp.Body = io.NopCloser(bytes.NewReader(respBody))
+			resp.ContentLength = int64(len(respBody))
+			return resp, nil
+		}
+
+		newBody, ok := swapThinkingType(body, altType)
+		if !ok {
+			// Body didn't have a thinking field, or wasn't valid JSON — surface
+			// the original 400 so the caller sees the actual error.
+			resp.Body = io.NopCloser(bytes.NewReader(respBody))
+			resp.ContentLength = int64(len(respBody))
+			return resp, nil
+		}
+
+		log.Info().
+			Str("alt_type", altType).
+			Int("attempt", attempt+1).
+			Int("max_attempts", maxThinkingRetries).
+			Int("orig_len", len(body)).
+			Int("new_len", len(newBody)).
+			Msg("retrying Anthropic request with alternate thinking.type after Vertex 400")
+
+		body = newBody
 	}
 
-	resp, err := t.base.RoundTrip(req)
-	if err != nil || resp == nil || resp.StatusCode != http.StatusBadRequest {
-		return resp, err
-	}
-
-	// Buffer the response body so we can inspect it. If it's not a thinking
-	// schema mismatch, we replay the original body to the caller unchanged.
-	respBody, readErr := io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
-	if readErr != nil {
-		return nil, readErr
-	}
-
-	altType := detectThinkingTypeMismatch(respBody)
-	if altType == "" {
-		resp.Body = io.NopCloser(bytes.NewReader(respBody))
-		resp.ContentLength = int64(len(respBody))
-		return resp, nil
-	}
-
-	newBody, ok := swapThinkingType(origBody, altType)
-	if !ok {
-		// Body didn't have a thinking field, or wasn't valid JSON — surface the
-		// original 400 so the caller sees the actual error.
-		resp.Body = io.NopCloser(bytes.NewReader(respBody))
-		resp.ContentLength = int64(len(respBody))
-		return resp, nil
-	}
-
-	log.Info().
-		Str("alt_type", altType).
-		Int("orig_len", len(origBody)).
-		Int("new_len", len(newBody)).
-		Msg("retrying Anthropic request with alternate thinking.type after Vertex 400")
-
-	retryReq := req.Clone(req.Context())
-	retryReq.Body = io.NopCloser(bytes.NewReader(newBody))
-	retryReq.ContentLength = int64(len(newBody))
-	retryReq.GetBody = func() (io.ReadCloser, error) {
-		return io.NopCloser(bytes.NewReader(newBody)), nil
-	}
-	// Drop any precomputed Content-Length header so the transport rewrites it
-	// from retryReq.ContentLength.
-	retryReq.Header.Del("Content-Length")
-
-	return t.base.RoundTrip(retryReq)
+	// Exhausted retries — return the most recent 400 so the caller sees the
+	// actual error rather than a generic timeout.
+	log.Warn().
+		Int("max_attempts", maxThinkingRetries).
+		Msg("exhausted thinking.type retries against Vertex — returning last 400 to caller")
+	resp.Body = io.NopCloser(bytes.NewReader(respBody))
+	resp.ContentLength = int64(len(respBody))
+	return resp, nil
 }
 
 // detectThinkingTypeMismatch inspects a 400 response body for either of the

--- a/api/pkg/anthropic/thinking_retry_test.go
+++ b/api/pkg/anthropic/thinking_retry_test.go
@@ -234,6 +234,79 @@ func TestSwapThinkingType_AdaptivePreservesExistingOutputConfigEffort(t *testing
 	assert.Equal(t, "keep_me", outputConfig["other_field"], "sibling fields under output_config must be preserved")
 }
 
+func TestThinkingRetryTransport_FlipFlopRecovers(t *testing.T) {
+	// Vertex's LB can route consecutive retries to pods with opposite
+	// thinking.type expectations. For opus-4-7 the original request is
+	// adaptive; pod A rejects with "want enabled"; we swap and retry; pod B
+	// rejects with "want adaptive"; we must keep going rather than give up.
+	rejectAdaptive := `{"type":"error","error":{"type":"invalid_request_error","message":"thinking: Input tag 'adaptive' found using 'type' does not match any of the expected tags: 'disabled', 'enabled'"}}`
+	rejectEnabled := `{"type":"error","error":{"type":"invalid_request_error","message":"\"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."}}`
+	success := `{"id":"msg_flip","type":"message","content":[]}`
+
+	rt := &fakeRoundTripper{
+		responses: []*http.Response{
+			newJSONResponse(http.StatusBadRequest, rejectAdaptive), // attempt 1: adaptive → pod A
+			newJSONResponse(http.StatusBadRequest, rejectEnabled),  // attempt 2: enabled → pod B
+			newJSONResponse(http.StatusOK, success),                // attempt 3: adaptive → pod that accepts
+		},
+	}
+	transport := &thinkingRetryTransport{base: rt}
+
+	req := newRequestWithThinking(t, map[string]interface{}{
+		"type": "adaptive",
+	})
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(3), rt.receivedCalls.Load(), "should retry past the first flip until success")
+
+	// Last sent body must be adaptive again, with output_config.effort populated.
+	var lastBody map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rt.receivedBody[2], &lastBody))
+	var thinking map[string]interface{}
+	require.NoError(t, json.Unmarshal(lastBody["thinking"], &thinking))
+	assert.Equal(t, "adaptive", thinking["type"])
+	var outputConfig map[string]interface{}
+	require.NoError(t, json.Unmarshal(lastBody["output_config"], &outputConfig))
+	assert.Equal(t, "medium", outputConfig["effort"])
+}
+
+func TestThinkingRetryTransport_FlipFlopExhaustsAndReturnsLast400(t *testing.T) {
+	// If the LB keeps flip-flopping for the whole retry budget, return the
+	// last 400 to the caller rather than hanging or dropping the response.
+	rejectAdaptive := `{"type":"error","error":{"type":"invalid_request_error","message":"thinking: Input tag 'adaptive' found using 'type' does not match any of the expected tags: 'disabled', 'enabled'"}}`
+	rejectEnabled := `{"type":"error","error":{"type":"invalid_request_error","message":"\"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."}}`
+
+	responses := make([]*http.Response, maxThinkingRetries)
+	for i := 0; i < maxThinkingRetries; i++ {
+		if i%2 == 0 {
+			responses[i] = newJSONResponse(http.StatusBadRequest, rejectAdaptive)
+		} else {
+			responses[i] = newJSONResponse(http.StatusBadRequest, rejectEnabled)
+		}
+	}
+	rt := &fakeRoundTripper{responses: responses}
+	transport := &thinkingRetryTransport{base: rt}
+
+	req := newRequestWithThinking(t, map[string]interface{}{
+		"type": "adaptive",
+	})
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, int32(maxThinkingRetries), rt.receivedCalls.Load())
+
+	// The returned body must be readable and non-empty (callers downstream
+	// rely on being able to forward it).
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
+	assert.NotEmpty(t, body)
+}
+
 func TestThinkingRetryTransport_NonThinking400PassesThrough(t *testing.T) {
 	rejection := `{"type":"error","error":{"type":"invalid_request_error","message":"max_tokens too high"}}`
 

--- a/frontend/src/components/system/Snackbar.tsx
+++ b/frontend/src/components/system/Snackbar.tsx
@@ -20,6 +20,7 @@ const Snackbar: React.FC = () => {
       autoHideDuration={ 5000 }
       anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
       onClose={ handleClose }
+      sx={{ zIndex: (theme) => theme.zIndex.tooltip + 100 }}
     >
       <Alert
         severity={ snackbarContext.snackbar.severity }

--- a/frontend/src/pages/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings.tsx
@@ -168,6 +168,7 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
   const [autoWarmDockerCache, setAutoWarmDockerCache] = useState(false);
   const [showGoldenBuildViewer, setShowGoldenBuildViewer] = useState(false);
   const [selectedGoldenSandboxId, setSelectedGoldenSandboxId] = useState("");
+  const [waitingForBuildStart, setWaitingForBuildStart] = useState(false);
   const [showTestSession, setShowTestSession] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleteConfirmName, setDeleteConfirmName] = useState("");
@@ -230,6 +231,26 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
     return () => clearInterval(interval);
   }, [showGoldenBuildViewer, anyBuilding, projectId]);
 
+  // After Prime Cache is clicked, the dev container takes several seconds to
+  // provision before the sandbox flips to "building". Poll fast for up to 60s
+  // so the UI doesn't appear inert and so we can open the build viewer the
+  // moment the build actually starts.
+  useEffect(() => {
+    if (!waitingForBuildStart) return;
+    const startedAt = Date.now();
+    const TIMEOUT_MS = 60_000;
+    const interval = setInterval(() => {
+      if (Date.now() - startedAt > TIMEOUT_MS) {
+        clearInterval(interval);
+        setWaitingForBuildStart(false);
+        snackbar.error("Build did not start within 60s — check sandbox status");
+        return;
+      }
+      queryClient.invalidateQueries({ queryKey: ["project", projectId] });
+    }, 2000);
+    return () => clearInterval(interval);
+  }, [waitingForBuildStart, projectId, queryClient, snackbar]);
+
   // Auto-close golden build viewer when selected sandbox's build finishes
   const selectedSandboxStatus = selectedGoldenSandboxId
     ? sandboxCacheMap[selectedGoldenSandboxId]?.status
@@ -245,6 +266,16 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
   const buildingSandbox = sandboxEntries.find(([, s]) => s.status === "building");
   const buildingSandboxId = buildingSandbox?.[0];
   const buildingSessionId = buildingSandbox?.[1]?.build_session_id;
+
+  // Hand off from "waiting for build to start" to the build viewer the moment
+  // a sandbox flips to "building".
+  useEffect(() => {
+    if (!waitingForBuildStart || !buildingSandboxId) return;
+    setSelectedGoldenSandboxId(buildingSandboxId);
+    setShowGoldenBuildViewer(true);
+    setWaitingForBuildStart(false);
+  }, [waitingForBuildStart, buildingSandboxId]);
+
   const blkioSamplesRef = useRef<{ time: number; writeBytes: number }[]>([]);
   const lastBuildSessionRef = useRef<string | undefined>();
 
@@ -360,21 +391,12 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
         .getApiClient()
         .v1ProjectsDockerCacheBuildCreate(projectId);
     },
-    onSuccess: async () => {
+    onSuccess: () => {
       snackbar.success("Golden build triggered on all sandboxes");
-      await new Promise((r) => setTimeout(r, 3000));
-      const freshProject = await queryClient.fetchQuery({
-        queryKey: ["project", projectId],
-        staleTime: 0,
-      });
-      const sandboxes = (freshProject as TypesProject)?.metadata?.docker_cache_status?.sandboxes;
-      if (sandboxes) {
-        const buildingSb = Object.entries(sandboxes).find(([, s]) => s.status === "building");
-        if (buildingSb) {
-          setSelectedGoldenSandboxId(buildingSb[0]);
-          setShowGoldenBuildViewer(true);
-        }
-      }
+      // The dev container takes several seconds to provision before the
+      // sandbox flips to "building". The polling effect handles the wait
+      // and opens the build viewer when the build actually starts.
+      setWaitingForBuildStart(true);
     },
     onError: (error: any) => {
       const data = error?.response?.data;
@@ -1164,10 +1186,19 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
                 <Button
                   size="small"
                   variant="outlined"
-                  disabled={primeCacheMutation.isPending || anyBuilding}
+                  disabled={primeCacheMutation.isPending || waitingForBuildStart || anyBuilding}
                   onClick={() => primeCacheMutation.mutate()}
+                  startIcon={
+                    primeCacheMutation.isPending || waitingForBuildStart ? (
+                      <CircularProgress size={14} />
+                    ) : undefined
+                  }
                 >
-                  {primeCacheMutation.isPending ? "Triggering..." : "Prime Cache"}
+                  {primeCacheMutation.isPending
+                    ? "Triggering..."
+                    : waitingForBuildStart
+                      ? "Waiting for build to start..."
+                      : "Prime Cache"}
                 </Button>
                 {anyBuilding && (
                   <Button

--- a/frontend/src/pages/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings.tsx
@@ -1280,9 +1280,11 @@ const ProjectSettings: FC<ProjectSettingsProps> = ({ projectId, tab = 'general' 
       </Box>
 
       {/* ZFS Snapshot/Clone Tree — below the Docker Cache flex row */}
-      {zfsTree?.available && zfsTree?.golden && zfsTree.golden.children?.some(
-        (snap: TypesZFSTreeNode) => snap.children && snap.children.length > 0
-      ) && (
+      {/* Render whenever a golden exists, even with no snapshots or clones —
+          a freshly-built golden with zero clones is still useful information
+          (otherwise the panel silently disappears post-build until the first
+          session clones from it). */}
+      {zfsTree?.available && zfsTree?.golden && (
         <Box sx={{ mt: 1, mb: 4, p: 2, bgcolor: "background.paper", borderRadius: 1, border: "1px solid", borderColor: "divider" }}>
           <Typography variant="subtitle2" sx={{ mb: 1, display: "flex", alignItems: "center", gap: 0.5 }}>
             <HubIcon fontSize="small" sx={{ color: "primary.main" }} />


### PR DESCRIPTION
## Summary

Three independent fixes on this branch.

### 1. Prime Cache button appeared inert (UI)

The prior flow:

```ts
onSuccess: async () => {
  snackbar.success("...");
  await new Promise(r => setTimeout(r, 3000));     // single 3s wait
  const fresh = await queryClient.fetchQuery(...); // single refetch
  if (sandboxes && building) { open viewer }       // silent if not yet
}
```

The dev container that runs the build typically takes longer than 3 s to provision, so the refetch found nothing actionable and the button just re-enabled with no feedback — looking like the click did nothing.

Replaced with:
- Set `waitingForBuildStart=true` on mutation success.
- Polling effect: invalidates the project query every 2 s for up to 60 s.
- Hand-off effect: when any sandbox flips to `"building"`, opens the build viewer and clears the waiting state.
- Timeout: if 60 s elapses with no build, surface an error snackbar.
- Button shows a `<CircularProgress size={14} />` + `"Waiting for build to start..."` while polling.

### 2. Snackbars rendered under modals (UI)

`MuiSnackbar` didn't set a `z-index`, so dialogs/drawers with their own MUI z-index handling could end up rendered above it. Pinned the snackbar to `theme.zIndex.tooltip + 100` (1600) so it always wins over the standard modal stack (1300+).

### 3. ZFS clone tree disappeared after a fresh golden (UI)

The render guard required at least one snapshot to have at least one clone. Right after a fresh golden is built (or right after the `helix-zvols` tree is wiped and the next session promotes a new one), the golden has snapshots but no clones yet — and the entire panel silently disappeared, making it look like the tree feature was broken.

Dropped the third clause so the golden + any snapshots render even with zero clones. The existing `children.map()` handles the empty case cleanly.

### 4. Vertex `thinking.type` flip-flop drops requests (anthropic proxy)

Vertex's global LB fronts pods with two different schemas. For `claude-opus-4-7`:
- Older pods know only `enabled`/`disabled` and reject `adaptive` with `"Input tag 'adaptive' found"`.
- Newer pods (the only ones that handle opus-4-7) require `adaptive` and reject `enabled` with `"thinking.type.enabled is not supported for this model"`.

Today's failure: original request was `adaptive`, pod A 400'd → swap to `enabled` → pod B 400'd → propagated to the client because the old code only retried once. With 5 attempts the failure probability for a 50/50 LB drops from ~50% per flip-flop to ~3%. Bounded loop returns the most recent 400 if the budget is exhausted.

Two new tests cover the recover-after-flip case and the exhaustion case.

## Test plan

- [x] `yarn build`
- [x] `go test ./api/pkg/anthropic/...` (19 tests including 2 new)
- [ ] On a deploy: open project settings → sandbox tab, click Prime Cache. Confirm spinner + "Waiting for build to start..." appears immediately and persists until the build viewer opens.
- [ ] Confirm the build viewer opens automatically when the sandbox flips to `building`.
- [ ] Force the dev container to fail/hang for 60+ s and confirm the timeout snackbar appears and the button re-enables.
- [ ] Trigger a snackbar (e.g. failed action) while a dialog is open and confirm it renders above the dialog.
- [ ] Wipe `helix-zvols` and confirm the ZFS tree panel still renders the golden as soon as it exists (no clones required).
- [ ] Monitor `retrying Anthropic request with alternate thinking.type` and `exhausted thinking.type retries` log lines after deploy to confirm the loop is exercised and recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)