### PR TITLE
fix(zed-config): org-aware provider snapshot + heal-on-read gating

### DIFF
--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -119,19 +119,7 @@ func GenerateZedMCPConfig(
 			ExternalURL: fmt.Sprintf("%s/api/v1/external-agents/sync?session_id=%s", helixAPIURL, sessionID),
 		},
 	}
-	// Find the zed_external assistant configuration
-	var assistant *types.AssistantConfig
-	for i := range app.Config.Helix.Assistants {
-		if app.Config.Helix.Assistants[i].AgentType == types.AgentTypeZedExternal {
-			assistant = &app.Config.Helix.Assistants[i]
-			break
-		}
-	}
-
-	// Fallback to first assistant if no zed_external found
-	if assistant == nil && len(app.Config.Helix.Assistants) > 0 {
-		assistant = &app.Config.Helix.Assistants[0]
-	}
+	assistant := FindZedExternalAssistant(app)
 
 	// For zed_external agents, prefer GenerationModel fields (where UI stores the selection)
 	var provider, model string
@@ -599,6 +587,27 @@ type ProviderRef struct {
 	Name string // current canonical name; for DB-backed providers this is the admin-set label
 }
 
+// FindZedExternalAssistant returns the assistant config that owns the
+// zed_external agent for the given app, falling back to the first
+// assistant when no zed_external entry is present (legacy/migration path).
+// Returns nil when the app has no assistants at all.
+//
+// Centralised here so GenerateZedMCPConfig, ValidateAssistantModelConfig,
+// and buildCodeAgentConfig agree on which assistant they're talking about
+// — a previous version had three independent walks, which would silently
+// diverge if anyone changed the matching rule.
+func FindZedExternalAssistant(app *types.App) *types.AssistantConfig {
+	if app == nil || len(app.Config.Helix.Assistants) == 0 {
+		return nil
+	}
+	for i := range app.Config.Helix.Assistants {
+		if app.Config.Helix.Assistants[i].AgentType == types.AgentTypeZedExternal {
+			return &app.Config.Helix.Assistants[i]
+		}
+	}
+	return &app.Config.Helix.Assistants[0]
+}
+
 // ResolveProvider matches a stored agent token (an ID for DB-backed providers,
 // the canonical name for globals) against the provider snapshot. ID match
 // wins; if no ID matches, falls back to a case-insensitive name match
@@ -618,9 +627,8 @@ func ResolveProvider(token string, snapshot []ProviderRef) (ref ProviderRef, byL
 			return p, false, true
 		}
 	}
