### PR TITLE
ci: restore arm64 builds, macOS DMG, and zed-e2e gating

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -928,14 +928,11 @@ platform:
   os: linux
   arch: arm64
 
-# TEMP: ARM64 builds disabled while flight (the arm64 runner host) is offline.
-# The Ugreen 2TB `Big` SSD that hosts /Volumes/Big/drone-cache is unplugged, and
-# Docker Desktop's containerd bbolt DB is corrupted (SIGBUS in bbolt.Page.FastCheck).
-# Re-enable once flight is back: restore `refs/heads/main` + `refs/tags/*` below.
 trigger:
   ref:
     include:
-      - refs/heads/__arm64_disabled_until_flight_back__
+      - refs/heads/main
+      - refs/tags/*
 
 volumes:
   - name: dockersocket
@@ -976,7 +973,7 @@ name: manifest-controlplane
 
 depends_on:
   - build-controlplane-amd64
-  # TEMP: build-controlplane-arm64 removed: arm64 builds disabled while flight is offline.
+  - build-controlplane-arm64
 
 trigger:
   ref:
@@ -1006,11 +1003,11 @@ steps:
           VERSION=$$(echo ${DRONE_COMMIT_SHA} | head -c 7)
         fi
         REPO="registry.helixml.tech/helix/controlplane"
-        # TEMP: arm64 entry removed while arm64 builds disabled. Manifest is amd64-only.
         docker manifest create --amend $${REPO}:$${VERSION} \
-          $${REPO}:$${VERSION}-linux-amd64
+          $${REPO}:$${VERSION}-linux-amd64 \
+          $${REPO}:$${VERSION}-linux-arm64
         docker manifest push $${REPO}:$${VERSION}
-        echo "Manifest pushed (amd64-only): $${REPO}:$${VERSION}"
+        echo "Multi-arch manifest pushed: $${REPO}:$${VERSION}"
         scripts/ghcr-manifest.sh $${REPO} $${VERSION}
     volumes:
       - name: dockersocket
@@ -1530,12 +1527,6 @@ steps:
   # to compile the Go test server with the current helix source.
   - name: zed-e2e-test
     image: docker:cli
-    # TEMP: ignore failures while Phase 15 Claude streaming regression is open.
-    # Phase 15 (added 2026-05-11) asserts >=30% of content arrives by midpoint;
-    # Claude Code's ACP path emits message_added with stale content until a
-    # final burst, so it fails. Zed-side fix only landed for start_streaming_reveal
-    # (zed-agent), not Claude's update path. Re-enable gating once that is fixed.
-    failure: ignore
     environment:
       DOCKER_HOST: unix:///var/run/docker.sock
       ANTHROPIC_API_KEY:
@@ -1771,12 +1762,11 @@ platform:
   os: linux
   arch: arm64
 
-# TEMP: ARM64 builds disabled while flight is offline. See build-controlplane-arm64
-# comment above for details. Restore `refs/heads/main` and `refs/tags/*` to re-enable.
 trigger:
   ref:
     include:
-      - refs/heads/__arm64_disabled_until_flight_back__
+      - refs/heads/main
+      - refs/tags/*
 
 volumes:
   - name: dockersocket
@@ -2053,7 +2043,7 @@ name: manifest-sandbox
 
 depends_on:
   - build-sandbox-amd64
-  # TEMP: build-sandbox-arm64 removed: arm64 builds disabled while flight is offline.
+  - build-sandbox-arm64
 
 trigger:
   ref:
@@ -2083,11 +2073,12 @@ steps:
           VERSION=$$(echo ${DRONE_COMMIT_SHA} | head -c 7)
         fi
         REPO="registry.helixml.tech/helix/helix-sandbox"
-        echo "Creating manifest for $${REPO}:$${VERSION} (TEMP: amd64-only, arm64 disabled)"
+        echo "Creating multi-arch manifest for $${REPO}:$${VERSION}"
         docker manifest create --amend $${REPO}:$${VERSION} \
-          $${REPO}:$${VERSION}-linux-amd64
+          $${REPO}:$${VERSION}-linux-amd64 \
+          $${REPO}:$${VERSION}-linux-arm64
         docker manifest push $${REPO}:$${VERSION}
-        echo "Manifest pushed (amd64-only): $${REPO}:$${VERSION}"
+        echo "Multi-arch manifest pushed: $${REPO}:$${VERSION}"
         scripts/ghcr-manifest.sh $${REPO} $${VERSION}
     volumes:
       - name: dockersocket
@@ -2109,11 +2100,12 @@ steps:
           VERSION=$$(echo ${DRONE_COMMIT_SHA} | head -c 7)
         fi
         REPO="registry.helixml.tech/helix/helix-sway"
-        echo "Creating manifest for $${REPO}:$${VERSION} (TEMP: amd64-only, arm64 disabled)"
+        echo "Creating multi-arch manifest for $${REPO}:$${VERSION}"
         docker manifest create --amend $${REPO}:$${VERSION} \
-          $${REPO}:$${VERSION}-linux-amd64
+          $${REPO}:$${VERSION}-linux-amd64 \
+          $${REPO}:$${VERSION}-linux-arm64
         docker manifest push $${REPO}:$${VERSION}
-        echo "Manifest pushed (amd64-only): $${REPO}:$${VERSION}"
+        echo "Multi-arch manifest pushed: $${REPO}:$${VERSION}"
         scripts/ghcr-manifest.sh $${REPO} $${VERSION}
     volumes:
       - name: dockersocket
@@ -2135,11 +2127,12 @@ steps:
           VERSION=$$(echo ${DRONE_COMMIT_SHA} | head -c 7)
         fi
         REPO="registry.helixml.tech/helix/helix-ubuntu"
-        echo "Creating manifest for $${REPO}:$${VERSION} (TEMP: amd64-only, arm64 disabled)"
+        echo "Creating multi-arch manifest for $${REPO}:$${VERSION}"
         docker manifest create --amend $${REPO}:$${VERSION} \
-          $${REPO}:$${VERSION}-linux-amd64
+          $${REPO}:$${VERSION}-linux-amd64 \
+          $${REPO}:$${VERSION}-linux-arm64
         docker manifest push $${REPO}:$${VERSION}
-        echo "Manifest pushed (amd64-only): $${REPO}:$${VERSION}"
+        echo "Multi-arch manifest pushed: $${REPO}:$${VERSION}"
         scripts/ghcr-manifest.sh $${REPO} $${VERSION}
     volumes:
       - name: dockersocket
@@ -2167,13 +2160,10 @@ depends_on:
   - build-controlplane-arm64
   - build-sandbox-arm64
 
-# TEMP: macOS DMG disabled while flight is offline. Pipeline runs on flight (exec
-# runner), needs /Volumes/Big (currently disconnected) for VM provisioning, and
-# depends on the arm64 docker images (also disabled). Restore `refs/tags/*` to re-enable.
 trigger:
   ref:
     include:
-      - refs/tags/__dmg_disabled_until_flight_back__
+      - refs/tags/*
 
 steps:
   # Step 1: Provision VM image and upload to R2
@@ -2306,12 +2296,12 @@ name: release-rollback
 depends_on:
   - default
   - build-controlplane-amd64
-  # TEMP: build-controlplane-arm64 removed: disabled while flight is offline.
+  - build-controlplane-arm64
   - manifest-controlplane
   - build-sandbox-amd64
-  # TEMP: build-sandbox-arm64 removed: disabled while flight is offline.
+  - build-sandbox-arm64
   - manifest-sandbox
-  # TEMP: build-macos-dmg removed: disabled while flight is offline.
+  - build-macos-dmg
 
 trigger:
   ref:

--- a/scripts/ghcr-manifest.sh
+++ b/scripts/ghcr-manifest.sh
@@ -57,10 +57,9 @@ ghcr_login() {
 }
 
 ghcr_manifest_create() {
-  # TEMP: arm64 leg removed while arm64 builds are disabled in .drone.yml.
-  # Restore the `"$GHCR_REPO:$VERSION-linux-arm64"` line below when arm64 is re-enabled.
   docker manifest create --amend "$GHCR_REPO:$VERSION" \
-    "$GHCR_REPO:$VERSION-linux-amd64"
+    "$GHCR_REPO:$VERSION-linux-amd64" \
+    "$GHCR_REPO:$VERSION-linux-arm64"
 }
 
 ghcr_manifest_push() {


### PR DESCRIPTION
## Summary

Reverts the temporary disables from https://github.com/helixml/helix/pull/2419 and the matching `scripts/ghcr-manifest.sh` arm64 entry from https://github.com/helixml/helix/pull/2420. The 2.11.3 release is out and flight is back, so arm64 builds and the macOS DMG pipeline can be re-enabled.

## Changes

| File | Reverted |
|---|---|
| `.drone.yml`: `build-controlplane-arm64`, `build-sandbox-arm64` triggers | sentinel ref -> `refs/heads/main` + `refs/tags/*` |
| `.drone.yml`: `build-macos-dmg` trigger | sentinel ref -> `refs/tags/*` |
| `.drone.yml`: `manifest-controlplane`, `manifest-sandbox` `depends_on` | arm64 pipelines re-added |
| `.drone.yml`: `manifest-controlplane`, `manifest-helix-sandbox`, `manifest-helix-sway`, `manifest-helix-ubuntu` `docker manifest create` lines | `-linux-arm64` leg re-added |
| `.drone.yml`: `release-rollback` `depends_on` | arm64 + DMG pipelines re-added |
| `.drone.yml`: `zed-e2e-test` step | `failure: ignore` removed |
| `scripts/ghcr-manifest.sh`: `ghcr_manifest_create` | `-linux-arm64` leg re-added |

The 6-retry + fail-loud semantics for both ghcr scripts (from PRs #2421 / #2422 / #2423) are unchanged.

## Heads-up

The Phase 15 Claude streaming regression on `zed-e2e-test` has not been fixed on the Zed side yet, so this step will start failing builds again until the Zed-side fix lands. Restoring the gate is intentional - we don't want that failure silently ignored once the release window is over.

If `zed-e2e-test` starts gating main again before the Zed fix is ready, options are:
- Land the Zed fix (preferred)
- Reapply `failure: ignore` with a clear time-boxed comment (least preferred, what this PR is undoing)

## Test plan

- [ ] Drone build picks up the PR
- [ ] arm64 stages run again (no longer skipped)
- [ ] `manifest-*` stages publish proper multi-arch manifests on both `registry.helixml.tech` and `ghcr.io/helixml`
- [ ] After merge, next tag push triggers the macOS DMG pipeline