### PR TITLE
fix(helix-npx): short-circuit when package is already a binary on PATH

### DIFF
--- a/desktop/shared/helix-npx.sh
+++ b/desktop/shared/helix-npx.sh
@@ -1,37 +1,76 @@
 #!/bin/bash
 # helix-npx — drop-in shim installed as /usr/local/bin/npx that shadows the
-# system /usr/bin/npx in PATH. Behaves exactly like npx but gives each
-# invocation its own NPM_CONFIG_CACHE so parallel npx spawns don't race.
+# system /usr/bin/npx in PATH. Two responsibilities:
 #
-# Background: npm's `_npx/<hash>` directory under NPM_CONFIG_CACHE does a
-# "reify mark retired" rename dance every spawn (rename
-# node_modules/<pkg> → .<pkg>-<rand>, reinstall, rename back). When two
-# npx invocations target the same package against the same cache (e.g.
-# Zed and Claude Code both spawning `npx -y chrome-devtools-mcp` at
-# session start, or two parallel Claude sessions starting `npx -y
-# @modelcontextprotocol/server-github`), the renames race and the
-# spawned MCP server's JSON-RPC `initialize` never returns. Spec-task
-# logs then surface `<server> context server failed to start: Context
-# server request timeout` after the 180s context_server_timeout fires.
+# 1) Short-circuit when the requested package is already a binary on PATH.
+#    Upstream npm's exec path detects "binary already installed" and shells
+#    out via `sh -c "<pkg>"` as a child, then npm itself EXITS. MCP clients
+#    that track the spawned PID (Claude Code via --mcp-config, Zed via
+#    context_server_store) see the npx PID exit and report `Connection
+#    closed`/`Context server request timeout` even though the MCP child is
+#    alive. Exec the binary directly so the PID the caller monitors IS the
+#    MCP process.
 #
-# Workaround: each invocation gets its own NPM_CONFIG_CACHE under
-# /tmp. The cache is fully isolated (no symlinks into the user's
-# shared `~/.npm/_cacache` — that path is root-owned in our spec-task
-# images so symlinking breaks npm with EACCES on first cacache write).
-# The cost is one tarball download per cold spawn (~2-3s for typical
-# MCP packages), which is the only the ONE-TIME startup cost per
-# MCP per session — long-running stdio MCPs stay attached for the
-# whole session.
+# 2) For real npm-install paths (scoped packages, packages not on PATH),
+#    give each invocation its own NPM_CONFIG_CACHE so parallel npx spawns
+#    don't race in npm's `_npx/<hash>` rename dance. Background: npm's
+#    "reify mark retired" rename (node_modules/<pkg> → .<pkg>-<rand>,
+#    reinstall, rename back) corrupts state when two npx invocations
+#    target the same package against the same cache (e.g. two parallel
+#    Claude sessions both spawning `npx -y @modelcontextprotocol/server-
+#    everything`). The cache is fully isolated under /tmp (no symlinks
+#    into the shared `~/.npm/_cacache` — that path is root-owned in our
+#    spec-task images so symlinking breaks npm with EACCES on first
+#    cacache write). The cost is one tarball download per cold spawn
+#    (~2-3s for typical MCP packages), paid once per MCP per session.
 #
 # This shim is installed at /usr/local/bin/npx in Dockerfile.ubuntu-helix
-# and takes precedence over /usr/bin/npx via standard PATH order. Zed's
-# own ACP-wrapper bootstrapping calls npm directly via absolute path so
-# it bypasses this shim — only stdio MCPs whose `command: "npx"`
-# (resolved via PATH at spawn time) are routed through here, which is
-# exactly the case that needed fixing.
+# and takes precedence over /usr/bin/npx via standard PATH order.
 
 set -e
 
