### PR TITLE
build: copy helix-org into sandbox/desktop/demos/sway Docker contexts

### DIFF
--- a/Dockerfile.demos
+++ b/Dockerfile.demos
@@ -2,8 +2,11 @@ FROM golang:1.25-alpine3.22@sha256:26b4d7113039cd51356bd7930ecafd1031d2975dc3b69
 WORKDIR /app
 RUN apk add --no-cache bash openssh
 COPY go.mod go.sum ./
+# Module resolution needs the replace target (see PR #2286).
+COPY helix-org/go.mod helix-org/go.sum ./helix-org/
 RUN go mod download
 COPY demos ./demos
+COPY helix-org ./helix-org
 WORKDIR /app/demos
 RUN go build -o /demos
 EXPOSE 80

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -14,9 +14,16 @@
 FROM golang:1.25-bookworm@sha256:e3a54b77385b4f8a31c1db4d12429ffb3718ea76865731a787c497755d409547 AS go-builder
 WORKDIR /build
 COPY go.mod go.sum ./
+# go.mod has `replace github.com/helixml/helix-org => ./helix-org`, so the
+# replaced module's go.mod must exist at module-resolution time even though
+# the binaries built here (hydra, sandbox-heartbeat, compose-manager) don't
+# import it. Without these two files `go mod download` fails with
+# "reading helix-org/go.mod: no such file or directory". See PR #2286.
+COPY helix-org/go.mod helix-org/go.sum ./helix-org/
 RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 COPY api/ ./api/
+COPY helix-org/ ./helix-org/
 # Build hydra (multi-Docker isolation daemon with built-in RevDial)
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \

--- a/Dockerfile.sway-helix
+++ b/Dockerfile.sway-helix
@@ -54,10 +54,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 COPY go.mod go.sum ./
+# Module resolution needs the replace target (see PR #2286).
+COPY helix-org/go.mod helix-org/go.sum ./helix-org/
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 # Copy Go source AFTER dependencies are downloaded for better caching
 COPY api ./api
+COPY helix-org ./helix-org
 WORKDIR /app/api
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \

--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -42,12 +42,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 COPY go.mod go.sum ./
+# go.mod has `replace github.com/helixml/helix-org => ./helix-org`, so the
+# replaced module's go.mod must exist at module-resolution time even though
+# none of the binaries built in this stage import it. Without these two
+# files `go mod download` fails with "reading helix-org/go.mod: no such
+# file or directory" on any fresh checkout. See PR #2286 (helix-org alpha).
+COPY helix-org/go.mod helix-org/go.sum ./helix-org/
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 # Copy Go source AFTER dependencies are downloaded for better caching.
 # Note: any Go file change invalidates this layer, but the go build cache
 # mount below ensures only changed packages are recompiled.
 COPY api ./api
+COPY helix-org ./helix-org
 WORKDIR /app/api
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \


### PR DESCRIPTION
## Summary

https://github.com/helixml/helix/pull/2458 already added the `helix-org/go.mod` COPY to the root `Dockerfile` (the api+frontend build path). This PR covers the four other Dockerfiles with the same shape — all of them do `COPY go.mod go.sum && go mod download` against the root `go.mod` that has the `replace github.com/helixml/helix-org => ./helix-org` directive, and all of them fail cold-cache without `helix-org/go.mod` present in the build context.

Same fix pattern as PR 2458, applied to:
- `Dockerfile.ubuntu-helix`
- `Dockerfile.sandbox`
- `Dockerfile.demos`
- `Dockerfile.sway-helix`

Without this, `./stack build-sandbox` (which builds desktop images + the sandbox container) hits:
```
go: github.com/helixml/helix-org@v0.0.0-... (replaced by ./helix-org):
reading helix-org/go.mod: open /app/helix-org/go.mod: no such file or directory
```

Drone's persistent BuildKit cache currently masks this in CI — `go mod download` is a cached layer carried over from before the replace was added, so the failure only fires on a cold-cache build (fresh dev box, or any host whose `COPY go.mod` layer invalidated). Confirmed on prime.

## Test plan

- [x] `bash -n` parse OK
- [x] Rebased onto current main after PR 2458 merged; no overlap with the root `Dockerfile`
- [ ] **NOT verified end-to-end** — would need a clean Docker host (or `docker builder prune -a`) to reproduce the cold-cache failure and confirm the fix. Folded into the `tmp/test-attach-and-credential` branch where it's being exercised by `./stack build-sandbox` on prime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)