### PR TITLE
Add Providers link to org sidebar

### DIFF
--- a/frontend/src/components/orgs/OrgSidebar.tsx
+++ b/frontend/src/components/orgs/OrgSidebar.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 
-import { User, Users, CreditCard, Settings, KeyRound } from 'lucide-react'
+import { User, Users, CreditCard, Settings, KeyRound, Plug } from 'lucide-react'
 
 import useRouter from '../../hooks/useRouter'
 import useAccount from '../../hooks/useAccount'
@@ -50,6 +50,13 @@ const OrgSidebar: FC = () => {
           icon: <KeyRound size={20} />,
           isActive: currentRouteName === 'org_api_keys',
           onClick: () => handleNavigationClick('org_api_keys')
+        },
+        {
+          id: 'providers',
+          label: 'Providers',
+          icon: <Plug size={20} />,
+          isActive: currentRouteName === 'org_providers',
+          onClick: () => handleNavigationClick('org_providers')
         },
         {
           id: 'settings',


### PR DESCRIPTION
## Summary

The Org sidebar lists People, Teams, Billing, API Keys, and Settings — but had no link to `/orgs/:org_id/providers`, even though the route and `Providers` page were already wired. Org admins had to type the URL by hand to configure org-scoped LLM providers. This adds the missing sidebar item.

## Changes

- `frontend/src/components/orgs/OrgSidebar.tsx`: import `Plug` from `lucide-react` and insert a "Providers" item between "API Keys" and "Settings" that navigates to the existing `org_providers` route. No new files, no router changes, no backend changes.

## Why this placement / icon

- **Between API Keys and Settings**: both Providers and API Keys are integration / credential surfaces, so they cluster naturally; Settings stays last as the catch-all item.
- **`Plug` icon**: already used in `GitRepoDetail.tsx` and `CodeIntelligenceTab.tsx` for connector / "Connect" UI in this codebase, so it's the consistent semantic choice for "Providers".

## Testing

- `yarn build` (run inside `helix-frontend-1`) passes with no TypeScript errors.
- Verified end-to-end in the browser: registered, created an org, opened `/orgs/test-org/people`, confirmed the "Providers" item appears in the sidebar, clicked it, confirmed navigation to `/orgs/test-org/providers` and that the Providers page renders correctly.

## Screenshots

![Org sidebar — Providers link added between API Keys and Settings](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001986_org-settings-is-missing/screenshots/01-org-sidebar-with-providers.png)

![Providers page after clicking the new sidebar link](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001986_org-settings-is-missing/screenshots/02-providers-page-after-click.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kqy69k2s8cz1f3eq2bcqj7pk)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001986_org-settings-is-missing/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001986_org-settings-is-missing/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001986_org-settings-is-missing/tasks.md)

🚀 Built with [Helix](https://helix.ml)