### PR TITLE
fix(api): inject project secrets on every desktop start

### DIFF
--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -23,6 +23,11 @@ type QuotaManager interface {
 	LimitReached(ctx context.Context, req *types.QuotaLimitReachedRequest) (*types.QuotaLimitReachedResponse, error)
 }
 
+// ProjectSecretsGetter returns project secrets as `KEY=value` env-var strings.
+// Wired to HelixAPIServer.GetProjectSecretsAsEnvVars at startup so HydraExecutor
+// can inject them on every container start without each caller remembering.
+type ProjectSecretsGetter func(ctx context.Context, projectID string) ([]string, error)
+
 // HydraExecutor implements the Executor interface using Hydra for dev container management.
 //
 // Architecture: Helix API -> Hydra -> Docker -> Dev Container
@@ -56,6 +61,10 @@ type HydraExecutor struct {
 
 	// License key for nested Helix instances
 	licenseKey string
+
+	// Callback to fetch project secrets, set via SetProjectSecretsGetter
+	// after HelixAPIServer is constructed (mirrors SetQuotaManager wiring).
+	getProjectSecrets ProjectSecretsGetter
 }
 
 // connmanInterface abstracts the connection manager for RevDial connections to sandboxes
@@ -97,6 +106,10 @@ func NewHydraExecutor(cfg HydraExecutorConfig) *HydraExecutor {
 
 func (h *HydraExecutor) SetQuotaManager(quotaManager QuotaManager) {
 	h.quotaManager = quotaManager
+}
+
+func (h *HydraExecutor) SetProjectSecretsGetter(getter ProjectSecretsGetter) {
+	h.getProjectSecrets = getter
 }
 
 // getOrCreateSessionLock returns a per-session mutex, creating one if needed.
@@ -143,6 +156,25 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 			StreamURL:     fmt.Sprintf("/api/v1/sessions/%s/stream", agent.SessionID),
 			Status:        "running",
 		}, nil
+	}
+
+	// Inject project secrets onto agent.Env so every fresh container picks up
+	// the project's secrets without each call site (spec task launch, exploratory
+	// session, resume, etc.) having to remember to load them.
+	//
+	// Ordering matters: secrets are appended BEFORE OnBeforeCreate so that the
+	// API-token env vars OnBeforeCreate adds (ANTHROPIC_API_KEY, USER_API_TOKEN,
+	// ...) appear later in agent.Env and therefore win duplicate-key resolution
+	// in Docker. This preserves the long-standing invariant that a user-defined
+	// project secret can't shadow the system-injected agent API tokens.
+	if h.getProjectSecrets != nil && agent.ProjectID != "" {
+		projectSecrets, err := h.getProjectSecrets(ctx, agent.ProjectID)
+		if err != nil {
+			log.Warn().Err(err).Str("project_id", agent.ProjectID).Str("session_id", agent.SessionID).Msg("Failed to load project secrets, continuing without them")
+		} else if len(projectSecrets) > 0 {
+			agent.Env = append(agent.Env, projectSecrets...)
+			log.Info().Int("secret_count", len(projectSecrets)).Str("project_id", agent.ProjectID).Str("session_id", agent.SessionID).Msg("Injected project secrets into desktop env")
+		}
 	}
 
 	// Call OnBeforeCreate hook inside the lock to refresh API keys.

--- a/api/pkg/server/project_handlers.go
+++ b/api/pkg/server/project_handlers.go
@@ -1413,6 +1413,7 @@ func (s *HelixAPIServer) startExploratorySession(_ http.ResponseWriter, r *http.
 			}
 
 			// Restart Zed agent with existing session
