### PR TITLE
fix(spectask): recognise GitLab in shouldOpenPullRequest

### DIFF
--- a/api/pkg/server/spec_task_workflow_handlers.go
+++ b/api/pkg/server/spec_task_workflow_handlers.go
@@ -820,6 +820,12 @@ func (s *HelixAPIServer) shouldOpenPullRequest(repo *types.GitRepository) bool {
 
 		// Github PRs implemented
 		return true
+	case repo.ExternalType == types.ExternalRepositoryTypeGitLab:
+		// GitLab MRs implemented (createGitLabMergeRequest in
+		// git_repository_service_pull_requests.go); auth resolution
+		// (OAuth -> repo.GitLab.PersonalAccessToken -> repo.Password)
+		// happens inside getGitLabClient, matching the GitHub branch.
+		return true
 	case repo.AzureDevOps != nil:
 		// ADO PRs implemented
 		return true

--- a/api/pkg/server/spec_task_workflow_handlers_test.go
+++ b/api/pkg/server/spec_task_workflow_handlers_test.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldOpenPullRequest(t *testing.T) {
+	s := &HelixAPIServer{}
+
+	cases := []struct {
+		name string
+		repo *types.GitRepository
+		want bool
+	}{
+		{
+			name: "GitHub with OAuth connection",
+			repo: &types.GitRepository{
+				ExternalType:      types.ExternalRepositoryTypeGitHub,
+				OAuthConnectionID: "conn_123",
+			},
+			want: true,
+		},
+		{
+			name: "GitHub with PAT only",
+			repo: &types.GitRepository{
+				ExternalType: types.ExternalRepositoryTypeGitHub,
+				GitHub:       &types.GitHub{PersonalAccessToken: "ghp_xxx"},
+			},
+			want: true,
+		},
+		{
+			name: "Azure DevOps configured",
+			repo: &types.GitRepository{
+				ExternalType: types.ExternalRepositoryTypeADO,
+				AzureDevOps:  &types.AzureDevOps{},
+			},
+			want: true,
+		},
+		{
+			name: "GitLab with OAuth connection",
+			repo: &types.GitRepository{
+				ExternalType:      types.ExternalRepositoryTypeGitLab,
+				OAuthConnectionID: "conn_456",
+			},
+			want: true,
+		},
+		{
+			name: "GitLab with personal access token",
+			repo: &types.GitRepository{
+				ExternalType: types.ExternalRepositoryTypeGitLab,
+				GitLab:       &types.GitLab{PersonalAccessToken: "glpat_xxx"},
+			},
+			want: true,
+		},
+		{
+			name: "GitLab with bare type (auth resolved at client layer)",
+			repo: &types.GitRepository{
+				ExternalType: types.ExternalRepositoryTypeGitLab,
+			},
+			want: true,
+		},
+		{
+			name: "Bitbucket — not yet wired into shouldOpenPullRequest",
+			repo: &types.GitRepository{
+				ExternalType: types.ExternalRepositoryTypeBitbucket,
+			},
+			want: false,
+		},
+		{
+			name: "Internal repo (no external type)",
+			repo: &types.GitRepository{},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, s.shouldOpenPullRequest(tc.repo))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

A user with a GitLab primary repo reported that clicking **Approve Implementation** jumped the task straight from *In Progress* to *Merged*, skipping the *Pull Request* column entirely (the column appears in the UI but the workflow bypasses it).

Root cause: `shouldOpenPullRequest()` in `api/pkg/server/spec_task_workflow_handlers.go` only had cases for GitHub and Azure DevOps. GitLab fell through to `false`, so `approveImplementation` took the "internal repo / unsupported" branch and did a server-side merge instead of opening a Merge Request.

## Why this is a six-line fix

All the GitLab MR machinery already exists in the codebase:

- `CreatePullRequest()` dispatcher in `api/pkg/services/git_repository_service_pull_requests.go:65-76` already routes `ExternalRepositoryTypeGitLab` to `createGitLabMergeRequest()`.
- `createGitLabMergeRequest()` (line 755-778) wraps `gitlab.Client.CreateMergeRequest()` from `api/pkg/agent/skill/gitlab/client.go`.
- `getGitLabClient()` (line 707-739) resolves auth (OAuth -> repo.GitLab.PersonalAccessToken -> repo.Password), mirroring the GitHub path.
- The PR-merge polling loop in `spec_task_orchestrator.go` is provider-agnostic — it already handles GitLab MRs the same way as GitHub PRs.

The only missing piece was the gate. With it added, every step downstream works as-is.

## Frontend / backend alignment

The frontend already shows the *Pull Request* column for any external repo (`SpecTasksPage.tsx:291-294` checks `!!external_type`), so this fix simply makes the backend behaviour match what the UI was already promising.

## Tests

New `TestShouldOpenPullRequest` table-driven test covering:

- GitHub with OAuth connection
- GitHub with PAT only
- Azure DevOps configured
- GitLab with OAuth connection
- GitLab with personal access token
- GitLab with bare type (auth resolved at the client layer)
- Bitbucket (still `false` — see Follow-up)
- Internal repo (no external type)

All 8 cases pass:

```
$ CGO_ENABLED=1 go test -v -run TestShouldOpenPullRequest ./pkg/server/ -count=1
PASS
ok      github.com/helixml/helix/api/pkg/server 0.969s
```

## Follow-up

Bitbucket has the same gap and a fully-implemented dispatcher case (`createBitbucketPullRequest` already exists). It's intentionally left at `false` here because no one has reported the bug for Bitbucket yet — flagging as a likely-trivial follow-up rather than expanding scope.

## Test plan

- [ ] CI green on this PR
- [ ] User to verify on their GitLab project: "Approve Implementation" now lands the task in the Pull Request column with an MR opened against the GitLab repo, instead of jumping straight to Merged