### PR TITLE
fix(zed): remove silent claude fallback, reference providers by ID, fix Zed model resolution

### DIFF
--- a/api/cmd/settings-sync-daemon/main.go
+++ b/api/cmd/settings-sync-daemon/main.go
@@ -836,6 +836,22 @@ var USER_PREFERENCE_FIELDS = map[string]bool{
 	"theme": true,
 }
 
+// HELIX_MANAGED_AGENT_FIELDS lists keys under "agent" that Helix owns and that
+// user-side overrides (i.e. whatever Zed wrote to settings.json) must never
+// clobber. When Zed boots and writes a different default_model — either because
+// the user picked one in the model picker or because Zed's built-in agent
+// profile fell back to its hardcoded Claude default — the daemon used to
+// faithfully sync that back to disk on the next poll, even though Helix had
+// the authoritative value.
+//
+// See deviqon/P1-5-zed-overrides-clobber-helix-default-model.md.
+var HELIX_MANAGED_AGENT_FIELDS = map[string]bool{
+	"default_model":          true,
+	"inline_assistant_model": true,
+	"commit_message_model":   true,
+	"thread_summary_model":   true,
+}
+
 // helixDefaults returns the static Helix-owned settings that must be present
 // in every settings.json. Both syncFromHelix() and checkHelixUpdates() use
 // this as the base, then layer on API response fields.
@@ -913,9 +929,14 @@ func (d *SettingsDaemon) mergeSettings(helix, user map[string]interface{}) map[s
 	}
 
 	for k, v := range user {
-		if k != "context_servers" && k != "languages" {
-			merged[k] = v
+		if k == "context_servers" || k == "languages" {
+			continue
 		}
+		if k == "agent" {
+			merged["agent"] = mergeAgentBlock(merged["agent"], v)
+			continue
+		}
+		merged[k] = v
 	}
 
 	// Preserve security-protected and user-preference fields from on-disk config.
@@ -940,6 +961,37 @@ func (d *SettingsDaemon) mergeSettings(helix, user map[string]interface{}) map[s
 	agentServers := d.generateAgentServerConfig()
 	if agentServers != nil {
 		merged["agent_servers"] = agentServers
+	}
+
+	return merged
+}
+
+// mergeAgentBlock deep-merges Zed's user-side "agent" block onto the helix-managed
+// one, dropping any user-side values for keys in HELIX_MANAGED_AGENT_FIELDS so
+// helix's model selections always win.
+func mergeAgentBlock(helixAgent, userAgent interface{}) interface{} {
+	userMap, ok := userAgent.(map[string]interface{})
+	if !ok {
+		// User override is not an object — keep helix's agent verbatim.
+		if helixAgent != nil {
+			return helixAgent
+		}
+		return userAgent
+	}
+
+	merged := make(map[string]interface{})
+	if helixMap, ok := helixAgent.(map[string]interface{}); ok {
+		for k, v := range helixMap {
+			merged[k] = v
+		}
+	}
+
+	for k, v := range userMap {
+		if HELIX_MANAGED_AGENT_FIELDS[k] {
+			log.Printf("dropping user override for helix-managed agent field: %s", k)
+			continue
+		}
+		merged[k] = v
 	}
 
 	return merged
@@ -989,12 +1041,46 @@ func extractUserOverrides(current, helix map[string]interface{}) map[string]inte
 		if k == "context_servers" || k == "languages" || SECURITY_PROTECTED_FIELDS[k] || USER_PREFERENCE_FIELDS[k] {
 			continue
 		}
+		if k == "agent" {
+			// Diff the agent block per-field, dropping helix-managed model fields so
+			// they never get uploaded back to the API. Defense-in-depth alongside
+			// the merge guard above.
+			if agentDiff := diffAgentBlock(v, helix["agent"]); agentDiff != nil {
+				overrides["agent"] = agentDiff
+			}
+			continue
+		}
 		if helixVal, inHelix := helix[k]; !inHelix || !deepEqual(v, helixVal) {
 			overrides[k] = v
 		}
 	}
 
 	return overrides
+}
+
+// diffAgentBlock returns the user-side keys under "agent" that differ from the
+// helix-managed value, with helix-managed model fields excluded. Returns nil if
+// there is nothing to upload.
+func diffAgentBlock(current, helix interface{}) map[string]interface{} {
+	currentMap, ok := current.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	helixMap, _ := helix.(map[string]interface{})
+
+	diff := make(map[string]interface{})
+	for k, v := range currentMap {
+		if HELIX_MANAGED_AGENT_FIELDS[k] {
+			continue
+		}
+		if helixVal, inHelix := helixMap[k]; !inHelix || !deepEqual(v, helixVal) {
+			diff[k] = v
+		}
+	}
+	if len(diff) == 0 {
+		return nil
+	}
+	return diff
 }
 
 // startWatcher monitors settings.json for Zed UI changes and

--- a/api/cmd/settings-sync-daemon/main_test.go
+++ b/api/cmd/settings-sync-daemon/main_test.go
@@ -233,3 +233,106 @@ func TestInjectAvailableModels(t *testing.T) {
 		})
 	}
 }
+
+// TestMergeAgentBlock_HelixManagedFieldsProtected verifies that the daemon's
+// client-side merge drops user-side overrides for helix-managed agent.* model
+// fields. See deviqon/P1-5-zed-overrides-clobber-helix-default-model.md.
+func TestMergeAgentBlock_HelixManagedFieldsProtected(t *testing.T) {
+	helixAgent := map[string]interface{}{
+		"default_model":          map[string]interface{}{"provider": "openai", "model": "numpty/openai/gpt-oss-120b"},
+		"inline_assistant_model": map[string]interface{}{"provider": "openai", "model": "numpty/openai/gpt-oss-120b"},
+		"commit_message_model":   map[string]interface{}{"provider": "openai", "model": "numpty/openai/gpt-oss-120b"},
+		"thread_summary_model":   map[string]interface{}{"provider": "openai", "model": "numpty/openai/gpt-oss-120b"},
+		"auto_open_panel":        true,
+		"show_onboarding":        false,
+	}
+
+	t.Run("user override of default_model is dropped", func(t *testing.T) {
+		userAgent := map[string]interface{}{
+			"default_model": map[string]interface{}{
+				"provider":        "anthropic",
+				"model":           "claude-sonnet-4-6-latest",
+				"effort":          "high",
+				"enable_thinking": true,
+			},
+		}
+		merged := mergeAgentBlock(helixAgent, userAgent).(map[string]interface{})
+
+		dm := merged["default_model"].(map[string]interface{})
+		assert.Equal(t, "openai", dm["provider"])
+		assert.Equal(t, "numpty/openai/gpt-oss-120b", dm["model"])
+		assert.NotContains(t, dm, "effort")
+		assert.NotContains(t, dm, "enable_thinking")
+	})
+
+	t.Run("all four model fields are protected", func(t *testing.T) {
+		userAgent := map[string]interface{}{
+			"default_model":          map[string]interface{}{"provider": "anthropic", "model": "claude"},
+			"inline_assistant_model": map[string]interface{}{"provider": "anthropic", "model": "claude"},
+			"commit_message_model":   map[string]interface{}{"provider": "anthropic", "model": "claude"},
+			"thread_summary_model":   map[string]interface{}{"provider": "anthropic", "model": "claude"},
+		}
+		merged := mergeAgentBlock(helixAgent, userAgent).(map[string]interface{})
+
+		for _, field := range []string{"default_model", "inline_assistant_model", "commit_message_model", "thread_summary_model"} {
+			dm := merged[field].(map[string]interface{})
+			assert.Equal(t, "openai", dm["provider"], "%s.provider", field)
+			assert.Equal(t, "numpty/openai/gpt-oss-120b", dm["model"], "%s.model", field)
+		}
+	})
+
+	t.Run("non-model agent fields can still be user-overridden", func(t *testing.T) {
+		userAgent := map[string]interface{}{
+			"default_model":              map[string]interface{}{"provider": "anthropic", "model": "claude"},
+			"play_sound_when_agent_done": true,
+			"button":                     false,
+		}
+		merged := mergeAgentBlock(helixAgent, userAgent).(map[string]interface{})
+
+		assert.Equal(t, "numpty/openai/gpt-oss-120b", merged["default_model"].(map[string]interface{})["model"])
+		assert.Equal(t, true, merged["play_sound_when_agent_done"])
+		assert.Equal(t, false, merged["button"])
+	})
+
+	t.Run("non-object user agent keeps helix verbatim", func(t *testing.T) {
+		merged := mergeAgentBlock(helixAgent, "not-an-object")
+		assert.Equal(t, helixAgent, merged)
+	})
+}
+
+// TestExtractUserOverrides_AgentDiffSkipsManagedFields verifies that the daemon
+// does not upload changes to helix-managed agent.* model fields.
+func TestExtractUserOverrides_AgentDiffSkipsManagedFields(t *testing.T) {
+	helix := map[string]interface{}{
+		"agent": map[string]interface{}{
+			"default_model":   map[string]interface{}{"provider": "openai", "model": "numpty/openai/gpt-oss-120b"},
+			"auto_open_panel": true,
+		},
+	}
+
+	t.Run("does not upload claude default_model", func(t *testing.T) {
+		current := map[string]interface{}{
+			"agent": map[string]interface{}{
+				"default_model":   map[string]interface{}{"provider": "anthropic", "model": "claude-sonnet-4-6-latest"},
+				"auto_open_panel": true,
+			},
+		}
+		got := extractUserOverrides(current, helix)
+		assert.NotContains(t, got, "agent")
+	})
+
+	t.Run("uploads non-model agent diffs only", func(t *testing.T) {
+		current := map[string]interface{}{
+			"agent": map[string]interface{}{
+				"default_model":              map[string]interface{}{"provider": "anthropic", "model": "claude"},
+				"auto_open_panel":            true,
+				"play_sound_when_agent_done": true,
+			},
+		}
+		got := extractUserOverrides(current, helix)
+		agent := got["agent"].(map[string]interface{})
+		assert.Equal(t, true, agent["play_sound_when_agent_done"])
+		assert.NotContains(t, agent, "default_model")
+		assert.NotContains(t, agent, "auto_open_panel")
+	})
+}

--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -75,9 +75,13 @@ type ContextServerConfig struct {
 	Headers map[string]string `json:"headers,omitempty"`
 }
 
