### PR TITLE
handle discounted Stripe top-up checkout sessions

### DIFF
--- a/api/pkg/store/store_wallet.go
+++ b/api/pkg/store/store_wallet.go
@@ -9,6 +9,7 @@ import (
 	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/types"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // Wallet methods
@@ -181,16 +182,26 @@ func (s *PostgresStore) UpdateWalletBalance(ctx context.Context, walletID string
 
 	var wallet types.Wallet
 	err := s.gdb.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// For deductions, check sufficient balance first
-		var currentBalance float64
-		if err := tx.Model(&types.Wallet{}).Where("id = ?", walletID).
-			Select("balance").Scan(&currentBalance).Error; err != nil {
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ?", walletID).
+			First(&wallet).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return ErrNotFound
 			}
 			return err
 		}
 
+		if meta.TransactionType == types.TransactionTypeTopUp {
+			alreadyProcessed, err := topUpAlreadyProcessed(tx, meta)
+			if err != nil {
+				return err
+			}
+			if alreadyProcessed {
+				return nil
+			}
+		}
+
+		currentBalance := wallet.Balance
 		if currentBalance+amount < 0 {
 			return fmt.Errorf("insufficient balance: current balance %.2f, attempted to deduct %.2f",
 				currentBalance, -amount)
@@ -234,12 +245,13 @@ func (s *PostgresStore) UpdateWalletBalance(ctx context.Context, walletID string
 		// If this is a top-up, create a top-up record (for tracking purposes)
 		if meta.TransactionType == types.TransactionTypeTopUp {
 			topUp := &types.TopUp{
-				ID:                    system.GenerateTopUpID(),
-				CreatedAt:             time.Now(),
-				UpdatedAt:             time.Now(),
-				WalletID:              walletID,
-				Amount:                amount,
-				StripePaymentIntentID: meta.StripePaymentIntentID,
+				ID:                      system.GenerateTopUpID(),
+				CreatedAt:               time.Now(),
+				UpdatedAt:               time.Now(),
+				WalletID:                walletID,
+				Amount:                  amount,
+				StripePaymentIntentID:   meta.StripePaymentIntentID,
+				StripeCheckoutSessionID: meta.StripeCheckoutSessionID,
 			}
 
 			if err := tx.Create(topUp).Error; err != nil {
@@ -260,6 +272,32 @@ func (s *PostgresStore) UpdateWalletBalance(ctx context.Context, walletID string
 	}
 
 	return &wallet, nil
+}
+
+func topUpAlreadyProcessed(tx *gorm.DB, meta types.TransactionMetadata) (bool, error) {
+	var topUp types.TopUp
+
+	if meta.StripeCheckoutSessionID != "" {
+		err := tx.Where("stripe_checkout_session_id = ?", meta.StripeCheckoutSessionID).First(&topUp).Error
+		if err == nil {
+			return true, nil
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, err
+		}
+	}
+
+	if meta.StripePaymentIntentID != "" {
+		err := tx.Where("stripe_payment_intent_id = ?", meta.StripePaymentIntentID).First(&topUp).Error
+		if err == nil {
+			return true, nil
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, err
+		}
+	}
+
+	return false, nil
 }
 
 type ListTransactionsQuery struct {

--- a/api/pkg/store/store_wallet_test.go
+++ b/api/pkg/store/store_wallet_test.go
@@ -453,6 +453,47 @@ func (suite *WalletTestSuite) TestUpdateWalletBalance_Positive() {
 	suite.Equal("test-top-up", transactions[0].TopUpID)
 }
 
+func (suite *WalletTestSuite) TestUpdateWalletBalance_TopUpIdempotency() {
+	userID := system.GenerateID()
+	wallet := &types.Wallet{
+		UserID:  userID,
+		Balance: 100.0,
+	}
+
+	createdWallet, err := suite.db.CreateWallet(suite.ctx, wallet)
+	suite.NoError(err)
+
+	paymentIntentID := "pi_" + system.GenerateID()
+	checkoutSessionID := "cs_" + system.GenerateID()
+
+	_, err = suite.db.UpdateWalletBalance(suite.ctx, createdWallet.ID, 50.0, types.TransactionMetadata{
+		TransactionType:         types.TransactionTypeTopUp,
+		StripePaymentIntentID:   paymentIntentID,
+		StripeCheckoutSessionID: checkoutSessionID,
+	})
+	suite.NoError(err)
+
+	_, err = suite.db.UpdateWalletBalance(suite.ctx, createdWallet.ID, 50.0, types.TransactionMetadata{
+		TransactionType:         types.TransactionTypeTopUp,
+		StripeCheckoutSessionID: checkoutSessionID,
+	})
+	suite.NoError(err)
+
+	_, err = suite.db.UpdateWalletBalance(suite.ctx, createdWallet.ID, 50.0, types.TransactionMetadata{
+		TransactionType:       types.TransactionTypeTopUp,
+		StripePaymentIntentID: paymentIntentID,
+	})
+	suite.NoError(err)
+
+	finalWallet, err := suite.db.GetWallet(suite.ctx, createdWallet.ID)
+	suite.NoError(err)
+	suite.Equal(150.0, finalWallet.Balance)
+
+	topUps, err := suite.db.ListTopUps(suite.ctx, &ListTopUpsQuery{WalletID: createdWallet.ID})
+	suite.NoError(err)
+	suite.Len(topUps, 1)
+}
+
 func (suite *WalletTestSuite) TestUpdateWalletBalance_Negative() {
 	userID := system.GenerateID()
 	wallet := &types.Wallet{

--- a/api/pkg/stripe/stripe.go
+++ b/api/pkg/stripe/stripe.go
@@ -168,6 +168,12 @@ func (s *Stripe) ProcessWebhook(w http.ResponseWriter, req *http.Request) {
 			log.Error().Msgf("Error handling invoice payment paid event: %s", err.Error())
 		}
 		return
+	case stripe.EventTypeCheckoutSessionCompleted:
+		err := s.handleTopUpCheckoutSessionCompletedEvent(event)
+		if err != nil {
+			log.Error().Msgf("Error handling checkout session completed event: %s", err.Error())
+		}
+		return
 	case stripe.EventTypePaymentIntentSucceeded:
 		err := s.handleTopUpEvent(event)
 		if err != nil {

--- a/api/pkg/stripe/stripe_topups.go
+++ b/api/pkg/stripe/stripe_topups.go
@@ -5,12 +5,22 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"strconv"
 
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/rs/zerolog/log"
 	"github.com/stripe/stripe-go/v76"
 	"github.com/stripe/stripe-go/v76/checkout/session"
+)
+
+const (
+	topUpMetadataType        = "type"
+	topUpMetadataUserID      = "user_id"
+	topUpMetadataOrgID       = "org_id"
+	topUpMetadataAmountCents = "topup_amount_cents"
+	topUpMetadataTypeValue   = "topup"
 )
 
 type TopUpSessionParams struct {
@@ -30,7 +40,8 @@ func (s *Stripe) GetTopUpSessionURL(
 	}
 
 	// Convert amount to cents for Stripe
-	amountInCents := int64(params.Amount * 100)
+	amountInCents := int64(math.Round(params.Amount * 100))
+	metadata := topUpMetadata(params.UserID, params.OrgID, amountInCents)
 
 	successURL := s.cfg.AppURL + "/account?success=true&session_id={CHECKOUT_SESSION_ID}"
 	if params.OrgID != "" {
@@ -45,13 +56,10 @@ func (s *Stripe) GetTopUpSessionURL(
 	checkoutParams := &stripe.CheckoutSessionParams{
 		AllowPromotionCodes: stripe.Bool(true),
 		Mode:                stripe.String(string(stripe.CheckoutSessionModePayment)),
+		Metadata:            cloneMetadata(metadata),
 		// this is how we link the payment to our user
 		PaymentIntentData: &stripe.CheckoutSessionPaymentIntentDataParams{
-			Metadata: map[string]string{
-				"user_id": params.UserID,
-				"org_id":  params.OrgID,
-				"type":    "topup",
-			},
+			Metadata: cloneMetadata(metadata),
 		},
 		LineItems: []*stripe.CheckoutSessionLineItemParams{
 			{
@@ -86,8 +94,8 @@ func (s *Stripe) handleTopUpEvent(event stripe.Event) error {
 		return fmt.Errorf("error parsing payment intent JSON: %s", err.Error())
 	}
 
-	userID := paymentIntent.Metadata["user_id"]
-	orgID := paymentIntent.Metadata["org_id"]
+	userID := paymentIntent.Metadata[topUpMetadataUserID]
+	orgID := paymentIntent.Metadata[topUpMetadataOrgID]
 
 	// If both are empty, do not process the event
 	if userID == "" && orgID == "" {
@@ -98,59 +106,23 @@ func (s *Stripe) handleTopUpEvent(event stripe.Event) error {
 	}
 
 	// Check if this is a topup payment
-	paymentType := paymentIntent.Metadata["type"]
-	if paymentType != "topup" {
+	paymentType := paymentIntent.Metadata[topUpMetadataType]
+	if paymentType != topUpMetadataTypeValue {
 		return fmt.Errorf("payment is not a topup")
 	}
 
-	// Calculate the amount in dollars (Stripe amounts are in cents)
-	amount := float64(paymentIntent.Amount) / 100.0
+	amount, err := topUpAmountDollars(paymentIntent.Metadata, paymentIntent.Amount)
+	if err != nil {
+		return err
+	}
 
 	ctx := context.Background()
-
-	var (
-		wallet *types.Wallet
-	)
-
-	switch {
-	case orgID != "":
-		wallet, err = s.store.GetWalletByOrg(ctx, orgID)
-		if err != nil {
-			if errors.Is(err, store.ErrNotFound) {
-				// Create wallet if it doesn't exist
-				wallet, err = s.store.CreateWallet(ctx, &types.Wallet{
-					OrgID:   orgID,
-					Balance: s.cfg.InitialBalance,
-				})
-				if err != nil {
-					return fmt.Errorf("failed to create wallet for org %s: %w", orgID, err)
-				}
-			}
-		}
-		if wallet == nil {
-			return fmt.Errorf("no wallet found for org %s", orgID)
-		}
-
-	case userID != "":
-		// Get or create user's wallet
-		wallet, err = s.store.GetWalletByUser(ctx, userID)
-		if err != nil {
-			if errors.Is(err, store.ErrNotFound) {
-				// Create wallet if it doesn't exist
-				wallet, err = s.store.CreateWallet(ctx, &types.Wallet{
-					UserID:  userID,
-					Balance: s.cfg.InitialBalance,
-				})
-				if err != nil {
-					return fmt.Errorf("failed to create wallet for user %s: %w", userID, err)
-				}
-			} else {
-				return fmt.Errorf("failed to get wallet for user %s: %w", userID, err)
-			}
-		}
-
-	default:
-		return fmt.Errorf("no wallet found for user %s or org %s", userID, orgID)
+	wallet, err := s.getTopUpWallet(ctx, userID, orgID, stripeCustomerIDFromPaymentIntent(&paymentIntent))
+	if err != nil {
+		return err
+	}
+	if wallet == nil {
+		return nil
 	}
 
 	_, err = s.store.UpdateWalletBalance(ctx, wallet.ID, amount, types.TransactionMetadata{
@@ -168,4 +140,187 @@ func (s *Stripe) handleTopUpEvent(event stripe.Event) error {
 		Msg("topup completed successfully")
 
 	return nil
+}
+
+func (s *Stripe) handleTopUpCheckoutSessionCompletedEvent(event stripe.Event) error {
+	var checkoutSession stripe.CheckoutSession
+	err := json.Unmarshal(event.Data.Raw, &checkoutSession)
+	if err != nil {
+		return fmt.Errorf("error parsing checkout session JSON: %s", err.Error())
+	}
+
+	if checkoutSession.Mode != stripe.CheckoutSessionModePayment {
+		return nil
+	}
+
+	if checkoutSession.PaymentStatus != stripe.CheckoutSessionPaymentStatusPaid &&
+		checkoutSession.PaymentStatus != stripe.CheckoutSessionPaymentStatusNoPaymentRequired {
+		log.Info().
+			Str("checkout_session_id", checkoutSession.ID).
+			Str("payment_status", string(checkoutSession.PaymentStatus)).
+			Msg("checkout session payment not complete, skipping topup")
+		return nil
+	}
+
+	paymentType := checkoutSession.Metadata[topUpMetadataType]
+	if paymentType != "" && paymentType != topUpMetadataTypeValue {
+		return nil
+	}
+
+	userID := checkoutSession.Metadata[topUpMetadataUserID]
+	orgID := checkoutSession.Metadata[topUpMetadataOrgID]
+	stripeCustomerID := stripeCustomerIDFromCheckoutSession(&checkoutSession)
+
+	if userID == "" && orgID == "" && stripeCustomerID == "" {
+		log.Info().
+			Str("checkout_session_id", checkoutSession.ID).
+			Msg("no user, org, or customer id found in checkout session metadata, skipping")
+		return nil
+	}
+
+	amount, err := topUpAmountDollars(checkoutSession.Metadata, checkoutSession.AmountSubtotal)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	wallet, err := s.getTopUpWallet(ctx, userID, orgID, stripeCustomerID)
+	if err != nil {
+		return err
+	}
+	if wallet == nil {
+		return nil
+	}
+
+	_, err = s.store.UpdateWalletBalance(ctx, wallet.ID, amount, types.TransactionMetadata{
+		TransactionType:         types.TransactionTypeTopUp,
+		StripePaymentIntentID:   paymentIntentIDFromCheckoutSession(&checkoutSession),
+		StripeCheckoutSessionID: checkoutSession.ID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create topup for checkout session %s: %w", checkoutSession.ID, err)
+	}
+
+	log.Info().
+		Str("user_id", userID).
+		Str("org_id", orgID).
+		Float64("amount", amount).
+		Str("wallet_id", wallet.ID).
+		Str("checkout_session_id", checkoutSession.ID).
+		Msg("topup checkout session completed successfully")
+
+	return nil
+}
+
+func (s *Stripe) getTopUpWallet(ctx context.Context, userID, orgID, stripeCustomerID string) (*types.Wallet, error) {
+	switch {
+	case orgID != "":
+		wallet, err := s.store.GetWalletByOrg(ctx, orgID)
+		if err == nil {
+			return wallet, nil
+		}
+		if !errors.Is(err, store.ErrNotFound) {
+			return nil, fmt.Errorf("failed to get wallet for org %s: %w", orgID, err)
+		}
+
+		wallet, err = s.store.CreateWallet(ctx, &types.Wallet{
+			OrgID:            orgID,
+			Balance:          s.cfg.InitialBalance,
+			StripeCustomerID: stripeCustomerID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create wallet for org %s: %w", orgID, err)
+		}
+		return wallet, nil
+
+	case userID != "":
+		wallet, err := s.store.GetWalletByUser(ctx, userID)
+		if err == nil {
+			return wallet, nil
+		}
+		if !errors.Is(err, store.ErrNotFound) {
+			return nil, fmt.Errorf("failed to get wallet for user %s: %w", userID, err)
+		}
+
+		wallet, err = s.store.CreateWallet(ctx, &types.Wallet{
+			UserID:           userID,
+			Balance:          s.cfg.InitialBalance,
+			StripeCustomerID: stripeCustomerID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create wallet for user %s: %w", userID, err)
+		}
+		return wallet, nil
+
+	case stripeCustomerID != "":
+		wallet, err := s.store.GetWalletByStripeCustomerID(ctx, stripeCustomerID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				log.Info().
+					Str("customer_id", stripeCustomerID).
+					Msg("no wallet found for stripe customer id, skipping topup")
+				return nil, nil
+			}
+			return nil, fmt.Errorf("failed to get wallet for stripe customer %s: %w", stripeCustomerID, err)
+		}
+		return wallet, nil
+
+	default:
+		return nil, fmt.Errorf("no wallet found for user %s or org %s", userID, orgID)
+	}
+}
+
+func topUpMetadata(userID, orgID string, amountInCents int64) map[string]string {
+	return map[string]string{
+		topUpMetadataUserID:      userID,
+		topUpMetadataOrgID:       orgID,
+		topUpMetadataType:        topUpMetadataTypeValue,
+		topUpMetadataAmountCents: strconv.FormatInt(amountInCents, 10),
+	}
+}
+
+func cloneMetadata(metadata map[string]string) map[string]string {
+	cloned := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func topUpAmountDollars(metadata map[string]string, fallbackCents int64) (float64, error) {
+	amountInCents := fallbackCents
+	if rawAmount := metadata[topUpMetadataAmountCents]; rawAmount != "" {
+		parsedAmount, err := strconv.ParseInt(rawAmount, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid topup amount metadata %q: %w", rawAmount, err)
+		}
+		amountInCents = parsedAmount
+	}
+
+	if amountInCents <= 0 {
+		return 0, fmt.Errorf("topup amount must be greater than 0")
+	}
+
+	return float64(amountInCents) / 100.0, nil
+}
+
+func stripeCustomerIDFromPaymentIntent(paymentIntent *stripe.PaymentIntent) string {
+	if paymentIntent == nil || paymentIntent.Customer == nil {
+		return ""
+	}
+	return paymentIntent.Customer.ID
+}
+
+func stripeCustomerIDFromCheckoutSession(checkoutSession *stripe.CheckoutSession) string {
+	if checkoutSession == nil || checkoutSession.Customer == nil {
+		return ""
+	}
+	return checkoutSession.Customer.ID
+}
+
+func paymentIntentIDFromCheckoutSession(checkoutSession *stripe.CheckoutSession) string {
+	if checkoutSession == nil || checkoutSession.PaymentIntent == nil {
+		return ""
+	}
+	return checkoutSession.PaymentIntent.ID
 }

--- a/api/pkg/stripe/stripe_topups_test.go
+++ b/api/pkg/stripe/stripe_topups_test.go
@@ -1,0 +1,141 @@
+package stripe
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	stripe "github.com/stripe/stripe-go/v76"
+	"go.uber.org/mock/gomock"
+)
+
+func TestHandleTopUpEvent_UsesRequestedAmountMetadata(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := store.NewMockStore(ctrl)
+	s := NewStripe(config.Stripe{}, db)
+	wallet := &types.Wallet{ID: "wallet_123"}
+
+	db.EXPECT().GetWalletByUser(gomock.Any(), "user_123").Return(wallet, nil)
+	db.EXPECT().UpdateWalletBalance(gomock.Any(), "wallet_123", 25.0, types.TransactionMetadata{
+		TransactionType:       types.TransactionTypeTopUp,
+		StripePaymentIntentID: "pi_123",
+	}).Return(wallet, nil)
+
+	event := stripeEvent(t, stripe.EventTypePaymentIntentSucceeded, &stripe.PaymentIntent{
+		ID:     "pi_123",
+		Amount: 500,
+		Metadata: map[string]string{
+			topUpMetadataType:        topUpMetadataTypeValue,
+			topUpMetadataUserID:      "user_123",
+			topUpMetadataAmountCents: "2500",
+		},
+	})
+
+	err := s.handleTopUpEvent(event)
+	require.NoError(t, err)
+}
+
+func TestHandleTopUpCheckoutSessionCompleted_NoPaymentRequired(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := store.NewMockStore(ctrl)
+	s := NewStripe(config.Stripe{}, db)
+	wallet := &types.Wallet{ID: "wallet_123"}
+
+	db.EXPECT().GetWalletByUser(gomock.Any(), "user_123").Return(wallet, nil)
+	db.EXPECT().UpdateWalletBalance(gomock.Any(), "wallet_123", 50.0, types.TransactionMetadata{
+		TransactionType:         types.TransactionTypeTopUp,
+		StripeCheckoutSessionID: "cs_free_123",
+	}).Return(wallet, nil)
+
+	event := stripeEvent(t, stripe.EventTypeCheckoutSessionCompleted, &stripe.CheckoutSession{
+		ID:             "cs_free_123",
+		Mode:           stripe.CheckoutSessionModePayment,
+		PaymentStatus:  stripe.CheckoutSessionPaymentStatusNoPaymentRequired,
+		AmountSubtotal: 5000,
+		Metadata: map[string]string{
+			topUpMetadataType:        topUpMetadataTypeValue,
+			topUpMetadataUserID:      "user_123",
+			topUpMetadataAmountCents: "5000",
+		},
+	})
+
+	err := s.handleTopUpCheckoutSessionCompletedEvent(event)
+	require.NoError(t, err)
+}
+
+func TestHandleTopUpCheckoutSessionCompleted_FallsBackToCustomerForOldSessions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := store.NewMockStore(ctrl)
+	s := NewStripe(config.Stripe{}, db)
+	wallet := &types.Wallet{ID: "wallet_123"}
+
+	db.EXPECT().GetWalletByStripeCustomerID(gomock.Any(), "cus_123").Return(wallet, nil)
+	db.EXPECT().UpdateWalletBalance(gomock.Any(), "wallet_123", 50.0, types.TransactionMetadata{
+		TransactionType:         types.TransactionTypeTopUp,
+		StripeCheckoutSessionID: "cs_free_123",
+	}).Return(wallet, nil)
+
+	event := stripeEvent(t, stripe.EventTypeCheckoutSessionCompleted, &stripe.CheckoutSession{
+		ID:             "cs_free_123",
+		Mode:           stripe.CheckoutSessionModePayment,
+		PaymentStatus:  stripe.CheckoutSessionPaymentStatusNoPaymentRequired,
+		AmountSubtotal: 5000,
+		Customer:       &stripe.Customer{ID: "cus_123"},
+	})
+
+	err := s.handleTopUpCheckoutSessionCompletedEvent(event)
+	require.NoError(t, err)
+}
+
+func TestHandleTopUpCheckoutSessionCompleted_IncludesPaymentIntentID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	db := store.NewMockStore(ctrl)
+	s := NewStripe(config.Stripe{}, db)
+	wallet := &types.Wallet{ID: "wallet_123"}
+
+	db.EXPECT().GetWalletByUser(gomock.Any(), "user_123").Return(wallet, nil)
+	db.EXPECT().UpdateWalletBalance(gomock.Any(), "wallet_123", 50.0, types.TransactionMetadata{
+		TransactionType:         types.TransactionTypeTopUp,
+		StripePaymentIntentID:   "pi_123",
+		StripeCheckoutSessionID: "cs_paid_123",
+	}).Return(wallet, nil)
+
+	event := stripeEvent(t, stripe.EventTypeCheckoutSessionCompleted, &stripe.CheckoutSession{
+		ID:             "cs_paid_123",
+		Mode:           stripe.CheckoutSessionModePayment,
+		PaymentStatus:  stripe.CheckoutSessionPaymentStatusPaid,
+		AmountSubtotal: 5000,
+		PaymentIntent:  &stripe.PaymentIntent{ID: "pi_123"},
+		Metadata: map[string]string{
+			topUpMetadataType:        topUpMetadataTypeValue,
+			topUpMetadataUserID:      "user_123",
+			topUpMetadataAmountCents: "5000",
+		},
+	})
+
+	err := s.handleTopUpCheckoutSessionCompletedEvent(event)
+	require.NoError(t, err)
+}
+
+func stripeEvent(t *testing.T, eventType stripe.EventType, object any) stripe.Event {
+	t.Helper()
+
+	raw, err := json.Marshal(object)
+	require.NoError(t, err)
+
+	return stripe.Event{
+		Type: eventType,
+		Data: &stripe.EventData{Raw: raw},
+	}
+}

--- a/api/pkg/types/wallet.go
+++ b/api/pkg/types/wallet.go
@@ -38,14 +38,15 @@ func (w *Wallet) IsSubscriptionActive() bool {
 }
 
 type TransactionMetadata struct {
-	InteractionID         string          `json:"interaction_id"`
-	LLMCallID             string          `json:"llm_call_id"`
-	SandboxID             string          `json:"sandbox_id"`
-	SandboxRuntime        SandboxRuntime  `json:"sandbox_runtime"`
-	SandboxPricingType    string          `json:"sandbox_pricing_type"`
-	TopUpID               string          `json:"top_up_id"`
-	StripePaymentIntentID string          `json:"stripe_payment_intent_id"`
-	TransactionType       TransactionType `json:"transaction_type"`
+	InteractionID           string          `json:"interaction_id"`
+	LLMCallID               string          `json:"llm_call_id"`
+	SandboxID               string          `json:"sandbox_id"`
+	SandboxRuntime          SandboxRuntime  `json:"sandbox_runtime"`
+	SandboxPricingType      string          `json:"sandbox_pricing_type"`
+	TopUpID                 string          `json:"top_up_id"`
+	StripePaymentIntentID   string          `json:"stripe_payment_intent_id"`
+	StripeCheckoutSessionID string          `json:"stripe_checkout_session_id"`
+	TransactionType         TransactionType `json:"transaction_type"`
 }
 
 type TransactionType string
@@ -79,12 +80,13 @@ type Transaction struct {
 }
 
 type TopUp struct {
-	ID                    string    `json:"id" gorm:"primaryKey"`
-	CreatedAt             time.Time `json:"created_at"`
-	UpdatedAt             time.Time `json:"updated_at"`
-	StripePaymentIntentID string    `json:"stripe_payment_intent_id"`
-	WalletID              string    `json:"wallet_id" gorm:"index"`
-	Amount                float64   `json:"amount"`
+	ID                      string    `json:"id" gorm:"primaryKey"`
+	CreatedAt               time.Time `json:"created_at"`
+	UpdatedAt               time.Time `json:"updated_at"`
+	StripePaymentIntentID   string    `json:"stripe_payment_intent_id" gorm:"index"`
+	StripeCheckoutSessionID string    `json:"stripe_checkout_session_id" gorm:"index"`
+	WalletID                string    `json:"wallet_id" gorm:"index"`
+	Amount                  float64   `json:"amount"`
 }
 
 type PaymentIntent struct {


### PR DESCRIPTION
## What changed

- Add top-up metadata to Stripe Checkout Sessions as well as PaymentIntents.
- Fulfill completed payment-mode Checkout Sessions, including no-cost sessions from 100% discounts.
- Credit the requested top-up amount from metadata instead of the post-discount PaymentIntent amount when available.
- Make top-up wallet balance updates idempotent across `checkout.session.completed`, `payment_intent.succeeded`, and webhook retries.

## Why

Stripe Checkout can complete a no-cost order without creating a PaymentIntent. The previous top-up flow only listened for `payment_intent.succeeded`, so a 100% discount code could complete checkout without crediting the wallet. Partial discounts also risked crediting only the amount paid instead of the selected top-up amount.

## Validation

- `go test ./api/pkg/stripe -count=1`
- `POSTGRES_HOST=localhost POSTGRES_DATABASE=postgres POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres go test ./api/pkg/store -run 'TestWalletTestSuite/TestUpdateWalletBalance_TopUpIdempotency' -count=1 -timeout=120s`
- `go build ./api/pkg/server/ ./api/pkg/store/ ./api/pkg/types/`
