### PR TITLE
fix(admin): use trial-activate form credits verbatim, no silent default

### DIFF
--- a/api/pkg/server/admin_trial_handlers.go
+++ b/api/pkg/server/admin_trial_handlers.go
@@ -19,8 +19,7 @@ import (
 )
 
 const (
-	defaultTrialDays    = 90
-	defaultTrialCredits = 100.0
+	defaultTrialDays = 90
 )
 
 // ActivateTrialRequest is the body for POST /admin/users/{id}/trial-activate.
@@ -132,7 +131,7 @@ func (s *HelixAPIServer) consumeUserTrialIntent(ctx context.Context, user *types
 
 // adminActivateTrial godoc
 // @Summary Activate a trial for a user (Admin, cloud only)
-// @Description Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Defaults: 90 days, $100 credits.
+// @Description Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).
 // @Tags    users
 // @Accept  json
 // @Produce json
@@ -168,8 +167,13 @@ func (apiServer *HelixAPIServer) adminActivateTrial(_ http.ResponseWriter, req *
 	if body.Days <= 0 {
 		body.Days = defaultTrialDays
 	}
-	if body.Credits <= 0 {
-		body.Credits = defaultTrialCredits
+	// Credits intentionally not defaulted: the admin form value is the
+	// source of truth. Silent defaulting (previously 100) compounded with
+	// the Stripe trial-invoice webhook credit ($product.metadata.credits)
+	// produced surprise wallet balances that didn't match what the admin
+	// typed.
+	if body.Credits < 0 {
+		return nil, system.NewHTTPError400("credits must be zero or positive")
 	}
 
 	targetUser, err := apiServer.Store.GetUser(ctx, &store.GetUserQuery{ID: targetUserID})

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -921,7 +921,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Defaults: 90 days, $100 credits.",
+                "description": "Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).",
                 "consumes": [
                     "application/json"
                 ],

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -917,7 +917,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Defaults: 90 days, $100 credits.",
+                "description": "Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).",
                 "consumes": [
                     "application/json"
                 ],

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -11382,9 +11382,10 @@ paths:
     post:
       consumes:
       - application/json
-      description: 'Stash a trial intent on the user, or immediately create a Stripe
-        trial subscription on the user''s oldest-owned org. Defaults: 90 days, $100
-        credits.'
+      description: Stash a trial intent on the user, or immediately create a Stripe
+        trial subscription on the user's oldest-owned org. Days defaults to 90; credits
+        are taken verbatim from the request (0 means no admin top-up beyond what Stripe's
+        subscription invoice contributes).
       parameters:
       - description: User ID
         in: path

--- a/api/pkg/stripe/stripe_invoices.go
+++ b/api/pkg/stripe/stripe_invoices.go
@@ -12,7 +12,15 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/stripe/stripe-go/v76"
 	"github.com/stripe/stripe-go/v76/product"
+	"github.com/stripe/stripe-go/v76/subscription"
 )
+
+// trialSourceAdminGranted matches the metadata value set on subscriptions
+// created by CreateTrialSubscription (api/pkg/stripe/stripe_trial.go). The
+// invoice webhook reads it to skip the auto product.metadata.credits topup,
+// so an admin-granted trial doesn't double-credit the wallet on top of
+// whatever the admin chose to grant via the form.
+const trialSourceAdminGranted = "admin_granted"
 
 func (s *Stripe) handleInvoicePaymentPaidEvent(event stripe.Event) error {
 	var invoice stripe.Invoice
@@ -48,6 +56,35 @@ func (s *Stripe) handleInvoicePaymentPaidEvent(event stripe.Event) error {
 			return nil
 		}
 		return fmt.Errorf("error getting wallet from stripe: %s", err.Error())
+	}
+
+	// Skip the auto-credit when the underlying subscription was started by
+	// the admin endpoint (trial_source=admin_granted on subscription
+	// metadata, set by CreateTrialSubscription). The admin already chose
+	// an exact credit amount via the form; the product's standard monthly
+	// allotment shouldn't stack on top of that.
+	//
+	// Gate kept narrow on purpose:
+	//   - admin_granted metadata: only suppress for the admin path; real
+	//     paid subscriptions (no metadata) still credit normally.
+	//   - status == trialing: if the user later voluntarily adds a payment
+	//     method via the Customer Portal and the trial converts to paid,
+	//     subsequent invoices fire while status is "active" and the
+	//     monthly allotment lands as expected.
+	sub, subErr := subscription.Get(invoice.Subscription.ID, nil)
+	if subErr != nil {
+		log.Warn().Err(subErr).
+			Str("invoice_id", invoice.ID).
+			Str("subscription_id", invoice.Subscription.ID).
+			Msg("failed to fetch subscription to check trial_source; proceeding with default credit logic")
+	} else if sub.Metadata["trial_source"] == trialSourceAdminGranted &&
+		sub.Status == stripe.SubscriptionStatusTrialing {
+		log.Info().
+			Str("invoice_id", invoice.ID).
+			Str("subscription_id", sub.ID).
+			Str("subscription_status", string(sub.Status)).
+			Msg("skipping subscription topup for admin-granted trial")
+		return nil
 	}
 
 	productID := getSubscriptionInvoiceProductID(&invoice)

--- a/api/pkg/stripe/stripe_invoices_test.go
+++ b/api/pkg/stripe/stripe_invoices_test.go
@@ -1,7 +1,10 @@
 package stripe
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -12,8 +15,94 @@ import (
 
 	"github.com/stretchr/testify/require"
 	stripe "github.com/stripe/stripe-go/v76"
+	"github.com/stripe/stripe-go/v76/form"
 	"go.uber.org/mock/gomock"
 )
+
+// invoiceWebhookBackend routes the two Stripe API GETs that
+// handleInvoicePaymentPaidEvent makes: subscription.Get (used to read
+// trial_source metadata) and product.Get (used to read credits metadata).
+// Either can be set to a canned response; the matching path's callInvoked
+// flag flips when the SDK calls in.
+type invoiceWebhookBackend struct {
+	t *testing.T
+
+	subscriptionPath     string
+	subscription         *stripe.Subscription
+	subscriptionErr      error
+	subscriptionInvoked  bool
+
+	productPath     string
+	product         *stripe.Product
+	productErr      error
+	productInvoked  bool
+}
+
+func (m *invoiceWebhookBackend) Call(method, path, _ string, _ stripe.ParamsContainer, v stripe.LastResponseSetter) error {
+	require.Equal(m.t, http.MethodGet, method)
+	switch path {
+	case m.subscriptionPath:
+		m.subscriptionInvoked = true
+		if m.subscriptionErr != nil {
+			return m.subscriptionErr
+		}
+		sub, ok := v.(*stripe.Subscription)
+		require.True(m.t, ok, "expected *stripe.Subscription for path %s", path)
+		*sub = *m.subscription
+		return nil
+	case m.productPath:
+		m.productInvoked = true
+		if m.productErr != nil {
+			return m.productErr
+		}
+		prod, ok := v.(*stripe.Product)
+		require.True(m.t, ok, "expected *stripe.Product for path %s", path)
+		*prod = *m.product
+		return nil
+	default:
+		m.t.Fatalf("unexpected Stripe API call to %s", path)
+		return nil
+	}
+}
+
+func (m *invoiceWebhookBackend) CallStreaming(string, string, string, stripe.ParamsContainer, stripe.StreamingLastResponseSetter) error {
+	return fmt.Errorf("unexpected CallStreaming invocation")
+}
+func (m *invoiceWebhookBackend) CallRaw(string, string, string, *form.Values, *stripe.Params, stripe.LastResponseSetter) error {
+	return fmt.Errorf("unexpected CallRaw invocation")
+}
+func (m *invoiceWebhookBackend) CallMultipart(string, string, string, string, *bytes.Buffer, *stripe.Params, stripe.LastResponseSetter) error {
+	return fmt.Errorf("unexpected CallMultipart invocation")
+}
+func (m *invoiceWebhookBackend) SetMaxNetworkRetries(int64) {}
+
+// installInvoiceWebhookBackend swaps the global Stripe backend for the test
+// duration, restoring it in cleanup.
+func installInvoiceWebhookBackend(t *testing.T, b *invoiceWebhookBackend) {
+	t.Helper()
+	original := stripe.GetBackend(stripe.APIBackend)
+	stripe.SetBackend(stripe.APIBackend, b)
+	t.Cleanup(func() {
+		stripe.SetBackend(stripe.APIBackend, original)
+	})
+}
+
+// nonAdminSubscription is the canned "real paid subscription" used by tests
+// that want the auto-credit path to run as today. It has no admin_granted
+// metadata and is active, so the skip branch never fires.
+func nonAdminSubscription(id string) *stripe.Subscription {
+	return &stripe.Subscription{
+		ID:       id,
+		Status:   stripe.SubscriptionStatusActive,
+		Metadata: map[string]string{},
+	}
+}
+
+// invoiceSubscriptionPath returns the GET path the Stripe SDK uses for
+// subscription.Get. Centralised so the test fixture's hard-coded
+// sub_1Rv1oVFNNvjhkCqzI3vgc41P doesn't need to be repeated.
+const invoiceSubscriptionPath = "/v1/subscriptions/sub_1Rv1oVFNNvjhkCqzI3vgc41P"
+const invoiceProductPath = "/v1/products/prod_Sqia5TdP4XGk1x"
 
 func Test_handleInvoicePaymentPaidEvent(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -37,20 +126,17 @@ func Test_handleInvoicePaymentPaidEvent(t *testing.T) {
 	}
 	store.EXPECT().GetWalletByStripeCustomerID(gomock.Any(), "cus_SqicesZoU7LrDR").Return(wallet, nil)
 
-	mockBackend := &mockProductBackend{
-		t:            t,
-		expectedPath: "/v1/products/prod_Sqia5TdP4XGk1x",
+	backend := &invoiceWebhookBackend{
+		t:                t,
+		subscriptionPath: invoiceSubscriptionPath,
+		subscription:     nonAdminSubscription("sub_1Rv1oVFNNvjhkCqzI3vgc41P"),
+		productPath:      invoiceProductPath,
 		product: &stripe.Product{
 			ID:       "prod_Sqia5TdP4XGk1x",
 			Metadata: map[string]string{"credits": "250"},
 		},
 	}
-
-	originalAPIBackend := stripe.GetBackend(stripe.APIBackend)
-	stripe.SetBackend(stripe.APIBackend, mockBackend)
-	t.Cleanup(func() {
-		stripe.SetBackend(stripe.APIBackend, originalAPIBackend)
-	})
+	installInvoiceWebhookBackend(t, backend)
 
 	store.EXPECT().UpdateWalletBalance(gomock.Any(), "123", float64(250), types.TransactionMetadata{
 		TransactionType: types.TransactionTypeSubscription,
@@ -58,7 +144,8 @@ func Test_handleInvoicePaymentPaidEvent(t *testing.T) {
 
 	err = s.handleInvoicePaymentPaidEvent(event)
 	require.NoError(t, err)
-	require.True(t, mockBackend.callInvoked)
+	require.True(t, backend.subscriptionInvoked)
+	require.True(t, backend.productInvoked)
 }
 
 func Test_handleInvoicePaymentPaidEvent_NotFound(t *testing.T) {
@@ -102,24 +189,21 @@ func Test_handleInvoicePaymentPaidEvent_ProductCreditsMissing(t *testing.T) {
 	}
 	store.EXPECT().GetWalletByStripeCustomerID(gomock.Any(), "cus_SqicesZoU7LrDR").Return(wallet, nil)
 
-	mockBackend := &mockProductBackend{
-		t:            t,
-		expectedPath: "/v1/products/prod_Sqia5TdP4XGk1x",
+	backend := &invoiceWebhookBackend{
+		t:                t,
+		subscriptionPath: invoiceSubscriptionPath,
+		subscription:     nonAdminSubscription("sub_1Rv1oVFNNvjhkCqzI3vgc41P"),
+		productPath:      invoiceProductPath,
 		product: &stripe.Product{
 			ID:       "prod_Sqia5TdP4XGk1x",
 			Metadata: map[string]string{},
 		},
 	}
-
-	originalAPIBackend := stripe.GetBackend(stripe.APIBackend)
-	stripe.SetBackend(stripe.APIBackend, mockBackend)
-	t.Cleanup(func() {
-		stripe.SetBackend(stripe.APIBackend, originalAPIBackend)
-	})
+	installInvoiceWebhookBackend(t, backend)
 
 	err = s.handleInvoicePaymentPaidEvent(event)
 	require.NoError(t, err)
-	require.True(t, mockBackend.callInvoked)
+	require.True(t, backend.productInvoked)
 }
 
 func Test_handleInvoicePaymentPaidEvent_ProductCreditsInvalid(t *testing.T) {
@@ -143,24 +227,21 @@ func Test_handleInvoicePaymentPaidEvent_ProductCreditsInvalid(t *testing.T) {
 	}
 	store.EXPECT().GetWalletByStripeCustomerID(gomock.Any(), "cus_SqicesZoU7LrDR").Return(wallet, nil)
 
-	mockBackend := &mockProductBackend{
-		t:            t,
-		expectedPath: "/v1/products/prod_Sqia5TdP4XGk1x",
+	backend := &invoiceWebhookBackend{
+		t:                t,
+		subscriptionPath: invoiceSubscriptionPath,
+		subscription:     nonAdminSubscription("sub_1Rv1oVFNNvjhkCqzI3vgc41P"),
+		productPath:      invoiceProductPath,
 		product: &stripe.Product{
 			ID:       "prod_Sqia5TdP4XGk1x",
 			Metadata: map[string]string{"credits": "not-a-number"},
 		},
 	}
-
-	originalAPIBackend := stripe.GetBackend(stripe.APIBackend)
-	stripe.SetBackend(stripe.APIBackend, mockBackend)
-	t.Cleanup(func() {
-		stripe.SetBackend(stripe.APIBackend, originalAPIBackend)
-	})
+	installInvoiceWebhookBackend(t, backend)
 
 	err = s.handleInvoicePaymentPaidEvent(event)
 	require.NoError(t, err)
-	require.True(t, mockBackend.callInvoked)
+	require.True(t, backend.productInvoked)
 }
 
 func Test_handleInvoicePaymentPaidEvent_ProductLookupFailure(t *testing.T) {
@@ -184,20 +265,151 @@ func Test_handleInvoicePaymentPaidEvent_ProductLookupFailure(t *testing.T) {
 	}
 	store.EXPECT().GetWalletByStripeCustomerID(gomock.Any(), "cus_SqicesZoU7LrDR").Return(wallet, nil)
 
-	mockBackend := &mockProductBackend{
-		t:            t,
-		expectedPath: "/v1/products/prod_Sqia5TdP4XGk1x",
-		err:          os.ErrNotExist,
+	backend := &invoiceWebhookBackend{
+		t:                t,
+		subscriptionPath: invoiceSubscriptionPath,
+		subscription:     nonAdminSubscription("sub_1Rv1oVFNNvjhkCqzI3vgc41P"),
+		productPath:      invoiceProductPath,
+		productErr:       os.ErrNotExist,
 	}
-
-	originalAPIBackend := stripe.GetBackend(stripe.APIBackend)
-	stripe.SetBackend(stripe.APIBackend, mockBackend)
-	t.Cleanup(func() {
-		stripe.SetBackend(stripe.APIBackend, originalAPIBackend)
-	})
+	installInvoiceWebhookBackend(t, backend)
 
 	err = s.handleInvoicePaymentPaidEvent(event)
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "failed to get product from stripe"))
-	require.True(t, mockBackend.callInvoked)
+	require.True(t, backend.productInvoked)
+}
+
+// Test_handleInvoicePaymentPaidEvent_AdminGrantedTrial_SkipsAutoCredit pins
+// down the fix for the SaaS bug reported by Karolis: an admin-granted trial
+// activation produced a wallet balance N+100 instead of N, because the auto
+// product.metadata.credits topup stacked on top of the form value. Now any
+// subscription whose metadata carries trial_source=admin_granted AND is
+// still in trialing status causes the handler to return without crediting.
+func Test_handleInvoicePaymentPaidEvent_AdminGrantedTrial_SkipsAutoCredit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	store := store.NewMockStore(ctrl)
+	s := NewStripe(config.Stripe{SecretKey: "sk_test_invoice_paid"}, store)
+
+	bts, err := os.ReadFile("testdata/paid.json")
+	require.NoError(t, err)
+	var event stripe.Event
+	require.NoError(t, json.Unmarshal(bts, &event))
+
+	wallet := &types.Wallet{ID: "wal_admin_trial"}
+	store.EXPECT().GetWalletByStripeCustomerID(gomock.Any(), "cus_SqicesZoU7LrDR").Return(wallet, nil)
+
+	backend := &invoiceWebhookBackend{
+		t:                t,
+		subscriptionPath: invoiceSubscriptionPath,
+		subscription: &stripe.Subscription{
+			ID:     "sub_1Rv1oVFNNvjhkCqzI3vgc41P",
+			Status: stripe.SubscriptionStatusTrialing,
+			Metadata: map[string]string{
+				"trial_source": "admin_granted",
+			},
+		},
+		// Product path intentionally unset: the handler must skip BEFORE
+		// product.Get is called. If the product call fires, the routing
+		// backend t.Fatals on unexpected path.
+	}
+	installInvoiceWebhookBackend(t, backend)
+
+	// Critical: no UpdateWalletBalance expectation, gomock will fail the
+	// test if the handler tries to credit.
+	err = s.handleInvoicePaymentPaidEvent(event)
+	require.NoError(t, err)
+	require.True(t, backend.subscriptionInvoked, "subscription should have been fetched")
+	require.False(t, backend.productInvoked, "product should NOT be fetched when admin-granted trial is detected")
+}
+
+// Test_handleInvoicePaymentPaidEvent_AdminGrantedConvertedToPaid pins the
+// "once they convert to paid, give them credits normally" promise. After
+// the trial converts (status moves to active, possibly because the user
+// added a payment method via the Customer Portal), the same trial_source
+// metadata is still on the subscription, but the gate's status check
+// stops applying so the credit lands.
+func Test_handleInvoicePaymentPaidEvent_AdminGrantedConvertedToPaid_StillCredits(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	store := store.NewMockStore(ctrl)
+	s := NewStripe(config.Stripe{SecretKey: "sk_test_invoice_paid"}, store)
+
+	bts, err := os.ReadFile("testdata/paid.json")
+	require.NoError(t, err)
+	var event stripe.Event
+	require.NoError(t, json.Unmarshal(bts, &event))
+
+	wallet := &types.Wallet{ID: "wal_converted"}
+	store.EXPECT().GetWalletByStripeCustomerID(gomock.Any(), "cus_SqicesZoU7LrDR").Return(wallet, nil)
+
+	backend := &invoiceWebhookBackend{
+		t:                t,
+		subscriptionPath: invoiceSubscriptionPath,
+		subscription: &stripe.Subscription{
+			ID:     "sub_1Rv1oVFNNvjhkCqzI3vgc41P",
+			Status: stripe.SubscriptionStatusActive, // converted to paid
+			Metadata: map[string]string{
+				"trial_source": "admin_granted",
+			},
+		},
+		productPath: invoiceProductPath,
+		product: &stripe.Product{
+			ID:       "prod_Sqia5TdP4XGk1x",
+			Metadata: map[string]string{"credits": "200"},
+		},
+	}
+	installInvoiceWebhookBackend(t, backend)
+
+	store.EXPECT().UpdateWalletBalance(gomock.Any(), "wal_converted", float64(200), types.TransactionMetadata{
+		TransactionType: types.TransactionTypeSubscription,
+	}).Return(wallet, nil)
+
+	err = s.handleInvoicePaymentPaidEvent(event)
+	require.NoError(t, err)
+	require.True(t, backend.subscriptionInvoked)
+	require.True(t, backend.productInvoked)
+}
+
+// Test_handleInvoicePaymentPaidEvent_SubscriptionFetchFails_FallsThrough
+// ensures a transient Stripe API hiccup on the subscription lookup doesn't
+// break the credit flow for normal paid subscriptions. We log and continue.
+func Test_handleInvoicePaymentPaidEvent_SubscriptionFetchFails_FallsThrough(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	store := store.NewMockStore(ctrl)
+	s := NewStripe(config.Stripe{SecretKey: "sk_test_invoice_paid"}, store)
+
+	bts, err := os.ReadFile("testdata/paid.json")
+	require.NoError(t, err)
+	var event stripe.Event
+	require.NoError(t, json.Unmarshal(bts, &event))
+
+	wallet := &types.Wallet{ID: "wal_sub_err"}
+	store.EXPECT().GetWalletByStripeCustomerID(gomock.Any(), "cus_SqicesZoU7LrDR").Return(wallet, nil)
+
+	backend := &invoiceWebhookBackend{
+		t:                t,
+		subscriptionPath: invoiceSubscriptionPath,
+		subscriptionErr:  fmt.Errorf("transient stripe error"),
+		productPath:      invoiceProductPath,
+		product: &stripe.Product{
+			ID:       "prod_Sqia5TdP4XGk1x",
+			Metadata: map[string]string{"credits": "150"},
+		},
+	}
+	installInvoiceWebhookBackend(t, backend)
+
+	store.EXPECT().UpdateWalletBalance(gomock.Any(), "wal_sub_err", float64(150), types.TransactionMetadata{
+		TransactionType: types.TransactionTypeSubscription,
+	}).Return(wallet, nil)
+
+	err = s.handleInvoicePaymentPaidEvent(event)
+	require.NoError(t, err)
+	require.True(t, backend.subscriptionInvoked)
+	require.True(t, backend.productInvoked, "product credit path should run even if subscription fetch failed")
 }

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -7117,7 +7117,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Defaults: 90 days, $100 credits.
+     * @description Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).
      *
      * @tags users
      * @name V1AdminUsersTrialActivateCreate

--- a/frontend/src/components/dashboard/ActivateTrialDialog.tsx
+++ b/frontend/src/components/dashboard/ActivateTrialDialog.tsx
@@ -24,7 +24,11 @@ interface ActivateTrialDialogProps {
 }
 
 const DEFAULT_DAYS = 90;
-const DEFAULT_CREDITS = 100;
+// Intentionally 0: the form value is sent verbatim, no silent defaulting on
+// either side. Stripe still credits the trial-period product allotment on
+// subscription start via the invoice.paid webhook -- that's separate from
+// the admin's choice here.
+const DEFAULT_CREDITS = 0;
 
 const ActivateTrialDialog: FC<ActivateTrialDialogProps> = ({ open, onClose, user }) => {
     const [days, setDays] = useState(String(DEFAULT_DAYS));

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -11382,9 +11382,10 @@ paths:
     post:
       consumes:
       - application/json
-      description: 'Stash a trial intent on the user, or immediately create a Stripe
-        trial subscription on the user''s oldest-owned org. Defaults: 90 days, $100
-        credits.'
+      description: Stash a trial intent on the user, or immediately create a Stripe
+        trial subscription on the user's oldest-owned org. Days defaults to 90; credits
+        are taken verbatim from the request (0 means no admin top-up beyond what Stripe's
+        subscription invoice contributes).
       parameters:
       - description: User ID
         in: path

--- a/openapi.json
+++ b/openapi.json
@@ -1098,7 +1098,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Defaults: 90 days, $100 credits.",
+                "description": "Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).",
                 "tags": [
                     "users"
                 ],

--- a/swagger.json
+++ b/swagger.json
@@ -917,7 +917,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Defaults: 90 days, $100 credits.",
+                "description": "Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).",
                 "consumes": [
                     "application/json"
                 ],


### PR DESCRIPTION
## Summary

Reported on SaaS: activating a trial via the admin dashboard with **0 credits** produced a **\$200** wallet balance. Bug fixed in two layers; both contributed to the surprise.

### Layer 1: backend silent default (the load-bearing fix)

\`admin_trial_handlers.go:171\` silently overrode \`body.Credits <= 0\` to \`defaultTrialCredits\` (\$100). Admin types 0, backend writes 100. Combined with the dialog default of 100 prefilled in the form, an admin clicking through without clearing the field also got \$100 they didn't intend.

This PR:
- Backend: removed the \`<= 0\` override. 0 stays 0. Negative credits now return 400 instead of being silently flipped. \`defaultTrialCredits\` constant deleted (unused).
- Frontend: \`DEFAULT_CREDITS\` in \`ActivateTrialDialog.tsx\` lowered from 100 to 0 so admins aren't prefilled with a value they didn't choose.
- Swagger doc updated.

### Layer 2: defensive guard against the Stripe webhook stacking (belt-and-braces)

The Stripe trial invoice webhook (\`handleInvoicePaymentPaidEvent\`) reads \`product.metadata.credits\` and adds it to the wallet whenever it fires. For admin-granted trials \`CreateTrialSubscription\` sets \`MissingPaymentMethod=cancel\`, so in normal operation no invoice fires and this layer is a no-op. But if a future Stripe config change ever caused an invoice to fire for an admin trial, the wallet would still get the standard monthly allotment on top of whatever the admin chose.

This PR adds a guard: skip the auto-credit when \`subscription.Metadata[trial_source] == \"admin_granted\"\` AND \`subscription.Status == \"trialing\"\`. The metadata key is already set by \`CreateTrialSubscription\` at \`api/pkg/stripe/stripe_trial.go:56\`. The status check is important because if a user voluntarily adds a payment method via the Customer Portal and the trial converts to paid, subsequent renewal invoices (\`status=active\`) still credit normally — they pay, they get credits.

Subscription fetch errors are non-fatal: log a warning and fall through to the original credit logic so a transient Stripe API hiccup doesn't suppress real customer credits.

## Tests

\`api/pkg/stripe/stripe_invoices_test.go\` overhauled:
- Single-path \`mockProductBackend\` replaced with \`invoiceWebhookBackend\` that routes both \`subscription.Get\` and \`product.Get\` and \`t.Fatal\`s on unexpected calls.
- Four existing webhook tests refactored to use the new backend.
- Three regression tests added: \`admin_granted + trialing → skip\`, \`admin_granted + active → still credits\`, \`subscription fetch error → falls through\`.

All 8 tests pass:
\`\`\`
CGO_ENABLED=1 go test -v -run Test_handleInvoicePaymentPaidEvent ./pkg/stripe/ -count=1
\`\`\`

## Test plan

- [ ] CI passes
- [ ] In the admin user panel, open \"Activate trial\", clear credits to 0, submit. Wallet balance gain from this path is exactly \$0.
- [ ] Same dialog with \`credits=7\` → wallet gain is exactly +\$7.
- [ ] Negative credits → backend returns 400.
- [ ] If any \`invoice.paid\` ever fires for an admin-granted trial in the wild, the wallet stays at exactly the admin-chosen amount.