### PR TITLE
fix(session): attach scroll listeners reliably (follow-up to #2346)

### DIFF
--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -324,17 +324,21 @@ const EmbeddedSessionView = forwardRef<
   //     shifts scrollTop without any input event.
   // This sidesteps the three race surfaces that killed the previous
   // sticky-scroll attempt (see commit 42c3a5112 for the autopsy).
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
+  //
+  // Listeners are wired via React's synthetic event props on the container
+  // JSX (NOT a useEffect) because the component renders early-return
+  // loading/empty states before the container exists. A useEffect with a
+  // stable dep array would run once with `containerRef.current === null`
+  // and never re-attach when the container later mounts. React's prop
+  // wiring guarantees attachment whenever the container actually renders.
+  const triggerUnlock = useCallback(() => {
+    setAutoScroll(false);
+    autoScrollRef.current = false;
+    upwardAccumRef.current = 0;
+  }, [setAutoScroll]);
 
-    const triggerUnlock = () => {
-      setAutoScroll(false);
-      autoScrollRef.current = false;
-      upwardAccumRef.current = 0;
-    };
-
-    const onWheel = (e: WheelEvent) => {
+  const handleWheel = useCallback(
+    (e: React.WheelEvent<HTMLDivElement>) => {
       if (!autoScrollRef.current) return;
       const now = performance.now();
       // New gesture if the previous wheel event was long enough ago.
@@ -350,18 +354,21 @@ const EmbeddedSessionView = forwardRef<
         // signals the user does NOT want to disengage auto-scroll.
         upwardAccumRef.current = 0;
       }
-    };
+    },
+    [triggerUnlock],
+  );
 
-    const onTouchStart = (e: TouchEvent) => {
-      if (!autoScrollRef.current) return;
-      const t = e.touches[0];
-      if (!t) return;
-      touchStartYRef.current = t.clientY;
-      lastTouchYRef.current = t.clientY;
-      upwardAccumRef.current = 0;
-    };
+  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLDivElement>) => {
+    if (!autoScrollRef.current) return;
+    const t = e.touches[0];
+    if (!t) return;
+    touchStartYRef.current = t.clientY;
+    lastTouchYRef.current = t.clientY;
+    upwardAccumRef.current = 0;
+  }, []);
 
-    const onTouchMove = (e: TouchEvent) => {
+  const handleTouchMove = useCallback(
+    (e: React.TouchEvent<HTMLDivElement>) => {
       if (!autoScrollRef.current) return;
       const t = e.touches[0];
       if (!t || lastTouchYRef.current === null) return;
@@ -376,28 +383,15 @@ const EmbeddedSessionView = forwardRef<
       } else if (dy < 0) {
         upwardAccumRef.current = 0;
       }
-    };
+    },
+    [triggerUnlock],
+  );
 
-    const onTouchEnd = () => {
-      touchStartYRef.current = null;
-      lastTouchYRef.current = null;
-      upwardAccumRef.current = 0;
-    };
-
-    container.addEventListener("wheel", onWheel, { passive: true });
-    container.addEventListener("touchstart", onTouchStart, { passive: true });
-    container.addEventListener("touchmove", onTouchMove, { passive: true });
-    container.addEventListener("touchend", onTouchEnd, { passive: true });
-    container.addEventListener("touchcancel", onTouchEnd, { passive: true });
-
-    return () => {
-      container.removeEventListener("wheel", onWheel);
-      container.removeEventListener("touchstart", onTouchStart);
-      container.removeEventListener("touchmove", onTouchMove);
-      container.removeEventListener("touchend", onTouchEnd);
-      container.removeEventListener("touchcancel", onTouchEnd);
-    };
-  }, [setAutoScroll]);
+  const handleTouchEnd = useCallback(() => {
+    touchStartYRef.current = null;
+    lastTouchYRef.current = null;
+    upwardAccumRef.current = 0;
+  }, []);
 
   // Reload session handler
   const handleReloadSession = useCallback(async () => {
@@ -536,6 +530,11 @@ const EmbeddedSessionView = forwardRef<
       <Box
         ref={containerRef}
         onScroll={handleScroll}
+        onWheel={handleWheel}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={handleTouchEnd}
         sx={{
           // Use height: 0 + flex: 1 to force this to be the scrollable container
           // Without height: 0, the container may expand to fit content on iOS

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -69,7 +69,7 @@ export interface EmbeddedSessionViewHandle {
  *   - A single global preference (`helix.autoScroll`, default ON) controls
  *     whether new content auto-scrolls the chat to the bottom.
  *   - When ON: every content-height *growth* (driven by ResizeObserver on
- *     contentRef) is followed by a scroll to bottom. Renders that don't
+ *     the inner content Box) is followed by a scroll to bottom. Renders that don't
  *     grow content (3s polls, WS keepalives, identical re-renders) do
  *     no scroll work — `scrollToBottom()` is a no-op when
  *     `container.scrollHeight === lastScrolledHeightRef.current`.
@@ -224,9 +224,19 @@ const EmbeddedSessionView = forwardRef<
     enabled: !!sessionId,
   });
 
-  // Ref to the inner content Box; observed by ResizeObserver so we only
-  // react to *actual* content size changes, not every React re-render.
-  const contentRef = useRef<HTMLDivElement>(null);
+  // The inner content Box is observed by ResizeObserver so we only react
+  // to *actual* content size changes, not every React re-render. Using a
+  // state-mirrored callback ref (NOT a plain useRef) so the ResizeObserver
+  // useEffect can re-run when the element actually mounts — necessary
+  // because EmbeddedSessionView has early returns (loading state when
+  // !session, empty state when no interactions) that render before the
+  // JSX containing this ref. A plain useRef + stable-deps useEffect runs
+  // once with `current === null` and never re-runs when the content
+  // finally mounts; the callback-ref state flip forces the re-run.
+  const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null);
+  const setContentRef = useCallback((el: HTMLDivElement | null) => {
+    setContentEl(el);
+  }, []);
   // Last observed content height. 0 until the first ResizeObserver callback.
   const lastContentHeightRef = useRef(0);
   // True once we've forced an initial scroll-to-bottom for this session.
@@ -283,10 +293,12 @@ const EmbeddedSessionView = forwardRef<
   // ResizeObserver-driven auto-scroll: only fires when the content's actual
   // size changes. Renders that don't grow content (e.g., the 3s React Query
   // poll returning identical data) do no scroll work at all.
+  //
+  // The dep array includes `contentEl` so the effect re-runs when the
+  // content element first mounts after a loading-state early return.
   useEffect(() => {
     const container = containerRef.current;
-    const content = contentRef.current;
-    if (!container || !content) return;
+    if (!container || !contentEl) return;
 
     const observer = new ResizeObserver((entries) => {
       const newHeight = entries[0]?.contentRect.height ?? 0;
@@ -309,9 +321,9 @@ const EmbeddedSessionView = forwardRef<
       }
     });
 
-    observer.observe(content);
+    observer.observe(contentEl);
     return () => observer.disconnect();
-  }, [isNearBottom]);
+  }, [contentEl, isNearBottom]);
 
   // Detect explicit user scroll-up and flip auto-scroll OFF when the user
   // accumulates >= USER_SCROLL_UNLOCK_PX upward within a single gesture.
