### PR TITLE
fix: hide "Create User" admin action when OIDC is configured

### DIFF
--- a/api/pkg/server/create_user_handler_test.go
+++ b/api/pkg/server/create_user_handler_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/auth"
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestCreateUser_OIDCMode_Rejected(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockAuth := auth.NewMockAuthenticator(ctrl)
+
+	// In OIDC mode, neither Store.GetUser nor authenticator.CreateUser must be called.
+	mockStore.EXPECT().GetUser(gomock.Any(), gomock.Any()).Times(0)
+	mockAuth.EXPECT().CreateUser(gomock.Any(), gomock.Any()).Times(0)
+
+	cfg := &config.ServerConfig{}
+	cfg.Auth.Provider = types.AuthProviderOIDC
+
+	server := &HelixAPIServer{
+		Cfg:           cfg,
+		Store:         mockStore,
+		authenticator: mockAuth,
+	}
+
+	body, err := json.Marshal(types.AdminCreateUserRequest{
+		Email:    "new-user@example.com",
+		Password: "irrelevant",
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := setTestRequestUser(req.Context(), &types.User{
+		ID:    "admin-123",
+		Email: "admin@example.com",
+		Admin: true,
+	})
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+
+	result, httpErr := server.createUser(rr, req)
+
+	require.Nil(t, result)
+	require.NotNil(t, httpErr)
+	assert.Contains(t, httpErr.Error(), "OIDC provider")
+
+	var sysErr *system.HTTPError
+	require.True(t, errors.As(httpErr, &sysErr), "expected *system.HTTPError")
+	assert.Equal(t, http.StatusBadRequest, sysErr.StatusCode)
+}
+
+func TestCreateUser_NonAdmin_Forbidden(t *testing.T) {
+	// Sanity check: the existing non-admin guard still fires before the OIDC guard.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockAuth := auth.NewMockAuthenticator(ctrl)
+
+	mockStore.EXPECT().GetUser(gomock.Any(), gomock.Any()).Times(0)
+	mockAuth.EXPECT().CreateUser(gomock.Any(), gomock.Any()).Times(0)
+
+	cfg := &config.ServerConfig{}
+	cfg.Auth.Provider = types.AuthProviderOIDC
+
+	server := &HelixAPIServer{
+		Cfg:           cfg,
+		Store:         mockStore,
+		authenticator: mockAuth,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", bytes.NewReader([]byte("{}")))
+	req.Header.Set("Content-Type", "application/json")
+	ctx := setTestRequestUser(req.Context(), &types.User{
+		ID:    "user-123",
+		Email: "user@example.com",
+		Admin: false,
+	})
+	req = req.WithContext(ctx)
+
+	rr := httptest.NewRecorder()
+
+	_, httpErr := server.createUser(rr, req)
+
+	require.NotNil(t, httpErr)
+	var sysErr *system.HTTPError
+	require.True(t, errors.As(httpErr, &sysErr), "expected *system.HTTPError")
+	assert.Equal(t, http.StatusForbidden, sysErr.StatusCode)
+}

--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -834,6 +834,13 @@ func (apiServer *HelixAPIServer) createUser(_ http.ResponseWriter, req *http.Req
 		return nil, system.NewHTTPError403("only admins can create users")
 	}
 
+	if apiServer.Cfg.Auth.Provider == types.AuthProviderOIDC {
+		return nil, system.NewHTTPError400(
+			"User creation is managed by your OIDC provider. " +
+				"Create the user in the OIDC provider's admin console; " +
+				"they will be provisioned in Helix on first login.")
+	}
+
 	var request types.AdminCreateUserRequest
 
 	if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {

--- a/frontend/src/components/dashboard/UsersTable.tsx
+++ b/frontend/src/components/dashboard/UsersTable.tsx
@@ -31,13 +31,14 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CardGiftcardIcon from "@mui/icons-material/CardGiftcard";
 import CancelIcon from "@mui/icons-material/Cancel";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
-import { TypesUser } from "../../api/api";
+import { TypesAuthProvider, TypesUser } from "../../api/api";
 import {
     useListUsers,
     useAdminApproveUser,
     useAdminRevokeTrial,
     UserListQuery,
 } from "../../services/dashboardService";
+import { useGetConfig } from "../../services/userService";
 import { AccountContext } from "../../contexts/account";
 import useSnackbar from "../../hooks/useSnackbar";
 import CreateUserDialog from "./CreateUserDialog";
@@ -151,6 +152,8 @@ interface UsersTableProps {
 const UsersTable: FC<UsersTableProps> = ({ onSelectUser }) => {
     const account = useContext(AccountContext);
     const isCloud = account.serverConfig?.edition === "cloud";
+    const { data: config } = useGetConfig();
+    const isOIDC = config?.auth_provider === TypesAuthProvider.AuthProviderOIDC;
 
     const [searchQuery, setSearchQuery] = useState("");
     const [waitlistFilter, setWaitlistFilter] = useState<WaitlistFilter>("all");
@@ -287,11 +290,13 @@ const UsersTable: FC<UsersTableProps> = ({ onSelectUser }) => {
 
     return (
         <>
-            <Box sx={{ mb: 2, display: "flex", justifyContent: "flex-end" }}>
-                <Button variant="contained" color="secondary" startIcon={<AddIcon />} onClick={() => setCreateDialogOpen(true)}>
-                    Create User
-                </Button>
-            </Box>
+            {!isOIDC && (
+                <Box sx={{ mb: 2, display: "flex", justifyContent: "flex-end" }}>
+                    <Button variant="contained" color="secondary" startIcon={<AddIcon />} onClick={() => setCreateDialogOpen(true)}>
+                        Create User
+                    </Button>
+                </Box>
+            )}
             <Paper sx={{ width: "100%", overflow: "hidden" }}>
                 <Box sx={{ p: 2, display: "flex", justifyContent: "space-between", alignItems: "center", gap: 2 }}>
                     <Box sx={{ display: "flex", alignItems: "center", gap: 2, flex: 1, flexWrap: "wrap" }}>


### PR DESCRIPTION
## Summary

When Helix runs in OIDC mode (`AUTH_PROVIDER=oidc`), the Admin Dashboard's **Create User** button still wrote a local DB row with `auth_provider=regular` and a bcrypt password hash. The new "user" had no working login path: the regular login form is hidden in OIDC mode, and the OIDC IdP knows nothing about them. The result was a misleading row that made admins think the user existed.

User provisioning in OIDC deployments has to happen in the OIDC provider's admin console (Okta, Google, GitHub, Azure AD, Keycloak, …). Each IdP has a different admin API and we are explicitly not implementing them here. JIT provisioning on first OIDC login (`api/pkg/auth/oidc.go`) already materialises the local row.

This PR removes the dead-end UI and rejects the API call when OIDC is the configured provider.

## Changes

- **`api/pkg/server/handlers.go`** — `createUser` returns HTTP 400 with a clear "user creation is managed by your OIDC provider" message when `Cfg.Auth.Provider == AuthProviderOIDC`. Guard sits next to the existing admin-only guard. No DB writes, no hash generation.
- **`api/pkg/server/create_user_handler_test.go`** (new) — gomock test asserts the OIDC guard returns 400 and that `Store.GetUser` and `authenticator.CreateUser` are never invoked. A second test confirms the existing non-admin 403 still fires first as a sanity check.
- **`frontend/src/components/dashboard/UsersTable.tsx`** — read `auth_provider` via the existing `useGetConfig()` hook (same pattern as `Login.tsx`), compute `isOIDC`, and wrap the **Create User** button + its right-aligning `<Box>` in `{!isOIDC && (...)}`.

No new dependencies. No DB migration. `CreateUserDialog.tsx` is unchanged — it stays as-is for regular auth and is unreachable in OIDC mode because the only entry point is gone.

## Test plan

- [x] `go build ./pkg/server/...` (clean)
- [x] `go test -v -run "TestCreateUser_OIDCMode_Rejected|TestCreateUser_NonAdmin_Forbidden" ./pkg/server/ -count=1` — both pass
- [x] `cd frontend && yarn build` — clean
- [ ] **WARNING: NOT verified in inner Helix browser.** The inner Helix stack was not running in the spec-task sandbox (helix-ubuntu image was still building per `/tmp/helix-startup.log`). The frontend change is a one-line conditional render that mirrors the exact `auth_provider === 'oidc'` pattern already used in `frontend/src/pages/Login.tsx:93`, and the backend path is fully covered by the new unit test. Reviewer or CI should confirm in a real OIDC deployment.

## Related

Same bug as task `002007_fix-bug-when-helix-is` (design docs only, no merged code). Either task fully closes the issue.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01krdnsp4310g1seqhkfhnzsfm)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002008_add-user-on-the-admin/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002008_add-user-on-the-admin/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002008_add-user-on-the-admin/tasks.md)

🚀 Built with [Helix](https://helix.ml)