### PR TITLE
fix(frontend): drop stopPropagation so Safari opens PR link

### DIFF
--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -769,7 +769,6 @@ export default function SpecTaskActionButtons({
               href={prUrl}
               target="_blank"
               rel="noopener noreferrer"
-              onClick={(e) => e.stopPropagation()}
             />
           </Box>
         );
@@ -788,7 +787,6 @@ export default function SpecTaskActionButtons({
                 href={prUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={(e) => e.stopPropagation()}
                 disabled={isArchived}
                 fullWidth={!isInline}
                 sx={buttonSx}


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/helixml/helix/pull/2498. The anchor fix worked in Chrome but the PR button still does nothing in Safari on a real left-click — even though right-click → "Open in New Tab" works from the same anchor.

Cause: Safari's pop-up blocker has a heuristic that treats an `<a target="_blank">` click whose JS handler calls `event.stopPropagation()` as "the script handled this, don't open the popup" and silently blocks the navigation. Chrome doesn't apply the same heuristic, which is why the previous fix worked there. Right-click → "Open in New Tab" bypasses all JS click handlers, so it always worked.

The `stopPropagation()` calls on the two anchor sites in `SpecTaskActionButtons.tsx` were only defensive:
- Detail page (inline variant): there's no parent click handler, so dropping it is a pure no-op.
- Kanban card (stacked variant): the card row has a click handler that opens the task detail. After this change, clicking the PR button there also navigates the current tab to the task detail in addition to opening the PR in a new tab — that's an acceptable trade-off for actually opening the PR in Safari at all.

(Menu-item case for multi-PR already had no `stopPropagation` — its `onClick` only closes the menu.)

## Test plan
- [ ] Safari: left-click "PR: infra" on https://meta.helix.ml/orgs/helix/projects/prj_01kstvt0y30n3xzqw2wzgy4rsd/tasks/spt_01ksw8h57g6vbbtap8ywp163m6 → opens https://github.com/helixml/infra/pull/11 in a new tab.
- [ ] Chrome: no regression — same click opens PR in new tab.
- [ ] Kanban card (Chrome + Safari): clicking PR button opens PR in new tab; current tab navigates to task detail (acceptable).
- [ ] Multi-PR menu (both browsers): clicking a menu item opens that PR in a new tab and closes the menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)