### PR TITLE
fix(spectask): set context_server_timeout=180 in settings.json (chrome MCP cold-start)

### DIFF
--- a/api/cmd/settings-sync-daemon/main.go
+++ b/api/cmd/settings-sync-daemon/main.go
@@ -849,6 +849,21 @@ func helixDefaults() map[string]interface{} {
 		// Disable auto-formatting globally - it mangles JS/TS/TSX in our codebases.
 		// Go keeps format_on_save via per-language override (gofmt is expected).
 		"format_on_save": "off",
+		// Bump context-server initialize timeout from upstream's 60s default to 180s.
+		// Several MCPs in our spec-task containers (chrome-devtools, github via
+		// `npx <pkg>@latest`, helixos via http to a still-warming-up api:8080) all
+		// fire their JSON-RPC `initialize` at the same moment Zed boots on a cold
+		// container, racing for CPU against settings-sync-daemon and language
+		// servers. The first npm download routinely overruns 60s and Zed marks the
+		// servers as failed; tools never appear (most visibly
+		// `mcp__chrome-devtools__*` go missing).
+		// helixml/zed#47 tried to fix this by bumping DEFAULT_REQUEST_TIMEOUT in
+		// crates/context_server/src/client.rs, but that constant is dead code in
+		// our path: project_settings.rs defaults context_server_timeout to 60 and
+		// passes Some(60) all the way to client.rs:370, where the .or(DEFAULT)
+		// fallback never fires. Fixing it here in settings.json works regardless
+		// of upstream changes and survives Zed rebases.
+		"context_server_timeout": 180,
 		"languages": map[string]interface{}{
 			"Go": map[string]interface{}{
 				"format_on_save": "on",


### PR DESCRIPTION
## Summary

Same chrome MCP cold-start bug helixml/zed#47 tried to fix on 2026-04-26 — \`No such tool available: mcp__chrome-devtools__*\` — recurred today on a fresh container start. \`Zed.log\` shows \`cancelled csp request task for \"initialize\" which took over 60s\`, exactly 66s after container start. PR #47 (bumping \`DEFAULT_REQUEST_TIMEOUT\` in \`crates/context_server/src/client.rs\`) turned out to be dead code in our usage path.

## Why PR #47 didn't take effect

\`client.rs:370\` reads \`self.request_timeout.or(Some(DEFAULT_REQUEST_TIMEOUT))\`. The \`.or()\` fallback only fires when \`request_timeout\` is \`None\`. In our flow it's **never None**: \`project_settings.rs:666\` defaults the per-project \`context_server_timeout\` to **60**, and that value is passed all the way down as \`Some(Duration::from_secs(60))\`. The bumped 180s default at the bottom of \`.or()\` never gets read.

## Fix

One line: set \`\"context_server_timeout\": 180\` at the top level of the generated \`settings.json\`. \`project_settings.rs\` reads that, propagates it as the per-server timeout, and Zed waits the full 180s for npm-cold-start MCPs (\`chrome-devtools\`, \`github\` via \`npx <pkg>@latest\`, \`helixos\` via http to a still-warming-up \`api:8080\`) to complete their JSON-RPC \`initialize\` handshake.

**Helix-only fix** — no Zed rebuild needed, survives any upstream rebase. Lives in settings-sync-daemon's \`helixDefaults()\` so it's part of the static Helix-owned settings written into every spec-task container's \`settings.json\`. User overrides can still change it via the existing \`mergeSettings()\` path if they want a different value.

## Evidence

- Affected session: \`spt_01kpakr3nvteta3wpgrxnrvfdt\`, container started 11:46:16 UTC.
- Failure: 11:47:22 UTC — \`chrome-devtools context server failed to start: Context server request timeout\` followed by repeated \`<tool_use_error>Error: No such tool available: mcp__chrome-devtools__fill</tool_use_error>\`.
- Confirmed running container's \`settings.json\` had no \`context_server_timeout\` key at all, so Zed used its 60s default.
- Confirmed PR #47's bumped 180s constant exists in the pinned Zed source (\`f5fab97857\`) and the binary (built 2026-04-27 09:19, after the merge) — but the constant is the wrong target.

## Deployment notes

- Settings-sync-daemon doesn't hot-reload (per \`CLAUDE.md\`). Requires \`./stack build-ubuntu\` + new session to take effect.
- For existing live sessions: manual workaround is editing \`settings.json\` in the container and toggling the failing MCP off/on in Zed's UI.

## Test plan

- [x] \`go build ./api/cmd/settings-sync-daemon/\` — clean.
- [x] \`go test ./api/cmd/settings-sync-daemon/\` — green.
- [ ] **Manual:** rebuild ubuntu image (\`./stack build-ubuntu\`), start a fresh spec task, confirm \`settings.json\` contains \`\"context_server_timeout\": 180\`, confirm chrome MCP tools are available immediately after Zed boots.
- [ ] **Manual:** verify a user override (\`\"context_server_timeout\": 300\` in their personal settings) still wins via the existing merge path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)