### PR TITLE
Move ACP Agent Logs terminal to last workspace instead of minimizing

### DIFF
--- a/desktop/ubuntu-config/gnome-extension/helix-cursor@helix.ml/extension.js
+++ b/desktop/ubuntu-config/gnome-extension/helix-cursor@helix.ml/extension.js
@@ -115,7 +115,10 @@ export default class HelixCursorExtension extends Extension {
 
     console.log("[HelixCursor] Connected to cursor-changed signal");
 
-    // Window management: minimize "ACP Agent Logs" terminal on creation
+    // Window management: move "ACP Agent Logs" terminal to the last
+    // workspace on creation, so it stays out of the way without being
+    // minimized (minimizing caused the dock icon to jiggle and the
+    // app-switcher to render a ghost preview).
     this._windowCreatedId = global.display.connect(
       "window-created",
       (display, window) => {
@@ -124,7 +127,7 @@ export default class HelixCursorExtension extends Extension {
     );
 
     console.log(
-      "[HelixCursor] Connected to window-created signal for auto-minimization",
+      "[HelixCursor] Connected to window-created signal for ACP log window placement",
     );
 
     // Send initial cursor after 1 second, then retry every 2 seconds until successful
@@ -195,13 +198,28 @@ export default class HelixCursorExtension extends Extension {
       try {
         const title = window.get_title();
         if (title && title.includes("ACP Agent Logs")) {
+          const workspaceManager = global.workspace_manager;
+          const nWorkspaces = workspaceManager.get_n_workspaces();
+          if (nWorkspaces < 2) {
+            console.log(
+              "[HelixCursor] Only " +
+                nWorkspaces +
+                " workspace(s) available; leaving ACP Agent Logs terminal in place: " +
+                title,
+            );
+            return GLib.SOURCE_REMOVE;
+          }
+          const targetIndex = nWorkspaces - 1;
           console.log(
-            "[HelixCursor] Minimizing ACP Agent Logs terminal: " + title,
+            "[HelixCursor] Moving ACP Agent Logs terminal to workspace " +
+              (targetIndex + 1) +
+              " (last): " +
+              title,
           );
-          window.minimize();
+          window.change_workspace_by_index(targetIndex, false);
         }
       } catch (e) {
-        console.log("[HelixCursor] Error minimizing window: " + e);
+        console.log("[HelixCursor] Error placing ACP Agent Logs window: " + e);
       }
       return GLib.SOURCE_REMOVE;
     });

--- a/desktop/ubuntu-config/gnome-extension/helix-cursor@helix.ml/metadata.json
+++ b/desktop/ubuntu-config/gnome-extension/helix-cursor@helix.ml/metadata.json
@@ -1,8 +1,8 @@
 {
   "uuid": "helix-cursor@helix.ml",
   "name": "Helix Cursor Tracker",
-  "description": "Tracks cursor shape changes and sends them to Helix desktop-bridge via Unix socket. Auto-minimizes ACP Agent Logs terminal.",
+  "description": "Tracks cursor shape changes and sends them to Helix desktop-bridge via Unix socket. Moves ACP Agent Logs terminal to last workspace.",
   "shell-version": ["45", "46", "47", "48", "49"],
-  "version": 2,
+  "version": 3,
   "url": "https://helix.ml"
 }


### PR DESCRIPTION
## Summary

Replaces the auto-minimize behavior in the `helix-cursor@helix.ml`
GNOME extension with a "move to the last workspace" behavior. The
old approach (`window.minimize()`) caused the dock icon to jiggle
continuously (because `tail -F` keeps emitting output and Mutter
treats those as `demands-attention` hints on a minimized surface)
and made the window appear as a ghost in the GNOME app-switcher
because its surface is unmapped while minimized.

The new behavior keeps the surface mapped on the last virtual
workspace (workspace 4 in our 4-workspace setup configured by
`dconf-settings.ini`), so:

- Dock icon stays calm — no jiggling.
- App-switcher shows a normal preview.
- The window is still discoverable from the GNOME activities
  overview.
- The user's active workspace (workspace 1, Zed) is not changed.

## Changes

- `desktop/ubuntu-config/gnome-extension/helix-cursor@helix.ml/extension.js`
  - `_onWindowCreated`: replaced `window.minimize()` with
    `window.change_workspace_by_index(n_workspaces - 1, false)`.
  - Added a defensive check that bails (with a log line, no crash)
    if `n_workspaces < 2`.
  - Updated the surrounding comment and the log messages to match
    the new behavior.
- `desktop/ubuntu-config/gnome-extension/helix-cursor@helix.ml/metadata.json`
  - Bumped `version` 2 → 3 so GNOME Shell reloads the manifest.
  - Updated `description` from "Auto-minimizes ACP Agent Logs
    terminal" to "Moves ACP Agent Logs terminal to last workspace".

## Test plan

- [ ] `./stack build-ubuntu` baked the new extension into the image.
- [ ] Started a new spec-task session with `SHOW_ACP_DEBUG_LOGS=true`.
- [ ] Confirmed the ACP Agent Logs terminal appears on workspace 4
  in the GNOME activities overview with a normal preview.
- [ ] Confirmed the dock icon does not jiggle.
- [ ] Confirmed the app-switcher shows it as a normal entry, not a
  ghost.
- [ ] Confirmed the user's active workspace stays workspace 1 (Zed)
  on session start.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kras61xp1n7f5s33f2xvg41d)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002000_i-think-we-ended-up/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002000_i-think-we-ended-up/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002000_i-think-we-ended-up/tasks.md)

🚀 Built with [Helix](https://helix.ml)