### PR TITLE
Show CI status on Kanban cards + notify the agent on transitions

### DIFF
--- a/api/pkg/agent/skill/azure_devops/client.go
+++ b/api/pkg/agent/skill/azure_devops/client.go
@@ -3,6 +3,7 @@ package azuredevops
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
+	adobuild "github.com/microsoft/azure-devops-go-api/azuredevops/v7/build"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
 )
 
@@ -273,4 +275,116 @@ func (c *AzureDevOpsClient) ListProjects(ctx context.Context) ([]string, error) 
 	}
 
 	return projects, nil
+}
+
+// CIStatusResult is the normalized verdict for an ADO commit. Status is
+// the raw build status (e.g. "succeeded", "inProgress", "failed"); the
+// caller normalises via services.NormalizeCIStatus("azure_devops", ...).
+// URL points at the build's web UI when available.
+type CIStatusResult struct {
+	Status string
+	URL    string
+}
+
+// ErrCIScopeMissing is returned when the PAT lacks the vso.build scope
+// required to read build status. Callers should treat it as "none" and
+// surface a one-time hint to the user (see design doc — no new mandatory
+// scope, gracefully degrade).
+var ErrCIScopeMissing = errors.New("azure devops: build read scope (vso.build) missing on PAT")
+
+// GetCIStatus fetches the most recent build that ran against the given
+// commit and returns its raw status/result + web URL. Returns nil result
+// with a nil error if no build is found for the commit.
+//
+// 401/403 from the Build API → ErrCIScopeMissing (PAT missing vso.build).
+//
+// project is the ADO project name; repositoryName is the Azure Repos Git
+// repository name (we resolve it to a UUID internally because the Build
+// API's RepositoryId filter requires the GUID for TfsGit).
+func (c *AzureDevOpsClient) GetCIStatus(ctx context.Context, project, repositoryName, commitID string) (*CIStatusResult, error) {
+	gitClient, err := git.NewClient(ctx, c.connection)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create azure devops git client: %w", err)
+	}
+	repo, err := gitClient.GetRepository(ctx, git.GetRepositoryArgs{
+		RepositoryId: &repositoryName,
+		Project:      &project,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve azure devops repository: %w", err)
+	}
+	if repo == nil || repo.Id == nil {
+		return nil, fmt.Errorf("azure devops repository %q not found in project %q", repositoryName, project)
+	}
+	repoUUID := repo.Id.String()
+
+	buildClient, err := adobuild.NewClient(ctx, c.connection)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create azure devops build client: %w", err)
+	}
+
+	top := 25 // walk recent builds and match by SourceVersion
+	queryOrder := adobuild.BuildQueryOrderValues.QueueTimeDescending
+	repoType := "TfsGit" // ADO Git repos
+	args := adobuild.GetBuildsArgs{
+		Project:        &project,
+		RepositoryId:   &repoUUID,
+		RepositoryType: &repoType,
+		Top:            &top,
+		QueryOrder:     &queryOrder,
+	}
+	resp, err := buildClient.GetBuilds(ctx, args)
+	if err != nil {
+		// The SDK wraps the HTTP error in azuredevops.WrappedError; check status.
+		// SDK returns WrappedError as both value and pointer in different
+		// paths; check both.
+		var sc *int
+		var wrappedVal azuredevops.WrappedError
+		if errors.As(err, &wrappedVal) {
+			sc = wrappedVal.StatusCode
+		}
+		var wrappedPtr *azuredevops.WrappedError
+		if sc == nil && errors.As(err, &wrappedPtr) && wrappedPtr != nil {
+			sc = wrappedPtr.StatusCode
+		}
+		if sc != nil && (*sc == http.StatusUnauthorized || *sc == http.StatusForbidden) {
+			return nil, ErrCIScopeMissing
+		}
+		return nil, fmt.Errorf("failed to list azure devops builds: %w", err)
+	}
+	if resp == nil || len(resp.Value) == 0 {
+		return nil, nil
+	}
+
+	// Find the most recent build that matches our commit. ADO doesn't
+	// have a direct "filter by sourceVersion" query so we check the
+	// returned set; in practice the latest 1 build per repo is the one
+	// we want when the agent has just pushed.
+	for i := range resp.Value {
+		b := &resp.Value[i]
+		if b.SourceVersion == nil || !strings.EqualFold(*b.SourceVersion, commitID) {
+			continue
+		}
+		raw := ""
+		if b.Status != nil {
+			raw = string(*b.Status)
+		}
+		// If the build completed, its Result holds the verdict; prefer
+		// that over the generic "completed" status string.
+		if b.Status != nil && *b.Status == adobuild.BuildStatusValues.Completed && b.Result != nil {
+			raw = string(*b.Result)
+		}
+		webURL := ""
+		if b.Links != nil {
+			if linkMap, ok := b.Links.(map[string]interface{}); ok {
+				if web, ok := linkMap["web"].(map[string]interface{}); ok {
+					if href, ok := web["href"].(string); ok {
+						webURL = href
+					}
+				}
+			}
+		}
+		return &CIStatusResult{Status: raw, URL: webURL}, nil
+	}
+	return nil, nil
 }

--- a/api/pkg/agent/skill/bitbucket/client.go
+++ b/api/pkg/agent/skill/bitbucket/client.go
@@ -832,3 +832,19 @@ func (r *Repository) ToRepositoryInfo() types.RepositoryInfo {
 		DefaultBranch: r.MainBranch,
 	}
 }
+
+// CIStatusResult is the normalized verdict for a head SHA.
+// TODO(v2): wire up Bitbucket Pipelines (Cloud) and Bitbucket build status
+// (Server). Until then, this method always reports "no CI configured" so the
+// frontend renders nothing for Bitbucket-attached repos.
+type CIStatusResult struct {
+	Status string
+	URL    string
+}
+
+// GetCIStatus is a v1 stub for Bitbucket. It returns nil (treated as
+// "none" by the caller) so we don't break the Kanban card view for
+// Bitbucket users.
+func (c *Client) GetCIStatus(_ context.Context, _, _, _ string) (*CIStatusResult, error) {
+	return nil, nil
+}

--- a/api/pkg/agent/skill/github/client.go
+++ b/api/pkg/agent/skill/github/client.go
@@ -341,6 +341,110 @@ func (c *Client) ListPullRequests(ctx context.Context, owner, repo string) ([]*g
 	return allPRs, nil
 }
 
