### PR TITLE
fix(auth): restrict logout redirect_uri to same-origin to prevent phishing

### DIFF
--- a/api/pkg/server/auth.go
+++ b/api/pkg/server/auth.go
@@ -144,12 +144,21 @@ func randString(nByte int) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
-// isSameOriginRedirect returns true if candidate is empty, a relative path,
-// or shares the scheme+host with serverURL. Used to keep the logout redirect_uri
-// query parameter from being weaponized as an open-redirect/phishing primitive.
+// isSameOriginRedirect returns true if candidate is a relative path or shares
+// the scheme+host with serverURL. Empty input is rejected so the caller falls
+// back to the configured WebServer.URL rather than 302-ing to an empty
+// Location. Used to keep the logout redirect_uri query parameter from being
+// weaponized as an open-redirect/phishing primitive.
 func isSameOriginRedirect(candidate, serverURL string) bool {
 	if candidate == "" {
-		return true
+		return false
+	}
+	// Browsers (notably Chrome) normalize backslashes to forward slashes when
+	// parsing authority components, so `/\evil.com/foo` is treated as host
+	// `evil.com`. Go's net/url does not, which would otherwise let a
+	// backslash-prefixed value slip through the relative-path branch.
+	if strings.ContainsAny(candidate, "\\") {
+		return false
 	}
 	cu, err := url.Parse(candidate)
 	if err != nil {
@@ -163,7 +172,8 @@ func isSameOriginRedirect(candidate, serverURL string) bool {
 	if err != nil || su.Host == "" {
 		return false
 	}
-	return cu.Scheme == su.Scheme && cu.Host == su.Host
+	// Host is case-insensitive per RFC 3986; scheme is case-insensitive too.
+	return strings.EqualFold(cu.Scheme, su.Scheme) && strings.EqualFold(cu.Host, su.Host)
 }
 
 // register godoc
@@ -969,11 +979,11 @@ func (s *HelixAPIServer) logout(w http.ResponseWriter, r *http.Request) {
 	// Remove legacy cookies (for backward compatibility during migration)
 	NewCookieManager(s.Cfg).DeleteAllCookies(w)
 
-	// Use redirect_uri from query param if provided (set by frontend from window.location.origin)
-	// This allows the logout redirect to work correctly regardless of which hostname is used.
-	// Reject cross-origin values: this endpoint is on insecureRouter and CSRF-exempt, so
-	// without validation any visitor can craft a logout link that 302s the victim to a
-	// phishing site from the trusted Helix origin.
+	// redirect_uri is set by the frontend from window.location.origin so the
+	// post-logout redirect works regardless of which hostname the user hit.
+	// Reject cross-origin values: this endpoint is on insecureRouter and
+	// CSRF-exempt, so without validation any visitor can craft a logout link
+	// that 302s the victim to a phishing site from the trusted Helix origin.
 	postLogoutRedirect := r.URL.Query().Get("redirect_uri")
 	if !isSameOriginRedirect(postLogoutRedirect, s.Cfg.WebServer.URL) {
 		if postLogoutRedirect != "" {

--- a/api/pkg/server/auth.go
+++ b/api/pkg/server/auth.go
@@ -144,6 +144,28 @@ func randString(nByte int) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
+// isSameOriginRedirect returns true if candidate is empty, a relative path,
+// or shares the scheme+host with serverURL. Used to keep the logout redirect_uri
+// query parameter from being weaponized as an open-redirect/phishing primitive.
+func isSameOriginRedirect(candidate, serverURL string) bool {
+	if candidate == "" {
+		return true
+	}
+	cu, err := url.Parse(candidate)
+	if err != nil {
+		return false
+	}
+	// Relative URLs (no scheme, no host) stay on this origin.
+	if cu.Scheme == "" && cu.Host == "" {
+		return true
+	}
+	su, err := url.Parse(serverURL)
+	if err != nil || su.Host == "" {
+		return false
+	}
+	return cu.Scheme == su.Scheme && cu.Host == su.Host
+}
+
 // register godoc
 // @Summary Register
 // @Description Register a new user
@@ -948,9 +970,15 @@ func (s *HelixAPIServer) logout(w http.ResponseWriter, r *http.Request) {
 	NewCookieManager(s.Cfg).DeleteAllCookies(w)
 
 	// Use redirect_uri from query param if provided (set by frontend from window.location.origin)
-	// This allows the logout redirect to work correctly regardless of which hostname is used
+	// This allows the logout redirect to work correctly regardless of which hostname is used.
+	// Reject cross-origin values: this endpoint is on insecureRouter and CSRF-exempt, so
+	// without validation any visitor can craft a logout link that 302s the victim to a
+	// phishing site from the trusted Helix origin.
 	postLogoutRedirect := r.URL.Query().Get("redirect_uri")
-	if postLogoutRedirect == "" {
+	if !isSameOriginRedirect(postLogoutRedirect, s.Cfg.WebServer.URL) {
+		if postLogoutRedirect != "" {
+			log.Warn().Str("rejected_redirect_uri", postLogoutRedirect).Msg("Cross-origin logout redirect rejected; falling back to configured WebServer.URL")
+		}
 		postLogoutRedirect = s.Cfg.WebServer.URL
 	}
 

--- a/api/pkg/server/auth_test.go
+++ b/api/pkg/server/auth_test.go
@@ -997,3 +997,65 @@ func TestNewCookieManager_ExplicitOverride(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSameOriginRedirect(t *testing.T) {
+	const serverURL = "https://helix.example.com"
+
+	tests := []struct {
+		name      string
+		candidate string
+		serverURL string
+		want      bool
+	}{
+		// Empty input is rejected so the caller falls back to WebServer.URL
+		// rather than 302-ing to an empty Location.
+		{"empty", "", serverURL, false},
+
+		// Relative paths stay on the current origin.
+		{"relative root", "/", serverURL, true},
+		{"relative path", "/dashboard", serverURL, true},
+		{"relative deep path", "/a/b/c?x=1#frag", serverURL, true},
+
+		// Same-origin absolute URLs are accepted.
+		{"same origin root", "https://helix.example.com", serverURL, true},
+		{"same origin path", "https://helix.example.com/welcome", serverURL, true},
+		{"same origin uppercase host", "https://Helix.Example.com/x", serverURL, true},
+		{"same origin uppercase scheme", "HTTPS://helix.example.com/x", serverURL, true},
+
+		// Cross-origin absolute URLs are rejected.
+		{"different host", "https://evil.com/fake-login", serverURL, false},
+		{"different host with same suffix", "https://evilhelix.example.com/", serverURL, false},
+		{"different scheme", "http://helix.example.com/", serverURL, false},
+		{"port mismatch", "https://helix.example.com:8443/", serverURL, false},
+
+		// Protocol-relative URLs are cross-origin in browsers.
+		{"protocol relative", "//evil.com/foo", serverURL, false},
+
+		// Backslash bypass: browsers normalize \ to / when parsing the
+		// authority component, so `/\evil.com/foo` becomes host `evil.com`.
+		{"backslash authority", "/\\evil.com/foo", serverURL, false},
+		{"double backslash", "\\\\evil.com/foo", serverURL, false},
+		{"mixed slash backslash", "/\\/evil.com", serverURL, false},
+
+		// Non-http schemes must never be honored.
+		{"javascript scheme", "javascript:alert(1)", serverURL, false},
+		{"data scheme", "data:text/html,<script>alert(1)</script>", serverURL, false},
+
+		// Garbage that fails url.Parse is rejected.
+		{"control char", "http://\x00.example.com", serverURL, false},
+
+		// Misconfigured serverURL (no host) is treated as untrusted base.
+		{"server url empty", "https://helix.example.com/", "", false},
+		{"server url no host", "/path", "not-a-url", true}, // relative still OK
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSameOriginRedirect(tt.candidate, tt.serverURL)
+			if got != tt.want {
+				t.Errorf("isSameOriginRedirect(%q, %q) = %v, want %v",
+					tt.candidate, tt.serverURL, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`POST /api/v1/auth/logout` is registered on `insecureRouter` (no authentication required) and is in `csrfExemptPaths`. The handler reads `redirect_uri` from the query string and passes it directly to `http.Redirect(302)` with no scheme or host validation — an open redirect.

An attacker can craft a URL like:
```
https://helix.example.com/api/v1/auth/logout?redirect_uri=https://evil.com/fake-login
```
and send it to a victim. The victim's browser hits the trusted Helix origin, Helix clears their session cookies (logging them out), and redirects them to `evil.com`. Because the 302 originates from the trusted Helix origin, the victim sees the Helix domain in their browser history, email link preview, and referrer chain before landing on the attacker-controlled page — prime conditions for a credential-theft phishing attack.

**Additional impact:**
- OIDC mode: the attacker-controlled URI is forwarded to the IdP as `post_logout_redirect_uri`, so the IdP will redirect back to `evil.com` if the registered redirect-URI allowlist is permissive (common in self-hosted Keycloak/Authentik deployments).
- `?get_url=true`: the same unvalidated URL is returned as JSON (`{"url": "https://evil.com/fake-login"}`), making any Helix UI widget that follows this response a phishing-link distribution point.

## Fix

Added `isSameOriginRedirect()` helper function in `api/pkg/server/auth.go`. The function:

1. Accepts empty strings (returns the safe default `s.Cfg.WebServer.URL` already)
2. Accepts relative paths (no scheme, no host) — preserves the legitimate `redirect_uri=/dashboard` frontend pattern
3. Accepts absolute URLs whose scheme+host exactly match `s.Cfg.WebServer.URL`
4. Rejects everything else (cross-origin absolute URLs, protocol-relative `//evil.com` forms, `javascript:` URIs)

The `postLogoutRedirect` variable is set to `s.Cfg.WebServer.URL` (the safe fallback) whenever `isSameOriginRedirect` returns false, before it reaches any of the three `http.Redirect` sinks or the `get_url=true` JSON response path.

## Test Plan

- [ ] `go test ./api/pkg/server/...` — existing test suite passes
- [ ] Manual: `POST /api/v1/auth/logout?redirect_uri=https://evil.com` → `302 Location: <WebServer.URL>` (cross-origin rejected)
- [ ] Manual: `POST /api/v1/auth/logout?redirect_uri=/welcome` → `302 Location: /welcome` (relative path accepted)
- [ ] Manual: `POST /api/v1/auth/logout?redirect_uri=https://helix.example.com/welcome` → `302 Location: https://helix.example.com/welcome` (same origin accepted)
- [ ] Manual: `POST /api/v1/auth/logout?redirect_uri=https://evil.com&get_url=true` → `{"url":"<WebServer.URL>"}` (cross-origin rejected in JSON path too)
- [ ] Server log: rejected values emit warning `"Cross-origin logout redirect rejected; falling back to configured WebServer.URL"` with the rejected URI for auditability

## Security Note

**Severity:** Medium (CVSS 6.1 — AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N)

No authentication required to trigger the redirect. The primary risk is phishing attacks leveraging the trusted Helix domain as a redirect intermediary. CWE-601.

**For operators with cross-origin post-logout redirect requirements:** the current fix restricts to same-origin redirects, which covers the standard use case (return user to the Helix UI after logout). If your deployment needs to redirect to a different domain after logout (e.g., a corporate SSO portal), a follow-up can add `Auth.AllowedPostLogoutRedirects []string` to the config struct as an explicit allowlist.