### PR TITLE
Refresh all Dockerfile base image SHA digest pins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Debian is required for CGo (hugot tokenizers link against glibc)
 # Pin to specific digest for stable layer caching.
 # Update digest when intentionally upgrading Go version.
-FROM golang:1.25-bookworm@sha256:29e59af995c51a5bf63d072eca973b918e0e7af4db0e4667aa73f1b8da1a6d8c AS api-base
+FROM golang:1.25-bookworm@sha256:e3a54b77385b4f8a31c1db4d12429ffb3718ea76865731a787c497755d409547 AS api-base
 WORKDIR /app
 # Install build dependencies for CGo (hugot/tokenizers)
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -115,7 +115,7 @@ RUN yarn build
 #-----------------------
 # Pin to specific digest for stable layer caching.
 # Update digest when intentionally upgrading Debian version.
-FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d
+FROM debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates git git-daemon-sysvinit \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.demos
+++ b/Dockerfile.demos
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine3.22@sha256:2c16ac01b3d038ca2ed421d66cea489e3cb670c251b4f8bbcfad2ebfb75f884c
+FROM golang:1.25-alpine3.22@sha256:26b4d7113039cd51356bd7930ecafd1031d2975dc3b6940ec8ed09457e17cf95
 WORKDIR /app
 RUN apk add --no-cache bash openssh
 COPY go.mod go.sum ./

--- a/Dockerfile.qwen-build
+++ b/Dockerfile.qwen-build
@@ -9,7 +9,7 @@
 #   packages/     — workspace packages (if present)
 #   package.json, package-lock.json
 
-FROM node:20-slim@sha256:f93745c153377ee2fbbdd6e24efcd03cd2e86d6ab1d8aa9916a3790c40313a55 AS builder
+FROM node:20-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0 AS builder
 
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.qwen-code-build
+++ b/Dockerfile.qwen-code-build
@@ -9,7 +9,7 @@
 #
 # Usage: ./stack build-qwen-code
 # ====================================================================
-FROM node:20-slim@sha256:f93745c153377ee2fbbdd6e24efcd03cd2e86d6ab1d8aa9916a3790c40313a55 AS builder
+FROM node:20-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0 AS builder
 
 # Install git (required for simple-git dependency)
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -11,7 +11,7 @@
 # ====================================================================
 # Pin to specific digest for stable layer caching.
 # Update digest when intentionally upgrading Go version.
-FROM golang:1.25-bookworm@sha256:29e59af995c51a5bf63d072eca973b918e0e7af4db0e4667aa73f1b8da1a6d8c AS go-builder
+FROM golang:1.25-bookworm@sha256:e3a54b77385b4f8a31c1db4d12429ffb3718ea76865731a787c497755d409547 AS go-builder
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \

--- a/Dockerfile.sway-helix
+++ b/Dockerfile.sway-helix
@@ -9,7 +9,7 @@
 # BASE IMAGE DIGESTS: Pinned for stable layer caching (2026-04-13).
 # Update digests when intentionally upgrading base images.
 # - ubuntu:25.10         -> sha256:4a9232cc47bf99defcc8860ef6222c99773330367fcecbf21ba2edb0b810a31e
-# - golang:1.25-bookworm -> sha256:29e59af995c51a5bf63d072eca973b918e0e7af4db0e4667aa73f1b8da1a6d8c
+# - golang:1.25-bookworm -> sha256:e3a54b77385b4f8a31c1db4d12429ffb3718ea76865731a787c497755d409547
 
 # ====================================================================
 # Build grim from source with JPEG support
@@ -36,7 +36,7 @@ RUN git clone https://git.sr.ht/~emersion/grim /grim && \
 # desktop-bridge requires go-gst bindings (CGO) for in-process GStreamer.
 # Pin to specific digest for stable layer caching (golang:1.25-bookworm as of 2026-04-13)
 # Update digest when intentionally upgrading Go version
-FROM golang:1.25-bookworm@sha256:29e59af995c51a5bf63d072eca973b918e0e7af4db0e4667aa73f1b8da1a6d8c AS go-build-env
+FROM golang:1.25-bookworm@sha256:e3a54b77385b4f8a31c1db4d12429ffb3718ea76865731a787c497755d409547 AS go-build-env
 
 # Install GStreamer development libraries for go-gst bindings
 # These are required for CGO compilation of desktop-bridge

--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -10,7 +10,7 @@
 # BASE IMAGE DIGESTS: Pinned for stable layer caching (2026-04-13).
 # Update digests when intentionally upgrading base images.
 # - ubuntu:25.10         -> sha256:4a9232cc47bf99defcc8860ef6222c99773330367fcecbf21ba2edb0b810a31e
-# - golang:1.25-bookworm -> sha256:29e59af995c51a5bf63d072eca973b918e0e7af4db0e4667aa73f1b8da1a6d8c
+# - golang:1.25-bookworm -> sha256:e3a54b77385b4f8a31c1db4d12429ffb3718ea76865731a787c497755d409547
 
 # Global ARG: must be before the first FROM to be visible to --build-arg
 # amd64 (default): pinned nvidia/cuda digest — cache-stable, no silent updates
@@ -24,7 +24,7 @@ ARG CUDA_BASE_IMAGE=nvidia/cuda:12.6.3-runtime-ubuntu24.04@sha256:92906d87596d63
 # desktop-bridge requires go-gst bindings (CGO) for in-process GStreamer.
 # Pin to specific digest for stable layer caching (golang:1.25-bookworm as of 2026-04-13)
 # Update digest when intentionally upgrading Go version
