### PR TITLE
fix(agent): detect image media type before sending to LLM

### DIFF
--- a/api/pkg/agent/skill/knowledge_skill.go
+++ b/api/pkg/agent/skill/knowledge_skill.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -181,7 +182,11 @@ func renderPageImages(ctx context.Context, renderer rag.PageImageRenderer, dataE
 				Msg("failed to render page image, skipping")
 			continue
 		}
-		dataURI := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(imgBytes)
+		// Detect the actual media type from the image bytes; the page renderer
+		// may return PNG, JPEG, WebP or GIF, and Anthropic 400s if the declared
+		// type doesn't match the magic bytes.
+		mediaType := http.DetectContentType(imgBytes)
+		dataURI := fmt.Sprintf("data:%s;base64,%s", mediaType, base64.StdEncoding.EncodeToString(imgBytes))
 		parts = append(parts, openai.ChatMessagePart{
 			Type: openai.ChatMessagePartTypeText,
 			Text: fmt.Sprintf("Page %d of %s (document_id: %s):", page, result.Source, result.DocumentID),

--- a/api/pkg/server/kodit_handlers.go
+++ b/api/pkg/server/kodit_handlers.go
@@ -1112,16 +1112,16 @@ func (apiServer *HelixAPIServer) pageImageRepository(w http.ResponseWriter, r *h
 		return
 	}
 
-	pngBytes, err := apiServer.koditService.RenderPageImage(r.Context(), koditRepoID, filePath, page)
+	imgBytes, err := apiServer.koditService.RenderPageImage(r.Context(), koditRepoID, filePath, page)
 	if err != nil {
 		handleKoditError(w, err, "Failed to render page image")
 		return
 	}
 
-	w.Header().Set("Content-Type", "image/png")
+	w.Header().Set("Content-Type", "image/jpeg")
 	w.Header().Set("Cache-Control", "public, max-age=3600")
 	w.WriteHeader(http.StatusOK)
-	w.Write(pngBytes)
+	w.Write(imgBytes)
 }
 
 // grepRepository runs git grep against a repository

--- a/api/pkg/services/kodit_service.go
+++ b/api/pkg/services/kodit_service.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"image/png"
+	"image/jpeg"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -947,7 +947,7 @@ func (s *KoditService) resolveFileResults(ctx context.Context, enrichments []enr
 	return results, nil
 }
 
-// RenderPageImage rasterizes a document page and returns the PNG bytes.
+// RenderPageImage rasterizes a document page and returns JPEG bytes.
 func (s *KoditService) RenderPageImage(ctx context.Context, koditRepoID int64, filePath string, page int) ([]byte, error) {
 	if !s.IsEnabled() {
 		return nil, fmt.Errorf("kodit service not enabled")
@@ -984,8 +984,8 @@ func (s *KoditService) RenderPageImage(ctx context.Context, koditRepoID int64, f
 	}
 
 	var buf bytes.Buffer
-	if err := png.Encode(&buf, img); err != nil {
-		return nil, fmt.Errorf("encode png: %w", err)
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80}); err != nil {
+		return nil, fmt.Errorf("encode jpeg: %w", err)
 	}
 
 	return buf.Bytes(), nil


### PR DESCRIPTION
## Summary

`renderPageImages` in `api/pkg/agent/skill/knowledge_skill.go` was unconditionally labelling every page-image returned by kodit's vision retrieval as `image/jpeg`, but `rag.PageImageRenderer.RenderPageImage` was returning PNG bytes. Anthropic strict-validates MIME against the image magic bytes and rejects with HTTP 400:

```
messages.N.content.M.image.source.base64: The image was specified using
the image/jpeg media type, but the image appears to be a image/png image
```

## Root Cause

`KoditService.RenderPageImage` in `api/pkg/services/kodit_service.go` was encoding rendered pages as PNG, while the downstream knowledge skill expected JPEG. This mismatch only manifested with Anthropic (OpenAI is more lenient).

## Fixes

1. **knowledge_skill.go**: Use `http.DetectContentType` to sniff the actual MIME from image bytes, matching what Anthropic does. This is defensive and handles PNG, JPEG, WebP, and GIF.

2. **kodit_service.go**: Change encoder from PNG to JPEG (quality 80) to match Kodit's internal rendering pipelines, eliminating the format mismatch at the source.

3. **kodit_handlers.go**: Update content-type header from `image/png` to `image/jpeg`.

## Reproduction

Reproduced live on a fresh GKE deployment of `helix-controlplane:2.11.0-rc2`:

1. Configure agent with Anthropic provider and a knowledge base that ingests a page with images (e.g. a BBC article)
2. Kodit indexes page screenshots into `vectorchord_vision_embeddings`
3. Send any prompt that triggers the Knowledge_* skill
4. Agent loop fails with the 400 above on the first turn that includes a retrieved image

OpenAI is more lenient and silently accepts the wrong label, so this is invisible when testing with `gpt-4o`.

## Test plan

- [x] `go build ./api/pkg/agent/skill/...`
- [x] `go build ./api/pkg/services/...`
- [x] `go build ./api/pkg/server/...`
- [ ] Drone CI green
- [ ] After merge, re-run the GKE smoke test scenario above and confirm Anthropic accepts the message