### PR TITLE
Skip "agent finished" notification when user is already active in session

### DIFF
--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -2558,8 +2558,36 @@ func (apiServer *HelixAPIServer) handleMessageCompleted(sessionID string, syncMs
 	if helixSession.Metadata.SpecTaskID != "" {
 		go apiServer.updateSpecTaskZedThreadActivity(context.Background(), acpThreadID)
 
-		// Emit attention event: agent interaction completed
-		if apiServer.attentionService != nil {
+		// Emit attention event: agent interaction completed.
+		//
+		// Skip the notification when the user is clearly already active in the
+		// session — either they interrupted the agent (sent a new message that
+		// caused this completion) or they sent a quick follow-up. In both cases
+		// a newer interaction with state=waiting already exists, and notifying
+		// is just noise because the user is looking right at the UI.
+		skipAttention := false
+		latestInteractions, _, listErr := apiServer.Controller.Options.Store.ListInteractions(context.Background(), &types.ListInteractionsQuery{
+			SessionID:    helixSessionID,
+			GenerationID: helixSession.GenerationID,
+			PerPage:      1,
+		})
+		if listErr != nil {
+			log.Warn().Err(listErr).
+				Str("session_id", helixSessionID).
+				Msg("Failed to list interactions for attention-event suppression check; emitting event as default")
+		} else if len(latestInteractions) > 0 {
+			latest := latestInteractions[len(latestInteractions)-1]
+			if latest.State == types.InteractionStateWaiting && latest.Created.After(targetInteraction.Created) {
+				log.Debug().
+					Str("session_id", helixSessionID).
+					Str("completed_interaction_id", targetInteraction.ID).
+					Str("newer_waiting_interaction_id", latest.ID).
+					Msg("Skipping agent_interaction_completed attention event: user already active in session")
+				skipAttention = true
+			}
+		}
+
+		if !skipAttention && apiServer.attentionService != nil {
 			go func() {
 				task, err := apiServer.Controller.Options.Store.GetSpecTask(context.Background(), helixSession.Metadata.SpecTaskID)
 				if err != nil {

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/helixml/helix/api/pkg/controller"
 	"github.com/helixml/helix/api/pkg/pubsub"
 	"github.com/helixml/helix/api/pkg/server/wsprotocol"
+	"github.com/helixml/helix/api/pkg/services"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/suite"
@@ -953,6 +954,153 @@ func (s *WebSocketSyncSuite) TestMessageCompleted_WithCommentFinalization() {
 	s.NoError(err)
 
 	time.Sleep(100 * time.Millisecond)
+}
+
+// TestMessageCompleted_SkipsAttentionWhenUserActive verifies that the
+// agent_interaction_completed attention event is suppressed when a newer
+// waiting interaction already exists in the session — i.e. the user has
+// either interrupted the agent or sent a quick follow-up. In both cases the
+// user is clearly looking at the UI and an "agent finished" notification
+// would just be noise.
+func (s *WebSocketSyncSuite) TestMessageCompleted_SkipsAttentionWhenUserActive() {
+	s.server.contextMappings["thread-skip"] = "ses_skip"
+	s.server.requestToInteractionMapping["req-skip"] = "int-target-skip"
+	s.server.attentionService = services.NewAttentionService(s.store, s.server.Cfg)
+
+	session := &types.Session{
+		ID:    "ses_skip",
+		Owner: "user-1",
+		Metadata: types.SessionMetadata{
+			SpecTaskID: "task-skip",
+		},
+	}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_skip").Return(session, nil).AnyTimes()
+
+	baseTime := time.Now().Add(-1 * time.Minute)
+	targetInteraction := &types.Interaction{
+		ID:              "int-target-skip",
+		SessionID:       "ses_skip",
+		State:           types.InteractionStateWaiting,
+		ResponseMessage: "AI response",
+		Created:         baseTime,
+	}
+	newerWaiting := &types.Interaction{
+		ID:        "int-newer-skip",
+		SessionID: "ses_skip",
+		State:     types.InteractionStateWaiting,
+		Created:   baseTime.Add(30 * time.Second),
+	}
+
+	s.store.EXPECT().GetInteraction(gomock.Any(), "int-target-skip").Return(targetInteraction, nil)
+	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).Return(targetInteraction, nil)
+
+	// ListInteractions is called for both the suppression check (PerPage=1)
+	// and the final session publish (PerPage=1000). Both return the same
+	// list — newerWaiting at the end is what triggers suppression.
+	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
+		[]*types.Interaction{targetInteraction, newerWaiting}, int64(2), nil,
+	).AnyTimes()
+
+	// updateSpecTaskZedThreadActivity goroutine — not a tracked thread
+	s.store.EXPECT().GetSpecTaskZedThreadByZedThreadID(gomock.Any(), "thread-skip").
+		Return(nil, fmt.Errorf("not found")).AnyTimes()
+
+	s.store.EXPECT().GetNextPendingPrompt(gomock.Any(), "ses_skip").Return(nil, nil).AnyTimes()
+	s.store.EXPECT().GetCommentByRequestID(gomock.Any(), "req-skip").
+		Return(nil, fmt.Errorf("not found")).AnyTimes()
+
+	// CRITICAL: GetSpecTask MUST NOT be called when the notification is suppressed.
+	// gomock's default strict mode will fail the test if it is called without an EXPECT.
+
+	syncMsg := &types.SyncMessage{
+		EventType: "message_completed",
+		Data: map[string]interface{}{
+			"acp_thread_id": "thread-skip",
+			"request_id":    "req-skip",
+		},
+	}
+
+	err := s.server.handleMessageCompleted("agent-1", syncMsg)
+	s.NoError(err)
+
+	// Give any goroutines (which we expect NOT to fire GetSpecTask) time to run
+	time.Sleep(150 * time.Millisecond)
+}
+
+// TestMessageCompleted_EmitsAttentionWhenNoFollowup verifies that the
+// agent_interaction_completed attention event IS emitted when there is no
+// newer waiting interaction — the normal completion case where the user is
+// not actively engaged.
+func (s *WebSocketSyncSuite) TestMessageCompleted_EmitsAttentionWhenNoFollowup() {
+	s.server.contextMappings["thread-emit"] = "ses_emit"
+	s.server.requestToInteractionMapping["req-emit"] = "int-target-emit"
+	s.server.attentionService = services.NewAttentionService(s.store, s.server.Cfg)
+
+	session := &types.Session{
+		ID:    "ses_emit",
+		Owner: "user-1",
+		Metadata: types.SessionMetadata{
+			SpecTaskID: "task-emit",
+		},
+	}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_emit").Return(session, nil).AnyTimes()
+
+	baseTime := time.Now().Add(-1 * time.Minute)
+	targetInteraction := &types.Interaction{
+		ID:              "int-target-emit",
+		SessionID:       "ses_emit",
+		State:           types.InteractionStateWaiting,
+		ResponseMessage: "AI response",
+		Created:         baseTime,
+	}
+
+	s.store.EXPECT().GetInteraction(gomock.Any(), "int-target-emit").Return(targetInteraction, nil)
+	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).Return(targetInteraction, nil)
+
+	// Only the target interaction exists — no newer waiting one. Suppression
+	// check sees Created.After(targetInteraction.Created) == false → emit.
+	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
+		[]*types.Interaction{targetInteraction}, int64(1), nil,
+	).AnyTimes()
+
+	s.store.EXPECT().GetSpecTaskZedThreadByZedThreadID(gomock.Any(), "thread-emit").
+		Return(nil, fmt.Errorf("not found")).AnyTimes()
+
+	s.store.EXPECT().GetNextPendingPrompt(gomock.Any(), "ses_emit").Return(nil, nil).AnyTimes()
+	s.store.EXPECT().GetCommentByRequestID(gomock.Any(), "req-emit").
+		Return(nil, fmt.Errorf("not found")).AnyTimes()
+
+	// GetSpecTask MUST be called when the notification is not suppressed.
+	// We return an error to short-circuit before EmitEvent — the test only
+	// needs to verify the goroutine reached this point.
+	gotSpecTaskCall := make(chan struct{}, 1)
+	s.store.EXPECT().GetSpecTask(gomock.Any(), "task-emit").DoAndReturn(
+		func(_ context.Context, _ string) (*types.SpecTask, error) {
+			select {
+			case gotSpecTaskCall <- struct{}{}:
+			default:
+			}
+			return nil, fmt.Errorf("test stub: spectask not loaded")
+		},
+	).MinTimes(1)
+
+	syncMsg := &types.SyncMessage{
+		EventType: "message_completed",
+		Data: map[string]interface{}{
+			"acp_thread_id": "thread-emit",
+			"request_id":    "req-emit",
+		},
+	}
+
+	err := s.server.handleMessageCompleted("agent-1", syncMsg)
+	s.NoError(err)
+
+	select {
+	case <-gotSpecTaskCall:
+		// success — GetSpecTask was reached, meaning the goroutine fired
+	case <-time.After(500 * time.Millisecond):
+		s.Fail("GetSpecTask was not called within timeout — attention event goroutine did not fire")
+	}
 }
 
 // ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

When an interaction ends because the user sent a new message — either interrupting the agent mid-response or following up immediately after it finishes — the system was emitting an "Agent finished working" attention event. That notification is just noise: the user is clearly already looking at the session.

This change suppresses the `agent_interaction_completed` attention event (and its downstream Slack post / browser notification) whenever the session already has a newer interaction in `waiting` state by the time `message_completed` is processed.

## Changes

- `api/pkg/server/websocket_external_agent_sync.go` — in `handleMessageCompleted()`, before kicking off the attention-event goroutine, query the latest interaction in the session. If it's `state=waiting` and was created after the just-completed interaction, skip the notification with a debug log.
- `api/pkg/server/websocket_external_agent_sync_test.go` — add `TestMessageCompleted_SkipsAttentionWhenUserActive` and `TestMessageCompleted_EmitsAttentionWhenNoFollowup` covering both paths. Tests verify that `GetSpecTask` (the first store call inside the goroutine) is not called when suppressed and is called when not suppressed.

## Behaviour

- Failure of the suppression query falls through to emit the event as normal (safe default).
- Non-spectask sessions are unaffected — the check sits inside the existing `if helixSession.Metadata.SpecTaskID != ""` block.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kn9ktwaxrggf342bw4m8f4fx)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001688_when-an-interaction-ends/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001688_when-an-interaction-ends/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001688_when-an-interaction-ends/tasks.md)

🚀 Built with [Helix](https://helix.ml)