### PR TITLE
fix: agent settings clobbering on save

### DIFF
--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -1050,7 +1050,7 @@ func (s *HelixAPIServer) updateApp(_ http.ResponseWriter, r *http.Request) (*typ
 
 	// Validate and default tools
 	for idx := range updatedWithTools.Config.Helix.Assistants {
-		assistant := &update.Config.Helix.Assistants[idx]
+		assistant := &updatedWithTools.Config.Helix.Assistants[idx]
 
 		// Ensure we don't have tools with duplicate names
 		toolNames := make(map[string]bool)

--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -96,7 +96,11 @@ const RECOMMENDED_MODELS = {
 interface AppSettingsProps {
   id: string,
   app: IAppFlatState,
-  onUpdate: (updates: IAppFlatState) => Promise<void>,
+  // Partial — every call site sends only the fields that actually changed.
+  // mergeFlatStateIntoApp ignores `undefined`, so omitted fields are
+  // preserved on the persisted assistant config (the bug this fix was
+  // written to address: full-state sends were clobbering hidden fields).
+  onUpdate: (updates: Partial<IAppFlatState>) => Promise<void>,
   readOnly?: boolean,
   showErrors?: boolean,
   isAdmin?: boolean,
@@ -273,13 +277,15 @@ const AppSettings: FC<AppSettingsProps> = ({
 
   // Advanced settings state. Defaults must match the useEffect re-init below
   // and DEFAULT_VALUES (which mirrors api/pkg/store/store_apps.go).
-  const [contextLimit, setContextLimit] = useState(app.context_limit || DEFAULT_VALUES.context_limit)
-  const [frequencyPenalty, setFrequencyPenalty] = useState(app.frequency_penalty || DEFAULT_VALUES.frequency_penalty)
-  const [maxTokens, setMaxTokens] = useState(app.max_tokens || DEFAULT_VALUES.max_tokens)
-  const [presencePenalty, setPresencePenalty] = useState(app.presence_penalty || DEFAULT_VALUES.presence_penalty)
-  const [reasoningEffort, setReasoningEffort] = useState(app.reasoning_effort || DEFAULT_VALUES.reasoning_effort)
-  const [temperature, setTemperature] = useState(app.temperature || DEFAULT_VALUES.temperature)
-  const [topP, setTopP] = useState(app.top_p || DEFAULT_VALUES.top_p)
+  // Use `??` so an explicitly persisted 0 (e.g. temperature: 0, top_p: 0)
+  // isn't silently rewritten to the default — `||` would treat 0 as falsy.
+  const [contextLimit, setContextLimit] = useState(app.context_limit ?? DEFAULT_VALUES.context_limit)
+  const [frequencyPenalty, setFrequencyPenalty] = useState(app.frequency_penalty ?? DEFAULT_VALUES.frequency_penalty)
+  const [maxTokens, setMaxTokens] = useState(app.max_tokens ?? DEFAULT_VALUES.max_tokens)
+  const [presencePenalty, setPresencePenalty] = useState(app.presence_penalty ?? DEFAULT_VALUES.presence_penalty)
+  const [reasoningEffort, setReasoningEffort] = useState(app.reasoning_effort ?? DEFAULT_VALUES.reasoning_effort)
+  const [temperature, setTemperature] = useState(app.temperature ?? DEFAULT_VALUES.temperature)
+  const [topP, setTopP] = useState(app.top_p ?? DEFAULT_VALUES.top_p)
 
   // Track if component has been initialized
   const isInitialized = useRef(false)
@@ -349,13 +355,13 @@ const AppSettings: FC<AppSettingsProps> = ({
       setSmallGenerationModelProvider(app.small_generation_model_provider || '')
 
       setProvider(app.provider || '')
-      setContextLimit(app.context_limit || DEFAULT_VALUES.context_limit)
-      setFrequencyPenalty(app.frequency_penalty || DEFAULT_VALUES.frequency_penalty)
-      setMaxTokens(app.max_tokens || DEFAULT_VALUES.max_tokens)
-      setPresencePenalty(app.presence_penalty || DEFAULT_VALUES.presence_penalty)
-      setReasoningEffort(app.reasoning_effort || DEFAULT_VALUES.reasoning_effort)
-      setTemperature(app.temperature || DEFAULT_VALUES.temperature)
-      setTopP(app.top_p || DEFAULT_VALUES.top_p)
+      setContextLimit(app.context_limit ?? DEFAULT_VALUES.context_limit)
+      setFrequencyPenalty(app.frequency_penalty ?? DEFAULT_VALUES.frequency_penalty)
+      setMaxTokens(app.max_tokens ?? DEFAULT_VALUES.max_tokens)
+      setPresencePenalty(app.presence_penalty ?? DEFAULT_VALUES.presence_penalty)
+      setReasoningEffort(app.reasoning_effort ?? DEFAULT_VALUES.reasoning_effort)
+      setTemperature(app.temperature ?? DEFAULT_VALUES.temperature)
+      setTopP(app.top_p ?? DEFAULT_VALUES.top_p)
       setMaxIterations(app.max_iterations ?? DEFAULT_VALUES.max_iterations)
 
       // Mark as initialized
@@ -366,7 +372,7 @@ const AppSettings: FC<AppSettingsProps> = ({
   // Auto-migrate helix_basic agents to helix_agent on first load
   useEffect(() => {
     if (app.default_agent_type === 'helix_basic') {
-      onUpdate({ default_agent_type: AGENT_TYPE_HELIX_AGENT } as Partial<IAppFlatState> as IAppFlatState)
+      onUpdate({ default_agent_type: AGENT_TYPE_HELIX_AGENT })
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -391,12 +397,8 @@ const AppSettings: FC<AppSettingsProps> = ({
   // can't clobber unrelated values with stale local state.
   const debouncedUpdate = useDebouncedCallback((field: AdvancedField, value: number | string) => {
     const flatField = ADVANCED_FIELD_MAP[field]
-    onUpdate({ [flatField]: value } as Partial<IAppFlatState> as IAppFlatState)
+    onUpdate({ [flatField]: value })
   }, 300)
-
-  const handleAdvancedChangeWithDebounce = (field: AdvancedField, value: number | string) => {
-    debouncedUpdate(field, value)
-  }
 
   // Handle checkbox changes - these update immediately since they're not typing events.
   // Send only the changed field; mergeFlatStateIntoApp leaves everything else alone.
@@ -406,7 +408,7 @@ const AppSettings: FC<AppSettingsProps> = ({
     } else if (field === 'agent_mode') {
       setAgentMode(value)
     }
-    onUpdate({ [field]: value } as Partial<IAppFlatState> as IAppFlatState)
+    onUpdate({ [field]: value })
   }
 
   // Handle agent type changes
@@ -419,13 +421,13 @@ const AppSettings: FC<AppSettingsProps> = ({
     if (config !== undefined) {
       updates.external_agent_config = config
     }
-    onUpdate(updates as IAppFlatState)
+    onUpdate(updates)
   }
 
   const handleModelChange = (provider: string, model: string) => {
     setModel(model)
     setProvider(provider)
-    onUpdate({ model, provider } as Partial<IAppFlatState> as IAppFlatState)
+    onUpdate({ model, provider })
   }
 
   // Helper function to check if a value matches its default
@@ -456,39 +458,39 @@ const AppSettings: FC<AppSettingsProps> = ({
     switch(field) {
       case 'context_limit':
         setContextLimit(value as number)
-        handleAdvancedChangeWithDebounce('contextLimit', value as number)
+        debouncedUpdate('contextLimit', value as number)
         break
       case 'temperature':
         setTemperature(value as number)
-        handleAdvancedChangeWithDebounce('temperature', value as number)
+        debouncedUpdate('temperature', value as number)
         break
       case 'frequency_penalty':
         setFrequencyPenalty(value as number)
-        handleAdvancedChangeWithDebounce('frequencyPenalty', value as number)
+        debouncedUpdate('frequencyPenalty', value as number)
         break
       case 'presence_penalty':
         setPresencePenalty(value as number)
-        handleAdvancedChangeWithDebounce('presencePenalty', value as number)
+        debouncedUpdate('presencePenalty', value as number)
         break
       case 'top_p':
         setTopP(value as number)
-        handleAdvancedChangeWithDebounce('topP', value as number)
+        debouncedUpdate('topP', value as number)
         break
       case 'max_tokens':
         setMaxTokens(value as number)
-        handleAdvancedChangeWithDebounce('maxTokens', value as number)
+        debouncedUpdate('maxTokens', value as number)
         break
       case 'reasoning_effort':
         setReasoningEffort(value as string)
-        handleAdvancedChangeWithDebounce('reasoningEffort', value as string)
+        debouncedUpdate('reasoningEffort', value as string)
         break
       case 'system_prompt':
         setSystemPrompt(value as string)
-        handleAdvancedChangeWithDebounce('system_prompt', value as string)
+        debouncedUpdate('system_prompt', value as string)
         break
       case 'max_iterations':
         setMaxIterations(value as number)
-        handleAdvancedChangeWithDebounce('maxIterations', value as number)
+        debouncedUpdate('maxIterations', value as number)
         break
     }
   }
@@ -515,11 +517,11 @@ const AppSettings: FC<AppSettingsProps> = ({
   const handleEffortSelect = (effort: string, isMain: boolean) => {
     if (isMain) {
       setReasoningModelEffort(effort);
-      onUpdate({ reasoning_model_effort: effort } as Partial<IAppFlatState> as IAppFlatState);
+      onUpdate({ reasoning_model_effort: effort });
       handleMainEffortClose();
     } else {
       setSmallReasoningModelEffort(effort);
-      onUpdate({ small_reasoning_model_effort: effort } as Partial<IAppFlatState> as IAppFlatState);
+      onUpdate({ small_reasoning_model_effort: effort });
       handleSmallEffortClose();
     }
   };
@@ -557,7 +559,7 @@ const AppSettings: FC<AppSettingsProps> = ({
             value={system_prompt}
             onChange={(e) => {
               setSystemPrompt(e.target.value)
-              handleAdvancedChangeWithDebounce('system_prompt', e.target.value)
+              debouncedUpdate('system_prompt', e.target.value)
             }}
             disabled={readOnly}
             placeholder="What does this agent do? How does it behave? What should it avoid doing?"
@@ -598,7 +600,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                   onChange={(e) => {
                     const newRuntime = e.target.value as 'zed_agent' | 'qwen_code' | 'claude_code';
                     setCodeAgentRuntime(newRuntime);
-                    onUpdate({ code_agent_runtime: newRuntime } as Partial<IAppFlatState> as IAppFlatState);
+                    onUpdate({ code_agent_runtime: newRuntime });
                   }}
                   disabled={readOnly}
                   renderValue={(value) => {
@@ -654,9 +656,9 @@ const AppSettings: FC<AppSettingsProps> = ({
                             code_agent_credential_type: 'subscription',
                             generation_model: '',
                             generation_model_provider: '',
-                          } as Partial<IAppFlatState> as IAppFlatState)
+                          })
                         } else {
-                          onUpdate({ code_agent_credential_type: 'api_key' } as Partial<IAppFlatState> as IAppFlatState)
+                          onUpdate({ code_agent_credential_type: 'api_key' })
                         }
                       }}
                     >
@@ -715,7 +717,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                         onUpdate({
                           generation_model: modelId,
                           generation_model_provider: provider,
-                        } as Partial<IAppFlatState> as IAppFlatState);
+                        });
                       }}
                       currentType="text"
                       displayMode="short"
@@ -736,7 +738,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                   onSelectModel={(provider, modelId) => {
                     setModel(modelId);
                     setProvider(provider);
-                    onUpdate({ model: modelId, provider } as Partial<IAppFlatState> as IAppFlatState);
+                    onUpdate({ model: modelId, provider });
                   }}
                   currentType="text"
                   displayMode="short"
@@ -776,7 +778,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                   setZoomLevel(newZoom);
                   const updatedConfig = { ...external_agent_config, resolution: newResolution, zoom_level: newZoom };
                   setExternalAgentConfig(updatedConfig);
-                  onUpdate({ external_agent_config: updatedConfig } as Partial<IAppFlatState> as IAppFlatState);
+                  onUpdate({ external_agent_config: updatedConfig });
                 }}
                 disabled={readOnly}
                 renderValue={(value) => value === '1080p' ? '1080p' : value === '4k' ? '4K' : '5K'}
@@ -816,7 +818,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                     setDesktopType(newDesktopType);
                     const updatedConfig = { ...external_agent_config, desktop_type: newDesktopType };
                     setExternalAgentConfig(updatedConfig);
-                    onUpdate({ external_agent_config: updatedConfig } as Partial<IAppFlatState> as IAppFlatState);
+                    onUpdate({ external_agent_config: updatedConfig });
                   }}
                   disabled={readOnly}
                   renderValue={(value) => value === 'ubuntu' ? 'Ubuntu Desktop' : 'Sway'}
@@ -850,7 +852,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                   setRefreshRate(newRefreshRate);
                   const updatedConfig = { ...external_agent_config, display_refresh_rate: newRefreshRate };
                   setExternalAgentConfig(updatedConfig);
-                  onUpdate({ external_agent_config: updatedConfig } as Partial<IAppFlatState> as IAppFlatState);
+                  onUpdate({ external_agent_config: updatedConfig });
                 }}
                 disabled={readOnly}
                 renderValue={(value) => `${value} fps`}
@@ -909,7 +911,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                   setZoomLevel(newZoom);
                   const updatedConfig = { ...external_agent_config, zoom_level: newZoom };
                   setExternalAgentConfig(updatedConfig);
-                  onUpdate({ external_agent_config: updatedConfig } as Partial<IAppFlatState> as IAppFlatState);
+                  onUpdate({ external_agent_config: updatedConfig });
                 }}
                 disabled={readOnly}
                 sx={{
@@ -951,7 +953,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                     onUpdate({
                       reasoning_model: model,
                       reasoning_model_provider: provider,
-                    } as Partial<IAppFlatState> as IAppFlatState);
+                    });
                   }}
                   currentType="text"
                   displayMode="short"
@@ -1063,7 +1065,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                   onUpdate({
                     generation_model: model,
                     generation_model_provider: provider,
-                  } as Partial<IAppFlatState> as IAppFlatState);
+                  });
                 }}
                 currentType="text"
                 displayMode="short"
