### PR TITLE
ci: temporarily disable arm64 + macOS DMG + zed-e2e gating

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -928,11 +928,14 @@ platform:
   os: linux
   arch: arm64
 
+# TEMP: ARM64 builds disabled while flight (the arm64 runner host) is offline.
+# The Ugreen 2TB `Big` SSD that hosts /Volumes/Big/drone-cache is unplugged, and
+# Docker Desktop's containerd bbolt DB is corrupted (SIGBUS in bbolt.Page.FastCheck).
+# Re-enable once flight is back: restore `refs/heads/main` + `refs/tags/*` below.
 trigger:
   ref:
     include:
-      - refs/heads/main
-      - refs/tags/*
+      - refs/heads/__arm64_disabled_until_flight_back__
 
 volumes:
   - name: dockersocket
@@ -973,7 +976,7 @@ name: manifest-controlplane
 
 depends_on:
   - build-controlplane-amd64
-  - build-controlplane-arm64
+  # TEMP: build-controlplane-arm64 removed: arm64 builds disabled while flight is offline.
 
 trigger:
   ref:
@@ -1003,11 +1006,11 @@ steps:
           VERSION=$$(echo ${DRONE_COMMIT_SHA} | head -c 7)
         fi
         REPO="registry.helixml.tech/helix/controlplane"
+        # TEMP: arm64 entry removed while arm64 builds disabled. Manifest is amd64-only.
         docker manifest create --amend $${REPO}:$${VERSION} \
-          $${REPO}:$${VERSION}-linux-amd64 \
-          $${REPO}:$${VERSION}-linux-arm64
+          $${REPO}:$${VERSION}-linux-amd64
         docker manifest push $${REPO}:$${VERSION}
-        echo "Multi-arch manifest pushed: $${REPO}:$${VERSION}"
+        echo "Manifest pushed (amd64-only): $${REPO}:$${VERSION}"
         scripts/ghcr-manifest.sh $${REPO} $${VERSION}
     volumes:
       - name: dockersocket
@@ -1527,6 +1530,12 @@ steps:
   # to compile the Go test server with the current helix source.
   - name: zed-e2e-test
     image: docker:cli
+    # TEMP: ignore failures while Phase 15 Claude streaming regression is open.
+    # Phase 15 (added 2026-05-11) asserts >=30% of content arrives by midpoint;
+    # Claude Code's ACP path emits message_added with stale content until a
+    # final burst, so it fails. Zed-side fix only landed for start_streaming_reveal
+    # (zed-agent), not Claude's update path. Re-enable gating once that is fixed.
+    failure: ignore
     environment:
       DOCKER_HOST: unix:///var/run/docker.sock
       ANTHROPIC_API_KEY:
@@ -1762,11 +1771,12 @@ platform:
   os: linux
   arch: arm64
 
+# TEMP: ARM64 builds disabled while flight is offline. See build-controlplane-arm64
+# comment above for details. Restore `refs/heads/main` and `refs/tags/*` to re-enable.
 trigger:
   ref:
     include:
-      - refs/heads/main
-      - refs/tags/*
+      - refs/heads/__arm64_disabled_until_flight_back__
 
 volumes:
   - name: dockersocket
@@ -2043,7 +2053,7 @@ name: manifest-sandbox
 
 depends_on:
   - build-sandbox-amd64
-  - build-sandbox-arm64
+  # TEMP: build-sandbox-arm64 removed: arm64 builds disabled while flight is offline.
 
 trigger:
   ref:
@@ -2073,12 +2083,11 @@ steps:
           VERSION=$$(echo ${DRONE_COMMIT_SHA} | head -c 7)
         fi
         REPO="registry.helixml.tech/helix/helix-sandbox"
-        echo "Creating multi-arch manifest for $${REPO}:$${VERSION}"
+        echo "Creating manifest for $${REPO}:$${VERSION} (TEMP: amd64-only, arm64 disabled)"
         docker manifest create --amend $${REPO}:$${VERSION} \
-          $${REPO}:$${VERSION}-linux-amd64 \
-          $${REPO}:$${VERSION}-linux-arm64
+          $${REPO}:$${VERSION}-linux-amd64
         docker manifest push $${REPO}:$${VERSION}
-        echo "Multi-arch manifest pushed: $${REPO}:$${VERSION}"
+        echo "Manifest pushed (amd64-only): $${REPO}:$${VERSION}"
         scripts/ghcr-manifest.sh $${REPO} $${VERSION}
     volumes:
       - name: dockersocket
@@ -2100,12 +2109,11 @@ steps:
           VERSION=$$(echo ${DRONE_COMMIT_SHA} | head -c 7)
         fi
         REPO="registry.helixml.tech/helix/helix-sway"
-        echo "Creating multi-arch manifest for $${REPO}:$${VERSION}"
+        echo "Creating manifest for $${REPO}:$${VERSION} (TEMP: amd64-only, arm64 disabled)"
         docker manifest create --amend $${REPO}:$${VERSION} \
-          $${REPO}:$${VERSION}-linux-amd64 \
-          $${REPO}:$${VERSION}-linux-arm64
+          $${REPO}:$${VERSION}-linux-amd64
         docker manifest push $${REPO}:$${VERSION}
-        echo "Multi-arch manifest pushed: $${REPO}:$${VERSION}"
+        echo "Manifest pushed (amd64-only): $${REPO}:$${VERSION}"
         scripts/ghcr-manifest.sh $${REPO} $${VERSION}
     volumes:
       - name: dockersocket
@@ -2127,12 +2135,11 @@ steps:
           VERSION=$$(echo ${DRONE_COMMIT_SHA} | head -c 7)
         fi
         REPO="registry.helixml.tech/helix/helix-ubuntu"
-        echo "Creating multi-arch manifest for $${REPO}:$${VERSION}"
+        echo "Creating manifest for $${REPO}:$${VERSION} (TEMP: amd64-only, arm64 disabled)"
         docker manifest create --amend $${REPO}:$${VERSION} \
-          $${REPO}:$${VERSION}-linux-amd64 \
-          $${REPO}:$${VERSION}-linux-arm64
+          $${REPO}:$${VERSION}-linux-amd64
         docker manifest push $${REPO}:$${VERSION}
-        echo "Multi-arch manifest pushed: $${REPO}:$${VERSION}"
+        echo "Manifest pushed (amd64-only): $${REPO}:$${VERSION}"
         scripts/ghcr-manifest.sh $${REPO} $${VERSION}
     volumes:
       - name: dockersocket
@@ -2160,10 +2167,13 @@ depends_on:
   - build-controlplane-arm64
   - build-sandbox-arm64
 
+# TEMP: macOS DMG disabled while flight is offline. Pipeline runs on flight (exec
+# runner), needs /Volumes/Big (currently disconnected) for VM provisioning, and
+# depends on the arm64 docker images (also disabled). Restore `refs/tags/*` to re-enable.
 trigger:
   ref:
     include:
-      - refs/tags/*
+      - refs/tags/__dmg_disabled_until_flight_back__
 
 steps:
   # Step 1: Provision VM image and upload to R2
@@ -2296,12 +2306,12 @@ name: release-rollback
 depends_on:
   - default
   - build-controlplane-amd64
-  - build-controlplane-arm64
+  # TEMP: build-controlplane-arm64 removed: disabled while flight is offline.
   - manifest-controlplane
   - build-sandbox-amd64
-  - build-sandbox-arm64
+  # TEMP: build-sandbox-arm64 removed: disabled while flight is offline.
   - manifest-sandbox
-  - build-macos-dmg
+  # TEMP: build-macos-dmg removed: disabled while flight is offline.
 
 trigger:
   ref:


### PR DESCRIPTION
## Summary

`flight` (the arm64 runner host) is offline. The arm64 docker pipelines and the macOS DMG pipeline have been stuck `pending` on every main build since whenever Docker Desktop on flight crashed; the queue is now ~7 builds deep. Separately, `zed-e2e-test` has been red since build 1364 on a real Claude Code streaming regression that is not getting fixed today. This PR unblocks Linux releases while both issues get sorted.

### What changed in `.drone.yml`

- `build-controlplane-arm64`, `build-sandbox-arm64`, `build-macos-dmg`: trigger redirected to sentinel refs (`__arm64_disabled_until_flight_back__` / `__dmg_disabled_until_flight_back__`) so the pipelines are skipped on every event.
- `manifest-controlplane`, `manifest-sandbox`: arm64 entries removed from both `depends_on` and the `docker manifest create` commands. The `:VERSION` tag now points at an amd64-only single-arch manifest for `controlplane`, `helix-sandbox`, `helix-sway`, `helix-ubuntu`. arm64 pulls will get "no matching manifest" instead of pulling a broken image.
- `release-rollback`: disabled pipelines removed from `depends_on` so it still fires on tag failures.
- `zed-e2e-test` step in `build-sandbox-amd64`: `failure: ignore` added. Step still runs and reports red in the Drone UI but does not fail the stage.

Every change is tagged with a `TEMP:` comment that names exactly what to restore.

### Root cause notes

- flight is offline because (a) the external 2TB `Big` SSD that hosts `/Volumes/Big/drone-cache` (Ugreen Thunderbolt 5 M.2 SSD) is physically unplugged, and (b) Docker Desktop's containerd bbolt DB has SIGBUS'd in `bbolt.(*Page).FastCheck`. Needs hands-on flight to plug the SSD back in and reset Docker Desktop.
- Phase 15 of `zed-e2e-test` is a new (2026-05-11) streaming-cadence regression test. It passes for `zed-agent` because the Zed-side fix landed for `start_streaming_reveal`, but fails for `claude` because Claude Code uses a different ACP code path that emits `message_added` events with stale content until a final burst, so `>= 30% by midpoint` never holds. Real regression; needs a sibling fix in Zed.

## Release impact

On a tag push during this window:
- `default`, `build-controlplane-amd64`, `build-sandbox-amd64`, `manifest-controlplane`, `manifest-sandbox` all run as before.
- `build-controlplane-arm64`, `build-sandbox-arm64`, `build-macos-dmg` are skipped.
- Consumers get amd64-only Linux images at `registry.helixml.tech/helix/{controlplane,helix-sandbox,helix-sway,helix-ubuntu}:VERSION`. No macOS DMG until flight is back.

## Test plan

- [ ] Drone picks up the PR build; `default` + `build-controlplane-amd64` + `build-sandbox-amd64` go green
- [ ] `build-sandbox-amd64` stage passes even with `zed-e2e-test` reporting red (failure: ignore)
- [ ] arm64 / DMG pipelines show as `skipped`, not `pending`
- [ ] `manifest-controlplane` and `manifest-sandbox` run, push amd64-only manifests
- [ ] After merge, the backlog of main builds drains and new pushes go green

## How to revert when flight is back

`grep -n 'TEMP:' .drone.yml` lists every disabled spot with a one-line revert hint.