### PR TITLE
ci(macos): retry R2 uploads + fail-fast probe before VM compression

### DIFF
--- a/for-mac/scripts/create-dmg.sh
+++ b/for-mac/scripts/create-dmg.sh
@@ -333,6 +333,11 @@ if [ "$UPLOAD" = true ]; then
     export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
     export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
 
+    # upload_file wraps `aws s3 cp` with bounded retries + exponential backoff.
+    # aws CLI's internal retries cover per-request blips inside a single
+    # multipart upload, but a TCP/DNS drop between part requests exits the cp
+    # non-zero — which used to fail the whole macOS release pipeline after the
+    # qcow2 was already built and compressed.
     upload_file() {
         local src="$1"
         local dest="$2"
@@ -341,9 +346,24 @@ if [ "$UPLOAD" = true ]; then
         local size
         size=$(du -h "$src" | awk '{print $1}')
         log "  Uploading ${filename} (${size}) -> s3://${R2_BUCKET}/${dest}"
-        aws s3 cp "$src" "s3://${R2_BUCKET}/${dest}" \
-            --endpoint-url "$R2_ENDPOINT" \
-            --no-progress
+        local max_attempts=4
+        local attempt=1
+        local delay=15
+        while :; do
+            if aws s3 cp "$src" "s3://${R2_BUCKET}/${dest}" \
+                --endpoint-url "$R2_ENDPOINT" \
+                --no-progress; then
+                return 0
+            fi
+            if [ "$attempt" -ge "$max_attempts" ]; then
+                log "  Upload failed after $max_attempts attempts: $filename"
+                return 1
+            fi
+            log "  Upload attempt $attempt/$max_attempts failed; retrying in ${delay}s..."
+            sleep "$delay"
+            attempt=$((attempt + 1))
+            delay=$((delay * 2))
+        done
     }
 
     # 1. Upload DMG

--- a/for-mac/scripts/upload-vm-images.sh
+++ b/for-mac/scripts/upload-vm-images.sh
@@ -61,6 +61,35 @@ SKIP_COMPRESS="${SKIP_COMPRESS:-0}"
 
 log() { echo "[$(date +%H:%M:%S)] $*"; }
 
+# r2_upload_with_retry runs `aws s3 cp` with bounded retries and exponential
+# backoff. The aws CLI's built-in retries cover per-request failures within a
+# single multipart upload, but a TCP drop or DNS hiccup between part requests
+# bubbles out as "Could not connect to the endpoint URL" and the whole cp
+# exits non-zero — burning the 7+ GB compression work and the entire macOS
+# pipeline. The wrapper retries the cp invocation itself so a transient blip
+# costs a few seconds instead of forcing a re-tag.
+r2_upload_with_retry() {
+    local src="$1"
+    local dest="$2"
+    shift 2
+    local max_attempts=4
+    local attempt=1
+    local delay=15
+    while :; do
+        if aws s3 cp "$src" "$dest" --endpoint-url "$R2_ENDPOINT" --no-progress "$@" 2>&1; then
+            return 0
+        fi
+        if [ "$attempt" -ge "$max_attempts" ]; then
+            log "  Upload failed after $max_attempts attempts: $src -> $dest"
+            return 1
+        fi
+        log "  Upload attempt $attempt/$max_attempts failed; retrying in ${delay}s..."
+        sleep "$delay"
+        attempt=$((attempt + 1))
+        delay=$((delay * 2))
+    done
+}
+
 # =============================================================================
 # Verify prerequisites
 # =============================================================================
@@ -81,7 +110,16 @@ if [ ! -f "${VM_DIR}/disk.qcow2" ]; then
     exit 1
 fi
 
-
+# Fail fast if R2 is unreachable rather than after ~10 minutes of qcow2
+# compression. A bucket head is cheap; if this fails we're not going to be
+# able to upload a 7+ GB file anyway.
+log "Probing R2 endpoint (${R2_ENDPOINT})..."
+if ! aws s3 ls "s3://${R2_BUCKET}/" --endpoint-url "$R2_ENDPOINT" --page-size 1 >/dev/null 2>&1; then
+    echo "ERROR: R2 endpoint unreachable or bucket inaccessible: ${R2_ENDPOINT}/${R2_BUCKET}"
+    echo "Check network connectivity and R2 credentials, then retry."
+    exit 1
+fi
+log "  R2 reachable."
 
 
 # =============================================================================