+			// (project secrets injected by HydraExecutor.StartDesktop)
 			zedAgent := &types.DesktopAgent{
 				OrganizationID:      project.OrganizationID,
 				SessionID:           existingSession.ID,
@@ -1429,15 +1430,6 @@ func (s *HelixAPIServer) startExploratorySession(_ http.ResponseWriter, r *http.
 				Resolution:          resolution,
 				ZoomLevel:           zoomLevel,
 				DesktopType:         desktopType,
-			}
-
-			// Inject project secrets as environment variables (matching spec task behavior)
-			projectSecrets, err := s.GetProjectSecretsAsEnvVars(r.Context(), projectID)
-			if err != nil {
-				log.Warn().Err(err).Str("project_id", projectID).Msg("Failed to get project secrets for exploratory restart, continuing without them")
-			} else if len(projectSecrets) > 0 {
-				zedAgent.Env = append(zedAgent.Env, projectSecrets...)
-				log.Info().Int("secret_count", len(projectSecrets)).Str("project_id", projectID).Msg("Injected project secrets into exploratory desktop env (restart)")
 			}
 
 			// Add user's API token inside session lock via OnBeforeCreate hook
@@ -1578,6 +1570,7 @@ func (s *HelixAPIServer) startExploratorySession(_ http.ResponseWriter, r *http.
 	}
 
 	// Create ZedAgent for team desktop
+	// (project secrets injected by HydraExecutor.StartDesktop)
 	zedAgent := &types.DesktopAgent{
 		OrganizationID:      project.OrganizationID,
 		SessionID:           createdSession.ID,
@@ -1594,15 +1587,6 @@ func (s *HelixAPIServer) startExploratorySession(_ http.ResponseWriter, r *http.
 		Resolution:          resolution,
 		ZoomLevel:           zoomLevel,
 		DesktopType:         desktopType,
-	}
-
-	// Inject project secrets as environment variables (matching spec task behavior)
-	projectSecrets, err := s.GetProjectSecretsAsEnvVars(r.Context(), projectID)
-	if err != nil {
-		log.Warn().Err(err).Str("project_id", projectID).Msg("Failed to get project secrets for exploratory session, continuing without them")
-	} else if len(projectSecrets) > 0 {
-		zedAgent.Env = append(zedAgent.Env, projectSecrets...)
-		log.Info().Int("secret_count", len(projectSecrets)).Str("project_id", projectID).Msg("Injected project secrets into exploratory desktop env")
 	}
 
 	// Add user's API token inside session lock via OnBeforeCreate hook

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -529,10 +529,12 @@ func NewServer(
 	apiServer.specDrivenTaskService.RegisterRequestMapping = apiServer.RegisterRequestToSessionMapping
 	// Set the message sender callback for SpecDrivenTaskService (for sending messages to agents via WebSocket)
 	apiServer.specDrivenTaskService.SendMessageToAgent = apiServer.sendMessageToSpecTaskAgent
-	// Set the project secrets callback for injecting secrets as env vars into desktop containers
-	apiServer.specDrivenTaskService.GetProjectSecrets = apiServer.GetProjectSecretsAsEnvVars
 	// Set the exec-in-desktop callback for running commands in containers (e.g., updating git identity)
 	apiServer.specDrivenTaskService.ExecInDesktop = apiServer.execCommandInDesktop
+	// Wire project-secret injection into HydraExecutor so every desktop container
+	// (spec task, exploratory session, resume) picks up project secrets without
+	// each caller having to remember.
+	externalAgentExecutor.SetProjectSecretsGetter(apiServer.GetProjectSecretsAsEnvVars)
 	// Set the attachment blob reader so the service can pull uploaded files from the filestore.
 	apiServer.specDrivenTaskService.ReadAttachmentBlob = apiServer.readSpecTaskAttachmentBlob
 

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -28,9 +28,6 @@ const (
 // RequestMappingRegistrar is a function type for registering request-to-session mappings
 type RequestMappingRegistrar func(requestID, sessionID string)
 
-// ProjectSecretsGetter is a function that retrieves project secrets as environment variables
-type ProjectSecretsGetter func(ctx context.Context, projectID string) ([]string, error)
-
 // DesktopExecFunc executes a command inside a running desktop container via RevDial.
 type DesktopExecFunc func(ctx context.Context, sessionID string, command []string) error
 
@@ -57,7 +54,6 @@ type SpecDrivenTaskService struct {
 	SessionContextService    *SessionContextService    // Service for inter-session coordination
 	auditLogService          *AuditLogService          // Service for audit logging
 	koditService             KoditServicer             // Kodit code intelligence (for MCP documentation in prompts)
-	GetProjectSecrets        ProjectSecretsGetter      // Callback to get project secrets as env vars
 	ExecInDesktop            DesktopExecFunc           // Callback to exec commands in running desktop containers
 	ReadAttachmentBlob       AttachmentBlobReader      // Callback to load attachment bytes from filestore
 	wg                       sync.WaitGroup
@@ -585,19 +581,9 @@ func (s *SpecDrivenTaskService) StartSpecGeneration(ctx context.Context, task *t
 
 	// Create ZedAgent struct with session info for Wolf executor
 	log.Debug().Str("task_id", task.ID).Msg("DEBUG: About to create ZedAgent struct")
-	// Build env vars (locale + project secrets, API key added in OnBeforeCreate hook)
+	// Build env vars (locale; API key added in OnBeforeCreate hook,
+	// project secrets injected by HydraExecutor.StartDesktop)
 	envVars := buildEnvWithLocale("", task.PlanningOptions)
-
-	// Inject project secrets as environment variables
-	if s.GetProjectSecrets != nil && task.ProjectID != "" {
-		projectSecrets, err := s.GetProjectSecrets(ctx, task.ProjectID)
-		if err != nil {
-			log.Warn().Err(err).Str("project_id", task.ProjectID).Msg("Failed to get project secrets, continuing without them")
-		} else if len(projectSecrets) > 0 {
-			envVars = append(envVars, projectSecrets...)
-			log.Info().Int("secret_count", len(projectSecrets)).Str("project_id", task.ProjectID).Msg("Injected project secrets into desktop env")
-		}
-	}
 
 	// Inject startup script from project YAML (stored in database).
 	// helix-workspace-setup.sh uses this as a fallback when no .helix/startup.sh
@@ -1024,19 +1010,8 @@ Follow these guidelines when making changes:
 		}
 	}
 
-	// Build env vars (base + locale + project secrets)
+	// Build env vars (base + locale; project secrets injected by HydraExecutor.StartDesktop)
 	envVarsJDI := buildEnvWithLocale(userAPIKey, task.PlanningOptions)
-
-	// Inject project secrets as environment variables
-	if s.GetProjectSecrets != nil && task.ProjectID != "" {
-		projectSecrets, err := s.GetProjectSecrets(ctx, task.ProjectID)
-		if err != nil {
-			log.Warn().Err(err).Str("project_id", task.ProjectID).Msg("Failed to get project secrets for JDI mode, continuing without them")
-		} else if len(projectSecrets) > 0 {
-			envVarsJDI = append(envVarsJDI, projectSecrets...)
-			log.Info().Int("secret_count", len(projectSecrets)).Str("project_id", task.ProjectID).Msg("Just Do It: Injected project secrets into desktop env")
-		}
-	}
 
 	// Inject startup script from project YAML (same as planning phase)
 	if project.StartupScriptYAML != "" {


### PR DESCRIPTION
## Summary

The **Restart** button on the spec-task desktop UI (`POST /api/v1/sessions/{id}/resume` → `session_handlers.resumeSession`) was never injecting project secrets into the freshly-recreated container. The first start of a spec task got secrets (via `spec_driven_task_service`); every subsequent Restart did not. The existing path also had four duplicated copies of the same "load secrets, append to `agent.Env`" block, which is why one was easy to forget.

Fix the asymmetry by moving the injection into `HydraExecutor.StartDesktop`. Now every fresh container picks up the project's secrets without each caller having to remember. Net `-13` lines, single source of truth, and impossible for a future caller of `StartDesktop` to silently miss them again.

## Why the bug existed

Five different places construct a `DesktopAgent` and call `StartDesktop`. Four of them remembered to do `agent.Env = append(agent.Env, GetProjectSecretsAsEnvVars(...)...)` first; `resumeSession` did not. The duplication itself was the bug — encoding the same precondition five times means somebody will forget the fifth.

## Ordering invariant preserved

In `StartDesktop`, secrets are appended to `agent.Env` **before** `OnBeforeCreate` runs. Since Docker resolves duplicate env keys last-wins, this preserves the long-standing behavior across every old caller: a user-defined project secret named e.g. `ANTHROPIC_API_KEY` cannot shadow the system-injected agent API tokens.

## Side effects on other callers

A few other `StartDesktop` callers had silently been missing secret injection too. They now get it for free:

- `session_handlers.go:728` (newSession zed_external) — sets `ProjectID`
- `spec_task_design_review_handlers.go:927` — sets `ProjectID` from spec task
- `golden_build_service.go:482` — sets `ProjectID` (golden cache build; startup-install scripts typically need `NPM_TOKEN` etc., so this was probably a quiet bug)

Callers that don't set `agent.ProjectID` are unchanged (`session_handlers.go:2464` programmatic API, `claude_subscription_handlers.go:542` Claude login, `zed_integration_service.go:61`).

## Test plan

- [ ] In the inner Helix: add a project secret, start a spec task, verify the secret env var is visible in the container.
- [ ] In the inner Helix: restart the desktop via the Restart button, verify the secret env var is still visible after restart.
- [ ] In the inner Helix: define a project secret named `ANTHROPIC_API_KEY` with garbage, verify the system value still wins (chat through agent still works).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)