### PR TITLE
fix(api): wake fresh zed_external sessions on /messages cold-start

### DIFF
--- a/api/pkg/server/auto_start_dev_container_test.go
+++ b/api/pkg/server/auto_start_dev_container_test.go
@@ -1,0 +1,146 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/controller"
+	external_agent "github.com/helixml/helix/api/pkg/external-agent"
+	"github.com/helixml/helix/api/pkg/pubsub"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+)
+
+// AutoStartDevContainerSuite covers autoStartDevContainerForSession and
+// startDevContainerForSession — specifically the cold-start case for fresh
+// zed_external sessions that have no spec task. See helixml/helix#2397.
+type AutoStartDevContainerSuite struct {
+	suite.Suite
+	ctrl     *gomock.Controller
+	store    *store.MockStore
+	executor *external_agent.MockExecutor
+	server   *HelixAPIServer
+}
+
+func TestAutoStartDevContainerSuite(t *testing.T) {
+	suite.Run(t, new(AutoStartDevContainerSuite))
+}
+
+func (s *AutoStartDevContainerSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.store = store.NewMockStore(s.ctrl)
+	s.executor = external_agent.NewMockExecutor(s.ctrl)
+	s.server = &HelixAPIServer{
+		Cfg: &config.ServerConfig{
+			WebServer: config.WebServer{URL: "http://localhost:0"},
+		},
+		Store:                 s.store,
+		pubsub:                pubsub.NewNoop(),
+		externalAgentExecutor: s.executor,
+		Controller: &controller.Controller{
+			Options: controller.Options{Store: s.store, PubSub: pubsub.NewNoop()},
+		},
+	}
+}
+
+func (s *AutoStartDevContainerSuite) TearDownTest() {
+	s.ctrl.Finish()
+}
+
+// Fresh zed_external session with no spec task — used to early-return without
+// calling the executor, leaving queued messages stuck. The fix: build a
+// DesktopAgent from the session and invoke StartDesktop. See
+// helixml/helix#2397.
+func (s *AutoStartDevContainerSuite) TestAutoStart_ExploratoryZedExternal_CallsStartDesktop() {
+	sessionID := "ses_exploratory"
+	projectID := "prj_exploratory"
+	orgID := "org_exploratory"
+
+	session := &types.Session{
+		ID:             sessionID,
+		Owner:          "user-1",
+		ProjectID:      projectID,
+		OrganizationID: orgID,
+		Metadata: types.SessionMetadata{
+			AgentType: "zed_external",
+			// Deliberately no SpecTaskID — exploratory session.
+		},
+	}
+
+	// autoStartDevContainerForSession does its own GetSession; startDevContainer-
+	// ForSession then re-fetches after StartDesktop returns. AnyTimes covers both.
+	s.store.EXPECT().GetSession(gomock.Any(), sessionID).Return(session, nil).AnyTimes()
+	s.store.EXPECT().ListGitRepositories(gomock.Any(), gomock.Any()).Return([]*types.GitRepository{}, nil)
+	// UpdateSession runs only when the post-StartDesktop refetch returns non-nil.
+	s.store.EXPECT().UpdateSession(gomock.Any(), gomock.Any()).Return(&types.Session{ID: sessionID}, nil).AnyTimes()
+
+	called := false
+	s.executor.EXPECT().StartDesktop(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, agent *types.DesktopAgent) (*types.DesktopAgentResponse, error) {
+			called = true
+			s.Equal(sessionID, agent.SessionID)
+			s.Equal(projectID, agent.ProjectID)
+			s.Equal(orgID, agent.OrganizationID)
+			s.Empty(agent.SpecTaskID, "exploratory session must not pin a spec task on the agent")
+			return &types.DesktopAgentResponse{SessionID: sessionID, Status: "running"}, nil
+		},
+	)
+
+	s.server.autoStartDevContainerForSession(sessionID)
+	s.True(called, "StartDesktop must be invoked for exploratory zed_external sessions")
+}
+
+// Non-zed_external session (e.g. a helix-agent text session) has no desktop
+// container to wake. The auto-start should be a no-op.
+func (s *AutoStartDevContainerSuite) TestAutoStart_NonZedExternal_IsNoop() {
+	sessionID := "ses_text"
+	session := &types.Session{
+		ID:    sessionID,
+		Owner: "user-1",
+		Metadata: types.SessionMetadata{
+			AgentType: "helix",
+		},
+	}
+	s.store.EXPECT().GetSession(gomock.Any(), sessionID).Return(session, nil)
+	// No StartDesktop expectation — gomock will fail if it's called.
+
+	s.server.autoStartDevContainerForSession(sessionID)
+}
+
+// startDevContainerForSession surfaces StartDesktop errors so callers can log
+// or retry. autoStartDevContainerForSession swallows the error (fire-and-forget),
+// but the helper itself should bubble it up.
+func (s *AutoStartDevContainerSuite) TestStartDevContainerForSession_PropagatesExecutorError() {
+	session := &types.Session{
+		ID:    "ses_err",
+		Owner: "user-1",
+		Metadata: types.SessionMetadata{
+			AgentType: "zed_external",
+		},
+	}
+	s.executor.EXPECT().StartDesktop(gomock.Any(), gomock.Any()).Return(nil, errors.New("boom"))
+
+	err := s.server.startDevContainerForSession(context.Background(), session)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "failed to start dev container")
+}
+
+// Defence-in-depth: if the executor isn't wired up, the helper must surface a
+// clear error rather than panicking on a nil deref.
+func (s *AutoStartDevContainerSuite) TestStartDevContainerForSession_NoExecutor() {
+	noExec := &HelixAPIServer{
+		Cfg:    &config.ServerConfig{},
+		Store:  s.store,
+		pubsub: pubsub.NewNoop(),
+		Controller: &controller.Controller{
+			Options: controller.Options{Store: s.store, PubSub: pubsub.NewNoop()},
+		},
+	}
+	err := noExec.startDevContainerForSession(context.Background(), &types.Session{ID: "ses_x"})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "external agent executor not available")
+}

