### PR TITLE
fix(specs): compute task dir directly from design_doc_path

### DIFF
--- a/api/pkg/services/git_helpers.go
+++ b/api/pkg/services/git_helpers.go
@@ -174,27 +174,41 @@ func (g *GitRepo) ListBranches() ([]string, error) {
 	return branches, nil
 }
 
-// FindTaskDirInBranch finds the directory for a specific task in the helix-specs branch.
-// Searches for either DesignDocPath or task ID in the directory structure.
+// FindTaskDirInBranch returns the helix-specs path for a spec task's
+// design-doc directory.
+//
+// When designDocPath is set (the modern path, populated for every task
+// created since the human-readable directory format landed), the answer
+// is structural: tasks live at `design/tasks/<designDocPath>` and
+// nothing else needs to be true. Computing it directly is faster and —
+// critically — independent of which files happen to be in the branch
+// at the moment we look.
+//
+// The previous implementation walked the tree and returned the parent
+// directory of the first filename containing designDocPath. That broke
+// the moment https://github.com/helixml/helix/pull/2449 added attachment
+// uploads: an attachment landing at
+// `design/tasks/<dir>/attachments/image.jpg` *before* the agent's first
+// docs push made the walk return `design/tasks/<dir>/attachments` as
+// the task root. ReadDesignDocs then looked for `requirements.md`
+// inside `attachments/`, found nothing, and left
+// spec_task_design_reviews.requirements_spec / .technical_design /
+// .implementation_plan empty — the UI showed "No requirements
+// specification available" even though the .md files were already
+// pushed at the correct path.
+//
+// The taskID-based fallback is kept for legacy rows whose
+// designDocPath is empty (pre-dating the format switch). Those rows
+// never had an attachments/ subdir to trip the walk.
 func (g *GitRepo) FindTaskDirInBranch(branchName, designDocPath, taskID string) (string, error) {
+	if designDocPath != "" {
+		return "design/tasks/" + designDocPath, nil
+	}
+
 	files, err := g.ListFilesInBranch(branchName)
 	if err != nil {
 		return "", err
 	}
-
-	// First try DesignDocPath (new human-readable format)
-	if designDocPath != "" {
-		for _, file := range files {
-			if strings.Contains(file, designDocPath) {
-				parts := strings.Split(file, "/")
-				if len(parts) >= 2 {
-					return strings.Join(parts[:len(parts)-1], "/"), nil
-				}
-			}
-		}
-	}
-
-	// Fall back to taskID for backwards compatibility
 	for _, file := range files {
 		if strings.Contains(file, taskID) {
 			parts := strings.Split(file, "/")


### PR DESCRIPTION
## Summary

Regression introduced by https://github.com/helixml/helix/pull/2449 (attachment uploads). Hit live on prime:

- Spec task `spt_01ks3pdfey88q1071z85bqk1y2` with an image attachment.
- Agent generated and pushed `requirements.md`, `design.md`, `tasks.md` to the right canonical path: `design/tasks/000059_what-does-this-image-say/`.
- Files are on the helix-specs branch in the bare repo, agent confirmed push success in the IDE.
- UI shows "No requirements specification available / No technical design available / No implementation plan available".
- `spec_task_design_reviews.requirements_spec`, `.technical_design`, `.implementation_plan` are all empty strings in Postgres.

## Root cause

`api/pkg/services/git_helpers.go:179` `FindTaskDirInBranch` walks the branch's file list and returns the **parent directory of the first filename containing `designDocPath`**:

```go
for _, file := range files {
    if strings.Contains(file, designDocPath) {
        parts := strings.Split(file, "/")
        if len(parts) >= 2 {
            return strings.Join(parts[:len(parts)-1], "/"), nil
        }
    }
}
```

For an attachment-first task the file ordering is:
```
design/tasks/<dir>/attachments/image.jpg     ← committed first by PR 2449
design/tasks/<dir>/design.md                  ← later
design/tasks/<dir>/requirements.md            ← later
design/tasks/<dir>/tasks.md                   ← later
```

The walk hits the attachment file first → returns `design/tasks/<dir>/attachments` as the task dir → `ReadDesignDocs` looks for `requirements.md` inside `attachments/` → 404 → post-push hook persists empty strings into `spec_task_design_reviews`.

Confirmed by API logs:
```
Design doc file not found ... path=design/tasks/000059_.../attachments/requirements.md
Design doc file not found ... path=design/tasks/000059_.../attachments/design.md
Design doc file not found ... path=design/tasks/000059_.../attachments/tasks.md
```

## Fix

Drop the file-walk heuristic when we already know where the task dir lives. Every modern task has a `DesignDocPath`, and the convention (see `spec_driven_task_service.go:2108` and `agent_instruction_service.go:51`) is unconditional: tasks live at `design/tasks/<DesignDocPath>`. Just return that path directly.

Keep the taskID-based walk for legacy rows whose `DesignDocPath` is empty (they pre-date the format switch and never had attachments to trip the walk).

## Test plan

- [x] `go build ./api/pkg/services/` clean
- [ ] **NOT end-to-end tested on prime yet** — to verify: create a fresh task with an attached image, let the agent push specs, confirm the design review UI shows the markdown
- [ ] Existing affected rows (e.g. the `05dc5eb3-…` review on prime) won't auto-fix on merge — they have empty strings persisted. They'd self-heal on the next push to helix-specs for that task, since the updated hook will then read the correct dir. Or a separate one-shot migration can backfill from git.

## Out of scope

- Backfill migration for already-broken review rows. Mentioning in case anyone wants to chase that as a follow-up.
- Wider review of other "find-by-substring" patterns in `git_helpers.go` — there may be related path resolutions that share the assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)