### PR TITLE
feat(charts): forward desktop-bridge envs and add sandbox.extraEnv

### DIFF
--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -1094,22 +1094,26 @@ func (h *HydraExecutor) buildEnvVars(agent *types.DesktopAgent, containerType, w
 	// NOTE: BUILDKIT_HOST env var is injected by Hydra server side (devcontainer.go buildEnv)
 	// which runs inside the sandbox where it can query the helix-buildkit container IP.
 
-	// Add custom env vars from agent request (includes USER_API_TOKEN for git + RevDial)
-	// Pass through HELIX_ENCODER from outer environment to desktop containers.
-	// This allows selecting the video encoder without rebuilding the desktop image.
-	// Supported values: vsock (default auto-detect), openh264, x264, nvenc
-	if encoderOverride := os.Getenv("HELIX_ENCODER"); encoderOverride != "" {
-		env = append(env, fmt.Sprintf("HELIX_ENCODER=%s", encoderOverride))
-	}
-
-	// Pass through HELIX_VIDEO_MODE so the in-container desktop-bridge can pick
-	// a non-default capture path. Needed on managed-GPU clusters (e.g. GKE T4)
-	// where the default zerocopy DmaBuf -> CUDA pipeline fails to reach
-	// PLAYING; "shm" forces shared-memory capture while keeping NVENC encode.
-	// Supported values: shm, native, zerocopy (default).
-	// Skip the macOS scanout case - that's set explicitly in devcontainer.go.
-	if videoMode := os.Getenv("HELIX_VIDEO_MODE"); videoMode != "" && videoMode != "scanout" {
-		env = append(env, fmt.Sprintf("HELIX_VIDEO_MODE=%s", videoMode))
+	// Forward desktop-bridge tunables from the controlplane env into dev
+	// containers. The desktop-bridge binary reads these inside the container,
+	// so without explicit forwarding here an operator setting them on
+	// `controlplane.extraEnv` would have no effect.
+	//
+	//   HELIX_ENCODER     - H.264 encoder (nvenc | vaapi | openh264 | x264 | ...)
+	//   HELIX_VIDEO_MODE  - PipeWire capture path (zerocopy | native | shm).
+	//                       Skip "scanout" - devcontainer.go sets that
+	//                       explicitly for the macOS QEMU virtio-gpu path.
+	//   HELIX_GOP_SIZE    - GOP size in frames (default 120 = 2s at 60fps)
+	//   HELIX_RENDER_NODE - VA-API render device (e.g. /dev/dri/renderD129)
+	for _, name := range []string{"HELIX_ENCODER", "HELIX_VIDEO_MODE", "HELIX_GOP_SIZE", "HELIX_RENDER_NODE"} {
+		val := os.Getenv(name)
+		if val == "" {
+			continue
+		}
+		if name == "HELIX_VIDEO_MODE" && val == "scanout" {
+			continue
+		}
+		env = append(env, fmt.Sprintf("%s=%s", name, val))
 	}
 
 	// These come LAST so they can override defaults (e.g., use user's token instead of runner token)

--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -1102,6 +1102,16 @@ func (h *HydraExecutor) buildEnvVars(agent *types.DesktopAgent, containerType, w
 		env = append(env, fmt.Sprintf("HELIX_ENCODER=%s", encoderOverride))
 	}
 
+	// Pass through HELIX_VIDEO_MODE so the in-container desktop-bridge can pick
+	// a non-default capture path. Needed on managed-GPU clusters (e.g. GKE T4)
+	// where the default zerocopy DmaBuf -> CUDA pipeline fails to reach
+	// PLAYING; "shm" forces shared-memory capture while keeping NVENC encode.
+	// Supported values: shm, native, zerocopy (default).
+	// Skip the macOS scanout case - that's set explicitly in devcontainer.go.
+	if videoMode := os.Getenv("HELIX_VIDEO_MODE"); videoMode != "" && videoMode != "scanout" {
+		env = append(env, fmt.Sprintf("HELIX_VIDEO_MODE=%s", videoMode))
+	}
+
 	// These come LAST so they can override defaults (e.g., use user's token instead of runner token)
 	hasUserAPIToken := false
 	for _, e := range agent.Env {

--- a/charts/helix-sandbox/templates/deployment.yaml
+++ b/charts/helix-sandbox/templates/deployment.yaml
@@ -173,8 +173,11 @@ spec:
             - name: GST_DEBUG
               value: {{ .Values.debug.gstDebug | quote }}
 
-            # Operator-supplied env (e.g. HELIX_SANDBOX_APT_MIRROR).
-            # Listed last so values here override anything above.
+            # Operator-supplied env. Chart-wide first, per-component last,
+            # so sandbox.extraEnv overrides global.extraEnv on conflict.
+            {{- with .Values.global.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- with .Values.sandbox.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/helix-sandbox/templates/deployment.yaml
+++ b/charts/helix-sandbox/templates/deployment.yaml
@@ -173,6 +173,12 @@ spec:
             - name: GST_DEBUG
               value: {{ .Values.debug.gstDebug | quote }}
 
+            # Operator-supplied env (e.g. HELIX_SANDBOX_APT_MIRROR).
+            # Listed last so values here override anything above.
+            {{- with .Values.sandbox.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
           volumeMounts:
             - name: docker-storage
               mountPath: /var/lib/docker

--- a/charts/helix-sandbox/values.yaml
+++ b/charts/helix-sandbox/values.yaml
@@ -2,6 +2,20 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  # Extra environment variables applied chart-wide (currently the sandbox
+  # container; future sub-deployments would consume the same value).
+  # Useful for proxy configuration in environments where all outbound traffic
+  # must go through a proxy. Per-component values (e.g. sandbox.extraEnv)
+  # render after these and therefore override on conflict.
+  # Example:
+  #   extraEnv:
+  #     - name: HTTPS_PROXY
+  #       value: "http://proxy:8080"
+  #     - name: NO_PROXY
+  #       value: "localhost,127.0.0.1,.svc,.cluster.local"
+  extraEnv: []
+
 replicaCount: 1
 
 # Deployment configuration

--- a/charts/helix-sandbox/values.yaml
+++ b/charts/helix-sandbox/values.yaml
@@ -73,6 +73,15 @@ sandbox:
   # 120-240 recommended for remote connections
   gopSize: 120
 
+  # Extra environment variables appended to the sandbox container's env block.
+  # Use this to set hydra-side knobs that don't have a structured value
+  # (e.g. HELIX_SANDBOX_APT_MIRROR for air-gapped APT mirrors).
+  # Example:
+  #   extraEnv:
+  #     - name: HELIX_SANDBOX_APT_MIRROR
+  #       value: "http://apt.internal/ubuntu"
+  extraEnv: []
+
 # Hydra configuration (multi-tenant container isolation)
 hydra:
   # Enable Hydra for per-session Docker daemon isolation


### PR DESCRIPTION
## Summary

Lets operators drive desktop-bridge tunables through helm `extraEnv` without rebuilding the desktop image, and introduces a `sandbox.extraEnv` lever for hydra-side knobs.

## Changes

1. **`api/pkg/external-agent/hydra_executor.go`** - extend the existing `HELIX_ENCODER` pass-through into a small forwarder that also handles `HELIX_VIDEO_MODE`, `HELIX_GOP_SIZE`, and `HELIX_RENDER_NODE`. The desktop-bridge binary inside each dev container reads all four; without this, setting them on `controlplane.extraEnv` would have no effect. The `HELIX_VIDEO_MODE=scanout` value is skipped because `devcontainer.go` already sets it explicitly for the macOS QEMU virtio-gpu path.
2. **`charts/helix-sandbox`** - add `sandbox.extraEnv` (defaulting to `[]`), render it at the end of the sandbox pod's env block so it can override anything the chart sets above. Lets operators set hydra-side runtime flags like `HELIX_SANDBOX_APT_MIRROR` from values.yaml.

## Motivating case

GKE T4: the default zerocopy DMA-BUF -> CUDA -> NVENC pipeline can't reach `PLAYING`. `desktop-bridge` logs `Received CUDA context via set_context` then `Pipeline cleaned up (was never started)`, and the streamer surfaces `failed to set pipeline to playing`. The browser shows endless reconnect attempts.

After this change:

```yaml
controlplane:
  extraEnv:
    - name: HELIX_VIDEO_MODE
      value: shm
```

`helm upgrade`, start a fresh spec task, stream connects (still NVENC for encode).

## Docs

Reference table for the four streaming env vars + the `controlplane.extraEnv` / `sandbox.extraEnv` / `global.extraEnv` scopes lands in https://github.com/helixml/helix-next/pull/92.

## Test plan

- [x] `go build ./api/pkg/external-agent/...` clean
- [x] `helm template` renders sandbox deployment with operator-supplied `sandbox.extraEnv` entries appearing after the chart-managed env block
- [ ] Reviewer: deploy 2.11.x with `controlplane.extraEnv: HELIX_VIDEO_MODE=shm` on a GKE T4 cluster, confirm `desktop-bridge` log shows `video_mode=shm` and the browser stream connects
- [ ] Reviewer: confirm zerocopy still works on a known-good rig when the env var is unset (i.e. forwarding is opt-in via env presence)