### PR TITLE
feat(admin): require explicit org_id when granting credits

### DIFF
--- a/api/pkg/server/admin_credit_handlers.go
+++ b/api/pkg/server/admin_credit_handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 
 	"github.com/gorilla/mux"
 
@@ -15,8 +16,23 @@ import (
 )
 
 // GrantCreditsRequest is the body for POST /admin/users/{id}/credits.
+//
+// org_id is required when the target user owns one or more organisations;
+// admins must pick explicitly which wallet receives the grant. It must be
+// omitted when the user owns no organisations (the grant is stashed on the
+// user and applied to their first owned org via consumeUserAdminCredits).
 type GrantCreditsRequest struct {
 	Credits float64 `json:"credits"`
+	OrgID   string  `json:"org_id,omitempty"`
+}
+
+// OwnedOrgSummary is the per-org payload returned by
+// GET /admin/users/{id}/owned-orgs. Kept narrow on purpose: the admin
+// dialog only needs id + name to populate its org picker.
+type OwnedOrgSummary struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name,omitempty"`
 }
 
 // GrantCreditsResponse describes the outcome of an admin credit grant.
@@ -91,12 +107,12 @@ func (s *HelixAPIServer) consumeUserAdminCredits(ctx context.Context, user *type
 
 // adminGrantCredits godoc
 // @Summary Grant credits to a user (Admin, cloud only)
-// @Description Adds credits to the wallet of the user's oldest owned org, or stashes the grant on the user for application at first org creation. Works regardless of subscription state, unlike adminActivateTrial.
+// @Description Adds credits to the wallet of an explicitly chosen organisation the user owns, or stashes the grant on the user when they own no organisations yet (the grant is applied to their first owned org on creation). Works regardless of subscription state.
 // @Tags    users
 // @Accept  json
 // @Produce json
 // @Param id path string true "User ID"
-// @Param request body GrantCreditsRequest true "Credits to grant (must be > 0)"
+// @Param request body GrantCreditsRequest true "Credits to grant (must be > 0) and the target org_id (required iff user owns ≥1 orgs)"
 // @Success 200 {object} GrantCreditsResponse
 // @Router /api/v1/admin/users/{id}/credits [post]
 // @Security BearerAuth
@@ -134,14 +150,18 @@ func (apiServer *HelixAPIServer) adminGrantCredits(_ http.ResponseWriter, req *h
 		return nil, system.NewHTTPError404("user not found")
 	}
 
-	oldestOrg, err := oldestOwnedOrg(ctx, apiServer.Store, targetUserID)
+	ownedOrgs, err := apiServer.Store.ListOrganizations(ctx, &store.ListOrganizationsQuery{Owner: targetUserID})
 	if err != nil {
 		return nil, system.NewHTTPError500("failed to list user organizations: " + err.Error())
 	}
 
 	// Path A: no owned org yet — stash on user, consumeUserAdminCredits applies
-	// it when the user creates their first org.
-	if oldestOrg == nil {
+	// it when the user creates their first org. Reject any org_id here since
+	// there's no org to validate it against.
+	if len(ownedOrgs) == 0 {
+		if body.OrgID != "" {
+			return nil, system.NewHTTPError400("user owns no organisations; remove org_id to stash the grant for their first owned org")
+		}
 		credits := body.Credits
 		targetUser.PendingAdminCreditsOnFirstOrg = &credits
 		updated, err := apiServer.Store.UpdateUser(ctx, targetUser)
@@ -156,11 +176,27 @@ func (apiServer *HelixAPIServer) adminGrantCredits(_ http.ResponseWriter, req *h
 		return &GrantCreditsResponse{User: updated, Status: "stashed"}, nil
 	}
 
-	// Path B: user already owns an org — apply directly, regardless of any
-	// active or absent Stripe subscription.
-	wallet, err := apiServer.getOrCreateWallet(ctx, targetUser, oldestOrg.ID)
+	// Path B: user owns one or more orgs. org_id MUST be supplied so the
+	// admin's intent is explicit; silent "oldest owned" picks land credits
+	// on the wrong wallet when the target user owns several orgs.
+	if body.OrgID == "" {
+		return nil, system.NewHTTPError400(fmt.Sprintf("org_id is required: user owns %d organisation(s), pick which one receives the grant", len(ownedOrgs)))
+	}
+
+	var selectedOrg *types.Organization
+	for _, org := range ownedOrgs {
+		if org.ID == body.OrgID {
+			selectedOrg = org
+			break
+		}
+	}
+	if selectedOrg == nil {
+		return nil, system.NewHTTPError400(fmt.Sprintf("user does not own organisation %s", body.OrgID))
+	}
+
+	wallet, err := apiServer.getOrCreateWallet(ctx, targetUser, selectedOrg.ID)
 	if err != nil {
-		return nil, system.NewHTTPError500("failed to get wallet for oldest owned org: " + err.Error())
+		return nil, system.NewHTTPError500("failed to get wallet for selected org: " + err.Error())
 	}
 
 	if _, err := apiServer.Store.UpdateWalletBalance(ctx, wallet.ID, body.Credits, types.TransactionMetadata{
@@ -172,10 +208,52 @@ func (apiServer *HelixAPIServer) adminGrantCredits(_ http.ResponseWriter, req *h
 	log.Info().
 		Str("admin_id", adminUser.ID).
 		Str("target_user_id", targetUserID).
-		Str("org_id", oldestOrg.ID).
+		Str("org_id", selectedOrg.ID).
 		Str("wallet_id", wallet.ID).
 		Float64("credits", body.Credits).
 		Msg("admin granted credits to org wallet")
 
-	return &GrantCreditsResponse{User: targetUser, OrgID: oldestOrg.ID, Status: "applied"}, nil
+	return &GrantCreditsResponse{User: targetUser, OrgID: selectedOrg.ID, Status: "applied"}, nil
+}
+
+// listUserOwnedOrgs godoc
+// @Summary List a user's owned organisations (Admin, cloud only)
+// @Description Returns the organisations the target user is the owner of, sorted by creation time ascending. Used by the admin "Grant credits" dialog to populate its org picker.
+// @Tags    users
+// @Produce json
+// @Param id path string true "User ID"
+// @Success 200 {array} OwnedOrgSummary
+// @Router /api/v1/admin/users/{id}/owned-orgs [get]
+// @Security BearerAuth
+func (apiServer *HelixAPIServer) listUserOwnedOrgs(_ http.ResponseWriter, req *http.Request) ([]OwnedOrgSummary, error) {
+	ctx := req.Context()
+	adminUser := getRequestUser(req)
+	if !adminUser.Admin {
+		return nil, system.NewHTTPError403("only admins can list a user's owned organisations")
+	}
+	if apiServer.Cfg.Edition != "cloud" {
+		return nil, system.NewHTTPError400("only available on the cloud edition")
+	}
+
+	targetUserID := mux.Vars(req)["id"]
+	if targetUserID == "" {
+		return nil, system.NewHTTPError400("user ID is required")
+	}
+
+	orgs, err := apiServer.Store.ListOrganizations(ctx, &store.ListOrganizationsQuery{Owner: targetUserID})
+	if err != nil {
+		return nil, system.NewHTTPError500("failed to list user organizations: " + err.Error())
+	}
+
+	sort.Slice(orgs, func(i, j int) bool { return orgs[i].CreatedAt.Before(orgs[j].CreatedAt) })
+
+	out := make([]OwnedOrgSummary, 0, len(orgs))
+	for _, org := range orgs {
+		out = append(out, OwnedOrgSummary{
+			ID:          org.ID,
+			Name:        org.Name,
+			DisplayName: org.DisplayName,
+		})
+	}
+	return out, nil
 }

--- a/api/pkg/server/admin_credit_handlers_test.go
+++ b/api/pkg/server/admin_credit_handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/helixml/helix/api/pkg/config"
@@ -181,7 +182,7 @@ func TestAdminGrantCredits_HasOrgWithWallet_TopsUp(t *testing.T) {
 		})
 
 	server := &HelixAPIServer{Store: mockStore, Cfg: cloudBillingCfg()}
-	body, _ := json.Marshal(GrantCreditsRequest{Credits: 50})
+	body, _ := json.Marshal(GrantCreditsRequest{Credits: 50, OrgID: "org-1"})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/target-1/credits", bytes.NewReader(body))
 	req = mux.SetURLVars(req, map[string]string{"id": "target-1"})
 	req = req.WithContext(setTestRequestUser(req.Context(), adminUser))
@@ -193,6 +194,133 @@ func TestAdminGrantCredits_HasOrgWithWallet_TopsUp(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.Equal(t, "applied", resp.Status)
 	assert.Equal(t, "org-1", resp.OrgID)
+}
+
+// User owns 3 orgs; admin picks the middle one. Verifies that the chosen
+// wallet receives the credit and the others are untouched.
+func TestAdminGrantCredits_MultipleOrgs_AppliesToSelected(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+
+	adminUser := &types.User{ID: "admin-1", Admin: true}
+	targetUser := &types.User{ID: "target-1", Email: "t@example.com"}
+	orgA := &types.Organization{ID: "org-a", Owner: "target-1"}
+	orgB := &types.Organization{ID: "org-b", Owner: "target-1"}
+	orgC := &types.Organization{ID: "org-c", Owner: "target-1"}
+	walletB := &types.Wallet{ID: "wal-b", OrgID: "org-b"}
+
+	mockStore.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "target-1"}).Return(targetUser, nil)
+	mockStore.EXPECT().ListOrganizations(gomock.Any(), gomock.Any()).Return([]*types.Organization{orgA, orgB, orgC}, nil)
+	mockStore.EXPECT().GetOrganization(gomock.Any(), &store.GetOrganizationQuery{ID: "org-b"}).Return(orgB, nil)
+	mockStore.EXPECT().GetWalletByOrg(gomock.Any(), "org-b").Return(walletB, nil)
+	mockStore.EXPECT().UpdateWalletBalance(gomock.Any(), "wal-b", 30.0, gomock.Any()).Return(walletB, nil)
+
+	server := &HelixAPIServer{Store: mockStore, Cfg: cloudBillingCfg()}
+	body, _ := json.Marshal(GrantCreditsRequest{Credits: 30, OrgID: "org-b"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/target-1/credits", bytes.NewReader(body))
+	req = mux.SetURLVars(req, map[string]string{"id": "target-1"})
+	req = req.WithContext(setTestRequestUser(req.Context(), adminUser))
+
+	rr := httptest.NewRecorder()
+	resp, httpErr := server.adminGrantCredits(rr, req)
+
+	require.Nil(t, httpErr)
+	assert.Equal(t, "applied", resp.Status)
+	assert.Equal(t, "org-b", resp.OrgID)
+}
+
+// User owns ≥1 orgs but admin didn't pass org_id -- handler rejects rather
+// than silently picking. This is the core determinism guarantee.
+func TestAdminGrantCredits_HasOrgs_MissingOrgID_Rejected(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+
+	adminUser := &types.User{ID: "admin-1", Admin: true}
+	targetUser := &types.User{ID: "target-1"}
+	orgs := []*types.Organization{
+		{ID: "org-a", Owner: "target-1"},
+		{ID: "org-b", Owner: "target-1"},
+	}
+
+	mockStore.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "target-1"}).Return(targetUser, nil)
+	mockStore.EXPECT().ListOrganizations(gomock.Any(), gomock.Any()).Return(orgs, nil)
+	// Critical: no UpdateWalletBalance, no GetOrganization, no UpdateUser.
+
+	server := &HelixAPIServer{Store: mockStore, Cfg: cloudBillingCfg()}
+	body, _ := json.Marshal(GrantCreditsRequest{Credits: 50}) // OrgID omitted
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/target-1/credits", bytes.NewReader(body))
+	req = mux.SetURLVars(req, map[string]string{"id": "target-1"})
+	req = req.WithContext(setTestRequestUser(req.Context(), adminUser))
+
+	rr := httptest.NewRecorder()
+	_, httpErr := server.adminGrantCredits(rr, req)
+
+	require.NotNil(t, httpErr)
+	he, ok := httpErr.(*system.HTTPError)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusBadRequest, he.StatusCode)
+	assert.Contains(t, he.Error(), "org_id is required")
+}
+
+// Admin picks an org the user doesn't own (typo, wrong dropdown value, or
+// an org owned by someone else entirely). Reject.
+func TestAdminGrantCredits_OrgIDNotOwnedByUser_Rejected(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+
+	adminUser := &types.User{ID: "admin-1", Admin: true}
+	targetUser := &types.User{ID: "target-1"}
+	ownedOrg := &types.Organization{ID: "org-a", Owner: "target-1"}
+
+	mockStore.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "target-1"}).Return(targetUser, nil)
+	mockStore.EXPECT().ListOrganizations(gomock.Any(), gomock.Any()).Return([]*types.Organization{ownedOrg}, nil)
+
+	server := &HelixAPIServer{Store: mockStore, Cfg: cloudBillingCfg()}
+	body, _ := json.Marshal(GrantCreditsRequest{Credits: 50, OrgID: "org-someone-else"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/target-1/credits", bytes.NewReader(body))
+	req = mux.SetURLVars(req, map[string]string{"id": "target-1"})
+	req = req.WithContext(setTestRequestUser(req.Context(), adminUser))
+
+	rr := httptest.NewRecorder()
+	_, httpErr := server.adminGrantCredits(rr, req)
+
+	require.NotNil(t, httpErr)
+	he, ok := httpErr.(*system.HTTPError)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusBadRequest, he.StatusCode)
+	assert.Contains(t, he.Error(), "does not own")
+}
+
+// Admin tries to pass org_id when user owns no orgs (the stash path).
+// Reject so the admin's intent isn't ambiguous (stash now vs apply later).
+func TestAdminGrantCredits_NoOrg_OrgIDProvided_Rejected(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+
+	adminUser := &types.User{ID: "admin-1", Admin: true}
+	targetUser := &types.User{ID: "target-1"}
+
+	mockStore.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "target-1"}).Return(targetUser, nil)
+	mockStore.EXPECT().ListOrganizations(gomock.Any(), gomock.Any()).Return([]*types.Organization{}, nil)
+
+	server := &HelixAPIServer{Store: mockStore, Cfg: cloudBillingCfg()}
+	body, _ := json.Marshal(GrantCreditsRequest{Credits: 50, OrgID: "org-anything"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/target-1/credits", bytes.NewReader(body))
+	req = mux.SetURLVars(req, map[string]string{"id": "target-1"})
+	req = req.WithContext(setTestRequestUser(req.Context(), adminUser))
+
+	rr := httptest.NewRecorder()
+	_, httpErr := server.adminGrantCredits(rr, req)
+
+	require.NotNil(t, httpErr)
+	he, ok := httpErr.(*system.HTTPError)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusBadRequest, he.StatusCode)
+	assert.Contains(t, he.Error(), "user owns no organisations")
 }
 
 // Verifies the "subscription state is irrelevant" promise: a wallet with an