-// GenerateZedMCPConfig creates Zed MCP configuration from Helix app config
-// projectSkills are optional project-level skills that overlay on top of agent skills
-// oauthTokenGetter is optional - if provided, OAuth tokens will be injected into stdio MCPs
+// GenerateZedMCPConfig creates Zed MCP configuration from Helix app config.
+// projectSkills are optional project-level skills that overlay on top of agent skills.
+// oauthTokenGetter is optional - if provided, OAuth tokens will be injected into stdio MCPs.
+// validProviders is an optional list of provider names registered in the Helix provider
+// manager (env-var-baked + DB-backed). When non-nil, the agent's stored provider is
+// validated against it and a missing provider is treated as misconfiguration. Pass nil
+// to skip validation (e.g. on the runner-side path where the manager isn't reachable).
 func GenerateZedMCPConfig(
 	ctx context.Context,
 	app *types.App,
@@ -88,6 +92,7 @@ func GenerateZedMCPConfig(
 	koditEnabled bool,
 	projectSkills *types.AssistantSkills,
 	oauthTokenGetter OAuthTokenGetter,
+	validProviders []string,
 ) (*ZedMCPConfig, error) {
 	config := &ZedMCPConfig{
 		ContextServers: make(map[string]ContextServerConfig),
@@ -128,43 +133,70 @@ func GenerateZedMCPConfig(
 		}
 	}
 
-	// Default to anthropic/claude-sonnet if nothing is configured
-	if provider == "" {
+	// Decide whether the agent's stored model fields are usable. There are
+	// two failure modes we MUST NOT paper over:
+	//
+	//   1. Empty fields. Previously the code silently substituted
+	//      anthropic/claude-sonnet-4-5-latest, which made misconfigured
+	//      external agents look like working Claude agents in Zed (Deviqon
+	//      bug, 2026-04-28).
+	//   2. Stale provider name. If the provider was renamed or removed in
+	//      admin, the agent record still holds the old string. We previously
+	//      fed that to mapHelixToZedProvider which encoded it into the
+	//      model name (e.g. "user-ollama/qwen-..."), and Zed sent every
+	//      chat completion with that unroutable string until the proxy
+	//      404'd. The agent should be flagged as misconfigured instead.
+	//
+	// In both cases we now leave Agent.DefaultModel unset and log loudly.
+	// Zed will fall back to its built-in default rather than us pretending
+	// to have configured one.
+	useAgentModel := true
+	switch {
+	case assistant == nil:
+		// No assistant means this is the default-app path used for sessions
+		// without a parent app. Keep the legacy SaaS-friendly default so
+		// those sessions still come up.
 		provider = "anthropic"
-	}
-	if model == "" {
 		model = "claude-sonnet-4-5-latest"
+	case provider == "" || model == "":
+		log.Error().
+			Str("app_id", app.ID).
+			Str("provider", provider).
+			Str("model", model).
+			Msg("zed-config: assistant has empty provider or model — refusing to write agent.default_model. Reconfigure the agent with a valid provider/model selection.")
+		useAgentModel = false
+	case !providerExists(provider, validProviders):
+		log.Error().
+			Str("app_id", app.ID).
+			Str("provider", provider).
+			Str("model", model).
+			Strs("known_providers", validProviders).
+			Msg("zed-config: assistant references a provider that is not registered (renamed or deleted?) — refusing to write agent.default_model. Reconfigure the agent or restore the provider.")
+		useAgentModel = false
 	}
 
-	// Map Helix provider to Zed's provider type and format model name
-	// Zed only knows: anthropic, openai, google, ollama, copilot, lmstudio, deepseek
-	// All other providers (nebius, together, openrouter, etc.) use OpenAI-compatible API
-	zedProvider, zedModel := mapHelixToZedProvider(provider, model)
-
-	// Configure agent with default model (CRITICAL: default_model goes in agent, not assistant!)
-	// Also set feature-specific models to prevent Zed from using its hardcoded gpt-4.1-mini
-	// default for "fast" operations (see zed-industries/zed#31420). If not set, these fall
-	// back to default_model, but we set them explicitly to ensure all LLM calls route through Helix.
+	// Configure agent. AlwaysAllowToolActions / ShowOnboarding / AutoOpenPanel
+	// are always set; default_model and the feature-specific model overrides
+	// are set only when we trust the agent's configuration.
 	config.Agent = &AgentConfig{
-		DefaultModel: &ModelConfig{
-			Provider: zedProvider,
-			Model:    zedModel,
-		},
-		InlineAssistantModel: &ModelConfig{
-			Provider: zedProvider,
-			Model:    zedModel,
-		},
-		CommitMessageModel: &ModelConfig{
-			Provider: zedProvider,
-			Model:    zedModel,
-		},
-		ThreadSummaryModel: &ModelConfig{
-			Provider: zedProvider,
-			Model:    zedModel,
-		},
 		AlwaysAllowToolActions: true,
 		ShowOnboarding:         false,
 		AutoOpenPanel:          true,
+	}
+	if useAgentModel {
+		// Map Helix provider to Zed's provider type and format model name
+		// Zed only knows: anthropic, openai, google, ollama, copilot, lmstudio, deepseek
+		// All other providers (nebius, together, openrouter, etc.) use OpenAI-compatible API
+		zedProvider, zedModel := mapHelixToZedProvider(provider, model)
+		// Set feature-specific models to prevent Zed from using its hardcoded
+		// gpt-4.1-mini default for "fast" operations (see
+		// zed-industries/zed#31420). If not set, these fall back to
+		// default_model, but we set them explicitly to ensure all LLM calls
+		// route through Helix.
+		config.Agent.DefaultModel = &ModelConfig{Provider: zedProvider, Model: zedModel}
+		config.Agent.InlineAssistantModel = &ModelConfig{Provider: zedProvider, Model: zedModel}
+		config.Agent.CommitMessageModel = &ModelConfig{Provider: zedProvider, Model: zedModel}
+		config.Agent.ThreadSummaryModel = &ModelConfig{Provider: zedProvider, Model: zedModel}
 	}
 	config.Theme = "Ayu Dark"
 
@@ -528,6 +560,25 @@ func normalizeModelIDForZed(modelID string) string {
 	return modelID
 }
 
+// providerExists reports whether name appears in validProviders. Comparison is
+// case-insensitive because some agents store provider names with mixed case
+// (e.g. the "OpenAI" provider on prime is registered as "openai" in the
+// manager). When validProviders is nil/empty we skip the check and return
+// true — callers without a manager handle (e.g. the runner-side code path)
+// pass nil to opt out of validation.
+func providerExists(name string, validProviders []string) bool {
+	if len(validProviders) == 0 {
+		return true
+	}
+	want := strings.ToLower(name)
+	for _, p := range validProviders {
+		if strings.ToLower(p) == want {
+			return true
+		}
+	}
+	return false
+}
+
 // mapHelixToZedProvider maps a Helix provider name to a Zed provider type and formats the model name.
 // Zed only recognizes a fixed set of providers: anthropic, openai, google, ollama, copilot, lmstudio, deepseek.
 // All other Helix providers (nebius, together, openrouter, etc.) are OpenAI-compatible and should use "openai".
@@ -644,7 +695,10 @@ func GetZedConfigForSession(ctx context.Context, s store.Store, sessionID string
 		return conn.AccessToken, nil
 	}
 
-	config, err := GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter)
+	// Runner-side path has no provider-manager handle, so we skip provider
+	// validation here. The handler-side callers (getZedConfig,
+	// getMergedZedSettings) do pass the live provider list.
+	config, err := GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate Zed config: %w", err)
 	}

--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -628,6 +628,47 @@ func ResolveProvider(token string, snapshot []ProviderRef) (ref ProviderRef, byL
 	return ProviderRef{}, false, false
 }
 
+// MigrateLegacyProviderRefs walks every provider-bearing field on every
+// assistant in app.Config and, where the stored value is a legacy name that
+// resolves (case-insensitively) to a current DB-backed provider, rewrites
+// the field in-place to that provider's immutable ID. Returns true if any
+// field changed — the caller is responsible for persisting via
+// Store.UpdateApp.
+//
+// Globals (ref.ID == "") are left alone: their canonical name is itself
+// immutable, so there's nothing to migrate. Misconfigured fields (resolver
+// miss) are also left alone — we have no ID to write.
+//
+// Called from session-start and spec-task pre-flight handlers so legacy
+// agents heal themselves on first use after the ID-based refactor lands,
+// without the operator having to re-save anything.
+func MigrateLegacyProviderRefs(app *types.App, snapshot []ProviderRef) bool {
+	if app == nil || snapshot == nil || len(app.Config.Helix.Assistants) == 0 {
+		return false
+	}
+	changed := false
+	rewrite := func(field *string) {
+		if field == nil || *field == "" {
+			return
+		}
+		ref, byLegacy, ok := ResolveProvider(*field, snapshot)
+		if !ok || !byLegacy || ref.ID == "" {
+			return
+		}
+		*field = ref.ID
+		changed = true
+	}
+	for i := range app.Config.Helix.Assistants {
+		a := &app.Config.Helix.Assistants[i]
+		rewrite(&a.Provider)
+		rewrite(&a.GenerationModelProvider)
+		rewrite(&a.SmallGenerationModelProvider)
+		rewrite(&a.ReasoningModelProvider)
+		rewrite(&a.SmallReasoningModelProvider)
+	}
+	return changed
+}
+
 // ValidateAssistantModelConfig checks whether the app's zed_external assistant
 // has a usable provider/model combination given the currently registered
 // providers. Returns the empty string when the configuration is usable;

--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -25,6 +25,15 @@ type ZedMCPConfig struct {
 	ExternalSync   *ExternalSyncConfig            `json:"external_sync,omitempty"`
 	Agent          *AgentConfig                   `json:"agent,omitempty"`
 	Theme          string                         `json:"theme,omitempty"`
+
+	// Misconfigured is set by GenerateZedMCPConfig when the agent's stored
+	// provider/model is empty or references a provider that is not in the
+	// supplied validProviders list. The fields are not serialized to clients
+	// — handlers inspect them and return HTTP 422 so that session start fails
+	// fast with a clear error in the spec-task UI rather than silently
+	// spinning up a sandbox the user can't actually use.
+	Misconfigured   bool   `json:"-"`
+	MisconfigReason string `json:"-"`
 }
 
 type ExternalSyncConfig struct {
@@ -165,6 +174,8 @@ func GenerateZedMCPConfig(
 			Str("model", model).
 			Msg("zed-config: assistant has empty provider or model — refusing to write agent.default_model. Reconfigure the agent with a valid provider/model selection.")
 		useAgentModel = false
+		config.Misconfigured = true
+		config.MisconfigReason = fmt.Sprintf("agent %q is missing a provider or model selection — open the agent settings and pick a provider and model", app.ID)
 	case !providerExists(provider, validProviders):
 		log.Error().
 			Str("app_id", app.ID).
@@ -173,6 +184,8 @@ func GenerateZedMCPConfig(
 			Strs("known_providers", validProviders).
 			Msg("zed-config: assistant references a provider that is not registered (renamed or deleted?) — refusing to write agent.default_model. Reconfigure the agent or restore the provider.")
 		useAgentModel = false
+		config.Misconfigured = true
+		config.MisconfigReason = fmt.Sprintf("agent %q references provider %q which is not registered (renamed or deleted?). Reconfigure the agent or restore the provider.", app.ID, provider)
 	}
 
 	// Configure agent. AlwaysAllowToolActions / ShowOnboarding / AutoOpenPanel

--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -846,118 +846,32 @@ func GetZedConfigForSession(ctx context.Context, s store.Store, sessionID string
 	return config, nil
 }
 
-// helixManagedAgentFields lists the keys under "agent" that Helix owns and that
-// user-side overrides (uploaded by the settings-sync-daemon from Zed's settings.json)
-// must never clobber. If Zed boots and writes a different default_model — either
-// because the user picked one in the model picker, or because Zed's built-in agent
-// profile fell back to its hardcoded Claude default — the daemon faithfully uploads
-// that to /zed-config/user. Without this guard, the merged /zed-settings endpoint
-// then serves Zed's value back to the desktop, and Zed re-reads the wrong model.
+// MergeContextServers returns the union of helix-managed MCP context servers
+// and the user-side ones uploaded via /zed-config/user. Used by the
+// /zed-settings endpoint to render the per-session "MCP Tools" UI panel.
 //
-// See deviqon/P1-5-zed-overrides-clobber-helix-default-model.md.
-var helixManagedAgentFields = map[string]struct{}{
-	"default_model":          {},
-	"inline_assistant_model": {},
-	"commit_message_model":   {},
-	"thread_summary_model":   {},
-}
+// Note: this is the only piece of the old MergeZedConfigWithUserOverrides
+// that had any live consumer. The agent / language_models / theme merge
+// previously here was dead code — the desktop hot path runs through the
+// settings-sync-daemon, which polls /zed-config and merges client-side.
+// Keeping the duplication invited drift (see P1-5).
+func MergeContextServers(helixServers map[string]ContextServerConfig, userOverrides map[string]interface{}) map[string]interface{} {
+	merged := make(map[string]interface{}, len(helixServers))
+	for name, server := range helixServers {
+		entry := map[string]interface{}{
+			"command": server.Command,
+			"args":    server.Args,
+		}
+		if len(server.Env) > 0 {
+			entry["env"] = server.Env
+		}
+		merged[name] = entry
+	}
 
-// MergeZedConfigWithUserOverrides merges Helix config with user overrides.
-//
-// Policy: helix-managed model fields under "agent" are authoritative. User
-// overrides for those specific keys are dropped. All other agent fields, and
-// all other top-level keys, remain user-overridable.
-func MergeZedConfigWithUserOverrides(helixConfig *ZedMCPConfig, userOverrides map[string]interface{}) map[string]interface{} {
-	result := make(map[string]interface{})
-
-	// Start with Helix context servers
-	result["context_servers"] = helixConfig.ContextServers
-
-	// Apply user overrides
 	if userServers, ok := userOverrides["context_servers"].(map[string]interface{}); ok {
-		// Deep merge: user additions and modifications
-		if helixServers, ok := result["context_servers"].(map[string]ContextServerConfig); ok {
-			merged := make(map[string]interface{})
-			// Convert Helix servers to map[string]interface{}
-			for name, server := range helixServers {
-				serverMap := map[string]interface{}{
-					"command": server.Command,
-					"args":    server.Args,
-				}
-				if len(server.Env) > 0 {
-					serverMap["env"] = server.Env
-				}
-				merged[name] = serverMap
-			}
-			// Apply user overrides
-			for name, server := range userServers {
-				merged[name] = server
-			}
-			result["context_servers"] = merged
+		for name, server := range userServers {
+			merged[name] = server
 		}
-	}
-
-	// Apply other user settings (non-MCP). The "agent" block needs a deep merge
-	// so user overrides cannot touch helix-managed model fields.
-	for k, v := range userOverrides {
-		if k == "context_servers" {
-			continue
-		}
-		if k == "agent" {
-			result["agent"] = mergeAgentBlock(helixConfig.Agent, v)
-			continue
-		}
-		result[k] = v
-	}
-
-	// If the user has no "agent" override at all, surface the helix-managed agent block.
-	if _, userHasAgent := userOverrides["agent"]; !userHasAgent && helixConfig.Agent != nil {
-		result["agent"] = helixConfig.Agent
-	}
-
-	return result
-}
-
-// mergeAgentBlock deep-merges Zed's user "agent" block with the helix-managed one,
-// dropping any user-side values for keys in helixManagedAgentFields.
-func mergeAgentBlock(helixAgent *AgentConfig, userAgent interface{}) interface{} {
-	userMap, ok := userAgent.(map[string]interface{})
-	if !ok {
-		// User override is not an object — ignore it and keep helix's agent verbatim.
-		if helixAgent != nil {
-			return helixAgent
-		}
-		return userAgent
-	}
-
-	merged := make(map[string]interface{})
-
-	// Seed with helix-managed values so they exist even if the user override didn't include them.
-	if helixAgent != nil {
-		if helixAgent.DefaultModel != nil {
-			merged["default_model"] = helixAgent.DefaultModel
-		}
-		if helixAgent.InlineAssistantModel != nil {
-			merged["inline_assistant_model"] = helixAgent.InlineAssistantModel
-		}
-		if helixAgent.CommitMessageModel != nil {
-			merged["commit_message_model"] = helixAgent.CommitMessageModel
-		}
-		if helixAgent.ThreadSummaryModel != nil {
-			merged["thread_summary_model"] = helixAgent.ThreadSummaryModel
-		}
-		merged["always_allow_tool_actions"] = helixAgent.AlwaysAllowToolActions
-		merged["show_onboarding"] = helixAgent.ShowOnboarding
-		merged["auto_open_panel"] = helixAgent.AutoOpenPanel
-	}
-
-	// Layer user values on top, but skip helix-managed model fields.
-	for k, v := range userMap {
-		if _, managed := helixManagedAgentFields[k]; managed {
-			log.Debug().Str("field", k).Msg("dropping user override for helix-managed agent field")
-			continue
-		}
-		merged[k] = v
 	}
 
 	return merged

--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -652,7 +652,27 @@ func GetZedConfigForSession(ctx context.Context, s store.Store, sessionID string
 	return config, nil
 }
 
-// MergeZedConfigWithUserOverrides merges Helix config with user overrides
+// helixManagedAgentFields lists the keys under "agent" that Helix owns and that
+// user-side overrides (uploaded by the settings-sync-daemon from Zed's settings.json)
+// must never clobber. If Zed boots and writes a different default_model — either
+// because the user picked one in the model picker, or because Zed's built-in agent
+// profile fell back to its hardcoded Claude default — the daemon faithfully uploads
+// that to /zed-config/user. Without this guard, the merged /zed-settings endpoint
+// then serves Zed's value back to the desktop, and Zed re-reads the wrong model.
+//
+// See deviqon/P1-5-zed-overrides-clobber-helix-default-model.md.
+var helixManagedAgentFields = map[string]struct{}{
+	"default_model":          {},
+	"inline_assistant_model": {},
+	"commit_message_model":   {},
+	"thread_summary_model":   {},
+}
+
+// MergeZedConfigWithUserOverrides merges Helix config with user overrides.
+//
+// Policy: helix-managed model fields under "agent" are authoritative. User
+// overrides for those specific keys are dropped. All other agent fields, and
+// all other top-level keys, remain user-overridable.
 func MergeZedConfigWithUserOverrides(helixConfig *ZedMCPConfig, userOverrides map[string]interface{}) map[string]interface{} {
 	result := make(map[string]interface{})
 
@@ -683,14 +703,70 @@ func MergeZedConfigWithUserOverrides(helixConfig *ZedMCPConfig, userOverrides ma
 		}
 	}
 
-	// Apply other user settings (non-MCP)
+	// Apply other user settings (non-MCP). The "agent" block needs a deep merge
+	// so user overrides cannot touch helix-managed model fields.
 	for k, v := range userOverrides {
-		if k != "context_servers" {
-			result[k] = v
+		if k == "context_servers" {
+			continue
 		}
+		if k == "agent" {
+			result["agent"] = mergeAgentBlock(helixConfig.Agent, v)
+			continue
+		}
+		result[k] = v
+	}
+
+	// If the user has no "agent" override at all, surface the helix-managed agent block.
+	if _, userHasAgent := userOverrides["agent"]; !userHasAgent && helixConfig.Agent != nil {
+		result["agent"] = helixConfig.Agent
 	}
 
 	return result
+}
+
+// mergeAgentBlock deep-merges Zed's user "agent" block with the helix-managed one,
+// dropping any user-side values for keys in helixManagedAgentFields.
+func mergeAgentBlock(helixAgent *AgentConfig, userAgent interface{}) interface{} {
+	userMap, ok := userAgent.(map[string]interface{})
+	if !ok {
+		// User override is not an object — ignore it and keep helix's agent verbatim.
+		if helixAgent != nil {
+			return helixAgent
+		}
+		return userAgent
+	}
+
+	merged := make(map[string]interface{})
+
+	// Seed with helix-managed values so they exist even if the user override didn't include them.
+	if helixAgent != nil {
+		if helixAgent.DefaultModel != nil {
+			merged["default_model"] = helixAgent.DefaultModel
+		}
+		if helixAgent.InlineAssistantModel != nil {
+			merged["inline_assistant_model"] = helixAgent.InlineAssistantModel
+		}
+		if helixAgent.CommitMessageModel != nil {
+			merged["commit_message_model"] = helixAgent.CommitMessageModel
+		}
+		if helixAgent.ThreadSummaryModel != nil {
+			merged["thread_summary_model"] = helixAgent.ThreadSummaryModel
+		}
+		merged["always_allow_tool_actions"] = helixAgent.AlwaysAllowToolActions
+		merged["show_onboarding"] = helixAgent.ShowOnboarding
+		merged["auto_open_panel"] = helixAgent.AutoOpenPanel
+	}
+
+	// Layer user values on top, but skip helix-managed model fields.
+	for k, v := range userMap {
+		if _, managed := helixManagedAgentFields[k]; managed {
+			log.Debug().Str("field", k).Msg("dropping user override for helix-managed agent field")
+			continue
+		}
+		merged[k] = v
+	}
+
+	return merged
 }
 
 // SaveUserZedOverrides saves user's Zed settings overrides

--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -673,7 +673,7 @@ func ValidateAssistantModelConfig(app *types.App, snapshot []ProviderRef) string
 		return ""
 	}
 	if _, _, ok := ResolveProvider(provider, snapshot); !ok {
-		return fmt.Sprintf("agent %q references provider %q which is no longer registered (provider deleted?). Reconfigure the agent or restore the provider.", app.ID, provider)
+		return fmt.Sprintf("agent %q references provider %q which does not match any current provider — the provider may have been renamed or deleted. Open the agent settings and re-pick a provider, or restore/rename the provider in admin.", app.ID, provider)
 	}
 	return ""
 }

--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -87,10 +87,14 @@ type ContextServerConfig struct {
 // GenerateZedMCPConfig creates Zed MCP configuration from Helix app config.
 // projectSkills are optional project-level skills that overlay on top of agent skills.
 // oauthTokenGetter is optional - if provided, OAuth tokens will be injected into stdio MCPs.
-// validProviders is an optional list of provider names registered in the Helix provider
-// manager (env-var-baked + DB-backed). When non-nil, the agent's stored provider is
-// validated against it and a missing provider is treated as misconfiguration. Pass nil
-// to skip validation (e.g. on the runner-side path where the manager isn't reachable).
+// providerSnapshot is an optional list of provider records visible to the owner
+// (env-baked globals + DB-backed). When non-nil, the agent's stored provider
+// reference (ID for DB-backed, canonical name for globals) is resolved
+// against it; the resolved provider's current name is used in the model
+// prefix written to settings.json. A missing provider is treated as
+// misconfiguration and Agent.DefaultModel is left unset. Pass nil to skip
+// resolution (e.g. on the runner-side path where the manager isn't
+// reachable) — the stored token is then used verbatim.
 func GenerateZedMCPConfig(
 	ctx context.Context,
 	app *types.App,
@@ -101,7 +105,7 @@ func GenerateZedMCPConfig(
 	koditEnabled bool,
 	projectSkills *types.AssistantSkills,
 	oauthTokenGetter OAuthTokenGetter,
-	validProviders []string,
+	providerSnapshot []ProviderRef,
 ) (*ZedMCPConfig, error) {
 	config := &ZedMCPConfig{
 		ContextServers: make(map[string]ContextServerConfig),
@@ -149,43 +153,50 @@ func GenerateZedMCPConfig(
 	//      anthropic/claude-sonnet-4-5-latest, which made misconfigured
 	//      external agents look like working Claude agents in Zed (Deviqon
 	//      bug, 2026-04-28).
-	//   2. Stale provider name. If the provider was renamed or removed in
-	//      admin, the agent record still holds the old string. We previously
-	//      fed that to mapHelixToZedProvider which encoded it into the
-	//      model name (e.g. "user-ollama/qwen-..."), and Zed sent every
-	//      chat completion with that unroutable string until the proxy
-	//      404'd. The agent should be flagged as misconfigured instead.
+	//   2. Provider deleted. The agent record stores the provider's
+	//      immutable ID (DB-backed) or canonical name (env-baked globals).
+	//      If the DB-backed provider is deleted, ID resolution fails and
+	//      we report misconfig instead of feeding an unroutable string into
+	//      the model prefix. Renames are no-ops because the ID survives.
 	//
-	// In both cases we now leave Agent.DefaultModel unset and log loudly.
-	// Zed will fall back to its built-in default rather than us pretending
-	// to have configured one.
+	// Spec-task entry handlers run the same validator
+	// (ValidateAssistantModelConfig) before transitioning a task to a queued
+	// state, so misconfigured agents should not reach session start. This
+	// block is the defense-in-depth for any caller that bypasses those entry
+	// handlers (default-app session, legacy code paths). When misconfigured,
+	// we leave Agent.DefaultModel unset and log loudly; Zed falls back to
+	// its built-in default.
 	useAgentModel := true
-	switch {
-	case assistant == nil:
+	if assistant == nil {
 		// No assistant means this is the default-app path used for sessions
 		// without a parent app. Keep the legacy SaaS-friendly default so
 		// those sessions still come up.
 		provider = "anthropic"
 		model = "claude-sonnet-4-5-latest"
-	case provider == "" || model == "":
+	} else if reason := ValidateAssistantModelConfig(app, providerSnapshot); reason != "" {
 		log.Error().
 			Str("app_id", app.ID).
 			Str("provider", provider).
 			Str("model", model).
-			Msg("zed-config: assistant has empty provider or model — refusing to write agent.default_model. Reconfigure the agent with a valid provider/model selection.")
+			Msg("zed-config: " + reason + " — refusing to write agent.default_model")
 		useAgentModel = false
 		config.Misconfigured = true
-		config.MisconfigReason = fmt.Sprintf("agent %q is missing a provider or model selection — open the agent settings and pick a provider and model", app.ID)
-	case !providerExists(provider, validProviders):
-		log.Error().
-			Str("app_id", app.ID).
-			Str("provider", provider).
-			Str("model", model).
-			Strs("known_providers", validProviders).
-			Msg("zed-config: assistant references a provider that is not registered (renamed or deleted?) — refusing to write agent.default_model. Reconfigure the agent or restore the provider.")
-		useAgentModel = false
-		config.Misconfigured = true
-		config.MisconfigReason = fmt.Sprintf("agent %q references provider %q which is not registered (renamed or deleted?). Reconfigure the agent or restore the provider.", app.ID, provider)
+		config.MisconfigReason = reason
+	} else if providerSnapshot != nil {
+		// Resolve the stored token (ID or legacy name) to the provider's
+		// current canonical name. settings.json carries the current name;
+		// the agent record carries the immutable ID. Renames flow into
+		// running sessions on the next 30s daemon poll.
+		resolved, byLegacy, _ := ResolveProvider(provider, providerSnapshot)
+		if byLegacy {
+			log.Warn().
+				Str("app_id", app.ID).
+				Str("stored_provider", provider).
+				Str("resolved_name", resolved.Name).
+				Str("resolved_id", resolved.ID).
+				Msg("zed-config: agent stores provider by name (legacy); re-save the agent so it stores the immutable provider ID")
+		}
+		provider = resolved.Name
 	}
 
 	// Configure agent. AlwaysAllowToolActions / ShowOnboarding / AutoOpenPanel
@@ -573,23 +584,98 @@ func normalizeModelIDForZed(modelID string) string {
 	return modelID
 }
 
-// providerExists reports whether name appears in validProviders. Comparison is
-// case-insensitive because some agents store provider names with mixed case
-// (e.g. the "OpenAI" provider on prime is registered as "openai" in the
-// manager). When validProviders is nil/empty we skip the check and return
-// true — callers without a manager handle (e.g. the runner-side code path)
-// pass nil to opt out of validation.
-func providerExists(name string, validProviders []string) bool {
-	if len(validProviders) == 0 {
-		return true
+// ProviderRef is the minimal projection of a provider endpoint that the
+// agent-config code path needs: a stable ID (empty for env-baked globals,
+// which have no DB row) and the current canonical name. Callers build the
+// snapshot from the provider manager's live state (globals + DB-backed user
+// providers visible to the owner).
+//
+// We deliberately store both ID and Name so resolution can be ID-first with
+// a name fallback for legacy agent records that were saved before agents
+// stored IDs. After such a fallback the agent should be re-saved so it picks
+// up the immutable reference.
+type ProviderRef struct {
+	ID   string // empty for env-baked global providers (openai, anthropic, ...)
+	Name string // current canonical name; for DB-backed providers this is the admin-set label
+}
+
+// ResolveProvider matches a stored agent token (an ID for DB-backed providers,
+// the canonical name for globals) against the provider snapshot. ID match
+// wins; if no ID matches, falls back to a case-insensitive name match
+// (legacy agents). The bool return distinguishes a successful resolve
+// (ok=true, byLegacyName=false), a legacy resolve that should be flagged for
+// rewriting (ok=true, byLegacyName=true), and a failed resolve (ok=false).
+//
+// snapshot==nil means "no manager handle" — the runner-side path opts out of
+// resolution this way; callers should treat this as "skip validation, trust
+// the stored value as a name".
+func ResolveProvider(token string, snapshot []ProviderRef) (ref ProviderRef, byLegacyName bool, ok bool) {
+	if snapshot == nil {
+		return ProviderRef{Name: token}, false, true
 	}
-	want := strings.ToLower(name)
-	for _, p := range validProviders {
-		if strings.ToLower(p) == want {
-			return true
+	for _, p := range snapshot {
+		if p.ID != "" && p.ID == token {
+			return p, false, true
 		}
 	}
-	return false
+	want := strings.ToLower(token)
+	for _, p := range snapshot {
+		if strings.EqualFold(p.Name, want) || strings.ToLower(p.Name) == want {
+			byLegacy := p.ID != "" // global with no ID is a normal match, not legacy
+			return p, byLegacy, true
+		}
+	}
+	return ProviderRef{}, false, false
+}
+
+// ValidateAssistantModelConfig checks whether the app's zed_external assistant
+// has a usable provider/model combination given the currently registered
+// providers. Returns the empty string when the configuration is usable;
+// otherwise an operator-friendly message suitable for surfacing in the
+// spec-task UI / API 422 response.
+//
+// snapshot is the list of provider records visible to the owner (env-baked
+// globals + DB-backed). Pass nil to skip provider-existence validation
+// (used by the runner-side path that has no manager handle).
+//
+// Default-app sessions (no parent app, len(Assistants)==0) skip validation —
+// they fall through to the legacy SaaS-friendly default in GenerateZedMCPConfig.
+//
+// Renames: agent records store the provider's immutable ID, so renaming a
+// provider in admin is a no-op for resolution.
+// Deletes: ID lookup fails and we report misconfig.
+func ValidateAssistantModelConfig(app *types.App, snapshot []ProviderRef) string {
+	if app == nil || len(app.Config.Helix.Assistants) == 0 {
+		return ""
+	}
+	var assistant *types.AssistantConfig
+	for i := range app.Config.Helix.Assistants {
+		if app.Config.Helix.Assistants[i].AgentType == types.AgentTypeZedExternal {
+			assistant = &app.Config.Helix.Assistants[i]
+			break
+		}
+	}
+	if assistant == nil {
+		assistant = &app.Config.Helix.Assistants[0]
+	}
+	provider := assistant.GenerationModelProvider
+	if provider == "" {
+		provider = assistant.Provider
+	}
+	model := assistant.GenerationModel
+	if model == "" {
+		model = assistant.Model
+	}
+	if provider == "" || model == "" {
+		return fmt.Sprintf("agent %q is missing a provider or model selection — open the agent settings and pick a provider and model", app.ID)
+	}
+	if snapshot == nil {
+		return ""
+	}
+	if _, _, ok := ResolveProvider(provider, snapshot); !ok {
+		return fmt.Sprintf("agent %q references provider %q which is no longer registered (provider deleted?). Reconfigure the agent or restore the provider.", app.ID, provider)
+	}
+	return ""
 }
 
 // mapHelixToZedProvider maps a Helix provider name to a Zed provider type and formats the model name.

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -243,3 +243,111 @@ func TestNormalizeModelIDForZed(t *testing.T) {
 		})
 	}
 }
+
+// TestMigrateLegacyProviderRefs covers the on-the-fly heal path that lets
+// agent records saved before the ID-based refactor silently rewrite their
+// stored provider name to the matching DB-backed provider's immutable ID.
+// Renames after the heal are no-ops; without the heal the first rename
+// would 422 the agent.
+func TestMigrateLegacyProviderRefs(t *testing.T) {
+	pe := ProviderRef{ID: "pe_user_provider_01", Name: "NVIDIA NIM"}
+	openai := ProviderRef{ID: "", Name: "openai"} // env-baked global
+
+	cases := []struct {
+		name           string
+		assistant      types.AssistantConfig
+		snapshot       []ProviderRef
+		wantChanged    bool
+		wantProvider   string
+		wantGenericGen string
+		why            string
+	}{
+		{
+			name: "legacy_name_to_id_rewrite",
+			assistant: types.AssistantConfig{
+				Provider: "NVIDIA NIM",
+				Model:    "openai/gpt-oss-120b",
+			},
+			snapshot:     []ProviderRef{pe, openai},
+			wantChanged:  true,
+			wantProvider: "pe_user_provider_01",
+			why:          "legacy stored name resolves to DB-backed ID and gets rewritten",
+		},
+		{
+			name: "id_already_present_no_op",
+			assistant: types.AssistantConfig{
+				Provider: "pe_user_provider_01",
+				Model:    "openai/gpt-oss-120b",
+			},
+			snapshot:     []ProviderRef{pe, openai},
+			wantChanged:  false,
+			wantProvider: "pe_user_provider_01",
+			why:          "ID already stored — resolver returns byLegacy=false, no rewrite",
+		},
+		{
+			name: "global_no_rewrite",
+			assistant: types.AssistantConfig{
+				Provider: "openai",
+				Model:    "gpt-4o",
+			},
+			snapshot:     []ProviderRef{pe, openai},
+			wantChanged:  false,
+			wantProvider: "openai",
+			why:          "env-baked global has no ID — leave the canonical name alone",
+		},
+		{
+			name: "deleted_provider_left_alone",
+			assistant: types.AssistantConfig{
+				Provider: "pe_deleted_01",
+				Model:    "qwen3-coder",
+			},
+			snapshot:     []ProviderRef{pe, openai},
+			wantChanged:  false,
+			wantProvider: "pe_deleted_01",
+			why:          "resolver miss — no ID to write, leave the field for the validator to flag",
+		},
+		{
+			name: "case_insensitive_legacy_match_rewrites",
+			assistant: types.AssistantConfig{
+				Provider: "nvidia nim", // lowercased legacy save
+				Model:    "openai/gpt-oss-120b",
+			},
+			snapshot:     []ProviderRef{pe, openai},
+			wantChanged:  true,
+			wantProvider: "pe_user_provider_01",
+			why:          "case-insensitive name match still triggers the rewrite to canonical ID",
+		},
+		{
+			name: "generation_field_also_rewrites",
+			assistant: types.AssistantConfig{
+				GenerationModelProvider: "NVIDIA NIM",
+				GenerationModel:         "openai/gpt-oss-120b",
+			},
+			snapshot:       []ProviderRef{pe, openai},
+			wantChanged:    true,
+			wantGenericGen: "pe_user_provider_01",
+			why:            "GenerationModelProvider migrates the same way as the legacy Provider field",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := &types.App{
+				ID: "test-app",
+				Config: types.AppConfig{
+					Helix: types.AppHelixConfig{
+						Assistants: []types.AssistantConfig{tc.assistant},
+					},
+				},
+			}
+			changed := MigrateLegacyProviderRefs(app, tc.snapshot)
+			assert.Equal(t, tc.wantChanged, changed, tc.why)
+			if tc.wantProvider != "" {
+				assert.Equal(t, tc.wantProvider, app.Config.Helix.Assistants[0].Provider, tc.why)
+			}
+			if tc.wantGenericGen != "" {
+				assert.Equal(t, tc.wantGenericGen, app.Config.Helix.Assistants[0].GenerationModelProvider, tc.why)
+			}
+		})
+	}
+}

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -55,3 +55,126 @@ func TestNormalizeModelIDForZed(t *testing.T) {
 		})
 	}
 }
+
+// TestMergeZedConfigWithUserOverrides_AgentModelFieldsProtected verifies that
+// the four helix-managed model fields under "agent" cannot be clobbered by
+// user-side overrides (uploaded by the settings-sync-daemon when Zed writes
+// to its local settings.json).
+//
+// See deviqon/P1-5-zed-overrides-clobber-helix-default-model.md.
+func TestMergeZedConfigWithUserOverrides_AgentModelFieldsProtected(t *testing.T) {
+	helixAgent := &AgentConfig{
+		DefaultModel:           &ModelConfig{Provider: "openai", Model: "numpty/openai/gpt-oss-120b"},
+		InlineAssistantModel:   &ModelConfig{Provider: "openai", Model: "numpty/openai/gpt-oss-120b"},
+		CommitMessageModel:     &ModelConfig{Provider: "openai", Model: "numpty/openai/gpt-oss-120b"},
+		ThreadSummaryModel:     &ModelConfig{Provider: "openai", Model: "numpty/openai/gpt-oss-120b"},
+		AlwaysAllowToolActions: true,
+		ShowOnboarding:         false,
+		AutoOpenPanel:          true,
+	}
+
+	helixConfig := &ZedMCPConfig{
+		ContextServers: map[string]ContextServerConfig{},
+		Agent:          helixAgent,
+	}
+
+	t.Run("user override of default_model is dropped", func(t *testing.T) {
+		userOverrides := map[string]interface{}{
+			"agent": map[string]interface{}{
+				"default_model": map[string]interface{}{
+					"provider":        "anthropic",
+					"model":           "claude-sonnet-4-6-latest",
+					"effort":          "high",
+					"enable_thinking": true,
+				},
+			},
+		}
+		merged := MergeZedConfigWithUserOverrides(helixConfig, userOverrides)
+
+		agent, ok := merged["agent"].(map[string]interface{})
+		assert.True(t, ok, "agent block should be a map")
+
+		dm, ok := agent["default_model"].(*ModelConfig)
+		assert.True(t, ok, "default_model should remain helix-managed *ModelConfig")
+		assert.Equal(t, "openai", dm.Provider)
+		assert.Equal(t, "numpty/openai/gpt-oss-120b", dm.Model)
+	})
+
+	t.Run("all four model fields are protected", func(t *testing.T) {
+		userOverrides := map[string]interface{}{
+			"agent": map[string]interface{}{
+				"default_model":          map[string]interface{}{"provider": "anthropic", "model": "claude"},
+				"inline_assistant_model": map[string]interface{}{"provider": "anthropic", "model": "claude"},
+				"commit_message_model":   map[string]interface{}{"provider": "anthropic", "model": "claude"},
+				"thread_summary_model":   map[string]interface{}{"provider": "anthropic", "model": "claude"},
+			},
+		}
+		merged := MergeZedConfigWithUserOverrides(helixConfig, userOverrides)
+		agent := merged["agent"].(map[string]interface{})
+
+		for _, field := range []string{"default_model", "inline_assistant_model", "commit_message_model", "thread_summary_model"} {
+			dm, ok := agent[field].(*ModelConfig)
+			assert.True(t, ok, "%s should remain helix-managed", field)
+			assert.Equal(t, "openai", dm.Provider, "%s.provider", field)
+			assert.Equal(t, "numpty/openai/gpt-oss-120b", dm.Model, "%s.model", field)
+		}
+	})
+
+	t.Run("non-model agent fields can still be user-overridden", func(t *testing.T) {
+		userOverrides := map[string]interface{}{
+			"agent": map[string]interface{}{
+				"default_model":  map[string]interface{}{"provider": "anthropic", "model": "claude"},
+				"play_sound_when_agent_done": true,
+				"button":                     false,
+			},
+		}
+		merged := MergeZedConfigWithUserOverrides(helixConfig, userOverrides)
+		agent := merged["agent"].(map[string]interface{})
+
+		// helix-managed model is protected
+		assert.Equal(t, "numpty/openai/gpt-oss-120b", agent["default_model"].(*ModelConfig).Model)
+		// arbitrary user-side keys land in the merged agent block
+		assert.Equal(t, true, agent["play_sound_when_agent_done"])
+		assert.Equal(t, false, agent["button"])
+	})
+
+	t.Run("top-level non-agent overrides still apply", func(t *testing.T) {
+		userOverrides := map[string]interface{}{
+			"theme":  "Dracula",
+			"keymap": "Vim",
+			"agent": map[string]interface{}{
+				"default_model": map[string]interface{}{"provider": "anthropic", "model": "claude"},
+			},
+		}
+		merged := MergeZedConfigWithUserOverrides(helixConfig, userOverrides)
+
+		assert.Equal(t, "Dracula", merged["theme"])
+		assert.Equal(t, "Vim", merged["keymap"])
+		// Helix model still wins
+		assert.Equal(t, "numpty/openai/gpt-oss-120b",
+			merged["agent"].(map[string]interface{})["default_model"].(*ModelConfig).Model)
+	})
+
+	t.Run("no agent override surfaces helix agent block verbatim", func(t *testing.T) {
+		userOverrides := map[string]interface{}{
+			"theme": "Light",
+		}
+		merged := MergeZedConfigWithUserOverrides(helixConfig, userOverrides)
+
+		// When the user has no agent override, the helix *AgentConfig is exposed directly.
+		agent, ok := merged["agent"].(*AgentConfig)
+		assert.True(t, ok, "agent should be the helix *AgentConfig when user has no override")
+		assert.Equal(t, "numpty/openai/gpt-oss-120b", agent.DefaultModel.Model)
+	})
+
+	t.Run("non-object agent override is ignored", func(t *testing.T) {
+		userOverrides := map[string]interface{}{
+			"agent": "not-an-object",
+		}
+		merged := MergeZedConfigWithUserOverrides(helixConfig, userOverrides)
+
+		agent, ok := merged["agent"].(*AgentConfig)
+		assert.True(t, ok, "agent should fall back to helix *AgentConfig when user override is not a map")
+		assert.Equal(t, "numpty/openai/gpt-oss-120b", agent.DefaultModel.Model)
+	})
+}

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -352,125 +352,44 @@ func TestMigrateLegacyProviderRefs(t *testing.T) {
 	}
 }
 
-// TestMergeZedConfigWithUserOverrides_AgentModelFieldsProtected verifies that
-// the four helix-managed model fields under "agent" cannot be clobbered by
-// user-side overrides (uploaded by the settings-sync-daemon when Zed writes
-// to its local settings.json).
-//
-// See deviqon/P1-5-zed-overrides-clobber-helix-default-model.md.
-func TestMergeZedConfigWithUserOverrides_AgentModelFieldsProtected(t *testing.T) {
-	helixAgent := &AgentConfig{
-		DefaultModel:           &ModelConfig{Provider: "openai", Model: "numpty/openai/gpt-oss-120b"},
-		InlineAssistantModel:   &ModelConfig{Provider: "openai", Model: "numpty/openai/gpt-oss-120b"},
-		CommitMessageModel:     &ModelConfig{Provider: "openai", Model: "numpty/openai/gpt-oss-120b"},
-		ThreadSummaryModel:     &ModelConfig{Provider: "openai", Model: "numpty/openai/gpt-oss-120b"},
-		AlwaysAllowToolActions: true,
-		ShowOnboarding:         false,
-		AutoOpenPanel:          true,
+func TestMergeContextServers(t *testing.T) {
+	helix := map[string]ContextServerConfig{
+		"helix-desktop": {URL: "http://api:8080/api/v1/mcp/desktop", Headers: map[string]string{"Authorization": "Bearer x"}},
+		"chrome":        {Command: "npx", Args: []string{"chrome-devtools-mcp@latest"}},
 	}
 
-	helixConfig := &ZedMCPConfig{
-		ContextServers: map[string]ContextServerConfig{},
-		Agent:          helixAgent,
-	}
-
-	t.Run("user override of default_model is dropped", func(t *testing.T) {
-		userOverrides := map[string]interface{}{
-			"agent": map[string]interface{}{
-				"default_model": map[string]interface{}{
-					"provider":        "anthropic",
-					"model":           "claude-sonnet-4-6-latest",
-					"effort":          "high",
-					"enable_thinking": true,
-				},
+	t.Run("user-only servers are added", func(t *testing.T) {
+		got := MergeContextServers(helix, map[string]interface{}{
+			"context_servers": map[string]interface{}{
+				"my-tool": map[string]interface{}{"command": "/usr/bin/mytool"},
 			},
-		}
-		merged := MergeZedConfigWithUserOverrides(helixConfig, userOverrides)
-
-		agent, ok := merged["agent"].(map[string]interface{})
-		assert.True(t, ok, "agent block should be a map")
-
-		dm, ok := agent["default_model"].(*ModelConfig)
-		assert.True(t, ok, "default_model should remain helix-managed *ModelConfig")
-		assert.Equal(t, "openai", dm.Provider)
-		assert.Equal(t, "numpty/openai/gpt-oss-120b", dm.Model)
+		})
+		assert.Contains(t, got, "helix-desktop")
+		assert.Contains(t, got, "chrome")
+		assert.Contains(t, got, "my-tool")
 	})
 
-	t.Run("all four model fields are protected", func(t *testing.T) {
-		userOverrides := map[string]interface{}{
-			"agent": map[string]interface{}{
-				"default_model":          map[string]interface{}{"provider": "anthropic", "model": "claude"},
-				"inline_assistant_model": map[string]interface{}{"provider": "anthropic", "model": "claude"},
-				"commit_message_model":   map[string]interface{}{"provider": "anthropic", "model": "claude"},
-				"thread_summary_model":   map[string]interface{}{"provider": "anthropic", "model": "claude"},
+	t.Run("user override of helix server replaces it", func(t *testing.T) {
+		got := MergeContextServers(helix, map[string]interface{}{
+			"context_servers": map[string]interface{}{
+				"chrome": map[string]interface{}{"command": "/custom/chrome"},
 			},
-		}
-		merged := MergeZedConfigWithUserOverrides(helixConfig, userOverrides)
-		agent := merged["agent"].(map[string]interface{})
-
-		for _, field := range []string{"default_model", "inline_assistant_model", "commit_message_model", "thread_summary_model"} {
-			dm, ok := agent[field].(*ModelConfig)
-			assert.True(t, ok, "%s should remain helix-managed", field)
-			assert.Equal(t, "openai", dm.Provider, "%s.provider", field)
-			assert.Equal(t, "numpty/openai/gpt-oss-120b", dm.Model, "%s.model", field)
-		}
+		})
+		assert.Equal(t, "/custom/chrome", got["chrome"].(map[string]interface{})["command"])
 	})
 
-	t.Run("non-model agent fields can still be user-overridden", func(t *testing.T) {
-		userOverrides := map[string]interface{}{
-			"agent": map[string]interface{}{
-				"default_model":  map[string]interface{}{"provider": "anthropic", "model": "claude"},
-				"play_sound_when_agent_done": true,
-				"button":                     false,
-			},
-		}
-		merged := MergeZedConfigWithUserOverrides(helixConfig, userOverrides)
-		agent := merged["agent"].(map[string]interface{})
-
-		// helix-managed model is protected
-		assert.Equal(t, "numpty/openai/gpt-oss-120b", agent["default_model"].(*ModelConfig).Model)
-		// arbitrary user-side keys land in the merged agent block
-		assert.Equal(t, true, agent["play_sound_when_agent_done"])
-		assert.Equal(t, false, agent["button"])
+	t.Run("no user overrides preserves helix servers", func(t *testing.T) {
+		got := MergeContextServers(helix, map[string]interface{}{})
+		assert.Contains(t, got, "helix-desktop")
+		assert.Contains(t, got, "chrome")
 	})
 
-	t.Run("top-level non-agent overrides still apply", func(t *testing.T) {
-		userOverrides := map[string]interface{}{
-			"theme":  "Dracula",
-			"keymap": "Vim",
-			"agent": map[string]interface{}{
-				"default_model": map[string]interface{}{"provider": "anthropic", "model": "claude"},
-			},
-		}
-		merged := MergeZedConfigWithUserOverrides(helixConfig, userOverrides)
-
-		assert.Equal(t, "Dracula", merged["theme"])
-		assert.Equal(t, "Vim", merged["keymap"])
-		// Helix model still wins
-		assert.Equal(t, "numpty/openai/gpt-oss-120b",
-			merged["agent"].(map[string]interface{})["default_model"].(*ModelConfig).Model)
-	})
-
-	t.Run("no agent override surfaces helix agent block verbatim", func(t *testing.T) {
-		userOverrides := map[string]interface{}{
-			"theme": "Light",
-		}
-		merged := MergeZedConfigWithUserOverrides(helixConfig, userOverrides)
-
-		// When the user has no agent override, the helix *AgentConfig is exposed directly.
-		agent, ok := merged["agent"].(*AgentConfig)
-		assert.True(t, ok, "agent should be the helix *AgentConfig when user has no override")
-		assert.Equal(t, "numpty/openai/gpt-oss-120b", agent.DefaultModel.Model)
-	})
-
-	t.Run("non-object agent override is ignored", func(t *testing.T) {
-		userOverrides := map[string]interface{}{
-			"agent": "not-an-object",
-		}
-		merged := MergeZedConfigWithUserOverrides(helixConfig, userOverrides)
-
-		agent, ok := merged["agent"].(*AgentConfig)
-		assert.True(t, ok, "agent should fall back to helix *AgentConfig when user override is not a map")
-		assert.Equal(t, "numpty/openai/gpt-oss-120b", agent.DefaultModel.Model)
+	t.Run("non-context_servers user keys are ignored", func(t *testing.T) {
+		got := MergeContextServers(helix, map[string]interface{}{
+			"agent":          map[string]interface{}{"default_model": "claude"},
+			"language_models": map[string]interface{}{},
+		})
+		assert.NotContains(t, got, "agent")
+		assert.NotContains(t, got, "language_models")
 	})
 }

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -25,19 +25,30 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 	helixURL := "http://api:8080"
 	helixToken := "test-token"
 
+	// Synthetic globals (no ID) and DB-backed providers (with ID) used by
+	// the cases below. Renames are demonstrated by mutating the .Name of a
+	// DB-backed provider while keeping its .ID stable; the agent's stored
+	// reference (the .ID) survives the rename.
+	var (
+		globalOpenAI    = ProviderRef{ID: "", Name: "openai"}
+		globalAnthropic = ProviderRef{ID: "", Name: "anthropic"}
+		dbScalewayID    = "pe_scaleway_01"
+		dbScaleway      = ProviderRef{ID: dbScalewayID, Name: "scaleway"}
+		dbScalewayPrime = ProviderRef{ID: dbScalewayID, Name: "scaleway-prime"} // same ID, renamed
+	)
+
 	cases := []struct {
 		name             string
 		assistants       []types.AssistantConfig // empty slice → no-assistant default-app path
-		validProviders   []string
+		snapshot         []ProviderRef
 		wantDefaultModel *ModelConfig // nil = expect Agent.DefaultModel == nil
 		wantMisconfig    bool         // expect ZedMCPConfig.Misconfigured to be set so handlers can return 422
 		why              string
 	}{
 		{
-			name:           "both_fields_empty_no_longer_falls_back_to_claude",
-			assistants:     []types.AssistantConfig{{AgentType: types.AgentTypeZedExternal}},
-			validProviders: []string{"openai", "anthropic"},
-			// Sub-A fix: silent claude fallback removed. Empty fields => no default_model.
+			name:             "both_fields_empty_no_longer_falls_back_to_claude",
+			assistants:       []types.AssistantConfig{{AgentType: types.AgentTypeZedExternal}},
+			snapshot:         []ProviderRef{globalOpenAI, globalAnthropic},
 			wantDefaultModel: nil,
 			wantMisconfig:    true,
 			why:              "P1-1 Sub-A: empty fields must not silently substitute Claude",
@@ -46,37 +57,48 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 			name: "model_empty_provider_set_no_default_model",
 			assistants: []types.AssistantConfig{{
 				AgentType:               types.AgentTypeZedExternal,
-				GenerationModelProvider: "scaleway",
+				GenerationModelProvider: dbScalewayID,
 			}},
-			validProviders:   []string{"scaleway", "openai"},
+			snapshot:         []ProviderRef{dbScaleway, globalOpenAI},
 			wantDefaultModel: nil,
 			wantMisconfig:    true,
 			why:              "P1-1 Sub-A: partial config (provider only) must not silently fill in claude-sonnet",
 		},
 		{
-			name: "stale_provider_no_default_model",
+			name: "deleted_provider_no_default_model",
 			assistants: []types.AssistantConfig{{
 				AgentType:               types.AgentTypeZedExternal,
-				GenerationModelProvider: "user-ollama",
+				GenerationModelProvider: "pe_user_ollama_01", // ID, but provider was deleted
 				GenerationModel:         "qwen3-coder",
 			}},
-			// Provider was renamed/deleted in admin → not in registry anymore
-			validProviders:   []string{"openai", "anthropic"},
+			snapshot:         []ProviderRef{globalOpenAI, globalAnthropic},
 			wantDefaultModel: nil,
 			wantMisconfig:    true,
-			why:              "P1-1 Sub-B: stale provider snapshot must not be encoded into the model string",
+			why:              "P1-3: deleted provider must not be encoded into the model string",
+		},
+		{
+			name: "rename_is_no_op_id_still_resolves",
+			assistants: []types.AssistantConfig{{
+				AgentType:               types.AgentTypeZedExternal,
+				GenerationModelProvider: dbScalewayID, // agent stored ID
+				GenerationModel:         "qwen3-coder-480b",
+			}},
+			snapshot:         []ProviderRef{dbScalewayPrime, globalOpenAI}, // admin renamed scaleway → scaleway-prime
+			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "scaleway-prime/qwen3-coder-480b"},
+			wantMisconfig:    false,
+			why:              "P1-3 core: provider rename must be a no-op for the agent — ID resolves to current name",
 		},
 		{
 			name: "configured_qwen_on_scaleway_works",
 			assistants: []types.AssistantConfig{{
 				AgentType:               types.AgentTypeZedExternal,
-				GenerationModelProvider: "scaleway",
+				GenerationModelProvider: dbScalewayID,
 				GenerationModel:         "qwen3-coder-480b",
 			}},
-			validProviders:   []string{"scaleway", "openai"},
+			snapshot:         []ProviderRef{dbScaleway, globalOpenAI},
 			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "scaleway/qwen3-coder-480b"},
 			wantMisconfig:    false,
-			why:              "control case: registered provider + non-empty model passes through unchanged",
+			why:              "control case: agent stored ID resolves to canonical scaleway name",
 		},
 		{
 			name: "configured_anthropic_passes_through",
@@ -85,42 +107,42 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 				GenerationModelProvider: "anthropic",
 				GenerationModel:         "claude-sonnet-4-5",
 			}},
-			validProviders:   []string{"anthropic"},
+			snapshot:         []ProviderRef{globalAnthropic},
 			wantDefaultModel: &ModelConfig{Provider: "anthropic", Model: "claude-sonnet-4-5-latest"},
 			wantMisconfig:    false,
-			why:              "control case: anthropic agents normalize the model id via -latest",
+			why:              "control case: env-baked global (no ID) resolves by canonical name; -latest normalization applies",
 		},
 		{
-			name: "case_insensitive_provider_match",
+			name: "legacy_name_match_still_works_for_unsaved_agents",
 			assistants: []types.AssistantConfig{{
 				AgentType:               types.AgentTypeZedExternal,
-				GenerationModelProvider: "OpenAI", // capital O as on prime row
+				GenerationModelProvider: "OpenAI", // capital O — legacy agent stored a name
 				GenerationModel:         "gpt-5.4",
 			}},
-			validProviders:   []string{"openai"},
-			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "OpenAI/gpt-5.4"},
+			snapshot:         []ProviderRef{globalOpenAI}, // global has Name=openai
+			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "openai/gpt-5.4"},
 			wantMisconfig:    false,
-			why:              "provider validation is case-insensitive (OpenAI vs openai)",
+			why:              "legacy fallback: agents stored before ID-based references still resolve via case-insensitive name match",
 		},
 		{
 			name:             "no_assistant_keeps_legacy_default_for_default_app",
 			assistants:       []types.AssistantConfig{},
-			validProviders:   []string{"anthropic"},
+			snapshot:         []ProviderRef{globalAnthropic},
 			wantDefaultModel: &ModelConfig{Provider: "anthropic", Model: "claude-sonnet-4-5-latest"},
 			wantMisconfig:    false,
 			why:              "default-app path (no parent app) keeps the SaaS-friendly default",
 		},
 		{
-			name: "nil_validProviders_skips_validation",
+			name: "nil_snapshot_skips_resolution",
 			assistants: []types.AssistantConfig{{
 				AgentType:               types.AgentTypeZedExternal,
-				GenerationModelProvider: "scaleway",
+				GenerationModelProvider: "scaleway", // runner-side: name passed verbatim
 				GenerationModel:         "qwen3-coder-480b",
 			}},
-			validProviders:   nil, // runner-side path passes nil
+			snapshot:         nil, // runner-side path passes nil
 			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "scaleway/qwen3-coder-480b"},
 			wantMisconfig:    false,
-			why:              "runner-side callers without a manager handle opt out of validation",
+			why:              "runner-side callers without a manager handle opt out of resolution and pass through verbatim",
 		},
 	}
 
@@ -145,7 +167,7 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 				false,
 				nil,
 				nil,
-				tc.validProviders,
+				tc.snapshot,
 			)
 			assert.NoError(t, err)
 			if !assert.NotNil(t, cfg) || !assert.NotNil(t, cfg.Agent) {

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -30,6 +30,7 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 		assistants       []types.AssistantConfig // empty slice → no-assistant default-app path
 		validProviders   []string
 		wantDefaultModel *ModelConfig // nil = expect Agent.DefaultModel == nil
+		wantMisconfig    bool         // expect ZedMCPConfig.Misconfigured to be set so handlers can return 422
 		why              string
 	}{
 		{
@@ -38,6 +39,7 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 			validProviders: []string{"openai", "anthropic"},
 			// Sub-A fix: silent claude fallback removed. Empty fields => no default_model.
 			wantDefaultModel: nil,
+			wantMisconfig:    true,
 			why:              "P1-1 Sub-A: empty fields must not silently substitute Claude",
 		},
 		{
@@ -48,6 +50,7 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 			}},
 			validProviders:   []string{"scaleway", "openai"},
 			wantDefaultModel: nil,
+			wantMisconfig:    true,
 			why:              "P1-1 Sub-A: partial config (provider only) must not silently fill in claude-sonnet",
 		},
 		{
@@ -60,6 +63,7 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 			// Provider was renamed/deleted in admin → not in registry anymore
 			validProviders:   []string{"openai", "anthropic"},
 			wantDefaultModel: nil,
+			wantMisconfig:    true,
 			why:              "P1-1 Sub-B: stale provider snapshot must not be encoded into the model string",
 		},
 		{
@@ -71,6 +75,7 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 			}},
 			validProviders:   []string{"scaleway", "openai"},
 			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "scaleway/qwen3-coder-480b"},
+			wantMisconfig:    false,
 			why:              "control case: registered provider + non-empty model passes through unchanged",
 		},
 		{
@@ -82,6 +87,7 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 			}},
 			validProviders:   []string{"anthropic"},
 			wantDefaultModel: &ModelConfig{Provider: "anthropic", Model: "claude-sonnet-4-5-latest"},
+			wantMisconfig:    false,
 			why:              "control case: anthropic agents normalize the model id via -latest",
 		},
 		{
@@ -93,6 +99,7 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 			}},
 			validProviders:   []string{"openai"},
 			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "OpenAI/gpt-5.4"},
+			wantMisconfig:    false,
 			why:              "provider validation is case-insensitive (OpenAI vs openai)",
 		},
 		{
@@ -100,6 +107,7 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 			assistants:       []types.AssistantConfig{},
 			validProviders:   []string{"anthropic"},
 			wantDefaultModel: &ModelConfig{Provider: "anthropic", Model: "claude-sonnet-4-5-latest"},
+			wantMisconfig:    false,
 			why:              "default-app path (no parent app) keeps the SaaS-friendly default",
 		},
 		{
@@ -111,6 +119,7 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 			}},
 			validProviders:   nil, // runner-side path passes nil
 			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "scaleway/qwen3-coder-480b"},
