### PR TITLE
Tweaks to on-hover add comment button on spec review page

### DIFF
--- a/frontend/src/components/spec-tasks/DesignReviewContent.tsx
+++ b/frontend/src/components/spec-tasks/DesignReviewContent.tsx
@@ -1119,7 +1119,7 @@ export default function DesignReviewContent({
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      <GlobalStyles styles={{ "::highlight(comment-highlight)": { backgroundColor: "#b3d7ff", color: "#000" } }} />
+      <GlobalStyles styles={{ "::highlight(comment-highlight)": { backgroundColor: "rgba(25, 118, 210, 0.4)" } }} />
       {/* Main Content Area */}
       <Box display="flex" flex={1} overflow="hidden">
         {/* Document Viewer */}

--- a/frontend/src/components/spec-tasks/DesignReviewContent.tsx
+++ b/frontend/src/components/spec-tasks/DesignReviewContent.tsx
@@ -1119,7 +1119,7 @@ export default function DesignReviewContent({
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      <GlobalStyles styles={{ "::highlight(comment-highlight)": { backgroundColor: "#b3d7ff" } }} />
+      <GlobalStyles styles={{ "::highlight(comment-highlight)": { backgroundColor: "#b3d7ff", color: "#000" } }} />
       {/* Main Content Area */}
       <Box display="flex" flex={1} overflow="hidden">
         {/* Document Viewer */}

--- a/frontend/src/components/spec-tasks/DesignReviewContent.tsx
+++ b/frontend/src/components/spec-tasks/DesignReviewContent.tsx
@@ -1119,7 +1119,7 @@ export default function DesignReviewContent({
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      <GlobalStyles styles={{ "::highlight(comment-highlight)": { backgroundColor: "#b3d7ff", color: "#000" } }} />
+      <GlobalStyles styles={{ "::highlight(comment-highlight)": { backgroundColor: "#b3d7ff" } }} />
       {/* Main Content Area */}
       <Box display="flex" flex={1} overflow="hidden">
         {/* Document Viewer */}
@@ -1300,6 +1300,16 @@ export default function DesignReviewContent({
               hoveredElementRef.current = null;
               setHoverButtonPosition(null);
             }}
+            onMouseMove={(e) => {
+              if (!hoverButtonPosition) return;
+              const containerRect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+              const mouseX = e.clientX - containerRect.left;
+              const buttonRightEdge = containerRect.width / 2 + 400 + 4 + 28;
+              if (mouseX > buttonRightEdge) {
+                setHoverButtonPosition(null);
+                hoveredElementRef.current = null;
+              }
+            }}
             sx={{
               bgcolor: "background.default",
               position: "relative",
@@ -1311,6 +1321,11 @@ export default function DesignReviewContent({
                 <IconButton
                   size="small"
                   onClick={() => {
+                    if (hoveredElementRef.current) {
+                      const range = document.createRange();
+                      range.selectNodeContents(hoveredElementRef.current);
+                      savedRangeRef.current = range;
+                    }
                     setSelectedText(hoverButtonPosition.elementText);
                     setCommentFormPosition({ x: 0, y: hoverButtonPosition.y });
                     setHoverButtonPosition(null);
@@ -1341,6 +1356,15 @@ export default function DesignReviewContent({
               onMouseMove={(e) => {
                 if (showCommentForm || isNarrowViewport) return;
                 const target = e.target as Node;
+                for (const bubble of commentRefs.current.values()) {
+                  if (bubble.contains(target)) {
+                    if (hoverButtonPosition) {
+                      setHoverButtonPosition(null);
+                      hoveredElementRef.current = null;
+                    }
+                    return;
+                  }
+                }
                 const blockTags = new Set(["P", "LI", "H1", "H2", "H3", "H4", "BLOCKQUOTE", "PRE"]);
                 let node: Node | null = target;
                 while (node && node !== markdownRef.current) {


### PR DESCRIPTION
## Summary

Four tweaks to the on-hover "Add comment" button and pseudo-highlight on the spec review page (`DesignReviewContent.tsx`):

1. Clicking the hover button now applies the same blue pseudo-highlight to the paragraph that manual selection does, so users can see exactly which block the comment is attached to.
2. The hover button now disappears when the cursor moves to the right past the button's right edge (previously it lingered until the cursor left the entire scroll container). Clicking the button is unaffected.
3. Pseudo-highlights spanning a code block are now visible across the code: dropped the conflicting `color: #000` from the `::highlight()` rule that was hiding under Prism's inline syntax-token colours, leaving `background-color: #b3d7ff` to paint correctly.
4. The hover button no longer appears when the cursor is over an existing inline comment panel (`InlineCommentBubble`).

All changes are in `frontend/src/components/spec-tasks/DesignReviewContent.tsx`.

## Changes

- `onClick` of the hover button now creates a `Range` over `hoveredElementRef.current` and assigns it to `savedRangeRef.current` so the existing `useEffect` applies the pseudo-highlight when the comment form opens.
- Added an `onMouseMove` handler to the outer scroll container that clears `hoverButtonPosition` when the cursor x-position exceeds the button's right edge (`containerWidth/2 + 432px`).
- Added an early-return in the inner Box's `onMouseMove` handler that clears the hover button when the cursor is inside any element tracked in `commentRefs.current`.
- Dropped `color: #000` from the `::highlight(comment-highlight)` `GlobalStyles` rule — Prism's inline `color: rgb(...)` styles win regardless, and removing the override lets syntax colours show through under the highlight background.

## Screenshots

![Highlight after fix - spans code block correctly](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001678_tweaks-to-the-new-on/screenshots/02-highlight-after-fix.png)
![Hover button visible on paragraph hover](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001678_tweaks-to-the-new-on/screenshots/03-hover-button-visible.png)
![Paragraph highlighted after clicking hover button](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001678_tweaks-to-the-new-on/screenshots/04-after-hover-button-click.png)
![No hover button when cursor over comment panel](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001678_tweaks-to-the-new-on/screenshots/05-hover-over-comment-panel.png)

## Test plan

- [x] Manual browser test in inner Helix: hover button click applies highlight
- [x] Manual browser test: cursor past right edge hides button (programmatic mousemove dispatch confirmed `stillVisibleAtButton:true` when cursor inside button rect, button cleared when cursor at x=1100 vs button right edge 1040)
- [x] Manual browser test: highlight spans code block with syntax colours preserved
- [x] Manual browser test: hovering over a comment panel hides the hover button
- [x] `cd frontend && yarn build` passes

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kn42hzt17zctx6bwrh7a62v7)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001678_tweaks-to-the-new-on/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001678_tweaks-to-the-new-on/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001678_tweaks-to-the-new-on/tasks.md)

🚀 Built with [Helix](https://helix.ml)