### PR TITLE
feat(hydra): admin runner logs — design + ring buffer + /logs WS endpoint

### DIFF
--- a/api/cmd/hydra/main.go
+++ b/api/cmd/hydra/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -60,8 +61,16 @@ func run(cmd *cobra.Command, args []string) {
 	}
 	zerolog.SetGlobalLevel(level)
 
-	// Use pretty logging for console output
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	// Create the shared log buffer first so we can tee zerolog into it
+	// alongside stderr. The admin /logs WS endpoint reads from this buffer,
+	// so capturing hydra's own diagnostics (not just inner-container output)
+	// makes start-up failures and runtime warnings visible to admins.
+	logBuffer := hydra.NewLogBuffer(0)
+	logOutput := io.MultiWriter(
+		zerolog.ConsoleWriter{Out: os.Stderr},
+		zerolog.ConsoleWriter{Out: logBuffer.Writer(), NoColor: true},
+	)
+	log.Logger = log.Output(logOutput)
 
 	log.Info().Msg("========================================")
 	log.Info().Msg("  Hydra daemon starting")
@@ -73,9 +82,10 @@ func run(cmd *cobra.Command, args []string) {
 		Bool("privileged_mode", os.Getenv("HYDRA_PRIVILEGED_MODE_ENABLED") == "true").
 		Msg("========================================")
 
-	// Create manager and server
+	// Create manager and server. The server takes ownership of the log
+	// buffer and exposes it via the /api/v1/logs WS endpoint.
 	manager := hydra.NewManager(socketDir, dataDir)
-	server := hydra.NewServer(manager, socketPath)
+	server := hydra.NewServerWithLogBuffer(manager, socketPath, logBuffer)
 
 	// Create context that cancels on SIGINT/SIGTERM
 	ctx, cancel := context.WithCancel(context.Background())

--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -69,15 +69,27 @@ type DevContainerManager struct {
 	// and polled by the API server via the /golden-copy-progress endpoint.
 	goldenCopyProgress   map[string]*GoldenCopyProgress
 	goldenCopyProgressMu sync.RWMutex
+
+	// Optional ring buffer that receives a copy of every inner-container log
+	// line streamed via streamContainerLogs. nil means no buffering.
+	logBuffer *LogBuffer
 }
 
 // NewDevContainerManager creates a new dev container manager
 func NewDevContainerManager(manager *Manager) *DevContainerManager {
+	return NewDevContainerManagerWithLogBuffer(manager, nil)
+}
+
+// NewDevContainerManagerWithLogBuffer creates a dev container manager that
+// also fans inner-container logs into the supplied LogBuffer. Pass nil to
+// disable buffering (equivalent to NewDevContainerManager).
+func NewDevContainerManagerWithLogBuffer(manager *Manager, logBuffer *LogBuffer) *DevContainerManager {
 	dm := &DevContainerManager{
 		manager:            manager,
 		containers:         make(map[string]*DevContainer),
 		goldenBuildResults: make(map[string]*GoldenBuildResult),
 		goldenCopyProgress: make(map[string]*GoldenCopyProgress),
+		logBuffer:          logBuffer,
 	}
 
 	// GC orphaned session dirs on startup and periodically
@@ -1827,12 +1839,19 @@ func (dm *DevContainerManager) streamContainerLogs(ctx context.Context, containe
 		stdcopy.StdCopy(pw, pw, logReader)
 	}()
 
-	// Read lines and print with prefix
+	// Read lines and print with prefix. Also feed the in-memory ring buffer
+	// (if configured) so the admin /logs WS endpoint can replay history and
+	// live-tail.
 	scanner := bufio.NewScanner(pr)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if line != "" {
-			fmt.Printf("%s%s\n", prefix, line)
+		if line == "" {
+			continue
+		}
+		formatted := fmt.Sprintf("%s%s", prefix, line)
+		fmt.Println(formatted)
+		if dm.logBuffer != nil {
+			dm.logBuffer.Write(formatted)
 		}
 	}
 

--- a/api/pkg/hydra/log_handlers.go
+++ b/api/pkg/hydra/log_handlers.go
@@ -1,0 +1,138 @@
+package hydra
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/rs/zerolog/log"
+)
+
+// logsUpgrader is the websocket upgrader for the /logs endpoint. Reachable
+// only via RevDial from the Helix API server, so origin checks are not
+// meaningful here — auth is enforced one hop up.
+var logsUpgrader = websocket.Upgrader{
+	ReadBufferSize:  4096,
+	WriteBufferSize: 16384,
+	CheckOrigin:     func(r *http.Request) bool { return true },
+}
+
+const (
+	logsDefaultTail = 200
+	logsMaxTail     = 5000
+	logsWriteWait   = 10 * time.Second
+	logsPingPeriod  = 30 * time.Second
+)
+
+// handleLogs streams hydra-aggregated runner logs (including streamed inner
+// container output) over a WebSocket. Query params:
+//
+//	tail    int   trailing line count to emit on connect (default 200, max 5000)
+//	follow  bool  stay subscribed after the tail (default true)
+//
+// Each emitted message is a JSON-encoded LogLine.
+func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
+	if s.logBuffer == nil {
+		http.Error(w, "log buffer not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	tail := logsDefaultTail
+	if v := r.URL.Query().Get("tail"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil {
+			tail = parsed
+		}
+	}
+	if tail < 0 {
+		tail = 0
+	}
+	if tail > logsMaxTail {
+		tail = logsMaxTail
+	}
+
+	follow := true
+	if v := r.URL.Query().Get("follow"); v != "" {
+		if parsed, err := strconv.ParseBool(v); err == nil {
+			follow = parsed
+		}
+	}
+
+	conn, err := logsUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Warn().Err(err).Msg("logs ws: upgrade failed")
+		return
+	}
+	defer conn.Close()
+
+	// Atomically snapshot the trailing N lines and subscribe to live lines.
+	// SnapshotAndSubscribe guarantees no lines are missed between the two
+	// (a plain Snapshot then Subscribe has a race window).
+	snapshot, sub, cancel := s.logBuffer.SnapshotAndSubscribe(tail)
+	defer cancel()
+
+	for _, line := range snapshot {
+		if err := writeLogLine(conn, line); err != nil {
+			return
+		}
+	}
+
+	if !follow {
+		_ = conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, "tail complete"),
+			time.Now().Add(logsWriteWait),
+		)
+		return
+	}
+
+	// Background goroutine to detect client disconnect and stop us.
+	clientGone := make(chan struct{})
+	go func() {
+		defer close(clientGone)
+		conn.SetReadLimit(512)
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	pingTicker := time.NewTicker(logsPingPeriod)
+	defer pingTicker.Stop()
+
+	for {
+		select {
+		case <-clientGone:
+			return
+		case line, ok := <-sub:
+			if !ok {
+				return
+			}
+			if err := writeLogLine(conn, line); err != nil {
+				return
+			}
+		case <-pingTicker.C:
+			if err := conn.WriteControl(
+				websocket.PingMessage,
+				nil,
+				time.Now().Add(logsWriteWait),
+			); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func writeLogLine(conn *websocket.Conn, line LogLine) error {
+	payload, err := json.Marshal(line)
+	if err != nil {
+		// Shouldn't happen for our shape, but don't kill the stream.
+		return nil
+	}
+	if err := conn.SetWriteDeadline(time.Now().Add(logsWriteWait)); err != nil {
+		return err
+	}
+	return conn.WriteMessage(websocket.TextMessage, payload)
+}

--- a/api/pkg/hydra/log_handlers.go
+++ b/api/pkg/hydra/log_handlers.go
@@ -24,12 +24,15 @@ const (
 	logsMaxTail     = 5000
 	logsWriteWait   = 10 * time.Second
 	logsPingPeriod  = 30 * time.Second
+	logsPongWait    = 90 * time.Second
 )
 
 // handleLogs streams hydra-aggregated runner logs (including streamed inner
 // container output) over a WebSocket. Query params:
 //
-//	tail    int   trailing line count to emit on connect (default 200, max 5000)
+//	tail    int   trailing line count to emit on connect.
+//	              default 200, max 5000, 0 means "no history, live tail only",
+//	              negatives are clamped to 0.
 //	follow  bool  stay subscribed after the tail (default true)
 //
 // Each emitted message is a JSON-encoded LogLine.
@@ -66,16 +69,53 @@ func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
 	}
 	defer conn.Close()
 
-	// Atomically snapshot the trailing N lines and subscribe to live lines.
-	// SnapshotAndSubscribe guarantees no lines are missed between the two
-	// (a plain Snapshot then Subscribe has a race window).
-	snapshot, sub, cancel := s.logBuffer.SnapshotAndSubscribe(tail)
+	// Read deadline + pong handler: a half-open TCP (laptop sleep, NAT
+	// timeout) is otherwise only detected when our next ping write fails,
+	// which can be 30+ seconds. With ReadDeadline + a pong-bumps-deadline
+	// pattern, the read loop unblocks with an error after logsPongWait and
+	// the subscriber tears down cleanly. SetPongHandler returns nil to
+	// signal "ping/pong handled, bump the deadline."
+	_ = conn.SetReadDeadline(time.Now().Add(logsPongWait))
+	conn.SetReadLimit(512)
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(logsPongWait))
+	})
+
+	// Subscribe BEFORE the snapshot so the live-tail buffer is live during
+	// snapshot delivery — if the snapshot send is slow (large tail, slow
+	// client), incoming lines accumulate in the per-subscriber channel
+	// rather than being lost. SnapshotAndSubscribe holds the buffer's lock
+	// across both, so no producer race.
+	snapshot, sub, cancel, err := s.logBuffer.SnapshotAndSubscribe(tail)
+	if err != nil {
+		// Subscriber cap exceeded. Send a clean WS close with the standard
+		// "try again later" code so the client can render the cap message
+		// instead of a generic disconnect.
+		log.Warn().Err(err).Msg("logs ws: rejecting new subscriber, cap reached")
+		_ = conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseTryAgainLater, err.Error()),
+			time.Now().Add(logsWriteWait),
+		)
+		return
+	}
 	defer cancel()
 
