### PR TITLE
Bump kodit to v1.3.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/go-retryablehttp v0.7.8
-	github.com/helixml/kodit v1.3.6
+	github.com/helixml/kodit v1.3.7
 	github.com/infracloudio/msbotbuilder-go v0.2.5
 	github.com/jfrog/froggit-go v1.20.1
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -540,8 +540,8 @@ github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/helixml/kodit v1.3.6 h1:a9M3P5Dxvemp8qDWNnA0o4j9tLwrcWLEiiZgOPNwGvw=
-github.com/helixml/kodit v1.3.6/go.mod h1:NhT1+0j9LZk6u0mZzuMbyc/P/Rfheh8OYLUxANN9JTg=
+github.com/helixml/kodit v1.3.7 h1:5s1n1UOsEIlh4ZjNPHpS+uHs14CArzpYh/qj8fJt2ic=
+github.com/helixml/kodit v1.3.7/go.mod h1:NhT1+0j9LZk6u0mZzuMbyc/P/Rfheh8OYLUxANN9JTg=
 github.com/helixml/langchaingo v0.1.15 h1:6cEwRQgEri4aDrvDnSESmsMY9H35UUoWuOEukSP3lJw=
 github.com/helixml/langchaingo v0.1.15/go.mod h1:EeervIv/DNYhSfQSMaql20wMFvhgF7lDaVaatp8lVPw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=


### PR DESCRIPTION
## Summary

Upgrades the in-process [helixml/kodit](https://github.com/helixml/kodit) Go library from v1.3.6 to v1.3.7. The release contains 9 PRs of bug fixes and internal refactors — notably a swap of the PDF text extractor to PDFium (#562) with empty-content warnings (#561), a deduplication fix for repos with >1000 enrichments (#557), and a unified BM25/embedding storage refactor (#560). No breaking API changes; helix's 12 kodit-importing files compile and run without modification.

## Changes

- `go.mod`: `github.com/helixml/kodit v1.3.6` → `v1.3.7`
- `go.sum`: regenerated via `go mod tidy`

## Verification

- `CGO_ENABLED=1 go build ./api/pkg/services/... ./api/pkg/server/... ./api/pkg/controller/knowledge/... ./api/pkg/rag/...` passes
- API container restarts cleanly with `KODIT_ENABLED=true`; logs show kodit v1.3.7 worker polling and "Using Kodit for RAG"
- End-to-end manual test: uploaded the arxiv paper [2604.25927v1](https://arxiv.org/pdf/2604.25927v1) (629 KB, 7 pages) as a Files knowledge source on an agent. Indexing went `preparing` → `indexing` → `ready`; kodit produced 27 code embeddings + 13 page-image embeddings via the new PDFium extractor with no PDF-extraction warnings. The agent then successfully invoked the `Knowledge_arxiv_pdf` skill (a `KnowledgeQuery` tool call) against the indexed content.

The `.drone.yml` E2E pipeline at line 1808 syncs the kodit version into the Zed WS test server's `go.mod` automatically — no manual sync needed.

## Screenshots

![Knowledge source ready after kodit v1.3.7 indexing](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001979_please-upgrade-helixs/screenshots/03-indexing-ready.png)

![Agent calling KnowledgeQuery against the kodit-indexed PDF](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001979_please-upgrade-helixs/screenshots/05-knowledge-query-working.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kqkxftmrjxzrwk73q48mcp85)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001979_please-upgrade-helixs/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001979_please-upgrade-helixs/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001979_please-upgrade-helixs/tasks.md)

🚀 Built with [Helix](https://helix.ml)