### PR TITLE
fix(helm): remove dead llamaindex env vars from controlplane chart

### DIFF
--- a/charts/helix-controlplane/templates/deployment.yaml
+++ b/charts/helix-controlplane/templates/deployment.yaml
@@ -152,12 +152,6 @@ spec:
               value: {{ .Values.controlplane.providersManagementEnabled | quote }}
             - name: FILESTORE_LOCALFS_PATH
               value: {{- with .Values.controlplane }} {{ .filestorePath | default "/filestore" }} {{- else }} "/filestore" {{- end }}
-            - name: TEXT_EXTRACTION_URL
-              value: http://{{ include "helix-controlplane.fullname" . }}-llamaindex:5000/api/v1/extract
-            - name: RAG_INDEX_URL
-              value: http://{{ include "helix-controlplane.fullname" . }}-llamaindex:5000/api/v1/rag/chunk
-            - name: RAG_QUERY_URL
-              value: http://{{ include "helix-controlplane.fullname" . }}-llamaindex:5000/api/v1/rag/query
             - name: RAG_CRAWLER_LAUNCHER_URL
               value: http://{{ include "helix-controlplane.fullname" . }}-chrome:7317
             # Postgres configuration


### PR DESCRIPTION
## Summary

`charts/helix-controlplane/templates/deployment.yaml` was wiring three env vars at a `{fullname}-llamaindex` Service that the chart no longer deploys (DNS lookup fails with `bad address`). PR https://github.com/helixml/helix/pull/2234 made Kodit the only RAG backend in `serve.go`, but these chart overrides were left behind:

- `TEXT_EXTRACTION_URL`
- `RAG_INDEX_URL`
- `RAG_QUERY_URL`

The Go config defaults for these env vars also point at a non-existent llamaindex, so removing the chart override is a no-op functionally - it just stops the chart from pretending to wire something it does not deploy.

**Kept** (still live):
- `RAG_CRAWLER_LAUNCHER_URL` - correctly wires to the deployed `*-chrome` Service
- `RAG_EMBEDDINGS_PROVIDER` - still read by `openai_embeddings_handlers.go:63`

**RAG path**: `rag.NewKoditRAG` is the active RAG client. `rag.NewLlamaindex` is only reached when a user supplies per-knowledge custom RAG URLs (via `RAGSettings.IndexURL` / `QueryURL`); in that case the user-supplied URL overrides the env default anyway. Marked `// TODO: remove this` in `api/pkg/controller/inference.go:1417`.

## Out of scope (follow-up)

`TEXT_EXTRACTION_URL` is wired to the unstructured/llamaindex extractor (`extract.NewDefaultExtractor`), which is actively called from `knowledge_extract.go` for PDFs/DOCX. Removing the chart env just falls back to the equally-broken Go default. Text-from-document extraction is a real feature gap when llamaindex is not deployed - separate fix needed (deploy llamaindex sidecar OR replace the extractor).

## Test plan

- [x] `helm template` diff confirms only the 3 env blocks above are removed; nothing else moves
- [x] `helm lint charts/helix-controlplane` passes
- [ ] Drone CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)