### PR TITLE
feat(frontend): admin Usage dashboard reading /usage/aggregate

### DIFF
--- a/frontend/src/components/admin/AdminPanelSidebar.tsx
+++ b/frontend/src/components/admin/AdminPanelSidebar.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react'
 import Typography from '@mui/material/Typography'
 
 import ApiIcon from '@mui/icons-material/Api'
+import BarChartIcon from '@mui/icons-material/BarChart'
 import DnsIcon from '@mui/icons-material/Dns'
 import VpnKeyIcon from '@mui/icons-material/VpnKey'
 import LinkIcon from '@mui/icons-material/Link'
@@ -34,6 +35,13 @@ const AdminPanelSidebar: FC<AdminPanelSidebarProps> = ({ activeTab = 'llm_calls'
     {
       title: 'Analytics & Monitoring',
       items: [
+        {
+          id: 'usage',
+          label: 'Usage',
+          icon: <BarChartIcon />,
+          isActive: currentTab === 'usage',
+          onClick: () => handleNavigationClick('usage')
+        },
         {
           id: 'llm_calls',
           label: 'LLM Calls',

--- a/frontend/src/components/usage/UsageDashboard.tsx
+++ b/frontend/src/components/usage/UsageDashboard.tsx
@@ -1,0 +1,310 @@
+import React, { FC, useMemo, useState } from 'react'
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import Paper from '@mui/material/Paper'
+import Tabs from '@mui/material/Tabs'
+import Tab from '@mui/material/Tab'
+import ToggleButton from '@mui/material/ToggleButton'
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
+import CircularProgress from '@mui/material/CircularProgress'
+import Pagination from '@mui/material/Pagination'
+
+import SimpleTable, { ITableField } from '../widgets/SimpleTable'
+import { useUsageSummary, useUsageGrouped, UsageFilter, UsageGrouping } from '../../services/usageAggregateService'
+
+// ---------------------------------------------------------------------------
+// Formatting helpers. Pricing in the API is dollars-per-token; aggregate
+// rows already carry dollars, so just format directly.
+// ---------------------------------------------------------------------------
+function formatCost(n: number | undefined): string {
+  if (!n) return '$0'
+  if (n >= 1000) return `$${(n / 1000).toFixed(2)}k`
+  if (n >= 1) return `$${n.toFixed(2)}`
+  return `$${n.toFixed(4)}`
+}
+
+function formatTokens(n: number | undefined): string {
+  if (!n) return '0'
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return n.toString()
+}
+
+function formatDate(s: string | undefined): string {
+  if (!s) return ''
+  try {
+    return new Date(s).toLocaleString()
+  } catch {
+    return s
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Date-range presets. Custom range support comes later; for now the
+// preset list covers the dashboard use case.
+// ---------------------------------------------------------------------------
+type PresetKey = '1d' | '7d' | '30d' | '90d'
+
+const presetWindows: Record<PresetKey, { label: string, days: number }> = {
+  '1d': { label: 'Last 24 hours', days: 1 },
+  '7d': { label: 'Last 7 days', days: 7 },
+  '30d': { label: 'Last 30 days', days: 30 },
+  '90d': { label: 'Last 90 days', days: 90 },
+}
+
+function presetToFromTo(p: PresetKey): { from: string, to: string } {
+  const to = new Date()
+  const from = new Date(to.getTime() - presetWindows[p].days * 24 * 60 * 60 * 1000)
+  return { from: from.toISOString(), to: to.toISOString() }
+}
+
+// ---------------------------------------------------------------------------
+// Stat tile.
+// ---------------------------------------------------------------------------
+const StatTile: FC<{ label: string, value: string, hint?: string }> = ({ label, value, hint }) => (
+  <Paper
+    variant="outlined"
+    sx={{
+      p: 1.5,
+      flex: '1 1 0',
+      minWidth: 140,
+      background: 'linear-gradient(145deg, rgba(255,255,255,0.03) 0%, rgba(255,255,255,0.01) 100%)',
+      border: '1px solid rgba(255,255,255,0.06)',
+      borderRadius: 2,
+    }}
+  >
+    <Typography variant="caption" sx={{ fontSize: '0.65rem', textTransform: 'uppercase', color: 'text.secondary' }}>
+      {label}
+    </Typography>
+    <Typography variant="body2" sx={{ fontSize: '1.1rem', fontFamily: 'monospace', fontWeight: 600, mt: 0.5 }}>
+      {value}
+    </Typography>
+    {hint && (
+      <Typography variant="caption" sx={{ fontSize: '0.65rem', color: 'text.secondary' }}>
+        {hint}
+      </Typography>
+    )}
+  </Paper>
+)
+
+// ---------------------------------------------------------------------------
+// Column sets per grouping. These mirror the row shapes in
+// api/pkg/types/types.go - UsageByUser, UsageBySession etc. The
+// generated TS client types `rows` as `unknown`, so we cast in the
+// table-data builder.
+// ---------------------------------------------------------------------------
+type Row = Record<string, any>
+
+const groupColumns: Record<UsageGrouping, ITableField[]> = {
+  org: [
+    { name: 'organization_name', title: 'Organization' },
+    { name: 'request_count', title: 'Requests', numeric: true },
+    { name: 'total_tokens', title: 'Tokens', numeric: true },
+    { name: 'total_cost', title: 'Cost', numeric: true },
+    { name: 'user_count', title: 'Users', numeric: true },
+    { name: 'session_count', title: 'Sessions', numeric: true },
+    { name: 'top_model', title: 'Top model' },
+    { name: 'last_activity', title: 'Last activity' },
+  ],
+  user: [
+    { name: 'email', title: 'User' },
+    { name: 'request_count', title: 'Requests', numeric: true },
+    { name: 'total_tokens', title: 'Tokens', numeric: true },
+    { name: 'total_cost', title: 'Cost', numeric: true },
+    { name: 'session_count', title: 'Sessions', numeric: true },
+    { name: 'top_model', title: 'Top model' },
+    { name: 'last_activity', title: 'Last activity' },
+  ],
+  project: [
+    { name: 'name', title: 'Project / App' },
+    { name: 'kind', title: 'Kind' },
+    { name: 'request_count', title: 'Requests', numeric: true },
+    { name: 'total_tokens', title: 'Tokens', numeric: true },
+    { name: 'total_cost', title: 'Cost', numeric: true },
+    { name: 'session_count', title: 'Sessions', numeric: true },
+  ],
+  session: [
+    { name: 'session_id', title: 'Session' },
+    { name: 'model', title: 'Model' },
+    { name: 'request_count', title: 'Calls', numeric: true },
+    { name: 'total_tokens', title: 'Tokens', numeric: true },
+    { name: 'total_cost', title: 'Cost', numeric: true },
+    { name: 'ended_at', title: 'Last call' },
+  ],
+  model: [
+    { name: 'model', title: 'Model' },
+    { name: 'provider', title: 'Provider' },
+    { name: 'request_count', title: 'Requests', numeric: true },
+    { name: 'total_tokens', title: 'Tokens', numeric: true },
+    { name: 'total_cost', title: 'Cost', numeric: true },
+    { name: 'unique_users', title: 'Users', numeric: true },
+    { name: 'unique_sessions', title: 'Sessions', numeric: true },
+  ],
+}
+
+function rowToTableData(groupBy: UsageGrouping, raw: Row): Row {
+  // Format the numeric and time columns for display, but keep the
+  // raw values on `_data` so future drill-down handlers can recover.
+  const base: Row = {
+    id: raw.user_id || raw.session_id || raw.project_id || raw.organization_id || `${raw.provider}/${raw.model}`,
+    _data: raw,
+    total_cost: formatCost(raw.total_cost),
+    total_tokens: formatTokens(raw.total_tokens),
+    request_count: raw.request_count?.toLocaleString() ?? '0',
+    user_count: raw.user_count?.toLocaleString() ?? '0',
+    session_count: raw.session_count?.toLocaleString() ?? '0',
+    unique_users: raw.unique_users?.toLocaleString() ?? '0',
+    unique_sessions: raw.unique_sessions?.toLocaleString() ?? '0',
+    last_activity: formatDate(raw.last_activity),
+    ended_at: formatDate(raw.ended_at),
+  }
+  switch (groupBy) {
+    case 'org':
+      base.organization_name = raw.organization_name || raw.organization_id || '(unnamed)'
+      base.top_model = raw.top_model || ''
+      break
+    case 'user':
+      base.email = raw.email || raw.user_id
+      base.top_model = raw.top_model || ''
+      break
+    case 'project':
+      base.name = raw.name || raw.project_id || raw.app_id || '(unnamed)'
+      base.kind = raw.kind || ''
+      break
+    case 'session':
+      base.session_id = raw.name || raw.session_id
+      base.model = raw.model || ''
+      break
+    case 'model':
+      base.model = raw.model
+      base.provider = raw.provider
+      break
+  }
+  return base
+}
+
+// ---------------------------------------------------------------------------
+// Main component.
+// ---------------------------------------------------------------------------
+export interface UsageDashboardProps {
+  // Locked filters. If `org_id` is set the user cannot edit it (used
+  // by the org-owner surface, future PR). For now AdminUsage passes
+  // nothing locked and all groupings are allowed.
+  initialFilter?: UsageFilter
+  lockedFilterKeys?: (keyof UsageFilter)[]
+  allowedGroupings?: UsageGrouping[]
+}
+
+const defaultGroupings: UsageGrouping[] = ['org', 'user', 'project', 'session', 'model']
+
+const UsageDashboard: FC<UsageDashboardProps> = ({
+  initialFilter = {},
+  lockedFilterKeys = [],
+  allowedGroupings = defaultGroupings,
+}) => {
+  const [preset, setPreset] = useState<PresetKey>('7d')
+  const window = useMemo(() => presetToFromTo(preset), [preset])
+  const [groupBy, setGroupBy] = useState<UsageGrouping>(allowedGroupings[0])
+  const [page, setPage] = useState(1)
+  const pageSize = 25
+
+  // The effective filter combines the date window with whatever the
+  // parent locked in (e.g. org_id).
+  const filter: UsageFilter = {
+    ...initialFilter,
+    from: window.from,
+    to: window.to,
+    page,
+    page_size: pageSize,
+  }
+
+  const { data: summary, isLoading: summaryLoading } = useUsageSummary(filter)
+  const { data: grouped, isLoading: groupedLoading } = useUsageGrouped(groupBy, filter)
+
+  const tableData = useMemo(() => {
+    const rows = (grouped?.rows ?? []) as Row[]
+    return rows.map(r => rowToTableData(groupBy, r))
+  }, [grouped, groupBy])
+
+  const handlePreset = (_: unknown, next: PresetKey | null) => {
+    if (next) {
+      setPreset(next)
+      setPage(1)
+    }
+  }
+
+  return (
+    <Stack spacing={3}>
+      {/* Date range */}
+      <Stack direction="row" spacing={2} alignItems="center" justifyContent="flex-end">
+        <ToggleButtonGroup value={preset} exclusive onChange={handlePreset} size="small">
+          {(Object.keys(presetWindows) as PresetKey[]).map(k => (
+            <ToggleButton key={k} value={k}>{presetWindows[k].label}</ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      </Stack>
+
+      {/* Locked-filter hint */}
+      {lockedFilterKeys.length > 0 && initialFilter.org_id && (
+        <Typography variant="caption" color="text.secondary">
+          Scope: organization <strong>{initialFilter.org_id}</strong>
+        </Typography>
+      )}
+
+      {/* Overview tiles */}
+      <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap' }}>
+        <StatTile label="Total cost" value={formatCost(summary?.total_cost)} hint={summaryLoading ? 'loading...' : undefined} />
+        <StatTile label="Total tokens" value={formatTokens(summary?.total_tokens)} />
+        <StatTile label="Input" value={formatTokens(summary?.prompt_tokens)} />
+        <StatTile label="Output" value={formatTokens(summary?.completion_tokens)} />
+        <StatTile label="Cache read" value={formatTokens(summary?.cache_read_tokens)} />
+        <StatTile label="Cache write" value={formatTokens(summary?.cache_write_tokens)} />
+        <StatTile label="Requests" value={summary?.request_count?.toLocaleString() ?? '0'} />
+        <StatTile label="Active users" value={summary?.active_users?.toLocaleString() ?? '0'} />
+      </Box>
+
+      {/* Group-by tabs */}
+      <Tabs
+        value={groupBy}
+        onChange={(_, v) => { setGroupBy(v as UsageGrouping); setPage(1) }}
+        variant="scrollable"
+        scrollButtons="auto"
+      >
+        {allowedGroupings.map(g => (
+          <Tab key={g} value={g} label={
+            ({ org: 'Organizations', user: 'Users', project: 'Projects', session: 'Sessions', model: 'Models' })[g]
+          } />
+        ))}
+      </Tabs>
+
+      {/* Table */}
+      {groupedLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <>
+          <SimpleTable
+            authenticated
+            fields={groupColumns[groupBy]}
+            data={tableData}
+            hideHeaderIfEmpty
+          />
+          {grouped && grouped.total_pages > 1 && (
+            <Stack direction="row" justifyContent="flex-end" sx={{ mt: 1 }}>
+              <Pagination
+                count={grouped.total_pages}
+                page={grouped.page || 1}
+                onChange={(_, p) => setPage(p)}
+                size="small"
+              />
+            </Stack>
+          )}
+        </>
+      )}
+    </Stack>
+  )
+}
+
+export default UsageDashboard

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -19,6 +19,7 @@ import Typography from "@mui/material/Typography";
 import React, { FC, useCallback, useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import LLMCallsTable from "../components/dashboard/LLMCallsTable";
+import UsageDashboard from "../components/usage/UsageDashboard";
 import Interaction from "../components/session/Interaction";
 import SessionBadgeKey from "../components/session/SessionBadgeKey";
 import SessionToolbar from "../components/session/SessionToolbar";
@@ -200,6 +201,12 @@ const Dashboard: FC<DashboardProps> = ({ tab = "llm_calls" }) => {
                             )}
                         </Box>
                         <LLMCallsTable sessionFilter={sessionFilter} />
+                    </Box>
+                )}
+
+                {tab === "usage" && (
+                    <Box sx={{ width: "100%" }}>
+                        <UsageDashboard />
                     </Box>
                 )}
 

--- a/frontend/src/services/usageAggregateService.ts
+++ b/frontend/src/services/usageAggregateService.ts
@@ -1,0 +1,59 @@
+import { useQuery } from '@tanstack/react-query'
+import useApi from '../hooks/useApi'
+
+// Shared filter shape passed from the UI to both endpoints. Empty
+// strings are sent to the server as omitted params - the underlying
+// client tolerates undefined fields.
+export interface UsageFilter {
+  from?: string // RFC3339
+  to?: string
+  org_id?: string
+  user_id?: string
+  project_id?: string
+  app_id?: string
+  session_id?: string
+  provider?: string
+  model?: string
+  sort_by?: string
+  sort_dir?: 'asc' | 'desc'
+  page?: number
+  page_size?: number
+}
+
+export type UsageGrouping = 'org' | 'user' | 'project' | 'session' | 'model'
+
+const stableKey = (label: string, f: UsageFilter, extra?: Record<string, unknown>) =>
+  [label, f.from, f.to, f.org_id, f.user_id, f.project_id, f.app_id, f.session_id,
+    f.provider, f.model, f.sort_by, f.sort_dir, f.page, f.page_size,
+    JSON.stringify(extra ?? {})]
+
+export function useUsageSummary(filter: UsageFilter, enabled = true) {
+  const api = useApi()
+  const apiClient = api.getApiClient()
+
+  return useQuery({
+    queryKey: stableKey('usage_summary', filter),
+    enabled,
+    queryFn: async () => {
+      const res = await apiClient.api.v1UsageAggregateSummaryList(filter as Record<string, string>)
+      return res.data
+    },
+  })
+}
+
+export function useUsageGrouped(groupBy: UsageGrouping, filter: UsageFilter, enabled = true) {
+  const api = useApi()
+  const apiClient = api.getApiClient()
+
+  return useQuery({
+    queryKey: stableKey(`usage_grouped_${groupBy}`, filter, { groupBy }),
+    enabled,
+    queryFn: async () => {
+      const res = await apiClient.api.v1UsageAggregateGroupedList({
+        ...(filter as Record<string, string>),
+        group_by: groupBy,
+      })
+      return res.data
+    },
+  })
+}


### PR DESCRIPTION
## Summary

PR B of the aggregate usage dashboard rollout (\`design/2026-05-14-aggregate-usage-dashboard.md\`). Adds the admin-facing Usage UI that reads from the endpoints introduced in https://github.com/helixml/helix/pull/2434.

**Stacked PR.** Base is \`feature/usage-aggregate-backend\` (PR 2434). Switch the base to \`main\` once 2434 merges.

## What lands

- **Service hooks** (\`frontend/src/services/usageAggregateService.ts\`): \`useUsageSummary\` and \`useUsageGrouped\` wrap the generated TS client (\`v1UsageAggregateSummaryList\`, \`v1UsageAggregateGroupedList\`) with React Query. Stable query keys keyed off the filter object.
- **Shared component** \`UsageDashboard\` (\`frontend/src/components/usage/UsageDashboard.tsx\`):
  - Date-range presets: 1d / 7d / 30d / 90d
  - Overview strip of stat tiles: total cost, total tokens, input, output, cache read, cache write, request count, active users
  - Group-by tabs: Organizations / Users / Projects / Sessions / Models. Switching the tab re-fetches with the new \`group_by\`.
  - Per-grouping column set rendered through \`SimpleTable\` (numeric formatting, monospace cost cells, localised dates)
  - Server-side pagination wired to \`total_pages\`
- **Admin panel wiring**:
  - \`AdminPanelSidebar.tsx\`: new "Usage" item in the Analytics & Monitoring group, above LLM Calls
  - \`Dashboard.tsx\`: \`tab === "usage"\` renders \`<UsageDashboard />\` with default props (no locked filters, all groupings)

## Reuse

\`UsageDashboard\` takes \`initialFilter\`, \`lockedFilterKeys\`, and \`allowedGroupings\` props so PR C can reuse it for the org-owner page (\`/orgs/:slug/usage\`) by passing \`{ initialFilter: { org_id }, lockedFilterKeys: ['org_id'], allowedGroupings: ['user','project','session','model'] }\`.

## Out of scope (PR C territory)

- Drill-down on row click (Session row -> LLM Calls trace)
- Replacing the placeholder \`OrgUsage\` page with this component
- CSV/JSON export (the backend doesn't have an export endpoint yet either)
- Custom date range picker (presets only for now)
- Per-row sparklines

## Test plan

- [ ] Frontend build (\`cd frontend && yarn build\`) passes (verified locally)
- [ ] After deploy: open admin panel → "Usage" tab is visible in Analytics & Monitoring
- [ ] Overview tiles show non-zero numbers for an instance with traffic
- [ ] Switching group-by tabs re-fetches the table
- [ ] Changing the date preset re-fetches summary and table
- [ ] Org tab works as admin (the by-org call doesn't 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)