### PR TITLE
fix(session): reject cross-org pe_… provider refs at persist time

### DIFF
--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -300,6 +300,9 @@ func (apiServer *HelixAPIServer) updateSession(_ http.ResponseWriter, req *http.
 	}
 
 	session.Name = update.Name
+	if err := apiServer.validateSessionProviderRef(ctx, update.Provider, session.OrganizationID, session.Owner); err != nil {
+		return nil, system.NewHTTPError400(err.Error())
+	}
 	session.Provider = update.Provider
 	session.ModelName = update.ModelName
 
@@ -557,7 +560,12 @@ If the user asks for information about Helix or installing Helix, refer them to 
 		if startReq.Provider == "" {
 			startReq.Provider = types.Provider(session.Provider)
 		} else {
-			// Update provider for the session
+			// Update provider for the session — validate that a pe_… reference
+			// is visible in this session's scope before persisting.
+			if err := s.validateSessionProviderRef(ctx, string(startReq.Provider), session.OrganizationID, session.Owner); err != nil {
+				http.Error(rw, err.Error(), http.StatusBadRequest)
+				return
+			}
 			session.Provider = string(startReq.Provider)
 		}
 
@@ -571,6 +579,11 @@ If the user asks for information about Helix or installing Helix, refer them to 
 		// Set default agent type if not specified
 		if startReq.AgentType == "" {
 			startReq.AgentType = "helix"
+		}
+
+		if err := s.validateSessionProviderRef(ctx, string(startReq.Provider), startReq.OrganizationID, user.ID); err != nil {
+			http.Error(rw, err.Error(), http.StatusBadRequest)
+			return
 		}
 
 		session = &types.Session{
@@ -2301,6 +2314,10 @@ func (s *HelixAPIServer) StartExternalAgentSession(ctx context.Context, req *typ
 		req.OrganizationID = user.OrganizationID
 	}
 
+	if err := s.validateSessionProviderRef(ctx, string(req.Provider), req.OrganizationID, userID); err != nil {
+		return nil, err
+	}
+
 	session := &types.Session{
 		ID:             system.GenerateSessionID(),
 		Name:           s.getTemporarySessionName(message),
@@ -2420,6 +2437,47 @@ func (s *HelixAPIServer) getSessionOutput(_ http.ResponseWriter, r *http.Request
 	}
 
 	return resp, nil
+}
+
+// validateSessionProviderRef rejects a session being persisted with a provider
+// reference (a pe_… DB ID) that isn't visible to the session's owner. Without
+// this fence, the frontend can leak a previously-selected pe_… across an org
+// switch — the row is written, then inference fails downstream with a cryptic
+// "no client found for provider: pe_… , available providers: [...]" because
+// MultiClientManager.GetClient correctly only sees the new org's providers.
+//
+// Empty refs and non-pe_ refs (env-baked global names like "openai") are
+// accepted: those are resolved at request time. Only ID-shaped refs need this
+// pre-flight check.
+//
+// A provider is visible if:
+//   - it is a global endpoint (ProviderEndpointTypeGlobal), or
+//   - its owner is the session's organization, or
+//   - its owner is the session's user (personal providers).
+//
+// Anything else returns an explicit "not visible" error so the UI can surface
+// the mismatch instead of inference 500-ing.
+func (s *HelixAPIServer) validateSessionProviderRef(ctx context.Context, providerRef, organizationID, userID string) error {
+	if providerRef == "" || !strings.HasPrefix(providerRef, system.ProviderEndpointPrefix) {
+		return nil
+	}
+	endpoint, err := s.Store.GetProviderEndpoint(ctx, &store.GetProviderEndpointsQuery{ID: providerRef})
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("provider %q not found", providerRef)
+		}
+		return fmt.Errorf("looking up provider %q: %w", providerRef, err)
+	}
+	if endpoint.EndpointType == types.ProviderEndpointTypeGlobal {
+		return nil
+	}
+	if organizationID != "" && endpoint.Owner == organizationID {
+		return nil
+	}
+	if userID != "" && endpoint.Owner == userID {
+		return nil
+	}
+	return fmt.Errorf("provider %q is not visible to this session", providerRef)
 }
 
 // triggerSummaryGeneration triggers async summary generation for an interaction

--- a/api/pkg/server/session_handlers_test.go
+++ b/api/pkg/server/session_handlers_test.go
@@ -789,3 +789,116 @@ func (s *SessionAuthzSuite) TestListSessions_NotOrgMemberDenied() {
 	s.Nil(result)
 	assertHTTPError(s, err, http.StatusForbidden)
 }
