### PR TITLE
fix(settings-sync-daemon): force-overwrite Helix-owned context_servers

### DIFF
--- a/api/cmd/settings-sync-daemon/main.go
+++ b/api/cmd/settings-sync-daemon/main.go
@@ -1007,6 +1007,33 @@ var HELIX_MANAGED_AGENT_FIELDS = map[string]bool{
 	"thread_summary_model":   true,
 }
 
+// HELIX_OWNED_CONTEXT_SERVERS lists context_server names whose configuration
+// Helix unconditionally owns. The names are the ones hardcoded in
+// api/pkg/external-agent/zed_config.go (chrome-devtools, helix-session,
+// helix-desktop) — i.e. servers that Helix sets up itself (not from a user's
+// project / app MCP config).
+//
+// Why: when these names already exist in the on-disk settings.json from a
+// previous run AND Helix updated their config in zed_config.go since then
+// (e.g. switched chrome-devtools from `npx chrome-devtools-mcp@latest` to
+// the global `/usr/bin/chrome-devtools-mcp` binary in PR #2418), the
+// daemon's deep-merge in `mergeSettings` would treat the on-disk entry as
+// a "user override" and let it win — leaving stale `npx`-based configs in
+// place forever, with the resulting 180s `chrome-devtools context server
+// failed to start: Context server request timeout` reported in
+// helix/design/2026-05-13-mcp-cache-contention-and-duplicate-claude-spawn.md.
+//
+// User-configured MCPs (from app or project skills, e.g. drone-ci, github,
+// custom servers) are NOT in this set — those legitimately can be edited by
+// the user in their on-disk settings.json and should round-trip back to the
+// API as overrides. They're also keyed by user-chosen names that we can't
+// enumerate here.
+var HELIX_OWNED_CONTEXT_SERVERS = map[string]bool{
+	"chrome-devtools": true,
+	"helix-session":   true,
+	"helix-desktop":   true,
+}
+
 // helixDefaults returns the static Helix-owned settings that must be present
 // in every settings.json. Both syncFromHelix() and checkHelixUpdates() use
 // this as the base, then layer on API response fields.
@@ -1076,14 +1103,33 @@ func (d *SettingsDaemon) mergeSettings(helix, user map[string]interface{}) map[s
 		merged[k] = v
 	}
 
-	// Deep merge context_servers
+	// Deep merge context_servers — user entries win, EXCEPT for Helix-owned
+	// names where Helix's hardcoded definition unconditionally wins. Without
+	// the latter clause an on-disk settings.json from a previous run pins
+	// the OLD config (stale `npx chrome-devtools-mcp@latest` etc.) forever;
+	// see HELIX_OWNED_CONTEXT_SERVERS for the full reasoning.
 	if userServers, ok := user["context_servers"].(map[string]interface{}); ok {
 		if helixServers, ok := merged["context_servers"].(map[string]interface{}); ok {
 			for name, config := range userServers {
+				if HELIX_OWNED_CONTEXT_SERVERS[name] {
+					log.Printf("dropping user override for helix-owned context_server: %s", name)
+					continue
+				}
 				helixServers[name] = config
 			}
 		} else {
-			merged["context_servers"] = userServers
+			// No helix-side servers at all — adopt user's verbatim, but
+			// still strip helix-owned names so a later API roll-out
+			// adding them isn't pre-empted by a stale on-disk entry.
+			filtered := make(map[string]interface{}, len(userServers))
+			for name, config := range userServers {
+				if HELIX_OWNED_CONTEXT_SERVERS[name] {
+					log.Printf("dropping user override for helix-owned context_server: %s", name)
+					continue
+				}
+				filtered[name] = config
+			}
+			merged["context_servers"] = filtered
 		}
 	}
 
