### PR TITLE
fix(sandbox): bake APP_VERSION into sandbox-heartbeat

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1695,6 +1695,7 @@ steps:
         COMMIT=$$(echo ${DRONE_COMMIT_SHA} | head -c 7)
         echo "Building sandbox with version: $${VERSION}, commit: $${COMMIT}"
         docker build --pull -f Dockerfile.sandbox \
+          --build-arg APP_VERSION="$${VERSION}" \
           -t helix-sandbox:$${VERSION}-linux-amd64 \
           -t registry.helixml.tech/helix/helix-sandbox:$${COMMIT}-linux-amd64 \
           -t registry.helixml.tech/helix/helix-sandbox:$${VERSION}-linux-amd64 \
@@ -2016,6 +2017,7 @@ steps:
         COMMIT=$$(echo ${DRONE_COMMIT_SHA} | head -c 7)
         echo "Building ARM64 sandbox with version: $${VERSION}, commit: $${COMMIT}"
         docker build --pull --provenance=false -f Dockerfile.sandbox \
+          --build-arg APP_VERSION="$${VERSION}" \
           -t helix-sandbox:$${VERSION}-linux-arm64 \
           -t registry.helixml.tech/helix/helix-sandbox:$${COMMIT}-linux-arm64 \
           -t registry.helixml.tech/helix/helix-sandbox:$${VERSION}-linux-arm64 \

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -16,7 +16,7 @@ FROM golang:1.25-bookworm@sha256:e3a54b77385b4f8a31c1db4d12429ffb3718ea76865731a
 # -ldflags so data.GetHelixVersion() returns a real value instead of "<unknown>".
 # The runner's heartbeat ships this field to the control plane, where it gates
 # desktop-version matching and shows up in the admin Agent Sandbox dropdown.
-ARG APP_VERSION=unknown
+ARG APP_VERSION="v0.0.0+unknown"
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -12,6 +12,11 @@
 # Pin to specific digest for stable layer caching.
 # Update digest when intentionally upgrading Go version.
 FROM golang:1.25-bookworm@sha256:e3a54b77385b4f8a31c1db4d12429ffb3718ea76865731a787c497755d409547 AS go-builder
+# APP_VERSION is the release tag (or short commit SHA) baked into binaries via
+# -ldflags so data.GetHelixVersion() returns a real value instead of "<unknown>".
+# The runner's heartbeat ships this field to the control plane, where it gates
+# desktop-version matching and shows up in the admin Agent Sandbox dropdown.
+ARG APP_VERSION=unknown
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod \
@@ -21,10 +26,10 @@ COPY api/ ./api/
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 go build -ldflags "-s -w" -o /hydra ./api/cmd/hydra
-# Build sandbox-heartbeat (disk monitoring)
+# Build sandbox-heartbeat (disk monitoring + helix_version heartbeat to the control plane)
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 go build -ldflags "-s -w" -o /sandbox-heartbeat ./api/cmd/sandbox-heartbeat
+    CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/helixml/helix/api/pkg/data.Version=${APP_VERSION}" -o /sandbox-heartbeat ./api/cmd/sandbox-heartbeat
 # Build compose-manager (sandbox-absorbs-runner pivot: applies operator-assigned
 # runner profiles by running `docker compose` against the inner dockerd).
 RUN --mount=type=cache,target=/go/pkg/mod \

--- a/stack
+++ b/stack
@@ -1502,7 +1502,9 @@ function build-sandbox() {
   _bs_elapsed "📦 Building helix-sandbox container..."
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-  docker buildx build -f Dockerfile.sandbox -t helix-sandbox:latest .
+  local SANDBOX_APP_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "dev")
+  docker buildx build --build-arg APP_VERSION="$SANDBOX_APP_VERSION" \
+    -f Dockerfile.sandbox -t helix-sandbox:latest .
 
   if [ $? -ne 0 ]; then
     echo "❌ Failed to build helix-sandbox container"


### PR DESCRIPTION
## Summary

Released sandbox runners report `helix_version=<unknown>` to the control plane. Verified on the AWS control plane's `sandbox_instances` table: both the 2.11.13 and 2.11.14 runners we ran today carry `<unknown>` rather than the actual release version.

The control plane uses `helix_version` to:
- gate desktop-version matching in `FindAvailableSandboxInstance`, and
- render the admin Agent Sandbox dropdown.

### Root cause

`sandbox-heartbeat` calls `data.GetHelixVersion()` and ships the result in `SandboxHeartbeatRequest.HelixVersion`. `GetHelixVersion()` checks the package-level `Version` var first (populated via `-ldflags -X github.com/helixml/helix/api/pkg/data.Version=...`) and falls back to `debug.ReadBuildInfo()` `vcs.revision`. `Dockerfile.sandbox` built the binary with `-ldflags "-s -w"` only, and Docker builds run without `.git` so `vcs.revision` is empty too. Both probes miss, so the default `"<unknown>"` ends up on the wire.

The main API server's Dockerfile already does this correctly (see `Dockerfile:91`); `Dockerfile.sandbox` just hadn't been updated when sandbox-heartbeat started shipping the field.

### Fix

- `Dockerfile.sandbox`: add `ARG APP_VERSION=unknown` and inject `-X github.com/helixml/helix/api/pkg/data.Version=${APP_VERSION}` into the `sandbox-heartbeat` build.
- `.drone.yml`: the amd64 + arm64 `build-sandbox` steps already compute a `VERSION` string (`DRONE_TAG` or 7-char `DRONE_COMMIT_SHA`); forward it as `--build-arg APP_VERSION="$VERSION"`.
- `stack` (local `./stack build-sandbox`): derive `APP_VERSION` from the short git SHA so dev builds also stop reporting `<unknown>`.

`hydra`, `compose-manager`, and `inference-proxy` do not currently call `GetHelixVersion()`, so their ldflags are unchanged.

### Verified locally

```
$ go build -ldflags "-s -w -X github.com/helixml/helix/api/pkg/data.Version=2.11.14-test" ...
$ strings /tmp/sandbox-heartbeat-versioned | grep 2.11.14
2.11.14-test
```

### Test plan

- [x] Local Go build with the ldflag bakes the version string into the binary
- [ ] Drone build-sandbox-amd64 + build-sandbox-arm64 pass
- [ ] Run a 2.11.x sandbox built from this branch; confirm the `sandbox_instances` row shows `helix_version=2.11.x` (not `<unknown>`)
- [ ] Admin Agent Sandbox dropdown shows the version

🤖 Generated with [Claude Code](https://claude.com/claude-code)