### PR TITLE
fix(agent): default credential_type to api_key for non-claude runtimes

### DIFF
--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -161,14 +161,24 @@ func GenerateZedMCPConfig(
 		// those sessions still come up.
 		provider = "anthropic"
 		model = "claude-sonnet-4-5-latest"
-	} else if assistant.CodeAgentCredentialType.IsSubscription() {
-		// Subscription-credential agents (e.g. Claude Code with OAuth) handle
-		// inference upstream, not through a Helix provider. Don't write a
-		// Helix-routed default into settings.json — Zed falls back to its
-		// built-in defaults for inline assistant / commit messages / thread
-		// summaries, and the agent itself (Claude Code) routes via its own
-		// OAuth path. The pre-flight ValidateAssistantModelConfig already
-		// applies the same bypass so spec-task start handlers don't 422.
+	} else if assistant.CodeAgentCredentialType.IsSubscription() && assistant.CodeAgentRuntime == types.CodeAgentRuntimeClaudeCode {
+		// Subscription credentials only make sense for Claude Code: it handles
+		// inference upstream via OAuth, not through a Helix provider. Don't
+		// write a Helix-routed default into settings.json — Zed falls back to
+		// its built-in defaults for inline assistant / commit messages / thread
+		// summaries, and Claude Code routes via its own OAuth path. The pre-
+		// flight ValidateAssistantModelConfig already applies the same bypass
+		// so spec-task start handlers don't 422.
+		//
+		// We deliberately scope this branch to claude_code: a non-Claude
+		// runtime (zed_agent, qwen_code, gemini_cli, codex_cli) cannot use a
+		// "subscription" credential — there's no OAuth path for it. Treating
+		// such an assistant as subscription-credentialed leaves agent.default_model
+		// unset, which trips start-zed-helix.sh's wait_for_zed_config (it greps
+		// for the literal "default_model" key) and the dev container times out
+		// with a generic "Agent never connected" banner. The misconfigured
+		// credential_type=subscription is almost always a stale UI default; we
+		// log it and fall through to the api_key path so the agent can boot.
 		useAgentModel = false
 	} else if reason := ValidateAssistantModelConfig(app, providerSnapshot); reason != "" {
 		log.Error().
@@ -715,18 +725,19 @@ func ValidateAssistantModelConfig(app *types.App, snapshot []ProviderRef) string
 	if assistant == nil {
 		return ""
 	}
-	// Subscription-credential agents (e.g. Claude Code with OAuth) auth
-	// directly with the upstream provider and do not route inference through
-	// a Helix provider, so empty provider/model is the documented shape
+	// Subscription-credential agents (Claude Code with OAuth) auth directly
+	// with the upstream provider and do not route inference through a Helix
+	// provider, so empty provider/model is the documented shape
 	// (see types.CodeAgentCredentialTypeSubscription). Validating against a
 	// Helix provider snapshot would be meaningless and incorrectly 422s any
 	// task started on such an agent.
 	//
-	// Today only zed_external+claude_code uses subscription credentials. If
-	// other runtimes ever adopt OAuth, audit this bypass — and the matching
-	// useAgentModel=false branch in GenerateZedMCPConfig — so we don't mask
-	// misconfig on agents that DO need a Helix-routed provider.
-	if assistant.CodeAgentCredentialType.IsSubscription() {
+	// Scoped to claude_code runtime: a zed_agent / qwen_code / gemini_cli /
+	// codex_cli assistant cannot use OAuth, so credential_type=subscription
+	// on those is misconfig (almost always a stale UI default) — we let it
+	// fall through to the normal provider/model check rather than silently
+	// bypassing it. See the matching condition in GenerateZedMCPConfig.
+	if assistant.CodeAgentCredentialType.IsSubscription() && assistant.CodeAgentRuntime == types.CodeAgentRuntimeClaudeCode {
 		return ""
 	}
 	provider := assistant.GenerationModelProvider

--- a/api/pkg/server/project_handlers.go
+++ b/api/pkg/server/project_handlers.go
@@ -2757,8 +2757,12 @@ func (s *HelixAPIServer) applyProject(_ http.ResponseWriter, r *http.Request) (*
 		// When omitted, a plain chat agent (helix_basic) is created.
 		agentType, codeRuntime := projectAgentRuntimeToTypes(agentSpec.Runtime)
 
-		var credType types.CodeAgentCredentialType
-		if agentSpec.Credentials == "subscription" {
+		// Default to api_key when the spec doesn't say otherwise. Only
+		// claude_code can legitimately carry "subscription"; everything else
+		// must be api_key so GenerateZedMCPConfig writes agent.default_model
+		// (start-zed-helix.sh greps for that literal key before launching Zed).
+		credType := types.CodeAgentCredentialTypeAPIKey
+		if agentSpec.Credentials == "subscription" && codeRuntime == types.CodeAgentRuntimeClaudeCode {
 			credType = types.CodeAgentCredentialTypeSubscription
 		}
 

--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -337,10 +337,15 @@ const AppSettings: FC<AppSettingsProps> = ({
       setGenerationModel(app.generation_model || '')
       setGenerationModelProvider(app.generation_model_provider || '')
       setCodeAgentRuntime(app.code_agent_runtime || 'zed_agent')
+      // Default to api_key when the field is unset. The previous fallback
+      // (`generation_model_provider ? 'api_key' : 'subscription'`) flipped a
+      // freshly-created zed_agent assistant to subscription mode, which then
+      // strips the Helix-routed default_model and leaves the dev container
+      // stuck at "Agent never connected" because start-zed-helix.sh waits for
+      // the default_model key before launching Zed. Subscription is opt-in
+      // (user must explicitly click the radio for a Claude Code agent).
       setClaudeCodeMode(
-        app.code_agent_credential_type === 'subscription' ? 'subscription' :
-        app.code_agent_credential_type === 'api_key' ? 'api_key' :
-        app.generation_model_provider ? 'api_key' : 'subscription'
+        app.code_agent_credential_type === 'subscription' ? 'subscription' : 'api_key'
       )
       // External agent display settings
       setResolution(app.external_agent_config?.resolution as '1080p' | '4k' | '5k' || '1080p')


### PR DESCRIPTION
## Summary

New zed_agent assistants were being silently flipped to `subscription` mode by a brittle UI default. That strips `agent.default_model` from `~/.config/zed/settings.json`, which traps `start-zed-helix.sh` in `wait_for_zed_config` (it greps for the literal `"default_model"` key before launching Zed). The dev container never starts Zed, no WebSocket ever connects, and the auto-wake worker eventually marks the interaction with the generic `Agent never connected after auto-wake cold-start retries` banner — burying the real cause.

Hit live on prime: a fresh project + agent created via the UI saved with `code_agent_credential_type: "subscription"` despite the user selecting OpenAI + Zed Agent runtime. There's no OAuth path for OpenAI; subscription only makes sense for Claude Code.

## Changes

**`frontend/src/components/app/AppSettings.tsx:343`**
The previous fallback was:
```js
app.code_agent_credential_type === 'subscription' ? 'subscription' :
app.code_agent_credential_type === 'api_key'      ? 'api_key' :
app.generation_model_provider                     ? 'api_key' : 'subscription'
```
That third branch fired for any newly-created agent whose `generation_model_provider` was empty (i.e. almost all of them — the UI stores the provider in `provider` and leaves `generation_model_provider` empty unless the user picks per-feature overrides). Replaced with: empty → `api_key`. Subscription stays opt-in via the radio.

**`api/pkg/server/project_handlers.go:2760`**
`var credType types.CodeAgentCredentialType` left the field as the empty-string zero value when the spec didn't say `subscription`. Now defaults to `api_key`, and only honours `subscription` when the runtime is `claude_code`.

**`api/pkg/external-agent/zed_config.go`** (`GenerateZedMCPConfig` and `ValidateAssistantModelConfig`)
Scoped `IsSubscription()` short-circuits to `CodeAgentRuntime == claude_code`. A stale `credential_type=subscription` on a `zed_agent` / `qwen_code` / `gemini_cli` / `codex_cli` assistant now falls through to the normal model write path instead of stripping `default_model`. Comment cross-references the symptom (cold-start banner) so the next person tracing this finds the connection.

## Test plan

- [x] `go build ./api/pkg/external-agent/ ./api/pkg/server/` clean
- [x] `tsc --noEmit` clean on the touched frontend file
- [ ] **NOT tested end-to-end on prime yet** — needs a freshly created agent on the patched build to verify `agent.default_model` appears in settings.json and Zed actually launches. Plan: deploy to prime, create a new project + zed_agent + openai assistant, confirm the dev container reaches `Launching Zed...` and the WebSocket connects.

## Out of scope

- **Existing DB rows** already saved with `credential_type=subscription` on non-claude runtimes will keep misbehaving until the user re-saves the agent (the patched UI will now write `api_key`) or a separate backfill migration ships.
- **Server-side validation** rejecting `subscription` on non-`claude_code` save paths. Worth a follow-up but bigger scope.
- The cold-start banner itself — see https://github.com/helixml/helix/pull/2460 for surfacing the real failure reason in the UI instead of the generic banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)