### PR TITLE
feat(frontend): regroup org admin sidebar into Settings/Members/Cost/Access

### DIFF
--- a/frontend/src/components/orgs/OrgSidebar.tsx
+++ b/frontend/src/components/orgs/OrgSidebar.tsx
@@ -1,6 +1,14 @@
 import { FC } from 'react'
 
-import { User, Users, CreditCard, Settings, KeyRound, Plug } from 'lucide-react'
+import {
+  SlidersHorizontal,
+  User,
+  Users,
+  CreditCard,
+  BarChart as ChartIcon,
+  KeyRound,
+  Plug,
+} from 'lucide-react'
 
 import useRouter from '../../hooks/useRouter'
 import useAccount from '../../hooks/useAccount'
@@ -21,52 +29,74 @@ const OrgSidebar: FC = () => {
 
   const sections: ContextSidebarSection[] = [
     {
-      title: 'Organization Management',
+      title: 'Settings',
+      items: [
+        {
+          id: 'general',
+          label: 'General',
+          icon: <SlidersHorizontal size={20} />,
+          isActive: currentRouteName === 'org_general' || currentRouteName === 'org_settings',
+          onClick: () => handleNavigationClick('org_general'),
+        },
+      ],
+    },
+    {
+      title: 'Members',
       items: [
         {
           id: 'people',
           label: 'People',
           icon: <User size={20} />,
           isActive: currentRouteName === 'org_people',
-          onClick: () => handleNavigationClick('org_people')
+          onClick: () => handleNavigationClick('org_people'),
         },
         {
           id: 'teams',
           label: 'Teams',
           icon: <Users size={20} />,
           isActive: currentRouteName === 'org_teams',
-          onClick: () => handleNavigationClick('org_teams')
+          onClick: () => handleNavigationClick('org_teams'),
         },
+      ],
+    },
+    {
+      title: 'Cost',
+      items: [
         {
           id: 'billing',
           label: 'Billing',
           icon: <CreditCard size={20} />,
           isActive: currentRouteName === 'org_billing',
-          onClick: () => handleNavigationClick('org_billing')
+          onClick: () => handleNavigationClick('org_billing'),
         },
+        {
+          id: 'usage',
+          label: 'Usage',
+          icon: <ChartIcon size={20} />,
+          isActive: currentRouteName === 'org_usage',
+          onClick: () => handleNavigationClick('org_usage'),
+        },
+      ],
+    },
+    {
+      title: 'Access',
+      items: [
         {
           id: 'api_keys',
           label: 'API Keys',
           icon: <KeyRound size={20} />,
           isActive: currentRouteName === 'org_api_keys',
-          onClick: () => handleNavigationClick('org_api_keys')
+          onClick: () => handleNavigationClick('org_api_keys'),
         },
         {
           id: 'providers',
           label: 'Providers',
           icon: <Plug size={20} />,
           isActive: currentRouteName === 'org_providers',
-          onClick: () => handleNavigationClick('org_providers')
+          onClick: () => handleNavigationClick('org_providers'),
         },
-        {
-          id: 'settings',
-          label: 'Settings',
-          icon: <Settings size={20} />,
-          isActive: currentRouteName === 'org_settings',
-          onClick: () => handleNavigationClick('org_settings')
-        }
-      ]
-    }
+      ],
+    },
   ]
 
   return (
@@ -77,4 +107,4 @@ const OrgSidebar: FC = () => {
   )
 }
 
-export default OrgSidebar 
+export default OrgSidebar

