### PR TITLE
fix(api): cache PR listings and back off on GitHub rate limits

### DIFF
--- a/api/pkg/services/git_repository_service.go
+++ b/api/pkg/services/git_repository_service.go
@@ -70,6 +70,11 @@ type GitRepositoryService struct {
 	// commits between receive-pack and upstream push.
 	repoLocks map[string]*sync.Mutex
 	locksMu   sync.Mutex // protects repoLocks map
+
+	// prListCache absorbs duplicate ListPullRequests calls (orchestrator polls,
+	// concurrent handler hits) so we don't hammer GitHub and trip its 5000 req/hr
+	// rate limit. Set on construction; safe for concurrent use.
+	prListCache *prListCache
 }
 
 // NewGitRepositoryService creates a new git repository service
@@ -97,6 +102,7 @@ func NewGitRepositoryService(
 		enableGitServer: true,
 		testMode:        false,
 		repoLocks:       make(map[string]*sync.Mutex),
+		prListCache:     newPRListCache(defaultPRListCacheTTL),
 	}
 }
 
@@ -288,9 +294,16 @@ func (s *GitRepositoryService) isBranchAheadOfRemote(ctx context.Context, repoPa
 		AddDynamicArguments(branch).
 		RunStdString(ctx, &gitcmd.RunOpts{Dir: repoPath})
 	if fetchErr != nil {
-		// Can't reach remote (no network, no auth, etc.) — skip rather than
-		// incorrectly concluding the branch is ahead.
-		log.Debug().Err(fetchErr).Str("branch", branch).Str("repo_path", repoPath).
+		// "couldn't find remote ref" is the common case for branches that
+		// exist locally but not on the remote (deleted PR branches, branches
+		// renamed upstream). Drop these to Trace so the ordinary recovery
+		// pass doesn't drown the log; reserve Debug for genuine remote/auth
+		// failures that an operator might want to investigate.
+		ev := log.Debug()
+		if strings.Contains(fetchErr.Error(), "couldn't find remote ref") {
+			ev = log.Trace()
+		}
+		ev.Err(fetchErr).Str("branch", branch).Str("repo_path", repoPath).
 			Msg("Failed to fetch remote before ahead check, skipping branch")
 		return false, nil
 	}

--- a/api/pkg/services/git_repository_service_pr_list_cache.go
+++ b/api/pkg/services/git_repository_service_pr_list_cache.go
@@ -1,0 +1,89 @@
+package services
+
+import (
+	"sync"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// defaultPRListCacheTTL is the default TTL for cached external PR list results.
+// 60s absorbs a 30s orchestrator poll cycle plus coincident user-driven requests
+// while keeping PR state visibly fresh in the UI.
+const defaultPRListCacheTTL = 60 * time.Second
+
+// prListCacheEntry holds either a successful PR list result or a cached error
+// (used to back off on rate-limit responses without re-hitting the upstream).
+type prListCacheEntry struct {
+	prs       []*types.PullRequest
+	err       error
+	expiresAt time.Time
+}
+
+// prListCache is an in-process TTL cache for ListPullRequests results, keyed by
+// repository ID. Successful results are cached for prListCache.ttl; rate-limit
+// errors are cached until their reset time (set explicitly via setError).
+type prListCache struct {
+	mu      sync.Mutex
+	entries map[string]prListCacheEntry
+	ttl     time.Duration
+}
+
+func newPRListCache(ttl time.Duration) *prListCache {
+	if ttl <= 0 {
+		ttl = defaultPRListCacheTTL
+	}
+	return &prListCache{
+		entries: make(map[string]prListCacheEntry),
+		ttl:     ttl,
+	}
+}
+
+// get returns the cached entry for repoID and true if it is still fresh,
+// otherwise the zero entry and false.
+func (c *prListCache) get(repoID string) ([]*types.PullRequest, error, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[repoID]
+	if !ok {
+		return nil, nil, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		delete(c.entries, repoID)
+		return nil, nil, false
+	}
+	return entry.prs, entry.err, true
+}
+
+// set caches a successful PR list result for the default TTL.
+func (c *prListCache) set(repoID string, prs []*types.PullRequest) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.entries[repoID] = prListCacheEntry{
+		prs:       prs,
+		expiresAt: time.Now().Add(c.ttl),
+	}
+}
+
+// setError caches an error result until expiresAt. Used to back off on
+// rate-limit errors so we don't re-hit the upstream until the limit resets.
+func (c *prListCache) setError(repoID string, err error, expiresAt time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.entries[repoID] = prListCacheEntry{
+		err:       err,
+		expiresAt: expiresAt,
+	}
+}
+
+// invalidate drops any cached entry for repoID. Call after a mutating
+// operation (e.g. CreatePullRequest) so the next read sees fresh state.
+func (c *prListCache) invalidate(repoID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	delete(c.entries, repoID)
+}

--- a/api/pkg/services/git_repository_service_pr_list_cache_test.go
+++ b/api/pkg/services/git_repository_service_pr_list_cache_test.go
@@ -1,0 +1,186 @@
+package services
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/types"
+
+	gh "github.com/google/go-github/v57/github"
+)
+
+func TestPRListCache_HitsThenExpires(t *testing.T) {
+	c := newPRListCache(50 * time.Millisecond)
+
+	if _, _, ok := c.get("repo-1"); ok {
+		t.Fatal("expected miss on empty cache")
+	}
+
+	prs := []*types.PullRequest{{ID: "1"}}
+	c.set("repo-1", prs)
+
+	got, cachedErr, ok := c.get("repo-1")
+	if !ok || cachedErr != nil || len(got) != 1 || got[0].ID != "1" {
+		t.Fatalf("expected cached prs, got hit=%v err=%v prs=%v", ok, cachedErr, got)
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	if _, _, ok := c.get("repo-1"); ok {
+		t.Fatal("expected expiry after TTL")
+	}
+}
+
+func TestPRListCache_ErrorCachedUntilExpiresAt(t *testing.T) {
+	c := newPRListCache(time.Hour) // long success TTL so it doesn't interfere
+
+	rlErr := errors.New("rate limited")
+	expiry := time.Now().Add(40 * time.Millisecond)
+	c.setError("repo-rl", rlErr, expiry)
+
+	_, gotErr, ok := c.get("repo-rl")
+	if !ok || gotErr == nil {
+		t.Fatalf("expected cached error, got hit=%v err=%v", ok, gotErr)
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	if _, _, ok := c.get("repo-rl"); ok {
+		t.Fatal("expected error entry to expire after its expiresAt")
+	}
+}
+
+func TestPRListCache_InvalidateClears(t *testing.T) {
+	c := newPRListCache(time.Hour)
+	c.set("repo-x", []*types.PullRequest{{ID: "1"}})
+
+	c.invalidate("repo-x")
+
+	if _, _, ok := c.get("repo-x"); ok {
+		t.Fatal("expected invalidate to clear the entry")
+	}
+}
+
+func TestRateLimitBackoffUntil_RateLimitError(t *testing.T) {
+	resetAt := time.Now().Add(2 * time.Minute)
+	rlErr := &gh.RateLimitError{
+		Rate: gh.Rate{Reset: gh.Timestamp{Time: resetAt}},
+		Response: &http.Response{
+			StatusCode: 403,
+			Request: &http.Request{
+				Method: "GET",
+				URL:    mustURL("https://api.github.com/repos/x/y/pulls"),
+			},
+		},
+		Message: "API rate limit exceeded",
+	}
+	wrapped := errors.New("wrap: " + rlErr.Error())
+	_ = wrapped // we need wrapped-with-%w to test errors.As; build inline below
+
+	until, ok := rateLimitBackoffUntil(rlErr)
+	if !ok {
+		t.Fatal("expected rate-limit error to be recognized")
+	}
+	if !until.Equal(resetAt) {
+		t.Fatalf("expected backoff until %v, got %v", resetAt, until)
+	}
+}
+
+func TestRateLimitBackoffUntil_RateLimitErrorWrapped(t *testing.T) {
+	resetAt := time.Now().Add(3 * time.Minute)
+	inner := &gh.RateLimitError{
+		Rate: gh.Rate{Reset: gh.Timestamp{Time: resetAt}},
+		Response: &http.Response{
+			StatusCode: 403,
+			Request: &http.Request{
+				Method: "GET",
+				URL:    mustURL("https://api.github.com/repos/x/y/pulls"),
+			},
+		},
+	}
+	wrapped := wrapErr(wrapErr(inner))
+
+	until, ok := rateLimitBackoffUntil(wrapped)
+	if !ok {
+		t.Fatal("expected wrapped rate-limit error to be recognized via errors.As")
+	}
+	if !until.Equal(resetAt) {
+		t.Fatalf("expected backoff until %v, got %v", resetAt, until)
+	}
+}
+
+func TestRateLimitBackoffUntil_AbuseRateLimitError(t *testing.T) {
+	retry := 90 * time.Second
+	abuse := &gh.AbuseRateLimitError{
+		RetryAfter: &retry,
+		Response: &http.Response{
+			StatusCode: 403,
+			Request: &http.Request{
+				Method: "GET",
+				URL:    mustURL("https://api.github.com/repos/x/y/pulls"),
+			},
+		},
+	}
+
+	before := time.Now()
+	until, ok := rateLimitBackoffUntil(abuse)
+	if !ok {
+		t.Fatal("expected abuse rate-limit error to be recognized")
+	}
+	if until.Before(before.Add(80*time.Second)) || until.After(before.Add(100*time.Second)) {
+		t.Fatalf("expected ~90s backoff, got %v (delta %v)", until, until.Sub(before))
+	}
+}
+
+func TestRateLimitBackoffUntil_RateLimitErrorPastReset(t *testing.T) {
+	rlErr := &gh.RateLimitError{
+		Rate: gh.Rate{Reset: gh.Timestamp{Time: time.Now().Add(-1 * time.Hour)}},
+		Response: &http.Response{
+			StatusCode: 403,
+			Request: &http.Request{
+				Method: "GET",
+				URL:    mustURL("https://api.github.com/repos/x/y/pulls"),
+			},
+		},
+	}
+
+	before := time.Now()
+	until, ok := rateLimitBackoffUntil(rlErr)
+	if !ok {
+		t.Fatal("expected rate-limit error to be recognized")
+	}
+	if until.Before(before.Add(rateLimitFallbackBackoff - 5*time.Second)) {
+		t.Fatalf("expected fallback backoff ~5m, got %v", until.Sub(before))
+	}
+}
+
+func TestRateLimitBackoffUntil_NotRateLimit(t *testing.T) {
+	if _, ok := rateLimitBackoffUntil(errors.New("some other failure")); ok {
+		t.Fatal("expected non-rate-limit error to be unrecognized")
+	}
+	if _, ok := rateLimitBackoffUntil(nil); ok {
+		t.Fatal("expected nil error to be unrecognized")
+	}
+}
+
+// wrapErr mimics the fmt.Errorf("...: %w", err) wrapping that
+// listGitHubPullRequests / Client.ListPullRequests apply on the way back up.
+func wrapErr(err error) error {
+	return &wrapErrT{inner: err}
+}
+
+type wrapErrT struct{ inner error }
+
+func (e *wrapErrT) Error() string { return "wrapped: " + e.inner.Error() }
+func (e *wrapErrT) Unwrap() error { return e.inner }
+
+func mustURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}

--- a/api/pkg/services/git_repository_service_pull_requests.go
+++ b/api/pkg/services/git_repository_service_pull_requests.go
@@ -2,10 +2,12 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	azuredevops "github.com/helixml/helix/api/pkg/agent/skill/azure_devops"
 	"github.com/helixml/helix/api/pkg/agent/skill/bitbucket"
@@ -18,6 +20,10 @@ import (
 	"github.com/rs/zerolog/log"
 	gl "github.com/xanzy/go-gitlab"
 )
+
+// rateLimitFallbackBackoff is used when GitHub returns a rate-limit / abuse error
+// without a usable reset time. We back off for this long before retrying.
+const rateLimitFallbackBackoff = 5 * time.Minute
 
 // OAuthRequiredError is returned when a user-initiated action requires
 // a GitHub OAuth connection that the acting user does not have.
@@ -62,6 +68,11 @@ func (s *GitRepositoryService) CreatePullRequest(ctx context.Context, repoID str
 		return "", fmt.Errorf("repository is not external, cannot create pull request")
 	}
 
+	// Drop any cached PR list for this repo so the next read sees the new PR.
+	if s.prListCache != nil {
+		s.prListCache.invalidate(repoID)
+	}
+
 	switch repo.ExternalType {
 	case types.ExternalRepositoryTypeADO:
 		return s.createAzureDevOpsPullRequest(ctx, repo, title, description, sourceBranch, targetBranch)
@@ -85,6 +96,11 @@ func (s *GitRepositoryService) UpdatePullRequest(ctx context.Context, repoID str
 
 	if repo.ExternalURL == "" {
 		return fmt.Errorf("repository is not external")
+	}
+
+	// Drop any cached PR list for this repo so the next read reflects the update.
+	if s.prListCache != nil {
+		s.prListCache.invalidate(repoID)
 	}
 
 	switch repo.ExternalType {
@@ -213,6 +229,41 @@ func (s *GitRepositoryService) createAzureDevOpsPullRequest(ctx context.Context,
 }
 
 func (s *GitRepositoryService) ListPullRequests(ctx context.Context, repoID string) ([]*types.PullRequest, error) {
+	if s.prListCache != nil {
+		if prs, cachedErr, ok := s.prListCache.get(repoID); ok {
+			return prs, cachedErr
+		}
+	}
+
+	prs, err := s.listPullRequestsUncached(ctx, repoID)
+	if s.prListCache == nil {
+		return prs, err
+	}
+
+	if err != nil {
+		// Cache rate-limit / abuse errors until their reset window so we don't
+		// re-hit the upstream from every concurrent caller while the limit is
+		// still in effect. Other errors are not cached so transient failures
+		// retry on the next call.
+		if backoffUntil, ok := rateLimitBackoffUntil(err); ok {
+			s.prListCache.setError(repoID, err, backoffUntil)
+			log.Warn().
+				Err(err).
+				Str("repo_id", repoID).
+				Dur("reset_in", time.Until(backoffUntil)).
+				Msg("GitHub rate limit hit; backing off ListPullRequests for this repo")
+		}
+		return nil, err
+	}
+
+	s.prListCache.set(repoID, prs)
+	return prs, nil
+}
+
+// listPullRequestsUncached performs the actual upstream PR list call, dispatched
+// by the repository's external provider type. ListPullRequests wraps this with
+// the prListCache.
+func (s *GitRepositoryService) listPullRequestsUncached(ctx context.Context, repoID string) ([]*types.PullRequest, error) {
 	repo, err := s.GetRepository(ctx, repoID)
 	if err != nil {
 		return nil, fmt.Errorf("repository not found: %w", err)
@@ -234,6 +285,28 @@ func (s *GitRepositoryService) ListPullRequests(ctx context.Context, repoID stri
 	default:
 		return nil, fmt.Errorf("unsupported external repository type: %s", repo.ExternalType)
 	}
+}
+
+// rateLimitBackoffUntil inspects err for a GitHub rate-limit / abuse error and,
+// if found, returns the time at which we should retry. Falls back to a fixed
+// 5-minute backoff if no reset time is available on the error.
+func rateLimitBackoffUntil(err error) (time.Time, bool) {
+	var rl *gh.RateLimitError
+	if errors.As(err, &rl) {
+		reset := rl.Rate.Reset.Time
+		if reset.IsZero() || reset.Before(time.Now()) {
+			reset = time.Now().Add(rateLimitFallbackBackoff)
+		}
+		return reset, true
+	}
+	var abuse *gh.AbuseRateLimitError
+	if errors.As(err, &abuse) {
+		if abuse.RetryAfter != nil && *abuse.RetryAfter > 0 {
+			return time.Now().Add(*abuse.RetryAfter), true
+		}
+		return time.Now().Add(rateLimitFallbackBackoff), true
+	}
+	return time.Time{}, false
 }
 
 func pullRequestStateFromAzureDevOps(state string) types.PullRequestState {

--- a/api/pkg/services/spec_task_orchestrator.go
+++ b/api/pkg/services/spec_task_orchestrator.go
@@ -983,8 +983,13 @@ func (o *SpecTaskOrchestrator) detectExternalPRActivity(ctx context.Context) {
 
 	log.Debug().Int("count", len(eligibleTasks)).Msg("Checking tasks for external PR activity")
 
+	// prsByRepo memoizes ListPullRequests results across this poll cycle so
+	// that N tasks all referencing the same upstream repo (e.g. helixml/helix)
+	// hit the GitHub API once per repo, not once per task. Combined with the
+	// service-level cache this keeps us well under the 5000 req/hr quota.
+	prsByRepo := make(map[string][]*types.PullRequest)
 	for _, task := range eligibleTasks {
-		err := o.checkTaskForExternalPRActivity(ctx, task)
+		err := o.checkTaskForExternalPRActivity(ctx, task, prsByRepo)
 		if err != nil {
 			// Don't spam logs for deleted projects
 			if isDeletedProjectError(err) {
@@ -1002,8 +1007,10 @@ func (o *SpecTaskOrchestrator) detectExternalPRActivity(ctx context.Context) {
 	}
 }
 
-// checkTaskForExternalPRActivity checks a single task for external PR activity
-func (o *SpecTaskOrchestrator) checkTaskForExternalPRActivity(ctx context.Context, task *types.SpecTask) error {
+// checkTaskForExternalPRActivity checks a single task for external PR activity.
+// prsByRepo is a per-cycle memo: callers should pass the same map across all
+// tasks in a poll cycle so PR lists for a given repo are fetched at most once.
+func (o *SpecTaskOrchestrator) checkTaskForExternalPRActivity(ctx context.Context, task *types.SpecTask, prsByRepo map[string][]*types.PullRequest) error {
 	project, err := o.store.GetProject(ctx, task.ProjectID)
 	if err != nil {
 		return fmt.Errorf("failed to get project: %w", err)
@@ -1025,11 +1032,19 @@ func (o *SpecTaskOrchestrator) checkTaskForExternalPRActivity(ctx context.Contex
 			continue
 		}
 
-		// Check for open or merged PRs on this branch
-		prs, err := o.gitService.ListPullRequests(ctx, repo.ID)
-		if err != nil {
-			log.Debug().Err(err).Str("repo_id", repo.ID).Msg("Failed to list PRs, skipping repo")
-			continue
+		// Reuse the per-cycle memo if we've already listed this repo's PRs
+		// for an earlier task in this batch.
+		prs, cached := prsByRepo[repo.ID]
+		if !cached {
+			prs, err = o.gitService.ListPullRequests(ctx, repo.ID)
+			if err != nil {
+				log.Debug().Err(err).Str("repo_id", repo.ID).Msg("Failed to list PRs, skipping repo")
+				// Memoize the empty result too so a failing repo is only
+				// attempted once per cycle.
+				prsByRepo[repo.ID] = nil
+				continue
+			}
+			prsByRepo[repo.ID] = prs
 		}
 
 		for _, pr := range prs {


### PR DESCRIPTION
## Summary

`api-1` was logging GitHub `403 API rate limit exceeded` continuously — `detectExternalPRActivity` runs every 30s, and for each of up to 10 eligible tasks it called `gitService.ListPullRequests` once per external repo, with no caching. With multiple task projects sharing the same upstream repos (`helixml/helix`, `helixml/helix-next`), the same `GET /repos/{owner}/{repo}/pulls` request fired ~20× per minute, blowing past GitHub's 5000 req/hr authenticated quota.

This adds a 60s in-process TTL cache on `GitRepositoryService.ListPullRequests` (shared across orchestrator, handlers, and the git HTTP server), explicit per-cycle dedup in the orchestrator, and rate-limit-aware backoff that caches the error until the upstream's reset window.

Also quiets the noisy "couldn't find remote ref" `Debug` line emitted by `recoverIncompletePushes` for branches that exist locally but not on the remote (deleted PR branches) — downgraded to `Trace` for that specific error class while keeping `Debug` for genuine remote/auth failures.

## Changes

- **New `prListCache`** (`git_repository_service_pr_list_cache.go`) — TTL-keyed `map[repoID] → {prs, err, expiresAt}`. Successful results cached for 60s; rate-limit errors cached until their reset time.
- **`ListPullRequests` wrapped** with cache lookup, miss-fetch, and cache-write. Detects `*github.RateLimitError` / `*github.AbuseRateLimitError` (via `errors.As`, so works through the wrapping layers) and logs once at WARN per backoff window with `repo_id` + `reset_in`.
- **Cache invalidation** added to `CreatePullRequest` and `UpdatePullRequest` so the next read sees fresh state.
- **Per-cycle dedup** in `detectExternalPRActivity` via a `map[repoID][]*types.PullRequest` memo — N tasks sharing M repos now hit the upstream M times per cycle, not N×M.
- **Quieter recovery log**: `isBranchAheadOfRemote` downgrades `couldn't find remote ref` to `Trace`.
- **Tests** for the cache (TTL hit/expire, error-until-expiresAt, invalidate) and `rateLimitBackoffUntil` (RateLimitError, wrapped via `%w`, AbuseRateLimitError, past-reset fallback, non-rate-limit pass-through).

## Why two layers (cache + per-cycle memo)?

The cache alone already satisfies "≤ 1 upstream call per repo per 60s". The orchestrator-level memo is defense-in-depth: it makes the per-cycle intent explicit at the call site, survives accidental cache-bypass refactors, and saves one map lookup per call.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -run 'TestPRListCache|TestRateLimitBackoff' ./pkg/services/` — 8/8 passing
- [x] `go test -run 'TestSpecTaskOrchestratorTestSuite' ./pkg/services/` — no regression
- [x] `go test -run 'TestEnsurePullRequest' ./pkg/server/` — no regression
- [ ] Operator verification post-deploy: tail `api-1` logs across two poll cycles, confirm `ListPullRequests` calls drop to one per unique external repo per ~60s, and `couldn't find remote ref` lines are gone from default-level logs.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01krbckg3tq6f8196jnvrf3gxk)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002006_gaah-api-1-2026-05/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002006_gaah-api-1-2026-05/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002006_gaah-api-1-2026-05/tasks.md)

🚀 Built with [Helix](https://helix.ml)