### PR TITLE
fix(sandbox): only pull experimental desktop images when enabled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,15 @@ See `design/2026-02-04-macos-dev-environment-setup.md` for setup.
 
 Full rebuild order: `build-zed` → `build-ubuntu` → `build-sandbox` (if needed) → start new session.
 
+**Experimental desktop pulls.** The sandbox startup script
+(`sandbox/04-start-dockerd.sh`) only pulls the *production* desktop image
+(`helix-ubuntu`) on every container start. Experimental desktops
+(`helix-sway`, `helix-zorin`, `helix-xfce`, `helix-kde`) are gated behind
+the `HELIX_EXPERIMENTAL_DESKTOPS` env var (space-separated, default
+empty). Set e.g. `HELIX_EXPERIMENTAL_DESKTOPS="sway"` in your environment
+to pre-pull sway at sandbox startup; otherwise it's pulled lazily by
+Docker the first time someone launches a sway desktop session.
+
 ### **CRITICAL: Bumping sandbox-versions.txt after Zed or Qwen changes**
 
 `sandbox-versions.txt` pins the exact commits CI uses to build the sandbox:

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -276,7 +276,8 @@ ENV HELIX_API_URL="" \
     ZED_IMAGE="helix-sway:latest" \
     HYDRA_ENABLED="true" \
     HELIX_KEEP_DEAD_CONTAINERS="false" \
-    HELIX_SANDBOX_REGISTRY=""
+    HELIX_SANDBOX_REGISTRY="" \
+    HELIX_EXPERIMENTAL_DESKTOPS=""
 
 # XDG_RUNTIME_DIR (creates volume when starting container)
 VOLUME /run/user/sandbox/

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -248,6 +248,9 @@ services:
       - ZED_IMAGE=helix-sway:latest
       # Debug: keep dead desktop containers for inspection (default: false = auto-remove)
       - HELIX_KEEP_DEAD_CONTAINERS=${HELIX_KEEP_DEAD_CONTAINERS:-false}
+      # Pre-pull experimental desktop images at startup (space-separated, e.g. "sway zorin").
+      # Default empty: only production desktops (helix-ubuntu) are pulled on upgrade.
+      - HELIX_EXPERIMENTAL_DESKTOPS=${HELIX_EXPERIMENTAL_DESKTOPS:-}
       # Sandbox data path for workspaces (must match volume mount)
       - SANDBOX_DATA_PATH=/data
       # Container Docker path for ZFS-backed inner dockerd (macOS desktop app)
@@ -341,6 +344,9 @@ services:
       - ZED_IMAGE=helix-sway:latest
       # Debug: keep dead desktop containers for inspection (default: false = auto-remove)
       - HELIX_KEEP_DEAD_CONTAINERS=${HELIX_KEEP_DEAD_CONTAINERS:-false}
+      # Pre-pull experimental desktop images at startup (space-separated, e.g. "sway zorin").
+      # Default empty: only production desktops (helix-ubuntu) are pulled on upgrade.
+      - HELIX_EXPERIMENTAL_DESKTOPS=${HELIX_EXPERIMENTAL_DESKTOPS:-}
       # Sandbox data path for workspaces (must match volume mount)
       - SANDBOX_DATA_PATH=/data
       # Container Docker path for ZFS-backed inner dockerd (macOS desktop app)
@@ -432,6 +438,9 @@ services:
       - ZED_IMAGE=helix-sway:latest
       # Debug: keep dead desktop containers for inspection (default: false = auto-remove)
       - HELIX_KEEP_DEAD_CONTAINERS=${HELIX_KEEP_DEAD_CONTAINERS:-false}
+      # Pre-pull experimental desktop images at startup (space-separated, e.g. "sway zorin").
+      # Default empty: only production desktops (helix-ubuntu) are pulled on upgrade.
+      - HELIX_EXPERIMENTAL_DESKTOPS=${HELIX_EXPERIMENTAL_DESKTOPS:-}
       # Sandbox data path for workspaces (must match volume mount)
       - SANDBOX_DATA_PATH=/data
       # Container Docker path for ZFS-backed inner dockerd (macOS desktop app)
@@ -517,6 +526,9 @@ services:
       - ZED_IMAGE=helix-ubuntu:latest
       # Debug: keep dead desktop containers for inspection (default: false = auto-remove)
       - HELIX_KEEP_DEAD_CONTAINERS=${HELIX_KEEP_DEAD_CONTAINERS:-false}
+      # Pre-pull experimental desktop images at startup (space-separated, e.g. "sway zorin").
+      # Default empty: only production desktops (helix-ubuntu) are pulled on upgrade.
+      - HELIX_EXPERIMENTAL_DESKTOPS=${HELIX_EXPERIMENTAL_DESKTOPS:-}
       # Sandbox data path for workspaces (must match volume mount)
       - SANDBOX_DATA_PATH=/data
       # Container Docker path — ZFS-backed storage for per-session inner dockerd

--- a/sandbox/04-start-dockerd.sh
+++ b/sandbox/04-start-dockerd.sh
@@ -244,11 +244,31 @@ load_desktop_image() {
     fi
 }
 
