### PR TITLE
Pin docker-ce and containerd.io versions in sandbox image

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -138,6 +138,20 @@ _INSTALL_ROCM
 # ====================================================================
 # Install Docker + NVIDIA Container Toolkit
 # ====================================================================
+# Pin docker-ce and containerd.io versions explicitly. Without pinning,
+# every sandbox image rebuild silently picks up whatever apt has on the
+# day, which has bitten us across Helix patch releases (e.g. 2.11.0 ->
+# 2.11.2 jumped to Docker 29.x and broke pods reusing the persisted
+# /var/lib/docker PVC). Bumping these is now a deliberate change.
+#
+# To find current versions in the Docker apt repo for the build's Ubuntu
+# release, inside a build of this stage run:
+#   apt-cache madison docker-ce containerd.io
+# Format is "5:VERSION-1~ubuntu.<release>~<codename>" for docker-ce and
+# "VERSION-1~ubuntu.<release>~<codename>" for containerd.io. Bump in
+# this file when ready to upgrade.
+ARG DOCKER_VERSION=5:29.2.1-1~ubuntu.25.04~plucky
+ARG CONTAINERD_VERSION=2.2.1-1~ubuntu.25.04~plucky
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -149,9 +163,9 @@ RUN apt-get update -y && \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends \
-    docker-ce-cli \
-    docker-ce \
-    containerd.io \
+    docker-ce-cli=${DOCKER_VERSION} \
+    docker-ce=${DOCKER_VERSION} \
+    containerd.io=${CONTAINERD_VERSION} \
     docker-buildx-plugin \
     docker-compose-plugin \
     iproute2 \


### PR DESCRIPTION
## Summary

- The sandbox image installs `docker-ce` / `containerd.io` via apt with no version pin, so each rebuild silently picks up whatever apt has on the day.
- Between Helix 2.11.0 and 2.11.2 this caused a major Docker version bump (to 29.2.1). Customer pods that reused the persisted `/var/lib/docker` Longhorn PVC then failed to start: the new dockerd's containerd handshake hung on runtime state left behind by the older daemon, the auto-restart loop never converged, and the readiness probe (`docker info`) never went green. Recovery required deleting the docker PVC by hand.
- Pin `docker-ce`, `docker-ce-cli`, and `containerd.io` to their current shipping versions via build `ARG`s. Bumps now require an explicit edit to `Dockerfile.sandbox`, so we don't silently ship daemon-version jumps in patch releases.

## Pinned versions

| Package | Pinned to |
|---|---|
| `docker-ce` / `docker-ce-cli` | `5:29.2.1-1~ubuntu.25.04~plucky` |
| `containerd.io` | `2.2.1-1~ubuntu.25.04~plucky` |

Both verified to exist on amd64 and arm64 in `https://download.docker.com/linux/ubuntu/dists/plucky/pool/stable/`. The containerd choice is the highest plucky-codename version available, which is what unpinned apt would have selected in the 2.11.2 build, so this preserves current shipping behavior while making it explicit.

## What this does NOT fix

Existing customers who already have a poisoned `/var/lib/docker` PVC from the silent daemon bump still need the PVC-wipe runbook to recover. This change just stops it from happening again on future bumps.

A separate proposal (version-stamp `/var/lib/docker` and targeted-wipe on mismatch) would self-heal that case for the next time we deliberately bump Docker, but is not in this PR.

## Test plan

- [ ] `./stack build-sandbox` succeeds against pinned versions
- [ ] Resulting image: `docker run --rm --privileged <image> dockerd --version` reports `29.2.1`
- [ ] Resulting image: `containerd --version` reports `2.2.1`
- [ ] CI sandbox-build pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)