### PR TITLE
fix(spectask): three queue/sync bugs that all surface as 'updates not arriving'

### DIFF
--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -13350,6 +13350,71 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/sessions/{id}/restart-agent": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Clears the dead acp_thread_id on the session and resets crashed prompts\n(those marked by MarkPromptAsCrashed when the Claude Agent process exited)\nback to pending. The next dispatch sends with empty acp_thread_id, causing\nZed to create a fresh thread + Claude Agent process. Requires the session\nto be an external Zed agent. Returns the count of prompts that were reset.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Restart Zed thread after a Claude Agent crash",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/sessions/{id}/resume": {
             "post": {
                 "security": [
@@ -16286,6 +16351,86 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/types.User"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/users/me/chat-settings": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get the current user's default chat settings (applied when chatting without an app)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Get user chat settings",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.UserChatSettings"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the current user's default chat settings (system prompt + LLM parameters used when chatting without an app)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Update user chat settings",
+                "parameters": [
+                    {
+                        "description": "Chat settings to persist",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.UserChatSettings"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.UserChatSettings"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
                         }
                     }
                 }
@@ -27911,6 +28056,10 @@ const docTemplate = `{
                     "description": "Charging for usage",
                     "type": "boolean"
                 },
+                "default_chat_system_prompt": {
+                    "description": "DefaultChatSystemPrompt is the system prompt the platform applies to\ndirect model chats when the user has not customised one. Surfaced to\nthe frontend so the chat-settings page can prefill the textbox.",
+                    "type": "string"
+                },
                 "deployment_id": {
                     "type": "string"
                 },
@@ -31333,6 +31482,33 @@ const docTemplate = `{
                 },
                 "is_admin": {
                     "type": "boolean"
+                }
+            }
+        },
+        "types.UserChatSettings": {
+            "type": "object",
+            "properties": {
+                "frequency_penalty": {
+                    "type": "number"
+                },
+                "max_tokens": {
+                    "type": "integer"
+                },
+                "presence_penalty": {
+                    "type": "number"
+                },
+                "system_prompt": {
+                    "type": "string"
+                },
+                "system_prompt_enabled": {
+                    "description": "SystemPromptEnabled toggles whether any system prompt at all is sent\nto the model. Pointer so nil means \"not set\" and we fall back to the\ndefault-on behaviour. When explicitly false, no system prompt is sent\nregardless of SystemPrompt.",
+                    "type": "boolean"
+                },
+                "temperature": {
+                    "type": "number"
+                },
+                "top_p": {
+                    "type": "number"
                 }
             }
         },

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -803,6 +803,7 @@ func (apiServer *HelixAPIServer) registerRoutes(_ context.Context) (*mux.Router,
 	authRouter.HandleFunc("/sessions/{id}/sandbox-state", apiServer.getSessionSandboxState).Methods(http.MethodGet)
 	authRouter.HandleFunc("/sessions/{id}/resume", apiServer.resumeSession).Methods(http.MethodPost)
 	authRouter.HandleFunc("/sessions/{id}/stop-external-agent", system.Wrapper(apiServer.stopExternalAgentSession)).Methods(http.MethodDelete)
+	authRouter.HandleFunc("/sessions/{id}/restart-agent", system.Wrapper(apiServer.restartCrashedAgentThread)).Methods(http.MethodPost)
 	authRouter.HandleFunc("/sessions/{id}/output", system.Wrapper(apiServer.getSessionOutput)).Methods(http.MethodGet)
 
 	// Port exposure for dev containers - expose services running inside dev containers

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -2193,6 +2193,83 @@ func (s *HelixAPIServer) stopExternalAgentSession(_ http.ResponseWriter, r *http
 	}, nil
 }
 
+// restartCrashedAgentThread godoc
+// @Summary Restart Zed thread after a Claude Agent crash
+// @Description Clears the dead acp_thread_id on the session and resets crashed prompts
+// @Description (those marked by MarkPromptAsCrashed when the Claude Agent process exited)
+// @Description back to pending. The next dispatch sends with empty acp_thread_id, causing
+// @Description Zed to create a fresh thread + Claude Agent process. Requires the session
+// @Description to be an external Zed agent. Returns the count of prompts that were reset.
+// @Tags Sessions
+// @Produce json
+// @Param id path string true "Session ID"
+// @Success 200 {object} map[string]any
+// @Failure 400 {object} system.HTTPError
+// @Failure 401 {object} system.HTTPError
+// @Failure 403 {object} system.HTTPError
+// @Failure 404 {object} system.HTTPError
+// @Failure 500 {object} system.HTTPError
+// @Security BearerAuth
+// @Router /api/v1/sessions/{id}/restart-agent [post]
+func (s *HelixAPIServer) restartCrashedAgentThread(_ http.ResponseWriter, r *http.Request) (map[string]any, *system.HTTPError) {
+	ctx := r.Context()
+	user := getRequestUser(r)
+	if user == nil {
+		return nil, system.NewHTTPError401("user not found")
+	}
+	sessionID := mux.Vars(r)["id"]
+
+	session, err := s.Store.GetSession(ctx, sessionID)
+	if err != nil {
+		log.Error().Err(err).Str("session_id", sessionID).Msg("Failed to get session for restart")
+		return nil, system.NewHTTPError404("session not found")
+	}
+	if err := s.authorizeUserToSession(ctx, user, session, types.ActionUpdate); err != nil {
+		return nil, system.NewHTTPError403(err.Error())
+	}
+	if session.Metadata.AgentType != "zed_external" {
+		return nil, system.NewHTTPError400("session does not have an external Zed agent")
+	}
+
+	// Drop the dead acp_thread_id so the next dispatched chat_message goes out with
+	// an empty thread id; Zed treats that as "create a new thread" and spins up a
+	// fresh Claude Agent ACP wrapper. The dead thread is left in Zed's UI as a
+	// zombie until the desktop container restarts; cleaning it up actively would
+	// require a delete-thread RPC we don't have today and is out of scope for the
+	// crash-recovery path. Losing the dead thread's chat history is unavoidable —
+	// the wrapper process took it with it.
+	previousThreadID := session.Metadata.ZedThreadID
+	session.Metadata.ZedThreadID = ""
+	if _, err := s.Store.UpdateSession(ctx, *session); err != nil {
+		log.Error().Err(err).Str("session_id", sessionID).Msg("Failed to clear ZedThreadID for restart")
+		return nil, system.NewHTTPError500(fmt.Sprintf("failed to update session: %s", err.Error()))
+	}
+
+	resetCount, err := s.Store.ResetCrashedPromptsForSession(ctx, sessionID)
+	if err != nil {
+		log.Error().Err(err).Str("session_id", sessionID).Msg("Failed to reset crashed prompts for restart")
+		return nil, system.NewHTTPError500(fmt.Sprintf("failed to reset crashed prompts: %s", err.Error()))
+	}
+
+	log.Info().
+		Str("session_id", sessionID).
+		Str("user_id", user.ID).
+		Str("previous_zed_thread_id", previousThreadID).
+		Int("prompts_reset", resetCount).
+		Msg("🔄 [HELIX] User-triggered Restart after Claude Agent crash — cleared ZedThreadID and reset crashed prompts")
+
+	// Kick the queue so the reset prompts get dispatched promptly. If the agent is
+	// asleep, sendCommandToExternalAgent will trigger autoStartDevContainerForSession
+	// (the no-WS path from PR #2311 keeps the prompt in 'sending' for delivery via
+	// pickupWaitingInteraction once the container reconnects).
+	go s.processAnyPendingPrompt(context.Background(), sessionID)
+
+	return map[string]any{
+		"session_id":    sessionID,
+		"prompts_reset": resetCount,
+	}, nil
+}
+
 // getSessionOutput godoc
 // StartExternalAgentSession creates a new external agent session programmatically.
 // This implements cron.ExternalAgentStarter for use by the cron trigger system.

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -13346,6 +13346,71 @@
                 }
             }
         },
+        "/api/v1/sessions/{id}/restart-agent": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Clears the dead acp_thread_id on the session and resets crashed prompts\n(those marked by MarkPromptAsCrashed when the Claude Agent process exited)\nback to pending. The next dispatch sends with empty acp_thread_id, causing\nZed to create a fresh thread + Claude Agent process. Requires the session\nto be an external Zed agent. Returns the count of prompts that were reset.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Restart Zed thread after a Claude Agent crash",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/sessions/{id}/resume": {
             "post": {
                 "security": [
@@ -16282,6 +16347,86 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/types.User"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/users/me/chat-settings": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get the current user's default chat settings (applied when chatting without an app)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Get user chat settings",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.UserChatSettings"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the current user's default chat settings (system prompt + LLM parameters used when chatting without an app)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Update user chat settings",
+                "parameters": [
+                    {
+                        "description": "Chat settings to persist",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.UserChatSettings"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.UserChatSettings"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
                         }
                     }
                 }
@@ -27907,6 +28052,10 @@
                     "description": "Charging for usage",
                     "type": "boolean"
                 },
+                "default_chat_system_prompt": {
+                    "description": "DefaultChatSystemPrompt is the system prompt the platform applies to\ndirect model chats when the user has not customised one. Surfaced to\nthe frontend so the chat-settings page can prefill the textbox.",
+                    "type": "string"
+                },
                 "deployment_id": {
                     "type": "string"
                 },
@@ -31329,6 +31478,33 @@
                 },
                 "is_admin": {
                     "type": "boolean"
+                }
+            }
+        },
+        "types.UserChatSettings": {
+            "type": "object",
+            "properties": {
+                "frequency_penalty": {
+                    "type": "number"
+                },
+                "max_tokens": {
+                    "type": "integer"
+                },
+                "presence_penalty": {
+                    "type": "number"
+                },
+                "system_prompt": {
+                    "type": "string"
+                },
+                "system_prompt_enabled": {
+                    "description": "SystemPromptEnabled toggles whether any system prompt at all is sent\nto the model. Pointer so nil means \"not set\" and we fall back to the\ndefault-on behaviour. When explicitly false, no system prompt is sent\nregardless of SystemPrompt.",
+                    "type": "boolean"
+                },
+                "temperature": {
+                    "type": "number"
+                },
+                "top_p": {
+                    "type": "number"
                 }
             }
         },

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -7642,6 +7642,12 @@ definitions:
       billing_enabled:
         description: Charging for usage
         type: boolean
+      default_chat_system_prompt:
+        description: |-
+          DefaultChatSystemPrompt is the system prompt the platform applies to
+          direct model chats when the user has not customised one. Surfaced to
+          the frontend so the chat-settings page can prefill the textbox.
+        type: string
       deployment_id:
         type: string
       disable_llm_call_logging:
@@ -10098,6 +10104,28 @@ definitions:
         type: boolean
       is_admin:
         type: boolean
+    type: object
+  types.UserChatSettings:
+    properties:
+      frequency_penalty:
+        type: number
+      max_tokens:
+        type: integer
+      presence_penalty:
+        type: number
+      system_prompt:
+        type: string
+      system_prompt_enabled:
+        description: |-
+          SystemPromptEnabled toggles whether any system prompt at all is sent
+          to the model. Pointer so nil means "not set" and we fall back to the
+          default-on behaviour. When explicitly false, no system prompt is sent
+          regardless of SystemPrompt.
+        type: boolean
+      temperature:
+        type: number
+      top_p:
+        type: number
     type: object
   types.UserGuidelinesResponse:
     properties:
@@ -18921,6 +18949,53 @@ paths:
       summary: Get streaming connection info for a session
       tags:
       - sessions
+  /api/v1/sessions/{id}/restart-agent:
+    post:
+      description: |-
+        Clears the dead acp_thread_id on the session and resets crashed prompts
+        (those marked by MarkPromptAsCrashed when the Claude Agent process exited)
+        back to pending. The next dispatch sends with empty acp_thread_id, causing
+        Zed to create a fresh thread + Claude Agent process. Requires the session
+        to be an external Zed agent. Returns the count of prompts that were reset.
+      parameters:
+      - description: Session ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Restart Zed thread after a Claude Agent crash
+      tags:
+      - Sessions
   /api/v1/sessions/{id}/resume:
     post:
       description: Restarts the external agent container for a session that has been
@@ -20884,6 +20959,58 @@ paths:
       summary: Get user stats (admin only)
       tags:
       - users
