### PR TITLE
refactor(api): remove phantom SystemSettings.MaxConcurrentDesktops

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -548,12 +548,18 @@ type SubscriptionQuotas struct {
 	Projects struct {
 		Enabled bool `envconfig:"PROJECTS_ENABLED" default:"true" description:"Enable project quotas"`
 		Free    struct {
+			// MaxConcurrentDesktops: cap on concurrent desktop sessions for users
+			// without an active Stripe subscription. Enforced per organisation
+			// when the session has an org, per user otherwise. -1 = unlimited.
 			MaxConcurrentDesktops int `envconfig:"PROJECTS_FREE_MAX_CONCURRENT_DESKTOPS" default:"2"`
 			MaxProjects           int `envconfig:"PROJECTS_FREE_MAX_PROJECTS" default:"3"`
 			MaxRepositories       int `envconfig:"PROJECTS_FREE_MAX_REPOSITORIES" default:"3"`
 			MaxSpecTasks          int `envconfig:"PROJECTS_FREE_MAX_SPEC_TASKS" default:"500"` // Non-archived/done
 		}
 		Pro struct {
+			// MaxConcurrentDesktops: cap on concurrent desktop sessions for users
+			// with an active Stripe subscription. Enforced per organisation when
+			// the session has an org, per user otherwise. -1 = unlimited.
 			MaxConcurrentDesktops int `envconfig:"PROJECTS_PRO_MAX_CONCURRENT_DESKTOPS" default:"30"`
 			MaxProjects           int `envconfig:"PROJECTS_PRO_MAX_PROJECTS" default:"50"`
 			MaxRepositories       int `envconfig:"PROJECTS_PRO_MAX_REPOSITORIES" default:"100"`

--- a/api/pkg/quota/quota_test.go
+++ b/api/pkg/quota/quota_test.go
@@ -692,3 +692,134 @@ func (s *QuotaManagerSuite) TestGetQuotas_RoutesToUserWhenNoOrgID() {
 	})
 	s.NoError(err)
 }
+
+// =============================================================================
+// TestQuotaDesktopResolution — truth table from design doc
+// design/tasks/002031_theres-a-bug-in-the/design.md
+//
+// Inputs:  enforce | freeEnv | proEnv | subscribed | ctx (user/org) | active
+// Outputs: effective MaxConcurrentDesktops, allowed (LimitReached == false)
+//
+// Confirms /api/v1/config and StartDesktop now agree, since the phantom
+// SystemSettings.MaxConcurrentDesktops override no longer exists and both
+// consult the same env-driven tier values via quota.go.
+// =============================================================================
+
+func (s *QuotaManagerSuite) TestQuotaDesktopResolution() {
+	cases := []struct {
+		name        string
+		enforce     bool
+		freeEnv     int
+		proEnv      int
+		subscribed  bool
+		orgScoped   bool
+		activeCount int
+		wantLimit   int
+		wantAllowed bool
+	}{
+		// Row 1: EnforceQuotas off short-circuits everything to -1 (user)
+		{"01_enforce-off-user", false, 2, 30, false, false, 99, -1, true},
+		// Row 2: EnforceQuotas off short-circuits everything to -1 (org)
+		{"02_enforce-off-org", false, 2, 30, true, true, 99, -1, true},
+		// Row 3: Free, per-user, under cap
+		{"03_free-user-under", true, 2, 30, false, false, 1, 2, true},
+		// Row 4: Free, per-user, at cap
+		{"04_free-user-at", true, 2, 30, false, false, 2, 2, false},
+		// Row 5: Free, per-org, under cap
+		{"05_free-org-under", true, 2, 30, false, true, 1, 2, true},
+		// Row 6: Free, per-org, at cap
+		{"06_free-org-at", true, 2, 30, false, true, 2, 2, false},
+		// Row 7: Pro, per-user, under cap
+		{"07_pro-user-under", true, 2, 30, true, false, 29, 30, true},
+		// Row 8: Pro, per-user, at cap
+		{"08_pro-user-at", true, 2, 30, true, false, 30, 30, false},
+		// Row 9: Pro, per-org, at cap
+		{"09_pro-org-at", true, 2, 30, true, true, 30, 30, false},
+		// Row 10: Free env set to -1 → unlimited (user)
+		{"10_free-env-unlimited", true, -1, 30, false, false, 999, -1, true},
+		// Row 11: Pro env set to -1 → unlimited (user)
+		{"11_pro-env-unlimited", true, 2, -1, true, false, 999, -1, true},
+		// Row 12: Custom finite Free cap, per-user, under
+		{"12_custom-free-under", true, 5, 30, false, false, 4, 5, true},
+		// Row 13: Custom finite Free cap, per-user, at
+		{"13_custom-free-at", true, 5, 30, false, false, 5, 5, false},
+		// Row 14: Custom finite Pro cap, per-org, at
+		{"14_custom-pro-org-at", true, 2, 50, true, true, 49, 50, true},
+		// Row 15: Pathological: Free env explicitly 0 (misconfiguration —
+		// operator should set -1 for unlimited). Resolver respects the value.
+		{"15_pathological-free-zero", true, 0, 30, false, false, 0, 0, false},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			// Per-subtest mock controller so we don't leak expectations.
+			ctrl := gomock.NewController(s.T())
+			defer ctrl.Finish()
+
+			st := store.NewMockStore(ctrl)
+			ex := external_agent.NewMockExecutor(ctrl)
+			cfg := &config.ServerConfig{}
+			cfg.SubscriptionQuotas.Projects.Enabled = true
+			cfg.SubscriptionQuotas.Projects.Free.MaxConcurrentDesktops = tc.freeEnv
+			cfg.SubscriptionQuotas.Projects.Pro.MaxConcurrentDesktops = tc.proEnv
+			mgr := NewDefaultQuotaManager(st, cfg, ex)
+
+			settings := &types.SystemSettings{EnforceQuotas: tc.enforce}
+
+			req := &types.QuotaLimitReachedRequest{
+				Resource: types.ResourceDesktop,
+			}
+
+			if tc.orgScoped {
+				wallet := &types.Wallet{OrgID: "org1"}
+				if tc.subscribed {
+					wallet.StripeSubscriptionID = "sub_org"
+					wallet.SubscriptionStatus = stripe.SubscriptionStatusActive
+				}
+				st.EXPECT().GetWalletByOrg(gomock.Any(), "org1").Return(wallet, nil)
+				st.EXPECT().GetSystemSettings(gomock.Any()).Return(settings, nil)
+
+				sessions := make([]*external_agent.ZedSession, tc.activeCount)
+				for i := range sessions {
+					sessions[i] = &external_agent.ZedSession{OrganizationID: "org1"}
+				}
+				ex.EXPECT().ListSessions().Return(sessions)
+
+				st.EXPECT().GetProjectsCount(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+				st.EXPECT().GetRepositoriesCount(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+				st.EXPECT().GetSpecTasksCount(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+				// EnforceQuotas false short-circuits before ListSandboxes is reached on the org path.
+				if tc.enforce {
+					st.EXPECT().ListSandboxes(gomock.Any(), gomock.Any()).Return(nil, nil)
+				} else {
+					st.EXPECT().ListSandboxes(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+				}
+				req.OrganizationID = "org1"
+			} else {
+				wallet := &types.Wallet{UserID: "user1"}
+				if tc.subscribed {
+					wallet.StripeSubscriptionID = "sub_user"
+					wallet.SubscriptionStatus = stripe.SubscriptionStatusActive
+				}
+				st.EXPECT().GetWalletByUser(gomock.Any(), "user1").Return(wallet, nil)
+				st.EXPECT().GetSystemSettings(gomock.Any()).Return(settings, nil)
+
+				sessions := make([]*external_agent.ZedSession, tc.activeCount)
+				for i := range sessions {
+					sessions[i] = &external_agent.ZedSession{UserID: "user1"}
+				}
+				ex.EXPECT().ListSessions().Return(sessions)
+
+				st.EXPECT().GetProjectsCount(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+				st.EXPECT().GetRepositoriesCount(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+				st.EXPECT().GetSpecTasksCount(gomock.Any(), gomock.Any()).Return(int64(0), nil)
+				req.UserID = "user1"
+			}
+
+			resp, err := mgr.LimitReached(context.Background(), req)
+			s.NoError(err)
+			s.Equal(tc.wantLimit, resp.Limit, "effective limit")
+			s.Equal(!tc.wantAllowed, resp.LimitReached, "LimitReached")
+		})
+	}
+}

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -28138,6 +28138,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "max_concurrent_desktops": {
+                    "description": "MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per\norganisation when the session has an org, per user otherwise.\n-1 = unlimited.",
                     "type": "integer"
                 },
                 "max_desktop_sandboxes": {
@@ -29057,6 +29058,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/types.FrontendLicenseInfo"
                 },
                 "max_concurrent_desktops": {
+                    "description": "MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per\norganisation when the session has an org, per user otherwise.\n-1 = unlimited. Note: /config is unauthenticated, so this is the\nFree-tier floor; real enforcement uses the resolved per-user/per-org cap.",
                     "type": "integer"
                 },
                 "organizations_create_enabled_for_non_admins": {
@@ -31392,9 +31394,6 @@ const docTemplate = `{
                 "max_concurrent_desktop_sandboxes": {
                     "type": "integer"
                 },
-                "max_concurrent_desktops": {
-                    "type": "integer"
-                },
                 "max_concurrent_headless_sandboxes": {
                     "type": "integer"
                 },
@@ -31494,10 +31493,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "max_concurrent_desktop_sandboxes": {
-                    "type": "integer"
-                },
-                "max_concurrent_desktops": {
-                    "description": "Per user",
                     "type": "integer"
                 },
                 "max_concurrent_headless_sandboxes": {

--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -113,14 +113,15 @@ func (apiServer *HelixAPIServer) getConfig(ctx context.Context) (types.ServerCon
 	if err != nil {
 		return types.ServerConfigForFrontend{}, system.NewHTTPError500(err.Error())
 	}
-	// Override the config with the system settings
 	config.ProvidersManagementEnabled = systemSettings.ProvidersManagementEnabled || apiServer.Cfg.Providers.EnableCustomUserProviders
-	config.MaxConcurrentDesktops = systemSettings.MaxConcurrentDesktops
 
-	// If system settings doesn't have a max, fall back to the free tier config
-	if config.MaxConcurrentDesktops == 0 {
-		config.MaxConcurrentDesktops = apiServer.Cfg.SubscriptionQuotas.Projects.Free.MaxConcurrentDesktops
-	}
+	// /config is unauthenticated (registered on insecureRouter), so we don't
+	// know which user is calling and can't ask the quota manager for their
+	// resolved cap. Return the Free-tier env value as the floor. Real
+	// enforcement still happens server-side in StartDesktop via the quota
+	// manager, which picks the correct Free or Pro tier per wallet. -1 in
+	// the env means unlimited.
+	config.MaxConcurrentDesktops = apiServer.Cfg.SubscriptionQuotas.Projects.Free.MaxConcurrentDesktops
 
 	// Check if any global AI providers are configured on this deployment
 	globalProviders, err := apiServer.Store.ListProviderEndpoints(ctx, &store.ListProviderEndpointsQuery{

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -28134,6 +28134,7 @@
                     "type": "integer"
                 },
                 "max_concurrent_desktops": {
+                    "description": "MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per\norganisation when the session has an org, per user otherwise.\n-1 = unlimited.",
                     "type": "integer"
                 },
                 "max_desktop_sandboxes": {
@@ -29053,6 +29054,7 @@
                     "$ref": "#/definitions/types.FrontendLicenseInfo"
                 },
                 "max_concurrent_desktops": {
+                    "description": "MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per\norganisation when the session has an org, per user otherwise.\n-1 = unlimited. Note: /config is unauthenticated, so this is the\nFree-tier floor; real enforcement uses the resolved per-user/per-org cap.",
                     "type": "integer"
                 },
                 "organizations_create_enabled_for_non_admins": {
@@ -31388,9 +31390,6 @@
                 "max_concurrent_desktop_sandboxes": {
                     "type": "integer"
                 },
-                "max_concurrent_desktops": {
-                    "type": "integer"
-                },
                 "max_concurrent_headless_sandboxes": {
                     "type": "integer"
                 },
@@ -31490,10 +31489,6 @@
                     "type": "string"
                 },
                 "max_concurrent_desktop_sandboxes": {
-                    "type": "integer"
-                },
-                "max_concurrent_desktops": {
-                    "description": "Per user",
                     "type": "integer"
                 },
                 "max_concurrent_headless_sandboxes": {

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -6933,6 +6933,10 @@ definitions:
       active_headless_sandboxes:
         type: integer
       max_concurrent_desktops:
+        description: |-
+          MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per
+          organisation when the session has an org, per user otherwise.
+          -1 = unlimited.
         type: integer
       max_desktop_sandboxes:
         type: integer
@@ -7640,6 +7644,11 @@ definitions:
       license:
         $ref: '#/definitions/types.FrontendLicenseInfo'
       max_concurrent_desktops:
+        description: |-
+          MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per
+          organisation when the session has an org, per user otherwise.
+          -1 = unlimited. Note: /config is unauthenticated, so this is the
+          Free-tier floor; real enforcement uses the resolved per-user/per-org cap.
         type: integer
       organizations_create_enabled_for_non_admins:
         type: boolean
@@ -9346,8 +9355,6 @@ definitions:
         type: string
       max_concurrent_desktop_sandboxes:
         type: integer
-      max_concurrent_desktops:
-        type: integer
       max_concurrent_headless_sandboxes:
         type: integer
       optimus_generation_model:
@@ -9417,9 +9424,6 @@ definitions:
         description: Kodit vision embedding model configuration
         type: string
       max_concurrent_desktop_sandboxes:
-        type: integer
-      max_concurrent_desktops:
-        description: Per user
         type: integer
       max_concurrent_headless_sandboxes:
         type: integer

--- a/api/pkg/server/system_settings_handlers.go
+++ b/api/pkg/server/system_settings_handlers.go
@@ -94,7 +94,6 @@ func (apiServer *HelixAPIServer) updateSystemSettings(rw http.ResponseWriter, r 
 		Str("admin_user", user.ID).
 		Bool("hf_token_updated", req.HuggingFaceToken != nil).
 		Bool("kodit_model_updated", req.KoditEnrichmentProvider != nil || req.KoditEnrichmentModel != nil).
-		Bool("max_concurrent_desktops_updated", req.MaxConcurrentDesktops != nil).
 		Bool("providers_management_enabled_updated", req.ProvidersManagementEnabled != nil).
 		Bool("enforce_quotas_updated", req.EnforceQuotas != nil).
 		Msg("system settings updated by admin")

--- a/api/pkg/store/store_system_settings.go
+++ b/api/pkg/store/store_system_settings.go
@@ -83,9 +83,6 @@ func (s *PostgresStore) UpdateSystemSettings(ctx context.Context, req *types.Sys
 	if req.KoditVisionEmbeddingModel != nil {
 		settings.KoditVisionEmbeddingModel = *req.KoditVisionEmbeddingModel
 	}
-	if req.MaxConcurrentDesktops != nil {
-		settings.MaxConcurrentDesktops = *req.MaxConcurrentDesktops
-	}
 	if req.ProvidersManagementEnabled != nil {
 		settings.ProvidersManagementEnabled = *req.ProvidersManagementEnabled
 	}

--- a/api/pkg/store/store_system_settings_test.go
+++ b/api/pkg/store/store_system_settings_test.go
@@ -40,7 +40,6 @@ func TestUpdateSystemSettings_UpdatesAllFields(t *testing.T) {
 		HuggingFaceToken:                     "old-token",
 		KoditEnrichmentProvider:              "old-kodit-provider",
 		KoditEnrichmentModel:                 "old-kodit-model",
-		MaxConcurrentDesktops:                1,
 		ProvidersManagementEnabled:           false,
 		EnforceQuotas:                        false,
 		SandboxBillingEnabled:                false,
@@ -65,7 +64,6 @@ func TestUpdateSystemSettings_UpdatesAllFields(t *testing.T) {
 		HuggingFaceToken:                     strPtr("new-token"),
 		KoditEnrichmentProvider:              strPtr("new-kodit-provider"),
 		KoditEnrichmentModel:                 strPtr("new-kodit-model"),
-		MaxConcurrentDesktops:                intPtr(25),
 		ProvidersManagementEnabled:           boolPtr(true),
 		EnforceQuotas:                        boolPtr(true),
 		SandboxBillingEnabled:                boolPtr(true),
@@ -92,7 +90,6 @@ func TestUpdateSystemSettings_UpdatesAllFields(t *testing.T) {
 	require.Equal(t, "new-token", updated.HuggingFaceToken)
 	require.Equal(t, "new-kodit-provider", updated.KoditEnrichmentProvider)
 	require.Equal(t, "new-kodit-model", updated.KoditEnrichmentModel)
-	require.Equal(t, 25, updated.MaxConcurrentDesktops)
 	require.True(t, updated.ProvidersManagementEnabled)
 	require.True(t, updated.EnforceQuotas)
 	require.True(t, updated.SandboxBillingEnabled)
@@ -130,7 +127,6 @@ func TestUpdateSystemSettings_PartialUpdateLeavesOtherFieldsUnchanged(t *testing
 		HuggingFaceToken:                     "seed-token",
 		KoditEnrichmentProvider:              "seed-kodit-provider",
 		KoditEnrichmentModel:                 "seed-kodit-model",
-		MaxConcurrentDesktops:                10,
 		ProvidersManagementEnabled:           true,
 		EnforceQuotas:                        false,
 		SandboxBillingEnabled:                true,
@@ -153,7 +149,6 @@ func TestUpdateSystemSettings_PartialUpdateLeavesOtherFieldsUnchanged(t *testing
 
 	req := &types.SystemSettingsRequest{
 		HuggingFaceToken:            strPtr("updated-token"),
-		MaxConcurrentDesktops:       intPtr(33),
 		OptimusReasoningModel:       strPtr("updated-reasoning-model"),
 		OptimusSmallGenerationModel: strPtr("updated-small-generation-model"),
 	}
@@ -163,7 +158,6 @@ func TestUpdateSystemSettings_PartialUpdateLeavesOtherFieldsUnchanged(t *testing
 	require.NotNil(t, updated)
 
 	require.Equal(t, "updated-token", updated.HuggingFaceToken)
-	require.Equal(t, 33, updated.MaxConcurrentDesktops)
 	require.Equal(t, "updated-reasoning-model", updated.OptimusReasoningModel)
 	require.Equal(t, "updated-small-generation-model", updated.OptimusSmallGenerationModel)
 
@@ -192,7 +186,6 @@ func TestUpdateSystemSettings_CreatesSystemRecordIfMissing(t *testing.T) {
 
 	req := &types.SystemSettingsRequest{
 		HuggingFaceToken:                     strPtr("created-token"),
-		MaxConcurrentDesktops:                intPtr(7),
 		EnforceQuotas:                        boolPtr(true),
 		SandboxBillingEnabled:                boolPtr(true),
 		SandboxHeadlessPriceCreditsPerSecond: floatPtr(0.04),
@@ -208,7 +201,6 @@ func TestUpdateSystemSettings_CreatesSystemRecordIfMissing(t *testing.T) {
 
 	require.Equal(t, types.SystemSettingsID, updated.ID)
 	require.Equal(t, "created-token", updated.HuggingFaceToken)
-	require.Equal(t, 7, updated.MaxConcurrentDesktops)
 	require.True(t, updated.EnforceQuotas)
 	require.True(t, updated.SandboxBillingEnabled)
 	require.Equal(t, 0.04, updated.SandboxHeadlessPriceCreditsPerSecond)

--- a/api/pkg/types/quota.go
+++ b/api/pkg/types/quota.go
@@ -10,7 +10,10 @@ type QuotaResponse struct {
 	OrganizationID string `json:"organization_id"` // If applicable
 
 	ActiveConcurrentDesktops int `json:"active_concurrent_desktops"`
-	MaxConcurrentDesktops    int `json:"max_concurrent_desktops"`
+	// MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per
+	// organisation when the session has an org, per user otherwise.
+	// -1 = unlimited.
+	MaxConcurrentDesktops int `json:"max_concurrent_desktops"`
 
 	// Sandbox API concurrency. Distinct from ActiveConcurrentDesktops above —
 	// that one counts external_agent sessions (the spec-task desktop stack),

--- a/api/pkg/types/system_settings.go
+++ b/api/pkg/types/system_settings.go
@@ -34,8 +34,6 @@ type SystemSettings struct {
 
 	EnforceQuotas bool `json:"enforce_quotas,omitempty" gorm:"column:enforce_quotas"`
 
-	MaxConcurrentDesktops int `json:"max_concurrent_desktops,omitempty"` // Per user
-
 	ProvidersManagementEnabled bool `json:"providers_management_enabled,omitempty"`
 
 	SandboxBillingEnabled                bool    `json:"sandbox_billing_enabled,omitempty" gorm:"column:sandbox_billing_enabled"`
@@ -75,8 +73,6 @@ type SystemSettingsRequest struct {
 	// Kodit vision embedding model configuration
 	KoditVisionEmbeddingProvider *string `json:"kodit_vision_embedding_provider,omitempty"`
 	KoditVisionEmbeddingModel    *string `json:"kodit_vision_embedding_model,omitempty"`
-
-	MaxConcurrentDesktops *int `json:"max_concurrent_desktops"`
 
 	ProvidersManagementEnabled *bool `json:"providers_management_enabled"`
 
@@ -127,8 +123,6 @@ type SystemSettingsResponse struct {
 	KoditVisionEmbeddingProvider string `json:"kodit_vision_embedding_provider"`
 	KoditVisionEmbeddingModel    string `json:"kodit_vision_embedding_model"`
 	KoditVisionEmbeddingModelSet bool   `json:"kodit_vision_embedding_model_set"`
-
-	MaxConcurrentDesktops int `json:"max_concurrent_desktops"` // Per user
 
 	ProvidersManagementEnabled bool `json:"providers_management_enabled"`
 
@@ -187,7 +181,6 @@ func (s *SystemSettings) ToResponseWithSource(dbToken, envToken string) *SystemS
 		KoditVisionEmbeddingProvider:         s.KoditVisionEmbeddingProvider,
 		KoditVisionEmbeddingModel:            s.KoditVisionEmbeddingModel,
 		KoditVisionEmbeddingModelSet:         s.KoditVisionEmbeddingProvider != "" && s.KoditVisionEmbeddingModel != "",
-		MaxConcurrentDesktops:                s.MaxConcurrentDesktops,
 		ProvidersManagementEnabled:           s.ProvidersManagementEnabled,
 		EnforceQuotas:                        s.EnforceQuotas,
 		SandboxBillingEnabled:                s.SandboxBillingEnabled,

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -1062,8 +1062,12 @@ type ServerConfigForFrontend struct {
 	OrganizationsCreateEnabledForNonAdmins bool                 `json:"organizations_create_enabled_for_non_admins"`
 	ProvidersManagementEnabled             bool                 `json:"providers_management_enabled"` // Controls if users can add their own AI provider API keys
 	HasProviders                           bool                 `json:"has_providers"`                // Whether any global AI provider with enabled chat models exists
-	MaxConcurrentDesktops                  int                  `json:"max_concurrent_desktops"`
-	ActiveConcurrentDesktops               int                  `json:"active_concurrent_desktops"`
+	// MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per
+	// organisation when the session has an org, per user otherwise.
+	// -1 = unlimited. Note: /config is unauthenticated, so this is the
+	// Free-tier floor; real enforcement uses the resolved per-user/per-org cap.
+	MaxConcurrentDesktops    int `json:"max_concurrent_desktops"`
+	ActiveConcurrentDesktops int `json:"active_concurrent_desktops"`
 	Edition                                string               `json:"edition,omitempty"` // "mac-desktop", "server", "cloud", etc.
 	// DefaultChatSystemPrompt is the system prompt the platform applies to
 	// direct model chats when the user has not customised one. Surfaced to

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -4230,6 +4230,11 @@ export interface TypesQuotaResponse {
    */
   active_desktop_sandboxes?: number;
   active_headless_sandboxes?: number;
+  /**
+   * MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per
+   * organisation when the session has an org, per user otherwise.
+   * -1 = unlimited.
+   */
   max_concurrent_desktops?: number;
   max_desktop_sandboxes?: number;
   max_headless_sandboxes?: number;
@@ -4672,6 +4677,12 @@ export interface TypesServerConfigForFrontend {
   has_providers?: boolean;
   latest_version?: string;
   license?: TypesFrontendLicenseInfo;
+  /**
+   * MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per
+   * organisation when the session has an org, per user otherwise.
+   * -1 = unlimited. Note: /config is unauthenticated, so this is the
+   * Free-tier floor; real enforcement uses the resolved per-user/per-org cap.
+   */
   max_concurrent_desktops?: number;
   organizations_create_enabled_for_non_admins?: boolean;
   /** Controls if users can add their own AI provider API keys */
@@ -5690,7 +5701,6 @@ export interface TypesSystemSettingsRequest {
   /** Kodit vision embedding model configuration */
   kodit_vision_embedding_provider?: string;
   max_concurrent_desktop_sandboxes?: number;
-  max_concurrent_desktops?: number;
   max_concurrent_headless_sandboxes?: number;
   optimus_generation_model?: string;
   optimus_generation_model_provider?: string;
@@ -5730,8 +5740,6 @@ export interface TypesSystemSettingsResponse {
   /** Kodit vision embedding model configuration */
   kodit_vision_embedding_provider?: string;
   max_concurrent_desktop_sandboxes?: number;
-  /** Per user */
-  max_concurrent_desktops?: number;
   max_concurrent_headless_sandboxes?: number;
   optimus_generation_model?: string;
   optimus_generation_model_provider?: string;

--- a/frontend/src/components/dashboard/SystemSettingsTable.tsx
+++ b/frontend/src/components/dashboard/SystemSettingsTable.tsx
@@ -48,8 +48,6 @@ const SystemSettingsTable: FC = () => {
   const [editDialogOpen, setEditDialogOpen] = useState(false)
   const [newHfToken, setNewHfToken] = useState('')
   const [showToken, setShowToken] = useState(false)
-  const [editingMaxDesktops, setEditingMaxDesktops] = useState(false)
-  const [maxDesktopsValue, setMaxDesktopsValue] = useState('')
   const [editingSandboxHeadlessPrice, setEditingSandboxHeadlessPrice] = useState(false)
   const [sandboxHeadlessPriceValue, setSandboxHeadlessPriceValue] = useState('')
   const [editingSandboxDesktopPrice, setEditingSandboxDesktopPrice] = useState(false)
@@ -101,27 +99,6 @@ const SystemSettingsTable: FC = () => {
         kodit_enrichment_model: model,
       })
       snackbar.success(`Code Intelligence model set to ${provider}/${model}`)
-    } catch (err: any) {
-      if (err.response?.status === 403) {
-        snackbar.error('Access denied: Admin privileges required')
-      } else {
-        snackbar.error(`Failed to update settings: ${err.message}`)
-      }
-    }
-  }
-
-  const handleSaveMaxDesktops = async () => {
-    try {
-      const value = parseInt(maxDesktopsValue, 10)
-      if (isNaN(value) || value < 0) {
-        snackbar.error('Please enter a valid non-negative number')
-        return
-      }
-      await updateSettings.mutateAsync({
-        max_concurrent_desktops: value,
-      })
-      setEditingMaxDesktops(false)
-      snackbar.success('Max concurrent desktops updated')
     } catch (err: any) {
       if (err.response?.status === 403) {
         snackbar.error('Access denied: Admin privileges required')
@@ -718,73 +695,6 @@ const SystemSettingsTable: FC = () => {
                           disabled={saving}
                         >
                           Clear
-                        </Button>
-                      )}
-                    </Box>
-                  </TableCell>
-                </TableRow>
-
-                {/* Max Concurrent Desktops Row */}
-                <TableRow>
-                  <TableCell>
-                    <Typography variant="body2" fontWeight="medium">
-                      Max Concurrent Desktops
-                    </Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      Maximum number of concurrent desktop sessions per user (0 = unlimited)
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <Chip
-                      label={settings?.max_concurrent_desktops ? `Limit: ${settings.max_concurrent_desktops}` : 'Unlimited'}
-                      color={settings?.max_concurrent_desktops ? 'primary' : 'default'}
-                      size="small"
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <Typography variant="body2" fontFamily="monospace">
-                      {settings?.max_concurrent_desktops ?? 0}
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <Box display="flex" gap={1} alignItems="center">
-                      {editingMaxDesktops ? (
-                        <>
-                          <TextField
-                            size="small"
-                            type="number"
-                            value={maxDesktopsValue}
-                            onChange={(e) => setMaxDesktopsValue(e.target.value)}
-                            inputProps={{ min: 0 }}
-                            sx={{ width: 100 }}
-                          />
-                          <Button
-                            startIcon={saving ? <CircularProgress size={16} /> : <SaveIcon />}
-                            onClick={handleSaveMaxDesktops}
-                            size="small"
-                            variant="contained"
-                            disabled={saving}
-                          >
-                            Save
-                          </Button>
-                          <Button
-                            onClick={() => setEditingMaxDesktops(false)}
-                            size="small"
-                            disabled={saving}
-                          >
-                            Cancel
-                          </Button>
-                        </>
-                      ) : (
-                        <Button
-                          startIcon={<EditIcon />}
-                          onClick={() => {
-                            setMaxDesktopsValue(String(settings?.max_concurrent_desktops ?? 0))
-                            setEditingMaxDesktops(true)
-                          }}
-                          size="small"
-                        >
-                          Edit
                         </Button>
                       )}
                     </Box>

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -6933,6 +6933,10 @@ definitions:
       active_headless_sandboxes:
         type: integer
       max_concurrent_desktops:
+        description: |-
+          MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per
+          organisation when the session has an org, per user otherwise.
+          -1 = unlimited.
         type: integer
       max_desktop_sandboxes:
         type: integer
@@ -7640,6 +7644,11 @@ definitions:
       license:
         $ref: '#/definitions/types.FrontendLicenseInfo'
       max_concurrent_desktops:
+        description: |-
+          MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per
+          organisation when the session has an org, per user otherwise.
+          -1 = unlimited. Note: /config is unauthenticated, so this is the
+          Free-tier floor; real enforcement uses the resolved per-user/per-org cap.
         type: integer
       organizations_create_enabled_for_non_admins:
         type: boolean
@@ -9346,8 +9355,6 @@ definitions:
         type: string
       max_concurrent_desktop_sandboxes:
         type: integer
-      max_concurrent_desktops:
-        type: integer
       max_concurrent_headless_sandboxes:
         type: integer
       optimus_generation_model:
@@ -9417,9 +9424,6 @@ definitions:
         description: Kodit vision embedding model configuration
         type: string
       max_concurrent_desktop_sandboxes:
-        type: integer
-      max_concurrent_desktops:
-        description: Per user
         type: integer
       max_concurrent_headless_sandboxes:
         type: integer

--- a/openapi.json
+++ b/openapi.json
@@ -32005,6 +32005,7 @@
                         "type": "integer"
                     },
                     "max_concurrent_desktops": {
+                        "description": "MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per\norganisation when the session has an org, per user otherwise.\n-1 = unlimited.",
                         "type": "integer"
                     },
                     "max_desktop_sandboxes": {
@@ -32924,6 +32925,7 @@
                         "$ref": "#/components/schemas/types.FrontendLicenseInfo"
                     },
                     "max_concurrent_desktops": {
+                        "description": "MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per\norganisation when the session has an org, per user otherwise.\n-1 = unlimited. Note: /config is unauthenticated, so this is the\nFree-tier floor; real enforcement uses the resolved per-user/per-org cap.",
                         "type": "integer"
                     },
                     "organizations_create_enabled_for_non_admins": {
@@ -35259,9 +35261,6 @@
                     "max_concurrent_desktop_sandboxes": {
                         "type": "integer"
                     },
-                    "max_concurrent_desktops": {
-                        "type": "integer"
-                    },
                     "max_concurrent_headless_sandboxes": {
                         "type": "integer"
                     },
@@ -35361,10 +35360,6 @@
                         "type": "string"
                     },
                     "max_concurrent_desktop_sandboxes": {
-                        "type": "integer"
-                    },
-                    "max_concurrent_desktops": {
-                        "description": "Per user",
                         "type": "integer"
                     },
                     "max_concurrent_headless_sandboxes": {

--- a/swagger.json
+++ b/swagger.json
@@ -28134,6 +28134,7 @@
                     "type": "integer"
                 },
                 "max_concurrent_desktops": {
+                    "description": "MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per\norganisation when the session has an org, per user otherwise.\n-1 = unlimited.",
                     "type": "integer"
                 },
                 "max_desktop_sandboxes": {
@@ -29053,6 +29054,7 @@
                     "$ref": "#/definitions/types.FrontendLicenseInfo"
                 },
                 "max_concurrent_desktops": {
+                    "description": "MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per\norganisation when the session has an org, per user otherwise.\n-1 = unlimited. Note: /config is unauthenticated, so this is the\nFree-tier floor; real enforcement uses the resolved per-user/per-org cap.",
                     "type": "integer"
                 },
                 "organizations_create_enabled_for_non_admins": {
@@ -31388,9 +31390,6 @@
                 "max_concurrent_desktop_sandboxes": {
                     "type": "integer"
                 },
-                "max_concurrent_desktops": {
-                    "type": "integer"
-                },
                 "max_concurrent_headless_sandboxes": {
                     "type": "integer"
                 },
@@ -31490,10 +31489,6 @@
                     "type": "string"
                 },
                 "max_concurrent_desktop_sandboxes": {
-                    "type": "integer"
-                },
-                "max_concurrent_desktops": {
-                    "description": "Per user",
                     "type": "integer"
                 },
                 "max_concurrent_headless_sandboxes": {


### PR DESCRIPTION
## Summary

The "Max Concurrent Desktops" field on `SystemSettings` was a phantom: it
was persisted, surfaced on `/api/v1/config`, and editable from the System
Settings admin UI, but no enforcement code ever read it. The real desktop
quota path (`hydra_executor.checkLimits` → `quota.LimitReached`) consults
only the Free/Pro env-var tier values
(`PROJECTS_FREE_MAX_CONCURRENT_DESKTOPS`,
`PROJECTS_PRO_MAX_CONCURRENT_DESKTOPS`).

Worse, the help text claimed `0 = unlimited` while `handlers.go` treated
`0` as "fall back to free tier" (default `2`). Admins selecting Unlimited
got `2`. This blocked the helix-org manufacturing demo with a
`desktop quota reached on Helix (2/2 active)` error.

This change deletes the phantom rather than papering over it. To get
unlimited desktops, operators set `PROJECTS_FREE_MAX_CONCURRENT_DESKTOPS=-1`
(and/or the PRO variant). `quota.go:268` already short-circuits negative
limits — no extra code path needed.

## Changes

### Backend deletions
- Drop `MaxConcurrentDesktops` from `SystemSettings`,
  `SystemSettingsRequest`, `SystemSettingsResponse`, and
  `ToResponseWithSource` (`api/pkg/types/system_settings.go`).
- Drop the patch branch in `api/pkg/store/store_system_settings.go`.
- Drop the `max_concurrent_desktops_updated` log key in
  `api/pkg/server/system_settings_handlers.go`.
- Drop the three assertions and two struct-literal fields in
  `api/pkg/store/store_system_settings_test.go`.

### `/api/v1/config` honesty
- Replace the inline fallback at `api/pkg/server/handlers.go:117-123` with
  the Free-tier env value. `/config` is registered on `insecureRouter`
  with no auth middleware, so the caller's user is never in context — we
  can't ask the quota manager for their resolved cap. Code comment
  documents why. Real enforcement still runs through the quota manager in
  `StartDesktop` and picks the correct Free/Pro tier per wallet.

### Documentation
- Add per-org-vs-per-user `-1=unlimited` doc comments on
  `PROJECTS_FREE_MAX_CONCURRENT_DESKTOPS` /
  `PROJECTS_PRO_MAX_CONCURRENT_DESKTOPS` in `api/pkg/config/config.go`,
  on `ServerConfigForFrontend.MaxConcurrentDesktops` in
  `api/pkg/types/types.go`, and on `QuotaResponse.MaxConcurrentDesktops`
  in `api/pkg/types/quota.go`.

### Frontend
- Remove the "Max Concurrent Desktops" `<TableRow>`, the
  `handleSaveMaxDesktops` handler, and the
  `maxDesktopsValue` / `editingMaxDesktops` state hooks from
  `frontend/src/components/dashboard/SystemSettingsTable.tsx`.

### Tests
- Add `TestQuotaDesktopResolution` in `api/pkg/quota/quota_test.go`
  implementing the 15-row truth table from the spec (`enforce × freeEnv
  × proEnv × subscribed × ctx × active → effective_limit, allowed`).
  All 15 subtests pass.

### Generated
- Regenerated swagger JSON/YAML, `docs.go`, and frontend `api.ts` via
  `./stack update_openapi`.

## Compatibility

- **DB**: the `system_settings.max_concurrent_desktops` column becomes
  orphan data. GORM AutoMigrate doesn't drop columns; no read references
  it. Add an explicit drop migration later if `pg_dump` diffs become
  noisy.
- **API JSON shape**: `SystemSettingsRequest` / `SystemSettingsResponse`
  lose the field. `ServerConfigForFrontend.MaxConcurrentDesktops` stays
  but its source changes from "system setting" to "Free-tier env value".
- **Operators who relied on the System Settings slider**: switch to the
  env vars. `-1` = unlimited.

## Verification

- `go build ./...` clean.
- `go vet` clean on all touched packages.
- `go test ./pkg/quota/ -count=1` passes including
  `TestQuotaDesktopResolution` (15 subtests, all green).
- `yarn tsc` clean.
- End-to-end in inner Helix:
  - System Settings UI no longer shows the row (screenshot below).
  - `PROJECTS_FREE_MAX_CONCURRENT_DESKTOPS=-1` → `/config` returns `-1`.
  - `PROJECTS_FREE_MAX_CONCURRENT_DESKTOPS=1` → `/config` returns `1`.

## Screenshots

![System Settings after — Max Concurrent Desktops row removed](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002031_theres-a-bug-in-the/screenshots/01-system-settings-after.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01krx8t1kr1z06jtktsey9ve9s)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002031_theres-a-bug-in-the/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002031_theres-a-bug-in-the/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002031_theres-a-bug-in-the/tasks.md)

🚀 Built with [Helix](https://helix.ml)