@@ -1088,7 +1090,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                     onUpdate({
                       small_reasoning_model: model,
                       small_reasoning_model_provider: provider,
-                    } as Partial<IAppFlatState> as IAppFlatState);
+                    });
                   }}
                   currentType="text"
                   displayMode="short"
@@ -1200,7 +1202,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                   onUpdate({
                     small_generation_model: model,
                     small_generation_model_provider: provider,
-                  } as Partial<IAppFlatState> as IAppFlatState);
+                  });
                 }}
                 currentType="text"
                 displayMode="short"
@@ -1231,7 +1233,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                 onChange={(e) => {
                   const value = parseInt(e.target.value) || DEFAULT_VALUES.max_iterations;
                   setMaxIterations(value);
-                  handleAdvancedChangeWithDebounce('maxIterations', value);
+                  debouncedUpdate('maxIterations', value);
                 }}
                 fullWidth
                 disabled={readOnly}

--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, FC, useRef, useCallback, useMemo } from 'react'
+import React, { useState, useEffect, FC, useRef, useMemo } from 'react'
 import Box from '@mui/material/Box'
 import Checkbox from '@mui/material/Checkbox'
 import FormControlLabel from '@mui/material/FormControlLabel'
@@ -35,6 +35,7 @@ import * as api from '../../api/api'
 
 
 import useApi from '../../hooks/useApi'
