### PR TITLE
fix(frontend): render PR buttons as real anchors so Safari opens them

### DIFF
--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -101,7 +101,13 @@ interface CompactActionButtonProps {
   fullWidth?: boolean;
   icon: React.ReactNode;
   label: string;
-  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  // When href is set, the button renders as a real anchor so that Safari's
+  // popup blocker treats it as a normal user-initiated navigation rather than
+  // blocking a window.open() call.
+  href?: string;
+  target?: string;
+  rel?: string;
   sx?: object;
 }
 
@@ -114,8 +120,14 @@ function CompactActionButton({
   icon,
   label,
   onClick,
+  href,
+  target,
+  rel,
   sx,
 }: CompactActionButtonProps) {
+  const anchorProps = href
+    ? { component: "a" as const, href, target, rel }
+    : {};
   return (
     <Tooltip title={tooltip} placement="top">
       <span style={{ width: fullWidth ? "100%" : "auto", display: "block" }}>
@@ -126,6 +138,7 @@ function CompactActionButton({
           disabled={disabled}
           fullWidth={fullWidth}
           onClick={onClick}
+          {...anchorProps}
           sx={{
             minWidth: 72,
             px: 1,
@@ -753,10 +766,10 @@ export default function SpecTaskActionButtons({
               disabled={isArchived}
               icon={<LaunchIcon sx={{ fontSize: 18 }} />}
               label={prLabel}
-              onClick={(e) => {
-                e.stopPropagation();
-                window.open(prUrl, "_blank");
-              }}
+              href={prUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
             />
           </Box>
         );
@@ -771,10 +784,11 @@ export default function SpecTaskActionButtons({
                 variant="contained"
                 color="secondary"
                 startIcon={<LaunchIcon />}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  window.open(prUrl, "_blank");
-                }}
+                component="a"
+                href={prUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
                 disabled={isArchived}
                 fullWidth={!isInline}
                 sx={buttonSx}
@@ -813,10 +827,11 @@ export default function SpecTaskActionButtons({
               {pullRequests.map((pr, idx) => (
                 <MenuItem
                   key={pr.repository_id || idx}
-                  onClick={() => {
-                    window.open(pr.pr_url, "_blank");
-                    setPrMenuAnchor(null);
-                  }}
+                  component="a"
+                  href={pr.pr_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => setPrMenuAnchor(null)}
                 >
                   <ListItemText
                     primary={pr.repository_name || `Repository ${idx + 1}`}
@@ -859,10 +874,11 @@ export default function SpecTaskActionButtons({
             {pullRequests.map((pr, idx) => (
               <MenuItem
                 key={pr.repository_id || idx}
-                onClick={() => {
-                  window.open(pr.pr_url, "_blank");
-                  setPrMenuAnchor(null);
-                }}
+                component="a"
+                href={pr.pr_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => setPrMenuAnchor(null)}
               >
                 <ListItemText
                   primary={pr.repository_name || `Repository ${idx + 1}`}


### PR DESCRIPTION
## Summary

- The "View Pull Request" button (and the multi-PR menu items) on the spec-task detail page and the kanban cards did nothing in Safari.
- Cause: `onClick={() => window.open(prUrl, "_blank")}`. Safari's pop-up blocker silently blocks cross-origin `window.open(_, "_blank")` calls even from a sync user-gesture click; Chrome is lenient about this so the bug was invisible there.
- Fix: render the four PR-link sites in `SpecTaskActionButtons.tsx` as real anchors (`<Button component="a" href={prUrl} target="_blank" rel="noopener noreferrer">` / `<MenuItem component="a" href=…>`). Safari treats anchor navigations as legit user-initiated, so the link opens normally. As a side benefit you also get the URL on hover, right-click "Copy link address", Cmd-click for background tab, etc.

Sites updated (all in `frontend/src/components/tasks/SpecTaskActionButtons.tsx`):
- inline single-PR button
- stacked single-PR button
- inline multi-PR `MenuItem`
- stacked multi-PR `MenuItem`

`CompactActionButton` gained optional `href`/`target`/`rel` props so the inline single-PR case can opt in without losing the existing tooltip wrapping.

## Test plan
- [ ] In Safari: open a task with a single PR (e.g. https://meta.helix.ml/orgs/helix/projects/prj_01kstvt0y30n3xzqw2wzgy4rsd/tasks/spt_01ksw8h57g6vbbtap8ywp163m6 ) — click "PR: infra" button → opens GitHub PR in a new tab.
- [ ] In Safari: same task, Cmd-click and right-click should now offer the usual link options.
- [ ] In Safari: open a task with multiple PRs — click "N Pull Requests", then click a menu item → opens GitHub PR in a new tab, menu closes.
- [ ] In Chrome: confirm no regression on any of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)