### PR TITLE
ci: drop arm64 from ghcr-manifest.sh while arm64 disabled

### DIFF
--- a/scripts/ghcr-manifest.sh
+++ b/scripts/ghcr-manifest.sh
@@ -18,8 +18,9 @@ GHCR_REPO=$(echo "$OLD_REPO" | sed 's|registry.helixml.tech/helix|ghcr.io/helixm
 
 echo "$GITHUB_TOKEN" | docker login ghcr.io -u helixml --password-stdin
 
+# TEMP: arm64 leg removed while arm64 builds are disabled in .drone.yml.
+# Restore the `"$GHCR_REPO:$VERSION-linux-arm64"` line below when arm64 is re-enabled.
 docker manifest create --amend "$GHCR_REPO:$VERSION" \
-  "$GHCR_REPO:$VERSION-linux-amd64" \
-  "$GHCR_REPO:$VERSION-linux-arm64"
+  "$GHCR_REPO:$VERSION-linux-amd64"
 docker manifest push "$GHCR_REPO:$VERSION"
-echo "GHCR multi-arch manifest pushed: $GHCR_REPO:$VERSION"
+echo "GHCR manifest pushed (amd64-only): $GHCR_REPO:$VERSION"


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/helixml/helix/pull/2419. That PR disabled arm64 in `.drone.yml`, but the merge picked up only the first commit (`71ba5b588`) and skipped the matching change to `scripts/ghcr-manifest.sh`. As a result:

- Build https://drone.lukemarsden.net/helixml/helix/1400/3/2 (the merge build for #2419) failed at `manifest-controlplane / manifest`.
- Build https://drone.lukemarsden.net/helixml/helix/1404 (latest main) failed at the same step.

The script still references `${VERSION}-linux-arm64` when mirroring the multi-arch manifest to `ghcr.io/helixml`. The `registry.helixml.tech` manifest push succeeds (amd64-only) and then the script errors with `manifest unknown` because no arm64 tag exists on GHCR.

## Change

Drop the arm64 leg from `scripts/ghcr-manifest.sh`, mirroring the same TEMP-comment pattern used in `.drone.yml`. Revert hint is inline.

## Test plan

- [ ] Drone build picks up this PR and `manifest-controlplane` step now goes green
- [ ] After merge, next main build's `manifest-controlplane` + `manifest-sandbox` succeed end-to-end (amd64-only multi-arch manifests pushed to both `registry.helixml.tech` and `ghcr.io/helixml`)

## Re-enable later

`grep -n TEMP: .drone.yml scripts/ghcr-manifest.sh` lists every disabled spot.