### PR TITLE
After approval, jump to chat/desktop and stop the auto-open bounce

### DIFF
--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -117,17 +117,7 @@ import {
   Copy,
 } from "lucide-react";
 
-// Module-level set: tracks which task IDs have already had their spec auto-opened
-// in this SPA session. Persists across component unmount/remount so that navigating
-// back from the spec review page does not immediately redirect the user again.
-const AUTO_OPENED_KEY = "helix_auto_opened_spec_tasks";
-const getAutoOpenedSpecTasks = (): Set<string> =>
-  new Set(JSON.parse(sessionStorage.getItem(AUTO_OPENED_KEY) || "[]"));
-const addAutoOpenedSpecTask = (id: string) => {
-  const set = getAutoOpenedSpecTasks();
-  set.add(id);
-  sessionStorage.setItem(AUTO_OPENED_KEY, JSON.stringify([...set]));
-};
+import { getAutoOpenedSpecTasks, addAutoOpenedSpecTask } from "../../lib/specTaskAutoOpen";
 
 interface SpecTaskDetailContentProps {
   taskId: string;
@@ -928,10 +918,13 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   // and design docs are available - triggers once per SPA session per task ID.
   // handleReviewSpec itself writes to sessionStorage before the async call, so returning
   // to chat (which remounts this component) never re-triggers the auto-open.
+  // The spec_approved_at guard prevents bouncing the user back to the review page in the
+  // brief window between approval and the cached task.status transitioning away from spec_review.
   useEffect(() => {
     if (
       task?.id &&
       !getAutoOpenedSpecTasks().has(task.id) &&
+      !task?.spec_approved_at &&
       task?.design_docs_pushed_at &&
       account.organizationTools.organization?.name &&
       (task?.status === TypesSpecTaskStatus.TaskStatusSpecReview ||
@@ -939,7 +932,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
     ) {
       handleReviewSpec();
     }
-  }, [task?.id, task?.status, task?.design_docs_pushed_at, handleReviewSpec, account.organizationTools.organization?.name]);
+  }, [task?.id, task?.status, task?.spec_approved_at, task?.design_docs_pushed_at, handleReviewSpec, account.organizationTools.organization?.name]);
 
   // Handle file upload to sandbox
   const handleUploadClick = useCallback(() => {

--- a/frontend/src/lib/specTaskAutoOpen.ts
+++ b/frontend/src/lib/specTaskAutoOpen.ts
@@ -1,0 +1,15 @@
+// Shared sessionStorage helpers for tracking which spec tasks have had their
+// review auto-opened. Used by SpecTaskDetailContent (to guard the auto-open
+// useEffect) and SpecTaskReviewPage (to mark the task on mount so that
+// navigating back to the task detail never re-triggers the auto-open).
+
+export const AUTO_OPENED_KEY = "helix_auto_opened_spec_tasks";
+
+export const getAutoOpenedSpecTasks = (): Set<string> =>
+  new Set(JSON.parse(sessionStorage.getItem(AUTO_OPENED_KEY) || "[]"));
+
+export const addAutoOpenedSpecTask = (id: string): void => {
+  const set = getAutoOpenedSpecTasks();
+  set.add(id);
+  sessionStorage.setItem(AUTO_OPENED_KEY, JSON.stringify([...set]));
+};

--- a/frontend/src/pages/SpecTaskReviewPage.tsx
+++ b/frontend/src/pages/SpecTaskReviewPage.tsx
@@ -18,6 +18,7 @@ import { useDesignReview } from '../services/designReviewService'
 import { useGetProject } from '../services'
 import useAccount from '../hooks/useAccount'
 import { cacheTaskName } from '../lib/navHistory'
+import { addAutoOpenedSpecTask } from '../lib/specTaskAutoOpen'
 
 /**
  * SpecTaskReviewPage - Standalone page for spec review
@@ -47,6 +48,13 @@ const SpecTaskReviewPage: FC = () => {
     if (taskId && task?.name) cacheTaskName(taskId, task.name)
   }, [taskId, task?.name])
 
+  // Mark this task so navigating back to the task detail page does not re-trigger
+  // the spec review auto-open useEffect in SpecTaskDetailContent. Covers any way
+  // the user reached this page (deep link, notification, breadcrumb, post-approval redirect).
+  useEffect(() => {
+    if (taskId) addAutoOpenedSpecTask(taskId)
+  }, [taskId])
+
   // Fetch review data
   const { isLoading: reviewLoading } = useDesignReview(taskId, reviewId, {
     enabled: !!taskId && !!reviewId,
@@ -58,8 +66,9 @@ const SpecTaskReviewPage: FC = () => {
   }
 
   const handleApproved = () => {
-    // After approval, navigate to the workspace so the user can see the agent working
-    account.orgNavigate('project-specs', { id: projectId, openTask: taskId })
+    // After approval the agent is implementing - jump straight to the task's
+    // chat/desktop so the user lands where the action is.
+    account.orgNavigate('project-task-detail', { id: projectId, taskId })
   }
 
   const handleOpenInWorkspace = () => {


### PR DESCRIPTION
## Summary

After a user approves a spec design from the standalone Spec Review page, the app now lands them on the task's chat/desktop view (where the agent is implementing) instead of bouncing them back to the project Kanban — and stays there.

Two changes were needed to make this stick. The navigation target alone was cosmetic: the existing auto-open spec-review `useEffect` in `SpecTaskDetailContent` would re-redirect the user back to the spec the moment they landed on the task detail page, because `task.status` is still cached at `spec_review` for a brief window after approval.

## Changes

- **`frontend/src/pages/SpecTaskReviewPage.tsx`**:
  - `handleApproved` now navigates to `project-task-detail` (chat/desktop) instead of `project-specs?openTask=...` (Kanban).
  - On mount, the page writes the task ID to the `helix_auto_opened_spec_tasks` sessionStorage dedupe set, so the auto-open useEffect on the task detail page never re-bounces the user — regardless of how they reached the review page (deep link, notification, breadcrumb, or this new redirect).
- **`frontend/src/lib/specTaskAutoOpen.ts`** (new): Extracts `getAutoOpenedSpecTasks` / `addAutoOpenedSpecTask` / `AUTO_OPENED_KEY` so both the review page and the detail content reference the same key.
- **`frontend/src/components/tasks/SpecTaskDetailContent.tsx`**:
  - Imports the helpers from the new shared module; deletes the inline copies.
  - Auto-open useEffect now also bails when `task.spec_approved_at` is set (defence-in-depth — the server sets this synchronously inside the approval handler, so it's a reliable signal even before the cached `task.status` refreshes through `spec_approved` → `implementation_queued`).

The same `onImplementationStarted` callback is fired by both the Approve submission and the Start Implementation button on the review page, so both paths land on the chat/desktop. The in-workspace `TabsView` flow is unchanged (it already replaces the review tab with a task tab in-place). The original "auto-open on first visit to a genuinely-awaiting-review task" behaviour is preserved.

## Test Plan

- TypeScript: `npx tsc --noEmit` clean (no type errors). `yarn build` transforms 21093 modules; only the dist write fails in this dev env due to a read-only bind mount, which is environment, not the code.
- **WARNING: NOT manually verified in browser** — the inner Helix sandbox was still building Rust/Zed dependencies during this session. Reviewer should walk through the manual verification steps in `tasks.md` (approve from review page → land on task detail → no bounce; Back button still returns to review URL; Request Changes still closes only; first-visit auto-open for a fresh `spec_review` task still works).

## Spec Reference

`helix-specs@HEAD:001920_after-approving-a-task` — see `design.md` for the full root-cause analysis and the coordination note with task 001661 (which this PR supersedes since 001661 is unmerged on `feature/001661-occasionally-when-i`).

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kq4az95xfv3q54xzvvnws4ft)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001920_after-approving-a-task/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001920_after-approving-a-task/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001920_after-approving-a-task/tasks.md)

🚀 Built with [Helix](https://helix.ml)