### PR TITLE
fix(frontend): make desktop viewer chrome light-mode aware

### DIFF
--- a/frontend/src/components/external-agent/ConnectionOverlay.tsx
+++ b/frontend/src/components/external-agent/ConnectionOverlay.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import { Box, Typography, Button, Alert, CircularProgress } from '@mui/material';
 import { Refresh } from '@mui/icons-material';
+import useLightTheme from '../../hooks/useLightTheme';
 
 export interface ConnectionOverlayProps {
   isConnected: boolean;
@@ -29,10 +30,19 @@ const ConnectionOverlay: React.FC<ConnectionOverlayProps> = ({
   onReconnect,
   onClearError,
 }) => {
+  const lightTheme = useLightTheme();
+
   // Don't render if we're connected and there's no pending state
   if (isConnected && !isConnecting && !error && retryCountdown === null) {
     return null;
   }
+
+  // Backdrop dims the streamed video underneath. White-with-alpha in light mode
+  // keeps the overlay readable without the dark frame the rest of the chrome
+  // dropped in light mode.
+  const overlayBg = lightTheme.isLight ? 'rgba(255, 255, 255, 0.85)' : 'rgba(0, 0, 0, 0.85)';
+  const primaryTextColor = lightTheme.isLight ? 'text.primary' : 'white';
+  const secondaryTextColor = lightTheme.isLight ? 'text.secondary' : 'grey.400';
 
   return (
     <Box
@@ -42,7 +52,7 @@ const ConnectionOverlay: React.FC<ConnectionOverlayProps> = ({
         left: 0,
         right: 0,
         bottom: 0,
-        backgroundColor: 'rgba(0, 0, 0, 0.85)',
+        backgroundColor: overlayBg,
         zIndex: 1000,
         display: 'flex',
         flexDirection: 'column',
@@ -54,7 +64,7 @@ const ConnectionOverlay: React.FC<ConnectionOverlayProps> = ({
     >
       {/* Connecting state - spinner with status message */}
       {isConnecting && (
-        <Box sx={{ color: 'white' }}>
+        <Box sx={{ color: primaryTextColor }}>
           <CircularProgress size={40} sx={{ mb: 2 }} />
           <Typography variant="body1">{status}</Typography>
         </Box>
@@ -70,10 +80,10 @@ const ConnectionOverlay: React.FC<ConnectionOverlayProps> = ({
       {/* Disconnected state - no active connection, no error, not connecting */}
       {!isConnecting && !isConnected && !error && retryCountdown === null && (
         <>
-          <Typography variant="h6" sx={{ color: 'white' }}>
+          <Typography variant="h6" sx={{ color: primaryTextColor }}>
             Disconnected
           </Typography>
-          <Typography variant="body2" sx={{ color: 'grey.400', textAlign: 'center', maxWidth: 300 }}>
+          <Typography variant="body2" sx={{ color: secondaryTextColor, textAlign: 'center', maxWidth: 300 }}>
             {status || 'Connection lost'}
           </Typography>
           <Button

--- a/frontend/src/components/external-agent/DesktopStreamViewer.tsx
+++ b/frontend/src/components/external-agent/DesktopStreamViewer.tsx
@@ -42,6 +42,7 @@ import {
   getStandardVideoFormats,
 } from "../../lib/helix-stream/stream/video";
 import useApi from "../../hooks/useApi";
+import useLightTheme from "../../hooks/useLightTheme";
 import { useAccount } from "../../contexts/account";
 import { useVideoStream } from "../../contexts/VideoStreamContext";
 import { TypesClipboardData } from "../../api/api";
@@ -144,6 +145,7 @@ const DesktopStreamViewer: React.FC<DesktopStreamViewerProps> = ({
   className = "",
   suppressOverlay = false,
 }) => {
+  const lightTheme = useLightTheme();
   const canvasRef = useRef<HTMLCanvasElement>(null); // Canvas for WebSocket video mode
   const containerRef = useRef<HTMLDivElement>(null);
   const hiddenInputRef = useRef<HTMLInputElement>(null); // Hidden input for iOS/iPad virtual keyboard
@@ -4445,7 +4447,10 @@ const DesktopStreamViewer: React.FC<DesktopStreamViewerProps> = ({
         minHeight: isIOSFullscreen ? undefined : keyboardHeight > 0 ? 150 : 400,
         // High z-index for iOS fullscreen to cover everything, or keyboard open
         zIndex: isIOSFullscreen ? 9999 : keyboardHeight > 0 ? 1000 : undefined,
-        backgroundColor: "#000",
+        // Letterbox/pillarbox bars around the streamed video. Match the page
+        // background so a light-mode desktop reads as fully light, not "light
+        // desktop in a black frame".
+        backgroundColor: lightTheme.isLight ? "#f4f4f4" : "#000",
         display: "flex",
         flexDirection: "column",
         outline: "none",

--- a/frontend/src/components/external-agent/ExternalAgentDesktopViewer.tsx
+++ b/frontend/src/components/external-agent/ExternalAgentDesktopViewer.tsx
@@ -20,6 +20,7 @@ import EmbeddedSessionView from "../session/EmbeddedSessionView";
 import RobustPromptInput from "../common/RobustPromptInput";
 import { optimisticallyMarkSessionStarting } from "../../utils/optimisticSessionStarting";
 import useApi from "../../hooks/useApi";
+import useLightTheme from "../../hooks/useLightTheme";
 import useSnackbar from "../../hooks/useSnackbar";
 import { useStreaming } from "../../contexts/streaming";
 import { SESSION_TYPE_TEXT } from "../../types";
@@ -130,6 +131,7 @@ const ExternalAgentDesktopViewer: FC<ExternalAgentDesktopViewerProps> = ({
   sandboxMode = false,
 }) => {
   const api = useApi();
+  const lightTheme = useLightTheme();
   const snackbar = useSnackbar();
   const queryClient = useQueryClient();
   const { NewInference, setCurrentSessionId } = useStreaming();
@@ -353,7 +355,7 @@ const ExternalAgentDesktopViewer: FC<ExternalAgentDesktopViewerProps> = ({
             borderColor: "divider",
             borderRadius: 1,
             overflow: "hidden",
-            backgroundColor: "#1a1a1a",
+            backgroundColor: lightTheme.panelColor,
             display: "flex",
             flexDirection: "column",
             alignItems: "center",
@@ -368,7 +370,7 @@ const ExternalAgentDesktopViewer: FC<ExternalAgentDesktopViewerProps> = ({
           ) : (
             <>
               <CircularProgress size={32} sx={{ color: 'primary.main' }} />
-              <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.7)', fontWeight: 500 }}>
+              <Typography variant="body2" sx={{ color: 'text.secondary', fontWeight: 500 }}>
                 {startingTooLong ? "Desktop may have failed to start" : (statusMessage || "Starting Desktop...")}
               </Typography>
               {!sandboxMode && (
@@ -377,7 +379,7 @@ const ExternalAgentDesktopViewer: FC<ExternalAgentDesktopViewerProps> = ({
                   size="small"
                   onClick={handleStopFromStarting}
                   disabled={isStopping}
-                  sx={{ color: 'rgba(255,255,255,0.6)', borderColor: 'rgba(255,255,255,0.3)', mt: 1 }}
+                  sx={{ mt: 1 }}
                 >
                   {isStopping ? "Stopping..." : "Stop"}
                 </Button>
@@ -402,7 +404,7 @@ const ExternalAgentDesktopViewer: FC<ExternalAgentDesktopViewerProps> = ({
             borderColor: "divider",
             borderRadius: 1,
             overflow: "hidden",
-            backgroundColor: "#1a1a1a",
+            backgroundColor: lightTheme.panelColor,
           }}
         >
           <Box
@@ -429,7 +431,7 @@ const ExternalAgentDesktopViewer: FC<ExternalAgentDesktopViewerProps> = ({
               left: 0,
               right: 0,
               bottom: 0,
-              backgroundColor: "rgba(0,0,0,0.3)",
+              backgroundColor: lightTheme.isLight ? "rgba(255,255,255,0.55)" : "rgba(0,0,0,0.3)",
               display: "flex",
               flexDirection: "column",
               alignItems: "center",
@@ -439,7 +441,7 @@ const ExternalAgentDesktopViewer: FC<ExternalAgentDesktopViewerProps> = ({
           >
             <Typography
               variant="body1"
-              sx={{ color: "rgba(255,255,255,0.9)", fontWeight: 500 }}
+              sx={{ color: lightTheme.isLight ? "text.primary" : "rgba(255,255,255,0.9)", fontWeight: 500 }}
             >
               {sandboxMode ? "Desktop Unavailable" : "Desktop Paused"}
             </Typography>
@@ -500,7 +502,7 @@ const ExternalAgentDesktopViewer: FC<ExternalAgentDesktopViewerProps> = ({
           borderColor: "divider",
           borderRadius: 1,
           overflow: "hidden",
-          backgroundColor: "#1a1a1a",
+          backgroundColor: lightTheme.panelColor,
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
@@ -515,7 +517,7 @@ const ExternalAgentDesktopViewer: FC<ExternalAgentDesktopViewerProps> = ({
         ) : (
           <>
             <CircularProgress size={32} sx={{ color: 'primary.main' }} />
-            <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.7)', fontWeight: 500 }}>
+            <Typography variant="body2" sx={{ color: 'text.secondary', fontWeight: 500 }}>
               {startingTooLong ? "Desktop may have failed to start — click Stop to retry" : (statusMessage || "Starting Desktop...")}
             </Typography>
             {!sandboxMode && (
@@ -524,7 +526,7 @@ const ExternalAgentDesktopViewer: FC<ExternalAgentDesktopViewerProps> = ({
                 size="small"
                 onClick={handleStopFromStarting}
                 disabled={isStopping}
-                sx={{ color: 'rgba(255,255,255,0.6)', borderColor: 'rgba(255,255,255,0.3)', mt: 1 }}
+                sx={{ mt: 1 }}
               >
                 {isStopping ? "Stopping..." : "Stop"}
               </Button>
@@ -549,7 +551,7 @@ const ExternalAgentDesktopViewer: FC<ExternalAgentDesktopViewerProps> = ({
           borderColor: "divider",
           borderRadius: 1,
           overflow: "hidden",
-          backgroundColor: "#1a1a1a",
+          backgroundColor: lightTheme.panelColor,
         }}
       >
         <Box
@@ -579,12 +581,12 @@ const ExternalAgentDesktopViewer: FC<ExternalAgentDesktopViewerProps> = ({
             alignItems: "center",
             justifyContent: "center",
             gap: 2,
-            backgroundColor: "rgba(0,0,0,0.3)",
+            backgroundColor: lightTheme.isLight ? "rgba(255,255,255,0.55)" : "rgba(0,0,0,0.3)",
           }}
         >
           <Typography
             variant="body1"
-            sx={{ color: "rgba(255,255,255,0.9)", fontWeight: 500 }}
+            sx={{ color: lightTheme.isLight ? "text.primary" : "rgba(255,255,255,0.9)", fontWeight: 500 }}
           >
             {sandboxMode ? "Desktop Unavailable" : "Desktop Paused"}
           </Typography>
@@ -666,14 +668,14 @@ const ExternalAgentDesktopViewer: FC<ExternalAgentDesktopViewerProps> = ({
                 alignItems: "center",
                 justifyContent: "center",
                 gap: 2,
-                backgroundColor: "rgba(0,0,0,0.7)",
+                backgroundColor: lightTheme.isLight ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.7)",
                 zIndex: 100,
               }}
             >
               <CircularProgress size={40} sx={{ color: "warning.main" }} />
               <Typography
                 variant="body1"
-                sx={{ color: "rgba(255,255,255,0.9)", fontWeight: 500 }}
+                sx={{ color: lightTheme.isLight ? "text.primary" : "rgba(255,255,255,0.9)", fontWeight: 500 }}
               >
                 {isPaused ? (sandboxMode ? "Desktop Unavailable" : "Desktop Paused") : "Reconnecting..."}
               </Typography>


### PR DESCRIPTION
## Summary

Follow-up to #2369. The light-mode rollout left the chrome around the streamed desktop viewer hardcoded dark, so light mode looked like "light app + black frame around a (potentially light) desktop." Make the surrounding panels and overlays theme-aware.

- **DesktopStreamViewer** outer container: black letterbox/pillarbox bars become `#f4f4f4` in light mode, `#000` in dark mode (line 4448 area).
- **ExternalAgentDesktopViewer** loading + paused panels (screenshot and stream variants): replace `#1a1a1a` with `lightTheme.panelColor`, drop hardcoded white text/borders on the Stop button so MUI defaults take over, switch the status `Typography` to `text.secondary`.
- **ExternalAgentDesktopViewer** paused-image dim overlay + reconnecting overlay: swap the dark translucent backdrop for a light translucent one in light mode and switch the heading text to `text.primary`.
- **ConnectionOverlay**: same treatment — light backdrop + `text.primary` / `text.secondary`.

The floating video toolbar (the row of icons at the top of the stream) keeps its `rgba(0,0,0,0.7)` HUD treatment with white icons — that's the universal video-controls pattern and reads cleanly on either theme. Easy follow-up if we change our minds.

## Test plan
- [ ] Toggle light mode in the Helix app
- [ ] Open a spec task and watch the desktop viewer:
  - [ ] Letterbox/pillarbox area around the streamed video is light gray (was black)
  - [ ] "Starting Desktop…" panel is light with dark text (was dark with white text)
  - [ ] "Desktop Paused" panel + button is readable in light mode (no white-on-white)
  - [ ] Reconnect overlay (force a transient disconnect — e.g. flip the API tab) shows readable dark text on a light backdrop
- [ ] Toggle back to dark mode — everything still looks like the previous PR's dark mode (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)