### PR TITLE
fix(frontend): recover desktop viewer after Safari BFCache restore

### DIFF
--- a/frontend/src/lib/helix-stream/stream/websocket-stream.ts
+++ b/frontend/src/lib/helix-stream/stream/websocket-stream.ts
@@ -88,6 +88,12 @@ export class WebSocketStream {
   private pageVisible = true
   private visibilityHandler: (() => void) | null = null
 
+  // BFCache restore tracking - Safari (and Chrome/Firefox) put pages into the
+  // back/forward cache on navigation, which closes the WebSocket without firing
+  // onclose. Without a pageshow listener the component never knows the socket
+  // is dead, leading to a frozen viewer with stuck cursor and ignored clicks.
+  private bfcacheRestoreHandler: ((e: PageTransitionEvent) => void) | null = null
+
   // Cursor cache - maps cursor ID to blob URL (for revoking old blob URLs)
   private cursorCache = new Map<number, CursorImageData>()
   private cursorX = 0  // Current cursor X position from server
@@ -2121,6 +2127,17 @@ export class WebSocketStream {
     }
     document.addEventListener("visibilitychange", this.visibilityHandler)
 
+    // Recover after Safari/Chrome restores the page from the back/forward cache.
+    // The browser silently kills the WebSocket on BFCache entry; without this
+    // listener, the next user interaction sees a dead socket and a frozen viewer.
+    this.bfcacheRestoreHandler = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        console.log("[WebSocketStream] BFCache restored, force-reconnecting")
+        this.reconnect()
+      }
+    }
+    window.addEventListener("pageshow", this.bfcacheRestoreHandler)
+
     this.heartbeatIntervalId = setInterval(() => {
       if (!this.connected) return
 
@@ -2158,6 +2175,12 @@ export class WebSocketStream {
     if (this.visibilityHandler) {
       document.removeEventListener("visibilitychange", this.visibilityHandler)
       this.visibilityHandler = null
+    }
+
+    // Clean up BFCache pageshow listener
+    if (this.bfcacheRestoreHandler) {
+      window.removeEventListener("pageshow", this.bfcacheRestoreHandler)
+      this.bfcacheRestoreHandler = null
     }
   }
 


### PR DESCRIPTION
## Summary

On Safari, navigating back-and-forth (especially via the trackpad swipe gesture) left the streaming desktop viewer frozen: stuck cursor, ignored mouse clicks, perceived lag. The same effect is reproducible on Chrome and Firefox to a lesser degree.

Root cause: Safari (and Chrome/Firefox) put the page into the back/forward cache on navigation. The browser silently kills the WebSocket on BFCache entry. The viewer's `WebSocketStream` had no `pageshow` listener, so on restore it believed it was still connected — but the socket was dead, the `VideoDecoder` was closed, and input events were being queued onto a dead pipe.

## Changes

- `frontend/src/lib/helix-stream/stream/websocket-stream.ts`: register a `window` `pageshow` listener inside `startHeartbeat()` (alongside the existing `visibilitychange` listener) that calls the already-public `this.reconnect()` when `event.persisted === true`. Unregister it in `stopHeartbeat()`. ~15 LOC total.

The existing `reconnect()` method already does everything needed for a clean restart: closes the dead socket, cancels any pending reconnect timeout, resets the attempt counter, and calls `connect()` which itself runs `cleanupDecoders()` and `resetStreamState()`. The `VideoDecoder` is recreated lazily by `onMessage` on the next keyframe, so no extra plumbing is required.

## Why minimal

- No `pagehide` handler: pages in BFCache are frozen — no JS runs, so there's nothing to "suspend".
- No changes in `DesktopStreamViewer.tsx` or `ExternalAgentDesktopViewer.tsx`: `WebSocketStream` already dispatches the `connecting`/`connected` info events that the wrapper components subscribe to for their reconnecting UI.
- No `beforeunload`/`unload` listeners (those would *disqualify* the page from BFCache — the opposite of what we want for the rest of the app).

## Testing

- `npx tsc --noEmit`: clean (exit 0)
- `yarn build`: all 21,115 modules transformed (the dev container's bind-mounted `dist/` prevents the actual write step but compilation succeeds)
- **Manual verification by user** required on:
  - Safari macOS — back-then-forward via trackpad swipe and arrow buttons
  - Safari iPadOS — edge-swipe gesture
  - Chrome / Firefox — confirm no regression
  - Safari hard refresh (Cmd+R) — confirm normal connect path unchanged
  - In-app React Router navigation away and back — confirm component unmount path still cleans up

## Specs

See [helix-specs design docs](https://github.com/helixml/helix/tree/helix-specs/design/tasks/002042_on-safari-going-back-and) for full investigation notes, decisions, and rejected alternatives.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01ks63ax30bfk91t9faec1cp3w)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002042_on-safari-going-back-and/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002042_on-safari-going-back-and/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002042_on-safari-going-back-and/tasks.md)

🚀 Built with [Helix](https://helix.ml)