### PR TITLE
fix(api): preserve interrupted state when message_completed has empty response

### DIFF
--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -2588,6 +2588,20 @@ func (apiServer *HelixAPIServer) handleMessageCompleted(sessionID string, syncMs
 		return nil
 	}
 
+	// An interaction already in Interrupted state is the expected terminal state
+	// after handleTurnCancelled — message_completed arrives shortly after as the
+	// agent finishes in-flight work, but the response can legitimately be empty
+	// if the cancel landed before any token streamed (Phase 13 of the Zed WS E2E
+	// test exercises exactly this race). Don't treat that as a bounce.
+	if targetInteraction.State == types.InteractionStateInterrupted &&
+		targetInteraction.ResponseMessage == "" && len(responseEntries) == 0 {
+		log.Info().
+			Str("helix_session_id", helixSessionID).
+			Str("interaction_id", targetInteraction.ID).
+			Msg("⏭️ [HELIX] message_completed for already-interrupted interaction with empty response — preserving interrupted state")
+		return nil
+	}
+
 	// If the response is empty, something went wrong — either the agent bounced the
 	// message (busy with another turn) or content was lost during the streaming flush.
 	// Mark as error and re-queue the prompt so it will be retried.

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -804,6 +804,54 @@ func (s *WebSocketSyncSuite) TestMessageCompleted_Normal() {
 	time.Sleep(50 * time.Millisecond)
 }
 
+// TestMessageCompleted_PreservesInterruptedStateOnEmptyResponse pins down the
+// race between handleTurnCancelled and handleMessageCompleted that Phase 13 of
+// the Zed WS E2E test exercises: a cancel lands before any token streamed, so
+// the interaction is marked Interrupted with an empty ResponseMessage. The
+// agent then emits message_completed for the same request_id as it tears the
+// turn down. Previously the empty-response branch in handleMessageCompleted
+// clobbered the Interrupted state with Error and re-queued the prompt, which
+// broke the E2E assertion "interaction in store with state=interrupted".
+// Verify the handler returns without touching the interaction.
+func (s *WebSocketSyncSuite) TestMessageCompleted_PreservesInterruptedStateOnEmptyResponse() {
+	s.server.contextMappings["thread-int"] = "ses_int"
+	s.server.requestToInteractionMapping = map[string]string{
+		"req-int": "int-int",
+	}
+
+	session := &types.Session{
+		ID:    "ses_int",
+		Owner: "user-1",
+	}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_int").Return(session, nil).AnyTimes()
+
+	interruptedInteraction := &types.Interaction{
+		ID:              "int-int",
+		SessionID:       "ses_int",
+		State:           types.InteractionStateInterrupted,
+		ResponseMessage: "",
+	}
+	s.store.EXPECT().GetInteraction(gomock.Any(), "int-int").Return(interruptedInteraction, nil)
+
+	// Critical: no UpdateInteraction, no RequeueBouncedPrompt, no
+	// processPromptQueue follow-up. The handler must return as soon as it
+	// sees the Interrupted-with-empty-response pattern. gomock's default
+	// strict mode fails the test if any unexpected store call is made.
+
+	syncMsg := &types.SyncMessage{
+		EventType: "message_completed",
+		Data: map[string]interface{}{
+			"acp_thread_id": "thread-int",
+			"request_id":    "req-int",
+		},
+	}
+
+	err := s.server.handleMessageCompleted("agent-1", syncMsg)
+	s.NoError(err)
+
+	time.Sleep(50 * time.Millisecond)
+}
+
 func (s *WebSocketSyncSuite) TestMessageCompleted_NoWaitingInteraction() {
 	s.server.contextMappings["thread-nw"] = "ses_nw"
 


### PR DESCRIPTION
## Summary

Fixes the `zed-e2e-test` step on the `release-tag` build that gated the release (Drone build [1610](https://drone.lukemarsden.net/helixml/helix/1610), `build-sandbox-amd64` stage). Phase 13 of the Zed WS E2E zed-agent round failed with `FAIL: Phase 13: No interaction in store with state=interrupted` after a successful `cancel_current_turn` round trip.

## Root cause

Race between `handleTurnCancelled` and `handleMessageCompleted` in `api/pkg/server/websocket_external_agent_sync.go`:

1. Test sends `cancel_current_turn` immediately after the first assistant token. `handleTurnCancelled` correctly marks the interaction as `Interrupted` (`response_message=""` because the cancel landed before any token streamed).
2. The agent then emits `message_completed` for the same `request_id` as it tears the turn down.
3. `handleMessageCompleted` reloads the interaction: `state_before=interrupted`, `response_length=0`.
4. The "already complete -- skip" guard at line 2583 does NOT fire (state is `Interrupted`, not `Complete`).
5. The empty-response branch at line 2594 DOES fire: state is overwritten to `Error`, prompt is re-queued, `marking as error and re-queuing` log line emitted.
6. The later "preserve Interrupted state" branch at line 2629 never runs because step 5 already returned.

Net effect: a perfectly successful cancel turned into an error-and-retry in the database.

Production log evidence from build 1610:
```
21:24:16 Marked interaction as interrupted
21:24:16 message_completed with EMPTY response -- marking as error and re-queuing
21:24:36 FAIL: Phase 13: No interaction in store with state=interrupted
```

## Fix

Add a symmetric guard ahead of the empty-response branch: if the interaction is already `Interrupted` and the response is empty, this `message_completed` is the cancel-tail and not a bounce. Return without touching the row.

## Test

Added `TestMessageCompleted_PreservesInterruptedStateOnEmptyResponse` to `WebSocketSyncSuite` ([websocket_external_agent_sync_test.go](https://github.com/helixml/helix/blob/fix/zed-e2e-phase13-preserve-interrupted/api/pkg/server/websocket_external_agent_sync_test.go)). It pins the exact race: Interrupted interaction, empty response, populated request_id mapping. The handler must return without calling `UpdateInteraction` or `RequeueBouncedPrompt` -- gomock's strict mode fails if either runs.

Verified locally: `go test -run TestWebSocketSyncSuite ./pkg/server/ -count=1` passes. New test fails the assertion without the fix.

## Test plan

- [ ] Drone CI passes on this branch (including `zed-e2e-test` for both `amd64` and `arm64`)
- [ ] Phase 13 logs no longer show `marking as error and re-queuing` for cancelled turns
- [ ] Release-tag build for the next release passes its `zed-e2e-test` step