### PR TITLE
fix(specs): check out feature branch in container on spec approval

### DIFF
--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -1345,6 +1345,31 @@ func (s *SpecDrivenTaskService) ApproveSpecs(ctx context.Context, task *types.Sp
 				Msg("Failed to update container git identity at approval; commits may be attributed to previous actor")
 		}
 
+		// For BranchMode=new tasks the feature branch name is only generated
+		// here (line ~1268 above), not when the planning container started.
+		// helix-workspace-setup.sh therefore couldn't create the branch at
+		// container boot (HELIX_WORKING_BRANCH was empty), so the working
+		// tree is still on the base branch (typically `main`). The
+		// implementation-phase prompt tells the agent to "verify branch" but
+		// never says "check out the feature branch" — agents that find
+		// themselves on `main` commit there and try to push to `main`. The
+		// server's pre-receive hook restricts pushes to helix-specs +
+		// the feature branch, so the push is rejected — but we've already
+		// wasted a turn and the agent is in a confused state.
+		//
+		// Make the branch state correct *before* the implementation prompt
+		// arrives. Idempotent: `checkout -B` works whether the branch exists
+		// locally, remotely, or not at all; `push -u` is a no-op if the
+		// remote already has it. Errors are logged but don't block the
+		// transition: the existing pre-receive hook stops genuinely-bad
+		// pushes, and the agent prompt still names the right branch.
+		if err := s.ensureFeatureBranchInContainer(ctx, sessionID, repo.Name, branchName, repo.DefaultBranch); err != nil {
+			log.Error().Err(err).
+				Str("task_id", task.ID).Str("session_id", sessionID).
+				Str("repo", repo.Name).Str("branch", branchName).Str("base", repo.DefaultBranch).
+				Msg("Failed to check out feature branch in container at approval; agent may start on base branch")
+		}
+
 		// Send instruction to existing agent session (reuse planning session)
 		if sessionID != "" && !s.testMode {
 			// Create agent instruction service
@@ -1531,6 +1556,67 @@ func (s *SpecDrivenTaskService) syncGitIdentityToUser(ctx context.Context, task 
 		Str("actor_name", actorName).Str("actor_email", actorEmail).
 		Msg("Updated git identity in container")
 	return nil
+}
+
+// ensureFeatureBranchInContainer checks out the spec task's feature branch
+// in the dev container's primary repo working tree at the moment we
+// transition the task into the implementation phase.
+//
+// Why this is needed: for BranchMode=new tasks the feature branch name
+// is only generated in ApproveSpecs (above) — well after the planning
+// container started. helix-workspace-setup.sh runs once at container
+// boot and only creates a feature branch when HELIX_WORKING_BRANCH is
+// already set in the container env. For planning-phase containers that
+// env var is empty (task.BranchName is empty until specs land), so the
+// working tree is left on the base branch. The implementation-phase
+// prompt assumes the right branch is already checked out, so agents
+// just commit to base (typically `main`). The pre-receive hook
+// rejects the push, the agent gets confused, and the user loses a turn.
+//
+// The fix runs the same git plumbing the workspace-setup script would
+// have run, but at the point we actually know the branch name. Safe to
+// re-run: `checkout -B` works whether the branch exists locally,
+// remotely, or not at all; `push -u` is a no-op if the remote already
+// has it.
+//
+// Failures are non-fatal: this is best-effort and the existing
+// pre-receive hook still stops genuinely-bad pushes to base. We log
+// loudly so operators see when it falls back to the broken default.
+func (s *SpecDrivenTaskService) ensureFeatureBranchInContainer(ctx context.Context, sessionID, repoName, branchName, baseBranch string) error {
+	if s.testMode || s.ExecInDesktop == nil {
+		return nil
+	}
+	if sessionID == "" || repoName == "" || branchName == "" || baseBranch == "" {
+		return fmt.Errorf("missing required arg: sessionID=%q repoName=%q branchName=%q baseBranch=%q",
+			sessionID, repoName, branchName, baseBranch)
+	}
+
+	// Single bash command so we get atomic chained semantics and one
+	// docker-exec round-trip. -B is idempotent. -u sets upstream once;
+	// subsequent runs are no-ops.
+	script := fmt.Sprintf(
+		"cd /home/retro/work/%s && git fetch origin %s && git checkout -B %s origin/%s && git push -u origin %s",
+		shellQuoteArg(repoName), shellQuoteArg(baseBranch),
+		shellQuoteArg(branchName), shellQuoteArg(baseBranch),
+		shellQuoteArg(branchName),
+	)
+	if err := s.ExecInDesktop(ctx, sessionID, []string{"bash", "-c", script}); err != nil {
+		return fmt.Errorf("git checkout/push feature branch: %w", err)
+	}
+
+	log.Info().
+		Str("session_id", sessionID).Str("repo", repoName).
+		Str("branch", branchName).Str("base", baseBranch).
+		Msg("Feature branch checked out and pushed in container")
+	return nil
+}
+
+// shellQuoteArg wraps an argument in single quotes and escapes any
+// embedded single quotes. Repository / branch names are validated
+// elsewhere but we don't want this helper to be the place an unexpected
+// metacharacter causes an injection — defence in depth.
+func shellQuoteArg(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // syncGitIdentityAsync runs syncGitIdentityToUser in the background, retrying


### PR DESCRIPTION
## Summary

Hit live on prime testing PR https://github.com/helixml/helix/pull/2449. The agent was given a perfectly clear implementation prompt naming the feature branch, but committed to `main` instead and got rejected by the pre-receive hook:

```
[main b29fa53] docs(content): add companion topic copy
remote: error: refusing to update refs/heads/main
remote: hint: This push is restricted to: helix-specs, feature/000060-write-short-topic-copy
remote: hint: Push to your assigned feature branch instead.
```

`spec_tasks.branch_name` was `feature/000060-write-short-topic-copy`, but `/home/retro/work/yom` in the dev container was on `main` with no feature branch existing locally at all. The agent's prompt told it the branch was already checked out, but it wasn't.

## Root cause

For `BranchMode=new` tasks the feature branch name is generated inside `ApproveSpecs` (line ~1268), well after the planning-phase container started. `helix-workspace-setup.sh` runs once at container boot and only creates the feature branch when `HELIX_WORKING_BRANCH` is set in the env. At planning-boot `task.BranchName` is empty, so `HELIX_WORKING_BRANCH` is empty too, so the script's branch-creation block at lines 396–409 is skipped. Container is left on the base branch.

When the user approves specs and we transition to implementation, the prompt builder at line ~903 helpfully tells the agent:
> *"Branch already checked out: Verify: `git branch --show-current` should show `feature/000060-…`"*

…but no code path actually checks out that branch. The assertion in the prompt is wishful thinking.

## Fix

In `ApproveSpecs`, immediately after `syncGitIdentityToUser`, run a single bash command via `ExecInDesktop`:

```bash
cd /home/retro/work/<repo> &&
  git fetch origin <base> &&
  git checkout -B <feature> origin/<base> &&
  git push -u origin <feature>
```

`-B` is idempotent (works whether the branch exists locally, remotely, or not at all), `push -u` is a no-op if the remote already has it. Args are single-quote-escaped via a small `shellQuoteArg` helper. Errors are logged but non-fatal: the pre-receive hook still stops genuinely-bad pushes, so the worst case is the existing broken behaviour.

## Test plan

- [x] `go build ./api/pkg/services/` clean
- [ ] **NOT end-to-end tested on prime yet.** To verify: create a new task in `new` branch mode, let planning complete, click approve, then check inside the dev container that the working tree of the primary repo is on the feature branch.

## Out of scope

- The implementation-phase prompt at `spec_driven_task_service.go:903` still asserts "Branch already checked out" — that's now actually true with this PR, but the prompt could be hardened to include explicit recovery instructions (`git checkout -B feature/...` if on the wrong branch). Worth a follow-up if we ever care about model robustness over server fixes.
- `BranchMode=existing` tasks already have `task.BranchName` set at planning-boot, so the workspace-setup script handles them correctly. They should not be affected by this change (we still call `ensureFeatureBranchInContainer`, but the branch already exists and checkout/push are no-ops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)