@@ -221,7 +349,7 @@ func TestAdminGrantCredits_HasOrgWithActiveSubscription_StillTopsUp(t *testing.T
 	mockStore.EXPECT().UpdateWalletBalance(gomock.Any(), "wal-1", 25.0, gomock.Any()).Return(wallet, nil)
 
 	server := &HelixAPIServer{Store: mockStore, Cfg: cloudBillingCfg()}
-	body, _ := json.Marshal(GrantCreditsRequest{Credits: 25})
+	body, _ := json.Marshal(GrantCreditsRequest{Credits: 25, OrgID: "org-1"})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/users/target-1/credits", bytes.NewReader(body))
 	req = mux.SetURLVars(req, map[string]string{"id": "target-1"})
 	req = req.WithContext(setTestRequestUser(req.Context(), adminUser))
@@ -255,4 +383,57 @@ func TestAdminGrantCredits_UserNotFound(t *testing.T) {
 	he, ok := httpErr.(*system.HTTPError)
 	require.True(t, ok)
 	assert.Equal(t, http.StatusNotFound, he.StatusCode)
+}
+
+func TestListUserOwnedOrgs_ReturnsSortedSummaries(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+
+	adminUser := &types.User{ID: "admin-1", Admin: true}
+	t0 := time.Now().Add(-72 * time.Hour)
+	t1 := t0.Add(time.Hour)
+	t2 := t1.Add(time.Hour)
+	// Returned in arbitrary order; handler must sort by CreatedAt ascending.
+	orgs := []*types.Organization{
+		{ID: "org-c", Name: "c", DisplayName: "Org C", CreatedAt: t2, Owner: "target-1"},
+		{ID: "org-a", Name: "a", DisplayName: "Org A", CreatedAt: t0, Owner: "target-1"},
+		{ID: "org-b", Name: "b", DisplayName: "Org B", CreatedAt: t1, Owner: "target-1"},
+	}
+
+	mockStore.EXPECT().
+		ListOrganizations(gomock.Any(), &store.ListOrganizationsQuery{Owner: "target-1"}).
+		Return(orgs, nil)
+
+	server := &HelixAPIServer{Store: mockStore, Cfg: cloudBillingCfg()}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users/target-1/owned-orgs", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "target-1"})
+	req = req.WithContext(setTestRequestUser(req.Context(), adminUser))
+
+	rr := httptest.NewRecorder()
+	resp, httpErr := server.listUserOwnedOrgs(rr, req)
+
+	require.Nil(t, httpErr)
+	require.Len(t, resp, 3)
+	assert.Equal(t, "org-a", resp[0].ID)
+	assert.Equal(t, "org-b", resp[1].ID)
+	assert.Equal(t, "org-c", resp[2].ID)
+	assert.Equal(t, "Org A", resp[0].DisplayName)
+}
+
+func TestListUserOwnedOrgs_NonAdminRejected(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStore := store.NewMockStore(ctrl)
+
+	server := &HelixAPIServer{Store: mockStore, Cfg: cloudBillingCfg()}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/users/target-1/owned-orgs", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "target-1"})
+	req = req.WithContext(setTestRequestUser(req.Context(), &types.User{ID: "u-1", Admin: false}))
+
+	_, httpErr := server.listUserOwnedOrgs(httptest.NewRecorder(), req)
+	require.NotNil(t, httpErr)
+	he, ok := httpErr.(*system.HTTPError)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusForbidden, he.StatusCode)
 }

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -857,7 +857,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Adds credits to the wallet of the user's oldest owned org, or stashes the grant on the user for application at first org creation. Works regardless of subscription state, unlike adminActivateTrial.",
+                "description": "Adds credits to the wallet of an explicitly chosen organisation the user owns, or stashes the grant on the user when they own no organisations yet (the grant is applied to their first owned org on creation). Works regardless of subscription state.",
                 "consumes": [
                     "application/json"
                 ],
