### PR TITLE
fix(desktop): disarm finalizer before manual GstMessage Unref

### DIFF
--- a/api/pkg/desktop/gst_pipeline.go
+++ b/api/pkg/desktop/gst_pipeline.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -322,7 +323,18 @@ func (g *GstPipeline) watchBus(ctx context.Context) {
 		// exception") because the message references elements that are no
 		// longer in a valid state. Deterministic Unref keeps the C-side
 		// lifetimes tight.
+		//
+		// CRITICAL: bus.TimedPop returns a *Message wrapped via go-gst's
+		// FromGstMessageUnsafeFull — the wrapper does NOT take an extra ref
+		// (the C call already transferred one) but DOES install a finalizer
+		// that calls gst_message_unref. If we just call msg.Unref() we drop
+		// the only ref to zero and free the C struct, then later the GC
+		// finalizer runs gst_message_unref a second time on freed memory —
+		// either tripping the "REFCOUNT_VALUE > 0" assertion or, worse,
+		// corrupting the heap once GStreamer reuses the slot. Disarm the
+		// finalizer first so only our explicit Unref decrements the refcount.
 		g.handleBusMessage(msg)
+		runtime.SetFinalizer(msg, nil)
 		msg.Unref()
 		if !g.running.Load() {
 			return


### PR DESCRIPTION
## Summary

- Disarm the GC finalizer on `*gst.Message` before calling `msg.Unref()` in `watchBus()` to prevent a double-unref that crashes desktop-bridge every 5-20s.

## Background

PR https://github.com/helixml/helix/pull/2478 added `msg.Unref()` in `watchBus()` to deterministically free bus messages. But `bus.TimedPop` returns a `*Message` wrapped via go-gst's `FromGstMessageUnsafeFull`:

- The wrapper does **not** take an extra ref (the C call already transferred one).
- The wrapper **does** install a finalizer that calls `gst_message_unref`.

So the explicit `msg.Unref()` drops the only ref to 0 and frees the C struct. Later, GC runs the wrapper's finalizer which calls `gst_message_unref` a second time on freed memory.

## Production symptoms

On every viewer attached to a desktop session, desktop-bridge SIGABRTs every 5-20 seconds with a mix of:

- `GStreamer-CRITICAL gst_mini_object_unref: assertion 'REFCOUNT_VALUE > 0' failed` (when the C struct slot hasn't been reused yet).
- `malloc(): unsorted double linked list corrupted` / `corrupted double-linked list (not small)` (when the slot has been reused — the second unref trashes someone else's data).
- Full Go stack ending in `runtime.runFinalizers -> (*Message).Unref -> _Cfunc_gst_message_unref`.

The supervisor (`while true; do desktop-bridge; sleep 2; done`) restarts the bridge within 2s, so gnome-shell / mutter / PipeWire stay up, but each browser viewer sees a stream WebSocket disconnect with code 1006 every ~20s. Console pattern:

```
[WebSocketStream] Disconnected: {code: 1006, reason: '(empty)', wasClean: false, connectionDurationMs: 19523, ...}
```

## Fix

`runtime.SetFinalizer(msg, nil)` before `msg.Unref()` so only one decrement reaches the C side.

The pipeline's existing `g.pipeline.Unref()` in `Stop()` is fine — pipelines use `glib.TransferNone` which both adds a ref AND installs a finalizer (refcount = 2 after construction), so explicit Unref + finalizer Unref correctly takes it from 2 → 0. Different math from messages.

## Test plan

- [ ] CI builds a fresh sandbox image with the fix.
- [ ] Roll new desktop container, open a session, leave the stream connected for 5+ minutes — should see continuous frames with no `Stream WebSocket connection closed` events in API logs.
- [ ] `docker exec helix-sandbox-nvidia-1 docker logs ubuntu-external-<id> | grep -E "SIGABRT|gst_mini_object_unref|corrupted"` should be empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)