### PR TITLE
fix(api): don't burn cold-start retries while StartDesktop is in flight

### DIFF
--- a/api/pkg/server/auto_wake_stuck_interactions.go
+++ b/api/pkg/server/auto_wake_stuck_interactions.go
@@ -162,6 +162,30 @@ const (
 	// autoWakeMaxRetries caps how many wake-ups we attempt for a single
 	// stuck interaction before giving up and marking it state=error.
 	autoWakeMaxRetries = 2
+
+	// defaultColdStartGracePeriod is how long we wait for an in-flight
+	// `StartDesktop` to bring up the dev container + Zed + claude-agent-acp
+	// before we count the wait against the cold-start retry budget.
+	//
+	// While `session.Metadata.ExternalAgentStatus == "starting"` the existing
+	// boot is in progress: re-kicking `autoStartDevContainerForSession` is
+	// a no-op (StartDesktop holds a per-session lock and bails when status
+	// is "running") but still increments AutoWakeCount on every scan tick.
+	// With autoWakeMaxRetries=2 and ~10s ticks the budget burned in <90s,
+	// while a cold helix-ubuntu boot routinely takes 90–150s. Result:
+	// `state=error` ("Agent never connected after auto-wake cold-start
+	// retries") fired ~30s before WS actually connected.
+	//
+	// Witnessed live on spt_01kreb7sevt5ecyagxhctv3ejh: container created
+	// at T+18s, retries exhausted at T+93s, WS connected at T+123s.
+	//
+	// 5 min covers the realistic boot envelope (ZFS clone of large
+	// snapshots, golden cache unpack, GNOME + Zed init, claude-agent-acp
+	// dial) with margin. After this we fall through to the normal
+	// retry-and-error path so genuinely-failed boots don't churn forever.
+	//
+	// Override at runtime with HELIX_COLD_START_GRACE_SECONDS.
+	defaultColdStartGracePeriod = 5 * time.Minute
 )
 
 // autoWakeStuckThreshold returns the configured stuck threshold.
@@ -175,6 +199,19 @@ func autoWakeStuckThreshold() time.Duration {
 		}
 	}
 	return defaultAutoWakeStuckThreshold
+}
+
+// coldStartGracePeriod returns how long an in-flight `StartDesktop` is
+// allowed to run before we count it against the cold-start retry budget.
+// Reads HELIX_COLD_START_GRACE_SECONDS so operators can dial it up on
+// slow disks (large ZFS clones, cold golden caches) without redeploying.
+func coldStartGracePeriod() time.Duration {
+	if raw := os.Getenv("HELIX_COLD_START_GRACE_SECONDS"); raw != "" {
+		if seconds, err := strconv.Atoi(raw); err == nil && seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+	}
+	return defaultColdStartGracePeriod
 }
 
 // startAutoWakeStuckInteractionsWorker launches the periodic scanner.
