### PR TITLE
fix(release): make rollback fail loudly when chart cleanup is impossible

### DIFF
--- a/scripts/release-rollback.sh
+++ b/scripts/release-rollback.sh
@@ -83,8 +83,9 @@ rollback_helm_charts() {
   if [ -z "${GCS_SERVICE_ACCOUNT_KEY:-}" ]; then
     # Fall back to ambient credentials (e.g. developer's local gcloud auth)
     if ! gsutil ls "$GCS_BUCKET" >/dev/null 2>&1; then
-      warn "No GCS credentials available, skipping helm chart cleanup"
-      return 0
+      echo "[rollback] ERROR: No GCS credentials available, cannot clean up helm charts" >&2
+      echo "[rollback] ERROR: Set the gcs_service_account_key Drone secret so failed releases don't leak orphan charts to $GCS_BUCKET" >&2
+      return 1
     fi
   else
     echo "$GCS_SERVICE_ACCOUNT_KEY" | base64 -d > /tmp/gcs-key.json
@@ -227,12 +228,17 @@ send_slack_notification() {
 log "Starting release rollback for $VERSION"
 log "============================================"
 
-rollback_github_release || warn "GitHub release cleanup encountered errors"
-rollback_git_tag        || warn "Git tag cleanup encountered errors"
-rollback_helm_charts    || warn "Helm chart cleanup encountered errors"
-rollback_r2_assets      || warn "R2 asset cleanup encountered errors"
-rollback_latest_json    || warn "latest.json revert encountered errors"
+FAILED=0
+rollback_github_release || { warn "GitHub release cleanup encountered errors"; FAILED=1; }
+rollback_git_tag        || { warn "Git tag cleanup encountered errors"; FAILED=1; }
+rollback_helm_charts    || { warn "Helm chart cleanup encountered errors"; FAILED=1; }
+rollback_r2_assets      || { warn "R2 asset cleanup encountered errors"; FAILED=1; }
+rollback_latest_json    || { warn "latest.json revert encountered errors"; FAILED=1; }
 send_slack_notification || warn "Slack notification encountered errors"
 
 log "============================================"
+if [ "$FAILED" -ne 0 ]; then
+  log "Release rollback for $VERSION FAILED - manual cleanup required"
+  exit 1
+fi
 log "Release rollback for $VERSION complete"


### PR DESCRIPTION
## Summary

- `rollback_helm_charts` now returns `1` with a clear error message naming the missing `gcs_service_account_key` Drone secret instead of warning and returning `0`.
- The main flow tracks per-step failures and exits non-zero if any cleanup actually failed, so a missing credential surfaces as a red `release-rollback` stage in Drone rather than a green build with leaked artifacts. Slack notification stays best-effort.

## Why

Build https://drone.lukemarsden.net/helixml/helix/803 (tag `2.10.1`) failed because of a transient sr.ht GnuTLS error in `build-sandbox-amd64`. The `release-rollback` stage ran, but its log shows:

```
[rollback] GitHub release 2.10.1 deleted
[rollback] Remote git tag 2.10.1 deleted
[rollback] WARNING: No GCS credentials available, skipping helm chart cleanup
[rollback] Deleted DMG: desktop/2.10.1/Helix-for-Mac.dmg
[rollback] Deleted VM assets: vm/2.10.1/
[rollback] Release rollback for 2.10.1 complete
```

`gcs_service_account_key` was never configured as a Drone secret on `helixml/helix`, so the rollback warned and returned 0. Result: `helix-controlplane-2.10.1.tgz` and `helix-runner-2.10.1.tgz` are still published at https://charts.helixml.tech/ pointing at `ghcr.io/helixml/controlplane:2.10.1`, which doesn't exist. Two users have hit `ImagePullBackOff` from `helm install`.

This change ensures the next time we hit the same gap, the rollback step is red in Drone and someone investigates instead of trusting a "successful" rollback.

The companion fixes (populate the secret, clean up the leaked 2.10.1 chart) are tracked separately.

## Test plan

- [x] `bash -n scripts/release-rollback.sh` (syntax)
- [ ] Drone run on this PR is green (only lint/test stages should run; the rollback path itself only triggers on failed tag builds)
- [ ] After merge + secret population, intentionally fail a test tag build in a non-prod context to confirm the rollback either succeeds or fails red

🤖 Generated with [Claude Code](https://claude.com/claude-code)