### PR TITLE
feat(admin): grant credits independent of subscription state

### DIFF
--- a/api/pkg/server/admin_credit_handlers.go
+++ b/api/pkg/server/admin_credit_handlers.go
@@ -1,0 +1,181 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/rs/zerolog/log"
+)
+
+// GrantCreditsRequest is the body for POST /admin/users/{id}/credits.
+type GrantCreditsRequest struct {
+	Credits float64 `json:"credits"`
+}
+
+// GrantCreditsResponse describes the outcome of an admin credit grant.
+//
+// Status values:
+//   - "stashed": user has no orgs yet; credits parked on the user and applied
+//     when they create their first org via consumeUserAdminCredits.
+//   - "applied": wallet on the user's oldest owned org was topped up right now,
+//     independent of any active or absent Stripe subscription.
+type GrantCreditsResponse struct {
+	User   *types.User `json:"user"`
+	OrgID  string      `json:"org_id,omitempty"`
+	Status string      `json:"status"`
+}
+
+// consumeUserAdminCredits applies any admin-stashed credit grant on the user
+// to the given org's wallet. Called after an org (and its owning membership)
+// has been created. Best-effort: errors are logged but do not fail the caller,
+// so a Stripe outage doesn't block org creation.
+//
+// On success: wallet balance is topped up by the stashed credits, the user's
+// PendingAdminCreditsOnFirstOrg field is cleared so subsequent orgs don't
+// trigger again.
+func (s *HelixAPIServer) consumeUserAdminCredits(ctx context.Context, user *types.User, orgID string) {
+	if user == nil || user.PendingAdminCreditsOnFirstOrg == nil || *user.PendingAdminCreditsOnFirstOrg <= 0 {
+		return
+	}
+	if !s.Cfg.Stripe.BillingEnabled {
+		log.Warn().
+			Str("user_id", user.ID).
+			Str("org_id", orgID).
+			Msg("user has stashed admin credit grant but billing is disabled; skipping")
+		return
+	}
+
+	credits := *user.PendingAdminCreditsOnFirstOrg
+
+	wallet, err := s.getOrCreateWallet(ctx, user, orgID)
+	if err != nil {
+		log.Warn().Err(err).
+			Str("user_id", user.ID).
+			Str("org_id", orgID).
+			Msg("failed to get/create wallet for admin credit consumption")
+		return
+	}
+
+	if _, err := s.Store.UpdateWalletBalance(ctx, wallet.ID, credits, types.TransactionMetadata{
+		TransactionType: types.TransactionTypeAdminGrant,
+	}); err != nil {
+		log.Warn().Err(err).
+			Str("wallet_id", wallet.ID).
+			Float64("credits", credits).
+			Msg("failed to apply stashed admin credit grant to wallet")
+		return
+	}
+
+	user.PendingAdminCreditsOnFirstOrg = nil
+	if _, err := s.Store.UpdateUser(ctx, user); err != nil {
+		log.Warn().Err(err).
+			Str("user_id", user.ID).
+			Msg("failed to clear PendingAdminCreditsOnFirstOrg after consumption")
+		return
+	}
+
+	log.Info().
+		Str("user_id", user.ID).
+		Str("org_id", orgID).
+		Str("wallet_id", wallet.ID).
+		Float64("credits", credits).
+		Msg("admin-stashed credit grant applied to wallet")
+}
+
+// adminGrantCredits godoc
+// @Summary Grant credits to a user (Admin, cloud only)
+// @Description Adds credits to the wallet of the user's oldest owned org, or stashes the grant on the user for application at first org creation. Works regardless of subscription state, unlike adminActivateTrial.
+// @Tags    users
+// @Accept  json
+// @Produce json
+// @Param id path string true "User ID"
+// @Param request body GrantCreditsRequest true "Credits to grant (must be > 0)"
+// @Success 200 {object} GrantCreditsResponse
+// @Router /api/v1/admin/users/{id}/credits [post]
+// @Security BearerAuth
+func (apiServer *HelixAPIServer) adminGrantCredits(_ http.ResponseWriter, req *http.Request) (*GrantCreditsResponse, error) {
+	ctx := req.Context()
+	adminUser := getRequestUser(req)
+	if !adminUser.Admin {
+		return nil, system.NewHTTPError403("only admins can grant credits")
+	}
+	if apiServer.Cfg.Edition != "cloud" {
+		return nil, system.NewHTTPError400("admin credit grants are only available on the cloud edition")
+	}
+	if !apiServer.Cfg.Stripe.BillingEnabled {
+		return nil, system.NewHTTPError400("Stripe billing must be enabled")
+	}
+
+	targetUserID := mux.Vars(req)["id"]
+	if targetUserID == "" {
+		return nil, system.NewHTTPError400("user ID is required")
+	}
+
+	body := GrantCreditsRequest{}
+	if req.Body == nil || req.ContentLength == 0 {
+		return nil, system.NewHTTPError400("request body is required")
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		return nil, system.NewHTTPError400("invalid request body: " + err.Error())
+	}
+	if body.Credits <= 0 {
+		return nil, system.NewHTTPError400("credits must be greater than 0")
+	}
+
+	targetUser, err := apiServer.Store.GetUser(ctx, &store.GetUserQuery{ID: targetUserID})
+	if err != nil {
+		return nil, system.NewHTTPError404("user not found")
+	}
+
+	oldestOrg, err := oldestOwnedOrg(ctx, apiServer.Store, targetUserID)
+	if err != nil {
+		return nil, system.NewHTTPError500("failed to list user organizations: " + err.Error())
+	}
+
+	// Path A: no owned org yet — stash on user, consumeUserAdminCredits applies
+	// it when the user creates their first org.
+	if oldestOrg == nil {
+		credits := body.Credits
+		targetUser.PendingAdminCreditsOnFirstOrg = &credits
+		updated, err := apiServer.Store.UpdateUser(ctx, targetUser)
+		if err != nil {
+			return nil, system.NewHTTPError500("failed to stash admin credit grant: " + err.Error())
+		}
+		log.Info().
+			Str("admin_id", adminUser.ID).
+			Str("target_user_id", targetUserID).
+			Float64("credits", credits).
+			Msg("admin stashed credit grant on user (no org yet)")
+		return &GrantCreditsResponse{User: updated, Status: "stashed"}, nil
+	}
+
+	// Path B: user already owns an org — apply directly, regardless of any
+	// active or absent Stripe subscription.
+	wallet, err := apiServer.getOrCreateWallet(ctx, targetUser, oldestOrg.ID)
+	if err != nil {
+		return nil, system.NewHTTPError500("failed to get wallet for oldest owned org: " + err.Error())
+	}
+
+	if _, err := apiServer.Store.UpdateWalletBalance(ctx, wallet.ID, body.Credits, types.TransactionMetadata{
+		TransactionType: types.TransactionTypeAdminGrant,
+	}); err != nil {
+		return nil, system.NewHTTPError500(fmt.Sprintf("failed to update wallet balance: %s", err))
+	}
+
+	log.Info().
+		Str("admin_id", adminUser.ID).
+		Str("target_user_id", targetUserID).
+		Str("org_id", oldestOrg.ID).
+		Str("wallet_id", wallet.ID).
+		Float64("credits", body.Credits).
+		Msg("admin granted credits to org wallet")
+
+	return &GrantCreditsResponse{User: targetUser, OrgID: oldestOrg.ID, Status: "applied"}, nil
+}

