### PR TITLE
Persist Skip Planning and Start Immediately Toggles

### DIFF
--- a/frontend/src/components/tasks/NewSpecTaskForm.tsx
+++ b/frontend/src/components/tasks/NewSpecTaskForm.tsx
@@ -52,6 +52,8 @@ import { useSpecTasks, useProjectLabels, useAddLabel } from "../../services/spec
 
 const LAST_LABELS_KEY = "helix_last_task_labels";
 const DRAFT_KEY_PREFIX = "helix_new_spectask_draft_";
+const LAST_JUST_DO_IT_KEY = "helix_new_spectask_just_do_it";
+const LAST_AUTO_START_KEY = "helix_new_spectask_auto_start";
 
 
 
@@ -117,8 +119,20 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
     string[]
   >([]);
   const [selectedHelixAgent, setSelectedHelixAgent] = useState("");
-  const [justDoItMode, setJustDoItMode] = useState(false);
-  const [autoStart, setAutoStart] = useState(false);
+  const [justDoItMode, setJustDoItMode] = useState<boolean>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(LAST_JUST_DO_IT_KEY) || "false");
+    } catch {
+      return false;
+    }
+  });
+  const [autoStart, setAutoStart] = useState<boolean>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(LAST_AUTO_START_KEY) || "false");
+    } catch {
+      return false;
+    }
+  });
   const [isCreating, setIsCreating] = useState(false);
 
   // Empty string = "Unassigned". Pre-filled with the current user below.
@@ -314,6 +328,25 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
     };
   }, []);
 
+  // Persist the two workflow toggles to localStorage on every change so they
+  // remember their state from one use of the form to the next.
+  const handleJustDoItChange = useCallback((checked: boolean) => {
+    setJustDoItMode(checked);
+    try {
+      localStorage.setItem(LAST_JUST_DO_IT_KEY, JSON.stringify(checked));
+    } catch {
+      /* localStorage may be unavailable (quota, private mode) — ignore */
+    }
+  }, []);
+  const handleAutoStartChange = useCallback((checked: boolean) => {
+    setAutoStart(checked);
+    try {
+      localStorage.setItem(LAST_AUTO_START_KEY, JSON.stringify(checked));
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
   // Handle inline agent creation
   // Reset form
   const resetForm = useCallback(() => {
@@ -323,8 +356,8 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
     // Labels intentionally kept — they persist to the next task via localStorage
     setSelectedDependencyTaskIds([]);
     setSelectedHelixAgent("");
-    setJustDoItMode(false);
-    setAutoStart(false);
+    // justDoItMode and autoStart intentionally kept — they persist to the next
+    // task via localStorage (see handleJustDoItChange / handleAutoStartChange)
     setBranchMode(TypesBranchMode.BranchModeNew);
     setBaseBranch(defaultBranchName);
     setBranchPrefix("");
@@ -452,13 +485,13 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === "j") {
         e.preventDefault();
-        setJustDoItMode((prev) => !prev);
+        handleJustDoItChange(!justDoItMode);
       }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, []);
+  }, [justDoItMode, handleJustDoItChange]);
 
   return (
     <Box sx={{ height: "100%", display: "flex", flexDirection: "column" }}>
@@ -987,7 +1020,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
                 control={
                   <Checkbox
                     checked={justDoItMode}
-                    onChange={(e) => setJustDoItMode(e.target.checked)}
+                    onChange={(e) => handleJustDoItChange(e.target.checked)}
                     color="warning"
                   />
                 }
@@ -1031,7 +1064,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
                 control={
                   <Checkbox
                     checked={autoStart}
-                    onChange={(e) => setAutoStart(e.target.checked)}
+                    onChange={(e) => handleAutoStartChange(e.target.checked)}
                     color="primary"
                   />
                 }


### PR DESCRIPTION
Skip planning and start immediately. These options should remember their state from one use of the new spec task form to the next. Probably local storage as well. 

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kreb7sevt5ecyagxhctv3ejh)

🚀 Built with [Helix](https://helix.ml)