### PR TITLE
fix(providers): invalidate model cache on delete and update

### DIFF
--- a/api/pkg/openai/manager/provider_manager.go
+++ b/api/pkg/openai/manager/provider_manager.go
@@ -345,13 +345,10 @@ func (m *MultiClientManager) ListProviderEndpoints(ctx context.Context, owner st
 	m.globalClientsMu.RLock()
 	endpoints := make([]*types.ProviderEndpoint, 0, len(m.globalClients))
 	for provider := range m.globalClients {
-		// Skip the Helix provider if there are no runners — same gate as
-		// ListProviders so the snapshots agree on what's reachable.
-		if provider == types.ProviderHelix && m.runnerController != nil {
-			if len(m.runnerController.RunnerIDs()) == 0 {
-				continue
-			}
-		}
+		// Always list global providers including Helix — runner availability is
+		// checked by the inferencerouter at request-routing time post sandbox-
+		// absorbs-runner pivot, not at provider-listing time. Matches
+		// ListProviders and the SetRunnerController no-op contract.
 		endpoints = append(endpoints, &types.ProviderEndpoint{
 			Name:         string(provider),
 			EndpointType: types.ProviderEndpointTypeGlobal,

--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -259,9 +259,25 @@ func (s *HelixAPIServer) listProviderEndpoints(rw http.ResponseWriter, r *http.R
 	writeResponse(rw, providerEndpoints, http.StatusOK)
 }
 
+// modelCacheKey is the single source of truth for the per-provider models cache
+// key. Anything that mutates a provider (delete, rename, URL/key/Models change)
+// must invalidate the entry under the OLD name and let the next read repopulate.
+func modelCacheKey(name, owner string) string {
+	return fmt.Sprintf("%s:%s", name, owner)
+}
+
+// invalidateProviderModelCache clears the cached model list for the given
+// provider so subsequent reads refetch from upstream. Call this whenever a
+// provider's identity (name) or content (BaseURL, Models, APIKey, billing
+// flags) changes, including deletes. Without this, a deleted/renamed/edited
+// provider continues serving stale models for up to ModelsCacheTTL.
+func (s *HelixAPIServer) invalidateProviderModelCache(name, owner string) {
+	s.cache.Del(modelCacheKey(name, owner))
+}
+
 func (s *HelixAPIServer) getProviderModels(ctx context.Context, providerEndpoint *types.ProviderEndpoint) ([]types.OpenAIModel, error) {
 	// Check for cached models
-	cacheKey := fmt.Sprintf("%s:%s", providerEndpoint.Name, providerEndpoint.Owner)
+	cacheKey := modelCacheKey(providerEndpoint.Name, providerEndpoint.Owner)
 	if cached, found := s.cache.Get(cacheKey); found {
 		var models []types.OpenAIModel
 		err := json.Unmarshal([]byte(cached), &models)
@@ -566,6 +582,11 @@ func (s *HelixAPIServer) updateProviderEndpoint(rw http.ResponseWriter, r *http.
 		return
 	}
 
+	// Capture identity BEFORE mutation so we can invalidate the cache entry
+	// keyed under the old name/owner — a rename leaves the old entry stranded
+	// otherwise.
+	prevName, prevOwner := existingEndpoint.Name, existingEndpoint.Owner
+
 	// Apply endpoint type change and update ownership accordingly
 	if updatedEndpoint.EndpointType != "" && updatedEndpoint.EndpointType != existingEndpoint.EndpointType {
 		switch updatedEndpoint.EndpointType {
@@ -642,6 +663,15 @@ func (s *HelixAPIServer) updateProviderEndpoint(rw http.ResponseWriter, r *http.
 		return
 	}
 
+	// Invalidate the model cache for both the old identity (covers renames /
+	// owner-type changes leaving a stranded entry) and the new identity (covers
+	// BaseURL / Models / APIKey edits where the key didn't change but the
+	// upstream might now return a different model list).
+	s.invalidateProviderModelCache(prevName, prevOwner)
+	if savedEndpoint.Name != prevName || savedEndpoint.Owner != prevOwner {
+		s.invalidateProviderModelCache(savedEndpoint.Name, savedEndpoint.Owner)
+	}
+
 	// Mask API key in response
 	savedEndpoint.APIKey = "*****"
 
@@ -711,6 +741,12 @@ func (s *HelixAPIServer) deleteProviderEndpoint(rw http.ResponseWriter, r *http.
 		http.Error(rw, "Error deleting provider endpoint: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	// Invalidate the model-list cache so the model picker, /v1/chat/completions
+	// routing, and /api/v1/providers/models stop serving the deleted provider's
+	// models. Without this, stale entries linger for up to ModelsCacheTTL and
+	// requests during that window can still resolve through a deleted provider.
+	s.invalidateProviderModelCache(existingEndpoint.Name, existingEndpoint.Owner)
 
 	rw.WriteHeader(http.StatusOK)
 }

--- a/api/pkg/server/provider_handlers_test.go
+++ b/api/pkg/server/provider_handlers_test.go
@@ -553,3 +553,159 @@ func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_SwitchToOrgRejected()
 	s.Equal(http.StatusBadRequest, rr.Code)
 	s.Contains(rr.Body.String(), "Unsupported endpoint type switch")
 }
+
+// TestDeleteProviderEndpoint_InvalidatesModelCache verifies that deleting a
+// provider clears its cached model list so subsequent reads stop serving the
+// deleted provider's models. Without invalidation, stale entries linger for up
+// to ModelsCacheTTL and a deleted provider can still resolve in /v1/chat/completions
+// routing during that window. See deviqon/P1-3.
+func (s *ProviderHandlersSuite) TestDeleteProviderEndpoint_InvalidatesModelCache() {
+	s.server.Cfg.Providers.EnableCustomUserProviders = true
+	endpointID := "ep_to_delete"
+
+	existing := &types.ProviderEndpoint{
+		ID:           endpointID,
+		Name:         "user-ollama",
+		Owner:        "user_id",
+		OwnerType:    types.OwnerTypeUser,
+		EndpointType: types.ProviderEndpointTypeUser,
+	}
+
+	// Pre-populate the cache as if a prior /providers/models call had filled it.
+	cacheKey := modelCacheKey(existing.Name, existing.Owner)
+	s.server.cache.SetWithTTL(cacheKey, `[{"id":"qwen3-coder"}]`, 1, time.Minute)
+	s.server.cache.Wait()
+	if _, found := s.server.cache.Get(cacheKey); !found {
+		s.Fail("precondition: cache should be populated before delete")
+	}
+
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{
+		ProvidersManagementEnabled: true,
+	}, nil)
+	s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{
+		ID: endpointID,
+	}).Return(existing, nil)
+	s.store.EXPECT().DeleteProviderEndpoint(gomock.Any(), endpointID).Return(nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/provider-endpoints/"+endpointID, nil)
+	req = req.WithContext(s.authCtx)
+	req = mux.SetURLVars(req, map[string]string{"id": endpointID})
+
+	rr := httptest.NewRecorder()
+	s.server.deleteProviderEndpoint(rr, req)
+
+	s.Equal(http.StatusOK, rr.Code)
+
+	s.server.cache.Wait()
+	_, found := s.server.cache.Get(cacheKey)
+	s.False(found, "cache entry for deleted provider must be cleared")
+}
+
+// TestUpdateProviderEndpoint_RenameInvalidatesOldKey covers the rename path:
+// the cache key includes the provider name, so a rename leaves a stranded
+// entry under the old name that nothing will ever clean up. The update handler
+// must drop both the old and new keys.
+func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_RenameInvalidatesOldKey() {
+	s.server.Cfg.Providers.EnableCustomUserProviders = true
+	endpointID := "ep_rename"
+
+	existing := &types.ProviderEndpoint{
+		ID:           endpointID,
+		Name:         "old-name",
+		BaseURL:      "http://localhost:11434",
+		Owner:        "user_id",
+		OwnerType:    types.OwnerTypeUser,
+		EndpointType: types.ProviderEndpointTypeUser,
+	}
+
+	oldKey := modelCacheKey("old-name", "user_id")
+	newKey := modelCacheKey("new-name", "user_id")
+	s.server.cache.SetWithTTL(oldKey, `[{"id":"m1"}]`, 1, time.Minute)
+	s.server.cache.SetWithTTL(newKey, `[{"id":"m2-stale"}]`, 1, time.Minute)
+	s.server.cache.Wait()
+
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{
+		ProvidersManagementEnabled: true,
+	}, nil)
+	s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{
+		ID: endpointID,
+	}).Return(existing, nil)
+	s.manager.EXPECT().ListProviders(gomock.Any(), "user_id").Return([]types.Provider{}, nil)
+	s.store.EXPECT().UpdateProviderEndpoint(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, ep *types.ProviderEndpoint) (*types.ProviderEndpoint, error) {
+			s.Equal("new-name", ep.Name)
+			return ep, nil
+		})
+
+	update := types.UpdateProviderEndpoint{
+		Name:    "new-name",
+		BaseURL: "http://localhost:11434",
+	}
+	body, _ := json.Marshal(update)
+	req := httptest.NewRequest(http.MethodPut, "/v1/provider-endpoints/"+endpointID, bytes.NewReader(body))
+	req = req.WithContext(s.authCtx)
+	req = mux.SetURLVars(req, map[string]string{"id": endpointID})
+
+	rr := httptest.NewRecorder()
+	s.server.updateProviderEndpoint(rr, req)
+
+	s.Equal(http.StatusOK, rr.Code)
+
+	s.server.cache.Wait()
+	_, foundOld := s.server.cache.Get(oldKey)
+	s.False(foundOld, "old-name cache entry must be cleared after rename")
+	_, foundNew := s.server.cache.Get(newKey)
+	s.False(foundNew, "new-name cache entry must be cleared so next read refetches with current upstream state")
+}
+
+// TestUpdateProviderEndpoint_NoRenameStillInvalidates covers the case where
+// only BaseURL/Models/APIKey changed — the cached models are now potentially
+// wrong because the upstream is different. Cache must be cleared even when
+// the name is unchanged.
+func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_NoRenameStillInvalidates() {
+	s.server.Cfg.Providers.EnableCustomUserProviders = true
+	endpointID := "ep_url_change"
+
+	existing := &types.ProviderEndpoint{
+		ID:           endpointID,
+		Name:         "stable-name",
+		BaseURL:      "http://old-host:11434",
+		Owner:        "user_id",
+		OwnerType:    types.OwnerTypeUser,
+		EndpointType: types.ProviderEndpointTypeUser,
+	}
+
+	key := modelCacheKey("stable-name", "user_id")
+	s.server.cache.SetWithTTL(key, `[{"id":"old-host-model"}]`, 1, time.Minute)
+	s.server.cache.Wait()
+
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{
+		ProvidersManagementEnabled: true,
+	}, nil)
+	s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{
+		ID: endpointID,
+	}).Return(existing, nil)
+	s.store.EXPECT().UpdateProviderEndpoint(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, ep *types.ProviderEndpoint) (*types.ProviderEndpoint, error) {
+			s.Equal("http://new-host:11434", ep.BaseURL)
+			return ep, nil
+		})
+
+	update := types.UpdateProviderEndpoint{
+		Name:    "stable-name",
+		BaseURL: "http://new-host:11434",
+	}
+	body, _ := json.Marshal(update)
+	req := httptest.NewRequest(http.MethodPut, "/v1/provider-endpoints/"+endpointID, bytes.NewReader(body))
+	req = req.WithContext(s.authCtx)
+	req = mux.SetURLVars(req, map[string]string{"id": endpointID})
+
+	rr := httptest.NewRecorder()
+	s.server.updateProviderEndpoint(rr, req)
+
+	s.Equal(http.StatusOK, rr.Code)
+
+	s.server.cache.Wait()
+	_, found := s.server.cache.Get(key)
+	s.False(found, "cache must be cleared after BaseURL change so next read sees the new upstream")
+}

--- a/frontend/src/components/dashboard/EditProviderEndpointDialog.tsx
+++ b/frontend/src/components/dashboard/EditProviderEndpointDialog.tsx
@@ -78,8 +78,7 @@ const EditProviderEndpointDialog: React.FC<EditProviderEndpointDialogProps> = ({
     headers: [] as Array<{ key: string; value: string }>,
   });
 
-  // Only initialize the mutation hook if we have a valid endpoint ID
-  const { mutate: updateProviderEndpoint } = useUpdateProviderEndpoint(endpoint?.id || '');
+  const { mutateAsync: updateProviderEndpoint } = useUpdateProviderEndpoint();
 
   // Reset form data when endpoint changes
   React.useEffect(() => {
@@ -215,7 +214,7 @@ const EditProviderEndpointDialog: React.FC<EditProviderEndpointDialogProps> = ({
         endpoint_type: (formData.endpoint_type as TypesProviderEndpointType),
         headers: Object.keys(headersObj).length > 0 ? headersObj : undefined,
       }
-      await updateProviderEndpoint(body);
+      await updateProviderEndpoint({ id: endpoint.id, body });
       refreshData();
       onClose();
     } catch (err) {

--- a/frontend/src/components/dashboard/EditProviderModelsDialog.tsx
+++ b/frontend/src/components/dashboard/EditProviderModelsDialog.tsx
@@ -32,7 +32,7 @@ const EditProviderModelsDialog: FC<EditProviderModelsDialogProps> = ({ open, end
   const [error, setError] = useState<string | null>(null);
   const api = useApi();
   const apiClient = api.getApiClient();
-  const { mutate: updateProviderEndpoint } = useUpdateProviderEndpoint(endpoint?.id || '');
+  const { mutateAsync: updateProviderEndpoint } = useUpdateProviderEndpoint();
 
   useEffect(() => {
     if (endpoint?.models) {
@@ -45,16 +45,19 @@ const EditProviderModelsDialog: FC<EditProviderModelsDialogProps> = ({ open, end
   }, [endpoint]);
 
   const saveModels = useCallback(async (modelsToSave: string[]) => {
-    if (!endpoint) return;
+    if (!endpoint?.id) return;
 
     setIsLoading(true);
     setError(null);
 
     try {
       await updateProviderEndpoint({
-        base_url: endpoint.base_url,
-        endpoint_type: endpoint.endpoint_type as TypesProviderEndpointType,
-        models: modelsToSave,
+        id: endpoint.id,
+        body: {
+          base_url: endpoint.base_url,
+          endpoint_type: endpoint.endpoint_type as TypesProviderEndpointType,
+          models: modelsToSave,
+        },
       });
       refreshData();
     } catch (err: any) {

--- a/frontend/src/components/providers/AddProviderDialog.tsx
+++ b/frontend/src/components/providers/AddProviderDialog.tsx
@@ -82,7 +82,7 @@ const AddProviderDialog: React.FC<AddProviderDialogProps> = ({
   const [showApiKey, setShowApiKey] = useState(false);
   const [isFieldFocused, setIsFieldFocused] = useState(false);
   const { mutateAsync: createProviderEndpoint, isPending: isCreating } = useCreateProviderEndpoint();
-  const { mutateAsync: updateProviderEndpoint, isPending: isUpdating } = useUpdateProviderEndpoint(existingProvider?.id || '');
+  const { mutateAsync: updateProviderEndpoint, isPending: isUpdating } = useUpdateProviderEndpoint();
   const { mutateAsync: deleteProviderEndpoint, isPending: isDeleting } = useDeleteProviderEndpoint();
 
   const { success: snackbarSuccess } = useSnackbar();
@@ -179,14 +179,17 @@ const AddProviderDialog: React.FC<AddProviderDialogProps> = ({
       const trimmedModel = modelName.trim();
       const presetModels = provider.is_custom && trimmedModel ? [trimmedModel] : undefined;
 
-      if (isEditing && existingProvider) {
+      if (isEditing && existingProvider?.id) {
         // Update existing provider
         await updateProviderEndpoint({
-          base_url: baseUrl,
-          api_key: apiKeyToUse,
-          endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeUser,
-          description: provider.description,
-          ...(provider.is_custom ? { models: presetModels ?? [] } : {}),
+          id: existingProvider.id,
+          body: {
+            base_url: baseUrl,
+            api_key: apiKeyToUse,
+            endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeUser,
+            description: provider.description,
+            ...(provider.is_custom ? { models: presetModels ?? [] } : {}),
+          },
         });
         snackbarSuccess('Provider updated successfully');
       } else {

--- a/frontend/src/services/providersService.ts
+++ b/frontend/src/services/providersService.ts
@@ -56,15 +56,23 @@ export function useCreateProviderEndpoint() {
   });
 }
 
-export function useUpdateProviderEndpoint(id: string) {
+export interface UpdateProviderEndpointArgs {
+  id: string;
+  body: Partial<TypesUpdateProviderEndpoint>;
+}
+
+export function useUpdateProviderEndpoint() {
   const api = useApi()
   const apiClient = api.getApiClient()
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (providerEndpoint: Partial<TypesUpdateProviderEndpoint>) => {
+    mutationFn: async ({ id, body }: UpdateProviderEndpointArgs) => {
+      if (!id) {
+        throw new Error('Cannot update provider endpoint: missing id')
+      }
       const result = await apiClient.v1ProviderEndpointsUpdate(id, {
-        body: providerEndpoint,
+        body,
         type: ContentType.Json
       } as RequestParams)
       return result.data


### PR DESCRIPTION
## Summary

Two related fixes for provider endpoint update/delete bugs.

### 1. Stale model cache on delete/update (server)

The model-list cache (`{name}:{owner}` → `[]OpenAIModel`, ~1 min TTL by default) was never invalidated on provider deletion or update. Three failure modes:

1. **Stale cache on delete.** Delete a provider — for the rest of the TTL window, `/api/v1/providers/models` still lists its models, the model picker still shows it, `/v1/chat/completions` routing still resolves the deleted provider's name, and the background refresh loop (which only iterates *current* providers) never sweeps the orphan entry.
2. **Stranded entry on rename.** The cache key is the provider name, so renaming `Foo` → `Bar` leaves a stale `Foo:owner` entry that nothing will clean up beyond TTL expiry.
3. **Stale models on URL/key edit.** Even when the name is unchanged, edits to `BaseURL`, `Models`, or the API key change what the upstream `/v1/models` would return — but the cache still serves the pre-edit list until TTL.

Fix: new `invalidateProviderModelCache(name, owner)` helper called from `deleteProviderEndpoint` (using captured `existingEndpoint.Name/Owner`) and `updateProviderEndpoint` (capture identity *before* mutation, drop both the previous key for rename/owner-swap and the new key for BaseURL/Models/APIKey edits).

### 2. Frontend update sent empty id in URL

Renaming a provider in the dashboard table produced `PUT /api/v1/provider-endpoints/` (no id segment) which the router rejected as `unknown API path`, so renames silently failed.

`useUpdateProviderEndpoint(id)` captured `id` at hook call time and used `id || ''` as a silent fallback. Move `id` into the mutate args, throw on empty, and update the three call sites (`EditProviderEndpointDialog`, `EditProviderModelsDialog`, `AddProviderDialog`).

### Drive-by build fix

`MultiClientManager.ListProviderEndpoints` (added in https://github.com/helixml/helix/pull/2324) referenced `m.runnerController`, which doesn't exist on the struct. `SetRunnerController` is documented as a no-op post sandbox-absorbs-runner pivot — runner availability is checked at request-routing time, not provider-listing time. Drop the dead gate so the package compiles and matches the documented contract / `ListProviders`.

## Test plan

- [x] `TestDeleteProviderEndpoint_InvalidatesModelCache` — pre-populate cache, call delete, verify cleared.
- [x] `TestUpdateProviderEndpoint_RenameInvalidatesOldKey` — pre-populate under both old and new names, rename, verify both cleared.
- [x] `TestUpdateProviderEndpoint_NoRenameStillInvalidates` — pre-populate, edit BaseURL only, verify cache cleared.
- [x] Existing `TestProviderHandlersSuite` (12 cases) still passes.
- [x] `yarn build` clean.
- [ ] End-to-end on staging: rename a custom provider in the dashboard table, verify the PUT URL includes the id and the rename persists. Then delete it and verify the model picker stops listing it immediately rather than after TTL.

## Out of scope

- Agent-list UI warning when an agent's stored provider doesn't resolve. The actionable case (session start) is already 422'd via the prior PR; surfacing it earlier in the agent edit panel is a separate UX task.
- Architectural decision on whether `provider/model` string concatenation is the right design. Current concat survives renames now (provider IDs stored in agent records), but stale provider names can still leak into Zed's settings.json under specific edge cases. Larger change touching Zed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)