-FROM golang:1.25-bookworm@sha256:29e59af995c51a5bf63d072eca973b918e0e7af4db0e4667aa73f1b8da1a6d8c AS go-build-env
+FROM golang:1.25-bookworm@sha256:e3a54b77385b4f8a31c1db4d12429ffb3718ea76865731a787c497755d409547 AS go-build-env
 
 # Install GStreamer development libraries for go-gst bindings
 # These are required for CGO compilation of desktop-bridge

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25-bookworm@sha256:29e59af995c51a5bf63d072eca973b918e0e7af4db0e4667aa73f1b8da1a6d8c AS builder
+FROM golang:1.25-bookworm@sha256:e3a54b77385b4f8a31c1db4d12429ffb3718ea76865731a787c497755d409547 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/scripts/sse-mcp-server/Dockerfile
+++ b/scripts/sse-mcp-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim@sha256:f93745c153377ee2fbbdd6e24efcd03cd2e86d6ab1d8aa9916a3790c40313a55
+FROM node:20-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Refresh every `@sha256:...` pin on `FROM` lines (and the `CUDA_BASE_IMAGE`
ARG default) across all Dockerfiles in the repo, so container builds pick
up the latest upstream security fixes for both `linux/amd64` and
`linux/arm64`. Image tags / version numbers are unchanged — this is a
digest refresh only, not a version upgrade.

Each new digest is the **multi-arch manifest-list digest** (the top-level
OCI image index), verified with `docker buildx imagetools inspect`. Where
the same `image:tag` appears in multiple Dockerfiles or stages, every
occurrence shares the same updated digest.

## Inspected: 11 distinct image:tags. Updated: 4

| Image | Old digest | New digest | Files touched |
| --- | --- | --- | --- |
| `golang:1.25-bookworm` | `sha256:29e59af9...da1a6d8c` | `sha256:e3a54b77385b4f8a31c1db4d12429ffb3718ea76865731a787c497755d409547` | `Dockerfile`, `Dockerfile.sandbox`, `Dockerfile.sway-helix`, `Dockerfile.ubuntu-helix`, `operator/Dockerfile` |
| `debian:bookworm-slim` | `sha256:4724b8cc...642182655d` | `sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3` | `Dockerfile` |
| `node:20-slim` | `sha256:f93745c1...0c40313a55` | `sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0` | `Dockerfile.qwen-build`, `Dockerfile.qwen-code-build`, `scripts/sse-mcp-server/Dockerfile` |
| `golang:1.25-alpine3.22` | `sha256:2c16ac01...fad2ebfb75f884c` | `sha256:26b4d7113039cd51356bd7930ecafd1031d2975dc3b6940ec8ed09457e17cf95` | `Dockerfile.demos` |

## Already current — left unchanged

These were inspected but the upstream manifest-list digest was identical
to the existing pin: `node:23-alpine`, `golangci/golangci-lint:v1.62-alpine`,
`golang:1.23-alpine3.21`, `ubuntu:25.04`, `ubuntu:25.10`,
`gcr.io/distroless/static:nonroot`, `nvidia/cuda:12.6.3-runtime-ubuntu24.04`.

## Multi-arch verification

For every refreshed image, the new digest is the manifest-list / image-index
digest and includes both `linux/amd64` and `linux/arm64` manifests:

- `golang:1.25-bookworm` — amd64, arm64/v8 (+ 386, arm/v7, mips64le, ppc64le, s390x)
- `debian:bookworm-slim` — amd64, arm64/v8 (+ 386, arm/v5, arm/v7, mips64le, ppc64le, s390x)
- `node:20-slim` — amd64, arm64/v8 (+ arm/v7, ppc64le, s390x)
- `golang:1.25-alpine3.22` — amd64, arm64/v8 (+ 386, arm/v6, arm/v7, ppc64le, riscv64, s390x)

`nvidia/cuda:12.6.3-runtime-ubuntu24.04` — observed during this sweep to
publish **both** `linux/amd64` and `linux/arm64`. The Dockerfile keeps the
existing convention of an arm64 `--build-arg CUDA_BASE_IMAGE=ubuntu:25.10`
override (no Dockerfile structural changes in this PR). Worth a follow-up
to consider if the override is still needed.

## Reachability check

Every pin in the diff was re-inspected as `image:tag@new-digest` via
`docker buildx imagetools inspect`. All 11 returned a valid manifest.

## Open questions (please review)

These version-consistency anomalies were observed during the sweep. Per
task scope they were **not silently fixed** — flagging here for stakeholder
review:

1. **`Dockerfile.lint` is on `golang:1.23-alpine3.21`** — every other
   Go-based Dockerfile in the repo is on `golang:1.25-bookworm` (or
   `1.25-alpine3.22`). Intentional pin to an older Go for lint
   compatibility, or stale?
2. **`Dockerfile.sandbox` is on `ubuntu:25.04`** — every other
   Ubuntu-based Dockerfile is on `25.10`. Intentional, or missed in a
   prior bump?
3. **`Dockerfile.demos` is on `golang:1.25-alpine3.22`** — siblings use
   `golang:1.25-bookworm`. Intentional alpine choice (smaller demo
   image), or drift?

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01krapjyxe6s5r43pyt1936mp9)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001999_refresh-all-dockerfile/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001999_refresh-all-dockerfile/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001999_refresh-all-dockerfile/tasks.md)

🚀 Built with [Helix](https://helix.ml)