### PR TITLE
fix(frontend): make theme follow OS appearance changes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -52,12 +52,8 @@
             // dark mode for users who prefer light. Mirrors the logic in
             // contexts/theme.tsx getInitialMode().
             (function () {
-                var stored = null;
-                try { stored = localStorage.getItem('themeMode'); } catch (e) {}
-                var mode = stored === 'light' || stored === 'dark'
-                    ? stored
-                    : (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches
-                        ? 'light' : 'dark');
+                var mode = (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches)
+                    ? 'light' : 'dark';
                 var bg = mode === 'light' ? '#ffffff' : '#121214';
                 var fg = mode === 'light' ? '#333' : '#e0e0e0';
                 document.documentElement.style.backgroundColor = bg;

--- a/frontend/src/contexts/theme.tsx
+++ b/frontend/src/contexts/theme.tsx
@@ -4,14 +4,15 @@ import useThemeConfig from '../hooks/useThemeConfig'
 import useApi from '../hooks/useApi'
 import { PaletteMode } from '@mui/material'
 
-const THEME_MODE_KEY = 'themeMode'
-
 function getInitialMode(): PaletteMode {
-  const stored = localStorage.getItem(THEME_MODE_KEY)
-  if (stored === 'light' || stored === 'dark') return stored
   if (window.matchMedia('(prefers-color-scheme: light)').matches) return 'light'
   return 'dark'
 }
+
+// Drop a stale preference from earlier versions that pinned the mode in
+// localStorage. We now keep the mode in memory only — every reload re-resolves
+// from the OS, and OS transitions or manual toggles set the current mode.
+try { localStorage.removeItem('themeMode') } catch { /* ignore */ }
 
 export const ThemeContext = React.createContext({
   mode: 'dark' as PaletteMode,
@@ -23,15 +24,13 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
   const api = useApi()
   const [mode, setMode] = useState<PaletteMode>(getInitialMode)
 
-  // Live OS preference sync: follow the OS only while the user has not explicitly
-  // toggled (no entry in localStorage). Once they toggle, their explicit choice wins.
-  // We also push the change to the API so the user's spec-task GNOME desktops and
-  // Zed editors flip with them — otherwise the OS-driven flip would only update
-  // the browser app, not the inner desktop.
+  // Live OS preference sync. The most recent change wins, regardless of source —
+  // an OS transition here, a manual toggle in toggleMode below. We always update
+  // local state and push to the API so the user's spec-task GNOME desktops and
+  // Zed editors flip too via the settings-sync-daemon's WS subscription.
   useEffect(() => {
     const mql = window.matchMedia('(prefers-color-scheme: light)')
     const handler = (e: MediaQueryListEvent) => {
-      if (localStorage.getItem(THEME_MODE_KEY)) return
       const next: PaletteMode = e.matches ? 'light' : 'dark'
       setMode(next)
       api.getApiClient().v1UsersMeColorSchemeUpdate({ color_scheme: next })
@@ -237,7 +236,6 @@ export const ThemeProviderWrapper = ({ children }: { children: ReactNode }) => {
   const toggleMode = () => {
     setMode((prevMode) => {
       const next = prevMode === 'dark' ? 'light' : 'dark'
-      localStorage.setItem(THEME_MODE_KEY, next)
       // Fire-and-forget: persist to the user's account so any spec-task
       // sessions they own can mirror the theme into GNOME and Zed within
       // ~100ms via the settings-sync-daemon's WS subscription.


### PR DESCRIPTION
## Summary

The Helix UI didn't reliably follow the OS-level light/dark setting (e.g., macOS System Settings → Appearance). The detection code was in place — `prefers-color-scheme` was read on initial load and a `change` listener was registered — but as soon as a user clicked the in-app sun/moon toggle once, a `localStorage.themeMode` value was written and the listener silently early-returned forever after, with no UI to clear it.

The fix removes the lockout entirely. The model is now **the most recent change wins**, regardless of source: an OS transition fires the media-query listener, a manual toggle flips local state, both push the resolved color to `/api/v1/users/me/color-scheme` so the inner GNOME desktop and Zed editor mirror the change via the existing `settings-sync-daemon` path. There is no persisted preference — every page load re-resolves from the OS.

## Changes

- `frontend/src/contexts/theme.tsx`: drop the `THEME_MODE_KEY` constant, the localStorage read in `getInitialMode()`, the localStorage gate in the media-query `change` listener, and the localStorage write in `toggleMode()`. Add a one-time cleanup that removes any leftover legacy `themeMode` key on load.
- `frontend/index.html`: drop the `localStorage.themeMode` read from the pre-mount no-flash script; resolve directly from `prefers-color-scheme` instead.

## Verification

End-to-end in the inner Helix at `localhost:8080` using Chrome DevTools `emulate.colorScheme`:

| Step | Expected | Result |
|---|---|---|
| First load with OS=light, empty localStorage | body bg white | ✅ `rgb(255,255,255)` |
| Seed legacy `themeMode=dark`, reload | key removed, body matches OS=light | ✅ key absent, body white |
| App in dark, emulate OS → light | body live-updates to light, no reload | ✅ |
| Click sun/moon toggle | body flips, no localStorage write | ✅ `themeMode` stays absent |
| After manual toggle, emulate OS → dark | body re-syncs to OS dark (last-change-wins) | ✅ `rgb(18,18,20)` |

Inner-desktop sync (GNOME color-scheme, GTK theme, wallpaper, Zed theme) still goes through the existing `v1UsersMeColorSchemeUpdate` → WebSocket → `settings-sync-daemon` path; it fires for both manual toggles and OS transitions. Verifying on a real macOS host is a manual check for the reviewer — the headless dev environment has no OS appearance to flip.

## Screenshots

![OS dark, app dark](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001997_light-mode-and-dark-mode/screenshots/01-os-dark-app-dark.png)

![OS light, app light](https://github.com/helixml/helix/raw/helix-specs/design/tasks/001997_light-mode-and-dark-mode/screenshots/02-os-light-app-light.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01krakr9j0q1jpdhg1tqwg3ztq)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001997_light-mode-and-dark-mode/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001997_light-mode-and-dark-mode/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/001997_light-mode-and-dark-mode/tasks.md)

🚀 Built with [Helix](https://helix.ml)