@@ -551,7 +563,7 @@ const EmbeddedSessionView = forwardRef<
         }}
       >
         <Box
-          ref={contentRef}
+          ref={setContentRef}
           sx={{
             width: "100%",
             maxWidth: 700,


### PR DESCRIPTION
## Summary

Two follow-up fixes to #2346. The user reported that explicit scroll-up wasn't disengaging auto-scroll on a MacBook trackpad in production — investigation showed the `useEffect` that attached the wheel/touch listeners was running during `EmbeddedSessionView`'s loading-state early return when `containerRef.current` was still null, returning early, and never re-attaching when the container later mounted.

While fixing it I noticed the pre-existing ResizeObserver `useEffect` has the same bug pattern — it never actually attached the observer to the content element either. Auto-scroll only appeared to work in production because `InteractionLiveStream.onMessageUpdate` calls `scrollToBottom` directly on every state change, masking the broken observer.

Both are fixed by moving DOM-element observation out of stable-deps `useEffect`s and into mechanisms that React can attach reliably during commit:

- **Wheel/touch handlers** (commit `ebb9a5e`) — wired via React's synthetic-event props (`onWheel`, `onTouchStart`, `onTouchMove`, `onTouchEnd`, `onTouchCancel`) on the container JSX. React handles attachment whenever the container mounts.
- **ResizeObserver** (commit `76c4d21`) — `contentRef` converted from `useRef` to a state-mirrored callback ref. The observer-attaching `useEffect` now depends on `[contentEl, isNearBottom]`, so it re-runs the moment the content element first mounts.

## Changes

- `frontend/src/components/session/EmbeddedSessionView.tsx`
  - Replaced the listener-attaching `useEffect` with `useCallback` handlers (`handleWheel`, `handleTouchStart`, `handleTouchMove`, `handleTouchEnd`) wired via JSX props.
  - Replaced `contentRef = useRef(...)` with `[contentEl, setContentEl] = useState(null)` plus a stable callback ref `setContentRef`.
  - ResizeObserver `useEffect` now keys on `[contentEl, isNearBottom]`.
  - Updated docstring.

## Test plan

End-to-end verified in inner Helix against the production code path (not an isolated algorithm replay this time):

- [x] `cd frontend && yarn build` passes.
- [x] **Wheel-listener attachment**: dispatched `WheelEvent { deltaY: -50 }` → `helix.autoScroll` stays `"true"` (below threshold). Cumulative `WheelEvent { deltaY: -60 }` → flips to `"false"`, button changes to "Resume auto-scroll" (`aria-pressed=false`).
- [x] **Gesture timeout**: two 30 px wheel-ups separated by 600 ms (> 500 ms gesture timeout) — accumulator resets each time, neither flips the toggle.
- [x] **Direction-change reset**: down 100, then up 70+70=140 cumulative — flips to `"false"` (downward scroll resets accum, then 140 upward exceeds threshold).
- [x] **ResizeObserver attachment, ON**: scrolled to top (`scrollTop=0`), injected a 500 px filler into the content element. `scrollTop` jumped to exactly `scrollHeight - clientHeight` (7068).
- [x] **ResizeObserver attachment, OFF**: same setup with `helix.autoScroll = "false"`. Content grew. `scrollTop` stayed at 0.

## Why I missed this in the original PR

I had "verified" the wheel logic by dispatching synthetic `WheelEvent`s at a JS listener I attached *myself* in the test script — that tested the algorithm, not the wiring. The real production handler attached at component mount was never exercised. CLAUDE.md note added in #2346 to never let this happen again.

---

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001973_when-user-explicitly/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001973_when-user-explicitly/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001973_when-user-explicitly/tasks.md)