@@ -149,9 +187,7 @@ log "  ${DISK_UPLOAD_NAME}:  $(echo "$DISK_SIZE" | awk '{printf "%.1f GB", $1/10
 log ""
 
 log "Uploading ${DISK_UPLOAD_NAME}..."
-aws s3 cp "$DISK_PATH" "s3://${R2_BUCKET}/vm/${VM_VERSION}/${DISK_UPLOAD_NAME}" \
-    --endpoint-url "$R2_ENDPOINT" \
-    --no-progress 2>&1
+r2_upload_with_retry "$DISK_PATH" "s3://${R2_BUCKET}/vm/${VM_VERSION}/${DISK_UPLOAD_NAME}"
 log "  Done."
 
 # =============================================================================
@@ -219,11 +255,9 @@ cat "$MANIFEST_PATH"
 # https://dl.helix.ml/vm/{VERSION}/manifest.json
 log ""
 log "Uploading vm-manifest.json to CDN..."
-aws s3 cp "$MANIFEST_PATH" "s3://${R2_BUCKET}/vm/${VM_VERSION}/manifest.json" \
-    --endpoint-url "$R2_ENDPOINT" \
+r2_upload_with_retry "$MANIFEST_PATH" "s3://${R2_BUCKET}/vm/${VM_VERSION}/manifest.json" \
     --content-type "application/json" \
-    --cache-control "no-cache, max-age=0" \
-    --no-progress 2>&1
+    --cache-control "no-cache, max-age=0"
 log "  Done."
 
 # Verify manifest is accessible


### PR DESCRIPTION
## Summary

Build [#1474](https://drone.lukemarsden.net/helixml/helix/1474) (tag \`2.11.10\`) died at part 615 of a 7.4 GB multipart upload to Cloudflare R2 with \"Could not connect to the endpoint URL\". Build #1428 had a related host-side hiccup on the same pipeline. The aws CLI's internal retries handle per-request failures inside a single multipart upload but don't recover when a TCP/DNS drop between part requests exits \`cp\` non-zero. That cost ~30 minutes of qcow2 build + compression and forced a re-tag of \`2.11.10\`.

## Changes

### \`for-mac/scripts/upload-vm-images.sh\`
- New \`r2_upload_with_retry\` wrapper: 4 attempts, 15s / 30s / 60s exponential backoff. Used for both the disk image upload (~7 GB) and the manifest upload.
- New R2 reachability probe (\`aws s3 ls --page-size 1\`) right after env validation, **before** the ~10 min qcow2 compression step. If R2 is unambiguously down we exit in seconds instead of after the heavy compute.

### \`for-mac/scripts/create-dmg.sh\`
- Same retry loop folded into the existing \`upload_file\` helper that handles the DMG and qcow2 uploads.

## Why retries here when aws CLI already has them

The CLI retries individual HTTP requests during a multipart upload but the failure mode we hit is \"the whole multipart upload session\'s endpoint goes unreachable for 30s\". The CLI gives up and exits 1. Wrapping the cp invocation as a whole lets us re-establish the multipart session from scratch on the next attempt.

## What this does NOT change

- \`scripts/release-rollback.sh\` still has two \`aws s3 cp\` calls for \`latest.json\`. Those are tiny single-part uploads on the rollback path itself, much less likely to be the limiting factor, and adding retries there would mostly add noise. Left alone.
- \`aws configure\` knobs (\`s3.max_concurrent_requests\`, \`cli-connect-timeout\`) untouched — defaults are fine, the wrapper handles the failure class we actually see.

## Test plan

- [x] \`bash -n\` on both scripts.
- [ ] Re-tag \`2.11.10\` once this merges and confirm the next macOS pipeline completes (or, if the network blip recurs, the retry kicks in and logs \"Upload attempt N/4 failed; retrying in ...s\").
- [ ] Manually invoke \`upload-vm-images.sh\` against a test bucket with the network briefly blocked (\`sudo pfctl\` or just \`R2_ENDPOINT=https://blackhole.example\`) to confirm the probe fails fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)