### PR TITLE
perf(frontend): stop layout thrashing in useUserMenuHeight

### DIFF
--- a/frontend/src/hooks/useUserMenuHeight.ts
+++ b/frontend/src/hooks/useUserMenuHeight.ts
@@ -1,82 +1,83 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect } from 'react'
 
-/**
- * Hook to track the height of the UserOrgSelector floating menu
- * This is used to dynamically adjust sidebar content height so it doesn't 
- * get covered by the variable-height floating user menu
- */
+// Hook to track the height of the UserOrgSelector floating menu, so the
+// sidebar's content area can leave room for it (Sidebar.tsx uses
+// `calc(100% - ${userMenuHeight}px)`).
+//
+// Earlier this hook ran a MutationObserver on document.body filtered by
+// childList/subtree/attributes(style,class) plus a 1s setInterval, and on every
+// fire walked parentElement chains calling getComputedStyle + offsetHeight.
+// During streaming (e.g. a spec task chat receiving Zed entry_patches at
+// ~60 Hz), every React render flips MUI inline styles somewhere on the page,
+// firing the observer constantly and producing forced synchronous layouts on
+// the main thread. On Safari this is enough to freeze the tab.
+//
+// Now: find the bottom-pinned overlay parent once, then ResizeObserver it
+// directly. ResizeObserver only fires when that element actually changes size,
+// and Chrome schedules its callbacks at a layout-safe point in the frame.
 export const useUserMenuHeight = () => {
   const [userMenuHeight, setUserMenuHeight] = useState(0)
 
-  const updateHeight = useCallback(() => {
-    // Find the floating menu - look for the fixed positioned container that contains user menu
-    // This is more specific to the UserOrgSelector implementation
-    const floatingMenus = document.querySelectorAll('[data-compact-user-menu]')
-    let totalHeight = 0
-    
-    // Find the parent container that overlays the sidebar bottom.
-    // The floating user menu is rendered position: absolute on a `bottom: 0`
-    // container inside the LEFT rail, with `right: -312px` so it extends to
-    // overlay the secondary sidebar. (It's NOT position: fixed.)
-    for (const menu of floatingMenus) {
-      if (menu instanceof HTMLElement) {
-        let parent = menu.parentElement
-        while (parent) {
-          const computedStyle = window.getComputedStyle(parent)
-          const isOverlay =
-            (computedStyle.position === 'absolute' || computedStyle.position === 'fixed') &&
-            computedStyle.bottom === '0px'
-          if (isOverlay) {
-            const isVisible = computedStyle.opacity === '1' && computedStyle.pointerEvents === 'auto'
-            if (isVisible) {
-              totalHeight = Math.max(totalHeight, parent.offsetHeight)
-            }
-            break
-          }
-          parent = parent.parentElement
-        }
-      }
-    }
-    
-    setUserMenuHeight(totalHeight)
-  }, [])
-
   useEffect(() => {
-    // Initial height calculation
-    updateHeight()
+    let cancelled = false
+    let ro: ResizeObserver | null = null
+    let retryTimer: ReturnType<typeof setTimeout> | null = null
 
-    // Set up a ResizeObserver to watch for changes in the floating menu size
-    const observer = new ResizeObserver(() => {
-      updateHeight()
-    })
-
-    // Set up a MutationObserver to watch for DOM changes (menu expanding/collapsing)
-    const mutationObserver = new MutationObserver(() => {
-      updateHeight()
-    })
-
-    // Observe changes to the body (where the floating menu is attached)
-    const targetNode = document.body
-    if (targetNode) {
-      mutationObserver.observe(targetNode, {
-        childList: true,
-        subtree: true,
-        attributes: true,
-        attributeFilter: ['style', 'class']
-      })
+    const findOverlayFor = (menu: HTMLElement): HTMLElement | null => {
+      let parent: HTMLElement | null = menu.parentElement
+      while (parent) {
+        const cs = window.getComputedStyle(parent)
+        if (
+          (cs.position === 'absolute' || cs.position === 'fixed') &&
+          cs.bottom === '0px'
+        ) {
+          return parent
+        }
+        parent = parent.parentElement
+      }
+      return null
     }
 
-    // Also set up a periodic check as a fallback
-    const intervalId = setInterval(updateHeight, 1000)
+    const tryAttach = () => {
+      if (cancelled) return
+
+      const menu = document.querySelector('[data-compact-user-menu]')
+      if (!(menu instanceof HTMLElement)) {
+        // Component hasn't mounted yet (or has unmounted). Retry slowly.
+        // 1s is fine for a layout-sizing decision; no-one notices a 1s wait
+        // for the sidebar bottom padding to settle.
+        retryTimer = setTimeout(tryAttach, 1000)
+        return
+      }
+
+      const overlay = findOverlayFor(menu)
+      if (!overlay) {
+        setUserMenuHeight(0)
+        return
+      }
+
+      const measure = () => {
+        const cs = window.getComputedStyle(overlay)
+        const visible =
+          cs.opacity === '1' && cs.pointerEvents === 'auto'
+        setUserMenuHeight(visible ? overlay.offsetHeight : 0)
+      }
+
+      measure()
+      ro = new ResizeObserver(measure)
+      ro.observe(overlay)
+    }
+
+    tryAttach()
 
     return () => {
-      observer.disconnect()
-      mutationObserver.disconnect()
-      clearInterval(intervalId)
+      cancelled = true
+      ro?.disconnect()
+      if (retryTimer) clearTimeout(retryTimer)
     }
-  }, [updateHeight])
+  }, [])
 
   return userMenuHeight
 }
 
-export default useUserMenuHeight 
+export default useUserMenuHeight


### PR DESCRIPTION
## Summary

- `useUserMenuHeight` was running a `MutationObserver` on `document.body` filtered by `childList + subtree + attributes(style, class)`, plus a 1s `setInterval`, and on every fire walked `parentElement` chains calling `getComputedStyle` and reading `offsetHeight` — classic forced synchronous layout.
- During Zed streaming on the spec task page, every entry_patch (~60 Hz) triggers React re-renders that flip MUI inline styles somewhere on the page, firing the observer constantly. On Safari this is enough to fully freeze the tab; on Chrome it's 156 ms of forced reflow over a few seconds of idle.
- Replace with a single `ResizeObserver` on the bottom-pinned overlay element itself. ResizeObserver only fires when that element actually changes size, and the browser schedules its callbacks at a layout-safe frame point — no forced reflow from JS.
- Also removed a dead `ResizeObserver` that was constructed but never `.observe()`d, and the 1s `setInterval` fallback.

## How this was found

User reported Safari freezing on a long-running spec task page (`spt_01ksw8h57g6vbbtap8ywp163m6`) during Zed streaming bursts. Chrome DevTools performance trace surfaced `ForcedReflow` totalling 156 ms on idle. The minified call site mapped back to `useUserMenuHeight.ts`. After fix, the same trace shows the ForcedReflow window down to ~140 µs.

## Test plan

- [x] `cd frontend && yarn build` — clean build
- [x] Hard-refreshed in Chrome on `https://meta.helix.ml/...spt_01ksw8h57g6vbbtap8ywp163m6` — page loads, sidebar layout unchanged
- [x] Re-ran a Zed streaming burst (chrome-devtools MCP calls) — perceived perf unchanged on Chrome (already fast), no regression
- [ ] Verify on Safari/Mac — was the original repro environment
- [ ] Verify sidebar bottom padding still adjusts correctly when the floating user menu expands (UserOrgSelector menu open vs closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)