### PR TITLE
test(tools): mock LLM in ActionTestSuite to remove TogetherAI dependency

### DIFF
--- a/api/pkg/tools/informative_or_actionable_test.go
+++ b/api/pkg/tools/informative_or_actionable_test.go
@@ -117,30 +117,12 @@ func (suite *ActionTestSuite) TestIsActionable_Yes() {
 }
 
 func (suite *ActionTestSuite) TestIsActionable_Retryable() {
-	defer suite.ctrl.Finish()
-
-	apiClient := openai.NewMockClient(suite.ctrl)
-	suite.strategy.apiClient = apiClient
-
-	apiClient.EXPECT().CreateChatCompletion(gomock.Any(), gomock.Any()).Return(openai_ext.ChatCompletionResponse{
-		Choices: []openai_ext.ChatCompletionChoice{
-			{
-				Message: openai_ext.ChatCompletionMessage{
-					Content: `incorrect json maybe? {"justification": "yes", "needs_tool": "yes", "api": "getWeather"}`,
-				},
-			},
-		},
-	}, nil)
-
-	apiClient.EXPECT().CreateChatCompletion(gomock.Any(), gomock.Any()).Return(openai_ext.ChatCompletionResponse{
-		Choices: []openai_ext.ChatCompletionChoice{
-			{
-				Message: openai_ext.ChatCompletionMessage{
-					Content: `{"justification": "yes", "needs_tool": "yes", "api": "getWeather"}`,
-				},
-			},
-		},
-	}, nil)
+	// Two LLM calls: the first returns malformed JSON to drive the retry
+	// path in IsActionable, the second returns valid JSON.
+	installLLMMock(suite,
+		`incorrect json maybe? {"justification": "yes", "needs_tool": "yes", "api": "getWeather"}`,
+		`{"justification": "yes", "needs_tool": "yes", "api": "getWeather"}`,
+	)
 
 	tools := []*types.Tool{
 		{

--- a/api/pkg/tools/informative_or_actionable_test.go
+++ b/api/pkg/tools/informative_or_actionable_test.go
@@ -104,6 +104,9 @@ func (suite *ActionTestSuite) TestIsActionable_Yes() {
 		},
 	}
 
+	// One LLM call -- the actionability classifier.
+	installLLMMock(suite, `{"needs_tool": "yes", "api": "getWeather", "justification": "user is asking about weather"}`)
+
 	resp, err := suite.strategy.IsActionable(suite.ctx, "session-123", "i-123", tools, history)
 	suite.Require().NoError(err)
 
@@ -224,6 +227,9 @@ func (suite *ActionTestSuite) TestIsActionable_NotActionable() {
 			Content: "What's the reason why oceans have less fish??",
 		},
 	}
+
+	// One LLM call -- the actionability classifier.
+	installLLMMock(suite, `{"needs_tool": "no", "api": "", "justification": "general knowledge question"}`)
 
 	resp, err := suite.strategy.IsActionable(suite.ctx, "session-123", "i-123", tools, history)
 	suite.NoError(err)

--- a/api/pkg/tools/tools_api_run_action_test.go
+++ b/api/pkg/tools/tools_api_run_action_test.go
@@ -67,6 +67,12 @@ func (suite *ActionTestSuite) TestAction_runApiAction_showPetById() {
 		},
 	}
 
+	// Two LLM calls: parameter extraction, then response interpretation.
+	installLLMMock(suite,
+		`{"petId": "99944"}`,
+		"Here are the details for pet 99944: a brown dog named doggie.",
+	)
+
 	resp, err := suite.strategy.RunAction(suite.ctx, "session-123", "i-123", getPetDetailsAPI, history, "showPetById")
 	suite.NoError(err)
 
@@ -234,6 +240,12 @@ func (suite *ActionTestSuite) TestAction_runApiAction_getWeather() {
 		},
 	}
 
+	// Two LLM calls: parameter extraction, then response interpretation.
+	installLLMMock(suite,
+		`{"q": "London"}`,
+		"The weather in London is broken clouds at around 21°C.",
+	)
+
 	resp, err := suite.strategy.RunAction(suite.ctx, "session-123", "i-123", getPetDetailsAPI, history, "CurrentWeatherData")
 	suite.NoError(err)
 
@@ -309,6 +321,13 @@ func (suite *ActionTestSuite) TestAction_runApiAction_history_getWeather() {
 			Content: "What's the weather like there?",
 		},
 	}
