### PR TITLE
fix(cli): make sandbox SIGWINCH resize handler portable to Windows

### DIFF
--- a/api/pkg/cli/sandbox/resize_unix.go
+++ b/api/pkg/cli/sandbox/resize_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package sandbox
+
+import (
+	"os"
+	"syscall"
+)
+
+var sigWinch os.Signal = syscall.SIGWINCH

--- a/api/pkg/cli/sandbox/resize_windows.go
+++ b/api/pkg/cli/sandbox/resize_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package sandbox
+
+import "os"
+
+var sigWinch os.Signal = nil

--- a/api/pkg/cli/sandbox/sandbox.go
+++ b/api/pkg/cli/sandbox/sandbox.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -712,9 +711,9 @@ func runTerminal(conn *websocket.Conn) error {
 		return fmt.Errorf("send resize: %w", err)
 	}
 
-	if isTTY {
+	if isTTY && sigWinch != nil {
 		ch := make(chan os.Signal, 1)
-		signal.Notify(ch, syscall.SIGWINCH)
+		signal.Notify(ch, sigWinch)
 		go func() {
 			for range ch {
 				if w, h, err := term.GetSize(stdinFd); err == nil {


### PR DESCRIPTION
## Summary

The 2.11.1 release tag build failed in the `release-backend` step because the helix CLI cross-compile loop targets `windows/amd64` and `syscall.SIGWINCH` is unix-only:

```
api/pkg/cli/sandbox/sandbox.go:717:29: undefined: syscall.SIGWINCH
```

Failing build: https://drone.lukemarsden.net/helixml/helix/1120/1/6

The SIGWINCH usage was introduced in d151a9aea ("sandbox") to drive terminal resize messages over the interactive sandbox websocket. The release pipeline didn't change - the new code simply isn't portable.

## Fix

Move the signal value behind a tiny build-tagged package var instead of duplicating the resize goroutine across two files:

- `api/pkg/cli/sandbox/sandbox.go` - drop the direct `syscall.SIGWINCH` reference; use `sigWinch` and guard the `signal.Notify` call with `if sigWinch != nil`.
- `api/pkg/cli/sandbox/resize_unix.go` (new, `//go:build !windows`) - `var sigWinch os.Signal = syscall.SIGWINCH`.
- `api/pkg/cli/sandbox/resize_windows.go` (new, `//go:build windows`) - `var sigWinch os.Signal = nil`.

On Windows, the resize goroutine is simply not registered. Windows terminals don't deliver resize events via `os/signal` anyway (they use the console API), so this is the correct no-op for that platform.

## Test plan

Verified locally against every target in the release matrix:

```
linux/amd64 OK
linux/arm64 OK
darwin/amd64 OK
darwin/arm64 OK
windows/amd64 OK
```

- [ ] CI green on this PR
- [ ] After merge, retag `2.11.1` (or cut `2.11.2`) and confirm `release-backend` succeeds and produces `helix-windows-amd64.exe`