### PR TITLE
Auto-clear attention events when a task transitions to Done

### DIFF
--- a/api/pkg/server/spec_task_workflow_handlers.go
+++ b/api/pkg/server/spec_task_workflow_handlers.go
@@ -381,6 +381,7 @@ func (s *HelixAPIServer) approveImplementation(w http.ResponseWriter, r *http.Re
 		http.Error(w, fmt.Sprintf("Failed to update spec task: %s", err.Error()), http.StatusInternalServerError)
 		return
 	}
+	services.DismissTaskAttentionEvents(ctx, s.Store, specTask.ID)
 
 	log.Info().
 		Str("task_id", specTask.ID).

--- a/api/pkg/services/attention_service.go
+++ b/api/pkg/services/attention_service.go
@@ -118,6 +118,26 @@ func (s *AttentionService) EmitEvent(
 	return created, nil
 }
 
+// DismissTaskAttentionEvents clears all active attention events for a task
+// that has reached a terminal state (typically "done" / merged to main). It is
+// best-effort: failures are logged but never propagated, so a notification
+// cleanup error cannot roll back a task state transition.
+func DismissTaskAttentionEvents(ctx context.Context, s store.Store, taskID string) {
+	if s == nil || taskID == "" {
+		return
+	}
+	n, err := s.DismissAttentionEventsForTask(ctx, taskID)
+	if err != nil {
+		log.Warn().Err(err).Str("task_id", taskID).
+			Msg("Failed to clear attention events for finished task (non-fatal)")
+		return
+	}
+	if n > 0 {
+		log.Info().Int64("dismissed", n).Str("task_id", taskID).
+			Msg("Cleared attention events for finished task")
+	}
+}
+
 // notifySlack posts an attention event as a threaded reply in the project's
 // Slack channel. It looks up the project's app with ProjectUpdates enabled,
 // finds the existing SlackThread for this spectask, and posts a reply.

--- a/api/pkg/services/git_http_server.go
+++ b/api/pkg/services/git_http_server.go
@@ -1125,6 +1125,7 @@ func (s *GitHTTPServer) tryAutoMergeAfterRebase(ctx context.Context, taskID stri
 		log.Error().Err(err).Str("task_id", task.ID).Msg("auto-merge: failed to mark task done after successful auto-merge")
 		return
 	}
+	DismissTaskAttentionEvents(ctx, s.store, task.ID)
 
 	log.Info().
 		Str("task_id", task.ID).
@@ -1173,7 +1174,9 @@ func (s *GitHTTPServer) handleMainBranchPush(ctx context.Context, repo *types.Gi
 			task.UpdatedAt = now
 			if err := s.store.UpdateSpecTask(ctx, task); err != nil {
 				log.Error().Err(err).Str("task_id", task.ID).Msg("Failed to update task")
+				continue
 			}
+			DismissTaskAttentionEvents(ctx, s.store, task.ID)
 		}
 	}
 }

--- a/api/pkg/services/git_http_server_auto_merge_test.go
+++ b/api/pkg/services/git_http_server_auto_merge_test.go
@@ -102,6 +102,7 @@ func TestTryAutoMergeAfterRebase_InternalRepoSuccess(t *testing.T) {
 	mockStore.EXPECT().GetProject(gomock.Any(), "prj_test").Return(project, nil)
 	mockStore.EXPECT().GetGitRepository(gomock.Any(), "repo_test").Return(gitRepo, nil)
 	mockStore.EXPECT().UpdateSpecTask(gomock.Any(), task).Return(nil)
+	mockStore.EXPECT().DismissAttentionEventsForTask(gomock.Any(), "spt_test").Return(int64(0), nil)
 
 	srv := &GitHTTPServer{store: mockStore}
 	srv.tryAutoMergeAfterRebase(ctx, "spt_test")

--- a/api/pkg/services/spec_task_orchestrator.go
+++ b/api/pkg/services/spec_task_orchestrator.go
@@ -810,7 +810,11 @@ func (o *SpecTaskOrchestrator) processExternalPullRequestStatus(ctx context.Cont
 			}
 		}
 