--- a/api/pkg/server/admin_credit_handlers_test.go
+++ b/api/pkg/server/admin_credit_handlers_test.go
@@ -1,0 +1,258 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// cloudBillingCfg returns the minimal config that lets the credit-grant
+// handler past its edition/billing gates.
+func cloudBillingCfg() *config.ServerConfig {
+	cfg := &config.ServerConfig{}
+	cfg.Edition = "cloud"
+	cfg.Stripe.BillingEnabled = true
+	return cfg
+}
+
+func TestAdminGrantCredits_Gates(t *testing.T) {
+	tests := []struct {
+		name           string
+		adminUser      *types.User
+		cfg            *config.ServerConfig
+		body           interface{}
+		expectedStatus int
+		expectedError  string
+	}{
+		{
+			name:           "non-admin is rejected",
+			adminUser:      &types.User{ID: "u-1", Admin: false},
+			cfg:            cloudBillingCfg(),
+			body:           GrantCreditsRequest{Credits: 50},
+			expectedStatus: http.StatusForbidden,
+			expectedError:  "only admins",
+		},
+		{
+			name: "non-cloud edition is rejected",
+			adminUser: &types.User{ID: "admin-1", Admin: true},
+			cfg: func() *config.ServerConfig {
+				c := cloudBillingCfg()
+				c.Edition = "server"
+				return c
+			}(),
+			body:           GrantCreditsRequest{Credits: 50},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "cloud edition",
+		},
+		{
+			name: "billing disabled is rejected",
+			adminUser: &types.User{ID: "admin-1", Admin: true},
+			cfg: func() *config.ServerConfig {
+				c := cloudBillingCfg()
+				c.Stripe.BillingEnabled = false
+				return c
+			}(),
+			body:           GrantCreditsRequest{Credits: 50},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "Stripe billing must be enabled",
+		},
+		{
+			name:           "zero credits is rejected",
+			adminUser:      &types.User{ID: "admin-1", Admin: true},
+			cfg:            cloudBillingCfg(),
+			body:           GrantCreditsRequest{Credits: 0},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "greater than 0",
+		},
+		{
+			name:           "negative credits is rejected",
+			adminUser:      &types.User{ID: "admin-1", Admin: true},
+			cfg:            cloudBillingCfg(),
+			body:           GrantCreditsRequest{Credits: -10},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "greater than 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockStore := store.NewMockStore(ctrl)
+
+			server := &HelixAPIServer{Store: mockStore, Cfg: tt.cfg}
+
+			body, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/u-2/credits", bytes.NewReader(body))
+			req = mux.SetURLVars(req, map[string]string{"id": "u-2"})
+			req = req.WithContext(setTestRequestUser(req.Context(), tt.adminUser))
+
+			rr := httptest.NewRecorder()
+			_, httpErr := server.adminGrantCredits(rr, req)
+
+			require.NotNil(t, httpErr)
+			assert.Contains(t, httpErr.Error(), tt.expectedError)
+			he, ok := httpErr.(*system.HTTPError)
+			require.True(t, ok, "expected *system.HTTPError, got %T", httpErr)
+			assert.Equal(t, tt.expectedStatus, he.StatusCode)
+		})
+	}
+}
+
+func TestAdminGrantCredits_NoOrg_StashesOnUser(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+
+	adminUser := &types.User{ID: "admin-1", Admin: true}
+	targetUser := &types.User{ID: "target-1", Email: "t@example.com"}
+
+	mockStore.EXPECT().
+		GetUser(gomock.Any(), &store.GetUserQuery{ID: "target-1"}).
+		Return(targetUser, nil)
+	// No owned orgs.
+	mockStore.EXPECT().
+		ListOrganizations(gomock.Any(), gomock.Any()).
+		Return([]*types.Organization{}, nil)
+	// Stash on user.
+	mockStore.EXPECT().
+		UpdateUser(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ interface{}, u *types.User) (*types.User, error) {
+			require.NotNil(t, u.PendingAdminCreditsOnFirstOrg)
+			assert.InDelta(t, 75.0, *u.PendingAdminCreditsOnFirstOrg, 0.0001)
+			return u, nil
+		})
+
+	server := &HelixAPIServer{Store: mockStore, Cfg: cloudBillingCfg()}
+	body, _ := json.Marshal(GrantCreditsRequest{Credits: 75})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/target-1/credits", bytes.NewReader(body))
+	req = mux.SetURLVars(req, map[string]string{"id": "target-1"})
+	req = req.WithContext(setTestRequestUser(req.Context(), adminUser))
+
+	rr := httptest.NewRecorder()
+	resp, httpErr := server.adminGrantCredits(rr, req)
+
+	require.Nil(t, httpErr)
+	require.NotNil(t, resp)
+	assert.Equal(t, "stashed", resp.Status)
+	assert.Empty(t, resp.OrgID)
+}
+
+func TestAdminGrantCredits_HasOrgWithWallet_TopsUp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+
+	adminUser := &types.User{ID: "admin-1", Admin: true}
+	targetUser := &types.User{ID: "target-1", Email: "t@example.com"}
+	org := &types.Organization{ID: "org-1", Owner: "target-1"}
+	wallet := &types.Wallet{ID: "wal-1", OrgID: "org-1", Balance: 0}
+
+	mockStore.EXPECT().
+		GetUser(gomock.Any(), &store.GetUserQuery{ID: "target-1"}).
+		Return(targetUser, nil)
+	mockStore.EXPECT().
+		ListOrganizations(gomock.Any(), gomock.Any()).
+		Return([]*types.Organization{org}, nil)
+	mockStore.EXPECT().
+		GetOrganization(gomock.Any(), &store.GetOrganizationQuery{ID: "org-1"}).
+		Return(org, nil)
+	mockStore.EXPECT().
+		GetWalletByOrg(gomock.Any(), "org-1").
+		Return(wallet, nil)
+	mockStore.EXPECT().
+		UpdateWalletBalance(gomock.Any(), "wal-1", 50.0, gomock.Any()).
+		DoAndReturn(func(_ interface{}, _ string, amount float64, meta types.TransactionMetadata) (*types.Wallet, error) {
+			assert.Equal(t, types.TransactionTypeAdminGrant, meta.TransactionType)
+			return wallet, nil
+		})
+
+	server := &HelixAPIServer{Store: mockStore, Cfg: cloudBillingCfg()}
+	body, _ := json.Marshal(GrantCreditsRequest{Credits: 50})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/target-1/credits", bytes.NewReader(body))
+	req = mux.SetURLVars(req, map[string]string{"id": "target-1"})
+	req = req.WithContext(setTestRequestUser(req.Context(), adminUser))
+
+	rr := httptest.NewRecorder()
+	resp, httpErr := server.adminGrantCredits(rr, req)
+
+	require.Nil(t, httpErr)
+	require.NotNil(t, resp)
+	assert.Equal(t, "applied", resp.Status)
+	assert.Equal(t, "org-1", resp.OrgID)
+}
+
+// Verifies the "subscription state is irrelevant" promise: a wallet with an
+// active Stripe subscription still accepts the top-up. This is the case that
+// adminActivateTrial used to refuse with "already has an active subscription".
+func TestAdminGrantCredits_HasOrgWithActiveSubscription_StillTopsUp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+
+	adminUser := &types.User{ID: "admin-1", Admin: true}
+	targetUser := &types.User{ID: "target-1", Email: "t@example.com"}
+	org := &types.Organization{ID: "org-1", Owner: "target-1"}
+	wallet := &types.Wallet{
+		ID:                   "wal-1",
+		OrgID:                "org-1",
+		Balance:              0,
+		StripeSubscriptionID: "sub_123",
+		SubscriptionStatus:   "active",
+	}
+
+	mockStore.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "target-1"}).Return(targetUser, nil)
+	mockStore.EXPECT().ListOrganizations(gomock.Any(), gomock.Any()).Return([]*types.Organization{org}, nil)
+	mockStore.EXPECT().GetOrganization(gomock.Any(), &store.GetOrganizationQuery{ID: "org-1"}).Return(org, nil)
+	mockStore.EXPECT().GetWalletByOrg(gomock.Any(), "org-1").Return(wallet, nil)
+	mockStore.EXPECT().UpdateWalletBalance(gomock.Any(), "wal-1", 25.0, gomock.Any()).Return(wallet, nil)
+
+	server := &HelixAPIServer{Store: mockStore, Cfg: cloudBillingCfg()}
+	body, _ := json.Marshal(GrantCreditsRequest{Credits: 25})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/target-1/credits", bytes.NewReader(body))
+	req = mux.SetURLVars(req, map[string]string{"id": "target-1"})
+	req = req.WithContext(setTestRequestUser(req.Context(), adminUser))
+
+	rr := httptest.NewRecorder()
+	resp, httpErr := server.adminGrantCredits(rr, req)
+
+	require.Nil(t, httpErr)
+	assert.Equal(t, "applied", resp.Status)
+}
+
+func TestAdminGrantCredits_UserNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+
+	mockStore.EXPECT().
+		GetUser(gomock.Any(), &store.GetUserQuery{ID: "ghost"}).
+		Return(nil, errors.New("not found"))
+
+	server := &HelixAPIServer{Store: mockStore, Cfg: cloudBillingCfg()}
+	body, _ := json.Marshal(GrantCreditsRequest{Credits: 10})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/ghost/credits", bytes.NewReader(body))
+	req = mux.SetURLVars(req, map[string]string{"id": "ghost"})
+	req = req.WithContext(setTestRequestUser(req.Context(), &types.User{ID: "admin-1", Admin: true}))
+
+	rr := httptest.NewRecorder()
+	_, httpErr := server.adminGrantCredits(rr, req)
+
+	require.NotNil(t, httpErr)
+	he, ok := httpErr.(*system.HTTPError)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusNotFound, he.StatusCode)
+}

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -850,6 +850,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/admin/users/{id}/credits": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Adds credits to the wallet of the user's oldest owned org, or stashes the grant on the user for application at first org creation. Works regardless of subscription state, unlike adminActivateTrial.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Grant credits to a user (Admin, cloud only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Credits to grant (must be \u003e 0)",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.GrantCreditsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.GrantCreditsResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/users/{id}/password": {
             "put": {
                 "security": [
@@ -20174,6 +20220,28 @@ const docTemplate = `{
                 }
             }
         },
+        "server.GrantCreditsRequest": {
+            "type": "object",
+            "properties": {
+                "credits": {
+                    "type": "number"
+                }
+            }
+        },
+        "server.GrantCreditsResponse": {
+            "type": "object",
+            "properties": {
+                "org_id": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "user": {
+                    "$ref": "#/definitions/types.User"
+                }
+            }
+        },
         "server.InitializeSampleRepositoriesRequest": {
             "type": "object",
             "properties": {
@@ -33106,6 +33174,10 @@ const docTemplate = `{
                 "organization_id": {
                     "description": "Organization this API key is scoped to (ephemeral keys)",
                     "type": "string"
+                },
+                "pending_admin_credits_on_first_org": {
+                    "description": "PendingAdminCreditsOnFirstOrg holds credits stashed by admin via the\n/admin/users/{id}/credits endpoint when the user has no owned org yet.\nConsumed by consumeUserAdminCredits on first owned org, then cleared.\nKept separate from TrialCreditsOnFirstOrg so admins can comp credits\nwithout entangling the grant with trial-state UI or revocation flows.",
+                    "type": "number"
                 },
                 "project_id": {
                     "description": "When running in Helix Code sandbox",

--- a/api/pkg/server/organization_handlers.go
+++ b/api/pkg/server/organization_handlers.go
@@ -333,6 +333,11 @@ func (apiServer *HelixAPIServer) createOrganization(rw http.ResponseWriter, r *h
 	// first owned org. Best-effort: logs errors but does not block.
 	apiServer.consumeUserTrialIntent(ctx, user, createdOrg.ID)
 
+	// Same for plain admin credit grants (PendingAdminCreditsOnFirstOrg), which
+	// are tracked separately from trial intent so an admin can comp credits
+	// without entangling them with trial-state UI or revocation flows.
+	apiServer.consumeUserAdminCredits(ctx, user, createdOrg.ID)
+
 	writeResponse(rw, createdOrg, http.StatusCreated)
 }
 

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1164,6 +1164,7 @@ func (apiServer *HelixAPIServer) registerRoutes(_ context.Context) (*mux.Router,
 	adminRouter.HandleFunc("/admin/users/{id}/approve", system.DefaultWrapper(apiServer.adminApproveUser)).Methods(http.MethodPost)
 	adminRouter.HandleFunc("/admin/users/{id}/trial-activate", system.DefaultWrapper(apiServer.adminActivateTrial)).Methods(http.MethodPost)
 	adminRouter.HandleFunc("/admin/users/{id}/trial-activate", system.DefaultWrapper(apiServer.adminRevokeTrial)).Methods(http.MethodDelete)
+	adminRouter.HandleFunc("/admin/users/{id}/credits", system.DefaultWrapper(apiServer.adminGrantCredits)).Methods(http.MethodPost)
 
 	adminRouter.HandleFunc("/admin/orgs", apiServer.adminListOrganizations).Methods(http.MethodGet)
 

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -846,6 +846,52 @@
                 }
             }
         },
+        "/api/v1/admin/users/{id}/credits": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Adds credits to the wallet of the user's oldest owned org, or stashes the grant on the user for application at first org creation. Works regardless of subscription state, unlike adminActivateTrial.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Grant credits to a user (Admin, cloud only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Credits to grant (must be \u003e 0)",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.GrantCreditsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.GrantCreditsResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/users/{id}/password": {
             "put": {
                 "security": [
@@ -20170,6 +20216,28 @@
                 }
             }
         },
+        "server.GrantCreditsRequest": {
+            "type": "object",
+            "properties": {
+                "credits": {
+                    "type": "number"
+                }
+            }
+        },
+        "server.GrantCreditsResponse": {
+            "type": "object",
+            "properties": {
+                "org_id": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "user": {
+                    "$ref": "#/definitions/types.User"
+                }
+            }
+        },
         "server.InitializeSampleRepositoriesRequest": {
             "type": "object",
             "properties": {
@@ -33102,6 +33170,10 @@
                 "organization_id": {
                     "description": "Organization this API key is scoped to (ephemeral keys)",
                     "type": "string"
+                },
+                "pending_admin_credits_on_first_org": {
+                    "description": "PendingAdminCreditsOnFirstOrg holds credits stashed by admin via the\n/admin/users/{id}/credits endpoint when the user has no owned org yet.\nConsumed by consumeUserAdminCredits on first owned org, then cleared.\nKept separate from TrialCreditsOnFirstOrg so admins can comp credits\nwithout entangling the grant with trial-state UI or revocation flows.",
+                    "type": "number"
                 },
                 "project_id": {
                     "description": "When running in Helix Code sandbox",

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -1145,6 +1145,20 @@ definitions:
       url:
         type: string
     type: object
+  server.GrantCreditsRequest:
+    properties:
+      credits:
+        type: number
+    type: object
+  server.GrantCreditsResponse:
+    properties:
+      org_id:
+        type: string
+      status:
+        type: string
+      user:
+        $ref: '#/definitions/types.User'
+    type: object
   server.InitializeSampleRepositoriesRequest:
     properties:
       organization_id:
@@ -10394,6 +10408,14 @@ definitions:
       organization_id:
         description: Organization this API key is scoped to (ephemeral keys)
         type: string
+      pending_admin_credits_on_first_org:
+        description: |-
+          PendingAdminCreditsOnFirstOrg holds credits stashed by admin via the
+          /admin/users/{id}/credits endpoint when the user has no owned org yet.
+          Consumed by consumeUserAdminCredits on first owned org, then cleared.
+          Kept separate from TrialCreditsOnFirstOrg so admins can comp credits
+          without entangling the grant with trial-state UI or revocation flows.
+        type: number
       project_id:
         description: When running in Helix Code sandbox
         type: string
@@ -11313,6 +11335,37 @@ paths:
       security:
       - BearerAuth: []
       summary: Approve a user (Admin only)
+      tags:
+      - users
+  /api/v1/admin/users/{id}/credits:
+    post:
+      consumes:
+      - application/json
+      description: Adds credits to the wallet of the user's oldest owned org, or stashes
+        the grant on the user for application at first org creation. Works regardless
+        of subscription state, unlike adminActivateTrial.
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Credits to grant (must be > 0)
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/server.GrantCreditsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.GrantCreditsResponse'
+      security:
+      - BearerAuth: []
+      summary: Grant credits to a user (Admin, cloud only)
       tags:
       - users
   /api/v1/admin/users/{id}/password:

--- a/api/pkg/types/authz.go
+++ b/api/pkg/types/authz.go
@@ -178,6 +178,13 @@ type User struct {
 	TrialDaysOnFirstOrg    *int     `json:"trial_days_on_first_org,omitempty"`
 	TrialCreditsOnFirstOrg *float64 `json:"trial_credits_on_first_org,omitempty"`
 
+	// PendingAdminCreditsOnFirstOrg holds credits stashed by admin via the
+	// /admin/users/{id}/credits endpoint when the user has no owned org yet.
+	// Consumed by consumeUserAdminCredits on first owned org, then cleared.
+	// Kept separate from TrialCreditsOnFirstOrg so admins can comp credits
+	// without entangling the grant with trial-state UI or revocation flows.
+	PendingAdminCreditsOnFirstOrg *float64 `json:"pending_admin_credits_on_first_org,omitempty"`
+
 	// Transient trial-display fields populated by the admin users list when
 	// ?include=trial is set. Not persisted (gorm:"-") and not emitted unless
 	// explicitly populated (json:"...,omitempty").

--- a/api/pkg/types/wallet.go
+++ b/api/pkg/types/wallet.go
@@ -55,6 +55,10 @@ const (
 	TransactionTypeUsage        TransactionType = "usage"
 	TransactionTypeTopUp        TransactionType = "top_up"
 	TransactionTypeSubscription TransactionType = "subscription"
+	// TransactionTypeAdminGrant marks a balance change written by an admin
+	// outside of any Stripe flow (e.g. comping a customer with credits when
+	// they already have an active subscription). Carries no Stripe ids.
+	TransactionTypeAdminGrant TransactionType = "admin_grant"
 )
 
 // Transaction is a record of a transaction on a wallet.

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -740,6 +740,16 @@ export interface ServerExposedPort {
   url?: string;
 }
 
+export interface ServerGrantCreditsRequest {
+  credits?: number;
+}
+
+export interface ServerGrantCreditsResponse {
+  org_id?: string;
+  status?: string;
+  user?: TypesUser;
+}
+
 export interface ServerInitializeSampleRepositoriesRequest {
   organization_id?: string;
   owner_id?: string;
@@ -6348,6 +6358,14 @@ export interface TypesUser {
   onboarding_completed_at?: string;
   /** Organization this API key is scoped to (ephemeral keys) */
   organization_id?: string;
+  /**
+   * PendingAdminCreditsOnFirstOrg holds credits stashed by admin via the
+   * /admin/users/{id}/credits endpoint when the user has no owned org yet.
+   * Consumed by consumeUserAdminCredits on first owned org, then cleared.
+   * Kept separate from TrialCreditsOnFirstOrg so admins can comp credits
+   * without entangling the grant with trial-state UI or revocation flows.
+   */
+  pending_admin_credits_on_first_org?: number;
   /** When running in Helix Code sandbox */
   project_id?: string;
   sb?: boolean;
@@ -7074,6 +7092,26 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         path: `/api/v1/admin/users/${id}/approve`,
         method: "POST",
         secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Adds credits to the wallet of the user's oldest owned org, or stashes the grant on the user for application at first org creation. Works regardless of subscription state, unlike adminActivateTrial.
+     *
+     * @tags users
+     * @name V1AdminUsersCreditsCreate
+     * @summary Grant credits to a user (Admin, cloud only)
+     * @request POST:/api/v1/admin/users/{id}/credits
+     * @secure
+     */
+    v1AdminUsersCreditsCreate: (id: string, request: ServerGrantCreditsRequest, params: RequestParams = {}) =>
+      this.request<ServerGrantCreditsResponse, any>({
+        path: `/api/v1/admin/users/${id}/credits`,
+        method: "POST",
+        body: request,
+        secure: true,
+        type: ContentType.Json,
         format: "json",
         ...params,
       }),

--- a/frontend/src/components/dashboard/GrantCreditsDialog.tsx
+++ b/frontend/src/components/dashboard/GrantCreditsDialog.tsx
@@ -1,0 +1,133 @@
+import React, { FC, useEffect, useState } from 'react';
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button,
+    TextField,
+    Box,
+    Alert,
+    CircularProgress,
+    IconButton,
+    Typography,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { TypesUser } from '../../api/api';
+import { useAdminGrantCredits } from '../../services/dashboardService';
+import useSnackbar from '../../hooks/useSnackbar';
+
+interface GrantCreditsDialogProps {
+    open: boolean;
+    onClose: () => void;
+    user: TypesUser | null;
+}
+
+const DEFAULT_CREDITS = 50;
+
+const GrantCreditsDialog: FC<GrantCreditsDialogProps> = ({ open, onClose, user }) => {
+    const [credits, setCredits] = useState(String(DEFAULT_CREDITS));
+    const [error, setError] = useState('');
+    const grantCredits = useAdminGrantCredits();
+    const snackbar = useSnackbar();
+
+    useEffect(() => {
+        if (open) {
+            setCredits(String(DEFAULT_CREDITS));
+            setError('');
+        }
+    }, [open]);
+
+    const handleSubmit = async () => {
+        if (!user?.id) return;
+        const creditsNum = parseFloat(credits);
+        if (!Number.isFinite(creditsNum) || creditsNum <= 0) {
+            setError('Credits must be greater than 0');
+            return;
+        }
+        try {
+            const result = await grantCredits.mutateAsync({
+                userId: user.id,
+                credits: creditsNum,
+            });
+            const status = (result as any)?.status as string | undefined;
+            if (status === 'stashed') {
+                snackbar.success(`Credits stashed, applied when ${user.email} creates their first org`);
+            } else {
+                snackbar.success(`$${creditsNum.toFixed(2)} credited to ${user.email}`);
+            }
+            onClose();
+        } catch (err: any) {
+            const msg = err?.response?.data?.error || err?.message || 'Failed to grant credits';
+            setError(msg);
+        }
+    };
+
+    const handleClose = () => {
+        if (!grantCredits.isPending) onClose();
+    };
+
+    return (
+        <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+            <DialogTitle
+                sx={{
+                    m: 0,
+                    p: 2,
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                }}
+            >
+                <Typography variant="h6" component="div">
+                    Grant credits
+                </Typography>
+                <IconButton aria-label="close" onClick={handleClose} disabled={grantCredits.isPending}>
+                    <CloseIcon />
+                </IconButton>
+            </DialogTitle>
+            <DialogContent>
+                <Box sx={{ mt: 2 }}>
+                    {user && (
+                        <Alert severity="info" sx={{ mb: 2 }}>
+                            Granting credits to <strong>{user.email || user.username}</strong>. Top-up lands on the
+                            user's oldest owned org regardless of subscription state. If the user has no organization
+                            yet, the grant is parked on the user and applied when they create their first org.
+                        </Alert>
+                    )}
+
+                    {error && (
+                        <Alert severity="error" sx={{ mb: 2 }}>
+                            {error}
+                        </Alert>
+                    )}
+
+                    <TextField
+                        fullWidth
+                        label="Credits (USD)"
+                        value={credits}
+                        onChange={(e) => setCredits(e.target.value)}
+                        margin="normal"
+                        disabled={grantCredits.isPending}
+                        helperText="Amount credited to the wallet"
+                    />
+                </Box>
+            </DialogContent>
+            <DialogActions sx={{ p: 2 }}>
+                <Button onClick={handleClose} disabled={grantCredits.isPending} variant="outlined">
+                    Cancel
+                </Button>
+                <Button
+                    onClick={handleSubmit}
+                    color="secondary"
+                    variant="contained"
+                    disabled={grantCredits.isPending}
+                    startIcon={grantCredits.isPending ? <CircularProgress size={20} /> : null}
+                >
+                    {grantCredits.isPending ? 'Granting…' : 'Grant credits'}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default GrantCreditsDialog;

--- a/frontend/src/components/dashboard/UsersTable.tsx
+++ b/frontend/src/components/dashboard/UsersTable.tsx
@@ -29,6 +29,7 @@ import LockResetIcon from "@mui/icons-material/LockReset";
 import DeleteIcon from "@mui/icons-material/Delete";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CardGiftcardIcon from "@mui/icons-material/CardGiftcard";
+import AttachMoneyIcon from "@mui/icons-material/AttachMoney";
 import CancelIcon from "@mui/icons-material/Cancel";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { TypesAuthProvider, TypesUser } from "../../api/api";
@@ -45,6 +46,7 @@ import CreateUserDialog from "./CreateUserDialog";
 import ResetPasswordDialog from "./ResetPasswordDialog";
 import DeleteUserDialog from "./DeleteUserDialog";
 import ActivateTrialDialog from "./ActivateTrialDialog";
+import GrantCreditsDialog from "./GrantCreditsDialog";
 
 // Helper function to format date for tooltip
 const formatFullDate = (dateString: string | undefined): string => {
@@ -163,6 +165,7 @@ const UsersTable: FC<UsersTableProps> = ({ onSelectUser }) => {
     const [resetPasswordDialogOpen, setResetPasswordDialogOpen] = useState(false);
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
     const [activateTrialDialogOpen, setActivateTrialDialogOpen] = useState(false);
+    const [grantCreditsDialogOpen, setGrantCreditsDialogOpen] = useState(false);
     const [selectedUser, setSelectedUser] = useState<TypesUser | null>(null);
     const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
     const [menuUser, setMenuUser] = useState<TypesUser | null>(null);
@@ -197,6 +200,12 @@ const UsersTable: FC<UsersTableProps> = ({ onSelectUser }) => {
         setSelectedUser(menuUser);
         closeMenu();
         setActivateTrialDialogOpen(true);
+    };
+
+    const handleGrantCredits = () => {
+        setSelectedUser(menuUser);
+        closeMenu();
+        setGrantCreditsDialogOpen(true);
     };
 
     const handleRevokeTrial = async () => {
@@ -468,6 +477,12 @@ const UsersTable: FC<UsersTableProps> = ({ onSelectUser }) => {
                         <ListItemText>Revoke trial</ListItemText>
                     </MenuItem>
                 )}
+                {isCloud && (
+                    <MenuItem onClick={handleGrantCredits}>
+                        <ListItemIcon><AttachMoneyIcon fontSize="small" /></ListItemIcon>
+                        <ListItemText>Grant credits</ListItemText>
+                    </MenuItem>
+                )}
                 <MenuItem onClick={handleResetPassword}>
                     <ListItemIcon><LockResetIcon fontSize="small" /></ListItemIcon>
                     <ListItemText>Reset password</ListItemText>
@@ -499,6 +514,14 @@ const UsersTable: FC<UsersTableProps> = ({ onSelectUser }) => {
                 open={activateTrialDialogOpen}
                 onClose={() => {
                     setActivateTrialDialogOpen(false);
+                    setSelectedUser(null);
+                }}
+                user={selectedUser}
+            />
+            <GrantCreditsDialog
+                open={grantCreditsDialogOpen}
+                onClose={() => {
+                    setGrantCreditsDialogOpen(false);
                     setSelectedUser(null);
                 }}
                 user={selectedUser}

--- a/frontend/src/services/dashboardService.ts
+++ b/frontend/src/services/dashboardService.ts
@@ -255,6 +255,11 @@ export interface ActivateTrialInput {
     credits?: number;
 }
 
+export interface GrantCreditsInput {
+    userId: string;
+    credits: number;
+}
+
 /**
  * Hook to activate a trial on a user (cloud edition, admin only).
  * If the user has no orgs yet, the intent is stashed and applied when they
@@ -271,6 +276,30 @@ export function useAdminActivateTrial() {
             const response = await apiClient.v1AdminUsersTrialActivateCreate(input.userId, {
                 days: input.days ?? 0,
                 credits: input.credits ?? 0,
+            });
+            return response.data;
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["users"] });
+        },
+    });
+}
+
+/**
+ * Hook to grant credits to a user (cloud edition, admin only). Unlike
+ * useAdminActivateTrial, this works regardless of subscription state: the
+ * wallet on the user's oldest owned org is topped up directly, or the grant
+ * is stashed on the user if they have no orgs yet.
+ */
+export function useAdminGrantCredits() {
+    const api = useApi();
+    const apiClient = api.getApiClient();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (input: GrantCreditsInput) => {
+            const response = await apiClient.v1AdminUsersCreditsCreate(input.userId, {
+                credits: input.credits,
             });
             return response.data;
         },

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -1145,6 +1145,20 @@ definitions:
       url:
         type: string
     type: object
+  server.GrantCreditsRequest:
+    properties:
+      credits:
+        type: number
+    type: object
+  server.GrantCreditsResponse:
+    properties:
+      org_id:
+        type: string
+      status:
+        type: string
+      user:
+        $ref: '#/definitions/types.User'
+    type: object
   server.InitializeSampleRepositoriesRequest:
     properties:
       organization_id:
@@ -10394,6 +10408,14 @@ definitions:
       organization_id:
         description: Organization this API key is scoped to (ephemeral keys)
         type: string
+      pending_admin_credits_on_first_org:
+        description: |-
+          PendingAdminCreditsOnFirstOrg holds credits stashed by admin via the
+          /admin/users/{id}/credits endpoint when the user has no owned org yet.
+          Consumed by consumeUserAdminCredits on first owned org, then cleared.
+          Kept separate from TrialCreditsOnFirstOrg so admins can comp credits
+          without entangling the grant with trial-state UI or revocation flows.
+        type: number
       project_id:
         description: When running in Helix Code sandbox
         type: string
@@ -11313,6 +11335,37 @@ paths:
       security:
       - BearerAuth: []
       summary: Approve a user (Admin only)
+      tags:
+      - users
+  /api/v1/admin/users/{id}/credits:
+    post:
+      consumes:
+      - application/json
+      description: Adds credits to the wallet of the user's oldest owned org, or stashes
+        the grant on the user for application at first org creation. Works regardless
+        of subscription state, unlike adminActivateTrial.
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Credits to grant (must be > 0)
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/server.GrantCreditsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.GrantCreditsResponse'
+      security:
+      - BearerAuth: []
+      summary: Grant credits to a user (Admin, cloud only)
       tags:
       - users
   /api/v1/admin/users/{id}/password:

--- a/openapi.json
+++ b/openapi.json
@@ -1013,6 +1013,54 @@
                 }
             }
         },
+        "/api/v1/admin/users/{id}/credits": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Adds credits to the wallet of the user's oldest owned org, or stashes the grant on the user for application at first org creation. Works regardless of subscription state, unlike adminActivateTrial.",
+                "tags": [
+                    "users"
+                ],
+                "summary": "Grant credits to a user (Admin, cloud only)",
+                "parameters": [
+                    {
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/server.GrantCreditsRequest"
+                            }
+                        }
+                    },
+                    "description": "Credits to grant (must be > 0)",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/server.GrantCreditsResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/users/{id}/password": {
             "put": {
                 "security": [
@@ -24098,6 +24146,28 @@
                     }
                 }
             },
+            "server.GrantCreditsRequest": {
+                "type": "object",
+                "properties": {
+                    "credits": {
+                        "type": "number"
+                    }
+                }
+            },
+            "server.GrantCreditsResponse": {
+                "type": "object",
+                "properties": {
+                    "org_id": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "user": {
+                        "$ref": "#/components/schemas/types.User"
+                    }
+                }
+            },
             "server.InitializeSampleRepositoriesRequest": {
                 "type": "object",
                 "properties": {
@@ -37030,6 +37100,10 @@
                     "organization_id": {
                         "description": "Organization this API key is scoped to (ephemeral keys)",
                         "type": "string"
+                    },
+                    "pending_admin_credits_on_first_org": {
+                        "description": "PendingAdminCreditsOnFirstOrg holds credits stashed by admin via the\n/admin/users/{id}/credits endpoint when the user has no owned org yet.\nConsumed by consumeUserAdminCredits on first owned org, then cleared.\nKept separate from TrialCreditsOnFirstOrg so admins can comp credits\nwithout entangling the grant with trial-state UI or revocation flows.",
+                        "type": "number"
                     },
                     "project_id": {
                         "description": "When running in Helix Code sandbox",

--- a/swagger.json
+++ b/swagger.json
@@ -846,6 +846,52 @@
                 }
             }
         },
+        "/api/v1/admin/users/{id}/credits": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Adds credits to the wallet of the user's oldest owned org, or stashes the grant on the user for application at first org creation. Works regardless of subscription state, unlike adminActivateTrial.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Grant credits to a user (Admin, cloud only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Credits to grant (must be \u003e 0)",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.GrantCreditsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.GrantCreditsResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/users/{id}/password": {
             "put": {
                 "security": [
@@ -20170,6 +20216,28 @@
                 }
             }
         },
+        "server.GrantCreditsRequest": {
+            "type": "object",
+            "properties": {
+                "credits": {
+                    "type": "number"
+                }
+            }
+        },
+        "server.GrantCreditsResponse": {
+            "type": "object",
+            "properties": {
+                "org_id": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "user": {
+                    "$ref": "#/definitions/types.User"
+                }
+            }
+        },
         "server.InitializeSampleRepositoriesRequest": {
             "type": "object",
             "properties": {
@@ -33102,6 +33170,10 @@
                 "organization_id": {
                     "description": "Organization this API key is scoped to (ephemeral keys)",
                     "type": "string"
+                },
+                "pending_admin_credits_on_first_org": {
+                    "description": "PendingAdminCreditsOnFirstOrg holds credits stashed by admin via the\n/admin/users/{id}/credits endpoint when the user has no owned org yet.\nConsumed by consumeUserAdminCredits on first owned org, then cleared.\nKept separate from TrialCreditsOnFirstOrg so admins can comp credits\nwithout entangling the grant with trial-state UI or revocation flows.",
+                    "type": "number"
                 },
                 "project_id": {
                     "description": "When running in Helix Code sandbox",


### PR DESCRIPTION
## Summary

Adds a credits-only admin action so admins can comp users without the existing \`already has an active subscription\` guard from \`adminActivateTrial\` blocking them. Resolves the three modes:

| Case | Tool |
|---|---|
| User has subscription, give credits only | **New** \`POST /api/v1/admin/users/{id}/credits\` |
| User has no subscription, give credits only | **New** \`POST /api/v1/admin/users/{id}/credits\` |
| User has neither, give subscription + credits | Existing \`POST /api/v1/admin/users/{id}/trial-activate\` |

The new endpoint goes through the wallet ledger directly via \`Store.UpdateWalletBalance\` -- no Stripe round trip, because no money moves. This mirrors today's behaviour of \`consumeUserTrialIntent\` for the credit portion (line 105 of \`admin_trial_handlers.go\`).

## Backend

- \`api/pkg/types/wallet.go\`: new \`TransactionTypeAdminGrant = \"admin_grant\"\` so transaction rows classify correctly. Today the SQL workaround in \`general/Admin runbook - grant wallet credits via SQL.md\` misuses \`subscription\`/\`top_up\`.
- \`api/pkg/types/authz.go\`: new \`PendingAdminCreditsOnFirstOrg *float64\` field. Kept separate from \`TrialCreditsOnFirstOrg\` so admin comps don't entangle with trial-state UI or revocation flows.
- \`api/pkg/server/admin_credit_handlers.go\`: new \`adminGrantCredits\` handler. Gates match \`adminActivateTrial\`: admin + cloud + Stripe billing. Validates \`credits > 0\`.
  - Has owned org → \`getOrCreateWallet\` + \`UpdateWalletBalance\` regardless of subscription state.
  - No owned org → stash on user, applied at first-org-create time by \`consumeUserAdminCredits\`.
- \`api/pkg/server/organization_handlers.go:339\`: \`consumeUserAdminCredits\` called alongside \`consumeUserTrialIntent\`, same best-effort error handling.
- \`api/pkg/server/server.go:1167\`: route registered.

## Frontend

- \`frontend/src/components/dashboard/GrantCreditsDialog.tsx\`: new dialog, one numeric input, snackbar feedback.
- \`frontend/src/services/dashboardService.ts\`: new \`useAdminGrantCredits\` hook using the regenerated client method.
- \`frontend/src/components/dashboard/UsersTable.tsx\`: new \"Grant credits\" menu item, visible whenever \`isCloud\` regardless of trial or subscription state. Sits below the existing trial actions.

## Tests

\`api/pkg/server/admin_credit_handlers_test.go\` covers:
- All four reject gates (non-admin, non-cloud, billing-off, non-positive credits)
- User-not-found 404
- No-org stash path
- Has-org with existing wallet top-up
- **Explicitly the has-active-subscription case** to pin the \"subscription state is irrelevant\" promise

All 8 cases pass locally:
\`\`\`
go test -v -run TestAdminGrantCredits ./pkg/server/ -count=1
\`\`\`

## Out of scope (separate PRs when needed)

- Clawback (negative grants)
- Reason field on the transaction row
- Revoke pending admin credits
- Reconciliation report

## Test plan

- [ ] CI passes
- [ ] Inner Helix: register admin, register another user, grant \$50 credits via the user menu. Confirm wallet \`balance\` reflects via \`SELECT balance FROM wallets WHERE org_id = ...\`. Confirm \`transactions\` row has \`type='admin_grant'\`.
- [ ] Same flow against a target user who has an active subscription (the case that prompted this PR). Confirm no 422.
- [ ] Same flow against a user with no orgs. Confirm \`pending_admin_credits_on_first_org\` is set, then create an org as that user and confirm wallet balance reflects on first org create.