### PR TITLE
Show pulsing green dot on Kanban cards while agent is running

### DIFF
--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -90,6 +90,15 @@ const spin = keyframes`
   }
 `;
 
+const pulseDot = keyframes`
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+`;
+
 
 type SpecTaskPhase =
   | "backlog"
@@ -631,6 +640,7 @@ function TaskCardInner({
 
   const { acknowledge } = useAttentionEvents();
   const hasUnreadNotification = attentionEvents.length > 0;
+  const isAgentWorking = task.agent_work_state === "working";
 
   const runningDuration = useRunningDuration(
     task.started_at,
@@ -753,7 +763,25 @@ function TaskCardInner({
         },
       }}
     >
-      {hasUnreadNotification && (
+      {isAgentWorking ? (
+        <Tooltip title="Agent is running">
+          <Box
+            sx={{
+              position: "absolute",
+              top: 8,
+              right: 8,
+              width: 10,
+              height: 10,
+              borderRadius: "50%",
+              backgroundColor: "success.main",
+              zIndex: 1,
+              border: "2px solid",
+              borderColor: "background.paper",
+              animation: `${pulseDot} 1.5s ease-in-out infinite`,
+            }}
+          />
+        </Tooltip>
+      ) : hasUnreadNotification ? (
         <Tooltip title="Agent finished - click to dismiss">
           <Box
             sx={{
@@ -770,7 +798,7 @@ function TaskCardInner({
             }}
           />
         </Tooltip>
-      )}
+      ) : null}
       <CardContent sx={{ p: 2, "&:last-child": { pb: 4 } }}>
         {/* Task name */}
         <Box


### PR DESCRIPTION
## Summary

When an agent is currently working on a task, the card now shows a pulsing
**green** dot in the top-right corner instead of the existing static **red**
"agent finished" dot. This makes it easy to skip in-progress tasks while
scanning the Kanban board, even when a stale unacknowledged attention event
from a previous run is still on the card.

## Behaviour

| State | Indicator |
|---|---|
| `agent_work_state === "working"` | Pulsing green dot, tooltip "Agent is running" |
| Unacknowledged attention event, agent not working | Static red dot (unchanged) |
| Otherwise | No dot |

The green dot takes precedence over the red dot when both signals are
present. The red dot reappears once the agent goes idle again — attention
events are not auto-acknowledged.

## Changes

- `frontend/src/components/tasks/TaskCard.tsx`
  - New `pulseDot` keyframes (opacity 1.0 → 0.4 → 1.0 over 1.5s, ease-in-out)
  - New `isAgentWorking = task.agent_work_state === "working"` derivation
  - Top-right dot now renders green-pulsing when working, else red-static when
    `hasUnreadNotification`, else nothing

## Why this is small

`agent_work_state` is already populated on every task in the existing
`useSpecTasks` poll (~3.1s refetch), so no new endpoint, websocket, or schema
change was needed. The diff is ~20 lines in one file.

## Screenshots

![Three dot states (green pulsing / red static / none)](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001994_when-an-agent-is-running/screenshots/01-dot-states-preview.png)

Note: this screenshot is from a standalone HTML preview, not the inner Helix —
see "Testing" below.

## Testing

- `cd frontend && yarn build` — clean.
- **Inner Helix end-to-end test was not possible in the implementation
  environment** (Docker stack still building when the change landed). A
  reviewer should spot-check in a running inner Helix:
  1. Start a task → green dot pulses while agent is working.
  2. Let agent finish → red dot appears.
  3. Send a follow-up prompt without dismissing → red dot is replaced by green
     pulsing dot, and reverts to red when the agent stops.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kr4nwvc40exwwf4q2dqg3xv2)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001994_when-an-agent-is-running/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001994_when-an-agent-is-running/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001994_when-an-agent-is-running/tasks.md)

🚀 Built with [Helix](https://helix.ml)