+import useDebouncedCallback from '../../hooks/useDebouncedCallback'
 import { AdvancedModelPicker } from '../create/AdvancedModelPicker'
 import { AgentTypeSelector } from '../agent'
 import Divider from '@mui/material/Divider'
@@ -99,21 +100,6 @@ interface AppSettingsProps {
   readOnly?: boolean,
   showErrors?: boolean,
   isAdmin?: boolean,
-}
-
-// Add this custom hook after the imports and before the AppSettings component
-const useDebounce = (callback: Function, delay: number) => {
-  const timeoutRef = useRef<NodeJS.Timeout>()
-
-  return useCallback((...args: any[]) => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current)
-    }
-
-    timeoutRef.current = setTimeout(() => {
-      callback(...args)
-    }, delay)
-  }, [callback, delay])
 }
 
 const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant called Helix. Today is {{ .LocalDate }}, local time is {{ .LocalTime }}.`
@@ -285,14 +271,15 @@ const AppSettings: FC<AppSettingsProps> = ({
   const hasClaudeSubscription = (claudeSubscriptions?.length ?? 0) > 0
   const hasAnthropicProvider = providerEndpoints.some(ep => ep.name === 'anthropic')
 
-  // Advanced settings state
-  const [contextLimit, setContextLimit] = useState(app.context_limit || 0)
-  const [frequencyPenalty, setFrequencyPenalty] = useState(app.frequency_penalty || 0)
-  const [maxTokens, setMaxTokens] = useState(app.max_tokens || 2000)
-  const [presencePenalty, setPresencePenalty] = useState(app.presence_penalty || 0)
-  const [reasoningEffort, setReasoningEffort] = useState(app.reasoning_effort || 'none')
+  // Advanced settings state. Defaults must match the useEffect re-init below
+  // and DEFAULT_VALUES (which mirrors api/pkg/store/store_apps.go).
+  const [contextLimit, setContextLimit] = useState(app.context_limit || DEFAULT_VALUES.context_limit)
+  const [frequencyPenalty, setFrequencyPenalty] = useState(app.frequency_penalty || DEFAULT_VALUES.frequency_penalty)
+  const [maxTokens, setMaxTokens] = useState(app.max_tokens || DEFAULT_VALUES.max_tokens)
+  const [presencePenalty, setPresencePenalty] = useState(app.presence_penalty || DEFAULT_VALUES.presence_penalty)
+  const [reasoningEffort, setReasoningEffort] = useState(app.reasoning_effort || DEFAULT_VALUES.reasoning_effort)
   const [temperature, setTemperature] = useState(app.temperature || DEFAULT_VALUES.temperature)
-  const [topP, setTopP] = useState(app.top_p || 1)
+  const [topP, setTopP] = useState(app.top_p || DEFAULT_VALUES.top_p)
 
   // Track if component has been initialized
   const isInitialized = useRef(false)
@@ -362,13 +349,13 @@ const AppSettings: FC<AppSettingsProps> = ({
       setSmallGenerationModelProvider(app.small_generation_model_provider || '')
 
       setProvider(app.provider || '')
-      setContextLimit(app.context_limit || 0)
-      setFrequencyPenalty(app.frequency_penalty || 0)
-      setMaxTokens(app.max_tokens || 0)
-      setPresencePenalty(app.presence_penalty || 0)
+      setContextLimit(app.context_limit || DEFAULT_VALUES.context_limit)
+      setFrequencyPenalty(app.frequency_penalty || DEFAULT_VALUES.frequency_penalty)
+      setMaxTokens(app.max_tokens || DEFAULT_VALUES.max_tokens)
+      setPresencePenalty(app.presence_penalty || DEFAULT_VALUES.presence_penalty)
       setReasoningEffort(app.reasoning_effort || DEFAULT_VALUES.reasoning_effort)
-      setTemperature(app.temperature || 0)
-      setTopP(app.top_p || 0)
+      setTemperature(app.temperature || DEFAULT_VALUES.temperature)
+      setTopP(app.top_p || DEFAULT_VALUES.top_p)
       setMaxIterations(app.max_iterations ?? DEFAULT_VALUES.max_iterations)
 
       // Mark as initialized
@@ -379,130 +366,66 @@ const AppSettings: FC<AppSettingsProps> = ({
   // Auto-migrate helix_basic agents to helix_agent on first load
   useEffect(() => {
     if (app.default_agent_type === 'helix_basic') {
-      onUpdate({ ...app, default_agent_type: AGENT_TYPE_HELIX_AGENT })
+      onUpdate({ default_agent_type: AGENT_TYPE_HELIX_AGENT } as Partial<IAppFlatState> as IAppFlatState)
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Create debounced version of the update function
-  const debouncedUpdate = useDebounce((field: 'contextLimit' | 'frequencyPenalty' | 'maxTokens' | 'presencePenalty' | 'reasoningEffort' | 'temperature' | 'topP' | 'system_prompt' | 'maxIterations', value: number | string) => {
-    const updatedApp: IAppFlatState = {
-      ...app,
-      global,
-      model,
-      agent_mode,
-      default_agent_type,
-      external_agent_config,
-      reasoning_model,
-      reasoning_model_provider,
-      reasoning_model_effort,
-      generation_model,
-      generation_model_provider,
-      small_reasoning_model,
-      small_reasoning_model_provider,
-      small_reasoning_model_effort,
-      small_generation_model,
-      small_generation_model_provider,
-      provider,
-      context_limit: field === 'contextLimit' ? value as number : contextLimit,
-      frequency_penalty: field === 'frequencyPenalty' ? value as number : frequencyPenalty,
-      max_tokens: field === 'maxTokens' ? value as number : maxTokens,
-      presence_penalty: field === 'presencePenalty' ? value as number : presencePenalty,
-      reasoning_effort: field === 'reasoningEffort' ? value as string : reasoningEffort,
-      temperature: field === 'temperature' ? value as number : temperature,
-      top_p: field === 'topP' ? value as number : topP,
-      system_prompt: field === 'system_prompt' ? value as string : system_prompt,
-      max_iterations: field === 'maxIterations' ? value as number : max_iterations
-    }
+  // Map UI field names to IAppFlatState keys. Keep this small — only the
+  // fields actually edited via the debounced text/number inputs.
+  const ADVANCED_FIELD_MAP = {
+    contextLimit: 'context_limit',
+    frequencyPenalty: 'frequency_penalty',
+    maxTokens: 'max_tokens',
+    presencePenalty: 'presence_penalty',
+    reasoningEffort: 'reasoning_effort',
+    temperature: 'temperature',
+    topP: 'top_p',
+    system_prompt: 'system_prompt',
+    maxIterations: 'max_iterations',
+  } as const satisfies Record<string, keyof IAppFlatState>
 
-    onUpdate(updatedApp)
+  type AdvancedField = keyof typeof ADVANCED_FIELD_MAP
+
+  // Debounced save: send ONLY the field that changed. mergeFlatStateIntoApp in
+  // useApp ignores fields that are undefined, so partial updates are safe and
+  // can't clobber unrelated values with stale local state.
+  const debouncedUpdate = useDebouncedCallback((field: AdvancedField, value: number | string) => {
+    const flatField = ADVANCED_FIELD_MAP[field]
+    onUpdate({ [flatField]: value } as Partial<IAppFlatState> as IAppFlatState)
   }, 300)
 
-  // Combine immediate state update with debounced API call
-  const handleAdvancedChangeWithDebounce = (field: 'contextLimit' | 'frequencyPenalty' | 'maxTokens' | 'presencePenalty' | 'reasoningEffort' | 'temperature' | 'topP' | 'system_prompt' | 'maxIterations', value: number | string) => {
+  const handleAdvancedChangeWithDebounce = (field: AdvancedField, value: number | string) => {
     debouncedUpdate(field, value)
   }
 
-  // Handle checkbox changes - these update immediately since they're not typing events
+  // Handle checkbox changes - these update immediately since they're not typing events.
+  // Send only the changed field; mergeFlatStateIntoApp leaves everything else alone.
   const handleCheckboxChange = (field: 'global' | 'agent_mode', value: boolean) => {
     if (field === 'global') {
       setGlobal(value)
     } else if (field === 'agent_mode') {
       setAgentMode(value)
     }
-
-    // Create updated state and call onUpdate immediately for checkboxes
-    const updatedApp: IAppFlatState = {
-      ...app,
-      global: field === 'global' ? value : global,
-      agent_mode: field === 'agent_mode' ? value : agent_mode,
-      default_agent_type,
-      external_agent_config,
-      model,
-      provider,
-      context_limit: contextLimit,
-      frequency_penalty: frequencyPenalty,
-      max_tokens: maxTokens,
-      presence_penalty: presencePenalty,
-      reasoning_effort: reasoningEffort,
-      temperature: temperature,
-      top_p: topP,
-      max_iterations: max_iterations
-    }
-
-    onUpdate(updatedApp)
+    onUpdate({ [field]: value } as Partial<IAppFlatState> as IAppFlatState)
   }
 
   // Handle agent type changes
   const handleAgentTypeChange = (agentType: IAgentType, config?: IExternalAgentConfig) => {
     setDefaultAgentType(agentType)
-
     if (config !== undefined) {
       setExternalAgentConfig(config)
     }
-
-    const updatedApp: IAppFlatState = {
-      ...app,
-      global,
-      agent_mode,
-      default_agent_type: agentType,
-      external_agent_config: config !== undefined ? config : external_agent_config,
-      model,
-      provider,
-      context_limit: contextLimit,
-      frequency_penalty: frequencyPenalty,
-      max_tokens: maxTokens,
-      presence_penalty: presencePenalty,
-      reasoning_effort: reasoningEffort,
-      temperature,
-      top_p: topP,
-      system_prompt: system_prompt,
-      max_iterations: max_iterations
+    const updates: Partial<IAppFlatState> = { default_agent_type: agentType }
+    if (config !== undefined) {
+      updates.external_agent_config = config
     }
-
-    onUpdate(updatedApp)
+    onUpdate(updates as IAppFlatState)
   }
 
   const handleModelChange = (provider: string, model: string) => {
     setModel(model)
     setProvider(provider)
-
-    // Create updated state and call onUpdate immediately for pickers
-    const updatedApp: IAppFlatState = {
-      ...app,
-      global,
-      model,
-      provider,
-      context_limit: contextLimit,
-      frequency_penalty: frequencyPenalty,
-      max_tokens: maxTokens,
-      presence_penalty: presencePenalty,
-      reasoning_effort: reasoningEffort,
-      temperature,
-      top_p: topP,
-      max_iterations: max_iterations
-    }
-
-    onUpdate(updatedApp)
+    onUpdate({ model, provider } as Partial<IAppFlatState> as IAppFlatState)
   }
 
   // Helper function to check if a value matches its default
@@ -592,19 +515,11 @@ const AppSettings: FC<AppSettingsProps> = ({
   const handleEffortSelect = (effort: string, isMain: boolean) => {
     if (isMain) {
       setReasoningModelEffort(effort);
-      const updatedApp: IAppFlatState = {
-        ...app,
-        reasoning_model_effort: effort,
-      };
-      onUpdate(updatedApp);
+      onUpdate({ reasoning_model_effort: effort } as Partial<IAppFlatState> as IAppFlatState);
       handleMainEffortClose();
     } else {
       setSmallReasoningModelEffort(effort);
-      const updatedApp: IAppFlatState = {
-        ...app,
-        small_reasoning_model_effort: effort,
-      };
-      onUpdate(updatedApp);
+      onUpdate({ small_reasoning_model_effort: effort } as Partial<IAppFlatState> as IAppFlatState);
       handleSmallEffortClose();
     }
   };
@@ -683,7 +598,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                   onChange={(e) => {
                     const newRuntime = e.target.value as 'zed_agent' | 'qwen_code' | 'claude_code';
                     setCodeAgentRuntime(newRuntime);
-                    onUpdate({ ...app, code_agent_runtime: newRuntime });
+                    onUpdate({ code_agent_runtime: newRuntime } as Partial<IAppFlatState> as IAppFlatState);
                   }}
                   disabled={readOnly}
                   renderValue={(value) => {
@@ -735,9 +650,13 @@ const AppSettings: FC<AppSettingsProps> = ({
                         if (mode === 'subscription') {
                           setGenerationModel('')
                           setGenerationModelProvider('')
-                          onUpdate({ ...app, code_agent_credential_type: 'subscription', generation_model: '', generation_model_provider: '' })
+                          onUpdate({
+                            code_agent_credential_type: 'subscription',
+                            generation_model: '',
+                            generation_model_provider: '',
+                          } as Partial<IAppFlatState> as IAppFlatState)
                         } else {
-                          onUpdate({ ...app, code_agent_credential_type: 'api_key' })
+                          onUpdate({ code_agent_credential_type: 'api_key' } as Partial<IAppFlatState> as IAppFlatState)
                         }
                       }}
                     >
@@ -793,7 +712,10 @@ const AppSettings: FC<AppSettingsProps> = ({
                       onSelectModel={(provider, modelId) => {
                         setGenerationModel(modelId);
                         setGenerationModelProvider(provider);
-                        onUpdate({ ...app, generation_model: modelId, generation_model_provider: provider });
+                        onUpdate({
+                          generation_model: modelId,
+                          generation_model_provider: provider,
+                        } as Partial<IAppFlatState> as IAppFlatState);
                       }}
                       currentType="text"
                       displayMode="short"
@@ -814,7 +736,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                   onSelectModel={(provider, modelId) => {
                     setModel(modelId);
                     setProvider(provider);
-                    onUpdate({ ...app, model: modelId, provider });
+                    onUpdate({ model: modelId, provider } as Partial<IAppFlatState> as IAppFlatState);
                   }}
                   currentType="text"
                   displayMode="short"
@@ -854,7 +776,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                   setZoomLevel(newZoom);
                   const updatedConfig = { ...external_agent_config, resolution: newResolution, zoom_level: newZoom };
                   setExternalAgentConfig(updatedConfig);
-                  onUpdate({ ...app, external_agent_config: updatedConfig });
+                  onUpdate({ external_agent_config: updatedConfig } as Partial<IAppFlatState> as IAppFlatState);
                 }}
                 disabled={readOnly}
                 renderValue={(value) => value === '1080p' ? '1080p' : value === '4k' ? '4K' : '5K'}
@@ -894,7 +816,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                     setDesktopType(newDesktopType);
                     const updatedConfig = { ...external_agent_config, desktop_type: newDesktopType };
                     setExternalAgentConfig(updatedConfig);
-                    onUpdate({ ...app, external_agent_config: updatedConfig });
+                    onUpdate({ external_agent_config: updatedConfig } as Partial<IAppFlatState> as IAppFlatState);
                   }}
                   disabled={readOnly}
                   renderValue={(value) => value === 'ubuntu' ? 'Ubuntu Desktop' : 'Sway'}
@@ -928,7 +850,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                   setRefreshRate(newRefreshRate);
                   const updatedConfig = { ...external_agent_config, display_refresh_rate: newRefreshRate };
                   setExternalAgentConfig(updatedConfig);
-                  onUpdate({ ...app, external_agent_config: updatedConfig });
+                  onUpdate({ external_agent_config: updatedConfig } as Partial<IAppFlatState> as IAppFlatState);
                 }}
                 disabled={readOnly}
                 renderValue={(value) => `${value} fps`}
@@ -987,7 +909,7 @@ const AppSettings: FC<AppSettingsProps> = ({
                   setZoomLevel(newZoom);
                   const updatedConfig = { ...external_agent_config, zoom_level: newZoom };
                   setExternalAgentConfig(updatedConfig);
-                  onUpdate({ ...app, external_agent_config: updatedConfig });
+                  onUpdate({ external_agent_config: updatedConfig } as Partial<IAppFlatState> as IAppFlatState);
                 }}
                 disabled={readOnly}
                 sx={{
@@ -1026,12 +948,10 @@ const AppSettings: FC<AppSettingsProps> = ({
                   onSelectModel={(provider, model) => {
                     setReasoningModel(model);
                     setReasoningModelProvider(provider);
-                    const updatedApp: IAppFlatState = {
-                      ...app,
+                    onUpdate({
                       reasoning_model: model,
                       reasoning_model_provider: provider,
-                    };
-                    onUpdate(updatedApp);
+                    } as Partial<IAppFlatState> as IAppFlatState);
                   }}
                   currentType="text"
                   displayMode="short"
@@ -1140,12 +1060,10 @@ const AppSettings: FC<AppSettingsProps> = ({
                 onSelectModel={(provider, model) => {
                   setGenerationModel(model);
                   setGenerationModelProvider(provider);
-                  const updatedApp: IAppFlatState = {
-                    ...app,
+                  onUpdate({
                     generation_model: model,
                     generation_model_provider: provider,
-                  };
-                  onUpdate(updatedApp);
+                  } as Partial<IAppFlatState> as IAppFlatState);
                 }}
                 currentType="text"
                 displayMode="short"
@@ -1167,12 +1085,10 @@ const AppSettings: FC<AppSettingsProps> = ({
                   onSelectModel={(provider, model) => {
                     setSmallReasoningModel(model);
                     setSmallReasoningModelProvider(provider);
-                    const updatedApp: IAppFlatState = {
-                      ...app,
+                    onUpdate({
                       small_reasoning_model: model,
                       small_reasoning_model_provider: provider,
-                    };
-                    onUpdate(updatedApp);
+                    } as Partial<IAppFlatState> as IAppFlatState);
                   }}
                   currentType="text"
                   displayMode="short"
@@ -1281,12 +1197,10 @@ const AppSettings: FC<AppSettingsProps> = ({
                 onSelectModel={(provider, model) => {
                   setSmallGenerationModel(model);
                   setSmallGenerationModelProvider(provider);
-                  const updatedApp: IAppFlatState = {
-                    ...app,
+                  onUpdate({
                     small_generation_model: model,
                     small_generation_model_provider: provider,
-                  };
-                  onUpdate(updatedApp);
+                  } as Partial<IAppFlatState> as IAppFlatState);
                 }}
                 currentType="text"
                 displayMode="short"

--- a/frontend/src/hooks/useApp.ts
+++ b/frontend/src/hooks/useApp.ts
@@ -254,7 +254,7 @@ export const useApp = (appId: string) => {
    * @param updates - The updates to apply
    * @returns The updated app
    */
-  const mergeFlatStateIntoApp = useCallback((existing: IApp, updates: IAppFlatState): IApp => {
+  const mergeFlatStateIntoApp = useCallback((existing: IApp, updates: Partial<IAppFlatState>): IApp => {
     // Create new app object with updated config
     // we do this with JSON.parse because then it copes with deep values not having the same reference
     const updatedApp = JSON.parse(JSON.stringify(existing)) as IApp
@@ -552,7 +552,7 @@ export const useApp = (appId: string) => {
    * @param updates - The updates to apply
    * @param opts - Options for the save operation
    */
-  const saveFlatApp = useCallback(async (updates: IAppFlatState, opts: { quiet?: boolean, forceSave?: boolean } = {}) => {
+  const saveFlatApp = useCallback(async (updates: Partial<IAppFlatState>, opts: { quiet?: boolean, forceSave?: boolean } = {}) => {
     if (!app) return
     
     // If forceSave isn't explicitly set and it's not safe to save, log warning and return

--- a/frontend/src/hooks/useDebouncedCallback.ts
+++ b/frontend/src/hooks/useDebouncedCallback.ts
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useRef } from 'react'
 
+interface DebouncedFn<A extends unknown[]> {
+  (...args: A): void
+  cancel: () => void
+}
+
 /**
  * Returns a stable callback that defers `fn` by `delay` ms and calls the
  * latest `fn` reference (no stale closures).
@@ -7,32 +12,43 @@ import { useEffect, useMemo, useRef } from 'react'
  * Unlike `useDebounce` (which debounces a *value*), this debounces a *side
  * effect*: rapid calls within `delay` cancel earlier scheduled invocations,
  * and only the final call's arguments fire.
+ *
+ * Auto-cancels any pending invocation on unmount, so a component that
+ * unmounts mid-debounce won't fire a late callback (which would otherwise
+ * call into stale closures, e.g. saving stale form state to the API after
+ * the user navigated away).
  */
 export default function useDebouncedCallback<A extends unknown[]>(
   fn: (...args: A) => void,
   delay: number,
-) {
+): DebouncedFn<A> {
   const fnRef = useRef(fn)
 
   useEffect(() => {
     fnRef.current = fn
   }, [fn])
 
-  return useMemo(() => {
+  const debounced = useMemo<DebouncedFn<A>>(() => {
     let timer: ReturnType<typeof setTimeout> | null = null
-    const debounced = (...args: A) => {
+    const wrapped = ((...args: A) => {
       if (timer) clearTimeout(timer)
       timer = setTimeout(() => {
         timer = null
         fnRef.current(...args)
       }, delay)
-    }
-    debounced.cancel = () => {
+    }) as DebouncedFn<A>
+    wrapped.cancel = () => {
       if (timer) {
         clearTimeout(timer)
         timer = null
       }
     }
-    return debounced
+    return wrapped
   }, [delay])
+
+  // Cancel any pending invocation when the component unmounts (or when
+  // `debounced` itself is replaced by a delay change).
+  useEffect(() => () => debounced.cancel(), [debounced])
+
+  return debounced
 }

--- a/frontend/src/hooks/useDebouncedCallback.ts
+++ b/frontend/src/hooks/useDebouncedCallback.ts
@@ -1,0 +1,38 @@
+import { useEffect, useMemo, useRef } from 'react'
+
+/**
+ * Returns a stable callback that defers `fn` by `delay` ms and calls the
+ * latest `fn` reference (no stale closures).
+ *
+ * Unlike `useDebounce` (which debounces a *value*), this debounces a *side
+ * effect*: rapid calls within `delay` cancel earlier scheduled invocations,
+ * and only the final call's arguments fire.
+ */
+export default function useDebouncedCallback<A extends unknown[]>(
+  fn: (...args: A) => void,
+  delay: number,
+) {
+  const fnRef = useRef(fn)
+
+  useEffect(() => {
+    fnRef.current = fn
+  }, [fn])
+
+  return useMemo(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const debounced = (...args: A) => {
+      if (timer) clearTimeout(timer)
+      timer = setTimeout(() => {
+        timer = null
+        fnRef.current(...args)
+      }, delay)
+    }
+    debounced.cancel = () => {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+    }
+    return debounced
+  }, [delay])
+}


### PR DESCRIPTION
## Summary

Agent configuration changes were silently overwriting other persisted fields. The autosave path in `AppSettings.tsx` was sending the *entire* local form state on every debounced save, including fields not visible on the current agent type. For `zed_external + claude_code` agents this clobbered `generation_model` and `generation_model_provider` with empty strings every time the user typed in System Instructions, because those fields are only set by the multi-turn Helix-agent UI which the user wasn't using.

The fix: each handler now sends only the field(s) that actually changed. `mergeFlatStateIntoApp` in `useApp.ts` already ignores `undefined` fields, so partial updates merge cleanly with the persisted assistant config.

## Reproduction (pre-fix)

1. Create a Claude Code agent (default during onboarding).
2. Open `/orgs/<org>/agent/<id>?tab=settings`.
3. Type into "System Instructions".
4. Inspect the PUT request body in the network panel: `generation_model: ""`, `generation_model_provider: ""` — even though the saved values were `claude-opus-4-5-20251101` / `anthropic`.
5. Reload the page → the Model picker now shows blank.

## Verification (post-fix)

- Reproduced the failure exactly as above (DB row went from `"claude-opus-4-5-20251101"` to `""`).
- Applied the fix; the same edit now sends only the system_prompt-related fields. DB row keeps `generation_model = "claude-opus-4-5-20251101"`.
- Cross-checked on a Helix-agent (Optimus) by editing `max_iterations` from 15 → 25 — value persisted, all other fields untouched.
- `cd api && go build ./pkg/server/ ./pkg/store/ ./pkg/types/` — passes.
- `cd frontend && npx tsc --noEmit` — clean.

## Changes

- `frontend/src/hooks/useDebouncedCallback.ts` (new): proper callback debouncer that uses a ref for the latest callback.
- `frontend/src/components/app/AppSettings.tsx`:
  - Replace inline `useDebounce` with the shared `useDebouncedCallback` hook.
  - `debouncedUpdate` now sends only the field that changed (`onUpdate({ [field]: value })`) instead of rebuilding the whole `IAppFlatState` from local state.
  - `handleCheckboxChange`, `handleAgentTypeChange`, `handleModelChange`, `handleEffortSelect`, the model pickers, runtime/credentials selects, and resolution/zoom controls all now send minimal updates.
  - Align `useState` defaults and the post-mount `useEffect` re-init defaults — both now reference `DEFAULT_VALUES` (which mirrors `api/pkg/store/store_apps.go::setAppDefaults`).
- `api/pkg/server/app_handlers.go`: fix variable mismatch in the `updateApp` tool/knowledge validation loop — was iterating `updatedWithTools.Config.Helix.Assistants` but reading from `update.Config.Helix.Assistants[idx]` (latent bug if `ParseAppTools` changes assistant order/count).

## Test plan

- [x] Pre-fix repro confirmed (DB clobber observed)
- [x] Post-fix verification on Claude Code agent (System Instructions edit)
- [x] Post-fix verification on Helix agent (max_iterations edit)
- [x] Frontend type-check clean
- [x] Go build clean
- [ ] Drone CI green

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kqx61ex8k57b724qwvt0meqk)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001985_there-seem-to-be/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001985_there-seem-to-be/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001985_there-seem-to-be/tasks.md)

🚀 Built with [Helix](https://helix.ml)