+# Parse: find the first positional (non-flag) argument — that's the
+# <pkg> in `npx [flags...] <pkg> [pkg-args...]`. Conservative: any flag
+# we don't recognise, or any "advanced" flag that changes resolution
+# semantics (-p/--package/--call), bails out to real npx.
+SHORTCUT_PKG=""
+SHORTCUT_SHIFT=0
+i=0
+for arg in "$@"; do
+    i=$((i+1))
+    case "$arg" in
+        -y|--yes|--no|--no-install|-q|--quiet|--silent|--no-shell|--shell-auto-fallback|--ignore-existing|--prefer-online|--prefer-offline|--offline|--legacy-peer-deps)
+            continue
+            ;;
+        -p|--package|--package=*|--call|-c|--with|-w|--workspace|--workspace=*|--workspaces|-ws|--include-workspace-root|--if-present|--node-options|--node-options=*)
+            SHORTCUT_PKG=""
+            break
+            ;;
+        --)
+            # Everything after `--` is positional but the FIRST one might
+            # not be the package name in some npx invocations — be safe.
+            SHORTCUT_PKG=""
+            break
+            ;;
+        -*)
+            # Unknown flag: don't try to be clever.
+            SHORTCUT_PKG=""
+            break
+            ;;
+        *)
+            SHORTCUT_PKG="$arg"
+            SHORTCUT_SHIFT=$i
+            break
+            ;;
+    esac
+done
+
+if [ -n "$SHORTCUT_PKG" ] && command -v "$SHORTCUT_PKG" >/dev/null 2>&1; then
+    shift "$SHORTCUT_SHIFT"
+    exec "$SHORTCUT_PKG" "$@"
+fi
+
+# Slow path: real npm install via isolated cache.
 ISOLATED_CACHE=$(mktemp -d -t helix-npx-XXXXXX)
 
 # Run the real npx (absolute path so we don't recurse into ourselves)


### PR DESCRIPTION
## Summary

Diagnosed while chasing a real spec-task failure where the `drone-ci`
MCP was silently absent from Claude's tool catalog. The Claude Code
debug log showed `MCP error -32000: Connection closed` ~575ms after
spawn — the MCP child *did* start (its `Helix Drone CI MCP server
running on stdio` stderr was captured), but Claude saw the spawned
PID exit and reported the connection dead.

Root cause: when `npx -y <pkg>` resolves `<pkg>` to a binary already
on PATH, npm's exec path does `sh -c "<pkg>"` as a child and then
**npm itself exits** instead of staying as the long-running stdio
shepherd. The MCP child outlives its grandparent as an orphan with
half-broken pipes; MCP clients that track the spawned PID see
`Connection closed` immediately.

Github MCP doesn't hit this because the npm package name
(`@modelcontextprotocol/server-github`) is different from the binary
name (`mcp-server-github`), so npx can't shortcut to PATH.

## Fix

`helix-npx.sh` now parses its args to find the first positional
(non-flag) argument — the `<pkg>`. If that name resolves on PATH,
exec it directly with the remaining args. Otherwise fall through to
the existing isolated-cache slow path.

## Scope (be honest about it)

This only protects callers that resolve `npx` via standard PATH
(`/usr/local/bin/npx` shadows `/usr/bin/npx`):

- Shell users / scripts
- Zed itself when spawning context_server MCPs

It does **not** cover Claude Code's child spawns — those inherit
Zed's PATH which prepends Zed's bundled node-v24/npm-v11, bypassing
the shim. npm v11 happens to handle the binary-on-PATH case
correctly in most cases (npm exec stays alive), so Claude Code is
mostly unaffected — though we did see intermittent failures across
container restarts, suggesting it can still trip in some
race/cache states.

The actual reliable fix for broken MCP configs is invoking the
installed binary directly (`command: "drone-ci-mcp"`, not
`command: "npx", args: ["-y", "drone-ci-mcp"]`). The frontend MCP
presets and `simple_sample_projects.go` already do this. The shim
is defense in depth for stale configs that haven't been migrated.

## Companion change

`helixml/zed` main commit
[`e60a1b2789`](https://github.com/helixml/zed/commit/e60a1b2789)
reverts `DEFAULT_REQUEST_TIMEOUT` from 180s back to upstream 60s.
The 180s bump was based on the wrong diagnosis (cold-start npm
download headroom) and was actually masking this bug — MCP child
dies in <1s, so 180s just delayed surfacing the failure by ~3 minutes.
Picks up in the next sandbox rebuild via `sandbox-versions.txt`.

## Test plan

- [x] `npx -y drone-ci-mcp ...` via shim → exec's `/usr/bin/drone-ci-mcp` directly, Claude `Successfully connected in 225ms`
- [x] Direct binary invocation still works (no regression)
- [x] Scoped packages (`@scope/pkg`) fall through to slow path
- [x] Bash arg parsing handles `-y`, `--yes`, `-q`, etc; bails out for `-p`/`--package`/unknown flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)