--- a/frontend/src/components/orgs/OrgUsage.tsx
+++ b/frontend/src/components/orgs/OrgUsage.tsx
@@ -1,0 +1,60 @@
+import { FC } from 'react'
+import Container from '@mui/material/Container'
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import Paper from '@mui/material/Paper'
+import { BarChart as ChartIcon } from 'lucide-react'
+
+import Page from '../system/Page'
+
+const OrgUsage: FC = () => {
+  return (
+    <Page
+      breadcrumbTitle="Usage"
+      breadcrumbParent={{
+        title: 'Organizations',
+        routeName: 'orgs',
+        useOrgRouter: false,
+      }}
+      breadcrumbShowHome={true}
+      orgBreadcrumbs={true}
+    >
+      <Container maxWidth="xl">
+        <Box sx={{ mt: 3, p: 2, maxWidth: 880 }}>
+          <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 3 }}>
+            <ChartIcon size={28} />
+            <Typography variant="h5" component="h2">
+              Usage
+            </Typography>
+          </Stack>
+          <Paper
+            variant="outlined"
+            sx={{
+              p: 3,
+              borderStyle: 'dashed',
+              backgroundColor: 'transparent',
+            }}
+          >
+            <Typography variant="body1" sx={{ mb: 1, fontWeight: 600 }}>
+              Coming soon
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              The aggregate LLM token usage and cost breakdown for this
+              organization is in design. It will show tokens and
+              estimated cost grouped by user, project/app/agent,
+              session, and model/provider, with date-range filters and
+              CSV/JSON export.
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Visible whether or not billing is enabled. Design:{' '}
+              <code>design/2026-05-14-aggregate-usage-dashboard.md</code>
+            </Typography>
+          </Paper>
+        </Box>
+      </Container>
+    </Page>
+  )
+}
+
+export default OrgUsage

--- a/frontend/src/components/orgs/UserOrgSelector.tsx
+++ b/frontend/src/components/orgs/UserOrgSelector.tsx
@@ -443,14 +443,26 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
       })
     }
 