-	for _, line := range snapshot {
-		if err := writeLogLine(conn, line); err != nil {
-			return
+	// Background goroutine to detect client disconnect; runs immediately so
+	// snapshot delivery to a dead client unblocks via the write-deadline
+	// rather than blocking the full snapshot before we notice.
+	clientGone := make(chan struct{})
+	go func() {
+		defer close(clientGone)
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
 		}
+	}()
+
+	if !sendSnapshot(conn, snapshot, clientGone) {
+		return
 	}
 
 	if !follow {
@@ -87,24 +127,14 @@ func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Background goroutine to detect client disconnect and stop us.
-	clientGone := make(chan struct{})
-	go func() {
-		defer close(clientGone)
-		conn.SetReadLimit(512)
-		for {
-			if _, _, err := conn.ReadMessage(); err != nil {
-				return
-			}
-		}
-	}()
-
 	pingTicker := time.NewTicker(logsPingPeriod)
 	defer pingTicker.Stop()
 
 	for {
 		select {
 		case <-clientGone:
+			return
+		case <-r.Context().Done():
 			return
 		case line, ok := <-sub:
 			if !ok {
@@ -125,11 +155,31 @@ func (s *Server) handleLogs(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// sendSnapshot writes the snapshot to the client, bailing early if the client
+// has already disconnected. Returns false if delivery failed (caller should
+// stop). Without this guard, a closed-client snapshot would write each line
+// up to its 10s deadline before noticing the connection is dead.
+func sendSnapshot(conn *websocket.Conn, snapshot []LogLine, clientGone <-chan struct{}) bool {
+	for _, line := range snapshot {
+		select {
+		case <-clientGone:
+			return false
+		default:
+		}
+		if err := writeLogLine(conn, line); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
 func writeLogLine(conn *websocket.Conn, line LogLine) error {
 	payload, err := json.Marshal(line)
 	if err != nil {
-		// Shouldn't happen for our shape, but don't kill the stream.
-		return nil
+		// json.Marshal cannot fail for our {time.Time, string} shape, but
+		// if the contract ever drifts, surface the error so the connection
+		// closes rather than silently dropping lines forever.
+		return err
 	}
 	if err := conn.SetWriteDeadline(time.Now().Add(logsWriteWait)); err != nil {
 		return err

--- a/api/pkg/hydra/logbuf.go
+++ b/api/pkg/hydra/logbuf.go
@@ -1,0 +1,175 @@
+package hydra
+
+import (
+	"sync"
+	"time"
+)
+
+// LogLine is one log line emitted by hydra or by an inner container whose logs
+// hydra is streaming. Held in LogBuffer's ring and broadcast to live
+// subscribers.
+type LogLine struct {
+	Time time.Time `json:"t"`
+	Line string    `json:"line"`
+}
+
+// LogBuffer is a bounded ring buffer of log lines with multi-subscriber
+// live-tail support.
+//
+// Writers call Write(line) for each line. Readers call Snapshot(n) for the
+// trailing n lines and Subscribe() for live lines. Subscribers receive lines
+// on a channel; if a subscriber falls behind by more than slowChanBuffer
+// lines, the buffer drops oldest queued lines for that subscriber rather than
+// blocking the writer (the live tail is best-effort, full history is in the
+// ring).
+type LogBuffer struct {
+	mu       sync.Mutex
+	ring     []LogLine
+	capacity int
+	// head is the index of the next slot to write. ring[head-1] is the most
+	// recent line. ring is logically circular; we use len < capacity to
+	// distinguish the warmup phase.
+	head    int
+	filled  bool
+	subs    map[int]chan LogLine
+	nextSub int
+}
+
+const (
+	defaultLogBufferCapacity = 10000
+	slowSubBuffer            = 256
+)
+
+// NewLogBuffer creates a buffer that retains up to capacity recent lines.
+// A capacity of zero or less uses the default of defaultLogBufferCapacity.
+func NewLogBuffer(capacity int) *LogBuffer {
+	if capacity <= 0 {
+		capacity = defaultLogBufferCapacity
+	}
+	return &LogBuffer{
+		ring:     make([]LogLine, capacity),
+		capacity: capacity,
+		subs:     make(map[int]chan LogLine),
+	}
+}
+
+// Write appends a line to the buffer and fans it out to all live subscribers.
+// Subscribers whose channel buffer is full have the oldest queued line dropped
+// to make room — the writer never blocks.
+func (b *LogBuffer) Write(line string) {
+	entry := LogLine{Time: time.Now().UTC(), Line: line}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.ring[b.head] = entry
+	b.head = (b.head + 1) % b.capacity
+	if b.head == 0 {
+		b.filled = true
+	}
+
+	for _, ch := range b.subs {
+		select {
+		case ch <- entry:
+		default:
+			// Subscriber is slow. Drop the oldest queued line and try again
+			// so the live tail keeps moving even under back-pressure.
+			select {
+			case <-ch:
+			default:
+			}
+			select {
+			case ch <- entry:
+			default:
+			}
+		}
+	}
+}
+
+// Snapshot returns the most recent n lines in chronological order. If n is
+// zero or negative, returns the entire buffer.
+func (b *LogBuffer) Snapshot(n int) []LogLine {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	var size int
+	if b.filled {
+		size = b.capacity
+	} else {
+		size = b.head
+	}
+	if n <= 0 || n > size {
+		n = size
+	}
+
+	out := make([]LogLine, 0, n)
+	// Walk backwards from head for n entries, then reverse.
+	for i := 0; i < n; i++ {
+		idx := (b.head - 1 - i + b.capacity) % b.capacity
+		out = append(out, b.ring[idx])
+	}
+	// Reverse in place for chronological order.
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out
+}
+
+// Subscribe returns a channel that receives every new line written after
+// subscription. The caller must call the returned cancel function to release
+// the subscription; failing to do so leaks a goroutine-sized buffer per
+// abandoned subscriber.
+func (b *LogBuffer) Subscribe() (<-chan LogLine, func()) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.subscribeLocked()
+}
+
+func (b *LogBuffer) subscribeLocked() (<-chan LogLine, func()) {
+	id := b.nextSub
+	b.nextSub++
+	ch := make(chan LogLine, slowSubBuffer)
+	b.subs[id] = ch
+
+	cancel := func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		if ch, ok := b.subs[id]; ok {
+			delete(b.subs, id)
+			close(ch)
+		}
+	}
+	return ch, cancel
+}
+
+// SnapshotAndSubscribe atomically returns the most recent n lines and a
+// subscription that delivers every line written after the snapshot point.
+// Use this when you want gap-free history-then-tail; Snapshot() followed by
+// Subscribe() has a small race window where lines written in between can be
+// missed.
+func (b *LogBuffer) SnapshotAndSubscribe(n int) ([]LogLine, <-chan LogLine, func()) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	var size int
+	if b.filled {
+		size = b.capacity
+	} else {
+		size = b.head
+	}
+	if n <= 0 || n > size {
+		n = size
+	}
+
+	out := make([]LogLine, 0, n)
+	for i := 0; i < n; i++ {
+		idx := (b.head - 1 - i + b.capacity) % b.capacity
+		out = append(out, b.ring[idx])
+	}
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+
+	ch, cancel := b.subscribeLocked()
+	return out, ch, cancel
+}

--- a/api/pkg/hydra/logbuf.go
+++ b/api/pkg/hydra/logbuf.go
@@ -1,6 +1,7 @@
 package hydra
 
 import (
+	"bytes"
 	"sync"
 	"time"
 )
@@ -38,7 +39,22 @@ type LogBuffer struct {
 const (
 	defaultLogBufferCapacity = 10000
 	slowSubBuffer            = 256
+	// maxSubscribers caps the number of live tailers per LogBuffer. The
+	// admin /logs WS endpoint is the only caller; in practice this means
+	// "at most N concurrent admin tabs across all browsers." Each
+	// subscriber holds a per-channel buffer plus a fanout cost in Write, so
+	// uncapped subscribers would let one buggy admin client (or a
+	// reconnect loop) starve the writer side.
+	maxSubscribers = 32
 )
+
+// ErrTooManySubscribers is returned by Subscribe / SnapshotAndSubscribe when
+// the per-buffer subscriber cap is exceeded.
+var ErrTooManySubscribers = errSubscriberCap{}
+
+type errSubscriberCap struct{}
+
+func (errSubscriberCap) Error() string { return "log buffer: too many subscribers" }
 
 // NewLogBuffer creates a buffer that retains up to capacity recent lines.
 // A capacity of zero or less uses the default of defaultLogBufferCapacity.
@@ -86,19 +102,25 @@ func (b *LogBuffer) Write(line string) {
 	}
 }
 
-// Snapshot returns the most recent n lines in chronological order. If n is
-// zero or negative, returns the entire buffer.
+// Snapshot returns the most recent n lines in chronological order.
+//
+// n=0 returns an empty slice (matches the WS handler "no history" contract).
+// n<0 is normalised to 0. n>capacity is clamped to capacity. Pass a large n
+// (e.g. defaultLogBufferCapacity) to mean "everything in the ring."
 func (b *LogBuffer) Snapshot(n int) []LogLine {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	if n < 0 {
+		n = 0
+	}
 	var size int
 	if b.filled {
 		size = b.capacity
 	} else {
 		size = b.head
 	}
-	if n <= 0 || n > size {
+	if n > size {
 		n = size
 	}
 
@@ -119,13 +141,19 @@ func (b *LogBuffer) Snapshot(n int) []LogLine {
 // subscription. The caller must call the returned cancel function to release
 // the subscription; failing to do so leaks a goroutine-sized buffer per
 // abandoned subscriber.
-func (b *LogBuffer) Subscribe() (<-chan LogLine, func()) {
+//
+// Returns ErrTooManySubscribers if maxSubscribers concurrent subscriptions
+// already exist on this buffer.
+func (b *LogBuffer) Subscribe() (<-chan LogLine, func(), error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.subscribeLocked()
 }
 
-func (b *LogBuffer) subscribeLocked() (<-chan LogLine, func()) {
+func (b *LogBuffer) subscribeLocked() (<-chan LogLine, func(), error) {
+	if len(b.subs) >= maxSubscribers {
+		return nil, func() {}, ErrTooManySubscribers
+	}
 	id := b.nextSub
 	b.nextSub++
 	ch := make(chan LogLine, slowSubBuffer)
@@ -139,7 +167,7 @@ func (b *LogBuffer) subscribeLocked() (<-chan LogLine, func()) {
 			close(ch)
 		}
 	}
-	return ch, cancel
+	return ch, cancel, nil
 }
 
 // SnapshotAndSubscribe atomically returns the most recent n lines and a
@@ -147,17 +175,28 @@ func (b *LogBuffer) subscribeLocked() (<-chan LogLine, func()) {
 // Use this when you want gap-free history-then-tail; Snapshot() followed by
 // Subscribe() has a small race window where lines written in between can be
 // missed.
-func (b *LogBuffer) SnapshotAndSubscribe(n int) ([]LogLine, <-chan LogLine, func()) {
+//
+// Returns ErrTooManySubscribers if maxSubscribers concurrent subscriptions
+// already exist. In that case the snapshot is still returned so a caller can
+// choose to render history without a live tail; the cancel function is a
+// no-op.
+//
+// n=0 means "no snapshot, live tail only" (matches the WS handler contract).
+// n<0 is normalised to 0. n>capacity is clamped to capacity.
+func (b *LogBuffer) SnapshotAndSubscribe(n int) ([]LogLine, <-chan LogLine, func(), error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	if n < 0 {
+		n = 0
+	}
 	var size int
 	if b.filled {
 		size = b.capacity
 	} else {
 		size = b.head
 	}
-	if n <= 0 || n > size {
+	if n > size {
 		n = size
 	}
 
@@ -170,6 +209,59 @@ func (b *LogBuffer) SnapshotAndSubscribe(n int) ([]LogLine, <-chan LogLine, func
 		out[i], out[j] = out[j], out[i]
 	}
 
-	ch, cancel := b.subscribeLocked()
-	return out, ch, cancel
+	ch, cancel, err := b.subscribeLocked()
+	return out, ch, cancel, err
+}
+
+// Writer returns an io.Writer that splits incoming bytes on newlines and
+// feeds each line into the buffer. Use this to tee a process's stdout/stderr
+// or a zerolog ConsoleWriter into the ring so the same admin /logs endpoint
+// surfaces hydra's own diagnostics, not just inner-container output.
+//
+// Partial lines are accumulated and emitted only on newline, so multi-write
+// log statements (which zerolog can produce when a level is split across two
+// Write calls) don't get fragmented. The accumulator caps at 64KiB; a single
+// line larger than that is force-flushed as one entry to avoid unbounded
+// memory growth from a pathological producer.
+func (b *LogBuffer) Writer() *LogBufferWriter {
+	return &LogBufferWriter{buf: b}
+}
+
+// LogBufferWriter implements io.Writer; see LogBuffer.Writer.
+type LogBufferWriter struct {
+	buf *LogBuffer
+	mu  sync.Mutex
+	acc bytes.Buffer
+}
+
+const lineWriterFlushCap = 64 * 1024
+
+// Write splits p on '\n' and forwards each completed line to the buffer.
+// Always returns len(p), nil — this writer is fan-out only and never blocks
+// or errors out the real stdout chain it sits alongside.
+func (w *LogBufferWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, b := range p {
+		if b == '\n' {
+			line := w.acc.String()
+			w.acc.Reset()
+			// Strip a trailing \r for CRLF producers (Windows / some
+			// docker log shapes); zerolog ConsoleWriter on Unix
+			// produces LF-only so this is cheap.
+			if n := len(line); n > 0 && line[n-1] == '\r' {
+				line = line[:n-1]
+			}
+			if line != "" {
+				w.buf.Write(line)
+			}
+			continue
+		}
+		w.acc.WriteByte(b)
+		if w.acc.Len() >= lineWriterFlushCap {
+			w.buf.Write(w.acc.String())
+			w.acc.Reset()
+		}
+	}
+	return len(p), nil
 }

--- a/api/pkg/hydra/logbuf_test.go
+++ b/api/pkg/hydra/logbuf_test.go
@@ -13,7 +13,7 @@ func TestLogBuffer_SnapshotReturnsChronological(t *testing.T) {
 	buf.Write("b")
 	buf.Write("c")
 
-	got := buf.Snapshot(0)
+	got := buf.Snapshot(100)
 	if len(got) != 3 {
 		t.Fatalf("want 3 lines, got %d", len(got))
 	}
@@ -24,12 +24,23 @@ func TestLogBuffer_SnapshotReturnsChronological(t *testing.T) {
 	}
 }
 
+func TestLogBuffer_SnapshotZeroIsEmpty(t *testing.T) {
+	buf := NewLogBuffer(10)
+	buf.Write("a")
+	buf.Write("b")
+
+	got := buf.Snapshot(0)
+	if len(got) != 0 {
+		t.Fatalf("Snapshot(0) want 0 lines, got %d", len(got))
+	}
+}
+
 func TestLogBuffer_RingWraps(t *testing.T) {
 	buf := NewLogBuffer(3)
 	for _, s := range []string{"a", "b", "c", "d", "e"} {
 		buf.Write(s)
 	}
-	got := buf.Snapshot(0)
+	got := buf.Snapshot(100)
 	if len(got) != 3 {
 		t.Fatalf("want 3 lines (capacity), got %d", len(got))
 	}
@@ -58,7 +69,10 @@ func TestLogBuffer_TailN(t *testing.T) {
 
 func TestLogBuffer_SubscribeReceivesLiveLines(t *testing.T) {
 	buf := NewLogBuffer(10)
-	ch, cancel := buf.Subscribe()
+	ch, cancel, err := buf.Subscribe()
+	if err != nil {
+		t.Fatalf("Subscribe failed: %v", err)
+	}
 	defer cancel()
 
 	go func() {
@@ -82,7 +96,10 @@ func TestLogBuffer_SubscribeReceivesLiveLines(t *testing.T) {
 
 func TestLogBuffer_CancelStopsSubscription(t *testing.T) {
 	buf := NewLogBuffer(10)
-	ch, cancel := buf.Subscribe()
+	ch, cancel, err := buf.Subscribe()
+	if err != nil {
+		t.Fatalf("Subscribe failed: %v", err)
+	}
 	cancel()
 
 	// Channel should be closed; receive should not block.
@@ -94,7 +111,10 @@ func TestLogBuffer_CancelStopsSubscription(t *testing.T) {
 
 func TestLogBuffer_SlowSubscriberDoesNotBlockWriter(t *testing.T) {
 	buf := NewLogBuffer(10)
-	_, cancel := buf.Subscribe() // never read from this channel
+	_, cancel, err := buf.Subscribe() // never read from this channel
+	if err != nil {
+		t.Fatalf("Subscribe failed: %v", err)
+	}
 	defer cancel()
 
 	// Write more lines than the per-subscriber buffer can hold. If the writer
@@ -139,7 +159,10 @@ func TestLogBuffer_ConcurrentWritersAndSubscribers(t *testing.T) {
 		subWg.Add(1)
 		go func() {
 			defer subWg.Done()
-			ch, cancel := buf.Subscribe()
+			ch, cancel, err := buf.Subscribe()
+	if err != nil {
+		t.Fatalf("Subscribe failed: %v", err)
+	}
 			defer cancel()
 			for {
 				select {
@@ -155,9 +178,101 @@ func TestLogBuffer_ConcurrentWritersAndSubscribers(t *testing.T) {
 	close(subDone)
 	subWg.Wait()
 
-	got := buf.Snapshot(0)
+	got := buf.Snapshot(2000)
 	if len(got) != 1000 {
 		t.Fatalf("want capacity (1000) lines after %d writes, got %d", writers*linesPerWriter, len(got))
+	}
+}
+
+func TestLogBufferWriter_SplitsOnNewline(t *testing.T) {
+	buf := NewLogBuffer(10)
+	w := buf.Writer()
+
+	// Single Write with multiple lines.
+	if _, err := w.Write([]byte("alpha\nbravo\ncharlie\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	// Partial line (no trailing newline) is held.
+	if _, err := w.Write([]byte("delta")); err != nil {
+		t.Fatalf("Write partial: %v", err)
+	}
+	if got := buf.Snapshot(100); len(got) != 3 {
+		t.Errorf("after partial, want 3 lines, got %d: %v", len(got), got)
+	}
+	// Finishing the line flushes it.
+	if _, err := w.Write([]byte(" extra\n")); err != nil {
+		t.Fatalf("Write rest: %v", err)
+	}
+	got := buf.Snapshot(100)
+	if len(got) != 4 {
+		t.Fatalf("after complete, want 4 lines, got %d", len(got))
+	}
+	for i, want := range []string{"alpha", "bravo", "charlie", "delta extra"} {
+		if got[i].Line != want {
+			t.Errorf("Snapshot[%d] = %q, want %q", i, got[i].Line, want)
+		}
+	}
+}
+
+func TestLogBufferWriter_StripsCRLF(t *testing.T) {
+	buf := NewLogBuffer(10)
+	w := buf.Writer()
+	_, _ = w.Write([]byte("hello\r\nworld\r\n"))
+	got := buf.Snapshot(100)
+	if len(got) != 2 || got[0].Line != "hello" || got[1].Line != "world" {
+		t.Errorf("CRLF strip failed: %v", got)
+	}
+}
+
+func TestLogBufferWriter_LongLineFlushesEarly(t *testing.T) {
+	buf := NewLogBuffer(10)
+	w := buf.Writer()
+	huge := make([]byte, lineWriterFlushCap+10) // no newline
+	for i := range huge {
+		huge[i] = 'x'
+	}
+	_, _ = w.Write(huge)
+	got := buf.Snapshot(100)
+	if len(got) == 0 {
+		t.Fatal("expected force-flush of oversized line")
+	}
+}
+
+func TestLogBuffer_SubscriberCap(t *testing.T) {
+	buf := NewLogBuffer(10)
+	cancels := make([]func(), 0, maxSubscribers)
+	for i := 0; i < maxSubscribers; i++ {
+		_, cancel, err := buf.Subscribe()
+		if err != nil {
+			t.Fatalf("subscribe %d failed: %v", i, err)
+		}
+		cancels = append(cancels, cancel)
+	}
+	defer func() {
+		for _, c := range cancels {
+			c()
+		}
+	}()
+
+	// One past the cap should fail.
+	_, _, err := buf.Subscribe()
+	if err == nil {
+		t.Fatal("Subscribe past cap should have failed")
+	}
+	if err != ErrTooManySubscribers {
+		t.Errorf("want ErrTooManySubscribers, got %v", err)
+	}
+
+	// After releasing one, a new subscription should succeed.
+	cancels[0]()
+	cancels = cancels[1:]
+	ch, cancel, err := buf.Subscribe()
+	if err != nil {
+		t.Fatalf("subscribe after release failed: %v", err)
+	}
+	cancels = append(cancels, cancel)
+	if ch == nil {
+		t.Fatal("returned channel is nil")
 	}
 }
 
@@ -173,7 +288,10 @@ func TestLogBuffer_SnapshotAndSubscribe_NoGap(t *testing.T) {
 		buf.Write(fmt.Sprintf("hist-%d", i))
 	}
 
-	hist, sub, cancel := buf.SnapshotAndSubscribe(0)
+	hist, sub, cancel, err := buf.SnapshotAndSubscribe(1000)
+	if err != nil {
+		t.Fatalf("SnapshotAndSubscribe failed: %v", err)
+	}
 	defer cancel()
 
 	// Concurrent writes after subscribe should land in the channel.

--- a/api/pkg/hydra/logbuf_test.go
+++ b/api/pkg/hydra/logbuf_test.go
@@ -1,0 +1,206 @@
+package hydra
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestLogBuffer_SnapshotReturnsChronological(t *testing.T) {
+	buf := NewLogBuffer(10)
+	buf.Write("a")
+	buf.Write("b")
+	buf.Write("c")
+
+	got := buf.Snapshot(0)
+	if len(got) != 3 {
+		t.Fatalf("want 3 lines, got %d", len(got))
+	}
+	for i, want := range []string{"a", "b", "c"} {
+		if got[i].Line != want {
+			t.Errorf("Snapshot[%d] = %q, want %q", i, got[i].Line, want)
+		}
+	}
+}
+
+func TestLogBuffer_RingWraps(t *testing.T) {
+	buf := NewLogBuffer(3)
+	for _, s := range []string{"a", "b", "c", "d", "e"} {
+		buf.Write(s)
+	}
+	got := buf.Snapshot(0)
+	if len(got) != 3 {
+		t.Fatalf("want 3 lines (capacity), got %d", len(got))
+	}
+	for i, want := range []string{"c", "d", "e"} {
+		if got[i].Line != want {
+			t.Errorf("Snapshot[%d] = %q, want %q", i, got[i].Line, want)
+		}
+	}
+}
+
+func TestLogBuffer_TailN(t *testing.T) {
+	buf := NewLogBuffer(10)
+	for i := 0; i < 7; i++ {
+		buf.Write(fmt.Sprintf("line-%d", i))
+	}
+	got := buf.Snapshot(3)
+	if len(got) != 3 {
+		t.Fatalf("want 3 lines, got %d", len(got))
+	}
+	for i, want := range []string{"line-4", "line-5", "line-6"} {
+		if got[i].Line != want {
+			t.Errorf("Snapshot[%d] = %q, want %q", i, got[i].Line, want)
+		}
+	}
+}
+
+func TestLogBuffer_SubscribeReceivesLiveLines(t *testing.T) {
+	buf := NewLogBuffer(10)
+	ch, cancel := buf.Subscribe()
+	defer cancel()
+
+	go func() {
+		for i := 0; i < 3; i++ {
+			buf.Write(fmt.Sprintf("live-%d", i))
+		}
+	}()
+
+	for i := 0; i < 3; i++ {
+		select {
+		case got := <-ch:
+			want := fmt.Sprintf("live-%d", i)
+			if got.Line != want {
+				t.Errorf("subscriber[%d] = %q, want %q", i, got.Line, want)
+			}
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("timeout waiting for line %d", i)
+		}
+	}
+}
+
+func TestLogBuffer_CancelStopsSubscription(t *testing.T) {
+	buf := NewLogBuffer(10)
+	ch, cancel := buf.Subscribe()
+	cancel()
+
+	// Channel should be closed; receive should not block.
+	_, ok := <-ch
+	if ok {
+		t.Fatal("expected channel to be closed after cancel")
+	}
+}
+
+func TestLogBuffer_SlowSubscriberDoesNotBlockWriter(t *testing.T) {
+	buf := NewLogBuffer(10)
+	_, cancel := buf.Subscribe() // never read from this channel
+	defer cancel()
+
+	// Write more lines than the per-subscriber buffer can hold. If the writer
+	// blocks, this test will time out at the global test timeout. With the
+	// drop-oldest policy, this completes immediately.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < slowSubBuffer*2; i++ {
+			buf.Write(fmt.Sprintf("line-%d", i))
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("writer was blocked by slow subscriber")
+	}
+}
+
+func TestLogBuffer_ConcurrentWritersAndSubscribers(t *testing.T) {
+	buf := NewLogBuffer(1000)
+
+	var wg sync.WaitGroup
+	const writers = 4
+	const linesPerWriter = 250
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < linesPerWriter; i++ {
+				buf.Write(fmt.Sprintf("w%d-%d", w, i))
+			}
+		}(w)
+	}
+
+	// Run a couple of subscribers in parallel, draining what they receive.
+	const subscribers = 2
+	subWg := sync.WaitGroup{}
+	subDone := make(chan struct{})
+	for s := 0; s < subscribers; s++ {
+		subWg.Add(1)
+		go func() {
+			defer subWg.Done()
+			ch, cancel := buf.Subscribe()
+			defer cancel()
+			for {
+				select {
+				case <-ch:
+				case <-subDone:
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(subDone)
+	subWg.Wait()
+
+	got := buf.Snapshot(0)
+	if len(got) != 1000 {
+		t.Fatalf("want capacity (1000) lines after %d writes, got %d", writers*linesPerWriter, len(got))
+	}
+}
+
+func TestLogBuffer_SnapshotAndSubscribe_NoGap(t *testing.T) {
+	// Ordering guarantee: history returned by SnapshotAndSubscribe should
+	// chain seamlessly with the subscription, with no missed or duplicated
+	// lines even if a writer fires between snapshot and subscribe under a
+	// plain Snapshot+Subscribe call.
+
+	buf := NewLogBuffer(100)
+	// Prime with 5 history lines.
+	for i := 0; i < 5; i++ {
+		buf.Write(fmt.Sprintf("hist-%d", i))
+	}
+
+	hist, sub, cancel := buf.SnapshotAndSubscribe(0)
+	defer cancel()
+
+	// Concurrent writes after subscribe should land in the channel.
+	go func() {
+		for i := 0; i < 5; i++ {
+			buf.Write(fmt.Sprintf("live-%d", i))
+		}
+	}()
+
+	if len(hist) != 5 {
+		t.Fatalf("want 5 history lines, got %d", len(hist))
+	}
+	for i, want := range []string{"hist-0", "hist-1", "hist-2", "hist-3", "hist-4"} {
+		if hist[i].Line != want {
+			t.Errorf("hist[%d] = %q, want %q", i, hist[i].Line, want)
+		}
+	}
+
+	for i := 0; i < 5; i++ {
+		select {
+		case got := <-sub:
+			want := fmt.Sprintf("live-%d", i)
+			if got.Line != want {
+				t.Errorf("live[%d] = %q, want %q", i, got.Line, want)
+			}
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("timeout waiting for live line %d", i)
+		}
+	}
+}

--- a/api/pkg/hydra/server.go
+++ b/api/pkg/hydra/server.go
@@ -32,6 +32,7 @@ type Server struct {
 	manager             *Manager
 	devContainerManager *DevContainerManager // Dev container management (desktop container lifecycle)
 	sandboxOps          *SandboxOps          // Sandboxes API: exec/files/terminal helpers
+	logBuffer           *LogBuffer           // In-memory ring of recent log lines for /logs ws endpoint
 	socketPath          string
 	listener            net.Listener
 	server              *http.Server
@@ -44,13 +45,19 @@ func NewServer(manager *Manager, socketPath string) *Server {
 		socketPath = DefaultSocketPath
 	}
 
+	// Shared log buffer captures hydra-aggregated runner output (currently:
+	// inner container streams from DevContainerManager.streamContainerLogs).
+	// Exposed via /logs WS for admin live-tail through RevDial.
+	logBuffer := NewLogBuffer(0)
+
 	// Create dev container manager for desktop container lifecycle functionality
-	devContainerManager := NewDevContainerManager(manager)
+	devContainerManager := NewDevContainerManagerWithLogBuffer(manager, logBuffer)
 
 	return &Server{
 		manager:             manager,
 		devContainerManager: devContainerManager,
 		sandboxOps:          NewSandboxOps(devContainerManager),
+		logBuffer:           logBuffer,
 		socketPath:          socketPath,
 	}
 }
@@ -190,6 +197,10 @@ func (s *Server) registerRoutes(router *mux.Router) {
 
 	// System stats (GPU info, active sessions)
 	api.HandleFunc("/system/stats", s.handleSystemStats).Methods("GET")
+
+	// Aggregated runner logs (admin live-tail). WebSocket upgrade; clients
+	// receive a snapshot of recent lines then live-tail.
+	api.HandleFunc("/logs", s.handleLogs).Methods("GET")
 
 	// Version and route listing (for diagnosing version mismatches)
 	api.HandleFunc("/version", s.handleVersion).Methods("GET")

--- a/api/pkg/hydra/server.go
+++ b/api/pkg/hydra/server.go
@@ -39,18 +39,30 @@ type Server struct {
 	router              *mux.Router
 }
 
-// NewServer creates a new Hydra server
+// NewServer creates a new Hydra server with an internally-allocated log
+// buffer. Use NewServerWithLogBuffer when the caller wants to tee zerolog
+// output (or other line streams) into the same buffer the /logs WS endpoint
+// serves.
 func NewServer(manager *Manager, socketPath string) *Server {
+	return NewServerWithLogBuffer(manager, socketPath, NewLogBuffer(0))
+}
+
+// NewServerWithLogBuffer creates a Hydra server backed by the supplied log
+// buffer. Used by cmd/hydra so the logger can tee into the same buffer the
+// admin /logs WS endpoint exposes. logBuffer must not be nil.
+func NewServerWithLogBuffer(manager *Manager, socketPath string, logBuffer *LogBuffer) *Server {
 	if socketPath == "" {
 		socketPath = DefaultSocketPath
 	}
+	if logBuffer == nil {
+		logBuffer = NewLogBuffer(0)
+	}
 
-	// Shared log buffer captures hydra-aggregated runner output (currently:
-	// inner container streams from DevContainerManager.streamContainerLogs).
-	// Exposed via /logs WS for admin live-tail through RevDial.
-	logBuffer := NewLogBuffer(0)
-
-	// Create dev container manager for desktop container lifecycle functionality
+	// Shared log buffer captures hydra-aggregated runner output: inner
+	// container streams from DevContainerManager.streamContainerLogs plus
+	// (when teed via LogBufferWriter at construction time) hydra's own
+	// zerolog output. Exposed via /logs WS for admin live-tail through
+	// RevDial.
 	devContainerManager := NewDevContainerManagerWithLogBuffer(manager, logBuffer)
 
 	return &Server{

--- a/api/pkg/server/admin_runner_logs.go
+++ b/api/pkg/server/admin_runner_logs.go
@@ -1,0 +1,160 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/rs/zerolog/log"
+
+	"github.com/helixml/helix/api/pkg/proxy"
+)
+
+// streamAdminRunnerLogs streams a Runner's hydra-aggregated log buffer over a
+// WebSocket so an admin can live-tail what the Runner is doing without SSH.
+//
+// Route: GET /api/v1/admin/runners/{runner_id}/logs
+// Query: tail=N (default 200, max 5000), follow=bool (default true)
+//
+// Auth is enforced by the admin subrouter middleware. Multiple admins can open
+// the same stream concurrently — hydra fans the same buffer to all
+// subscribers; there is no supersede semantic here (unlike the screenshot
+// stream WS which dedupes per browser tab).
+//
+// Pattern mirrors the screenshot stream WS proxy at
+// external_agent_handlers.go: hijack, dial hydra via RevDial, do the upgrade
+// dance, then hand off to proxy.NewResilientProxy for byte pumping.
+func (apiServer *HelixAPIServer) streamAdminRunnerLogs(res http.ResponseWriter, req *http.Request) {
+	runnerID := mux.Vars(req)["runner_id"]
+	if runnerID == "" {
+		http.Error(res, "runner_id required", http.StatusBadRequest)
+		return
+	}
+
+	// Forward tail and follow query params through to hydra. Unknown params
+	// are dropped to keep the surface area small.
+	hydraQuery := url.Values{}
+	if v := req.URL.Query().Get("tail"); v != "" {
+		hydraQuery.Set("tail", v)
+	}
+	if v := req.URL.Query().Get("follow"); v != "" {
+		hydraQuery.Set("follow", v)
+	}
+	hydraPath := "/api/v1/logs"
+	if encoded := hydraQuery.Encode(); encoded != "" {
+		hydraPath = hydraPath + "?" + encoded
+	}
+
+	hydraRunnerID := "hydra-" + runnerID
+	wsKey := req.Header.Get("Sec-WebSocket-Key")
+	if wsKey == "" {
+		http.Error(res, "missing Sec-WebSocket-Key", http.StatusBadRequest)
+		return
+	}
+
+	hijacker, ok := res.(http.Hijacker)
+	if !ok {
+		http.Error(res, "server does not support connection hijacking", http.StatusInternalServerError)
+		return
+	}
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		log.Error().Err(err).Msg("admin runner logs: hijack failed")
+		http.Error(res, "failed to hijack connection", http.StatusInternalServerError)
+		return
+	}
+	defer clientConn.Close()
+
+	dialCtx, dialCancel := context.WithTimeout(req.Context(), 10*time.Second)
+	defer dialCancel()
+
+	serverConn, err := apiServer.connman.Dial(dialCtx, hydraRunnerID)
+	if err != nil {
+		log.Warn().
+			Err(err).
+			Str("runner_id", runnerID).
+			Msg("admin runner logs: failed to dial runner via RevDial")
+		_, _ = clientConn.Write([]byte("HTTP/1.1 503 Service Unavailable\r\nContent-Type: text/plain\r\n\r\nRunner not connected"))
+		return
+	}
+	defer serverConn.Close()
+
+	// Send WebSocket upgrade request to hydra.
+	upgradeReq := fmt.Sprintf("GET %s HTTP/1.1\r\n"+
+		"Host: localhost:9876\r\n"+
+		"Upgrade: websocket\r\n"+
+		"Connection: Upgrade\r\n"+
+		"Sec-WebSocket-Key: %s\r\n"+
+		"Sec-WebSocket-Version: 13\r\n"+
+		"\r\n", hydraPath, wsKey)
+	if _, err := serverConn.Write([]byte(upgradeReq)); err != nil {
+		log.Warn().Err(err).Msg("admin runner logs: failed to send upgrade to hydra")
+		_, _ = clientConn.Write([]byte("HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain\r\n\r\nHydra upgrade write failed"))
+		return
+	}
+
+	serverReader := bufio.NewReader(serverConn)
+	upgradeResp, err := http.ReadResponse(serverReader, nil)
+	if err != nil {
+		log.Warn().Err(err).Msg("admin runner logs: failed to read upgrade response from hydra")
+		_, _ = clientConn.Write([]byte("HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain\r\n\r\nHydra upgrade response read failed"))
+		return
+	}
+	defer upgradeResp.Body.Close()
+
+	if upgradeResp.StatusCode != http.StatusSwitchingProtocols {
+		log.Warn().
+			Int("status", upgradeResp.StatusCode).
+			Str("runner_id", runnerID).
+			Msg("admin runner logs: hydra refused WebSocket upgrade")
+		_, _ = clientConn.Write([]byte(fmt.Sprintf("HTTP/1.1 %d %s\r\nContent-Type: text/plain\r\n\r\nHydra refused upgrade", upgradeResp.StatusCode, upgradeResp.Status)))
+		return
+	}
+
+	// Forward the 101 to the client. We pass hydra's Sec-WebSocket-Accept
+	// through verbatim — hydra computed it from the same wsKey we sent
+	// (which is the client's wsKey), so the value the client expects matches.
+	clientAccept := upgradeResp.Header.Get("Sec-WebSocket-Accept")
+	clientUpgradeResp := fmt.Sprintf("HTTP/1.1 101 Switching Protocols\r\n"+
+		"Upgrade: websocket\r\n"+
+		"Connection: Upgrade\r\n"+
+		"Sec-WebSocket-Accept: %s\r\n"+
+		"\r\n", clientAccept)
+	if _, err := clientConn.Write([]byte(clientUpgradeResp)); err != nil {
+		log.Warn().Err(err).Msg("admin runner logs: failed to forward 101 to client")
+		return
+	}
+
+	log.Info().
+		Str("runner_id", runnerID).
+		Str("hydra_path", hydraPath).
+		Msg("admin runner logs: WebSocket established, starting proxy")
+
+	// Pump bytes via the resilient proxy. On RevDial reconnect, the same
+	// upgrade dance is replayed against the new server connection.
+	dialFunc := func(ctx context.Context) (net.Conn, error) {
+		return apiServer.connman.Dial(ctx, hydraRunnerID)
+	}
+	upgradeFunc := proxy.CreateWebSocketUpgradeFunc(hydraPath, wsKey)
+
+	rp := proxy.NewResilientProxy(proxy.ResilientProxyConfig{
+		SessionID:   "admin-runner-logs-" + runnerID,
+		ClientConn:  clientConn,
+		ServerConn:  serverConn,
+		DialFunc:    dialFunc,
+		UpgradeFunc: upgradeFunc,
+	})
+	defer rp.Close()
+	if err := rp.Run(req.Context()); err != nil {
+		log.Debug().Err(err).Str("runner_id", runnerID).Msg("admin runner logs: proxy exited with error")
+	}
+
+	log.Info().
+		Str("runner_id", runnerID).
+		Msg("admin runner logs: WebSocket connection closed")
+}

--- a/api/pkg/server/admin_runner_logs.go
+++ b/api/pkg/server/admin_runner_logs.go
@@ -3,10 +3,14 @@ package server
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -15,11 +19,18 @@ import (
 	"github.com/helixml/helix/api/pkg/proxy"
 )
 
+const (
+	// logsTailMaxFromAPI mirrors hydra's max-tail clamp so we reject
+	// nonsense before opening a RevDial connection. Hydra also clamps,
+	// this is defence in depth.
+	logsTailMaxFromAPI = 5000
+)
+
 // streamAdminRunnerLogs streams a Runner's hydra-aggregated log buffer over a
 // WebSocket so an admin can live-tail what the Runner is doing without SSH.
 //
 // Route: GET /api/v1/admin/runners/{runner_id}/logs
-// Query: tail=N (default 200, max 5000), follow=bool (default true)
+// Query: tail=N (default 200, max 5000, 0 = no history), follow=bool (default true)
 //
 // Auth is enforced by the admin subrouter middleware. Multiple admins can open
 // the same stream concurrently — hydra fans the same buffer to all
@@ -29,6 +40,27 @@ import (
 // Pattern mirrors the screenshot stream WS proxy at
 // external_agent_handlers.go: hijack, dial hydra via RevDial, do the upgrade
 // dance, then hand off to proxy.NewResilientProxy for byte pumping.
+//
+// Caveat about the URL var `runner_id`: this matches the existing
+// /admin/runners/{runner_id}/... family which treats the value as a
+// sandbox_instances row ID. The same value is the RevDial registration key
+// (`hydra-<id>`). Hydra serves the *aggregated* buffer for the whole runner
+// process — every inner desktop container, plus hydra's own zerolog output.
+// This endpoint does not filter to a single inner container.
+//
+// Auth scope: Runners are global infrastructure (no `OrganizationID` field
+// on the SandboxInstance row), so any admin can view any Runner's logs.
+// This matches the rest of the /admin/runners/... family. If Runners ever
+// gain org-scoping, this handler will need to call s.lookupOrg() and check
+// membership, matching the wallet_handlers.go pattern. Documented openly so
+// the next reader doesn't assume the scoping that doesn't exist.
+//
+// Content disclosure: streamed `docker logs` output may contain whatever the
+// inner desktop containers printed to stdout/stderr — including any API
+// keys, OAuth tokens, or environment variable dumps that the agent or its
+// children emitted. Treat this endpoint as carrying the same trust as
+// reading every running container's stdout directly. "Admin" should be a
+// trusted operator role.
 func (apiServer *HelixAPIServer) streamAdminRunnerLogs(res http.ResponseWriter, req *http.Request) {
 	runnerID := mux.Vars(req)["runner_id"]
 	if runnerID == "" {
@@ -36,13 +68,48 @@ func (apiServer *HelixAPIServer) streamAdminRunnerLogs(res http.ResponseWriter, 
 		return
 	}
 
-	// Forward tail and follow query params through to hydra. Unknown params
-	// are dropped to keep the surface area small.
+	// Origin check (CSRF defence). The same-site WS hijack is otherwise
+	// reachable by an authenticated admin's browser session from any
+	// origin, which is the classic WS-CSRF shape. Allow only requests
+	// whose Origin matches the server's configured public URL, or is empty
+	// (curl / wscat clients, fine because they have to forge auth too).
+	if origin := req.Header.Get("Origin"); origin != "" {
+		serverURL := apiServer.Cfg.WebServer.URL
+		if serverURL == "" || !originAllowed(origin, serverURL) {
+			log.Warn().
+				Str("origin", origin).
+				Str("server_url", serverURL).
+				Msg("admin runner logs: rejecting WS upgrade from disallowed Origin")
+			http.Error(res, "forbidden origin", http.StatusForbidden)
+			return
+		}
+	}
+
+	// Validate + clamp `tail` before opening a RevDial connection so an
+	// admin requesting an absurd value gets a clean 400, not a stalled
+	// upgrade.
 	hydraQuery := url.Values{}
 	if v := req.URL.Query().Get("tail"); v != "" {
-		hydraQuery.Set("tail", v)
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			http.Error(res, "invalid tail", http.StatusBadRequest)
+			return
+		}
+		if n < 0 {
+			n = 0
+		}
+		if n > logsTailMaxFromAPI {
+			n = logsTailMaxFromAPI
+		}
+		hydraQuery.Set("tail", strconv.Itoa(n))
 	}
 	if v := req.URL.Query().Get("follow"); v != "" {
+		// Accept only literal "true" / "false" so we don't forward
+		// arbitrary user input verbatim.
+		if v != "true" && v != "false" {
+			http.Error(res, "invalid follow", http.StatusBadRequest)
+			return
+		}
 		hydraQuery.Set("follow", v)
 	}
 	hydraPath := "/api/v1/logs"
@@ -56,6 +123,10 @@ func (apiServer *HelixAPIServer) streamAdminRunnerLogs(res http.ResponseWriter, 
 		http.Error(res, "missing Sec-WebSocket-Key", http.StatusBadRequest)
 		return
 	}
+
+	// Per-request session ID so two concurrent admin tabs against the same
+	// runner are distinguishable in logs.
+	sessionID := fmt.Sprintf("admin-runner-logs-%s-%s", runnerID, randHex(6))
 
 	hijacker, ok := res.(http.Hijacker)
 	if !ok {
@@ -78,6 +149,7 @@ func (apiServer *HelixAPIServer) streamAdminRunnerLogs(res http.ResponseWriter, 
 		log.Warn().
 			Err(err).
 			Str("runner_id", runnerID).
+			Str("session_id", sessionID).
 			Msg("admin runner logs: failed to dial runner via RevDial")
 		_, _ = clientConn.Write([]byte("HTTP/1.1 503 Service Unavailable\r\nContent-Type: text/plain\r\n\r\nRunner not connected"))
 		return
@@ -93,15 +165,23 @@ func (apiServer *HelixAPIServer) streamAdminRunnerLogs(res http.ResponseWriter, 
 		"Sec-WebSocket-Version: 13\r\n"+
 		"\r\n", hydraPath, wsKey)
 	if _, err := serverConn.Write([]byte(upgradeReq)); err != nil {
-		log.Warn().Err(err).Msg("admin runner logs: failed to send upgrade to hydra")
+		log.Warn().Err(err).Str("session_id", sessionID).Msg("admin runner logs: failed to send upgrade to hydra")
 		_, _ = clientConn.Write([]byte("HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain\r\n\r\nHydra upgrade write failed"))
 		return
 	}
 
+	// CRITICAL: bufio reader can buffer bytes past the 101 response into
+	// memory. With this PR's snapshot-on-connect, hydra writes the 101
+	// then immediately follows with up to 5000 snapshot WS frames; many of
+	// those will land in the bufio reader's buffer during ReadResponse.
+	// Once we hand serverConn to ResilientProxy below, the proxy reads
+	// from the raw conn and any bytes still in the bufio reader are lost.
+	// We drain `serverReader.Buffered()` to the client right after the
+	// upgrade dance to avoid silent snapshot truncation.
 	serverReader := bufio.NewReader(serverConn)
 	upgradeResp, err := http.ReadResponse(serverReader, nil)
 	if err != nil {
-		log.Warn().Err(err).Msg("admin runner logs: failed to read upgrade response from hydra")
+		log.Warn().Err(err).Str("session_id", sessionID).Msg("admin runner logs: failed to read upgrade response from hydra")
 		_, _ = clientConn.Write([]byte("HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain\r\n\r\nHydra upgrade response read failed"))
 		return
 	}
@@ -111,6 +191,7 @@ func (apiServer *HelixAPIServer) streamAdminRunnerLogs(res http.ResponseWriter, 
 		log.Warn().
 			Int("status", upgradeResp.StatusCode).
 			Str("runner_id", runnerID).
+			Str("session_id", sessionID).
 			Msg("admin runner logs: hydra refused WebSocket upgrade")
 		_, _ = clientConn.Write([]byte(fmt.Sprintf("HTTP/1.1 %d %s\r\nContent-Type: text/plain\r\n\r\nHydra refused upgrade", upgradeResp.StatusCode, upgradeResp.Status)))
 		return
@@ -126,24 +207,45 @@ func (apiServer *HelixAPIServer) streamAdminRunnerLogs(res http.ResponseWriter, 
 		"Sec-WebSocket-Accept: %s\r\n"+
 		"\r\n", clientAccept)
 	if _, err := clientConn.Write([]byte(clientUpgradeResp)); err != nil {
-		log.Warn().Err(err).Msg("admin runner logs: failed to forward 101 to client")
+		log.Warn().Err(err).Str("session_id", sessionID).Msg("admin runner logs: failed to forward 101 to client")
 		return
+	}
+
+	// Drain any post-101 bytes already buffered by the http.ReadResponse
+	// call and forward them to the client before ResilientProxy takes
+	// over. Without this, the entire initial snapshot is silently dropped.
+	if buffered := serverReader.Buffered(); buffered > 0 {
+		buf := make([]byte, buffered)
+		if _, err := serverReader.Read(buf); err == nil {
+			if _, werr := clientConn.Write(buf); werr != nil {
+				log.Warn().Err(werr).Str("session_id", sessionID).Msg("admin runner logs: failed to flush buffered upgrade tail to client")
+				return
+			}
+		}
 	}
 
 	log.Info().
 		Str("runner_id", runnerID).
+		Str("session_id", sessionID).
 		Str("hydra_path", hydraPath).
 		Msg("admin runner logs: WebSocket established, starting proxy")
 
-	// Pump bytes via the resilient proxy. On RevDial reconnect, the same
-	// upgrade dance is replayed against the new server connection.
+	// Pump bytes via the resilient proxy. On RevDial reconnect, the
+	// upgrade is replayed — but with tail=0 so the client doesn't receive
+	// a duplicate snapshot every reconnect. The follow flag is preserved.
 	dialFunc := func(ctx context.Context) (net.Conn, error) {
 		return apiServer.connman.Dial(ctx, hydraRunnerID)
 	}
-	upgradeFunc := proxy.CreateWebSocketUpgradeFunc(hydraPath, wsKey)
+	reconnectQuery := url.Values{}
+	reconnectQuery.Set("tail", "0")
+	if v := hydraQuery.Get("follow"); v != "" {
+		reconnectQuery.Set("follow", v)
+	}
+	reconnectPath := "/api/v1/logs?" + reconnectQuery.Encode()
+	upgradeFunc := proxy.CreateWebSocketUpgradeFunc(reconnectPath, wsKey)
 
 	rp := proxy.NewResilientProxy(proxy.ResilientProxyConfig{
-		SessionID:   "admin-runner-logs-" + runnerID,
+		SessionID:   sessionID,
 		ClientConn:  clientConn,
 		ServerConn:  serverConn,
 		DialFunc:    dialFunc,
@@ -151,10 +253,38 @@ func (apiServer *HelixAPIServer) streamAdminRunnerLogs(res http.ResponseWriter, 
 	})
 	defer rp.Close()
 	if err := rp.Run(req.Context()); err != nil {
-		log.Debug().Err(err).Str("runner_id", runnerID).Msg("admin runner logs: proxy exited with error")
+		log.Debug().Err(err).Str("runner_id", runnerID).Str("session_id", sessionID).Msg("admin runner logs: proxy exited with error")
 	}
 
 	log.Info().
 		Str("runner_id", runnerID).
+		Str("session_id", sessionID).
 		Msg("admin runner logs: WebSocket connection closed")
+}
+
+// originAllowed returns true when the request Origin matches the scheme+host
+// of the configured public server URL. Simple exact-match on origin string;
+// callers running multiple frontends behind the same control plane should
+// extend this once that requirement actually exists.
+func originAllowed(origin, serverURL string) bool {
+	serverParsed, err := url.Parse(serverURL)
+	if err != nil || serverParsed.Host == "" {
+		return false
+	}
+	originParsed, err := url.Parse(origin)
+	if err != nil || originParsed.Host == "" {
+		return false
+	}
+	return strings.EqualFold(originParsed.Host, serverParsed.Host) &&
+		strings.EqualFold(originParsed.Scheme, serverParsed.Scheme)
+}
+
+func randHex(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback to a timestamp-derived suffix; uniqueness still good
+		// enough for log correlation.
+		return strconv.FormatInt(time.Now().UnixNano(), 16)
+	}
+	return hex.EncodeToString(b)
 }

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1182,6 +1182,9 @@ func (apiServer *HelixAPIServer) registerRoutes(_ context.Context) (*mux.Router,
 	adminRouter.HandleFunc("/runners/{runner_id}/assignment", apiServer.getRunnerAssignment).Methods(http.MethodGet)
 	adminRouter.HandleFunc("/runners/{runner_id}/assign-profile", apiServer.assignRunnerProfile).Methods(http.MethodPost)
 	adminRouter.HandleFunc("/runners/{runner_id}/clear-profile", apiServer.clearRunnerProfile).Methods(http.MethodPost)
+	// Live-tail of a runner's hydra-aggregated logs over WebSocket.
+	// See design/2026-05-29-admin-runner-logs.md.
+	adminRouter.HandleFunc("/runners/{runner_id}/logs", apiServer.streamAdminRunnerLogs).Methods(http.MethodGet)
 
 	// Runner-token-authenticated read paths so the sandbox-side compose-
 	// manager can fetch its own assignment + profile content using the

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1184,7 +1184,13 @@ func (apiServer *HelixAPIServer) registerRoutes(_ context.Context) (*mux.Router,
 	adminRouter.HandleFunc("/runners/{runner_id}/clear-profile", apiServer.clearRunnerProfile).Methods(http.MethodPost)
 	// Live-tail of a runner's hydra-aggregated logs over WebSocket.
 	// See design/2026-05-29-admin-runner-logs.md.
-	adminRouter.HandleFunc("/runners/{runner_id}/logs", apiServer.streamAdminRunnerLogs).Methods(http.MethodGet)
+	// NOTE: adminRouter is auth-based, not path-based (MatcherFunc, no
+	// PathPrefix). Existing admin user routes hard-prefix `/admin/` so
+	// they live at /api/v1/admin/... — the runner-profile family above
+	// (`/runner-profiles`, `/runners/...`) lives at /api/v1/... and is
+	// an existing naming inconsistency. This new route follows the
+	// /admin/... convention to match the frontend's URL builder.
+	adminRouter.HandleFunc("/admin/runners/{runner_id}/logs", apiServer.streamAdminRunnerLogs).Methods(http.MethodGet)
 
 	// Runner-token-authenticated read paths so the sandbox-side compose-
 	// manager can fetch its own assignment + profile content using the

--- a/design/2026-05-29-admin-runner-logs.md
+++ b/design/2026-05-29-admin-runner-logs.md
@@ -170,6 +170,23 @@ Estimated effort: 1-2 days end-to-end for one engineer.
 - **Frontend dependency.** Resolved: `xterm.js` is already in the bundle (used by `SandboxTerminal.tsx`); no new dependency added. xterm passes ANSI escape sequences through, so hydra's colored output keeps its formatting.
 - **Drain on Runner disconnect.** Resolved in v1: hydra-side handler holds the WS open while the runner runs and closes cleanly on shutdown; control-plane side uses `proxy.ResilientProxy` which handles RevDial reconnects transparently. On reconnect, the upgrade request uses `tail=0` so the client doesn't receive a duplicate history dump every drop-and-recover cycle. Frontend renders a "Reconnecting…" chip during the gap and "Disconnected" if a second close happens before the first reconnect succeeded.
 
+## Memory bounds
+
+All three layers are explicitly bounded so a long-running tail or a chatty inner container can't OOM anything:
+
+| Layer | Bound | Knob |
+|---|---|---|
+| Hydra `LogBuffer` ring | 10 000 lines × ~256 B ≈ **2.5 MB** per Runner | `defaultLogBufferCapacity` |
+| Hydra per-subscriber channel | 256 lines × ~256 B ≈ **65 KB** | `slowSubBuffer` |
+| Hydra concurrent subscribers | **32** (cap → `CloseTryAgainLater` on overflow) | `maxSubscribers` |
+| Control-plane `ResilientProxy` | input + output 512 KB each ≈ **1 MB** per active tab | `proxy.DefaultBufferSize` |
+| Browser xterm scrollback | 10 000 lines × ~256 B ≈ **2.5 MB** per tab | `scrollback` in `RunnerLogs.tsx` |
+| Browser pause queue | 2 000 lines × ~256 B ≈ **500 KB** per tab | `queueWhilePausedCap` |
+
+Worst case under heavy use: ~5 MB hydra + (~1 MB × N control-plane WS proxies) + (~3 MB × M browser tabs). With 5 admins × 20 Runners = 100 active streams that's ~500 MB on the control plane and ~15 MB per admin browser. Fine for a control plane running a database; trivial for a browser tab.
+
+Not enforced: rate-limiting on producer-side hydra writes. A pathological inner container that prints 100 k lines/sec floods through `Write`, the ring constantly overwrites, and downstream WS pipes saturate but don't OOM — the drop-oldest fanout keeps the producer running. Worth adding a producer-side cap in v2 if we see this in practice.
+
 ## Followups (explicit non-goals captured for later)
 
 - v2: per-container filter.

--- a/design/2026-05-29-admin-runner-logs.md
+++ b/design/2026-05-29-admin-runner-logs.md
@@ -1,0 +1,173 @@
+# Admin Runner Logs
+
+Date: 2026-05-29
+Status: Proposal
+
+## Motivation
+
+When something goes wrong inside a Runner (outer helix-sandbox container or its inner ubuntu-external dev container), the path to "see what is happening" today is:
+
+- For Runners that the operator owns (dev boxes, local infra): `docker logs <name>` on the host.
+- For Runners hosted by a customer or partner (separate VPC, on-prem behind a firewall, third-party scheduler): there is no in-product path. Operators currently either ask for SSH access or wait for the task to finish and pull post-mortem logs from whatever object store the Runner was configured to upload to.
+
+A recent end-to-end test against remote Runner infrastructure made the cost concrete. A spec task dispatched fine, the agent did its work, but live video streaming failed with `failed to change state to PLAYING`. Diagnosing the cause required pulling a post-mortem log file from object storage (4MB, ~3700 lines), grepping through it, and finding `[render-node] WARNING: Could not find nvidia driver for GPU_VENDOR=nvidia, falling back to software rendering` near the top. That information was there the whole time, but only visible after the run completed. A live log view in the admin UI would have surfaced it within seconds of the Runner starting.
+
+This problem is not specific to any one deployment. Any time Helix runs in an environment where operators cannot SSH to the box, the same gap exists. The fix is reusable across every customer engagement.
+
+## Goal
+
+Add an admin-only endpoint that streams Runner logs to the operator's browser in near-real-time, via the existing RevDial control connection from the Runner back to the control plane. Surface it in the admin UI on the Agent Sandboxes panel that already lists Runners.
+
+In scope for v1:
+
+- One endpoint that streams the outer Runner container's stdout (which already includes hydra's prefixed stream of inner-container logs).
+- One frontend tab inside the existing Agent Sandboxes admin panel that opens this stream for the selected Runner.
+- Admin-only auth gating, matching the rest of the `/admin/runners/...` namespace.
+- WebSocket transport, matching the existing streaming WS used for video.
+
+Out of scope for v1:
+
+- Selecting a specific inner container (e.g. only `ubuntu-external-<id>`). The outer Runner stdout already contains everything, prefix-tagged. Per-container filtering is a follow-up.
+- Historical log retention beyond what hydra naturally buffers in its current process lifetime.
+- Searching, regex filtering, downloading. Future.
+- Aggregated multi-Runner views.
+
+## Why this is small
+
+There is strong precedent for every layer of the stack.
+
+### Admin URL namespace already exists
+
+`server.go:1176-1184` registers a family of `/admin/runners/{runner_id}/...` endpoints:
+
+```
+/admin/runner-profiles                                  GET POST
+/admin/runner-profiles/{id}                             GET PUT DELETE
+/admin/runners/{runner_id}/compatible-profiles          GET
+/admin/runners/{runner_id}/assignment                   GET
+/admin/runners/{runner_id}/assign-profile               POST
+/admin/runners/{runner_id}/clear-profile                POST
+```
+
+Adding `/admin/runners/{runner_id}/logs` (WS upgrade) slots straight in. Auth and admin gating already wired by the admin router.
+
+### Runner-via-RevDial exec helper already exists
+
+`claude_subscription_handlers.go:672` defines `execInContainer(ctx, runnerID, command)` which dials a runner over RevDial, POSTs to `http://localhost:9876/exec` on the runner side, and returns the result. That endpoint is implemented in hydra. Today it is request/response, not streaming.
+
+We do not extend `execInContainer` directly. Instead we follow the same pattern: a new hydra endpoint that streams.
+
+### Streaming via RevDial already works
+
+`session_expose_handlers.go` proxies HTTP requests and WebSocket upgrades through the RevDial connection to hydra. The streaming WS for desktop video (`external_agent_handlers.go:1424` `Proxying stream WebSocket to screenshot-server via RevDial`) is the closest precedent: it upgrades the client connection to WS, dials hydra, opens a WS back, and pumps bytes both directions with reconnect support (`pkg/proxy/resilient.go`).
+
+The admin logs endpoint can lift this pattern verbatim. The only differences are which RevDial endpoint we point at, and the auth check (admin instead of session-owner).
+
+### Hydra already streams container logs to its own stdout
+
+Post-mortem log files from recent test runs show hydra prefixing inner-container logs with `[HYDRA] [DESKTOP ubuntu-external-<id>] ...` and emitting them on its own stdout. That stream is already running for every active Runner. The new hydra endpoint just needs to fan a WebSocket subscription onto that existing stream.
+
+## Design
+
+### Endpoint
+
+```
+GET /api/v1/admin/runners/{runner_id}/logs
+Upgrade: websocket
+```
+
+Query parameters (v1):
+
+- `tail` (int, default 200): number of trailing lines to send on connect, before live tail starts.
+- `follow` (bool, default true): stay connected and emit new lines. If false, send tail then close.
+
+Response: WebSocket sending one log line per message, encoded as JSON:
+
+```json
+{"t":"2026-05-29T10:34:01.863Z","stream":"stdout","line":"[HYDRA] [DESKTOP ubuntu-external-...] ..."}
+```
+
+`stream` is `stdout` or `stderr`. Hydra may not distinguish today; if not, emit `stdout` always for v1.
+
+On error (runner not connected, RevDial failure), close with a clean WebSocket close code and a status frame:
+
+```json
+{"error":"runner not connected"}
+```
+
+### Auth
+
+The handler validates the requesting token has admin scope. The existing admin router middleware enforces this for `/admin/...` routes. No new auth code.
+
+### Server-side handler
+
+New file `api/pkg/server/admin_runner_logs.go`:
+
+```
+func (s *HelixAPIServer) streamRunnerLogs(w http.ResponseWriter, r *http.Request) {
+    runnerID := mux.Vars(r)["runner_id"]
+
+    // 1. Validate runner is registered + admin can see it.
+    // 2. Upgrade the incoming connection to a WebSocket.
+    // 3. Dial the runner over RevDial.
+    // 4. Send a control message to hydra: GET /logs?tail=200&follow=true.
+    // 5. Pump bytes from RevDial WS -> client WS, line-by-line.
+    // 6. On disconnect, close both.
+}
+```
+
+Reuse the existing `pkg/proxy/resilient.go` helpers if they fit; otherwise model after `external_agent_handlers.go:1424`.
+
+### Runner-side endpoint (hydra)
+
+New endpoint in hydra: `GET /logs?tail=N&follow=true` on `http://localhost:9876`.
+
+Hydra already maintains its own log buffer (the stream we see in `taskoutput.txt`). The endpoint:
+
+1. Upgrades to WebSocket.
+2. Emits the trailing N lines.
+3. Subscribes to the live tail and emits each new line as a WS message.
+4. Closes when the client disconnects.
+
+Implementation note: hydra's log capture is already running. The endpoint is a fan-out, not a fresh `docker logs -f` invocation. This matters because spawning per-subscriber `docker logs` would leak processes if a connection dies uncleanly.
+
+### Frontend
+
+In `frontend/src/components/admin/AgentSandboxes.tsx`, add a "Logs" tab next to the existing per-sandbox controls. When opened:
+
+1. Open WS to `wss://{control-plane-host}/api/v1/admin/runners/{runner_id}/logs?tail=200&follow=true`.
+2. Render lines in a virtualized, scroll-locked terminal-style view. Reuse the dependency already in the repo for any existing log display (check Kodit Repositories tab, settings logs, etc. for an existing component).
+3. Show a connection status indicator at the top: connected / reconnecting / disconnected.
+4. Provide a "pause" toggle that stops auto-scrolling so the operator can read.
+5. Provide a "download last 5000 lines" button that fetches a snapshot HTTP endpoint (out of scope v1; future).
+
+UX detail: the same panel already shows the half-baked Inference Profile section flagged in `Task #5 (Admin dashboard cleanup)`. This is a good moment to fix both together if the user wants to bundle.
+
+## Implementation plan
+
+Ordered by dependency:
+
+1. **Hydra side: `/logs` WebSocket endpoint.** Smallest, most self-contained. Test directly against a running hydra inside the helix-sandbox container with `websocat`. Land first.
+2. **Helix API: `/api/v1/admin/runners/{runner_id}/logs` handler.** Proxy WS via RevDial to hydra. Test from a curl-style WS client (`wscat`) once authenticated as admin.
+3. **Frontend: admin panel Logs tab.** Build against the new endpoint. Includes connection status, pause, basic styling.
+4. **End-to-end test.** Spin up a Runner (local or remote), trigger a spec task, watch logs flow in real time.
+5. **Docs.** Brief mention in the admin UI section of the README.
+
+Estimated effort: 1-2 days end-to-end for one engineer.
+
+## Open questions
+
+- **Per-container filtering.** Hydra's stdout includes prefix-tagged lines from every inner container. Operators often only want one container's logs. Should v1 support a `container=<name>` query parameter that drops lines not matching that prefix? Adds complexity to hydra. **Recommend deferring to v2** unless an operator hits this on day one.
+- **Multiple concurrent subscribers per Runner.** If two admins open the logs tab simultaneously, hydra should fan out without re-reading any history. Verify the buffer model supports that before landing.
+- **Auth model for "admin sees logs of any Runner."** Today, admin scope is a single boolean. If Helix grows org-scoped admin (which it has, per `[[feedback_org_membership_git_403]]` design doc), the logs endpoint should respect that — an org admin should only see Runners assigned to their org. Check `lookupOrg` pattern in `wallet_handlers.go` for the standard.
+- **Log retention.** Hydra likely buffers a bounded amount (e.g. last 10k lines) in process memory. If an admin opens logs for a Runner that has been running for a week, history beyond that buffer is gone. Acceptable for v1; document the limit clearly.
+- **Frontend dependency.** Is there an existing in-repo virtualized log viewer component? If yes, reuse. If not, this PR may need to add `react-window` or similar — that adds bundle size, worth flagging.
+- **Drain on Runner disconnect.** If the Runner's RevDial connection drops mid-stream, what does the admin see? Recommend: brief reconnect attempt (5s), then close with a clear "runner disconnected" status. Do not silently hang.
+
+## Followups (explicit non-goals captured for later)
+
+- v2: per-container filter.
+- v2: server-side log retention (a circular file buffer on the control plane, optional, off by default).
+- v2: `/admin/runners/{runner_id}/logs/snapshot.txt` for downloading the last N lines as a static file (admins love this for ticket attachments).
+- v2: search and grep within the live stream.
+- v2: integration with admin notifications (e.g. "tail N lines on every error-level line").

--- a/design/2026-05-29-admin-runner-logs.md
+++ b/design/2026-05-29-admin-runner-logs.md
@@ -65,7 +65,12 @@ The admin logs endpoint can lift this pattern verbatim. The only differences are
 
 ### Hydra already streams container logs to its own stdout
 
-Post-mortem log files from recent test runs show hydra prefixing inner-container logs with `[HYDRA] [DESKTOP ubuntu-external-<id>] ...` and emitting them on its own stdout. That stream is already running for every active Runner. The new hydra endpoint just needs to fan a WebSocket subscription onto that existing stream.
+Post-mortem log files from recent test runs show hydra prefixing inner-container logs with `[HYDRA] [DESKTOP ubuntu-external-<id>] ...` and emitting them on its own stdout. That stream is already running for every active Runner. The new hydra endpoint fans a WebSocket subscription onto an in-memory ring (`LogBuffer`) that captures:
+
+- Inner-container logs from `DevContainerManager.streamContainerLogs` (the `[DESKTOP ...]` prefixed stream).
+- Hydra's own zerolog output (info / warn / error). The cmd/hydra main wraps the logger output in an `io.MultiWriter` that fans into stderr AND the buffer, so admin viewers see hydra-level diagnostics (startup failures, NVIDIA detection warnings, RevDial reconnect events) alongside container output.
+
+Not captured: dockerd's own logs (it runs as a sibling process), systemd/journal entries on the host, or anything written before hydra constructs its logger. For deeper post-mortem these still require host-level access.
 
 ## Design
 
@@ -158,11 +163,12 @@ Estimated effort: 1-2 days end-to-end for one engineer.
 ## Open questions
 
 - **Per-container filtering.** Hydra's stdout includes prefix-tagged lines from every inner container. Operators often only want one container's logs. Should v1 support a `container=<name>` query parameter that drops lines not matching that prefix? Adds complexity to hydra. **Recommend deferring to v2** unless an operator hits this on day one.
-- **Multiple concurrent subscribers per Runner.** If two admins open the logs tab simultaneously, hydra should fan out without re-reading any history. Verify the buffer model supports that before landing.
-- **Auth model for "admin sees logs of any Runner."** Today, admin scope is a single boolean. If Helix grows org-scoped admin (which it has, per `[[feedback_org_membership_git_403]]` design doc), the logs endpoint should respect that — an org admin should only see Runners assigned to their org. Check `lookupOrg` pattern in `wallet_handlers.go` for the standard.
-- **Log retention.** Hydra likely buffers a bounded amount (e.g. last 10k lines) in process memory. If an admin opens logs for a Runner that has been running for a week, history beyond that buffer is gone. Acceptable for v1; document the limit clearly.
-- **Frontend dependency.** Is there an existing in-repo virtualized log viewer component? If yes, reuse. If not, this PR may need to add `react-window` or similar — that adds bundle size, worth flagging.
-- **Drain on Runner disconnect.** If the Runner's RevDial connection drops mid-stream, what does the admin see? Recommend: brief reconnect attempt (5s), then close with a clear "runner disconnected" status. Do not silently hang.
+- **Multiple concurrent subscribers per Runner.** Resolved in v1: `LogBuffer` fans every line out to all subscribers without re-reading history (`logbuf.go:Write`); subscriber count is capped at `maxSubscribers=32` per buffer so a buggy reconnect loop or a hostile client can't starve the writer.
+- **Auth model for "admin sees logs of any Runner."** Runners are global infrastructure in the current model — the `SandboxInstance` row has no `OrganizationID`, so there is no org to scope against. Documented in the handler comment. If Runners ever gain org-scoping, the handler will need to call `lookupOrg()` and check membership, matching `wallet_handlers.go`.
+- **Log retention.** Resolved: hydra buffers the last 10,000 lines in process memory. History beyond that is gone. **Hydra restart wipes the buffer entirely** — this is the same scenario where logs are most useful (a crashed daemon), and the v1 endpoint will return an empty buffer on the next start. Operators chasing post-mortem evidence after a hydra crash should fall back to `docker logs <outer-sandbox>` or the S3 taskoutput.txt from the task-running platform. Persistent on-disk retention is a v2 follow-up.
+- **Content disclosure.** Streamed `docker logs` output contains whatever the inner desktop containers printed — API keys, OAuth tokens, environment-variable dumps from crash traces. Documented as carrying the same trust as reading every running container's stdout. Treat "admin" as a trusted operator role.
+- **Frontend dependency.** Resolved: `xterm.js` is already in the bundle (used by `SandboxTerminal.tsx`); no new dependency added. xterm passes ANSI escape sequences through, so hydra's colored output keeps its formatting.
+- **Drain on Runner disconnect.** Resolved in v1: hydra-side handler holds the WS open while the runner runs and closes cleanly on shutdown; control-plane side uses `proxy.ResilientProxy` which handles RevDial reconnects transparently. On reconnect, the upgrade request uses `tail=0` so the client doesn't receive a duplicate history dump every drop-and-recover cycle. Frontend renders a "Reconnecting…" chip during the gap and "Disconnected" if a second close happens before the first reconnect succeeded.
 
 ## Followups (explicit non-goals captured for later)
 

--- a/frontend/src/components/admin/AgentSandboxes.tsx
+++ b/frontend/src/components/admin/AgentSandboxes.tsx
@@ -29,6 +29,9 @@ import DesktopWindowsIcon from '@mui/icons-material/DesktopWindows'
 import PersonIcon from '@mui/icons-material/Person'
 import ThermostatIcon from '@mui/icons-material/Thermostat'
 import VideocamIcon from '@mui/icons-material/Videocam'
+import DescriptionIcon from '@mui/icons-material/Description'
+
+import RunnerLogs from './RunnerLogs'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAccount } from '../../contexts/account'
 import useApi from '../../hooks/useApi'
@@ -846,6 +849,31 @@ const AgentSandboxes: FC<AgentSandboxesProps> = ({ selectedSandboxId }) => {
             </Card>
           </Grid>
         )}
+
+        {/* Runner Logs: live-tail hydra-aggregated logs from the selected
+            Runner. Requires a specific Runner selection — the stream is
+            per-Runner so "All Sandboxes" shows a prompt. */}
+        <Grid item xs={12}>
+          <Card>
+            <CardHeader
+              avatar={<DescriptionIcon />}
+              title="Runner Logs"
+              subheader="Live tail of hydra-aggregated logs (Runner stdout + inner desktop containers)"
+            />
+            <CardContent>
+              {selectedSandboxId ? (
+                <RunnerLogs runnerId={selectedSandboxId} />
+              ) : (
+                <Box sx={{ textAlign: 'center', py: 4 }}>
+                  <DescriptionIcon sx={{ fontSize: 48, color: 'text.secondary', mb: 2 }} />
+                  <Typography variant="body2" color="text.secondary">
+                    Pick a Runner from the selector above to live-tail its logs.
+                  </Typography>
+                </Box>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
 
         {/* Dev Containers */}
         <Grid item xs={12}>

--- a/frontend/src/components/admin/RunnerLogs.tsx
+++ b/frontend/src/components/admin/RunnerLogs.tsx
@@ -1,0 +1,272 @@
+import { FC, useCallback, useEffect, useRef, useState } from 'react'
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import DeleteSweepIcon from '@mui/icons-material/DeleteSweep'
+import PauseIcon from '@mui/icons-material/Pause'
+import PlayArrowIcon from '@mui/icons-material/PlayArrow'
+import VerticalAlignBottomIcon from '@mui/icons-material/VerticalAlignBottom'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import '@xterm/xterm/css/xterm.css'
+
+interface Props {
+  runnerId: string
+  // tail is the number of historical lines hydra emits on connect. Default
+  // matches the server-side default; raise for deeper context.
+  tail?: number
+  // height of the terminal area. Defaults to a roomy 480px to match the
+  // SandboxTerminal component.
+  height?: number | string
+}
+
+type ConnectionState = 'connecting' | 'open' | 'reconnecting' | 'closed' | 'error'
+
+const reconnectDelayMs = 2000
+const queueWhilePausedCap = 2000
+
+// Build the WebSocket URL for the admin runner logs endpoint. Uses
+// same-origin so cookies flow through; admin auth is enforced by the
+// admin subrouter middleware.
+function runnerLogsUrl(runnerId: string, tail: number): string {
+  const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${proto}//${window.location.host}/api/v1/admin/runners/${encodeURIComponent(
+    runnerId,
+  )}/logs?tail=${tail}&follow=true`
+}
+
+// RunnerLogs streams a Runner's hydra-aggregated log buffer over a WebSocket
+// and renders it in an xterm.js terminal. Lines arrive as JSON
+// `{t: RFC3339, line: string}`. ANSI escape sequences in `line` are passed
+// through to xterm verbatim, so hydra's own colored output keeps its
+// formatting.
+//
+// Pause holds the terminal at its current scroll/content state and queues
+// incoming lines into an in-memory buffer (capped at queueWhilePausedCap).
+// Resume drains the queue into the terminal. The WebSocket stays open while
+// paused — pausing is purely a render gate.
+//
+// Reconnect: on close or error, the component schedules a single reconnect
+// attempt after reconnectDelayMs. If that also fails, status flips to
+// `closed` and the user can manually reload by toggling pause off-then-on
+// (handled by including pause in the effect's dependency list would be
+// over-engineering for v1; instead we surface the state for a future manual
+// "Reconnect" button).
+const RunnerLogs: FC<Props> = ({ runnerId, tail = 500, height = 480 }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const termRef = useRef<Terminal | undefined>()
+  const fitRef = useRef<FitAddon | undefined>()
+  const wsRef = useRef<WebSocket | undefined>()
+  const pausedRef = useRef<boolean>(false)
+  const queueRef = useRef<string[]>([])
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>()
+  const attemptRef = useRef<number>(0)
+
+  const [status, setStatus] = useState<ConnectionState>('connecting')
+  const [paused, setPaused] = useState<boolean>(false)
+  const [queuedCount, setQueuedCount] = useState<number>(0)
+
+  const writeLine = useCallback((line: string) => {
+    const term = termRef.current
+    if (!term) return
+    term.writeln(line)
+  }, [])
+
+  const handleIncoming = useCallback(
+    (line: string) => {
+      if (pausedRef.current) {
+        const q = queueRef.current
+        q.push(line)
+        if (q.length > queueWhilePausedCap) {
+          q.splice(0, q.length - queueWhilePausedCap)
+        }
+        setQueuedCount(q.length)
+        return
+      }
+      writeLine(line)
+    },
+    [writeLine],
+  )
+
+  const togglePause = useCallback(() => {
+    setPaused((prev) => {
+      const next = !prev
+      pausedRef.current = next
+      if (!next) {
+        // Resuming: drain queue, then scroll to bottom.
+        const q = queueRef.current
+        for (const line of q) writeLine(line)
+        queueRef.current = []
+        setQueuedCount(0)
+        termRef.current?.scrollToBottom()
+      }
+      return next
+    })
+  }, [writeLine])
+
+  const clearTerminal = useCallback(() => {
+    termRef.current?.clear()
+    queueRef.current = []
+    setQueuedCount(0)
+  }, [])
+
+  const scrollToBottom = useCallback(() => {
+    termRef.current?.scrollToBottom()
+  }, [])
+
+  // Open/maintain the WebSocket. The terminal itself is set up once per
+  // `runnerId` change; the WS lifecycle is nested inside so reconnect doesn't
+  // tear down xterm.
+  useEffect(() => {
+    if (!containerRef.current || !runnerId) return
+
+    const term = new Terminal({
+      fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+      fontSize: 12,
+      theme: { background: '#000000' },
+      convertEol: true,
+      cursorBlink: false,
+      disableStdin: true,
+      scrollback: 10000,
+    })
+    const fit = new FitAddon()
+    term.loadAddon(fit)
+    term.open(containerRef.current)
+    termRef.current = term
+    fitRef.current = fit
+    try {
+      fit.fit()
+    } catch {
+      // ignore — first paint may not have laid out yet
+    }
+
+    const onResize = () => {
+      try {
+        fit.fit()
+      } catch {
+        // ignore
+      }
+    }
+    window.addEventListener('resize', onResize)
+
+    let cancelled = false
+
+    const connect = () => {
+      if (cancelled) return
+      attemptRef.current += 1
+      setStatus(attemptRef.current === 1 ? 'connecting' : 'reconnecting')
+
+      const ws = new WebSocket(runnerLogsUrl(runnerId, tail))
+      wsRef.current = ws
+
+      ws.onopen = () => {
+        if (cancelled) return
+        setStatus('open')
+        attemptRef.current = 0
+      }
+      ws.onmessage = (e) => {
+        if (typeof e.data !== 'string') return
+        try {
+          const msg = JSON.parse(e.data) as { t?: string; line?: string }
+          if (typeof msg.line === 'string') handleIncoming(msg.line)
+        } catch {
+          // Backend always emits JSON; if it ever sends raw text, render it
+          // unparsed so we don't silently drop log output.
+          handleIncoming(e.data)
+        }
+      }
+      ws.onerror = () => {
+        if (cancelled) return
+        setStatus('error')
+      }
+      ws.onclose = () => {
+        if (cancelled) return
+        // One short retry. After that, status sticks at "closed" until the
+        // user navigates away and back.
+        if (attemptRef.current <= 1) {
+          setStatus('reconnecting')
+          reconnectTimerRef.current = setTimeout(connect, reconnectDelayMs)
+        } else {
+          setStatus('closed')
+        }
+      }
+    }
+
+    connect()
+
+    return () => {
+      cancelled = true
+      window.removeEventListener('resize', onResize)
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current)
+      wsRef.current?.close()
+      term.dispose()
+      termRef.current = undefined
+      fitRef.current = undefined
+      wsRef.current = undefined
+      queueRef.current = []
+      attemptRef.current = 0
+    }
+  }, [runnerId, tail, handleIncoming])
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+        <StatusChip status={status} />
+        <Box sx={{ flexGrow: 1 }} />
+        {paused && queuedCount > 0 && (
+          <Typography variant="caption" color="text.secondary">
+            {queuedCount} line{queuedCount !== 1 ? 's' : ''} queued
+          </Typography>
+        )}
+        <Tooltip title={paused ? 'Resume' : 'Pause'}>
+          <IconButton size="small" onClick={togglePause}>
+            {paused ? <PlayArrowIcon fontSize="small" /> : <PauseIcon fontSize="small" />}
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Scroll to bottom">
+          <IconButton size="small" onClick={scrollToBottom}>
+            <VerticalAlignBottomIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Clear">
+          <IconButton size="small" onClick={clearTerminal}>
+            <DeleteSweepIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </Stack>
+      <Box
+        ref={containerRef}
+        sx={{
+          flexGrow: 1,
+          minHeight: height,
+          backgroundColor: '#000000',
+          borderRadius: 1,
+          overflow: 'hidden',
+        }}
+      />
+    </Box>
+  )
+}
+
+const StatusChip: FC<{ status: ConnectionState }> = ({ status }) => {
+  const props = (() => {
+    switch (status) {
+      case 'open':
+        return { label: 'Live', color: 'success' as const }
+      case 'connecting':
+        return { label: 'Connecting…', color: 'default' as const }
+      case 'reconnecting':
+        return { label: 'Reconnecting…', color: 'warning' as const }
+      case 'error':
+        return { label: 'Error', color: 'error' as const }
+      case 'closed':
+        return { label: 'Disconnected', color: 'error' as const }
+    }
+  })()
+  return <Chip size="small" label={props.label} color={props.color} />
+}
+
+export default RunnerLogs

--- a/frontend/src/components/admin/RunnerLogs.tsx
+++ b/frontend/src/components/admin/RunnerLogs.tsx
@@ -9,6 +9,10 @@ import DeleteSweepIcon from '@mui/icons-material/DeleteSweep'
 import PauseIcon from '@mui/icons-material/Pause'
 import PlayArrowIcon from '@mui/icons-material/PlayArrow'
 import VerticalAlignBottomIcon from '@mui/icons-material/VerticalAlignBottom'
+import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord'
+import SyncIcon from '@mui/icons-material/Sync'
+import ErrorIcon from '@mui/icons-material/Error'
+import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
@@ -46,36 +50,36 @@ function runnerLogsUrl(runnerId: string, tail: number): string {
 //
 // Pause holds the terminal at its current scroll/content state and queues
 // incoming lines into an in-memory buffer (capped at queueWhilePausedCap).
-// Resume drains the queue into the terminal. The WebSocket stays open while
-// paused — pausing is purely a render gate.
+// Resume drains the queue into the terminal in one batched write. The
+// WebSocket stays open while paused — pausing is purely a render gate.
 //
-// Reconnect: on close or error, the component schedules a single reconnect
-// attempt after reconnectDelayMs. If that also fails, status flips to
-// `closed` and the user can manually reload by toggling pause off-then-on
-// (handled by including pause in the effect's dependency list would be
-// over-engineering for v1; instead we surface the state for a future manual
-// "Reconnect" button).
+// Reconnect: one short retry on close. After it also fails, status flips
+// to `closed` until the user navigates away and back. The retry is gated
+// by a one-shot `hasRetriedRef` flag (separate from the
+// connecting-vs-reconnecting state) so a flapping connection doesn't loop
+// forever resetting itself on every successful onopen.
 const RunnerLogs: FC<Props> = ({ runnerId, tail = 500, height = 480 }) => {
   const containerRef = useRef<HTMLDivElement | null>(null)
-  const termRef = useRef<Terminal | undefined>()
-  const fitRef = useRef<FitAddon | undefined>()
-  const wsRef = useRef<WebSocket | undefined>()
+  const termRef = useRef<Terminal | null>(null)
+  const fitRef = useRef<FitAddon | null>(null)
+  const wsRef = useRef<WebSocket | null>(null)
   const pausedRef = useRef<boolean>(false)
   const queueRef = useRef<string[]>([])
-  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>()
-  const attemptRef = useRef<number>(0)
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const hasRetriedRef = useRef<boolean>(false)
+  // handleIncomingRef lets the WS handlers call the latest write logic
+  // without re-creating the WS effect on every render. The WS effect only
+  // depends on `runnerId` and `tail` — see the long comment in the effect.
+  const handleIncomingRef = useRef<(line: string) => void>(() => {})
 
   const [status, setStatus] = useState<ConnectionState>('connecting')
   const [paused, setPaused] = useState<boolean>(false)
   const [queuedCount, setQueuedCount] = useState<number>(0)
 
-  const writeLine = useCallback((line: string) => {
-    const term = termRef.current
-    if (!term) return
-    term.writeln(line)
-  }, [])
-
-  const handleIncoming = useCallback(
+  // Refresh handleIncomingRef on every render so the WS callbacks see
+  // current state (paused flag, write function). The actual handler is
+  // bound to refs only, so this is cheap.
+  handleIncomingRef.current = useCallback(
     (line: string) => {
       if (pausedRef.current) {
         const q = queueRef.current
@@ -86,9 +90,9 @@ const RunnerLogs: FC<Props> = ({ runnerId, tail = 500, height = 480 }) => {
         setQueuedCount(q.length)
         return
       }
-      writeLine(line)
+      termRef.current?.writeln(line)
     },
-    [writeLine],
+    [],
   )
 
   const togglePause = useCallback(() => {
@@ -96,16 +100,20 @@ const RunnerLogs: FC<Props> = ({ runnerId, tail = 500, height = 480 }) => {
       const next = !prev
       pausedRef.current = next
       if (!next) {
-        // Resuming: drain queue, then scroll to bottom.
+        // Resuming. Batch the queued lines into a single xterm.write call
+        // (~one render commit) so large drains don't block the main
+        // thread the way per-line writelns of 2000 lines would.
         const q = queueRef.current
-        for (const line of q) writeLine(line)
+        if (q.length > 0) {
+          termRef.current?.write(q.join('\r\n') + '\r\n')
+        }
         queueRef.current = []
         setQueuedCount(0)
         termRef.current?.scrollToBottom()
       }
       return next
     })
-  }, [writeLine])
+  }, [])
 
   const clearTerminal = useCallback(() => {
     termRef.current?.clear()
@@ -117,9 +125,11 @@ const RunnerLogs: FC<Props> = ({ runnerId, tail = 500, height = 480 }) => {
     termRef.current?.scrollToBottom()
   }, [])
 
-  // Open/maintain the WebSocket. The terminal itself is set up once per
-  // `runnerId` change; the WS lifecycle is nested inside so reconnect doesn't
-  // tear down xterm.
+  // One effect owns the entire xterm + WS lifecycle, keyed on the runner
+  // we're tailing. The WS handlers read from `handleIncomingRef.current`
+  // (not a captured closure) so render-driven state changes don't tear
+  // the WS down. The effect's only deps are `runnerId` and `tail` —
+  // anything else would cause unwanted teardowns.
   useEffect(() => {
     if (!containerRef.current || !runnerId) return
 
@@ -137,27 +147,30 @@ const RunnerLogs: FC<Props> = ({ runnerId, tail = 500, height = 480 }) => {
     term.open(containerRef.current)
     termRef.current = term
     fitRef.current = fit
-    try {
-      fit.fit()
-    } catch {
-      // ignore — first paint may not have laid out yet
-    }
 
-    const onResize = () => {
+    // Initial fit may run before layout settles. ResizeObserver fires
+    // after layout and on any subsequent container resize (e.g. tab
+    // open/close), which the plain window-resize listener misses.
+    const safeFit = () => {
       try {
         fit.fit()
       } catch {
-        // ignore
+        // ignore — happens during teardown if dimensions are zero
       }
     }
-    window.addEventListener('resize', onResize)
+    safeFit()
+    const ro =
+      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(safeFit) : null
+    if (ro && containerRef.current) ro.observe(containerRef.current)
+    window.addEventListener('resize', safeFit)
 
     let cancelled = false
+    hasRetriedRef.current = false
+    setStatus('connecting')
 
-    const connect = () => {
+    const connect = (isRetry: boolean) => {
       if (cancelled) return
-      attemptRef.current += 1
-      setStatus(attemptRef.current === 1 ? 'connecting' : 'reconnecting')
+      setStatus(isRetry ? 'reconnecting' : 'connecting')
 
       const ws = new WebSocket(runnerLogsUrl(runnerId, tail))
       wsRef.current = ws
@@ -165,17 +178,25 @@ const RunnerLogs: FC<Props> = ({ runnerId, tail = 500, height = 480 }) => {
       ws.onopen = () => {
         if (cancelled) return
         setStatus('open')
-        attemptRef.current = 0
+        // Reset the retry budget so a long-lived connection that
+        // eventually drops gets one more shot. Without this, every
+        // future drop would be the second-and-final attempt.
+        hasRetriedRef.current = false
       }
       ws.onmessage = (e) => {
         if (typeof e.data !== 'string') return
         try {
           const msg = JSON.parse(e.data) as { t?: string; line?: string }
-          if (typeof msg.line === 'string') handleIncoming(msg.line)
+          if (typeof msg.line === 'string') {
+            handleIncomingRef.current(msg.line)
+          }
         } catch {
-          // Backend always emits JSON; if it ever sends raw text, render it
-          // unparsed so we don't silently drop log output.
-          handleIncoming(e.data)
+          // Backend always emits JSON. Non-JSON is a contract break and
+          // dumping it raw into the terminal as a "fallback" risks
+          // visually corrupting the log view, so just drop with a console
+          // warning.
+          // eslint-disable-next-line no-console
+          console.warn('[RunnerLogs] received non-JSON WS message; dropping')
         }
       }
       ws.onerror = () => {
@@ -184,32 +205,46 @@ const RunnerLogs: FC<Props> = ({ runnerId, tail = 500, height = 480 }) => {
       }
       ws.onclose = () => {
         if (cancelled) return
-        // One short retry. After that, status sticks at "closed" until the
-        // user navigates away and back.
-        if (attemptRef.current <= 1) {
+        // Clear any in-flight reconnect timer before scheduling a new
+        // one — without this a fast flap leaks setTimeouts.
+        if (reconnectTimerRef.current) {
+          clearTimeout(reconnectTimerRef.current)
+          reconnectTimerRef.current = null
+        }
+        if (!hasRetriedRef.current) {
+          hasRetriedRef.current = true
           setStatus('reconnecting')
-          reconnectTimerRef.current = setTimeout(connect, reconnectDelayMs)
+          reconnectTimerRef.current = setTimeout(() => connect(true), reconnectDelayMs)
         } else {
           setStatus('closed')
         }
       }
     }
 
-    connect()
+    connect(false)
 
     return () => {
       cancelled = true
-      window.removeEventListener('resize', onResize)
-      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current)
+      if (ro) ro.disconnect()
+      window.removeEventListener('resize', safeFit)
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current)
+        reconnectTimerRef.current = null
+      }
       wsRef.current?.close()
+      wsRef.current = null
       term.dispose()
-      termRef.current = undefined
-      fitRef.current = undefined
-      wsRef.current = undefined
+      termRef.current = null
+      fitRef.current = null
+      // Reset paused-related state so a re-mount with a different
+      // runner_id doesn't display a stale "N lines queued" hint.
       queueRef.current = []
-      attemptRef.current = 0
+      setQueuedCount(0)
+      setPaused(false)
+      pausedRef.current = false
+      hasRetriedRef.current = false
     }
-  }, [runnerId, tail, handleIncoming])
+  }, [runnerId, tail])
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
@@ -251,22 +286,45 @@ const RunnerLogs: FC<Props> = ({ runnerId, tail = 500, height = 480 }) => {
   )
 }
 
+// StatusChip renders the WS state as a labelled chip with a leading icon so
+// the state is not communicated by colour alone (accessibility + colour-blind
+// users). Icon + label + colour each carry the same signal.
 const StatusChip: FC<{ status: ConnectionState }> = ({ status }) => {
-  const props = (() => {
+  const view = (() => {
     switch (status) {
       case 'open':
-        return { label: 'Live', color: 'success' as const }
+        return {
+          label: 'Live',
+          color: 'success' as const,
+          icon: <FiberManualRecordIcon sx={{ fontSize: 14 }} />,
+        }
       case 'connecting':
-        return { label: 'Connecting…', color: 'default' as const }
+        return {
+          label: 'Connecting…',
+          color: 'default' as const,
+          icon: <HourglassEmptyIcon sx={{ fontSize: 14 }} />,
+        }
       case 'reconnecting':
-        return { label: 'Reconnecting…', color: 'warning' as const }
+        return {
+          label: 'Reconnecting…',
+          color: 'warning' as const,
+          icon: <SyncIcon sx={{ fontSize: 14 }} />,
+        }
       case 'error':
-        return { label: 'Error', color: 'error' as const }
+        return {
+          label: 'Error',
+          color: 'error' as const,
+          icon: <ErrorIcon sx={{ fontSize: 14 }} />,
+        }
       case 'closed':
-        return { label: 'Disconnected', color: 'error' as const }
+        return {
+          label: 'Disconnected',
+          color: 'error' as const,
+          icon: <ErrorIcon sx={{ fontSize: 14 }} />,
+        }
     }
   })()
-  return <Chip size="small" label={props.label} color={props.color} />
+  return <Chip size="small" label={view.label} color={view.color} icon={view.icon} />
 }
 
 export default RunnerLogs

--- a/frontend/src/components/admin/RunnerLogs.tsx
+++ b/frontend/src/components/admin/RunnerLogs.tsx
@@ -13,6 +13,7 @@ import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord'
 import SyncIcon from '@mui/icons-material/Sync'
 import ErrorIcon from '@mui/icons-material/Error'
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
@@ -25,6 +26,11 @@ interface Props {
   // height of the terminal area. Defaults to a roomy 480px to match the
   // SandboxTerminal component.
   height?: number | string
+  // showOpenInNewTab renders an "Open in new tab" icon button in the
+  // toolbar that opens /admin/runner-logs/:runner_id as a standalone
+  // full-screen page. Hide when the component is already rendered as
+  // that standalone page (otherwise the user can recursively pop out).
+  showOpenInNewTab?: boolean
 }
 
 type ConnectionState = 'connecting' | 'open' | 'reconnecting' | 'closed' | 'error'
@@ -58,7 +64,12 @@ function runnerLogsUrl(runnerId: string, tail: number): string {
 // by a one-shot `hasRetriedRef` flag (separate from the
 // connecting-vs-reconnecting state) so a flapping connection doesn't loop
 // forever resetting itself on every successful onopen.
-const RunnerLogs: FC<Props> = ({ runnerId, tail = 500, height = 480 }) => {
+const RunnerLogs: FC<Props> = ({
+  runnerId,
+  tail = 500,
+  height = 480,
+  showOpenInNewTab = true,
+}) => {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const termRef = useRef<Terminal | null>(null)
   const fitRef = useRef<FitAddon | null>(null)
@@ -255,6 +266,19 @@ const RunnerLogs: FC<Props> = ({ runnerId, tail = 500, height = 480 }) => {
           <Typography variant="caption" color="text.secondary">
             {queuedCount} line{queuedCount !== 1 ? 's' : ''} queued
           </Typography>
+        )}
+        {showOpenInNewTab && (
+          <Tooltip title="Open in new tab">
+            <IconButton
+              size="small"
+              component="a"
+              href={`/admin/runner-logs/${encodeURIComponent(runnerId)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <OpenInNewIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
         )}
         <Tooltip title={paused ? 'Resume' : 'Pause'}>
           <IconButton size="small" onClick={togglePause}>

--- a/frontend/src/components/admin/RunnerLogs.tsx
+++ b/frontend/src/components/admin/RunnerLogs.tsx
@@ -300,7 +300,14 @@ const RunnerLogs: FC<Props> = ({
         ref={containerRef}
         sx={{
           flexGrow: 1,
-          minHeight: height,
+          // minHeight only applies for fixed pixel heights — used by the
+          // card view to guarantee a readable terminal. When the parent
+          // sizes us via flex (height='100%'), flexGrow:1 fills the
+          // remaining space and setting minHeight: '100%' would force the
+          // box to be the FULL parent height, overflowing by the toolbar
+          // strip's height.
+          minHeight: typeof height === 'number' ? height : 0,
+          minWidth: 0,
           backgroundColor: '#000000',
           borderRadius: 1,
           overflow: 'hidden',

--- a/frontend/src/pages/AdminRunnerLogsPage.tsx
+++ b/frontend/src/pages/AdminRunnerLogsPage.tsx
@@ -33,17 +33,21 @@ const AdminRunnerLogsPage: FC = () => {
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        height: '100vh',
+        position: 'fixed',
+        inset: 0,
         p: 2,
         backgroundColor: 'background.default',
+        // Prevent the page from being scrolled by the terminal's content;
+        // the terminal does its own internal scroll.
+        overflow: 'hidden',
       }}
     >
-      <Box sx={{ mb: 1 }}>
+      <Box sx={{ mb: 1, flexShrink: 0 }}>
         <Typography variant="subtitle1" sx={{ fontFamily: 'monospace' }}>
           Runner Logs · {runnerId}
         </Typography>
       </Box>
-      <Box sx={{ flexGrow: 1, minHeight: 0 }}>
+      <Box sx={{ flexGrow: 1, minHeight: 0, minWidth: 0 }}>
         <RunnerLogs runnerId={runnerId} height="100%" showOpenInNewTab={false} />
       </Box>
     </Box>

--- a/frontend/src/pages/AdminRunnerLogsPage.tsx
+++ b/frontend/src/pages/AdminRunnerLogsPage.tsx
@@ -1,0 +1,53 @@
+import { FC } from 'react'
+import { useRoute } from 'react-router5'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+
+import RunnerLogs from '../components/admin/RunnerLogs'
+
+// AdminRunnerLogsPage renders the live Runner Logs viewer full-screen as a
+// standalone tab. The component reads `runner_id` from the route params and
+// hands off to <RunnerLogs/> which owns the WS lifecycle, snapshot,
+// pause/clear, and connection-status UI.
+//
+// Route: /admin/runner-logs/:runner_id (top-level, no org scope — Runners
+// are global infrastructure, see the handler comment in
+// api/pkg/server/admin_runner_logs.go).
+const AdminRunnerLogsPage: FC = () => {
+  const { route } = useRoute()
+  const runnerId = (route?.params?.runner_id as string) || ''
+
+  if (!runnerId) {
+    return (
+      <Box sx={{ p: 4 }}>
+        <Typography variant="h6">Missing runner_id</Typography>
+        <Typography variant="body2" color="text.secondary">
+          This page expects a runner id in the URL path.
+        </Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100vh',
+        p: 2,
+        backgroundColor: 'background.default',
+      }}
+    >
+      <Box sx={{ mb: 1 }}>
+        <Typography variant="subtitle1" sx={{ fontFamily: 'monospace' }}>
+          Runner Logs · {runnerId}
+        </Typography>
+      </Box>
+      <Box sx={{ flexGrow: 1, minHeight: 0 }}>
+        <RunnerLogs runnerId={runnerId} height="100%" showOpenInNewTab={false} />
+      </Box>
+    </Box>
+  )
+}
+
+export default AdminRunnerLogsPage

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -4,6 +4,7 @@ import { useRoute } from 'react-router5'
 import browserPlugin from 'router5-plugin-browser'
 
 import Session from './pages/Session'
+import AdminRunnerLogsPage from './pages/AdminRunnerLogsPage'
 import Apps from './pages/Apps'
 import Providers from './pages/Providers'
 import Orgs from './pages/Orgs'
@@ -517,6 +518,19 @@ const routes: IApplicationRoute[] = [
     title: 'Login',
   },
   render: () => <Login />,
+}, {
+  // Standalone live-tail of one Runner's hydra-aggregated logs. Opened from
+  // the admin "Runner Logs" card via target="_blank". No drawer / no nav,
+  // so the viewer takes the full viewport. Admin auth still applies via
+  // the standard cookie session.
+  name: 'admin_runner_logs',
+  path: '/admin/runner-logs/:runner_id',
+  meta: {
+    drawer: false,
+    fullscreen: true,
+    title: 'Runner Logs',
+  },
+  render: () => <AdminRunnerLogsPage />,
 }, NOT_FOUND_ROUTE]
 
 export const router = createRouter(routes, {


### PR DESCRIPTION
## Summary

Design proposal for `/api/v1/admin/runners/{runner_id}/logs` — a WebSocket endpoint that lets admins tail a Runner's logs from the existing Agent Sandboxes panel, without needing SSH on the host. Useful any time Helix runs in a customer/partner environment where the operator does not own the box.

## Why it's small

Three existing patterns in the codebase give us most of the implementation for free:

- **Admin URL namespace already exists** — `server.go:1176-1184` registers `/admin/runners/{runner_id}/...` endpoints (assignment, assign-profile, etc.). The logs endpoint slots straight in. Auth wiring already done.
- **`execInContainer` RevDial helper exists** — `claude_subscription_handlers.go:672` already dials a Runner over RevDial and runs commands. Hydra-side endpoint follows the same pattern, but as a streaming WebSocket fan-out.
- **Streaming WS proxy pattern exists** — `external_agent_handlers.go:1424` ("Proxying stream WebSocket to screenshot-server via RevDial") is verbatim what we need, modulo the auth check.

Hydra already streams inner-container logs to its own stdout (visible as `[HYDRA] [DESKTOP ubuntu-external-<id>] ...` lines in post-mortem captures). The new hydra endpoint just fans WS subscriptions onto that existing stream — no per-subscriber `docker logs -f` invocations to leak.

## v1 scope

- Backend: hydra endpoint + control-plane handler + WS proxy
- Frontend: one tab in the Agent Sandboxes admin panel
- Admin-only auth (existing middleware)

## Out of scope (captured as v2)

Per-container filtering, log retention beyond hydra's process buffer, search/grep, multi-Runner aggregation, snapshot download.

## Implementation plan

Ordered by dependency: hydra `/logs` WS endpoint → control-plane handler → frontend tab → end-to-end test → docs. Estimated 1-2 engineer-days.

## Open questions captured

Six items, each with a recommended default: per-container filter (defer), concurrent subscribers (verify), org-scoped admin auth (use the `lookupOrg` pattern from `wallet_handlers.go`), retention (document buffer limit), frontend log viewer dependency (audit before adding), drain-on-disconnect (5s reconnect, then close with status).

## Motivation

A recent end-to-end test against a remotely hosted Runner had video streaming fail with `failed to change state to PLAYING`. The root cause (`[render-node] WARNING: Could not find nvidia driver for GPU_VENDOR=nvidia, falling back to software rendering`) was visible in the post-mortem log dump, but only after the run completed. Live log access would have surfaced it within seconds of Runner startup.

## Test plan (after implementation)

- [ ] Hydra `/logs` endpoint streams tail + live lines locally via `websocat`
- [ ] Control-plane handler proxies WS to hydra, auth gating works (admin succeeds, non-admin gets 403)
- [ ] Frontend tab renders streamed lines, pause/resume works, reconnect on connection drop
- [ ] End-to-end: trigger a spec task on a Runner, watch hydra/inner-container logs flow in real time