+
+	// Two LLM calls: parameter extraction (resolving "there" → London from
+	// the preceding history), then response interpretation.
+	installLLMMock(suite,
+		`{"q": "London"}`,
+		"The weather in London is broken clouds at around 21°C.",
+	)
 
 	resp, err := suite.strategy.RunAction(suite.ctx, "session-123", "i-123", getWeatherAPI, history, "CurrentWeatherData")
 	suite.NoError(err)

--- a/api/pkg/tools/tools_api_test.go
+++ b/api/pkg/tools/tools_api_test.go
@@ -17,8 +17,40 @@ import (
 	oai "github.com/sashabaranov/go-openai"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	golden "gotest.tools/v3/golden"
 )
+
+// installLLMMock swaps the suite's apiClient with a mock that returns each
+// of the provided responses in order. Tests in this suite previously relied
+// on a real TogetherAI call to extract parameters / interpret responses,
+// which made the entire suite an availability test for an upstream LLM
+// provider rather than a unit test for tool logic. The CI flake that
+// motivated this is a sustained 503 on whichever gpt-oss model is "healthy
+// this week" -- retry doesn't help because the outages last hours, not
+// seconds, and bumping the model name is a treadmill.
+//
+// Test authors set the canned responses they want back. The first call to
+// the chat completion API returns responses[0], the second returns
+// responses[1], etc. Each test should pass exactly as many strings as the
+// path through the production code makes LLM calls -- param extraction
+// (RunAction + getAPIRequestParameters) is one call; response
+// interpretation (RunAction only) adds a second.
+func installLLMMock(suite *ActionTestSuite, responses ...string) *openai.MockClient {
+	suite.T().Helper()
+	mock := openai.NewMockClient(suite.ctrl)
+	suite.strategy.apiClient = mock
+	for _, content := range responses {
+		mock.EXPECT().
+			CreateChatCompletion(gomock.Any(), gomock.Any()).
+			Return(oai.ChatCompletionResponse{
+				Choices: []oai.ChatCompletionChoice{
+					{Message: oai.ChatCompletionMessage{Content: content}},
+				},
+			}, nil)
+	}
+	return mock
+}
 
 // TestAction_CallAPI tests query formation for a single API call to
 // fetch a single record from the database
@@ -167,13 +199,8 @@ func (suite *ActionTestSuite) TestAction_getAPIRequestParameters_Path_SinglePara
 		},
 	}
 
-	// suite.store.EXPECT().CreateLLMCall(gomock.Any(), gomock.Any()).DoAndReturn(
-	// 	func(ctx context.Context, call *types.LLMCall) (*types.LLMCall, error) {
-	// 		suite.Equal("session-123", call.SessionID)
-	// 		suite.Equal(types.LLMCallStepPrepareAPIRequest, call.Step)
-
-	// 		return call, nil
-	// 	})
+	// One LLM call -- parameter extraction from the user message.
+	installLLMMock(suite, `{"petId": "55443"}`)
 
 	resp, err := suite.strategy.getAPIRequestParameters(suite.ctx, suite.strategy.apiClient, "session-123", "i-123", getPetDetailsAPI, history, "showPetById")
 	suite.NoError(err)
@@ -211,6 +238,9 @@ func (suite *ActionTestSuite) TestAction_getAPIRequestParameters_Path_SingleItem
 			Content: "Can you please give me the details for pet 55443?",
 		},
 	}
+
+	// One LLM call -- parameter extraction from the user message.
+	installLLMMock(suite, `{"petId": "55443"}`)
 
 	resp, err := suite.strategy.getAPIRequestParameters(suite.ctx, suite.strategy.apiClient, "session-123", "i-123", getPetDetailsAPI, history, "showPetById")
 	suite.NoError(err)

--- a/api/pkg/tools/tools_api_test.go
+++ b/api/pkg/tools/tools_api_test.go
@@ -22,34 +22,29 @@ import (
 )
 
 // installLLMMock swaps the suite's apiClient with a mock that returns each
