### PR TITLE
fix(frontend): expand lightText to 6-char hex for Monaco

### DIFF
--- a/frontend/src/themes.tsx
+++ b/frontend/src/themes.tsx
@@ -119,7 +119,7 @@ export const THEMES: Record<string, ITheme> = {
     lightBackgroundColor: "#ffffff",
     lightBackgroundImage: "url('/img/nebula-light.png')",
     lightBorder: "1px solid #aeaeae",
-    lightText: "#000",
+    lightText: "#000000",
     // "Faded" in light mode = sunlit-iPad readable, not actually faded.
     // 7.7:1 contrast vs white (#aeaeae was 3.3:1 — failed AA for body text).
     lightTextFaded: "#4a4a4a",


### PR DESCRIPTION
## Summary
- `lightText: \"#000\"` (3-char hex) flows into Monaco's light theme as `editor.foreground`. Monaco's `parseHexColor` only accepts `#rrggbb` / `#rrggbbaa` and rejects shorthand, throwing `Illegal value for token color: #000` on every render of the Monaco editor on the specs page.
- One-char fix: `\"#000\"` → `\"#000000\"` in `frontend/src/themes.tsx`.

## Test plan
- [x] Confirmed Monaco's hex-color parser rejects 3-char shorthand
- [ ] Verify the specs page Monaco editor loads without the JS error after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)