-		return o.store.UpdateSpecTask(ctx, task)
+		if err := o.store.UpdateSpecTask(ctx, task); err != nil {
+			return err
+		}
+		DismissTaskAttentionEvents(ctx, o.store, task.ID)
+		return nil
 	}
 
 	if allClosed && !anyOpen && len(task.RepoPullRequests) > 0 {
@@ -867,7 +871,11 @@ func (o *SpecTaskOrchestrator) processExternalPullRequestStatus(ctx context.Cont
 			task.MergedAt = &now
 			task.CompletedAt = &now
 			task.UpdatedAt = now
-			return o.store.UpdateSpecTask(ctx, task)
+			if err := o.store.UpdateSpecTask(ctx, task); err != nil {
+				return err
+			}
+			DismissTaskAttentionEvents(ctx, o.store, task.ID)
+			return nil
 		}
 	}
 
@@ -1096,7 +1104,11 @@ func (o *SpecTaskOrchestrator) checkTaskForExternalPRActivity(ctx context.Contex
 				task.MergedAt = &now
 				task.CompletedAt = &now
 				task.UpdatedAt = now
-				return o.store.UpdateSpecTask(ctx, task)
+				if err := o.store.UpdateSpecTask(ctx, task); err != nil {
+					return err
+				}
+				DismissTaskAttentionEvents(ctx, o.store, task.ID)
+				return nil
 			}
 		}
 	}
