### PR TITLE
fix(desktop): surface workspace-setup failures instead of hanging cold-start

### DIFF
--- a/api/pkg/server/auto_wake_stuck_interactions.go
+++ b/api/pkg/server/auto_wake_stuck_interactions.go
@@ -122,14 +122,64 @@ package server
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"strconv"
 	"time"
 
+	"github.com/helixml/helix/api/pkg/hydra"
 	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/rs/zerolog/log"
 )
+
+// setupFailedSentinelPath is where helix-workspace-setup.sh writes a JSON
+// failure report on non-zero exit. Reading it from outside the container
+// lets us replace the generic "agent never connected" banner with the real
+// reason setup failed (e.g. a git clone 403, a missing dependency).
+const setupFailedSentinelPath = "/home/retro/.helix-setup-failed"
+
+// setupFailedSentinel matches the JSON shape written by
+// helix-workspace-setup.sh's cleanup_and_prompt trap.
+type setupFailedSentinel struct {
+	ExitCode int    `json:"exit_code"`
+	LogTail  string `json:"log_tail"`
+}
+
+// readSetupFailureSentinel pulls ~/.helix-setup-failed from the session's
+// dev container via hydra and returns its parsed contents. Returns nil if
+// the file isn't present, the container or sandbox aren't reachable, or the
+// JSON is malformed — every code path the caller hits when the sentinel
+// can't be read should fall back to the generic banner.
+func (apiServer *HelixAPIServer) readSetupFailureSentinel(ctx context.Context, sessionID, sandboxID string) *setupFailedSentinel {
+	if sandboxID == "" {
+		return nil
+	}
+	hydraRunnerID := fmt.Sprintf("hydra-%s", sandboxID)
+	hydraClient := hydra.NewRevDialClient(apiServer.connman, hydraRunnerID)
+
+	ctxTimeout, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	data, err := hydraClient.ReadSandboxFile(ctxTimeout, sessionID, setupFailedSentinelPath)
+	if err != nil {
+		log.Debug().Err(err).
+			Str("session_id", sessionID).
+			Str("sandbox_id", sandboxID).
+			Msg("[AUTO_WAKE] No setup-failed sentinel found (or unreadable) — falling back to generic banner")
+		return nil
+	}
+	var parsed setupFailedSentinel
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		log.Warn().Err(err).
+			Str("session_id", sessionID).
+			Int("bytes", len(data)).
+			Msg("[AUTO_WAKE] Setup-failed sentinel present but unparseable; falling back to generic banner")
+		return nil
+	}
+	return &parsed
+}
 
 const (
 	// autoWakeScanInterval is how often the worker checks for stuck
@@ -511,6 +561,29 @@ func (apiServer *HelixAPIServer) maybeKickColdStart(ctx context.Context, stuck *
 	if stuck.AutoWakeCount >= autoWakeMaxRetries {
 		stuck.State = types.InteractionStateError
 		stuck.Error = "Agent never connected after auto-wake cold-start retries (no WebSocket — see helixml/helix#2397)"
+		// Before giving up with the generic banner, see if the dev
+		// container's workspace-setup script wrote a failure sentinel.
+		// If it did, the real cause is in there (e.g. a clone 403) and
+		// the user deserves to see that instead of an infrastructure
+		// timeout.
+		if session, err := apiServer.Store.GetSession(ctx, stuck.SessionID); err == nil && session != nil {
+			if sentinel := apiServer.readSetupFailureSentinel(ctx, stuck.SessionID, session.SandboxID); sentinel != nil {
+				// Truncate aggressively: the Interaction.Error column
+				// renders inline in the UI. Full log lives in the
+				// container's ~/.helix-setup.log for follow-up.
+				const maxTail = 1200
+				tail := sentinel.LogTail
+				if len(tail) > maxTail {
+					tail = "…" + tail[len(tail)-maxTail:]
+				}
+				stuck.Error = fmt.Sprintf("Workspace setup failed (exit code %d): %s", sentinel.ExitCode, tail)
+				log.Info().
+					Str("interaction_id", stuck.ID).
+					Str("session_id", stuck.SessionID).
+					Int("exit_code", sentinel.ExitCode).
+					Msg("[AUTO_WAKE] Surfaced workspace setup failure from sentinel")
+			}
+		}
 		stuck.Updated = time.Now()
 		stuck.Completed = time.Now()
 		if _, err := apiServer.Store.UpdateInteraction(ctx, stuck); err != nil {

--- a/api/pkg/server/auto_wake_stuck_interactions.go
+++ b/api/pkg/server/auto_wake_stuck_interactions.go
@@ -537,25 +537,31 @@ func (apiServer *HelixAPIServer) maybeAutoWake(ctx context.Context, stuck *types
 // Re-kicking during the boot window only races against the existing
 // per-session lock and burns retry budget for nothing.
 func (apiServer *HelixAPIServer) maybeKickColdStart(ctx context.Context, stuck *types.Interaction) {
-	// Skip if a StartDesktop is genuinely in progress and we're still
-	// inside the grace period. Failing to load the session is non-fatal
-	// — fall through to the existing path so a transient store error
-	// doesn't permanently disable the cold-start kick.
-	if session, err := apiServer.Store.GetSession(ctx, stuck.SessionID); err == nil && session != nil {
-		if session.Metadata.ExternalAgentStatus == "starting" &&
-			time.Since(stuck.Created) < coldStartGracePeriod() {
-			log.Debug().
-				Str("interaction_id", stuck.ID).
-				Str("session_id", stuck.SessionID).
-				Dur("interaction_age", time.Since(stuck.Created)).
-				Dur("grace_period", coldStartGracePeriod()).
-				Msg("[AUTO_WAKE] StartDesktop in progress — deferring cold-start kick (no budget burn)")
-			return
-		}
-	} else if err != nil {
+	// Load the session once for the two checks below: the
+	// StartDesktop-in-progress gate, and (on cap-exhaustion) the
+	// SandboxID lookup used to read the workspace-setup failure
+	// sentinel. Failing to load is non-fatal — fall through so a
+	// transient store error doesn't permanently disable cold-start.
+	session, err := apiServer.Store.GetSession(ctx, stuck.SessionID)
+	if err != nil {
 		log.Warn().Err(err).
 			Str("interaction_id", stuck.ID).
 			Msg("[AUTO_WAKE] Failed to load session for cold-start status check; proceeding with kick")
+		session = nil
+	}
+
+	// Skip if a StartDesktop is genuinely in progress and we're still
+	// inside the grace period.
+	if session != nil &&
+		session.Metadata.ExternalAgentStatus == "starting" &&
+		time.Since(stuck.Created) < coldStartGracePeriod() {
+		log.Debug().
+			Str("interaction_id", stuck.ID).
+			Str("session_id", stuck.SessionID).
+			Dur("interaction_age", time.Since(stuck.Created)).
+			Dur("grace_period", coldStartGracePeriod()).
+			Msg("[AUTO_WAKE] StartDesktop in progress — deferring cold-start kick (no budget burn)")
+		return
 	}
 
 	if stuck.AutoWakeCount >= autoWakeMaxRetries {
@@ -565,8 +571,10 @@ func (apiServer *HelixAPIServer) maybeKickColdStart(ctx context.Context, stuck *
 		// container's workspace-setup script wrote a failure sentinel.
 		// If it did, the real cause is in there (e.g. a clone 403) and
 		// the user deserves to see that instead of an infrastructure
-		// timeout.
-		if session, err := apiServer.Store.GetSession(ctx, stuck.SessionID); err == nil && session != nil {
+		// timeout. Reuses the session loaded at the top of this
+		// function — no extra store roundtrip (and no extra mock
+		// expectation in the cap-exhausted unit tests).
+		if session != nil {
 			if sentinel := apiServer.readSetupFailureSentinel(ctx, stuck.SessionID, session.SandboxID); sentinel != nil {
 				// Truncate aggressively: the Interaction.Error column
 				// renders inline in the UI. Full log lives in the

--- a/desktop/shared/helix-workspace-setup.sh
+++ b/desktop/shared/helix-workspace-setup.sh
@@ -17,6 +17,10 @@
 # Signal files:
 #   $HOME/.helix-setup-complete  - Touched when setup is done
 #   $HOME/.helix-zed-folders     - List of folders for Zed to open
+#   $HOME/.helix-setup-failed    - JSON written on failure: { exit_code, log_tail }
+#                                  The API reads this from outside the container
+#                                  to surface the real error in the UI instead of
+#                                  the generic "agent never connected" banner.
 
 # Exit on error - but trap will catch it and keep terminal open
 set -e
@@ -27,6 +31,25 @@ set -e
 # message, blocking session startup on the user typing :wq in vim.
 # Real merge conflicts still fail loudly — only the editor prompt is suppressed.
 export GIT_MERGE_AUTOEDIT=no
+
+# Capture all stdout/stderr to a log file in addition to the terminal so the
+# failure sentinel can include a tail of what went wrong. tee writes the same
+# bytes to both, so the user still sees live output in the ghostty window.
+SETUP_LOG="$HOME/.helix-setup.log"
+: > "$SETUP_LOG" || true
+exec > >(tee -a "$SETUP_LOG") 2>&1
+
+# How long the cleanup_and_prompt menu waits for a human at the terminal before
+# giving up and exiting with the original failure code. Without this timeout an
+# unattended spec-task agent's setup failure parks the script on `read` forever:
+# Zed never sees ~/.helix-setup-complete, no WebSocket ever connects, and the
+# API eventually times out with the generic
+#   "Agent never connected after auto-wake cold-start retries"
+# banner — burying the real error in the framebuffer scrollback.
+#
+# 60s gives a watching human plenty of time to react while still freeing the
+# session for the API to report the real failure when no one is there.
+HELIX_SETUP_PROMPT_TIMEOUT="${HELIX_SETUP_PROMPT_TIMEOUT:-60}"
 
 # Trap any exit (success or failure) to show interactive menu
 # This ensures users can see errors and debug
@@ -39,6 +62,28 @@ cleanup_and_prompt() {
         echo "========================================="
         echo ""
         echo "Check the errors above."
+
+        # Persist the failure so the API can read it from outside the
+        # container and surface the real error to the UI. We escape just
+        # enough for valid JSON; jq is not guaranteed to exist in every
+        # desktop image.
+        if [ -f "$SETUP_LOG" ]; then
+            local log_tail
+            log_tail=$(tail -n 80 "$SETUP_LOG" \
+                | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' \
+                2>/dev/null \
+                || tail -n 80 "$SETUP_LOG" \
+                    | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/$/\\n/' \
+                    | tr -d '\n' \
+                    | awk '{print "\""$0"\""}')
+            cat > "$HOME/.helix-setup-failed" <<JSON
+{"exit_code": $exit_code, "log_tail": $log_tail}
+JSON
+        else
+            cat > "$HOME/.helix-setup-failed" <<JSON
+{"exit_code": $exit_code, "log_tail": ""}
+JSON
+        fi
     fi
 
     echo ""
@@ -46,15 +91,20 @@ cleanup_and_prompt() {
     echo "  1) Close this window"
     echo "  2) Start an interactive shell for debugging"
     echo ""
-    read -p "Enter choice [1-2]: " choice
+    # Time out the prompt so unattended containers don't block forever on
+    # read. Default to "1) Close" so the container exits with the real
+    # exit code, which lets the API observe and report the failure.
+    local choice=""
+    if read -t "$HELIX_SETUP_PROMPT_TIMEOUT" -p "Enter choice [1-2] (auto-close in ${HELIX_SETUP_PROMPT_TIMEOUT}s): " choice; then
+        : # got input
+    else
+        echo ""
+        echo "(no input within ${HELIX_SETUP_PROMPT_TIMEOUT}s — closing)"
+        choice=1
+    fi
 
     case "$choice" in
-        1)
-            # Disable trap before exiting to avoid infinite loop
-            trap - EXIT
-            exit $exit_code
-            ;;
-        2|*)
+        2)
             echo ""
             echo "Starting interactive shell..."
             echo "Type 'exit' to close this window."
@@ -66,9 +116,19 @@ cleanup_and_prompt() {
             fi
             exec bash
             ;;
+        *)
+            # Default (1 or timeout): disable trap to avoid recursion and
+            # exit with the original code so the parent observes the failure.
+            trap - EXIT
+            exit $exit_code
+            ;;
     esac
 }
 trap cleanup_and_prompt EXIT
+
+# Clear any failure sentinel from a previous run so a successful setup
+# doesn't appear failed.
+rm -f "$HOME/.helix-setup-failed" 2>/dev/null || true
 
 echo "========================================="
 echo "Helix Workspace Setup - $(date)"


### PR DESCRIPTION
## Summary

Workspace-setup failures in a dev container's ghostty terminal previously hung forever on `read -p` from the exit trap's debug menu, because no human was at the keyboard. The container kept its setup process alive but Zed never saw `~/.helix-setup-complete`, so no WebSocket connected. Five minutes later the auto-wake worker gave up with the generic `Agent never connected after auto-wake cold-start retries` banner, and the real cause (git clone 403, missing dependency, anything that `set -e`'d out) was only visible in the framebuffer scrollback.

This PR makes the script exit cleanly when unattended **and** propagates the real failure reason out to the UI.

## Changes

**`desktop/shared/helix-workspace-setup.sh`**
- New env `HELIX_SETUP_PROMPT_TIMEOUT` (default 60s) added to the menu's `read`. Defaults to "1) Close" on timeout so unattended setups exit cleanly with the original exit code instead of parking on the prompt.
- All stdout/stderr mirrored to `~/.helix-setup.log` via `exec > >(tee ...)` so the failure trap has a log tail to attach.
- On non-zero exit, writes `~/.helix-setup-failed` as JSON: `{"exit_code": N, "log_tail": "<last 80 lines>"}`. Stale sentinels from prior runs are cleared on script start so successful runs don't appear failed.

**`api/pkg/server/auto_wake_stuck_interactions.go`**
- New helper `readSetupFailureSentinel` reads `~/.helix-setup-failed` from the dev container via the existing `hydra.ReadSandboxFile` RevDial call (keyed by session + sandbox id). Returns nil on any error so the fallback path is untouched.
- When cold-start retries exhaust, attempt the sentinel read first. If present, replace the generic banner with `Workspace setup failed (exit code N): <log tail>` (tail truncated to 1.2KB for the inline column; full log stays in the container).

The generic banner is preserved as the fallback when the sentinel is genuinely absent (e.g. the container died before reaching the script).

## Test plan

- [x] `bash -n` passes on the modified script
- [x] Local failure path: forced `exit 7` writes a valid sentinel JSON, menu times out and exits 7
- [x] Local success path: stale sentinel from a previous run is cleared, no new sentinel written
- [x] `go build ./api/pkg/server/` clean
- [ ] **NOT tested in-container yet** — needs `./stack build-ubuntu` to bake the script into the desktop image + a fresh spec-task session against a project whose setup actually fails (e.g. an org the user isn't a member of, which trips the git 403 path that surfaced this).

## Related

- See https://github.com/helixml/helix/issues/2397 — the cold-start grace + banner this PR feeds a real reason into.
- Follow-up not in this PR: the underlying admin / org-membership mismatch that produced the 403 in the first place. Captured in `design/2026-05-20-admin-vs-org-membership-git-403.md` for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)