+  /api/v1/users/me/chat-settings:
+    get:
+      description: Get the current user's default chat settings (applied when chatting
+        without an app)
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.UserChatSettings'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get user chat settings
+      tags:
+      - Users
+    put:
+      consumes:
+      - application/json
+      description: Update the current user's default chat settings (system prompt
+        + LLM parameters used when chatting without an app)
+      parameters:
+      - description: Chat settings to persist
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/types.UserChatSettings'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.UserChatSettings'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Update user chat settings
+      tags:
+      - Users
   /api/v1/users/me/guidelines:
     get:
       description: Get the current user's personal workspace guidelines

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -1591,18 +1591,46 @@ func (apiServer *HelixAPIServer) getOrCreateStreamingContext(ctx context.Context
 	// When the user types in Zed, the interaction is created without a mapping.
 	// Zed reuses the same request_id for the response, so we need to register
 	// it here so handleMessageCompleted can route correctly.
-	if requestID != "" && newInteractionID != "" && newInteractionID != expectedInteractionID {
+	//
+	// CRITICAL: distinguish "request_id never seen" from "request_id already
+	// consumed by handleMessageCompleted (sentinel '')". The wrapper inside Zed
+	// buffers events that aren't direct ACP responses (background bash, hooks,
+	// subagent completions, etc. — see auto_wake_stuck_interactions.go) and
+	// flushes them later tagged with the *last* request_id it saw. Those
+	// flushed events show up here with a request_id whose mapping was already
+	// consumed; rebinding that consumed sentinel to the current Waiting
+	// interaction defeats handleMessageCompleted's duplicate-completion dedup
+	// and prematurely marks an unrelated mid-turn interaction Complete. See
+	// design/2026-04-28-stale-request-id-rebind-loses-zed-updates.md.
+	if requestID != "" && newInteractionID != "" {
 		apiServer.contextMappingsMutex.Lock()
 		if apiServer.requestToInteractionMapping == nil {
 			apiServer.requestToInteractionMapping = make(map[string]string)
 		}
-		apiServer.requestToInteractionMapping[requestID] = newInteractionID
-		apiServer.contextMappingsMutex.Unlock()
-		log.Info().
-			Str("session_id", helixSessionID).
-			Str("request_id", requestID).
-			Str("interaction_id", newInteractionID).
-			Msg("🗺️ [HELIX] Populated requestToInteractionMapping from streaming context (Zed-initiated message)")
+		existing, alreadySeen := apiServer.requestToInteractionMapping[requestID]
+		switch {
+		case alreadySeen && existing == "":
+			// Stale wrapper replay — leave the consumed sentinel in place so the
+			// follow-up message_completed is dropped by the dedup. Streaming
+			// tokens still flow into the current interaction via the most-recent-
+			// Waiting fallback at line 1551-1558, so no content is lost.
+			apiServer.contextMappingsMutex.Unlock()
+			log.Debug().
+				Str("session_id", helixSessionID).
+				Str("request_id", requestID).
+				Str("would_have_bound", newInteractionID).
+				Msg("🛡️ [HELIX] Ignoring stale request_id rebind (mapping previously consumed by completion)")
+		case existing != newInteractionID:
+			apiServer.requestToInteractionMapping[requestID] = newInteractionID
+			apiServer.contextMappingsMutex.Unlock()
+			log.Info().
+				Str("session_id", helixSessionID).
+				Str("request_id", requestID).
+				Str("interaction_id", newInteractionID).
+				Msg("🗺️ [HELIX] Populated requestToInteractionMapping from streaming context (Zed-initiated message)")
+		default:
+			apiServer.contextMappingsMutex.Unlock()
+		}
 	}
 
 	// If we have an existing context (from a transition), update it instead of creating new

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -19,6 +20,14 @@ import (
 	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/types"
 )
+
+// ErrNoExternalAgentWS is returned by sendCommandToExternalAgent when no
+// WebSocket connection exists for the target session. This is an expected,
+// transient state (the dev container may be sleeping or still booting): the
+// caller's persisted interaction will be picked up by pickupWaitingInteraction
+// when the agent reconnects, so no retry is needed at the prompt-queue layer.
+// Callers distinguish this from real send failures using errors.Is.
+var ErrNoExternalAgentWS = errors.New("no external agent WebSocket connection")
 
 // streamingContext caches DB query results during token streaming to avoid
 // redundant queries. Created on first message_added, cleared on message_completed.
@@ -1786,9 +1795,11 @@ func (apiServer *HelixAPIServer) sendCommandToExternalAgent(sessionID string, co
 	if !exists || wsConn == nil {
 		// No connection — auto-start the dev container if this session belongs to a spec task.
 		// The caller's interaction/prompt is already persisted; pickupWaitingInteraction
-		// will deliver it when the agent reconnects via WebSocket.
+		// will deliver it when the agent reconnects via WebSocket. Wrap the sentinel so
+		// callers (e.g. sendQueuedPromptToSession) can recognise this as an expected
+		// transient state via errors.Is and avoid surfacing it as a queue failure.
 		go apiServer.autoStartDevContainerForSession(sessionID)
-		return fmt.Errorf("no WebSocket connection found for session %s", sessionID)
+		return fmt.Errorf("session %s: %w", sessionID, ErrNoExternalAgentWS)
 	}
 
 	// Send command to the specific Zed agent.
@@ -2775,6 +2786,26 @@ func (apiServer *HelixAPIServer) sendQueuedPromptToSession(ctx context.Context, 
 			Order:        "id DESC",
 		})
 		if recheckErr == nil && len(latestInteractions) > 0 && latestInteractions[0].State == types.InteractionStateWaiting {
+			// Before reporting "busy", check whether this Waiting interaction is
+			// the one we already created for THIS prompt on a previous dispatch
+			// attempt (e.g. the no-WS path persisted I1, the agent then connected
+			// and pickupWaitingInteraction sent it, and now the prompt's retry
+			// timer is firing while I1 is still mid-turn). The mapping is the
+			// authoritative link from interaction → originating prompt; if it
+			// points back at us, the message is already in flight and we must
+			// NOT create a duplicate. handleMessageAdded will mark this prompt
+			// 'sent' when Zed acknowledges the existing interaction.
+			apiServer.contextMappingsMutex.Lock()
+			mappedPromptID, mapped := apiServer.interactionToPromptMapping[latestInteractions[0].ID]
+			apiServer.contextMappingsMutex.Unlock()
+			if mapped && mappedPromptID == prompt.ID {
+				log.Info().
+					Str("session_id", sessionID).
+					Str("interaction_id", latestInteractions[0].ID).
+					Str("prompt_id", prompt.ID).
+					Msg("✅ [QUEUE] Prompt is already in flight via existing Waiting interaction — skipping duplicate dispatch")
+				return nil
+			}
 			return fmt.Errorf("session %s became busy (interaction %s is Waiting), deferring queue prompt", sessionID, latestInteractions[0].ID)
 		}
 	}
@@ -2816,6 +2847,11 @@ func (apiServer *HelixAPIServer) sendQueuedPromptToSession(ctx context.Context, 
 
 	// CRITICAL: Store request_id->session mapping so thread_created can find the right session
 	// This is needed for the FIRST message when ZedThreadID is empty and a new thread will be created
+	// Also stash interaction → prompt mapping NOW (not after a successful dispatch) so that the
+	// no-WS path — which still leaves I1 in the DB for pickupWaitingInteraction to deliver — can
+	// be marked 'sent' when Zed eventually acknowledges. Without this pre-set, dispatch failures
+	// orphan the prompt from its interaction and the queue UI shows it as failed forever even
+	// though Zed processed the message after the agent woke up.
 	apiServer.contextMappingsMutex.Lock()
 	if apiServer.requestToSessionMapping == nil {
 		apiServer.requestToSessionMapping = make(map[string]string)
@@ -2826,6 +2862,10 @@ func (apiServer *HelixAPIServer) sendQueuedPromptToSession(ctx context.Context, 
 		apiServer.requestToInteractionMapping = make(map[string]string)
 	}
 	apiServer.requestToInteractionMapping[requestID] = createdInteraction.ID
+	if apiServer.interactionToPromptMapping == nil {
+		apiServer.interactionToPromptMapping = make(map[string]string)
+	}
+	apiServer.interactionToPromptMapping[createdInteraction.ID] = prompt.ID
 	apiServer.contextMappingsMutex.Unlock()
 	log.Info().
 		Str("request_id", requestID).
@@ -2856,50 +2896,62 @@ func (apiServer *HelixAPIServer) sendQueuedPromptToSession(ctx context.Context, 
 		Msg("📤 [QUEUE] Sending queued prompt via sendCommandToExternalAgent")
 
 	// Use the unified sendCommandToExternalAgent which handles connection lookup,
-	// adds session_id to data, and updates agent work state
+	// adds session_id to data, and updates agent work state.
 	//
-	// IMPORTANT: We don't return error if sending to agent fails, because the
-	// interaction was already created. The queue's job is to persist the message
-	// to the backend - which succeeded. Agent send failures are logged but don't
-	// affect the prompt status. The user will see the interaction in the session
-	// and can retry if needed.
+	// Two failure modes need different treatment:
+	//
+	//  1. No WebSocket connection (ErrNoExternalAgentWS): the agent is sleeping
+	//     or still booting. sendCommandToExternalAgent has already kicked off
+	//     autoStartDevContainerForSession; pickupWaitingInteraction will deliver
+	//     the persisted Waiting interaction once the agent reconnects. The
+	//     interactionToPromptMapping we set above survives the failure, so when
+	//     Zed acknowledges I1 the prompt gets marked 'sent' via handleMessageAdded.
+	//     We must NOT mark the prompt as failed in this case — doing so used to
+	//     surface a misleading "no WebSocket connection" error in the queue UI
+	//     and trigger a retry that, once I1 reached Zed, collided with the
+	//     in-flight interaction and produced a second misleading "session became
+	//     busy" failure. The message was being delivered exactly once all along.
+	//
+	//  2. Real dispatch failures (channel full, connection replaced mid-send):
+	//     the connection exists but the send didn't take. Mark the prompt failed
+	//     so the queue's exponential-backoff retry kicks in. Tear down the
+	//     mapping so the next attempt starts clean.
 	if err := apiServer.sendCommandToExternalAgent(sessionID, command); err != nil {
+		if errors.Is(err, ErrNoExternalAgentWS) {
+			log.Info().
+				Str("session_id", sessionID).
+				Str("interaction_id", createdInteraction.ID).
+				Str("prompt_id", prompt.ID).
+				Msg("⏸️ [QUEUE] Agent not connected — interaction persisted, awaiting pickupWaitingInteraction on reconnect")
+			// Don't tear down requestToSessionMapping/requestToInteractionMapping
+			// or the interactionToPromptMapping: pickupWaitingInteraction will
+			// assemble its own request_id mappings, and we need the
+			// interaction→prompt link intact so the eventual delivery marks the
+			// prompt as 'sent'. The prompt stays in 'sending' state so the queue
+			// UI shows the spinner instead of a red error.
+			return nil
+		}
+
 		log.Warn().Err(err).
 			Str("session_id", sessionID).
 			Str("interaction_id", createdInteraction.ID).
 			Str("prompt_id", prompt.ID).
-			Msg("❌ [QUEUE] Failed to send to agent (dev container auto-start triggered by sendCommandToExternalAgent)")
+			Msg("❌ [QUEUE] Failed to send to agent (real dispatch failure, will retry)")
 
-		// Clean up in-memory state so pickupWaitingInteraction can set it up
-		// fresh on reconnect. Without this, stale message_completed events from
-		// the agent's previous context get matched to this interaction.
+		// Clean up in-memory state so the next retry starts clean. Without this,
+		// stale message_completed events from a prior agent context could match
+		// this interaction.
 		apiServer.contextMappingsMutex.Lock()
 		delete(apiServer.requestToSessionMapping, requestID)
 		delete(apiServer.requestToInteractionMapping, requestID)
+		delete(apiServer.interactionToPromptMapping, createdInteraction.ID)
 		apiServer.contextMappingsMutex.Unlock()
 
-		// Mark the prompt as failed so the queue UI shows it as needing retry
-		// instead of leaving it stuck in 'sending' forever. Previously the
-		// caller marked the prompt as 'sent' unconditionally after this
-		// function returned nil — that hid dispatch failures from the user.
 		if markErr := apiServer.Store.MarkPromptAsFailed(context.Background(), prompt.ID, err.Error()); markErr != nil {
 			log.Error().Err(markErr).Str("prompt_id", prompt.ID).Msg("Failed to mark prompt as failed after dispatch failure")
 		}
 		return nil
 	}
-
-	// Dispatch succeeded. Stash the interaction → prompt mapping so we can mark
-	// the prompt as 'sent' when Zed actually starts processing it (i.e. the
-	// first assistant message_added arrives). Until then the prompt stays
-	// 'sending' and remains visible in the frontend queue UI — restoring the
-	// pre-regression UX where queued prompts show as in-flight, not as if
-	// they'd already been delivered.
-	apiServer.contextMappingsMutex.Lock()
-	if apiServer.interactionToPromptMapping == nil {
-		apiServer.interactionToPromptMapping = make(map[string]string)
-	}
-	apiServer.interactionToPromptMapping[createdInteraction.ID] = prompt.ID
-	apiServer.contextMappingsMutex.Unlock()
 
 	return nil
 }

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -29,6 +29,32 @@ import (
 // Callers distinguish this from real send failures using errors.Is.
 var ErrNoExternalAgentWS = errors.New("no external agent WebSocket connection")
 
+// agentCrashErrorMarkers identify thread_load_error events that originate from
+// the Claude Agent ACP wrapper inside Zed having exited. Once the wrapper
+// process is gone, every subsequent follow-up the user sends bounces with
+// "Session not found" — Zed's THREAD_SERVICE has no agent to dispatch to and
+// no first-class way to respawn one for an existing thread. Helix's only
+// recovery is to abandon the dead acp_thread_id and create a fresh thread,
+// which we don't do silently because the user loses the chat history kept in
+// the dead process. Instead the queue surfaces a Restart button; the handler
+// wired up by ResetCrashedPromptsForSession clears ZedThreadID and re-sends
+// the prompt so the next dispatch creates a new thread.
+var agentCrashErrorMarkers = []string{
+	"Claude Agent process exited",
+	"Session not found",
+}
+
+// isAgentCrashError reports whether errMsg matches a known terminal Claude
+// Agent failure that no number of auto-retries can recover from.
+func isAgentCrashError(errMsg string) bool {
+	for _, marker := range agentCrashErrorMarkers {
+		if strings.Contains(errMsg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
 // streamingContext caches DB query results during token streaming to avoid
 // redundant queries. Created on first message_added, cleared on message_completed.
 // Also buffers interaction updates: DB writes are throttled to at most once per
@@ -3086,6 +3112,13 @@ func (apiServer *HelixAPIServer) handleThreadLoadError(sessionID string, syncMsg
 						// in 'sending' state (deferred MarkPromptAsSent flow), mark
 						// the prompt as failed so the user sees retry, not a
 						// stuck "queued" entry.
+						//
+						// Distinguish terminal Claude Agent crashes (process exit,
+						// "Session not found") from transient errors. For crashes,
+						// auto-retry is futile — every subsequent send hits the same
+						// dead process and rebounds. We pin next_retry_at far in the
+						// future via MarkPromptAsCrashed so the queue stops looping,
+						// and the frontend's crash detector renders a Restart button.
 						apiServer.contextMappingsMutex.Lock()
 						promptID, hasPrompt := apiServer.interactionToPromptMapping[interactions[i].ID]
 						if hasPrompt {
@@ -3093,11 +3126,23 @@ func (apiServer *HelixAPIServer) handleThreadLoadError(sessionID string, syncMsg
 						}
 						apiServer.contextMappingsMutex.Unlock()
 						if hasPrompt {
-							if markErr := apiServer.Controller.Options.Store.MarkPromptAsFailed(context.Background(), promptID, fmt.Sprintf("Thread load failed: %s", errorMsg)); markErr != nil {
+							failureMsg := fmt.Sprintf("Thread load failed: %s", errorMsg)
+							var markErr error
+							if isAgentCrashError(errorMsg) {
+								log.Warn().
+									Str("prompt_id", promptID).
+									Str("interaction_id", interactions[i].ID).
+									Str("acp_thread_id", acpThreadID).
+									Msg("💥 [HELIX] Claude Agent crashed — marking prompt crashed (suppress auto-retry, awaits user Restart)")
+								markErr = apiServer.Controller.Options.Store.MarkPromptAsCrashed(context.Background(), promptID, failureMsg)
+							} else {
+								markErr = apiServer.Controller.Options.Store.MarkPromptAsFailed(context.Background(), promptID, failureMsg)
+							}
+							if markErr != nil {
 								log.Error().Err(markErr).
 									Str("prompt_id", promptID).
 									Str("interaction_id", interactions[i].ID).
-									Msg("Failed to mark prompt as failed after thread load error")
+									Msg("Failed to mark prompt after thread load error")
 							}
 						}
 

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -1264,6 +1264,91 @@ func (s *WebSocketSyncSuite) TestFindSessionByZedThreadID_NotFound() {
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
+// handleThreadLoadError tests — Claude Agent crash detection
+// ──────────────────────────────────────────────────────────────────────────────
+
+func (s *WebSocketSyncSuite) TestThreadLoadError_AgentCrash_MarksPromptCrashed() {
+	// Map an interaction to a prompt so the crash path has a prompt to update.
+	s.server.contextMappings["thread-crashed"] = "ses_crash"
+	s.server.interactionToPromptMapping["int-crashed"] = "prompt-crashed"
+
+	session := &types.Session{ID: "ses_crash", GenerationID: 1}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_crash").Return(session, nil)
+	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
+		[]*types.Interaction{{ID: "int-crashed", State: types.InteractionStateWaiting}}, int64(1), nil,
+	)
+	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).Return(nil, nil)
+
+	// Crash detection: the error string includes "Claude Agent process exited"
+	// → MarkPromptAsCrashed (not MarkPromptAsFailed) so auto-retry stops.
+	s.store.EXPECT().MarkPromptAsCrashed(gomock.Any(), "prompt-crashed", gomock.Any()).Return(nil)
+
+	syncMsg := &types.SyncMessage{
+		EventType: "thread_load_error",
+		Data: map[string]interface{}{
+			"acp_thread_id": "thread-crashed",
+			"request_id":    "int-crashed",
+			"error":         "Failed to send follow-up: Internal error: The Claude Agent process exited unexpectedly. Please start a new session.",
+		},
+	}
+	err := s.server.handleThreadLoadError("ses_crash", syncMsg)
+	s.NoError(err)
+}
+
+func (s *WebSocketSyncSuite) TestThreadLoadError_SessionNotFound_AlsoCrash() {
+	// "Session not found" is the steady-state error after the Claude Agent
+	// process is gone. Same crash path applies.
+	s.server.contextMappings["thread-snf"] = "ses_snf"
+	s.server.interactionToPromptMapping["int-snf"] = "prompt-snf"
+
+	session := &types.Session{ID: "ses_snf", GenerationID: 1}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_snf").Return(session, nil)
+	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
+		[]*types.Interaction{{ID: "int-snf", State: types.InteractionStateWaiting}}, int64(1), nil,
+	)
+	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.store.EXPECT().MarkPromptAsCrashed(gomock.Any(), "prompt-snf", gomock.Any()).Return(nil)
+
+	syncMsg := &types.SyncMessage{
+		EventType: "thread_load_error",
+		Data: map[string]interface{}{
+			"acp_thread_id": "thread-snf",
+			"request_id":    "int-snf",
+			"error":         "Failed to send follow-up: Session not found",
+		},
+	}
+	err := s.server.handleThreadLoadError("ses_snf", syncMsg)
+	s.NoError(err)
+}
+
+func (s *WebSocketSyncSuite) TestThreadLoadError_TransientError_StillUsesMarkAsFailed() {
+	// Non-crash thread_load_errors (e.g. socket closed mid-flight, transient
+	// failure) must still go through the normal MarkPromptAsFailed path so the
+	// queue's exponential backoff can recover automatically.
+	s.server.contextMappings["thread-transient"] = "ses_transient"
+	s.server.interactionToPromptMapping["int-transient"] = "prompt-transient"
+
+	session := &types.Session{ID: "ses_transient", GenerationID: 1}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_transient").Return(session, nil)
+	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
+		[]*types.Interaction{{ID: "int-transient", State: types.InteractionStateWaiting}}, int64(1), nil,
+	)
+	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).Return(nil, nil)
+	s.store.EXPECT().MarkPromptAsFailed(gomock.Any(), "prompt-transient", gomock.Any()).Return(nil)
+
+	syncMsg := &types.SyncMessage{
+		EventType: "thread_load_error",
+		Data: map[string]interface{}{
+			"acp_thread_id": "thread-transient",
+			"request_id":    "int-transient",
+			"error":         "Failed to send follow-up: API Error: The socket connection was closed unexpectedly.",
+		},
+	}
+	err := s.server.handleThreadLoadError("ses_transient", syncMsg)
+	s.NoError(err)
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
 // handleUserCreatedThread tests
 // ──────────────────────────────────────────────────────────────────────────────
 

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -1264,6 +1264,79 @@ func (s *WebSocketSyncSuite) TestFindSessionByZedThreadID_NotFound() {
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
+// getOrCreateStreamingContext — stale request_id rebind protection
+// (regression for design/2026-04-28-stale-request-id-rebind-loses-zed-updates.md)
+// ──────────────────────────────────────────────────────────────────────────────
+
+func (s *WebSocketSyncSuite) TestStreamingContext_StaleRequestIDRebind_PreservesConsumedSentinel() {
+	// Scenario reproduced from the spt_01kq8cnjzfqc51nn0c6ddxkw8r incident:
+	// 1. handleMessageCompleted previously consumed the mapping for req_X by
+	//    setting requestToInteractionMapping[req_X] = "" (the dedup sentinel).
+	// 2. The wrapper inside Zed flushes a buffered message_added later, tagged
+	//    with the *stale* req_X.
+	// 3. getOrCreateStreamingContext is called with helixSessionID + req_X for
+	//    that flushed event, finds the most-recent Waiting interaction (a
+	//    different turn), and used to overwrite the consumed sentinel — which
+	//    later let a stale message_completed for req_X mark the new turn
+	//    complete prematurely.
+	//
+	// After the fix the rebind must be skipped when the existing mapping is the
+	// consumed sentinel; the sentinel must remain "" so the next stale
+	// message_completed is routed through the duplicate-detection branch.
+
+	s.server.requestToInteractionMapping["req_stale"] = "" // pre-consumed sentinel
+
+	helixSession := &types.Session{ID: "ses_stale", GenerationID: 1}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_stale").Return(helixSession, nil)
+	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
+		[]*types.Interaction{
+			{ID: "int-old", State: types.InteractionStateComplete},
+			{ID: "int-new", State: types.InteractionStateWaiting},
+		},
+		int64(2), nil,
+	)
+
+	sctx := s.server.getOrCreateStreamingContext(context.Background(), "ses_stale", "req_stale")
+	s.NotNil(sctx)
+	// Streaming context must still find an interaction to attach content to —
+	// the most-recent Waiting one — because the wrapper's buffered tokens have
+	// to land somewhere visible to the user.
+	s.Equal("int-new", sctx.interactionID)
+
+	// The consumed sentinel must be intact so handleMessageCompleted's dedup
+	// drops the stale completion that follows.
+	s.server.contextMappingsMutex.Lock()
+	mapped, exists := s.server.requestToInteractionMapping["req_stale"]
+	s.server.contextMappingsMutex.Unlock()
+	s.True(exists, "mapping entry should still exist")
+	s.Equal("", mapped, "consumed sentinel must NOT be overwritten by stale rebind")
+}
+
+func (s *WebSocketSyncSuite) TestStreamingContext_FirstSightRequestID_RegistersMapping() {
+	// Counterpart to the test above: when the request_id has never been seen
+	// (genuine Zed-initiated message — user typed in Zed, no prior dispatch
+	// from Helix), the mapping MUST still be populated so handleMessageCompleted
+	// can route the eventual completion correctly.
+
+	helixSession := &types.Session{ID: "ses_fresh", GenerationID: 1}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_fresh").Return(helixSession, nil)
+	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
+		[]*types.Interaction{{ID: "int-fresh", State: types.InteractionStateWaiting}},
+		int64(1), nil,
+	)
+
+	sctx := s.server.getOrCreateStreamingContext(context.Background(), "ses_fresh", "req_fresh")
+	s.NotNil(sctx)
+	s.Equal("int-fresh", sctx.interactionID)
+
+	s.server.contextMappingsMutex.Lock()
+	mapped, exists := s.server.requestToInteractionMapping["req_fresh"]
+	s.server.contextMappingsMutex.Unlock()
+	s.True(exists)
+	s.Equal("int-fresh", mapped, "first-sight request_id must be registered for completion routing")
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
 // handleThreadLoadError tests — Claude Agent crash detection
 // ──────────────────────────────────────────────────────────────────────────────
 

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -61,6 +61,7 @@ func (s *WebSocketSyncSuite) SetupTest() {
 		contextMappings:             make(map[string]string),
 		requestToSessionMapping:     make(map[string]string),
 		requestToInteractionMapping: make(map[string]string),
+		interactionToPromptMapping:  make(map[string]string),
 		externalAgentSessionMapping: make(map[string]string),
 		externalAgentUserMapping:    make(map[string]string),
 		sessionCommentTimeout:       make(map[string]*time.Timer),
@@ -882,9 +883,10 @@ func (s *WebSocketSyncSuite) TestAgentReady_WithPendingPrompt() {
 			return &types.Interaction{ID: "int-prompt", SessionID: "ses_pending"}, nil
 		},
 	)
-	// Dispatch failure path: with no WS connection registered, the prompt is
-	// marked failed so the queue UI shows retry instead of sticking on 'sending'.
-	s.store.EXPECT().MarkPromptAsFailed(gomock.Any(), "prompt-1", gomock.Any()).Return(nil)
+	// No-WS dispatch path: the interaction is persisted and the
+	// interactionToPromptMapping is left intact so handleMessageAdded marks the
+	// prompt 'sent' once Zed acknowledges via pickupWaitingInteraction. We must
+	// NOT mark it failed here.
 	// GetSpecTask for getAgentNameForSession + autoStartDevContainerForSession
 	s.store.EXPECT().GetSpecTask(gomock.Any(), gomock.Any()).Return(nil, store.ErrNotFound).AnyTimes()
 
@@ -1002,7 +1004,6 @@ func (s *WebSocketSyncSuite) TestProcessPromptQueue_HasPending() {
 		Status:    "pending",
 	}
 	s.store.EXPECT().GetNextPendingPrompt(gomock.Any(), "ses_pq").Return(prompt, nil)
-	// MarkPromptAsPending no longer called - prompt is atomically claimed by GetNextPendingPrompt
 
 	// sendQueuedPromptToSession calls
 	session := &types.Session{
@@ -1019,15 +1020,26 @@ func (s *WebSocketSyncSuite) TestProcessPromptQueue_HasPending() {
 	)
 	s.store.EXPECT().GetSpecTask(gomock.Any(), gomock.Any()).Return(nil, store.ErrNotFound).AnyTimes()
 
-	// sendCommandToExternalAgent will fail (no WS connection). Under the
-	// deferred-mark-sent flow, dispatch failure inside sendQueuedPromptToSession
-	// marks the prompt as failed (so the user sees retry), and the caller's
-	// MarkPromptAsSent has been removed entirely — the prompt is marked sent
-	// later by handleMessageAdded when Zed actually starts responding.
-	s.store.EXPECT().MarkPromptAsFailed(gomock.Any(), "prompt-pq", gomock.Any()).Return(nil)
+	// sendCommandToExternalAgent fails with ErrNoExternalAgentWS (no WS
+	// registered). The agent is sleeping, autoStartDevContainerForSession kicks
+	// off, and the persisted Waiting interaction will be delivered by
+	// pickupWaitingInteraction once the agent reconnects. The prompt MUST stay
+	// in 'sending' (handleMessageAdded marks it 'sent' via interactionToPromptMapping
+	// when Zed acknowledges) — marking it failed here used to surface a
+	// misleading "no WebSocket connection" error in the queue UI and trigger a
+	// retry that collided with the in-flight delivery.
+	// So: no MarkPromptAsFailed expectation.
 
 	s.server.processPromptQueue(context.Background(), "ses_pq")
 	time.Sleep(50 * time.Millisecond) // let autoStartDevContainerForSession goroutine complete
+
+	// Mapping must persist past the no-WS failure so handleMessageAdded can
+	// mark the prompt 'sent' when Zed eventually responds to int-pq.
+	s.server.contextMappingsMutex.Lock()
+	mappedPromptID, ok := s.server.interactionToPromptMapping["int-pq"]
+	s.server.contextMappingsMutex.Unlock()
+	s.True(ok, "interactionToPromptMapping should be retained after no-WS failure")
+	s.Equal("prompt-pq", mappedPromptID)
 }
 
 func (s *WebSocketSyncSuite) TestProcessPromptQueue_SendFails_GetSessionFails() {
@@ -1071,8 +1083,6 @@ func (s *WebSocketSyncSuite) TestProcessAnyPendingPrompt_HasPending() {
 		Content:   "any prompt",
 	}
 	s.store.EXPECT().GetAnyPendingPrompt(gomock.Any(), "ses_any").Return(prompt, nil)
-	// Note: ClaimPromptForSending is NOT called — GetAnyPendingPrompt already atomically claimed it
-	// MarkPromptAsSent is NOT called here under the deferred-mark flow.
 
 	session := &types.Session{
 		ID:    "ses_any",
@@ -1087,8 +1097,10 @@ func (s *WebSocketSyncSuite) TestProcessAnyPendingPrompt_HasPending() {
 		&types.Interaction{ID: "int-any", SessionID: "ses_any"}, nil,
 	)
 	s.store.EXPECT().GetSpecTask(gomock.Any(), gomock.Any()).Return(nil, store.ErrNotFound).AnyTimes()
-	// No WS connection → dispatch fails → prompt marked failed (so retry kicks in).
-	s.store.EXPECT().MarkPromptAsFailed(gomock.Any(), "prompt-any", gomock.Any()).Return(nil)
+	// No WS connection → dispatch returns ErrNoExternalAgentWS → prompt stays
+	// in 'sending' (interaction persisted, pickupWaitingInteraction will deliver
+	// it on reconnect, handleMessageAdded marks it sent).
+	// No MarkPromptAsFailed expectation.
 
 	s.server.processAnyPendingPrompt(context.Background(), "ses_any")
 	time.Sleep(50 * time.Millisecond) // let autoStartDevContainerForSession goroutine complete
@@ -1114,52 +1126,109 @@ func (s *WebSocketSyncSuite) TestProcessAnyPendingPrompt_SendFails_MarkedFailed(
 // sendQueuedPromptToSession — in-memory state cleanup on send failure
 // ──────────────────────────────────────────────────────────────────────────────
 
-func (s *WebSocketSyncSuite) TestSendQueuedPrompt_SendFails_CleansUpInMemoryState() {
-	// When sendCommandToExternalAgent fails (no WS connection),
-	// requestToSessionMapping and requestToInteractionMapping must be cleaned
-	// up so pickupWaitingInteraction sets them fresh on reconnect.
-	// Otherwise a stale message_completed from the agent's previous context
-	// gets matched to the new interaction (wrong response bug).
+func (s *WebSocketSyncSuite) TestSendQueuedPrompt_NoWS_KeepsMappingForLaterDelivery() {
+	// When sendCommandToExternalAgent returns ErrNoExternalAgentWS (agent is
+	// sleeping), the persisted Waiting interaction will be delivered by
+	// pickupWaitingInteraction once the agent reconnects. We keep the mappings
+	// (especially interactionToPromptMapping) intact so that handleMessageAdded
+	// can mark the prompt 'sent' when Zed acknowledges the existing interaction.
+	// The prompt is NOT marked failed in this case.
 
 	session := &types.Session{
-		ID:    "ses_cleanup",
+		ID:    "ses_nows",
 		Owner: "user-1",
 	}
-	s.store.EXPECT().GetSession(gomock.Any(), "ses_cleanup").Return(session, nil).AnyTimes()
-	// Re-check idle state before creating interaction
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_nows").Return(session, nil).AnyTimes()
 	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
 		[]*types.Interaction{}, int64(0), nil,
 	)
 	s.store.EXPECT().CreateInteraction(gomock.Any(), gomock.Any()).Return(
-		&types.Interaction{ID: "int-cleanup", SessionID: "ses_cleanup"}, nil,
+		&types.Interaction{ID: "int-nows", SessionID: "ses_nows"}, nil,
 	)
 	s.store.EXPECT().GetSpecTask(gomock.Any(), gomock.Any()).Return(nil, store.ErrNotFound).AnyTimes()
 
 	prompt := &types.PromptHistoryEntry{
-		ID:        "prompt-cleanup",
-		SessionID: "ses_cleanup",
+		ID:        "prompt-nows",
+		SessionID: "ses_nows",
 		Content:   "test prompt",
 	}
 
-	// Dispatch failure now also marks the prompt as failed so the queue UI
-	// surfaces the failure (under the deferred-mark-sent flow) instead of
-	// leaving it stuck in 'sending' forever.
-	s.store.EXPECT().MarkPromptAsFailed(gomock.Any(), "prompt-cleanup", gomock.Any()).Return(nil)
+	// No MarkPromptAsFailed expectation — the no-WS path must not surface as a
+	// queue failure.
 
-	// No WS connection registered → sendCommandToExternalAgent will fail
-	err := s.server.sendQueuedPromptToSession(context.Background(), "ses_cleanup", prompt)
-	s.NoError(err) // interaction was created, send failure is not returned as error
-
+	err := s.server.sendQueuedPromptToSession(context.Background(), "ses_nows", prompt)
+	s.NoError(err)
 	time.Sleep(50 * time.Millisecond) // let autoStartDevContainerForSession goroutine complete
 
-	// Verify in-memory state was cleaned up
+	// All three mappings must survive the no-WS dispatch failure: pickupWaitingInteraction
+	// reuses requestToSessionMapping (or makes its own), and handleMessageAdded
+	// needs interactionToPromptMapping to mark the prompt 'sent' on Zed's first
+	// message_added.
 	s.server.contextMappingsMutex.Lock()
-	_, hasSessionMapping := s.server.requestToSessionMapping["int-cleanup"]
-	_, hasInteractionMapping := s.server.requestToInteractionMapping["int-cleanup"]
+	mappedPrompt, hasPromptMapping := s.server.interactionToPromptMapping["int-nows"]
 	s.server.contextMappingsMutex.Unlock()
+	s.True(hasPromptMapping, "interactionToPromptMapping must persist past the no-WS failure")
+	s.Equal("prompt-nows", mappedPrompt)
+}
 
-	s.False(hasSessionMapping, "requestToSessionMapping should be cleaned up after send failure")
-	s.False(hasInteractionMapping, "requestToInteractionMapping should be cleaned up after send failure")
+func (s *WebSocketSyncSuite) TestSendQueuedPrompt_BusyWithOwnInteraction_ReturnsSuccess() {
+	// Regression: after the no-WS path stashes I1 with mapping[I1] = P1 and the
+	// retry timer fires while pickupWaitingInteraction is still in flight, the
+	// busy re-check must recognise the in-flight interaction as our own and
+	// return success — NOT "session became busy" (which previously marked the
+	// prompt failed and made it look like delivery had failed twice).
+
+	// Pre-seed the mapping as if a previous attempt persisted I1 for P1.
+	s.server.interactionToPromptMapping["int-inflight"] = "prompt-busy"
+
+	session := &types.Session{ID: "ses_busy", Owner: "user-1"}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_busy").Return(session, nil)
+	// Latest interaction is the one we already dispatched, still Waiting.
+	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
+		[]*types.Interaction{{ID: "int-inflight", State: types.InteractionStateWaiting}}, int64(1), nil,
+	)
+	// No CreateInteraction, no MarkPromptAsFailed — the function must return
+	// nil without doing any further work.
+
+	prompt := &types.PromptHistoryEntry{
+		ID:        "prompt-busy",
+		SessionID: "ses_busy",
+		Content:   "retry of in-flight prompt",
+	}
+
+	err := s.server.sendQueuedPromptToSession(context.Background(), "ses_busy", prompt)
+	s.NoError(err, "in-flight delivery must not surface as a busy/failure error")
+
+	// Mapping must still be present so handleMessageAdded can mark it sent later.
+	s.server.contextMappingsMutex.Lock()
+	mapped, ok := s.server.interactionToPromptMapping["int-inflight"]
+	s.server.contextMappingsMutex.Unlock()
+	s.True(ok)
+	s.Equal("prompt-busy", mapped)
+}
+
+func (s *WebSocketSyncSuite) TestSendQueuedPrompt_BusyWithOtherInteraction_DefersAsBefore() {
+	// Counterpart to the test above: when the in-flight Waiting interaction is
+	// NOT our own (some other prompt or a Zed-initiated user message), the
+	// busy-check must still defer with an error so the queue retries later.
+
+	s.server.interactionToPromptMapping["int-other"] = "prompt-other"
+
+	session := &types.Session{ID: "ses_busy2", Owner: "user-1"}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_busy2").Return(session, nil)
+	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
+		[]*types.Interaction{{ID: "int-other", State: types.InteractionStateWaiting}}, int64(1), nil,
+	)
+
+	prompt := &types.PromptHistoryEntry{
+		ID:        "prompt-mine",
+		SessionID: "ses_busy2",
+		Content:   "I should wait my turn",
+	}
+
+	err := s.server.sendQueuedPromptToSession(context.Background(), "ses_busy2", prompt)
+	s.Error(err)
+	s.Contains(err.Error(), "became busy")
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/api/pkg/store/memorystore/memorystore.go
+++ b/api/pkg/store/memorystore/memorystore.go
@@ -296,6 +296,12 @@ func (m *MemoryStore) MarkPromptAsSent(_ context.Context, _ string) error       
 func (m *MemoryStore) MarkPromptAsFailed(_ context.Context, _ string, _ string) error {
 	return nil
 }
+func (m *MemoryStore) MarkPromptAsCrashed(_ context.Context, _ string, _ string) error {
+	return nil
+}
+func (m *MemoryStore) ResetCrashedPromptsForSession(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
 func (m *MemoryStore) RequeueBouncedPrompt(_ context.Context, _ string) error     { return nil }
 func (m *MemoryStore) DeletePromptHistoryEntry(_ context.Context, _ string) error { return nil }
 func (m *MemoryStore) ClaimPromptForSending(_ context.Context, _ string) (bool, error) {

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -732,6 +732,19 @@ type Store interface {
 	// for exponential backoff. errorMsg is shown to the user in the UI; pass err.Error()
 	// from whatever produced the failure. Truncated to 500 chars by the implementation.
 	MarkPromptAsFailed(ctx context.Context, promptID string, errorMsg string) error
+	// MarkPromptAsCrashed records the failure reason but pins next_retry_at far in the
+	// future so the auto-retry loop never picks the prompt back up. Used for terminal
+	// errors that no number of retries can recover from (e.g. the Claude Agent process
+	// inside Zed exited and Helix has no way to respawn it without the user creating a
+	// fresh thread). The frontend recognises this state and offers a manual Restart
+	// action which calls ResetCrashedPromptsForSession to undo it.
+	MarkPromptAsCrashed(ctx context.Context, promptID string, errorMsg string) error
+	// ResetCrashedPromptsForSession finds every prompt for sessionID whose status is
+	// 'failed' and whose next_retry_at is the far-future sentinel set by
+	// MarkPromptAsCrashed, and resets them to status='pending' with retry_count=0,
+	// next_retry_at=NULL, error_message=''. Returns the number of prompts reset.
+	// Called when the user clicks Restart after a Claude Agent crash.
+	ResetCrashedPromptsForSession(ctx context.Context, sessionID string) (int, error)
 	// RequeueBouncedPrompt finds the most recent "sent" prompt for a session and marks
 	// it as "failed" so the retry mechanism picks it up. Used when message_completed
 	// arrives with an empty response (bounce).

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -4881,8 +4881,22 @@ func (mr *MockStoreMockRecorder) LookupKnowledge(ctx, q any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookupKnowledge", reflect.TypeOf((*MockStore)(nil).LookupKnowledge), ctx, q)
 }
 
+// MarkPromptAsCrashed mocks base method.
+func (m *MockStore) MarkPromptAsCrashed(ctx context.Context, promptID, errorMsg string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkPromptAsCrashed", ctx, promptID, errorMsg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MarkPromptAsCrashed indicates an expected call of MarkPromptAsCrashed.
+func (mr *MockStoreMockRecorder) MarkPromptAsCrashed(ctx, promptID, errorMsg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkPromptAsCrashed", reflect.TypeOf((*MockStore)(nil).MarkPromptAsCrashed), ctx, promptID, errorMsg)
+}
+
 // MarkPromptAsFailed mocks base method.
-func (m *MockStore) MarkPromptAsFailed(ctx context.Context, promptID string, errorMsg string) error {
+func (m *MockStore) MarkPromptAsFailed(ctx context.Context, promptID, errorMsg string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MarkPromptAsFailed", ctx, promptID, errorMsg)
 	ret0, _ := ret[0].(error)
@@ -4978,6 +4992,21 @@ func (m *MockStore) RequeueBouncedPrompt(ctx context.Context, sessionID string) 
 func (mr *MockStoreMockRecorder) RequeueBouncedPrompt(ctx, sessionID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequeueBouncedPrompt", reflect.TypeOf((*MockStore)(nil).RequeueBouncedPrompt), ctx, sessionID)
+}
+
+// ResetCrashedPromptsForSession mocks base method.
+func (m *MockStore) ResetCrashedPromptsForSession(ctx context.Context, sessionID string) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResetCrashedPromptsForSession", ctx, sessionID)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResetCrashedPromptsForSession indicates an expected call of ResetCrashedPromptsForSession.
+func (mr *MockStoreMockRecorder) ResetCrashedPromptsForSession(ctx, sessionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetCrashedPromptsForSession", reflect.TypeOf((*MockStore)(nil).ResetCrashedPromptsForSession), ctx, sessionID)
 }
 
 // ResetRunningExecutions mocks base method.

--- a/api/pkg/store/store_prompt_history.go
+++ b/api/pkg/store/store_prompt_history.go
@@ -282,6 +282,14 @@ func (s *PostgresStore) RequeueBouncedPrompt(ctx context.Context, sessionID stri
 // logs still carry the full error for debugging.
 const promptErrorMessageMaxLen = 500
 
+// crashedPromptRetrySentinel is the next_retry_at value used by
+// MarkPromptAsCrashed to suppress auto-retry. Picked far enough in the future
+// that the queue's exponential-backoff selector will never match it, but a
+// fixed timestamp (not max time.Time) so it serialises cleanly through GORM
+// and Postgres timestamptz. ResetCrashedPromptsForSession identifies crashed
+// rows by matching exactly this value.
+var crashedPromptRetrySentinel = time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
+
 // MarkPromptAsFailed marks a prompt as failed with exponential backoff retry,
 // recording the failure reason for display in the UI.
 func (s *PostgresStore) MarkPromptAsFailed(ctx context.Context, promptID string, errorMsg string) error {
@@ -313,6 +321,58 @@ func (s *PostgresStore) MarkPromptAsFailed(ctx context.Context, promptID string,
 			"error_message": errorMsg,
 		}).
 		Error
+}
+
+// MarkPromptAsCrashed marks a prompt as failed but pins next_retry_at to a
+// far-future sentinel so the queue's auto-retry never picks it back up. Used
+// for terminal failures (the Claude Agent process inside Zed exited and Helix
+// can't respawn it without a fresh thread). The user must explicitly click
+// Restart to recover, which calls ResetCrashedPromptsForSession.
+//
+// We don't introduce a separate 'crashed' status because GetNextPendingPrompt
+// only selects 'pending' and 'failed' — pinning next_retry_at to year 9999
+// keeps the row out of the selector while still letting existing failed-state
+// UI render naturally with the error message.
+func (s *PostgresStore) MarkPromptAsCrashed(ctx context.Context, promptID string, errorMsg string) error {
+	if len(errorMsg) > promptErrorMessageMaxLen {
+		errorMsg = errorMsg[:promptErrorMessageMaxLen]
+	}
+
+	return s.gdb.WithContext(ctx).
+		Model(&types.PromptHistoryEntry{}).
+		Where("id = ?", promptID).
+		Updates(map[string]interface{}{
+			"status":        "failed",
+			"next_retry_at": crashedPromptRetrySentinel,
+			"error_message": errorMsg,
+		}).
+		Error
+}
+
+// ResetCrashedPromptsForSession resets every prompt for sessionID that was
+// marked crashed by MarkPromptAsCrashed: status becomes 'pending', retry_count
+// is zeroed, next_retry_at and error_message are cleared. The auto-retry
+// selector picks the prompts up on the next idle tick. Returns the number of
+// prompts reset.
+//
+// Identifies crashed rows by next_retry_at = the sentinel; that's a tighter
+// match than checking the error_message text and survives error-message
+// rewording.
+func (s *PostgresStore) ResetCrashedPromptsForSession(ctx context.Context, sessionID string) (int, error) {
+	result := s.gdb.WithContext(ctx).
+		Model(&types.PromptHistoryEntry{}).
+		Where("session_id = ? AND status = ? AND next_retry_at = ? AND deleted_at IS NULL",
+			sessionID, "failed", crashedPromptRetrySentinel).
+		Updates(map[string]interface{}{
+			"status":        "pending",
+			"retry_count":   0,
+			"next_retry_at": nil,
+			"error_message": "",
+		})
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return int(result.RowsAffected), nil
 }
 
 // ListPromptHistory returns prompt history entries for a user

--- a/design/2026-04-28-stale-request-id-rebind-loses-zed-updates.md
+++ b/design/2026-04-28-stale-request-id-rebind-loses-zed-updates.md
@@ -1,0 +1,141 @@
+# Stale `request_id` rebind loses Zed→Helix updates
+
+**Date:** 2026-04-28
+**Spec task that surfaced it:** `spt_01kq8cnjzfqc51nn0c6ddxkw8r`
+**Helix session:** `ses_01kq8cnnkmww35bacpscbrehn0`
+**Zed thread:** `7dbafa8b-6ff7-40c0-b667-9e81c530e99e`
+
+## Symptom (user report)
+
+> "another example of a session where zed is pushing out updates and helix is failing to receive them"
+>
+> Later: "now it's sync'd up again but at the point at which i told you it was stuck..."
+
+Helix is receiving the WebSocket frames from Zed (the `External agent added message` log fires ~50k times in 2h on this session, the connection never disconnects), but the user-visible chat in the Helix UI lags behind, drops content, or shows "stale" completions while the next turn is still in flight.
+
+## Evidence
+
+`requestToInteractionMapping` lookup-by-`request_id` is the authoritative router that decides which interaction a given `message_completed` belongs to. `handleMessageCompleted` consumes the mapping by setting it to the empty string `""` after first use; subsequent events with the same `request_id` are intended to be dropped as duplicates (`websocket_external_agent_sync.go:2287-2315`).
+
+In the failing window the same `request_id` `req_eead10e3-d5b8-40a4-a75c-5f0ed91e3c9f` was processed as `message_completed` **four times**, each routed to a **different** Helix interaction:
+
+```
+07:48:09Z  Sent comment to agent             request_id=req_eead10e3...  interaction_id=int_01kq9gym4v16n4zz2fxegv3q5e
+07:57:23Z  RECEIVED MESSAGE_COMPLETED        request_id=req_eead10e3...
+07:57:23Z  Matched interaction by mapping    request_id=req_eead10e3...  interaction_id=int_01kq9gym4v16n4zz2fxegv3q5e   (correct - original turn)
+
+07:57:56Z  Populated requestToInteractionMapping from streaming context (Zed-initiated message)
+                                             request_id=req_eead10e3...  interaction_id=int_01kq9hgcee4f6pmjve4e990cgq   ← OVERWRITES the consumed sentinel
+07:58:42Z  RECEIVED MESSAGE_COMPLETED        request_id=req_eead10e3...
+07:58:42Z  Matched interaction by mapping    request_id=req_eead10e3...  interaction_id=int_01kq9hgcee4f6pmjve4e990cgq   ← stale completion routed to new interaction
+07:58:42Z  Marked interaction as complete    interaction_id=int_01kq9hgcee4f6pmjve4e990cgq                                ← prematurely completed mid-stream
+
+08:04:41Z  Populated requestToInteractionMapping ...  interaction_id=int_01kq9hws3pjchmrq4rsns6c3zy
+08:04:44Z  RECEIVED MESSAGE_COMPLETED       request_id=req_eead10e3...
+08:04:44Z  Matched interaction by mapping   request_id=req_eead10e3...  interaction_id=int_01kq9hws3pjchmrq4rsns6c3zy
+08:04:44Z  Marked interaction as complete   interaction_id=int_01kq9hws3pjchmrq4rsns6c3zy                                 ← same pattern, again
+
+08:04:49Z  Populated requestToInteractionMapping ...  interaction_id=int_01kq9hx01evpeh9g89dgc11r00
+08:04:52Z  RECEIVED MESSAGE_COMPLETED       request_id=req_eead10e3...
+08:04:52Z  Matched interaction by mapping   request_id=req_eead10e3...  interaction_id=int_01kq9hx01evpeh9g89dgc11r00
+08:04:52Z  Marked interaction as complete   interaction_id=int_01kq9hx01evpeh9g89dgc11r00                                 ← and again
+```
+
+`req_eead10e3...` was the request id Helix generated when it dispatched a *single* design review comment at 07:48:09. The wrapper inside Zed buffered events that were not directly downstream of an ACP `session/prompt` (see `auto_wake_stuck_interactions.go:1-50` for the full background — it documents the wrapper's event-buffering behaviour and the `agentclientprotocol/agent-client-protocol#554` upstream issue) and flushed them later, tagging each flushed `message_completed` with the *last* `request_id` it saw — the now-stale `req_eead10e3`.
+
+## Root cause
+
+`getOrCreateStreamingContext` rebuilds `requestToInteractionMapping` on every `message_added` whose `request_id` ↔ `interaction_id` pair doesn't already match (`websocket_external_agent_sync.go:1590-1606`):
+
+```go
+// Populate requestToInteractionMapping for Zed-initiated messages.
+// When the user types in Zed, the interaction is created without a mapping.
+// Zed reuses the same request_id for the response, so we need to register
+// it here so handleMessageCompleted can route correctly.
+if requestID != "" && newInteractionID != "" && newInteractionID != expectedInteractionID {
+    apiServer.contextMappingsMutex.Lock()
+    if apiServer.requestToInteractionMapping == nil {
+        apiServer.requestToInteractionMapping = make(map[string]string)
+    }
+    apiServer.requestToInteractionMapping[requestID] = newInteractionID   // ← unconditional overwrite
+    apiServer.contextMappingsMutex.Unlock()
+    ...
+}
+```
+
+`expectedInteractionID` was read with a single-value lookup at line 1438-1441, so it returns `""` for *both* "no entry" and "consumed entry" states. The condition `newInteractionID != expectedInteractionID` therefore can't tell them apart, and the unconditional `requestToInteractionMapping[requestID] = newInteractionID` clobbers the `""` sentinel that `handleMessageCompleted` planted.
+
+Once the sentinel is gone, the next stale `message_completed` carrying `req_eead10e3` no longer hits the dedup branch (`mappingConsumed = true`); it matches the freshly-bound interaction and runs the full completion path on it — flushing the streaming context, marking state Complete, publishing a final session update — even though that interaction is mid-turn and has its own real completion still pending.
+
+## Why the user sees "Helix failing to receive updates"
+
+From the user's perspective the UI shows:
+
+- The current turn's interaction transitions to Complete prematurely (the stale `message_completed` from the wrapper's buffer).
+- Subsequent `message_added` tokens for the *real* current turn are still appended (the streaming context still points there) but the turn is already "done" in the UI, so the chat composer un-greys, the spinner stops, etc.
+- When the *real* `message_completed` for the current turn finally arrives, it hits the early-return at `websocket_external_agent_sync.go:2391-2397` (`Interaction already complete ... skipping redundant completion`) and the actual final response state is never published. The UI stops updating until the next turn pulls a fresh state.
+
+The user described this as "Zed pushing updates and Helix failing to receive them": Helix is receiving fine, but it's mis-routing the completions and dropping the publish on the floor.
+
+## Hypothesis tests
+
+| Hypothesis | Result |
+|---|---|
+| WebSocket disconnect/reconnect dropping events. | **Refuted.** Single `External agent WebSocket connected` at 06:24:00, no unregister/disconnect for this session in the next 2 h. |
+| Real session-level error from Zed (`thread_load_error` etc.). | **Refuted.** Only one warning in this session in 2 h, and it's a comment-response timeout unrelated to chat. No `thread_load_error` events. |
+| Wrapper crash (the Bug-2 case from PR #2311). | **Refuted.** No `Claude Agent process exited` / `Session not found` in the logs for this session. |
+| Stale `request_id` defeats dedup → mis-routes `message_completed`. | **Confirmed.** Trace above shows the rebind→re-match→premature-complete pattern repeating four times for the same `request_id`. |
+
+## Fix
+
+`getOrCreateStreamingContext` must distinguish "request_id never seen" from "request_id consumed by completion". Two-value lookup:
+
+```go
+if requestID != "" && newInteractionID != "" {
+    apiServer.contextMappingsMutex.Lock()
+    if apiServer.requestToInteractionMapping == nil {
+        apiServer.requestToInteractionMapping = make(map[string]string)
+    }
+    existing, alreadySeen := apiServer.requestToInteractionMapping[requestID]
+    switch {
+    case alreadySeen && existing == "":
+        // Consumed sentinel — wrapper is replaying buffered events with a stale
+        // request_id (see auto_wake_stuck_interactions.go for background). Do
+        // NOT rebind: that would defeat the duplicate-completion dedup in
+        // handleMessageCompleted and prematurely complete an unrelated mid-turn
+        // interaction. Stale streaming tokens still flow into the current
+        // interaction via the streaming context fallback, but the stale
+        // completion is dropped where it should be.
+        apiServer.contextMappingsMutex.Unlock()
+        log.Debug().
+            Str("session_id", helixSessionID).
+            Str("request_id", requestID).
+            Str("would_have_bound", newInteractionID).
+            Msg("🛡️ [HELIX] Ignoring stale request_id rebind (mapping previously consumed)")
+    case existing != newInteractionID:
+        apiServer.requestToInteractionMapping[requestID] = newInteractionID
+        apiServer.contextMappingsMutex.Unlock()
+        log.Info().
+            Str("session_id", helixSessionID).
+            Str("request_id", requestID).
+            Str("interaction_id", newInteractionID).
+            Msg("🗺️ [HELIX] Populated requestToInteractionMapping from streaming context (Zed-initiated message)")
+    default:
+        apiServer.contextMappingsMutex.Unlock()
+    }
+}
+```
+
+The `alreadySeen && existing == ""` branch is the new behaviour. The other two branches preserve the existing semantics: register on first sight, rebind only when the request_id is now associated with a different live interaction.
+
+## Why this is safe
+
+- **Live conversations (existing == newInteractionID):** no-op — same as today.
+- **First-time request_ids (!alreadySeen):** registered as today.
+- **Cross-turn rebinds where the previous turn is still in flight (existing != "" && existing != newInteractionID):** still rebinds — preserves the "user sent a follow-up while the previous turn was running" path.
+- **Stale wrapper-buffered events (existing == ""):** dropped from the routing table. Their content still flows into the current Waiting interaction via the streaming context fallback at line 1551-1558 (`find most recent waiting interaction`), so no streaming tokens are lost. What we *don't* let through is the final `message_completed`, which would otherwise prematurely complete the current turn — that's the actual bug.
+
+## Test plan
+
+1. **Unit test in `websocket_external_agent_sync_test.go`:** simulate the trace — register a request_id via `sendMessageToSpecTaskAgent`, fire a `message_completed` (consumes), then fire a `message_added` whose Waiting interaction differs from the consumed one, then a second `message_completed` carrying the same stale request_id. Assert: second completion is logged as `Duplicate message_completed for consumed request_id mapping — ignoring`, the mid-stream interaction is *not* marked Complete.
+2. **Manual:** dispatch a comment to a long-running spec task, wait for the first turn to complete, then trigger more agent activity (e.g. a Zed user-typed message). Confirm the new turn streams through to completion without spurious "Marked interaction as complete" events for it before its real `message_completed` arrives.

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -6036,22 +6036,6 @@ export interface TypesUpdateTeamRequest {
   name?: string;
 }
 
-export interface TypesUserChatSettings {
-  frequency_penalty?: number;
-  max_tokens?: number;
-  presence_penalty?: number;
-  system_prompt?: string;
-  /**
-   * SystemPromptEnabled toggles whether any system prompt at all is sent
-   * to the model. Pointer so nil means "not set" and we fall back to the
-   * default-on behaviour. When explicitly false, no system prompt is sent
-   * regardless of SystemPrompt.
-   */
-  system_prompt_enabled?: boolean;
-  temperature?: number;
-  top_p?: number;
-}
-
 export interface TypesUpdateUserGuidelinesRequest {
   guidelines?: string;
 }
@@ -6113,6 +6097,22 @@ export interface TypesUserAppAccessResponse {
   can_read?: boolean;
   can_write?: boolean;
   is_admin?: boolean;
+}
+
+export interface TypesUserChatSettings {
+  frequency_penalty?: number;
+  max_tokens?: number;
+  presence_penalty?: number;
+  system_prompt?: string;
+  /**
+   * SystemPromptEnabled toggles whether any system prompt at all is sent
+   * to the model. Pointer so nil means "not set" and we fall back to the
+   * default-on behaviour. When explicitly false, no system prompt is sent
+   * regardless of SystemPrompt.
+   */
+  system_prompt_enabled?: boolean;
+  temperature?: number;
+  top_p?: number;
 }
 
 export interface TypesUserGuidelinesResponse {
@@ -12495,6 +12495,24 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
+     * @description Clears the dead acp_thread_id on the session and resets crashed prompts (those marked by MarkPromptAsCrashed when the Claude Agent process exited) back to pending. The next dispatch sends with empty acp_thread_id, causing Zed to create a fresh thread + Claude Agent process. Requires the session to be an external Zed agent. Returns the count of prompts that were reset.
+     *
+     * @tags Sessions
+     * @name V1SessionsRestartAgentCreate
+     * @summary Restart Zed thread after a Claude Agent crash
+     * @request POST:/api/v1/sessions/{id}/restart-agent
+     * @secure
+     */
+    v1SessionsRestartAgentCreate: (id: string, params: RequestParams = {}) =>
+      this.request<Record<string, any>, SystemHTTPError>({
+        path: `/api/v1/sessions/${id}/restart-agent`,
+        method: "POST",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
      * @description Restarts the external agent container for a session that has been stopped
      *
      * @tags sessions
@@ -13807,6 +13825,44 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
+     * @description Get the current user's default chat settings (applied when chatting without an app)
+     *
+     * @tags Users
+     * @name V1UsersMeChatSettingsList
+     * @summary Get user chat settings
+     * @request GET:/api/v1/users/me/chat-settings
+     * @secure
+     */
+    v1UsersMeChatSettingsList: (params: RequestParams = {}) =>
+      this.request<TypesUserChatSettings, SystemHTTPError>({
+        path: `/api/v1/users/me/chat-settings`,
+        method: "GET",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Update the current user's default chat settings (system prompt + LLM parameters used when chatting without an app)
+     *
+     * @tags Users
+     * @name V1UsersMeChatSettingsUpdate
+     * @summary Update user chat settings
+     * @request PUT:/api/v1/users/me/chat-settings
+     * @secure
+     */
+    v1UsersMeChatSettingsUpdate: (request: TypesUserChatSettings, params: RequestParams = {}) =>
+      this.request<TypesUserChatSettings, SystemHTTPError>({
+        path: `/api/v1/users/me/chat-settings`,
+        method: "PUT",
+        body: request,
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
      * @description Get the current user's personal workspace guidelines
      *
      * @tags Users
@@ -13858,44 +13914,6 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         path: `/api/v1/users/me/guidelines-history`,
         method: "GET",
         secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Get the current user's default chat settings (applied when chatting without an app)
-     *
-     * @tags Users
-     * @name V1UsersMeChatSettingsList
-     * @summary Get user chat settings
-     * @request GET:/api/v1/users/me/chat-settings
-     * @secure
-     */
-    v1UsersMeChatSettingsList: (params: RequestParams = {}) =>
-      this.request<TypesUserChatSettings, SystemHTTPError>({
-        path: `/api/v1/users/me/chat-settings`,
-        method: "GET",
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Update the current user's default chat settings
-     *
-     * @tags Users
-     * @name V1UsersMeChatSettingsUpdate
-     * @summary Update user chat settings
-     * @request PUT:/api/v1/users/me/chat-settings
-     * @secure
-     */
-    v1UsersMeChatSettingsUpdate: (request: TypesUserChatSettings, params: RequestParams = {}) =>
-      this.request<TypesUserChatSettings, SystemHTTPError>({
-        path: `/api/v1/users/me/chat-settings`,
-        method: "PUT",
-        body: request,
-        secure: true,
-        type: ContentType.Json,
         format: "json",
         ...params,
       }),

--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -128,6 +128,8 @@ interface SortableQueueItemProps {
   handleRemoveFromQueue: (id: string) => void
   handleToggleInterrupt: (id: string) => void
   truncateContent: (content: string, maxLen?: number) => string
+  handleRestartAgent: () => void
+  isRestarting: boolean
 }
 
 // Sortable queue item component
@@ -147,6 +149,8 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
   handleRemoveFromQueue,
   handleToggleInterrupt,
   truncateContent,
+  handleRestartAgent,
+  isRestarting,
 }) => {
   const {
     attributes,
@@ -181,9 +185,23 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
     'connection replaced',
     'empty response',
   ]
-  const isTransientFailure = isFailed && !!entry.errorMessage &&
+  // A *crashed* failure is the terminal Claude Agent process death case. The
+  // backend detects these strings in handleThreadLoadError and calls
+  // MarkPromptAsCrashed (pinning next_retry_at far in the future) so the
+  // queue's auto-retry stops. The user has to click Restart to recover —
+  // restart clears ZedThreadID + re-sends, causing Zed to spawn a fresh thread
+  // and Claude Agent process. Detected by error_message marker (authoritative)
+  // rather than nextRetryAt timestamp comparison so the UI reacts immediately
+  // even before the polled prompt sync lands the new next_retry_at value.
+  const crashedErrorMarkers = [
+    'Claude Agent process exited',
+    'Session not found',
+  ]
+  const isCrashed = isFailed && !!entry.errorMessage &&
+    crashedErrorMarkers.some(marker => entry.errorMessage!.includes(marker))
+  const isTransientFailure = !isCrashed && isFailed && !!entry.errorMessage &&
     transientErrorMarkers.some(marker => entry.errorMessage!.includes(marker))
-  const failColor = isTransientFailure ? 'warning.main' : 'error.main'
+  const failColor = isCrashed ? 'error.main' : isTransientFailure ? 'warning.main' : 'error.main'
 
   // Force re-render every second for failed items with retry countdown
   const [, forceUpdate] = useState(0)
@@ -353,8 +371,10 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
           </Box>
           {isFailed && (
             <Box>
-              <Typography variant="caption" sx={{ color: failColor, display: 'block' }}>
-                {entry.nextRetryAt ? (
+              <Typography variant="caption" sx={{ color: failColor, display: 'block', fontWeight: isCrashed ? 600 : 'inherit' }}>
+                {isCrashed ? (
+                  'Agent crashed. Click restart to attempt to recover.'
+                ) : entry.nextRetryAt ? (
                   (() => {
                     const secondsUntilRetry = Math.max(0, Math.ceil((entry.nextRetryAt - Date.now()) / 1000))
                     if (isTransientFailure) {
@@ -370,7 +390,47 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
                   isTransientFailure ? 'Waiting for agent' : 'Failed - will retry'
                 )}
               </Typography>
-              {entry.errorMessage && (
+              {isCrashed && (
+                <Box sx={{ mt: 0.5 }}>
+                  <Box
+                    component="button"
+                    onClick={(e: React.MouseEvent) => {
+                      e.stopPropagation()
+                      handleRestartAgent()
+                    }}
+                    disabled={isRestarting}
+                    sx={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 0.5,
+                      px: 1,
+                      py: 0.25,
+                      border: '1px solid',
+                      borderColor: 'error.main',
+                      borderRadius: 1,
+                      bgcolor: 'transparent',
+                      color: 'error.main',
+                      cursor: isRestarting ? 'wait' : 'pointer',
+                      fontSize: '0.75rem',
+                      fontFamily: 'inherit',
+                      '&:hover': !isRestarting ? {
+                        bgcolor: (theme) => alpha(theme.palette.error.main, 0.08),
+                      } : undefined,
+                      '&:disabled': { opacity: 0.6 },
+                    }}
+                  >
+                    {isRestarting ? (
+                      <>
+                        <CircularProgress size={10} sx={{ color: 'error.main' }} />
+                        Restarting...
+                      </>
+                    ) : (
+                      'Restart'
+                    )}
+                  </Box>
+                </Box>
+              )}
+              {entry.errorMessage && !isCrashed && (
                 <Typography
                   variant="caption"
                   sx={{
@@ -453,6 +513,7 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
   const editTextareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [sendingId, setSendingId] = useState<string | null>(null)
+  const [isRestartingAgent, setIsRestartingAgent] = useState(false)
   // Pending attachments that will be sent with the message
   const [attachments, setAttachments] = useState<PendingAttachment[]>([])
   const [isUploading, setIsUploading] = useState(false)
@@ -634,6 +695,25 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
       updateInterrupt(entryId, entry.interrupt === false)
     }
   }, [failedPrompts, pendingPrompts, updateInterrupt])
+
+  // Restart Zed thread after a Claude Agent crash. Calls the backend endpoint
+  // which clears the dead acp_thread_id and resets crashed prompts back to
+  // pending — the queue then re-dispatches them, Zed creates a fresh thread,
+  // and a new Claude Agent ACP wrapper is spawned. The local queue UI catches
+  // up via the existing prompt-history poll (~1-2s) so we just disable the
+  // button while the request is in flight; we don't optimistically mutate
+  // local state because the backend is the source of truth for prompt status.
+  const handleRestartAgent = useCallback(() => {
+    if (!apiClient || !sessionId || isRestartingAgent) return
+    setIsRestartingAgent(true)
+    apiClient.v1SessionsRestartAgentCreate(sessionId)
+      .catch((err: unknown) => {
+        console.error('Failed to restart agent thread:', err)
+      })
+      .finally(() => {
+        setIsRestartingAgent(false)
+      })
+  }, [apiClient, sessionId, isRestartingAgent])
 
   // Start editing a queued message.
   // To genuinely pause sending, we remove the entry from the backend queue
@@ -1086,6 +1166,8 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
                       handleRemoveFromQueue={handleRemoveFromQueue}
                       handleToggleInterrupt={handleToggleInterrupt}
                       truncateContent={truncateContent}
+                      handleRestartAgent={handleRestartAgent}
+                      isRestarting={isRestartingAgent}
                     />
                   ))}
               </SortableContext>

--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -165,6 +165,26 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
 
   const isFailed = entry.status === 'failed'
 
+  // A transient failure is one we expect to recover from automatically: the
+  // agent is sleeping/booting, the prior turn hasn't drained yet, the WebSocket
+  // is mid-reconnect, etc. The retry will land soon and the message will get
+  // through. These should look like a soft "still working on it" rather than a
+  // hard red error — they're not the user's problem and we don't want them to
+  // act on the warning. Anything else (auth failures, malformed payloads) stays
+  // red so it's visually distinct.
+  const transientErrorMarkers = [
+    'no WebSocket',
+    'no external agent WebSocket',
+    'became busy',
+    'deferring queue prompt',
+    'channel full',
+    'connection replaced',
+    'empty response',
+  ]
+  const isTransientFailure = isFailed && !!entry.errorMessage &&
+    transientErrorMarkers.some(marker => entry.errorMessage!.includes(marker))
+  const failColor = isTransientFailure ? 'warning.main' : 'error.main'
+
   // Force re-render every second for failed items with retry countdown
   const [, forceUpdate] = useState(0)
   useEffect(() => {
@@ -191,7 +211,10 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
           : isEditing
             ? (theme) => alpha(theme.palette.info.main, 0.12)
             : isFailed
-              ? (theme) => alpha(theme.palette.error.main, 0.08)
+              ? (theme) => alpha(
+                  isTransientFailure ? theme.palette.warning.main : theme.palette.error.main,
+                  0.08,
+                )
               : 'transparent',
         transition: 'background-color 0.2s',
         '&:hover': !isEditing && !isSending && !isDragging ? {
@@ -310,7 +333,7 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
-                color: isFailed ? 'error.main' : 'text.primary',
+                color: isFailed ? failColor : 'text.primary',
                 flex: 1,
               }}
             >
@@ -330,23 +353,28 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
           </Box>
           {isFailed && (
             <Box>
-              <Typography variant="caption" sx={{ color: 'error.main', display: 'block' }}>
+              <Typography variant="caption" sx={{ color: failColor, display: 'block' }}>
                 {entry.nextRetryAt ? (
                   (() => {
                     const secondsUntilRetry = Math.max(0, Math.ceil((entry.nextRetryAt - Date.now()) / 1000))
+                    if (isTransientFailure) {
+                      return secondsUntilRetry > 0
+                        ? `Waiting for agent — retrying in ${secondsUntilRetry}s`
+                        : 'Waiting for agent — retrying now...'
+                    }
                     return secondsUntilRetry > 0
                       ? `Failed - retrying in ${secondsUntilRetry}s`
                       : 'Failed - retrying now...'
                   })()
                 ) : (
-                  'Failed - will retry'
+                  isTransientFailure ? 'Waiting for agent' : 'Failed - will retry'
                 )}
               </Typography>
               {entry.errorMessage && (
                 <Typography
                   variant="caption"
                   sx={{
-                    color: 'error.main',
+                    color: failColor,
                     opacity: 0.8,
                     display: 'block',
                     whiteSpace: 'normal',

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -7642,6 +7642,12 @@ definitions:
       billing_enabled:
         description: Charging for usage
         type: boolean
+      default_chat_system_prompt:
+        description: |-
+          DefaultChatSystemPrompt is the system prompt the platform applies to
+          direct model chats when the user has not customised one. Surfaced to
+          the frontend so the chat-settings page can prefill the textbox.
+        type: string
       deployment_id:
         type: string
       disable_llm_call_logging:
@@ -10098,6 +10104,28 @@ definitions:
         type: boolean
       is_admin:
         type: boolean
+    type: object
+  types.UserChatSettings:
+    properties:
+      frequency_penalty:
+        type: number
+      max_tokens:
+        type: integer
+      presence_penalty:
+        type: number
+      system_prompt:
+        type: string
+      system_prompt_enabled:
+        description: |-
+          SystemPromptEnabled toggles whether any system prompt at all is sent
+          to the model. Pointer so nil means "not set" and we fall back to the
+          default-on behaviour. When explicitly false, no system prompt is sent
+          regardless of SystemPrompt.
+        type: boolean
+      temperature:
+        type: number
+      top_p:
+        type: number
     type: object
   types.UserGuidelinesResponse:
     properties:
@@ -18921,6 +18949,53 @@ paths:
       summary: Get streaming connection info for a session
       tags:
       - sessions
+  /api/v1/sessions/{id}/restart-agent:
+    post:
+      description: |-
+        Clears the dead acp_thread_id on the session and resets crashed prompts
+        (those marked by MarkPromptAsCrashed when the Claude Agent process exited)
+        back to pending. The next dispatch sends with empty acp_thread_id, causing
+        Zed to create a fresh thread + Claude Agent process. Requires the session
+        to be an external Zed agent. Returns the count of prompts that were reset.
+      parameters:
+      - description: Session ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Restart Zed thread after a Claude Agent crash
+      tags:
+      - Sessions
   /api/v1/sessions/{id}/resume:
     post:
       description: Restarts the external agent container for a session that has been
@@ -20884,6 +20959,58 @@ paths:
       summary: Get user stats (admin only)
       tags:
       - users
+  /api/v1/users/me/chat-settings:
+    get:
+      description: Get the current user's default chat settings (applied when chatting
+        without an app)
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.UserChatSettings'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get user chat settings
+      tags:
+      - Users
+    put:
+      consumes:
+      - application/json
+      description: Update the current user's default chat settings (system prompt
+        + LLM parameters used when chatting without an app)
+      parameters:
+      - description: Chat settings to persist
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/types.UserChatSettings'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.UserChatSettings'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Update user chat settings
+      tags:
+      - Users
   /api/v1/users/me/guidelines:
     get:
       description: Get the current user's personal workspace guidelines

--- a/openapi.json
+++ b/openapi.json
@@ -16202,6 +16202,94 @@
                 }
             }
         },
+        "/api/v1/sessions/{id}/restart-agent": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Clears the dead acp_thread_id on the session and resets crashed prompts\n(those marked by MarkPromptAsCrashed when the Claude Agent process exited)\nback to pending. The next dispatch sends with empty acp_thread_id, causing\nZed to create a fresh thread + Claude Agent process. Requires the session\nto be an external Zed agent. Returns the count of prompts that were reset.",
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Restart Zed thread after a Claude Agent crash",
+                "parameters": [
+                    {
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/sessions/{id}/resume": {
             "post": {
                 "security": [
@@ -19758,6 +19846,97 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/types.User"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/users/me/chat-settings": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get the current user's default chat settings (applied when chatting without an app)",
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Get user chat settings",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.UserChatSettings"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the current user's default chat settings (system prompt + LLM parameters used when chatting without an app)",
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Update user chat settings",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/types.UserChatSettings"
+                            }
+                        }
+                    },
+                    "description": "Chat settings to persist",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.UserChatSettings"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
                                 }
                             }
                         }
@@ -31569,6 +31748,10 @@
                         "description": "Charging for usage",
                         "type": "boolean"
                     },
+                    "default_chat_system_prompt": {
+                        "description": "DefaultChatSystemPrompt is the system prompt the platform applies to\ndirect model chats when the user has not customised one. Surfaced to\nthe frontend so the chat-settings page can prefill the textbox.",
+                        "type": "string"
+                    },
                     "deployment_id": {
                         "type": "string"
                     },
@@ -34991,6 +35174,33 @@
                     },
                     "is_admin": {
                         "type": "boolean"
+                    }
+                }
+            },
+            "types.UserChatSettings": {
+                "type": "object",
+                "properties": {
+                    "frequency_penalty": {
+                        "type": "number"
+                    },
+                    "max_tokens": {
+                        "type": "integer"
+                    },
+                    "presence_penalty": {
+                        "type": "number"
+                    },
+                    "system_prompt": {
+                        "type": "string"
+                    },
+                    "system_prompt_enabled": {
+                        "description": "SystemPromptEnabled toggles whether any system prompt at all is sent\nto the model. Pointer so nil means \"not set\" and we fall back to the\ndefault-on behaviour. When explicitly false, no system prompt is sent\nregardless of SystemPrompt.",
+                        "type": "boolean"
+                    },
+                    "temperature": {
+                        "type": "number"
+                    },
+                    "top_p": {
+                        "type": "number"
                     }
                 }
             },

--- a/swagger.json
+++ b/swagger.json
@@ -13346,6 +13346,71 @@
                 }
             }
         },
+        "/api/v1/sessions/{id}/restart-agent": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Clears the dead acp_thread_id on the session and resets crashed prompts\n(those marked by MarkPromptAsCrashed when the Claude Agent process exited)\nback to pending. The next dispatch sends with empty acp_thread_id, causing\nZed to create a fresh thread + Claude Agent process. Requires the session\nto be an external Zed agent. Returns the count of prompts that were reset.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Restart Zed thread after a Claude Agent crash",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/sessions/{id}/resume": {
             "post": {
                 "security": [
@@ -16282,6 +16347,86 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/types.User"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/users/me/chat-settings": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get the current user's default chat settings (applied when chatting without an app)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Get user chat settings",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.UserChatSettings"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update the current user's default chat settings (system prompt + LLM parameters used when chatting without an app)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Update user chat settings",
+                "parameters": [
+                    {
+                        "description": "Chat settings to persist",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.UserChatSettings"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.UserChatSettings"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
                         }
                     }
                 }
@@ -27907,6 +28052,10 @@
                     "description": "Charging for usage",
                     "type": "boolean"
                 },
+                "default_chat_system_prompt": {
+                    "description": "DefaultChatSystemPrompt is the system prompt the platform applies to\ndirect model chats when the user has not customised one. Surfaced to\nthe frontend so the chat-settings page can prefill the textbox.",
+                    "type": "string"
+                },
                 "deployment_id": {
                     "type": "string"
                 },
@@ -31329,6 +31478,33 @@
                 },
                 "is_admin": {
                     "type": "boolean"
+                }
+            }
+        },
+        "types.UserChatSettings": {
+            "type": "object",
+            "properties": {
+                "frequency_penalty": {
+                    "type": "number"
+                },
+                "max_tokens": {
+                    "type": "integer"
+                },
+                "presence_penalty": {
+                    "type": "number"
+                },
+                "system_prompt": {
+                    "type": "string"
+                },
+                "system_prompt_enabled": {
+                    "description": "SystemPromptEnabled toggles whether any system prompt at all is sent\nto the model. Pointer so nil means \"not set\" and we fall back to the\ndefault-on behaviour. When explicitly false, no system prompt is sent\nregardless of SystemPrompt.",
+                    "type": "boolean"
+                },
+                "temperature": {
+                    "type": "number"
+                },
+                "top_p": {
+                    "type": "number"
                 }
             }
         },


### PR DESCRIPTION
## Summary

Three independent bugs that all show up to the user the same way — the spec-task queue or chat looking stuck, errors appearing where the message actually got through, or the current turn appearing "done" mid-stream. Backends roots are unrelated, so each is a separate commit. Test plan at the bottom.

---

### Bug 1 — \"no WebSocket\" + \"became busy\" false failures (commit `acdcd166a`)

When a queued message went to a sleeping spec-task agent the user saw two misleading red errors back-to-back, even though the message reached Zed exactly once:

1. \`no WebSocket connection found for session ...\`
2. \`session ... became busy (interaction ... is Waiting), deferring queue prompt\`

\`sendQueuedPromptToSession\` only registered \`interactionToPromptMapping[I1] = P1\` on a *successful* dispatch, so the no-WS failure path orphaned the prompt from its persisted Waiting interaction. The auto-retry then collided with \`pickupWaitingInteraction\`'s in-flight delivery and produced the second false \"busy\" error.

**Fix:**
- Added \`ErrNoExternalAgentWS\` sentinel; the no-WS path returns it via \`fmt.Errorf(\"...: %w\", ...)\` so callers can recognise it via \`errors.Is\`.
- Set \`interactionToPromptMapping[I1.ID] = P1.ID\` **before** the dispatch attempt so the link survives a no-WS failure.
- No-WS dispatch returns \`nil\` without marking the prompt failed and **keeps** all three mappings intact. The prompt stays in \`'sending'\` (UI shows the spinner), \`pickupWaitingInteraction\` delivers \`I1\` on reconnect, and \`handleMessageAdded\` marks the prompt \`'sent'\` via the preserved mapping.
- Real dispatch failures (channel-full, connection-replaced) still mark the prompt failed and tear down mappings for retry.
- Busy re-check now reverse-looks up \`interactionToPromptMapping[latestWaitingInteraction.ID]\` — if it matches the current prompt, the message is already in flight, so we return \`nil\` instead of \"became busy\".

**Frontend:** failures whose \`error_message\` matches a transient marker (\`no WebSocket\`, \`became busy\`, \`channel full\`, \`connection replaced\`, \`empty response\`, \`deferring queue prompt\`) render in \`warning.main\` amber as \"Waiting for agent — retrying in Ns\" instead of red \"Failed - retrying in Ns\". Hard errors (auth, malformed payload) stay red.

---

### Bug 2 — Claude Agent crash → infinite \"Session not found\" retry loop (commit `343875c09`)

A spec-task chat would loop forever showing red errors like \`Thread load failed: Failed to send follow-up: Session not found\`. The WebSocket to Zed was healthy and Zed received every retried message — but Zed's THREAD_SERVICE could not deliver to its dead Claude Agent ACP wrapper child, so it bounced each one with \`thread_load_error\`. Once the wrapper is gone, no retry against the same \`acp_thread_id\` will ever succeed.

**Fix:**
- Added \`isAgentCrashError()\` — substring-matches \"Claude Agent process exited\" / \"Session not found\" in thread_load_error messages.
- New \`Store.MarkPromptAsCrashed\` sets \`next_retry_at\` to a far-future sentinel (year 9999) so \`GetNextPendingPrompt\`'s retry selector permanently skips the row. Reuses \`'failed'\` status to keep the migration delta zero.
- New \`Store.ResetCrashedPromptsForSession\` undoes the sentinel for every crashed prompt in a session in one update.
- New endpoint **\`POST /api/v1/sessions/{id}/restart-agent\`** clears \`Metadata.ZedThreadID\`, resets crashed prompts, and kicks the queue. Next \`chat_message\` dispatch goes out with empty \`acp_thread_id\` → Zed creates a fresh thread + spawns a new Claude Agent wrapper.

**Frontend:** crashed items render **\"Agent crashed. Click restart to attempt to recover.\"** in red with a **Restart** button (no countdown, no raw error string — user can't act on it). Restart calls the new endpoint and shows a spinner until it settles; local state catches up via the existing 1–2 s prompt-history poll.

**Out of scope** (follow-up work):
- Cleaning up the zombie dead thread in Zed's UI (needs a delete-thread RPC we don't have today).
- Zed-side automatic respawn of the wrapper. Proper fix lives in \`crates/external_websocket_sync\` — the Helix-side circuit-breaker here is the quick win that stops the noisy retry loop today.

---

### Bug 3 — Stale `request_id` rebind silently misroutes Zed's mid-stream completions (commit `307cc5bbe`)

Long-running chat would show updates \"stuck\": the current turn's interaction prematurely transitioned to Complete in the UI mid-stream, the spinner stopped and the chat composer un-greyed even though the agent was still working, then the next turn would pull a fresh state and things appeared to re-sync. User-visible symptom: \"Zed is pushing out updates and Helix is failing to receive them.\" In reality Helix received every event but mis-routed the completions.

**Root cause** (full evidence + timeline in `design/2026-04-28-stale-request-id-rebind-loses-zed-updates.md`):

`requestToInteractionMapping` is the authoritative router for `message_completed → interaction`. `handleMessageCompleted` consumes the mapping after first use by setting it to `\"\"` (a sentinel checked by the dedup branch).

`getOrCreateStreamingContext` at `websocket_external_agent_sync.go:1594` was unconditionally rebinding the mapping for any \"Zed-initiated message\" whose interaction differed from the expected one. But `expectedInteractionID` came from a single-value lookup that returns `\"\"` for **both** \"no entry\" and \"consumed entry\" — so the rebind couldn't tell them apart and clobbered the consumed sentinel.

The wrapper inside Zed buffers events that aren't direct ACP responses (background bash, hooks, subagent completions, MCP `tools/list_changed`, etc. — documented in `auto_wake_stuck_interactions.go`) and flushes them later tagged with the **last** `request_id` it saw. With the sentinel clobbered, every flushed `message_completed` matched the freshly-bound (unrelated) Waiting interaction and ran the full completion path on it.

For `ses_01kq8cnnkmww35bacpscbrehn0`, the same `req_eead10e3-d5b8-40a4-a75c-5f0ed91e3c9f` (originally a comment dispatch at 07:48:09) ended up triggering \"Marked interaction as complete\" on **four different mid-stream interactions** over 17 minutes.

**Fix:** two-value lookup in the rebind. Three branches:
- `!alreadySeen` → first sight, register as before (genuine Zed-initiated user-typed message).
- `alreadySeen && existing == \"\"` → consumed sentinel, leave intact so dedup drops the stale completion. Streaming tokens still reach the current Waiting interaction via the existing most-recent-Waiting fallback, so no content is lost — only the misrouted completion is dropped.
- `existing != newInteractionID` (live) → cross-turn rebind, same as before (user sent a follow-up while previous turn was running).

---

## Test plan

- [x] `CGO_ENABLED=1 go test -count=1 ./api/pkg/server/` — green (3 existing tests updated, 8 new regression tests added across all three bugs).
- [x] `yarn build` in `frontend/` — clean.
- [x] CI: Drone build [#985](https://drone.lukemarsden.net/helixml/helix/985) **passing**.
- [ ] **Bug 1 manual:** on a project with a sleeping spec task, send a message via the queue. Expected: queue item shows the spinner, then transitions to `'sent'` once Zed acknowledges. No red errors, no duplicate messages.
- [ ] **Bug 1 manual:** while one prompt is mid-flight, queue a second prompt. Expected: second prompt waits in queue, gets delivered after the first completes (cross-prompt busy-defer still works).
- [ ] **Bug 2 manual:** kill the Claude Agent process inside the desktop container while a chat is mid-turn (e.g. `docker exec ... pkill -f claude-agent-acp`), send a message. Expected: red \"Agent crashed. Click restart to attempt to recover.\" with a Restart button. Click Restart — message goes through on the new thread.
- [ ] **Bug 3 manual:** dispatch a design review comment on a long-running spec task, wait for the comment turn to complete, then trigger more agent activity (Zed user-typed message or background subagent completion). Expected: new turn streams through to its real completion without spurious \"Marked interaction as complete\" log lines, and the UI doesn't prematurely un-grey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)