--- a/api/pkg/server/spec_task_design_review_handlers.go
+++ b/api/pkg/server/spec_task_design_review_handlers.go
@@ -1006,6 +1006,105 @@ func (s *HelixAPIServer) startDevContainerForSpecTask(ctx context.Context, specT
 	return nil
 }
 
+// startDevContainerForSession is the non-spec-task counterpart to
+// startDevContainerForSpecTask. It rebuilds a DesktopAgent from the session
+// itself (project, repos, display) and idempotently re-runs StartDesktop —
+// triggering the dev container to come up if it isn't already, so the Zed
+// agent inside dials home via /ws/external-agent-runner. Used by
+// autoStartDevContainerForSession when a fresh zed_external session has a
+// queued message but no live WebSocket. See helixml/helix#2397.
+func (s *HelixAPIServer) startDevContainerForSession(ctx context.Context, session *types.Session) error {
+	if session == nil {
+		return fmt.Errorf("session is nil")
+	}
+	if s.externalAgentExecutor == nil {
+		return fmt.Errorf("external agent executor not available")
+	}
+
+	agent := &types.DesktopAgent{
+		SessionID:      session.ID,
+		UserID:         session.Owner,
+		Input:          "Resume session",
+		ProjectPath:    "workspace",
+		OrganizationID: session.OrganizationID,
+	}
+
+	// ProjectID can sit on either Session.ProjectID (canonical) or
+	// Session.Metadata.ProjectID (older code paths) — prefer the former.
+	projectID := session.ProjectID
+	if projectID == "" {
+		projectID = session.Metadata.ProjectID
+	}
+	agent.ProjectID = projectID
+
+	if agent.ProjectID != "" {
+		projectRepos, err := s.Store.ListGitRepositories(ctx, &types.ListGitRepositoriesRequest{
+			ProjectID: agent.ProjectID,
+		})
+		if err == nil && len(projectRepos) > 0 {
+			agent.RepositoryIDs = make([]string, 0, len(projectRepos))
+			for _, repo := range projectRepos {
+				if repo.ID != "" {
+					agent.RepositoryIDs = append(agent.RepositoryIDs, repo.ID)
+				}
+			}
+			project, err := s.Store.GetProject(ctx, agent.ProjectID)
+			if err == nil && project != nil && project.DefaultRepoID != "" {
+				agent.PrimaryRepositoryID = project.DefaultRepoID
+			} else if len(projectRepos) > 0 {
+				agent.PrimaryRepositoryID = projectRepos[0].ID
+			}
+		}
+	}
+
+	if session.ParentApp != "" {
+		app, err := s.Controller.Options.Store.GetApp(ctx, session.ParentApp)
+		if err == nil && app != nil && app.Config.Helix.ExternalAgentConfig != nil {
+			width, height := app.Config.Helix.ExternalAgentConfig.GetEffectiveResolution()
+			agent.DisplayWidth = width
+			agent.DisplayHeight = height
+			if app.Config.Helix.ExternalAgentConfig.DisplayRefreshRate > 0 {
+				agent.DisplayRefreshRate = app.Config.Helix.ExternalAgentConfig.DisplayRefreshRate
+			}
+			agent.Resolution = app.Config.Helix.ExternalAgentConfig.Resolution
+			agent.ZoomLevel = app.Config.Helix.ExternalAgentConfig.GetEffectiveZoomLevel()
+			agent.DesktopType = app.Config.Helix.ExternalAgentConfig.GetEffectiveDesktopType()
+		}
+	}
+
+	ownerID := session.Owner
+	agent.OnBeforeCreate = func(hookCtx context.Context, a *types.DesktopAgent) error {
+		return s.addUserAPITokenToAgent(hookCtx, a, ownerID)
+	}
+
+	log.Info().
+		Str("session_id", session.ID).
+		Str("project_id", agent.ProjectID).
+		Msg("Auto-starting dev container for session (backend-initiated resume)")
+
+	response, err := s.externalAgentExecutor.StartDesktop(ctx, agent)
+	if err != nil {
+		return fmt.Errorf("failed to start dev container: %w", err)
+	}
+
+	refreshed, err := s.Store.GetSession(ctx, session.ID)
+	if err == nil && refreshed != nil {
+		if response.DevContainerID != "" {
+			refreshed.Metadata.DevContainerID = response.DevContainerID
+		}
+		refreshed.Metadata.PausedScreenshotPath = ""
+		if _, err := s.Store.UpdateSession(ctx, *refreshed); err != nil {
+			log.Warn().Err(err).Str("session_id", session.ID).Msg("Failed to update session metadata after auto-start")
+		}
+	}
+
+	log.Info().
+		Str("session_id", session.ID).
+		Msg("✅ Dev container auto-started for session, agent will reconnect via WebSocket")
+
+	return nil
+}
+
 // sendCommentToAgentNow actually sends a comment to the agent (called from queue processor)
 func (s *HelixAPIServer) sendCommentToAgentNow(
 	ctx context.Context,

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -3215,10 +3215,17 @@ func (apiServer *HelixAPIServer) sendQueuedPromptToSession(ctx context.Context, 
 	return nil
 }
 
-// autoStartDevContainerForSession checks if a session belongs to a spec task and,
-// if so, auto-starts its dev container. This is fire-and-forget — the caller's
-// message is already persisted and will be picked up by pickupWaitingInteraction
-// when the agent reconnects.
+// autoStartDevContainerForSession auto-starts the dev container for a session
+// whose external agent isn't currently WebSocket-connected. Fire-and-forget —
+// the caller's message is already persisted; pickupWaitingInteraction delivers
+// it when the agent reconnects.
+//
+// Spec-task sessions delegate to startDevContainerForSpecTask (which derives
+// the project from the spec task). Exploratory zed_external sessions delegate
+// to startDevContainerForSession (which derives it from the session itself).
+// Without the exploratory branch, fresh zed_external sessions whose agent
+// never WebSocket-connected sit in `state=waiting` forever — pickupWaiting-
+// Interaction has no peer to deliver to. See helixml/helix#2397.
 func (apiServer *HelixAPIServer) autoStartDevContainerForSession(sessionID string) {
 	ctx := context.Background()
 	session, err := apiServer.Controller.Options.Store.GetSession(ctx, sessionID)
@@ -3230,21 +3237,38 @@ func (apiServer *HelixAPIServer) autoStartDevContainerForSession(sessionID strin
 		log.Warn().Str("session_id", sessionID).Msg("autoStartDevContainerForSession: session is nil")
 		return
 	}
-	if session.Metadata.SpecTaskID == "" {
-		log.Debug().Str("session_id", sessionID).Msg("autoStartDevContainerForSession: no spec task ID on session, skipping")
+
+	if session.Metadata.SpecTaskID != "" {
+		specTask, err := apiServer.Controller.Options.Store.GetSpecTask(ctx, session.Metadata.SpecTaskID)
+		if err != nil {
+			log.Error().Err(err).Str("spec_task_id", session.Metadata.SpecTaskID).Msg("Failed to load spec task for dev container auto-start")
+			return
+		}
+		log.Info().
+			Str("session_id", sessionID).
+			Str("spec_task_id", specTask.ID).
+			Msg("Auto-starting dev container for spec-task session with no WebSocket connection")
+		if startErr := apiServer.startDevContainerForSpecTask(ctx, specTask); startErr != nil {
+			log.Error().Err(startErr).Str("spec_task_id", specTask.ID).Msg("Failed to auto-start dev container")
+		}
 		return
 	}
-	specTask, err := apiServer.Controller.Options.Store.GetSpecTask(ctx, session.Metadata.SpecTaskID)
-	if err != nil {
-		log.Error().Err(err).Str("spec_task_id", session.Metadata.SpecTaskID).Msg("Failed to load spec task for dev container auto-start")
+
+	// Non-spec-task fallback. Only zed_external sessions have a desktop
+	// container to wake — anything else (helix-agent text sessions, etc.)
+	// has no analogue.
+	if session.Metadata.AgentType != "zed_external" {
+		log.Debug().
+			Str("session_id", sessionID).
+			Str("agent_type", session.Metadata.AgentType).
+			Msg("autoStartDevContainerForSession: non-zed_external session, skipping")
 		return
 	}
 	log.Info().
 		Str("session_id", sessionID).
-		Str("spec_task_id", specTask.ID).
-		Msg("Auto-starting dev container for session with no WebSocket connection")
-	if startErr := apiServer.startDevContainerForSpecTask(ctx, specTask); startErr != nil {
-		log.Error().Err(startErr).Str("spec_task_id", specTask.ID).Msg("Failed to auto-start dev container")
+		Msg("Auto-starting dev container for exploratory zed_external session with no WebSocket connection")
+	if startErr := apiServer.startDevContainerForSession(ctx, session); startErr != nil {
+		log.Error().Err(startErr).Str("session_id", sessionID).Msg("Failed to auto-start dev container for exploratory session")
 	}
 }
 


### PR DESCRIPTION
## Summary

`autoStartDevContainerForSession` early-returned when the session had no `SpecTaskID`, leaving exploratory `zed_external` sessions whose Zed agent never WebSocket-connected stuck — `pickupWaitingInteraction` had no peer to deliver the queued message to. After `POST /sessions/{id}/messages` (added in #2375) persisted a `Waiting` interaction, nothing in the request path provoked the agent to dial home, so the interaction sat in `waiting` forever until a human visited the desktop URL.

Generalise the helper: spec-task sessions still go through `startDevContainerForSpecTask`; non-spec-task `zed_external` sessions now go through a new `startDevContainerForSession` that rebuilds the `DesktopAgent` from the session itself (project, repos, display) and idempotently re-runs `StartDesktop`. Other agent types remain a no-op (no desktop container to wake).

This is fix **A** from the issue — the smallest change that fixes the cold-start case for all callers of `/messages`, since `sendCommandToExternalAgent` already invokes `autoStartDevContainerForSession` when there's no live WS.

Closes https://github.com/helixml/helix/issues/2397

## Changes

- `api/pkg/server/websocket_external_agent_sync.go` — `autoStartDevContainerForSession` now dispatches: spec-task → `startDevContainerForSpecTask` (unchanged), non-spec-task `zed_external` → new `startDevContainerForSession`, other → no-op log.
- `api/pkg/server/spec_task_design_review_handlers.go` — added `startDevContainerForSession`, the non-spec-task counterpart to `startDevContainerForSpecTask`. Project, repos, and display config all derive from the session.
- `api/pkg/server/auto_start_dev_container_test.go` — four-test suite covering: exploratory `zed_external` → `StartDesktop` is invoked with the right args; non-`zed_external` → no-op; helper propagates executor errors; helper surfaces a clear error when executor isn't wired.

## Test plan

- [x] `go test -run TestAutoStartDevContainerSuite ./pkg/server/` (4 new tests pass)
- [x] `go test -run "TestSessionMessagesHandlerSuite|TestSpecTaskKeepAliveSuite|TestPromptHistoryHandlersSuite|TestWebSocketSyncSuite" ./pkg/server/` (regression checks pass)
- [x] `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- [ ] Manual reproducer from the issue (fresh `zed_external` session via `/sessions/chat` → cold-start error → `POST /messages` → confirm interaction delivers without the user opening the desktop URL)

Assisted by AI. Co-Authored-By: Helix <noreply@helix.ml>