-# Load desktop images (sway is required, others are optional)
-load_desktop_image "sway" "false"
-load_desktop_image "zorin" "false"
-load_desktop_image "ubuntu" "false"
-load_desktop_image "kde" "false"
+# Load desktop images.
+#
+# Production desktops are pulled on every startup. Experimental desktops are
+# only pulled when listed in $HELIX_EXPERIMENTAL_DESKTOPS (space-separated,
+# e.g. "sway zorin"). Keep this categorization in sync with PRODUCTION_DESKTOPS
+# / AVAILABLE_EXPERIMENTAL_DESKTOPS in the top-level `stack` script.
+PRODUCTION_DESKTOPS=("ubuntu")
+AVAILABLE_EXPERIMENTAL_DESKTOPS=("sway" "zorin" "xfce" "kde")
+
+for desktop in "${PRODUCTION_DESKTOPS[@]}"; do
+    load_desktop_image "$desktop" "false"
+done
+
+declare -A ENABLED_EXPERIMENTAL=()
+for desktop in ${HELIX_EXPERIMENTAL_DESKTOPS:-}; do
+    ENABLED_EXPERIMENTAL[$desktop]=1
+done
+
+for desktop in "${AVAILABLE_EXPERIMENTAL_DESKTOPS[@]}"; do
+    if [ -n "${ENABLED_EXPERIMENTAL[$desktop]:-}" ]; then
+        load_desktop_image "$desktop" "false"
+    else
+        echo "ℹ️  helix-${desktop} is experimental; skipping pull (set HELIX_EXPERIMENTAL_DESKTOPS=\"${desktop} ...\" to enable)"
+    fi
+done
 
 # ================================================================================
 # Clean up old desktop images to free disk space


### PR DESCRIPTION
## Summary

On every sandbox upgrade, `sandbox/04-start-dockerd.sh` was eagerly
pulling **every** desktop image referenced under `/opt/images/*.version`
— including `helix-sway`, an experimental image that production isn't
even using. Each upgrade burned multi-GB of bandwidth and disk on an
image no session would touch:

```
🔄 Pulling ghcr.io/helixml/helix-sway:2.11.4-linux-amd64 from registry...
2.11.4-linux-amd64: Pulling from helixml/helix-sway
0962d14975c5: Already exists
…
```

The build-side `stack` script already classified desktops as
`PRODUCTION_DESKTOPS=(ubuntu)` vs
`AVAILABLE_EXPERIMENTAL_DESKTOPS=(sway zorin xfce kde)`, but that split
wasn't honoured at runtime. This PR mirrors it inside the sandbox
startup script, gated by a new `HELIX_EXPERIMENTAL_DESKTOPS` env var
(default empty).

After this change:

- Default upgrade pulls only `helix-ubuntu`. Each experimental desktop
  logs a single `ℹ️ helix-<name> is experimental; skipping pull (set
  HELIX_EXPERIMENTAL_DESKTOPS="<name> ...") to enable` line.
- Operators / developers who use sway can opt in with
  `HELIX_EXPERIMENTAL_DESKTOPS="sway"`; behaviour is then identical to
  before this PR.
- A user who flips a session to a non-pre-pulled desktop still works —
  hydra resolves the image name to its `ghcr.io/helixml/...` ref and
  Docker pulls on `docker run`. First session is slower, subsequent
  sessions cached.

CI still builds and pushes `helix-sway` to the registry; nothing about
the build pipeline or distribution changes.

## Changes

- `sandbox/04-start-dockerd.sh` — replace the hard-coded
  `load_desktop_image "sway|zorin|ubuntu|kde"` block with a
  production/experimental split keyed off `HELIX_EXPERIMENTAL_DESKTOPS`.
  Skipped desktops log a single info line so operators can see the
  opt-in path.
- `Dockerfile.sandbox` — declare `HELIX_EXPERIMENTAL_DESKTOPS=""` as
  the env default.
- `docker-compose.dev.yaml` — pass `HELIX_EXPERIMENTAL_DESKTOPS` through
  to all four sandbox services (`sandbox-nvidia`, `sandbox-amd`,
  `sandbox-cpu`, `sandbox-macos`).
- `CLAUDE.md` — short note in the Build Pipeline section explaining the
  new env var and the lazy-pull fallback.

## Test plan

- [x] `bash -n sandbox/04-start-dockerd.sh` — script parses cleanly.
- [x] Stub-`load_desktop_image` harness across five env-var
  permutations (empty, `"sway"`, `"sway zorin"`, `"sway zorin xfce
  kde"`, `"banana sway"` to test unknown-name handling). All five
  produce the expected pull/skip output.
- [x] `docker compose -f docker-compose.dev.yaml config --quiet` — the
  compose file still parses with the new env var added in 4 places.
- [ ] CI sandbox-build pipeline (Drone) — please confirm the build
  still passes and the new info log line shows up on a fresh sandbox
  start.
- [ ] One opted-in deploy (`HELIX_EXPERIMENTAL_DESKTOPS="sway"`) to
  confirm the opt-in path is unchanged from current behaviour.

Spec: `helix-specs/design/tasks/002023_on-upgrades-when-the/`

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01krgwtn8q5mhctdwxf6831ysg)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002023_on-upgrades-when-the/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002023_on-upgrades-when-the/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002023_on-upgrades-when-the/tasks.md)

🚀 Built with [Helix](https://helix.ml)