### PR TITLE
fix(frontend): suppress runtime.sendMessage noise in iPad error overlay

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -100,21 +100,33 @@ if (isMobileOrTablet()) {
     })
   }
 
+  // Errors we've observed in the wild that don't originate from our code and
+  // shouldn't be promoted to a full-screen overlay. Add new patterns here only
+  // when you've actually seen them — don't speculate.
+  //   - runtime.sendMessage / Tab not found: iPad Safari, no extensions
+  //     installed; appears to come from a WebKit-internal extension shim.
+  const NOISE_PATTERNS: RegExp[] = [
+    /runtime\.sendMessage.*Tab not found/i,
+  ]
+
+  function isNoise(message: string): boolean {
+    return NOISE_PATTERNS.some(p => p.test(message))
+  }
+
   window.onerror = (message, _source, _lineno, _colno, error) => {
-    renderErrorOverlay(
-      String(message),
-      error?.stack
-    )
+    const msg = String(message)
+    if (!isNoise(msg)) {
+      renderErrorOverlay(msg, error?.stack)
+    }
     // Return true to prevent default browser error handling (which causes the white page)
     return true
   }
 
   window.addEventListener('unhandledrejection', (event) => {
     const reason = event.reason
-    renderErrorOverlay(
-      reason?.message || String(reason) || 'Unhandled promise rejection',
-      reason?.stack
-    )
+    const msg = reason?.message || String(reason) || 'Unhandled promise rejection'
+    if (isNoise(msg)) return
+    renderErrorOverlay(msg, reason?.stack)
   })
 
   // On page load, check for previous errors from a WebKit process crash.


### PR DESCRIPTION
## Summary
- iPad Safari (no extensions) was throwing `Invalid call to runtime.sendMessage(). Tab not found.` from a WebKit-internal extension shim
- Our mobile error overlay (`window.onerror` in `frontend/src/index.tsx`) was promoting it to a full-screen red panel on every page load
- Filter the one observed message before rendering the overlay; still swallow it from default browser handling so the white-screen recovery path keeps working

## Test plan
- [x] `cd frontend && yarn build` — clean
- [ ] Load https://meta.helix.ml on iPad Safari — overlay should no longer appear
- [ ] Trigger a real error (e.g. throw from a component) on iPad — overlay should still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)