### PR TITLE
Fix 404 on "Continue reading" link in cron-trigger emails

### DIFF
--- a/api/pkg/notification/notification_email.go
+++ b/api/pkg/notification/notification_email.go
@@ -163,7 +163,7 @@ func (e *Email) getEmailMessage(n *Notification) (title, message string, err err
 
 		err = cronTriggerCompleteTmpl.Execute(&buf, &templateData{
 			Message:     template.HTML(n.Message),
-			SessionURL:  fmt.Sprintf("%s/session/%s", e.cfg.AppURL, n.Session.ID),
+			SessionURL:  fmt.Sprintf("%s/orgs/%s/session/%s", e.cfg.AppURL, n.Session.OrganizationID, n.Session.ID),
 			SessionName: n.Session.Name,
 		})
 		if err != nil {
@@ -176,7 +176,7 @@ func (e *Email) getEmailMessage(n *Notification) (title, message string, err err
 
 		err = cronTriggerFailedTmpl.Execute(&buf, &templateData{
 			Message:      template.HTML(n.Message),
-			SessionURL:   fmt.Sprintf("%s/session/%s", e.cfg.AppURL, n.Session.ID),
+			SessionURL:   fmt.Sprintf("%s/orgs/%s/session/%s", e.cfg.AppURL, n.Session.OrganizationID, n.Session.ID),
 			SessionName:  n.Session.Name,
 			ErrorMessage: n.Message,
 		})

--- a/api/pkg/notification/notification_email_test.go
+++ b/api/pkg/notification/notification_email_test.go
@@ -21,8 +21,9 @@ func Test_getEmailMessage_CronTriggerComplete(t *testing.T) {
 	title, message, err := notifier.getEmailMessage(&Notification{
 		Event: types.EventCronTriggerComplete,
 		Session: &types.Session{
-			ID:   "123",
-			Name: "Test Session",
+			ID:             "123",
+			Name:           "Test Session",
+			OrganizationID: "org_abc",
 		},
 		Message: "Test Message",
 	})
@@ -34,8 +35,9 @@ func Test_getEmailMessage_CronTriggerComplete(t *testing.T) {
 	// Check that message contains expected content
 	require.NotEmpty(t, message)
 
-	// Check that message contains the session URL
-	expectedURL := "https://app.helix.ai/session/123"
+	// Check that message contains the org-scoped session URL (frontend has no
+	// root /session/:id route — only /orgs/:org_id/session/:session_id).
+	expectedURL := "https://app.helix.ai/orgs/org_abc/session/123"
 	require.Contains(t, message, expectedURL, "expected message to contain URL '%s', but it doesn't", expectedURL)
 
 	// Check that message contains the session name
@@ -117,8 +119,9 @@ func Test_getEmailMessage_CronTriggerFailed(t *testing.T) {
 	title, message, err := notifier.getEmailMessage(&Notification{
 		Event: types.EventCronTriggerFailed,
 		Session: &types.Session{
-			ID:   "456",
-			Name: "Failed Session",
+			ID:             "456",
+			Name:           "Failed Session",
+			OrganizationID: "org_xyz",
 		},
 		Message: "Task failed due to error",
 	})
@@ -131,8 +134,8 @@ func Test_getEmailMessage_CronTriggerFailed(t *testing.T) {
 	// Check that message contains expected content
 	require.NotEmpty(t, message)
 
-	// Check that message contains the session URL
-	expectedURL := "https://app.helix.ai/session/456"
+	// Check that message contains the org-scoped session URL.
+	expectedURL := "https://app.helix.ai/orgs/org_xyz/session/456"
 	require.Contains(t, message, expectedURL, "expected message to contain URL '%s', but it doesn't", expectedURL)
 
 	// Check that message contains the test message


### PR DESCRIPTION
## Summary

Cron-trigger notification emails (e.g. the "Daily Weather Update" task) built
the "Continue reading" link as `<AppURL>/session/<session_id>`. The frontend
router only defines org-scoped session routes
(`/orgs/:org_id/session/:session_id` — `frontend/src/router.tsx:290`), so every
recipient hit a 404 even when logged in with org access.

`Session.OrganizationID` is already populated by the cron trigger
(`api/pkg/trigger/trigger_cron.go:473`); the email builder just wasn't using
it. Both the API org-resolver
(`api/pkg/server/organization_handlers.go:201`) and the frontend (e.g.
`frontend/src/components/tasks/ExecutionsHistory.tsx:94`) accept either the
`org_xxx` ID or the org name in that URL slot, so passing the ID directly works
without an extra DB lookup.

## Changes

- `api/pkg/notification/notification_email.go`: build `SessionURL` as
  `<AppURL>/orgs/<OrganizationID>/session/<SessionID>` for both
  `EventCronTriggerComplete` and `EventCronTriggerFailed`. No fallback path —
  cron triggers always set `OrganizationID`; if that ever fails, the resulting
  404 surfaces the upstream bug rather than masking it.
- `api/pkg/notification/notification_email_test.go`: updated existing tests for
  both events to set `OrganizationID` and assert the new URL shape.

## Out of Scope / Follow-up

Personal (non-org) sessions still have no frontend route. Fixing that requires
a router change (add `/session/:id` and bootstrap `Session.tsx` without an
`org_id` param) and is left as a separate task.

## Test Plan

- [x] `go build ./pkg/notification/...`
- [x] `go test -v -run Test_getEmailMessage ./pkg/notification/...` (4/4 pass)
- [ ] End-to-end manual click-through deferred — see design doc Test Plan;
      change is fully covered by the unit test plus router inspection.

Spec: `design/tasks/001953_fix-bug-continue-reading/` on the `helix-specs` branch.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kq7gz4hm2cdphrzs7fsby8kh)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001953_fix-bug-continue-reading/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001953_fix-bug-continue-reading/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001953_fix-bug-continue-reading/tasks.md)

🚀 Built with [Helix](https://helix.ml)