-// of the provided responses in order. Tests in this suite previously relied
-// on a real TogetherAI call to extract parameters / interpret responses,
-// which made the entire suite an availability test for an upstream LLM
-// provider rather than a unit test for tool logic. The CI flake that
-// motivated this is a sustained 503 on whichever gpt-oss model is "healthy
-// this week" -- retry doesn't help because the outages last hours, not
-// seconds, and bumping the model name is a treadmill.
-//
-// Test authors set the canned responses they want back. The first call to
-// the chat completion API returns responses[0], the second returns
-// responses[1], etc. Each test should pass exactly as many strings as the
-// path through the production code makes LLM calls -- param extraction
-// (RunAction + getAPIRequestParameters) is one call; response
-// interpretation (RunAction only) adds a second.
-func installLLMMock(suite *ActionTestSuite, responses ...string) *openai.MockClient {
+// of the provided responses in order. Pass one string per LLM call the
+// production code path makes -- param extraction is one call; response
+// interpretation adds a second. gomock.InOrder pins the sequence so a
+// future reordering in production surfaces as a test failure instead of
+// silently swapping the responses.
+func installLLMMock(suite *ActionTestSuite, responses ...string) {
 	suite.T().Helper()
 	mock := openai.NewMockClient(suite.ctrl)
 	suite.strategy.apiClient = mock
+	var prev *gomock.Call
 	for _, content := range responses {
-		mock.EXPECT().
+		call := mock.EXPECT().
 			CreateChatCompletion(gomock.Any(), gomock.Any()).
 			Return(oai.ChatCompletionResponse{
 				Choices: []oai.ChatCompletionChoice{
 					{Message: oai.ChatCompletionMessage{Content: content}},
 				},
 			}, nil)
+		if prev != nil {
+			call.After(prev)
+		}
+		prev = call
 	}
-	return mock
 }
 
 // TestAction_CallAPI tests query formation for a single API call to
@@ -435,8 +430,6 @@ func (suite *ActionTestSuite) TestAction_getAPIRequestParameters_Query_MultipleP
 }
 
 func (suite *ActionTestSuite) TestAction_CustomRequestPrompt() {
-	defer suite.ctrl.Finish()
-
 	apiClient := openai.NewMockClient(suite.ctrl)
 	suite.strategy.apiClient = apiClient
 


### PR DESCRIPTION
## Summary

ActionTestSuite has been the load-bearing reason CI's been red across multiple PRs this week. The failure is HTTP 503 from TogetherAI on whichever \`gpt-oss-*\` model is currently \"healthy\" -- the in-tree comment at \`api/pkg/tools/informative_or_actionable_test.go:54-57\` documents this is a recurring sustained outage pattern, not a transient flake:

> \"gpt-oss-20b became unreliable on TogetherAI (sustained 503s in May 2026 CI runs even after credit/account issues were resolved); 120b sibling is healthy. Bump again if this one starts 503ing.\"

I went down a retry path first; honest pushback in review pointed out that retries only help for transient flakes (seconds) and don't fix sustained outages (hours). Unit tests shouldn't depend on a remote LLM provider being up anyway. So: mock instead.

## Changes

Drop the real-provider path for the seven tests that call \`client.CreateChatCompletion\` and replace it with canned mock responses that match what the LLM would return on the happy path:

| Test | Mocks |
|---|---|
| \`TestAction_runApiAction_showPetById\` | 2 (param extract + interp) |
| \`TestAction_runApiAction_getWeather\` | 2 (param extract + interp) |
| \`TestAction_runApiAction_history_getWeather\` | 2 (param extract + interp) |
| \`TestAction_getAPIRequestParameters_Path_SingleParam\` | 1 (param only) |
| \`TestAction_getAPIRequestParameters_Path_SingleItem\` | 1 (param only) |
| \`TestIsActionable_Yes\` | 1 (classifier only) |
| \`TestIsActionable_NotActionable\` | 1 (classifier only) |

A small \`installLLMMock(suite, responses...)\` helper centralises the mock setup so each test reads as \"here are the LLM responses I expect\" rather than re-deriving the mock plumbing.

The local \`httptest\` API servers and the parameter-substitution logic are still verified end-to-end. The only thing removed is the LLM-quality assertion, which was never a code-correctness test and shouldn't gate PR merges anyway.

## Net effect

- ActionTestSuite drops from ~450s with intermittent failure to ~0.5s reliably
- No external dependency on TogetherAI
- No more \"bump the model\" treadmill
- Unblocks PRs 2488, 2491 (and anyone else's PRs that were red on this same step)

## Out of scope

- The existing comment about bumping the model can be deleted in a follow-up once we're confident no test relies on the real provider; left in place here so the history of the workaround stays visible.
- LLM-quality canaries (\"does the real LLM actually extract parameters correctly\") belong in a separate suite that runs nightly and doesn't gate merges.

## Test plan

- [x] \`go test -run TestActionTestSuite ./pkg/tools/ -count=1\` passes locally
- [ ] CI passes
- [ ] Rebase #2488 and #2491 on top once this merges; their failures should clear.