### PR TITLE
feat(billing): default initial wallet balance to 0, lead onboarding with BYO Claude

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -347,7 +347,7 @@ type Stripe struct {
 	RequireActiveSubscription bool `envconfig:"STRIPE_BILLING_REQUIRE_ACTIVE_SUBSCRIPTION" default:"false" description:"Whether require an active subscription before allowing to use the product"` //
 
 	MinimumInferenceBalance float64 `envconfig:"STRIPE_MINIMUM_INFERENCE_BALANCE" default:"0.01" description:"Minimum balance required for an inference call."`
-	InitialBalance          float64 `envconfig:"STRIPE_INITIAL_BALANCE" default:"10" description:"The initial balance for the wallet"`
+	InitialBalance          float64 `envconfig:"STRIPE_INITIAL_BALANCE" default:"0" description:"The initial balance seeded into a newly created wallet. Defaults to 0 so new signups arrive with an empty wallet; on-prem deployments that want to hand out free trial credits can set this to a positive value."`
 
 	AppURL               string
 	SecretKey            string `envconfig:"STRIPE_SECRET_KEY" description:"The secret key for stripe."`

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -1447,22 +1447,51 @@ export default function Onboarding() {
                     <AnthropicLogo style={{ width: 24, height: 24 }} />
                   </Box>
                   <Box sx={{ flex: 1, minWidth: 0 }}>
-                    <Typography
+                    <Box
                       sx={{
-                        color: palette.TEXT_PRIMARY,
-                        fontWeight: 500,
-                        fontSize: "0.78rem",
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 0.75,
                       }}
                     >
-                      Claude Subscription
-                    </Typography>
+                      <Typography
+                        sx={{
+                          color: palette.TEXT_PRIMARY,
+                          fontWeight: 500,
+                          fontSize: "0.78rem",
+                        }}
+                      >
+                        Claude Subscription
+                      </Typography>
+                      {!hasClaudeSubscription && (
+                        <Box
+                          component="span"
+                          sx={{
+                            display: "inline-flex",
+                            alignItems: "center",
+                            fontSize: "0.62rem",
+                            fontWeight: 600,
+                            letterSpacing: "0.04em",
+                            textTransform: "uppercase",
+                            color: ACCENT,
+                            bgcolor: ACCENT_DIM,
+                            border: `1px solid ${ACCENT}`,
+                            borderRadius: 999,
+                            px: 0.75,
+                            py: 0.1,
+                          }}
+                        >
+                          Recommended
+                        </Box>
+                      )}
+                    </Box>
                     <Typography
                       sx={{
                         color: palette.TEXT_FADED,
                         fontSize: "0.7rem",
                       }}
                     >
-                      Use your Claude account with Claude Code in desktop agents
+                      Connect your Claude Pro or Max account to use Helix with your existing subscription, no Helix credits needed.
                     </Typography>
                   </Box>
                   {createdOrg && (

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -1491,7 +1491,9 @@ export default function Onboarding() {
                         fontSize: "0.7rem",
                       }}
                     >
-                      Connect your Claude Pro or Max account to use Helix with your existing subscription, no Helix credits needed.
+                      {serverConfig?.billing_enabled
+                        ? "Connect your Claude Pro or Max account to use Helix with your existing subscription, no Helix credits needed."
+                        : "Connect your Claude Pro or Max account to use Helix with your existing Claude subscription."}
                     </Typography>
                   </Box>
                   {createdOrg && (

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -367,11 +367,23 @@ export default function Onboarding() {
     if (!serverConfig?.billing_enabled) {
       steps = steps.filter((step) => step.type !== "subscription");
     }
-    if (serverConfig?.has_providers) {
+    // Skip the provider step when admin-configured global providers already
+    // cover the user's needs (typical on self-hosted). On cloud we keep it
+    // visible regardless so new signups still see the BYO Claude prompt at
+    // the top of the step, even though SaaS has env-baked Anthropic/OpenAI
+    // keys that would otherwise satisfy has_providers.
+    if (
+      serverConfig?.has_providers &&
+      serverConfig?.edition !== "cloud"
+    ) {
       steps = steps.filter((step) => step.type !== "provider");
     }
     return steps;
-  }, [serverConfig?.billing_enabled, serverConfig?.has_providers]);
+  }, [
+    serverConfig?.billing_enabled,
+    serverConfig?.has_providers,
+    serverConfig?.edition,
+  ]);
 
   // Helper to get step index by type (in the visible steps array)
   const getStepIndexByType = useCallback(
@@ -1491,7 +1503,7 @@ export default function Onboarding() {
                         fontSize: "0.7rem",
                       }}
                     >
-                      {serverConfig?.billing_enabled
+                      {serverConfig?.edition === "cloud"
                         ? "Connect your Claude Pro or Max account to use Helix with your existing subscription, no Helix credits needed."
                         : "Connect your Claude Pro or Max account to use Helix with your existing Claude subscription."}
                     </Typography>


### PR DESCRIPTION
## Summary

Two coupled changes targeting new-signup behaviour on SaaS.

**Backend (code alignment, not a behaviour change on SaaS)**: `STRIPE_INITIAL_BALANCE` in-code default flips from `10` to `0`. SaaS (`app.helix.ml`) has had `STRIPE_INITIAL_BALANCE=0` set in `.env` for some time, so live SaaS behaviour was already `$0` for new signups. The code default at `10` was dead in production. This PR aligns the in-code default with operational reality so:
- Fresh deployments don't accidentally hand out `$10` of free credits.
- Anyone reading `api/pkg/config/config.go` sees the right answer.
- Self-hosted deployments that want the old `$10` trial credit need to pin `STRIPE_INITIAL_BALANCE=10` in their `.env`. Documented inline on the config field.

No DB migration; existing wallets unaffected.

**Frontend (the real user-visible improvement on SaaS)**: the BYO Claude Subscription card was being stripped out of onboarding entirely on cloud because SaaS reports `has_providers=true` (env-baked Anthropic/OpenAI keys), and the previous filter at `Onboarding.tsx:370` hid the whole provider step in that case. New signups never saw the Claude OAuth option in flow.

This PR:
- Skips the provider step only when `has_providers && edition !== "cloud"` (the original "self-hosted with admin-configured globals" convenience). On cloud, the step stays visible regardless.
- Rewrites the Claude Subscription card subtitle to lead with the cost benefit, with a cloud variant ("Connect your Claude Pro or Max account to use Helix with your existing subscription, no Helix credits needed.") and a universal fallback for non-cloud deployments where credits aren't a concept.
- Adds a small "Recommended" pill next to the card title when no Claude subscription is connected, signalling the BYO path as the lead.

Continue button logic at `Onboarding.tsx:351-354` already treats Claude OAuth as a valid provider so the gate behaviour is unchanged.

## Files

- `api/pkg/config/config.go:350` — default flip + description rewrite.
- `frontend/src/pages/Onboarding.tsx` — filter fix (uses `serverConfig?.edition`), card subtitle conditional, Recommended pill.

## Rollback

Set `STRIPE_INITIAL_BALANCE=10` in `.env` and `./stack rebuild api` to revert the backend default for new signups. Frontend changes can be reverted by reverting this PR; no state to clean up.

## Follow-up (separate PR)

Admin user-panel today bundles subscription + credits into one action (`adminActivateTrial`, refuses orgs with an active subscription). Unbundling that into a credits-only admin action is in #2488.