@@ -440,7 +477,37 @@ func (apiServer *HelixAPIServer) maybeAutoWake(ctx context.Context, stuck *types
 // from its in-memory copy). A Save here would race-clobber AutoWakeCount
 // back to a stale value, and the cap would never engage. See the file
 // header at lines 75-86 for the original incident on spt_01kq2308n428ss3wrm67ta6mjd.
+//
+// Container-state-aware retry budget: before bumping AutoWakeCount we look
+// at `session.Metadata.ExternalAgentStatus`. If a `StartDesktop` is already
+// in flight ("starting") and the interaction is younger than the cold-start
+// grace period, we skip without touching the budget — the existing boot
+// will either finish (Zed dials home and pickupWaitingInteraction delivers)
+// or trip the StartDesktop hard timeout (20 min) and clear the status.
+// Re-kicking during the boot window only races against the existing
+// per-session lock and burns retry budget for nothing.
 func (apiServer *HelixAPIServer) maybeKickColdStart(ctx context.Context, stuck *types.Interaction) {
+	// Skip if a StartDesktop is genuinely in progress and we're still
+	// inside the grace period. Failing to load the session is non-fatal
+	// — fall through to the existing path so a transient store error
+	// doesn't permanently disable the cold-start kick.
+	if session, err := apiServer.Store.GetSession(ctx, stuck.SessionID); err == nil && session != nil {
+		if session.Metadata.ExternalAgentStatus == "starting" &&
+			time.Since(stuck.Created) < coldStartGracePeriod() {
+			log.Debug().
+				Str("interaction_id", stuck.ID).
+				Str("session_id", stuck.SessionID).
+				Dur("interaction_age", time.Since(stuck.Created)).
+				Dur("grace_period", coldStartGracePeriod()).
+				Msg("[AUTO_WAKE] StartDesktop in progress — deferring cold-start kick (no budget burn)")
+			return
+		}
+	} else if err != nil {
+		log.Warn().Err(err).
+			Str("interaction_id", stuck.ID).
+			Msg("[AUTO_WAKE] Failed to load session for cold-start status check; proceeding with kick")
+	}
+
 	if stuck.AutoWakeCount >= autoWakeMaxRetries {
 		stuck.State = types.InteractionStateError
 		stuck.Error = "Agent never connected after auto-wake cold-start retries (no WebSocket — see helixml/helix#2397)"

--- a/api/pkg/server/auto_wake_stuck_interactions_test.go
+++ b/api/pkg/server/auto_wake_stuck_interactions_test.go
@@ -74,6 +74,8 @@ func (s *AutoWakeColdStartSuite) TestKicksAutoStartWhenNoWS() {
 
 	// autoStartDevContainerForSession runs in a goroutine — it will call
 	// GetSession (and possibly more, depending on session shape).
+	// ExternalAgentStatus is empty: no StartDesktop in flight, so the new
+	// container-state-aware gate falls through to the kick path.
 	session := &types.Session{
 		ID:    "ses_cold",
 		Owner: "user-1",
@@ -104,10 +106,111 @@ func (s *AutoWakeColdStartSuite) TestKicksAutoStartWhenNoWS() {
 	}
 }
 
+// TestSkipsBudgetWhileStartDesktopInFlight: when ExternalAgentStatus is
+// "starting" and the interaction is still inside the cold-start grace
+// period, maybeKickColdStart must skip without bumping AutoWakeCount or
+// invoking StartDesktop. This is the fix for the
+// spt_01kreb7sevt5ecyagxhctv3ejh failure mode (container booting normally,
+// but retry budget burned before WS connect).
+func (s *AutoWakeColdStartSuite) TestSkipsBudgetWhileStartDesktopInFlight() {
+	// Old enough to clear the SQL stuck threshold (60s default), but
+	// firmly inside the 5-minute cold-start grace window — exactly the
+	// regime that used to burn the retry budget for nothing while the
+	// boot was still legitimately running.
+	stuck := &types.Interaction{
+		ID:            "int-starting",
+		SessionID:     "ses_starting",
+		State:         types.InteractionStateWaiting,
+		PromptMessage: "do the thing",
+		Created:       time.Now().Add(-90 * time.Second),
+		AutoWakeCount: 0,
+	}
+
+	session := &types.Session{
+		ID:    "ses_starting",
+		Owner: "user-1",
+		Metadata: types.SessionMetadata{
+			AgentType:           "zed_external",
+			ProjectID:           "prj_x",
+			ExternalAgentStatus: "starting",
+		},
+	}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_starting").Return(session, nil).Times(1)
+
+	// IncrementInteractionAutoWakeCount and StartDesktop must NOT be called —
+	// gomock fails the test on unexpected calls.
+
+	s.server.maybeAutoWake(context.Background(), stuck)
+}
+
+// TestKicksAfterColdStartGraceExpires: if a "starting" status persists
+// past the grace period, fall through to the normal kick + budget burn
+// path so a genuinely-stuck boot eventually surfaces as state=error
+// instead of hanging forever.
+func (s *AutoWakeColdStartSuite) TestKicksAfterColdStartGraceExpires() {
+	// Force a tiny grace period via the env override so we don't have to
+	// wait minutes for this test to mature.
+	s.T().Setenv("HELIX_COLD_START_GRACE_SECONDS", "1")
+
+	stuck := &types.Interaction{
+		ID:            "int-grace-expired",
+		SessionID:     "ses_grace_expired",
+		State:         types.InteractionStateWaiting,
+		PromptMessage: "do the thing",
+		// Older than both stuck threshold (60s) AND the 1-second grace.
+		Created:       time.Now().Add(-5 * time.Minute),
+		AutoWakeCount: 0,
+	}
+
+	session := &types.Session{
+		ID:    "ses_grace_expired",
+		Owner: "user-1",
+		Metadata: types.SessionMetadata{
+			AgentType:           "zed_external",
+			ProjectID:           "prj_x",
+			ExternalAgentStatus: "starting", // stuck in starting past grace
+		},
+	}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_grace_expired").Return(session, nil).AnyTimes()
+	s.store.EXPECT().ListGitRepositories(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	s.store.EXPECT().UpdateSession(gomock.Any(), gomock.Any()).Return(&types.Session{}, nil).AnyTimes()
+
+	// Now we DO expect the kick to fire and the budget to burn.
+	s.store.EXPECT().IncrementInteractionAutoWakeCount(gomock.Any(), "int-grace-expired").Return(1, nil)
+
+	startCalled := make(chan struct{}, 1)
+	s.executor.EXPECT().StartDesktop(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *types.DesktopAgent) (*types.DesktopAgentResponse, error) {
+			startCalled <- struct{}{}
+			return &types.DesktopAgentResponse{DevContainerID: "dev_1"}, nil
+		},
+	).Times(1)
+
+	s.server.maybeAutoWake(context.Background(), stuck)
+
+	select {
+	case <-startCalled:
+		// Good — past the grace, the kick fires.
+	case <-time.After(2 * time.Second):
+		s.FailNow("StartDesktop should have been invoked once grace expired")
+	}
+}
+
 // TestMarksAsErrorAfterMaxRetries: once AutoWakeCount has hit the cap,
 // further scans must mark the interaction state=error and stop kicking.
 func (s *AutoWakeColdStartSuite) TestMarksAsErrorAfterMaxRetries() {
 	stuck := stuckInteraction("int-2", "ses_exhausted", autoWakeMaxRetries)
+
+	// GetSession is now consulted by maybeKickColdStart's container-state
+	// gate. Return a session whose ExternalAgentStatus is not "starting",
+	// so the gate falls through to the existing exhausted-cap path.
+	session := &types.Session{
+		ID: "ses_exhausted",
+		Metadata: types.SessionMetadata{
+			AgentType: "zed_external",
+		},
+	}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_exhausted").Return(session, nil).Times(1)
 
 	var captured *types.Interaction
 	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).DoAndReturn(


### PR DESCRIPTION
## Summary

Fixes a class of spurious `Agent never connected after auto-wake cold-start retries (no WebSocket — see helixml/helix#2397)` errors on sessions whose dev containers were booting normally but slowly.

`maybeKickColdStart` was bumping `AutoWakeCount` on every scan tick during the boot window, even though the in-flight `StartDesktop` was already doing the work and a re-kick would just no-op (the per-session lock in `HydraExecutor.StartDesktop` blocks duplicates and bails when status is "running").

With `autoWakeMaxRetries=2` and ~10s ticks, the budget burned at ~T+93s. A cold `helix-ubuntu` boot (ZFS clone of the snapshot, golden cache unpack, GNOME + Zed + claude-agent-acp init) routinely takes 90–150s on production hardware. Result: sessions whose boot took >~90s got a `state=error` ~30s before the WebSocket actually connected.

## Witnessed timeline

`spt_01kreb7sevt5ecyagxhctv3ejh` / `ses_01kreb7swxqh9ks2yd2239nxxq`:

| Time | Event |
|---|---|
| T+0s   | spec-gen interaction created |
| T+2s   | `StartDesktop` called |
| T+18s  | Hydra reports container created |
| T+61s  | auto-wake cold-start kick attempt 1 (no-op, container already booting) |
| T+77s  | auto-wake cold-start kick attempt 2 (no-op) |
| **T+93s**  | **\"Exhausted cold-start retries\" → state=error** ← spurious failure |
| T+123s | External agent WebSocket connected (30s too late) |

## Fix

Gate `maybeKickColdStart` on `session.Metadata.ExternalAgentStatus`. While `\"starting\"` AND the interaction is younger than the cold-start grace period:

- Don't bump `AutoWakeCount`
- Don't call `autoStartDevContainerForSession`
- Just return — the existing boot will either finish (and `pickupWaitingInteraction` delivers) or trip `StartDesktop`'s 20-min hard timeout (which clears the status back to `\"\"`).

Default grace = **5 min**, override via `HELIX_COLD_START_GRACE_SECONDS`. Past the grace, falls through to the existing kick-and-burn path so genuinely-stuck boots still eventually surface as `state=error`.

## Why not query the sandbox/container row directly?

`session.Metadata.ExternalAgentStatus` is the same signal: `HydraExecutor.StartDesktop` sets it to `\"starting\"` as the first thing it does (`hydra_executor.go:369`) and to `\"running\"` after the container is up (`hydra_executor.go:480`). The `defer` clears it on error. One DB read, no cross-package dependency.

## Test plan

- [x] `CGO_ENABLED=1 go test -v -run TestAutoWake ./api/pkg/server/ -count=1` — all 5 cold-start cases pass
- [x] `CGO_ENABLED=1 go test -v -run \"TestAutoWake|TestStartDevContainerForSession|TestSessionMessagesHandler\" ./api/pkg/server/ -count=1` — all related suites pass
- [x] `go build ./api/pkg/server/ ./api/pkg/external-agent/ ./api/pkg/store/ ./api/pkg/types/` — clean
- [ ] CI (Drone)

New tests:
- `TestSkipsBudgetWhileStartDesktopInFlight` — asserts no `IncrementInteractionAutoWakeCount` or `StartDesktop` fires while boot is in progress
- `TestKicksAfterColdStartGraceExpires` — asserts fall-through still works once grace expires (uses `HELIX_COLD_START_GRACE_SECONDS=1` to keep the test fast)