### PR TITLE
ci(zed-e2e): move arm64 sandbox-build-cache off virtiofs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1772,14 +1772,27 @@ volumes:
   - name: dockersocket
     host:
       path: /var/run/docker.sock
-  # Use a per-pipeline temp volume rather than a host bind on the external
-  # drive. The external drive flowed through Docker Desktop virtiofs (fakeowner),
-  # which produced an intermittent `getcwd()` race during `git init` after
-  # `rm -rf` (see builds 1428 and 1432). A temp volume lives in the Docker VM's
-  # native ext4 — no virtiofs, no race. BuildKit cache mounts in the qwen/zed
-  # Dockerfiles handle the actual cargo/npm caching across builds.
+  # Persistent cache for clone-dependencies / build-zed. The bind target
+  # lives inside Docker's VM-internal volume storage, so I/O goes through
+  # virtio-blk → Linux ext4 inside Docker.raw, NOT through Docker Desktop's
+  # fakeowner virtiofs. (Docker.raw itself still lives on /Volumes/Big on
+  # the runner — we can't escape that — but virtio-blk block I/O doesn't
+  # have the metadata-sync race that virtiofs does.)
+  #   * Fixes the `getcwd()` ENOENT race that killed `git init` mid-step
+  #     when the prior path was on virtiofs (see builds 1428 and 1432).
+  #   * Docker auto-creates this path on first bind (verified), so a fresh
+  #     runner or full Docker Desktop reset just rebuilds the Zed binary
+  #     once (~12 min) and is warm again from then on — no admin step
+  #     required to "bless" the runner.
+  #   * The dir is not a registered `docker volume`, so `docker volume
+  #     prune` can't touch it. Only a full Docker reset clears it.
+  # What's in it:
+  #   * /drone/src/cache/{zed,qwen}-source — transient (re-cloned each build)
+  #   * /drone/src/cache/zed-bin-<sha>/zed — the prize: avoids a ~12 min
+  #     `docker build` of Zed when ZED_COMMIT hasn't changed.
   - name: sandbox-build-cache
-    temp: {}
+    host:
+      path: /var/lib/docker/volumes/helix-sandbox-build-cache/_data
 
 steps:
   # Step 1: Clone external repositories (same as amd64)
@@ -1802,9 +1815,14 @@ steps:
         if [ "$${QWEN_COMMIT}" != "$${QWEN_HEAD}" ]; then
           echo "⚠️  QWEN_COMMIT is behind upstream HEAD ($${QWEN_HEAD:0:12})"
         fi
+      # Re-create the source dirs each run to avoid stale state from a
+      # previous build at a different commit. Safe here: we're on the VM's
+      # ext4 (no virtiofs), so rm/mkdir/cd are synchronous and `git init`
+      # works inline.
       - |
         . /drone/src/sandbox-versions.txt
         echo "Cloning Zed at commit $${ZED_COMMIT}..."
+        rm -rf /drone/src/cache/zed-source
         mkdir -p /drone/src/cache/zed-source
         cd /drone/src/cache/zed-source
         git init -q .
@@ -1814,6 +1832,7 @@ steps:
       - |
         . /drone/src/sandbox-versions.txt
         echo "Cloning qwen-code at commit $${QWEN_COMMIT}..."
+        rm -rf /drone/src/cache/qwen-source
         mkdir -p /drone/src/cache/qwen-source
         cd /drone/src/cache/qwen-source
         git init -q .

--- a/.drone.yml
+++ b/.drone.yml
@@ -1797,24 +1797,33 @@ steps:
         if [ "$${QWEN_COMMIT}" != "$${QWEN_HEAD}" ]; then
           echo "⚠️  QWEN_COMMIT is behind upstream HEAD ($${QWEN_HEAD:0:12})"
         fi
+      # Cache dir is on the external drive via Docker Desktop virtiofs (fakeowner).
+      # `git init <path>` does an internal mkdir → chdir → getcwd, which races
+      # against virtiofs metadata sync after the preceding `rm -rf` and produces
+      # `fatal: unable to get current working directory: No such file or directory`.
+      # Driving the mkdir/cd from the shell first sidesteps that race.
       - |
         . /drone/src/sandbox-versions.txt
         echo "Cloning Zed at commit $${ZED_COMMIT}..."
-        cd /
         rm -rf /drone/src/cache/zed-source
-        git init /drone/src/cache/zed-source
-        git -C /drone/src/cache/zed-source fetch --depth 1 https://github.com/helixml/zed.git $${ZED_COMMIT}
-        git -C /drone/src/cache/zed-source checkout FETCH_HEAD
-        echo "✓ Zed source at $$(git -C /drone/src/cache/zed-source rev-parse HEAD)"
+        mkdir -p /drone/src/cache/zed-source
+        sync
+        cd /drone/src/cache/zed-source
+        git init -q .
+        git fetch --depth 1 https://github.com/helixml/zed.git $${ZED_COMMIT}
+        git checkout FETCH_HEAD
+        echo "✓ Zed source at $$(git rev-parse HEAD)"
       - |
         . /drone/src/sandbox-versions.txt
         echo "Cloning qwen-code at commit $${QWEN_COMMIT}..."
-        cd /
         rm -rf /drone/src/cache/qwen-source
