### PR TITLE
fix(hydra): mount NVIDIA DRM render node into inner desktop container

### DIFF
--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -1354,8 +1354,42 @@ func (dm *DevContainerManager) configureGPU(hostConfig *container.HostConfig, ve
 				},
 			)
 		}
+		// DRM render node pass-through. nvidia-container-toolkit normally
+		// handles this, but on hosts where /dev/dri/renderD* for the NVIDIA
+		// driver was missing at the time nvidia-container-toolkit ran
+		// (notably the AWS Deep Learning AMI, which builds the driver with
+		// NV_EXCLUDE_BUILD_MODULES='nvidia-drm' so nvidia_drm has to be
+		// modprobed at boot via userdata) the toolkit doesn't pass anything
+		// and the inner desktop falls back to software rendering.
+		// enumerateDRMDevices walks sysfs and only returns devices whose
+		// kernel driver is "nvidia", so it's a no-op on hosts without
+		// nvidia_drm loaded.
+		nvDRM := enumerateDRMDevices("nvidia")
+		for _, d := range nvDRM {
+			if gpuIndex != nil {
+				if *gpuIndex < 0 || *gpuIndex >= len(nvDRM) {
+					break
+				}
+				if d != nvDRM[*gpuIndex] {
+					continue
+				}
+			}
+			for _, dev := range []string{d.renderNode, d.cardDevice} {
+				if dev == "" {
+					continue
+				}
+				hostConfig.Devices = append(hostConfig.Devices,
+					container.DeviceMapping{
+						PathOnHost:        dev,
+						PathInContainer:   dev,
+						CgroupPermissions: "rwm",
+					},
+				)
+			}
+		}
 		log.Debug().
 			Strs("device_ids", deviceIDs).
+			Int("nv_drm_devs", len(nvDRM)).
 			Int("explicit_dev_mounts", len(hostConfig.Devices)).
 			Msg("Configured NVIDIA GPU passthrough")
 


### PR DESCRIPTION
## Summary

Follow-up to #2502. That PR made `/dev/nvidia*` char devices reach the inner desktop (sufficient for CUDA / NVENC). This PR adds the corresponding DRM render node + card device, which the inner compositor needs to produce GPU-backed dmabufs.

## Failure mode it fixes

On hosts where the NVIDIA driver was installed without the `nvidia_drm` kernel module - notably the AWS Deep Learning AMI, which builds the driver with `NV_EXCLUDE_BUILD_MODULES='nvidia-drm '` (the `nvidia-drm.ko` source and prebuilt `.ko` are present under `/usr/src/nvidia-<ver>/` but never copied into `/lib/modules/<ver>/`) - `nvidia-container-toolkit` finds no `/dev/dri/renderD<N>` for the GPU at the time it runs and passes nothing through.

Inside the desktop container, `/etc/cont-init.d/15-detect-gpu.sh` sources `detect-render-node.sh`, which walks `/sys/class/drm/` looking for a node whose kernel driver is `nvidia`. With no such node it sets `HELIX_RENDER_NODE=SOFTWARE`, GNOME Mutter falls back to surfaceless rendering, and the GStreamer pipeline:

```
pipewirezerocopysrc ! video/x-raw(memory:CUDAMemory) ! cudascale ! nvh264enc ! ...
```

fails with `failed to change state to PLAYING` because the PipeWire source can only emit CPU buffers from a software compositor and `cudascale` rejects them.

## What the fix does

In `configureGPU`'s `nvidia` branch, after the existing explicit `/dev/nvidia*` mounts (added in #2502), call `enumerateDRMDevices("nvidia")` (the helper already used by AMD / Intel paths) to discover any NVIDIA-driver-owned `/dev/dri/renderD<N>` and `/dev/dri/card<N>` and add them to `hostConfig.Devices`.

This is a no-op when:
- `nvidia_drm` is not loaded on the host (the helper returns an empty slice).
- The host-side `nvidia-container-toolkit` already passed the DRM node through (the explicit mount duplicates what's there - same path, harmless).

AMD / Intel / virtio paths are unchanged.

## Companion fixes (out of scope here)

To fully unblock the failing-host case, two things are needed alongside this PR but live in deployment configuration, not in this codebase:

1. Boot-time `modprobe nvidia_drm modeset=1` on the host (so the kernel module is loaded and `/dev/dri/renderD<N>` exists at all). On the AWS DLAMI this means manually copying `nvidia-drm.ko` from `/usr/src/nvidia-<ver>/` into `/lib/modules/<ver>/updates/dkms/`, `depmod -a`, then `modprobe`.
2. Outer container `docker run` must include `--device /dev/dri/renderD<N>` so the L0 -> L1 layer (sandbox container) sees the device that L1 -> L2 (this PR) then propagates.

These belong in operator-side deployment scripts / runner-bootstrap and are tracked separately.

## Test plan

- [ ] Build green; sandbox image published.
- [ ] On an AWS DLAMI host with `nvidia_drm` modprobed and `--device /dev/dri/renderD128` on the outer container: spawn a desktop session and verify the inner container shows `HELIX_RENDER_NODE=/dev/dri/renderD128` (not `SOFTWARE`).
- [ ] Pipeline enters PLAYING; video stream renders.
- [ ] Hosts that worked already (Prime / Lambda / dev) still work - the explicit mount is redundant with what nvidia-container-toolkit already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)