### PR TITLE
ci(ghcr-manifest): retry harder, fail loud on exhaustion

### DIFF
--- a/scripts/ghcr-manifest.sh
+++ b/scripts/ghcr-manifest.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Mirror a multi-arch manifest from registry.helixml.tech onto ghcr.io/helixml.
+# Publish a multi-arch manifest on ghcr.io/helixml.
 # Usage: scripts/ghcr-manifest.sh <old-repo> <version>
 # Example: scripts/ghcr-manifest.sh registry.helixml.tech/helix/controlplane v1.0
 #
@@ -7,12 +7,19 @@
 # Skips silently if GITHUB_TOKEN is not set (allows gradual rollout).
 #
 # Resilience:
-#   GHCR is a downstream mirror; registry.helixml.tech is the source of truth.
-#   Each ghcr.io call is retried 3x with backoff. If all retries fail (e.g.
-#   transient ghcr.io 5xx/timeout), the script logs loudly and exits 0 so a
-#   single mirror blip does not fail the build and trigger release-rollback.
-#   Re-running scripts/ghcr-manifest.sh against the same version safely
-#   re-creates the manifest on the mirror.
+#   ghcr.io/helixml is the customer-facing registry (helm charts + install.sh
+#   pull from here since PR #1901). A missing :VERSION manifest on GHCR
+#   breaks `helm install` and install.sh with "no matching manifest", so we
+#   cannot exit 0 on failure here.
+#
+#   Each ghcr.io call is retried 6x with linear backoff (30s, 60s, 90s,
+#   120s, 150s = up to ~7.5min total) to ride out transient ghcr.io
+#   timeouts and 5xx. `docker manifest create --amend` is idempotent so
+#   retrying a half-completed push is safe.
+#
+#   If all retries exhaust, exit 1 to fail the build. release-rollback
+#   then tears down half-published artifacts (correct behavior given the
+#   release is genuinely incomplete on the customer registry).
 set -e
 
 if [ -z "$GITHUB_TOKEN" ]; then
@@ -60,21 +67,25 @@ ghcr_manifest_push() {
   docker manifest push "$GHCR_REPO:$VERSION"
 }
 
-# Three retries with 5s, 10s, 15s backoff. Each operation is independent;
-# `docker manifest create --amend` is idempotent.
-if ! retry 3 5 ghcr_login; then
-  echo "[ghcr-manifest] WARNING: ghcr.io login failed after retries; skipping mirror for $GHCR_REPO:$VERSION (registry.helixml.tech is the source of truth)" >&2
-  exit 0
+# Six retries with 30s, 60s, 90s, 120s, 150s backoff (up to ~7.5min total).
+# `docker manifest create --amend` is idempotent, so retrying after a partial
+# push is safe.
+if ! retry 6 30 ghcr_login; then
+  echo "[ghcr-manifest] ERROR: ghcr.io login failed after 6 retries for $GHCR_REPO:$VERSION" >&2
+  echo "[ghcr-manifest] ERROR: ghcr.io/helixml is the customer-facing registry; cannot continue" >&2
+  exit 1
 fi
 
-if ! retry 3 5 ghcr_manifest_create; then
-  echo "[ghcr-manifest] WARNING: docker manifest create failed after retries; skipping mirror for $GHCR_REPO:$VERSION" >&2
-  exit 0
+if ! retry 6 30 ghcr_manifest_create; then
+  echo "[ghcr-manifest] ERROR: docker manifest create failed after 6 retries for $GHCR_REPO:$VERSION" >&2
+  echo "[ghcr-manifest] ERROR: ghcr.io/helixml is the customer-facing registry; cannot continue" >&2
+  exit 1
 fi
 
-if ! retry 3 5 ghcr_manifest_push; then
-  echo "[ghcr-manifest] WARNING: docker manifest push failed after retries; skipping mirror for $GHCR_REPO:$VERSION" >&2
-  exit 0
+if ! retry 6 30 ghcr_manifest_push; then
+  echo "[ghcr-manifest] ERROR: docker manifest push failed after 6 retries for $GHCR_REPO:$VERSION" >&2
+  echo "[ghcr-manifest] ERROR: ghcr.io/helixml is the customer-facing registry; cannot continue" >&2
+  exit 1
 fi
 
 echo "GHCR manifest pushed (amd64-only): $GHCR_REPO:$VERSION"


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/helixml/helix/pull/2421 which added 3-attempt retries to `scripts/ghcr-manifest.sh` but **exited 0 on final failure**. That was wrong: `ghcr.io/helixml` is the customer-facing registry (helm charts + `install.sh` pull from it since https://github.com/helixml/helix/pull/1901), so silently skipping a failed manifest push would ship a release with a missing `:VERSION` tag on GHCR and break `helm install` / `install.sh` for that release.

## Changes to `scripts/ghcr-manifest.sh`

| Before (#2421) | After (this PR) |
|---|---|
| 3 retries | 6 retries |
| 5s base linear backoff (5/10/15s, ~30s total) | 30s base linear backoff (30/60/90/120/150s, ~7.5min total) |
| `exit 0` with WARNING on exhaustion | `exit 1` with ERROR on exhaustion |
| Header comment: "GHCR is a downstream mirror" | Header comment: "GHCR is customer-facing per #1901" |

The longer backoff is to ride out the failure mode we saw on build 1408 - a single ~30s timeout pinging `ghcr.io/v2/` while other GHCR pushes seconds either side succeeded. Six attempts with progressively longer backoff should clear a transient blip without giving up.

If GHCR is genuinely down for >7 minutes, the build now fails and `release-rollback` runs - which is correct, because at that point the release truly is incomplete on the customer-facing registry.

The `GITHUB_TOKEN not set -> exit 0` path is unchanged (legitimate gradual-rollout skip).

## Test plan

- [ ] Drone PR build goes green (this script isn't exercised on PR builds, but a future tag push will be)
- [ ] After merge, next tag build's `manifest-*` steps succeed end-to-end including GHCR mirror, OR fail-and-rollback if GHCR is actually down