+
+// -----------------------------------------------------------------------------
+// validateSessionProviderRef tests — the fence that stops a previously-selected
+// pe_… ID from leaking across an org switch on session create/update.
+// -----------------------------------------------------------------------------
+
+type SessionProviderRefValidationSuite struct {
+	suite.Suite
+
+	ctrl   *gomock.Controller
+	store  *store.MockStore
+	server *HelixAPIServer
+
+	userID string
+	orgID  string
+}
+
+func TestSessionProviderRefValidationSuite(t *testing.T) {
+	suite.Run(t, new(SessionProviderRefValidationSuite))
+}
+
+func (s *SessionProviderRefValidationSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.store = store.NewMockStore(s.ctrl)
+	s.server = &HelixAPIServer{
+		Cfg:   &config.ServerConfig{},
+		Store: s.store,
+	}
+	s.userID = "user_123"
+	s.orgID = "org_session"
+}
+
+func (s *SessionProviderRefValidationSuite) TestEmptyRef_NoLookup() {
+	// No DB call should happen for the empty-string case.
+	err := s.server.validateSessionProviderRef(context.Background(), "", s.orgID, s.userID)
+	s.NoError(err)
+}
+
+func (s *SessionProviderRefValidationSuite) TestNonPeRef_NoLookup() {
+	// Env-baked global names (e.g. "openai") are accepted without a DB roundtrip;
+	// runtime resolves them on the inference path.
+	err := s.server.validateSessionProviderRef(context.Background(), "openai", s.orgID, s.userID)
+	s.NoError(err)
+}
+
+func (s *SessionProviderRefValidationSuite) TestPeRef_GlobalEndpoint_OK() {
+	peID := system.ProviderEndpointPrefix + "01abc"
+	s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{ID: peID}).
+		Return(&types.ProviderEndpoint{
+			ID:           peID,
+			Owner:        "someone_else",
+			EndpointType: types.ProviderEndpointTypeGlobal,
+		}, nil)
+
+	err := s.server.validateSessionProviderRef(context.Background(), peID, s.orgID, s.userID)
+	s.NoError(err)
+}
+
+func (s *SessionProviderRefValidationSuite) TestPeRef_OwnedByOrg_OK() {
+	peID := system.ProviderEndpointPrefix + "01abc"
+	s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{ID: peID}).
+		Return(&types.ProviderEndpoint{
+			ID:           peID,
+			Owner:        s.orgID,
+			EndpointType: types.ProviderEndpointTypeUser,
+		}, nil)
+
+	err := s.server.validateSessionProviderRef(context.Background(), peID, s.orgID, s.userID)
+	s.NoError(err)
+}
+
+func (s *SessionProviderRefValidationSuite) TestPeRef_OwnedByUser_OK() {
+	peID := system.ProviderEndpointPrefix + "01abc"
+	s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{ID: peID}).
+		Return(&types.ProviderEndpoint{
+			ID:           peID,
+			Owner:        s.userID,
+			EndpointType: types.ProviderEndpointTypeUser,
+		}, nil)
+
+	// Org-less personal session — userID match is enough.
+	err := s.server.validateSessionProviderRef(context.Background(), peID, "", s.userID)
+	s.NoError(err)
+}
+
+func (s *SessionProviderRefValidationSuite) TestPeRef_CrossOrg_Rejected() {
+	// Reproduces the prime bug: a pe_… ID from a previously-active org leaks
+	// into a session being created in a different org. We must reject before
+	// the row is persisted, not let inference fail later with a cryptic
+	// "no client found" error.
+	peID := system.ProviderEndpointPrefix + "01ola"
+	s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{ID: peID}).
+		Return(&types.ProviderEndpoint{
+			ID:           peID,
+			Owner:        "org_ola",
+			EndpointType: types.ProviderEndpointTypeUser,
+		}, nil)
+
+	err := s.server.validateSessionProviderRef(context.Background(), peID, "org_mola", s.userID)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "not visible")
+	s.Contains(err.Error(), peID)
+}
+
+func (s *SessionProviderRefValidationSuite) TestPeRef_NotFound_Rejected() {
+	peID := system.ProviderEndpointPrefix + "01missing"
+	s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{ID: peID}).
+		Return(nil, store.ErrNotFound)
+
+	err := s.server.validateSessionProviderRef(context.Background(), peID, s.orgID, s.userID)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "not found")
+}


### PR DESCRIPTION
## Summary
- Sessions could be created with a \`pe_…\` provider id from a different org than their \`organization_id\`. Frontend persisted a previously-selected provider across an org switch; the row got written; inference later 500'd with a cryptic \`no client found for provider: pe_… , available providers: [...]\`.
- New \`validateSessionProviderRef\` helper runs at every site that persists \`session.Provider\` (updateSession, startChatSessionHandler new-session and existing-session-override paths, StartExternalAgentSession). Rejects \`pe_…\` refs that aren't global, owned by the session's org, or owned by the session's user.

## Why this matters
Bug observed on prime: session \`ses_01kqx5pw4cwspftpjgey97j64z\` (org=mola) had provider=\`pe_01kqx3b2422pf8cy8zk882p4qj\` (org=ola). The new-session create path didn't validate the cross-org reference, so the inference path produced an unhelpful error. Pre-flight at session create surfaces the mismatch immediately.

Empty refs and non-\`pe_\` global names (\"openai\", etc.) skip the check — those resolve at request time and don't need DB-visibility validation.

## Test plan
- [x] \`go test -run TestSessionProviderRefValidationSuite ./api/pkg/server/\` (7 cases)
- [x] \`go test -run 'TestSessionAuthzSuite|TestExternalAgentSessionSuite|TestAppendOrOverwriteSuite' ./api/pkg/server/\` (existing session tests still pass)
- [ ] Drone CI green
- [ ] On prime: switch orgs after picking a DB-backed provider, start a new chat — confirm 400 instead of cryptic "no client found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)