### PR TITLE
fix(zed-config): gate language_models injection on configured Helix providers

### DIFF
--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -212,7 +212,7 @@ func GenerateZedMCPConfig(
 	}
 	config.Theme = "Ayu Dark"
 
-	// Configure language_models to route API calls through Helix proxy
+	// Configure language_models to route API calls through Helix proxy.
 	// CRITICAL: Zed reads api_url from settings.json, NOT from environment variables!
 	// We must explicitly set api_url in language_models for each provider.
 	//
@@ -221,14 +221,14 @@ func GenerateZedMCPConfig(
 	// - OpenAI: base URL + /v1 (Zed appends /chat/completions)
 	// api_key is NOT set here — Zed reads ANTHROPIC_API_KEY / OPENAI_API_KEY from
 	// container env vars (set by DesktopAgentAPIEnvVars). Only api_url routing is needed.
-	config.LanguageModels = map[string]LanguageModelConfig{
-		"anthropic": {
-			APIURL: helixAPIURL, // Zed appends /v1/messages
-		},
-		"openai": {
-			APIURL: helixAPIURL + "/v1", // Zed appends /chat/completions
-		},
-	}
+	//
+	// We only inject the entries the user actually has Helix providers for.
+	// If we unconditionally inject "anthropic", Zed's bottom-left model picker
+	// shows Claude Sonnet as a default option even when the user has no
+	// Anthropic provider configured — picking it then fails with
+	// "provider \"openai\" not found" from /v1/messages because Zed sends
+	// the wrong provider on the Anthropic-only endpoint.
+	config.LanguageModels = buildLanguageModels(providerSnapshot, helixAPIURL)
 
 	// 1. Add Helix native tools via HTTP MCP gateway (APIs, Knowledge, Zapier)
 	// Uses the unified MCP gateway at /api/v1/mcp/helix instead of helix-cli
@@ -716,6 +716,45 @@ func ValidateAssistantModelConfig(app *types.App, snapshot []ProviderRef) string
 		return fmt.Sprintf("agent %q references provider %q which does not match any current provider — the provider may have been renamed or deleted. Open the agent settings and re-pick a provider, or restore/rename the provider in admin.", app.ID, provider)
 	}
 	return ""
+}
+
+// buildLanguageModels returns the language_models block for Zed's settings.json,
+// containing only the provider entries the user actually has Helix providers
+// for. The mapping mirrors mapHelixToZedProvider:
+//
+//   - A Helix "anthropic" provider unlocks Zed's "anthropic" entry (routes to
+//     Helix's /v1/messages).
+//   - Any other Helix provider (openai, nebius, together, openrouter, ...)
+//     unlocks Zed's "openai" entry (routes to Helix's /v1/chat/completions).
+//
+// snapshot==nil is the runner-side opt-out path; we preserve historical
+// behaviour there by injecting both entries.
+func buildLanguageModels(snapshot []ProviderRef, helixAPIURL string) map[string]LanguageModelConfig {
+	if snapshot == nil {
+		return map[string]LanguageModelConfig{
+			"anthropic": {APIURL: helixAPIURL},
+			"openai":    {APIURL: helixAPIURL + "/v1"},
+		}
+	}
+
+	hasAnthropic := false
+	hasOpenAICompat := false
+	for _, p := range snapshot {
+		if strings.EqualFold(p.Name, "anthropic") {
+			hasAnthropic = true
+		} else {
+			hasOpenAICompat = true
+		}
+	}
+
+	out := map[string]LanguageModelConfig{}
+	if hasAnthropic {
+		out["anthropic"] = LanguageModelConfig{APIURL: helixAPIURL}
+	}
+	if hasOpenAICompat {
+		out["openai"] = LanguageModelConfig{APIURL: helixAPIURL + "/v1"}
+	}
+	return out
 }
 
 // mapHelixToZedProvider maps a Helix provider name to a Zed provider type and formats the model name.

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -393,3 +393,79 @@ func TestMergeContextServers(t *testing.T) {
 		assert.NotContains(t, got, "language_models")
 	})
 }
