### PR TITLE
Spec design-review comments interrupt the agent

### DIFF
--- a/api/pkg/server/spec_task_design_review_handlers.go
+++ b/api/pkg/server/spec_task_design_review_handlers.go
@@ -373,9 +373,11 @@ func (s *HelixAPIServer) submitDesignReview(w http.ResponseWriter, r *http.Reque
 			return
 		}
 
-		// Notify agent of requested changes via WebSocket
+		// Notify agent of requested changes via WebSocket.
+		// interrupt=true: reviewer-driven feedback should preempt any in-flight agent turn,
+		// matching the comment-queue semantic.
 		message := services.BuildRevisionInstructionPrompt(specTask, req.OverallComment)
-		_, _, err = s.sendMessageToSpecTaskAgent(ctx, specTask, message, user.ID)
+		_, _, err = s.sendMessageToSpecTaskAgent(ctx, specTask, message, user.ID, true)
 		if err != nil {
 			log.Error().
 				Err(err).
@@ -1018,7 +1020,9 @@ func (s *HelixAPIServer) sendCommentToAgentNow(
 	// interactionID is returned directly — avoids the fragile session-based queue
 	// lookup that breaks when the connected session differs from PlanningSessionID
 	// (e.g. after Zed thread compaction creates a new work session).
-	requestID, interactionID, err := s.sendMessageToSpecTaskAgent(ctx, specTask, promptText, comment.CommentedBy)
+	// interrupt=true: a design-review comment is reactive feedback that should preempt
+	// any in-flight agent turn so the latest input takes priority over stale work.
+	requestID, interactionID, err := s.sendMessageToSpecTaskAgent(ctx, specTask, promptText, comment.CommentedBy, true)
 	if err != nil {
 		log.Error().
 			Err(err).
@@ -1467,11 +1471,16 @@ func sanitizeBranchName(name string) string {
 // It handles: finding connected session, generating request ID, setting up response routing, and sending
 // If no session is connected, it auto-starts the dev container and waits up to 90s for the agent to connect.
 // Returns (requestID, interactionID, error). Both IDs are needed by callers that track comment responses.
+//
+// interrupt=true tells the agent to cancel its current turn before processing this message. Use it for
+// reactive feedback (design-review comments, request-changes flows). Use false for system-driven
+// instructions (approval kickoff, post-merge push/rebase) that should respect the agent's queue.
 func (s *HelixAPIServer) sendMessageToSpecTaskAgent(
 	ctx context.Context,
 	specTask *types.SpecTask,
 	message string,
 	notifyUserID string, // Optional: user to notify of responses (e.g., commenter). Empty = no extra notification
+	interrupt bool,
 ) (string, string, error) {
 	// Find a connected session for this spec task, falling back to PlanningSessionID.
 	// If no session is connected, sendChatMessageToExternalAgent will still create
@@ -1508,7 +1517,7 @@ func (s *HelixAPIServer) sendMessageToSpecTaskAgent(
 
 	// Send the message via the canonical path which creates an interaction,
 	// enqueues it, and sends the WebSocket command.
-	interactionID, err := s.sendChatMessageToExternalAgent(sessionID, message, requestID)
+	interactionID, err := s.sendChatMessageToExternalAgent(sessionID, message, requestID, interrupt)
 	if err != nil {
 		if notifyUserID != "" {
 			s.contextMappingsMutex.Lock()
@@ -1569,7 +1578,8 @@ func (s *HelixAPIServer) sendApprovalInstructionToAgent(
 	// Build the prompt using the shared function from services package
 	message := services.BuildApprovalInstructionPrompt(specTask, branchName, baseBranch, guidelines, primaryRepoName, koditDoc, repoSection, nonPrimaryRepoNames, screenshotBaseURL)
 
-	_, _, err := s.sendMessageToSpecTaskAgent(ctx, specTask, message, "")
+	// interrupt=false: approval kickoff begins a new phase with an idle agent; respect the queue.
+	_, _, err := s.sendMessageToSpecTaskAgent(ctx, specTask, message, "", false)
 	if err != nil {
 		return err
 	}

--- a/api/pkg/server/spec_task_workflow_handlers.go
+++ b/api/pkg/server/spec_task_workflow_handlers.go
@@ -208,7 +208,9 @@ func (s *HelixAPIServer) approveImplementation(w http.ResponseWriter, r *http.Re
 				return
 			}
 
-			_, _, err = s.sendMessageToSpecTaskAgent(context.Background(), specTask, message, "")
+			// interrupt=false: post-merge push instruction is a system-driven follow-up, not
+			// reactive feedback — let it queue behind any in-flight agent turn.
+			_, _, err = s.sendMessageToSpecTaskAgent(context.Background(), specTask, message, "", false)
 			if err != nil {
 				log.Error().
 					Err(err).
@@ -291,7 +293,8 @@ func (s *HelixAPIServer) approveImplementation(w http.ResponseWriter, r *http.Re
 				return
 			}
 
-			_, _, err = s.sendMessageToSpecTaskAgent(context.Background(), specTask, message, "")
+			// interrupt=false: post-merge-failure rebase instruction is system-driven follow-up.
+			_, _, err = s.sendMessageToSpecTaskAgent(context.Background(), specTask, message, "", false)
 			if err != nil {
 				log.Error().
 					Err(err).

--- a/api/pkg/server/test_helpers.go
+++ b/api/pkg/server/test_helpers.go
@@ -70,8 +70,19 @@ func (s *HelixAPIServer) QueueCommand(sessionID string, cmd types.ExternalAgentC
 // SendChatMessage sends a chat message through the production code path,
 // creating an interaction and sending the WebSocket command. This is the
 // same path used by sendMessageToSpecTaskAgent.
+//
+// Defaults interrupt=false to preserve historical behaviour for the cross-repo
+// e2e test server (zed-repo). Use SendChatMessageWithInterrupt for tests that
+// need to exercise the interrupt path.
 func (s *HelixAPIServer) SendChatMessage(sessionID, message, requestID string) error {
-	_, err := s.sendChatMessageToExternalAgent(sessionID, message, requestID)
+	_, err := s.sendChatMessageToExternalAgent(sessionID, message, requestID, false)
+	return err
+}
+
+// SendChatMessageWithInterrupt sends a chat message with the interrupt flag set,
+// matching the semantic used by design-review comments and the prompt-history queue.
+func (s *HelixAPIServer) SendChatMessageWithInterrupt(sessionID, message, requestID string, interrupt bool) error {
+	_, err := s.sendChatMessageToExternalAgent(sessionID, message, requestID, interrupt)
 	return err
 }
 

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -1709,7 +1709,12 @@ func (apiServer *HelixAPIServer) handleContextTitleChanged(sessionID string, syn
 // to an external agent. It creates a waiting interaction, enqueues it for response
 // routing, and sends the WebSocket command. All callers that need to send a message
 // to an agent should use this function.
-func (apiServer *HelixAPIServer) sendChatMessageToExternalAgent(sessionID, message, requestID string) (interactionID string, err error) {
+//
+// interrupt=true tells the agent to cancel its current turn before processing the
+// message, matching the semantic used by prompt-history queue messages. Used for
+// reactive feedback (e.g. design review comments) where the latest input should
+// take priority over in-flight work.
+func (apiServer *HelixAPIServer) sendChatMessageToExternalAgent(sessionID, message, requestID string, interrupt bool) (interactionID string, err error) {
 	ctx := context.Background()
 
 	// Look up the session to get its ZedThreadID and agent name
@@ -1766,6 +1771,7 @@ func (apiServer *HelixAPIServer) sendChatMessageToExternalAgent(sessionID, messa
 			"request_id":    requestID,
 			"acp_thread_id": acpThreadID, // Use existing thread if available, nil = create new
 			"agent_name":    agentName,   // Which agent to use (e.g., "claude", "qwen", "zed-agent")
+			"interrupt":     interrupt,   // Tell agent to cancel current turn before sending (mirrors prompt-queue path)
 		},
 	}
 

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -973,6 +973,80 @@ func (s *WebSocketSyncSuite) TestAgentReady_NoOpenThreadWhenThreadIDPresent() {
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
+// sendChatMessageToExternalAgent tests — interrupt flag plumbing
+// ──────────────────────────────────────────────────────────────────────────────
+
+func (s *WebSocketSyncSuite) TestSendChatMessage_InterruptTrue() {
+	// Verifies the interrupt flag is forwarded into the chat_message command Data,
+	// matching the semantic spec-task design-review comments rely on.
+	sessionID := "ses_interrupt_true"
+
+	sendChan := make(chan types.ExternalAgentCommand, 4)
+	conn := &ExternalAgentWSConnection{SessionID: sessionID, SendChan: sendChan}
+	s.server.externalAgentWSManager.registerConnection(sessionID, conn)
+
+	session := &types.Session{
+		ID:    sessionID,
+		Owner: "user-1",
+		Metadata: types.SessionMetadata{
+			AgentType:   "zed_external",
+			ZedThreadID: "thread-int",
+		},
+	}
+	s.store.EXPECT().GetSession(gomock.Any(), sessionID).Return(session, nil)
+	s.store.EXPECT().CreateInteraction(gomock.Any(), gomock.Any()).Return(
+		&types.Interaction{ID: "int-1", SessionID: sessionID}, nil,
+	)
+
+	_, err := s.server.sendChatMessageToExternalAgent(sessionID, "review feedback", "req-int-1", true)
+	s.NoError(err)
+
+	select {
+	case cmd := <-sendChan:
+		s.Equal("chat_message", cmd.Type)
+		s.Equal(true, cmd.Data["interrupt"], "interrupt=true must be forwarded into chat_message command")
+		s.Equal("review feedback", cmd.Data["message"])
+		s.Equal("req-int-1", cmd.Data["request_id"])
+	case <-time.After(time.Second):
+		s.Fail("expected chat_message command on send channel")
+	}
+}
+
+func (s *WebSocketSyncSuite) TestSendChatMessage_InterruptFalse() {
+	// System-driven messages (approval kickoff, post-merge instructions) must NOT
+	// carry interrupt=true — they should respect the agent's queue.
+	sessionID := "ses_interrupt_false"
+
+	sendChan := make(chan types.ExternalAgentCommand, 4)
+	conn := &ExternalAgentWSConnection{SessionID: sessionID, SendChan: sendChan}
+	s.server.externalAgentWSManager.registerConnection(sessionID, conn)
+
+	session := &types.Session{
+		ID:    sessionID,
+		Owner: "user-2",
+		Metadata: types.SessionMetadata{
+			AgentType:   "zed_external",
+			ZedThreadID: "thread-noint",
+		},
+	}
+	s.store.EXPECT().GetSession(gomock.Any(), sessionID).Return(session, nil)
+	s.store.EXPECT().CreateInteraction(gomock.Any(), gomock.Any()).Return(
+		&types.Interaction{ID: "int-2", SessionID: sessionID}, nil,
+	)
+
+	_, err := s.server.sendChatMessageToExternalAgent(sessionID, "approval kickoff", "req-noint-1", false)
+	s.NoError(err)
+
+	select {
+	case cmd := <-sendChan:
+		s.Equal("chat_message", cmd.Type)
+		s.Equal(false, cmd.Data["interrupt"], "interrupt=false must be forwarded into chat_message command")
+	case <-time.After(time.Second):
+		s.Fail("expected chat_message command on send channel")
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
 // processPromptQueue tests
 // ──────────────────────────────────────────────────────────────────────────────
 

--- a/api/pkg/services/agent_instruction_service.go
+++ b/api/pkg/services/agent_instruction_service.go
@@ -657,7 +657,8 @@ func (s *AgentInstructionService) SendApprovalInstruction(
 	// NOTE: We do NOT call sendMessage here - that would create a duplicate interaction
 	// and overwrite the requestToInteractionMapping, causing responses to go
 	// to the wrong (empty) interaction.
-	_, _, err := s.messageSender(ctx, task, message, userID)
+	// interrupt=false: approval kickoff begins a new phase with an idle agent; respect the queue.
+	_, _, err := s.messageSender(ctx, task, message, userID, false)
 	if err != nil {
 		return fmt.Errorf("failed to send approval instruction to agent: %w", err)
 	}

--- a/api/pkg/services/git_http_server.go
+++ b/api/pkg/services/git_http_server.go
@@ -31,7 +31,11 @@ type AuthorizationToRepositoryFunc func(ctx context.Context, user *types.User, r
 
 // SpecTaskMessageSender is a function type for sending messages to spec task agents.
 // Returns (requestID, interactionID, error).
-type SpecTaskMessageSender func(ctx context.Context, task *types.SpecTask, message string, docPath string) (string, string, error)
+//
+// The fourth string is a notifyUserID (empty = no extra notification). interrupt=true
+// tells the agent to cancel its current turn before processing — use it for reactive
+// feedback like design-review comments; use false for system-driven instructions.
+type SpecTaskMessageSender func(ctx context.Context, task *types.SpecTask, message string, notifyUserID string, interrupt bool) (string, string, error)
 
 // BranchRestriction holds the result of checking branch permissions for an API key
 type BranchRestriction struct {

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -1407,7 +1407,9 @@ func (s *SpecDrivenTaskService) ApproveSpecs(ctx context.Context, task *types.Sp
 		if s.SendMessageToAgent != nil && !s.testMode {
 			go func(t *types.SpecTask, comments string) {
 				message := BuildRevisionInstructionPrompt(t, comments)
-				_, _, err := s.SendMessageToAgent(context.Background(), t, message, "")
+				// interrupt=true: revision instruction is reviewer-driven feedback delivered via the
+				// task-state machine — same semantic as a comment, should preempt in-flight work.
+				_, _, err := s.SendMessageToAgent(context.Background(), t, message, "", true)
 				if err != nil {
 					log.Error().
 						Err(err).

--- a/api/pkg/services/spec_driven_task_service_test.go
+++ b/api/pkg/services/spec_driven_task_service_test.go
@@ -394,7 +394,7 @@ func TestSpecDrivenTaskService_ApproveSpecs_LosesAtomicTransitionRace(t *testing
 	// messageSender is wired up so we can prove it is NOT called when the
 	// transition loses the race.
 	sendCalls := 0
-	sender := func(_ context.Context, _ *types.SpecTask, _, _ string) (string, string, error) {
+	sender := func(_ context.Context, _ *types.SpecTask, _, _ string, _ bool) (string, string, error) {
 		sendCalls++
 		return "", "", nil
 	}


### PR DESCRIPTION
## Summary

When a reviewer leaves a comment on a spec-task design document (or submits "request changes" overall feedback), the comment is now sent to the agent with `interrupt=true`. The agent cancels its current turn and processes the comment immediately, instead of letting the comment wait behind in-flight work that may already be stale.

System-driven messages (approval-phase kickoff, post-merge push/rebase instructions) keep `interrupt=false` — they should respect the agent's queue rather than preempt it.

This piggybacks on the existing `interrupt` field that the prompt-history queue already passes in the same `chat_message` WebSocket command (`websocket_external_agent_sync.go:2845`), so no agent-side (Zed/Claude/Qwen) change is needed.

## Changes

- `sendChatMessageToExternalAgent` gains an `interrupt bool` parameter; the value is forwarded into the `chat_message` `Data["interrupt"]` field.
- `sendMessageToSpecTaskAgent` (the unified spec-task message helper) gains the same parameter and passes it through.
- `SpecTaskMessageSender` function type updated to match.
- Comment / request-changes / auto-revision callers pass `interrupt=true`. Approval kickoff and post-merge workflow callers pass `interrupt=false`. Each call site has a one-line comment explaining the choice.
- New unit tests `TestSendChatMessage_InterruptTrue` / `TestSendChatMessage_InterruptFalse` capture the outgoing command and assert `Data["interrupt"]` is correct.
- Test helper `SendChatMessage` keeps its old signature (defaults `interrupt=false`) for the Zed e2e test server's compatibility; added `SendChatMessageWithInterrupt` for tests that need to exercise the flag.

## Test plan

- [x] `go build ./pkg/server/ ./pkg/services/ ./pkg/types/ ./pkg/store/`
- [x] `CGO_ENABLED=1 go test -run TestWebSocketSyncSuite ./pkg/server/ -count=1`
- [x] `CGO_ENABLED=1 go test ./pkg/services/... -count=1`
- [ ] Manual: start a spec task in inner Helix, wait for the agent to begin a long response, drop a new design-review comment, observe the prior turn cancel and the comment response start within a few seconds.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kq9gzn623n66q105y2ve2q6c)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001962_spec-comments-should-be/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001962_spec-comments-should-be/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001962_spec-comments-should-be/tasks.md)

🚀 Built with [Helix](https://helix.ml)