### PR TITLE
ci: make ghcr-manifest.sh resilient to transient ghcr.io failures

### DIFF
--- a/scripts/ghcr-manifest.sh
+++ b/scripts/ghcr-manifest.sh
@@ -1,10 +1,18 @@
 #!/bin/sh
-# Create and push a multi-arch manifest on ghcr.io/helixml (primary registry).
+# Mirror a multi-arch manifest from registry.helixml.tech onto ghcr.io/helixml.
 # Usage: scripts/ghcr-manifest.sh <old-repo> <version>
 # Example: scripts/ghcr-manifest.sh registry.helixml.tech/helix/controlplane v1.0
 #
 # Requires GITHUB_TOKEN environment variable for authentication.
 # Skips silently if GITHUB_TOKEN is not set (allows gradual rollout).
+#
+# Resilience:
+#   GHCR is a downstream mirror; registry.helixml.tech is the source of truth.
+#   Each ghcr.io call is retried 3x with backoff. If all retries fail (e.g.
+#   transient ghcr.io 5xx/timeout), the script logs loudly and exits 0 so a
+#   single mirror blip does not fail the build and trigger release-rollback.
+#   Re-running scripts/ghcr-manifest.sh against the same version safely
+#   re-creates the manifest on the mirror.
 set -e
 
 if [ -z "$GITHUB_TOKEN" ]; then
@@ -16,11 +24,57 @@ OLD_REPO="$1"
 VERSION="$2"
 GHCR_REPO=$(echo "$OLD_REPO" | sed 's|registry.helixml.tech/helix|ghcr.io/helixml|')
 
-echo "$GITHUB_TOKEN" | docker login ghcr.io -u helixml --password-stdin
+# retry <max-attempts> <sleep-secs-base> -- <cmd...>
+# Runs the command, retries on failure with linear backoff (base, base*2, ...).
+# Returns the command's final exit code.
+retry() {
+  max="$1"; base="$2"; shift 2
+  attempt=1
+  while :; do
+    if "$@"; then
+      return 0
+    fi
+    rc=$?
+    if [ "$attempt" -ge "$max" ]; then
+      return "$rc"
+    fi
+    delay=$((base * attempt))
+    echo "[ghcr-manifest] attempt $attempt/$max failed (rc=$rc), retrying in ${delay}s: $*" >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+  done
+}
 
-# TEMP: arm64 leg removed while arm64 builds are disabled in .drone.yml.
-# Restore the `"$GHCR_REPO:$VERSION-linux-arm64"` line below when arm64 is re-enabled.
-docker manifest create --amend "$GHCR_REPO:$VERSION" \
-  "$GHCR_REPO:$VERSION-linux-amd64"
-docker manifest push "$GHCR_REPO:$VERSION"
+ghcr_login() {
+  echo "$GITHUB_TOKEN" | docker login ghcr.io -u helixml --password-stdin
+}
+
+ghcr_manifest_create() {
+  # TEMP: arm64 leg removed while arm64 builds are disabled in .drone.yml.
+  # Restore the `"$GHCR_REPO:$VERSION-linux-arm64"` line below when arm64 is re-enabled.
+  docker manifest create --amend "$GHCR_REPO:$VERSION" \
+    "$GHCR_REPO:$VERSION-linux-amd64"
+}
+
+ghcr_manifest_push() {
+  docker manifest push "$GHCR_REPO:$VERSION"
+}
+
+# Three retries with 5s, 10s, 15s backoff. Each operation is independent;
+# `docker manifest create --amend` is idempotent.
+if ! retry 3 5 ghcr_login; then
+  echo "[ghcr-manifest] WARNING: ghcr.io login failed after retries; skipping mirror for $GHCR_REPO:$VERSION (registry.helixml.tech is the source of truth)" >&2
+  exit 0
+fi
+
+if ! retry 3 5 ghcr_manifest_create; then
+  echo "[ghcr-manifest] WARNING: docker manifest create failed after retries; skipping mirror for $GHCR_REPO:$VERSION" >&2
+  exit 0
+fi
+
+if ! retry 3 5 ghcr_manifest_push; then
+  echo "[ghcr-manifest] WARNING: docker manifest push failed after retries; skipping mirror for $GHCR_REPO:$VERSION" >&2
+  exit 0
+fi
+
 echo "GHCR manifest pushed (amd64-only): $GHCR_REPO:$VERSION"


### PR DESCRIPTION
## Summary

Tag build 1408 for `v2.11.3` failed at `manifest-helix-ubuntu` because the third sequential `docker manifest push` to ghcr.io timed out:

> `Get "https://ghcr.io/v2/": net/http: request canceled (Client.Timeout exceeded while awaiting headers)`

The other two GHCR pushes seconds earlier succeeded - it was a one-off ghcr.io blip, not a config issue. That single failed HTTP request cascaded into `release-rollback`, which tore down the v2.11.3 GitHub release, git tag, and Helm chart from GCS, even though `registry.helixml.tech` (the source of truth) and three of four GHCR manifests had already pushed cleanly.

A transient mirror failure rolling back a fully-pushed release is wrong.

## Change

`scripts/ghcr-manifest.sh`:
- Wrap `docker login`, `docker manifest create --amend`, and `docker manifest push` in a small POSIX retry helper (3 attempts, 5s/10s/15s linear backoff). `--amend` is idempotent, so retrying a half-completed push is safe.
- If all retries exhaust, log a loud `WARNING` and `exit 0` instead of failing the build. registry.helixml.tech is the source of truth; GHCR is a downstream mirror, and a missing-temporarily multi-arch tag for one image is not worth rolling a release back over.
- Re-running `scripts/ghcr-manifest.sh` against the same version later (manually, or on the next tag build) safely re-creates the manifest. Layers are already pushed by the earlier per-arch step.

## Out of scope

`scripts/ghcr-push.sh` (the per-arch image mirror) has the same class of risk - a transient ghcr.io 5xx during `docker push` to the mirror would fail the per-arch publish step and cascade. Left for a focused follow-up PR.

## Test plan

- [ ] PR Drone build goes green (this script isn't exercised on PR builds, but a future tag push will)
- [ ] After merge, re-tag `v2.11.3` and confirm `manifest-controlplane` + `manifest-sandbox` go green end-to-end, including all GHCR mirror pushes
- [ ] Optionally simulate failure mode locally: temporarily set `GHCR_REPO=ghcr.io/helixml/nonexistent` to force `manifest create` to fail and confirm the script logs a WARNING and exits 0 after retries