### PR TITLE
build: pass GO_VERSION as --build-arg, stop COPY-ing go.mod into final stage

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1634,9 +1634,11 @@ steps:
       # Build and push helix-sway
       - |
         VERSION=$$(if [ -n "${DRONE_TAG}" ]; then echo ${DRONE_TAG}; else echo ${DRONE_COMMIT_SHA} | head -c 7; fi)
+        GO_VERSION=$$(awk '/^go [0-9]/ {print $$2; exit}' go.mod)
         echo "Building helix-sway..."
         docker build --pull --provenance=false \
           -f Dockerfile.sway-helix \
+          --build-arg GO_VERSION=$${GO_VERSION} \
           -t registry.helixml.tech/helix/helix-sway:$${VERSION}-linux-amd64 \
           .
         docker push registry.helixml.tech/helix/helix-sway:$${VERSION}-linux-amd64
@@ -1645,10 +1647,12 @@ steps:
       # Build and push helix-ubuntu
       - |
         VERSION=$$(if [ -n "${DRONE_TAG}" ]; then echo ${DRONE_TAG}; else echo ${DRONE_COMMIT_SHA} | head -c 7; fi)
+        GO_VERSION=$$(awk '/^go [0-9]/ {print $$2; exit}' go.mod)
         echo "Building helix-ubuntu..."
         docker build --pull --provenance=false \
           -f Dockerfile.ubuntu-helix \
           --build-arg CUDA_BASE_IMAGE=nvidia/cuda:12.6.3-runtime-ubuntu24.04@sha256:2c8193530ecc423e0f123d0c85b68a15d1395adcddabfc943e2523dbfde172e1 \
+          --build-arg GO_VERSION=$${GO_VERSION} \
           -t registry.helixml.tech/helix/helix-ubuntu:$${VERSION}-linux-amd64 \
           .
         docker push registry.helixml.tech/helix/helix-ubuntu:$${VERSION}-linux-amd64
@@ -1928,9 +1932,11 @@ steps:
       # Build and push helix-sway (arm64)
       - |
         VERSION=$$(if [ -n "${DRONE_TAG}" ]; then echo ${DRONE_TAG}; else echo ${DRONE_COMMIT_SHA} | head -c 7; fi)
+        GO_VERSION=$$(awk '/^go [0-9]/ {print $$2; exit}' go.mod)
         echo "Building helix-sway (arm64)..."
         docker build --pull --provenance=false \
           -f Dockerfile.sway-helix \
+          --build-arg GO_VERSION=$${GO_VERSION} \
           -t registry.helixml.tech/helix/helix-sway:$${VERSION}-linux-arm64 \
           .
         docker push registry.helixml.tech/helix/helix-sway:$${VERSION}-linux-arm64
@@ -1939,10 +1945,12 @@ steps:
       # Build and push helix-ubuntu (arm64, no CUDA)
       - |
         VERSION=$$(if [ -n "${DRONE_TAG}" ]; then echo ${DRONE_TAG}; else echo ${DRONE_COMMIT_SHA} | head -c 7; fi)
+        GO_VERSION=$$(awk '/^go [0-9]/ {print $$2; exit}' go.mod)
         echo "Building helix-ubuntu (arm64, no CUDA)..."
         docker build --pull --provenance=false \
           -f Dockerfile.ubuntu-helix \
           --build-arg CUDA_BASE_IMAGE=ubuntu:25.10@sha256:91e7ac4c041dd191af1b9012fadbf489280894699c3f31e180969c4478781b7b \
+          --build-arg GO_VERSION=$${GO_VERSION} \
           -t registry.helixml.tech/helix/helix-ubuntu:$${VERSION}-linux-arm64 \
           .
         docker push registry.helixml.tech/helix/helix-ubuntu:$${VERSION}-linux-arm64

--- a/Dockerfile.sway-helix
+++ b/Dockerfile.sway-helix
@@ -401,13 +401,14 @@ PINEOF
 
 _INSTALL_BASE
 
-# Install Go (version extracted from go.mod)
-# This makes Go available for agents running inside the container (Helix-in-Helix)
-COPY go.mod /tmp/go.mod
-RUN GO_VERSION=$(grep -E "^go [0-9]" /tmp/go.mod | awk '{print $2}') && \
+# Install Go (version passed via --build-arg from stack, derived from go.mod on host).
+# Passing as a build-arg (instead of COPY-ing go.mod) means dependency bumps in
+# go.mod don't invalidate this layer or any of the downstream apt/npm/install layers —
+# only an actual Go-version change does. TARGETARCH is set by Docker buildx.
+ARG GO_VERSION
+RUN [ -n "${GO_VERSION}" ] || { echo "ERROR: --build-arg GO_VERSION=... is required" >&2; exit 1; } && \
     echo "Installing Go ${GO_VERSION} for ${TARGETARCH}..." && \
     curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -C /usr/local -xz && \
-    rm /tmp/go.mod && \
     /usr/local/go/bin/go version
 ENV PATH="/usr/local/go/bin:${PATH}"
 

--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -325,14 +325,14 @@ PINEOF
 
 _INSTALL_BASE
 
