### PR TITLE
feat(api): add /usage/aggregate (summary + grouped) endpoints

### DIFF
--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -17122,226 +17122,29 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/v1/usage/aggregate/by-model": {
+        "/api/v1/usage/aggregate/grouped": {
             "get": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
+                "description": "One endpoint, five groupings. Pass ` + "`" + `group_by` + "`" + ` to choose what each row represents. ` + "`" + `group_by=org` + "`" + ` is global-admin only.\nRow shape per ` + "`" + `group_by` + "`" + ` (see types/types.go):\n- org: UsageByOrg (organization_id, organization_name, user_count, session_count, top_model, last_activity)\n- user: UsageByUser (user_id, email, organization_id, session_count, top_model, last_activity)\n- project: UsageByProject (project_id, app_id, name, kind, owner_user_id, organization_id, session_count)\n- session: UsageBySession (session_id, name, user_id, project_id, organization_id, provider, model, call_count, started_at, ended_at)\n- model: UsageByModel (provider, model, unique_users, unique_sessions, unique_projects)\nEvery row also carries the shared UsageTotals fields (prompt/completion/cache tokens and costs, total_cost, request_count).",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "usage"
                 ],
-                "summary": "Usage grouped by model / provider",
+                "summary": "Aggregate usage grouped by a dimension",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Start of window (RFC3339)",
-                        "name": "from",
-                        "in": "query"
+                        "description": "Grouping: org|user|project|session|model",
+                        "name": "group_by",
+                        "in": "query",
+                        "required": true
                     },
-                    {
-                        "type": "string",
-                        "description": "End of window (RFC3339)",
-                        "name": "to",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Organization id or slug",
-                        "name": "org_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort column",
-                        "name": "sort_by",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "asc or desc",
-                        "name": "sort_dir",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size",
-                        "name": "page_size",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedUsageByModel"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/usage/aggregate/by-org": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Global-admin only. One row per organization with tokens, costs, user/session counts and last activity.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "usage"
-                ],
-                "summary": "Usage grouped by organization",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Start of window (RFC3339)",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "End of window (RFC3339)",
-                        "name": "to",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort column: total_cost, total_tokens, request_count, last_activity",
-                        "name": "sort_by",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "asc or desc",
-                        "name": "sort_dir",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page (1-indexed)",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size (max 200, default 25)",
-                        "name": "page_size",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedUsageByOrg"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/usage/aggregate/by-project": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "usage"
-                ],
-                "summary": "Usage grouped by project / app / agent",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Start of window (RFC3339)",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "End of window (RFC3339)",
-                        "name": "to",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Organization id or slug",
-                        "name": "org_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by user id",
-                        "name": "user_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort column",
-                        "name": "sort_by",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "asc or desc",
-                        "name": "sort_dir",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size",
-                        "name": "page_size",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedUsageByProject"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/usage/aggregate/by-session": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "usage"
-                ],
-                "summary": "Usage grouped by session",
-                "parameters": [
                     {
                         "type": "string",
                         "description": "Start of window (RFC3339)",
@@ -17374,6 +17177,18 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by app id",
+                        "name": "app_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by session id",
+                        "name": "session_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by provider",
                         "name": "provider",
                         "in": "query"
@@ -17386,7 +17201,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Sort column",
+                        "description": "Sort column (per-grouping whitelist)",
                         "name": "sort_by",
                         "in": "query"
                     },
@@ -17398,13 +17213,13 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Page",
+                        "description": "Page (1-indexed)",
                         "name": "page",
                         "in": "query"
                     },
                     {
                         "type": "integer",
-                        "description": "Page size",
+                        "description": "Page size (max 200, default 25)",
                         "name": "page_size",
                         "in": "query"
                     }
@@ -17413,76 +17228,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/types.PaginatedUsageBySession"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/usage/aggregate/by-user": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Org members get rows scoped to their org. Global admins may omit org_id to list across all orgs.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "usage"
-                ],
-                "summary": "Usage grouped by user",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Start of window (RFC3339)",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "End of window (RFC3339)",
-                        "name": "to",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Organization id or slug. Required for non-admins.",
-                        "name": "org_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort column",
-                        "name": "sort_by",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "asc or desc",
-                        "name": "sort_dir",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size",
-                        "name": "page_size",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedUsageByUser"
+                            "$ref": "#/definitions/types.UsageGroupedResponse"
                         }
                     }
                 }
@@ -17495,7 +17241,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns whole-set totals plus a daily time-series. Org owners must pass org_id matching their org; global admins may omit it to summarize cross-org.",
+                "description": "Returns whole-set totals plus a daily time-series. Org members must pass org_id; global admins may omit it to summarize cross-org.",
                 "produces": [
                     "application/json"
                 ],
@@ -27031,136 +26777,6 @@ const docTemplate = `{
                 }
             }
         },
-        "types.PaginatedUsageByModel": {
-            "type": "object",
-            "properties": {
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.UsageByModel"
-                    }
-                },
-                "total": {
-                    "$ref": "#/definitions/types.UsageTotals"
-                },
-                "total_pages": {
-                    "type": "integer"
-                },
-                "total_rows": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.PaginatedUsageByOrg": {
-            "type": "object",
-            "properties": {
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.UsageByOrg"
-                    }
-                },
-                "total": {
-                    "$ref": "#/definitions/types.UsageTotals"
-                },
-                "total_pages": {
-                    "type": "integer"
-                },
-                "total_rows": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.PaginatedUsageByProject": {
-            "type": "object",
-            "properties": {
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.UsageByProject"
-                    }
-                },
-                "total": {
-                    "$ref": "#/definitions/types.UsageTotals"
-                },
-                "total_pages": {
-                    "type": "integer"
-                },
-                "total_rows": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.PaginatedUsageBySession": {
-            "type": "object",
-            "properties": {
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.UsageBySession"
-                    }
-                },
-                "total": {
-                    "$ref": "#/definitions/types.UsageTotals"
-                },
-                "total_pages": {
-                    "type": "integer"
-                },
-                "total_rows": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.PaginatedUsageByUser": {
-            "type": "object",
-            "properties": {
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.UsageByUser"
-                    }
-                },
-                "total": {
-                    "$ref": "#/definitions/types.UsageTotals"
-                },
-                "total_pages": {
-                    "type": "integer"
-                },
-                "total_rows": {
-                    "type": "integer"
-                }
-            }
-        },
         "types.PaginatedUsersList": {
             "type": "object",
             "properties": {
@@ -32695,296 +32311,28 @@ const docTemplate = `{
                 }
             }
         },
