### PR TITLE
fix(frontend): include new comment form in spec-review bubble stacking

### DIFF
--- a/frontend/src/components/spec-tasks/DesignReviewContent.tsx
+++ b/frontend/src/components/spec-tasks/DesignReviewContent.tsx
@@ -144,6 +144,12 @@ export default function DesignReviewContent({
   const documentRef = useRef<HTMLDivElement>(null);
   const markdownRef = useRef<HTMLDivElement>(null);
   const commentRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  // Ref to the in-progress new-comment form so we can measure its rendered
+  // height and feed it into the bubble-stacking algorithm.
+  const commentFormRef = useRef<HTMLDivElement | null>(null);
+  // Bump to force re-stacking after the form mounts/unmounts and we have its
+  // measured height (offsetHeight isn't reactive on its own).
+  const [commentFormMeasureTick, setCommentFormMeasureTick] = useState(0);
 
   // Refs and state for highlight preservation and hover button
   const savedRangeRef = useRef<Range | null>(null);
@@ -703,10 +709,30 @@ export default function DesignReviewContent({
   const positionRetryRef = useRef(0);
   const maxPositionRetries = 5;
 
+  // Sentinel id used to represent the in-progress new-comment form inside
+  // the bubble-stacking algorithm so the form participates in collision
+  // resolution alongside existing comment bubbles.
+  const NEW_COMMENT_FORM_KEY = "__new_comment_form__";
+
+  // Stable callback so passing it as a ref prop doesn't cause repeated
+  // null/node toggling and infinite re-renders.
+  const handleCommentFormRef = useCallback((el: HTMLDivElement | null) => {
+    commentFormRef.current = el;
+    // The form just mounted/unmounted — trigger a re-stack so the
+    // algorithm can pick up the real measured height.
+    setCommentFormMeasureTick((t) => t + 1);
+  }, []);
+
   useEffect(() => {
+    // On narrow viewports bubbles render inline (position: relative) and
+    // the form is a bottom-sheet (position: fixed). Stacking math is
+    // irrelevant in that mode.
+    const formActive =
+      !isNarrowViewport && showCommentForm && !!selectedText;
+
     if (
       !documentRef.current ||
-      inlineComments.length === 0 ||
+      (inlineComments.length === 0 && !formActive) ||
       !documentContent
     ) {
       setCommentPositions((prev) => (prev.size === 0 ? prev : new Map()));
@@ -737,6 +763,22 @@ export default function DesignReviewContent({
 
         positions.push({ id: comment.id!, baseY, height });
       });
+
+      if (formActive) {
+        // 220 is a sensible default matching the form's typical rendered
+        // height with a 3-line TextField; the real value replaces it once
+        // the form has mounted and the ref callback bumps the tick.
+        const formHeight = commentFormRef.current?.offsetHeight || 220;
+        positions.push({
+          id: NEW_COMMENT_FORM_KEY,
+          baseY: commentFormPosition.y,
+          height: formHeight,
+        });
+      }
+
+      // Sort top-to-bottom so the item with the higher anchor wins its
+      // preferred slot; later items get pushed down to avoid overlap.
+      positions.sort((a, b) => a.baseY - b.baseY);
 
       if (hasInvalidPositions && retryCount < maxPositionRetries) {
         return false;
@@ -802,7 +844,16 @@ export default function DesignReviewContent({
     const timeoutId = scheduleCalculation(0);
 
     return () => clearTimeout(timeoutId);
-  }, [inlineCommentIds, activeTab, documentContent]);
+  }, [
+    inlineCommentIds,
+    activeTab,
+    documentContent,
+    showCommentForm,
+    selectedText,
+    commentFormPosition.y,
+    commentFormMeasureTick,
+    isNarrowViewport,
+  ]);
 
   // Helper to find the Y position of quoted text
   const findQuotedTextPosition = (quotedText: string): number | null => {
@@ -1563,7 +1614,10 @@ export default function DesignReviewContent({
               {/* New Comment Form (Inline) */}
               <InlineCommentForm
                 show={showCommentForm}
-                yPos={commentFormPosition.y}
+                yPos={
+                  commentPositions.get(NEW_COMMENT_FORM_KEY) ??
+                  commentFormPosition.y
+                }
                 selectedText={selectedText}
                 commentText={commentText}
                 onCommentChange={setCommentText}
@@ -1576,6 +1630,7 @@ export default function DesignReviewContent({
                 }}
                 isNarrowViewport={isNarrowViewport}
                 isSubmitting={createCommentMutation.isPending}
+                outerRef={handleCommentFormRef}
               />
             </Box>
           </Box>

--- a/frontend/src/components/spec-tasks/InlineCommentForm.tsx
+++ b/frontend/src/components/spec-tasks/InlineCommentForm.tsx
@@ -11,6 +11,9 @@ interface InlineCommentFormProps {
   onCancel: () => void;
   isNarrowViewport?: boolean;
   isSubmitting?: boolean;
+  // Optional outer ref used by the parent to measure the rendered form
+  // height — needed so the bubble-stacking algorithm can include this form.
+  outerRef?: (el: HTMLDivElement | null) => void;
 }
 
 export default function InlineCommentForm({
@@ -23,8 +26,14 @@ export default function InlineCommentForm({
   onCancel,
   isNarrowViewport = false,
   isSubmitting = false,
+  outerRef,
 }: InlineCommentFormProps) {
   const paperRef = useRef<HTMLDivElement>(null);
+
+  const setRefs = (el: HTMLDivElement | null) => {
+    (paperRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+    if (outerRef) outerRef(el);
+  };
 
   // Auto-scroll to ensure the comment form is visible after it appears
   useEffect(() => {
@@ -64,7 +73,7 @@ export default function InlineCommentForm({
 
   return (
     <Paper
-      ref={paperRef}
+      ref={setRefs}
       sx={{
         ...(isNarrowViewport ? narrowStyles : wideStyles),
         p: 2,


### PR DESCRIPTION
## Summary

On the spec review page, opening a new inline comment near an existing
comment caused the new `InlineCommentForm` to render directly on top of
the existing `InlineCommentBubble` — both elements share the same
`position: absolute; left: 820px; width: 300px` column on wide
viewports.

Root cause: the bubble-stacking algorithm in `DesignReviewContent.tsx`
(the `useEffect` at the old line 706) computed collision-avoided
positions for `inlineComments` only. The form's Y was fed directly
from `commentFormPosition.y` (raw selection rect) and never
participated in collision resolution.

Fix: include the open form as a pseudo-entry (sentinel id
`__new_comment_form__`) in the same stacking algorithm. Sort entries
by `baseY` so whichever element is higher in the document wins its
preferred slot; the other gets pushed down past it.

## Changes

- `frontend/src/components/spec-tasks/InlineCommentForm.tsx` — added
  an optional `outerRef` callback prop so the parent can measure the
  form's rendered height.
- `frontend/src/components/spec-tasks/DesignReviewContent.tsx`
  - new `commentFormRef`, `commentFormMeasureTick` state, and stable
    `handleCommentFormRef` callback that bumps the tick on mount /
    unmount so the algorithm re-runs with the real measured height
    (fallback 220 px before mount);
  - stacking `useEffect` now appends a `{ id: NEW_COMMENT_FORM_KEY,
    baseY: commentFormPosition.y, height }` pseudo-entry when the form
    is open on a wide viewport, sorts entries by `baseY`, then runs
    the existing overlap-resolution loop unchanged;
  - deps extended with `showCommentForm`, `selectedText`,
    `commentFormPosition.y`, `commentFormMeasureTick`,
    `isNarrowViewport` so opening / moving / closing the form
    triggers a re-stack;
  - form's `yPos` prop now reads from
    `commentPositions.get(NEW_COMMENT_FORM_KEY)` (with raw-selection
    fallback), so it inherits the collision-avoided position.

Narrow-viewport behaviour is intentionally untouched — bubbles render
inline (`position: relative`) and the form is a bottom-sheet
(`position: fixed`), so collision math is irrelevant there.

## Testing

- `yarn tsc` — clean (no type errors).
- `vite build` — transformed all 21,104 modules successfully; the
  final dist-write step failed only due to `frontend/dist`
  bind-mount permissions in this dev environment (unrelated to the
  change).
- Inner-Helix Vite HMR (`helix-frontend-1`, port 8081) reloaded both
  modified files with no errors.
- Live end-to-end click-through deferred: the inner Helix has zero
  existing spec tasks and seeding one requires a multi-minute LLM
  generation cycle. Please verify on a real spec review session that
  opening a second comment near an existing bubble no longer
  overlaps it (and that cancel / submit cleanly re-stack the
  bubbles).

## Design docs

See
[`helix-specs/design/tasks/002037_fix-messy-ui-on-the-spec/`](https://github.com/helixml/helix/tree/helix-specs/design/tasks/002037_fix-messy-ui-on-the-spec)
for full requirements, design rationale, and implementation notes.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01ks05bfzatqp20y26vgd5ttwr)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002037_fix-messy-ui-on-the-spec/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002037_fix-messy-ui-on-the-spec/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002037_fix-messy-ui-on-the-spec/tasks.md)

🚀 Built with [Helix](https://helix.ml)