+// CIStatusResult is the normalized verdict for a head SHA, aggregated
+// across the legacy combined status and the modern check runs APIs.
+// Status is the worst of any individual status/check found:
+// "failed" > "running" > "passed" > "none". Status is the lower-cased
+// raw value — callers normalise via services.NormalizeCIStatus(...).
+// URL points at the GitHub PR's "Checks" tab (computed by the caller from
+// PR data, since this method takes only owner/repo/sha).
+type CIStatusResult struct {
+	// Status is the raw worst-state string. Empty when no statuses or
+	// check runs exist for the SHA. Callers normalise into the canonical
+	// services.CIStatus* values.
+	Status string
+	// HeadSHA echoes the SHA queried; useful when callers chain calls.
+	HeadSHA string
+}
+
+// GetCIStatus fetches the combined commit status AND the check runs for a
+// SHA, then returns the worst raw verdict. We query both because GitHub
+// has two overlapping CI surfaces: the legacy Statuses API (used by
+// many third-party CI services) and the Checks API (used by GitHub
+// Actions). A repo can use one, the other, or both.
+func (c *Client) GetCIStatus(ctx context.Context, owner, repo, sha string) (*CIStatusResult, error) {
+	const (
+		// Severity ordering for "worst-state wins" aggregation.
+		// Higher number = worse / more attention-demanding.
+		sevPassed  = 1
+		sevRunning = 2
+		sevFailed  = 3
+	)
+
+	verdict := func(state string) int {
+		switch strings.ToLower(strings.TrimSpace(state)) {
+		case "success", "neutral", "skipped":
+			return sevPassed
+		case "pending", "queued", "in_progress":
+			return sevRunning
+		case "":
+			return 0
+		default:
+			// failure, error, cancelled, timed_out, action_required, stale, ...
+			return sevFailed
+		}
+	}
+
+	worstSev := 0
+	worstRaw := ""
+	consider := func(state string) {
+		if state == "" {
+			return
+		}
+		s := verdict(state)
+		if s > worstSev {
+			worstSev = s
+			worstRaw = strings.ToLower(strings.TrimSpace(state))
+		}
+	}
+
+	combined, _, err := c.client.Repositories.GetCombinedStatus(ctx, owner, repo, sha, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get combined status: %w", err)
+	}
+	if combined != nil {
+		// Walk individual statuses (rather than the aggregate State) so
+		// we use the same "worst-state wins" rule across both surfaces.
+		for _, s := range combined.Statuses {
+			if s != nil && s.State != nil {
+				consider(*s.State)
+			}
+		}
+	}
+
+	checkOpts := &github.ListCheckRunsOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+	for {
+		runs, resp, err := c.client.Checks.ListCheckRunsForRef(ctx, owner, repo, sha, checkOpts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list check runs: %w", err)
+		}
+		if runs != nil {
+			for _, r := range runs.CheckRuns {
+				if r == nil {
+					continue
+				}
+				// Status is "queued" | "in_progress" | "completed".
+				// When completed, Conclusion holds the verdict.
+				if r.Status != nil && *r.Status != "completed" {
+					consider(*r.Status)
+					continue
+				}
+				if r.Conclusion != nil {
+					consider(*r.Conclusion)
+				}
+			}
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		checkOpts.Page = resp.NextPage
+	}
+
+	return &CIStatusResult{Status: worstRaw, HeadSHA: sha}, nil
+}
+
 // GetRepository gets a repository by owner and name
 func (c *Client) GetRepository(ctx context.Context, owner, repo string) (*github.Repository, error) {
 	repository, _, err := c.client.Repositories.Get(ctx, owner, repo)

--- a/api/pkg/agent/skill/gitlab/client.go
+++ b/api/pkg/agent/skill/gitlab/client.go
@@ -138,6 +138,36 @@ func (c *Client) ListMergeRequests(ctx context.Context, projectID int) ([]*gitla
 	return allMRs, nil
 }
 
+// CIStatusResult is the normalized verdict for a head SHA. Status is the
+// raw GitLab pipeline status (e.g. "success", "running", "failed"); the
+// caller normalises via services.NormalizeCIStatus("gitlab", ...).
+type CIStatusResult struct {
+	Status string
+	URL    string // Pipeline web URL — directly clickable.
+}
+
+// GetCIStatus fetches the most recent pipeline for the given SHA on the
+// project and returns its raw status + web URL. Returns nil result with a
+// nil error if no pipeline exists for the SHA — callers should treat that
+// as "none".
+func (c *Client) GetCIStatus(ctx context.Context, projectID int, sha string) (*CIStatusResult, error) {
+	opt := &gitlab.ListProjectPipelinesOptions{
+		SHA:         gitlab.Ptr(sha),
+		OrderBy:     gitlab.Ptr("id"),
+		Sort:        gitlab.Ptr("desc"),
+		ListOptions: gitlab.ListOptions{PerPage: 1, Page: 1},
+	}
+	pipelines, _, err := c.client.Pipelines.ListProjectPipelines(projectID, opt, gitlab.WithContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list project pipelines: %w", err)
+	}
+	if len(pipelines) == 0 {
+		return nil, nil
+	}
+	p := pipelines[0]
+	return &CIStatusResult{Status: p.Status, URL: p.WebURL}, nil
+}
+
 // GetProject gets a project by ID
 func (c *Client) GetProject(ctx context.Context, projectID int) (*gitlab.Project, error) {
 	project, _, err := c.client.Projects.GetProject(projectID, nil, gitlab.WithContext(ctx))

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -22459,14 +22459,18 @@ const docTemplate = `{
                 "agent_interaction_completed",
                 "spec_failed",
                 "implementation_failed",
-                "pr_ready"
+                "pr_ready",
+                "ci_passed",
+                "ci_failed"
             ],
             "x-enum-varnames": [
                 "AttentionEventSpecsPushed",
                 "AttentionEventAgentInteractionCompleted",
                 "AttentionEventSpecFailed",
                 "AttentionEventImplementationFailed",
-                "AttentionEventPRReady"
+                "AttentionEventPRReady",
+                "AttentionEventCIPassed",
+                "AttentionEventCIFailed"
             ]
         },
         "types.AttentionEventUpdateRequest": {
@@ -27639,6 +27643,10 @@ const docTemplate = `{
                 "description": {
                     "type": "string"
                 },
+                "head_sha": {
+                    "description": "HeadSHA is the commit SHA at the tip of the PR's source branch.\nUsed by the CI status poller to detect new pushes and to query the\nprovider's CI/build APIs for the right commit. Empty if the\nprovider response did not include it.",
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -27974,6 +27982,19 @@ const docTemplate = `{
         "types.RepoPR": {
             "type": "object",
             "properties": {
+                "ci_head_sha": {
+                    "type": "string"
+                },
+                "ci_status": {
+                    "description": "CI status, populated by the spec task orchestrator's PR poll loop.\nCIStatus is one of: \"\" (not yet evaluated), \"running\", \"passed\",\n\"failed\", \"none\" (CI not configured for the PR's head SHA).\nCIHeadSHA is the head commit we last evaluated; it lets the poller\ndetect a new push and reset CIStatus so a stale \"passed\" doesn't\nsuppress a fresh notification when the next commit fails.",
+                    "type": "string"
+                },
+                "ci_updated_at": {
+                    "type": "string"
+                },
+                "ci_url": {
+                    "type": "string"
+                },
                 "pr_id": {
                     "type": "string"
                 },

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -544,6 +544,7 @@ func NewServer(
 	apiServer.specTaskOrchestrator.SetGoldenBuildService(apiServer.goldenBuildService)
 	apiServer.specTaskOrchestrator.SetEnsurePRsFunc(apiServer.ensurePullRequestsForAllRepos)
 	apiServer.specTaskOrchestrator.SetAttentionService(apiServer.attentionService)
+	apiServer.specTaskOrchestrator.SetCINotifier(services.NewMessageSenderCINotifier(apiServer.sendMessageToSpecTaskAgent))
 
 	// Recover golden builds that were in progress when the API last restarted.
 	// Re-attaches monitoring goroutines for still-running builds, resets stale ones.

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -22455,14 +22455,18 @@
                 "agent_interaction_completed",
                 "spec_failed",
                 "implementation_failed",
-                "pr_ready"
+                "pr_ready",
+                "ci_passed",
+                "ci_failed"
             ],
             "x-enum-varnames": [
                 "AttentionEventSpecsPushed",
                 "AttentionEventAgentInteractionCompleted",
                 "AttentionEventSpecFailed",
                 "AttentionEventImplementationFailed",
-                "AttentionEventPRReady"
+                "AttentionEventPRReady",
+                "AttentionEventCIPassed",
+                "AttentionEventCIFailed"
             ]
         },
         "types.AttentionEventUpdateRequest": {
@@ -27635,6 +27639,10 @@
                 "description": {
                     "type": "string"
                 },
+                "head_sha": {
+                    "description": "HeadSHA is the commit SHA at the tip of the PR's source branch.\nUsed by the CI status poller to detect new pushes and to query the\nprovider's CI/build APIs for the right commit. Empty if the\nprovider response did not include it.",
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -27970,6 +27978,19 @@
         "types.RepoPR": {
             "type": "object",
             "properties": {
+                "ci_head_sha": {
+                    "type": "string"
+                },
+                "ci_status": {
+                    "description": "CI status, populated by the spec task orchestrator's PR poll loop.\nCIStatus is one of: \"\" (not yet evaluated), \"running\", \"passed\",\n\"failed\", \"none\" (CI not configured for the PR's head SHA).\nCIHeadSHA is the head commit we last evaluated; it lets the poller\ndetect a new push and reset CIStatus so a stale \"passed\" doesn't\nsuppress a fresh notification when the next commit fails.",
+                    "type": "string"
+                },
+                "ci_updated_at": {
+                    "type": "string"
+                },
+                "ci_url": {
+                    "type": "string"
+                },
                 "pr_id": {
                     "type": "string"
                 },

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -3040,6 +3040,8 @@ definitions:
     - spec_failed
     - implementation_failed
     - pr_ready
+    - ci_passed
+    - ci_failed
     type: string
     x-enum-varnames:
     - AttentionEventSpecsPushed
@@ -3047,6 +3049,8 @@ definitions:
     - AttentionEventSpecFailed
     - AttentionEventImplementationFailed
     - AttentionEventPRReady
+    - AttentionEventCIPassed
+    - AttentionEventCIFailed
   types.AttentionEventUpdateRequest:
     properties:
       acknowledge:
@@ -6715,6 +6719,13 @@ definitions:
         type: string
       description:
         type: string
+      head_sha:
+        description: |-
+          HeadSHA is the commit SHA at the tip of the PR's source branch.
+          Used by the CI status poller to detect new pushes and to query the
+          provider's CI/build APIs for the right commit. Empty if the
+          provider response did not include it.
+        type: string
       id:
         type: string
       number:
@@ -6956,6 +6967,21 @@ definitions:
     type: object
   types.RepoPR:
     properties:
+      ci_head_sha:
+        type: string
+      ci_status:
+        description: |-
+          CI status, populated by the spec task orchestrator's PR poll loop.
+          CIStatus is one of: "" (not yet evaluated), "running", "passed",
+          "failed", "none" (CI not configured for the PR's head SHA).
+          CIHeadSHA is the head commit we last evaluated; it lets the poller
+          detect a new push and reset CIStatus so a stale "passed" doesn't
+          suppress a fresh notification when the next commit fails.
+        type: string
+      ci_updated_at:
+        type: string
+      ci_url:
+        type: string
       pr_id:
         type: string
       pr_number:

--- a/api/pkg/services/attention_service.go
+++ b/api/pkg/services/attention_service.go
@@ -238,6 +238,10 @@ func buildTitle(eventType types.AttentionEventType, task *types.SpecTask) string
 		return "Implementation failed"
 	case types.AttentionEventPRReady:
 		return "Pull request ready"
+	case types.AttentionEventCIPassed:
+		return "CI passed"
+	case types.AttentionEventCIFailed:
+		return "CI failed"
 	default:
 		return "Attention needed"
 	}
@@ -263,6 +267,10 @@ func buildDescription(eventType types.AttentionEventType, task *types.SpecTask) 
 		return fmt.Sprintf("Implementation failed for \"%s\" — needs triage", name)
 	case types.AttentionEventPRReady:
 		return fmt.Sprintf("Pull request opened for \"%s\" — awaiting merge", name)
+	case types.AttentionEventCIPassed:
+		return fmt.Sprintf("CI passed for \"%s\"", name)
+	case types.AttentionEventCIFailed:
+		return fmt.Sprintf("CI failed for \"%s\" — needs investigation", name)
 	default:
 		return fmt.Sprintf("Task \"%s\" needs your attention", name)
 	}
@@ -274,10 +282,12 @@ func eventEmoji(eventType types.AttentionEventType) string {
 		return "📋"
 	case types.AttentionEventAgentInteractionCompleted:
 		return "🛑"
-	case types.AttentionEventSpecFailed, types.AttentionEventImplementationFailed:
+	case types.AttentionEventSpecFailed, types.AttentionEventImplementationFailed, types.AttentionEventCIFailed:
 		return "❌"
 	case types.AttentionEventPRReady:
 		return "🔀"
+	case types.AttentionEventCIPassed:
+		return "✅"
 	default:
 		return "🔔"
 	}

--- a/api/pkg/services/ci_status.go
+++ b/api/pkg/services/ci_status.go
@@ -1,0 +1,71 @@
+package services
+
+import "strings"
+
+// CI status canonical values stored on RepoPR.CIStatus.
+const (
+	CIStatusRunning = "running"
+	CIStatusPassed  = "passed"
+	CIStatusFailed  = "failed"
+	CIStatusNone    = "none"
+)
+
+// NormalizeCIStatus collapses provider-specific CI verdicts to one of the
+// canonical CI status values. An unknown raw value is treated as failed
+// rather than silently ignored — surfacing surprises beats hiding them.
+//
+// provider is one of "github", "gitlab", "azure_devops", "bitbucket". An
+// empty raw string returns CIStatusNone, regardless of provider.
+func NormalizeCIStatus(provider, raw string) string {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	if raw == "" {
+		return CIStatusNone
+	}
+
+	switch provider {
+	case "github":
+		// Combined Status: success | pending | failure | error
+		// Check Run conclusion: success | failure | neutral | cancelled |
+		// timed_out | action_required | stale | skipped (or status when
+		// queued/in_progress).
+		switch raw {
+		case "success", "neutral", "skipped":
+			return CIStatusPassed
+		case "pending", "queued", "in_progress":
+			return CIStatusRunning
+		case "failure", "error", "cancelled", "timed_out", "action_required", "stale":
+			return CIStatusFailed
+		}
+	case "gitlab":
+		// Pipeline status: created | waiting_for_resource | preparing |
+		// pending | running | success | failed | canceled | skipped |
+		// manual | scheduled.
+		switch raw {
+		case "success":
+			return CIStatusPassed
+		case "created", "waiting_for_resource", "preparing", "pending", "running", "manual", "scheduled":
+			return CIStatusRunning
+		case "failed", "canceled":
+			return CIStatusFailed
+		case "skipped":
+			return CIStatusPassed
+		}
+	case "azure_devops":
+		// Build status: notStarted | inProgress | completed.
+		// Build result (when completed): succeeded | partiallySucceeded |
+		// failed | canceled.
+		switch raw {
+		case "succeeded", "partiallysucceeded":
+			return CIStatusPassed
+		case "notstarted", "inprogress":
+			return CIStatusRunning
+		case "failed", "canceled":
+			return CIStatusFailed
+		}
+	case "bitbucket":
+		// Reserved for v2 — no Bitbucket CI yet.
+		return CIStatusNone
+	}
+
+	return CIStatusFailed
+}

--- a/api/pkg/services/ci_status_test.go
+++ b/api/pkg/services/ci_status_test.go
@@ -1,0 +1,67 @@
+package services
+
+import "testing"
+
+func TestNormalizeCIStatus(t *testing.T) {
+	cases := []struct {
+		provider string
+		raw      string
+		want     string
+	}{
+		// Empty raw is always "none".
+		{"github", "", CIStatusNone},
+		{"gitlab", "", CIStatusNone},
+		{"azure_devops", "", CIStatusNone},
+		{"bitbucket", "", CIStatusNone},
+
+		// GitHub combined status + check run conclusions.
+		{"github", "success", CIStatusPassed},
+		{"github", "neutral", CIStatusPassed},
+		{"github", "skipped", CIStatusPassed},
+		{"github", "pending", CIStatusRunning},
+		{"github", "queued", CIStatusRunning},
+		{"github", "in_progress", CIStatusRunning},
+		{"github", "failure", CIStatusFailed},
+		{"github", "error", CIStatusFailed},
+		{"github", "cancelled", CIStatusFailed},
+		{"github", "timed_out", CIStatusFailed},
+		{"github", "action_required", CIStatusFailed},
+		{"github", "stale", CIStatusFailed},
+		// Case- and whitespace-insensitive.
+		{"github", "  SUCCESS ", CIStatusPassed},
+
+		// GitLab pipeline statuses.
+		{"gitlab", "success", CIStatusPassed},
+		{"gitlab", "running", CIStatusRunning},
+		{"gitlab", "pending", CIStatusRunning},
+		{"gitlab", "preparing", CIStatusRunning},
+		{"gitlab", "manual", CIStatusRunning},
+		{"gitlab", "scheduled", CIStatusRunning},
+		{"gitlab", "failed", CIStatusFailed},
+		{"gitlab", "canceled", CIStatusFailed},
+		{"gitlab", "skipped", CIStatusPassed},
+
+		// Azure DevOps build status / result.
+		{"azure_devops", "succeeded", CIStatusPassed},
+		{"azure_devops", "partiallySucceeded", CIStatusPassed},
+		{"azure_devops", "inProgress", CIStatusRunning},
+		{"azure_devops", "notStarted", CIStatusRunning},
+		{"azure_devops", "failed", CIStatusFailed},
+		{"azure_devops", "canceled", CIStatusFailed},
+
+		// Bitbucket: always "none" in v1.
+		{"bitbucket", "SUCCESSFUL", CIStatusNone},
+
+		// Unknown raw values surface as "failed" rather than swallowed.
+		{"github", "lolwut", CIStatusFailed},
+		{"gitlab", "lolwut", CIStatusFailed},
+	}
+
+	for _, c := range cases {
+		got := NormalizeCIStatus(c.provider, c.raw)
+		if got != c.want {
+			t.Errorf("NormalizeCIStatus(%q, %q) = %q, want %q",
+				c.provider, c.raw, got, c.want)
+		}
+	}
+}

--- a/api/pkg/services/git_repository_service_ci_status.go
+++ b/api/pkg/services/git_repository_service_ci_status.go
@@ -1,0 +1,135 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	azuredevops "github.com/helixml/helix/api/pkg/agent/skill/azure_devops"
+	"github.com/helixml/helix/api/pkg/agent/skill/github"
+	"github.com/helixml/helix/api/pkg/types"
+
+	"github.com/rs/zerolog/log"
+)
+
+// GetCIStatus fetches the CI verdict for a PR's current head SHA. The
+// returned types.CIStatus.State is one of CIStatusRunning / CIStatusPassed /
+// CIStatusFailed / CIStatusNone. Empty headSHA → returns "none" without
+// hitting any provider.
+//
+// The provider is determined by the repository's ExternalType. Bitbucket
+// always returns "none" in v1 (CI integration not yet implemented).
+//
+// Errors here are non-fatal for the caller — the PR poll loop should log
+// and continue rather than abort the whole loop.
+func (s *GitRepositoryService) GetCIStatus(ctx context.Context, repoID, prID, headSHA string) (*types.CIStatus, error) {
+	if headSHA == "" {
+		return &types.CIStatus{State: CIStatusNone}, nil
+	}
+
+	repo, err := s.GetRepository(ctx, repoID)
+	if err != nil {
+		return nil, fmt.Errorf("repository not found: %w", err)
+	}
+	if repo.ExternalURL == "" {
+		return nil, fmt.Errorf("repository is not external")
+	}
+
+	switch repo.ExternalType {
+	case types.ExternalRepositoryTypeGitHub:
+		return s.getGitHubCIStatus(ctx, repo, prID, headSHA)
+	case types.ExternalRepositoryTypeGitLab:
+		return s.getGitLabCIStatus(ctx, repo, headSHA)
+	case types.ExternalRepositoryTypeADO:
+		return s.getAzureDevOpsCIStatus(ctx, repo, headSHA)
+	case types.ExternalRepositoryTypeBitbucket:
+		// Stub in v1 — see Bitbucket client's GetCIStatus.
+		return &types.CIStatus{State: CIStatusNone, HeadSHA: headSHA}, nil
+	default:
+		return &types.CIStatus{State: CIStatusNone, HeadSHA: headSHA}, nil
+	}
+}
+
+func (s *GitRepositoryService) getGitHubCIStatus(ctx context.Context, repo *types.GitRepository, prID, headSHA string) (*types.CIStatus, error) {
+	client, err := s.getGitHubClient(ctx, repo, "")
+	if err != nil {
+		return nil, err
+	}
+	owner, repoName, err := github.ParseGitHubURL(repo.ExternalURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse GitHub URL: %w", err)
+	}
+	res, err := client.GetCIStatus(ctx, owner, repoName, headSHA)
+	if err != nil {
+		return nil, err
+	}
+	state := NormalizeCIStatus("github", res.Status)
+	url := ""
+	if state != CIStatusNone {
+		// Link to the PR's "Checks" tab — directly clickable for users.
+		if prNum, err := strconv.Atoi(prID); err == nil && prNum > 0 {
+			url = fmt.Sprintf("https://github.com/%s/%s/pull/%d/checks", owner, repoName, prNum)
+		}
+	}
+	return &types.CIStatus{State: state, URL: url, HeadSHA: headSHA}, nil
+}
+
+func (s *GitRepositoryService) getGitLabCIStatus(ctx context.Context, repo *types.GitRepository, headSHA string) (*types.CIStatus, error) {
+	client, err := s.getGitLabClient(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	projectID, err := s.getGitLabProjectID(ctx, client, repo)
+	if err != nil {
+		return nil, err
+	}
+	res, err := client.GetCIStatus(ctx, projectID, headSHA)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return &types.CIStatus{State: CIStatusNone, HeadSHA: headSHA}, nil
+	}
+	return &types.CIStatus{
+		State:   NormalizeCIStatus("gitlab", res.Status),
+		URL:     res.URL,
+		HeadSHA: headSHA,
+	}, nil
+}
+
+func (s *GitRepositoryService) getAzureDevOpsCIStatus(ctx context.Context, repo *types.GitRepository, headSHA string) (*types.CIStatus, error) {
+	client, err := s.getAzureDevOpsClient(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	project, err := s.getAzureDevOpsProject(repo)
+	if err != nil {
+		return nil, err
+	}
+	repoName, err := s.getAzureDevOpsRepositoryName(repo)
+	if err != nil {
+		return nil, err
+	}
+	res, err := client.GetCIStatus(ctx, project, repoName, headSHA)
+	if err != nil {
+		// PAT missing the Build Read scope: gracefully degrade to "none"
+		// so existing connections without vso.build don't break the UI.
+		// Log once at warn level — admins should re-issue the PAT.
+		if errors.Is(err, azuredevops.ErrCIScopeMissing) {
+			log.Warn().
+				Str("repo_id", repo.ID).
+				Msg("Azure DevOps PAT missing vso.build scope; CI status hidden for this repo")
+			return &types.CIStatus{State: CIStatusNone, HeadSHA: headSHA}, nil
+		}
+		return nil, err
+	}
+	if res == nil {
+		return &types.CIStatus{State: CIStatusNone, HeadSHA: headSHA}, nil
+	}
+	return &types.CIStatus{
+		State:   NormalizeCIStatus("azure_devops", res.Status),
+		URL:     res.URL,
+		HeadSHA: headSHA,
+	}, nil
+}

--- a/api/pkg/services/git_repository_service_pull_requests.go
+++ b/api/pkg/services/git_repository_service_pull_requests.go
@@ -427,6 +427,10 @@ func (s *GitRepositoryService) getAzureDevOpsPullRequest(ctx context.Context, re
 		pr.URL = fmt.Sprintf("%s/pullrequest/%d", repo.ExternalURL, *adoPR.PullRequestId)
 	}
 
+	if adoPR.LastMergeSourceCommit != nil && adoPR.LastMergeSourceCommit.CommitId != nil {
+		pr.HeadSHA = *adoPR.LastMergeSourceCommit.CommitId
+	}
+
 	return pr, nil
 }
 
@@ -669,6 +673,7 @@ func (s *GitRepositoryService) getGitHubPullRequest(ctx context.Context, repo *t
 		SourceBranch: ghPR.GetHead().GetRef(),
 		TargetBranch: ghPR.GetBase().GetRef(),
 		URL:          ghPR.GetHTMLURL(),
+		HeadSHA:      ghPR.GetHead().GetSHA(),
 	}
 
 	if ghPR.GetUser() != nil {
@@ -863,6 +868,7 @@ func (s *GitRepositoryService) getGitLabMergeRequest(ctx context.Context, repo *
 		SourceBranch: glMR.SourceBranch,
 		TargetBranch: glMR.TargetBranch,
 		URL:          glMR.WebURL,
+		HeadSHA:      glMR.SHA,
 	}
 
 	if glMR.Author != nil {

--- a/api/pkg/services/spec_task_ci_notifier.go
+++ b/api/pkg/services/spec_task_ci_notifier.go
@@ -1,0 +1,52 @@
+package services
+
+import (
+	"context"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// CINotifier delivers a CI result message to the agent currently working
+// on a spec task. The orchestrator calls this from the PR poll loop once
+// per (pr, transition) — see the dedup logic in handleCIStatusTransition.
+//
+// Implementations are expected to be best-effort: if the agent is
+// offline, the message should be queued (e.g. as a waiting Interaction)
+// for delivery when the agent reconnects, not failed loudly. Returning
+// an error is fine for *unexpected* failures — the orchestrator logs
+// them and continues with the next task.
+type CINotifier interface {
+	NotifyCIResult(ctx context.Context, task *types.SpecTask, repo *types.RepoPR, status string) error
+}
+
+// MessageSenderCINotifier wraps a SpecTaskMessageSender (already used by
+// the design-review and approval flows) and delivers CI messages over
+// the same path. This way agents that are offline fall through to the
+// existing waiting-interaction queue without us having to reinvent that
+// logic. Constructed by the API server, where the sender is wired up.
+type MessageSenderCINotifier struct {
+	sender SpecTaskMessageSender
+}
+
+// NewMessageSenderCINotifier returns a CINotifier that pushes CI messages
+// through the given SpecTaskMessageSender. interrupt is always false:
+// CI results aren't urgent enough to interrupt mid-turn — the agent picks
+// them up at the next message-pump tick.
+func NewMessageSenderCINotifier(sender SpecTaskMessageSender) *MessageSenderCINotifier {
+	return &MessageSenderCINotifier{sender: sender}
+}
+
+// NotifyCIResult sends the CI message to the agent. notifyUserID is left
+// empty — CI results aren't tied to a specific commenter.
+func (n *MessageSenderCINotifier) NotifyCIResult(
+	ctx context.Context,
+	task *types.SpecTask,
+	_ *types.RepoPR,
+	message string,
+) error {
+	if n == nil || n.sender == nil {
+		return nil
+	}
+	_, _, err := n.sender(ctx, task, message, "", false)
+	return err
+}

--- a/api/pkg/services/spec_task_orchestrator.go
+++ b/api/pkg/services/spec_task_orchestrator.go
@@ -37,6 +37,7 @@ type SpecTaskOrchestrator struct {
 	containerExecutor     ContainerExecutor // Executor for external agent containers
 	goldenBuildService    *GoldenBuildService
 	attentionService      *AttentionService
+	ciNotifier            CINotifier    // Delivers ci_passed / ci_failed messages to running agents
 	ensurePRs             EnsurePRsFunc // Callback to create missing PRs (set by server)
 	stopChan              chan struct{}
 	wg                    sync.WaitGroup
@@ -91,6 +92,13 @@ func (o *SpecTaskOrchestrator) SetGoldenBuildService(svc *GoldenBuildService) {
 // SetAttentionService sets the attention service for emitting human-needed events.
 func (o *SpecTaskOrchestrator) SetAttentionService(svc *AttentionService) {
 	o.attentionService = svc
+}
+
+// SetCINotifier sets the notifier used to deliver CI result messages to a
+// running agent. When nil, the orchestrator still tracks CI status on the
+// task but skips agent-side messaging (human attention events still fire).
+func (o *SpecTaskOrchestrator) SetCINotifier(n CINotifier) {
+	o.ciNotifier = n
 }
 
 // Start begins the orchestration loop
@@ -747,6 +755,12 @@ func (o *SpecTaskOrchestrator) processExternalPullRequestStatus(ctx context.Cont
 		newState := string(pr.State)
 		if task.RepoPullRequests[i].PRState != newState {
 			task.RepoPullRequests[i].PRState = newState
+			updated = true
+		}
+
+		// CI status: poll the provider for the PR's head SHA, fire
+		// transition notifications, persist if anything changed.
+		if o.pollCIStatusForPR(ctx, task, &task.RepoPullRequests[i], pr) {
 			updated = true
 		}
 

--- a/api/pkg/services/spec_task_orchestrator_ci.go
+++ b/api/pkg/services/spec_task_orchestrator_ci.go
@@ -1,0 +1,144 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/types"
+
+	"github.com/rs/zerolog/log"
+)
+
+// pollCIStatusForPR fetches the latest CI verdict for the given PR's head
+// SHA and updates the in-memory RepoPR. When the cached HeadSHA differs
+// from the new one, the cached CIStatus is reset (a new push happened, so
+// the previous verdict is stale and we want a clean transition the next
+// time CI completes). When the new state differs from the previous, a
+// transition is fired: chat message to the agent + attention event to
+// the human.
+//
+// Returns true if the RepoPR was mutated and the caller should persist
+// the parent task. Errors are logged and swallowed — never abort the
+// caller's loop on a single PR's CI lookup failure.
+func (o *SpecTaskOrchestrator) pollCIStatusForPR(
+	ctx context.Context,
+	task *types.SpecTask,
+	repoPR *types.RepoPR,
+	pr *types.PullRequest,
+) bool {
+	headSHA := pr.HeadSHA
+	if headSHA == "" {
+		// Provider didn't surface a head SHA — nothing to query against.
+		return false
+	}
+
+	prevState := repoPR.CIStatus
+	prevHead := repoPR.CIHeadSHA
+	mutated := false
+
+	// New commit → reset prevState so we don't suppress a transition
+	// notification when the next commit's CI lands. Persist the SHA
+	// reset even if we fail to fetch the new verdict.
+	if prevHead != "" && prevHead != headSHA {
+		repoPR.CIStatus = ""
+		repoPR.CIHeadSHA = headSHA
+		repoPR.CIUpdatedAt = time.Now()
+		prevState = ""
+		mutated = true
+	}
+
+	status, err := o.gitService.GetCIStatus(ctx, repoPR.RepositoryID, repoPR.PRID, headSHA)
+	if err != nil {
+		log.Debug().
+			Err(err).
+			Str("task_id", task.ID).
+			Str("repo_id", repoPR.RepositoryID).
+			Str("pr_id", repoPR.PRID).
+			Msg("Failed to fetch CI status, leaving cached value")
+		return mutated
+	}
+	if status == nil {
+		return mutated
+	}
+
+	if status.State != prevState || repoPR.CIURL != status.URL || repoPR.CIHeadSHA != headSHA {
+		repoPR.CIStatus = status.State
+		repoPR.CIURL = status.URL
+		repoPR.CIHeadSHA = headSHA
+		repoPR.CIUpdatedAt = time.Now()
+		mutated = true
+	}
+
+	o.handleCIStatusTransition(ctx, task, repoPR, prevState, status.State)
+	return mutated
+}
+
+// handleCIStatusTransition fires notifications when the CI verdict
+// transitions from "running" to a terminal state. We only notify on
+// running→passed and running→failed; first-observation (prev == "") is
+// silent because we don't know what happened before we started watching.
+func (o *SpecTaskOrchestrator) handleCIStatusTransition(
+	ctx context.Context,
+	task *types.SpecTask,
+	repoPR *types.RepoPR,
+	prevState, newState string,
+) {
+	if prevState != CIStatusRunning {
+		return
+	}
+	if newState != CIStatusPassed && newState != CIStatusFailed {
+		return
+	}
+
+	prRef := fmt.Sprintf("PR #%d (%s)", repoPR.PRNumber, repoPR.RepositoryName)
+	var msg string
+	var eventType types.AttentionEventType
+	switch newState {
+	case CIStatusPassed:
+		msg = fmt.Sprintf("CI passed for %s. %s", prRef, repoPR.CIURL)
+		eventType = types.AttentionEventCIPassed
+	case CIStatusFailed:
+		msg = fmt.Sprintf("CI failed for %s. Check the logs: %s. Please investigate and push a fix.", prRef, repoPR.CIURL)
+		eventType = types.AttentionEventCIFailed
+	}
+
+	log.Info().
+		Str("task_id", task.ID).
+		Str("repo_id", repoPR.RepositoryID).
+		Str("pr_id", repoPR.PRID).
+		Str("ci_state", newState).
+		Msg("CI status transition")
+
+	if o.ciNotifier != nil {
+		// Best-effort delivery; the notifier persists for offline agents.
+		if err := o.ciNotifier.NotifyCIResult(ctx, task, repoPR, msg); err != nil {
+			log.Warn().
+				Err(err).
+				Str("task_id", task.ID).
+				Str("ci_state", newState).
+				Msg("Failed to notify agent of CI result")
+		}
+	}
+
+	if o.attentionService != nil {
+		go func(t *types.SpecTask, evt types.AttentionEventType, prID, ciURL string) {
+			_, err := o.attentionService.EmitEvent(
+				context.Background(),
+				evt,
+				t,
+				prID,
+				map[string]interface{}{
+					"pr_id":  prID,
+					"ci_url": ciURL,
+				},
+			)
+			if err != nil {
+				log.Warn().Err(err).
+					Str("spec_task_id", t.ID).
+					Str("event_type", string(evt)).
+					Msg("Failed to emit CI attention event")
+			}
+		}(task, eventType, repoPR.PRID, repoPR.CIURL)
+	}
+}

--- a/api/pkg/services/spec_task_orchestrator_ci_test.go
+++ b/api/pkg/services/spec_task_orchestrator_ci_test.go
@@ -1,0 +1,135 @@
+package services
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+// recordedNotify is one captured CINotifier invocation.
+type recordedNotify struct {
+	taskID  string
+	prID    string
+	message string
+}
+
+// recordingCINotifier captures every NotifyCIResult call so tests can
+// assert what (and how many times) the orchestrator notified.
+type recordingCINotifier struct {
+	mu    sync.Mutex
+	calls []recordedNotify
+	err   error
+}
+
+func (r *recordingCINotifier) NotifyCIResult(_ context.Context, task *types.SpecTask, repo *types.RepoPR, message string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, recordedNotify{
+		taskID:  task.ID,
+		prID:    repo.PRID,
+		message: message,
+	})
+	return r.err
+}
+
+func (r *recordingCINotifier) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
+}
+
+// orchestrator under test — no store, no git service; we exercise the
+// pure transition logic on handleCIStatusTransition directly.
+func newOrchestratorForCITest(notifier CINotifier) *SpecTaskOrchestrator {
+	return &SpecTaskOrchestrator{
+		ciNotifier: notifier,
+	}
+}
+
+func TestCITransition_FirstObservation_DoesNotNotify(t *testing.T) {
+	notifier := &recordingCINotifier{}
+	o := newOrchestratorForCITest(notifier)
+
+	task := &types.SpecTask{ID: "task-1"}
+	pr := &types.RepoPR{PRID: "pr-1", PRNumber: 7, RepositoryName: "owner/repo"}
+
+	// prev is empty (first observation) — never notify.
+	o.handleCIStatusTransition(context.Background(), task, pr, "", CIStatusPassed)
+	o.handleCIStatusTransition(context.Background(), task, pr, "", CIStatusFailed)
+	o.handleCIStatusTransition(context.Background(), task, pr, "", CIStatusRunning)
+
+	require.Equal(t, 0, notifier.count(), "first observation must not notify")
+}
+
+func TestCITransition_RunningToPassed_NotifiesOnce(t *testing.T) {
+	notifier := &recordingCINotifier{}
+	o := newOrchestratorForCITest(notifier)
+
+	task := &types.SpecTask{ID: "task-1"}
+	pr := &types.RepoPR{
+		PRID: "pr-1", PRNumber: 7, RepositoryName: "owner/repo",
+		CIURL: "https://example.com/checks",
+	}
+
+	o.handleCIStatusTransition(context.Background(), task, pr, CIStatusRunning, CIStatusPassed)
+
+	require.Equal(t, 1, notifier.count())
+	require.Contains(t, notifier.calls[0].message, "CI passed")
+	require.Contains(t, notifier.calls[0].message, "PR #7 (owner/repo)")
+	require.Contains(t, notifier.calls[0].message, "https://example.com/checks")
+}
+
+func TestCITransition_RunningToFailed_NotifiesOnce(t *testing.T) {
+	notifier := &recordingCINotifier{}
+	o := newOrchestratorForCITest(notifier)
+
+	task := &types.SpecTask{ID: "task-1"}
+	pr := &types.RepoPR{
+		PRID: "pr-2", PRNumber: 12, RepositoryName: "owner/repo",
+		CIURL: "https://example.com/run/42",
+	}
+
+	o.handleCIStatusTransition(context.Background(), task, pr, CIStatusRunning, CIStatusFailed)
+
+	require.Equal(t, 1, notifier.count())
+	require.Contains(t, notifier.calls[0].message, "CI failed")
+	require.Contains(t, notifier.calls[0].message, "https://example.com/run/42")
+	require.Contains(t, notifier.calls[0].message, "Please investigate")
+}
+
+func TestCITransition_NoOpTransitions_DoNotNotify(t *testing.T) {
+	notifier := &recordingCINotifier{}
+	o := newOrchestratorForCITest(notifier)
+
+	task := &types.SpecTask{ID: "task-1"}
+	pr := &types.RepoPR{PRID: "pr-1", PRNumber: 1, RepositoryName: "r"}
+
+	// Steady-state and other transitions — none should notify.
+	cases := [][2]string{
+		{CIStatusPassed, CIStatusPassed},
+		{CIStatusFailed, CIStatusFailed},
+		{CIStatusPassed, CIStatusFailed}, // not from running — silent (transition was missed)
+		{CIStatusFailed, CIStatusPassed},
+		{CIStatusRunning, CIStatusRunning},
+		{CIStatusRunning, CIStatusNone},
+	}
+	for _, c := range cases {
+		o.handleCIStatusTransition(context.Background(), task, pr, c[0], c[1])
+	}
+
+	require.Equal(t, 0, notifier.count(), "non-running-terminal transitions must not notify")
+}
+
+func TestCITransition_NilNotifier_NoPanic(t *testing.T) {
+	o := newOrchestratorForCITest(nil)
+	task := &types.SpecTask{ID: "task-1"}
+	pr := &types.RepoPR{PRID: "pr-1", PRNumber: 1, RepositoryName: "r"}
+
+	require.NotPanics(t, func() {
+		o.handleCIStatusTransition(context.Background(), task, pr, CIStatusRunning, CIStatusPassed)
+	})
+}

--- a/api/pkg/types/attention_event.go
+++ b/api/pkg/types/attention_event.go
@@ -39,6 +39,8 @@ const (
 	AttentionEventSpecFailed                AttentionEventType = "spec_failed"
 	AttentionEventImplementationFailed      AttentionEventType = "implementation_failed"
 	AttentionEventPRReady                   AttentionEventType = "pr_ready"
+	AttentionEventCIPassed                  AttentionEventType = "ci_passed"
+	AttentionEventCIFailed                  AttentionEventType = "ci_failed"
 )
 
 // AttentionEventFilters controls optional filtering when listing attention events.

--- a/api/pkg/types/git_repositories.go
+++ b/api/pkg/types/git_repositories.go
@@ -300,6 +300,21 @@ type PullRequest struct {
 	CreatedAt    time.Time        `json:"created_at"`
 	UpdatedAt    time.Time        `json:"updated_at"`
 	URL          string           `json:"url,omitempty"`
+	// HeadSHA is the commit SHA at the tip of the PR's source branch.
+	// Used by the CI status poller to detect new pushes and to query the
+	// provider's CI/build APIs for the right commit. Empty if the
+	// provider response did not include it.
+	HeadSHA string `json:"head_sha,omitempty"`
+}
+
+// CIStatus is the normalized CI verdict returned by GitRepositoryService.
+// State is one of services.CIStatus* values: "running", "passed",
+// "failed", "none". URL is a clickable link to the provider's CI/build
+// page. HeadSHA echoes the SHA queried.
+type CIStatus struct {
+	State   string `json:"state"`
+	URL     string `json:"url,omitempty"`
+	HeadSHA string `json:"head_sha,omitempty"`
 }
 
 type PullRequestState string

--- a/api/pkg/types/simple_spec_task.go
+++ b/api/pkg/types/simple_spec_task.go
@@ -32,6 +32,17 @@ type RepoPR struct {
 	PRNumber       int    `json:"pr_number"`
 	PRURL          string `json:"pr_url"`
 	PRState        string `json:"pr_state"` // "open", "closed", "merged"
+
+	// CI status, populated by the spec task orchestrator's PR poll loop.
+	// CIStatus is one of: "" (not yet evaluated), "running", "passed",
+	// "failed", "none" (CI not configured for the PR's head SHA).
+	// CIHeadSHA is the head commit we last evaluated; it lets the poller
+	// detect a new push and reset CIStatus so a stale "passed" doesn't
+	// suppress a fresh notification when the next commit fails.
+	CIStatus    string    `json:"ci_status,omitempty"`
+	CIURL       string    `json:"ci_url,omitempty"`
+	CIUpdatedAt time.Time `json:"ci_updated_at,omitempty"`
+	CIHeadSHA   string    `json:"ci_head_sha,omitempty"`
 }
 
 // GetFirstOpenPR returns the first open PR from RepoPullRequests, or nil if none.

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1872,6 +1872,8 @@ export enum TypesAttentionEventType {
   AttentionEventSpecFailed = "spec_failed",
   AttentionEventImplementationFailed = "implementation_failed",
   AttentionEventPRReady = "pr_ready",
+  AttentionEventCIPassed = "ci_passed",
+  AttentionEventCIFailed = "ci_failed",
 }
 
 export interface TypesAttentionEventUpdateRequest {
@@ -4113,6 +4115,13 @@ export interface TypesPullRequest {
   author?: string;
   created_at?: string;
   description?: string;
+  /**
+   * HeadSHA is the commit SHA at the tip of the PR's source branch.
+   * Used by the CI status poller to detect new pushes and to query the
+   * provider's CI/build APIs for the right commit. Empty if the
+   * provider response did not include it.
+   */
+  head_sha?: string;
   id?: string;
   number?: number;
   source_branch?: string;
@@ -4259,6 +4268,18 @@ export interface TypesRegisterRequest {
 }
 
 export interface TypesRepoPR {
+  ci_head_sha?: string;
+  /**
+   * CI status, populated by the spec task orchestrator's PR poll loop.
+   * CIStatus is one of: "" (not yet evaluated), "running", "passed",
+   * "failed", "none" (CI not configured for the PR's head SHA).
+   * CIHeadSHA is the head commit we last evaluated; it lets the poller
+   * detect a new push and reset CIStatus so a stale "passed" doesn't
+   * suppress a fresh notification when the next commit fails.
+   */
+  ci_status?: string;
+  ci_updated_at?: string;
+  ci_url?: string;
   pr_id?: string;
   pr_number?: number;
   /** "open", "closed", "merged" */

--- a/frontend/src/components/git/SettingsTab.tsx
+++ b/frontend/src/components/git/SettingsTab.tsx
@@ -224,7 +224,7 @@ const SettingsTab: FC<SettingsTabProps> = ({
                     helperText={
                       repository.azure_devops?.personal_access_token
                         ? "Leave blank to keep current token"
-                        : "Personal Access Token for Azure DevOps. Get yours from https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows"
+                        : "Personal Access Token for Azure DevOps. Required scopes: Code (Read & Write) and Build (Read) — Build is needed to display CI status on Kanban cards. Get yours from https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows"
                     }
                     InputProps={{
                       endAdornment: (

--- a/frontend/src/components/tasks/CIStatusIcon.tsx
+++ b/frontend/src/components/tasks/CIStatusIcon.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { Box, Tooltip, Typography, keyframes } from "@mui/material";
+import {
+  CheckCircle as PassedIcon,
+  Cancel as FailedIcon,
+  Sync as RunningIcon,
+} from "@mui/icons-material";
+import { TypesRepoPR } from "../../api/api";
+
+const spin = keyframes`
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+`;
+
+type CIWorstState = "running" | "passed" | "failed" | "none";
+
+const CI_SEVERITY: Record<CIWorstState, number> = {
+  failed: 3,
+  running: 2,
+  passed: 1,
+  none: 0,
+};
+
+function normalize(state?: string): CIWorstState {
+  switch (state) {
+    case "running":
+    case "passed":
+    case "failed":
+      return state;
+    default:
+      return "none";
+  }
+}
+
+function worstStatus(prs: TypesRepoPR[]): CIWorstState {
+  let worst: CIWorstState = "none";
+  for (const pr of prs) {
+    const s = normalize(pr.ci_status);
+    if (CI_SEVERITY[s] > CI_SEVERITY[worst]) worst = s;
+  }
+  return worst;
+}
+
+interface CIStatusIconProps {
+  prs?: TypesRepoPR[];
+}
+
+const CIStatusIcon: React.FC<CIStatusIconProps> = ({ prs }) => {
+  if (!prs || prs.length === 0) return null;
+
+  const worst = worstStatus(prs);
+  if (worst === "none") return null;
+
+  let icon: React.ReactNode;
+  let color: string;
+  let label: string;
+  switch (worst) {
+    case "passed":
+      icon = <PassedIcon sx={{ fontSize: 14 }} />;
+      color = "#10b981";
+      label = "CI passed";
+      break;
+    case "failed":
+      icon = <FailedIcon sx={{ fontSize: 14 }} />;
+      color = "#ef4444";
+      label = "CI failed";
+      break;
+    case "running":
+      icon = (
+        <RunningIcon
+          sx={{ fontSize: 14, animation: `${spin} 2s linear infinite` }}
+        />
+      );
+      color = "#f59e0b";
+      label = "CI running";
+      break;
+  }
+
+  // Pick the first PR that has a usable CI URL — when only one PR is
+  // tracked (the common case), this opens the right page directly.
+  const targetURL = prs.find((p) => p.ci_url)?.ci_url;
+
+  const tooltip = (
+    <Box>
+      <Typography variant="caption" sx={{ fontWeight: 600 }}>
+        {label}
+      </Typography>
+      {prs.map((pr, idx) => {
+        const state = normalize(pr.ci_status);
+        if (state === "none") return null;
+        return (
+          <Box key={`${pr.repository_id}-${idx}`} sx={{ mt: 0.5 }}>
+            <Typography variant="caption" sx={{ display: "block" }}>
+              {pr.repository_name} #{pr.pr_number}: {state}
+            </Typography>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (targetURL) window.open(targetURL, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <Tooltip title={tooltip} placement="top" arrow>
+      <Box
+        onClick={handleClick}
+        sx={{
+          display: "inline-flex",
+          alignItems: "center",
+          color,
+          cursor: targetURL ? "pointer" : "default",
+          ml: 0.25,
+          flexShrink: 0,
+        }}
+      >
+        {icon}
+      </Box>
+    </Tooltip>
+  );
+};
+
+export default CIStatusIcon;

--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -54,6 +54,7 @@ import {
   ServerBatchTaskUsageMetric,
 } from "../../api/api";
 import UsagePulseChart from "./UsagePulseChart";
+import CIStatusIcon from "./CIStatusIcon";
 import ExternalAgentDesktopViewer from "../external-agent/ExternalAgentDesktopViewer";
 import CloneTaskDialog from "../specTask/CloneTaskDialog";
 import CloneGroupProgressFull from "../specTask/CloneGroupProgress";
@@ -125,6 +126,10 @@ export interface SpecTaskWithExtras {
     pr_number?: number;
     pr_url?: string;
     pr_state?: string;
+    ci_status?: string;
+    ci_url?: string;
+    ci_updated_at?: string;
+    ci_head_sha?: string;
   }>;
   implementation_approved_at?: string;
   // Branch tracking for direct-push detection
@@ -1022,6 +1027,7 @@ function TaskCardInner({
                 • {runningDuration}
               </Typography>
             )}
+            <CIStatusIcon prs={task.repo_pull_requests} />
           </Box>
 
           {/* Assignee avatar */}
@@ -1609,6 +1615,15 @@ function TaskCardInner({
   );
 }
 
+// Compact signature of CI state across all PRs — picks up changes to any
+// ci_status / ci_url / ci_head_sha so the card re-renders when CI moves.
+function ciSignature(prs?: SpecTaskWithExtras["repo_pull_requests"]): string {
+  if (!prs || prs.length === 0) return "";
+  return prs
+    .map((p) => `${p.pr_id ?? ""}:${p.ci_status ?? ""}:${p.ci_head_sha ?? ""}`)
+    .join("|");
+}
+
 // Memoized TaskCard to prevent unnecessary re-renders
 const TaskCard = React.memo(TaskCardInner, (prevProps, nextProps) => {
   // Only re-render when meaningful props change
@@ -1619,6 +1634,7 @@ const TaskCard = React.memo(TaskCardInner, (prevProps, nextProps) => {
     prevProps.task.agent_work_state === nextProps.task.agent_work_state &&
     prevProps.task.sandbox_state === nextProps.task.sandbox_state &&
     prevProps.task.sandbox_status_message === nextProps.task.sandbox_status_message &&
+    ciSignature(prevProps.task.repo_pull_requests) === ciSignature(nextProps.task.repo_pull_requests) &&
     prevProps.isArchiving === nextProps.isArchiving &&
     prevProps.isVisible === nextProps.isVisible &&
     prevProps.focusStartPlanning === nextProps.focusStartPlanning &&

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -3040,6 +3040,8 @@ definitions:
     - spec_failed
     - implementation_failed
     - pr_ready
+    - ci_passed
+    - ci_failed
     type: string
     x-enum-varnames:
     - AttentionEventSpecsPushed
@@ -3047,6 +3049,8 @@ definitions:
     - AttentionEventSpecFailed
     - AttentionEventImplementationFailed
     - AttentionEventPRReady
+    - AttentionEventCIPassed
+    - AttentionEventCIFailed
   types.AttentionEventUpdateRequest:
     properties:
       acknowledge:
@@ -6715,6 +6719,13 @@ definitions:
         type: string
       description:
         type: string
+      head_sha:
+        description: |-
+          HeadSHA is the commit SHA at the tip of the PR's source branch.
+          Used by the CI status poller to detect new pushes and to query the
+          provider's CI/build APIs for the right commit. Empty if the
+          provider response did not include it.
+        type: string
       id:
         type: string
       number:
@@ -6956,6 +6967,21 @@ definitions:
     type: object
   types.RepoPR:
     properties:
+      ci_head_sha:
+        type: string
+      ci_status:
+        description: |-
+          CI status, populated by the spec task orchestrator's PR poll loop.
+          CIStatus is one of: "" (not yet evaluated), "running", "passed",
+          "failed", "none" (CI not configured for the PR's head SHA).
+          CIHeadSHA is the head commit we last evaluated; it lets the poller
+          detect a new push and reset CIStatus so a stale "passed" doesn't
+          suppress a fresh notification when the next commit fails.
+        type: string
+      ci_updated_at:
+        type: string
+      ci_url:
+        type: string
       pr_id:
         type: string
       pr_number:

--- a/openapi.json
+++ b/openapi.json
@@ -26279,14 +26279,18 @@
                     "agent_interaction_completed",
                     "spec_failed",
                     "implementation_failed",
-                    "pr_ready"
+                    "pr_ready",
+                    "ci_passed",
+                    "ci_failed"
                 ],
                 "x-enum-varnames": [
                     "AttentionEventSpecsPushed",
                     "AttentionEventAgentInteractionCompleted",
                     "AttentionEventSpecFailed",
                     "AttentionEventImplementationFailed",
-                    "AttentionEventPRReady"
+                    "AttentionEventPRReady",
+                    "AttentionEventCIPassed",
+                    "AttentionEventCIFailed"
                 ]
             },
             "types.AttentionEventUpdateRequest": {
@@ -31459,6 +31463,10 @@
                     "description": {
                         "type": "string"
                     },
+                    "head_sha": {
+                        "description": "HeadSHA is the commit SHA at the tip of the PR's source branch.\nUsed by the CI status poller to detect new pushes and to query the\nprovider's CI/build APIs for the right commit. Empty if the\nprovider response did not include it.",
+                        "type": "string"
+                    },
                     "id": {
                         "type": "string"
                     },
@@ -31794,6 +31802,19 @@
             "types.RepoPR": {
                 "type": "object",
                 "properties": {
+                    "ci_head_sha": {
+                        "type": "string"
+                    },
+                    "ci_status": {
+                        "description": "CI status, populated by the spec task orchestrator's PR poll loop.\nCIStatus is one of: \"\" (not yet evaluated), \"running\", \"passed\",\n\"failed\", \"none\" (CI not configured for the PR's head SHA).\nCIHeadSHA is the head commit we last evaluated; it lets the poller\ndetect a new push and reset CIStatus so a stale \"passed\" doesn't\nsuppress a fresh notification when the next commit fails.",
+                        "type": "string"
+                    },
+                    "ci_updated_at": {
+                        "type": "string"
+                    },
+                    "ci_url": {
+                        "type": "string"
+                    },
                     "pr_id": {
                         "type": "string"
                     },

--- a/swagger.json
+++ b/swagger.json
@@ -22455,14 +22455,18 @@
                 "agent_interaction_completed",
                 "spec_failed",
                 "implementation_failed",
-                "pr_ready"
+                "pr_ready",
+                "ci_passed",
+                "ci_failed"
             ],
             "x-enum-varnames": [
                 "AttentionEventSpecsPushed",
                 "AttentionEventAgentInteractionCompleted",
                 "AttentionEventSpecFailed",
                 "AttentionEventImplementationFailed",
-                "AttentionEventPRReady"
+                "AttentionEventPRReady",
+                "AttentionEventCIPassed",
+                "AttentionEventCIFailed"
             ]
         },
         "types.AttentionEventUpdateRequest": {
@@ -27635,6 +27639,10 @@
                 "description": {
                     "type": "string"
                 },
+                "head_sha": {
+                    "description": "HeadSHA is the commit SHA at the tip of the PR's source branch.\nUsed by the CI status poller to detect new pushes and to query the\nprovider's CI/build APIs for the right commit. Empty if the\nprovider response did not include it.",
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -27970,6 +27978,19 @@
         "types.RepoPR": {
             "type": "object",
             "properties": {
+                "ci_head_sha": {
+                    "type": "string"
+                },
+                "ci_status": {
+                    "description": "CI status, populated by the spec task orchestrator's PR poll loop.\nCIStatus is one of: \"\" (not yet evaluated), \"running\", \"passed\",\n\"failed\", \"none\" (CI not configured for the PR's head SHA).\nCIHeadSHA is the head commit we last evaluated; it lets the poller\ndetect a new push and reset CIStatus so a stale \"passed\" doesn't\nsuppress a fresh notification when the next commit fails.",
+                    "type": "string"
+                },
+                "ci_updated_at": {
+                    "type": "string"
+                },
+                "ci_url": {
+                    "type": "string"
+                },
                 "pr_id": {
                     "type": "string"
                 },


### PR DESCRIPTION
## Summary

Adds a small CI status indicator to each Kanban task card (running / passed / failed) and pipes CI transitions through to the running agent + the human attention feed — all without making the card any taller. Polling reuses the existing 30 s PR poll loop in the spec-task orchestrator, so there's no new infrastructure.

Closes the user's request: "Show a CI status field in the Kanban card view. I want to know if CI is running, failed, or passed at a glance. ... we should immediately notify the agent ... we should also be careful not to make the card view any taller."

## Changes

**Backend**
- `RepoPR` extended with `CIStatus` / `CIURL` / `CIUpdatedAt` / `CIHeadSHA` (JSONB — no migration).
- Provider clients gain `GetCIStatus`:
  - **GitHub** combines Combined Status API + Check Runs API, worst-state wins.
  - **GitLab** uses `Pipelines.ListProjectPipelines` filtered by SHA.
  - **Azure DevOps** queries the Build API and matches by `SourceVersion`. **Requires `vso.build` scope**; missing-scope errors degrade gracefully to "none" and emit a one-time warn log so existing PATs don't break the UI.
  - **Bitbucket** stub returns `none` (v2).
- `types.PullRequest.HeadSHA` plumbed through every provider's PR mapper.
- New `GitRepositoryService.GetCIStatus(repoID, prID, headSHA)` dispatcher + `services.NormalizeCIStatus(provider, raw)` helper (one canonical of `running` / `passed` / `failed` / `none`).
- Orchestrator extended: inside the existing `processExternalPullRequestStatus`, every tracked PR now also has its CI status polled. New head SHA → cached state reset (so a stale "passed" doesn't suppress the next failure notification). On `running → passed` and `running → failed`, fires both:
  - A chat message to the running agent via the existing `SpecTaskMessageSender` (offline → waiting interaction queue, same as design-review notifications), `interrupt: false`.
  - A `ci_passed` / `ci_failed` `AttentionEvent` for the human (red dot on the card, optional Slack).
- New `CINotifier` interface + `MessageSenderCINotifier` implementation, wired in `pkg/server/server.go`.

**Frontend**
- New `CIStatusIcon.tsx` component renders a single 14 px MUI icon (animated `Sync` for running, `CheckCircle` for passed, `Cancel` for failed), with a tooltip listing each PR's CI state and clickable through to the provider's CI page. Worst-state aggregation across multiple PRs (failed > running > passed > none).
- Slotted inline into the existing status row in `TaskCard.tsx` between the phase label and the assignee avatar — **no extra row, no height change**.
- Memo comparator updated with a CI signature so cards re-render when CI moves.
- Generated API client regenerated via `./stack update_openapi`.

**Tests**
- `NormalizeCIStatus` unit tests cover every provider's verdicts (including unknown → failed).
- Orchestrator transition tests verify: first-observation silent, `running → passed` notifies once, `running → failed` notifies once with logs link, no-op transitions don't notify, nil notifier doesn't panic.

## Visual verification

Inserted three spec tasks directly into the DB with hand-crafted CI states; the Kanban board renders all three icons inline in the existing status row with no card-height change.

![Kanban cards showing CI status icons](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001993_show-a-ci-status-field/screenshots/01-kanban-with-ci-icons.png)

## Out of scope (follow-ups)

- Webhook-driven CI updates for github.com (latency optimisation; polling at 30 s is fine for v1).
- Bitbucket CI status implementation.
- Per-project notification toggle in settings.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kr11z60ss4c2crdr7hj88va8)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001993_show-a-ci-status-field/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001993_show-a-ci-status-field/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001993_show-a-ci-status-field/tasks.md)

🚀 Built with [Helix](https://helix.ml)