@@ -1171,12 +1217,21 @@ func mergeAgentBlock(helixAgent, userAgent interface{}) interface{} {
 func extractUserOverrides(current, helix map[string]interface{}) map[string]interface{} {
 	overrides := make(map[string]interface{})
 
-	// Deep diff context_servers (per-server)
+	// Deep diff context_servers (per-server). Helix-owned names are never
+	// captured as user overrides — Helix sets them itself in zed_config.go
+	// and any divergence on disk is stale state from a prior run, not a
+	// user customization. Without this guard the daemon would round-trip
+	// the stale value back to the API and the next sync would re-write it
+	// to disk, pinning the old config forever (see
+	// HELIX_OWNED_CONTEXT_SERVERS).
 	if currentServers, ok := current["context_servers"].(map[string]interface{}); ok {
 		helixServers, _ := helix["context_servers"].(map[string]interface{})
 		userServers := make(map[string]interface{})
 
 		for name, config := range currentServers {
+			if HELIX_OWNED_CONTEXT_SERVERS[name] {
+				continue
+			}
 			if helixConfig, inHelix := helixServers[name]; !inHelix {
 				userServers[name] = config
 			} else if !deepEqual(config, helixConfig) {

--- a/api/cmd/settings-sync-daemon/main_test.go
+++ b/api/cmd/settings-sync-daemon/main_test.go
@@ -336,3 +336,167 @@ func TestExtractUserOverrides_AgentDiffSkipsManagedFields(t *testing.T) {
 		assert.NotContains(t, agent, "auto_open_panel")
 	})
 }
+
+// TestMergeSettings_HelixOwnedContextServersWin is the regression test for the
+// stale-MCP-config bug documented in
+// helix/design/2026-05-13-mcp-cache-contention-and-duplicate-claude-spawn.md.
+//
+// Sequence pre-fix:
+//  1. Old API code generated `chrome-devtools` config with `command: "npx"` and
+//     wrote it to disk via the daemon.
+//  2. PR #2418 changed `chrome-devtools` to use `/usr/bin/chrome-devtools-mcp`.
+//  3. On the next daemon poll the API returned the NEW config — but the
+//     deep-merge in `mergeSettings` treated the on-disk OLD entry as a
+//     "user override" and let it win, pinning the broken `npx` config
+//     forever and producing 180s `chrome-devtools context server failed
+//     to start: Context server request timeout` errors.
+//
+// To verify regression power: comment out the
+// `if HELIX_OWNED_CONTEXT_SERVERS[name] { continue }` guard in the
+// `mergeSettings` deep-merge of `context_servers` and re-run; the
+// "force-overwrite" sub-tests below will fail because the user's stale
+// `npx`-based entry will win.
+func TestMergeSettings_HelixOwnedContextServersWin(t *testing.T) {
+	d := &SettingsDaemon{}
+
+	// Helix base — what zed_config.go produces post-fix
+	helix := map[string]interface{}{
+		"context_servers": map[string]interface{}{
+			"chrome-devtools": map[string]interface{}{
+				"command": "/usr/bin/chrome-devtools-mcp",
+				"args":    []interface{}{"--viewport", "1280x800"},
+			},
+			"helix-session": map[string]interface{}{
+				"url":     "http://api:8080/api/v1/mcp/session?session_id=ses_new",
+				"headers": map[string]interface{}{"Authorization": "Bearer fresh"},
+			},
+			"helix-desktop": map[string]interface{}{
+				"url": "http://api:8080/api/v1/mcp/desktop?session_id=ses_new",
+			},
+		},
+	}
+
+	t.Run("force-overwrite chrome-devtools when user has stale npx version", func(t *testing.T) {
+		user := map[string]interface{}{
+			"context_servers": map[string]interface{}{
+				"chrome-devtools": map[string]interface{}{
+					// THIS is the bug — the persisted on-disk entry from
+					// before PR #2418. Without the guard, this wins.
+					"command": "npx",
+					"args":    []interface{}{"chrome-devtools-mcp@latest"},
+				},
+			},
+		}
+		merged := d.mergeSettings(helix, user)
+		got := merged["context_servers"].(map[string]interface{})["chrome-devtools"].(map[string]interface{})
+		assert.Equal(t, "/usr/bin/chrome-devtools-mcp", got["command"],
+			"chrome-devtools must use Helix's hardcoded path, not the user's stale npx entry")
+	})
+
+	t.Run("force-overwrite helix-session when user has stale session_id", func(t *testing.T) {
+		user := map[string]interface{}{
+			"context_servers": map[string]interface{}{
+				"helix-session": map[string]interface{}{
+					"url":     "http://api:8080/api/v1/mcp/session?session_id=ses_OLD",
+					"headers": map[string]interface{}{"Authorization": "Bearer STALE"},
+				},
+			},
+		}
+		merged := d.mergeSettings(helix, user)
+		got := merged["context_servers"].(map[string]interface{})["helix-session"].(map[string]interface{})
+		assert.Equal(t, "http://api:8080/api/v1/mcp/session?session_id=ses_new", got["url"])
+		assert.Equal(t, "Bearer fresh", got["headers"].(map[string]interface{})["Authorization"])
+	})
+
+	t.Run("user-configured MCP (e.g. drone-ci) still wins", func(t *testing.T) {
+		// drone-ci is a user/project-configured MCP, NOT in
+		// HELIX_OWNED_CONTEXT_SERVERS. Users editing their on-disk
+		// settings.json to customize it must round-trip.
+		user := map[string]interface{}{
+			"context_servers": map[string]interface{}{
+				"drone-ci": map[string]interface{}{
+					"command": "drone-ci-mcp",
+					"args":    []interface{}{},
+					"env":     map[string]interface{}{"DRONE_ACCESS_TOKEN": "user-token"},
+				},
+			},
+		}
+		merged := d.mergeSettings(helix, user)
+		got := merged["context_servers"].(map[string]interface{})["drone-ci"].(map[string]interface{})
+		assert.Equal(t, "drone-ci-mcp", got["command"])
+		assert.Equal(t, "user-token", got["env"].(map[string]interface{})["DRONE_ACCESS_TOKEN"])
+	})
+
+	t.Run("strips helix-owned names even when helix has no servers", func(t *testing.T) {
+		// Defensive: if Helix temporarily emits no context_servers (e.g.
+		// during a transient API state) we shouldn't accidentally
+		// resurrect a user's stale chrome-devtools from disk.
+		emptyHelix := map[string]interface{}{}
+		user := map[string]interface{}{
+			"context_servers": map[string]interface{}{
+				"chrome-devtools": map[string]interface{}{
+					"command": "npx",
+					"args":    []interface{}{"chrome-devtools-mcp@latest"},
+				},
+				"my-custom-mcp": map[string]interface{}{
+					"command": "my-custom-mcp",
+				},
+			},
+		}
+		merged := d.mergeSettings(emptyHelix, user)
+		cs := merged["context_servers"].(map[string]interface{})
+		assert.NotContains(t, cs, "chrome-devtools",
+			"helix-owned name must be stripped even when helix has no servers")
+		assert.Contains(t, cs, "my-custom-mcp",
+			"non-helix-owned user MCP must survive")
+	})
+}
+
+// TestExtractUserOverrides_SkipsHelixOwnedContextServers verifies the round-trip
+// half of the fix: extractUserOverrides must NOT capture helix-owned names as
+// user overrides. Otherwise a stale on-disk chrome-devtools entry is uploaded
+// to the API, the API treats it as the canonical user customization, the next
+// sync re-writes it to disk — and Helix's force-overwrite is permanently
+// nullified one round-trip later.
+func TestExtractUserOverrides_SkipsHelixOwnedContextServers(t *testing.T) {
+	helix := map[string]interface{}{
+		"context_servers": map[string]interface{}{
+			"chrome-devtools": map[string]interface{}{
+				"command": "/usr/bin/chrome-devtools-mcp",
+			},
+		},
+	}
+
+	t.Run("does not upload stale chrome-devtools as user override", func(t *testing.T) {
+		current := map[string]interface{}{
+			"context_servers": map[string]interface{}{
+				"chrome-devtools": map[string]interface{}{
+					"command": "npx",
+					"args":    []interface{}{"chrome-devtools-mcp@latest"},
+				},
+			},
+		}
+		got := extractUserOverrides(current, helix)
+		assert.NotContains(t, got, "context_servers",
+			"stale on-disk helix-owned entry must not be captured as user override")
+	})
+
+	t.Run("does upload non-helix user MCP overrides", func(t *testing.T) {
+		current := map[string]interface{}{
+			"context_servers": map[string]interface{}{
+				"chrome-devtools": map[string]interface{}{
+					"command": "npx",
+					"args":    []interface{}{"chrome-devtools-mcp@latest"},
+				},
+				"my-custom-mcp": map[string]interface{}{
+					"command": "/opt/my-custom-mcp/run",
+				},
+			},
+		}
+		got := extractUserOverrides(current, helix)
+		cs, ok := got["context_servers"].(map[string]interface{})
+		assert.True(t, ok, "user override for my-custom-mcp must be captured")
+		assert.NotContains(t, cs, "chrome-devtools")
+		assert.Contains(t, cs, "my-custom-mcp")
+	})
+}


### PR DESCRIPTION
## Summary

Tail-end fix for the MCP-cache-contention investigation that PR #2418 addressed. After PR #2418 merged, the user reported `chrome-devtools / drone-ci / github` still showing **"Context server request timeout"** in Zed on a long-running spec-task container — even though the container was running the new `helix-ubuntu:6de75e` image (with all the global MCP binaries) and `helix-api` was running the new `zed_config.go` (with `chrome-devtools` pointing at `/usr/bin/chrome-devtools-mcp` instead of `npx`).

Root cause: `~/.config/zed/settings.json` is a symlink to `/home/retro/work/.zed-state/config/settings.json`, which lives on the persistent ZFS-backed `/home/retro/work` volume. The settings-sync-daemon's `mergeSettings` deep-merge of `context_servers` lets USER entries win for every name, so the OLD `command: "npx", args: ["chrome-devtools-mcp@latest"]` written by the pre-PR-#2418 API last week was treated as a user customization and pinned forever, no matter how many times the new API generated the correct config.

`extractUserOverrides` had the symmetric bug: it captured the stale on-disk entry as a user override and round-tripped it back to the API.

## Fix

New constant `HELIX_OWNED_CONTEXT_SERVERS = {chrome-devtools, helix-session, helix-desktop}` — the names hardcoded in `api/pkg/external-agent/zed_config.go`. Two corresponding behavior changes in `api/cmd/settings-sync-daemon/main.go`:

1. **`mergeSettings`** — skip user-side `context_servers` entries whose name is in `HELIX_OWNED_CONTEXT_SERVERS` so Helix's hardcoded definition unconditionally wins. Also strip helix-owned names from the "user-only" branch so a stale on-disk entry can't survive even when the API temporarily emits no `context_servers`.

2. **`extractUserOverrides`** — never capture helix-owned names as user overrides (otherwise the stale entry would round-trip back to the API and force the next sync to re-write the OLD value to disk, permanently nullifying the force-overwrite from #1).

User-configured MCPs (e.g. drone-ci, github, custom servers from project skills or app config) are **NOT** in the helix-owned set — those legitimately can be edited by the user in their on-disk settings.json and must round-trip.

## Tests

- **`TestMergeSettings_HelixOwnedContextServersWin`** (4 sub-tests):
  - force-overwrite `chrome-devtools` when user has stale `npx` version
  - force-overwrite `helix-session` when user has stale `session_id` URL/token
  - user-configured `drone-ci` still wins (positive control — non-helix-owned MCP)
  - strips helix-owned names even when helix temporarily has no `context_servers`
- **`TestExtractUserOverrides_SkipsHelixOwnedContextServers`** (2 sub-tests):
  - stale on-disk helix-owned entries are not captured as user overrides
  - non-helix user overrides still round-trip (positive control)

**Verified regression-test power**: with both guards commented out (`if false && HELIX_OWNED_CONTEXT_SERVERS[name] {`), all 5 of the 6 force-overwrite/skip sub-tests fail with the diagnostic messages in the assertions — exactly the regression we're guarding against.

## Test plan

- [x] `CGO_ENABLED=0 go test -v -run "TestMergeSettings_HelixOwned|TestExtractUserOverrides_SkipsHelix" ./api/cmd/settings-sync-daemon/ -count=1` — all 6 sub-tests pass.
- [x] Disabled both guards, re-ran — 5 of 6 fail with the expected diagnostic. Restored.
- [x] `go build ./api/cmd/settings-sync-daemon/` clean.
- [ ] CI (Drone)

## Follow-up after merge

The user's affected long-running container (`spt_01kqc4ev5rt9rknk6g8dbkzj9a`) needs a `./stack build-ubuntu` + new session for the daemon binary to be replaced (per `CLAUDE.md`: settings-sync-daemon does not hot-reload). Once the new daemon runs, it'll force-overwrite the stale chrome-devtools/helix-session/helix-desktop entries on the next sync, and Zed will pick up the new `/usr/bin/chrome-devtools-mcp` config.

## Related

- **Builds on PR #2418**: https://github.com/helixml/helix/pull/2418 (npx-cache-contention + Fix 1a/1b/2)
- **Builds on Zed PR #56**: https://github.com/helixml/zed/pull/56
- **Design doc**: [`design/2026-05-13-mcp-cache-contention-and-duplicate-claude-spawn.md`](https://github.com/helixml/helix/blob/main/design/2026-05-13-mcp-cache-contention-and-duplicate-claude-spawn.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)