-    // Add org settings button when we have an org context
+    // Add org settings button when we have an org context.
+    // Highlights for any of the grouped admin pages (general, members,
+    // cost, access), and lands on General by default since that's the
+    // canonical "settings" leaf.
     if (currentOrgSlug) {
       baseButtons.push(
         {
           icon: <Settings size={NAV_BUTTON_SIZE} />,
           tooltip: "Organization settings",
-          isActive: isActive('org_people'),
-          onClick: () => orgNavigateTo('org_people', { org_id: currentOrgSlug }),
+          isActive: isActive([
+            'org_general',
+            'org_settings',
+            'org_people',
+            'org_teams',
+            'org_billing',
+            'org_usage',
+            'org_api_keys',
+            'org_providers',
+          ]),
+          onClick: () => orgNavigateTo('org_general', { org_id: currentOrgSlug }),
           label: "Settings",
         }
       )

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -432,11 +432,14 @@ const Layout: FC<{
         // Individual app pages use the new context sidebar for agent navigation
         return <AppSidebar />;
 
+      case "org_general":
       case "org_settings":
       case "org_people":
       case "org_teams":
       case "org_billing":
+      case "org_usage":
       case "org_api_keys":
+      case "org_providers":
       case "team_people":
         // Organization management pages use the org context sidebar
         return <OrgSidebar />;

--- a/frontend/src/pages/OrgSettings.tsx
+++ b/frontend/src/pages/OrgSettings.tsx
@@ -137,7 +137,7 @@ const OrgSettings: FC = () => {
       snackbar.success("Organization updated successfully");
 
       if (slug != organization.name) {
-        router.navigate("org_settings", { org_id: slug });
+        router.navigate("org_general", { org_id: slug });
       }
     } catch (error) {
       console.error("Error updating organization:", error);
@@ -195,7 +195,7 @@ const OrgSettings: FC = () => {
 
   return (
     <Page
-      breadcrumbTitle={organization ? `Settings` : "Organization Settings"}
+      breadcrumbTitle={organization ? `General` : "General"}
       breadcrumbParent={{
         title: "Organizations",
         routeName: "orgs",
@@ -207,7 +207,7 @@ const OrgSettings: FC = () => {
       <Container maxWidth="xl">
         <Box sx={{ mt: 3, p: 2 }}>
           <Typography variant="h5" component="h2" gutterBottom>
-            Organization Settings
+            General
             {isReadOnly && (
               <Typography
                 variant="caption"

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -13,6 +13,7 @@ import OrgPeople from './pages/OrgPeople'
 import TeamPeople from './pages/TeamPeople'
 import OrgApiKeys from './pages/OrgApiKeys'
 import OrgBilling from './components/orgs/OrgBilling'
+import OrgUsage from './components/orgs/OrgUsage'
 import App from './pages/App'
 import Create from './pages/Create'
 import Home from './pages/Home'
@@ -347,14 +348,36 @@ const routes: IApplicationRoute[] = [
     <Orgs />
   ),
 }, {
-  name: 'org_settings',
-  path: '/orgs/:org_id/settings',
+  name: 'org_general',
+  path: '/orgs/:org_id/general',
   meta: {
     drawer: true,
     menu: 'orgs',
   },
   render: () => (
     <OrgSettings />
+  ),
+}, {
+  // Backward compat: redirect /settings to /general
+  name: 'org_settings',
+  path: '/orgs/:org_id/settings',
+  meta: { drawer: false },
+  render: () => {
+    const { navigateReplace, params } = useRouter()
+    React.useEffect(() => {
+      navigateReplace('org_general', { org_id: params.org_id })
+    }, [])
+    return null
+  },
+}, {
+  name: 'org_usage',
+  path: '/orgs/:org_id/usage',
+  meta: {
+    drawer: true,
+    menu: 'orgs',
+  },
+  render: () => (
+    <OrgUsage />
   ),
 }, {
   name: 'org_people',


### PR DESCRIPTION
## Summary

- Replaces the flat seven-item org admin sidebar with four labelled groups: **Settings**, **Members**, **Cost**, **Access**.
- Removes the two-Settings name collision: outer rail cog now lands on **General** (was previously the surprise default of People), and General is the renamed inner Settings leaf.
- Slots a **Usage** placeholder under Cost ahead of the aggregate usage dashboard work (design at \`design/2026-05-14-aggregate-usage-dashboard.md\`, separate PR).

## Sidebar before vs. after

| Before (flat) | After (grouped) |
|---|---|
| People, Teams, Billing, API Keys, Providers, Settings | **Settings**: General<br>**Members**: People, Teams<br>**Cost**: Billing, Usage<br>**Access**: API Keys, Providers |

## Changes

- Inner Settings leaf renamed to **General**. New route \`/orgs/:org_id/general\` (\`org_general\`) renders the existing \`OrgSettings\` page (name, slug, auto-join domain, danger zone). Page heading and breadcrumb updated to match.
- Legacy \`/orgs/:org_id/settings\` (\`org_settings\`) kept as a redirect to \`/general\` using the same \`navigateReplace\` pattern as the existing \`/apps\` -> \`/agents\` and \`/git-repos\` -> projects redirects.
- Outer rail Settings cog (\`UserOrgSelector.tsx\`) now navigates to \`org_general\` and highlights for any of the seven admin route names, not just \`org_people\`.
- New \`OrgUsage\` placeholder page at \`/orgs/:org_id/usage\` so the Cost group has both items present for IA review. The full usage dashboard lands later.
- \`Layout.tsx\` switch updated to render \`OrgSidebar\` for \`org_general\`, \`org_usage\`, and \`org_providers\` (\`org_providers\` was previously missing, so the sidebar disappeared on that page - fixed as part of this change).

## Why now

We were about to add a Usage tab to the org sidebar for the aggregate LLM usage dashboard, which would have made the existing IA worse (eight flat items, still with the two-Settings collision). Decided to fix the grouping first so Usage lands in a coherent structure.

## Test plan

- [ ] Visit \`/orgs/<slug>/\` admin section via the outer rail cog. Should land on **General**, not People.
- [ ] Sidebar shows four labelled groups in order: Settings, Members, Cost, Access.
- [ ] Clicking each item routes to the matching page; the active item highlights.
- [ ] Outer rail cog stays highlighted while you are on any of the seven admin pages.
- [ ] Visit \`/orgs/<slug>/settings\` directly - confirm it redirects to \`/orgs/<slug>/general\`.
- [ ] Visit \`/orgs/<slug>/usage\` - see the "Coming soon" placeholder page.
- [ ] Visit \`/orgs/<slug>/providers\` - confirm the OrgSidebar is rendered (previously it disappeared).
- [ ] Edit the org slug on General; confirm the URL updates to the new \`/orgs/<new-slug>/general\` and not \`/settings\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)