### PR TITLE
fix(rag): preserve knowledge subfolder in kodit RAG citations and page-image rendering

### DIFF
--- a/api/pkg/rag/rag_kodit.go
+++ b/api/pkg/rag/rag_kodit.go
@@ -280,6 +280,11 @@ func (k *KoditRAG) mergeAndConvert(entity *types.DataEntity, maxResults int, res
 
 // RenderPageImage implements rag.PageImageRenderer. It renders a document page
 // as a PNG and returns the raw bytes.
+//
+// Callers pass result.Source, which mergeAndConvert sets to the path relative
+// to the filestore root (e.g. "dev/apps/<app_id>/docs/file.pdf"). Kodit's
+// Blobs.DiskPath expects the path relative to the registered directory
+// (e.g. "file.pdf"), so we strip the registered-dir prefix before delegating.
 func (k *KoditRAG) RenderPageImage(ctx context.Context, dataEntityID string, filePath string, page int) ([]byte, error) {
 	entity, err := k.store.GetDataEntity(ctx, dataEntityID)
 	if err != nil {
@@ -288,7 +293,13 @@ func (k *KoditRAG) RenderPageImage(ctx context.Context, dataEntityID string, fil
 	if entity.KoditRepositoryID == nil {
 		return nil, fmt.Errorf("data entity %s has no kodit repository ID", dataEntityID)
 	}
-	return k.kodit.RenderPageImage(ctx, *entity.KoditRepositoryID, filePath, page)
+
+	relDir := strings.TrimPrefix(entity.Config.FilestorePath, k.fsCfg.LocalFSPath)
+	relDir = strings.TrimPrefix(relDir, "/")
+	repoRelPath := strings.TrimPrefix(filePath, relDir)
+	repoRelPath = strings.TrimPrefix(repoRelPath, "/")
+
+	return k.kodit.RenderPageImage(ctx, *entity.KoditRepositoryID, repoRelPath, page)
 }
 
 // Delete cleans up the data entity for a knowledge version. Each version of a

--- a/api/pkg/rag/rag_kodit.go
+++ b/api/pkg/rag/rag_kodit.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/data"
@@ -234,13 +235,20 @@ func (k *KoditRAG) mergeAndConvert(entity *types.DataEntity, maxResults int, res
 		merged = merged[:maxResults]
 	}
 
+	// Path returned by kodit is relative to the directory that was registered
+	// (entity.Config.FilestorePath, an absolute path on disk). The session
+	// controller and frontend expect Source to be the path relative to the
+	// filestore root so the viewer URL resolves correctly.
+	relDir := strings.TrimPrefix(entity.Config.FilestorePath, k.fsCfg.LocalFSPath)
+	relDir = strings.TrimPrefix(relDir, "/")
+
 	// Convert to RAG results.
 	ragResults := make([]*types.SessionRAGResult, 0, len(merged))
 	for _, r := range merged {
 		result := &types.SessionRAGResult{
 			Content:  r.Content,
-			Source:   r.Path,
-			Filename: r.Path,
+			Source:   filepath.Join(relDir, r.Path),
+			Filename: filepath.Base(r.Path),
 			Distance: 1.0 - r.Score,
 		}
 

--- a/api/pkg/rag/rag_kodit_test.go
+++ b/api/pkg/rag/rag_kodit_test.go
@@ -32,6 +32,7 @@ type koditServiceMock struct {
 	deleteRepositoryFn     func(ctx context.Context, koditRepoID int64) error
 	rescanCommitFn         func(ctx context.Context, koditRepoID int64, commitSHA string) error
 	getRepositoryCommitsFn func(ctx context.Context, koditRepoID int64, limit int) ([]repository.Commit, error)
+	renderPageImageFn      func(ctx context.Context, koditRepoID int64, filePath string, page int) ([]byte, error)
 }
 
 var _ services.KoditServicer = (*koditServiceMock)(nil)
@@ -132,7 +133,10 @@ func (m *koditServiceMock) ActiveTasks(context.Context) ([]services.KoditActiveT
 func (m *koditServiceMock) UpdateChunkingConfig(context.Context, int64, int, int, int) error {
 	return nil
 }
-func (m *koditServiceMock) RenderPageImage(context.Context, int64, string, int) ([]byte, error) {
+func (m *koditServiceMock) RenderPageImage(ctx context.Context, id int64, filePath string, page int) ([]byte, error) {
+	if m.renderPageImageFn != nil {
+		return m.renderPageImageFn(ctx, id, filePath, page)
+	}
 	return nil, nil
 }
 
@@ -339,6 +343,45 @@ func (s *KoditRAGSuite) TestQuery_FilenameStripsSubpath() {
 	s.Require().Len(results, 1)
 	s.Equal("dev/apps/app_abc/files/subdir/nested.pdf", results[0].Source)
 	s.Equal("nested.pdf", results[0].Filename)
+}
+
+// TestRenderPageImage_StripsRegisteredDir asserts that RenderPageImage strips
+// the registered-directory prefix from the caller's filestore-relative path
+// before delegating to kodit, since kodit's Blobs.DiskPath expects the path
+// relative to the registered directory.
+func (s *KoditRAGSuite) TestRenderPageImage_StripsRegisteredDir() {
+	repoID := int64(13)
+	entity := &types.DataEntity{
+		ID:                "de_render",
+		KoditRepositoryID: &repoID,
+		Config: types.DataEntityConfig{
+			FilestorePath: "/tmp/helix/filestore/dev/apps/app_xyz/docs",
+		},
+	}
+
+	s.mockStore.EXPECT().
+		GetDataEntity(gomock.Any(), "de_render").
+		Return(entity, nil)
+
+	var capturedPath string
+	s.mockSvc.renderPageImageFn = func(_ context.Context, id int64, filePath string, page int) ([]byte, error) {
+		s.Equal(repoID, id)
+		s.Equal(3, page)
+		capturedPath = filePath
+		return []byte("png"), nil
+	}
+
+	// Caller passes the same filestore-root-relative path that mergeAndConvert
+	// puts on result.Source.
+	bytes, err := s.rag.RenderPageImage(
+		context.Background(),
+		"de_render",
+		"dev/apps/app_xyz/docs/report.pdf",
+		3,
+	)
+	s.NoError(err)
+	s.Equal([]byte("png"), bytes)
+	s.Equal("report.pdf", capturedPath)
 }
 
 func (s *KoditRAGSuite) TestQuery_ErrorWhenNoRepoID() {

--- a/api/pkg/rag/rag_kodit_test.go
+++ b/api/pkg/rag/rag_kodit_test.go
@@ -268,6 +268,79 @@ func (s *KoditRAGSuite) TestQuery_UsesStoredRepoID() {
 	s.Equal("some content", results[0].Content)
 }
 
+// TestQuery_SourceIncludesRegisteredDir asserts that Source carries the path
+// of the kodit-registered directory relative to the filestore root, joined
+// with the file path kodit returned. The session controller relies on this
+// to build the citation viewer URL — if Source is just the basename, the
+// knowledge subfolder gets dropped and the viewer 404s.
+func (s *KoditRAGSuite) TestQuery_SourceIncludesRegisteredDir() {
+	repoID := int64(11)
+	entity := &types.DataEntity{
+		ID:                "de_q2",
+		KoditRepositoryID: &repoID,
+		Config: types.DataEntityConfig{
+			// Absolute on-disk path of the registered directory. LocalFSPath
+			// in SetupTest is "/tmp/helix/filestore", so the filestore-root
+			// relative portion is "dev/apps/app_xyz/docs".
+			FilestorePath: "/tmp/helix/filestore/dev/apps/app_xyz/docs",
+		},
+	}
+
+	s.mockStore.EXPECT().
+		GetDataEntity(gomock.Any(), "de_q2").
+		Return(entity, nil)
+
+	s.mockSvc.semanticSearchFn = func(_ context.Context, _ int64, _ string, _ int, _ string) ([]services.KoditFileResult, error) {
+		return []services.KoditFileResult{
+			{Path: "report.pdf", Content: "snippet", Score: 0.8},
+		}, nil
+	}
+
+	results, err := s.rag.Query(context.Background(), &types.SessionRAGQuery{
+		DataEntityID: "de_q2",
+		Prompt:       "any",
+		MaxResults:   5,
+	})
+	s.NoError(err)
+	s.Require().Len(results, 1)
+	s.Equal("dev/apps/app_xyz/docs/report.pdf", results[0].Source)
+	s.Equal("report.pdf", results[0].Filename)
+}
+
+// TestQuery_FilenameStripsSubpath asserts that when kodit returns a path with
+// a subdirectory (e.g. when the registered directory contains nested folders),
+// Source preserves the full path while Filename is just the basename.
+func (s *KoditRAGSuite) TestQuery_FilenameStripsSubpath() {
+	repoID := int64(12)
+	entity := &types.DataEntity{
+		ID:                "de_q3",
+		KoditRepositoryID: &repoID,
+		Config: types.DataEntityConfig{
+			FilestorePath: "/tmp/helix/filestore/dev/apps/app_abc/files",
+		},
+	}
+
+	s.mockStore.EXPECT().
+		GetDataEntity(gomock.Any(), "de_q3").
+		Return(entity, nil)
+
+	s.mockSvc.semanticSearchFn = func(_ context.Context, _ int64, _ string, _ int, _ string) ([]services.KoditFileResult, error) {
+		return []services.KoditFileResult{
+			{Path: "subdir/nested.pdf", Content: "snippet", Score: 0.7},
+		}, nil
+	}
+
+	results, err := s.rag.Query(context.Background(), &types.SessionRAGQuery{
+		DataEntityID: "de_q3",
+		Prompt:       "any",
+		MaxResults:   5,
+	})
+	s.NoError(err)
+	s.Require().Len(results, 1)
+	s.Equal("dev/apps/app_abc/files/subdir/nested.pdf", results[0].Source)
+	s.Equal("nested.pdf", results[0].Filename)
+}
+
 func (s *KoditRAGSuite) TestQuery_ErrorWhenNoRepoID() {
 	entity := &types.DataEntity{ID: "de_norepo", KoditRepositoryID: nil}
 


### PR DESCRIPTION
## Summary
Two related kodit RAG bugs surfaced together when an app's knowledge lives under a subfolder (e.g. `docs/`):

1. **Citation viewer 404** — clicking `[1]` on a RAG-grounded answer hit `/api/v1/filestore/viewer/dev/apps/<app_id>/<filename>` (no subfolder) and 404'd. The file was actually at `dev/apps/<app_id>/docs/<filename>`.
2. **Page-image rendering failure** — once the citation `Source` was fixed to be the full filestore-relative path, `KoditRAG.RenderPageImage` was forwarding it straight to kodit's `Blobs.DiskPath`, which expects a path relative to the registered directory. Result: doubled prefix on disk (`/filestore/dev/apps/x/docs/dev/apps/x/docs/<file>`), `unable to read file`, no images attached to the LLM call.

## Fix
- `mergeAndConvert` in `api/pkg/rag/rag_kodit.go` now derives the registered directory's path relative to the filestore root (`entity.Config.FilestorePath` minus `LocalFSPath`) and uses it to build `Source = <relDir>/<r.Path>` and `Filename = filepath.Base(r.Path)`. The session controller already handles `Source` values that start with `FilePrefixGlobal` correctly (skips its own prepend logic), so the citation URL the frontend builds resolves.
- `KoditRAG.RenderPageImage` strips the same `relDir` prefix back off before delegating to kodit, since kodit's `Blobs.DiskPath` expects the repo-relative path.

## Why this is the right fix site
The kodit RAG adapter owns the registered-directory <-> filestore mapping. The session controller and the page-image render path stay agnostic.

## Test plan
- [x] `cd api && CGO_ENABLED=0 go test -v -run 'TestKoditRAGSuite/(TestQuery_|TestRenderPageImage_)' ./pkg/rag/` — 4/4 pass:
  - `TestQuery_UsesStoredRepoID` (existing, unchanged behaviour with empty `FilestorePath`)
  - `TestQuery_SourceIncludesRegisteredDir` (new — `Source` carries the full filestore-relative path)
  - `TestQuery_FilenameStripsSubpath` (new — nested `r.Path` preserved in `Source`, basename in `Filename`)
  - `TestRenderPageImage_StripsRegisteredDir` (new — `Blobs.DiskPath` receives the repo-relative path)
- [x] Reproduced and verified end-to-end on `prime` against an app with knowledge under `docs/` — citation viewer URL resolves; page-image render no longer 'unable to read file'.

## Out of scope (separate tickets queued)
- Kodit's gorm logger spams every SQL query at debug level even after our `LOG_LEVEL` filter — needs an upstream `WithGormLogging(bool)` option.
- Kodit's PDF text extractor failed on both PDFs we tested (`failed to load xref` / `unexpected character at position 1659`). RAG returns hits but with empty `Content`, so the LLM gets only page images (which now work). Upstream kodit PDF-parser issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)