### PR TITLE
feat(frontend): open chat markdown links in a new tab

### DIFF
--- a/frontend/src/components/session/Markdown.tsx
+++ b/frontend/src/components/session/Markdown.tsx
@@ -1163,6 +1163,38 @@ const MemoizedMarkdownRenderer: FC<{ processedContent: string }> = React.memo(
             </code>
           );
         },
+        a(props: any) {
+          const { node, href, target, children, ...rest } = props;
+          // Internal action links (filter mentions, doc-group links) use
+          // href="#" and have JS click handlers — leave them alone. Same
+          // for in-page anchors like [Top](#section).
+          if (!href || href === "#" || href.startsWith("#")) {
+            return (
+              <a href={href} {...rest}>
+                {children}
+              </a>
+            );
+          }
+          // Respect an explicit target already set on the source HTML
+          // (e.g. doc-citation links from processDocumentIds).
+          if (target) {
+            return (
+              <a href={href} target={target} {...rest}>
+                {children}
+              </a>
+            );
+          }
+          return (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              {...rest}
+            >
+              {children}
+            </a>
+          );
+        },
       }),
       [],
     );


### PR DESCRIPTION
## Summary

Markdown links rendered in the spec task chat (inline comment bubbles
and the comment log sidebar) and in regular session chat used to open
in the **same tab**, navigating users away from Helix and discarding
their place in the chat. This PR fixes that.

The fix is one override in the shared `InteractionMarkdown` renderer in
`frontend/src/components/session/Markdown.tsx`, so it covers every
surface that uses the renderer with a single change.

## Changes

- Add an `a` component override to `markdownComponents` inside
  `MemoizedMarkdownRenderer` (`Markdown.tsx`).
- Plain markdown links (`[text](https://…)`) now render with
  `target="_blank"` and `rel="noopener noreferrer"` (the standard
  mitigation for reverse-tabnabbing).
- Existing `processDocumentIds` doc-citation links (which already set
  `target="_blank"` explicitly) are preserved — the override respects
  any pre-existing `target` on the anchor.
- Internal action links (`href="#"` filter mentions, doc-group links)
  and in-page anchors (`href="#section"`) are left untouched so their
  JS handlers and same-tab navigation continue to work.

## Why

The user's report: *"Links in the spec task chat should open a new tab.
To be honest, this is probably a common interaction display component
that's used in sessions as well."* — and yes, both the spec task chat
and the session chat flow through the same `InteractionMarkdown`
component, so a single override fixes both.

## Testing

- `cd frontend && yarn build` — passes (no type or build errors).
- **Live component verification in inner Helix**: imported the actual
  `InteractionMarkdown` component into the running browser via Vite
  ESM, rendered all four anchor classes through it, and inspected the
  resulting DOM:

  | Input | Rendered `target` | Rendered `rel` | Result |
  |---|---|---|---|
  | `[example](https://example.com)` | `_blank` | `noopener noreferrer` | ✅ external opens new tab |
  | `[Top](#top)` | (none) | (none) | ✅ in-page anchor untouched |
  | `<a target="_self" …>` | `_self` (preserved) | (none) | ✅ pre-existing target respected — protects doc-citation links |
  | `<a href="#" class="filter-mention">` | (none) | (none) | ✅ internal action link untouched, class preserved |

## Screenshots

![Rendered anchors with new-tab override applied](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002044_links-in-the-spec-task/screenshots/01-rendered-anchors.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01ks672kgn92ng61dckwrphq0b)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002044_links-in-the-spec-task/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002044_links-in-the-spec-task/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002044_links-in-the-spec-task/tasks.md)

🚀 Built with [Helix](https://helix.ml)