### PR TITLE
fix(inferencerouter): drop 'runner' from user-facing error message

### DIFF
--- a/api/pkg/inferencerouter/router.go
+++ b/api/pkg/inferencerouter/router.go
@@ -50,9 +50,12 @@ func (r *RunnerState) RouteableModels() []string {
 	return out
 }
 
-// ErrNoRunner is returned when no connected runner can serve the requested
-// model. Callers translate to HTTP 503 with the available-models list.
-var ErrNoRunner = errors.New("no runner available for requested model")
+// ErrNoRunner is the package-internal sentinel returned when no Helix-hosted
+// model serves the request. Symbol name is preserved for backwards
+// compatibility; the user-facing string deliberately avoids "runner"
+// terminology so it doesn't leak the Helix-sandbox internals to end users
+// who see this error surfaced via OpenAI-compatible 503 responses.
+var ErrNoRunner = errors.New("requested model is not available")
 
 // NoRunnerError is the rich version of ErrNoRunner — includes the requested
 // model and a list of currently-available models so callers can return a
@@ -64,9 +67,9 @@ type NoRunnerError struct {
 
 func (e *NoRunnerError) Error() string {
 	if len(e.AvailableModels) == 0 {
-		return fmt.Sprintf("no runner has model %q (no models are currently available)", e.RequestedModel)
+		return fmt.Sprintf("model %q is not available (no models are currently configured)", e.RequestedModel)
 	}
-	return fmt.Sprintf("no runner has model %q (currently available: %s)",
+	return fmt.Sprintf("model %q is not available (currently configured: %s)",
 		e.RequestedModel, strings.Join(e.AvailableModels, ", "))
 }
 

--- a/api/pkg/inferencerouter/router_test.go
+++ b/api/pkg/inferencerouter/router_test.go
@@ -2,6 +2,7 @@ package inferencerouter
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -163,12 +164,36 @@ func TestRouter_RouteableModels_NilProfileNoneSkipped(t *testing.T) {
 
 func TestRouter_NoRunnerError_AvailableModelsEmptyMessage(t *testing.T) {
 	r := NewRouter()
-	_, err := r.PickRunner("anything")
+	_, err := r.PickRunner("gpt-5.4")
 	var nre *NoRunnerError
 	if !errors.As(err, &nre) {
 		t.Fatal("expected NoRunnerError")
 	}
-	if nre.Error() == "" {
-		t.Error("error message should be non-empty")
+	got := nre.Error()
+	// User-facing wording: must not leak Helix-internal "runner" terminology
+	// (this string surfaces as an OpenAI 503 to end users) and must name
+	// the requested model so they can see what was rejected.
+	if strings.Contains(got, "runner") {
+		t.Errorf("error message should not mention %q (user-facing): %q", "runner", got)
+	}
+	if !strings.Contains(got, `"gpt-5.4"`) {
+		t.Errorf("error message should quote the requested model name: %q", got)
+	}
+	if !strings.Contains(got, "not available") {
+		t.Errorf("error message should say model is not available: %q", got)
+	}
+}
+
+func TestRouter_NoRunnerError_AvailableModelsListMessage(t *testing.T) {
+	nre := &NoRunnerError{
+		RequestedModel:  "gpt-5.4",
+		AvailableModels: []string{"qwen3-coder", "llama-3.3"},
+	}
+	got := nre.Error()
+	if strings.Contains(got, "runner") {
+		t.Errorf("error message should not mention %q (user-facing): %q", "runner", got)
+	}
+	if !strings.Contains(got, "qwen3-coder") || !strings.Contains(got, "llama-3.3") {
+		t.Errorf("error message should list available models: %q", got)
 	}
 }

--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -162,8 +162,8 @@ func (s *HelixAPIServer) listProviderEndpoints(rw http.ResponseWriter, r *http.R
 		// Sandbox-absorbs-runner equivalent of the old runnerController
 		// gate: skip the Helix provider when no sandbox is currently
 		// serving any model. Otherwise the picker offers an option that
-		// returns "no runner has model X" for every request, which is a
-		// worse UX than not advertising it at all.
+		// returns "model X is not available" for every request, which
+		// is a worse UX than not advertising it at all.
 		if provider == types.ProviderHelix && s.inferenceRouter != nil {
 			if len(s.inferenceRouter.AvailableModels()) == 0 {
 				continue


### PR DESCRIPTION
## Summary

The error string \"no runner has model X\" leaks Helix-internal terminology to end users. A customer testing on prime hit this via the Zed model picker:

\`\`\`
OpenAI's API server reported an internal server error: error enqueuing request:
  no runner has model \"gpt-5.4\" (no models are currently available)
\`\`\`

\"Runner\" is meaningless to end users — the sandbox-absorbs-runner pivot retired the runner concept publicly, but the error string was still hard-coded in \`api/pkg/inferencerouter/router.go\`.

## Change

Reword \`NoRunnerError.Error()\` and the \`ErrNoRunner\` sentinel string. Same shape, same information, no leaked vocabulary:

| | Before | After |
|---|---|---|
| empty list | \`no runner has model \"gpt-5.4\" (no models are currently available)\` | \`model \"gpt-5.4\" is not available (no models are currently configured)\` |
| with list | \`no runner has model \"gpt-5.4\" (currently available: a, b)\` | \`model \"gpt-5.4\" is not available (currently configured: a, b)\` |

The \`ErrNoRunner\` Go symbol is kept for backwards compatibility (purely package-internal — no end-user impact). The associated comment in \`provider_handlers.go\` that quotes the message is updated.

## Tests

\`TestRouter_NoRunnerError_AvailableModelsEmptyMessage\` strengthened: now asserts the wording must NOT contain \"runner\", must quote the requested model, and must say \"not available\". A future refactor will fail-loud if it regresses.

\`TestRouter_NoRunnerError_AvailableModelsListMessage\` added for the populated-list branch.

## Out of scope

This PR fixes only the user-facing wording. The deeper question raised by the same bug report is **why** the request for \`gpt-5.4\` ended up in the inferencerouter at all — it should have routed to the user's OpenAI provider proxy, since \`gpt-5.4\` is not a Helix-hosted model. That is a separate routing investigation; flagged in the test plan below.

## Test plan

- [ ] CI green on this PR
- [ ] Confirm new wording surfaces verbatim in next end-user 503 response
- [ ] **Follow-up issue:** investigate why Zed model picker requests for non-Helix models (e.g. \`gpt-5.4\`, \`gpt-4o\`) end up in the inferencerouter rather than the OpenAI provider proxy