-        git init /drone/src/cache/qwen-source
-        git -C /drone/src/cache/qwen-source fetch --depth 1 https://github.com/helixml/qwen-code.git $${QWEN_COMMIT}
-        git -C /drone/src/cache/qwen-source checkout FETCH_HEAD
-        echo "✓ qwen-code source at $$(git -C /drone/src/cache/qwen-source rev-parse HEAD)"
+        mkdir -p /drone/src/cache/qwen-source
+        sync
+        cd /drone/src/cache/qwen-source
+        git init -q .
+        git fetch --depth 1 https://github.com/helixml/qwen-code.git $${QWEN_COMMIT}
+        git checkout FETCH_HEAD
+        echo "✓ qwen-code source at $$(git rev-parse HEAD)"
       - echo "=== Dependency versions ==="
       - echo "Zed:" && cat /drone/src/zed-commit.txt
       - echo "qwen-code:" && cat /drone/src/qwen-code-commit.txt

--- a/.drone.yml
+++ b/.drone.yml
@@ -1772,9 +1772,14 @@ volumes:
   - name: dockersocket
     host:
       path: /var/run/docker.sock
+  # Use a per-pipeline temp volume rather than a host bind on the external
+  # drive. The external drive flowed through Docker Desktop virtiofs (fakeowner),
+  # which produced an intermittent `getcwd()` race during `git init` after
+  # `rm -rf` (see builds 1428 and 1432). A temp volume lives in the Docker VM's
+  # native ext4 — no virtiofs, no race. BuildKit cache mounts in the qwen/zed
+  # Dockerfiles handle the actual cargo/npm caching across builds.
   - name: sandbox-build-cache
-    host:
-      path: /Volumes/Big/drone-cache/sandbox-build
+    temp: {}
 
 steps:
   # Step 1: Clone external repositories (same as amd64)
@@ -1797,17 +1802,10 @@ steps:
         if [ "$${QWEN_COMMIT}" != "$${QWEN_HEAD}" ]; then
           echo "⚠️  QWEN_COMMIT is behind upstream HEAD ($${QWEN_HEAD:0:12})"
         fi
-      # Cache dir is on the external drive via Docker Desktop virtiofs (fakeowner).
-      # `git init <path>` does an internal mkdir → chdir → getcwd, which races
-      # against virtiofs metadata sync after the preceding `rm -rf` and produces
-      # `fatal: unable to get current working directory: No such file or directory`.
-      # Driving the mkdir/cd from the shell first sidesteps that race.
       - |
         . /drone/src/sandbox-versions.txt
         echo "Cloning Zed at commit $${ZED_COMMIT}..."
-        rm -rf /drone/src/cache/zed-source
         mkdir -p /drone/src/cache/zed-source
-        sync
         cd /drone/src/cache/zed-source
         git init -q .
         git fetch --depth 1 https://github.com/helixml/zed.git $${ZED_COMMIT}
@@ -1816,9 +1814,7 @@ steps:
       - |
         . /drone/src/sandbox-versions.txt
         echo "Cloning qwen-code at commit $${QWEN_COMMIT}..."
-        rm -rf /drone/src/cache/qwen-source
         mkdir -p /drone/src/cache/qwen-source
-        sync
         cd /drone/src/cache/qwen-source
         git init -q .
         git fetch --depth 1 https://github.com/helixml/qwen-code.git $${QWEN_COMMIT}


### PR DESCRIPTION
## Summary
- `build-sandbox-arm64` clone-dependencies has been intermittently failing with `fatal: unable to get current working directory: No such file or directory` at `git init /drone/src/cache/qwen-source` — see https://drone.lukemarsden.net/helixml/helix/1428 and https://drone.lukemarsden.net/helixml/helix/1432.
- **Root cause:** the arm64 pipeline mounted the cache from `/Volumes/Big/drone-cache/sandbox-build` via Docker Desktop's **fakeowner virtiofs**. After the preceding `rm -rf`, virtiofs metadata sync races against `git init`'s internal `mkdir → chdir → getcwd`. Zed (run first) is fine; qwen-code (immediately after) catches the race. Evidence on the runner: after a failed run, `qwen-source/` exists but is empty — `mkdir` ran, nothing after it did.
- **Fix:** move the host bind to a VM-internal path under `/var/lib/docker/volumes/helix-sandbox-build-cache/_data`. I/O goes through virtio-blk → Linux ext4 inside Docker.raw, **not** through the fakeowner-virtiofs proxy. (Docker.raw still lives on the external drive, but block-level virtio-blk I/O doesn't have the metadata-sync race.)
- **Self-healing**: Docker auto-creates the path on first bind (verified). A fresh runner or a full Docker Desktop reset just costs one Zed binary rebuild and is warm from then on — no admin "bless this runner" incantation. The dir is not a registered Docker volume so `docker volume prune` can't touch it; only a full Docker reset wipes it.

## What's actually cached
- `zed-source/`, `qwen-source/` — transient (re-cloned each build, ~9s total). `rm -rf` + fresh `git init` each build to avoid stale state from a different `ZED_COMMIT`.
- `zed-bin-<ZED_SHA>/zed` — **the prize.** `build-zed` reads this and `cp`s instead of `docker build`-ing, saving ~12 min on every arm64 build where `ZED_COMMIT` in `sandbox-versions.txt` hasn't changed.

## Local verification
- New pattern run twice (fresh path → cache populated → re-run with pre-existing cache). Both succeeded. `zed-bin-<sha>/` correctly persists between runs.
- Confirmed via mount info that the bind is `ext4 on /dev/vda1` (Linux native), not `fakeowner virtiofs`.

## Notes
- amd64 is untouched: it runs on a Linux runner without Docker Desktop / virtiofs.
- `temp:` was considered but rejected: it would force a fresh `docker build` of Zed every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
