### PR TITLE
fix(provider): resolve env-baked globals on /v1/messages

### DIFF
--- a/api/pkg/server/anthropic_api_proxy_handler.go
+++ b/api/pkg/server/anthropic_api_proxy_handler.go
@@ -282,20 +282,38 @@ func (s *HelixAPIServer) getProviderEndpoint(ctx context.Context, user *types.Us
 
 	// Fall back to built-in Anthropic provider from environment variables
 	// This allows ANTHROPIC_API_KEY to work without database configuration
-	return s.getBuiltInProviderEndpoint(provider)
+	return s.getBuiltInProviderEndpoint(ctx, provider)
 }
 
-// getBuiltInProviderEndpoint returns a ProviderEndpoint for the built-in Anthropic provider
-// configured via environment variables.
+// getBuiltInProviderEndpoint returns a ProviderEndpoint for built-in (env-baked)
+// providers.
 //
-// When ANTHROPIC_VERTEX_PROJECT_ID is set, Vertex AI wins unconditionally — all inference
-// traffic routes through Vertex. ANTHROPIC_API_KEY is only used for model listing in that case.
-// When Vertex is not configured, ANTHROPIC_API_KEY or ANTHROPIC_API_KEY_FILE is required.
+// Anthropic gets the rich path because /v1/messages actually proxies through here:
+// when ANTHROPIC_VERTEX_PROJECT_ID is set, Vertex AI wins unconditionally and
+// ANTHROPIC_API_KEY is only used for model listing; otherwise ANTHROPIC_API_KEY
+// (or ANTHROPIC_API_KEY_FILE) is required. Set PROVIDERS_BILLING_ENABLED=true to
+// track usage on this built-in (separate from STRIPE_BILLING_ENABLED).
 //
-// To enable usage tracking/billing for this built-in provider, set PROVIDERS_BILLING_ENABLED=true.
-// This is separate from STRIPE_BILLING_ENABLED which controls the platform-level Stripe integration.
-func (s *HelixAPIServer) getBuiltInProviderEndpoint(provider string) (*types.ProviderEndpoint, error) {
+// Other env-baked globals (openai, togetherai, helix, ...) are returned as
+// Name-only synthetics from MultiClientManager.globalClients. We don't need
+// their full BaseURL/APIKey here because /v1/messages will reject them via
+// isAnthropicCompatible with the actionable "use /v1/chat/completions" message
+// — and the synthetic carries enough (Name, EndpointType=Global) to drive that
+// branch instead of the cryptic "provider %q not found" error.
+func (s *HelixAPIServer) getBuiltInProviderEndpoint(ctx context.Context, provider string) (*types.ProviderEndpoint, error) {
 	if provider != string(types.ProviderAnthropic) {
+		// Resolve env-baked globals (openai etc.) from the provider manager so
+		// callers get a real endpoint they can interrogate, not a "not found".
+		if s.providerManager != nil {
+			globals, err := s.providerManager.ListProviderEndpoints(ctx, "")
+			if err == nil {
+				for _, ep := range globals {
+					if strings.EqualFold(ep.Name, provider) {
+						return ep, nil
+					}
+				}
+			}
+		}
 		return nil, fmt.Errorf("provider %q not found", provider)
 	}
 

--- a/api/pkg/server/anthropic_api_proxy_handler_test.go
+++ b/api/pkg/server/anthropic_api_proxy_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/openai/manager"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/types"
@@ -337,6 +338,49 @@ func Test_isAnthropicCompatible(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func Test_getBuiltInProviderEndpoint_envBakedNonAnthropic(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockMgr := manager.NewMockProviderManager(ctrl)
+	mockMgr.EXPECT().
+		ListProviderEndpoints(gomock.Any(), "").
+		Return([]*types.ProviderEndpoint{
+			{Name: "openai", EndpointType: types.ProviderEndpointTypeGlobal},
+			{Name: "togetherai", EndpointType: types.ProviderEndpointTypeGlobal},
+		}, nil).
+		AnyTimes()
+
+	server := &HelixAPIServer{
+		Cfg:             &config.ServerConfig{},
+		providerManager: mockMgr,
+	}
+
+	// Env-baked openai now resolves through the manager so /v1/messages can
+	// reject it via isAnthropicCompatible with an actionable error instead of
+	// the cryptic "provider %q not found".
+	got, err := server.getBuiltInProviderEndpoint(context.Background(), "openai")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "openai", got.Name)
+	assert.Equal(t, types.ProviderEndpointTypeGlobal, got.EndpointType)
+	assert.False(t, isAnthropicCompatible(got),
+		"synthetic openai global must fail Anthropic-compat check so the handler emits the /v1/chat/completions hint")
+
+	// Case-insensitive: agents may store legacy mixed-case names.
+	mixed, err := server.getBuiltInProviderEndpoint(context.Background(), "OpenAI")
+	require.NoError(t, err)
+	assert.Equal(t, "openai", mixed.Name)
+
+	// Unknown provider: still surfaces the explicit error so callers can
+	// distinguish "no global by that name" from "global rejected downstream".
+	_, err = server.getBuiltInProviderEndpoint(context.Background(), "made-up")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `provider "made-up" not found`)
 }
 
 func Test_parseAnthropicRequestModel(t *testing.T) {

--- a/api/pkg/server/openai_model_handlers.go
+++ b/api/pkg/server/openai_model_handlers.go
@@ -120,7 +120,7 @@ func (apiServer *HelixAPIServer) listModelsAnthropic(rw http.ResponseWriter, r *
 		return
 	}
 
-	endpoint, err := apiServer.getBuiltInProviderEndpoint(string(types.ProviderAnthropic))
+	endpoint, err := apiServer.getBuiltInProviderEndpoint(r.Context(), string(types.ProviderAnthropic))
 	if err != nil {
 		log.Err(err).Msg("failed to get Anthropic provider endpoint")
 		http.Error(rw, "Anthropic provider not configured: "+err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
## Summary
- `/v1/messages` was returning a cryptic 400 `provider "openai" not found` when a project app's assistant referenced an env-baked global like `openai`. `getBuiltInProviderEndpoint` only handled env-baked Anthropic.
- Pass `ctx` through and consult `ProviderManager.ListProviderEndpoints("")` for non-Anthropic globals so `isAnthropicCompatible` can reject them with the actionable "use /v1/chat/completions for OpenAI-compatible providers" message instead.

## Why this matters
Project apps store `assistant.Provider` as the canonical name for env-baked globals (per the convention from the provider-by-ID refactor) — agents created when the org has no DB-backed openai correctly persist `"openai"`. The runtime resolver wasn't keeping up.

## Test plan
- [x] `go test -run 'Test_getBuiltInProviderEndpoint_envBakedNonAnthropic|Test_getProviderEndpoint|Test_isAnthropicCompatible' ./api/pkg/server/`
- [ ] Drone CI green
- [ ] On prime: pick a project whose default Helix app has `provider="openai"`, hit `/v1/messages`, confirm response is the "use /v1/chat/completions" 400 (not "provider %q not found")

🤖 Generated with [Claude Code](https://claude.com/claude-code)