### PR TITLE
Allow setting an assignee when creating a spec task

### DIFF
--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -23624,6 +23624,10 @@ const docTemplate = `{
                     "description": "Optional: Helix agent to use for spec generation",
                     "type": "string"
                 },
+                "assignee_id": {
+                    "description": "Optional: team member assigned to the task",
+                    "type": "string"
+                },
                 "base_branch": {
                     "description": "For new mode: branch to create from (defaults to repo default)",
                     "type": "string"

--- a/api/pkg/server/spec_driven_task_assignee_test.go
+++ b/api/pkg/server/spec_driven_task_assignee_test.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+type SpecTaskAssigneeSuite struct {
+	suite.Suite
+
+	ctrl   *gomock.Controller
+	store  *store.MockStore
+	server *HelixAPIServer
+}
+
+func TestSpecTaskAssigneeSuite(t *testing.T) {
+	suite.Run(t, new(SpecTaskAssigneeSuite))
+}
+
+func (s *SpecTaskAssigneeSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.store = store.NewMockStore(s.ctrl)
+	s.server = &HelixAPIServer{
+		Cfg:   &config.ServerConfig{},
+		Store: s.store,
+	}
+}
+
+func (s *SpecTaskAssigneeSuite) TearDownTest() {
+	s.ctrl.Finish()
+}
+
+// validateAssigneeIsOrgMember should short-circuit on empty assignee
+// (unassigned is a valid state on both create and update paths).
+func (s *SpecTaskAssigneeSuite) TestValidateAssignee_Empty_IsAlwaysValid() {
+	err := s.server.validateAssigneeIsOrgMember(context.Background(), "org1", "")
+	s.NoError(err)
+}
+
+func (s *SpecTaskAssigneeSuite) TestValidateAssignee_Member_IsValid() {
+	s.store.EXPECT().
+		GetOrganizationMembership(gomock.Any(), &store.GetOrganizationMembershipQuery{
+			OrganizationID: "org1",
+			UserID:         "user_member",
+		}).
+		Return(&types.OrganizationMembership{OrganizationID: "org1", UserID: "user_member"}, nil)
+
+	err := s.server.validateAssigneeIsOrgMember(context.Background(), "org1", "user_member")
+	s.NoError(err)
+}
+
+func (s *SpecTaskAssigneeSuite) TestValidateAssignee_NonMember_ReturnsError() {
+	s.store.EXPECT().
+		GetOrganizationMembership(gomock.Any(), &store.GetOrganizationMembershipQuery{
+			OrganizationID: "org1",
+			UserID:         "user_outsider",
+		}).
+		Return(nil, errors.New("not found"))
+
+	err := s.server.validateAssigneeIsOrgMember(context.Background(), "org1", "user_outsider")
+	s.Error(err)
+}
+
+// createTaskFromPrompt returns 400 when the requested assignee isn't a member
+// of the project's organization. This is the new validation gate added so the
+// kanban filter can't silently hide a freshly-created task with a bad assignee.
+func (s *SpecTaskAssigneeSuite) TestCreateTaskFromPrompt_NonMemberAssignee_Returns400() {
+	const (
+		ownerID  = "user_owner"
+		orgID    = "org1"
+		projID   = "proj_with_assignee_test"
+		nonMember = "user_outsider"
+	)
+
+	project := &types.Project{
+		ID:             projID,
+		OrganizationID: orgID,
+		UserID:         ownerID,
+	}
+
+	// authorizeUserToProjectByID loads the project, then authorizeUserToProject
+	// calls authorizeOrgMember which queries org membership for the *caller*.
+	s.store.EXPECT().
+		GetProject(gomock.Any(), projID).
+		Return(project, nil)
+	s.store.EXPECT().
+		GetOrganizationMembership(gomock.Any(), &store.GetOrganizationMembershipQuery{
+			OrganizationID: orgID,
+			UserID:         ownerID,
+		}).
+		Return(&types.OrganizationMembership{OrganizationID: orgID, UserID: ownerID, Role: types.OrganizationRoleMember}, nil)
+
+	// The validation block in createTaskFromPrompt loads the project a second
+	// time to read OrganizationID, then queries membership for the *assignee*.
+	s.store.EXPECT().
+		GetProject(gomock.Any(), projID).
+		Return(project, nil)
+	s.store.EXPECT().
+		GetOrganizationMembership(gomock.Any(), &store.GetOrganizationMembershipQuery{
+			OrganizationID: orgID,
+			UserID:         nonMember,
+		}).
+		Return(nil, errors.New("not found"))
+
+	body, err := json.Marshal(types.CreateTaskRequest{
+		ProjectID:  projID,
+		Prompt:     "do the thing",
+		AssigneeID: nonMember,
+	})
+	s.Require().NoError(err)
+
+	req := httptest.NewRequest("POST", "/api/v1/spec-tasks/from-prompt", bytes.NewReader(body))
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: ownerID}))
+
+	rr := httptest.NewRecorder()
+	s.server.createTaskFromPrompt(rr, req)
+
+	s.Equal(http.StatusBadRequest, rr.Code)
+	s.Contains(rr.Body.String(), "assignee must be an organization member")
+}

--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -19,6 +19,21 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// validateAssigneeIsOrgMember returns nil if assigneeID is empty (unassigned is valid)
+// or if the assignee is a member of the given organization. Returns the underlying
+// store error otherwise — callers are responsible for logging context (task_id /
+// project_id) and translating to an HTTP response.
+func (s *HelixAPIServer) validateAssigneeIsOrgMember(ctx context.Context, orgID, assigneeID string) error {
+	if assigneeID == "" {
+		return nil
+	}
+	_, err := s.Store.GetOrganizationMembership(ctx, &store.GetOrganizationMembershipQuery{
+		OrganizationID: orgID,
+		UserID:         assigneeID,
+	})
+	return err
+}
+
 // createTaskFromPrompt godoc
 // @Summary Create spec-driven task from simple prompt
 // @Description Create a new task from a simple description and start spec generation
@@ -57,6 +72,26 @@ func (s *HelixAPIServer) createTaskFromPrompt(w http.ResponseWriter, r *http.Req
 	if err := s.authorizeUserToProjectByID(ctx, user, req.ProjectID, types.ActionCreate); err != nil {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
+	}
+
+	// Validate assignee (if provided) is a member of the project's organization
+	if req.AssigneeID != "" {
+		project, err := s.Store.GetProject(ctx, req.ProjectID)
+		if err != nil {
+			log.Error().Err(err).Str("project_id", req.ProjectID).Msg("Failed to load project for assignee validation")
+			http.Error(w, "failed to load project", http.StatusInternalServerError)
+			return
+		}
+		if err := s.validateAssigneeIsOrgMember(ctx, project.OrganizationID, req.AssigneeID); err != nil {
+			log.Warn().
+				Str("project_id", req.ProjectID).
+				Str("assignee_id", req.AssigneeID).
+				Str("org_id", project.OrganizationID).
+				Err(err).
+				Msg("Assignee is not an organization member")
+			http.Error(w, "assignee must be an organization member", http.StatusBadRequest)
+			return
+		}
 	}
 
 	// Set user ID and email from context
@@ -1053,23 +1088,15 @@ func (s *HelixAPIServer) updateSpecTask(w http.ResponseWriter, r *http.Request) 
 	// Update assignee (pointer allows clearing with empty string to unassign)
 	if updateReq.AssigneeID != nil {
 		newAssigneeID := *updateReq.AssigneeID
-		// Only validate if assigning (not when clearing)
-		if newAssigneeID != "" {
-			// Validate that assignee is an organization member
-			_, err := s.Store.GetOrganizationMembership(ctx, &store.GetOrganizationMembershipQuery{
-				OrganizationID: task.OrganizationID,
-				UserID:         newAssigneeID,
-			})
-			if err != nil {
-				log.Warn().
-					Str("task_id", taskID).
-					Str("assignee_id", newAssigneeID).
-					Str("org_id", task.OrganizationID).
-					Err(err).
-					Msg("Assignee is not an organization member")
-				http.Error(w, "assignee must be an organization member", http.StatusBadRequest)
-				return
-			}
+		if err := s.validateAssigneeIsOrgMember(ctx, task.OrganizationID, newAssigneeID); err != nil {
+			log.Warn().
+				Str("task_id", taskID).
+				Str("assignee_id", newAssigneeID).
+				Str("org_id", task.OrganizationID).
+				Err(err).
+				Msg("Assignee is not an organization member")
+			http.Error(w, "assignee must be an organization member", http.StatusBadRequest)
+			return
 		}
 		task.AssigneeID = newAssigneeID
 	}

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -23620,6 +23620,10 @@
                     "description": "Optional: Helix agent to use for spec generation",
                     "type": "string"
                 },
+                "assignee_id": {
+                    "description": "Optional: team member assigned to the task",
+                    "type": "string"
+                },
                 "base_branch": {
                     "description": "For new mode: branch to create from (defaults to repo default)",
                     "type": "string"

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -3868,6 +3868,9 @@ definitions:
       app_id:
         description: 'Optional: Helix agent to use for spec generation'
         type: string
+      assignee_id:
+        description: 'Optional: team member assigned to the task'
+        type: string
       base_branch:
         description: 'For new mode: branch to create from (defaults to repo default)'
         type: string

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -176,6 +176,7 @@ func (s *SpecDrivenTaskService) CreateTaskFromPrompt(ctx context.Context, req *t
 		ProjectID:      req.ProjectID,
 		UserID:         req.UserID,
 		OrganizationID: organizationID,
+		AssigneeID:     req.AssigneeID, // Optional: handler validates org membership before this is reached
 		Name:           GenerateTaskNameFromPrompt(req.Prompt),
 		Description:    req.Prompt,
 		Type:           req.Type,

--- a/api/pkg/types/simple_spec_task.go
+++ b/api/pkg/types/simple_spec_task.go
@@ -80,6 +80,7 @@ type CreateTaskRequest struct {
 	AppID        string           `json:"app_id"`               // Optional: Helix agent to use for spec generation
 	JustDoItMode bool             `json:"just_do_it_mode"`      // Optional: Skip spec planning, go straight to implementation
 	DependsOn    []string         `json:"depends_on"`           // Optional: IDs of tasks this task depends on
+	AssigneeID   string           `json:"assignee_id,omitempty"` // Optional: team member assigned to the task
 
 	// Branch configuration
 	BranchMode    BranchMode `json:"branch_mode,omitempty"`    // "new" or "existing" - defaults to "new"

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -2375,6 +2375,8 @@ export interface TypesCreateSecretRequest {
 export interface TypesCreateTaskRequest {
   /** Optional: Helix agent to use for spec generation */
   app_id?: string;
+  /** Optional: team member assigned to the task */
+  assignee_id?: string;
   /** For new mode: branch to create from (defaults to repo default) */
   base_branch?: string;
   /** Branch configuration */

--- a/frontend/src/components/tasks/NewSpecTaskForm.tsx
+++ b/frontend/src/components/tasks/NewSpecTaskForm.tsx
@@ -7,6 +7,7 @@ import React, {
 } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  Avatar,
   Box,
   Button,
   Typography,
@@ -25,7 +26,8 @@ import {
   IconButton,
 } from "@mui/material";
 import { Add as AddIcon, Close as CloseIcon } from "@mui/icons-material";
-import { X } from "lucide-react";
+import { ChevronDown, UserCircle2, X } from "lucide-react";
+import AssigneeSelector from "./AssigneeSelector";
 import { RECOMMENDED_CODING_MODELS } from "../../constants/models";
 
 import { CodeAgentRuntime, generateAgentName } from "../../contexts/apps";
@@ -35,6 +37,7 @@ import {
   TypesBranchMode,
   TypesSpecTask,
   TypesSpecTaskStatus,
+  TypesUser,
 } from "../../api/api";
 import AgentDropdown from "../agent/AgentDropdown";
 import CodingAgentForm, {
@@ -116,6 +119,44 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
   const [selectedHelixAgent, setSelectedHelixAgent] = useState("");
   const [justDoItMode, setJustDoItMode] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
+
+  // Empty string = "Unassigned". Pre-filled with the current user below.
+  const [assigneeId, setAssigneeId] = useState<string>("");
+  const [assigneeTouched, setAssigneeTouched] = useState(false);
+  const [assigneeAnchorEl, setAssigneeAnchorEl] =
+    useState<HTMLElement | null>(null);
+
+  const orgMembers =
+    account.organizationTools.organization?.memberships || [];
+  const currentUserId = account.user?.id;
+
+  // Pre-fill with current user once known. Don't overwrite a user choice
+  // (including an explicit "Unassigned"), tracked via assigneeTouched.
+  useEffect(() => {
+    if (!assigneeTouched && currentUserId) {
+      setAssigneeId(currentUserId);
+    }
+  }, [currentUserId, assigneeTouched]);
+
+  const assignedUser = useMemo(() => {
+    if (!assigneeId) return undefined;
+    const member = orgMembers.find((m) => m.user_id === assigneeId);
+    return member?.user as TypesUser | undefined;
+  }, [assigneeId, orgMembers]);
+
+  const getAssigneeDisplayName = (user: TypesUser | undefined): string => {
+    if (!user) return "Unknown user";
+    return user.full_name || user.username || user.email || "Unknown user";
+  };
+  const getAssigneeInitials = (user: TypesUser | undefined): string => {
+    if (!user) return "?";
+    const name = user.full_name || user.username || user.email || "";
+    const parts = name.split(" ");
+    if (parts.length >= 2) {
+      return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+    }
+    return name.slice(0, 2).toUpperCase();
+  };
 
   // Branch configuration state
   const [branchMode, setBranchMode] = useState<TypesBranchMode>(
@@ -294,7 +335,9 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
     setSelectedModel("");
     setNewAgentName("-");
     setUserModifiedName(false);
-  }, [defaultBranchName]);
+    setAssigneeId(currentUserId || "");
+    setAssigneeTouched(false);
+  }, [defaultBranchName, currentUserId]);
 
   // Handle task creation
   const handleCreateTask = async () => {
@@ -329,6 +372,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
         priority: taskPriority as TypesSpecTaskPriority,
         project_id: projectId,
         app_id: agentId || undefined,
+        assignee_id: assigneeId || undefined,
         just_do_it_mode: justDoItMode,
         depends_on: selectedDependencyTasks
           .map((task) => task.id || "")
@@ -458,6 +502,49 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
               <MenuItem value="critical">Critical</MenuItem>
             </Select>
           </FormControl>
+
+          {/* Assignee Selector */}
+          <Button
+            variant="outlined"
+            fullWidth
+            onClick={(e) => setAssigneeAnchorEl(e.currentTarget)}
+            endIcon={<ChevronDown size={16} />}
+            sx={{
+              justifyContent: "space-between",
+              textTransform: "none",
+              color: "text.primary",
+              borderColor: "rgba(255,255,255,0.23)",
+              px: 1.5,
+              py: 1,
+              "&:hover": { borderColor: "text.primary" },
+            }}
+          >
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1, minWidth: 0 }}>
+              {assignedUser ? (
+                <Avatar sx={{ width: 24, height: 24, fontSize: "0.7rem" }}>
+                  {getAssigneeInitials(assignedUser)}
+                </Avatar>
+              ) : (
+                <UserCircle2 size={20} style={{ opacity: 0.5 }} />
+              )}
+              <Typography variant="body2" sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {assignedUser
+                  ? `Assignee: ${getAssigneeDisplayName(assignedUser)}`
+                  : "Assignee: Unassigned"}
+              </Typography>
+            </Box>
+          </Button>
+          <AssigneeSelector
+            assigneeId={assigneeId || undefined}
+            members={orgMembers}
+            currentUserId={currentUserId}
+            onAssigneeChange={(userId) => {
+              setAssigneeId(userId || "");
+              setAssigneeTouched(true);
+            }}
+            anchorEl={assigneeAnchorEl}
+            onClose={() => setAssigneeAnchorEl(null)}
+          />
 
           {/* Labels */}
           <Autocomplete

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -3868,6 +3868,9 @@ definitions:
       app_id:
         description: 'Optional: Helix agent to use for spec generation'
         type: string
+      assignee_id:
+        description: 'Optional: team member assigned to the task'
+        type: string
       base_branch:
         description: 'For new mode: branch to create from (defaults to repo default)'
         type: string

--- a/openapi.json
+++ b/openapi.json
@@ -27444,6 +27444,10 @@
                         "description": "Optional: Helix agent to use for spec generation",
                         "type": "string"
                     },
+                    "assignee_id": {
+                        "description": "Optional: team member assigned to the task",
+                        "type": "string"
+                    },
                     "base_branch": {
                         "description": "For new mode: branch to create from (defaults to repo default)",
                         "type": "string"

--- a/swagger.json
+++ b/swagger.json
@@ -23620,6 +23620,10 @@
                     "description": "Optional: Helix agent to use for spec generation",
                     "type": "string"
                 },
+                "assignee_id": {
+                    "description": "Optional: team member assigned to the task",
+                    "type": "string"
+                },
                 "base_branch": {
                     "description": "For new mode: branch to create from (defaults to repo default)",
                     "type": "string"


### PR DESCRIPTION
## Summary

Fixes the bug where a freshly-created task vanishes from the kanban board when the user has an assignee filter active. Previously the create-task endpoint had no way to set an assignee, so every new task started with `assignee_id = ""`. The board's client-side filter (`SpecTaskKanbanBoard.tsx`) treats `""` as `__unassigned__` and only shows it when the user has explicitly selected "Unassigned" in the filter — so any active filter would silently hide the new task.

The create-task form now offers an optional assignee field (defaulting to the current user, with "Unassigned" as a peer option). The selected ID flows through `CreateTaskRequest` → `SpecDrivenTaskService.CreateTaskFromPrompt` → DB. The handler validates that the assignee is a member of the project's organization, mirroring the rule already enforced on update.

## Changes

- `api/pkg/types/simple_spec_task.go` — add optional `AssigneeID` to `CreateTaskRequest`
- `api/pkg/server/spec_driven_task_handlers.go`
  - extract the existing assignee org-membership check from `updateSpecTask` into a shared `validateAssigneeIsOrgMember` helper
  - call the helper from `createTaskFromPrompt` after authorization (HTTP 400 on a non-member assignee, matching the update path)
- `api/pkg/services/spec_driven_task_service.go` — copy `req.AssigneeID` onto the new `SpecTask`
- `frontend/src/components/tasks/NewSpecTaskForm.tsx` — add an assignee selector below the priority picker, reusing `AssigneeSelector`. Defaults to the current user once known; an `assigneeTouched` flag prevents an explicit user choice (including "Unassigned") from being clobbered if the user object loads after first render
- `api/pkg/server/spec_driven_task_assignee_test.go` — new test suite covering the helper (empty / member / non-member) and the handler-level 400 path
- regenerated swagger / TypeScript client to expose `assignee_id` on `CreateTaskRequest`

## Test plan

- [x] `go test -v -run TestSpecTaskAssigneeSuite ./api/pkg/server/` — passes locally (4/4)
- [x] `cd frontend && yarn build` — passes
- [ ] **Not tested in this environment** (no running inner Helix to drive a browser against): manual smoke test in the inner Helix —
  - register/log in, open the New Task panel
  - confirm the assignee field defaults to the current user
  - change to another org member, submit, confirm the new card shows that assignee
  - open the form again, change the assignee to "Unassigned", submit, confirm the new card is unassigned
  - set the kanban filter to "current user only", create a task with the default, confirm it lands in the visible columns immediately (the original bug repro)
  - try to assign to a non-member via the API directly, confirm HTTP 400 with `assignee must be an organization member`

## Notes

- The kanban assignee filter remains client-side (`SpecTaskKanbanBoard.tsx`) — backend list filtering by `assignee_id` was deliberately left out of scope (data volumes don't justify it; see design doc).
- The update endpoint still uses `*string` for `AssigneeID` to distinguish "clear" from "no change". Create uses plain `string` because empty already unambiguously means "no assignee".

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kqg7whkhyqdvs83f9np0ngdp)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001976_a-task-disappears-when-i/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001976_a-task-disappears-when-i/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001976_a-task-disappears-when-i/tasks.md)

🚀 Built with [Helix](https://helix.ml)