### PR TITLE
fix(external-agent): skip provider/model validation for subscription agents

### DIFF
--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -161,6 +161,15 @@ func GenerateZedMCPConfig(
 		// those sessions still come up.
 		provider = "anthropic"
 		model = "claude-sonnet-4-5-latest"
+	} else if assistant.CodeAgentCredentialType.IsSubscription() {
+		// Subscription-credential agents (e.g. Claude Code with OAuth) handle
+		// inference upstream, not through a Helix provider. Don't write a
+		// Helix-routed default into settings.json — Zed falls back to its
+		// built-in defaults for inline assistant / commit messages / thread
+		// summaries, and the agent itself (Claude Code) routes via its own
+		// OAuth path. The pre-flight ValidateAssistantModelConfig already
+		// applies the same bypass so spec-task start handlers don't 422.
+		useAgentModel = false
 	} else if reason := ValidateAssistantModelConfig(app, providerSnapshot); reason != "" {
 		log.Error().
 			Str("app_id", app.ID).
@@ -712,6 +721,11 @@ func ValidateAssistantModelConfig(app *types.App, snapshot []ProviderRef) string
 	// (see types.CodeAgentCredentialTypeSubscription). Validating against a
 	// Helix provider snapshot would be meaningless and incorrectly 422s any
 	// task started on such an agent.
+	//
+	// Today only zed_external+claude_code uses subscription credentials. If
+	// other runtimes ever adopt OAuth, audit this bypass — and the matching
+	// useAgentModel=false branch in GenerateZedMCPConfig — so we don't mask
+	// misconfig on agents that DO need a Helix-routed provider.
 	if assistant.CodeAgentCredentialType.IsSubscription() {
 		return ""
 	}

--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -706,6 +706,15 @@ func ValidateAssistantModelConfig(app *types.App, snapshot []ProviderRef) string
 	if assistant == nil {
 		return ""
 	}
+	// Subscription-credential agents (e.g. Claude Code with OAuth) auth
+	// directly with the upstream provider and do not route inference through
+	// a Helix provider, so empty provider/model is the documented shape
+	// (see types.CodeAgentCredentialTypeSubscription). Validating against a
+	// Helix provider snapshot would be meaningless and incorrectly 422s any
+	// task started on such an agent.
+	if assistant.CodeAgentCredentialType.IsSubscription() {
+		return ""
+	}
 	provider := assistant.GenerationModelProvider
 	if provider == "" {
 		provider = assistant.Provider

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -469,3 +469,86 @@ func TestBuildLanguageModels(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateAssistantModelConfig_SubscriptionBypass guards the carve-out for
+// subscription-credential agents (e.g. Claude Code with OAuth). These agents
+// deliberately ship empty provider/model — the upstream auth lives in the
+// container, not in a Helix provider — so the validator must not 422 them.
+// The api_key cases stay as regression guards so we don't silently widen the
+// bypass to runtimes that DO need a Helix-routed provider.
+func TestValidateAssistantModelConfig_SubscriptionBypass(t *testing.T) {
+	globalAnthropic := ProviderRef{ID: "", Name: "anthropic"}
+
+	cases := []struct {
+		name      string
+		assistant types.AssistantConfig
+		snapshot  []ProviderRef
+		wantEmpty bool // true = no error returned (config considered valid)
+		why       string
+	}{
+		{
+			name: "subscription_empty_fields_ok",
+			assistant: types.AssistantConfig{
+				AgentType:               types.AgentTypeZedExternal,
+				CodeAgentRuntime:        types.CodeAgentRuntimeClaudeCode,
+				CodeAgentCredentialType: types.CodeAgentCredentialTypeSubscription,
+			},
+			snapshot:  []ProviderRef{globalAnthropic},
+			wantEmpty: true,
+			why:       "subscription agents auth upstream directly; empty provider/model is the documented shape",
+		},
+		{
+			name: "subscription_populated_fields_also_ok",
+			assistant: types.AssistantConfig{
+				AgentType:               types.AgentTypeZedExternal,
+				CodeAgentRuntime:        types.CodeAgentRuntimeClaudeCode,
+				CodeAgentCredentialType: types.CodeAgentCredentialTypeSubscription,
+				GenerationModelProvider: "anthropic",
+				GenerationModel:         "claude-sonnet-4-5",
+			},
+			snapshot:  []ProviderRef{globalAnthropic},
+			wantEmpty: true,
+			why:       "even with stored fields, subscription bypass short-circuits validation",
+		},
+		{
+			name: "api_key_empty_fields_still_errors",
+			assistant: types.AssistantConfig{
+				AgentType:               types.AgentTypeZedExternal,
+				CodeAgentRuntime:        types.CodeAgentRuntimeClaudeCode,
+				CodeAgentCredentialType: types.CodeAgentCredentialTypeAPIKey,
+			},
+			snapshot:  []ProviderRef{globalAnthropic},
+			wantEmpty: false,
+			why:       "regression guard: api_key runtimes must still surface missing provider/model",
+		},
+		{
+			name: "empty_credential_type_treated_as_api_key",
+			assistant: types.AssistantConfig{
+				AgentType:        types.AgentTypeZedExternal,
+				CodeAgentRuntime: types.CodeAgentRuntimeZedAgent,
+			},
+			snapshot:  []ProviderRef{globalAnthropic},
+			wantEmpty: false,
+			why:       "default (empty) credential type is api_key per the type docs; validator must still catch misconfig",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := &types.App{
+				ID: "test-app",
+				Config: types.AppConfig{
+					Helix: types.AppHelixConfig{
+						Assistants: []types.AssistantConfig{tc.assistant},
+					},
+				},
+			}
+			got := ValidateAssistantModelConfig(app, tc.snapshot)
+			if tc.wantEmpty {
+				assert.Empty(t, got, tc.why)
+			} else {
+				assert.NotEmpty(t, got, tc.why)
+			}
+		})
+	}
+}

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -144,6 +144,18 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 			wantMisconfig:    false,
 			why:              "runner-side callers without a manager handle opt out of resolution and pass through verbatim",
 		},
+		{
+			name: "subscription_agent_no_default_model_written",
+			assistants: []types.AssistantConfig{{
+				AgentType:               types.AgentTypeZedExternal,
+				CodeAgentRuntime:        types.CodeAgentRuntimeClaudeCode,
+				CodeAgentCredentialType: types.CodeAgentCredentialTypeSubscription,
+			}},
+			snapshot:         []ProviderRef{globalAnthropic},
+			wantDefaultModel: nil,
+			wantMisconfig:    false,
+			why:              "subscription agents auth upstream directly; Zed must use its built-in defaults rather than a Helix-routed model. wantMisconfig=false so the spec-task entry handler does not 422.",
+		},
 	}
 
 	for _, tc := range cases {
@@ -483,7 +495,7 @@ func TestValidateAssistantModelConfig_SubscriptionBypass(t *testing.T) {
 		name      string
 		assistant types.AssistantConfig
 		snapshot  []ProviderRef
-		wantEmpty bool // true = no error returned (config considered valid)
+		wantValid bool // true = no error returned (config considered valid)
 		why       string
 	}{
 		{
@@ -494,7 +506,7 @@ func TestValidateAssistantModelConfig_SubscriptionBypass(t *testing.T) {
 				CodeAgentCredentialType: types.CodeAgentCredentialTypeSubscription,
 			},
 			snapshot:  []ProviderRef{globalAnthropic},
-			wantEmpty: true,
+			wantValid: true,
 			why:       "subscription agents auth upstream directly; empty provider/model is the documented shape",
 		},
 		{
@@ -507,7 +519,7 @@ func TestValidateAssistantModelConfig_SubscriptionBypass(t *testing.T) {
 				GenerationModel:         "claude-sonnet-4-5",
 			},
 			snapshot:  []ProviderRef{globalAnthropic},
-			wantEmpty: true,
+			wantValid: true,
 			why:       "even with stored fields, subscription bypass short-circuits validation",
 		},
 		{
@@ -518,7 +530,7 @@ func TestValidateAssistantModelConfig_SubscriptionBypass(t *testing.T) {
 				CodeAgentCredentialType: types.CodeAgentCredentialTypeAPIKey,
 			},
 			snapshot:  []ProviderRef{globalAnthropic},
-			wantEmpty: false,
+			wantValid: false,
 			why:       "regression guard: api_key runtimes must still surface missing provider/model",
 		},
 		{
@@ -528,7 +540,7 @@ func TestValidateAssistantModelConfig_SubscriptionBypass(t *testing.T) {
 				CodeAgentRuntime: types.CodeAgentRuntimeZedAgent,
 			},
 			snapshot:  []ProviderRef{globalAnthropic},
-			wantEmpty: false,
+			wantValid: false,
 			why:       "default (empty) credential type is api_key per the type docs; validator must still catch misconfig",
 		},
 	}
@@ -544,7 +556,7 @@ func TestValidateAssistantModelConfig_SubscriptionBypass(t *testing.T) {
 				},
 			}
 			got := ValidateAssistantModelConfig(app, tc.snapshot)
