### PR TITLE
fix(stream): break supersede reconnect storm with clean close + Stats log

### DIFF
--- a/api/pkg/proxy/resilient.go
+++ b/api/pkg/proxy/resilient.go
@@ -4,6 +4,7 @@ package proxy
 import (
 	"bufio"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -56,9 +57,10 @@ type ResilientProxy struct {
 	bufferSize   int
 
 	// Connections
-	clientConn net.Conn // Browser connection (stable)
-	serverConn net.Conn // Server connection (may reconnect)
-	serverMu   sync.Mutex
+	clientConn    net.Conn // Browser connection (stable)
+	clientWriteMu sync.Mutex // Serializes writes to clientConn (copier + close-frame senders)
+	serverConn    net.Conn // Server connection (may reconnect)
+	serverMu      sync.Mutex
 
 	// Input buffering (client → server direction)
 	inputBuffer    []byte
@@ -310,8 +312,10 @@ func (p *ResilientProxy) copyServerToClient(ctx context.Context) error {
 			continue
 		}
 
-		// Write to client
+		// Write to client (serialized with close-frame senders via clientWriteMu)
+		p.clientWriteMu.Lock()
 		_, err = p.clientConn.Write(buf[:n])
+		p.clientWriteMu.Unlock()
 		if err != nil {
 			return err // Client error - fatal
 		}
@@ -438,7 +442,9 @@ func (p *ResilientProxy) flushOutputBuffer() error {
 		Int("buffered_bytes", p.outputBufferPos).
 		Msg("Flushing output buffer after reconnection")
 
+	p.clientWriteMu.Lock()
 	_, err := p.clientConn.Write(p.outputBuffer[:p.outputBufferPos])
+	p.clientWriteMu.Unlock()
 	if err != nil {
 		return fmt.Errorf("failed to flush output buffer: %w", err)
 	}
@@ -546,6 +552,52 @@ func (p *ResilientProxy) isClientError(err error) bool {
 	return strings.Contains(errStr, "use of closed network connection") ||
 		strings.Contains(errStr, "connection reset by peer") ||
 		errors.Is(err, io.EOF)
+}
+
+// CloseClientWithCode sends a WebSocket Close frame to the client with the given
+// status code and reason, before any TCP-level close happens. This lets the caller
+// signal an application-level handover (e.g. "this connection has been superseded
+// by a newer one from the same tab") so the browser can distinguish an intentional
+// server close from a network failure and skip its own reconnect logic.
+//
+// The frame is serialized with the proxy's normal writes via clientWriteMu, so
+// callers don't need to coordinate with copyServerToClient / flushOutputBuffer.
+//
+// Callers should still cancel the proxy's context (or call Close()) afterwards
+// to fully tear down the connection. CloseClientWithCode does NOT close the TCP
+// connection itself — it only writes the close frame.
+//
+// RFC 6455 §5.5.1: server-side close frames are unmasked, payload = 2-byte
+// big-endian status code + optional UTF-8 reason. We use short-form payload
+// length so total reason+code must fit in 125 bytes.
+func (p *ResilientProxy) CloseClientWithCode(code uint16, reason string) error {
+	if p.closed.Load() {
+		return nil
+	}
+	if p.clientConn == nil {
+		return nil
+	}
+
+	payload := make([]byte, 2+len(reason))
+	binary.BigEndian.PutUint16(payload[0:2], code)
+	copy(payload[2:], reason)
+	if len(payload) > 125 {
+		return fmt.Errorf("close payload too long: %d bytes (max 125)", len(payload))
+	}
+
+	frame := make([]byte, 2+len(payload))
+	frame[0] = 0x88 // FIN | opcode 8 (close)
+	frame[1] = byte(len(payload))
+	copy(frame[2:], payload)
+
+	p.clientWriteMu.Lock()
+	defer p.clientWriteMu.Unlock()
+
+	// Tight deadline so a wedged client can't block teardown.
+	_ = p.clientConn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	_, err := p.clientConn.Write(frame)
+	_ = p.clientConn.SetWriteDeadline(time.Time{})
+	return err
 }
 
 // Close stops the proxy and closes all connections

--- a/api/pkg/proxy/resilient_test.go
+++ b/api/pkg/proxy/resilient_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -561,4 +562,101 @@ func TestResilientProxy_ServerToClientFlow(t *testing.T) {
 	cancel()
 	proxy.Close()
 	close(serverSendCh)
+}
+
+// TestResilientProxy_CloseClientWithCode verifies that we emit a well-formed
+// unmasked WebSocket Close frame (RFC 6455 §5.5.1) on the client connection
+// with the given status code and reason. This is what lets the browser
+// distinguish "the server intentionally replaced your connection" from "the
+// network died" — see design/2026-05-21-stream-reconnect-storm-root-cause.md.
+func TestResilientProxy_CloseClientWithCode(t *testing.T) {
+	server := newTestServer(t, true)
+	defer server.close()
+
+	clientConn, proxyClientConn := net.Pipe()
+	defer clientConn.Close()
+	defer proxyClientConn.Close()
+
+	serverConn, err := net.Dial("tcp", server.addr)
+	if err != nil {
+		t.Fatalf("Failed to dial server: %v", err)
+	}
+	if _, err := server.waitForConn(time.Second); err != nil {
+		t.Fatalf("Server didn't accept: %v", err)
+	}
+
+	p := NewResilientProxy(ResilientProxyConfig{
+		SessionID:  "test-supersede",
+		ClientConn: proxyClientConn,
+		ServerConn: serverConn,
+		DialFunc: func(ctx context.Context) (net.Conn, error) {
+			return net.Dial("tcp", server.addr)
+		},
+		UpgradeFunc: nil,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = p.Run(ctx) }()
+
+	// Read the close frame off the client side
+	got := make(chan []byte, 1)
+	go func() {
+		buf := make([]byte, 64)
+		_ = clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		n, err := clientConn.Read(buf)
+		if err != nil {
+			got <- nil
+			return
+		}
+		got <- buf[:n]
+	}()
+
+	if err := p.CloseClientWithCode(4000, "superseded"); err != nil {
+		t.Fatalf("CloseClientWithCode: %v", err)
+	}
+
+	select {
+	case frame := <-got:
+		if frame == nil {
+			t.Fatal("client read failed")
+		}
+		// Expected: 0x88, 0x0C, 0x0F, 0xA0, 's','u','p','e','r','s','e','d','e','d'
+		want := []byte{0x88, 0x0C, 0x0F, 0xA0, 's', 'u', 'p', 'e', 'r', 's', 'e', 'd', 'e', 'd'}
+		if len(frame) != len(want) {
+			t.Fatalf("frame length mismatch: got %d want %d (frame=%x)", len(frame), len(want), frame)
+		}
+		for i := range want {
+			if frame[i] != want[i] {
+				t.Fatalf("frame byte %d: got 0x%02x want 0x%02x (frame=%x)", i, frame[i], want[i], frame)
+			}
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for close frame")
+	}
+
+	cancel()
+	p.Close()
+}
+
+// TestResilientProxy_CloseClientWithCode_RejectsOversizeReason verifies the
+// short-form payload guard rejects reasons that would exceed 125 bytes (the
+// max for a short-form WebSocket frame payload).
+func TestResilientProxy_CloseClientWithCode_RejectsOversizeReason(t *testing.T) {
+	clientConn, proxyClientConn := net.Pipe()
+	defer clientConn.Close()
+	defer proxyClientConn.Close()
+
+	p := NewResilientProxy(ResilientProxyConfig{
+		SessionID:   "test-oversize",
+		ClientConn:  proxyClientConn,
+		ServerConn:  &net.TCPConn{}, // unused
+		DialFunc:    func(ctx context.Context) (net.Conn, error) { return nil, nil },
+		UpgradeFunc: nil,
+	})
+
+	oversized := strings.Repeat("x", 124) // 124 + 2-byte code = 126 > 125
+	if err := p.CloseClientWithCode(4000, oversized); err == nil {
+		t.Fatal("expected error for oversized reason, got nil")
+	}
 }

--- a/api/pkg/server/external_agent_handlers.go
+++ b/api/pkg/server/external_agent_handlers.go
@@ -1384,10 +1384,9 @@ func (apiServer *HelixAPIServer) proxyStreamWebSocket(res http.ResponseWriter, r
 	defer proxyCancel()
 
 	proxySessionID := generateProxySessionID()
+	dedupeKey := "stream:" + sessionID + ":" + clientID
 
 	if clientID != "" {
-		dedupeKey := "stream:" + sessionID + ":" + clientID
-
 		// Look up and replace any existing proxy for this session+client.
 		// Cancel outside the lock to avoid holding it during teardown.
 		apiServer.activeStreamProxiesMu.Lock()
@@ -1405,6 +1404,23 @@ func (apiServer *HelixAPIServer) proxyStreamWebSocket(res http.ResponseWriter, r
 				Str("old_proxy", prev.proxySessionID).
 				Str("new_proxy", proxySessionID).
 				Msg("Superseding previous stream proxy for same client")
+			// Send a clean WebSocket close frame with code 4000 "superseded" so the
+			// browser can distinguish a server-initiated handover from a network
+			// failure and skip its own reconnect logic. Without this, the cancel
+			// below results in a raw TCP close (1006 abnormal closure on the
+			// client), which triggers the browser to reconnect, which arrives
+			// while THIS handler's entry is still in activeStreamProxies, which
+			// supersedes again — fueling a reconnect storm.
+			// See design/2026-05-21-stream-reconnect-storm-root-cause.md.
+			if prev.proxy != nil {
+				if err := prev.proxy.CloseClientWithCode(4000, "superseded"); err != nil {
+					log.Debug().
+						Err(err).
+						Str("session_id", sessionID).
+						Str("old_proxy", prev.proxySessionID).
+						Msg("Failed to send superseded close frame (likely client already gone)")
+				}
+			}
 			prev.cancel()
 		}
 
@@ -1521,6 +1537,17 @@ func (apiServer *HelixAPIServer) proxyStreamWebSocket(res http.ResponseWriter, r
 		UpgradeFunc: upgradeFunc,
 	})
 	defer resilientProxy.Close()
+
+	// Publish the proxy reference so that a subsequent supersede (above) can
+	// send a clean WebSocket close frame on this client connection instead of
+	// dropping the TCP socket abruptly.
+	if clientID != "" {
+		apiServer.activeStreamProxiesMu.Lock()
+		if cur, ok := apiServer.activeStreamProxies[dedupeKey]; ok && cur.proxySessionID == proxySessionID {
+			cur.proxy = resilientProxy
+		}
+		apiServer.activeStreamProxiesMu.Unlock()
+	}
 
 	// Run the proxy (blocks until connection closes or error)
 	if err := resilientProxy.Run(proxyCtx); err != nil {

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/helixml/helix/api/pkg/oauth"
 	"github.com/helixml/helix/api/pkg/openai"
 	"github.com/helixml/helix/api/pkg/openai/manager"
+	"github.com/helixml/helix/api/pkg/proxy"
 	"github.com/helixml/helix/api/pkg/pubsub"
 	"github.com/helixml/helix/api/pkg/quota"
 	"github.com/helixml/helix/api/pkg/revdial"
@@ -81,9 +82,17 @@ type Options struct {
 // activeStreamProxy tracks a single active WebSocket proxy for deduplication.
 // When the same browser tab reconnects (same session + client_id), the previous
 // proxy is cancelled to prevent cascading duplicate connections.
+//
+// proxy is populated after NewResilientProxy is constructed so that a supersede
+// can send a clean WebSocket close frame (code 4000 "superseded") on the old
+// client connection before cancelling — otherwise the supersede manifests as a
+// raw TCP close (code 1006) which the browser indistinguishably treats as a
+// network failure and reconnects from, fueling a reconnect storm.
+// See design/2026-05-21-stream-reconnect-storm-root-cause.md.
 type activeStreamProxy struct {
 	proxySessionID string
 	cancel         context.CancelFunc
+	proxy          *proxy.ResilientProxy
 }
 
 type HelixAPIServer struct {

--- a/design/2026-05-21-stream-reconnect-storm-root-cause.md
+++ b/design/2026-05-21-stream-reconnect-storm-root-cause.md
@@ -1,0 +1,273 @@
+# Stream Reconnect Storm Root-Cause Investigation
+
+**Date:** 2026-05-21
+**Status:** Investigation — hypotheses narrowed; needs browser logs to disambiguate H1 vs H2
+**Reporter:** Luke
+**Subject session:** `spt_01ks63ax30bfk91t9faec1cp3w` (URL) → `ses_01ks63b0btvj0ax8kzsy43xr4r` (external-agent session) → desktop container `ubuntu-external-01ks63b0btvj0ax8kzsy43xr`
+**Subject client_id:** `7307a64c-7165-4a7c-aa4b-4906e2e592f2` (single browser tab)
+
+Prior context: `design/2026-04-12-frontend-reconnect-loop-investigation.md` (different mechanism — fixed in `f8c926cad`).
+
+---
+
+## Symptom
+
+The "Stats for Nerds" panel shows a perfect 5-7s reconnect cycle while video is otherwise flowing at 61fps:
+
+```
+21:38:43 WebSocket opened
+21:38:43 Connection complete
+21:38:47 Error: WebSocket error
+21:38:47 Disconnected unexpectedly (code: 1006)
+21:38:48 WebSocket opened
+21:38:48 Connection complete
+21:38:54 Error: WebSocket error
+21:38:54 Disconnected unexpectedly (code: 1006)
+21:38:55 WebSocket opened
+21:38:56 Connection complete
+```
+
+Despite the visible reconnects, the GPU pipeline never sees a real outage — `pipeline_received` increases monotonically in `VIDEO LATENCY STATS` while `ws_frames` resets ~every 5s.
+
+---
+
+## Evidence
+
+### Server (API) — `pkg/server/external_agent_handlers.go`
+
+Each cycle on the API:
+
+```
+INF Stream WebSocket connection established        proxy_session_id=A
+INF Superseding previous stream proxy for same client  client_id=7307a64c…  new_proxy=B  old_proxy=A
+INF Proxying stream WebSocket to screenshot-server via RevDial  proxy_session_id=B
+WRN Resilient proxy ended with error               proxy_session_id=A  error="context canceled"
+INF Stream WebSocket connection closed             proxy_session_id=A  reconnect_count=0
+INF Stream WebSocket connection established        proxy_session_id=B
+```
+
+The dedup code (`external_agent_handlers.go:1379-1418`) registers `activeStreamProxies["stream:<sess>:<client_id>"] = {proxy_session_id, cancel}`. When a new WS arrives with the same key it cancels the prior proxy's context. The old `resilientProxy.Run()` returns with `context canceled`, `defer clientConn.Close()` does a raw TCP close — *no WebSocket Close frame is sent* — so the browser sees `code: 1006 "abnormal closure"` and reconnects.
+
+### Sandbox (desktop-bridge) — same window
+
+```
+INF stream init received   width=1920 height=1080 fps=60 …
+INF websocket closed       close_code=1006 close_text="unexpected EOF" duration=14s frames_sent=900
+INF stream init received   …
+INF websocket closed       close_code=1006 close_text="unexpected EOF" duration=1s   frames_sent=111
+WRN ping failed, closing dead connection   err="write tcp [::1]:9876->[::1]:51972: write: connection reset by peer"
+```
+
+The `[::1]:9876 → [::1]:51972` write is on the internal localhost socket between hydra (inside `helix-sandbox-nvidia-1`) and desktop-bridge (inside the ubuntu-external container). RST comes from the hydra side because the API tore its end of the resilient proxy down on supersede.
+
+### Per-connection lifetime (one observation window, ~85s)
+
+Extracted from the API log timeline above (each row = one proxy_session_id from establishment to close):
+
+| Time     | proxy_session_id | lifetime | trigger                              |
+|----------|------------------|----------|--------------------------------------|
+| 20:39:24 | 5995…            | 4 s      | superseded                           |
+| 20:39:28 | cde0…            | 1 s      | superseded                           |
+| 20:39:29 | 5878…            | 8 s      | superseded                           |
+| 20:39:37 | 9ce0…            | 1 s      | superseded                           |
+| 20:39:38 | fc90…            | 14 s     | superseded                           |
+| 20:39:52 | fe7e…            | 1 s      | superseded                           |
+| 20:39:53 | 4644…            | 7 s      | superseded                           |
+| 20:40:00 | 1293…            | 1 s      | superseded                           |
+| 20:40:01 | 5558…            | 2 s      | superseded                           |
+| 20:40:03 | eb00…            | 10 s     | superseded                           |
+| 20:40:13 | c5a7…            | 1 s      | superseded                           |
+| 20:40:14 | 909f…            | 2 s      | superseded                           |
+| 20:40:16 | 2492…            | 15 s     | superseded                           |
+| 20:40:31 | 74e6…            | 14 s     | superseded                           |
+| 20:40:45 | 92c1…            | 1 s      | superseded                           |
+| 20:40:46 | 056d…            | <1s      | client clean close (reconnect_count=1) |
+
+Two distinct populations: **long-lived (4-15 s)** and **short-lived (1-2 s)**. The pattern is overwhelmingly **long → short → long → short → …**. Every long-lived session is followed by a short-lived one before the next long-lived one starts.
+
+That alternation is the key — it means the client opens **two** new WS connections in rapid succession after each long-lived stream dies. Exactly one of them gets to live for any meaningful time.
+
+---
+
+## Architecture refresher
+
+```
+Browser tab (DesktopStreamViewer + WebSocketStream)
+   │ WebSocket (sessionId + client_id query param)
+   ▼
+helix-api  /api/v1/external-agents/{sessionId}/ws/stream
+   │  hijack + activeStreamProxies dedup keyed by stream:<sess>:<client_id>
+   │  RevDial bridge → resilient proxy
+   ▼
+hydra (in helix-sandbox-nvidia-1)
+   │ localhost socket → :9876 (desktop-bridge HTTP server inside ubuntu-external)
+   ▼
+desktop-bridge (in ubuntu-external container)
+   │  GStreamer pipeline → /ws/stream
+   ▼
+Browser canvas
+```
+
+Stable identifiers:
+- `componentInstanceIdRef` = `getOrCreateStreamUUID(sessionId)` — stored in `sessionStorage`, survives remounts within a tab.
+- One `DesktopStreamViewer` per page (`SpecTaskDetailContent.tsx:2350` and `:2842` are if/else on layout). `ScreenshotViewer` uses HTTP polling, not WebSocket.
+
+The 2026-04-12 fix in `f8c926cad` removed the component-level `ws.readyState === CLOSED` check that previously fought `WebSocketStream`'s internal backoff. **That fix is still in place** — the current `checkFrameHealth` only acts on `decoderState === "closed"` or `lastWsMessageTime > 0 && timeSinceWsData > 5000ms`, both with a `DECODER_CRASH_RECONNECT_COOLDOWN_MS = 10s` rate limit.
+
+---
+
+## Hypotheses
+
+I've eliminated a long list (component-level CLOSED check — gone; dual viewer mount — only one renders; ScreenshotViewer — HTTP not WS; bandwidth/quality changes — user-driven only; `getOrCreateStreamUUID` instability — sessionStorage-backed). Three remain plausible:
+
+### H1: WSStream internal reconnect + component-level reconnect both fire (the duplicate-connect race)
+
+Each long-lived stream dies for *some* reason (H4 below), then **two** code paths each try to re-establish it:
+
+1. **`WebSocketStream.onClose`** (`websocket-stream.ts:465`) sees `this.closed === false`, schedules `this.connect()` with exponential-backoff jittered delay (`reconnectDelay * 2^(attempt-1) * (0.5..1)`, first attempt ≈ 0.5–2 s). This reuses the **same WSStream instance** and `streamRef.current` remains the same object.
+2. **Component** receives `disconnected` event → just sets `Reconnecting…` UI, doesn't itself reconnect. BUT if a `reconnectAborted` (line 938) or `error` (line 856) is dispatched, the component calls `reconnectRef.current(1000, …)` (lines 877 / 966), which immediately `disconnect(true)`s and re-`connect()`s the WHOLE WSStream after 1 s.
+
+The component-level `reconnect()` calls `streamRef.current.close()` which cancels the internal backoff (`WSStream.close()` at line 2251 clears `reconnectTimeoutId`) — *if* it runs before the internal timer fires.
+
+If the internal timer fires *first* (likely, because its minimum is ~0.5 s while the component's path is exactly 1 s), the SAME WSStream opens WS_B. Then 1 s later the component's `reconnect()` setTimeout fires:
+- `connect()` at line 600 sees `streamRef.current` (still WSStream A), closes it (closing WS_B!), creates WSStream B (new instance), which opens WS_C.
+
+Net: two new WS connections opened ~1 s apart. Server sees WS_B → registers proxy_B; server sees WS_C → supersedes proxy_B → cancels WS_B → 1006 to client → … but at that point the active stream is WS_C anyway, and the cycle ends *if* nothing kicks it off again.
+
+The trigger for the next cycle is again H4 (something causing WS_C to die after another ~5-15 s).
+
+**Predicts in browser logs:**
+- `[WebSocketStream] Reconnecting (attempt N)...` immediately followed (within ~500 ms) by `[DesktopStreamViewer] Closing existing stream before creating new one`.
+- Either `[DesktopStreamViewer] Reconnect aborted by stream` or `[DesktopStreamViewer] Ignoring error during explicit close` shortly before.
+- Two `[WebSocketStream] Connecting to: ws://…` log lines per disconnect cycle.
+
+### H2: Visibility / focus / ResizeObserver re-render trips `useEffect(connect)` despite the `hasConnectedRef` guard
+
+The auto-connect effect (line 1866-1901) has deps `[sandboxId, sessionId, isVisible, width, height, account.initialized]`. The guard is:
+
+```ts
+if (hasConnectedRef.current) return;
+```
+
+This means *after* the first connection, `connect()` is never called from this effect again. Good. BUT every dep change re-runs the effect body; if anything makes `hasConnectedRef.current` false again, it reconnects. Nothing in the code currently flips it back to false, but it's worth verifying. Also: `width` and `height` come from props and *change with the layout*, e.g. a `containerSize` change can flow back to props. A nearby effect (line 2625, `[containerSize, isConnected]`) also touches canvas geometry — worth checking that nothing in that chain causes the parent to remount the viewer.
+
+Mid-investigation finding that argues against H2 in this specific session: the *same* `client_id` and the *same* WSStream instance ref logs ("Closing existing stream before creating new one") would or wouldn't appear — browser logs will tell us.
+
+**Predicts in browser logs:**
+- `[DesktopStreamViewer] Component unmounting, calling disconnect()` paired with `Component mounted, setting up cleanup handler`.
+- Or `[DesktopStreamViewer] Auto-connecting at … Mbps for WxH` lines firing more than once.
+
+### H3: Server-side supersede semantics turn one legitimate reconnect into many
+
+This is the *amplifier*, not the root cause, but worth fixing anyway.
+
+When the dedup cancels `prev`, `defer clientConn.Close()` performs a raw TCP close. The browser sees `code: 1006`. The client (correctly, for a real network failure) treats 1006 as transient and reconnects with backoff. That reconnect arrives at the server, finds the previous *new* proxy still in `activeStreamProxies` (because the cleanup defer hasn't yet removed it), supersedes it, and the loop maintains itself.
+
+If the supersede sent a clean WebSocket close frame with a recognizable application code (e.g. `4000 "superseded"`), the client could distinguish "the server intentionally replaced you" from "the network died" and *not* reconnect. That alone breaks the loop regardless of H1 vs H2.
+
+**Predicts in browser logs:**
+- `[WebSocketStream] Disconnected: { code: 1006, reason: "(empty)", wasClean: false, … }` for every disconnect (vs. `code: 4000` after the fix).
+
+### H4: The trigger that kills each long-lived connection in the first place
+
+H1/H2 explain why *one* trigger fans out to many connections, but not what fires the original close every 4-15 s on a connection that's otherwise streaming at 60fps. Candidates:
+
+- **WSStream heartbeat false positive** (`websocket-stream.ts:2124-2148`): fires `ws.close()` when `Date.now() - lastMessageTime > 10_000ms`. `lastMessageTime` is updated on *every* `onMessage`. With server keepalive at 500 ms, this should never fire under healthy streaming. *But* the irregular long lifetimes (4, 8, 14, 7, 10, 15, 14 s) don't match any single timer cadence, so this is unlikely as a primary cause.
+- **Component health check stale detect** (`DesktopStreamViewer.tsx:2010`): fires `reconnect(500, "Reconnecting (connection stalled)…")` when `timeSinceWsData > 5000ms`, with 10 s cooldown. Same argument: keepalive should prevent this.
+- **VideoDecoder crash** (line 1982): forces `reconnect(500, "Reconnecting (decoder crashed)…")`. Plausible on iPad / Safari; less so on a regular tab. Browser logs will confirm/refute via `Decoder crashed (state=closed)` lines.
+- **Tab visibility / focus / network handover**: each transient `visibilitychange` event resets `lastMessageTime` (line 2119) but if the network actually drops a packet during the hidden→visible transition, the stream may briefly stall.
+- **Server-side `ping failed` cascade**: the `WRN ping failed` line was observed once. If write backpressure intermittently makes the server's 5 s heartbeat-ping fail (`api/pkg/desktop/ws_stream.go:1362-1384`), the server unconditionally calls `v.ws.UnderlyingConn().Close()` — RST — and the client sees 1006. This would manifest as the first 1006 of a cycle being initiated server-side rather than client-side.
+- **A genuine network blip** on the LAN / loopback path.
+
+Without browser logs we cannot tell which fires first. The fact that the same trigger fires irregularly (4 / 8 / 14 / 7 / 10 / 15) makes it look more like an *event-driven* cause (user interaction, decoder hiccup, transient backpressure) than a *timer*.
+
+---
+
+## What I think is most likely
+
+**H3 is in play for every observed disconnect** (the raw-TCP-close turning supersede into 1006 is verified in code). **H1 most likely explains the long-short-long-short alternation.** **H4** is the trigger — and is probably a mix of (a) occasional server-side ping write failure / write backpressure and (b) the iPad/Safari-tier decoder/visibility quirks the component health-check exists to cover.
+
+The clean way to break the storm is **H3 alone**: emit a WS close frame with code `4000 "superseded"` on the cancel path; have `WebSocketStream.onClose` recognise the code and skip its own reconnect *and* dispatch `reconnectAborted` to the component. That converts the cycle into a single bounded event ("server replaced your connection, we honor it") and makes H1's race irrelevant because the supersede no longer triggers a client retry.
+
+H1 should still be fixed properly afterwards (the dual-path reconnect coordination is the same shape of bug that bit us in April).
+
+---
+
+## Raw evidence
+
+### Server API stream events for `ses_01ks63b0btvj0ax8kzsy43xr4r`
+
+(Excerpt — 80 lines saved to `/tmp/api-events.txt` during investigation.)
+
+```
+20:39:24Z INF  Stream WebSocket connection closed       proxy_session_id=9242f197a05987a5  reconnect_count=0
+20:39:24Z INF  Stream WebSocket connection established  proxy_session_id=5995…  (initial)
+20:39:28Z INF  Superseding previous stream proxy for same client  client_id=7307a64c-7165-4a7c-aa4b-4906e2e592f2  new_proxy=cde02798c4f59cf8  old_proxy=59952b574f6b1d79
+20:39:28Z INF  Proxying stream WebSocket to screenshot-server via RevDial  proxy_session_id=cde02798c4f59cf8
+20:39:28Z WRN  Resilient proxy ended with error  error="context canceled"  proxy_session_id=59952b574f6b1d79
+20:39:28Z INF  Stream WebSocket connection closed       proxy_session_id=59952b574f6b1d79  reconnect_count=0
+20:39:28Z INF  Stream WebSocket connection established  proxy_session_id=cde02798c4f59cf8
+20:39:29Z INF  Superseding previous stream proxy for same client  client_id=7307a64c-7165-4a7c-aa4b-4906e2e592f2  new_proxy=587876ff143952dc  old_proxy=cde02798c4f59cf8
+20:39:29Z INF  Proxying stream WebSocket to screenshot-server via RevDial  proxy_session_id=587876ff143952dc
+20:39:29Z WRN  Resilient proxy ended with error  error="context canceled"  proxy_session_id=cde02798c4f59cf8
+20:39:29Z INF  Stream WebSocket connection closed       proxy_session_id=cde02798c4f59cf8  reconnect_count=0
+20:39:29Z INF  Stream WebSocket connection established  proxy_session_id=587876ff143952dc
+[…same shape repeats, lifetimes: 8s 1s 14s 1s 7s 1s 2s 10s 1s 2s 15s 14s 1s …]
+```
+
+All 80 events share `client_id=7307a64c-7165-4a7c-aa4b-4906e2e592f2` — one browser tab.
+
+### Sandbox / desktop-bridge events
+
+```
+21:38:48 stream init received  width=1920 height=1080 fps=60 bitrate=8294  user="Luke Marsden"
+21:38:54 websocket closed      close_code=1006 close_text="unexpected EOF" duration=6s  frames_sent=425
+21:38:54 stream init received
+21:38:55 websocket closed      close_code=1006 close_text="unexpected EOF" duration=1s  frames_sent=134
+21:38:55 stream init received
+[…same shape repeats…]
+21:40:31 WRN ping failed, closing dead connection   err="write tcp [::1]:9876->[::1]:51972: write: connection reset by peer"
+21:40:31 websocket closed      close_code=1006 close_text="unexpected EOF" duration=15s frames_sent=869
+[…]
+21:40:46 websocket closed      close_code=1001 close_text=""               duration=0s  frames_sent=68
+21:40:46 ERROR failed to read init message  err="websocket: close 1006 (abnormal closure): unexpected EOF"
+```
+
+`close_code=1001` at 21:40:46 = a clean "going away" close (browser tab closed or navigated away). The 1006s before that are all consistent with the server-side raw-TCP-close path.
+
+`pipeline_received` in the periodic `VIDEO LATENCY STATS` lines never drops — the GStreamer pipeline keeps running and feeding frames at 60 Hz. Only the WS outbound transport is being recycled.
+
+### Frontend console logs
+
+**TODO — Luke to paste.** The doc is complete on the server side; the missing piece is which client-side code path fires when. The most informative ~60 s with filter prefix `[DesktopStreamViewer]` / `[WebSocketStream]` will disambiguate H1 vs H2.
+
+Specific log lines that decide the question:
+
+| Log line                                                       | Means                                                       |
+|----------------------------------------------------------------|-------------------------------------------------------------|
+| `[DesktopStreamViewer] Closing existing stream before creating new one` | `connect()` ran while `streamRef.current` was still set — H1 confirmed |
+| `[DesktopStreamViewer] Reconnect aborted by stream`            | `WSStream.close()` was called externally, then onClose saw `closed=true` — H1 path 1 |
+| `[DesktopStreamViewer] Decoder crashed (state=closed)`         | H4 candidate (Safari decoder)                                |
+| `[DesktopStreamViewer] WS data stall: …ms since last message`  | H4 candidate (stall detect)                                  |
+| `[WebSocketStream] Stale connection detected`                  | H4 candidate (heartbeat)                                     |
+| `[WebSocketStream] Connection timeout`                         | H4 candidate (initial WS open never completed)               |
+| `[WebSocketStream] Disconnected: {code: …}`                    | Confirms it's 1006 on every cycle                            |
+| `[WebSocketStream] Will reconnect in Xms (attempt N/M)`        | WSStream internal reconnect about to fire                    |
+| `[DesktopStreamViewer] Bitrate changed from … to …`            | If present, blames the bitrate-change effect at line 1717   |
+| `[DesktopStreamViewer] Lobby changed from … to …`              | If present, blames the lobby-change effect at line 1761     |
+| `[DesktopStreamViewer] Component unmounting`                   | Parent is unmounting the viewer — H2                         |
+
+---
+
+## Recommended fixes
+
+In order of (1) breaks the storm immediately, (2) prevents recurrence, (3) makes future incidents debuggable:
+
+1. **Make supersede a clean WS close, not a TCP RST.** On the cancel path in `external_agent_handlers.go:1408`, write a WebSocket close frame with a custom application code (`4000 superseded`) before `prev.cancel()`. In `WebSocketStream.onClose`, treat `code === 4000` as "do not reconnect"; dispatch `reconnectAborted` to the component; component recognizes the explicit-replacement case and does nothing. **This alone stops the storm.**
+2. **Coordinate the dual reconnect paths in the component.** Either:
+   - Remove the component-level reconnect on `disconnected` / `error` paths entirely; let `WebSocketStream` own *all* reconnect decisions and have it expose `reconnectAborted` only for the "I really am giving up" case; OR
+   - Have `WebSocketStream` expose an `isReconnecting()` predicate so the component's reconnect refuses to fire while internal backoff is pending.
+3. **Add a log line on every NEW `WebSocketStream` construction** — `console.log("[WebSocketStream] new instance", { instanceId, sessionId, clientUniqueId })` — so we can count instances per cycle in production telemetry.
+4. **Investigate the server-side ping-write failure** observed in `ping failed, closing dead connection`. If write backpressure on the desktop-bridge → hydra socket is real, fixing it removes one trigger for H4.
+
+Tactical: PR (1) is small and self-contained. PR (2)/(3) is the proper coordination cleanup. PR (4) is a separate workstream.

--- a/frontend/src/components/external-agent/DesktopStreamViewer.tsx
+++ b/frontend/src/components/external-agent/DesktopStreamViewer.tsx
@@ -247,7 +247,9 @@ const DesktopStreamViewer: React.FC<DesktopStreamViewerProps> = ({
   const addConnectionLog = useCallback((msg: string) => {
     const time = new Date().toLocaleTimeString();
     console.log(`[DesktopStreamViewer] ${msg}`);
-    setConnectionLog((prev) => [...prev.slice(-9), { time, msg }]); // Keep last 10 entries
+    // Keep last 49 entries so the user can grab Stats-for-Nerds → Log and have
+    // ~5+ reconnect cycles of context for debugging. Display caps height + scrolls.
+    setConnectionLog((prev) => [...prev.slice(-49), { time, msg }]);
   }, []);
 
   // Shared retry logic for AlreadyStreaming errors.
@@ -598,6 +600,7 @@ const DesktopStreamViewer: React.FC<DesktopStreamViewerProps> = ({
     // but this ensures we never have two streams active at once even if connect() is
     // called directly or there's a race condition
     if (streamRef.current) {
+      addConnectionLog("connect() called while stream still alive — closing it first");
       console.log(
         "[DesktopStreamViewer] Closing existing stream before creating new one",
       );
@@ -909,6 +912,17 @@ const DesktopStreamViewer: React.FC<DesktopStreamViewerProps> = ({
           setIsConnected(false);
           onConnectionChange?.(false);
 
+          // Server-initiated supersede: a newer connection from this same tab is
+          // already taking over. Don't flash "Reconnecting…" — the new stream
+          // will drive isConnected back to true momentarily.
+          if (data.superseded) {
+            addConnectionLog("Disconnected (superseded by server)");
+            console.log(
+              "[DesktopStreamViewer] Disconnected because superseded by server",
+            );
+            return;
+          }
+
           // If explicitly closed (unmount, HMR, user-initiated disconnect), show Disconnected overlay
           // Otherwise, WebSocketStream will auto-reconnect, so show "Reconnecting..." state
           if (isExplicitlyClosingRef.current) {
@@ -920,7 +934,7 @@ const DesktopStreamViewer: React.FC<DesktopStreamViewerProps> = ({
             setStatus("Disconnected");
           } else {
             addConnectionLog(
-              `Disconnected unexpectedly (code: ${data.code || "unknown"})`,
+              `Disconnected unexpectedly (code: ${data.code || "unknown"}${data.reason ? `, ${data.reason}` : ""})`,
             );
             console.log(
               "[DesktopStreamViewer] Unexpected disconnect - will auto-reconnect",
@@ -935,6 +949,18 @@ const DesktopStreamViewer: React.FC<DesktopStreamViewerProps> = ({
           );
           setIsConnecting(true);
           setStatus(`Reconnecting (attempt ${data.attempt})...`);
+        } else if (data.type === "reconnectScheduled") {
+          addConnectionLog(
+            `WS backoff reconnect in ${data.delayMs}ms (attempt ${data.attempt}/${data.maxAttempts})`,
+          );
+        } else if (data.type === "heartbeatStale") {
+          addConnectionLog(
+            `WS heartbeat stale (${data.elapsedMs}ms since last msg)`,
+          );
+        } else if (data.type === "connectionTimeout") {
+          addConnectionLog(`WS open timed out after ${data.timeoutMs}ms`);
+        } else if (data.type === "visibility") {
+          addConnectionLog(`Page ${data.visible ? "visible" : "hidden"}`);
         } else if (data.type === "reconnectAborted") {
           // WebSocketStream refused to reconnect (this.closed was true unexpectedly)
           // IMPORTANT: Only handle if this event is from the CURRENT stream.
@@ -951,6 +977,19 @@ const DesktopStreamViewer: React.FC<DesktopStreamViewerProps> = ({
             "[DesktopStreamViewer] Reconnect aborted by stream:",
             data.reason,
           );
+
+          // Server-initiated supersede: a newer connection from this same tab has
+          // already taken over. Do NOT manually reconnect — that just supersedes
+          // the new stream and triggers the storm again. The new connection's
+          // events will drive the UI from here.
+          // See design/2026-05-21-stream-reconnect-storm-root-cause.md.
+          if (data.superseded) {
+            addConnectionLog("Superseded by server (no reconnect)");
+            console.log(
+              "[DesktopStreamViewer] Superseded by server — letting newer connection take over, suppressing reconnect",
+            );
+            return;
+          }
 
           // If we weren't explicitly closing, this is unexpected - try to reconnect ourselves
           // But limit to 3 attempts to prevent infinite loops
@@ -1261,9 +1300,13 @@ const DesktopStreamViewer: React.FC<DesktopStreamViewerProps> = ({
   // Default 1 second delay for fast reconnects - infrastructure is reliable now
   const reconnect = useCallback(
     (delayMs = 1000, reason?: string) => {
+      addConnectionLog(
+        `Component reconnect requested in ${delayMs}ms${reason ? ` (${reason})` : ""}`,
+      );
       // CRITICAL: Cancel any pending reconnect to prevent duplicate streams
       // This happens when user rapidly changes bitrate or mode
       if (pendingReconnectTimeoutRef.current) {
+        addConnectionLog("Cancelling previous pending reconnect");
         console.log("[DesktopStreamViewer] Cancelling pending reconnect");
         clearTimeout(pendingReconnectTimeoutRef.current);
         pendingReconnectTimeoutRef.current = null;
@@ -1285,7 +1328,7 @@ const DesktopStreamViewer: React.FC<DesktopStreamViewerProps> = ({
         connectRef.current();
       }, delayMs);
     },
-    [disconnect],
+    [disconnect, addConnectionLog],
   );
 
   // Ref to reconnect function for use in closures (avoids stale closure issues)
@@ -1896,16 +1939,22 @@ const DesktopStreamViewer: React.FC<DesktopStreamViewerProps> = ({
     );
     setUserBitrate(defaultBitrate);
     setRequestedBitrate(defaultBitrate);
+    addConnectionLog(
+      `Auto-connecting at ${defaultBitrate} Mbps for ${width}x${height}`,
+    );
     connect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sandboxId, sessionId, isVisible, width, height, account.initialized]); // Only trigger on props and visibility, not on function identity changes
 
   // Cleanup on unmount
   useEffect(() => {
+    addConnectionLog("Component mounted");
     console.log(
       "[DesktopStreamViewer] Component mounted, setting up cleanup handler",
     );
     return () => {
+      // No addConnectionLog here — the component is unmounting so the log
+      // state will be discarded immediately. Console only.
       console.log(
         "[DesktopStreamViewer] Component unmounting, calling disconnect()",
       );

--- a/frontend/src/lib/helix-stream/stream/websocket-stream.ts
+++ b/frontend/src/lib/helix-stream/stream/websocket-stream.ts
@@ -400,6 +400,7 @@ export class WebSocketStream {
     this.clearConnectionTimeout()
     this.connectionTimeoutId = setTimeout(() => {
       console.warn(`[WebSocketStream] Connection timeout (${this.CONNECTION_TIMEOUT_MS}ms), forcing reconnect`)
+      this.dispatchInfoEvent({ type: "connectionTimeout", timeoutMs: this.CONNECTION_TIMEOUT_MS })
       this.dispatchInfoEvent({ type: "error", message: "Connection timeout" })
       // Close the stuck WebSocket and trigger reconnection
       if (this.ws) {
@@ -476,6 +477,17 @@ export class WebSocketStream {
     })
     this.connected = false
 
+    // Application close code 4000 = "superseded": the server has replaced this
+    // connection with a newer one from the same browser tab. Do NOT reconnect —
+    // reconnecting just supersedes the server's new proxy, fueling a storm.
+    // The handover is intentional, treat it as an explicit close.
+    // See design/2026-05-21-stream-reconnect-storm-root-cause.md.
+    const isSuperseded = event.code === 4000
+    if (isSuperseded) {
+      console.log("[WebSocketStream] Connection superseded by server, suppressing reconnect")
+      this.closed = true
+    }
+
     // Clear connection stability timer if connection drops before stabilizing
     if (this.connectionStabilityTimer) {
       clearTimeout(this.connectionStabilityTimer)
@@ -495,14 +507,15 @@ export class WebSocketStream {
     // Stop event loop tracking
     this.stopEventLoopTracking()
 
-    this.dispatchInfoEvent({ type: "disconnected", code: event.code })
+    this.dispatchInfoEvent({ type: "disconnected", code: event.code, reason: event.reason, superseded: isSuperseded })
 
-    // Don't reconnect if explicitly closed
+    // Don't reconnect if explicitly closed (or if the server superseded us)
     if (this.closed) {
-      console.log("[WebSocketStream] Not reconnecting - stream was explicitly closed")
+      const abortReason = isSuperseded ? "superseded by server" : "explicitly closed"
+      console.log(`[WebSocketStream] Not reconnecting - ${abortReason}`)
       // Dispatch event so DesktopStreamViewer knows reconnection was skipped
       // This prevents the UI from getting stuck on "Reconnecting..." forever
-      this.dispatchInfoEvent({ type: "reconnectAborted", reason: "explicitly closed" })
+      this.dispatchInfoEvent({ type: "reconnectAborted", reason: abortReason, superseded: isSuperseded })
       return
     }
 
@@ -519,6 +532,15 @@ export class WebSocketStream {
       const baseDelay = Math.min(this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1), 30000)
       const delay = baseDelay * (0.5 + Math.random() * 0.5)
       this.dispatchInfoEvent({ type: "reconnecting", attempt: this.reconnectAttempts })
+      // Surface the scheduled-reconnect to Stats-for-Nerds so we can tell from
+      // the log alone whether duplicate connect attempts are happening (e.g.
+      // WSStream backoff racing with a component-level reconnect call).
+      this.dispatchInfoEvent({
+        type: "reconnectScheduled",
+        attempt: this.reconnectAttempts,
+        maxAttempts: this.maxReconnectAttempts,
+        delayMs: Math.round(delay),
+      })
 
       console.log(`[WebSocketStream] Will reconnect in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`)
 
@@ -2116,7 +2138,10 @@ export class WebSocketStream {
         // Page just became visible again - reset lastMessageTime to avoid false stale detection
         // iOS suspends JS when page is hidden, so elapsed time includes suspension
         console.log("[WebSocketStream] Page became visible, resetting heartbeat timer")
+        this.dispatchInfoEvent({ type: "visibility", visible: true })
         this.lastMessageTime = Date.now()
+      } else if (!this.pageVisible && !wasHidden) {
+        this.dispatchInfoEvent({ type: "visibility", visible: false })
       }
     }
     document.addEventListener("visibilitychange", this.visibilityHandler)
@@ -2134,6 +2159,9 @@ export class WebSocketStream {
 
       if (elapsed > this.heartbeatTimeout) {
         console.warn(`[WebSocketStream] Stale connection detected (${elapsed}ms since last message), forcing reconnect`)
+        // Surface to Stats-for-Nerds so future incidents can be diagnosed from
+        // the log alone, without dev-tools console.
+        this.dispatchInfoEvent({ type: "heartbeatStale", elapsedMs: elapsed })
         this.dispatchInfoEvent({ type: "error", message: "Connection stale - no data received" })
 
         // Force close and trigger reconnection

--- a/frontend/src/lib/helix-stream/stream/websocket-stream.types.ts
+++ b/frontend/src/lib/helix-stream/stream/websocket-stream.types.ts
@@ -96,8 +96,12 @@ export type WsStreamInfoEvent = CustomEvent<
   | { type: "error"; message: string }
   | { type: "connecting" }
   | { type: "connected" }
-  | { type: "disconnected"; code?: number }
+  | { type: "disconnected"; code?: number; reason?: string; superseded?: boolean }
   | { type: "reconnecting"; attempt: number }
+  | { type: "reconnectScheduled"; attempt: number; maxAttempts: number; delayMs: number }
+  | { type: "heartbeatStale"; elapsedMs: number }
+  | { type: "connectionTimeout"; timeoutMs: number }
+  | { type: "visibility"; visible: boolean }
   | { type: "streamInit"; width: number; height: number; fps: number }
   | { type: "connectionComplete"; capabilities: StreamCapabilities }
   | { type: "addDebugLine"; line: string }
@@ -112,7 +116,7 @@ export type WsStreamInfoEvent = CustomEvent<
   | { type: "agentCursor"; agent: AgentCursorInfo }
   | { type: "remoteTouch"; touch: RemoteTouchInfo }
   | { type: "selfId"; clientId: number }
-  | { type: "reconnectAborted"; reason: string }
+  | { type: "reconnectAborted"; reason: string; superseded?: boolean }
   | { type: "videoStarted" }
 >
 export type WsStreamInfoEventListener = (event: WsStreamInfoEvent) => void


### PR DESCRIPTION
## Summary

Spec-task desktop streams have been stuck in 5-7s reconnect cycles for some users (e.g. `spt_01ks63ax30bfk91t9faec1cp3w` on meta). Full root-cause investigation in `design/2026-05-21-stream-reconnect-storm-root-cause.md`.

The mechanism is a self-perpetuating loop between the server's proxy dedup and the browser's reconnect logic:

1. Server's `proxyStreamWebSocket` dedup cancels the previous proxy via `proxyCancel()` — `clientConn.Close()` then performs a raw TCP close (no WS Close frame).
2. Browser sees `code: 1006 abnormal closure`, treats it as a transient network failure, and reconnects.
3. The reconnect arrives at the server while *its own* new proxy is still in `activeStreamProxies`, supersede fires again, and the cycle keeps itself alive.

API logs from the affected session show this exact alternation — long-lived (4-15 s) streams interleaved with 1 s "supersede victim" streams, every one from the same `client_id` (one browser tab):

```
20:39:24  proxy 5995… established      (lifetime 4s)
20:39:28  Superseding…  new=cde0  old=5995
20:39:28  proxy cde0… established      (lifetime 1s)
20:39:29  Superseding…  new=5878  old=cde0
20:39:29  proxy 5878… established      (lifetime 8s)
… [repeats for the whole session]
```

## Fix — server side

- Add `ResilientProxy.CloseClientWithCode(code, reason)` (`api/pkg/proxy/resilient.go`) which writes a proper RFC 6455 WebSocket Close frame on the client connection, serialized via a new `clientWriteMu` so it can't interleave with `copyServerToClient` / `flushOutputBuffer` writes.
- Store `*proxy.ResilientProxy` on the `activeStreamProxy` entry once constructed.
- On supersede in `proxyStreamWebSocket`, call `prev.proxy.CloseClientWithCode(4000, "superseded")` **before** `prev.cancel()`.

## Fix — client side

- `WebSocketStream.onClose` treats code 4000 as "superseded": sets `closed=true`, skips its internal reconnect, and tags both `disconnected` and `reconnectAborted` events with `superseded: true`.
- `DesktopStreamViewer` recognises the supersede flag and (a) doesn't flash "Reconnecting…", (b) doesn't trigger its manual reconnect fallback — both of which would re-open a connection and re-arm the cycle.

## Stats-for-Nerds → Log expansion

Per request, so the next incident can be diagnosed from the log paste alone (no devtools required):
- Buffer bumped from 10 → 50 entries (display already scrolls).
- New WSStream → component events surfaced: `heartbeatStale`, `connectionTimeout`, `reconnectScheduled` (with attempt/max/delay), `visibility`.
- Component logs now include: mount, auto-connect, component-level reconnect requests (with delay + reason), cancellations of pending reconnects, and the `connect() called while stream still alive` branch that was console-only.
- Disconnect log line now includes close reason text alongside the code.

## Why this is the right fix (vs the alternatives explored in the design doc)

H3 from the design doc — the clean-close approach implemented here — breaks the loop regardless of which exact client-side trigger originally killed the long-lived stream. That's important because I can't reliably reproduce the trigger (could be a server-side ping write fail, a transient Safari decoder crash, a heartbeat false positive, or a dual reconnect-path race — see H1/H2/H4 in the doc). Whatever the trigger, this fix prevents *one* legitimate reconnect from cascading into a storm.

The "proper" follow-up — coordinating WSStream's internal backoff with the component-level `reconnect()` calls (H1) — needs browser logs to identify which paths are firing in parallel. The richer Stats-for-Nerds log added here is what we'll need to confirm.

## Test plan

- [x] `go test -count=1 ./api/pkg/proxy/` (incl. new `TestResilientProxy_CloseClientWithCode` verifying exact wire bytes, and `_RejectsOversizeReason` for the 125-byte short-form guard)
- [x] `yarn build` (frontend type-check clean)
- [x] Outer Helix Air rebuild succeeded with the new code in place — no runtime breakage
- [ ] Once deployed, watch a fresh long-lived stream in Stats-for-Nerds → Log. Expected: no rapid 1006 cycles; if supersede does fire (e.g. user opens a second tab), log should show `Disconnected (superseded by server)` / `Superseded by server (no reconnect)` rather than a reconnect chain
- [ ] Confirm via `docker compose logs api | grep -E "Superseding|Stream WebSocket"` that supersede events on the API are no longer immediately followed by another supersede 1-2 s later

🤖 Generated with [Claude Code](https://claude.com/claude-code)