### PR TITLE
fix(specs): tell agent push is HTTPS, forbid gh/ssh-add

### DIFF
--- a/api/pkg/services/agent_instruction_service.go
+++ b/api/pkg/services/agent_instruction_service.go
@@ -190,7 +190,15 @@ git add -A && git commit -m "chore(specs): update progress" && git push origin h
    ` + "`cd /home/retro/work/{{.PrimaryRepoName}} && git fetch origin {{.BaseBranch}} && git merge origin/{{.BaseBranch}}`" + `
    Resolve any conflicts and commit before pushing.
 5. When all tasks done, push code: ` + "`git push origin {{.BranchName}}`" + `
-6. **Do NOT create pull requests yourself** (no ` + "`gh pr create`" + `, no GitHub MCP tools). Pushing to the branch is sufficient — the Helix platform creates the GitHub PR automatically when the user clicks "Open PR" in the UI.
+6. **Do NOT create pull requests yourself** (no ` + "`gh pr create`" + `, no GitHub MCP tools). Pushing to the branch is sufficient. The Helix platform creates the GitHub PR automatically when the user clicks "Open PR" in the UI.
+
+## How Pushing Works (Read This Before Debugging Any Push Failure)
+
+` + "`origin`" + ` in every repo under ` + "`/home/retro/work/`" + ` points at the Helix-hosted intermediate git server over HTTPS. Credentials come from ` + "`~/.git-credentials`" + ` via the ` + "`store`" + ` credential helper. There is no SSH, no SSH agent, no SSH keys, and no GitHub CLI in this environment. The Helix API relays your pushes to the external GitHub/GitLab/ADO repo using the OAuth credential the user configured.
+
+**Do NOT run any of these to "debug" a push failure:** ` + "`gh`" + ` (any subcommand), ` + "`ssh-add`" + `, ` + "`ssh-keygen`" + `, ` + "`ssh-agent`" + `, ` + "`eval $(ssh-agent)`" + `, or anything that touches ` + "`~/.ssh/`" + `. None of those tools or files exist or apply here. Running them is a waste of turns and produces misleading output.
+
+If ` + "`git push`" + ` fails: paste the full verbatim stderr to the user in the chat, then stop. Do not guess at the cause, do not invent "SSH authentication issues" or "credential" explanations, and do not retry with alternative tools. The user (or a Helix engineer) will diagnose the underlying issue from the actual error message.
 
 {{if .KoditSection}}
 {{.KoditSection}}


### PR DESCRIPTION
## Summary

- When `git push` fails inside a spec-task sandbox, agents have been summarising the failure as "SSH authentication issues (no SSH keys configured)" and then running `gh auth status`, `ssh-add -l` and similar to "debug" it. None of those tools exist in the sandbox and the push path is HTTPS, not SSH, so the chase is always a dead end and the real error gets buried.
- This PR adds a `## How Pushing Works` section to the agent instruction template in `agent_instruction_service.go`. It states that `origin` is HTTPS to the Helix intermediate git server with credentials in `~/.git-credentials`, lists the forbidden debug commands (`gh`, `ssh-add`, `ssh-keygen`, `ssh-agent`, anything in `~/.ssh/`), and requires the agent to paste verbatim `git push` stderr and stop on failure instead of self-diagnosing.
- Also drops the em dash in step 6 for consistency.

This does not fix any underlying push failure, but it stops the misleading-summary problem so the next time a push fails the actual error reaches the user.

## Test plan

- [ ] Build passes (`go build ./pkg/services/`).
- [ ] Trigger a spec task and confirm the new section appears in the agent's initial instructions.
- [ ] Force a `git push` failure (e.g. revoke the API token) and confirm the agent surfaces the literal stderr instead of inventing an SSH story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)