-			if tc.wantEmpty {
+			if tc.wantValid {
 				assert.Empty(t, got, tc.why)
 			} else {
 				assert.NotEmpty(t, got, tc.why)


### PR DESCRIPTION
## Summary

- Spec tasks started on a Claude-Code-with-subscription agent fail with `422 agent_misconfigured "missing a provider or model selection"`. Confirmed on SaaS (`app.helix.ml`) and reproduced on local installs.
- Root cause: subscription-credential agents (`CodeAgentCredentialType == subscription`) deliberately ship empty provider/model — they auth upstream via OAuth and don't route inference through a Helix provider. The pre-flight `ValidateAssistantModelConfig` (added in `fde795378`) doesn't know about that and 422s them.
- Fix: short-circuit `ValidateAssistantModelConfig` to "" when the resolved assistant uses subscription credentials. `api_key` agents still get the full check.

## Evidence

DB row for the failing agent on SaaS:

| provider | model | agent_type   | runtime     | cred_type    |
|----------|-------|--------------|-------------|--------------|
| `""`     | `""`  | zed_external | claude_code | subscription |

Response body before fix:

```json
{"error":"agent_misconfigured","message":"agent \"app_…\" is missing a provider or model selection — open the agent settings and pick a provider and model"}
```

## Out of scope

A separate issue: `spec_tasks.helix_app_id` is sticky after creation, so reassigning the project's default agent doesn't unblock existing tasks — only new ones. Captured for a follow-up; not in this PR.

## Test plan

- [x] New `TestValidateAssistantModelConfig_SubscriptionBypass` covers four cases: subscription + empty fields → ok, subscription + populated fields → ok, api_key + empty fields → still errors, empty cred_type → still errors.
- [x] `go test ./pkg/external-agent/ -count=1` passes (full suite).
- [ ] Verify on SaaS after deploy: the previously-failing `app_01krny4zrfgysw88k1vq69vbht` task starts planning successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)