+
+func TestBuildLanguageModels(t *testing.T) {
+	const helixURL = "http://api:8080"
+
+	cases := []struct {
+		name     string
+		snapshot []ProviderRef
+		want     map[string]LanguageModelConfig
+	}{
+		{
+			name:     "nil snapshot preserves legacy both-providers behaviour",
+			snapshot: nil,
+			want: map[string]LanguageModelConfig{
+				"anthropic": {APIURL: helixURL},
+				"openai":    {APIURL: helixURL + "/v1"},
+			},
+		},
+		{
+			name:     "empty snapshot injects nothing",
+			snapshot: []ProviderRef{},
+			want:     map[string]LanguageModelConfig{},
+		},
+		{
+			name:     "openai-only does not inject anthropic",
+			snapshot: []ProviderRef{{Name: "openai"}},
+			want: map[string]LanguageModelConfig{
+				"openai": {APIURL: helixURL + "/v1"},
+			},
+		},
+		{
+			name:     "anthropic-only does not inject openai",
+			snapshot: []ProviderRef{{Name: "anthropic"}},
+			want: map[string]LanguageModelConfig{
+				"anthropic": {APIURL: helixURL},
+			},
+		},
+		{
+			name: "both global providers inject both entries",
+			snapshot: []ProviderRef{
+				{Name: "openai"},
+				{Name: "anthropic"},
+			},
+			want: map[string]LanguageModelConfig{
+				"anthropic": {APIURL: helixURL},
+				"openai":    {APIURL: helixURL + "/v1"},
+			},
+		},
+		{
+			name: "non-anthropic custom provider unlocks openai entry only",
+			snapshot: []ProviderRef{
+				{ID: "p_nebius", Name: "Nebius EU"},
+			},
+			want: map[string]LanguageModelConfig{
+				"openai": {APIURL: helixURL + "/v1"},
+			},
+		},
+		{
+			name: "case insensitive anthropic match",
+			snapshot: []ProviderRef{
+				{Name: "Anthropic"},
+				{Name: "OpenAI"},
+			},
+			want: map[string]LanguageModelConfig{
+				"anthropic": {APIURL: helixURL},
+				"openai":    {APIURL: helixURL + "/v1"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildLanguageModels(tc.snapshot, helixURL)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

A user with only an OpenAI provider configured on the Helix side saw Zed's bottom-left model picker default to Claude Sonnet, then hit:

\`\`\`
HTTP 400 from /v1/messages: provider \"openai\" not found.
Note: /v1/messages only supports Anthropic-compatible providers.
For OpenAI-compatible providers (Ollama, OpenRouter, etc.), use /v1/chat/completions instead.
\`\`\`

## Root cause

\`GenerateZedMCPConfig\` unconditionally injected **both** \`language_models.anthropic.api_url\` and \`language_models.openai.api_url\` in \`api/pkg/external-agent/zed_config.go\`. So Zed presented Anthropic as a valid option in its picker — and selecting Claude Sonnet sent a request to \`/v1/messages\` even when no Anthropic Helix provider existed.

## Fix

Gate the injection on what the providerSnapshot actually contains, mirroring \`mapHelixToZedProvider\` (line 735-751):

- \`\"anthropic\"\` entry only when the snapshot has an Anthropic provider
- \`\"openai\"\` entry whenever the snapshot has any non-Anthropic provider (every other Helix provider routes through Zed's OpenAI-compatible adapter)

\`snapshot == nil\` keeps the legacy \"inject both\" behaviour for the runner-side opt-out path. The API path always passes a real snapshot.

## Tests

\`TestBuildLanguageModels\` — 7 cases:
- nil snapshot preserves legacy both-providers behaviour
- empty snapshot injects nothing
- openai-only does not inject anthropic
- anthropic-only does not inject openai
- both global providers inject both entries
- non-anthropic custom provider (e.g. Nebius) unlocks openai entry only
- case-insensitive matching for provider names

All 7 new cases plus existing \`TestGenerateZedMCPConfig_AgentDefaultModel\` (9 cases) pass.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, user with only an OpenAI provider opens a Zed session: bottom-left picker no longer offers Claude Sonnet, default_model is respected, requests go to \`/v1/chat/completions\`