### PR TITLE
fix(sandbox): default GPU_VENDOR not GPU_TYPE in Dockerfile.sandbox

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -270,7 +270,7 @@ RUN chmod +x /opt/gow/startup-app.sh
 ENV HELIX_API_URL="" \
     SANDBOX_INSTANCE_ID="" \
     RUNNER_TOKEN="" \
-    GPU_TYPE="nvidia" \
+    GPU_VENDOR="nvidia" \
     MAX_SANDBOXES="10" \
     HELIX_DEV_MODE="false" \
     ZED_IMAGE="helix-sway:latest" \


### PR DESCRIPTION
## Summary

- `Dockerfile.sandbox` defaulted `GPU_TYPE=nvidia` but nothing in the repo reads `GPU_TYPE`.
- `sandbox/04-start-dockerd.sh:45` and every deployment path (`docker-compose.dev.yaml`, helm charts, `install.sh` via `GPU_ENV_FLAGS`, `for-mac/` scripts) read `GPU_VENDOR`.
- Production deployments always pass `GPU_VENDOR=...` explicitly, so behaviour is unchanged for them.
- Direct `docker run` invocations of the sandbox image (e.g. running the Runner on a bare host or under YellowDog) silently fell through to "no GPU" because the only default ENV was dead. They had to pass `-e GPU_VENDOR=nvidia` as a workaround.

This renames the default ENV so it matches what the consumer script actually reads.

## Test plan

- [ ] Sandbox image still builds (CI)
- [ ] `docker-compose.dev.yaml up sandbox-nvidia` still configures the NVIDIA container runtime (env var is set explicitly there, so behaviour identical)
- [ ] `docker run --gpus all --privileged helix-sandbox:<tag>` without setting any env now picks up NVIDIA runtime via the new default