### PR TITLE
ci(drone): gate parallel build pipelines on the default pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -870,6 +870,9 @@ kind: pipeline
 type: docker
 name: build-controlplane-amd64
 
+depends_on:
+  - default
+
 platform:
   os: linux
   arch: amd64
@@ -917,6 +920,9 @@ steps:
 kind: pipeline
 type: docker
 name: build-controlplane-arm64
+
+depends_on:
+  - default
 
 platform:
   os: linux
@@ -1012,6 +1018,9 @@ kind: pipeline
 type: docker
 name: build-runner
 
+depends_on:
+  - default
+
 trigger:
   ref:
     include:
@@ -1058,6 +1067,9 @@ steps:
 kind: pipeline
 type: docker
 name: build-runner-small
+
+depends_on:
+  - default
 
 trigger:
   ref:
@@ -1126,6 +1138,9 @@ kind: pipeline
 type: docker
 name: build-runner-large
 
+depends_on:
+  - default
+
 trigger:
   ref:
     include:
@@ -1192,6 +1207,9 @@ steps:
 kind: pipeline
 type: docker
 name: build-demos
+
+depends_on:
+  - default
 
 trigger:
   ref:
@@ -1596,6 +1614,9 @@ kind: pipeline
 type: docker
 name: build-sandbox-amd64
 
+depends_on:
+  - default
+
 platform:
   os: linux
   arch: amd64
@@ -1989,6 +2010,9 @@ steps:
 kind: pipeline
 type: docker
 name: build-sandbox-arm64
+
+depends_on:
+  - default
 
 platform:
   os: linux


### PR DESCRIPTION
## Summary

Make the heavy-image-build pipelines (`build-controlplane-*`, `build-runner*`, `build-demos`, `build-sandbox-*`) wait for the `default` pipeline to succeed before they start.

Motivation: the failed 2.11.1 tag build (https://drone.lukemarsden.net/helixml/helix/1120). `release-backend` failed in `default`, but the parallel pipelines:

1. **Wasted work**: started in parallel, succeeded, and pushed images to the registry/GHCR for a release that would never ship.
2. **Blocked the rollback**: `release-rollback` `depends_on: [default, build-controlplane-amd64, build-controlplane-arm64, manifest-*, build-runner*, build-demos, build-sandbox-*, build-macos-dmg]` and only fires on `status: failure`. While arm64 / macos-dmg pipelines were `pending` / `waiting_on_dependencies`, the rollback couldn't start.

Adding `depends_on: [default]` to the build pipelines means they don't start at all on a failed `default`, which lets the rollback fire immediately (because the unstarted pipelines transition to `skipped`).

## Pipelines updated

```
build-controlplane-amd64
build-controlplane-arm64
build-runner
build-runner-small
build-runner-large
build-demos
build-sandbox-amd64
build-sandbox-arm64
```

`manifest-controlplane`, `manifest-sandbox`, `build-macos-dmg`, and `release-rollback` are unchanged - they already gate transitively (or directly, for rollback) on `default`.

## Trade-off

Happy-path latency: build pipelines now serialise behind `default` (unit tests, helm lint, build-backend, build-frontend, release-backend) instead of running in parallel. That's a real cost - `default` typically takes a few minutes longer than the lightest build pipeline. Acceptable in exchange for clean failure semantics on tag builds; if it bites we can move tests into a separate pipeline that the build-* ones gate on (rather than the whole `default`).

## Test plan

- [ ] CI green on this PR (this is a config change to a YAML the Drone server reads on the next build, so verification is the next tag build / next push to main)
- [ ] On the next failing main/tag build, confirm `release-rollback` fires promptly without waiting on parallel pipelines