### PR TITLE
Hide secrets and keys in the UI

### DIFF
--- a/frontend/src/components/app/APIKeysSection.tsx
+++ b/frontend/src/components/app/APIKeysSection.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC } from 'react';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
@@ -8,11 +8,11 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
-import { Copy, Check, Trash2, Plus } from 'lucide-react';
+import { Trash2, Plus } from 'lucide-react';
 
+import MaskedSecret from '../widgets/MaskedSecret';
 import { IApiKey } from '../../types';
 
 interface APIKeysSectionProps {
@@ -23,33 +23,6 @@ interface APIKeysSectionProps {
   setAllowedDomains: (domains: string[]) => void;
   isReadOnly: boolean;
 }
-
-function maskKey(key: string): string {
-  if (key.length <= 8) return key;
-  return key.slice(0, 5) + '...' + key.slice(-3);
-}
-
-const CopyKeyButton: FC<{ apiKey: string }> = ({ apiKey }) => {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(apiKey);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy:', err);
-    }
-  };
-
-  return (
-    <Tooltip title={copied ? 'Copied!' : 'Copy API key'}>
-      <IconButton size="small" onClick={handleCopy}>
-        {copied ? <Check size={16} /> : <Copy size={16} />}
-      </IconButton>
-    </Tooltip>
-  );
-};
 
 const APIKeysSection: React.FC<APIKeysSectionProps> = ({
   apiKeys,
@@ -101,15 +74,7 @@ const APIKeysSection: React.FC<APIKeysSectionProps> = ({
               apiKeys.map((apiKey) => (
                 <TableRow key={apiKey.key} hover>
                   <TableCell>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      <Chip
-                        label={maskKey(apiKey.key)}
-                        size="small"
-                        variant="outlined"
-                        sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}
-                      />
-                      <CopyKeyButton apiKey={apiKey.key} />
-                    </Box>
+                    <MaskedSecret value={apiKey.key} ariaLabel="API key" />
                   </TableCell>
                   <TableCell align="right">
                     <Tooltip title="Delete API Key">

--- a/frontend/src/components/app/CodeExamples.tsx
+++ b/frontend/src/components/app/CodeExamples.tsx
@@ -1,11 +1,13 @@
-import React, { FC, useState, memo } from 'react';
+import React, { FC, useState, useEffect, useRef, useCallback, memo } from 'react';
 import Box from '@mui/material/Box';
 import Tab from '@mui/material/Tab';
 import Grid from '@mui/material/Grid';
 import Tabs from '@mui/material/Tabs';
-import Typography from '@mui/material/Typography';
+import Tooltip from '@mui/material/Tooltip';
 import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { Eye, EyeOff } from 'lucide-react';
 import { CODE_EXAMPLES } from '../../data/codeExamples';
 import { Prism as SyntaxHighlighterPrism } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
@@ -16,11 +18,47 @@ interface CodeExamplesProps {
 
 const SyntaxHighlighter = SyntaxHighlighterPrism as unknown as React.FC<any>;
 
+const MASKED_KEY_PLACEHOLDER = 'hl-••••••••';
+const AUTO_HIDE_MS = 30_000;
+
 const CodeExamples: FC<CodeExamplesProps> = ({ apiKey }) => {
   const [selectedTab, setSelectedTab] = useState(0);
+  const [showKey, setShowKey] = useState(false);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearHideTimer = useCallback(() => {
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+  }, []);
+
+  // Auto-hide after 30s
+  useEffect(() => {
+    if (!showKey) return;
+    hideTimerRef.current = setTimeout(() => {
+      setShowKey(false);
+      hideTimerRef.current = null;
+    }, AUTO_HIDE_MS);
+    return clearHideTimer;
+  }, [showKey, clearHideTimer]);
+
+  // Hide on tab/window blur
+  useEffect(() => {
+    if (!showKey) return;
+    const onVisibility = () => {
+      if (document.visibilityState === 'hidden') {
+        setShowKey(false);
+        clearHideTimer();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, [showKey, clearHideTimer]);
 
   const address = window.location.origin;
 
+  // Always copy with the real key, regardless of reveal state
   const handleCopyCode = async () => {
     try {
       await navigator.clipboard.writeText(CODE_EXAMPLES[selectedTab].code(address, apiKey));
@@ -28,6 +66,8 @@ const CodeExamples: FC<CodeExamplesProps> = ({ apiKey }) => {
       console.error('Failed to copy code:', err);
     }
   };
+
+  const displayKey = showKey ? apiKey : MASKED_KEY_PLACEHOLDER;
 
   return (
     <Grid item xs={12} md={6}>
@@ -53,16 +93,41 @@ const CodeExamples: FC<CodeExamplesProps> = ({ apiKey }) => {
           >
             {selectedTab === index && (
               <>
-                <Box sx={{ position: 'absolute', right: 2, top: 2, zIndex: 1 }}>
+                <Box
+                  sx={{
+                    position: 'absolute',
+                    right: 2,
+                    top: 2,
+                    zIndex: 1,
+                    display: 'flex',
+                    gap: 0.5,
+                    alignItems: 'center',
+                  }}
+                >
+                  <Tooltip title={showKey ? 'Hide key in code' : 'Show key in code'}>
+                    <IconButton
+                      size="small"
+                      onClick={() => setShowKey((prev) => !prev)}
+                      aria-label={showKey ? 'Hide API key in code examples' : 'Show API key in code examples'}
+                      sx={{
+                        color: '#F8FAFC',
+                        backgroundColor: 'rgba(0, 0, 0, 0.6)',
+                        '&:hover': { backgroundColor: 'rgba(0, 0, 0, 0.8)' },
+                      }}
+                    >
+                      {showKey ? <EyeOff size={16} /> : <Eye size={16} />}
+                    </IconButton>
+                  </Tooltip>
                   <Button
                     size="small"
                     onClick={handleCopyCode}
                     startIcon={<ContentCopyIcon />}
                     sx={{
+                      color: '#F8FAFC',
                       backgroundColor: 'rgba(0, 0, 0, 0.6)',
                       '&:hover': {
                         backgroundColor: 'rgba(0, 0, 0, 0.8)',
-                      }
+                      },
                     }}
                   >
                     Copy
@@ -76,7 +141,7 @@ const CodeExamples: FC<CodeExamplesProps> = ({ apiKey }) => {
                     borderRadius: '4px',
                   }}
                 >
-                  {example.code(address, apiKey)}
+                  {example.code(address, displayKey)}
                 </SyntaxHighlighter>
               </>
             )}
@@ -87,4 +152,4 @@ const CodeExamples: FC<CodeExamplesProps> = ({ apiKey }) => {
   );
 };
 
-export default memo(CodeExamples); 
+export default memo(CodeExamples);

--- a/frontend/src/components/widgets/MaskedSecret.tsx
+++ b/frontend/src/components/widgets/MaskedSecret.tsx
@@ -1,0 +1,155 @@
+import React, { FC, useCallback, useEffect, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import { Copy, Check, Eye, EyeOff } from 'lucide-react';
+
+const MASK = '•'.repeat(16); // 16 bullets, fixed width — does not encode key length
+const DEFAULT_AUTO_HIDE_MS = 30_000;
+
+const PALETTE = {
+  text: '#F8FAFC',
+  border: '#4A5568',
+  borderHover: '#718096',
+  borderFocus: '#3182CE',
+  iconMuted: '#A0AEC0',
+};
+
+export interface MaskedSecretProps {
+  value: string;
+  monospace?: boolean;
+  copyable?: boolean;
+  revealable?: boolean;
+  autoHideMs?: number;
+  ariaLabel?: string;
+}
+
+const MaskedSecret: FC<MaskedSecretProps> = ({
+  value,
+  monospace = true,
+  copyable = true,
+  revealable = true,
+  autoHideMs = DEFAULT_AUTO_HIDE_MS,
+  ariaLabel = 'Secret value',
+}) => {
+  const [revealed, setRevealed] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearHideTimer = useCallback(() => {
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+  }, []);
+
+  const hide = useCallback(() => {
+    clearHideTimer();
+    setRevealed(false);
+  }, [clearHideTimer]);
+
+  // Auto-hide after timeout when revealed
+  useEffect(() => {
+    if (!revealed || autoHideMs <= 0) return;
+    hideTimerRef.current = setTimeout(() => {
+      setRevealed(false);
+      hideTimerRef.current = null;
+    }, autoHideMs);
+    return clearHideTimer;
+  }, [revealed, autoHideMs, clearHideTimer]);
+
+  // Hide immediately when the tab is hidden / window loses focus
+  useEffect(() => {
+    if (!revealed) return;
+    const onVisibility = () => {
+      if (document.visibilityState === 'hidden') {
+        hide();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, [revealed, hide]);
+
+  const handleToggleReveal = () => {
+    setRevealed((prev) => !prev);
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  };
+
+  const display = revealed ? value : MASK;
+
+  return (
+    <Box
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 0.5,
+        px: 1,
+        py: 0.25,
+        borderRadius: 1,
+        border: `1px solid ${PALETTE.border}`,
+        backgroundColor: 'transparent',
+        color: PALETTE.text,
+        '&:hover': { borderColor: PALETTE.borderHover },
+        '&:focus-within': { borderColor: PALETTE.borderFocus },
+      }}
+    >
+      <Box
+        component="span"
+        aria-label={ariaLabel}
+        sx={{
+          fontFamily: monospace ? 'monospace' : undefined,
+          fontSize: '0.8rem',
+          color: PALETTE.text,
+          userSelect: revealed ? 'text' : 'none',
+          maxWidth: 320,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          px: 0.5,
+          flexShrink: 1,
+          minWidth: 0,
+        }}
+        title={revealed ? value : undefined}
+      >
+        {display}
+      </Box>
+
+      {revealable && (
+        <Tooltip title={revealed ? 'Hide' : 'Reveal'}>
+          <IconButton
+            size="small"
+            onClick={handleToggleReveal}
+            sx={{ color: PALETTE.iconMuted, '&:hover': { color: PALETTE.text } }}
+            aria-label={revealed ? 'Hide secret' : 'Reveal secret'}
+          >
+            {revealed ? <EyeOff size={16} /> : <Eye size={16} />}
+          </IconButton>
+        </Tooltip>
+      )}
+
+      {copyable && (
+        <Tooltip title={copied ? 'Copied!' : 'Copy'}>
+          <IconButton
+            size="small"
+            onClick={handleCopy}
+            sx={{ color: PALETTE.iconMuted, '&:hover': { color: PALETTE.text } }}
+            aria-label="Copy secret"
+          >
+            {copied ? <Check size={16} /> : <Copy size={16} />}
+          </IconButton>
+        </Tooltip>
+      )}
+    </Box>
+  );
+};
+
+export default MaskedSecret;


### PR DESCRIPTION
## Summary

The agent settings "Keys" tab was rendering API keys in plain text — visually
masked in the table (`xxxxx...xxx`) but the **full key was rendered inline in
the cURL / Python / Go / JS code examples** in the right-hand panel. This PR
hides keys by default everywhere they appear on that tab, with an explicit
reveal toggle and auto-hide on tab blur or after 30 s.

## Changes

- **New widget `frontend/src/components/widgets/MaskedSecret.tsx`** — fixed-length
  bullet mask, eye-icon reveal toggle, copy button, 30 s auto-hide, hide
  immediately when the tab loses focus. Styled explicitly for dark mode (text
  `#F8FAFC` / border `#4A5568` / focused border `#3182CE`) so it doesn't depend
  on the missing global MUI theme overrides.
- **`frontend/src/components/app/APIKeysSection.tsx`** — replaced the
  `Chip` + `CopyKeyButton` group (which leaked first 5 + last 3 chars of every
  key) with `<MaskedSecret value={apiKey.key} />`.
- **`frontend/src/components/app/CodeExamples.tsx`** — added a "Show / hide
  key in code" toggle. By default the rendered snippet shows
  `"hl-••••••••"`, but the COPY button always writes the snippet with the
  real key. Same 30 s + visibility-blur auto-hide rule.

## Audit notes

The original design also called out
`frontend/src/components/settings/OAuthSettings.tsx` (RSA private key field).
During implementation I discovered that file is dead code — zero imports
across the codebase, last touched in two `wip` commits. The live OAuth
provider admin (`frontend/src/components/dashboard/OAuthProvidersTable.tsx`)
has no private key field at all and already uses `type="password"` for
`client_secret`. So no change is needed there. Other audited locations
(`Account.tsx`, `Secrets.tsx`, `AddProviderDialog.tsx`, `GitRepoDetail.tsx`)
were already masking correctly and are unchanged.

## Testing

- `yarn build` (in `helix-frontend` container) — passes, no type errors.
- Manual end-to-end in the inner Helix:
  - Registered, created an org and an agent, opened the Keys tab.
  - Default state: key shows as `••••••••••••••••`; copy works.
  - Click eye → key revealed; click again → re-hidden; auto-hides after 30 s.
  - Code examples panel: default `"hl-••••••••"`; COPY copies the real key
    regardless; "Show key in code" toggle reveals.
  - Dark theme verified — no white form elements.

## Screenshots

![Keys tab — masked by default](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001951_there-are-a-few-places/screenshots/01-keys-tab-masked-default.png)

![Keys tab — key revealed](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001951_there-are-a-few-places/screenshots/02-keys-tab-revealed.png)

![Code example — key revealed in snippet](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001951_there-are-a-few-places/screenshots/03-code-example-revealed.png)

## Out of scope (follow-ups)

- Backend hardening: `GET /apps/:id/api_keys` still returns the full key
  string. Industry standard (GitHub / Stripe / AWS) is to return the key once
  on creation and never again. That's a breaking API change with downstream
  impact (CLI, generated SDK) — separate task.
- Deleting the dead `OAuthSettings.tsx` file — separate cleanup task.

Design doc: `/design/tasks/001951_there-are-a-few-places/`

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kq7besac1k70mh4vmzqtq4ab)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001951_there-are-a-few-places/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001951_there-are-a-few-places/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001951_there-are-a-few-places/tasks.md)

🚀 Built with [Helix](https://helix.ml)