-        "types.UsageByModel": {
+        "types.UsageGroupedResponse": {
             "type": "object",
             "properties": {
-                "cache_read_cost": {
-                    "type": "number"
-                },
-                "cache_read_tokens": {
-                    "type": "integer"
-                },
-                "cache_write_cost": {
-                    "type": "number"
-                },
-                "cache_write_tokens": {
-                    "type": "integer"
-                },
-                "completion_cost": {
-                    "type": "number"
-                },
-                "completion_tokens": {
-                    "type": "integer"
-                },
-                "model": {
+                "group_by": {
+                    "description": "\"org\" | \"user\" | \"project\" | \"session\" | \"model\"",
                     "type": "string"
                 },
-                "prompt_cost": {
-                    "type": "number"
-                },
-                "prompt_tokens": {
+                "page": {
                     "type": "integer"
                 },
-                "provider": {
-                    "type": "string"
-                },
-                "request_count": {
+                "page_size": {
                     "type": "integer"
                 },
-                "total_cost": {
-                    "type": "number"
+                "rows": {},
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
                 },
-                "total_tokens": {
+                "total_pages": {
                     "type": "integer"
                 },
-                "unique_projects": {
+                "total_rows": {
                     "type": "integer"
-                },
-                "unique_sessions": {
-                    "type": "integer"
-                },
-                "unique_users": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.UsageByOrg": {
-            "type": "object",
-            "properties": {
-                "cache_read_cost": {
-                    "type": "number"
-                },
-                "cache_read_tokens": {
-                    "type": "integer"
-                },
-                "cache_write_cost": {
-                    "type": "number"
-                },
-                "cache_write_tokens": {
-                    "type": "integer"
-                },
-                "completion_cost": {
-                    "type": "number"
-                },
-                "completion_tokens": {
-                    "type": "integer"
-                },
-                "last_activity": {
-                    "type": "string"
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "organization_name": {
-                    "type": "string"
-                },
-                "prompt_cost": {
-                    "type": "number"
-                },
-                "prompt_tokens": {
-                    "type": "integer"
-                },
-                "request_count": {
-                    "type": "integer"
-                },
-                "session_count": {
-                    "type": "integer"
-                },
-                "top_model": {
-                    "type": "string"
-                },
-                "total_cost": {
-                    "type": "number"
-                },
-                "total_tokens": {
-                    "type": "integer"
-                },
-                "user_count": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.UsageByProject": {
-            "type": "object",
-            "properties": {
-                "app_id": {
-                    "type": "string"
-                },
-                "cache_read_cost": {
-                    "type": "number"
-                },
-                "cache_read_tokens": {
-                    "type": "integer"
-                },
-                "cache_write_cost": {
-                    "type": "number"
-                },
-                "cache_write_tokens": {
-                    "type": "integer"
-                },
-                "completion_cost": {
-                    "type": "number"
-                },
-                "completion_tokens": {
-                    "type": "integer"
-                },
-                "kind": {
-                    "description": "\"project\" | \"app\" | \"agent\"",
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "owner_user_id": {
-                    "type": "string"
-                },
-                "project_id": {
-                    "type": "string"
-                },
-                "prompt_cost": {
-                    "type": "number"
-                },
-                "prompt_tokens": {
-                    "type": "integer"
-                },
-                "request_count": {
-                    "type": "integer"
-                },
-                "session_count": {
-                    "type": "integer"
-                },
-                "total_cost": {
-                    "type": "number"
-                },
-                "total_tokens": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.UsageBySession": {
-            "type": "object",
-            "properties": {
-                "cache_read_cost": {
-                    "type": "number"
-                },
-                "cache_read_tokens": {
-                    "type": "integer"
-                },
-                "cache_write_cost": {
-                    "type": "number"
-                },
-                "cache_write_tokens": {
-                    "type": "integer"
-                },
-                "call_count": {
-                    "type": "integer"
-                },
-                "completion_cost": {
-                    "type": "number"
-                },
-                "completion_tokens": {
-                    "type": "integer"
-                },
-                "ended_at": {
-                    "type": "string"
-                },
-                "model": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "project_id": {
-                    "type": "string"
-                },
-                "prompt_cost": {
-                    "type": "number"
-                },
-                "prompt_tokens": {
-                    "type": "integer"
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "request_count": {
-                    "type": "integer"
-                },
-                "session_id": {
-                    "type": "string"
-                },
-                "started_at": {
-                    "type": "string"
-                },
-                "total_cost": {
-                    "type": "number"
-                },
-                "total_tokens": {
-                    "type": "integer"
-                },
-                "user_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "types.UsageByUser": {
-            "type": "object",
-            "properties": {
-                "cache_read_cost": {
-                    "type": "number"
-                },
-                "cache_read_tokens": {
-                    "type": "integer"
-                },
-                "cache_write_cost": {
-                    "type": "number"
-                },
-                "cache_write_tokens": {
-                    "type": "integer"
-                },
-                "completion_cost": {
-                    "type": "number"
-                },
-                "completion_tokens": {
-                    "type": "integer"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "last_activity": {
-                    "type": "string"
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "prompt_cost": {
-                    "type": "number"
-                },
-                "prompt_tokens": {
-                    "type": "integer"
-                },
-                "request_count": {
-                    "type": "integer"
-                },
-                "session_count": {
-                    "type": "integer"
-                },
-                "top_model": {
-                    "type": "string"
-                },
-                "total_cost": {
-                    "type": "number"
-                },
-                "total_tokens": {
-                    "type": "integer"
-                },
-                "user_id": {
-                    "type": "string"
                 }
             }
         },

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -17122,6 +17122,447 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/usage/aggregate/by-model": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by model / provider",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization id or slug",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedUsageByModel"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/by-org": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Global-admin only. One row per organization with tokens, costs, user/session counts and last activity.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by organization",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column: total_cost, total_tokens, request_count, last_activity",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page (1-indexed)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size (max 200, default 25)",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedUsageByOrg"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/by-project": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by project / app / agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization id or slug",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by user id",
+                        "name": "user_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedUsageByProject"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/by-session": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization id or slug",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by user id",
+                        "name": "user_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by project id",
+                        "name": "project_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by provider",
+                        "name": "provider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by model",
+                        "name": "model",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedUsageBySession"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/by-user": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Org members get rows scoped to their org. Global admins may omit org_id to list across all orgs.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization id or slug. Required for non-admins.",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedUsageByUser"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/summary": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns whole-set totals plus a daily time-series. Org owners must pass org_id matching their org; global admins may omit it to summarize cross-org.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Aggregate usage summary",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339). Defaults to 7 days ago.",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339). Defaults to now.",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization id or slug. Required for non-admins.",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by user id",
+                        "name": "user_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by project id",
+                        "name": "project_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by app id",
+                        "name": "app_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by provider",
+                        "name": "provider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by model",
+                        "name": "model",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.UsageSummary"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/users": {
             "get": {
                 "security": [
@@ -26590,6 +27031,136 @@ const docTemplate = `{
                 }
             }
         },
+        "types.PaginatedUsageByModel": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageByModel"
+                    }
+                },
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
+                },
+                "total_pages": {
+                    "type": "integer"
+                },
+                "total_rows": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.PaginatedUsageByOrg": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageByOrg"
+                    }
+                },
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
+                },
+                "total_pages": {
+                    "type": "integer"
+                },
+                "total_rows": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.PaginatedUsageByProject": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageByProject"
+                    }
+                },
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
+                },
+                "total_pages": {
+                    "type": "integer"
+                },
+                "total_rows": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.PaginatedUsageBySession": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageBySession"
+                    }
+                },
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
+                },
+                "total_pages": {
+                    "type": "integer"
+                },
+                "total_rows": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.PaginatedUsageByUser": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageByUser"
+                    }
+                },
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
+                },
+                "total_pages": {
+                    "type": "integer"
+                },
+                "total_rows": {
+                    "type": "integer"
+                }
+            }
+        },
         "types.PaginatedUsersList": {
             "type": "object",
             "properties": {
@@ -32118,6 +32689,396 @@ const docTemplate = `{
                 },
                 "prompt_tokens": {
                     "type": "integer"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageByModel": {
+            "type": "object",
+            "properties": {
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                },
+                "unique_projects": {
+                    "type": "integer"
+                },
+                "unique_sessions": {
+                    "type": "integer"
+                },
+                "unique_users": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageByOrg": {
+            "type": "object",
+            "properties": {
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "last_activity": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "organization_name": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "session_count": {
+                    "type": "integer"
+                },
+                "top_model": {
+                    "type": "string"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                },
+                "user_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageByProject": {
+            "type": "object",
+            "properties": {
+                "app_id": {
+                    "type": "string"
+                },
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "kind": {
+                    "description": "\"project\" | \"app\" | \"agent\"",
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "owner_user_id": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "session_count": {
+                    "type": "integer"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageBySession": {
+            "type": "object",
+            "properties": {
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "call_count": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "ended_at": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.UsageByUser": {
+            "type": "object",
+            "properties": {
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "last_activity": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "session_count": {
+                    "type": "integer"
+                },
+                "top_model": {
+                    "type": "string"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.UsageSummary": {
+            "type": "object",
+            "properties": {
+                "active_projects": {
+                    "type": "integer"
+                },
+                "active_sessions": {
+                    "type": "integer"
+                },
+                "active_users": {
+                    "type": "integer"
+                },
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "from": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "time_series": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.AggregatedUsageMetric"
+                    }
+                },
+                "to": {
+                    "type": "string"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageTotals": {
+            "type": "object",
+            "properties": {
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "total_cost": {
+                    "type": "number"
                 },
                 "total_tokens": {
                     "type": "integer"

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1118,16 +1118,14 @@ func (apiServer *HelixAPIServer) registerRoutes(_ context.Context) (*mux.Router,
 	// endpoints removed — no scheduler, no slots.
 	adminRouter.HandleFunc("/llm_calls", system.Wrapper(apiServer.listLLMCalls)).Methods(http.MethodGet)
 
-	// /usage/aggregate/* powers the admin and org-owner Usage dashboards.
-	// On authRouter (not adminRouter) - the handler enforces per-request
-	// scoping: global admins may list cross-org; everyone else must pass
-	// an org_id they belong to.
+	// /usage/aggregate powers the admin and org-owner Usage dashboards.
+	// Two endpoints: /summary for whole-set totals + time series, and
+	// /grouped for per-(org|user|project|session|model) breakdowns.
+	// Both are on authRouter; the handler enforces per-request scoping:
+	// global admins may list cross-org, everyone else must pass an
+	// org_id they belong to, and group_by=org is admin-only.
 	authRouter.HandleFunc("/usage/aggregate/summary", system.Wrapper(apiServer.usageSummary)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/usage/aggregate/by-org", system.Wrapper(apiServer.usageByOrg)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/usage/aggregate/by-user", system.Wrapper(apiServer.usageByUser)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/usage/aggregate/by-project", system.Wrapper(apiServer.usageByProject)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/usage/aggregate/by-session", system.Wrapper(apiServer.usageBySession)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/usage/aggregate/by-model", system.Wrapper(apiServer.usageByModel)).Methods(http.MethodGet)
+	authRouter.HandleFunc("/usage/aggregate/grouped", system.Wrapper(apiServer.usageGrouped)).Methods(http.MethodGet)
 
 	// Runner profiles (compose-based runner replacement). All routes are
 	// admin-only — operators define and assign profiles.

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1118,6 +1118,17 @@ func (apiServer *HelixAPIServer) registerRoutes(_ context.Context) (*mux.Router,
 	// endpoints removed — no scheduler, no slots.
 	adminRouter.HandleFunc("/llm_calls", system.Wrapper(apiServer.listLLMCalls)).Methods(http.MethodGet)
 
+	// /usage/aggregate/* powers the admin and org-owner Usage dashboards.
+	// On authRouter (not adminRouter) - the handler enforces per-request
+	// scoping: global admins may list cross-org; everyone else must pass
+	// an org_id they belong to.
+	authRouter.HandleFunc("/usage/aggregate/summary", system.Wrapper(apiServer.usageSummary)).Methods(http.MethodGet)
+	authRouter.HandleFunc("/usage/aggregate/by-org", system.Wrapper(apiServer.usageByOrg)).Methods(http.MethodGet)
+	authRouter.HandleFunc("/usage/aggregate/by-user", system.Wrapper(apiServer.usageByUser)).Methods(http.MethodGet)
+	authRouter.HandleFunc("/usage/aggregate/by-project", system.Wrapper(apiServer.usageByProject)).Methods(http.MethodGet)
+	authRouter.HandleFunc("/usage/aggregate/by-session", system.Wrapper(apiServer.usageBySession)).Methods(http.MethodGet)
+	authRouter.HandleFunc("/usage/aggregate/by-model", system.Wrapper(apiServer.usageByModel)).Methods(http.MethodGet)
+
 	// Runner profiles (compose-based runner replacement). All routes are
 	// admin-only — operators define and assign profiles.
 	adminRouter.HandleFunc("/runner-profiles", apiServer.listRunnerProfiles).Methods(http.MethodGet)

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -17118,6 +17118,447 @@
                 }
             }
         },
+        "/api/v1/usage/aggregate/by-model": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by model / provider",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization id or slug",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedUsageByModel"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/by-org": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Global-admin only. One row per organization with tokens, costs, user/session counts and last activity.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by organization",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column: total_cost, total_tokens, request_count, last_activity",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page (1-indexed)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size (max 200, default 25)",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedUsageByOrg"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/by-project": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by project / app / agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization id or slug",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by user id",
+                        "name": "user_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedUsageByProject"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/by-session": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization id or slug",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by user id",
+                        "name": "user_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by project id",
+                        "name": "project_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by provider",
+                        "name": "provider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by model",
+                        "name": "model",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedUsageBySession"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/by-user": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Org members get rows scoped to their org. Global admins may omit org_id to list across all orgs.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization id or slug. Required for non-admins.",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedUsageByUser"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/summary": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns whole-set totals plus a daily time-series. Org owners must pass org_id matching their org; global admins may omit it to summarize cross-org.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Aggregate usage summary",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339). Defaults to 7 days ago.",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339). Defaults to now.",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization id or slug. Required for non-admins.",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by user id",
+                        "name": "user_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by project id",
+                        "name": "project_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by app id",
+                        "name": "app_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by provider",
+                        "name": "provider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by model",
+                        "name": "model",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.UsageSummary"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/users": {
             "get": {
                 "security": [
@@ -26586,6 +27027,136 @@
                 }
             }
         },
+        "types.PaginatedUsageByModel": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageByModel"
+                    }
+                },
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
+                },
+                "total_pages": {
+                    "type": "integer"
+                },
+                "total_rows": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.PaginatedUsageByOrg": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageByOrg"
+                    }
+                },
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
+                },
+                "total_pages": {
+                    "type": "integer"
+                },
+                "total_rows": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.PaginatedUsageByProject": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageByProject"
+                    }
+                },
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
+                },
+                "total_pages": {
+                    "type": "integer"
+                },
+                "total_rows": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.PaginatedUsageBySession": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageBySession"
+                    }
+                },
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
+                },
+                "total_pages": {
+                    "type": "integer"
+                },
+                "total_rows": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.PaginatedUsageByUser": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageByUser"
+                    }
+                },
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
+                },
+                "total_pages": {
+                    "type": "integer"
+                },
+                "total_rows": {
+                    "type": "integer"
+                }
+            }
+        },
         "types.PaginatedUsersList": {
             "type": "object",
             "properties": {
@@ -32114,6 +32685,396 @@
                 },
                 "prompt_tokens": {
                     "type": "integer"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageByModel": {
+            "type": "object",
+            "properties": {
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                },
+                "unique_projects": {
+                    "type": "integer"
+                },
+                "unique_sessions": {
+                    "type": "integer"
+                },
+                "unique_users": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageByOrg": {
+            "type": "object",
+            "properties": {
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "last_activity": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "organization_name": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "session_count": {
+                    "type": "integer"
+                },
+                "top_model": {
+                    "type": "string"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                },
+                "user_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageByProject": {
+            "type": "object",
+            "properties": {
+                "app_id": {
+                    "type": "string"
+                },
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "kind": {
+                    "description": "\"project\" | \"app\" | \"agent\"",
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "owner_user_id": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "session_count": {
+                    "type": "integer"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageBySession": {
+            "type": "object",
+            "properties": {
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "call_count": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "ended_at": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.UsageByUser": {
+            "type": "object",
+            "properties": {
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "last_activity": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "session_count": {
+                    "type": "integer"
+                },
+                "top_model": {
+                    "type": "string"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.UsageSummary": {
+            "type": "object",
+            "properties": {
+                "active_projects": {
+                    "type": "integer"
+                },
+                "active_sessions": {
+                    "type": "integer"
+                },
+                "active_users": {
+                    "type": "integer"
+                },
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "from": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "time_series": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.AggregatedUsageMetric"
+                    }
+                },
+                "to": {
+                    "type": "string"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageTotals": {
+            "type": "object",
+            "properties": {
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "total_cost": {
+                    "type": "number"
                 },
                 "total_tokens": {
                     "type": "integer"

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -17118,226 +17118,29 @@
                 }
             }
         },
-        "/api/v1/usage/aggregate/by-model": {
+        "/api/v1/usage/aggregate/grouped": {
             "get": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
+                "description": "One endpoint, five groupings. Pass `group_by` to choose what each row represents. `group_by=org` is global-admin only.\nRow shape per `group_by` (see types/types.go):\n- org: UsageByOrg (organization_id, organization_name, user_count, session_count, top_model, last_activity)\n- user: UsageByUser (user_id, email, organization_id, session_count, top_model, last_activity)\n- project: UsageByProject (project_id, app_id, name, kind, owner_user_id, organization_id, session_count)\n- session: UsageBySession (session_id, name, user_id, project_id, organization_id, provider, model, call_count, started_at, ended_at)\n- model: UsageByModel (provider, model, unique_users, unique_sessions, unique_projects)\nEvery row also carries the shared UsageTotals fields (prompt/completion/cache tokens and costs, total_cost, request_count).",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "usage"
                 ],
-                "summary": "Usage grouped by model / provider",
+                "summary": "Aggregate usage grouped by a dimension",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Start of window (RFC3339)",
-                        "name": "from",
-                        "in": "query"
+                        "description": "Grouping: org|user|project|session|model",
+                        "name": "group_by",
+                        "in": "query",
+                        "required": true
                     },
-                    {
-                        "type": "string",
-                        "description": "End of window (RFC3339)",
-                        "name": "to",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Organization id or slug",
-                        "name": "org_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort column",
-                        "name": "sort_by",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "asc or desc",
-                        "name": "sort_dir",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size",
-                        "name": "page_size",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedUsageByModel"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/usage/aggregate/by-org": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Global-admin only. One row per organization with tokens, costs, user/session counts and last activity.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "usage"
-                ],
-                "summary": "Usage grouped by organization",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Start of window (RFC3339)",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "End of window (RFC3339)",
-                        "name": "to",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort column: total_cost, total_tokens, request_count, last_activity",
-                        "name": "sort_by",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "asc or desc",
-                        "name": "sort_dir",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page (1-indexed)",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size (max 200, default 25)",
-                        "name": "page_size",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedUsageByOrg"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/usage/aggregate/by-project": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "usage"
-                ],
-                "summary": "Usage grouped by project / app / agent",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Start of window (RFC3339)",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "End of window (RFC3339)",
-                        "name": "to",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Organization id or slug",
-                        "name": "org_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by user id",
-                        "name": "user_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort column",
-                        "name": "sort_by",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "asc or desc",
-                        "name": "sort_dir",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size",
-                        "name": "page_size",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedUsageByProject"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/usage/aggregate/by-session": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "usage"
-                ],
-                "summary": "Usage grouped by session",
-                "parameters": [
                     {
                         "type": "string",
                         "description": "Start of window (RFC3339)",
@@ -17370,6 +17173,18 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by app id",
+                        "name": "app_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by session id",
+                        "name": "session_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by provider",
                         "name": "provider",
                         "in": "query"
@@ -17382,7 +17197,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Sort column",
+                        "description": "Sort column (per-grouping whitelist)",
                         "name": "sort_by",
                         "in": "query"
                     },
@@ -17394,13 +17209,13 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Page",
+                        "description": "Page (1-indexed)",
                         "name": "page",
                         "in": "query"
                     },
                     {
                         "type": "integer",
-                        "description": "Page size",
+                        "description": "Page size (max 200, default 25)",
                         "name": "page_size",
                         "in": "query"
                     }
@@ -17409,76 +17224,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/types.PaginatedUsageBySession"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/usage/aggregate/by-user": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Org members get rows scoped to their org. Global admins may omit org_id to list across all orgs.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "usage"
-                ],
-                "summary": "Usage grouped by user",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Start of window (RFC3339)",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "End of window (RFC3339)",
-                        "name": "to",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Organization id or slug. Required for non-admins.",
-                        "name": "org_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort column",
-                        "name": "sort_by",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "asc or desc",
-                        "name": "sort_dir",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size",
-                        "name": "page_size",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedUsageByUser"
+                            "$ref": "#/definitions/types.UsageGroupedResponse"
                         }
                     }
                 }
@@ -17491,7 +17237,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns whole-set totals plus a daily time-series. Org owners must pass org_id matching their org; global admins may omit it to summarize cross-org.",
+                "description": "Returns whole-set totals plus a daily time-series. Org members must pass org_id; global admins may omit it to summarize cross-org.",
                 "produces": [
                     "application/json"
                 ],
@@ -27027,136 +26773,6 @@
                 }
             }
         },
-        "types.PaginatedUsageByModel": {
-            "type": "object",
-            "properties": {
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.UsageByModel"
-                    }
-                },
-                "total": {
-                    "$ref": "#/definitions/types.UsageTotals"
-                },
-                "total_pages": {
-                    "type": "integer"
-                },
-                "total_rows": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.PaginatedUsageByOrg": {
-            "type": "object",
-            "properties": {
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.UsageByOrg"
-                    }
-                },
-                "total": {
-                    "$ref": "#/definitions/types.UsageTotals"
-                },
-                "total_pages": {
-                    "type": "integer"
-                },
-                "total_rows": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.PaginatedUsageByProject": {
-            "type": "object",
-            "properties": {
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.UsageByProject"
-                    }
-                },
-                "total": {
-                    "$ref": "#/definitions/types.UsageTotals"
-                },
-                "total_pages": {
-                    "type": "integer"
-                },
-                "total_rows": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.PaginatedUsageBySession": {
-            "type": "object",
-            "properties": {
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.UsageBySession"
-                    }
-                },
-                "total": {
-                    "$ref": "#/definitions/types.UsageTotals"
-                },
-                "total_pages": {
-                    "type": "integer"
-                },
-                "total_rows": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.PaginatedUsageByUser": {
-            "type": "object",
-            "properties": {
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.UsageByUser"
-                    }
-                },
-                "total": {
-                    "$ref": "#/definitions/types.UsageTotals"
-                },
-                "total_pages": {
-                    "type": "integer"
-                },
-                "total_rows": {
-                    "type": "integer"
-                }
-            }
-        },
         "types.PaginatedUsersList": {
             "type": "object",
             "properties": {
@@ -32691,296 +32307,28 @@
                 }
             }
         },
-        "types.UsageByModel": {
+        "types.UsageGroupedResponse": {
             "type": "object",
             "properties": {
-                "cache_read_cost": {
-                    "type": "number"
-                },
-                "cache_read_tokens": {
-                    "type": "integer"
-                },
-                "cache_write_cost": {
-                    "type": "number"
-                },
-                "cache_write_tokens": {
-                    "type": "integer"
-                },
-                "completion_cost": {
-                    "type": "number"
-                },
-                "completion_tokens": {
-                    "type": "integer"
-                },
-                "model": {
+                "group_by": {
+                    "description": "\"org\" | \"user\" | \"project\" | \"session\" | \"model\"",
                     "type": "string"
                 },
-                "prompt_cost": {
-                    "type": "number"
-                },
-                "prompt_tokens": {
+                "page": {
                     "type": "integer"
                 },
-                "provider": {
-                    "type": "string"
-                },
-                "request_count": {
+                "page_size": {
                     "type": "integer"
                 },
-                "total_cost": {
-                    "type": "number"
+                "rows": {},
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
                 },
-                "total_tokens": {
+                "total_pages": {
                     "type": "integer"
                 },
-                "unique_projects": {
+                "total_rows": {
                     "type": "integer"
-                },
-                "unique_sessions": {
-                    "type": "integer"
-                },
-                "unique_users": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.UsageByOrg": {
-            "type": "object",
-            "properties": {
-                "cache_read_cost": {
-                    "type": "number"
-                },
-                "cache_read_tokens": {
-                    "type": "integer"
-                },
-                "cache_write_cost": {
-                    "type": "number"
-                },
-                "cache_write_tokens": {
-                    "type": "integer"
-                },
-                "completion_cost": {
-                    "type": "number"
-                },
-                "completion_tokens": {
-                    "type": "integer"
-                },
-                "last_activity": {
-                    "type": "string"
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "organization_name": {
-                    "type": "string"
-                },
-                "prompt_cost": {
-                    "type": "number"
-                },
-                "prompt_tokens": {
-                    "type": "integer"
-                },
-                "request_count": {
-                    "type": "integer"
-                },
-                "session_count": {
-                    "type": "integer"
-                },
-                "top_model": {
-                    "type": "string"
-                },
-                "total_cost": {
-                    "type": "number"
-                },
-                "total_tokens": {
-                    "type": "integer"
-                },
-                "user_count": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.UsageByProject": {
-            "type": "object",
-            "properties": {
-                "app_id": {
-                    "type": "string"
-                },
-                "cache_read_cost": {
-                    "type": "number"
-                },
-                "cache_read_tokens": {
-                    "type": "integer"
-                },
-                "cache_write_cost": {
-                    "type": "number"
-                },
-                "cache_write_tokens": {
-                    "type": "integer"
-                },
-                "completion_cost": {
-                    "type": "number"
-                },
-                "completion_tokens": {
-                    "type": "integer"
-                },
-                "kind": {
-                    "description": "\"project\" | \"app\" | \"agent\"",
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "owner_user_id": {
-                    "type": "string"
-                },
-                "project_id": {
-                    "type": "string"
-                },
-                "prompt_cost": {
-                    "type": "number"
-                },
-                "prompt_tokens": {
-                    "type": "integer"
-                },
-                "request_count": {
-                    "type": "integer"
-                },
-                "session_count": {
-                    "type": "integer"
-                },
-                "total_cost": {
-                    "type": "number"
-                },
-                "total_tokens": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.UsageBySession": {
-            "type": "object",
-            "properties": {
-                "cache_read_cost": {
-                    "type": "number"
-                },
-                "cache_read_tokens": {
-                    "type": "integer"
-                },
-                "cache_write_cost": {
-                    "type": "number"
-                },
-                "cache_write_tokens": {
-                    "type": "integer"
-                },
-                "call_count": {
-                    "type": "integer"
-                },
-                "completion_cost": {
-                    "type": "number"
-                },
-                "completion_tokens": {
-                    "type": "integer"
-                },
-                "ended_at": {
-                    "type": "string"
-                },
-                "model": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "project_id": {
-                    "type": "string"
-                },
-                "prompt_cost": {
-                    "type": "number"
-                },
-                "prompt_tokens": {
-                    "type": "integer"
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "request_count": {
-                    "type": "integer"
-                },
-                "session_id": {
-                    "type": "string"
-                },
-                "started_at": {
-                    "type": "string"
-                },
-                "total_cost": {
-                    "type": "number"
-                },
-                "total_tokens": {
-                    "type": "integer"
-                },
-                "user_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "types.UsageByUser": {
-            "type": "object",
-            "properties": {
-                "cache_read_cost": {
-                    "type": "number"
-                },
-                "cache_read_tokens": {
-                    "type": "integer"
-                },
-                "cache_write_cost": {
-                    "type": "number"
-                },
-                "cache_write_tokens": {
-                    "type": "integer"
-                },
-                "completion_cost": {
-                    "type": "number"
-                },
-                "completion_tokens": {
-                    "type": "integer"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "last_activity": {
-                    "type": "string"
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "prompt_cost": {
-                    "type": "number"
-                },
-                "prompt_tokens": {
-                    "type": "integer"
-                },
-                "request_count": {
-                    "type": "integer"
-                },
-                "session_count": {
-                    "type": "integer"
-                },
-                "top_model": {
-                    "type": "string"
-                },
-                "total_cost": {
-                    "type": "number"
-                },
-                "total_tokens": {
-                    "type": "integer"
-                },
-                "user_id": {
-                    "type": "string"
                 }
             }
         },

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -5959,6 +5959,91 @@ definitions:
       totalPages:
         type: integer
     type: object
+  types.PaginatedUsageByModel:
+    properties:
+      page:
+        type: integer
+      page_size:
+        type: integer
+      rows:
+        items:
+          $ref: '#/definitions/types.UsageByModel'
+        type: array
+      total:
+        $ref: '#/definitions/types.UsageTotals'
+      total_pages:
+        type: integer
+      total_rows:
+        type: integer
+    type: object
+  types.PaginatedUsageByOrg:
+    properties:
+      page:
+        type: integer
+      page_size:
+        type: integer
+      rows:
+        items:
+          $ref: '#/definitions/types.UsageByOrg'
+        type: array
+      total:
+        $ref: '#/definitions/types.UsageTotals'
+      total_pages:
+        type: integer
+      total_rows:
+        type: integer
+    type: object
+  types.PaginatedUsageByProject:
+    properties:
+      page:
+        type: integer
+      page_size:
+        type: integer
+      rows:
+        items:
+          $ref: '#/definitions/types.UsageByProject'
+        type: array
+      total:
+        $ref: '#/definitions/types.UsageTotals'
+      total_pages:
+        type: integer
+      total_rows:
+        type: integer
+    type: object
+  types.PaginatedUsageBySession:
+    properties:
+      page:
+        type: integer
+      page_size:
+        type: integer
+      rows:
+        items:
+          $ref: '#/definitions/types.UsageBySession'
+        type: array
+      total:
+        $ref: '#/definitions/types.UsageTotals'
+      total_pages:
+        type: integer
+      total_rows:
+        type: integer
+    type: object
+  types.PaginatedUsageByUser:
+    properties:
+      page:
+        type: integer
+      page_size:
+        type: integer
+      rows:
+        items:
+          $ref: '#/definitions/types.UsageByUser'
+        type: array
+      total:
+        $ref: '#/definitions/types.UsageTotals'
+      total_pages:
+        type: integer
+      total_rows:
+        type: integer
+    type: object
   types.PaginatedUsersList:
     properties:
       page:
@@ -9970,6 +10055,264 @@ definitions:
         type: integer
       prompt_tokens:
         type: integer
+      total_tokens:
+        type: integer
+    type: object
+  types.UsageByModel:
+    properties:
+      cache_read_cost:
+        type: number
+      cache_read_tokens:
+        type: integer
+      cache_write_cost:
+        type: number
+      cache_write_tokens:
+        type: integer
+      completion_cost:
+        type: number
+      completion_tokens:
+        type: integer
+      model:
+        type: string
+      prompt_cost:
+        type: number
+      prompt_tokens:
+        type: integer
+      provider:
+        type: string
+      request_count:
+        type: integer
+      total_cost:
+        type: number
+      total_tokens:
+        type: integer
+      unique_projects:
+        type: integer
+      unique_sessions:
+        type: integer
+      unique_users:
+        type: integer
+    type: object
+  types.UsageByOrg:
+    properties:
+      cache_read_cost:
+        type: number
+      cache_read_tokens:
+        type: integer
+      cache_write_cost:
+        type: number
+      cache_write_tokens:
+        type: integer
+      completion_cost:
+        type: number
+      completion_tokens:
+        type: integer
+      last_activity:
+        type: string
+      organization_id:
+        type: string
+      organization_name:
+        type: string
+      prompt_cost:
+        type: number
+      prompt_tokens:
+        type: integer
+      request_count:
+        type: integer
+      session_count:
+        type: integer
+      top_model:
+        type: string
+      total_cost:
+        type: number
+      total_tokens:
+        type: integer
+      user_count:
+        type: integer
+    type: object
+  types.UsageByProject:
+    properties:
+      app_id:
+        type: string
+      cache_read_cost:
+        type: number
+      cache_read_tokens:
+        type: integer
+      cache_write_cost:
+        type: number
+      cache_write_tokens:
+        type: integer
+      completion_cost:
+        type: number
+      completion_tokens:
+        type: integer
+      kind:
+        description: '"project" | "app" | "agent"'
+        type: string
+      name:
+        type: string
+      organization_id:
+        type: string
+      owner_user_id:
+        type: string
+      project_id:
+        type: string
+      prompt_cost:
+        type: number
+      prompt_tokens:
+        type: integer
+      request_count:
+        type: integer
+      session_count:
+        type: integer
+      total_cost:
+        type: number
+      total_tokens:
+        type: integer
+    type: object
+  types.UsageBySession:
+    properties:
+      cache_read_cost:
+        type: number
+      cache_read_tokens:
+        type: integer
+      cache_write_cost:
+        type: number
+      cache_write_tokens:
+        type: integer
+      call_count:
+        type: integer
+      completion_cost:
+        type: number
+      completion_tokens:
+        type: integer
+      ended_at:
+        type: string
+      model:
+        type: string
+      name:
+        type: string
+      organization_id:
+        type: string
+      project_id:
+        type: string
+      prompt_cost:
+        type: number
+      prompt_tokens:
+        type: integer
+      provider:
+        type: string
+      request_count:
+        type: integer
+      session_id:
+        type: string
+      started_at:
+        type: string
+      total_cost:
+        type: number
+      total_tokens:
+        type: integer
+      user_id:
+        type: string
+    type: object
+  types.UsageByUser:
+    properties:
+      cache_read_cost:
+        type: number
+      cache_read_tokens:
+        type: integer
+      cache_write_cost:
+        type: number
+      cache_write_tokens:
+        type: integer
+      completion_cost:
+        type: number
+      completion_tokens:
+        type: integer
+      email:
+        type: string
+      last_activity:
+        type: string
+      organization_id:
+        type: string
+      prompt_cost:
+        type: number
+      prompt_tokens:
+        type: integer
+      request_count:
+        type: integer
+      session_count:
+        type: integer
+      top_model:
+        type: string
+      total_cost:
+        type: number
+      total_tokens:
+        type: integer
+      user_id:
+        type: string
+    type: object
+  types.UsageSummary:
+    properties:
+      active_projects:
+        type: integer
+      active_sessions:
+        type: integer
+      active_users:
+        type: integer
+      cache_read_cost:
+        type: number
+      cache_read_tokens:
+        type: integer
+      cache_write_cost:
+        type: number
+      cache_write_tokens:
+        type: integer
+      completion_cost:
+        type: number
+      completion_tokens:
+        type: integer
+      from:
+        type: string
+      prompt_cost:
+        type: number
+      prompt_tokens:
+        type: integer
+      request_count:
+        type: integer
+      time_series:
+        items:
+          $ref: '#/definitions/types.AggregatedUsageMetric'
+        type: array
+      to:
+        type: string
+      total_cost:
+        type: number
+      total_tokens:
+        type: integer
+    type: object
+  types.UsageTotals:
+    properties:
+      cache_read_cost:
+        type: number
+      cache_read_tokens:
+        type: integer
+      cache_write_cost:
+        type: number
+      cache_write_tokens:
+        type: integer
+      completion_cost:
+        type: number
+      completion_tokens:
+        type: integer
+      prompt_cost:
+        type: number
+      prompt_tokens:
+        type: integer
+      request_count:
+        type: integer
+      total_cost:
+        type: number
       total_tokens:
         type: integer
     type: object
@@ -21358,6 +21701,290 @@ paths:
       security:
       - BearerAuth: []
       summary: Get daily usage
+      tags:
+      - usage
+  /api/v1/usage/aggregate/by-model:
+    get:
+      parameters:
+      - description: Start of window (RFC3339)
+        in: query
+        name: from
+        type: string
+      - description: End of window (RFC3339)
+        in: query
+        name: to
+        type: string
+      - description: Organization id or slug
+        in: query
+        name: org_id
+        type: string
+      - description: Sort column
+        in: query
+        name: sort_by
+        type: string
+      - description: asc or desc
+        in: query
+        name: sort_dir
+        type: string
+      - description: Page
+        in: query
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.PaginatedUsageByModel'
+      security:
+      - BearerAuth: []
+      summary: Usage grouped by model / provider
+      tags:
+      - usage
+  /api/v1/usage/aggregate/by-org:
+    get:
+      description: Global-admin only. One row per organization with tokens, costs,
+        user/session counts and last activity.
+      parameters:
+      - description: Start of window (RFC3339)
+        in: query
+        name: from
+        type: string
+      - description: End of window (RFC3339)
+        in: query
+        name: to
+        type: string
+      - description: 'Sort column: total_cost, total_tokens, request_count, last_activity'
+        in: query
+        name: sort_by
+        type: string
+      - description: asc or desc
+        in: query
+        name: sort_dir
+        type: string
+      - description: Page (1-indexed)
+        in: query
+        name: page
+        type: integer
+      - description: Page size (max 200, default 25)
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.PaginatedUsageByOrg'
+      security:
+      - BearerAuth: []
+      summary: Usage grouped by organization
+      tags:
+      - usage
+  /api/v1/usage/aggregate/by-project:
+    get:
+      parameters:
+      - description: Start of window (RFC3339)
+        in: query
+        name: from
+        type: string
+      - description: End of window (RFC3339)
+        in: query
+        name: to
+        type: string
+      - description: Organization id or slug
+        in: query
+        name: org_id
+        type: string
+      - description: Filter by user id
+        in: query
+        name: user_id
+        type: string
+      - description: Sort column
+        in: query
+        name: sort_by
+        type: string
+      - description: asc or desc
+        in: query
+        name: sort_dir
+        type: string
+      - description: Page
+        in: query
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.PaginatedUsageByProject'
+      security:
+      - BearerAuth: []
+      summary: Usage grouped by project / app / agent
+      tags:
+      - usage
+  /api/v1/usage/aggregate/by-session:
+    get:
+      parameters:
+      - description: Start of window (RFC3339)
+        in: query
+        name: from
+        type: string
+      - description: End of window (RFC3339)
+        in: query
+        name: to
+        type: string
+      - description: Organization id or slug
+        in: query
+        name: org_id
+        type: string
+      - description: Filter by user id
+        in: query
+        name: user_id
+        type: string
+      - description: Filter by project id
+        in: query
+        name: project_id
+        type: string
+      - description: Filter by provider
+        in: query
+        name: provider
+        type: string
+      - description: Filter by model
+        in: query
+        name: model
+        type: string
+      - description: Sort column
+        in: query
+        name: sort_by
+        type: string
+      - description: asc or desc
+        in: query
+        name: sort_dir
+        type: string
+      - description: Page
+        in: query
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.PaginatedUsageBySession'
+      security:
+      - BearerAuth: []
+      summary: Usage grouped by session
+      tags:
+      - usage
+  /api/v1/usage/aggregate/by-user:
+    get:
+      description: Org members get rows scoped to their org. Global admins may omit
+        org_id to list across all orgs.
+      parameters:
+      - description: Start of window (RFC3339)
+        in: query
+        name: from
+        type: string
+      - description: End of window (RFC3339)
+        in: query
+        name: to
+        type: string
+      - description: Organization id or slug. Required for non-admins.
+        in: query
+        name: org_id
+        type: string
+      - description: Sort column
+        in: query
+        name: sort_by
+        type: string
+      - description: asc or desc
+        in: query
+        name: sort_dir
+        type: string
+      - description: Page
+        in: query
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.PaginatedUsageByUser'
+      security:
+      - BearerAuth: []
+      summary: Usage grouped by user
+      tags:
+      - usage
+  /api/v1/usage/aggregate/summary:
+    get:
+      description: Returns whole-set totals plus a daily time-series. Org owners must
+        pass org_id matching their org; global admins may omit it to summarize cross-org.
+      parameters:
+      - description: Start of window (RFC3339). Defaults to 7 days ago.
+        in: query
+        name: from
+        type: string
+      - description: End of window (RFC3339). Defaults to now.
+        in: query
+        name: to
+        type: string
+      - description: Organization id or slug. Required for non-admins.
+        in: query
+        name: org_id
+        type: string
+      - description: Filter by user id
+        in: query
+        name: user_id
+        type: string
+      - description: Filter by project id
+        in: query
+        name: project_id
+        type: string
+      - description: Filter by app id
+        in: query
+        name: app_id
+        type: string
+      - description: Filter by provider
+        in: query
+        name: provider
+        type: string
+      - description: Filter by model
+        in: query
+        name: model
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.UsageSummary'
+      security:
+      - BearerAuth: []
+      summary: Aggregate usage summary
       tags:
       - usage
   /api/v1/users:

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -5959,91 +5959,6 @@ definitions:
       totalPages:
         type: integer
     type: object
-  types.PaginatedUsageByModel:
-    properties:
-      page:
-        type: integer
-      page_size:
-        type: integer
-      rows:
-        items:
-          $ref: '#/definitions/types.UsageByModel'
-        type: array
-      total:
-        $ref: '#/definitions/types.UsageTotals'
-      total_pages:
-        type: integer
-      total_rows:
-        type: integer
-    type: object
-  types.PaginatedUsageByOrg:
-    properties:
-      page:
-        type: integer
-      page_size:
-        type: integer
-      rows:
-        items:
-          $ref: '#/definitions/types.UsageByOrg'
-        type: array
-      total:
-        $ref: '#/definitions/types.UsageTotals'
-      total_pages:
-        type: integer
-      total_rows:
-        type: integer
-    type: object
-  types.PaginatedUsageByProject:
-    properties:
-      page:
-        type: integer
-      page_size:
-        type: integer
-      rows:
-        items:
-          $ref: '#/definitions/types.UsageByProject'
-        type: array
-      total:
-        $ref: '#/definitions/types.UsageTotals'
-      total_pages:
-        type: integer
-      total_rows:
-        type: integer
-    type: object
-  types.PaginatedUsageBySession:
-    properties:
-      page:
-        type: integer
-      page_size:
-        type: integer
-      rows:
-        items:
-          $ref: '#/definitions/types.UsageBySession'
-        type: array
-      total:
-        $ref: '#/definitions/types.UsageTotals'
-      total_pages:
-        type: integer
-      total_rows:
-        type: integer
-    type: object
-  types.PaginatedUsageByUser:
-    properties:
-      page:
-        type: integer
-      page_size:
-        type: integer
-      rows:
-        items:
-          $ref: '#/definitions/types.UsageByUser'
-        type: array
-      total:
-        $ref: '#/definitions/types.UsageTotals'
-      total_pages:
-        type: integer
-      total_rows:
-        type: integer
-    type: object
   types.PaginatedUsersList:
     properties:
       page:
@@ -10058,199 +9973,22 @@ definitions:
       total_tokens:
         type: integer
     type: object
-  types.UsageByModel:
+  types.UsageGroupedResponse:
     properties:
-      cache_read_cost:
-        type: number
-      cache_read_tokens:
-        type: integer
-      cache_write_cost:
-        type: number
-      cache_write_tokens:
-        type: integer
-      completion_cost:
-        type: number
-      completion_tokens:
-        type: integer
-      model:
+      group_by:
+        description: '"org" | "user" | "project" | "session" | "model"'
         type: string
-      prompt_cost:
-        type: number
-      prompt_tokens:
+      page:
         type: integer
-      provider:
-        type: string
-      request_count:
+      page_size:
         type: integer
-      total_cost:
-        type: number
-      total_tokens:
+      rows: {}
+      total:
+        $ref: '#/definitions/types.UsageTotals'
+      total_pages:
         type: integer
-      unique_projects:
+      total_rows:
         type: integer
-      unique_sessions:
-        type: integer
-      unique_users:
-        type: integer
-    type: object
-  types.UsageByOrg:
-    properties:
-      cache_read_cost:
-        type: number
-      cache_read_tokens:
-        type: integer
-      cache_write_cost:
-        type: number
-      cache_write_tokens:
-        type: integer
-      completion_cost:
-        type: number
-      completion_tokens:
-        type: integer
-      last_activity:
-        type: string
-      organization_id:
-        type: string
-      organization_name:
-        type: string
-      prompt_cost:
-        type: number
-      prompt_tokens:
-        type: integer
-      request_count:
-        type: integer
-      session_count:
-        type: integer
-      top_model:
-        type: string
-      total_cost:
-        type: number
-      total_tokens:
-        type: integer
-      user_count:
-        type: integer
-    type: object
-  types.UsageByProject:
-    properties:
-      app_id:
-        type: string
-      cache_read_cost:
-        type: number
-      cache_read_tokens:
-        type: integer
-      cache_write_cost:
-        type: number
-      cache_write_tokens:
-        type: integer
-      completion_cost:
-        type: number
-      completion_tokens:
-        type: integer
-      kind:
-        description: '"project" | "app" | "agent"'
-        type: string
-      name:
-        type: string
-      organization_id:
-        type: string
-      owner_user_id:
-        type: string
-      project_id:
-        type: string
-      prompt_cost:
-        type: number
-      prompt_tokens:
-        type: integer
-      request_count:
-        type: integer
-      session_count:
-        type: integer
-      total_cost:
-        type: number
-      total_tokens:
-        type: integer
-    type: object
-  types.UsageBySession:
-    properties:
-      cache_read_cost:
-        type: number
-      cache_read_tokens:
-        type: integer
-      cache_write_cost:
-        type: number
-      cache_write_tokens:
-        type: integer
-      call_count:
-        type: integer
-      completion_cost:
-        type: number
-      completion_tokens:
-        type: integer
-      ended_at:
-        type: string
-      model:
-        type: string
-      name:
-        type: string
-      organization_id:
-        type: string
-      project_id:
-        type: string
-      prompt_cost:
-        type: number
-      prompt_tokens:
-        type: integer
-      provider:
-        type: string
-      request_count:
-        type: integer
-      session_id:
-        type: string
-      started_at:
-        type: string
-      total_cost:
-        type: number
-      total_tokens:
-        type: integer
-      user_id:
-        type: string
-    type: object
-  types.UsageByUser:
-    properties:
-      cache_read_cost:
-        type: number
-      cache_read_tokens:
-        type: integer
-      cache_write_cost:
-        type: number
-      cache_write_tokens:
-        type: integer
-      completion_cost:
-        type: number
-      completion_tokens:
-        type: integer
-      email:
-        type: string
-      last_activity:
-        type: string
-      organization_id:
-        type: string
-      prompt_cost:
-        type: number
-      prompt_tokens:
-        type: integer
-      request_count:
-        type: integer
-      session_count:
-        type: integer
-      top_model:
-        type: string
-      total_cost:
-        type: number
-      total_tokens:
-        type: integer
-      user_id:
-        type: string
     type: object
   types.UsageSummary:
     properties:
@@ -21703,9 +21441,23 @@ paths:
       summary: Get daily usage
       tags:
       - usage
-  /api/v1/usage/aggregate/by-model:
+  /api/v1/usage/aggregate/grouped:
     get:
+      description: |-
+        One endpoint, five groupings. Pass `group_by` to choose what each row represents. `group_by=org` is global-admin only.
+        Row shape per `group_by` (see types/types.go):
+        - org: UsageByOrg (organization_id, organization_name, user_count, session_count, top_model, last_activity)
+        - user: UsageByUser (user_id, email, organization_id, session_count, top_model, last_activity)
+        - project: UsageByProject (project_id, app_id, name, kind, owner_user_id, organization_id, session_count)
+        - session: UsageBySession (session_id, name, user_id, project_id, organization_id, provider, model, call_count, started_at, ended_at)
+        - model: UsageByModel (provider, model, unique_users, unique_sessions, unique_projects)
+        Every row also carries the shared UsageTotals fields (prompt/completion/cache tokens and costs, total_cost, request_count).
       parameters:
+      - description: 'Grouping: org|user|project|session|model'
+        in: query
+        name: group_by
+        required: true
+        type: string
       - description: Start of window (RFC3339)
         in: query
         name: from
@@ -21718,48 +21470,31 @@ paths:
         in: query
         name: org_id
         type: string
-      - description: Sort column
+      - description: Filter by user id
         in: query
-        name: sort_by
+        name: user_id
         type: string
-      - description: asc or desc
+      - description: Filter by project id
         in: query
-        name: sort_dir
+        name: project_id
         type: string
-      - description: Page
+      - description: Filter by app id
         in: query
-        name: page
-        type: integer
-      - description: Page size
-        in: query
-        name: page_size
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.PaginatedUsageByModel'
-      security:
-      - BearerAuth: []
-      summary: Usage grouped by model / provider
-      tags:
-      - usage
-  /api/v1/usage/aggregate/by-org:
-    get:
-      description: Global-admin only. One row per organization with tokens, costs,
-        user/session counts and last activity.
-      parameters:
-      - description: Start of window (RFC3339)
-        in: query
-        name: from
+        name: app_id
         type: string
-      - description: End of window (RFC3339)
+      - description: Filter by session id
         in: query
-        name: to
+        name: session_id
         type: string
-      - description: 'Sort column: total_cost, total_tokens, request_count, last_activity'
+      - description: Filter by provider
+        in: query
+        name: provider
+        type: string
+      - description: Filter by model
+        in: query
+        name: model
+        type: string
+      - description: Sort column (per-grouping whitelist)
         in: query
         name: sort_by
         type: string
@@ -21781,167 +21516,16 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/types.PaginatedUsageByOrg'
+            $ref: '#/definitions/types.UsageGroupedResponse'
       security:
       - BearerAuth: []
-      summary: Usage grouped by organization
-      tags:
-      - usage
-  /api/v1/usage/aggregate/by-project:
-    get:
-      parameters:
-      - description: Start of window (RFC3339)
-        in: query
-        name: from
-        type: string
-      - description: End of window (RFC3339)
-        in: query
-        name: to
-        type: string
-      - description: Organization id or slug
-        in: query
-        name: org_id
-        type: string
-      - description: Filter by user id
-        in: query
-        name: user_id
-        type: string
-      - description: Sort column
-        in: query
-        name: sort_by
-        type: string
-      - description: asc or desc
-        in: query
-        name: sort_dir
-        type: string
-      - description: Page
-        in: query
-        name: page
-        type: integer
-      - description: Page size
-        in: query
-        name: page_size
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.PaginatedUsageByProject'
-      security:
-      - BearerAuth: []
-      summary: Usage grouped by project / app / agent
-      tags:
-      - usage
-  /api/v1/usage/aggregate/by-session:
-    get:
-      parameters:
-      - description: Start of window (RFC3339)
-        in: query
-        name: from
-        type: string
-      - description: End of window (RFC3339)
-        in: query
-        name: to
-        type: string
-      - description: Organization id or slug
-        in: query
-        name: org_id
-        type: string
-      - description: Filter by user id
-        in: query
-        name: user_id
-        type: string
-      - description: Filter by project id
-        in: query
-        name: project_id
-        type: string
-      - description: Filter by provider
-        in: query
-        name: provider
-        type: string
-      - description: Filter by model
-        in: query
-        name: model
-        type: string
-      - description: Sort column
-        in: query
-        name: sort_by
-        type: string
-      - description: asc or desc
-        in: query
-        name: sort_dir
-        type: string
-      - description: Page
-        in: query
-        name: page
-        type: integer
-      - description: Page size
-        in: query
-        name: page_size
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.PaginatedUsageBySession'
-      security:
-      - BearerAuth: []
-      summary: Usage grouped by session
-      tags:
-      - usage
-  /api/v1/usage/aggregate/by-user:
-    get:
-      description: Org members get rows scoped to their org. Global admins may omit
-        org_id to list across all orgs.
-      parameters:
-      - description: Start of window (RFC3339)
-        in: query
-        name: from
-        type: string
-      - description: End of window (RFC3339)
-        in: query
-        name: to
-        type: string
-      - description: Organization id or slug. Required for non-admins.
-        in: query
-        name: org_id
-        type: string
-      - description: Sort column
-        in: query
-        name: sort_by
-        type: string
-      - description: asc or desc
-        in: query
-        name: sort_dir
-        type: string
-      - description: Page
-        in: query
-        name: page
-        type: integer
-      - description: Page size
-        in: query
-        name: page_size
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.PaginatedUsageByUser'
-      security:
-      - BearerAuth: []
-      summary: Usage grouped by user
+      summary: Aggregate usage grouped by a dimension
       tags:
       - usage
   /api/v1/usage/aggregate/summary:
     get:
-      description: Returns whole-set totals plus a daily time-series. Org owners must
-        pass org_id matching their org; global admins may omit it to summarize cross-org.
+      description: Returns whole-set totals plus a daily time-series. Org members
+        must pass org_id; global admins may omit it to summarize cross-org.
       parameters:
       - description: Start of window (RFC3339). Defaults to 7 days ago.
         in: query

--- a/api/pkg/server/usage_aggregate_handlers.go
+++ b/api/pkg/server/usage_aggregate_handlers.go
@@ -12,28 +12,29 @@ import (
 )
 
 const (
-	defaultUsageWindow      = 7 * 24 * time.Hour
-	maxUsageWindow          = 366 * 24 * time.Hour
-	defaultUsagePageSize    = 25
-	maxUsagePageSize        = 200
-	maxUsageExportRows      = 100_000
+	defaultUsageWindow   = 7 * 24 * time.Hour
+	maxUsageWindow       = 366 * 24 * time.Hour
+	defaultUsagePageSize = 25
+	maxUsagePageSize     = 200
 )
 
 // parseUsageQuery turns the request's query string into a GroupedUsageQuery.
 // It applies auth: if org_id is set the caller must be a member; if empty
-// the caller must be a global admin. by-org callers pass requireAdmin=true
-// to reject org-scoped callers regardless of org_id.
+// the caller must be a global admin. The `requireAdmin` flag is for
+// admin-only groupings (group_by=org) and rejects org-scoped callers
+// regardless of whether they pass org_id.
 func (s *HelixAPIServer) parseUsageQuery(r *http.Request, requireAdmin bool) (*store.GroupedUsageQuery, *system.HTTPError) {
 	user := getRequestUser(r)
 	q := r.URL.Query()
+
+	if requireAdmin && !isAdmin(user) {
+		return nil, system.NewHTTPError403("this grouping is admin-only")
+	}
 
 	// Org scoping.
 	orgParam := q.Get("org_id")
 	var orgID string
 	if orgParam != "" {
-		if requireAdmin && !isAdmin(user) {
-			return nil, system.NewHTTPError403("by-org listing is admin-only")
-		}
 		org, err := s.lookupOrg(r.Context(), orgParam)
 		if err != nil {
 			return nil, system.NewHTTPError404("organization not found")
@@ -46,7 +47,7 @@ func (s *HelixAPIServer) parseUsageQuery(r *http.Request, requireAdmin bool) (*s
 		return nil, system.NewHTTPError403("org_id is required for non-admin callers")
 	}
 
-	// Date range. Default to last 7 days, cap at 366 days.
+	// Date range. Default last 7 days, cap 366 days.
 	now := time.Now()
 	to := now
 	from := now.Add(-defaultUsageWindow)
@@ -104,9 +105,16 @@ func pageTotals(totalRows, pageSize int) int {
 	return (totalRows + pageSize - 1) / pageSize
 }
 
+func max1(n int) int {
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
 // usageSummary godoc
 // @Summary Aggregate usage summary
-// @Description Returns whole-set totals plus a daily time-series. Org owners must pass org_id matching their org; global admins may omit it to summarize cross-org.
+// @Description Returns whole-set totals plus a daily time-series. Org members must pass org_id; global admins may omit it to summarize cross-org.
 // @Tags    usage
 // @Produce json
 // @Param   from        query  string  false  "Start of window (RFC3339). Defaults to 7 days ago."
@@ -132,154 +140,76 @@ func (s *HelixAPIServer) usageSummary(_ http.ResponseWriter, r *http.Request) (*
 	return res, nil
 }
 
-// usageByOrg godoc
-// @Summary Usage grouped by organization
-// @Description Global-admin only. One row per organization with tokens, costs, user/session counts and last activity.
+// usageGrouped godoc
+// @Summary Aggregate usage grouped by a dimension
+// @Description One endpoint, five groupings. Pass `group_by` to choose what each row represents. `group_by=org` is global-admin only.
+//
+// @Description Row shape per `group_by` (see types/types.go):
+// @Description   - org: UsageByOrg (organization_id, organization_name, user_count, session_count, top_model, last_activity)
+// @Description   - user: UsageByUser (user_id, email, organization_id, session_count, top_model, last_activity)
+// @Description   - project: UsageByProject (project_id, app_id, name, kind, owner_user_id, organization_id, session_count)
+// @Description   - session: UsageBySession (session_id, name, user_id, project_id, organization_id, provider, model, call_count, started_at, ended_at)
+// @Description   - model: UsageByModel (provider, model, unique_users, unique_sessions, unique_projects)
+//
+// @Description Every row also carries the shared UsageTotals fields (prompt/completion/cache tokens and costs, total_cost, request_count).
+//
 // @Tags    usage
 // @Produce json
-// @Param   from       query  string  false  "Start of window (RFC3339)"
-// @Param   to         query  string  false  "End of window (RFC3339)"
-// @Param   sort_by    query  string  false  "Sort column: total_cost, total_tokens, request_count, last_activity"
-// @Param   sort_dir   query  string  false  "asc or desc"
-// @Param   page       query  int     false  "Page (1-indexed)"
-// @Param   page_size  query  int     false  "Page size (max 200, default 25)"
-// @Success 200 {object} types.PaginatedUsageByOrg
-// @Router /api/v1/usage/aggregate/by-org [get]
-// @Security BearerAuth
-func (s *HelixAPIServer) usageByOrg(_ http.ResponseWriter, r *http.Request) (*types.PaginatedUsageByOrg, *system.HTTPError) {
-	if !isAdmin(getRequestUser(r)) {
-		return nil, system.NewHTTPError403("by-org listing is admin-only")
-	}
-	q, httpErr := s.parseUsageQuery(r, true)
-	if httpErr != nil {
-		return nil, httpErr
-	}
-	rows, total, err := s.Store.GetUsageGroupedByOrg(r.Context(), q)
-	if err != nil {
-		return nil, system.NewHTTPError500(err.Error())
-	}
-	totals, err := s.usageTotalsFor(r.Context(), q)
-	if err != nil {
-		return nil, system.NewHTTPError500(err.Error())
-	}
-	return &types.PaginatedUsageByOrg{
-		Rows:       rows,
-		Total:      *totals,
-		Page:       max1(q.Page),
-		PageSize:   q.PageSize,
-		TotalRows:  total,
-		TotalPages: pageTotals(total, q.PageSize),
-	}, nil
-}
-
-// usageByUser godoc
-// @Summary Usage grouped by user
-// @Description Org members get rows scoped to their org. Global admins may omit org_id to list across all orgs.
-// @Tags    usage
-// @Produce json
-// @Param   from       query  string  false  "Start of window (RFC3339)"
-// @Param   to         query  string  false  "End of window (RFC3339)"
-// @Param   org_id     query  string  false  "Organization id or slug. Required for non-admins."
-// @Param   sort_by    query  string  false  "Sort column"
-// @Param   sort_dir   query  string  false  "asc or desc"
-// @Param   page       query  int     false  "Page"
-// @Param   page_size  query  int     false  "Page size"
-// @Success 200 {object} types.PaginatedUsageByUser
-// @Router /api/v1/usage/aggregate/by-user [get]
-// @Security BearerAuth
-func (s *HelixAPIServer) usageByUser(_ http.ResponseWriter, r *http.Request) (*types.PaginatedUsageByUser, *system.HTTPError) {
-	q, httpErr := s.parseUsageQuery(r, false)
-	if httpErr != nil {
-		return nil, httpErr
-	}
-	rows, total, err := s.Store.GetUsageGroupedByUser(r.Context(), q)
-	if err != nil {
-		return nil, system.NewHTTPError500(err.Error())
-	}
-	totals, err := s.usageTotalsFor(r.Context(), q)
-	if err != nil {
-		return nil, system.NewHTTPError500(err.Error())
-	}
-	return &types.PaginatedUsageByUser{
-		Rows:       rows,
-		Total:      *totals,
-		Page:       max1(q.Page),
-		PageSize:   q.PageSize,
-		TotalRows:  total,
-		TotalPages: pageTotals(total, q.PageSize),
-	}, nil
-}
-
-// usageByProject godoc
-// @Summary Usage grouped by project / app / agent
-// @Tags    usage
-// @Produce json
-// @Param   from       query  string  false  "Start of window (RFC3339)"
-// @Param   to         query  string  false  "End of window (RFC3339)"
-// @Param   org_id     query  string  false  "Organization id or slug"
-// @Param   user_id    query  string  false  "Filter by user id"
-// @Param   sort_by    query  string  false  "Sort column"
-// @Param   sort_dir   query  string  false  "asc or desc"
-// @Param   page       query  int     false  "Page"
-// @Param   page_size  query  int     false  "Page size"
-// @Success 200 {object} types.PaginatedUsageByProject
-// @Router /api/v1/usage/aggregate/by-project [get]
-// @Security BearerAuth
-func (s *HelixAPIServer) usageByProject(_ http.ResponseWriter, r *http.Request) (*types.PaginatedUsageByProject, *system.HTTPError) {
-	q, httpErr := s.parseUsageQuery(r, false)
-	if httpErr != nil {
-		return nil, httpErr
-	}
-	rows, total, err := s.Store.GetUsageGroupedByProject(r.Context(), q)
-	if err != nil {
-		return nil, system.NewHTTPError500(err.Error())
-	}
-	totals, err := s.usageTotalsFor(r.Context(), q)
-	if err != nil {
-		return nil, system.NewHTTPError500(err.Error())
-	}
-	return &types.PaginatedUsageByProject{
-		Rows:       rows,
-		Total:      *totals,
-		Page:       max1(q.Page),
-		PageSize:   q.PageSize,
-		TotalRows:  total,
-		TotalPages: pageTotals(total, q.PageSize),
-	}, nil
-}
-
-// usageBySession godoc
-// @Summary Usage grouped by session
-// @Tags    usage
-// @Produce json
+// @Param   group_by    query  string  true   "Grouping: org|user|project|session|model"
 // @Param   from        query  string  false  "Start of window (RFC3339)"
 // @Param   to          query  string  false  "End of window (RFC3339)"
 // @Param   org_id      query  string  false  "Organization id or slug"
 // @Param   user_id     query  string  false  "Filter by user id"
 // @Param   project_id  query  string  false  "Filter by project id"
+// @Param   app_id      query  string  false  "Filter by app id"
+// @Param   session_id  query  string  false  "Filter by session id"
 // @Param   provider    query  string  false  "Filter by provider"
 // @Param   model       query  string  false  "Filter by model"
-// @Param   sort_by     query  string  false  "Sort column"
+// @Param   sort_by     query  string  false  "Sort column (per-grouping whitelist)"
 // @Param   sort_dir    query  string  false  "asc or desc"
-// @Param   page        query  int     false  "Page"
-// @Param   page_size   query  int     false  "Page size"
-// @Success 200 {object} types.PaginatedUsageBySession
-// @Router /api/v1/usage/aggregate/by-session [get]
+// @Param   page        query  int     false  "Page (1-indexed)"
+// @Param   page_size   query  int     false  "Page size (max 200, default 25)"
+// @Success 200 {object} types.UsageGroupedResponse
+// @Router /api/v1/usage/aggregate/grouped [get]
 // @Security BearerAuth
-func (s *HelixAPIServer) usageBySession(_ http.ResponseWriter, r *http.Request) (*types.PaginatedUsageBySession, *system.HTTPError) {
-	q, httpErr := s.parseUsageQuery(r, false)
+func (s *HelixAPIServer) usageGrouped(_ http.ResponseWriter, r *http.Request) (*types.UsageGroupedResponse, *system.HTTPError) {
+	groupBy := r.URL.Query().Get("group_by")
+	if groupBy == "" {
+		return nil, system.NewHTTPError400("group_by is required")
+	}
+	q, httpErr := s.parseUsageQuery(r, groupBy == "org")
 	if httpErr != nil {
 		return nil, httpErr
 	}
-	rows, total, err := s.Store.GetUsageGroupedBySession(r.Context(), q)
+
+	var rows any
+	var total int
+	var err error
+	switch groupBy {
+	case "org":
+		rows, total, err = unpackGroup[*types.UsageByOrg](s.Store.GetUsageGroupedByOrg(r.Context(), q))
+	case "user":
+		rows, total, err = unpackGroup[*types.UsageByUser](s.Store.GetUsageGroupedByUser(r.Context(), q))
+	case "project":
+		rows, total, err = unpackGroup[*types.UsageByProject](s.Store.GetUsageGroupedByProject(r.Context(), q))
+	case "session":
+		rows, total, err = unpackGroup[*types.UsageBySession](s.Store.GetUsageGroupedBySession(r.Context(), q))
+	case "model":
+		rows, total, err = unpackGroup[*types.UsageByModel](s.Store.GetUsageGroupedByModel(r.Context(), q))
+	default:
+		return nil, system.NewHTTPError400("group_by must be one of: org, user, project, session, model")
+	}
 	if err != nil {
 		return nil, system.NewHTTPError500(err.Error())
 	}
+
 	totals, err := s.usageTotalsFor(r.Context(), q)
 	if err != nil {
 		return nil, system.NewHTTPError500(err.Error())
 	}
-	return &types.PaginatedUsageBySession{
+
+	return &types.UsageGroupedResponse{
+		GroupBy:    groupBy,
 		Rows:       rows,
 		Total:      *totals,
 		Page:       max1(q.Page),
@@ -289,41 +219,13 @@ func (s *HelixAPIServer) usageBySession(_ http.ResponseWriter, r *http.Request) 
 	}, nil
 }
 
-// usageByModel godoc
-// @Summary Usage grouped by model / provider
-// @Tags    usage
-// @Produce json
-// @Param   from       query  string  false  "Start of window (RFC3339)"
-// @Param   to         query  string  false  "End of window (RFC3339)"
-// @Param   org_id     query  string  false  "Organization id or slug"
-// @Param   sort_by    query  string  false  "Sort column"
-// @Param   sort_dir   query  string  false  "asc or desc"
-// @Param   page       query  int     false  "Page"
-// @Param   page_size  query  int     false  "Page size"
-// @Success 200 {object} types.PaginatedUsageByModel
-// @Router /api/v1/usage/aggregate/by-model [get]
-// @Security BearerAuth
-func (s *HelixAPIServer) usageByModel(_ http.ResponseWriter, r *http.Request) (*types.PaginatedUsageByModel, *system.HTTPError) {
-	q, httpErr := s.parseUsageQuery(r, false)
-	if httpErr != nil {
-		return nil, httpErr
-	}
-	rows, total, err := s.Store.GetUsageGroupedByModel(r.Context(), q)
+// unpackGroup is a tiny generic helper that lets the switch above call
+// the typed store methods uniformly without losing the row type.
+func unpackGroup[T any](rows []T, total int, err error) (any, int, error) {
 	if err != nil {
-		return nil, system.NewHTTPError500(err.Error())
+		return nil, 0, err
 	}
-	totals, err := s.usageTotalsFor(r.Context(), q)
-	if err != nil {
-		return nil, system.NewHTTPError500(err.Error())
-	}
-	return &types.PaginatedUsageByModel{
-		Rows:       rows,
-		Total:      *totals,
-		Page:       max1(q.Page),
-		PageSize:   q.PageSize,
-		TotalRows:  total,
-		TotalPages: pageTotals(total, q.PageSize),
-	}, nil
+	return rows, total, nil
 }
 
 // usageTotalsFor reuses GetUsageSummary to get the cross-page totals.
@@ -335,11 +237,4 @@ func (s *HelixAPIServer) usageTotalsFor(ctx context.Context, q *store.GroupedUsa
 		return nil, err
 	}
 	return &sum.UsageTotals, nil
-}
-
-func max1(n int) int {
-	if n < 1 {
-		return 1
-	}
-	return n
 }

--- a/api/pkg/server/usage_aggregate_handlers.go
+++ b/api/pkg/server/usage_aggregate_handlers.go
@@ -1,0 +1,345 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+const (
+	defaultUsageWindow      = 7 * 24 * time.Hour
+	maxUsageWindow          = 366 * 24 * time.Hour
+	defaultUsagePageSize    = 25
+	maxUsagePageSize        = 200
+	maxUsageExportRows      = 100_000
+)
+
+// parseUsageQuery turns the request's query string into a GroupedUsageQuery.
+// It applies auth: if org_id is set the caller must be a member; if empty
+// the caller must be a global admin. by-org callers pass requireAdmin=true
+// to reject org-scoped callers regardless of org_id.
+func (s *HelixAPIServer) parseUsageQuery(r *http.Request, requireAdmin bool) (*store.GroupedUsageQuery, *system.HTTPError) {
+	user := getRequestUser(r)
+	q := r.URL.Query()
+
+	// Org scoping.
+	orgParam := q.Get("org_id")
+	var orgID string
+	if orgParam != "" {
+		if requireAdmin && !isAdmin(user) {
+			return nil, system.NewHTTPError403("by-org listing is admin-only")
+		}
+		org, err := s.lookupOrg(r.Context(), orgParam)
+		if err != nil {
+			return nil, system.NewHTTPError404("organization not found")
+		}
+		if _, err := s.authorizeOrgMember(r.Context(), user, org.ID); err != nil {
+			return nil, system.NewHTTPError403(err.Error())
+		}
+		orgID = org.ID
+	} else if !isAdmin(user) {
+		return nil, system.NewHTTPError403("org_id is required for non-admin callers")
+	}
+
+	// Date range. Default to last 7 days, cap at 366 days.
+	now := time.Now()
+	to := now
+	from := now.Add(-defaultUsageWindow)
+	if v := q.Get("from"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return nil, system.NewHTTPError400("from must be RFC3339")
+		}
+		from = t
+	}
+	if v := q.Get("to"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return nil, system.NewHTTPError400("to must be RFC3339")
+		}
+		to = t
+	}
+	if !to.After(from) {
+		return nil, system.NewHTTPError400("to must be after from")
+	}
+	if to.Sub(from) > maxUsageWindow {
+		return nil, system.NewHTTPError400("date range exceeds 366 days")
+	}
+
+	page, _ := strconv.Atoi(q.Get("page"))
+	pageSize, _ := strconv.Atoi(q.Get("page_size"))
+	if pageSize <= 0 {
+		pageSize = defaultUsagePageSize
+	}
+	if pageSize > maxUsagePageSize {
+		pageSize = maxUsagePageSize
+	}
+
+	return &store.GroupedUsageQuery{
+		From:           from,
+		To:             to,
+		OrganizationID: orgID,
+		UserID:         q.Get("user_id"),
+		ProjectID:      q.Get("project_id"),
+		AppID:          q.Get("app_id"),
+		SessionID:      q.Get("session_id"),
+		Provider:       q.Get("provider"),
+		Model:          q.Get("model"),
+		SortBy:         q.Get("sort_by"),
+		SortDir:        q.Get("sort_dir"),
+		Page:           page,
+		PageSize:       pageSize,
+	}, nil
+}
+
+func pageTotals(totalRows, pageSize int) int {
+	if pageSize <= 0 || totalRows <= 0 {
+		return 0
+	}
+	return (totalRows + pageSize - 1) / pageSize
+}
+
+// usageSummary godoc
+// @Summary Aggregate usage summary
+// @Description Returns whole-set totals plus a daily time-series. Org owners must pass org_id matching their org; global admins may omit it to summarize cross-org.
+// @Tags    usage
+// @Produce json
+// @Param   from        query  string  false  "Start of window (RFC3339). Defaults to 7 days ago."
+// @Param   to          query  string  false  "End of window (RFC3339). Defaults to now."
+// @Param   org_id      query  string  false  "Organization id or slug. Required for non-admins."
+// @Param   user_id     query  string  false  "Filter by user id"
+// @Param   project_id  query  string  false  "Filter by project id"
+// @Param   app_id      query  string  false  "Filter by app id"
+// @Param   provider    query  string  false  "Filter by provider"
+// @Param   model       query  string  false  "Filter by model"
+// @Success 200 {object} types.UsageSummary
+// @Router /api/v1/usage/aggregate/summary [get]
+// @Security BearerAuth
+func (s *HelixAPIServer) usageSummary(_ http.ResponseWriter, r *http.Request) (*types.UsageSummary, *system.HTTPError) {
+	q, httpErr := s.parseUsageQuery(r, false)
+	if httpErr != nil {
+		return nil, httpErr
+	}
+	res, err := s.Store.GetUsageSummary(r.Context(), q)
+	if err != nil {
+		return nil, system.NewHTTPError500(err.Error())
+	}
+	return res, nil
+}
+
+// usageByOrg godoc
+// @Summary Usage grouped by organization
+// @Description Global-admin only. One row per organization with tokens, costs, user/session counts and last activity.
+// @Tags    usage
+// @Produce json
+// @Param   from       query  string  false  "Start of window (RFC3339)"
+// @Param   to         query  string  false  "End of window (RFC3339)"
+// @Param   sort_by    query  string  false  "Sort column: total_cost, total_tokens, request_count, last_activity"
+// @Param   sort_dir   query  string  false  "asc or desc"
+// @Param   page       query  int     false  "Page (1-indexed)"
+// @Param   page_size  query  int     false  "Page size (max 200, default 25)"
+// @Success 200 {object} types.PaginatedUsageByOrg
+// @Router /api/v1/usage/aggregate/by-org [get]
+// @Security BearerAuth
+func (s *HelixAPIServer) usageByOrg(_ http.ResponseWriter, r *http.Request) (*types.PaginatedUsageByOrg, *system.HTTPError) {
+	if !isAdmin(getRequestUser(r)) {
+		return nil, system.NewHTTPError403("by-org listing is admin-only")
+	}
+	q, httpErr := s.parseUsageQuery(r, true)
+	if httpErr != nil {
+		return nil, httpErr
+	}
+	rows, total, err := s.Store.GetUsageGroupedByOrg(r.Context(), q)
+	if err != nil {
+		return nil, system.NewHTTPError500(err.Error())
+	}
+	totals, err := s.usageTotalsFor(r.Context(), q)
+	if err != nil {
+		return nil, system.NewHTTPError500(err.Error())
+	}
+	return &types.PaginatedUsageByOrg{
+		Rows:       rows,
+		Total:      *totals,
+		Page:       max1(q.Page),
+		PageSize:   q.PageSize,
+		TotalRows:  total,
+		TotalPages: pageTotals(total, q.PageSize),
+	}, nil
+}
+
+// usageByUser godoc
+// @Summary Usage grouped by user
+// @Description Org members get rows scoped to their org. Global admins may omit org_id to list across all orgs.
+// @Tags    usage
+// @Produce json
+// @Param   from       query  string  false  "Start of window (RFC3339)"
+// @Param   to         query  string  false  "End of window (RFC3339)"
+// @Param   org_id     query  string  false  "Organization id or slug. Required for non-admins."
+// @Param   sort_by    query  string  false  "Sort column"
+// @Param   sort_dir   query  string  false  "asc or desc"
+// @Param   page       query  int     false  "Page"
+// @Param   page_size  query  int     false  "Page size"
+// @Success 200 {object} types.PaginatedUsageByUser
+// @Router /api/v1/usage/aggregate/by-user [get]
+// @Security BearerAuth
+func (s *HelixAPIServer) usageByUser(_ http.ResponseWriter, r *http.Request) (*types.PaginatedUsageByUser, *system.HTTPError) {
+	q, httpErr := s.parseUsageQuery(r, false)
+	if httpErr != nil {
+		return nil, httpErr
+	}
+	rows, total, err := s.Store.GetUsageGroupedByUser(r.Context(), q)
+	if err != nil {
+		return nil, system.NewHTTPError500(err.Error())
+	}
+	totals, err := s.usageTotalsFor(r.Context(), q)
+	if err != nil {
+		return nil, system.NewHTTPError500(err.Error())
+	}
+	return &types.PaginatedUsageByUser{
+		Rows:       rows,
+		Total:      *totals,
+		Page:       max1(q.Page),
+		PageSize:   q.PageSize,
+		TotalRows:  total,
+		TotalPages: pageTotals(total, q.PageSize),
+	}, nil
+}
+
+// usageByProject godoc
+// @Summary Usage grouped by project / app / agent
+// @Tags    usage
+// @Produce json
+// @Param   from       query  string  false  "Start of window (RFC3339)"
+// @Param   to         query  string  false  "End of window (RFC3339)"
+// @Param   org_id     query  string  false  "Organization id or slug"
+// @Param   user_id    query  string  false  "Filter by user id"
+// @Param   sort_by    query  string  false  "Sort column"
+// @Param   sort_dir   query  string  false  "asc or desc"
+// @Param   page       query  int     false  "Page"
+// @Param   page_size  query  int     false  "Page size"
+// @Success 200 {object} types.PaginatedUsageByProject
+// @Router /api/v1/usage/aggregate/by-project [get]
+// @Security BearerAuth
+func (s *HelixAPIServer) usageByProject(_ http.ResponseWriter, r *http.Request) (*types.PaginatedUsageByProject, *system.HTTPError) {
+	q, httpErr := s.parseUsageQuery(r, false)
+	if httpErr != nil {
+		return nil, httpErr
+	}
+	rows, total, err := s.Store.GetUsageGroupedByProject(r.Context(), q)
+	if err != nil {
+		return nil, system.NewHTTPError500(err.Error())
+	}
+	totals, err := s.usageTotalsFor(r.Context(), q)
+	if err != nil {
+		return nil, system.NewHTTPError500(err.Error())
+	}
+	return &types.PaginatedUsageByProject{
+		Rows:       rows,
+		Total:      *totals,
+		Page:       max1(q.Page),
+		PageSize:   q.PageSize,
+		TotalRows:  total,
+		TotalPages: pageTotals(total, q.PageSize),
+	}, nil
+}
+
+// usageBySession godoc
+// @Summary Usage grouped by session
+// @Tags    usage
+// @Produce json
+// @Param   from        query  string  false  "Start of window (RFC3339)"
+// @Param   to          query  string  false  "End of window (RFC3339)"
+// @Param   org_id      query  string  false  "Organization id or slug"
+// @Param   user_id     query  string  false  "Filter by user id"
+// @Param   project_id  query  string  false  "Filter by project id"
+// @Param   provider    query  string  false  "Filter by provider"
+// @Param   model       query  string  false  "Filter by model"
+// @Param   sort_by     query  string  false  "Sort column"
+// @Param   sort_dir    query  string  false  "asc or desc"
+// @Param   page        query  int     false  "Page"
+// @Param   page_size   query  int     false  "Page size"
+// @Success 200 {object} types.PaginatedUsageBySession
+// @Router /api/v1/usage/aggregate/by-session [get]
+// @Security BearerAuth
+func (s *HelixAPIServer) usageBySession(_ http.ResponseWriter, r *http.Request) (*types.PaginatedUsageBySession, *system.HTTPError) {
+	q, httpErr := s.parseUsageQuery(r, false)
+	if httpErr != nil {
+		return nil, httpErr
+	}
+	rows, total, err := s.Store.GetUsageGroupedBySession(r.Context(), q)
+	if err != nil {
+		return nil, system.NewHTTPError500(err.Error())
+	}
+	totals, err := s.usageTotalsFor(r.Context(), q)
+	if err != nil {
+		return nil, system.NewHTTPError500(err.Error())
+	}
+	return &types.PaginatedUsageBySession{
+		Rows:       rows,
+		Total:      *totals,
+		Page:       max1(q.Page),
+		PageSize:   q.PageSize,
+		TotalRows:  total,
+		TotalPages: pageTotals(total, q.PageSize),
+	}, nil
+}
+
+// usageByModel godoc
+// @Summary Usage grouped by model / provider
+// @Tags    usage
+// @Produce json
+// @Param   from       query  string  false  "Start of window (RFC3339)"
+// @Param   to         query  string  false  "End of window (RFC3339)"
+// @Param   org_id     query  string  false  "Organization id or slug"
+// @Param   sort_by    query  string  false  "Sort column"
+// @Param   sort_dir   query  string  false  "asc or desc"
+// @Param   page       query  int     false  "Page"
+// @Param   page_size  query  int     false  "Page size"
+// @Success 200 {object} types.PaginatedUsageByModel
+// @Router /api/v1/usage/aggregate/by-model [get]
+// @Security BearerAuth
+func (s *HelixAPIServer) usageByModel(_ http.ResponseWriter, r *http.Request) (*types.PaginatedUsageByModel, *system.HTTPError) {
+	q, httpErr := s.parseUsageQuery(r, false)
+	if httpErr != nil {
+		return nil, httpErr
+	}
+	rows, total, err := s.Store.GetUsageGroupedByModel(r.Context(), q)
+	if err != nil {
+		return nil, system.NewHTTPError500(err.Error())
+	}
+	totals, err := s.usageTotalsFor(r.Context(), q)
+	if err != nil {
+		return nil, system.NewHTTPError500(err.Error())
+	}
+	return &types.PaginatedUsageByModel{
+		Rows:       rows,
+		Total:      *totals,
+		Page:       max1(q.Page),
+		PageSize:   q.PageSize,
+		TotalRows:  total,
+		TotalPages: pageTotals(total, q.PageSize),
+	}, nil
+}
+
+// usageTotalsFor reuses GetUsageSummary to get the cross-page totals.
+// Cheaper than another round of aggregate SQL since summary already
+// produces them.
+func (s *HelixAPIServer) usageTotalsFor(ctx context.Context, q *store.GroupedUsageQuery) (*types.UsageTotals, error) {
+	sum, err := s.Store.GetUsageSummary(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	return &sum.UsageTotals, nil
+}
+
+func max1(n int) int {
+	if n < 1 {
+		return 1
+	}
+	return n
+}

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -455,6 +455,14 @@ type Store interface {
 	GetAggregatedUsageMetrics(ctx context.Context, q *GetAggregatedUsageMetricsQuery) ([]*types.AggregatedUsageMetric, error)
 	GetSandboxUsageMetrics(ctx context.Context, q *GetAggregatedUsageMetricsQuery) ([]*types.AggregatedUsageMetric, error)
 
+	// Aggregate usage dashboard backends. See store_usage_aggregate.go.
+	GetUsageSummary(ctx context.Context, q *GroupedUsageQuery) (*types.UsageSummary, error)
+	GetUsageGroupedByOrg(ctx context.Context, q *GroupedUsageQuery) ([]*types.UsageByOrg, int, error)
+	GetUsageGroupedByUser(ctx context.Context, q *GroupedUsageQuery) ([]*types.UsageByUser, int, error)
+	GetUsageGroupedByProject(ctx context.Context, q *GroupedUsageQuery) ([]*types.UsageByProject, int, error)
+	GetUsageGroupedBySession(ctx context.Context, q *GroupedUsageQuery) ([]*types.UsageBySession, int, error)
+	GetUsageGroupedByModel(ctx context.Context, q *GroupedUsageQuery) ([]*types.UsageByModel, int, error)
+
 	CreateSlackThread(ctx context.Context, thread *types.SlackThread) (*types.SlackThread, error)
 	GetSlackThread(ctx context.Context, appID, channel, threadKey string) (*types.SlackThread, error)
 	GetSlackThreadBySpecTaskID(ctx context.Context, appID, specTaskID string) (*types.SlackThread, error)

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -24,6 +24,7 @@ import (
 type MockStore struct {
 	ctrl     *gomock.Controller
 	recorder *MockStoreMockRecorder
+	isgomock struct{}
 }
 
 // MockStoreMockRecorder is the mock recorder for MockStore.
@@ -3598,6 +3599,101 @@ func (m *MockStore) GetUnresolvedCommentsForTask(ctx context.Context, specTaskID
 func (mr *MockStoreMockRecorder) GetUnresolvedCommentsForTask(ctx, specTaskID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnresolvedCommentsForTask", reflect.TypeOf((*MockStore)(nil).GetUnresolvedCommentsForTask), ctx, specTaskID)
+}
+
+// GetUsageGroupedByModel mocks base method.
+func (m *MockStore) GetUsageGroupedByModel(ctx context.Context, q *GroupedUsageQuery) ([]*types.UsageByModel, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUsageGroupedByModel", ctx, q)
+	ret0, _ := ret[0].([]*types.UsageByModel)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetUsageGroupedByModel indicates an expected call of GetUsageGroupedByModel.
+func (mr *MockStoreMockRecorder) GetUsageGroupedByModel(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsageGroupedByModel", reflect.TypeOf((*MockStore)(nil).GetUsageGroupedByModel), ctx, q)
+}
+
+// GetUsageGroupedByOrg mocks base method.
+func (m *MockStore) GetUsageGroupedByOrg(ctx context.Context, q *GroupedUsageQuery) ([]*types.UsageByOrg, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUsageGroupedByOrg", ctx, q)
+	ret0, _ := ret[0].([]*types.UsageByOrg)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetUsageGroupedByOrg indicates an expected call of GetUsageGroupedByOrg.
+func (mr *MockStoreMockRecorder) GetUsageGroupedByOrg(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsageGroupedByOrg", reflect.TypeOf((*MockStore)(nil).GetUsageGroupedByOrg), ctx, q)
+}
+
+// GetUsageGroupedByProject mocks base method.
+func (m *MockStore) GetUsageGroupedByProject(ctx context.Context, q *GroupedUsageQuery) ([]*types.UsageByProject, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUsageGroupedByProject", ctx, q)
+	ret0, _ := ret[0].([]*types.UsageByProject)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetUsageGroupedByProject indicates an expected call of GetUsageGroupedByProject.
+func (mr *MockStoreMockRecorder) GetUsageGroupedByProject(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsageGroupedByProject", reflect.TypeOf((*MockStore)(nil).GetUsageGroupedByProject), ctx, q)
+}
+
+// GetUsageGroupedBySession mocks base method.
+func (m *MockStore) GetUsageGroupedBySession(ctx context.Context, q *GroupedUsageQuery) ([]*types.UsageBySession, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUsageGroupedBySession", ctx, q)
+	ret0, _ := ret[0].([]*types.UsageBySession)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetUsageGroupedBySession indicates an expected call of GetUsageGroupedBySession.
+func (mr *MockStoreMockRecorder) GetUsageGroupedBySession(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsageGroupedBySession", reflect.TypeOf((*MockStore)(nil).GetUsageGroupedBySession), ctx, q)
+}
+
+// GetUsageGroupedByUser mocks base method.
+func (m *MockStore) GetUsageGroupedByUser(ctx context.Context, q *GroupedUsageQuery) ([]*types.UsageByUser, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUsageGroupedByUser", ctx, q)
+	ret0, _ := ret[0].([]*types.UsageByUser)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetUsageGroupedByUser indicates an expected call of GetUsageGroupedByUser.
+func (mr *MockStoreMockRecorder) GetUsageGroupedByUser(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsageGroupedByUser", reflect.TypeOf((*MockStore)(nil).GetUsageGroupedByUser), ctx, q)
+}
+
+// GetUsageSummary mocks base method.
+func (m *MockStore) GetUsageSummary(ctx context.Context, q *GroupedUsageQuery) (*types.UsageSummary, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUsageSummary", ctx, q)
+	ret0, _ := ret[0].(*types.UsageSummary)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUsageSummary indicates an expected call of GetUsageSummary.
+func (mr *MockStoreMockRecorder) GetUsageSummary(ctx, q any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsageSummary", reflect.TypeOf((*MockStore)(nil).GetUsageSummary), ctx, q)
 }
 
 // GetUser mocks base method.

--- a/api/pkg/store/store_usage_aggregate.go
+++ b/api/pkg/store/store_usage_aggregate.go
@@ -1,0 +1,416 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/types"
+	"gorm.io/gorm"
+)
+
+// GroupedUsageQuery is the shared filter+pagination shape used by every
+// /api/v1/usage/aggregate/* endpoint. All filters AND together; empty
+// fields are not filtered. From/To are required and must be set by the
+// caller (the handler defaults them to the last 7 days).
+type GroupedUsageQuery struct {
+	From, To time.Time
+
+	OrganizationID string
+	UserID         string
+	ProjectID      string
+	AppID          string
+	SessionID      string
+	Provider       string
+	Model          string
+
+	// SortBy is one of the column aliases produced by the query
+	// (e.g. "total_cost", "total_tokens", "request_count", "last_activity").
+	// Invalid values fall back to a sensible default per endpoint.
+	SortBy  string
+	SortDir string // "asc" or "desc"; defaults to "desc"
+
+	Page     int // 1-indexed
+	PageSize int
+}
+
+// applyUsageFilters adds the WHERE clauses common to every aggregate
+// query to a *gorm.DB selecting from usage_metrics.
+func applyUsageFilters(db *gorm.DB, q *GroupedUsageQuery) *gorm.DB {
+	db = db.Where("created >= ? AND created <= ?", q.From, q.To)
+	if q.OrganizationID != "" {
+		db = db.Where("organization_id = ?", q.OrganizationID)
+	}
+	if q.UserID != "" {
+		db = db.Where("user_id = ?", q.UserID)
+	}
+	if q.ProjectID != "" {
+		db = db.Where("project_id = ?", q.ProjectID)
+	}
+	if q.AppID != "" {
+		db = db.Where("app_id = ?", q.AppID)
+	}
+	if q.SessionID != "" {
+		// usage_metrics has interaction_id, not session_id. Resolve via
+		// the sessions table - one session has many interactions.
+		db = db.Where("interaction_id IN (?)",
+			db.Session(&gorm.Session{NewDB: true}).
+				Table("interactions").
+				Select("id").
+				Where("session_id = ?", q.SessionID))
+	}
+	if q.Provider != "" {
+		db = db.Where("provider = ?", q.Provider)
+	}
+	if q.Model != "" {
+		db = db.Where("model = ?", q.Model)
+	}
+	return db
+}
+
+// usageTotalsSelect is the SELECT fragment producing every UsageTotals
+// column. Used as a base for the GROUP BY queries.
+const usageTotalsSelect = `
+	COALESCE(SUM(prompt_tokens), 0)        AS prompt_tokens,
+	COALESCE(SUM(completion_tokens), 0)    AS completion_tokens,
+	COALESCE(SUM(cache_read_tokens), 0)    AS cache_read_tokens,
+	COALESCE(SUM(cache_write_tokens), 0)   AS cache_write_tokens,
+	COALESCE(SUM(total_tokens), 0)         AS total_tokens,
+	COALESCE(SUM(prompt_cost), 0)          AS prompt_cost,
+	COALESCE(SUM(completion_cost), 0)      AS completion_cost,
+	COALESCE(SUM(cache_read_cost), 0)      AS cache_read_cost,
+	COALESCE(SUM(cache_write_cost), 0)     AS cache_write_cost,
+	COALESCE(SUM(total_cost), 0)           AS total_cost,
+	COUNT(DISTINCT interaction_id)         AS request_count
+`
+
+func paginate(page, pageSize int) (offset, limit int) {
+	if pageSize <= 0 {
+		pageSize = 25
+	}
+	if pageSize > 200 {
+		pageSize = 200
+	}
+	if page <= 0 {
+		page = 1
+	}
+	return (page - 1) * pageSize, pageSize
+}
+
+func orderClause(sortBy, sortDir string, allowed map[string]string, fallback string) string {
+	col, ok := allowed[sortBy]
+	if !ok {
+		col = allowed[fallback]
+	}
+	dir := "DESC"
+	if sortDir == "asc" || sortDir == "ASC" {
+		dir = "ASC"
+	}
+	return col + " " + dir
+}
+
+// GetUsageSummary returns whole-set totals plus a daily time-series.
+// The handler is responsible for whichever scoping (cross-org, org-locked)
+// is appropriate to the caller's role.
+func (s *PostgresStore) GetUsageSummary(ctx context.Context, q *GroupedUsageQuery) (*types.UsageSummary, error) {
+	totals, err := s.usageTotals(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("get usage totals: %w", err)
+	}
+
+	// Distinct counts for active users / sessions / projects within the
+	// filtered window. Cheap on indexed columns.
+	var counts struct {
+		ActiveUsers    int
+		ActiveSessions int
+		ActiveProjects int
+	}
+	base := applyUsageFilters(s.gdb.WithContext(ctx).Model(&types.UsageMetric{}), q)
+	if err := base.
+		Select(`
+			COUNT(DISTINCT user_id) AS active_users,
+			COUNT(DISTINCT (
+				SELECT i.session_id FROM interactions i
+				WHERE i.id = usage_metrics.interaction_id
+			)) AS active_sessions,
+			COUNT(DISTINCT project_id) AS active_projects
+		`).
+		Scan(&counts).Error; err != nil {
+		return nil, fmt.Errorf("get usage counts: %w", err)
+	}
+
+	// Time series: reuse the existing aggregate that already handles
+	// fill-in-missing-dates and the various aggregation levels.
+	series, err := s.GetAggregatedUsageMetrics(ctx, &GetAggregatedUsageMetricsQuery{
+		From:           q.From,
+		To:             q.To,
+		OrganizationID: q.OrganizationID,
+		UserID:         q.UserID,
+		ProjectID:      q.ProjectID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get usage time series: %w", err)
+	}
+
+	return &types.UsageSummary{
+		From:           q.From,
+		To:             q.To,
+		UsageTotals:    *totals,
+		ActiveUsers:    counts.ActiveUsers,
+		ActiveSessions: counts.ActiveSessions,
+		ActiveProjects: counts.ActiveProjects,
+		TimeSeries:     series,
+	}, nil
+}
+
+func (s *PostgresStore) usageTotals(ctx context.Context, q *GroupedUsageQuery) (*types.UsageTotals, error) {
+	var t types.UsageTotals
+	err := applyUsageFilters(s.gdb.WithContext(ctx).Model(&types.UsageMetric{}), q).
+		Select(usageTotalsSelect).
+		Scan(&t).Error
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+var byOrgSortCols = map[string]string{
+	"total_cost":    "total_cost",
+	"total_tokens":  "total_tokens",
+	"request_count": "request_count",
+	"last_activity": "last_activity",
+	"":              "total_cost",
+}
+
+// GetUsageGroupedByOrg aggregates usage by organization. Global admin only;
+// the handler must enforce that.
+func (s *PostgresStore) GetUsageGroupedByOrg(ctx context.Context, q *GroupedUsageQuery) ([]*types.UsageByOrg, int, error) {
+	base := applyUsageFilters(s.gdb.WithContext(ctx).Model(&types.UsageMetric{}), q).
+		Where("organization_id != ''")
+
+	var totalRows int64
+	if err := base.Session(&gorm.Session{}).
+		Distinct("organization_id").
+		Count(&totalRows).Error; err != nil {
+		return nil, 0, fmt.Errorf("count orgs: %w", err)
+	}
+
+	offset, limit := paginate(q.Page, q.PageSize)
+	order := orderClause(q.SortBy, q.SortDir, byOrgSortCols, "")
+
+	var rows []*types.UsageByOrg
+	err := base.
+		Select(`
+			usage_metrics.organization_id          AS organization_id,
+			COALESCE(orgs.display_name, orgs.name) AS organization_name,
+			` + usageTotalsSelect + `,
+			COUNT(DISTINCT user_id)    AS user_count,
+			COUNT(DISTINCT (SELECT i.session_id FROM interactions i WHERE i.id = usage_metrics.interaction_id)) AS session_count,
+			MAX(created) AS last_activity
+		`).
+		Joins("LEFT JOIN organizations orgs ON orgs.id = usage_metrics.organization_id").
+		Group("usage_metrics.organization_id, organization_name").
+		Order(order).
+		Offset(offset).
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("list orgs: %w", err)
+	}
+	return rows, int(totalRows), nil
+}
+
+var byUserSortCols = map[string]string{
+	"total_cost":    "total_cost",
+	"total_tokens":  "total_tokens",
+	"request_count": "request_count",
+	"last_activity": "last_activity",
+	"":              "total_cost",
+}
+
+func (s *PostgresStore) GetUsageGroupedByUser(ctx context.Context, q *GroupedUsageQuery) ([]*types.UsageByUser, int, error) {
+	base := applyUsageFilters(s.gdb.WithContext(ctx).Model(&types.UsageMetric{}), q).
+		Where("user_id != ''")
+
+	var totalRows int64
+	if err := base.Session(&gorm.Session{}).
+		Distinct("user_id").
+		Count(&totalRows).Error; err != nil {
+		return nil, 0, fmt.Errorf("count users: %w", err)
+	}
+
+	offset, limit := paginate(q.Page, q.PageSize)
+	order := orderClause(q.SortBy, q.SortDir, byUserSortCols, "")
+
+	var rows []*types.UsageByUser
+	err := base.
+		Select(`
+			usage_metrics.user_id              AS user_id,
+			COALESCE(users.email, '')          AS email,
+			usage_metrics.organization_id      AS organization_id,
+			` + usageTotalsSelect + `,
+			COUNT(DISTINCT (SELECT i.session_id FROM interactions i WHERE i.id = usage_metrics.interaction_id)) AS session_count,
+			MAX(created) AS last_activity
+		`).
+		Joins("LEFT JOIN users ON users.id = usage_metrics.user_id").
+		Group("usage_metrics.user_id, users.email, usage_metrics.organization_id").
+		Order(order).
+		Offset(offset).
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("list users: %w", err)
+	}
+	return rows, int(totalRows), nil
+}
+
+var byProjectSortCols = map[string]string{
+	"total_cost":    "total_cost",
+	"total_tokens":  "total_tokens",
+	"request_count": "request_count",
+	"":              "total_cost",
+}
+
+func (s *PostgresStore) GetUsageGroupedByProject(ctx context.Context, q *GroupedUsageQuery) ([]*types.UsageByProject, int, error) {
+	// Group by (project_id, app_id) so both project-level and
+	// app-level rows surface. The handler can fan out by Kind.
+	base := applyUsageFilters(s.gdb.WithContext(ctx).Model(&types.UsageMetric{}), q).
+		Where("project_id != '' OR app_id != ''")
+
+	var totalRows int64
+	if err := base.Session(&gorm.Session{}).
+		Distinct("project_id", "app_id").
+		Count(&totalRows).Error; err != nil {
+		return nil, 0, fmt.Errorf("count projects: %w", err)
+	}
+
+	offset, limit := paginate(q.Page, q.PageSize)
+	order := orderClause(q.SortBy, q.SortDir, byProjectSortCols, "")
+
+	var rows []*types.UsageByProject
+	err := base.
+		Select(`
+			usage_metrics.project_id           AS project_id,
+			usage_metrics.app_id               AS app_id,
+			COALESCE(NULLIF(apps.id, ''), projects.id, '') AS _ignore_id,
+			COALESCE(NULLIF(apps.id, ''), projects.name, '') AS name,
+			CASE WHEN usage_metrics.app_id != '' THEN 'app' ELSE 'project' END AS kind,
+			COALESCE(NULLIF(apps.owner, ''), projects.owner, '') AS owner_user_id,
+			usage_metrics.organization_id      AS organization_id,
+			` + usageTotalsSelect + `,
+			COUNT(DISTINCT (SELECT i.session_id FROM interactions i WHERE i.id = usage_metrics.interaction_id)) AS session_count
+		`).
+		Joins("LEFT JOIN projects ON projects.id = usage_metrics.project_id").
+		Joins("LEFT JOIN apps ON apps.id = usage_metrics.app_id").
+		Group("usage_metrics.project_id, usage_metrics.app_id, apps.id, apps.owner, projects.id, projects.name, projects.owner, usage_metrics.organization_id").
+		Order(order).
+		Offset(offset).
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("list projects: %w", err)
+	}
+	return rows, int(totalRows), nil
+}
+
+var bySessionSortCols = map[string]string{
+	"total_cost":   "total_cost",
+	"total_tokens": "total_tokens",
+	"call_count":   "call_count",
+	"started_at":   "started_at",
+	"ended_at":     "ended_at",
+	"":             "ended_at",
+}
+
+func (s *PostgresStore) GetUsageGroupedBySession(ctx context.Context, q *GroupedUsageQuery) ([]*types.UsageBySession, int, error) {
+	base := applyUsageFilters(s.gdb.WithContext(ctx).Model(&types.UsageMetric{}), q).
+		Joins("INNER JOIN interactions ON interactions.id = usage_metrics.interaction_id")
+
+	var totalRows int64
+	if err := base.Session(&gorm.Session{}).
+		Distinct("interactions.session_id").
+		Count(&totalRows).Error; err != nil {
+		return nil, 0, fmt.Errorf("count sessions: %w", err)
+	}
+
+	offset, limit := paginate(q.Page, q.PageSize)
+	order := orderClause(q.SortBy, q.SortDir, bySessionSortCols, "")
+
+	var rows []*types.UsageBySession
+	err := base.
+		Select(`
+			interactions.session_id        AS session_id,
+			COALESCE(sessions.name, '')    AS name,
+			usage_metrics.user_id          AS user_id,
+			usage_metrics.project_id       AS project_id,
+			usage_metrics.organization_id  AS organization_id,
+			MAX(usage_metrics.provider)    AS provider,
+			MAX(usage_metrics.model)       AS model,
+			COALESCE(SUM(usage_metrics.prompt_tokens), 0)      AS prompt_tokens,
+			COALESCE(SUM(usage_metrics.completion_tokens), 0)  AS completion_tokens,
+			COALESCE(SUM(usage_metrics.cache_read_tokens), 0)  AS cache_read_tokens,
+			COALESCE(SUM(usage_metrics.cache_write_tokens), 0) AS cache_write_tokens,
+			COALESCE(SUM(usage_metrics.total_tokens), 0)       AS total_tokens,
+			COALESCE(SUM(usage_metrics.prompt_cost), 0)        AS prompt_cost,
+			COALESCE(SUM(usage_metrics.completion_cost), 0)    AS completion_cost,
+			COALESCE(SUM(usage_metrics.cache_read_cost), 0)    AS cache_read_cost,
+			COALESCE(SUM(usage_metrics.cache_write_cost), 0)   AS cache_write_cost,
+			COALESCE(SUM(usage_metrics.total_cost), 0)         AS total_cost,
+			COUNT(DISTINCT usage_metrics.interaction_id)       AS request_count,
+			COUNT(DISTINCT usage_metrics.interaction_id)       AS call_count,
+			MIN(usage_metrics.created)     AS started_at,
+			MAX(usage_metrics.created)     AS ended_at
+		`).
+		Joins("LEFT JOIN sessions ON sessions.id = interactions.session_id").
+		Group("interactions.session_id, sessions.name, usage_metrics.user_id, usage_metrics.project_id, usage_metrics.organization_id").
+		Order(order).
+		Offset(offset).
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("list sessions: %w", err)
+	}
+	return rows, int(totalRows), nil
+}
+
+var byModelSortCols = map[string]string{
+	"total_cost":    "total_cost",
+	"total_tokens":  "total_tokens",
+	"request_count": "request_count",
+	"":              "total_cost",
+}
+
+func (s *PostgresStore) GetUsageGroupedByModel(ctx context.Context, q *GroupedUsageQuery) ([]*types.UsageByModel, int, error) {
+	base := applyUsageFilters(s.gdb.WithContext(ctx).Model(&types.UsageMetric{}), q).
+		Where("provider != '' AND model != ''")
+
+	var totalRows int64
+	if err := base.Session(&gorm.Session{}).
+		Distinct("provider", "model").
+		Count(&totalRows).Error; err != nil {
+		return nil, 0, fmt.Errorf("count models: %w", err)
+	}
+
+	offset, limit := paginate(q.Page, q.PageSize)
+	order := orderClause(q.SortBy, q.SortDir, byModelSortCols, "")
+
+	var rows []*types.UsageByModel
+	err := base.
+		Select(`
+			provider,
+			model,
+			` + usageTotalsSelect + `,
+			COUNT(DISTINCT user_id) AS unique_users,
+			COUNT(DISTINCT (SELECT i.session_id FROM interactions i WHERE i.id = usage_metrics.interaction_id)) AS unique_sessions,
+			COUNT(DISTINCT project_id) AS unique_projects
+		`).
+		Group("provider, model").
+		Order(order).
+		Offset(offset).
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, 0, fmt.Errorf("list models: %w", err)
+	}
+	return rows, int(totalRows), nil
+}

--- a/api/pkg/store/store_usage_aggregate_test.go
+++ b/api/pkg/store/store_usage_aggregate_test.go
@@ -1,0 +1,204 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestUsageAggregateTestSuite(t *testing.T) {
+	suite.Run(t, new(UsageAggregateTestSuite))
+}
+
+type UsageAggregateTestSuite struct {
+	suite.Suite
+	ctx context.Context
+	db  *PostgresStore
+}
+
+func (s *UsageAggregateTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.db = GetTestDB()
+}
+
+func (s *UsageAggregateTestSuite) TearDownTestSuite() {
+	_ = s.db.Close()
+}
+
+// seedRow creates a usage_metrics row plus an interaction tied to a
+// session so the SUBSELECT-based session-distinct counts in the
+// aggregate queries can find a value.
+func (s *UsageAggregateTestSuite) seedRow(orgID, userID, projectID, appID, sessionID, model string, promptTokens int, cost float64) {
+	interactionID := "int_" + system.GenerateID()
+
+	_, err := s.db.CreateUsageMetric(s.ctx, &types.UsageMetric{
+		OrganizationID:   orgID,
+		UserID:           userID,
+		ProjectID:        projectID,
+		AppID:            appID,
+		InteractionID:    interactionID,
+		Created:          time.Now(),
+		Date:             time.Now().Truncate(24 * time.Hour),
+		Provider:         string(types.ProviderAnthropic),
+		Model:            model,
+		PromptTokens:     promptTokens,
+		CompletionTokens: promptTokens / 4,
+		CacheReadTokens:  promptTokens / 10,
+		CacheWriteTokens: promptTokens / 20,
+		TotalTokens:      promptTokens + promptTokens/4 + promptTokens/10 + promptTokens/20,
+		PromptCost:       cost,
+		CompletionCost:   cost * 5,
+		CacheReadCost:    cost * 0.1,
+		CacheWriteCost:   cost * 1.25,
+		TotalCost:        cost + cost*5 + cost*0.1 + cost*1.25,
+	})
+	s.Require().NoError(err)
+
+	if sessionID != "" {
+		// Seed a minimal interaction row so the SUBSELECT for session_id
+		// resolves. Using GORM Create directly to avoid the heavyweight
+		// CreateInteraction logic.
+		err := s.db.gdb.WithContext(s.ctx).Exec(
+			"INSERT INTO interactions (id, session_id, created_at, updated_at) VALUES (?, ?, NOW(), NOW())",
+			interactionID, sessionID,
+		).Error
+		s.Require().NoError(err)
+	}
+}
+
+func (s *UsageAggregateTestSuite) buildQuery(orgID string) *GroupedUsageQuery {
+	return &GroupedUsageQuery{
+		From:           time.Now().Add(-24 * time.Hour),
+		To:             time.Now().Add(24 * time.Hour),
+		OrganizationID: orgID,
+		Page:           1,
+		PageSize:       50,
+	}
+}
+
+func (s *UsageAggregateTestSuite) TestGetUsageSummary() {
+	orgID := "org_" + system.GenerateID()
+	userA := "user_" + system.GenerateID()
+	userB := "user_" + system.GenerateID()
+	sessionA := "ses_" + system.GenerateID()
+	sessionB := "ses_" + system.GenerateID()
+
+	s.seedRow(orgID, userA, "prj_x", "", sessionA, "claude-opus-4-7", 1000, 0.01)
+	s.seedRow(orgID, userA, "prj_x", "", sessionA, "claude-opus-4-7", 2000, 0.02)
+	s.seedRow(orgID, userB, "prj_y", "", sessionB, "claude-sonnet-4-6", 500, 0.005)
+
+	sum, err := s.db.GetUsageSummary(s.ctx, s.buildQuery(orgID))
+	s.Require().NoError(err)
+	s.Equal(3500, sum.PromptTokens, "prompt tokens")
+	s.InDelta(0.035, sum.PromptCost, 1e-9, "prompt cost")
+	s.Equal(3, sum.RequestCount, "request count")
+	s.Equal(2, sum.ActiveUsers)
+	s.Equal(2, sum.ActiveSessions)
+	s.Equal(2, sum.ActiveProjects)
+	s.NotEmpty(sum.TimeSeries)
+}
+
+func (s *UsageAggregateTestSuite) TestGetUsageGroupedByUser() {
+	orgID := "org_" + system.GenerateID()
+	userA := "user_" + system.GenerateID()
+	userB := "user_" + system.GenerateID()
+
+	s.seedRow(orgID, userA, "prj_x", "", "ses_"+system.GenerateID(), "claude-opus-4-7", 1000, 0.01)
+	s.seedRow(orgID, userA, "prj_x", "", "ses_"+system.GenerateID(), "claude-opus-4-7", 2000, 0.02)
+	s.seedRow(orgID, userB, "prj_y", "", "ses_"+system.GenerateID(), "claude-sonnet-4-6", 500, 0.005)
+
+	rows, total, err := s.db.GetUsageGroupedByUser(s.ctx, s.buildQuery(orgID))
+	s.Require().NoError(err)
+	s.Equal(2, total)
+	s.Len(rows, 2)
+	// Sorted by total_cost desc by default -> userA first
+	s.Equal(userA, rows[0].UserID)
+	s.Equal(3000, rows[0].PromptTokens)
+	s.InDelta(0.03, rows[0].PromptCost, 1e-9)
+	s.Equal(userB, rows[1].UserID)
+}
+
+func (s *UsageAggregateTestSuite) TestGetUsageGroupedByModel() {
+	orgID := "org_" + system.GenerateID()
+	user := "user_" + system.GenerateID()
+	s.seedRow(orgID, user, "prj_x", "", "ses_"+system.GenerateID(), "claude-opus-4-7", 1000, 0.01)
+	s.seedRow(orgID, user, "prj_x", "", "ses_"+system.GenerateID(), "claude-opus-4-7", 2000, 0.02)
+	s.seedRow(orgID, user, "prj_x", "", "ses_"+system.GenerateID(), "claude-sonnet-4-6", 500, 0.005)
+
+	rows, total, err := s.db.GetUsageGroupedByModel(s.ctx, s.buildQuery(orgID))
+	s.Require().NoError(err)
+	s.Equal(2, total)
+	s.Len(rows, 2)
+	s.Equal("claude-opus-4-7", rows[0].Model)
+	s.Equal(3000, rows[0].PromptTokens)
+	s.Equal("claude-sonnet-4-6", rows[1].Model)
+}
+
+func (s *UsageAggregateTestSuite) TestGetUsageGroupedBySession() {
+	orgID := "org_" + system.GenerateID()
+	user := "user_" + system.GenerateID()
+	sessA := "ses_" + system.GenerateID()
+	sessB := "ses_" + system.GenerateID()
+
+	s.seedRow(orgID, user, "prj_x", "", sessA, "claude-opus-4-7", 1000, 0.01)
+	s.seedRow(orgID, user, "prj_x", "", sessA, "claude-opus-4-7", 2000, 0.02)
+	s.seedRow(orgID, user, "prj_x", "", sessB, "claude-opus-4-7", 500, 0.005)
+
+	rows, total, err := s.db.GetUsageGroupedBySession(s.ctx, s.buildQuery(orgID))
+	s.Require().NoError(err)
+	s.Equal(2, total)
+	s.Len(rows, 2)
+	// ordered by ended_at desc, both seeded "now"; assert presence
+	ids := map[string]int{rows[0].SessionID: rows[0].PromptTokens, rows[1].SessionID: rows[1].PromptTokens}
+	s.Equal(3000, ids[sessA])
+	s.Equal(500, ids[sessB])
+}
+
+func (s *UsageAggregateTestSuite) TestGetUsageGroupedByOrg() {
+	orgA := "org_" + system.GenerateID()
+	orgB := "org_" + system.GenerateID()
+	s.seedRow(orgA, "u1", "prj_x", "", "ses_"+system.GenerateID(), "claude-opus-4-7", 1000, 0.01)
+	s.seedRow(orgB, "u2", "prj_y", "", "ses_"+system.GenerateID(), "claude-opus-4-7", 2000, 0.02)
+
+	// Wide query (no org filter) so we see both orgs.
+	q := &GroupedUsageQuery{
+		From:     time.Now().Add(-24 * time.Hour),
+		To:       time.Now().Add(24 * time.Hour),
+		Page:     1,
+		PageSize: 50,
+	}
+	rows, total, err := s.db.GetUsageGroupedByOrg(s.ctx, q)
+	s.Require().NoError(err)
+	s.GreaterOrEqual(total, 2)
+	// orgA + orgB must be present.
+	found := map[string]bool{}
+	for _, r := range rows {
+		found[r.OrganizationID] = true
+	}
+	s.True(found[orgA], "orgA must be in by-org rows")
+	s.True(found[orgB], "orgB must be in by-org rows")
+}
+
+func (s *UsageAggregateTestSuite) TestGetUsageGroupedByProject() {
+	orgID := "org_" + system.GenerateID()
+	prjA := "prj_" + system.GenerateID()
+	prjB := "prj_" + system.GenerateID()
+	user := "user_" + system.GenerateID()
+
+	s.seedRow(orgID, user, prjA, "", "ses_"+system.GenerateID(), "claude-opus-4-7", 1000, 0.01)
+	s.seedRow(orgID, user, prjA, "", "ses_"+system.GenerateID(), "claude-opus-4-7", 2000, 0.02)
+	s.seedRow(orgID, user, prjB, "", "ses_"+system.GenerateID(), "claude-opus-4-7", 500, 0.005)
+
+	rows, total, err := s.db.GetUsageGroupedByProject(s.ctx, s.buildQuery(orgID))
+	s.Require().NoError(err)
+	s.Equal(2, total)
+	s.Len(rows, 2)
+	// Sorted by total_cost desc -> prjA first
+	s.Equal(prjA, rows[0].ProjectID)
+	s.Equal(3000, rows[0].PromptTokens)
+	s.Equal(prjB, rows[1].ProjectID)
+}

--- a/api/pkg/store/store_usage_aggregate_test.go
+++ b/api/pkg/store/store_usage_aggregate_test.go
@@ -60,12 +60,16 @@ func (s *UsageAggregateTestSuite) seedRow(orgID, userID, projectID, appID, sessi
 
 	if sessionID != "" {
 		// Seed a minimal interaction row so the SUBSELECT for session_id
-		// resolves. Using GORM Create directly to avoid the heavyweight
-		// CreateInteraction logic.
-		err := s.db.gdb.WithContext(s.ctx).Exec(
-			"INSERT INTO interactions (id, session_id, created_at, updated_at) VALUES (?, ?, NOW(), NOW())",
-			interactionID, sessionID,
-		).Error
+		// resolves. Use GORM Create rather than raw SQL so column names
+		// stay in sync with the model (`created`/`updated`, not the
+		// GORM-default `created_at`/`updated_at`).
+		err := s.db.gdb.WithContext(s.ctx).Create(&types.Interaction{
+			ID:           interactionID,
+			GenerationID: 0,
+			SessionID:    sessionID,
+			Created:      time.Now(),
+			Updated:      time.Now(),
+		}).Error
 		s.Require().NoError(err)
 	}
 }

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -2517,6 +2517,148 @@ type AggregatedUsageMetric struct {
 	TotalRequests     int     `json:"total_requests"`
 }
 
+// UsageTotals is the common token/cost shape returned by every aggregate
+// usage row, regardless of grouping.
+type UsageTotals struct {
+	PromptTokens     int     `json:"prompt_tokens"`
+	CompletionTokens int     `json:"completion_tokens"`
+	CacheReadTokens  int     `json:"cache_read_tokens"`
+	CacheWriteTokens int     `json:"cache_write_tokens"`
+	TotalTokens      int     `json:"total_tokens"`
+	PromptCost       float64 `json:"prompt_cost"`
+	CompletionCost   float64 `json:"completion_cost"`
+	CacheReadCost    float64 `json:"cache_read_cost"`
+	CacheWriteCost   float64 `json:"cache_write_cost"`
+	TotalCost        float64 `json:"total_cost"`
+	RequestCount     int     `json:"request_count"`
+}
+
+// UsageSummary is the platform/org-level overview returned by
+// /api/v1/usage/aggregate/summary.
+type UsageSummary struct {
+	From            time.Time                `json:"from"`
+	To              time.Time                `json:"to"`
+	UsageTotals     `json:",inline"`
+	ActiveUsers     int                      `json:"active_users"`
+	ActiveSessions  int                      `json:"active_sessions"`
+	ActiveProjects  int                      `json:"active_projects"`
+	TimeSeries      []*AggregatedUsageMetric `json:"time_series"`
+}
+
+// UsageByOrg is one row of /api/v1/usage/aggregate/by-org (global admin only).
+type UsageByOrg struct {
+	OrganizationID   string    `json:"organization_id"`
+	OrganizationName string    `json:"organization_name"`
+	UsageTotals      `json:",inline"`
+	UserCount        int       `json:"user_count"`
+	SessionCount     int       `json:"session_count"`
+	TopModel         string    `json:"top_model,omitempty"`
+	LastActivity     time.Time `json:"last_activity"`
+}
+
+// UsageByUser is one row of /api/v1/usage/aggregate/by-user.
+type UsageByUser struct {
+	UserID         string    `json:"user_id"`
+	Email          string    `json:"email"`
+	OrganizationID string    `json:"organization_id"`
+	UsageTotals    `json:",inline"`
+	SessionCount   int       `json:"session_count"`
+	TopModel       string    `json:"top_model,omitempty"`
+	LastActivity   time.Time `json:"last_activity"`
+}
+
+// UsageByProject is one row of /api/v1/usage/aggregate/by-project. Covers
+// projects, apps, and agents - the Kind field distinguishes which kind of
+// resource this row represents.
+type UsageByProject struct {
+	ProjectID      string `json:"project_id"`
+	AppID          string `json:"app_id,omitempty"`
+	Name           string `json:"name"`
+	Kind           string `json:"kind"` // "project" | "app" | "agent"
+	OwnerUserID    string `json:"owner_user_id,omitempty"`
+	OrganizationID string `json:"organization_id"`
+	UsageTotals    `json:",inline"`
+	SessionCount   int `json:"session_count"`
+}
+
+// UsageBySession is one row of /api/v1/usage/aggregate/by-session.
+type UsageBySession struct {
+	SessionID      string    `json:"session_id"`
+	Name           string    `json:"name,omitempty"`
+	UserID         string    `json:"user_id"`
+	ProjectID      string    `json:"project_id,omitempty"`
+	OrganizationID string    `json:"organization_id"`
+	Provider       string    `json:"provider"`
+	Model          string    `json:"model"`
+	UsageTotals    `json:",inline"`
+	CallCount      int       `json:"call_count"`
+	StartedAt      time.Time `json:"started_at"`
+	EndedAt        time.Time `json:"ended_at"`
+}
+
+// UsageByModel is one row of /api/v1/usage/aggregate/by-model. Aggregates
+// across (provider, model) pairs within the filtered scope.
+type UsageByModel struct {
+	Provider     string `json:"provider"`
+	Model        string `json:"model"`
+	UsageTotals  `json:",inline"`
+	UniqueUsers    int `json:"unique_users"`
+	UniqueSessions int `json:"unique_sessions"`
+	UniqueProjects int `json:"unique_projects"`
+}
+
+// Paginated wrappers for the by-* endpoints. Generics would be nicer
+// but the swagger generator (swag) doesn't model parameterized types,
+// so we expand by hand.
+//
+// `Total` carries the aggregate totals across all pages (not just the
+// page being returned) so the UI can show whole-result-set numbers
+// alongside per-row data.
+type PaginatedUsageByOrg struct {
+	Rows       []*UsageByOrg `json:"rows"`
+	Total      UsageTotals   `json:"total"`
+	Page       int           `json:"page"`
+	PageSize   int           `json:"page_size"`
+	TotalRows  int           `json:"total_rows"`
+	TotalPages int           `json:"total_pages"`
+}
+
+type PaginatedUsageByUser struct {
+	Rows       []*UsageByUser `json:"rows"`
+	Total      UsageTotals    `json:"total"`
+	Page       int            `json:"page"`
+	PageSize   int            `json:"page_size"`
+	TotalRows  int            `json:"total_rows"`
+	TotalPages int            `json:"total_pages"`
+}
+
+type PaginatedUsageByProject struct {
+	Rows       []*UsageByProject `json:"rows"`
+	Total      UsageTotals       `json:"total"`
+	Page       int               `json:"page"`
+	PageSize   int               `json:"page_size"`
+	TotalRows  int               `json:"total_rows"`
+	TotalPages int               `json:"total_pages"`
+}
+
+type PaginatedUsageBySession struct {
+	Rows       []*UsageBySession `json:"rows"`
+	Total      UsageTotals       `json:"total"`
+	Page       int               `json:"page"`
+	PageSize   int               `json:"page_size"`
+	TotalRows  int               `json:"total_rows"`
+	TotalPages int               `json:"total_pages"`
+}
+
+type PaginatedUsageByModel struct {
+	Rows       []*UsageByModel `json:"rows"`
+	Total      UsageTotals     `json:"total"`
+	Page       int             `json:"page"`
+	PageSize   int             `json:"page_size"`
+	TotalRows  int             `json:"total_rows"`
+	TotalPages int             `json:"total_pages"`
+}
+
 // Response for the user access endpoint
 type UserAppAccessResponse struct {
 	CanRead  bool `json:"can_read"`

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -2607,56 +2607,19 @@ type UsageByModel struct {
 	UniqueProjects int `json:"unique_projects"`
 }
 
-// Paginated wrappers for the by-* endpoints. Generics would be nicer
-// but the swagger generator (swag) doesn't model parameterized types,
-// so we expand by hand.
-//
-// `Total` carries the aggregate totals across all pages (not just the
-// page being returned) so the UI can show whole-result-set numbers
-// alongside per-row data.
-type PaginatedUsageByOrg struct {
-	Rows       []*UsageByOrg `json:"rows"`
-	Total      UsageTotals   `json:"total"`
-	Page       int           `json:"page"`
-	PageSize   int           `json:"page_size"`
-	TotalRows  int           `json:"total_rows"`
-	TotalPages int           `json:"total_pages"`
-}
-
-type PaginatedUsageByUser struct {
-	Rows       []*UsageByUser `json:"rows"`
-	Total      UsageTotals    `json:"total"`
-	Page       int            `json:"page"`
-	PageSize   int            `json:"page_size"`
-	TotalRows  int            `json:"total_rows"`
-	TotalPages int            `json:"total_pages"`
-}
-
-type PaginatedUsageByProject struct {
-	Rows       []*UsageByProject `json:"rows"`
-	Total      UsageTotals       `json:"total"`
-	Page       int               `json:"page"`
-	PageSize   int               `json:"page_size"`
-	TotalRows  int               `json:"total_rows"`
-	TotalPages int               `json:"total_pages"`
-}
-
-type PaginatedUsageBySession struct {
-	Rows       []*UsageBySession `json:"rows"`
-	Total      UsageTotals       `json:"total"`
-	Page       int               `json:"page"`
-	PageSize   int               `json:"page_size"`
-	TotalRows  int               `json:"total_rows"`
-	TotalPages int               `json:"total_pages"`
-}
-
-type PaginatedUsageByModel struct {
-	Rows       []*UsageByModel `json:"rows"`
-	Total      UsageTotals     `json:"total"`
-	Page       int             `json:"page"`
-	PageSize   int             `json:"page_size"`
-	TotalRows  int             `json:"total_rows"`
-	TotalPages int             `json:"total_pages"`
+// UsageGroupedResponse is the unified envelope returned by
+// /api/v1/usage/aggregate/grouped regardless of the `group_by` chosen.
+// `Rows` is a typed slice (UsageByUser, UsageByOrg, etc.) at runtime;
+// the JSON-on-the-wire is an array of objects keyed off `GroupBy`.
+// Frontends switch on GroupBy and cast.
+type UsageGroupedResponse struct {
+	GroupBy    string      `json:"group_by"` // "org" | "user" | "project" | "session" | "model"
+	Rows       any         `json:"rows"`
+	Total      UsageTotals `json:"total"`
+	Page       int         `json:"page"`
+	PageSize   int         `json:"page_size"`
+	TotalRows  int         `json:"total_rows"`
+	TotalPages int         `json:"total_pages"`
 }
 
 // Response for the user access endpoint

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -3646,6 +3646,51 @@ export interface TypesPaginatedSessionsList {
   totalPages?: number;
 }
 
+export interface TypesPaginatedUsageByModel {
+  page?: number;
+  page_size?: number;
+  rows?: TypesUsageByModel[];
+  total?: TypesUsageTotals;
+  total_pages?: number;
+  total_rows?: number;
+}
+
+export interface TypesPaginatedUsageByOrg {
+  page?: number;
+  page_size?: number;
+  rows?: TypesUsageByOrg[];
+  total?: TypesUsageTotals;
+  total_pages?: number;
+  total_rows?: number;
+}
+
+export interface TypesPaginatedUsageByProject {
+  page?: number;
+  page_size?: number;
+  rows?: TypesUsageByProject[];
+  total?: TypesUsageTotals;
+  total_pages?: number;
+  total_rows?: number;
+}
+
+export interface TypesPaginatedUsageBySession {
+  page?: number;
+  page_size?: number;
+  rows?: TypesUsageBySession[];
+  total?: TypesUsageTotals;
+  total_pages?: number;
+  total_rows?: number;
+}
+
+export interface TypesPaginatedUsageByUser {
+  page?: number;
+  page_size?: number;
+  rows?: TypesUsageByUser[];
+  total?: TypesUsageTotals;
+  total_pages?: number;
+  total_rows?: number;
+}
+
 export interface TypesPaginatedUsersList {
   page?: number;
   pageSize?: number;
@@ -6094,6 +6139,145 @@ export interface TypesUsage {
   /** How long the request took in milliseconds */
   duration_ms?: number;
   prompt_tokens?: number;
+  total_tokens?: number;
+}
+
+export interface TypesUsageByModel {
+  cache_read_cost?: number;
+  cache_read_tokens?: number;
+  cache_write_cost?: number;
+  cache_write_tokens?: number;
+  completion_cost?: number;
+  completion_tokens?: number;
+  model?: string;
+  prompt_cost?: number;
+  prompt_tokens?: number;
+  provider?: string;
+  request_count?: number;
+  total_cost?: number;
+  total_tokens?: number;
+  unique_projects?: number;
+  unique_sessions?: number;
+  unique_users?: number;
+}
+
+export interface TypesUsageByOrg {
+  cache_read_cost?: number;
+  cache_read_tokens?: number;
+  cache_write_cost?: number;
+  cache_write_tokens?: number;
+  completion_cost?: number;
+  completion_tokens?: number;
+  last_activity?: string;
+  organization_id?: string;
+  organization_name?: string;
+  prompt_cost?: number;
+  prompt_tokens?: number;
+  request_count?: number;
+  session_count?: number;
+  top_model?: string;
+  total_cost?: number;
+  total_tokens?: number;
+  user_count?: number;
+}
+
+export interface TypesUsageByProject {
+  app_id?: string;
+  cache_read_cost?: number;
+  cache_read_tokens?: number;
+  cache_write_cost?: number;
+  cache_write_tokens?: number;
+  completion_cost?: number;
+  completion_tokens?: number;
+  /** "project" | "app" | "agent" */
+  kind?: string;
+  name?: string;
+  organization_id?: string;
+  owner_user_id?: string;
+  project_id?: string;
+  prompt_cost?: number;
+  prompt_tokens?: number;
+  request_count?: number;
+  session_count?: number;
+  total_cost?: number;
+  total_tokens?: number;
+}
+
+export interface TypesUsageBySession {
+  cache_read_cost?: number;
+  cache_read_tokens?: number;
+  cache_write_cost?: number;
+  cache_write_tokens?: number;
+  call_count?: number;
+  completion_cost?: number;
+  completion_tokens?: number;
+  ended_at?: string;
+  model?: string;
+  name?: string;
+  organization_id?: string;
+  project_id?: string;
+  prompt_cost?: number;
+  prompt_tokens?: number;
+  provider?: string;
+  request_count?: number;
+  session_id?: string;
+  started_at?: string;
+  total_cost?: number;
+  total_tokens?: number;
+  user_id?: string;
+}
+
+export interface TypesUsageByUser {
+  cache_read_cost?: number;
+  cache_read_tokens?: number;
+  cache_write_cost?: number;
+  cache_write_tokens?: number;
+  completion_cost?: number;
+  completion_tokens?: number;
+  email?: string;
+  last_activity?: string;
+  organization_id?: string;
+  prompt_cost?: number;
+  prompt_tokens?: number;
+  request_count?: number;
+  session_count?: number;
+  top_model?: string;
+  total_cost?: number;
+  total_tokens?: number;
+  user_id?: string;
+}
+
+export interface TypesUsageSummary {
+  active_projects?: number;
+  active_sessions?: number;
+  active_users?: number;
+  cache_read_cost?: number;
+  cache_read_tokens?: number;
+  cache_write_cost?: number;
+  cache_write_tokens?: number;
+  completion_cost?: number;
+  completion_tokens?: number;
+  from?: string;
+  prompt_cost?: number;
+  prompt_tokens?: number;
+  request_count?: number;
+  time_series?: TypesAggregatedUsageMetric[];
+  to?: string;
+  total_cost?: number;
+  total_tokens?: number;
+}
+
+export interface TypesUsageTotals {
+  cache_read_cost?: number;
+  cache_read_tokens?: number;
+  cache_write_cost?: number;
+  cache_write_tokens?: number;
+  completion_cost?: number;
+  completion_tokens?: number;
+  prompt_cost?: number;
+  prompt_tokens?: number;
+  request_count?: number;
+  total_cost?: number;
   total_tokens?: number;
 }
 
@@ -14209,6 +14393,238 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         query: query,
         secure: true,
         type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags usage
+     * @name V1UsageAggregateByModelList
+     * @summary Usage grouped by model / provider
+     * @request GET:/api/v1/usage/aggregate/by-model
+     * @secure
+     */
+    v1UsageAggregateByModelList: (
+      query?: {
+        /** Start of window (RFC3339) */
+        from?: string;
+        /** End of window (RFC3339) */
+        to?: string;
+        /** Organization id or slug */
+        org_id?: string;
+        /** Sort column */
+        sort_by?: string;
+        /** asc or desc */
+        sort_dir?: string;
+        /** Page */
+        page?: number;
+        /** Page size */
+        page_size?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesPaginatedUsageByModel, any>({
+        path: `/api/v1/usage/aggregate/by-model`,
+        method: "GET",
+        query: query,
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Global-admin only. One row per organization with tokens, costs, user/session counts and last activity.
+     *
+     * @tags usage
+     * @name V1UsageAggregateByOrgList
+     * @summary Usage grouped by organization
+     * @request GET:/api/v1/usage/aggregate/by-org
+     * @secure
+     */
+    v1UsageAggregateByOrgList: (
+      query?: {
+        /** Start of window (RFC3339) */
+        from?: string;
+        /** End of window (RFC3339) */
+        to?: string;
+        /** Sort column: total_cost, total_tokens, request_count, last_activity */
+        sort_by?: string;
+        /** asc or desc */
+        sort_dir?: string;
+        /** Page (1-indexed) */
+        page?: number;
+        /** Page size (max 200, default 25) */
+        page_size?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesPaginatedUsageByOrg, any>({
+        path: `/api/v1/usage/aggregate/by-org`,
+        method: "GET",
+        query: query,
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags usage
+     * @name V1UsageAggregateByProjectList
+     * @summary Usage grouped by project / app / agent
+     * @request GET:/api/v1/usage/aggregate/by-project
+     * @secure
+     */
+    v1UsageAggregateByProjectList: (
+      query?: {
+        /** Start of window (RFC3339) */
+        from?: string;
+        /** End of window (RFC3339) */
+        to?: string;
+        /** Organization id or slug */
+        org_id?: string;
+        /** Filter by user id */
+        user_id?: string;
+        /** Sort column */
+        sort_by?: string;
+        /** asc or desc */
+        sort_dir?: string;
+        /** Page */
+        page?: number;
+        /** Page size */
+        page_size?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesPaginatedUsageByProject, any>({
+        path: `/api/v1/usage/aggregate/by-project`,
+        method: "GET",
+        query: query,
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags usage
+     * @name V1UsageAggregateBySessionList
+     * @summary Usage grouped by session
+     * @request GET:/api/v1/usage/aggregate/by-session
+     * @secure
+     */
+    v1UsageAggregateBySessionList: (
+      query?: {
+        /** Start of window (RFC3339) */
+        from?: string;
+        /** End of window (RFC3339) */
+        to?: string;
+        /** Organization id or slug */
+        org_id?: string;
+        /** Filter by user id */
+        user_id?: string;
+        /** Filter by project id */
+        project_id?: string;
+        /** Filter by provider */
+        provider?: string;
+        /** Filter by model */
+        model?: string;
+        /** Sort column */
+        sort_by?: string;
+        /** asc or desc */
+        sort_dir?: string;
+        /** Page */
+        page?: number;
+        /** Page size */
+        page_size?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesPaginatedUsageBySession, any>({
+        path: `/api/v1/usage/aggregate/by-session`,
+        method: "GET",
+        query: query,
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Org members get rows scoped to their org. Global admins may omit org_id to list across all orgs.
+     *
+     * @tags usage
+     * @name V1UsageAggregateByUserList
+     * @summary Usage grouped by user
+     * @request GET:/api/v1/usage/aggregate/by-user
+     * @secure
+     */
+    v1UsageAggregateByUserList: (
+      query?: {
+        /** Start of window (RFC3339) */
+        from?: string;
+        /** End of window (RFC3339) */
+        to?: string;
+        /** Organization id or slug. Required for non-admins. */
+        org_id?: string;
+        /** Sort column */
+        sort_by?: string;
+        /** asc or desc */
+        sort_dir?: string;
+        /** Page */
+        page?: number;
+        /** Page size */
+        page_size?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesPaginatedUsageByUser, any>({
+        path: `/api/v1/usage/aggregate/by-user`,
+        method: "GET",
+        query: query,
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Returns whole-set totals plus a daily time-series. Org owners must pass org_id matching their org; global admins may omit it to summarize cross-org.
+     *
+     * @tags usage
+     * @name V1UsageAggregateSummaryList
+     * @summary Aggregate usage summary
+     * @request GET:/api/v1/usage/aggregate/summary
+     * @secure
+     */
+    v1UsageAggregateSummaryList: (
+      query?: {
+        /** Start of window (RFC3339). Defaults to 7 days ago. */
+        from?: string;
+        /** End of window (RFC3339). Defaults to now. */
+        to?: string;
+        /** Organization id or slug. Required for non-admins. */
+        org_id?: string;
+        /** Filter by user id */
+        user_id?: string;
+        /** Filter by project id */
+        project_id?: string;
+        /** Filter by app id */
+        app_id?: string;
+        /** Filter by provider */
+        provider?: string;
+        /** Filter by model */
+        model?: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesUsageSummary, any>({
+        path: `/api/v1/usage/aggregate/summary`,
+        method: "GET",
+        query: query,
+        secure: true,
         format: "json",
         ...params,
       }),

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -3646,51 +3646,6 @@ export interface TypesPaginatedSessionsList {
   totalPages?: number;
 }
 
-export interface TypesPaginatedUsageByModel {
-  page?: number;
-  page_size?: number;
-  rows?: TypesUsageByModel[];
-  total?: TypesUsageTotals;
-  total_pages?: number;
-  total_rows?: number;
-}
-
-export interface TypesPaginatedUsageByOrg {
-  page?: number;
-  page_size?: number;
-  rows?: TypesUsageByOrg[];
-  total?: TypesUsageTotals;
-  total_pages?: number;
-  total_rows?: number;
-}
-
-export interface TypesPaginatedUsageByProject {
-  page?: number;
-  page_size?: number;
-  rows?: TypesUsageByProject[];
-  total?: TypesUsageTotals;
-  total_pages?: number;
-  total_rows?: number;
-}
-
-export interface TypesPaginatedUsageBySession {
-  page?: number;
-  page_size?: number;
-  rows?: TypesUsageBySession[];
-  total?: TypesUsageTotals;
-  total_pages?: number;
-  total_rows?: number;
-}
-
-export interface TypesPaginatedUsageByUser {
-  page?: number;
-  page_size?: number;
-  rows?: TypesUsageByUser[];
-  total?: TypesUsageTotals;
-  total_pages?: number;
-  total_rows?: number;
-}
-
 export interface TypesPaginatedUsersList {
   page?: number;
   pageSize?: number;
@@ -6142,109 +6097,15 @@ export interface TypesUsage {
   total_tokens?: number;
 }
 
-export interface TypesUsageByModel {
-  cache_read_cost?: number;
-  cache_read_tokens?: number;
-  cache_write_cost?: number;
-  cache_write_tokens?: number;
-  completion_cost?: number;
-  completion_tokens?: number;
-  model?: string;
-  prompt_cost?: number;
-  prompt_tokens?: number;
-  provider?: string;
-  request_count?: number;
-  total_cost?: number;
-  total_tokens?: number;
-  unique_projects?: number;
-  unique_sessions?: number;
-  unique_users?: number;
-}
-
-export interface TypesUsageByOrg {
-  cache_read_cost?: number;
-  cache_read_tokens?: number;
-  cache_write_cost?: number;
-  cache_write_tokens?: number;
-  completion_cost?: number;
-  completion_tokens?: number;
-  last_activity?: string;
-  organization_id?: string;
-  organization_name?: string;
-  prompt_cost?: number;
-  prompt_tokens?: number;
-  request_count?: number;
-  session_count?: number;
-  top_model?: string;
-  total_cost?: number;
-  total_tokens?: number;
-  user_count?: number;
-}
-
-export interface TypesUsageByProject {
-  app_id?: string;
-  cache_read_cost?: number;
-  cache_read_tokens?: number;
-  cache_write_cost?: number;
-  cache_write_tokens?: number;
-  completion_cost?: number;
-  completion_tokens?: number;
-  /** "project" | "app" | "agent" */
-  kind?: string;
-  name?: string;
-  organization_id?: string;
-  owner_user_id?: string;
-  project_id?: string;
-  prompt_cost?: number;
-  prompt_tokens?: number;
-  request_count?: number;
-  session_count?: number;
-  total_cost?: number;
-  total_tokens?: number;
-}
-
-export interface TypesUsageBySession {
-  cache_read_cost?: number;
-  cache_read_tokens?: number;
-  cache_write_cost?: number;
-  cache_write_tokens?: number;
-  call_count?: number;
-  completion_cost?: number;
-  completion_tokens?: number;
-  ended_at?: string;
-  model?: string;
-  name?: string;
-  organization_id?: string;
-  project_id?: string;
-  prompt_cost?: number;
-  prompt_tokens?: number;
-  provider?: string;
-  request_count?: number;
-  session_id?: string;
-  started_at?: string;
-  total_cost?: number;
-  total_tokens?: number;
-  user_id?: string;
-}
-
-export interface TypesUsageByUser {
-  cache_read_cost?: number;
-  cache_read_tokens?: number;
-  cache_write_cost?: number;
-  cache_write_tokens?: number;
-  completion_cost?: number;
-  completion_tokens?: number;
-  email?: string;
-  last_activity?: string;
-  organization_id?: string;
-  prompt_cost?: number;
-  prompt_tokens?: number;
-  request_count?: number;
-  session_count?: number;
-  top_model?: string;
-  total_cost?: number;
-  total_tokens?: number;
-  user_id?: string;
+export interface TypesUsageGroupedResponse {
+  /** "org" | "user" | "project" | "session" | "model" */
+  group_by?: string;
+  page?: number;
+  page_size?: number;
+  rows?: any;
+  total?: TypesUsageTotals;
+  total_pages?: number;
+  total_rows?: number;
 }
 
 export interface TypesUsageSummary {
@@ -14398,127 +14259,18 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * No description
+     * @description One endpoint, five groupings. Pass `group_by` to choose what each row represents. `group_by=org` is global-admin only. Row shape per `group_by` (see types/types.go): - org: UsageByOrg (organization_id, organization_name, user_count, session_count, top_model, last_activity) - user: UsageByUser (user_id, email, organization_id, session_count, top_model, last_activity) - project: UsageByProject (project_id, app_id, name, kind, owner_user_id, organization_id, session_count) - session: UsageBySession (session_id, name, user_id, project_id, organization_id, provider, model, call_count, started_at, ended_at) - model: UsageByModel (provider, model, unique_users, unique_sessions, unique_projects) Every row also carries the shared UsageTotals fields (prompt/completion/cache tokens and costs, total_cost, request_count).
      *
      * @tags usage
-     * @name V1UsageAggregateByModelList
-     * @summary Usage grouped by model / provider
-     * @request GET:/api/v1/usage/aggregate/by-model
+     * @name V1UsageAggregateGroupedList
+     * @summary Aggregate usage grouped by a dimension
+     * @request GET:/api/v1/usage/aggregate/grouped
      * @secure
      */
-    v1UsageAggregateByModelList: (
-      query?: {
-        /** Start of window (RFC3339) */
-        from?: string;
-        /** End of window (RFC3339) */
-        to?: string;
-        /** Organization id or slug */
-        org_id?: string;
-        /** Sort column */
-        sort_by?: string;
-        /** asc or desc */
-        sort_dir?: string;
-        /** Page */
-        page?: number;
-        /** Page size */
-        page_size?: number;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<TypesPaginatedUsageByModel, any>({
-        path: `/api/v1/usage/aggregate/by-model`,
-        method: "GET",
-        query: query,
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Global-admin only. One row per organization with tokens, costs, user/session counts and last activity.
-     *
-     * @tags usage
-     * @name V1UsageAggregateByOrgList
-     * @summary Usage grouped by organization
-     * @request GET:/api/v1/usage/aggregate/by-org
-     * @secure
-     */
-    v1UsageAggregateByOrgList: (
-      query?: {
-        /** Start of window (RFC3339) */
-        from?: string;
-        /** End of window (RFC3339) */
-        to?: string;
-        /** Sort column: total_cost, total_tokens, request_count, last_activity */
-        sort_by?: string;
-        /** asc or desc */
-        sort_dir?: string;
-        /** Page (1-indexed) */
-        page?: number;
-        /** Page size (max 200, default 25) */
-        page_size?: number;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<TypesPaginatedUsageByOrg, any>({
-        path: `/api/v1/usage/aggregate/by-org`,
-        method: "GET",
-        query: query,
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @tags usage
-     * @name V1UsageAggregateByProjectList
-     * @summary Usage grouped by project / app / agent
-     * @request GET:/api/v1/usage/aggregate/by-project
-     * @secure
-     */
-    v1UsageAggregateByProjectList: (
-      query?: {
-        /** Start of window (RFC3339) */
-        from?: string;
-        /** End of window (RFC3339) */
-        to?: string;
-        /** Organization id or slug */
-        org_id?: string;
-        /** Filter by user id */
-        user_id?: string;
-        /** Sort column */
-        sort_by?: string;
-        /** asc or desc */
-        sort_dir?: string;
-        /** Page */
-        page?: number;
-        /** Page size */
-        page_size?: number;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<TypesPaginatedUsageByProject, any>({
-        path: `/api/v1/usage/aggregate/by-project`,
-        method: "GET",
-        query: query,
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @tags usage
-     * @name V1UsageAggregateBySessionList
-     * @summary Usage grouped by session
-     * @request GET:/api/v1/usage/aggregate/by-session
-     * @secure
-     */
-    v1UsageAggregateBySessionList: (
-      query?: {
+    v1UsageAggregateGroupedList: (
+      query: {
+        /** Grouping: org|user|project|session|model */
+        group_by: string;
         /** Start of window (RFC3339) */
         from?: string;
         /** End of window (RFC3339) */
@@ -14529,23 +14281,27 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         user_id?: string;
         /** Filter by project id */
         project_id?: string;
+        /** Filter by app id */
+        app_id?: string;
+        /** Filter by session id */
+        session_id?: string;
         /** Filter by provider */
         provider?: string;
         /** Filter by model */
         model?: string;
-        /** Sort column */
+        /** Sort column (per-grouping whitelist) */
         sort_by?: string;
         /** asc or desc */
         sort_dir?: string;
-        /** Page */
+        /** Page (1-indexed) */
         page?: number;
-        /** Page size */
+        /** Page size (max 200, default 25) */
         page_size?: number;
       },
       params: RequestParams = {},
     ) =>
-      this.request<TypesPaginatedUsageBySession, any>({
-        path: `/api/v1/usage/aggregate/by-session`,
+      this.request<TypesUsageGroupedResponse, any>({
+        path: `/api/v1/usage/aggregate/grouped`,
         method: "GET",
         query: query,
         secure: true,
@@ -14554,44 +14310,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Org members get rows scoped to their org. Global admins may omit org_id to list across all orgs.
-     *
-     * @tags usage
-     * @name V1UsageAggregateByUserList
-     * @summary Usage grouped by user
-     * @request GET:/api/v1/usage/aggregate/by-user
-     * @secure
-     */
-    v1UsageAggregateByUserList: (
-      query?: {
-        /** Start of window (RFC3339) */
-        from?: string;
-        /** End of window (RFC3339) */
-        to?: string;
-        /** Organization id or slug. Required for non-admins. */
-        org_id?: string;
-        /** Sort column */
-        sort_by?: string;
-        /** asc or desc */
-        sort_dir?: string;
-        /** Page */
-        page?: number;
-        /** Page size */
-        page_size?: number;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<TypesPaginatedUsageByUser, any>({
-        path: `/api/v1/usage/aggregate/by-user`,
-        method: "GET",
-        query: query,
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Returns whole-set totals plus a daily time-series. Org owners must pass org_id matching their org; global admins may omit it to summarize cross-org.
+     * @description Returns whole-set totals plus a daily time-series. Org members must pass org_id; global admins may omit it to summarize cross-org.
      *
      * @tags usage
      * @name V1UsageAggregateSummaryList

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -5959,6 +5959,91 @@ definitions:
       totalPages:
         type: integer
     type: object
+  types.PaginatedUsageByModel:
+    properties:
+      page:
+        type: integer
+      page_size:
+        type: integer
+      rows:
+        items:
+          $ref: '#/definitions/types.UsageByModel'
+        type: array
+      total:
+        $ref: '#/definitions/types.UsageTotals'
+      total_pages:
+        type: integer
+      total_rows:
+        type: integer
+    type: object
+  types.PaginatedUsageByOrg:
+    properties:
+      page:
+        type: integer
+      page_size:
+        type: integer
+      rows:
+        items:
+          $ref: '#/definitions/types.UsageByOrg'
+        type: array
+      total:
+        $ref: '#/definitions/types.UsageTotals'
+      total_pages:
+        type: integer
+      total_rows:
+        type: integer
+    type: object
+  types.PaginatedUsageByProject:
+    properties:
+      page:
+        type: integer
+      page_size:
+        type: integer
+      rows:
+        items:
+          $ref: '#/definitions/types.UsageByProject'
+        type: array
+      total:
+        $ref: '#/definitions/types.UsageTotals'
+      total_pages:
+        type: integer
+      total_rows:
+        type: integer
+    type: object
+  types.PaginatedUsageBySession:
+    properties:
+      page:
+        type: integer
+      page_size:
+        type: integer
+      rows:
+        items:
+          $ref: '#/definitions/types.UsageBySession'
+        type: array
+      total:
+        $ref: '#/definitions/types.UsageTotals'
+      total_pages:
+        type: integer
+      total_rows:
+        type: integer
+    type: object
+  types.PaginatedUsageByUser:
+    properties:
+      page:
+        type: integer
+      page_size:
+        type: integer
+      rows:
+        items:
+          $ref: '#/definitions/types.UsageByUser'
+        type: array
+      total:
+        $ref: '#/definitions/types.UsageTotals'
+      total_pages:
+        type: integer
+      total_rows:
+        type: integer
+    type: object
   types.PaginatedUsersList:
     properties:
       page:
@@ -9970,6 +10055,264 @@ definitions:
         type: integer
       prompt_tokens:
         type: integer
+      total_tokens:
+        type: integer
+    type: object
+  types.UsageByModel:
+    properties:
+      cache_read_cost:
+        type: number
+      cache_read_tokens:
+        type: integer
+      cache_write_cost:
+        type: number
+      cache_write_tokens:
+        type: integer
+      completion_cost:
+        type: number
+      completion_tokens:
+        type: integer
+      model:
+        type: string
+      prompt_cost:
+        type: number
+      prompt_tokens:
+        type: integer
+      provider:
+        type: string
+      request_count:
+        type: integer
+      total_cost:
+        type: number
+      total_tokens:
+        type: integer
+      unique_projects:
+        type: integer
+      unique_sessions:
+        type: integer
+      unique_users:
+        type: integer
+    type: object
+  types.UsageByOrg:
+    properties:
+      cache_read_cost:
+        type: number
+      cache_read_tokens:
+        type: integer
+      cache_write_cost:
+        type: number
+      cache_write_tokens:
+        type: integer
+      completion_cost:
+        type: number
+      completion_tokens:
+        type: integer
+      last_activity:
+        type: string
+      organization_id:
+        type: string
+      organization_name:
+        type: string
+      prompt_cost:
+        type: number
+      prompt_tokens:
+        type: integer
+      request_count:
+        type: integer
+      session_count:
+        type: integer
+      top_model:
+        type: string
+      total_cost:
+        type: number
+      total_tokens:
+        type: integer
+      user_count:
+        type: integer
+    type: object
+  types.UsageByProject:
+    properties:
+      app_id:
+        type: string
+      cache_read_cost:
+        type: number
+      cache_read_tokens:
+        type: integer
+      cache_write_cost:
+        type: number
+      cache_write_tokens:
+        type: integer
+      completion_cost:
+        type: number
+      completion_tokens:
+        type: integer
+      kind:
+        description: '"project" | "app" | "agent"'
+        type: string
+      name:
+        type: string
+      organization_id:
+        type: string
+      owner_user_id:
+        type: string
+      project_id:
+        type: string
+      prompt_cost:
+        type: number
+      prompt_tokens:
+        type: integer
+      request_count:
+        type: integer
+      session_count:
+        type: integer
+      total_cost:
+        type: number
+      total_tokens:
+        type: integer
+    type: object
+  types.UsageBySession:
+    properties:
+      cache_read_cost:
+        type: number
+      cache_read_tokens:
+        type: integer
+      cache_write_cost:
+        type: number
+      cache_write_tokens:
+        type: integer
+      call_count:
+        type: integer
+      completion_cost:
+        type: number
+      completion_tokens:
+        type: integer
+      ended_at:
+        type: string
+      model:
+        type: string
+      name:
+        type: string
+      organization_id:
+        type: string
+      project_id:
+        type: string
+      prompt_cost:
+        type: number
+      prompt_tokens:
+        type: integer
+      provider:
+        type: string
+      request_count:
+        type: integer
+      session_id:
+        type: string
+      started_at:
+        type: string
+      total_cost:
+        type: number
+      total_tokens:
+        type: integer
+      user_id:
+        type: string
+    type: object
+  types.UsageByUser:
+    properties:
+      cache_read_cost:
+        type: number
+      cache_read_tokens:
+        type: integer
+      cache_write_cost:
+        type: number
+      cache_write_tokens:
+        type: integer
+      completion_cost:
+        type: number
+      completion_tokens:
+        type: integer
+      email:
+        type: string
+      last_activity:
+        type: string
+      organization_id:
+        type: string
+      prompt_cost:
+        type: number
+      prompt_tokens:
+        type: integer
+      request_count:
+        type: integer
+      session_count:
+        type: integer
+      top_model:
+        type: string
+      total_cost:
+        type: number
+      total_tokens:
+        type: integer
+      user_id:
+        type: string
+    type: object
+  types.UsageSummary:
+    properties:
+      active_projects:
+        type: integer
+      active_sessions:
+        type: integer
+      active_users:
+        type: integer
+      cache_read_cost:
+        type: number
+      cache_read_tokens:
+        type: integer
+      cache_write_cost:
+        type: number
+      cache_write_tokens:
+        type: integer
+      completion_cost:
+        type: number
+      completion_tokens:
+        type: integer
+      from:
+        type: string
+      prompt_cost:
+        type: number
+      prompt_tokens:
+        type: integer
+      request_count:
+        type: integer
+      time_series:
+        items:
+          $ref: '#/definitions/types.AggregatedUsageMetric'
+        type: array
+      to:
+        type: string
+      total_cost:
+        type: number
+      total_tokens:
+        type: integer
+    type: object
+  types.UsageTotals:
+    properties:
+      cache_read_cost:
+        type: number
+      cache_read_tokens:
+        type: integer
+      cache_write_cost:
+        type: number
+      cache_write_tokens:
+        type: integer
+      completion_cost:
+        type: number
+      completion_tokens:
+        type: integer
+      prompt_cost:
+        type: number
+      prompt_tokens:
+        type: integer
+      request_count:
+        type: integer
+      total_cost:
+        type: number
       total_tokens:
         type: integer
     type: object
@@ -21358,6 +21701,290 @@ paths:
       security:
       - BearerAuth: []
       summary: Get daily usage
+      tags:
+      - usage
+  /api/v1/usage/aggregate/by-model:
+    get:
+      parameters:
+      - description: Start of window (RFC3339)
+        in: query
+        name: from
+        type: string
+      - description: End of window (RFC3339)
+        in: query
+        name: to
+        type: string
+      - description: Organization id or slug
+        in: query
+        name: org_id
+        type: string
+      - description: Sort column
+        in: query
+        name: sort_by
+        type: string
+      - description: asc or desc
+        in: query
+        name: sort_dir
+        type: string
+      - description: Page
+        in: query
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.PaginatedUsageByModel'
+      security:
+      - BearerAuth: []
+      summary: Usage grouped by model / provider
+      tags:
+      - usage
+  /api/v1/usage/aggregate/by-org:
+    get:
+      description: Global-admin only. One row per organization with tokens, costs,
+        user/session counts and last activity.
+      parameters:
+      - description: Start of window (RFC3339)
+        in: query
+        name: from
+        type: string
+      - description: End of window (RFC3339)
+        in: query
+        name: to
+        type: string
+      - description: 'Sort column: total_cost, total_tokens, request_count, last_activity'
+        in: query
+        name: sort_by
+        type: string
+      - description: asc or desc
+        in: query
+        name: sort_dir
+        type: string
+      - description: Page (1-indexed)
+        in: query
+        name: page
+        type: integer
+      - description: Page size (max 200, default 25)
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.PaginatedUsageByOrg'
+      security:
+      - BearerAuth: []
+      summary: Usage grouped by organization
+      tags:
+      - usage
+  /api/v1/usage/aggregate/by-project:
+    get:
+      parameters:
+      - description: Start of window (RFC3339)
+        in: query
+        name: from
+        type: string
+      - description: End of window (RFC3339)
+        in: query
+        name: to
+        type: string
+      - description: Organization id or slug
+        in: query
+        name: org_id
+        type: string
+      - description: Filter by user id
+        in: query
+        name: user_id
+        type: string
+      - description: Sort column
+        in: query
+        name: sort_by
+        type: string
+      - description: asc or desc
+        in: query
+        name: sort_dir
+        type: string
+      - description: Page
+        in: query
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.PaginatedUsageByProject'
+      security:
+      - BearerAuth: []
+      summary: Usage grouped by project / app / agent
+      tags:
+      - usage
+  /api/v1/usage/aggregate/by-session:
+    get:
+      parameters:
+      - description: Start of window (RFC3339)
+        in: query
+        name: from
+        type: string
+      - description: End of window (RFC3339)
+        in: query
+        name: to
+        type: string
+      - description: Organization id or slug
+        in: query
+        name: org_id
+        type: string
+      - description: Filter by user id
+        in: query
+        name: user_id
+        type: string
+      - description: Filter by project id
+        in: query
+        name: project_id
+        type: string
+      - description: Filter by provider
+        in: query
+        name: provider
+        type: string
+      - description: Filter by model
+        in: query
+        name: model
+        type: string
+      - description: Sort column
+        in: query
+        name: sort_by
+        type: string
+      - description: asc or desc
+        in: query
+        name: sort_dir
+        type: string
+      - description: Page
+        in: query
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.PaginatedUsageBySession'
+      security:
+      - BearerAuth: []
+      summary: Usage grouped by session
+      tags:
+      - usage
+  /api/v1/usage/aggregate/by-user:
+    get:
+      description: Org members get rows scoped to their org. Global admins may omit
+        org_id to list across all orgs.
+      parameters:
+      - description: Start of window (RFC3339)
+        in: query
+        name: from
+        type: string
+      - description: End of window (RFC3339)
+        in: query
+        name: to
+        type: string
+      - description: Organization id or slug. Required for non-admins.
+        in: query
+        name: org_id
+        type: string
+      - description: Sort column
+        in: query
+        name: sort_by
+        type: string
+      - description: asc or desc
+        in: query
+        name: sort_dir
+        type: string
+      - description: Page
+        in: query
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.PaginatedUsageByUser'
+      security:
+      - BearerAuth: []
+      summary: Usage grouped by user
+      tags:
+      - usage
+  /api/v1/usage/aggregate/summary:
+    get:
+      description: Returns whole-set totals plus a daily time-series. Org owners must
+        pass org_id matching their org; global admins may omit it to summarize cross-org.
+      parameters:
+      - description: Start of window (RFC3339). Defaults to 7 days ago.
+        in: query
+        name: from
+        type: string
+      - description: End of window (RFC3339). Defaults to now.
+        in: query
+        name: to
+        type: string
+      - description: Organization id or slug. Required for non-admins.
+        in: query
+        name: org_id
+        type: string
+      - description: Filter by user id
+        in: query
+        name: user_id
+        type: string
+      - description: Filter by project id
+        in: query
+        name: project_id
+        type: string
+      - description: Filter by app id
+        in: query
+        name: app_id
+        type: string
+      - description: Filter by provider
+        in: query
+        name: provider
+        type: string
+      - description: Filter by model
+        in: query
+        name: model
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.UsageSummary'
+      security:
+      - BearerAuth: []
+      summary: Aggregate usage summary
       tags:
       - usage
   /api/v1/users:

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -5959,91 +5959,6 @@ definitions:
       totalPages:
         type: integer
     type: object
-  types.PaginatedUsageByModel:
-    properties:
-      page:
-        type: integer
-      page_size:
-        type: integer
-      rows:
-        items:
-          $ref: '#/definitions/types.UsageByModel'
-        type: array
-      total:
-        $ref: '#/definitions/types.UsageTotals'
-      total_pages:
-        type: integer
-      total_rows:
-        type: integer
-    type: object
-  types.PaginatedUsageByOrg:
-    properties:
-      page:
-        type: integer
-      page_size:
-        type: integer
-      rows:
-        items:
-          $ref: '#/definitions/types.UsageByOrg'
-        type: array
-      total:
-        $ref: '#/definitions/types.UsageTotals'
-      total_pages:
-        type: integer
-      total_rows:
-        type: integer
-    type: object
-  types.PaginatedUsageByProject:
-    properties:
-      page:
-        type: integer
-      page_size:
-        type: integer
-      rows:
-        items:
-          $ref: '#/definitions/types.UsageByProject'
-        type: array
-      total:
-        $ref: '#/definitions/types.UsageTotals'
-      total_pages:
-        type: integer
-      total_rows:
-        type: integer
-    type: object
-  types.PaginatedUsageBySession:
-    properties:
-      page:
-        type: integer
-      page_size:
-        type: integer
-      rows:
-        items:
-          $ref: '#/definitions/types.UsageBySession'
-        type: array
-      total:
-        $ref: '#/definitions/types.UsageTotals'
-      total_pages:
-        type: integer
-      total_rows:
-        type: integer
-    type: object
-  types.PaginatedUsageByUser:
-    properties:
-      page:
-        type: integer
-      page_size:
-        type: integer
-      rows:
-        items:
-          $ref: '#/definitions/types.UsageByUser'
-        type: array
-      total:
-        $ref: '#/definitions/types.UsageTotals'
-      total_pages:
-        type: integer
-      total_rows:
-        type: integer
-    type: object
   types.PaginatedUsersList:
     properties:
       page:
@@ -10058,199 +9973,22 @@ definitions:
       total_tokens:
         type: integer
     type: object
-  types.UsageByModel:
+  types.UsageGroupedResponse:
     properties:
-      cache_read_cost:
-        type: number
-      cache_read_tokens:
-        type: integer
-      cache_write_cost:
-        type: number
-      cache_write_tokens:
-        type: integer
-      completion_cost:
-        type: number
-      completion_tokens:
-        type: integer
-      model:
+      group_by:
+        description: '"org" | "user" | "project" | "session" | "model"'
         type: string
-      prompt_cost:
-        type: number
-      prompt_tokens:
+      page:
         type: integer
-      provider:
-        type: string
-      request_count:
+      page_size:
         type: integer
-      total_cost:
-        type: number
-      total_tokens:
+      rows: {}
+      total:
+        $ref: '#/definitions/types.UsageTotals'
+      total_pages:
         type: integer
-      unique_projects:
+      total_rows:
         type: integer
-      unique_sessions:
-        type: integer
-      unique_users:
-        type: integer
-    type: object
-  types.UsageByOrg:
-    properties:
-      cache_read_cost:
-        type: number
-      cache_read_tokens:
-        type: integer
-      cache_write_cost:
-        type: number
-      cache_write_tokens:
-        type: integer
-      completion_cost:
-        type: number
-      completion_tokens:
-        type: integer
-      last_activity:
-        type: string
-      organization_id:
-        type: string
-      organization_name:
-        type: string
-      prompt_cost:
-        type: number
-      prompt_tokens:
-        type: integer
-      request_count:
-        type: integer
-      session_count:
-        type: integer
-      top_model:
-        type: string
-      total_cost:
-        type: number
-      total_tokens:
-        type: integer
-      user_count:
-        type: integer
-    type: object
-  types.UsageByProject:
-    properties:
-      app_id:
-        type: string
-      cache_read_cost:
-        type: number
-      cache_read_tokens:
-        type: integer
-      cache_write_cost:
-        type: number
-      cache_write_tokens:
-        type: integer
-      completion_cost:
-        type: number
-      completion_tokens:
-        type: integer
-      kind:
-        description: '"project" | "app" | "agent"'
-        type: string
-      name:
-        type: string
-      organization_id:
-        type: string
-      owner_user_id:
-        type: string
-      project_id:
-        type: string
-      prompt_cost:
-        type: number
-      prompt_tokens:
-        type: integer
-      request_count:
-        type: integer
-      session_count:
-        type: integer
-      total_cost:
-        type: number
-      total_tokens:
-        type: integer
-    type: object
-  types.UsageBySession:
-    properties:
-      cache_read_cost:
-        type: number
-      cache_read_tokens:
-        type: integer
-      cache_write_cost:
-        type: number
-      cache_write_tokens:
-        type: integer
-      call_count:
-        type: integer
-      completion_cost:
-        type: number
-      completion_tokens:
-        type: integer
-      ended_at:
-        type: string
-      model:
-        type: string
-      name:
-        type: string
-      organization_id:
-        type: string
-      project_id:
-        type: string
-      prompt_cost:
-        type: number
-      prompt_tokens:
-        type: integer
-      provider:
-        type: string
-      request_count:
-        type: integer
-      session_id:
-        type: string
-      started_at:
-        type: string
-      total_cost:
-        type: number
-      total_tokens:
-        type: integer
-      user_id:
-        type: string
-    type: object
-  types.UsageByUser:
-    properties:
-      cache_read_cost:
-        type: number
-      cache_read_tokens:
-        type: integer
-      cache_write_cost:
-        type: number
-      cache_write_tokens:
-        type: integer
-      completion_cost:
-        type: number
-      completion_tokens:
-        type: integer
-      email:
-        type: string
-      last_activity:
-        type: string
-      organization_id:
-        type: string
-      prompt_cost:
-        type: number
-      prompt_tokens:
-        type: integer
-      request_count:
-        type: integer
-      session_count:
-        type: integer
-      top_model:
-        type: string
-      total_cost:
-        type: number
-      total_tokens:
-        type: integer
-      user_id:
-        type: string
     type: object
   types.UsageSummary:
     properties:
@@ -21703,9 +21441,23 @@ paths:
       summary: Get daily usage
       tags:
       - usage
-  /api/v1/usage/aggregate/by-model:
+  /api/v1/usage/aggregate/grouped:
     get:
+      description: |-
+        One endpoint, five groupings. Pass `group_by` to choose what each row represents. `group_by=org` is global-admin only.
+        Row shape per `group_by` (see types/types.go):
+        - org: UsageByOrg (organization_id, organization_name, user_count, session_count, top_model, last_activity)
+        - user: UsageByUser (user_id, email, organization_id, session_count, top_model, last_activity)
+        - project: UsageByProject (project_id, app_id, name, kind, owner_user_id, organization_id, session_count)
+        - session: UsageBySession (session_id, name, user_id, project_id, organization_id, provider, model, call_count, started_at, ended_at)
+        - model: UsageByModel (provider, model, unique_users, unique_sessions, unique_projects)
+        Every row also carries the shared UsageTotals fields (prompt/completion/cache tokens and costs, total_cost, request_count).
       parameters:
+      - description: 'Grouping: org|user|project|session|model'
+        in: query
+        name: group_by
+        required: true
+        type: string
       - description: Start of window (RFC3339)
         in: query
         name: from
@@ -21718,48 +21470,31 @@ paths:
         in: query
         name: org_id
         type: string
-      - description: Sort column
+      - description: Filter by user id
         in: query
-        name: sort_by
+        name: user_id
         type: string
-      - description: asc or desc
+      - description: Filter by project id
         in: query
-        name: sort_dir
+        name: project_id
         type: string
-      - description: Page
+      - description: Filter by app id
         in: query
-        name: page
-        type: integer
-      - description: Page size
-        in: query
-        name: page_size
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.PaginatedUsageByModel'
-      security:
-      - BearerAuth: []
-      summary: Usage grouped by model / provider
-      tags:
-      - usage
-  /api/v1/usage/aggregate/by-org:
-    get:
-      description: Global-admin only. One row per organization with tokens, costs,
-        user/session counts and last activity.
-      parameters:
-      - description: Start of window (RFC3339)
-        in: query
-        name: from
+        name: app_id
         type: string
-      - description: End of window (RFC3339)
+      - description: Filter by session id
         in: query
-        name: to
+        name: session_id
         type: string
-      - description: 'Sort column: total_cost, total_tokens, request_count, last_activity'
+      - description: Filter by provider
+        in: query
+        name: provider
+        type: string
+      - description: Filter by model
+        in: query
+        name: model
+        type: string
+      - description: Sort column (per-grouping whitelist)
         in: query
         name: sort_by
         type: string
@@ -21781,167 +21516,16 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/types.PaginatedUsageByOrg'
+            $ref: '#/definitions/types.UsageGroupedResponse'
       security:
       - BearerAuth: []
-      summary: Usage grouped by organization
-      tags:
-      - usage
-  /api/v1/usage/aggregate/by-project:
-    get:
-      parameters:
-      - description: Start of window (RFC3339)
-        in: query
-        name: from
-        type: string
-      - description: End of window (RFC3339)
-        in: query
-        name: to
-        type: string
-      - description: Organization id or slug
-        in: query
-        name: org_id
-        type: string
-      - description: Filter by user id
-        in: query
-        name: user_id
-        type: string
-      - description: Sort column
-        in: query
-        name: sort_by
-        type: string
-      - description: asc or desc
-        in: query
-        name: sort_dir
-        type: string
-      - description: Page
-        in: query
-        name: page
-        type: integer
-      - description: Page size
-        in: query
-        name: page_size
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.PaginatedUsageByProject'
-      security:
-      - BearerAuth: []
-      summary: Usage grouped by project / app / agent
-      tags:
-      - usage
-  /api/v1/usage/aggregate/by-session:
-    get:
-      parameters:
-      - description: Start of window (RFC3339)
-        in: query
-        name: from
-        type: string
-      - description: End of window (RFC3339)
-        in: query
-        name: to
-        type: string
-      - description: Organization id or slug
-        in: query
-        name: org_id
-        type: string
-      - description: Filter by user id
-        in: query
-        name: user_id
-        type: string
-      - description: Filter by project id
-        in: query
-        name: project_id
-        type: string
-      - description: Filter by provider
-        in: query
-        name: provider
-        type: string
-      - description: Filter by model
-        in: query
-        name: model
-        type: string
-      - description: Sort column
-        in: query
-        name: sort_by
-        type: string
-      - description: asc or desc
-        in: query
-        name: sort_dir
-        type: string
-      - description: Page
-        in: query
-        name: page
-        type: integer
-      - description: Page size
-        in: query
-        name: page_size
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.PaginatedUsageBySession'
-      security:
-      - BearerAuth: []
-      summary: Usage grouped by session
-      tags:
-      - usage
-  /api/v1/usage/aggregate/by-user:
-    get:
-      description: Org members get rows scoped to their org. Global admins may omit
-        org_id to list across all orgs.
-      parameters:
-      - description: Start of window (RFC3339)
-        in: query
-        name: from
-        type: string
-      - description: End of window (RFC3339)
-        in: query
-        name: to
-        type: string
-      - description: Organization id or slug. Required for non-admins.
-        in: query
-        name: org_id
-        type: string
-      - description: Sort column
-        in: query
-        name: sort_by
-        type: string
-      - description: asc or desc
-        in: query
-        name: sort_dir
-        type: string
-      - description: Page
-        in: query
-        name: page
-        type: integer
-      - description: Page size
-        in: query
-        name: page_size
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.PaginatedUsageByUser'
-      security:
-      - BearerAuth: []
-      summary: Usage grouped by user
+      summary: Aggregate usage grouped by a dimension
       tags:
       - usage
   /api/v1/usage/aggregate/summary:
     get:
-      description: Returns whole-set totals plus a daily time-series. Org owners must
-        pass org_id matching their org; global admins may omit it to summarize cross-org.
+      description: Returns whole-set totals plus a daily time-series. Org members
+        must pass org_id; global admins may omit it to summarize cross-org.
       parameters:
       - description: Start of window (RFC3339). Defaults to 7 days ago.
         in: query

--- a/openapi.json
+++ b/openapi.json
@@ -20715,6 +20715,547 @@
                 }
             }
         },
+        "/api/v1/usage/aggregate/by-model": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by model / provider",
+                "parameters": [
+                    {
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Organization id or slug",
+                        "name": "org_id",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Page",
+                        "name": "page",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.PaginatedUsageByModel"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/by-org": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Global-admin only. One row per organization with tokens, costs, user/session counts and last activity.",
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by organization",
+                "parameters": [
+                    {
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Sort column: total_cost, total_tokens, request_count, last_activity",
+                        "name": "sort_by",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Page (1-indexed)",
+                        "name": "page",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Page size (max 200, default 25)",
+                        "name": "page_size",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.PaginatedUsageByOrg"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/by-project": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by project / app / agent",
+                "parameters": [
+                    {
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Organization id or slug",
+                        "name": "org_id",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by user id",
+                        "name": "user_id",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Page",
+                        "name": "page",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.PaginatedUsageByProject"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/by-session": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by session",
+                "parameters": [
+                    {
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Organization id or slug",
+                        "name": "org_id",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by user id",
+                        "name": "user_id",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by project id",
+                        "name": "project_id",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by provider",
+                        "name": "provider",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by model",
+                        "name": "model",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Page",
+                        "name": "page",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.PaginatedUsageBySession"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/by-user": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Org members get rows scoped to their org. Global admins may omit org_id to list across all orgs.",
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by user",
+                "parameters": [
+                    {
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Organization id or slug. Required for non-admins.",
+                        "name": "org_id",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Page",
+                        "name": "page",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.PaginatedUsageByUser"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/summary": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns whole-set totals plus a daily time-series. Org owners must pass org_id matching their org; global admins may omit it to summarize cross-org.",
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Aggregate usage summary",
+                "parameters": [
+                    {
+                        "description": "Start of window (RFC3339). Defaults to 7 days ago.",
+                        "name": "from",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "End of window (RFC3339). Defaults to now.",
+                        "name": "to",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Organization id or slug. Required for non-admins.",
+                        "name": "org_id",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by user id",
+                        "name": "user_id",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by project id",
+                        "name": "project_id",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by app id",
+                        "name": "app_id",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by provider",
+                        "name": "provider",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by model",
+                        "name": "model",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.UsageSummary"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/users": {
             "get": {
                 "security": [
@@ -30407,6 +30948,136 @@
                     }
                 }
             },
+            "types.PaginatedUsageByModel": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "integer"
+                    },
+                    "page_size": {
+                        "type": "integer"
+                    },
+                    "rows": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/types.UsageByModel"
+                        }
+                    },
+                    "total": {
+                        "$ref": "#/components/schemas/types.UsageTotals"
+                    },
+                    "total_pages": {
+                        "type": "integer"
+                    },
+                    "total_rows": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "types.PaginatedUsageByOrg": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "integer"
+                    },
+                    "page_size": {
+                        "type": "integer"
+                    },
+                    "rows": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/types.UsageByOrg"
+                        }
+                    },
+                    "total": {
+                        "$ref": "#/components/schemas/types.UsageTotals"
+                    },
+                    "total_pages": {
+                        "type": "integer"
+                    },
+                    "total_rows": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "types.PaginatedUsageByProject": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "integer"
+                    },
+                    "page_size": {
+                        "type": "integer"
+                    },
+                    "rows": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/types.UsageByProject"
+                        }
+                    },
+                    "total": {
+                        "$ref": "#/components/schemas/types.UsageTotals"
+                    },
+                    "total_pages": {
+                        "type": "integer"
+                    },
+                    "total_rows": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "types.PaginatedUsageBySession": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "integer"
+                    },
+                    "page_size": {
+                        "type": "integer"
+                    },
+                    "rows": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/types.UsageBySession"
+                        }
+                    },
+                    "total": {
+                        "$ref": "#/components/schemas/types.UsageTotals"
+                    },
+                    "total_pages": {
+                        "type": "integer"
+                    },
+                    "total_rows": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "types.PaginatedUsageByUser": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "type": "integer"
+                    },
+                    "page_size": {
+                        "type": "integer"
+                    },
+                    "rows": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/types.UsageByUser"
+                        }
+                    },
+                    "total": {
+                        "$ref": "#/components/schemas/types.UsageTotals"
+                    },
+                    "total_pages": {
+                        "type": "integer"
+                    },
+                    "total_rows": {
+                        "type": "integer"
+                    }
+                }
+            },
             "types.PaginatedUsersList": {
                 "type": "object",
                 "properties": {
@@ -35935,6 +36606,396 @@
                     },
                     "prompt_tokens": {
                         "type": "integer"
+                    },
+                    "total_tokens": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "types.UsageByModel": {
+                "type": "object",
+                "properties": {
+                    "cache_read_cost": {
+                        "type": "number"
+                    },
+                    "cache_read_tokens": {
+                        "type": "integer"
+                    },
+                    "cache_write_cost": {
+                        "type": "number"
+                    },
+                    "cache_write_tokens": {
+                        "type": "integer"
+                    },
+                    "completion_cost": {
+                        "type": "number"
+                    },
+                    "completion_tokens": {
+                        "type": "integer"
+                    },
+                    "model": {
+                        "type": "string"
+                    },
+                    "prompt_cost": {
+                        "type": "number"
+                    },
+                    "prompt_tokens": {
+                        "type": "integer"
+                    },
+                    "provider": {
+                        "type": "string"
+                    },
+                    "request_count": {
+                        "type": "integer"
+                    },
+                    "total_cost": {
+                        "type": "number"
+                    },
+                    "total_tokens": {
+                        "type": "integer"
+                    },
+                    "unique_projects": {
+                        "type": "integer"
+                    },
+                    "unique_sessions": {
+                        "type": "integer"
+                    },
+                    "unique_users": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "types.UsageByOrg": {
+                "type": "object",
+                "properties": {
+                    "cache_read_cost": {
+                        "type": "number"
+                    },
+                    "cache_read_tokens": {
+                        "type": "integer"
+                    },
+                    "cache_write_cost": {
+                        "type": "number"
+                    },
+                    "cache_write_tokens": {
+                        "type": "integer"
+                    },
+                    "completion_cost": {
+                        "type": "number"
+                    },
+                    "completion_tokens": {
+                        "type": "integer"
+                    },
+                    "last_activity": {
+                        "type": "string"
+                    },
+                    "organization_id": {
+                        "type": "string"
+                    },
+                    "organization_name": {
+                        "type": "string"
+                    },
+                    "prompt_cost": {
+                        "type": "number"
+                    },
+                    "prompt_tokens": {
+                        "type": "integer"
+                    },
+                    "request_count": {
+                        "type": "integer"
+                    },
+                    "session_count": {
+                        "type": "integer"
+                    },
+                    "top_model": {
+                        "type": "string"
+                    },
+                    "total_cost": {
+                        "type": "number"
+                    },
+                    "total_tokens": {
+                        "type": "integer"
+                    },
+                    "user_count": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "types.UsageByProject": {
+                "type": "object",
+                "properties": {
+                    "app_id": {
+                        "type": "string"
+                    },
+                    "cache_read_cost": {
+                        "type": "number"
+                    },
+                    "cache_read_tokens": {
+                        "type": "integer"
+                    },
+                    "cache_write_cost": {
+                        "type": "number"
+                    },
+                    "cache_write_tokens": {
+                        "type": "integer"
+                    },
+                    "completion_cost": {
+                        "type": "number"
+                    },
+                    "completion_tokens": {
+                        "type": "integer"
+                    },
+                    "kind": {
+                        "description": "\"project\" | \"app\" | \"agent\"",
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "organization_id": {
+                        "type": "string"
+                    },
+                    "owner_user_id": {
+                        "type": "string"
+                    },
+                    "project_id": {
+                        "type": "string"
+                    },
+                    "prompt_cost": {
+                        "type": "number"
+                    },
+                    "prompt_tokens": {
+                        "type": "integer"
+                    },
+                    "request_count": {
+                        "type": "integer"
+                    },
+                    "session_count": {
+                        "type": "integer"
+                    },
+                    "total_cost": {
+                        "type": "number"
+                    },
+                    "total_tokens": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "types.UsageBySession": {
+                "type": "object",
+                "properties": {
+                    "cache_read_cost": {
+                        "type": "number"
+                    },
+                    "cache_read_tokens": {
+                        "type": "integer"
+                    },
+                    "cache_write_cost": {
+                        "type": "number"
+                    },
+                    "cache_write_tokens": {
+                        "type": "integer"
+                    },
+                    "call_count": {
+                        "type": "integer"
+                    },
+                    "completion_cost": {
+                        "type": "number"
+                    },
+                    "completion_tokens": {
+                        "type": "integer"
+                    },
+                    "ended_at": {
+                        "type": "string"
+                    },
+                    "model": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "organization_id": {
+                        "type": "string"
+                    },
+                    "project_id": {
+                        "type": "string"
+                    },
+                    "prompt_cost": {
+                        "type": "number"
+                    },
+                    "prompt_tokens": {
+                        "type": "integer"
+                    },
+                    "provider": {
+                        "type": "string"
+                    },
+                    "request_count": {
+                        "type": "integer"
+                    },
+                    "session_id": {
+                        "type": "string"
+                    },
+                    "started_at": {
+                        "type": "string"
+                    },
+                    "total_cost": {
+                        "type": "number"
+                    },
+                    "total_tokens": {
+                        "type": "integer"
+                    },
+                    "user_id": {
+                        "type": "string"
+                    }
+                }
+            },
+            "types.UsageByUser": {
+                "type": "object",
+                "properties": {
+                    "cache_read_cost": {
+                        "type": "number"
+                    },
+                    "cache_read_tokens": {
+                        "type": "integer"
+                    },
+                    "cache_write_cost": {
+                        "type": "number"
+                    },
+                    "cache_write_tokens": {
+                        "type": "integer"
+                    },
+                    "completion_cost": {
+                        "type": "number"
+                    },
+                    "completion_tokens": {
+                        "type": "integer"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "last_activity": {
+                        "type": "string"
+                    },
+                    "organization_id": {
+                        "type": "string"
+                    },
+                    "prompt_cost": {
+                        "type": "number"
+                    },
+                    "prompt_tokens": {
+                        "type": "integer"
+                    },
+                    "request_count": {
+                        "type": "integer"
+                    },
+                    "session_count": {
+                        "type": "integer"
+                    },
+                    "top_model": {
+                        "type": "string"
+                    },
+                    "total_cost": {
+                        "type": "number"
+                    },
+                    "total_tokens": {
+                        "type": "integer"
+                    },
+                    "user_id": {
+                        "type": "string"
+                    }
+                }
+            },
+            "types.UsageSummary": {
+                "type": "object",
+                "properties": {
+                    "active_projects": {
+                        "type": "integer"
+                    },
+                    "active_sessions": {
+                        "type": "integer"
+                    },
+                    "active_users": {
+                        "type": "integer"
+                    },
+                    "cache_read_cost": {
+                        "type": "number"
+                    },
+                    "cache_read_tokens": {
+                        "type": "integer"
+                    },
+                    "cache_write_cost": {
+                        "type": "number"
+                    },
+                    "cache_write_tokens": {
+                        "type": "integer"
+                    },
+                    "completion_cost": {
+                        "type": "number"
+                    },
+                    "completion_tokens": {
+                        "type": "integer"
+                    },
+                    "from": {
+                        "type": "string"
+                    },
+                    "prompt_cost": {
+                        "type": "number"
+                    },
+                    "prompt_tokens": {
+                        "type": "integer"
+                    },
+                    "request_count": {
+                        "type": "integer"
+                    },
+                    "time_series": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/types.AggregatedUsageMetric"
+                        }
+                    },
+                    "to": {
+                        "type": "string"
+                    },
+                    "total_cost": {
+                        "type": "number"
+                    },
+                    "total_tokens": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "types.UsageTotals": {
+                "type": "object",
+                "properties": {
+                    "cache_read_cost": {
+                        "type": "number"
+                    },
+                    "cache_read_tokens": {
+                        "type": "integer"
+                    },
+                    "cache_write_cost": {
+                        "type": "number"
+                    },
+                    "cache_write_tokens": {
+                        "type": "integer"
+                    },
+                    "completion_cost": {
+                        "type": "number"
+                    },
+                    "completion_tokens": {
+                        "type": "integer"
+                    },
+                    "prompt_cost": {
+                        "type": "number"
+                    },
+                    "prompt_tokens": {
+                        "type": "integer"
+                    },
+                    "request_count": {
+                        "type": "integer"
+                    },
+                    "total_cost": {
+                        "type": "number"
                     },
                     "total_tokens": {
                         "type": "integer"

--- a/openapi.json
+++ b/openapi.json
@@ -20715,268 +20715,28 @@
                 }
             }
         },
-        "/api/v1/usage/aggregate/by-model": {
+        "/api/v1/usage/aggregate/grouped": {
             "get": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
+                "description": "One endpoint, five groupings. Pass `group_by` to choose what each row represents. `group_by=org` is global-admin only.\nRow shape per `group_by` (see types/types.go):\n- org: UsageByOrg (organization_id, organization_name, user_count, session_count, top_model, last_activity)\n- user: UsageByUser (user_id, email, organization_id, session_count, top_model, last_activity)\n- project: UsageByProject (project_id, app_id, name, kind, owner_user_id, organization_id, session_count)\n- session: UsageBySession (session_id, name, user_id, project_id, organization_id, provider, model, call_count, started_at, ended_at)\n- model: UsageByModel (provider, model, unique_users, unique_sessions, unique_projects)\nEvery row also carries the shared UsageTotals fields (prompt/completion/cache tokens and costs, total_cost, request_count).",
                 "tags": [
                     "usage"
                 ],
-                "summary": "Usage grouped by model / provider",
+                "summary": "Aggregate usage grouped by a dimension",
                 "parameters": [
                     {
-                        "description": "Start of window (RFC3339)",
-                        "name": "from",
+                        "description": "Grouping: org|user|project|session|model",
+                        "name": "group_by",
                         "in": "query",
+                        "required": true,
                         "schema": {
                             "type": "string"
                         }
                     },
-                    {
-                        "description": "End of window (RFC3339)",
-                        "name": "to",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Organization id or slug",
-                        "name": "org_id",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Sort column",
-                        "name": "sort_by",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "asc or desc",
-                        "name": "sort_dir",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Page",
-                        "name": "page",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer"
-                        }
-                    },
-                    {
-                        "description": "Page size",
-                        "name": "page_size",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.PaginatedUsageByModel"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/usage/aggregate/by-org": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Global-admin only. One row per organization with tokens, costs, user/session counts and last activity.",
-                "tags": [
-                    "usage"
-                ],
-                "summary": "Usage grouped by organization",
-                "parameters": [
-                    {
-                        "description": "Start of window (RFC3339)",
-                        "name": "from",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "End of window (RFC3339)",
-                        "name": "to",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Sort column: total_cost, total_tokens, request_count, last_activity",
-                        "name": "sort_by",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "asc or desc",
-                        "name": "sort_dir",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Page (1-indexed)",
-                        "name": "page",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer"
-                        }
-                    },
-                    {
-                        "description": "Page size (max 200, default 25)",
-                        "name": "page_size",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.PaginatedUsageByOrg"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/usage/aggregate/by-project": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "tags": [
-                    "usage"
-                ],
-                "summary": "Usage grouped by project / app / agent",
-                "parameters": [
-                    {
-                        "description": "Start of window (RFC3339)",
-                        "name": "from",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "End of window (RFC3339)",
-                        "name": "to",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Organization id or slug",
-                        "name": "org_id",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Filter by user id",
-                        "name": "user_id",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Sort column",
-                        "name": "sort_by",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "asc or desc",
-                        "name": "sort_dir",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Page",
-                        "name": "page",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer"
-                        }
-                    },
-                    {
-                        "description": "Page size",
-                        "name": "page_size",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.PaginatedUsageByProject"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/usage/aggregate/by-session": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "tags": [
-                    "usage"
-                ],
-                "summary": "Usage grouped by session",
-                "parameters": [
                     {
                         "description": "Start of window (RFC3339)",
                         "name": "from",
@@ -21018,6 +20778,22 @@
                         }
                     },
                     {
+                        "description": "Filter by app id",
+                        "name": "app_id",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by session id",
+                        "name": "session_id",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "description": "Filter by provider",
                         "name": "provider",
                         "in": "query",
@@ -21034,7 +20810,7 @@
                         }
                     },
                     {
-                        "description": "Sort column",
+                        "description": "Sort column (per-grouping whitelist)",
                         "name": "sort_by",
                         "in": "query",
                         "schema": {
@@ -21050,7 +20826,7 @@
                         }
                     },
                     {
-                        "description": "Page",
+                        "description": "Page (1-indexed)",
                         "name": "page",
                         "in": "query",
                         "schema": {
@@ -21058,7 +20834,7 @@
                         }
                     },
                     {
-                        "description": "Page size",
+                        "description": "Page size (max 200, default 25)",
                         "name": "page_size",
                         "in": "query",
                         "schema": {
@@ -21072,91 +20848,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/types.PaginatedUsageBySession"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/usage/aggregate/by-user": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Org members get rows scoped to their org. Global admins may omit org_id to list across all orgs.",
-                "tags": [
-                    "usage"
-                ],
-                "summary": "Usage grouped by user",
-                "parameters": [
-                    {
-                        "description": "Start of window (RFC3339)",
-                        "name": "from",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "End of window (RFC3339)",
-                        "name": "to",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Organization id or slug. Required for non-admins.",
-                        "name": "org_id",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Sort column",
-                        "name": "sort_by",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "asc or desc",
-                        "name": "sort_dir",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Page",
-                        "name": "page",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer"
-                        }
-                    },
-                    {
-                        "description": "Page size",
-                        "name": "page_size",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.PaginatedUsageByUser"
+                                    "$ref": "#/components/schemas/types.UsageGroupedResponse"
                                 }
                             }
                         }
@@ -21171,7 +20863,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns whole-set totals plus a daily time-series. Org owners must pass org_id matching their org; global admins may omit it to summarize cross-org.",
+                "description": "Returns whole-set totals plus a daily time-series. Org members must pass org_id; global admins may omit it to summarize cross-org.",
                 "tags": [
                     "usage"
                 ],
@@ -30948,136 +30640,6 @@
                     }
                 }
             },
-            "types.PaginatedUsageByModel": {
-                "type": "object",
-                "properties": {
-                    "page": {
-                        "type": "integer"
-                    },
-                    "page_size": {
-                        "type": "integer"
-                    },
-                    "rows": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/types.UsageByModel"
-                        }
-                    },
-                    "total": {
-                        "$ref": "#/components/schemas/types.UsageTotals"
-                    },
-                    "total_pages": {
-                        "type": "integer"
-                    },
-                    "total_rows": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "types.PaginatedUsageByOrg": {
-                "type": "object",
-                "properties": {
-                    "page": {
-                        "type": "integer"
-                    },
-                    "page_size": {
-                        "type": "integer"
-                    },
-                    "rows": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/types.UsageByOrg"
-                        }
-                    },
-                    "total": {
-                        "$ref": "#/components/schemas/types.UsageTotals"
-                    },
-                    "total_pages": {
-                        "type": "integer"
-                    },
-                    "total_rows": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "types.PaginatedUsageByProject": {
-                "type": "object",
-                "properties": {
-                    "page": {
-                        "type": "integer"
-                    },
-                    "page_size": {
-                        "type": "integer"
-                    },
-                    "rows": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/types.UsageByProject"
-                        }
-                    },
-                    "total": {
-                        "$ref": "#/components/schemas/types.UsageTotals"
-                    },
-                    "total_pages": {
-                        "type": "integer"
-                    },
-                    "total_rows": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "types.PaginatedUsageBySession": {
-                "type": "object",
-                "properties": {
-                    "page": {
-                        "type": "integer"
-                    },
-                    "page_size": {
-                        "type": "integer"
-                    },
-                    "rows": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/types.UsageBySession"
-                        }
-                    },
-                    "total": {
-                        "$ref": "#/components/schemas/types.UsageTotals"
-                    },
-                    "total_pages": {
-                        "type": "integer"
-                    },
-                    "total_rows": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "types.PaginatedUsageByUser": {
-                "type": "object",
-                "properties": {
-                    "page": {
-                        "type": "integer"
-                    },
-                    "page_size": {
-                        "type": "integer"
-                    },
-                    "rows": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/types.UsageByUser"
-                        }
-                    },
-                    "total": {
-                        "$ref": "#/components/schemas/types.UsageTotals"
-                    },
-                    "total_pages": {
-                        "type": "integer"
-                    },
-                    "total_rows": {
-                        "type": "integer"
-                    }
-                }
-            },
             "types.PaginatedUsersList": {
                 "type": "object",
                 "properties": {
@@ -36612,296 +36174,28 @@
                     }
                 }
             },
-            "types.UsageByModel": {
+            "types.UsageGroupedResponse": {
                 "type": "object",
                 "properties": {
-                    "cache_read_cost": {
-                        "type": "number"
-                    },
-                    "cache_read_tokens": {
-                        "type": "integer"
-                    },
-                    "cache_write_cost": {
-                        "type": "number"
-                    },
-                    "cache_write_tokens": {
-                        "type": "integer"
-                    },
-                    "completion_cost": {
-                        "type": "number"
-                    },
-                    "completion_tokens": {
-                        "type": "integer"
-                    },
-                    "model": {
+                    "group_by": {
+                        "description": "\"org\" | \"user\" | \"project\" | \"session\" | \"model\"",
                         "type": "string"
                     },
-                    "prompt_cost": {
-                        "type": "number"
-                    },
-                    "prompt_tokens": {
+                    "page": {
                         "type": "integer"
                     },
-                    "provider": {
-                        "type": "string"
-                    },
-                    "request_count": {
+                    "page_size": {
                         "type": "integer"
                     },
-                    "total_cost": {
-                        "type": "number"
+                    "rows": {},
+                    "total": {
+                        "$ref": "#/components/schemas/types.UsageTotals"
                     },
-                    "total_tokens": {
+                    "total_pages": {
                         "type": "integer"
                     },
-                    "unique_projects": {
+                    "total_rows": {
                         "type": "integer"
-                    },
-                    "unique_sessions": {
-                        "type": "integer"
-                    },
-                    "unique_users": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "types.UsageByOrg": {
-                "type": "object",
-                "properties": {
-                    "cache_read_cost": {
-                        "type": "number"
-                    },
-                    "cache_read_tokens": {
-                        "type": "integer"
-                    },
-                    "cache_write_cost": {
-                        "type": "number"
-                    },
-                    "cache_write_tokens": {
-                        "type": "integer"
-                    },
-                    "completion_cost": {
-                        "type": "number"
-                    },
-                    "completion_tokens": {
-                        "type": "integer"
-                    },
-                    "last_activity": {
-                        "type": "string"
-                    },
-                    "organization_id": {
-                        "type": "string"
-                    },
-                    "organization_name": {
-                        "type": "string"
-                    },
-                    "prompt_cost": {
-                        "type": "number"
-                    },
-                    "prompt_tokens": {
-                        "type": "integer"
-                    },
-                    "request_count": {
-                        "type": "integer"
-                    },
-                    "session_count": {
-                        "type": "integer"
-                    },
-                    "top_model": {
-                        "type": "string"
-                    },
-                    "total_cost": {
-                        "type": "number"
-                    },
-                    "total_tokens": {
-                        "type": "integer"
-                    },
-                    "user_count": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "types.UsageByProject": {
-                "type": "object",
-                "properties": {
-                    "app_id": {
-                        "type": "string"
-                    },
-                    "cache_read_cost": {
-                        "type": "number"
-                    },
-                    "cache_read_tokens": {
-                        "type": "integer"
-                    },
-                    "cache_write_cost": {
-                        "type": "number"
-                    },
-                    "cache_write_tokens": {
-                        "type": "integer"
-                    },
-                    "completion_cost": {
-                        "type": "number"
-                    },
-                    "completion_tokens": {
-                        "type": "integer"
-                    },
-                    "kind": {
-                        "description": "\"project\" | \"app\" | \"agent\"",
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "organization_id": {
-                        "type": "string"
-                    },
-                    "owner_user_id": {
-                        "type": "string"
-                    },
-                    "project_id": {
-                        "type": "string"
-                    },
-                    "prompt_cost": {
-                        "type": "number"
-                    },
-                    "prompt_tokens": {
-                        "type": "integer"
-                    },
-                    "request_count": {
-                        "type": "integer"
-                    },
-                    "session_count": {
-                        "type": "integer"
-                    },
-                    "total_cost": {
-                        "type": "number"
-                    },
-                    "total_tokens": {
-                        "type": "integer"
-                    }
-                }
-            },
-            "types.UsageBySession": {
-                "type": "object",
-                "properties": {
-                    "cache_read_cost": {
-                        "type": "number"
-                    },
-                    "cache_read_tokens": {
-                        "type": "integer"
-                    },
-                    "cache_write_cost": {
-                        "type": "number"
-                    },
-                    "cache_write_tokens": {
-                        "type": "integer"
-                    },
-                    "call_count": {
-                        "type": "integer"
-                    },
-                    "completion_cost": {
-                        "type": "number"
-                    },
-                    "completion_tokens": {
-                        "type": "integer"
-                    },
-                    "ended_at": {
-                        "type": "string"
-                    },
-                    "model": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "organization_id": {
-                        "type": "string"
-                    },
-                    "project_id": {
-                        "type": "string"
-                    },
-                    "prompt_cost": {
-                        "type": "number"
-                    },
-                    "prompt_tokens": {
-                        "type": "integer"
-                    },
-                    "provider": {
-                        "type": "string"
-                    },
-                    "request_count": {
-                        "type": "integer"
-                    },
-                    "session_id": {
-                        "type": "string"
-                    },
-                    "started_at": {
-                        "type": "string"
-                    },
-                    "total_cost": {
-                        "type": "number"
-                    },
-                    "total_tokens": {
-                        "type": "integer"
-                    },
-                    "user_id": {
-                        "type": "string"
-                    }
-                }
-            },
-            "types.UsageByUser": {
-                "type": "object",
-                "properties": {
-                    "cache_read_cost": {
-                        "type": "number"
-                    },
-                    "cache_read_tokens": {
-                        "type": "integer"
-                    },
-                    "cache_write_cost": {
-                        "type": "number"
-                    },
-                    "cache_write_tokens": {
-                        "type": "integer"
-                    },
-                    "completion_cost": {
-                        "type": "number"
-                    },
-                    "completion_tokens": {
-                        "type": "integer"
-                    },
-                    "email": {
-                        "type": "string"
-                    },
-                    "last_activity": {
-                        "type": "string"
-                    },
-                    "organization_id": {
-                        "type": "string"
-                    },
-                    "prompt_cost": {
-                        "type": "number"
-                    },
-                    "prompt_tokens": {
-                        "type": "integer"
-                    },
-                    "request_count": {
-                        "type": "integer"
-                    },
-                    "session_count": {
-                        "type": "integer"
-                    },
-                    "top_model": {
-                        "type": "string"
-                    },
-                    "total_cost": {
-                        "type": "number"
-                    },
-                    "total_tokens": {
-                        "type": "integer"
-                    },
-                    "user_id": {
-                        "type": "string"
                     }
                 }
             },

--- a/swagger.json
+++ b/swagger.json
@@ -17118,6 +17118,447 @@
                 }
             }
         },
+        "/api/v1/usage/aggregate/by-model": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by model / provider",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization id or slug",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedUsageByModel"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/by-org": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Global-admin only. One row per organization with tokens, costs, user/session counts and last activity.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by organization",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column: total_cost, total_tokens, request_count, last_activity",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page (1-indexed)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size (max 200, default 25)",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedUsageByOrg"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/by-project": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by project / app / agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization id or slug",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by user id",
+                        "name": "user_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedUsageByProject"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/by-session": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization id or slug",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by user id",
+                        "name": "user_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by project id",
+                        "name": "project_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by provider",
+                        "name": "provider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by model",
+                        "name": "model",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedUsageBySession"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/by-user": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Org members get rows scoped to their org. Global admins may omit org_id to list across all orgs.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Usage grouped by user",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339)",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339)",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization id or slug. Required for non-admins.",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort column",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "asc or desc",
+                        "name": "sort_dir",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedUsageByUser"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/usage/aggregate/summary": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns whole-set totals plus a daily time-series. Org owners must pass org_id matching their org; global admins may omit it to summarize cross-org.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "usage"
+                ],
+                "summary": "Aggregate usage summary",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Start of window (RFC3339). Defaults to 7 days ago.",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End of window (RFC3339). Defaults to now.",
+                        "name": "to",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization id or slug. Required for non-admins.",
+                        "name": "org_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by user id",
+                        "name": "user_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by project id",
+                        "name": "project_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by app id",
+                        "name": "app_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by provider",
+                        "name": "provider",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by model",
+                        "name": "model",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.UsageSummary"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/users": {
             "get": {
                 "security": [
@@ -26586,6 +27027,136 @@
                 }
             }
         },
+        "types.PaginatedUsageByModel": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageByModel"
+                    }
+                },
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
+                },
+                "total_pages": {
+                    "type": "integer"
+                },
+                "total_rows": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.PaginatedUsageByOrg": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageByOrg"
+                    }
+                },
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
+                },
+                "total_pages": {
+                    "type": "integer"
+                },
+                "total_rows": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.PaginatedUsageByProject": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageByProject"
+                    }
+                },
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
+                },
+                "total_pages": {
+                    "type": "integer"
+                },
+                "total_rows": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.PaginatedUsageBySession": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageBySession"
+                    }
+                },
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
+                },
+                "total_pages": {
+                    "type": "integer"
+                },
+                "total_rows": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.PaginatedUsageByUser": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.UsageByUser"
+                    }
+                },
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
+                },
+                "total_pages": {
+                    "type": "integer"
+                },
+                "total_rows": {
+                    "type": "integer"
+                }
+            }
+        },
         "types.PaginatedUsersList": {
             "type": "object",
             "properties": {
@@ -32114,6 +32685,396 @@
                 },
                 "prompt_tokens": {
                     "type": "integer"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageByModel": {
+            "type": "object",
+            "properties": {
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                },
+                "unique_projects": {
+                    "type": "integer"
+                },
+                "unique_sessions": {
+                    "type": "integer"
+                },
+                "unique_users": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageByOrg": {
+            "type": "object",
+            "properties": {
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "last_activity": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "organization_name": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "session_count": {
+                    "type": "integer"
+                },
+                "top_model": {
+                    "type": "string"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                },
+                "user_count": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageByProject": {
+            "type": "object",
+            "properties": {
+                "app_id": {
+                    "type": "string"
+                },
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "kind": {
+                    "description": "\"project\" | \"app\" | \"agent\"",
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "owner_user_id": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "session_count": {
+                    "type": "integer"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageBySession": {
+            "type": "object",
+            "properties": {
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "call_count": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "ended_at": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "started_at": {
+                    "type": "string"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.UsageByUser": {
+            "type": "object",
+            "properties": {
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "last_activity": {
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "session_count": {
+                    "type": "integer"
+                },
+                "top_model": {
+                    "type": "string"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.UsageSummary": {
+            "type": "object",
+            "properties": {
+                "active_projects": {
+                    "type": "integer"
+                },
+                "active_sessions": {
+                    "type": "integer"
+                },
+                "active_users": {
+                    "type": "integer"
+                },
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "from": {
+                    "type": "string"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "time_series": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.AggregatedUsageMetric"
+                    }
+                },
+                "to": {
+                    "type": "string"
+                },
+                "total_cost": {
+                    "type": "number"
+                },
+                "total_tokens": {
+                    "type": "integer"
+                }
+            }
+        },
+        "types.UsageTotals": {
+            "type": "object",
+            "properties": {
+                "cache_read_cost": {
+                    "type": "number"
+                },
+                "cache_read_tokens": {
+                    "type": "integer"
+                },
+                "cache_write_cost": {
+                    "type": "number"
+                },
+                "cache_write_tokens": {
+                    "type": "integer"
+                },
+                "completion_cost": {
+                    "type": "number"
+                },
+                "completion_tokens": {
+                    "type": "integer"
+                },
+                "prompt_cost": {
+                    "type": "number"
+                },
+                "prompt_tokens": {
+                    "type": "integer"
+                },
+                "request_count": {
+                    "type": "integer"
+                },
+                "total_cost": {
+                    "type": "number"
                 },
                 "total_tokens": {
                     "type": "integer"

--- a/swagger.json
+++ b/swagger.json
@@ -17118,226 +17118,29 @@
                 }
             }
         },
-        "/api/v1/usage/aggregate/by-model": {
+        "/api/v1/usage/aggregate/grouped": {
             "get": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
+                "description": "One endpoint, five groupings. Pass `group_by` to choose what each row represents. `group_by=org` is global-admin only.\nRow shape per `group_by` (see types/types.go):\n- org: UsageByOrg (organization_id, organization_name, user_count, session_count, top_model, last_activity)\n- user: UsageByUser (user_id, email, organization_id, session_count, top_model, last_activity)\n- project: UsageByProject (project_id, app_id, name, kind, owner_user_id, organization_id, session_count)\n- session: UsageBySession (session_id, name, user_id, project_id, organization_id, provider, model, call_count, started_at, ended_at)\n- model: UsageByModel (provider, model, unique_users, unique_sessions, unique_projects)\nEvery row also carries the shared UsageTotals fields (prompt/completion/cache tokens and costs, total_cost, request_count).",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "usage"
                 ],
-                "summary": "Usage grouped by model / provider",
+                "summary": "Aggregate usage grouped by a dimension",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Start of window (RFC3339)",
-                        "name": "from",
-                        "in": "query"
+                        "description": "Grouping: org|user|project|session|model",
+                        "name": "group_by",
+                        "in": "query",
+                        "required": true
                     },
-                    {
-                        "type": "string",
-                        "description": "End of window (RFC3339)",
-                        "name": "to",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Organization id or slug",
-                        "name": "org_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort column",
-                        "name": "sort_by",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "asc or desc",
-                        "name": "sort_dir",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size",
-                        "name": "page_size",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedUsageByModel"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/usage/aggregate/by-org": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Global-admin only. One row per organization with tokens, costs, user/session counts and last activity.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "usage"
-                ],
-                "summary": "Usage grouped by organization",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Start of window (RFC3339)",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "End of window (RFC3339)",
-                        "name": "to",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort column: total_cost, total_tokens, request_count, last_activity",
-                        "name": "sort_by",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "asc or desc",
-                        "name": "sort_dir",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page (1-indexed)",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size (max 200, default 25)",
-                        "name": "page_size",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedUsageByOrg"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/usage/aggregate/by-project": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "usage"
-                ],
-                "summary": "Usage grouped by project / app / agent",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Start of window (RFC3339)",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "End of window (RFC3339)",
-                        "name": "to",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Organization id or slug",
-                        "name": "org_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by user id",
-                        "name": "user_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort column",
-                        "name": "sort_by",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "asc or desc",
-                        "name": "sort_dir",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size",
-                        "name": "page_size",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedUsageByProject"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/usage/aggregate/by-session": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "usage"
-                ],
-                "summary": "Usage grouped by session",
-                "parameters": [
                     {
                         "type": "string",
                         "description": "Start of window (RFC3339)",
@@ -17370,6 +17173,18 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by app id",
+                        "name": "app_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by session id",
+                        "name": "session_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Filter by provider",
                         "name": "provider",
                         "in": "query"
@@ -17382,7 +17197,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Sort column",
+                        "description": "Sort column (per-grouping whitelist)",
                         "name": "sort_by",
                         "in": "query"
                     },
@@ -17394,13 +17209,13 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Page",
+                        "description": "Page (1-indexed)",
                         "name": "page",
                         "in": "query"
                     },
                     {
                         "type": "integer",
-                        "description": "Page size",
+                        "description": "Page size (max 200, default 25)",
                         "name": "page_size",
                         "in": "query"
                     }
@@ -17409,76 +17224,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/types.PaginatedUsageBySession"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/usage/aggregate/by-user": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Org members get rows scoped to their org. Global admins may omit org_id to list across all orgs.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "usage"
-                ],
-                "summary": "Usage grouped by user",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Start of window (RFC3339)",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "End of window (RFC3339)",
-                        "name": "to",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Organization id or slug. Required for non-admins.",
-                        "name": "org_id",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Sort column",
-                        "name": "sort_by",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "asc or desc",
-                        "name": "sort_dir",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size",
-                        "name": "page_size",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedUsageByUser"
+                            "$ref": "#/definitions/types.UsageGroupedResponse"
                         }
                     }
                 }
@@ -17491,7 +17237,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns whole-set totals plus a daily time-series. Org owners must pass org_id matching their org; global admins may omit it to summarize cross-org.",
+                "description": "Returns whole-set totals plus a daily time-series. Org members must pass org_id; global admins may omit it to summarize cross-org.",
                 "produces": [
                     "application/json"
                 ],
@@ -27027,136 +26773,6 @@
                 }
             }
         },
-        "types.PaginatedUsageByModel": {
-            "type": "object",
-            "properties": {
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.UsageByModel"
-                    }
-                },
-                "total": {
-                    "$ref": "#/definitions/types.UsageTotals"
-                },
-                "total_pages": {
-                    "type": "integer"
-                },
-                "total_rows": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.PaginatedUsageByOrg": {
-            "type": "object",
-            "properties": {
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.UsageByOrg"
-                    }
-                },
-                "total": {
-                    "$ref": "#/definitions/types.UsageTotals"
-                },
-                "total_pages": {
-                    "type": "integer"
-                },
-                "total_rows": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.PaginatedUsageByProject": {
-            "type": "object",
-            "properties": {
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.UsageByProject"
-                    }
-                },
-                "total": {
-                    "$ref": "#/definitions/types.UsageTotals"
-                },
-                "total_pages": {
-                    "type": "integer"
-                },
-                "total_rows": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.PaginatedUsageBySession": {
-            "type": "object",
-            "properties": {
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.UsageBySession"
-                    }
-                },
-                "total": {
-                    "$ref": "#/definitions/types.UsageTotals"
-                },
-                "total_pages": {
-                    "type": "integer"
-                },
-                "total_rows": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.PaginatedUsageByUser": {
-            "type": "object",
-            "properties": {
-                "page": {
-                    "type": "integer"
-                },
-                "page_size": {
-                    "type": "integer"
-                },
-                "rows": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.UsageByUser"
-                    }
-                },
-                "total": {
-                    "$ref": "#/definitions/types.UsageTotals"
-                },
-                "total_pages": {
-                    "type": "integer"
-                },
-                "total_rows": {
-                    "type": "integer"
-                }
-            }
-        },
         "types.PaginatedUsersList": {
             "type": "object",
             "properties": {
@@ -32691,296 +32307,28 @@
                 }
             }
         },
-        "types.UsageByModel": {
+        "types.UsageGroupedResponse": {
             "type": "object",
             "properties": {
-                "cache_read_cost": {
-                    "type": "number"
-                },
-                "cache_read_tokens": {
-                    "type": "integer"
-                },
-                "cache_write_cost": {
-                    "type": "number"
-                },
-                "cache_write_tokens": {
-                    "type": "integer"
-                },
-                "completion_cost": {
-                    "type": "number"
-                },
-                "completion_tokens": {
-                    "type": "integer"
-                },
-                "model": {
+                "group_by": {
+                    "description": "\"org\" | \"user\" | \"project\" | \"session\" | \"model\"",
                     "type": "string"
                 },
-                "prompt_cost": {
-                    "type": "number"
-                },
-                "prompt_tokens": {
+                "page": {
                     "type": "integer"
                 },
-                "provider": {
-                    "type": "string"
-                },
-                "request_count": {
+                "page_size": {
                     "type": "integer"
                 },
-                "total_cost": {
-                    "type": "number"
+                "rows": {},
+                "total": {
+                    "$ref": "#/definitions/types.UsageTotals"
                 },
-                "total_tokens": {
+                "total_pages": {
                     "type": "integer"
                 },
-                "unique_projects": {
+                "total_rows": {
                     "type": "integer"
-                },
-                "unique_sessions": {
-                    "type": "integer"
-                },
-                "unique_users": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.UsageByOrg": {
-            "type": "object",
-            "properties": {
-                "cache_read_cost": {
-                    "type": "number"
-                },
-                "cache_read_tokens": {
-                    "type": "integer"
-                },
-                "cache_write_cost": {
-                    "type": "number"
-                },
-                "cache_write_tokens": {
-                    "type": "integer"
-                },
-                "completion_cost": {
-                    "type": "number"
-                },
-                "completion_tokens": {
-                    "type": "integer"
-                },
-                "last_activity": {
-                    "type": "string"
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "organization_name": {
-                    "type": "string"
-                },
-                "prompt_cost": {
-                    "type": "number"
-                },
-                "prompt_tokens": {
-                    "type": "integer"
-                },
-                "request_count": {
-                    "type": "integer"
-                },
-                "session_count": {
-                    "type": "integer"
-                },
-                "top_model": {
-                    "type": "string"
-                },
-                "total_cost": {
-                    "type": "number"
-                },
-                "total_tokens": {
-                    "type": "integer"
-                },
-                "user_count": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.UsageByProject": {
-            "type": "object",
-            "properties": {
-                "app_id": {
-                    "type": "string"
-                },
-                "cache_read_cost": {
-                    "type": "number"
-                },
-                "cache_read_tokens": {
-                    "type": "integer"
-                },
-                "cache_write_cost": {
-                    "type": "number"
-                },
-                "cache_write_tokens": {
-                    "type": "integer"
-                },
-                "completion_cost": {
-                    "type": "number"
-                },
-                "completion_tokens": {
-                    "type": "integer"
-                },
-                "kind": {
-                    "description": "\"project\" | \"app\" | \"agent\"",
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "owner_user_id": {
-                    "type": "string"
-                },
-                "project_id": {
-                    "type": "string"
-                },
-                "prompt_cost": {
-                    "type": "number"
-                },
-                "prompt_tokens": {
-                    "type": "integer"
-                },
-                "request_count": {
-                    "type": "integer"
-                },
-                "session_count": {
-                    "type": "integer"
-                },
-                "total_cost": {
-                    "type": "number"
-                },
-                "total_tokens": {
-                    "type": "integer"
-                }
-            }
-        },
-        "types.UsageBySession": {
-            "type": "object",
-            "properties": {
-                "cache_read_cost": {
-                    "type": "number"
-                },
-                "cache_read_tokens": {
-                    "type": "integer"
-                },
-                "cache_write_cost": {
-                    "type": "number"
-                },
-                "cache_write_tokens": {
-                    "type": "integer"
-                },
-                "call_count": {
-                    "type": "integer"
-                },
-                "completion_cost": {
-                    "type": "number"
-                },
-                "completion_tokens": {
-                    "type": "integer"
-                },
-                "ended_at": {
-                    "type": "string"
-                },
-                "model": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "project_id": {
-                    "type": "string"
-                },
-                "prompt_cost": {
-                    "type": "number"
-                },
-                "prompt_tokens": {
-                    "type": "integer"
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "request_count": {
-                    "type": "integer"
-                },
-                "session_id": {
-                    "type": "string"
-                },
-                "started_at": {
-                    "type": "string"
-                },
-                "total_cost": {
-                    "type": "number"
-                },
-                "total_tokens": {
-                    "type": "integer"
-                },
-                "user_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "types.UsageByUser": {
-            "type": "object",
-            "properties": {
-                "cache_read_cost": {
-                    "type": "number"
-                },
-                "cache_read_tokens": {
-                    "type": "integer"
-                },
-                "cache_write_cost": {
-                    "type": "number"
-                },
-                "cache_write_tokens": {
-                    "type": "integer"
-                },
-                "completion_cost": {
-                    "type": "number"
-                },
-                "completion_tokens": {
-                    "type": "integer"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "last_activity": {
-                    "type": "string"
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "prompt_cost": {
-                    "type": "number"
-                },
-                "prompt_tokens": {
-                    "type": "integer"
-                },
-                "request_count": {
-                    "type": "integer"
-                },
-                "session_count": {
-                    "type": "integer"
-                },
-                "top_model": {
-                    "type": "string"
-                },
-                "total_cost": {
-                    "type": "number"
-                },
-                "total_tokens": {
-                    "type": "integer"
-                },
-                "user_id": {
-                    "type": "string"
                 }
             }
         },


### PR DESCRIPTION
## Summary

Step A (originally PRs 3+4 of the rollout, merged per design discussion) of \`design/2026-05-14-aggregate-usage-dashboard.md\`. Adds the backend the admin and org-owner Usage dashboards will read from. No UI changes - PR B is the dashboard component.

Six read endpoints under \`/api/v1/usage/aggregate/\`, all mounted on \`authRouter\` and scoped per-request:

| Endpoint | Returns | Auth |
|---|---|---|
| \`GET /summary\` | \`UsageSummary\`: totals + time series + active counts | Org member or global admin |
| \`GET /by-org\` | Paginated \`UsageByOrg\` | Global admin only |
| \`GET /by-user\` | Paginated \`UsageByUser\` | Org member or global admin |
| \`GET /by-project\` | Paginated \`UsageByProject\` | Org member or global admin |
| \`GET /by-session\` | Paginated \`UsageBySession\` | Org member or global admin |
| \`GET /by-model\` | Paginated \`UsageByModel\` | Org member or global admin |

\`org_id\` is required for non-admins (id or slug, resolved via \`lookupOrg\`); global admins may omit it to summarise cross-org.

## Changes

- **\`api/pkg/types/types.go\`**: new types - \`UsageTotals\`, \`UsageSummary\`, five row types, five paginated wrappers. Generics would be tidier but \`swag\` does not handle parameterized types in \`@Success\`.
- **\`api/pkg/store/store.go\`**: new \`GroupedUsageQuery\` shared filter struct and six new methods on the \`Store\` interface.
- **\`api/pkg/store/store_usage_aggregate.go\`** (new): Postgres implementations. Shared \`applyUsageFilters\` builds the WHERE clause; each method GROUPs by its dimension and LEFT JOINs the relevant entity table for display names so the handler does not need an N+1 fan-out. Pagination + sort whitelist per endpoint.
- **\`api/pkg/store/store_mocks.go\`**: regenerated via \`go generate ./pkg/store\`.
- **\`api/pkg/server/usage_aggregate_handlers.go\`** (new): six handlers + \`parseUsageQuery\` helper that does date-range parsing, auth, and field normalization. Default window 7 days, hard cap 366 days. Pagination defaults \`page_size=25\`, capped at 200.
- **\`api/pkg/server/server.go\`**: route registration on \`authRouter\` with a comment explaining the per-request scoping.
- **Swagger** annotations on every handler, regenerated \`docs.go\`/\`swagger.{json,yaml}\` and the TypeScript client. New methods: \`v1UsageAggregateSummaryList\`, \`v1UsageAggregateByOrgList\`, \`v1UsageAggregateByUserList\`, \`v1UsageAggregateByProjectList\`, \`v1UsageAggregateBySessionList\`, \`v1UsageAggregateByModelList\`.
- **\`api/pkg/store/store_usage_aggregate_test.go\`** (new): six Postgres-backed test cases - one per method - seeding minimal \`usage_metric\` + \`interaction\` rows and asserting the aggregate shape.

## Out of scope (deliberately)

- **No export endpoint yet** (\`/aggregate/export\`). Reserved for PR B because it's UI-driven (the user picks a tab and exports the same row set).
- **No frontend changes.** The TS client is regenerated so the new methods exist, but nothing consumes them.
- **No drill-down wiring** into \`/llm_calls\` - that's PR C and depends on https://github.com/helixml/helix/pull/2433.

## Test plan

- [ ] CI: \`TestUsageAggregateTestSuite\` (six cases) passes
- [ ] CI: full server test suite passes
- [ ] After deploy, as a global admin: \`GET /api/v1/usage/aggregate/by-org\` returns one row per org with non-zero traffic in the last 7 days, sorted by total_cost descending
- [ ] After deploy, as an org member: \`GET /api/v1/usage/aggregate/by-user?org_id=<my-slug>\` returns only that org's users
- [ ] After deploy, as a non-admin: \`GET /api/v1/usage/aggregate/by-org\` returns 403
- [ ] After deploy, as a non-admin with no \`org_id\`: \`GET /api/v1/usage/aggregate/summary\` returns 403

## Related PRs

- https://github.com/helixml/helix/pull/2429 (merged) - cache fields fix in \`GetAggregatedUsageMetrics\` SELECT. Without it, the time series in \`/summary\` would still show \$0 cache cost.
- https://github.com/helixml/helix/pull/2432 (merged) - model_info.json refresh. Without it, several newer Claude models would have null pricing and the aggregate cost columns would be 0.
- https://github.com/helixml/helix/pull/2433 - org_id filter on \`/llm_calls\`. Independent of this PR but required for PR C drill-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)