@@ -1139,7 +1151,11 @@ func (o *SpecTaskOrchestrator) checkTaskForExternalPRActivity(ctx context.Contex
 		task.MergedAt = &now
 		task.CompletedAt = &now
 		task.UpdatedAt = now
-		return o.store.UpdateSpecTask(ctx, task)
+		if err := o.store.UpdateSpecTask(ctx, task); err != nil {
+			return err
+		}
+		DismissTaskAttentionEvents(ctx, o.store, task.ID)
+		return nil
 	}
 
 	return nil

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -610,6 +610,7 @@ type Store interface {
 	GetAttentionEvent(ctx context.Context, id string) (*types.AttentionEvent, error)
 	UpdateAttentionEvent(ctx context.Context, id string, update *types.AttentionEventUpdateRequest) error
 	BulkDismissAttentionEvents(ctx context.Context, userID, organizationID string) (int64, error)
+	DismissAttentionEventsForTask(ctx context.Context, specTaskID string) (int64, error)
 	CleanupExpiredAttentionEvents(ctx context.Context, olderThan time.Duration) (int64, error)
 
 	// Clone Group methods

--- a/api/pkg/store/store_attention_events.go
+++ b/api/pkg/store/store_attention_events.go
@@ -202,6 +202,26 @@ func (s *PostgresStore) BulkDismissAttentionEvents(ctx context.Context, userID, 
 	return result.RowsAffected, nil
 }
 
+// DismissAttentionEventsForTask marks every active (not yet dismissed) attention
+// event for the given spec task as dismissed. Used to auto-clear notifications
+// when a task transitions to a terminal state. Idempotent.
+func (s *PostgresStore) DismissAttentionEventsForTask(ctx context.Context, specTaskID string) (int64, error) {
+	if specTaskID == "" {
+		return 0, fmt.Errorf("spec task ID is required")
+	}
+
+	now := time.Now()
+	result := s.gdb.WithContext(ctx).
+		Model(&types.AttentionEvent{}).
+		Where("spec_task_id = ? AND dismissed_at IS NULL", specTaskID).
+		Update("dismissed_at", &now)
+	if result.Error != nil {
+		return 0, fmt.Errorf("failed to dismiss attention events for task: %w", result.Error)
+	}
+
+	return result.RowsAffected, nil
+}
+
 // CleanupExpiredAttentionEvents deletes dismissed events older than the given duration.
 func (s *PostgresStore) CleanupExpiredAttentionEvents(ctx context.Context, olderThan time.Duration) (int64, error) {
 	cutoff := time.Now().Add(-olderThan)

--- a/api/pkg/store/store_attention_events_test.go
+++ b/api/pkg/store/store_attention_events_test.go
@@ -1,0 +1,79 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// TestPostgresStore_DismissAttentionEventsForTask covers the auto-clear path
+// used when a spec task transitions to a terminal state (e.g. merged to main).
+func (suite *PostgresStoreTestSuite) TestPostgresStore_DismissAttentionEventsForTask() {
+	ctx := context.Background()
+
+	taskA := "task_" + system.GenerateUUID()
+	taskB := "task_" + system.GenerateUUID()
+	user := "user_" + system.GenerateUUID()
+	org := "org_" + system.GenerateUUID()
+	project := "prj_" + system.GenerateUUID()
+
+	mkEvent := func(taskID string, qualifier string) *types.AttentionEvent {
+		return &types.AttentionEvent{
+			ID:             system.GenerateAttentionEventID(),
+			UserID:         user,
+			OrganizationID: org,
+			ProjectID:      project,
+			SpecTaskID:     taskID,
+			EventType:      types.AttentionEventAgentInteractionCompleted,
+			Title:          "Agent finished working",
+			CreatedAt:      time.Now(),
+			IdempotencyKey: types.BuildAttentionEventIdempotencyKey(taskID, types.AttentionEventAgentInteractionCompleted, qualifier),
+		}
+	}
+
+	e1 := mkEvent(taskA, "1")
+	e2 := mkEvent(taskA, "2")
+	other := mkEvent(taskB, "1")
+
+	for _, e := range []*types.AttentionEvent{e1, e2, other} {
+		_, err := suite.db.CreateAttentionEvent(ctx, e)
+		suite.Require().NoError(err)
+		suite.T().Cleanup(func() {
+			_ = suite.db.gdb.WithContext(ctx).Where("id = ?", e.ID).Delete(&types.AttentionEvent{}).Error
+		})
+	}
+
+	// First call dismisses both events for taskA.
+	n, err := suite.db.DismissAttentionEventsForTask(ctx, taskA)
+	suite.Require().NoError(err)
+	suite.Equal(int64(2), n)
+
+	// taskA events are dismissed.
+	got1, err := suite.db.GetAttentionEvent(ctx, e1.ID)
+	suite.Require().NoError(err)
+	suite.NotNil(got1.DismissedAt)
+	got2, err := suite.db.GetAttentionEvent(ctx, e2.ID)
+	suite.Require().NoError(err)
+	suite.NotNil(got2.DismissedAt)
+
+	// taskB event is untouched.
+	gotOther, err := suite.db.GetAttentionEvent(ctx, other.ID)
+	suite.Require().NoError(err)
+	suite.Nil(gotOther.DismissedAt)
+
+	// Idempotent: a second call returns 0 with no error.
+	n, err = suite.db.DismissAttentionEventsForTask(ctx, taskA)
+	suite.Require().NoError(err)
+	suite.Equal(int64(0), n)
+
+	// Unknown task ID is a no-op (0 rows, no error).
+	n, err = suite.db.DismissAttentionEventsForTask(ctx, "task_does_not_exist")
+	suite.Require().NoError(err)
+	suite.Equal(int64(0), n)
+
+	// Empty task ID is a validation error.
+	_, err = suite.db.DismissAttentionEventsForTask(ctx, "")
+	suite.Error(err)
+}

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -2010,6 +2010,21 @@ func (mr *MockStoreMockRecorder) DetachRepositoryFromProject(ctx, projectID, rep
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachRepositoryFromProject", reflect.TypeOf((*MockStore)(nil).DetachRepositoryFromProject), ctx, projectID, repoID)
 }
 
+// DismissAttentionEventsForTask mocks base method.
+func (m *MockStore) DismissAttentionEventsForTask(ctx context.Context, specTaskID string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DismissAttentionEventsForTask", ctx, specTaskID)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DismissAttentionEventsForTask indicates an expected call of DismissAttentionEventsForTask.
+func (mr *MockStoreMockRecorder) DismissAttentionEventsForTask(ctx, specTaskID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DismissAttentionEventsForTask", reflect.TypeOf((*MockStore)(nil).DismissAttentionEventsForTask), ctx, specTaskID)
+}
+
 // EnsureUserMeta mocks base method.
 func (m *MockStore) EnsureUserMeta(ctx context.Context, UserMeta types.UserMeta) (*types.UserMeta, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary

When a spec task is merged to main, the bell-icon notifications and Kanban red-dot badges that accumulated during its lifecycle (specs pushed, agent finished, PR ready, etc.) used to linger until the user clicked them or hit "Dismiss all". They're no longer actionable once the task is done — so we now clear them automatically as part of the Done transition.

## Changes

- **`api/pkg/store/store.go`** — added `DismissAttentionEventsForTask(ctx, specTaskID) (int64, error)` to the `Store` interface.
- **`api/pkg/store/store_attention_events.go`** — implemented it: a single `UPDATE attention_events SET dismissed_at = now() WHERE spec_task_id = ? AND dismissed_at IS NULL`. Idempotent.
- **`api/pkg/store/store_mocks.go`** — regenerated by `mockgen`.
- **`api/pkg/store/store_attention_events_test.go`** (new) — covers: dismisses target task only, leaves other tasks alone, idempotent re-run returns 0, unknown task ID is a no-op, empty task ID is a validation error.
- **`api/pkg/services/attention_service.go`** — added a small free function `DismissTaskAttentionEvents(ctx, store, taskID)` that wraps the store call with best-effort logging (failures are logged but never propagated, so a notification-clear failure cannot roll back a task state transition).
- **Wired into 7 Done-transition call sites:**
  - `api/pkg/services/git_http_server.go` — agent auto-merge after rebase, and the post-push branch-merged-to-main detector.
  - `api/pkg/services/spec_task_orchestrator.go` — all-PRs-merged path, the per-PR merge detection, the branch-merged-without-PR fallback, and the branch-merge poll fallback.
  - `api/pkg/server/spec_task_workflow_handlers.go` — the user-driven "Approve Implementation" server-side merge handler.

## Why this approach

- **Server-side dismissal, not a new acknowledge endpoint.** The events are no longer actionable, so we *dismiss* (remove from the active list) rather than acknowledge (which only clears the "new" state but keeps them visible).
- **No new API or pubsub.** With a fixed handful of call sites, calling a helper directly is simpler and easier to grep than introducing an event channel.
- **Best-effort, not transactional.** A DB failure on the dismiss call must not roll back the Done transition — we log and move on. Manual "Dismiss all" still works.
- **No frontend changes.** `useAttentionEvents` already polls every 10s and `ListAttentionEvents` already filters out dismissed rows; the next poll naturally drops the events.

## Test plan

- [ ] CI runs the new `TestPostgresStore_DismissAttentionEventsForTask` against Postgres
- [ ] Manual smoke: create a task, let it accumulate at least one attention event (e.g. let agent push specs), merge to main, and confirm the red dot disappears from its Kanban card and the bell badge count drops within ~10s

## Out of scope

- Archived tasks (separate user action; we still let users dismiss manually)
- Failed tasks (`spec_failed` / `implementation_failed`) — the failure event itself is the signal the user needs
- Browser/OS push notifications already popped (owned by the OS, dedup'd by tag)
- Already-posted Slack thread replies (not retracted)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kn3478kfhzxbnbete22488zw)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001673_when-a-task-is-finished/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001673_when-a-task-is-finished/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001673_when-a-task-is-finished/tasks.md)

🚀 Built with [Helix](https://helix.ml)