### PR TITLE
chore(api): refresh model_info.json and harden lookup for prefixed ids

### DIFF
--- a/api/pkg/model/model_info.go
+++ b/api/pkg/model/model_info.go
@@ -28,9 +28,10 @@ type ModelInfoRequest struct { //nolint:revive
 }
 
 type BaseModelInfoProvider struct {
-	dataMu    *sync.RWMutex
-	data      map[string]types.ModelInfo // Keyed by provider model ID
-	providers map[string]string          // Keyed by provider base URL
+	dataMu     *sync.RWMutex
+	data       map[string]types.ModelInfo // Keyed by provider_model_id
+	normalized map[string]types.ModelInfo // Keyed by normalizeModelID(provider_model_id)
+	providers  map[string]string          // Keyed by provider base URL
 }
 
 func NewBaseModelInfoProvider() (*BaseModelInfoProvider, error) {
@@ -47,33 +48,64 @@ func NewBaseModelInfoProvider() (*BaseModelInfoProvider, error) {
 
 	providers := make(map[string]string)
 
-	data := make(map[string]types.ModelInfo)
-	for _, model := range response.Data {
-		data[model.Endpoint.ProviderModelID] = types.ModelInfo{
-			ProviderSlug:        model.Endpoint.ProviderSlug,
-			ProviderModelID:     model.Endpoint.ProviderModelID,
-			Name:                model.Name,
-			Slug:                model.Slug,
-			Permaslug:           model.Permaslug,
-			Author:              model.Author,
-			Description:         model.Description,
-			InputModalities:     model.InputModalities,
-			OutputModalities:    model.OutputModalities,
-			SupportsReasoning:   model.Endpoint.SupportsReasoning,
-			ContextLength:       model.ContextLength,
-			SupportedParameters: model.Endpoint.SupportedParameters,
-			MaxCompletionTokens: model.Endpoint.MaxCompletionTokens,
-			Pricing:             model.Endpoint.Pricing,
+	// Preserve last-write-wins for the primary `data` map (matches
+	// pre-change behaviour) and build a parallel `normalized` index
+	// so requests for plain ids resolve to Bedrock-prefixed entries
+	// (e.g. claude-sonnet-4-6 -> eu.anthropic.claude-sonnet-4-6).
+	// On collision in the normalized index, prefer the entry whose
+	// upstream provider slug is "anthropic" - that's the direct API
+	// route, not a regional Bedrock/Vertex variant.
+	data := make(map[string]types.ModelInfo, len(response.Data))
+	normalized := make(map[string]types.ModelInfo)
+	normalizedIsDirect := make(map[string]bool)
+	for _, m := range response.Data {
+		pmid := m.Endpoint.ProviderModelID
+		if pmid == "" {
+			continue
 		}
-
-		providers[model.Endpoint.ProviderInfo.BaseURL] = model.Endpoint.ProviderInfo.Slug
+		providers[m.Endpoint.ProviderInfo.BaseURL] = m.Endpoint.ProviderInfo.Slug
+		mi := toModelInfo(m)
+		data[pmid] = mi
+		n := normalizeModelID(pmid)
+		if n == "" || n == pmid {
+			continue
+		}
+		isDirect := isAnthropicDirectSlug(m.Endpoint.ProviderInfo.Slug)
+		if _, exists := normalized[n]; !exists || (isDirect && !normalizedIsDirect[n]) {
+			normalized[n] = mi
+			normalizedIsDirect[n] = isDirect
+		}
 	}
 
 	return &BaseModelInfoProvider{
-		dataMu:    &sync.RWMutex{},
-		data:      data,
-		providers: providers,
+		dataMu:     &sync.RWMutex{},
+		data:       data,
+		normalized: normalized,
+		providers:  providers,
 	}, nil
+}
+
+func toModelInfo(m ModelInfoData) types.ModelInfo {
+	return types.ModelInfo{
+		ProviderSlug:        m.Endpoint.ProviderSlug,
+		ProviderModelID:     m.Endpoint.ProviderModelID,
+		Name:                m.Name,
+		Slug:                m.Slug,
+		Permaslug:           m.Permaslug,
+		Author:              m.Author,
+		Description:         m.Description,
+		InputModalities:     m.InputModalities,
+		OutputModalities:    m.OutputModalities,
+		SupportsReasoning:   m.Endpoint.SupportsReasoning,
+		ContextLength:       m.ContextLength,
+		SupportedParameters: m.Endpoint.SupportedParameters,
+		MaxCompletionTokens: m.Endpoint.MaxCompletionTokens,
+		Pricing:             m.Endpoint.Pricing,
+	}
+}
+
+func isAnthropicDirectSlug(s string) bool {
+	return s == "anthropic"
 }
 
 func (p *BaseModelInfoProvider) GetModelInfo(_ context.Context, request *ModelInfoRequest) (*types.ModelInfo, error) {
@@ -128,7 +160,57 @@ func (p *BaseModelInfoProvider) GetModelInfo(_ context.Context, request *ModelIn
 		}
 	}
 
+	// Last resort: normalize the request id and consult the normalized
+	// index. Catches plain ids that match a Bedrock-prefixed entry
+	// (e.g. claude-sonnet-4-6 -> eu.anthropic.claude-sonnet-4-6), and
+	// vice versa, plus Vertex date syntax (X@YYYYMMDD -> X-YYYYMMDD).
+	if n := normalizeModelID(modelName); n != "" {
+		if mi, ok := p.normalized[n]; ok {
+			return &mi, nil
+		}
+	}
+
 	return nil, fmt.Errorf("model info not found for model: %s (%s)", modelName, slug)
+}
+
+// normalizeModelID strips region prefixes, Bedrock version suffixes, and
+// Vertex date syntax so equivalent ids from different providers map to the
+// same key. The function is intentionally conservative — only known prefix
+// shapes are stripped, so it won't shadow unrelated ids.
+func normalizeModelID(id string) string {
+	s := strings.ToLower(id)
+	// Bedrock region prefixes: us./eu./apac./global./ap./ca. + vendor.
+	regions := []string{"us.", "eu.", "apac.", "global.", "ap.", "ca."}
+	vendors := []string{"anthropic.", "amazon.", "cohere.", "meta.", "mistral.", "ai21."}
+	for _, r := range regions {
+		for _, v := range vendors {
+			if strings.HasPrefix(s, r+v) {
+				s = s[len(r)+len(v):]
+				break
+			}
+		}
+	}
+	// Bedrock version suffix: "-v1:0" first (longest), then "-v1", then ":0".
+	s = strings.TrimSuffix(s, "-v1:0")
+	s = strings.TrimSuffix(s, "-v1")
+	s = strings.TrimSuffix(s, ":0")
+	// Vertex date syntax: replace "@YYYYMMDD" with "-YYYYMMDD".
+	if i := strings.Index(s, "@"); i >= 0 {
+		suf := s[i+1:]
+		if len(suf) == 8 && allDigits(suf) {
+			s = s[:i] + "-" + suf
+		}
+	}
+	return s
+}
+
+func allDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func (p *BaseModelInfoProvider) getProvider(baseURL string) (string, bool) {

--- a/api/pkg/model/model_info_test.go
+++ b/api/pkg/model/model_info_test.go
@@ -175,3 +175,63 @@ func Test_GetClaudeSonnet4_CustomUserProvider(t *testing.T) {
 	assert.Equal(t, "Anthropic: Claude Sonnet 4", modelInfo.Name)
 	assert.Equal(t, "0.000015", modelInfo.Pricing.Completion)
 }
+
+// Test_NormalizeModelID locks in the id-normalization rules so the
+// fallback lookup keeps catching ids that share a normalized form.
+func Test_NormalizeModelID(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		// Plain Anthropic ids stay put.
+		{"claude-sonnet-4-6", "claude-sonnet-4-6"},
+		{"claude-opus-4-7", "claude-opus-4-7"},
+		// Bedrock region prefixes get stripped.
+		{"eu.anthropic.claude-sonnet-4-6", "claude-sonnet-4-6"},
+		{"us.anthropic.claude-opus-4-1-20250805-v1:0", "claude-opus-4-1-20250805"},
+		{"global.anthropic.claude-opus-4-6-v1", "claude-opus-4-6"},
+		{"apac.anthropic.claude-haiku-4-5-20251001-v1", "claude-haiku-4-5-20251001"},
+		// Bedrock version suffixes.
+		{"claude-opus-4-7-v1:0", "claude-opus-4-7"},
+		{"claude-opus-4-7-v1", "claude-opus-4-7"},
+		// Vertex @-date syntax becomes hyphenated.
+		{"claude-3-7-sonnet@20250219", "claude-3-7-sonnet-20250219"},
+		{"claude-sonnet-4-5@20250929", "claude-sonnet-4-5-20250929"},
+		// Things we should NOT strip.
+		{"gpt-4o-mini", "gpt-4o-mini"},
+		{"o3", "o3"},
+		{"models/gemini-2.0-flash-001", "models/gemini-2.0-flash-001"},
+	}
+	for _, c := range cases {
+		got := normalizeModelID(c.in)
+		assert.Equal(t, c.want, got, "normalizeModelID(%q)", c.in)
+	}
+}
+
+// Test_GetSonnet46_BedrockKeyed confirms a plain "claude-sonnet-4-6"
+// request resolves through the normalized fallback when the JSON only
+// has the Bedrock-prefixed key for it.
+func Test_GetSonnet46_BedrockKeyed(t *testing.T) {
+	b, err := NewBaseModelInfoProvider()
+	require.NoError(t, err)
+
+	mi, err := b.GetModelInfo(context.Background(), &ModelInfoRequest{
+		Provider: "anthropic",
+		Model:    "claude-sonnet-4-6",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, mi.Pricing.Completion, "sonnet 4-6 must resolve to a priced entry")
+}
+
+// Test_GetOpus47_NewModel confirms claude-opus-4-7 (which only appears
+// under both plain and Vertex-regional keys in fresh dumps) resolves.
+func Test_GetOpus47_NewModel(t *testing.T) {
+	b, err := NewBaseModelInfoProvider()
+	require.NoError(t, err)
+
+	mi, err := b.GetModelInfo(context.Background(), &ModelInfoRequest{
+		Provider: "anthropic",
+		Model:    "claude-opus-4-7",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, mi.Pricing.Completion)
+}


### PR DESCRIPTION
## Summary

Refreshes the static \`api/pkg/model/model_info.json\` (last bumped 2026-03-07) with a fresh dump from \`https://openrouter.ai/api/frontend/models\`, and hardens \`BaseModelInfoProvider.GetModelInfo\` so plain Anthropic ids resolve to Bedrock-prefixed entries.

Surfaces while looking at the org billing page showing \`\$0.0000 TOTAL SPEND\`: the underlying \`llm_calls\` rows had zero cost columns because the Anthropic proxy at \`api/pkg/anthropic/anthropic_proxy.go:461\` calls \`pricing.CalculateTokenPrice\` only after \`getModelInfo\` returns nil error - and several newer Anthropic models (\`claude-opus-4-6\`, \`claude-opus-4-7\`, etc.) were not in the embedded JSON in a shape the lookup recognised.

## What's in the PR

- **\`api/pkg/model/model_info.json\`** - full refresh, 642 -> 738 entries, 4.7MB -> 3.3MB.
- **\`api/pkg/model/model_info.go\`** - adds a parallel \`normalized\` index keyed by a normalized provider_model_id, consulted as a last-resort fallback in \`GetModelInfo\`. On collision, prefers entries whose upstream provider slug is \`anthropic\` (direct route) over regional Bedrock/Vertex variants.
- **\`api/pkg/model/model_info_test.go\`** - new tests:
  - \`Test_NormalizeModelID\` (table-driven, locks the rules in)
  - \`Test_GetSonnet46_BedrockKeyed\` (plain \`claude-sonnet-4-6\` resolves through Bedrock-prefixed entry)
  - \`Test_GetOpus47_NewModel\` (newly-added model resolves)

## Normalization rules

| Input | Output |
|---|---|
| \`claude-sonnet-4-6\` | unchanged |
| \`eu.anthropic.claude-sonnet-4-6\` | \`claude-sonnet-4-6\` |
| \`us.anthropic.claude-opus-4-1-20250805-v1:0\` | \`claude-opus-4-1-20250805\` |
| \`global.anthropic.claude-opus-4-6-v1\` | \`claude-opus-4-6\` |
| \`claude-3-7-sonnet@20250219\` | \`claude-3-7-sonnet-20250219\` |
| \`gpt-4o-mini\`, \`o3\`, \`models/gemini-2.0-flash-001\` | unchanged |

Vendor list and region list are explicit (no wildcard stripping) so unrelated ids are not shadowed.

## Coverage delta (20-model sample)

| | Hits | Misses |
|---|---|---|
| Old JSON + old lookup | 9 | 11 |
| New JSON + old lookup (naive refresh) | 8 | 12 |
| **New JSON + new lookup (this PR)** | **13** | **7** |

The 7 remaining misses: \`claude-3-7-sonnet@20250219\` and \`claude-3-5-sonnet-20241022\` (dropped from OpenRouter's catalog) and \`gpt-4o-mini\`, \`gpt-5-mini\`, \`o1\`, \`o3\`, \`o3-mini\` (not in either dump - separate gap).

## Why a parallel index rather than restructuring \`data\`

The existing slug/permaslug scan in \`GetModelInfo\` depends on every candidate from the JSON being represented in \`data\`. The naive fix - bucket-by-provider_model_id then pick a winner - destructively evicts the Vertex variant of \`claude-opus-4-6\` and breaks \`Test_GetOpus46\`. Keeping \`data\` as last-write-wins (existing behaviour) and adding a separate normalized index sidesteps that and is a smaller behavioural change.

## Trade-off on multi-endpoint collisions

When two candidates share a normalized id (Anthropic-direct vs Vertex-regional, often at different prices), the normalized index prefers the Anthropic-direct entry. For users routing through Anthropic's native API this is more accurate; for users hitting OpenRouter or Vertex it may overstate cost. The right long-term fix is route-aware pricing (separate keys per upstream provider), which is a larger change tracked separately.

## Maintenance note

The JSON is still manually committed every 1-2 months by one developer. This PR doesn't change that workflow. Live fetching from OpenRouter at startup is option (c) from the design discussion and a candidate for a follow-up.

## Test plan

- [ ] CI: full test suite passes including \`./api/pkg/model/...\`
- [ ] After deploy: an org with Anthropic traffic using \`claude-opus-4-6\` / \`claude-opus-4-7\` shows non-zero \`prompt_cost\` and \`completion_cost\` on new \`llm_calls\` rows (visible directly in the DB; surfaces on the org billing page once the cache-fields fix in https://github.com/helixml/helix/pull/2429 also ships)
- [ ] Admin Pricing page (\`PricingTable.tsx\`): \`claude-opus-4-6\` and \`claude-opus-4-7\` now show prices with source "Provider" instead of "Not Set"

🤖 Generated with [Claude Code](https://claude.com/claude-code)