### PR TITLE
build(dockerfile): cache uv wheels and HF snapshots in embedding-model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,18 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # Uses kodit's download-model tool (Go binary that embeds the Python conversion script).
 FROM api-base AS embedding-model
 COPY --from=ghcr.io/astral-sh/uv:debian-slim /usr/local/bin/uv /usr/local/bin/uv
+# Cache the uv wheel downloads (~2GB of torch/transformers/cuda-* wheels) and
+# the HuggingFace model snapshot so re-running these stages on the same builder
+# doesn't re-download from PyPI / HF Hub each time.
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=cache,target=/root/.cache/huggingface \
     go run github.com/helixml/kodit/cmd/download-model /build/models/flax-sentence-embeddings_st-codesearch-distilroberta-base
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=cache,target=/root/.cache/huggingface \
     go run github.com/helixml/kodit/cmd/download-siglip2 /build/models/google_siglip2-base-patch16-512
 
 ### Tokenizers library ###


### PR DESCRIPTION
## Summary
- The `embedding-model` stage in `Dockerfile` runs `download-model` and `download-siglip2`. Both exec `uv run` against an inline-deps Python script, which pulls ~2GB of wheels (torch, transformers, onnxruntime, nvidia-cublas/cudnn/cufft/cusolver/etc.) plus the HuggingFace model snapshot.
- The previous RUN lines declared `--mount=type=cache` for `/go/pkg/mod` and `/root/.cache/go-build` only. uv's cache (`/root/.cache/uv`) and HF's cache (`/root/.cache/huggingface`) were unmounted, so every cold-layer build paid the full ~2GB download.
- Observed live on arm64 in https://drone.lukemarsden.net/helixml/helix/1441/3/2 — step `#26` sat downloading wheels for 16+ minutes.

## Why this matters every week
The `golang:1.25-bookworm` base image is pinned by digest (`api-base`, line 6) and that digest is bumped on a weekly cadence. Every bump invalidates `api-base` and cascades into `embedding-model`, forcing the RUN to re-execute. Without uv/HF cache mounts, every weekly bump cost a full ~2GB re-download on every runner. With the cache mounts, the post-bump rebuild collapses to seconds because uv and HF caches outlive the image layer.

This isn't a "fallback for rare invalidations" — it's the primary caching mechanism for these downloads given the weekly digest churn.

## Notes
- `download-ort` (next RUN, line 33) is pure Go `net/http` with no cache directory of its own, so it's left alone.
- Independent from #2430 (the arm64 sandbox-build-cache fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
