### PR TITLE
ci(ghcr-push): retry transient ghcr.io failures, fail loud on exhaustion

### DIFF
--- a/scripts/ghcr-push.sh
+++ b/scripts/ghcr-push.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Mirror images from old registry to ghcr.io/helixml (primary).
+# Mirror per-arch images onto ghcr.io/helixml (customer-facing registry).
 # Usage: scripts/ghcr-push.sh <image1> [image2] ...
 # Example: scripts/ghcr-push.sh registry.helixml.tech/helix/controlplane:v1.0-linux-amd64
 #
@@ -8,6 +8,17 @@
 #
 # Adds org.opencontainers.image.source label so GHCR links the package
 # to the helix repository automatically.
+#
+# Resilience:
+#   ghcr.io/helixml is the customer-facing registry (helm charts +
+#   install.sh pull from it since PR #1901). A missing per-arch tag on
+#   GHCR breaks the subsequent multi-arch manifest publish for that
+#   release, so we cannot exit 0 on push failure.
+#
+#   docker login + docker push are retried 6x with linear backoff (30s,
+#   60s, 90s, 120s, 150s = up to ~7.5min total). `docker push` is
+#   idempotent for already-pushed layers. If all retries exhaust, exit 1
+#   so the build fails (and release-rollback runs on tag builds).
 set -e
 
 if [ -z "$GITHUB_TOKEN" ]; then
@@ -15,7 +26,36 @@ if [ -z "$GITHUB_TOKEN" ]; then
   exit 0
 fi
 
-echo "$GITHUB_TOKEN" | docker login ghcr.io -u helixml --password-stdin
+# retry <max-attempts> <sleep-secs-base> -- <cmd...>
+# Runs the command, retries on failure with linear backoff (base, base*2, ...).
+# Returns the command's final exit code.
+retry() {
+  max="$1"; base="$2"; shift 2
+  attempt=1
+  while :; do
+    if "$@"; then
+      return 0
+    fi
+    rc=$?
+    if [ "$attempt" -ge "$max" ]; then
+      return "$rc"
+    fi
+    delay=$((base * attempt))
+    echo "[ghcr-push] attempt $attempt/$max failed (rc=$rc), retrying in ${delay}s: $*" >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+  done
+}
+
+ghcr_login() {
+  echo "$GITHUB_TOKEN" | docker login ghcr.io -u helixml --password-stdin
+}
+
+if ! retry 6 30 ghcr_login; then
+  echo "[ghcr-push] ERROR: ghcr.io login failed after 6 retries" >&2
+  echo "[ghcr-push] ERROR: ghcr.io/helixml is the customer-facing registry; cannot continue" >&2
+  exit 1
+fi
 
 for IMAGE in "$@"; do
   GHCR_IMAGE=$(echo "$IMAGE" | sed 's|registry.helixml.tech/helix|ghcr.io/helixml|')
@@ -23,5 +63,9 @@ for IMAGE in "$@"; do
   echo "FROM $IMAGE" | docker build --provenance=false \
     --label "org.opencontainers.image.source=https://github.com/helixml/helix" \
     -t "$GHCR_IMAGE" -
-  docker push "$GHCR_IMAGE"
+  if ! retry 6 30 docker push "$GHCR_IMAGE"; then
+    echo "[ghcr-push] ERROR: docker push failed after 6 retries for $GHCR_IMAGE" >&2
+    echo "[ghcr-push] ERROR: ghcr.io/helixml is the customer-facing registry; cannot continue" >&2
+    exit 1
+  fi
 done


### PR DESCRIPTION
## Summary

Build https://drone.lukemarsden.net/helixml/helix/1412/4/6 (`build-desktops` step on a main push) failed when `docker push` to `ghcr.io/helixml/helix-sway:be03670-linux-amd64` hit:

> `Get "https://ghcr.io/v2/": context deadline exceeded (Client.Timeout exceeded while awaiting headers)`

Same transient ghcr.io class of failure that prompted https://github.com/helixml/helix/pull/2421 + https://github.com/helixml/helix/pull/2422 for `scripts/ghcr-manifest.sh`, but those PRs deliberately left `scripts/ghcr-push.sh` (the per-arch image mirror) for a focused follow-up. **This is that follow-up.**

## Change to `scripts/ghcr-push.sh`

- Wrap `docker login` and `docker push` in a 6-attempt retry helper with linear backoff (30s, 60s, 90s, 120s, 150s = up to ~7.5min wallclock).
- `docker push` is idempotent for already-pushed layers, so retrying after a half-completed push is safe.
- `exit 1` if all retries exhaust. `ghcr.io/helixml` is the customer-facing registry (helm charts + `install.sh` pull from it since https://github.com/helixml/helix/pull/1901), so failing loud is correct — silently skipping a per-arch tag would break the subsequent multi-arch manifest publish.
- `GITHUB_TOKEN`-not-set still `exit 0` (legitimate gradual-rollout skip, unchanged).

This brings parity with `scripts/ghcr-manifest.sh` from PR #2422.

## Test plan

- [ ] Drone PR build goes green (this script isn't exercised on PR builds, but a future main push or tag will be)
- [ ] After merge, next main build's `build-desktops` step succeeds end-to-end including GHCR mirror — or fails loud after 7.5min if GHCR is actually down