@@ -877,7 +877,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "Credits to grant (must be \u003e 0)",
+                        "description": "Credits to grant (must be \u003e 0) and the target org_id (required iff user owns ≥1 orgs)",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -891,6 +891,43 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/server.GrantCreditsResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/users/{id}/owned-orgs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the organisations the target user is the owner of, sorted by creation time ascending. Used by the admin \"Grant credits\" dialog to populate its org picker.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "List a user's owned organisations (Admin, cloud only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/server.OwnedOrgSummary"
+                            }
                         }
                     }
                 }
@@ -18935,37 +18972,6 @@ const docTemplate = `{
                 "DevContainerTypeHeadless"
             ]
         },
-        "hydra.GPUInfo": {
-            "type": "object",
-            "properties": {
-                "index": {
-                    "type": "integer"
-                },
-                "memory_free_bytes": {
-                    "type": "integer"
-                },
-                "memory_total_bytes": {
-                    "type": "integer"
-                },
-                "memory_used_bytes": {
-                    "type": "integer"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "temperature_celsius": {
-                    "type": "integer"
-                },
-                "utilization_percent": {
-                    "description": "GPU core utilization",
-                    "type": "integer"
-                },
-                "vendor": {
-                    "description": "\"nvidia\", \"amd\", \"intel\"",
-                    "type": "string"
-                }
-            }
-        },
         "hydra.ListSandboxCommandsResponse": {
             "type": "object",
             "properties": {
@@ -19862,7 +19868,7 @@ const docTemplate = `{
                 "gpus": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/hydra.GPUInfo"
+                        "$ref": "#/definitions/server.GPUInfoWithSandbox"
                     }
                 },
                 "message": {
@@ -20220,11 +20226,48 @@ const docTemplate = `{
                 }
             }
         },
+        "server.GPUInfoWithSandbox": {
+            "type": "object",
+            "properties": {
+                "index": {
+                    "type": "integer"
+                },
+                "memory_free_bytes": {
+                    "type": "integer"
+                },
+                "memory_total_bytes": {
+                    "type": "integer"
+                },
+                "memory_used_bytes": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "sandbox_id": {
+                    "type": "string"
+                },
+                "temperature_celsius": {
+                    "type": "integer"
+                },
+                "utilization_percent": {
+                    "description": "GPU core utilization",
+                    "type": "integer"
+                },
+                "vendor": {
+                    "description": "\"nvidia\", \"amd\", \"intel\"",
+                    "type": "string"
+                }
+            }
+        },
         "server.GrantCreditsRequest": {
             "type": "object",
             "properties": {
                 "credits": {
                     "type": "number"
+                },
+                "org_id": {
+                    "type": "string"
                 }
             }
         },
@@ -21237,6 +21280,20 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "organization_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "server.OwnedOrgSummary": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 }
             }

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1185,6 +1185,7 @@ func (apiServer *HelixAPIServer) registerRoutes(_ context.Context) (*mux.Router,
 	adminRouter.HandleFunc("/admin/users/{id}/trial-activate", system.DefaultWrapper(apiServer.adminActivateTrial)).Methods(http.MethodPost)
 	adminRouter.HandleFunc("/admin/users/{id}/trial-activate", system.DefaultWrapper(apiServer.adminRevokeTrial)).Methods(http.MethodDelete)
 	adminRouter.HandleFunc("/admin/users/{id}/credits", system.DefaultWrapper(apiServer.adminGrantCredits)).Methods(http.MethodPost)
+	adminRouter.HandleFunc("/admin/users/{id}/owned-orgs", system.DefaultWrapper(apiServer.listUserOwnedOrgs)).Methods(http.MethodGet)
 
 	adminRouter.HandleFunc("/admin/orgs", apiServer.adminListOrganizations).Methods(http.MethodGet)
 

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -853,7 +853,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Adds credits to the wallet of the user's oldest owned org, or stashes the grant on the user for application at first org creation. Works regardless of subscription state, unlike adminActivateTrial.",
+                "description": "Adds credits to the wallet of an explicitly chosen organisation the user owns, or stashes the grant on the user when they own no organisations yet (the grant is applied to their first owned org on creation). Works regardless of subscription state.",
                 "consumes": [
                     "application/json"
                 ],
@@ -873,7 +873,7 @@
                         "required": true
                     },
                     {
-                        "description": "Credits to grant (must be \u003e 0)",
+                        "description": "Credits to grant (must be \u003e 0) and the target org_id (required iff user owns ≥1 orgs)",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -887,6 +887,43 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/server.GrantCreditsResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/users/{id}/owned-orgs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the organisations the target user is the owner of, sorted by creation time ascending. Used by the admin \"Grant credits\" dialog to populate its org picker.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "List a user's owned organisations (Admin, cloud only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/server.OwnedOrgSummary"
+                            }
                         }
                     }
                 }
@@ -18931,37 +18968,6 @@
                 "DevContainerTypeHeadless"
             ]
         },
-        "hydra.GPUInfo": {
-            "type": "object",
-            "properties": {
-                "index": {
-                    "type": "integer"
-                },
-                "memory_free_bytes": {
-                    "type": "integer"
-                },
-                "memory_total_bytes": {
-                    "type": "integer"
-                },
-                "memory_used_bytes": {
-                    "type": "integer"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "temperature_celsius": {
-                    "type": "integer"
-                },
-                "utilization_percent": {
-                    "description": "GPU core utilization",
-                    "type": "integer"
-                },
-                "vendor": {
-                    "description": "\"nvidia\", \"amd\", \"intel\"",
-                    "type": "string"
-                }
-            }
-        },
         "hydra.ListSandboxCommandsResponse": {
             "type": "object",
             "properties": {
@@ -19858,7 +19864,7 @@
                 "gpus": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/hydra.GPUInfo"
+                        "$ref": "#/definitions/server.GPUInfoWithSandbox"
                     }
                 },
                 "message": {
@@ -20216,11 +20222,48 @@
                 }
             }
         },
+        "server.GPUInfoWithSandbox": {
+            "type": "object",
+            "properties": {
+                "index": {
+                    "type": "integer"
+                },
+                "memory_free_bytes": {
+                    "type": "integer"
+                },
+                "memory_total_bytes": {
+                    "type": "integer"
+                },
+                "memory_used_bytes": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "sandbox_id": {
+                    "type": "string"
+                },
+                "temperature_celsius": {
+                    "type": "integer"
+                },
+                "utilization_percent": {
+                    "description": "GPU core utilization",
+                    "type": "integer"
+                },
+                "vendor": {
+                    "description": "\"nvidia\", \"amd\", \"intel\"",
+                    "type": "string"
+                }
+            }
+        },
         "server.GrantCreditsRequest": {
             "type": "object",
             "properties": {
                 "credits": {
                     "type": "number"
+                },
+                "org_id": {
+                    "type": "string"
                 }
             }
         },
@@ -21233,6 +21276,20 @@
                     "type": "string"
                 },
                 "organization_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "server.OwnedOrgSummary": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 }
             }

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -223,27 +223,6 @@ definitions:
     - DevContainerTypeSway
     - DevContainerTypeUbuntu
     - DevContainerTypeHeadless
-  hydra.GPUInfo:
-    properties:
-      index:
-        type: integer
-      memory_free_bytes:
-        type: integer
-      memory_total_bytes:
-        type: integer
-      memory_used_bytes:
-        type: integer
-      name:
-        type: string
-      temperature_celsius:
-        type: integer
-      utilization_percent:
-        description: GPU core utilization
-        type: integer
-      vendor:
-        description: '"nvidia", "amd", "intel"'
-        type: string
-    type: object
   hydra.ListSandboxCommandsResponse:
     properties:
       commands:
@@ -911,7 +890,7 @@ definitions:
         type: array
       gpus:
         items:
-          $ref: '#/definitions/hydra.GPUInfo'
+          $ref: '#/definitions/server.GPUInfoWithSandbox'
         type: array
       message:
         type: string
@@ -1145,10 +1124,35 @@ definitions:
       url:
         type: string
     type: object
+  server.GPUInfoWithSandbox:
+    properties:
+      index:
+        type: integer
+      memory_free_bytes:
+        type: integer
+      memory_total_bytes:
+        type: integer
+      memory_used_bytes:
+        type: integer
+      name:
+        type: string
+      sandbox_id:
+        type: string
+      temperature_celsius:
+        type: integer
+      utilization_percent:
+        description: GPU core utilization
+        type: integer
+      vendor:
+        description: '"nvidia", "amd", "intel"'
+        type: string
+    type: object
   server.GrantCreditsRequest:
     properties:
       credits:
         type: number
+      org_id:
+        type: string
     type: object
   server.GrantCreditsResponse:
     properties:
@@ -1806,6 +1810,15 @@ definitions:
       organization_id:
         type: string
       organization_name:
+        type: string
+    type: object
+  server.OwnedOrgSummary:
+    properties:
+      display_name:
+        type: string
+      id:
+        type: string
+      name:
         type: string
     type: object
   server.PhaseProgress:
@@ -11341,16 +11354,18 @@ paths:
     post:
       consumes:
       - application/json
-      description: Adds credits to the wallet of the user's oldest owned org, or stashes
-        the grant on the user for application at first org creation. Works regardless
-        of subscription state, unlike adminActivateTrial.
+      description: Adds credits to the wallet of an explicitly chosen organisation
+        the user owns, or stashes the grant on the user when they own no organisations
+        yet (the grant is applied to their first owned org on creation). Works regardless
+        of subscription state.
       parameters:
       - description: User ID
         in: path
         name: id
         required: true
         type: string
-      - description: Credits to grant (must be > 0)
+      - description: Credits to grant (must be > 0) and the target org_id (required
+          iff user owns ≥1 orgs)
         in: body
         name: request
         required: true
@@ -11366,6 +11381,31 @@ paths:
       security:
       - BearerAuth: []
       summary: Grant credits to a user (Admin, cloud only)
+      tags:
+      - users
+  /api/v1/admin/users/{id}/owned-orgs:
+    get:
+      description: Returns the organisations the target user is the owner of, sorted
+        by creation time ascending. Used by the admin "Grant credits" dialog to populate
+        its org picker.
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/server.OwnedOrgSummary'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List a user's owned organisations (Admin, cloud only)
       tags:
       - users
   /api/v1/admin/users/{id}/password:

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -150,19 +150,6 @@ export enum HydraDevContainerType {
   DevContainerTypeHeadless = "headless",
 }
 
-export interface HydraGPUInfo {
-  index?: number;
-  memory_free_bytes?: number;
-  memory_total_bytes?: number;
-  memory_used_bytes?: number;
-  name?: string;
-  temperature_celsius?: number;
-  /** GPU core utilization */
-  utilization_percent?: number;
-  /** "nvidia", "amd", "intel" */
-  vendor?: string;
-}
-
 export interface HydraListSandboxCommandsResponse {
   commands?: HydraSandboxCommandResponse[];
 }
@@ -599,7 +586,7 @@ export interface ServerActivateTrialResponse {
 
 export interface ServerAgentSandboxesDebugResponse {
   dev_containers?: ServerDevContainerWithClients[];
-  gpus?: HydraGPUInfo[];
+  gpus?: ServerGPUInfoWithSandbox[];
   message?: string;
   sandboxes?: ServerSandboxInstanceInfo[];
 }
@@ -740,8 +727,23 @@ export interface ServerExposedPort {
   url?: string;
 }
 
+export interface ServerGPUInfoWithSandbox {
+  index?: number;
+  memory_free_bytes?: number;
+  memory_total_bytes?: number;
+  memory_used_bytes?: number;
+  name?: string;
+  sandbox_id?: string;
+  temperature_celsius?: number;
+  /** GPU core utilization */
+  utilization_percent?: number;
+  /** "nvidia", "amd", "intel" */
+  vendor?: string;
+}
+
 export interface ServerGrantCreditsRequest {
   credits?: number;
+  org_id?: string;
 }
 
 export interface ServerGrantCreditsResponse {
@@ -1122,6 +1124,12 @@ export interface ServerOrganizationDomainInfo {
   auto_join_domain?: string;
   organization_id?: string;
   organization_name?: string;
+}
+
+export interface ServerOwnedOrgSummary {
+  display_name?: string;
+  id?: string;
+  name?: string;
 }
 
 export interface ServerPhaseProgress {
@@ -7097,7 +7105,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Adds credits to the wallet of the user's oldest owned org, or stashes the grant on the user for application at first org creation. Works regardless of subscription state, unlike adminActivateTrial.
+     * @description Adds credits to the wallet of an explicitly chosen organisation the user owns, or stashes the grant on the user when they own no organisations yet (the grant is applied to their first owned org on creation). Works regardless of subscription state.
      *
      * @tags users
      * @name V1AdminUsersCreditsCreate
@@ -7112,6 +7120,24 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         body: request,
         secure: true,
         type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Returns the organisations the target user is the owner of, sorted by creation time ascending. Used by the admin "Grant credits" dialog to populate its org picker.
+     *
+     * @tags users
+     * @name V1AdminUsersOwnedOrgsDetail
+     * @summary List a user's owned organisations (Admin, cloud only)
+     * @request GET:/api/v1/admin/users/{id}/owned-orgs
+     * @secure
+     */
+    v1AdminUsersOwnedOrgsDetail: (id: string, params: RequestParams = {}) =>
+      this.request<ServerOwnedOrgSummary[], any>({
+        path: `/api/v1/admin/users/${id}/owned-orgs`,
+        method: "GET",
+        secure: true,
         format: "json",
         ...params,
       }),

--- a/frontend/src/components/dashboard/GrantCreditsDialog.tsx
+++ b/frontend/src/components/dashboard/GrantCreditsDialog.tsx
@@ -11,10 +11,14 @@ import {
     CircularProgress,
     IconButton,
     Typography,
+    FormControl,
+    InputLabel,
+    Select,
+    MenuItem,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { TypesUser } from '../../api/api';
-import { useAdminGrantCredits } from '../../services/dashboardService';
+import { useAdminGrantCredits, useAdminUserOwnedOrgs } from '../../services/dashboardService';
 import useSnackbar from '../../hooks/useSnackbar';
 
 interface GrantCreditsDialogProps {
@@ -27,9 +31,11 @@ const DEFAULT_CREDITS = 50;
 
 const GrantCreditsDialog: FC<GrantCreditsDialogProps> = ({ open, onClose, user }) => {
     const [credits, setCredits] = useState(String(DEFAULT_CREDITS));
+    const [orgId, setOrgId] = useState<string>('');
     const [error, setError] = useState('');
     const grantCredits = useAdminGrantCredits();
     const snackbar = useSnackbar();
+    const { data: ownedOrgs, isLoading: isLoadingOrgs } = useAdminUserOwnedOrgs(user?.id, open);
 
     useEffect(() => {
         if (open) {
@@ -38,6 +44,25 @@ const GrantCreditsDialog: FC<GrantCreditsDialogProps> = ({ open, onClose, user }
         }
     }, [open]);
 
+    // Pre-select the only owned org when there's exactly one, so the admin
+    // doesn't have to interact with a one-item dropdown. Multi-org or
+    // no-org cases require an explicit choice (or none, for the stash path).
+    useEffect(() => {
+        if (!ownedOrgs) return;
+        if (ownedOrgs.length === 1) {
+            setOrgId(ownedOrgs[0].id);
+        } else {
+            setOrgId('');
+        }
+    }, [ownedOrgs]);
+
+    const hasOrgs = (ownedOrgs?.length ?? 0) > 0;
+    const willStash = !isLoadingOrgs && !hasOrgs;
+    const submitDisabled =
+        grantCredits.isPending ||
+        isLoadingOrgs ||
+        (hasOrgs && !orgId);
+
     const handleSubmit = async () => {
         if (!user?.id) return;
         const creditsNum = parseFloat(credits);
@@ -45,10 +70,15 @@ const GrantCreditsDialog: FC<GrantCreditsDialogProps> = ({ open, onClose, user }
             setError('Credits must be greater than 0');
             return;
         }
+        if (hasOrgs && !orgId) {
+            setError('Pick which organisation receives the grant');
+            return;
+        }
         try {
             const result = await grantCredits.mutateAsync({
                 userId: user.id,
                 credits: creditsNum,
+                orgId: hasOrgs ? orgId : undefined,
             });
             const status = (result as any)?.status as string | undefined;
             if (status === 'stashed') {
@@ -89,9 +119,15 @@ const GrantCreditsDialog: FC<GrantCreditsDialogProps> = ({ open, onClose, user }
                 <Box sx={{ mt: 2 }}>
                     {user && (
                         <Alert severity="info" sx={{ mb: 2 }}>
-                            Granting credits to <strong>{user.email || user.username}</strong>. Top-up lands on the
-                            user's oldest owned org regardless of subscription state. If the user has no organization
-                            yet, the grant is parked on the user and applied when they create their first org.
+                            Granting credits to <strong>{user.email || user.username}</strong>. The grant lands
+                            on the wallet of the selected organisation, regardless of subscription state.
+                        </Alert>
+                    )}
+
+                    {willStash && (
+                        <Alert severity="warning" sx={{ mb: 2 }}>
+                            This user owns no organisations yet. The grant will be stashed and applied
+                            automatically when they create their first owned org.
                         </Alert>
                     )}
 
@@ -99,6 +135,24 @@ const GrantCreditsDialog: FC<GrantCreditsDialogProps> = ({ open, onClose, user }
                         <Alert severity="error" sx={{ mb: 2 }}>
                             {error}
                         </Alert>
+                    )}
+
+                    {hasOrgs && (
+                        <FormControl fullWidth margin="normal" disabled={grantCredits.isPending}>
+                            <InputLabel id="grant-credits-org-label">Organisation</InputLabel>
+                            <Select
+                                labelId="grant-credits-org-label"
+                                label="Organisation"
+                                value={orgId}
+                                onChange={(e) => setOrgId(e.target.value as string)}
+                            >
+                                {ownedOrgs!.map((org) => (
+                                    <MenuItem key={org.id} value={org.id}>
+                                        {org.display_name || org.name} ({org.id})
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                        </FormControl>
                     )}
 
                     <TextField
@@ -120,7 +174,7 @@ const GrantCreditsDialog: FC<GrantCreditsDialogProps> = ({ open, onClose, user }
                     onClick={handleSubmit}
                     color="secondary"
                     variant="contained"
-                    disabled={grantCredits.isPending}
+                    disabled={submitDisabled}
                     startIcon={grantCredits.isPending ? <CircularProgress size={20} /> : null}
                 >
                     {grantCredits.isPending ? 'Granting…' : 'Grant credits'}

--- a/frontend/src/services/dashboardService.ts
+++ b/frontend/src/services/dashboardService.ts
@@ -258,6 +258,34 @@ export interface ActivateTrialInput {
 export interface GrantCreditsInput {
     userId: string;
     credits: number;
+    // org_id is REQUIRED when the user owns one or more orgs; omitted only
+    // when the grant is stashed against a user who owns no orgs yet.
+    orgId?: string;
+}
+
+export interface OwnedOrgSummary {
+    id: string;
+    name: string;
+    display_name?: string;
+}
+
+/**
+ * Hook to fetch the organisations a target user owns (cloud edition, admin
+ * only). Used by the Grant Credits dialog to populate its org picker so the
+ * admin's choice is explicit rather than a silent "oldest owned" pick.
+ */
+export function useAdminUserOwnedOrgs(userId: string | undefined, enabled: boolean) {
+    const api = useApi();
+    const apiClient = api.getApiClient();
+
+    return useQuery({
+        queryKey: ["admin-user-owned-orgs", userId],
+        enabled: !!userId && enabled,
+        queryFn: async () => {
+            const response = await apiClient.v1AdminUsersOwnedOrgsDetail(userId!);
+            return (response.data as OwnedOrgSummary[]) ?? [];
+        },
+    });
 }
 
 /**
@@ -300,6 +328,7 @@ export function useAdminGrantCredits() {
         mutationFn: async (input: GrantCreditsInput) => {
             const response = await apiClient.v1AdminUsersCreditsCreate(input.userId, {
                 credits: input.credits,
+                org_id: input.orgId,
             });
             return response.data;
         },

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -223,27 +223,6 @@ definitions:
     - DevContainerTypeSway
     - DevContainerTypeUbuntu
     - DevContainerTypeHeadless
-  hydra.GPUInfo:
-    properties:
-      index:
-        type: integer
-      memory_free_bytes:
-        type: integer
-      memory_total_bytes:
-        type: integer
-      memory_used_bytes:
-        type: integer
-      name:
-        type: string
-      temperature_celsius:
-        type: integer
-      utilization_percent:
-        description: GPU core utilization
-        type: integer
-      vendor:
-        description: '"nvidia", "amd", "intel"'
-        type: string
-    type: object
   hydra.ListSandboxCommandsResponse:
     properties:
       commands:
@@ -911,7 +890,7 @@ definitions:
         type: array
       gpus:
         items:
-          $ref: '#/definitions/hydra.GPUInfo'
+          $ref: '#/definitions/server.GPUInfoWithSandbox'
         type: array
       message:
         type: string
@@ -1145,10 +1124,35 @@ definitions:
       url:
         type: string
     type: object
+  server.GPUInfoWithSandbox:
+    properties:
+      index:
+        type: integer
+      memory_free_bytes:
+        type: integer
+      memory_total_bytes:
+        type: integer
+      memory_used_bytes:
+        type: integer
+      name:
+        type: string
+      sandbox_id:
+        type: string
+      temperature_celsius:
+        type: integer
+      utilization_percent:
+        description: GPU core utilization
+        type: integer
+      vendor:
+        description: '"nvidia", "amd", "intel"'
+        type: string
+    type: object
   server.GrantCreditsRequest:
     properties:
       credits:
         type: number
+      org_id:
+        type: string
     type: object
   server.GrantCreditsResponse:
     properties:
@@ -1806,6 +1810,15 @@ definitions:
       organization_id:
         type: string
       organization_name:
+        type: string
+    type: object
+  server.OwnedOrgSummary:
+    properties:
+      display_name:
+        type: string
+      id:
+        type: string
+      name:
         type: string
     type: object
   server.PhaseProgress:
@@ -11341,16 +11354,18 @@ paths:
     post:
       consumes:
       - application/json
-      description: Adds credits to the wallet of the user's oldest owned org, or stashes
-        the grant on the user for application at first org creation. Works regardless
-        of subscription state, unlike adminActivateTrial.
+      description: Adds credits to the wallet of an explicitly chosen organisation
+        the user owns, or stashes the grant on the user when they own no organisations
+        yet (the grant is applied to their first owned org on creation). Works regardless
+        of subscription state.
       parameters:
       - description: User ID
         in: path
         name: id
         required: true
         type: string
-      - description: Credits to grant (must be > 0)
+      - description: Credits to grant (must be > 0) and the target org_id (required
+          iff user owns ≥1 orgs)
         in: body
         name: request
         required: true
@@ -11366,6 +11381,31 @@ paths:
       security:
       - BearerAuth: []
       summary: Grant credits to a user (Admin, cloud only)
+      tags:
+      - users
+  /api/v1/admin/users/{id}/owned-orgs:
+    get:
+      description: Returns the organisations the target user is the owner of, sorted
+        by creation time ascending. Used by the admin "Grant credits" dialog to populate
+        its org picker.
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/server.OwnedOrgSummary'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List a user's owned organisations (Admin, cloud only)
       tags:
       - users
   /api/v1/admin/users/{id}/password:

--- a/openapi.json
+++ b/openapi.json
@@ -1020,7 +1020,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Adds credits to the wallet of the user's oldest owned org, or stashes the grant on the user for application at first org creation. Works regardless of subscription state, unlike adminActivateTrial.",
+                "description": "Adds credits to the wallet of an explicitly chosen organisation the user owns, or stashes the grant on the user when they own no organisations yet (the grant is applied to their first owned org on creation). Works regardless of subscription state.",
                 "tags": [
                     "users"
                 ],
@@ -1044,7 +1044,7 @@
                             }
                         }
                     },
-                    "description": "Credits to grant (must be > 0)",
+                    "description": "Credits to grant (must be > 0) and the target org_id (required iff user owns ≥1 orgs)",
                     "required": true
                 },
                 "responses": {
@@ -1054,6 +1054,46 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/server.GrantCreditsResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/users/{id}/owned-orgs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the organisations the target user is the owner of, sorted by creation time ascending. Used by the admin \"Grant credits\" dialog to populate its org picker.",
+                "tags": [
+                    "users"
+                ],
+                "summary": "List a user's owned organisations (Admin, cloud only)",
+                "parameters": [
+                    {
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/server.OwnedOrgSummary"
+                                    }
                                 }
                             }
                         }
@@ -22861,37 +22901,6 @@
                     "DevContainerTypeHeadless"
                 ]
             },
-            "hydra.GPUInfo": {
-                "type": "object",
-                "properties": {
-                    "index": {
-                        "type": "integer"
-                    },
-                    "memory_free_bytes": {
-                        "type": "integer"
-                    },
-                    "memory_total_bytes": {
-                        "type": "integer"
-                    },
-                    "memory_used_bytes": {
-                        "type": "integer"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "temperature_celsius": {
-                        "type": "integer"
-                    },
-                    "utilization_percent": {
-                        "description": "GPU core utilization",
-                        "type": "integer"
-                    },
-                    "vendor": {
-                        "description": "\"nvidia\", \"amd\", \"intel\"",
-                        "type": "string"
-                    }
-                }
-            },
             "hydra.ListSandboxCommandsResponse": {
                 "type": "object",
                 "properties": {
@@ -23788,7 +23797,7 @@
                     "gpus": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/hydra.GPUInfo"
+                            "$ref": "#/components/schemas/server.GPUInfoWithSandbox"
                         }
                     },
                     "message": {
@@ -24146,11 +24155,48 @@
                     }
                 }
             },
+            "server.GPUInfoWithSandbox": {
+                "type": "object",
+                "properties": {
+                    "index": {
+                        "type": "integer"
+                    },
+                    "memory_free_bytes": {
+                        "type": "integer"
+                    },
+                    "memory_total_bytes": {
+                        "type": "integer"
+                    },
+                    "memory_used_bytes": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "sandbox_id": {
+                        "type": "string"
+                    },
+                    "temperature_celsius": {
+                        "type": "integer"
+                    },
+                    "utilization_percent": {
+                        "description": "GPU core utilization",
+                        "type": "integer"
+                    },
+                    "vendor": {
+                        "description": "\"nvidia\", \"amd\", \"intel\"",
+                        "type": "string"
+                    }
+                }
+            },
             "server.GrantCreditsRequest": {
                 "type": "object",
                 "properties": {
                     "credits": {
                         "type": "number"
+                    },
+                    "org_id": {
+                        "type": "string"
                     }
                 }
             },
@@ -25163,6 +25209,20 @@
                         "type": "string"
                     },
                     "organization_name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "server.OwnedOrgSummary": {
+                "type": "object",
+                "properties": {
+                    "display_name": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
                         "type": "string"
                     }
                 }

--- a/swagger.json
+++ b/swagger.json
@@ -853,7 +853,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Adds credits to the wallet of the user's oldest owned org, or stashes the grant on the user for application at first org creation. Works regardless of subscription state, unlike adminActivateTrial.",
+                "description": "Adds credits to the wallet of an explicitly chosen organisation the user owns, or stashes the grant on the user when they own no organisations yet (the grant is applied to their first owned org on creation). Works regardless of subscription state.",
                 "consumes": [
                     "application/json"
                 ],
@@ -873,7 +873,7 @@
                         "required": true
                     },
                     {
-                        "description": "Credits to grant (must be \u003e 0)",
+                        "description": "Credits to grant (must be \u003e 0) and the target org_id (required iff user owns ≥1 orgs)",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -887,6 +887,43 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/server.GrantCreditsResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/users/{id}/owned-orgs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the organisations the target user is the owner of, sorted by creation time ascending. Used by the admin \"Grant credits\" dialog to populate its org picker.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "List a user's owned organisations (Admin, cloud only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/server.OwnedOrgSummary"
+                            }
                         }
                     }
                 }
@@ -18931,37 +18968,6 @@
                 "DevContainerTypeHeadless"
             ]
         },
-        "hydra.GPUInfo": {
-            "type": "object",
-            "properties": {
-                "index": {
-                    "type": "integer"
-                },
-                "memory_free_bytes": {
-                    "type": "integer"
-                },
-                "memory_total_bytes": {
-                    "type": "integer"
-                },
-                "memory_used_bytes": {
-                    "type": "integer"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "temperature_celsius": {
-                    "type": "integer"
-                },
-                "utilization_percent": {
-                    "description": "GPU core utilization",
-                    "type": "integer"
-                },
-                "vendor": {
-                    "description": "\"nvidia\", \"amd\", \"intel\"",
-                    "type": "string"
-                }
-            }
-        },
         "hydra.ListSandboxCommandsResponse": {
             "type": "object",
             "properties": {
@@ -19858,7 +19864,7 @@
                 "gpus": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/hydra.GPUInfo"
+                        "$ref": "#/definitions/server.GPUInfoWithSandbox"
                     }
                 },
                 "message": {
@@ -20216,11 +20222,48 @@
                 }
             }
         },
+        "server.GPUInfoWithSandbox": {
+            "type": "object",
+            "properties": {
+                "index": {
+                    "type": "integer"
+                },
+                "memory_free_bytes": {
+                    "type": "integer"
+                },
+                "memory_total_bytes": {
+                    "type": "integer"
+                },
+                "memory_used_bytes": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "sandbox_id": {
+                    "type": "string"
+                },
+                "temperature_celsius": {
+                    "type": "integer"
+                },
+                "utilization_percent": {
+                    "description": "GPU core utilization",
+                    "type": "integer"
+                },
+                "vendor": {
+                    "description": "\"nvidia\", \"amd\", \"intel\"",
+                    "type": "string"
+                }
+            }
+        },
         "server.GrantCreditsRequest": {
             "type": "object",
             "properties": {
                 "credits": {
                     "type": "number"
+                },
+                "org_id": {
+                    "type": "string"
                 }
             }
         },
@@ -21233,6 +21276,20 @@
                     "type": "string"
                 },
                 "organization_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "server.OwnedOrgSummary": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 }
             }


### PR DESCRIPTION
## Summary

The original \`/admin/users/{id}/credits\` endpoint silently picked the user's **oldest owned** org as the grant target. Reported on SaaS as a determinism problem: admins can't tell which wallet got the credit, and can land credits on the wrong org when the user owns more than one.

This PR makes the org choice explicit: the admin now picks which org receives the grant from a dropdown populated with the user's owned orgs. The backend rejects ambiguous requests rather than guessing.

## Backend

- \`GrantCreditsRequest\` gains an optional \`org_id\` field.
- Handler decision matrix (\`api/pkg/server/admin_credit_handlers.go\`):

  | User owns | \`org_id\` | Outcome |
  |---|---|---|
  | ≥ 1 orgs | provided + matches | grants to that wallet ✅ |
  | ≥ 1 orgs | provided + mismatched | 400 \"does not own organisation X\" |
  | ≥ 1 orgs | missing | 400 \"org_id is required\" |
  | 0 orgs | missing | stashes on user (today's behaviour) ✅ |
  | 0 orgs | provided | 400 \"user owns no organisations\" |

- New endpoint \`GET /api/v1/admin/users/{id}/owned-orgs\` returns \`[{id, name, display_name}]\` sorted by creation time. Used by the dialog to populate the picker without a broader org-list scope.

## Frontend

- New \`useAdminUserOwnedOrgs\` hook fetches the user's orgs on dialog open.
- \`GrantCreditsDialog\` renders an Organisation dropdown:
  - **1 org** → pre-selected
  - **2+ orgs** → no default, Submit disabled until chosen
  - **0 orgs** → dropdown hidden; explicit warning banner explains the stash semantics
- Picker shows display name + raw id so admins can disambiguate orgs that share a display name.

## Tests

12 cases pass locally:
- Gate tests unchanged (admin, cloud, billing, credits>0).
- Happy paths updated to pass \`org_id\`.
- New: multi-org user — handler applies to the chosen one.
- New: missing \`org_id\` with ≥1 owned orgs → 400.
- New: \`org_id\` for an org the user doesn't own → 400.
- New: \`org_id\` provided when user owns 0 orgs → 400 (forces unambiguous stash vs apply).
- New: \`listUserOwnedOrgs\` returns sorted summaries; non-admin → 403.

\`\`\`
CGO_ENABLED=1 go test -v -run 'TestAdminGrantCredits|TestListUserOwnedOrgs' ./pkg/server/ -count=1
\`\`\`

## Out of scope

- **Activate Trial** uses the same silent oldest-owned pick. Identical fix applies but kept in a separate PR for scope discipline. Trivial follow-up.

## Test plan

- [ ] CI passes
- [ ] In the admin user panel, target a user with 2+ owned orgs. \"Grant credits\" dialog should show a dropdown with no default selection. Submit disabled until an org is chosen.
- [ ] Target a user with exactly 1 owned org. Dropdown pre-selected with that org.
- [ ] Target a user with 0 owned orgs. Warning banner explaining stash behaviour, no dropdown.
- [ ] Submit; verify wallet of the picked org receives the credit and \`transactions\` table has \`type='admin_grant'\` row with the right \`wallet_id\`.