+			wantMisconfig:    false,
 			why:              "runner-side callers without a manager handle opt out of validation",
 		},
 	}
@@ -152,6 +161,12 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 					assert.Equal(t, tc.wantDefaultModel.Provider, cfg.Agent.DefaultModel.Provider, tc.why)
 					assert.Equal(t, tc.wantDefaultModel.Model, cfg.Agent.DefaultModel.Model, tc.why)
 				}
+			}
+			assert.Equal(t, tc.wantMisconfig, cfg.Misconfigured, tc.why)
+			if tc.wantMisconfig {
+				assert.NotEmpty(t, cfg.MisconfigReason, "misconfigured config must include a human-readable reason for the 422 response")
+			} else {
+				assert.Empty(t, cfg.MisconfigReason, tc.why)
 			}
 		})
 	}

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -1,10 +1,161 @@
 package external_agent
 
 import (
+	"context"
 	"testing"
 
+	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
+
+// TestGenerateZedMCPConfig_AgentDefaultModel covers P1-1 from the Deviqon
+// 2026-04-28 customer call. The original bug: when an agent had empty model
+// fields, the API silently substituted anthropic/claude-sonnet-4-5-latest;
+// when an agent referenced a renamed/deleted provider, the provider name
+// was still encoded into the model string and Zed sent unroutable requests.
+// Both paths caused customers to see "Claude Sonnet 4.5" in Zed when they
+// thought they had configured Qwen on Scaleway.
+//
+// After the fix, GenerateZedMCPConfig leaves Agent.DefaultModel == nil for
+// any misconfigured assistant. Zed falls back to its own built-in default
+// rather than us pretending we configured one. Operators get a loud error
+// log pointing at the broken agent.
+func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
+	ctx := context.Background()
+	helixURL := "http://api:8080"
+	helixToken := "test-token"
+
+	cases := []struct {
+		name             string
+		assistants       []types.AssistantConfig // empty slice → no-assistant default-app path
+		validProviders   []string
+		wantDefaultModel *ModelConfig // nil = expect Agent.DefaultModel == nil
+		why              string
+	}{
+		{
+			name:           "both_fields_empty_no_longer_falls_back_to_claude",
+			assistants:     []types.AssistantConfig{{AgentType: types.AgentTypeZedExternal}},
+			validProviders: []string{"openai", "anthropic"},
+			// Sub-A fix: silent claude fallback removed. Empty fields => no default_model.
+			wantDefaultModel: nil,
+			why:              "P1-1 Sub-A: empty fields must not silently substitute Claude",
+		},
+		{
+			name: "model_empty_provider_set_no_default_model",
+			assistants: []types.AssistantConfig{{
+				AgentType:               types.AgentTypeZedExternal,
+				GenerationModelProvider: "scaleway",
+			}},
+			validProviders:   []string{"scaleway", "openai"},
+			wantDefaultModel: nil,
+			why:              "P1-1 Sub-A: partial config (provider only) must not silently fill in claude-sonnet",
+		},
+		{
+			name: "stale_provider_no_default_model",
+			assistants: []types.AssistantConfig{{
+				AgentType:               types.AgentTypeZedExternal,
+				GenerationModelProvider: "user-ollama",
+				GenerationModel:         "qwen3-coder",
+			}},
+			// Provider was renamed/deleted in admin → not in registry anymore
+			validProviders:   []string{"openai", "anthropic"},
+			wantDefaultModel: nil,
+			why:              "P1-1 Sub-B: stale provider snapshot must not be encoded into the model string",
+		},
+		{
+			name: "configured_qwen_on_scaleway_works",
+			assistants: []types.AssistantConfig{{
+				AgentType:               types.AgentTypeZedExternal,
+				GenerationModelProvider: "scaleway",
+				GenerationModel:         "qwen3-coder-480b",
+			}},
+			validProviders:   []string{"scaleway", "openai"},
+			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "scaleway/qwen3-coder-480b"},
+			why:              "control case: registered provider + non-empty model passes through unchanged",
+		},
+		{
+			name: "configured_anthropic_passes_through",
+			assistants: []types.AssistantConfig{{
+				AgentType:               types.AgentTypeZedExternal,
+				GenerationModelProvider: "anthropic",
+				GenerationModel:         "claude-sonnet-4-5",
+			}},
+			validProviders:   []string{"anthropic"},
+			wantDefaultModel: &ModelConfig{Provider: "anthropic", Model: "claude-sonnet-4-5-latest"},
+			why:              "control case: anthropic agents normalize the model id via -latest",
+		},
+		{
+			name: "case_insensitive_provider_match",
+			assistants: []types.AssistantConfig{{
+				AgentType:               types.AgentTypeZedExternal,
+				GenerationModelProvider: "OpenAI", // capital O as on prime row
+				GenerationModel:         "gpt-5.4",
+			}},
+			validProviders:   []string{"openai"},
+			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "OpenAI/gpt-5.4"},
+			why:              "provider validation is case-insensitive (OpenAI vs openai)",
+		},
+		{
+			name:             "no_assistant_keeps_legacy_default_for_default_app",
+			assistants:       []types.AssistantConfig{},
+			validProviders:   []string{"anthropic"},
+			wantDefaultModel: &ModelConfig{Provider: "anthropic", Model: "claude-sonnet-4-5-latest"},
+			why:              "default-app path (no parent app) keeps the SaaS-friendly default",
+		},
+		{
+			name: "nil_validProviders_skips_validation",
+			assistants: []types.AssistantConfig{{
+				AgentType:               types.AgentTypeZedExternal,
+				GenerationModelProvider: "scaleway",
+				GenerationModel:         "qwen3-coder-480b",
+			}},
+			validProviders:   nil, // runner-side path passes nil
+			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "scaleway/qwen3-coder-480b"},
+			why:              "runner-side callers without a manager handle opt out of validation",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := &types.App{
+				ID: "test-app",
+				Config: types.AppConfig{
+					Helix: types.AppHelixConfig{
+						Assistants: tc.assistants,
+					},
+				},
+			}
+
+			cfg, err := GenerateZedMCPConfig(
+				ctx,
+				app,
+				"user-1",
+				"session-1",
+				helixURL,
+				helixToken,
+				false,
+				nil,
+				nil,
+				tc.validProviders,
+			)
+			assert.NoError(t, err)
+			if !assert.NotNil(t, cfg) || !assert.NotNil(t, cfg.Agent) {
+				return
+			}
+			if tc.wantDefaultModel == nil {
+				assert.Nil(t, cfg.Agent.DefaultModel, tc.why)
+				assert.Nil(t, cfg.Agent.InlineAssistantModel, tc.why)
+				assert.Nil(t, cfg.Agent.CommitMessageModel, tc.why)
+				assert.Nil(t, cfg.Agent.ThreadSummaryModel, tc.why)
+			} else {
+				if assert.NotNil(t, cfg.Agent.DefaultModel, tc.why) {
+					assert.Equal(t, tc.wantDefaultModel.Provider, cfg.Agent.DefaultModel.Provider, tc.why)
+					assert.Equal(t, tc.wantDefaultModel.Model, cfg.Agent.DefaultModel.Model, tc.why)
+				}
+			}
+		})
+	}
+}
 
 func TestNormalizeModelIDForZed(t *testing.T) {
 	tests := []struct {

--- a/api/pkg/openai/manager/manager_mocks.go
+++ b/api/pkg/openai/manager/manager_mocks.go
@@ -95,6 +95,21 @@ func (mr *MockProviderManagerMockRecorder) GetClient(ctx, req any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClient", reflect.TypeOf((*MockProviderManager)(nil).GetClient), ctx, req)
 }
 
+// ListProviderEndpoints mocks base method.
+func (m *MockProviderManager) ListProviderEndpoints(ctx context.Context, owner string) ([]*types.ProviderEndpoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListProviderEndpoints", ctx, owner)
+	ret0, _ := ret[0].([]*types.ProviderEndpoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListProviderEndpoints indicates an expected call of ListProviderEndpoints.
+func (mr *MockProviderManagerMockRecorder) ListProviderEndpoints(ctx, owner any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProviderEndpoints", reflect.TypeOf((*MockProviderManager)(nil).ListProviderEndpoints), ctx, owner)
+}
+
 // ListProviders mocks base method.
 func (m *MockProviderManager) ListProviders(ctx context.Context, owner string) ([]types.Provider, error) {
 	m.ctrl.T.Helper()

--- a/api/pkg/openai/manager/provider_manager.go
+++ b/api/pkg/openai/manager/provider_manager.go
@@ -37,6 +37,13 @@ type ProviderManager interface {
 	GetClient(ctx context.Context, req *GetClientRequest) (openai.Client, error)
 	// ListProviders returns a list of providers that are available
 	ListProviders(ctx context.Context, owner string) ([]types.Provider, error)
+	// ListProviderEndpoints returns the full provider records visible to the
+	// owner: synthetic entries for env-baked global providers (ID="",
+	// Name=canonical) plus DB-backed user/org provider records. Used by
+	// agent-config code paths that need to resolve an agent's stored
+	// provider reference (an immutable ID for DB-backed, the canonical name
+	// for globals) to the current canonical name.
+	ListProviderEndpoints(ctx context.Context, owner string) ([]*types.ProviderEndpoint, error)
 	// SetRunnerController sets the runner controller for checking runner availability
 	SetRunnerController(controller RunnerControllerStatus)
 }
@@ -331,6 +338,46 @@ func (m *MultiClientManager) ListProviders(ctx context.Context, owner string) ([
 	}
 
 	return providers, nil
+}
+
+// ListProviderEndpoints returns full provider records visible to the owner.
+// Env-baked globals are returned as synthetic *ProviderEndpoint values with
+// ID="" and Name=canonical; DB-backed user/org providers are returned with
+// their real ID and current admin-set Name. Use this when callers need to
+// resolve an agent's stored provider reference to its current canonical name
+// — the agent record stores the immutable ID, settings.json carries the
+// current name. Renames flow into running sessions on the next sync poll.
+func (m *MultiClientManager) ListProviderEndpoints(ctx context.Context, owner string) ([]*types.ProviderEndpoint, error) {
+	m.globalClientsMu.RLock()
+	endpoints := make([]*types.ProviderEndpoint, 0, len(m.globalClients))
+	for provider := range m.globalClients {
+		// Skip the Helix provider if there are no runners — same gate as
+		// ListProviders so the snapshots agree on what's reachable.
+		if provider == types.ProviderHelix && m.runnerController != nil {
+			if len(m.runnerController.RunnerIDs()) == 0 {
+				continue
+			}
+		}
+		endpoints = append(endpoints, &types.ProviderEndpoint{
+			Name:         string(provider),
+			EndpointType: types.ProviderEndpointTypeGlobal,
+		})
+	}
+	m.globalClientsMu.RUnlock()
+
+	if owner == "" {
+		return endpoints, nil
+	}
+
+	userProviders, err := m.store.ListProviderEndpoints(ctx, &store.ListProviderEndpointsQuery{
+		Owner:      owner,
+		WithGlobal: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	endpoints = append(endpoints, userProviders...)
+	return endpoints, nil
 }
 
 func (m *MultiClientManager) GetClient(_ context.Context, req *GetClientRequest) (openai.Client, error) {

--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"time"
 
@@ -69,8 +68,11 @@ func (s *HelixAPIServer) applyModelSubstitutions(ctx context.Context, user *type
 		owner = app.OrganizationID
 	}
 
-	// Get available providers for the user
-	availableProviders, err := s.providerManager.ListProviders(ctx, owner)
+	// Get available providers for the user. Use the endpoint-aware listing
+	// so we can match agent records that store the provider's immutable ID
+	// (DB-backed) as well as the canonical name (env-baked globals + legacy
+	// agents that haven't been re-saved yet).
+	availableEndpoints, err := s.providerManager.ListProviderEndpoints(ctx, owner)
 	if err != nil {
 		log.Error().
 			Err(err).
@@ -79,15 +81,24 @@ func (s *HelixAPIServer) applyModelSubstitutions(ctx context.Context, user *type
 		return substitutions, err
 	}
 
-	// Create a set of available providers for fast lookup
+	// Create a set of available providers for fast lookup, indexed by both
+	// ID and (lowercased) Name. Substitution catalogs are name-keyed so
+	// alt.Provider is always a name; the agent-stored value may be an ID,
+	// a canonical global name, or a legacy mixed-case name.
 	providerSet := make(map[types.Provider]bool)
-	for _, provider := range availableProviders {
-		providerSet[provider] = true
+	for _, ep := range availableEndpoints {
+		if ep.ID != "" {
+			providerSet[types.Provider(ep.ID)] = true
+		}
+		if ep.Name != "" {
+			providerSet[types.Provider(ep.Name)] = true
+			providerSet[types.Provider(strings.ToLower(ep.Name))] = true
+		}
 	}
 
 	log.Info().
 		Str("user_id", user.ID).
-		Interface("available_providers", availableProviders).
+		Int("available_endpoints", len(availableEndpoints)).
 		Msg("Available providers for model substitution")
 
 	// Apply substitutions to each assistant
@@ -582,7 +593,7 @@ func (s *HelixAPIServer) validateProvidersAndModels(ctx context.Context, user *t
 		owner = app.OrganizationID
 	}
 
-	providers, err := s.providerManager.ListProviders(ctx, owner)
+	endpoints, err := s.providerManager.ListProviderEndpoints(ctx, owner)
 	if err != nil {
 		log.Error().
 			Err(err).
@@ -593,19 +604,48 @@ func (s *HelixAPIServer) validateProvidersAndModels(ctx context.Context, user *t
 
 	// When creating org apps, also include the user's personal providers
 	if app.OrganizationID != "" {
-		userProviders, err := s.providerManager.ListProviders(ctx, user.ID)
+		userEndpoints, err := s.providerManager.ListProviderEndpoints(ctx, user.ID)
 		if err == nil {
-			for _, p := range userProviders {
-				if !slices.Contains(providers, p) {
-					providers = append(providers, p)
+			seen := make(map[string]struct{}, len(endpoints))
+			for _, ep := range endpoints {
+				key := ep.ID
+				if key == "" {
+					key = "name:" + ep.Name
+				}
+				seen[key] = struct{}{}
+			}
+			for _, ep := range userEndpoints {
+				key := ep.ID
+				if key == "" {
+					key = "name:" + ep.Name
+				}
+				if _, ok := seen[key]; !ok {
+					endpoints = append(endpoints, ep)
+					seen[key] = struct{}{}
 				}
 			}
 		}
 	}
 
+	// Provider references are IDs for DB-backed providers, canonical names
+	// for env-baked globals. Match incoming agent values against either —
+	// case-insensitive on names so a legacy agent that stored "OpenAI" still
+	// matches the canonical "openai" record.
+	providerKnown := func(ref string) bool {
+		for _, ep := range endpoints {
+			if ep.ID != "" && ep.ID == ref {
+				return true
+			}
+			if strings.EqualFold(ep.Name, ref) {
+				return true
+			}
+		}
+		return false
+	}
+
 	log.Info().
 		Str("user_id", user.ID).
-		Interface("available_providers", providers).
+		Int("available_endpoints", len(endpoints)).
 		Msg("Available providers during validation")
 
 	// Helper function to validate a provider/model pair
@@ -625,13 +665,13 @@ func (s *HelixAPIServer) validateProvidersAndModels(ctx context.Context, user *t
 
 		// If provider set, check if we have it
 		if provider != "" && !isAgentMode {
-			if !slices.Contains(providers, types.Provider(provider)) {
+			if !providerKnown(provider) {
 				log.Error().
 					Str("user_id", user.ID).
 					Str("assistant_name", assistantName).
 					Str("field_name", fieldName).
 					Str("provider", provider).
-					Interface("available_providers", providers).
+					Int("available_endpoints", len(endpoints)).
 					Msg("Validation failed: provider not available")
 				return fmt.Errorf("provider '%s' is not available for %s", provider, fieldName)
 			}

--- a/api/pkg/server/app_handlers_test.go
+++ b/api/pkg/server/app_handlers_test.go
@@ -322,8 +322,8 @@ func TestApplyModelSubstitutions(t *testing.T) {
 	t.Run("substitutes model when provider unavailable", func(t *testing.T) {
 		// Mock provider manager to return only "helix" as available
 		mockProviderManager.EXPECT().
-			ListProviders(ctx, user.ID).
-			Return([]types.Provider{types.ProviderHelix}, nil)
+			ListProviderEndpoints(ctx, user.ID).
+			Return([]*types.ProviderEndpoint{{Name: "helix"}}, nil)
 
 		app := &types.App{
 			Config: types.AppConfig{
@@ -356,8 +356,8 @@ func TestApplyModelSubstitutions(t *testing.T) {
 	t.Run("preserves all other fields during substitution", func(t *testing.T) {
 		// Mock provider manager to return only "helix" as available
 		mockProviderManager.EXPECT().
-			ListProviders(ctx, user.ID).
-			Return([]types.Provider{types.ProviderHelix}, nil)
+			ListProviderEndpoints(ctx, user.ID).
+			Return([]*types.ProviderEndpoint{{Name: "helix"}}, nil)
 
 		// Create an assistant with all possible fields populated
 		originalAssistant := types.AssistantConfig{
@@ -430,8 +430,8 @@ func TestApplyModelSubstitutions(t *testing.T) {
 	t.Run("preserves original values when no substitution needed", func(t *testing.T) {
 		// Mock provider manager to return "together" as available
 		mockProviderManager.EXPECT().
-			ListProviders(ctx, user.ID).
-			Return([]types.Provider{"together"}, nil)
+			ListProviderEndpoints(ctx, user.ID).
+			Return([]*types.ProviderEndpoint{{Name: "together"}}, nil)
 
 		originalAssistant := types.AssistantConfig{
 			Name:                 "test-assistant",
@@ -465,8 +465,8 @@ func TestApplyModelSubstitutions(t *testing.T) {
 	t.Run("handles multiple assistants independently", func(t *testing.T) {
 		// Mock provider manager to return only "helix" as available
 		mockProviderManager.EXPECT().
-			ListProviders(ctx, user.ID).
-			Return([]types.Provider{types.ProviderHelix}, nil)
+			ListProviderEndpoints(ctx, user.ID).
+			Return([]*types.ProviderEndpoint{{Name: "helix"}}, nil)
 
 		app := &types.App{
 			Config: types.AppConfig{
@@ -535,8 +535,8 @@ func TestCreateAppWithModelSubstitutions(t *testing.T) {
 
 	// Mock provider manager to return only "helix" as available (forcing substitution)
 	mockProviderManager.EXPECT().
-		ListProviders(ctx, user.ID).
-		Return([]types.Provider{types.ProviderHelix}, nil)
+		ListProviderEndpoints(ctx, user.ID).
+		Return([]*types.ProviderEndpoint{{Name: "helix"}}, nil)
 
 	app := &types.App{
 		Config: types.AppConfig{
@@ -603,8 +603,8 @@ func TestApplyModelSubstitutions_AgentMode(t *testing.T) {
 
 	// Mock provider manager to return only "helix" as available
 	mockProviderManager.EXPECT().
-		ListProviders(ctx, user.ID).
-		Return([]types.Provider{types.ProviderHelix}, nil)
+		ListProviderEndpoints(ctx, user.ID).
+		Return([]*types.ProviderEndpoint{{Name: "helix"}}, nil)
 
 	app := &types.App{
 		Config: types.AppConfig{
@@ -698,8 +698,8 @@ func TestApplyModelSubstitutions_AgentModePartialSubstitution(t *testing.T) {
 
 	// Mock provider manager to return "helix" and "anthropic" as available
 	mockProviderManager.EXPECT().
-		ListProviders(ctx, user.ID).
-		Return([]types.Provider{types.ProviderHelix, types.ProviderAnthropic}, nil)
+		ListProviderEndpoints(ctx, user.ID).
+		Return([]*types.ProviderEndpoint{{Name: "helix"}, {Name: "anthropic"}}, nil)
 
 	app := &types.App{
 		Config: types.AppConfig{
@@ -802,8 +802,8 @@ func TestO3MiniSubstitution(t *testing.T) {
 
 	// Mock provider manager to return only "helix" and "anthropic" as available (no openai)
 	mockProviderManager.EXPECT().
-		ListProviders(ctx, user.ID).
-		Return([]types.Provider{types.ProviderHelix, types.ProviderAnthropic}, nil)
+		ListProviderEndpoints(ctx, user.ID).
+		Return([]*types.ProviderEndpoint{{Name: "helix"}, {Name: "anthropic"}}, nil)
 
 	app := &types.App{
 		Config: types.AppConfig{

--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -438,6 +438,19 @@ func (s *HelixAPIServer) approveSpecs(w http.ResponseWriter, r *http.Request) {
 				log.Warn().Err(err).Str("task_id", taskID).Msg("Non-OAuthRequired error validating approver OAuth; proceeding with approval")
 			}
 		}
+
+		// Refuse to queue implementation if the agent's provider/model
+		// snapshot is stale or empty — same backstop as start-planning, so
+		// post-spec approval can't sneak past with a broken config.
+		if reason, vErr := s.validateSpecTaskAgentConfig(ctx, existingTask, user.ID); vErr != nil {
+			log.Warn().Err(vErr).Str("task_id", taskID).Msg("Failed to pre-validate agent config; proceeding with approval")
+		} else if reason != "" {
+			writeResponse(w, map[string]interface{}{
+				"error":   "agent_misconfigured",
+				"message": reason,
+			}, http.StatusUnprocessableEntity)
+			return
+		}
 	}
 
 	now := time.Now()
@@ -856,6 +869,20 @@ func (s *HelixAPIServer) startPlanning(w http.ResponseWriter, r *http.Request) {
 					Msg("Non-OAuthRequired error validating planner OAuth; proceeding with planning")
 			}
 		}
+	}
+
+	// Refuse to queue if the agent's provider/model snapshot is stale or
+	// empty — otherwise the orchestrator would spawn a desktop that boots
+	// fine but can't reach a routable model, and the user has to dig
+	// through API logs to find the cause.
+	if reason, vErr := s.validateSpecTaskAgentConfig(ctx, task, user.ID); vErr != nil {
+		log.Warn().Err(vErr).Str("task_id", taskID).Msg("Failed to pre-validate agent config; proceeding with planning")
+	} else if reason != "" {
+		writeResponse(w, map[string]interface{}{
+			"error":   "agent_misconfigured",
+			"message": reason,
+		}, http.StatusUnprocessableEntity)
+		return
 	}
 
 	task.PlanningOptions = opts

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -135,7 +135,11 @@ func (apiServer *HelixAPIServer) getZedConfig(_ http.ResponseWriter, req *http.R
 		// Use empty scopes - the token getter will use whatever scopes the user has
 		return apiServer.oauthManager.GetTokenForTool(ctx, userID, providerName, nil)
 	}
-	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, sandboxAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter)
+	validProviders, err := apiServer.listValidProviderNames(ctx, session.Owner)
+	if err != nil {
+		log.Warn().Err(err).Str("session_id", sessionID).Msg("zed-config: failed to list providers; provider validation will be skipped")
+	}
+	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, sandboxAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, validProviders)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
 		return nil, system.NewHTTPError500("failed to generate Zed config")
@@ -435,7 +439,11 @@ func (apiServer *HelixAPIServer) getMergedZedSettings(_ http.ResponseWriter, req
 		}
 		return apiServer.oauthManager.GetTokenForTool(ctx, userID, providerName, nil)
 	}
-	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, apiServer.Cfg.Kodit.Enabled, projectSkills, oauthTokenGetter)
+	validProviders, err := apiServer.listValidProviderNames(ctx, session.Owner)
+	if err != nil {
+		log.Warn().Err(err).Str("session_id", sessionID).Msg("zed-config: failed to list providers; provider validation will be skipped")
+	}
+	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, apiServer.Cfg.Kodit.Enabled, projectSkills, oauthTokenGetter, validProviders)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
 		return nil, system.NewHTTPError500("failed to generate Zed config")
@@ -627,6 +635,27 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.C
 		MaxTokens:       maxTokens,
 		MaxOutputTokens: maxOutputTokens,
 	}
+}
+
+// listValidProviderNames returns every provider name registered in the
+// provider manager — both env-var-baked globals and DB-backed user/org
+// providers visible to the given owner. Used to validate that an agent's
+// stored provider snapshot still matches a real provider before we feed it
+// to GenerateZedMCPConfig (Deviqon 2026-04-28: stale provider names were
+// silently encoded into the model string and surfaced as 404s in Zed).
+func (apiServer *HelixAPIServer) listValidProviderNames(ctx context.Context, owner string) ([]string, error) {
+	if apiServer.providerManager == nil {
+		return nil, nil
+	}
+	providers, err := apiServer.providerManager.ListProviders(ctx, owner)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(providers))
+	for _, p := range providers {
+		names = append(names, string(p))
+	}
+	return names, nil
 }
 
 // checkSpecTaskKoditIndexing checks if a SpecTask's project has any repositories with Kodit indexing enabled.

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -135,11 +135,11 @@ func (apiServer *HelixAPIServer) getZedConfig(_ http.ResponseWriter, req *http.R
 		// Use empty scopes - the token getter will use whatever scopes the user has
 		return apiServer.oauthManager.GetTokenForTool(ctx, userID, providerName, nil)
 	}
-	validProviders, err := apiServer.listValidProviderNames(ctx, session.Owner)
+	providerSnapshot, err := apiServer.getProviderSnapshot(ctx, session.Owner)
 	if err != nil {
-		log.Warn().Err(err).Str("session_id", sessionID).Msg("zed-config: failed to list providers; provider validation will be skipped")
+		log.Warn().Err(err).Str("session_id", sessionID).Msg("zed-config: failed to list providers; provider resolution will be skipped")
 	}
-	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, sandboxAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, validProviders)
+	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, sandboxAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, providerSnapshot)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
 		return nil, system.NewHTTPError500("failed to generate Zed config")
@@ -449,11 +449,11 @@ func (apiServer *HelixAPIServer) getMergedZedSettings(_ http.ResponseWriter, req
 		}
 		return apiServer.oauthManager.GetTokenForTool(ctx, userID, providerName, nil)
 	}
-	validProviders, err := apiServer.listValidProviderNames(ctx, session.Owner)
+	providerSnapshot, err := apiServer.getProviderSnapshot(ctx, session.Owner)
 	if err != nil {
-		log.Warn().Err(err).Str("session_id", sessionID).Msg("zed-config: failed to list providers; provider validation will be skipped")
+		log.Warn().Err(err).Str("session_id", sessionID).Msg("zed-config: failed to list providers; provider resolution will be skipped")
 	}
-	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, apiServer.Cfg.Kodit.Enabled, projectSkills, oauthTokenGetter, validProviders)
+	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, apiServer.Cfg.Kodit.Enabled, projectSkills, oauthTokenGetter, providerSnapshot)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
 		return nil, system.NewHTTPError500("failed to generate Zed config")
@@ -650,25 +650,62 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.C
 	}
 }
 
-// listValidProviderNames returns every provider name registered in the
-// provider manager — both env-var-baked globals and DB-backed user/org
-// providers visible to the given owner. Used to validate that an agent's
-// stored provider snapshot still matches a real provider before we feed it
-// to GenerateZedMCPConfig (Deviqon 2026-04-28: stale provider names were
-// silently encoded into the model string and surfaced as 404s in Zed).
-func (apiServer *HelixAPIServer) listValidProviderNames(ctx context.Context, owner string) ([]string, error) {
+// getProviderSnapshot returns a slice of ProviderRef summarising every
+// provider visible to the owner — env-baked globals (ID="", Name=canonical)
+// plus DB-backed user/org records (ID set, Name=current admin label). Used
+// by zed-config code paths to resolve an agent's stored provider reference
+// to its current canonical name. Returning nil from this helper (e.g. when
+// the manager isn't wired) tells GenerateZedMCPConfig to skip resolution.
+func (apiServer *HelixAPIServer) getProviderSnapshot(ctx context.Context, owner string) ([]external_agent.ProviderRef, error) {
 	if apiServer.providerManager == nil {
 		return nil, nil
 	}
-	providers, err := apiServer.providerManager.ListProviders(ctx, owner)
+	endpoints, err := apiServer.providerManager.ListProviderEndpoints(ctx, owner)
 	if err != nil {
 		return nil, err
 	}
-	names := make([]string, 0, len(providers))
-	for _, p := range providers {
-		names = append(names, string(p))
+	refs := make([]external_agent.ProviderRef, 0, len(endpoints))
+	for _, ep := range endpoints {
+		refs = append(refs, external_agent.ProviderRef{ID: ep.ID, Name: ep.Name})
 	}
-	return names, nil
+	return refs, nil
+}
+
+// validateSpecTaskAgentConfig pre-flights the agent's provider/model snapshot
+// against the registered providers visible to the actor. Returns a
+// human-readable reason (suitable for HTTP 422) when the agent is
+// misconfigured, or "" when usable. Used by spec-task entry handlers
+// (start-planning, approve-specs) to refuse to queue a task whose agent
+// would fail at session start. Without this, a stale agent record would
+// spawn a desktop that boots but can't reach a routable model — the user
+// has to dig through API logs to find the cause.
+//
+// Resolves the agent the same way the spec-driven task service does:
+// task.HelixAppID first, falling back to project.DefaultHelixAppID. If
+// neither is set, returns "" — the absent-agent failure is surfaced
+// downstream with its own dedicated message.
+func (apiServer *HelixAPIServer) validateSpecTaskAgentConfig(ctx context.Context, task *types.SpecTask, actorID string) (string, error) {
+	appID := task.HelixAppID
+	if appID == "" {
+		project, err := apiServer.Store.GetProject(ctx, task.ProjectID)
+		if err != nil {
+			return "", fmt.Errorf("failed to load project: %w", err)
+		}
+		appID = project.DefaultHelixAppID
+	}
+	if appID == "" {
+		return "", nil
+	}
+	app, err := apiServer.Store.GetApp(ctx, appID)
+	if err != nil {
+		return "", fmt.Errorf("failed to load agent app %s: %w", appID, err)
+	}
+	snapshot, err := apiServer.getProviderSnapshot(ctx, actorID)
+	if err != nil {
+		log.Warn().Err(err).Str("app_id", appID).Msg("spec-task: failed to list providers; skipping agent config validation")
+		return "", nil
+	}
+	return external_agent.ValidateAssistantModelConfig(app, snapshot), nil
 }
 
 // checkSpecTaskKoditIndexing checks if a SpecTask's project has any repositories with Kodit indexing enabled.

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -139,6 +139,7 @@ func (apiServer *HelixAPIServer) getZedConfig(_ http.ResponseWriter, req *http.R
 	if err != nil {
 		log.Warn().Err(err).Str("session_id", sessionID).Msg("zed-config: failed to list providers; provider resolution will be skipped")
 	}
+	apiServer.healLegacyProviderRefs(ctx, app, providerSnapshot)
 	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, sandboxAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, providerSnapshot)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
@@ -453,6 +454,7 @@ func (apiServer *HelixAPIServer) getMergedZedSettings(_ http.ResponseWriter, req
 	if err != nil {
 		log.Warn().Err(err).Str("session_id", sessionID).Msg("zed-config: failed to list providers; provider resolution will be skipped")
 	}
+	apiServer.healLegacyProviderRefs(ctx, app, providerSnapshot)
 	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, apiServer.Cfg.Kodit.Enabled, projectSkills, oauthTokenGetter, providerSnapshot)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
@@ -705,7 +707,23 @@ func (apiServer *HelixAPIServer) validateSpecTaskAgentConfig(ctx context.Context
 		log.Warn().Err(err).Str("app_id", appID).Msg("spec-task: failed to list providers; skipping agent config validation")
 		return "", nil
 	}
+	apiServer.healLegacyProviderRefs(ctx, app, snapshot)
 	return external_agent.ValidateAssistantModelConfig(app, snapshot), nil
+}
+
+// healLegacyProviderRefs rewrites name-based provider references on the app
+// to the matching DB-backed provider's immutable ID, so future renames are
+// silent. Best-effort — a write failure just logs and lets the next read
+// retry. See external_agent.MigrateLegacyProviderRefs for the rules.
+func (apiServer *HelixAPIServer) healLegacyProviderRefs(ctx context.Context, app *types.App, snapshot []external_agent.ProviderRef) {
+	if !external_agent.MigrateLegacyProviderRefs(app, snapshot) {
+		return
+	}
+	if _, err := apiServer.Store.UpdateApp(ctx, app); err != nil {
+		log.Warn().Err(err).Str("app_id", app.ID).Msg("agent legacy-name → ID migration: persist failed; will retry on next read")
+		return
+	}
+	log.Info().Str("app_id", app.ID).Msg("agent legacy-name → ID migration: rewrote provider fields to immutable IDs")
 }
 
 // checkSpecTaskKoditIndexing checks if a SpecTask's project has any repositories with Kodit indexing enabled.

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -145,6 +145,16 @@ func (apiServer *HelixAPIServer) getZedConfig(_ http.ResponseWriter, req *http.R
 		return nil, system.NewHTTPError500("failed to generate Zed config")
 	}
 
+	// Hard-fail when the agent's stored model config is empty or references
+	// an unknown provider. The settings-sync-daemon uses this endpoint as
+	// its source of truth on session start; failing fast here surfaces the
+	// real problem (broken agent config) in the spec-task UI rather than
+	// silently spinning up a sandbox where Zed would fall back to its
+	// built-in default model and confuse the user.
+	if zedConfig.Misconfigured {
+		return nil, system.NewHTTPError422(zedConfig.MisconfigReason)
+	}
+
 	// Convert to response format - include ALL fields from zedConfig
 	contextServers := make(map[string]interface{})
 	for name, server := range zedConfig.ContextServers {
@@ -447,6 +457,9 @@ func (apiServer *HelixAPIServer) getMergedZedSettings(_ http.ResponseWriter, req
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
 		return nil, system.NewHTTPError500("failed to generate Zed config")
+	}
+	if zedConfig.Misconfigured {
+		return nil, system.NewHTTPError422(zedConfig.MisconfigReason)
 	}
 
 	// Get user overrides

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -534,7 +534,20 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfig(ctx context.Context, app *
 	// Find the assistant with AgentType = zed_external
 	for _, assistant := range app.Config.Helix.Assistants {
 		if assistant.AgentType == types.AgentTypeZedExternal {
-			return apiServer.buildCodeAgentConfigFromAssistant(ctx, &assistant, helixURL)
+			// Resolve the agent's stored provider token (ID or legacy name) to
+			// the provider's current canonical name so the model identifier
+			// matches what GenerateZedMCPConfig writes into agent.default_model.
+			// Without this resolution available_models would carry "pe_xxx/..."
+			// while default_model carries "numpty/..." (the renamed provider's
+			// current name) — Zed's model picker fails the lookup and falls
+			// back to its built-in Claude default.
+			//
+			// See deviqon/P1-5-zed-overrides-clobber-helix-default-model.md.
+			snapshot, err := apiServer.getProviderSnapshot(ctx, app.Owner)
+			if err != nil {
+				log.Warn().Err(err).Str("app_id", app.ID).Msg("buildCodeAgentConfig: provider snapshot unavailable; model prefix may not match agent.default_model")
+			}
+			return apiServer.buildCodeAgentConfigFromAssistant(ctx, &assistant, helixURL, snapshot)
 		}
 	}
 	return nil
@@ -544,7 +557,7 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfig(ctx context.Context, app *
 // For zed_external agents, use GenerationModelProvider/GenerationModel - that's where the UI
 // stores the user's model selection for external agents.
 // The CodeAgentRuntime determines how the LLM is configured in Zed (built-in agent vs qwen).
-func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.Context, assistant *types.AssistantConfig, helixURL string) *types.CodeAgentConfig {
+func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.Context, assistant *types.AssistantConfig, helixURL string, providerSnapshot []external_agent.ProviderRef) *types.CodeAgentConfig {
 	// Get the code agent runtime, default to zed_agent
 	runtime := assistant.CodeAgentRuntime
 	if runtime == "" {
@@ -563,6 +576,16 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.C
 	modelName := assistant.GenerationModel
 	if modelName == "" {
 		modelName = assistant.Model
+	}
+
+	// Resolve the agent's stored provider token (ID or legacy name) to the
+	// provider's current canonical name. Required so the model prefix here
+	// matches what GenerateZedMCPConfig produces for agent.default_model —
+	// see comment in buildCodeAgentConfig.
+	if providerSnapshot != nil && providerName != "" {
+		if resolved, _, ok := external_agent.ResolveProvider(providerName, providerSnapshot); ok {
+			providerName = resolved.Name
+		}
 	}
 
 	// Subscription agents don't need provider/model (they use OAuth credentials).

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -362,8 +362,12 @@ func (apiServer *HelixAPIServer) updateZedUserSettings(_ http.ResponseWriter, re
 	return map[string]string{"status": "ok"}, nil
 }
 
-// @Summary Get merged Zed settings
-// @Description Get merged Helix + user Zed settings for a session
+// @Summary Get merged Zed MCP context_servers for a session
+// @Description Returns the union of helix-managed and user-side MCP context_servers,
+// @Description for the session "MCP Tools" panel in the UI. Other Zed settings
+// @Description (agent.*, language_models, theme) are owned by the daemon — anything
+// @Description that needs the full Zed view goes through the settings-sync-daemon
+// @Description on /zed-config + a local merge.
 // @Tags Zed
 // @Accept json
 // @Produce json
@@ -379,41 +383,29 @@ func (apiServer *HelixAPIServer) getMergedZedSettings(_ http.ResponseWriter, req
 	vars := mux.Vars(req)
 	sessionID := vars["id"]
 
-	// Get session to verify access
 	session, err := apiServer.Store.GetSession(ctx, sessionID)
 	if err != nil {
 		log.Error().Err(err).Str("session_id", sessionID).Msg("Failed to get session")
 		return nil, system.NewHTTPError404("session not found")
 	}
 
-	// Verify user owns this session
 	user := getRequestUser(req)
 	if user == nil || session.Owner != user.ID {
 		return nil, system.NewHTTPError403("access denied")
 	}
 
-	// Get app config - fall back to default if not found or not set
 	var app *types.App
 	if session.ParentApp != "" {
-		var err error
 		app, err = apiServer.Store.GetApp(ctx, session.ParentApp)
 		if err != nil {
 			log.Warn().Err(err).Str("app_id", session.ParentApp).Str("session_id", sessionID).Msg("Parent app not found - using default config")
 			app = nil
 		}
 	}
-
-	// If no app found, use a default app with sensible defaults
 	if app == nil {
-		log.Debug().Str("session_id", sessionID).Msg("No parent app - using default Zed config with claude-sonnet")
-		app = &types.App{
-			ID:     "default-agent",
-			Config: types.AppConfig{},
-		}
+		app = &types.App{ID: "default-agent", Config: types.AppConfig{}}
 	}
 
-	// Use SANDBOX_API_URL for what Zed inside sandbox uses
-	// If not explicitly set, default to external-facing URL (SERVER_URL)
 	helixAPIURL := apiServer.Cfg.WebServer.SandboxAPIURL
 	if helixAPIURL == "" {
 		helixAPIURL = apiServer.Cfg.WebServer.URL
@@ -422,14 +414,12 @@ func (apiServer *HelixAPIServer) getMergedZedSettings(_ http.ResponseWriter, req
 		}
 	}
 
-	// Get API key for MCP and LLM authentication
 	helixToken, err := apiServer.getAPIKeyForSession(ctx, session)
 	if err != nil {
 		log.Error().Err(err).Str("session_id", sessionID).Msg("Failed to get API key for session")
 		return nil, system.NewHTTPError500("failed to get API key for session")
 	}
 
-	// Get project skills if session has a project
 	var projectSkills *types.AssistantSkills
 	if session.ProjectID != "" {
 		project, err := apiServer.Store.GetProject(ctx, session.ProjectID)
@@ -440,41 +430,30 @@ func (apiServer *HelixAPIServer) getMergedZedSettings(_ http.ResponseWriter, req
 		projectSkills = project.Skills
 	}
 
-	// Always generate config - GenerateZedMCPConfig has sensible defaults
-	// (anthropic/claude-sonnet-4-5-latest, theme, language_models routing, etc.)
-	//
-	// Create OAuth token getter for stdio MCPs that need OAuth tokens
 	oauthTokenGetter := func(ctx context.Context, userID, providerName string) (string, error) {
 		if apiServer.oauthManager == nil {
 			return "", nil
 		}
 		return apiServer.oauthManager.GetTokenForTool(ctx, userID, providerName, nil)
 	}
-	providerSnapshot, err := apiServer.getProviderSnapshot(ctx, session.Owner)
-	if err != nil {
-		log.Warn().Err(err).Str("session_id", sessionID).Msg("zed-config: failed to list providers; provider resolution will be skipped")
-	}
-	apiServer.healLegacyProviderRefs(ctx, app, providerSnapshot)
-	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, apiServer.Cfg.Kodit.Enabled, projectSkills, oauthTokenGetter, providerSnapshot)
+	// providerSnapshot=nil here: this endpoint only exposes context_servers,
+	// which don't depend on provider resolution or model validation. The
+	// daemon hits /zed-config separately and handles those concerns there.
+	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, apiServer.Cfg.Kodit.Enabled, projectSkills, oauthTokenGetter, nil)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
 		return nil, system.NewHTTPError500("failed to generate Zed config")
 	}
-	if zedConfig.Misconfigured {
-		return nil, system.NewHTTPError422(zedConfig.MisconfigReason)
-	}
 
-	// Get user overrides
 	userOverrides, err := external_agent.GetUserZedOverrides(ctx, apiServer.Store, sessionID)
 	if err != nil {
 		log.Error().Err(err).Str("session_id", sessionID).Msg("Failed to get user overrides")
 		return nil, system.NewHTTPError500("failed to get user overrides")
 	}
 
-	// Merge
-	merged := external_agent.MergeZedConfigWithUserOverrides(zedConfig, userOverrides)
-
-	return merged, nil
+	return map[string]interface{}{
+		"context_servers": external_agent.MergeContextServers(zedConfig.ContextServers, userOverrides),
+	}, nil
 }
 
 // getAgentNameForSession determines which code agent to use for a session.

--- a/api/pkg/server/zed_config_handlers_test.go
+++ b/api/pkg/server/zed_config_handlers_test.go
@@ -194,7 +194,7 @@ func TestBuildCodeAgentConfigFromAssistant(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := apiServer.buildCodeAgentConfigFromAssistant(ctx, tt.assistant, helixURL)
+			got := apiServer.buildCodeAgentConfigFromAssistant(ctx, tt.assistant, helixURL, nil)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/api/pkg/system/http.go
+++ b/api/pkg/system/http.go
@@ -84,6 +84,13 @@ func NewHTTPError404(message string) *HTTPError {
 	}
 }
 
+func NewHTTPError422(message string) *HTTPError {
+	return &HTTPError{
+		StatusCode: http.StatusUnprocessableEntity,
+		Message:    message,
+	}
+}
+
 func NewHTTPError500(message string) *HTTPError {
 	return &HTTPError{
 		StatusCode: http.StatusInternalServerError,

--- a/frontend/src/components/create/AdvancedModelPicker.tsx
+++ b/frontend/src/components/create/AdvancedModelPicker.tsx
@@ -111,6 +111,26 @@ interface ModelWithProvider extends TypesOpenAIModel {
   provider_base_url: string;
 }
 
+// Returns the stable reference we persist on the agent record for a given
+// provider: env-baked globals have no DB ID, so we use their canonical name
+// (which is itself immutable). DB-backed providers use their ID, so admin
+// renames are a no-op for the agent.
+const providerRef = (provider: TypesProviderEndpoint | undefined): string => {
+  if (!provider) return '';
+  if (provider.endpoint_type === 'global') return provider.name || '';
+  return provider.id || provider.name || '';
+};
+
+// Matches a stored agent reference against a provider. Tries ID first
+// (current scheme) then falls back to a case-insensitive name match
+// (legacy agents stored before the switch to ID-based references).
+const matchesStoredRef = (provider: TypesProviderEndpoint | undefined, storedRef: string | undefined): boolean => {
+  if (!provider || !storedRef) return false;
+  if (provider.id && provider.id === storedRef) return true;
+  if (provider.name && provider.name.toLowerCase() === storedRef.toLowerCase()) return true;
+  return false;
+};
+
 function fuzzySearch(query: string, models: ModelWithProvider[], modelType: string) {
   return models.filter((model) => {    
     // If provider is togetherai or openai or helix, check model type
@@ -235,29 +255,28 @@ export const AdvancedModelPicker: React.FC<AdvancedModelPickerProps> = ({
           firstModel = allModels.find(model => model.enabled && model.type === effectiveType);
         }
         if (firstModel && firstModel.id) {
-          onSelectModel(firstModel.provider?.name || '', firstModel.id);
+          onSelectModel(providerRef(firstModel.provider), firstModel.id);
         }
-      } 
+      }
       // If a model is selected, check if its type matches current type
       else {
-        // console.log('selected model, finding it from our list', selectedProvider, selectedModelId)
         const currentModel = allModels.find(model => model.id === selectedModelId);
 
         // If current model doesn't match the expected type, select a new one
-        if (currentModel && currentModel.type && currentModel.type !== effectiveType) {          
+        if (currentModel && currentModel.type && currentModel.type !== effectiveType) {
           // Try to find a model of the right type from the same provider first
-          let newModel = allModels.find(model => 
-            model.type === effectiveType && 
-            model.provider?.name === selectedProvider
+          let newModel = allModels.find(model =>
+            model.type === effectiveType &&
+            matchesStoredRef(model.provider, selectedProvider)
           );
-          
+
           // If no model found from the same provider, fall back to any provider
           if (!newModel) {
             newModel = allModels.find(model => model.type === effectiveType);
           }
-          
+
           if (newModel && newModel.id) {
-            onSelectModel(newModel.provider?.name || '', newModel.id);
+            onSelectModel(providerRef(newModel.provider), newModel.id);
           }
         }
       }
@@ -274,16 +293,22 @@ export const AdvancedModelPicker: React.FC<AdvancedModelPickerProps> = ({
     return friendlyName || "Select Model";
   }, [selectedModelId, allModels]);
   
-  // Determine tooltip title based on disabled state - include provider name
+  // Determine tooltip title based on disabled state - include provider name.
+  // Resolve the stored ref (ID or legacy name) against the live providers
+  // list so the tooltip shows the current canonical name even after a rename.
   const tooltipTitle = useMemo(() => {
     if (disabled) return "Model selection is disabled";
     const selectedModel = allModels.find(model => model.id === selectedModelId);
-    const providerName = selectedModel?.provider?.name || selectedProvider;
+    let providerName = selectedModel?.provider?.name;
+    if (!providerName && selectedProvider) {
+      const matched = providers?.find((p: TypesProviderEndpoint) => matchesStoredRef(p, selectedProvider));
+      providerName = matched?.name || selectedProvider;
+    }
     if (providerName) {
       return `${displayModelName} (${providerName})`;
     }
     return displayModelName;
-  }, [disabled, displayModelName, allModels, selectedModelId, selectedProvider]);
+  }, [disabled, displayModelName, allModels, selectedModelId, selectedProvider, providers]);
 
   // Check if monthly token limit is reached
   const isMonthlyLimitReached = useMemo(() => {
@@ -518,7 +543,7 @@ export const AdvancedModelPicker: React.FC<AdvancedModelPickerProps> = ({
 
               const listItemContent = (
                 <ListItem
-                  onClick={() => !isModelDisabled && model.id && handleSelectModel(model.provider?.name || '', model.id)}
+                  onClick={() => !isModelDisabled && model.id && handleSelectModel(providerRef(model.provider), model.id)}
                   disabled={isModelDisabled}
                   sx={{
                     '&:hover': {

--- a/frontend/src/components/create/AdvancedModelPicker.tsx
+++ b/frontend/src/components/create/AdvancedModelPicker.tsx
@@ -111,22 +111,36 @@ interface ModelWithProvider extends TypesOpenAIModel {
   provider_base_url: string;
 }
 
+// Returns true if the provider has a real DB-row ID. Env-baked globals
+// surface as the sentinel id "-" (or empty); DB-backed providers (whether
+// user-private, org-, team- or globally-shared) all have a "pe_..." id.
+// We deliberately do NOT key off endpoint_type because a user-created
+// provider that the owner has marked as "global" to share across the
+// instance still has a stable DB id and must be referenced by id, not by
+// its mutable name. The presence of a real id is the only reliable signal
+// for "this is a DB row that survives a rename."
+const hasRealID = (provider: TypesProviderEndpoint | undefined): boolean => {
+  if (!provider) return false;
+  const id = provider.id || '';
+  return id !== '' && id !== '-';
+};
+
 // Returns the stable reference we persist on the agent record for a given
-// provider: env-baked globals have no DB ID, so we use their canonical name
-// (which is itself immutable). DB-backed providers use their ID, so admin
+// provider: env-baked globals have no DB row, so we use their canonical
+// name (itself immutable). DB-backed providers use their ID, so admin
 // renames are a no-op for the agent.
 const providerRef = (provider: TypesProviderEndpoint | undefined): string => {
   if (!provider) return '';
-  if (provider.endpoint_type === 'global') return provider.name || '';
-  return provider.id || provider.name || '';
+  if (hasRealID(provider)) return provider.id || '';
+  return provider.name || '';
 };
 
 // Matches a stored agent reference against a provider. Tries ID first
 // (current scheme) then falls back to a case-insensitive name match
-// (legacy agents stored before the switch to ID-based references).
+// (globals + legacy agents stored before the switch to ID-based references).
 const matchesStoredRef = (provider: TypesProviderEndpoint | undefined, storedRef: string | undefined): boolean => {
   if (!provider || !storedRef) return false;
-  if (provider.id && provider.id === storedRef) return true;
+  if (hasRealID(provider) && provider.id === storedRef) return true;
   if (provider.name && provider.name.toLowerCase() === storedRef.toLowerCase()) return true;
   return false;
 };


### PR DESCRIPTION
## Summary

Two bugs in the same code path made external agents look like working Claude agents in Zed. Both are fixed here.

### API silently substitutes Claude
- Remove silent fallback to `anthropic/claude-sonnet-4-5-latest` when an agent's model fields are empty. Hard-fail with HTTP 422 instead.
- Pre-flight 422 at spec-task entry (`start-planning`, `approve-specs`) so a misconfigured agent never spawns a sandbox.
- Refactor agent records to reference DB-backed providers by their immutable ID, not their mutable name. Renames are now no-ops; only deletes cause misconfig.
- On-the-fly heal: legacy name-based agent records are rewritten in place to ID-based on first read. Customers don't need to re-save anything.

### Zed shows Claude even when settings.json says otherwise

Three layers of fix; the first is the actual root cause, the others are policy enforcement.

1. **Provider resolution mismatch (root cause)**. `GenerateZedMCPConfig` resolved the agent's stored provider token (`pe_xxx`) to its current canonical name (`numpty`) when writing `agent.default_model`, but `buildCodeAgentConfigFromAssistant` used the raw stored ID when constructing the model identifier in `code_agent_config.model` (which becomes `available_models[].name`). settings.json ended up with `default_model.model = "numpty/openai/gpt-oss-120b"` and `available_models[0].name = "pe_xxx/openai/gpt-oss-120b"` — Zed couldn't find `default_model` in `available_models`, fell back to its built-in agent profile (Claude Sonnet 4.6 with `effort=high` + `enable_thinking=true`). Fixed by passing `providerSnapshot` into `buildCodeAgentConfigFromAssistant` and resolving via `ResolveProvider`.

2. **Daemon-side policy guard**. `settings-sync-daemon.mergeSettings()` blindly applied user-side overrides over the helix `agent` block. So if Zed *ever* writes a different `default_model` (model picker, manual edit), the daemon would faithfully sync it back into settings.json. Now deep-merges the agent block, dropping user-side values for the four helix-managed model fields (`default_model`, `inline_assistant_model`, `commit_message_model`, `thread_summary_model`).

3. **Daemon-side upload guard**. `extractUserOverrides` now drops helix-managed `agent.*` fields before POSTing diffs to `/zed-config/user`, so stale rows in `zed_settings_overrides` don't accumulate.

### Cleanup: delete dead `/zed-settings` merge

While investigating, found that `/zed-settings` and the daemon's `mergeSettings` were duplicated merge implementations of the same concept, and they had drifted. The desktop hot path runs entirely through the daemon — `/zed-settings` had exactly one consumer (`ZedSettingsViewer.tsx`) which only reads `context_servers`. Deleted `MergeZedConfigWithUserOverrides` and the agent merge code that grew during this PR; replaced with a focused `MergeContextServers` helper. Slimmed the `/zed-settings` handler to drop provider snapshot, heal, and 422 work it no longer needs. **−188 LOC net.**

## Test plan

- [x] Unit tests for empty fields, deleted provider, rename-is-no-op, legacy name fallback, nil snapshot, on-the-fly heal of all five provider fields.
- [x] Daemon unit tests: helix-managed agent fields protected against user-side merge; `extractUserOverrides` skips helix-managed agent diffs.
- [x] `MergeContextServers` unit tests: user-side additions, override of helix server, no-overrides, non-`context_servers` keys ignored.
- [x] End-to-end on staging: agent configured for `openai/gpt-oss-120b` via a user-created provider, rename the provider, agent keeps working. Zed UI shows the configured model — no more Claude fallback.
- [x] Empty fields → 422 with operator-friendly message in the response body.

## Out of scope (follow-up filed separately)
- Surfacing runtime LLM errors (org not verified, quota, etc.) in the Helix spec-task UI. Today they show in Zed's panel via the desktop stream and in API logs, but the spec-task page is silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)