### PR TITLE
feat(api): add org_id filter to /llm_calls and unlock for org members

### DIFF
--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -7054,7 +7054,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "List LLM calls with pagination and optional session filtering",
+                "description": "List LLM calls with pagination and optional filtering. Global admins can list across all orgs; non-admins must pass an org_id they belong to.",
                 "produces": [
                     "application/json"
                 ],
@@ -7085,6 +7085,18 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Filter by interaction ID",
                         "name": "interaction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by app ID",
+                        "name": "appId",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by organization (id or slug). Required for non-admins.",
+                        "name": "org_id",
                         "in": "query"
                     }
                 ],

--- a/api/pkg/server/llm_calls_handlers.go
+++ b/api/pkg/server/llm_calls_handlers.go
@@ -12,17 +12,38 @@ import (
 
 // listLLMCalls godoc
 // @Summary List LLM calls
-// @Description List LLM calls with pagination and optional session filtering
+// @Description List LLM calls with pagination and optional filtering. Global admins can list across all orgs; non-admins must pass an org_id they belong to.
 // @Tags    llm_calls
 // @Produce json
 // @Param   page          query    int     false  "Page number"
 // @Param   pageSize      query    int     false  "Page size"
 // @Param   session       query    string  false  "Filter by session ID"
 // @Param   interaction   query    string  false  "Filter by interaction ID"
+// @Param   appId         query    string  false  "Filter by app ID"
+// @Param   org_id        query    string  false  "Filter by organization (id or slug). Required for non-admins."
 // @Success 200 {object} types.PaginatedLLMCalls
 // @Router /api/v1/llm_calls [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) listLLMCalls(_ http.ResponseWriter, r *http.Request) (*types.PaginatedLLMCalls, *system.HTTPError) {
+	user := getRequestUser(r)
+
+	// Org scoping: global admins may omit org_id to list across all orgs.
+	// Non-admins must pass an org_id matching one they belong to.
+	orgParam := r.URL.Query().Get("org_id")
+	var orgID string
+	if orgParam != "" {
+		org, err := s.lookupOrg(r.Context(), orgParam)
+		if err != nil {
+			return nil, system.NewHTTPError404("organization not found")
+		}
+		if _, err := s.authorizeOrgMember(r.Context(), user, org.ID); err != nil {
+			return nil, system.NewHTTPError403(err.Error())
+		}
+		orgID = org.ID
+	} else if !isAdmin(user) {
+		return nil, system.NewHTTPError403("org_id is required for non-admin callers")
+	}
+
 	// Parse query parameters
 	page, err := strconv.Atoi(r.URL.Query().Get("page"))
 	if err != nil || page < 1 {
@@ -39,11 +60,12 @@ func (s *HelixAPIServer) listLLMCalls(_ http.ResponseWriter, r *http.Request) (*
 
 	// Call the ListLLMCalls function from the store with the session filter
 	calls, totalCount, err := s.Store.ListLLMCalls(r.Context(), &store.ListLLMCallsQuery{
-		Page:          page,
-		PerPage:       pageSize,
-		SessionID:     sessionFilter,
-		InteractionID: interactionFilter,
-		AppID:         r.URL.Query().Get("appId"),
+		OrganizationID: orgID,
+		Page:           page,
+		PerPage:        pageSize,
+		SessionID:      sessionFilter,
+		InteractionID:  interactionFilter,
+		AppID:          r.URL.Query().Get("appId"),
 	})
 	if err != nil {
 		return nil, system.NewHTTPError500(err.Error())

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1116,7 +1116,13 @@ func (apiServer *HelixAPIServer) registerRoutes(_ context.Context) (*mux.Router,
 
 	// Sandbox-absorbs-runner pivot: /scheduler/heartbeats and /slots
 	// endpoints removed — no scheduler, no slots.
-	adminRouter.HandleFunc("/llm_calls", system.Wrapper(apiServer.listLLMCalls)).Methods(http.MethodGet)
+	//
+	// /llm_calls is on authRouter (not adminRouter) because org members
+	// need it to drill down from the org Usage page into per-call
+	// traces. The handler scopes the result set: global admins may omit
+	// org_id to list across all orgs; everyone else must pass an org_id
+	// they belong to.
+	authRouter.HandleFunc("/llm_calls", system.Wrapper(apiServer.listLLMCalls)).Methods(http.MethodGet)
 
 	// Runner profiles (compose-based runner replacement). All routes are
 	// admin-only — operators define and assign profiles.

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -7050,7 +7050,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "List LLM calls with pagination and optional session filtering",
+                "description": "List LLM calls with pagination and optional filtering. Global admins can list across all orgs; non-admins must pass an org_id they belong to.",
                 "produces": [
                     "application/json"
                 ],
@@ -7081,6 +7081,18 @@
                         "type": "string",
                         "description": "Filter by interaction ID",
                         "name": "interaction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by app ID",
+                        "name": "appId",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by organization (id or slug). Required for non-admins.",
+                        "name": "org_id",
                         "in": "query"
                     }
                 ],

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -14887,7 +14887,8 @@ paths:
       summary: Set license key
   /api/v1/llm_calls:
     get:
-      description: List LLM calls with pagination and optional session filtering
+      description: List LLM calls with pagination and optional filtering. Global admins
+        can list across all orgs; non-admins must pass an org_id they belong to.
       parameters:
       - description: Page number
         in: query
@@ -14904,6 +14905,14 @@ paths:
       - description: Filter by interaction ID
         in: query
         name: interaction
+        type: string
+      - description: Filter by app ID
+        in: query
+        name: appId
+        type: string
+      - description: Filter by organization (id or slug). Required for non-admins.
+        in: query
+        name: org_id
         type: string
       produces:
       - application/json

--- a/api/pkg/store/store_llm_calls.go
+++ b/api/pkg/store/store_llm_calls.go
@@ -25,10 +25,11 @@ func (s *PostgresStore) CreateLLMCall(ctx context.Context, call *types.LLMCall) 
 }
 
 type ListLLMCallsQuery struct {
-	AppID         string
-	SessionID     string
-	InteractionID string
-	UserID        string
+	OrganizationID string
+	AppID          string
+	SessionID      string
+	InteractionID  string
+	UserID         string
 
 	Page    int
 	PerPage int
@@ -42,6 +43,10 @@ func (s *PostgresStore) ListLLMCalls(ctx context.Context, q *ListLLMCallsQuery) 
 	offset := (q.Page - 1) * q.PerPage
 
 	query := s.gdb.WithContext(ctx).Model(&types.LLMCall{})
+
+	if q.OrganizationID != "" {
+		query = query.Where("organization_id = ?", q.OrganizationID)
+	}
 
 	if q.SessionID != "" {
 		query = query.Where("session_id = ?", q.SessionID)

--- a/api/pkg/store/store_llm_calls_test.go
+++ b/api/pkg/store/store_llm_calls_test.go
@@ -1,0 +1,90 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestLLMCallsTestSuite(t *testing.T) {
+	suite.Run(t, new(LLMCallsTestSuite))
+}
+
+type LLMCallsTestSuite struct {
+	suite.Suite
+	ctx context.Context
+	db  *PostgresStore
+}
+
+func (suite *LLMCallsTestSuite) SetupTest() {
+	suite.ctx = context.Background()
+	suite.db = GetTestDB()
+}
+
+func (suite *LLMCallsTestSuite) TearDownTestSuite() {
+	_ = suite.db.Close()
+}
+
+// TestListLLMCalls_OrganizationIDFilter verifies the new OrganizationID
+// query field scopes results. Without this filter the admin endpoint
+// listed across orgs; the Usage dashboard drill-down relies on it to
+// stop an org member seeing other orgs' traces.
+func (suite *LLMCallsTestSuite) TestListLLMCalls_OrganizationIDFilter() {
+	orgA := "org_" + system.GenerateID()
+	orgB := "org_" + system.GenerateID()
+
+	// Two rows in orgA, one row in orgB.
+	for i := range 2 {
+		_, err := suite.db.CreateLLMCall(suite.ctx, &types.LLMCall{
+			OrganizationID: orgA,
+			Model:          "claude-opus-4-7",
+			Provider:       string(types.ProviderAnthropic),
+			TotalTokens:    int64(100 + i),
+		})
+		suite.Require().NoError(err)
+	}
+	_, err := suite.db.CreateLLMCall(suite.ctx, &types.LLMCall{
+		OrganizationID: orgB,
+		Model:          "claude-opus-4-7",
+		Provider:       string(types.ProviderAnthropic),
+		TotalTokens:    999,
+	})
+	suite.Require().NoError(err)
+
+	// orgA filter sees only orgA rows.
+	got, total, err := suite.db.ListLLMCalls(suite.ctx, &ListLLMCallsQuery{
+		OrganizationID: orgA,
+		Page:           1,
+		PerPage:        50,
+	})
+	suite.Require().NoError(err)
+	suite.Equal(int64(2), total, "orgA total")
+	suite.Len(got, 2)
+	for _, c := range got {
+		suite.Equal(orgA, c.OrganizationID)
+	}
+
+	// orgB filter sees only the orgB row.
+	got, total, err = suite.db.ListLLMCalls(suite.ctx, &ListLLMCallsQuery{
+		OrganizationID: orgB,
+		Page:           1,
+		PerPage:        50,
+	})
+	suite.Require().NoError(err)
+	suite.Equal(int64(1), total, "orgB total")
+	suite.Len(got, 1)
+	suite.Equal(orgB, got[0].OrganizationID)
+
+	// Empty OrganizationID does NOT add a where clause (caller-side
+	// admin scoping is what we rely on). Both orgA rows + orgB row
+	// surface, plus any pre-existing rows from other tests.
+	_, total, err = suite.db.ListLLMCalls(suite.ctx, &ListLLMCallsQuery{
+		Page:    1,
+		PerPage: 50,
+	})
+	suite.Require().NoError(err)
+	suite.GreaterOrEqual(total, int64(3), "no-filter must include all seeded rows")
+}

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -9730,7 +9730,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description List LLM calls with pagination and optional session filtering
+     * @description List LLM calls with pagination and optional filtering. Global admins can list across all orgs; non-admins must pass an org_id they belong to.
      *
      * @tags llm_calls
      * @name V1LlmCallsList
@@ -9748,6 +9748,10 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         session?: string;
         /** Filter by interaction ID */
         interaction?: string;
+        /** Filter by app ID */
+        appId?: string;
+        /** Filter by organization (id or slug). Required for non-admins. */
+        org_id?: string;
       },
       params: RequestParams = {},
     ) =>

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -14887,7 +14887,8 @@ paths:
       summary: Set license key
   /api/v1/llm_calls:
     get:
-      description: List LLM calls with pagination and optional session filtering
+      description: List LLM calls with pagination and optional filtering. Global admins
+        can list across all orgs; non-admins must pass an org_id they belong to.
       parameters:
       - description: Page number
         in: query
@@ -14904,6 +14905,14 @@ paths:
       - description: Filter by interaction ID
         in: query
         name: interaction
+        type: string
+      - description: Filter by app ID
+        in: query
+        name: appId
+        type: string
+      - description: Filter by organization (id or slug). Required for non-admins.
+        in: query
+        name: org_id
         type: string
       produces:
       - application/json

--- a/openapi.json
+++ b/openapi.json
@@ -8588,7 +8588,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "List LLM calls with pagination and optional session filtering",
+                "description": "List LLM calls with pagination and optional filtering. Global admins can list across all orgs; non-admins must pass an org_id they belong to.",
                 "tags": [
                     "llm_calls"
                 ],
@@ -8621,6 +8621,22 @@
                     {
                         "description": "Filter by interaction ID",
                         "name": "interaction",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by app ID",
+                        "name": "appId",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by organization (id or slug). Required for non-admins.",
+                        "name": "org_id",
                         "in": "query",
                         "schema": {
                             "type": "string"

--- a/swagger.json
+++ b/swagger.json
@@ -7050,7 +7050,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "List LLM calls with pagination and optional session filtering",
+                "description": "List LLM calls with pagination and optional filtering. Global admins can list across all orgs; non-admins must pass an org_id they belong to.",
                 "produces": [
                     "application/json"
                 ],
@@ -7081,6 +7081,18 @@
                         "type": "string",
                         "description": "Filter by interaction ID",
                         "name": "interaction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by app ID",
+                        "name": "appId",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by organization (id or slug). Required for non-admins.",
+                        "name": "org_id",
                         "in": "query"
                     }
                 ],


### PR DESCRIPTION
## Summary

Step 2 of the aggregate usage dashboard rollout (\`design/2026-05-14-aggregate-usage-dashboard.md\`). Opens \`/api/v1/llm_calls\` to org members behind an \`org_id\` query parameter so the upcoming org Usage page can drill down from session rows into per-call traces.

- Move route from \`adminRouter\` to \`authRouter\`. Handler now does its own scoping rather than relying on the \`requireAdmin\` middleware.
- Global admins can omit \`org_id\` to list across all orgs (existing behaviour).
- Non-admins must pass an \`org_id\` matching one they belong to. Cross-org id guesses 403 via \`authorizeOrgMember\`.
- \`org_id\` accepts either the canonical \`org_…\` id or a slug, resolved via the existing \`lookupOrg\` helper.

## Changes

- \`api/pkg/store/store_llm_calls.go\`: add \`OrganizationID\` field to \`ListLLMCallsQuery\`, add matching \`WHERE\` clause.
- \`api/pkg/server/llm_calls_handlers.go\`: new \`org_id\` query parameter + auth path described above. Swagger annotations updated.
- \`api/pkg/server/server.go\`: route moved \`adminRouter\` -> \`authRouter\` with a comment explaining why.
- \`api/pkg/store/store_llm_calls_test.go\` (new): \`TestListLLMCalls_OrganizationIDFilter\` covers filtered + unfiltered queries.
- Regenerated OpenAPI artefacts (\`docs.go\`, \`swagger.json/yaml\`, \`openapi.json\`, \`frontend/src/api/api.ts\`) so the TS client knows about the new param.

## What this does NOT change

- App-scoped \`/api/v1/apps/{id}/llm-calls\` is unchanged.
- No change to the existing per-app usage charts or the global admin LLM Calls view rendered in \`AppUsage.tsx\`.

## Test plan

- [ ] CI: \`TestUsageMetricsTestSuite\` (unrelated) and the new \`TestLLMCallsTestSuite/TestListLLMCalls_OrganizationIDFilter\` pass
- [ ] CI: full server test suite passes
- [ ] After deploy: \`GET /api/v1/llm_calls\` as a global admin without \`org_id\` returns the same shape as today
- [ ] After deploy: \`GET /api/v1/llm_calls?org_id=<my-slug>\` as a non-admin org member returns only that org's rows
- [ ] After deploy: \`GET /api/v1/llm_calls?org_id=<some-other-org>\` as a non-admin returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)