-# Install Go (version extracted from go.mod)
-# This makes Go available for agents running inside the container (Helix-in-Helix)
-# TARGETARCH is set by Docker buildx (amd64 or arm64)
-COPY go.mod /tmp/go.mod
-RUN GO_VERSION=$(grep -E "^go [0-9]" /tmp/go.mod | awk '{print $2}') && \
+# Install Go (version passed via --build-arg from stack, derived from go.mod on host).
+# Passing as a build-arg (instead of COPY-ing go.mod) means dependency bumps in
+# go.mod don't invalidate this layer or any of the downstream apt/npm/install
+# layers — only an actual Go-version change does. TARGETARCH is set by Docker buildx.
+ARG GO_VERSION
+RUN [ -n "${GO_VERSION}" ] || { echo "ERROR: --build-arg GO_VERSION=... is required" >&2; exit 1; } && \
     echo "Installing Go ${GO_VERSION} for ${TARGETARCH}..." && \
     curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -C /usr/local -xz && \
-    rm /tmp/go.mod && \
     /usr/local/go/bin/go version
 ENV PATH="/usr/local/go/bin:${PATH}"
 

--- a/stack
+++ b/stack
@@ -797,7 +797,15 @@ function build-zed-agent() {
     return 1
   fi
 
-  docker buildx build -t helix-sway:latest -f Dockerfile.sway-helix .
+  local GO_VERSION
+  GO_VERSION=$(awk '/^go [0-9]/ {print $2; exit}' go.mod)
+  if [ -z "$GO_VERSION" ]; then
+    echo "❌ Could not extract Go version from go.mod"
+    return 1
+  fi
+
+  docker buildx build --build-arg "GO_VERSION=${GO_VERSION}" \
+    -t helix-sway:latest -f Dockerfile.sway-helix .
 
   if [ $? -eq 0 ]; then
     echo "✅ Zed agent Docker image built successfully"
@@ -1040,7 +1048,18 @@ function build-desktop() {
   # Docker automatically detects Go code changes via COPY layers
   _dt_elapsed "🔨 Building ${IMAGE_NAME}:latest..."
 
+  # Extract Go version from go.mod and pass as build-arg. Avoids COPY-ing go.mod
+  # into the final stage just to grep one line — every dep bump would otherwise
+  # invalidate every downstream apt/npm/install layer.
+  local GO_VERSION
+  GO_VERSION=$(awk '/^go [0-9]/ {print $2; exit}' go.mod)
+  if [ -z "$GO_VERSION" ]; then
+    echo "❌ Could not extract Go version from go.mod"
+    exit 1
+  fi
+
   docker buildx build --provenance=false -f "$DOCKERFILE" \
+    --build-arg "GO_VERSION=${GO_VERSION}" \
     -t "${IMAGE_NAME}:latest" \
     .
 


### PR DESCRIPTION
## Summary

Stop invalidating ~15+ minutes of unrelated work in `Dockerfile.{ubuntu,sway}-helix` every time someone bumps a Go dependency.

The final stage had:

\`\`\`dockerfile
COPY go.mod /tmp/go.mod
RUN GO_VERSION=$(grep -E "^go [0-9]" /tmp/go.mod | awk '{print $2}') && \
    curl ... go${GO_VERSION}.linux-${TARGETARCH}.tar.gz ...
\`\`\`

…purely to read the Go version string. Every change to `go.mod` (19 commits in the last 60 days — kodit bumps, removing tika, etc.) invalidated this layer **and every downstream layer in the final stage**: ONLYOFFICE install, user creation, Chrome install, chrome-devtools-mcp npm install, drone-ci npm install, gst plugin install, ghostty install, cursor theme generation, qwen + Zed copies, and the Go-binary copies from `go-build-env`.

After this PR, dep bumps don't invalidate any of that. Only an actual Go-version change does.

## What changed

- `Dockerfile.ubuntu-helix` / `Dockerfile.sway-helix`: replace the COPY+RUN with `ARG GO_VERSION` immediately followed by the install RUN. The arg is required (the RUN errors out with a clear message if it's empty).
- `stack`: `build-desktop` and `build-zed-agent` now extract `GO_VERSION` from `go.mod` on the host and pass it via `--build-arg`.
- `.drone.yml`: same in all four `docker build` invocations under `build-desktops` (amd64 + arm64 × sway + ubuntu).

## Why build-args are cache-stable here

Build args don't participate in the COPY-content cache key the way file copies do. BuildKit only invalidates the `RUN` that actually references the arg when the arg's value changes. The `ARG GO_VERSION` declaration above the RUN is itself cache-neutral — only the resolved value flowing into the RUN matters. Dep bumps in `go.mod` change file content but not the `go X.Y.Z` line, so the value stays the same and the layer stays cached.

## Test plan

- [ ] Local: `./stack build-ubuntu` — expect Go-install layer to install Go 1.25.4 once, then re-runs of unmodified `go.mod` should hit cache; bumping a dep in `go.mod` and rebuilding should NOT re-run apt/npm/install layers
- [ ] CI: `build-desktops` step in Drone should still produce identical-content images; verify `go version` inside the desktop container reports the right Go
- [ ] Negative: removing `--build-arg GO_VERSION=` from the docker build should fail fast with the helpful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)