-	want := strings.ToLower(token)
 	for _, p := range snapshot {
-		if strings.EqualFold(p.Name, want) || strings.ToLower(p.Name) == want {
+		if strings.EqualFold(p.Name, token) {
 			byLegacy := p.ID != "" // global with no ID is a normal match, not legacy
 			return p, byLegacy, true
 		}
@@ -686,18 +694,9 @@ func MigrateLegacyProviderRefs(app *types.App, snapshot []ProviderRef) bool {
 // provider in admin is a no-op for resolution.
 // Deletes: ID lookup fails and we report misconfig.
 func ValidateAssistantModelConfig(app *types.App, snapshot []ProviderRef) string {
-	if app == nil || len(app.Config.Helix.Assistants) == 0 {
-		return ""
-	}
-	var assistant *types.AssistantConfig
-	for i := range app.Config.Helix.Assistants {
-		if app.Config.Helix.Assistants[i].AgentType == types.AgentTypeZedExternal {
-			assistant = &app.Config.Helix.Assistants[i]
-			break
-		}
-	}
+	assistant := FindZedExternalAssistant(app)
 	if assistant == nil {
-		assistant = &app.Config.Helix.Assistants[0]
+		return ""
 	}
 	provider := assistant.GenerationModelProvider
 	if provider == "" {

--- a/api/pkg/openai/manager/provider_manager.go
+++ b/api/pkg/openai/manager/provider_manager.go
@@ -342,16 +342,12 @@ func (m *MultiClientManager) ListProviders(ctx context.Context, owner string) ([
 // — the agent record stores the immutable ID, settings.json carries the
 // current name. Renames flow into running sessions on the next sync poll.
 func (m *MultiClientManager) ListProviderEndpoints(ctx context.Context, owner string) ([]*types.ProviderEndpoint, error) {
+	// Sandbox-absorbs-runner pivot: the helix provider is always listed
+	// (see SetRunnerController). Individual model availability flows via
+	// /v1/models from the inferencerouter at request time.
 	m.globalClientsMu.RLock()
 	endpoints := make([]*types.ProviderEndpoint, 0, len(m.globalClients))
 	for provider := range m.globalClients {
-		// Skip the Helix provider if there are no runners — same gate as
-		// ListProviders so the snapshots agree on what's reachable.
-		if provider == types.ProviderHelix && m.runnerController != nil {
-			if len(m.runnerController.RunnerIDs()) == 0 {
-				continue
-			}
-		}
 		endpoints = append(endpoints, &types.ProviderEndpoint{
 			Name:         string(provider),
 			EndpointType: types.ProviderEndpointTypeGlobal,

--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -63,16 +63,9 @@ type AppCreateResponse struct {
 func (s *HelixAPIServer) applyModelSubstitutions(ctx context.Context, user *types.User, app *types.App, modelClasses []ModelClass) ([]ModelSubstitution, error) {
 	var substitutions []ModelSubstitution
 
-	owner := user.ID
-	if app.OrganizationID != "" {
-		owner = app.OrganizationID
-	}
-
-	// Get available providers for the user. Use the endpoint-aware listing
-	// so we can match agent records that store the provider's immutable ID
-	// (DB-backed) as well as the canonical name (env-baked globals + legacy
-	// agents that haven't been re-saved yet).
-	availableEndpoints, err := s.providerManager.ListProviderEndpoints(ctx, owner)
+	// Use the org-aware endpoint list so an org agent referencing the user's
+	// personal provider still finds it (mirrors validateProvidersAndModels).
+	availableEndpoints, err := s.listEndpointsForApp(ctx, user.ID, app)
 	if err != nil {
 		log.Error().
 			Err(err).
@@ -81,19 +74,24 @@ func (s *HelixAPIServer) applyModelSubstitutions(ctx context.Context, user *type
 		return substitutions, err
 	}
 
-	// Create a set of available providers for fast lookup, indexed by both
-	// ID and (lowercased) Name. Substitution catalogs are name-keyed so
-	// alt.Provider is always a name; the agent-stored value may be an ID,
-	// a canonical global name, or a legacy mixed-case name.
-	providerSet := make(map[types.Provider]bool)
-	for _, ep := range availableEndpoints {
-		if ep.ID != "" {
-			providerSet[types.Provider(ep.ID)] = true
+	// One predicate, case-insensitive on names: substitution catalogs are
+	// name-keyed (alt.Provider is always a canonical name) but the
+	// agent-stored value may be an ID, a canonical global name, or a
+	// legacy mixed-case name. Single helper avoids the case-sensitive Go
+	// map gotcha that the previous double-keyed providerSet papered over.
+	providerKnown := func(ref string) bool {
+		if ref == "" {
+			return false
 		}
-		if ep.Name != "" {
-			providerSet[types.Provider(ep.Name)] = true
-			providerSet[types.Provider(strings.ToLower(ep.Name))] = true
+		for _, ep := range availableEndpoints {
+			if ep.ID != "" && ep.ID == ref {
+				return true
+			}
+			if strings.EqualFold(ep.Name, ref) {
+				return true
+			}
 		}
+		return false
 	}
 
 	log.Info().
@@ -126,7 +124,7 @@ func (s *HelixAPIServer) applyModelSubstitutions(ctx context.Context, user *type
 				return
 			}
 
-			substitute := s.findModelSubstitution(originalProvider, originalModel, modelClasses, providerSet)
+			substitute := s.findModelSubstitution(originalProvider, originalModel, modelClasses, providerKnown)
 			if substitute != nil {
 				// Only record a substitution if the provider or model actually changed
 				if substitute.Provider != originalProvider || substitute.Model != originalModel {
@@ -207,16 +205,15 @@ func (s *HelixAPIServer) applyModelSubstitutions(ctx context.Context, user *type
 	return substitutions, nil
 }
 
-// findModelSubstitution finds the first available model from the alternatives list
-func (s *HelixAPIServer) findModelSubstitution(originalProvider, originalModel string, modelClasses []ModelClass, providerSet map[types.Provider]bool) *AlternativeModelOption {
-	// First check if the original provider is available
-	if providerSet[types.Provider(originalProvider)] {
+// findModelSubstitution finds the first available model from the alternatives list.
+// providerKnown is a case-insensitive predicate over the actor-visible
+// providers (env globals + DB-backed user/org).
+func (s *HelixAPIServer) findModelSubstitution(originalProvider, originalModel string, modelClasses []ModelClass, providerKnown func(string) bool) *AlternativeModelOption {
+	if providerKnown(originalProvider) {
 		return nil
 	}
 
-	// Original provider is not available, look for substitutions
 	for _, class := range modelClasses {
-		// Check if the original provider/model combination exists in this class
 		found := false
 		for _, alt := range class.Alternatives {
 			if alt.Provider == originalProvider && alt.Model == originalModel {
@@ -224,17 +221,15 @@ func (s *HelixAPIServer) findModelSubstitution(originalProvider, originalModel s
 				break
 			}
 		}
-
-		if found {
-			// Found the original model in this class, now look for available alternatives
-			for _, alt := range class.Alternatives {
-				if providerSet[types.Provider(alt.Provider)] {
-					return &alt
-				}
-			}
-
-			return nil
+		if !found {
+			continue
 		}
+		for _, alt := range class.Alternatives {
+			if providerKnown(alt.Provider) {
+				return &alt
+			}
+		}
+		return nil
 	}
 
 	return nil
@@ -587,44 +582,13 @@ func (s *HelixAPIServer) createApp(_ http.ResponseWriter, r *http.Request) (*App
 // validateProvidersAndModels checks if the provider and model are valid. Provider
 // can be empty, however model is required
 func (s *HelixAPIServer) validateProvidersAndModels(ctx context.Context, user *types.User, app *types.App) error {
-
-	owner := user.ID
-	if app.OrganizationID != "" {
-		owner = app.OrganizationID
-	}
-
-	endpoints, err := s.providerManager.ListProviderEndpoints(ctx, owner)
+	endpoints, err := s.listEndpointsForApp(ctx, user.ID, app)
 	if err != nil {
 		log.Error().
 			Err(err).
 			Str("user_id", user.ID).
 			Msg("Failed to get available providers during validation")
 		return fmt.Errorf("failed to get available providers: %w", err)
-	}
-
-	// When creating org apps, also include the user's personal providers
-	if app.OrganizationID != "" {
-		userEndpoints, err := s.providerManager.ListProviderEndpoints(ctx, user.ID)
-		if err == nil {
-			seen := make(map[string]struct{}, len(endpoints))
-			for _, ep := range endpoints {
-				key := ep.ID
-				if key == "" {
-					key = "name:" + ep.Name
-				}
-				seen[key] = struct{}{}
-			}
-			for _, ep := range userEndpoints {
-				key := ep.ID
-				if key == "" {
-					key = "name:" + ep.Name
-				}
-				if _, ok := seen[key]; !ok {
-					endpoints = append(endpoints, ep)
-					seen[key] = struct{}{}
-				}
-			}
-		}
 	}
 
 	// Provider references are IDs for DB-backed providers, canonical names

--- a/api/pkg/server/app_handlers_test.go
+++ b/api/pkg/server/app_handlers_test.go
@@ -174,6 +174,16 @@ func handleDuplicateAppNames(app *types.App, existingApps []*types.App) {
 func TestFindModelSubstitution(t *testing.T) {
 	server := &HelixAPIServer{}
 
+	// findModelSubstitution now takes a predicate (case-insensitive on
+	// names) instead of a map. Each test still expresses availability as
+	// a map of canonical names; the helper adapts that to the predicate
+	// without leaking the case-handling details into every assertion.
+	mapToPredicate := func(set map[types.Provider]bool) func(string) bool {
+		return func(ref string) bool {
+			return set[types.Provider(ref)]
+		}
+	}
+
 	// Create test model classes similar to substitutions.yaml
 	modelClasses := []ModelClass{
 		{
@@ -211,7 +221,7 @@ func TestFindModelSubstitution(t *testing.T) {
 			"together":  false,
 		}
 
-		result := server.findModelSubstitution("together", "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", modelClasses, availableProviders)
+		result := server.findModelSubstitution("together", "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", modelClasses, mapToPredicate(availableProviders))
 
 		require.NotNil(t, result)
 		require.Equal(t, "helix", result.Provider)
@@ -226,7 +236,7 @@ func TestFindModelSubstitution(t *testing.T) {
 			"together":  false,
 		}
 
-		result := server.findModelSubstitution("together", "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", modelClasses, availableProviders)
+		result := server.findModelSubstitution("together", "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", modelClasses, mapToPredicate(availableProviders))
 
 		require.NotNil(t, result)
 		require.Equal(t, "anthropic", result.Provider)
@@ -241,7 +251,7 @@ func TestFindModelSubstitution(t *testing.T) {
 			"together":  false,
 		}
 
-		result := server.findModelSubstitution("together", "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", modelClasses, availableProviders)
+		result := server.findModelSubstitution("together", "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", modelClasses, mapToPredicate(availableProviders))
 
 		require.Nil(t, result)
 	})
@@ -255,7 +265,7 @@ func TestFindModelSubstitution(t *testing.T) {
 		}
 
 		// Use a model that doesn't exist in any class - should NOT fall back
-		result := server.findModelSubstitution("unknown", "unknown-model", modelClasses, availableProviders)
+		result := server.findModelSubstitution("unknown", "unknown-model", modelClasses, mapToPredicate(availableProviders))
 
 		require.Nil(t, result)
 	})
@@ -263,7 +273,7 @@ func TestFindModelSubstitution(t *testing.T) {
 	t.Run("returns nil when no alternatives available at all", func(t *testing.T) {
 		availableProviders := map[types.Provider]bool{}
 
-		result := server.findModelSubstitution("together", "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", modelClasses, availableProviders)
+		result := server.findModelSubstitution("together", "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", modelClasses, mapToPredicate(availableProviders))
 
 		require.Nil(t, result)
 	})
@@ -273,7 +283,7 @@ func TestFindModelSubstitution(t *testing.T) {
 			"helix": true,
 		}
 
-		result := server.findModelSubstitution("together", "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", []ModelClass{}, availableProviders)
+		result := server.findModelSubstitution("together", "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", []ModelClass{}, mapToPredicate(availableProviders))
 
 		require.Nil(t, result)
 	})
@@ -288,7 +298,7 @@ func TestFindModelSubstitution(t *testing.T) {
 
 		// Test model that appears in multiple classes - gpt-4o appears in both large-reasoning and vision-model
 		// Since lightweight class is checked first and helix is available in large-reasoning, it should return helix alternative
-		result := server.findModelSubstitution("openai", "gpt-4o", modelClasses, availableProviders)
+		result := server.findModelSubstitution("openai", "gpt-4o", modelClasses, mapToPredicate(availableProviders))
 
 		require.NotNil(t, result) // Should find helix alternative from large-reasoning class (processed first)
 		require.Equal(t, "helix", result.Provider)
@@ -884,4 +894,73 @@ func TestO3MiniSubstitution(t *testing.T) {
 		assert.Equal(t, "anthropic", sub.NewProvider)
 		assert.Equal(t, "claude-3-5-sonnet-20241022", sub.NewModel)
 	}
+}
+
+// TestListEndpointsForApp covers the org-aware behaviour added in the
+// snapshot-helper refactor: org-owned apps must see both the org bucket
+// and the actor's personal providers, with sensible de-dup.
+func TestListEndpointsForApp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProviderManager := manager.NewMockProviderManager(ctrl)
+	server := &HelixAPIServer{providerManager: mockProviderManager}
+	ctx := context.Background()
+
+	t.Run("personal app uses user owner only", func(t *testing.T) {
+		mockProviderManager.EXPECT().
+			ListProviderEndpoints(ctx, "user1").
+			Return([]*types.ProviderEndpoint{{ID: "pe_user_01", Name: "user-prov"}}, nil)
+		app := &types.App{ID: "app1"}
+		eps, err := server.listEndpointsForApp(ctx, "user1", app)
+		require.NoError(t, err)
+		require.Len(t, eps, 1)
+		require.Equal(t, "pe_user_01", eps[0].ID)
+	})
+
+	t.Run("org app merges org and user buckets and de-dups", func(t *testing.T) {
+		// Both buckets see the same env-baked global ("openai", no ID); the
+		// merge must not double-count it. The user also has a personal
+		// provider that the org bucket doesn't see — that should land.
+		mockProviderManager.EXPECT().
+			ListProviderEndpoints(ctx, "org1").
+			Return([]*types.ProviderEndpoint{
+				{ID: "pe_org_01", Name: "org-prov"},
+				{Name: "openai"},
+			}, nil)
+		mockProviderManager.EXPECT().
+			ListProviderEndpoints(ctx, "user1").
+			Return([]*types.ProviderEndpoint{
+				{ID: "pe_user_01", Name: "user-prov"},
+				{Name: "openai"},
+			}, nil)
+
+		app := &types.App{ID: "app1", OrganizationID: "org1"}
+		eps, err := server.listEndpointsForApp(ctx, "user1", app)
+		require.NoError(t, err)
+
+		got := map[string]bool{}
+		for _, ep := range eps {
+			got[endpointKey(ep)] = true
+		}
+		require.True(t, got["id:pe_org_01"], "org-bucket DB provider should be present")
+		require.True(t, got["id:pe_user_01"], "user-bucket DB provider should be merged in for org apps")
+		require.True(t, got["name:openai"], "global should be present exactly once")
+		require.Len(t, eps, 3, "duplicate global must not be appended twice")
+	})
+
+	t.Run("personal-bucket failure still returns org bucket", func(t *testing.T) {
+		mockProviderManager.EXPECT().
+			ListProviderEndpoints(ctx, "org1").
+			Return([]*types.ProviderEndpoint{{ID: "pe_org_01", Name: "org-prov"}}, nil)
+		mockProviderManager.EXPECT().
+			ListProviderEndpoints(ctx, "user1").
+			Return(nil, fmt.Errorf("transient store error"))
+
+		app := &types.App{ID: "app1", OrganizationID: "org1"}
+		eps, err := server.listEndpointsForApp(ctx, "user1", app)
+		require.NoError(t, err, "personal-bucket failure should not propagate; org bucket is still useful")
+		require.Len(t, eps, 1)
+		require.Equal(t, "pe_org_01", eps[0].ID)
+	})
 }

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -135,11 +135,15 @@ func (apiServer *HelixAPIServer) getZedConfig(_ http.ResponseWriter, req *http.R
 		// Use empty scopes - the token getter will use whatever scopes the user has
 		return apiServer.oauthManager.GetTokenForTool(ctx, userID, providerName, nil)
 	}
-	providerSnapshot, err := apiServer.getProviderSnapshot(ctx, session.Owner)
+	providerSnapshot, err := apiServer.getProviderSnapshot(ctx, session.Owner, app)
 	if err != nil {
 		log.Warn().Err(err).Str("session_id", sessionID).Msg("zed-config: failed to list providers; provider resolution will be skipped")
 	}
-	apiServer.healLegacyProviderRefs(ctx, app, providerSnapshot)
+	// Heal-on-read rewrites legacy name refs to immutable IDs. Skip the
+	// persisted write for runner-token requests so two concurrent runner
+	// pulls don't race UpdateApp and runner traffic doesn't bump
+	// app.UpdatedAt — the in-memory rewrite still feeds Generate below.
+	apiServer.healLegacyProviderRefs(ctx, app, providerSnapshot, user.TokenType != types.TokenTypeRunner)
 	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, sandboxAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, providerSnapshot)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
@@ -521,8 +525,10 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfig(ctx context.Context, app *
 			// current name) — Zed's model picker fails the lookup and falls
 			// back to its built-in Claude default.
 			//
-			// See deviqon/P1-5-zed-overrides-clobber-helix-default-model.md.
-			snapshot, err := apiServer.getProviderSnapshot(ctx, app.Owner)
+			// app.Owner drives the actor identity here — buildCodeAgentConfig
+			// has no session/request context. Org providers are still
+			// resolved via the org bucket inside getProviderSnapshot.
+			snapshot, err := apiServer.getProviderSnapshot(ctx, app.Owner, app)
 			if err != nil {
 				log.Warn().Err(err).Str("app_id", app.ID).Msg("buildCodeAgentConfig: provider snapshot unavailable; model prefix may not match agent.default_model")
 			}
@@ -654,17 +660,26 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.C
 	}
 }
 
-// getProviderSnapshot returns a slice of ProviderRef summarising every
-// provider visible to the owner — env-baked globals (ID="", Name=canonical)
-// plus DB-backed user/org records (ID set, Name=current admin label). Used
-// by zed-config code paths to resolve an agent's stored provider reference
-// to its current canonical name. Returning nil from this helper (e.g. when
-// the manager isn't wired) tells GenerateZedMCPConfig to skip resolution.
-func (apiServer *HelixAPIServer) getProviderSnapshot(ctx context.Context, owner string) ([]external_agent.ProviderRef, error) {
+// getProviderSnapshot returns a ProviderRef snapshot of every provider
+// visible to the actor for the given app — env-baked globals (ID="",
+// Name=canonical) plus DB-backed user/org records (ID set, Name=current
+// admin label). Used by zed-config code paths to resolve an agent's stored
+// provider reference to its current canonical name.
+//
+// The app argument is what makes this org-aware: when app.OrganizationID
+// is set, org-owned providers are listed first and the user's personal
+// providers are merged in (so a user running an org agent that references
+// their own personal provider still resolves). actorID may be "" when
+// there's no user context (rare; e.g. system-driven paths) — in that case
+// only the app-owner bucket is returned.
+//
+// Returning nil from this helper (e.g. when the manager isn't wired) tells
+// GenerateZedMCPConfig to skip resolution.
+func (apiServer *HelixAPIServer) getProviderSnapshot(ctx context.Context, actorID string, app *types.App) ([]external_agent.ProviderRef, error) {
 	if apiServer.providerManager == nil {
 		return nil, nil
 	}
-	endpoints, err := apiServer.providerManager.ListProviderEndpoints(ctx, owner)
+	endpoints, err := apiServer.listEndpointsForApp(ctx, actorID, app)
 	if err != nil {
 		return nil, err
 	}
@@ -673,6 +688,63 @@ func (apiServer *HelixAPIServer) getProviderSnapshot(ctx context.Context, owner 
 		refs = append(refs, external_agent.ProviderRef{ID: ep.ID, Name: ep.Name})
 	}
 	return refs, nil
+}
+
+// listEndpointsForApp returns ProviderEndpoint records visible to the actor
+// for the given app, with the org-first + user-merge pattern that
+// validateProvidersAndModels established. Centralising it here means every
+// caller (substitution, validation, zed-config, spec-task pre-flight) sees
+// the same view of "what providers can this agent legitimately reference".
+//
+// Without the merge, an org-owned agent that references the org member's
+// personal provider would 422 at session start; with it, both buckets
+// participate in resolution.
+func (apiServer *HelixAPIServer) listEndpointsForApp(ctx context.Context, actorID string, app *types.App) ([]*types.ProviderEndpoint, error) {
+	if apiServer.providerManager == nil {
+		return nil, nil
+	}
+	owner := actorID
+	if app != nil && app.OrganizationID != "" {
+		owner = app.OrganizationID
+	}
+	endpoints, err := apiServer.providerManager.ListProviderEndpoints(ctx, owner)
+	if err != nil {
+		return nil, err
+	}
+	if app == nil || app.OrganizationID == "" || actorID == "" || actorID == app.OrganizationID {
+		return endpoints, nil
+	}
+	userEndpoints, uerr := apiServer.providerManager.ListProviderEndpoints(ctx, actorID)
+	if uerr != nil {
+		// Best-effort merge: a personal-provider lookup failure shouldn't
+		// hide the org bucket we already have. Log and return what we got.
+		log.Warn().Err(uerr).Str("app_id", app.ID).Str("actor_id", actorID).Msg("listEndpointsForApp: failed to list personal providers; using org bucket only")
+		return endpoints, nil
+	}
+	seen := make(map[string]struct{}, len(endpoints))
+	for _, ep := range endpoints {
+		seen[endpointKey(ep)] = struct{}{}
+	}
+	for _, ep := range userEndpoints {
+		k := endpointKey(ep)
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		endpoints = append(endpoints, ep)
+	}
+	return endpoints, nil
+}
+
+// endpointKey produces a stable de-dup key for a provider endpoint. ID wins
+// when present; for env-baked globals (ID=="") the name namespace is used
+// to keep "openai" from colliding with a DB-backed provider also named
+// "openai".
+func endpointKey(ep *types.ProviderEndpoint) string {
+	if ep.ID != "" {
+		return "id:" + ep.ID
+	}
+	return "name:" + ep.Name
 }
 
 // validateSpecTaskAgentConfig pre-flights the agent's provider/model snapshot
@@ -704,12 +776,15 @@ func (apiServer *HelixAPIServer) validateSpecTaskAgentConfig(ctx context.Context
 	if err != nil {
 		return "", fmt.Errorf("failed to load agent app %s: %w", appID, err)
 	}
-	snapshot, err := apiServer.getProviderSnapshot(ctx, actorID)
+	snapshot, err := apiServer.getProviderSnapshot(ctx, actorID, app)
 	if err != nil {
 		log.Warn().Err(err).Str("app_id", appID).Msg("spec-task: failed to list providers; skipping agent config validation")
 		return "", nil
 	}
-	apiServer.healLegacyProviderRefs(ctx, app, snapshot)
+	// Spec-task entry handlers always run with a real user token, so persist
+	// the heal-on-read rewrite — runner-token entry into this code path is
+	// not a thing for these handlers.
+	apiServer.healLegacyProviderRefs(ctx, app, snapshot, true)
 	return external_agent.ValidateAssistantModelConfig(app, snapshot), nil
 }
 
@@ -717,8 +792,17 @@ func (apiServer *HelixAPIServer) validateSpecTaskAgentConfig(ctx context.Context
 // to the matching DB-backed provider's immutable ID, so future renames are
 // silent. Best-effort — a write failure just logs and lets the next read
 // retry. See external_agent.MigrateLegacyProviderRefs for the rules.
-func (apiServer *HelixAPIServer) healLegacyProviderRefs(ctx context.Context, app *types.App, snapshot []external_agent.ProviderRef) {
+//
+// persist=false skips the UpdateApp write (used on runner-token reads of
+// /zed-config so two concurrent runner pulls don't race UpdateApp and
+// runner traffic doesn't bump app.UpdatedAt). The in-memory rewrite still
+// happens — that's what feeds the immediate Generate / Validate call.
+func (apiServer *HelixAPIServer) healLegacyProviderRefs(ctx context.Context, app *types.App, snapshot []external_agent.ProviderRef, persist bool) {
 	if !external_agent.MigrateLegacyProviderRefs(app, snapshot) {
+		return
+	}
+	if !persist {
+		log.Debug().Str("app_id", app.ID).Msg("agent legacy-name → ID migration: in-memory only (runner-token read)")
 		return
 	}
 	if _, err := apiServer.Store.UpdateApp(ctx, app); err != nil {


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/helixml/helix/pull/2324. That PR introduced the `ProviderRef` snapshot path but several callers passed a single user-scoped owner where `validateProvidersAndModels` uses an org-first + user-merge pattern. Result on `main` today: an org member starting a spec task whose agent references an org-level provider gets a 422 + a never-healing legacy ref. Same gap existed in `applyModelSubstitutions`.

## What's in here

- **Org-aware snapshot helper.** New `listEndpointsForApp(ctx, actorID, app)`: when `app.OrganizationID` is set, list the org bucket and merge the actor's personal providers with id/name de-dup. Personal-bucket failure no longer hides the org bucket. `getProviderSnapshot`, `validateProvidersAndModels` and `applyModelSubstitutions` now all route through it. `getZedConfig`, `buildCodeAgentConfig` and `validateSpecTaskAgentConfig` pass the app so org providers participate in resolution.
- **Heal gated for runner-token reads.** `healLegacyProviderRefs(persist=false)` on runner-token requests to `/zed-config` so concurrent runner pulls don't race `UpdateApp` and runner traffic doesn't bump `app.UpdatedAt`. The in-memory rewrite still feeds `Generate`/`Validate`.
- **Drop redundant case-fold** in `ResolveProvider`: one `strings.EqualFold` against the original token replaces the `EqualFold || ToLower` clause.
- **One zed_external resolver.** New `external_agent.FindZedExternalAssistant`, reused from `GenerateZedMCPConfig` and `ValidateAssistantModelConfig` so the `zed_external` + `Assistants[0]` fallback rule lives in one place. `buildCodeAgentConfig` deliberately stays strict (no fallback) — different semantics.
- **Predicate-based provider lookup.** `findModelSubstitution` now takes a `func(string) bool` (case-insensitive on names via `strings.EqualFold`) instead of a double-keyed Go map. Matches the `validateProvidersAndModels` pattern and removes the case-sensitivity trap.
- **Compile fix on top of `main`.** `MultiClientManager.ListProviderEndpoints` referenced `m.runnerController`, but the field was removed by 5d9abe3fc and `SetRunnerController` is already a no-op. The original PR was added without rebasing, leaving `main` not compiling. Removed the dead gate to match the existing no-op semantics.

## Test plan

- [x] `go build ./api/...` (CGO on)
- [x] `TestListEndpointsForApp` (new) - personal app, org+user merge with de-dup, personal-bucket failure resilience
- [x] `TestFindModelSubstitution` (existing) - updated to thread availability through the new predicate
- [x] `TestApplyModelSubstitutions*` (existing) - all green
- [x] `TestGenerateZedMCPConfig_AgentDefaultModel`, `TestMigrateLegacyProviderRefs`, `TestNormalizeModelIDForZed` - all green
- [x] `go test ./api/pkg/openai/manager/` - all green
- [ ] CI - to confirm on push

## Out of scope / follow-ups

- Frontend `AdvancedModelPicker` predicate work (`hasRealID`, `matchesStoredRef`) - already case-insensitive after #2324, no change needed here.
- Daemon-side `mergeAgentBlock` - left alone; it's the right policy point and already has its own coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)