### PR TITLE
fix(desktop): seed default branch on empty repos, surface worktree errors

### DIFF
--- a/desktop/shared/helix-specs-create.sh
+++ b/desktop/shared/helix-specs-create.sh
@@ -132,6 +132,37 @@ create_helix_specs_branch() {
         echo "  Repository is empty (no commits yet)"
     fi
 
+    # Determine the default-branch name we want the upstream to settle on.
+    # For empty repos we will push this branch FIRST, so the upstream picks
+    # it up as the default before we push helix-specs.
+    local RETURN_BRANCH="${CURRENT_BRANCH:-$REPO_DEFAULT_BRANCH}"
+
+    # For empty upstream repos, push the default branch BEFORE creating
+    # helix-specs. GitHub (and most providers) auto-promote the first pushed
+    # branch to default. If we push helix-specs first the upstream ends up
+    # with helix-specs as its default, which then breaks the worktree-add
+    # step in helix-workspace-setup.sh (you cannot `git worktree add` a
+    # branch that is already checked out in the primary repo). Pushing
+    # $RETURN_BRANCH first means the orphan we push next lands as a
+    # secondary branch and the upstream default is something sensible like
+    # main or master.
+    if [ "$REPO_IS_EMPTY" = true ]; then
+        echo "  Empty repo: seeding default branch $RETURN_BRANCH before helix-specs..."
+        if ! git -C "$REPO_PATH" show-ref --verify "refs/heads/$RETURN_BRANCH" >/dev/null 2>&1; then
+            git -C "$REPO_PATH" checkout --orphan "$RETURN_BRANCH" 2>&1 || true
+            git -C "$REPO_PATH" commit --allow-empty -m "Initial commit" 2>&1 || true
+            if git -C "$REPO_PATH" push -u origin "$RETURN_BRANCH" 2>&1; then
+                echo "  Seeded $RETURN_BRANCH on upstream as default"
+            else
+                echo "  Warning: failed to seed $RETURN_BRANCH on upstream"
+                echo "  helix-specs may end up as the upstream default branch,"
+                echo "  which will block the design-docs worktree on subsequent runs."
+            fi
+        else
+            git -C "$REPO_PATH" checkout "$RETURN_BRANCH" >/dev/null 2>&1 || true
+        fi
+    fi
+
     # 1. Create orphan branch (no parent, no files)
     # 2. Remove any staged files (only if not empty repo)
     # 3. Commit empty state
@@ -157,22 +188,15 @@ create_helix_specs_branch() {
         fi
     fi
 
-    # Return to original state
-    # Determine which branch to return to (prefer CURRENT_BRANCH, fallback to REPO_DEFAULT_BRANCH)
-    local RETURN_BRANCH="${CURRENT_BRANCH:-$REPO_DEFAULT_BRANCH}"
+    # Return to original state. RETURN_BRANCH was set earlier (before the
+    # empty-repo seed step) so it is already in scope.
 
     if [ "$CREATE_SUCCESS" = true ]; then
         if [ "$REPO_IS_EMPTY" = true ]; then
-            # For empty repos, create the default branch with an initial commit
-            # so we have somewhere to return to
-            if ! git -C "$REPO_PATH" show-ref --verify "refs/heads/$RETURN_BRANCH" >/dev/null 2>&1; then
-                echo "  Creating initial $RETURN_BRANCH branch..."
-                git -C "$REPO_PATH" checkout --orphan "$RETURN_BRANCH" 2>&1 || true
-                git -C "$REPO_PATH" commit --allow-empty -m "Initial commit" 2>&1 || true
-                git -C "$REPO_PATH" push -u origin "$RETURN_BRANCH" 2>&1 || true
-            else
-                git -C "$REPO_PATH" checkout "$RETURN_BRANCH" >/dev/null 2>&1 || true
-            fi
+            # For empty repos we already seeded $RETURN_BRANCH on the upstream
+            # before pushing helix-specs (see above), so it definitely exists
+            # now. Just check it out.
+            git -C "$REPO_PATH" checkout "$RETURN_BRANCH" >/dev/null 2>&1 || true
         elif [ -n "$DETACHED_HEAD" ]; then
             # Return to detached HEAD state
             echo "  Returning to detached HEAD at $DETACHED_HEAD..."

--- a/desktop/shared/helix-workspace-setup.sh
+++ b/desktop/shared/helix-workspace-setup.sh
@@ -510,7 +510,15 @@ if [ -n "$HELIX_PRIMARY_REPO_NAME" ]; then
 
             if [ ! -d "$WORKTREE_PATH" ]; then
                 echo "  Creating design docs worktree at $WORKTREE_PATH..."
-                if git -C "$PRIMARY_REPO_PATH" worktree add "$WORKTREE_PATH" helix-specs 2>&1; then
+                # Capture stderr separately so the actual git error survives into
+                # the failure path. Without this the message ("helix-specs is
+                # already checked out at ...", "fatal: invalid reference", etc.)
+                # was lost when the worktree add failed, and the agent had no
+                # way to know why setup broke.
+                WORKTREE_OUTPUT=$(git -C "$PRIMARY_REPO_PATH" worktree add "$WORKTREE_PATH" helix-specs 2>&1)
+                WORKTREE_RC=$?
+                echo "$WORKTREE_OUTPUT"
+                if [ $WORKTREE_RC -eq 0 ]; then
                     echo "  Design docs worktree ready at ~/work/helix-specs"
                     CURRENT_BRANCH=$(git -C "$WORKTREE_PATH" branch --show-current)
                     echo "  Current branch: $CURRENT_BRANCH"
@@ -522,7 +530,27 @@ if [ -n "$HELIX_PRIMARY_REPO_NAME" ]; then
                         echo "  Created task directory: design/tasks/$HELIX_SPEC_DIR_NAME"
                     fi
                 else
-                    echo "  Warning: Failed to create worktree"
+                    # Hard fail. The previous behaviour swallowed this with a
+                    # "Warning" and let the script exit zero, leaving the agent
+                    # with no helix-specs/ directory. The agent then improvised
+                    # by running `git init` somewhere, committing design docs
+                    # to a remoteless repo, and confabulating reasons it could
+                    # not push. Exiting non-zero lets the May 2026 cold-start
+                    # surfacing path (writes ~/.helix-setup-failed, read by the
+                    # API via hydra ReadSandboxFile) show the real error in the
+                    # UI instead of the generic "agent never connected" banner.
+                    echo ""
+                    echo "  ========================================="
+                    echo "  FATAL: Failed to create helix-specs worktree"
+                    echo "  ========================================="
+                    echo ""
+                    echo "  Common cause: helix-specs is the default branch on the upstream"
+                    echo "  repository, so it is already checked out in the primary repo at"
+                    echo "  $PRIMARY_REPO_PATH and git worktree refuses to check the same"
+                    echo "  branch out twice. Configure a non-helix-specs default branch"
+                    echo "  (main/master) on the upstream repo and restart this spec task."
+                    echo ""
+                    exit 1
                 fi
             else
                 echo "  Design docs worktree already exists"


### PR DESCRIPTION
## Summary

Two atomic commits that together prevent and surface the helix-specs worktree bootstrap failure we have been chasing through customer reports.

### Root cause

`desktop/shared/helix-specs-create.sh` pushes the `helix-specs` orphan branch as the first commit to a freshly-attached upstream repo. GitHub auto-promotes the first pushed branch to default, so any customer who attaches a brand-new empty repo ends up with `helix-specs` as their upstream default. On the next session, `desktop/shared/helix-workspace-setup.sh` clones the repo, finds `helix-specs` checked out in the primary working directory, then calls `git worktree add ./helix-specs helix-specs` and gets `fatal: 'helix-specs' is already checked out at ...`. The failure was swallowed by an `if/else` with a `Warning:` log line and `set -e` is suppressed in if-conditions, so the script exited zero, the May 2026 cold-start sentinel never fired, and the agent landed in a runner with no `helix-specs/` directory. The agent then `git init`-ed an ad-hoc local repo and started inventing reasons it could not push.

### Changes

1. **`helix-specs-create.sh`** - for empty upstream repos, push the detected default branch (`main`/`master`, same value the existing code already computes as `RETURN_BRANCH`) with an empty initial commit *before* pushing the helix-specs orphan. The upstream then settles on `main` as default, helix-specs becomes a secondary branch, and the worktree-add on subsequent runs succeeds. Non-empty repos take the unchanged path.

2. **`helix-workspace-setup.sh`** - capture the actual git stderr from `worktree add`, hard-exit non-zero on failure, and print a named diagnostic that calls out the helix-specs-as-default case explicitly. The non-zero exit lets the `~/.helix-setup-failed` sentinel from PR #2460 fire so the API replaces the generic "Agent never connected" banner with the real error.

New customers stop hitting this at the source. Existing customers already in the broken state see a clear, actionable error pointing them at the GitHub-side fix instead of an agent confabulating about SSH keys.

### What this does not do

It does not auto-recover an upstream repo that already has `helix-specs` as its GitHub default. Mutating a customer's repo configuration via the GitHub API without explicit consent feels out of bounds. The diagnostic message tells them what to do (configure `main`/`master` as default on the upstream) and they can do it themselves in five minutes.

## Test plan

- [x] `bash -n` syntax-clean on both scripts
- [x] Existing `desktop/shared/test-helix-specs-creation.sh` suite passes (11/11)
- [ ] Build sandbox image (`./stack build-ubuntu`) and exercise against a freshly-created empty GitHub repo to confirm `main` lands as default and helix-specs as secondary
- [ ] Trigger the failure path on an existing repo with `helix-specs` as default and confirm the sentinel writes itself and the UI surfaces the real error

🤖 Generated with [Claude Code](https://claude.com/claude-code)