### PR TITLE
fix(frontend): make Reject Design button responsive

### DIFF
--- a/frontend/src/components/spec-tasks/DesignReviewContent.tsx
+++ b/frontend/src/components/spec-tasks/DesignReviewContent.tsx
@@ -71,7 +71,7 @@ import CommentLogSidebar from "./CommentLogSidebar";
 import ReviewActionFooter from "./ReviewActionFooter";
 import ReviewSubmitDialog from "./ReviewSubmitDialog";
 import RejectDesignDialog from "./RejectDesignDialog";
-import { useSpecTask } from "../../services/specTaskService";
+import { useSpecTask, useArchiveSpecTask } from "../../services/specTaskService";
 import { TypesSpecTaskStatus } from "../../api/api";
 
 type DocumentType = "requirements" | "technical_design" | "implementation_plan";
@@ -132,6 +132,7 @@ export default function DesignReviewContent({
   const viewedContentRef = useRef<Map<DocumentType, string>>(new Map());
   const [showRejectDialog, setShowRejectDialog] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
+  const archiveMutation = useArchiveSpecTask();
   const [shareLinkCopied, setShareLinkCopied] = useState(false);
   const [commentPositions, setCommentPositions] = useState<Map<string, number>>(
     new Map(),
@@ -1040,11 +1041,7 @@ export default function DesignReviewContent({
 
   const handleRejectDesign = async () => {
     try {
-      const apiClient = api.getApiClient();
-      await apiClient.v1SpecTasksArchivePartialUpdate(specTaskId, {
-        archived: true,
-      });
-
+      await archiveMutation.mutateAsync({ taskId: specTaskId, archived: true });
       snackbar.success("Design rejected - spec task archived");
       setShowRejectDialog(false);
       onClose();
@@ -1623,6 +1620,7 @@ export default function DesignReviewContent({
         reason={rejectReason}
         onReasonChange={setRejectReason}
         onReject={handleRejectDesign}
+        isSubmitting={archiveMutation.isPending}
       />
     </Box>
   );

--- a/frontend/src/components/spec-tasks/RejectDesignDialog.tsx
+++ b/frontend/src/components/spec-tasks/RejectDesignDialog.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Box,
   Alert,
+  CircularProgress,
 } from '@mui/material'
 
 interface RejectDesignDialogProps {
@@ -15,6 +16,7 @@ interface RejectDesignDialogProps {
   reason: string
   onReasonChange: (value: string) => void
   onReject: () => void
+  isSubmitting?: boolean
 }
 
 export default function RejectDesignDialog({
@@ -23,6 +25,7 @@ export default function RejectDesignDialog({
   reason,
   onReasonChange,
   onReject,
+  isSubmitting = false,
 }: RejectDesignDialogProps) {
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth sx={{ zIndex: 200000 }}>
@@ -39,16 +42,19 @@ export default function RejectDesignDialog({
           value={reason}
           onChange={e => onReasonChange(e.target.value)}
           placeholder="Explain why this design is being rejected..."
+          disabled={isSubmitting}
         />
       </DialogContent>
       <Box p={2} display="flex" gap={2} justifyContent="flex-end">
-        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={onClose} disabled={isSubmitting}>Cancel</Button>
         <Button
           variant="contained"
           color="error"
           onClick={onReject}
+          disabled={isSubmitting}
+          startIcon={isSubmitting ? <CircularProgress size={16} color="inherit" /> : undefined}
         >
-          Reject Design
+          {isSubmitting ? 'Rejecting...' : 'Reject Design'}
         </Button>
       </Box>
     </Dialog>

--- a/frontend/src/services/specTaskService.ts
+++ b/frontend/src/services/specTaskService.ts
@@ -284,6 +284,30 @@ export function useApproveSpecTask() {
   });
 }
 
+export function useArchiveSpecTask() {
+  const api = useApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      taskId,
+      archived,
+    }: {
+      taskId: string;
+      archived: boolean;
+    }) => {
+      const response = await api
+        .getApiClient()
+        .v1SpecTasksArchivePartialUpdate(taskId, { archived });
+      return response.data;
+    },
+    onSuccess: (_, { taskId }) => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.specTask(taskId) });
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.specTasksBase });
+    },
+  });
+}
+
 export function useSendZedEvent() {
   const api = useApi();
   const queryClient = useQueryClient();
@@ -538,6 +562,7 @@ const specTaskService = {
   // Mutation functions
   useUpdateSpecTask,
   useApproveSpecTask,
+  useArchiveSpecTask,
   useSendZedEvent,
   useCloneTask,
   useDeleteSpecTask,


### PR DESCRIPTION
## Summary

- The **Reject Design** button on the design-review surface felt unresponsive — clicking it once did nothing, clicking it several more times eventually let the page update.
- Root cause: Reject was a one-shot `async` handler that called the archive endpoint directly. No `isPending` flag (so the button stayed clickable while the PATCH was in flight, firing duplicate requests), and no cache invalidation (so the UI only refreshed when React Query happened to refetch on its own).
- Approve / Request Changes does not have this problem because it uses a `useMutation` hook (`useSubmitReview`) that handles both concerns automatically.

## Changes

- **`specTaskService.ts`** — new `useArchiveSpecTask()` mutation mirroring `useApproveSpecTask()`. Invalidates `specTask(taskId)` + `specTasksBase` on success.
- **`DesignReviewContent.tsx`** — `handleRejectDesign` now uses `archiveMutation.mutateAsync(...)`. Passes `archiveMutation.isPending` into the dialog.
- **`RejectDesignDialog.tsx`** — accepts `isSubmitting?: boolean`. Disables the Cancel button, Reject button, and reason textfield during submit; swaps the label to "Rejecting..." with an inline spinner. Otherwise structurally identical to `ReviewSubmitDialog`.

## Out of scope (follow-up)

Three other sites still call `v1SpecTasksArchivePartialUpdate` inline: `SpecTaskKanbanBoard.tsx`, `TabsView.tsx`, `SpecTaskDetailContent.tsx`. They would all benefit from adopting the new `useArchiveSpecTask` hook, but that is a separate cleanup.

## Test plan

- [ ] Open a spec task in design-review state, click **Reject Design**.
- [ ] Confirm the Reject button in the confirmation dialog disables and shows "Rejecting..." while the request is in flight.
- [ ] Confirm rapid double-clicks fire only one archive PATCH (devtools network panel).
- [ ] Confirm the design-review view closes and the spec task disappears from the active board immediately on success (no manual refresh needed).
- [ ] Confirm Approve Design / Request Changes still work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)