### PR TITLE
fix(api): scope streaming writes to content columns so interrupts stick

### DIFF
--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -1287,8 +1287,18 @@ func (apiServer *HelixAPIServer) handleMessageAdded(sessionID string, syncMsg *t
 				if entriesJSON, entErr := json.Marshal(acc.Entries()); entErr == nil {
 					_ = json.Unmarshal(entriesJSON, &targetInteraction.ResponseEntries)
 				}
-				_, err := apiServer.Controller.Options.Store.UpdateInteraction(context.Background(), targetInteraction)
-				if err != nil {
+				// Column-scoped write: never touch state/completed/error here,
+				// so that a concurrent handleTurnCancelled / handleMessageCompleted
+				// transition can't be clobbered by this in-flight streaming flush.
+				if err := apiServer.Controller.Options.Store.UpdateInteractionStreamingFields(
+					context.Background(),
+					targetInteraction.ID,
+					targetInteraction.GenerationID,
+					targetInteraction.ResponseMessage,
+					targetInteraction.ResponseEntries,
+					targetInteraction.LastZedMessageOffset,
+					targetInteraction.LastZedMessageID,
+				); err != nil {
 					return fmt.Errorf("failed to update interaction %s: %w", targetInteraction.ID, err)
 				}
 				sctx.lastDBWrite = now
@@ -1473,43 +1483,72 @@ func (apiServer *HelixAPIServer) getOrCreateStreamingContext(ctx context.Context
 				Str("request_id", requestID).
 				Msg("🔄 [PERF] Interaction transition detected! Resetting streaming context for new interaction")
 
-			// Flush any dirty state for the old interaction before switching
+			// Flush any dirty state for the old interaction before switching.
+			//
+			// Both branches below write through column-scoped helpers
+			// (UpdateInteractionStreamingFields for content,
+			// MarkInteractionCompleteIfWaiting for the auto-complete state
+			// transition) so they cannot clobber a concurrent transition
+			// written by handleTurnCancelled / handleMessageCompleted. The
+			// in-memory sctx.interaction.State is a snapshot from when the
+			// turn started — checking it here is fine because the actual
+			// state mutation is guarded server-side.
 			if sctx.interaction != nil {
-				// Auto-complete the old interaction if it's still Waiting.
-				// Claude Code (via the Anthropic API) sometimes starts sending interrupt
-				// tokens BEFORE emitting message_completed for the cancelled turn.
-				// Without this, the cancelled interaction stays Waiting forever and the
-				// E2E ordering check fails ("interrupt tokens before first message_completed").
-				if sctx.interaction.State == types.InteractionStateWaiting {
-					sctx.interaction.State = types.InteractionStateComplete
-					sctx.interaction.Completed = time.Now()
-					sctx.interaction.Updated = time.Now()
-					// Store accumulated response entries and content
-					if sctx.accumulator != nil {
-						sctx.accumulator.Rebuild()
-						sctx.interaction.ResponseMessage = sctx.accumulator.Content
-						sctx.interaction.LastZedMessageOffset = sctx.accumulator.Offset
-						entries := sctx.accumulator.Entries()
-						if len(entries) > 0 {
-							if entriesJSON, err := json.Marshal(entries); err == nil {
-								_ = json.Unmarshal(entriesJSON, &sctx.interaction.ResponseEntries)
-							}
+				// Rebuild and persist any pending streaming content first.
+				if sctx.accumulator != nil {
+					sctx.accumulator.Rebuild()
+					sctx.interaction.ResponseMessage = sctx.accumulator.Content
+					sctx.interaction.LastZedMessageOffset = sctx.accumulator.Offset
+					entries := sctx.accumulator.Entries()
+					if len(entries) > 0 {
+						if entriesJSON, err := json.Marshal(entries); err == nil {
+							_ = json.Unmarshal(entriesJSON, &sctx.interaction.ResponseEntries)
 						}
 					}
-					if _, err := apiServer.Controller.Options.Store.UpdateInteraction(ctx, sctx.interaction); err != nil {
-						log.Error().Err(err).
-							Str("interaction_id", sctx.interactionID).
-							Msg("Failed to auto-complete old interaction during interrupt transition")
-					} else {
-						log.Info().
-							Str("interaction_id", sctx.interactionID).
-							Msg("⚡ [TRANSITION] Auto-completed cancelled interaction (interrupt arrived before message_completed)")
-					}
-				} else if sctx.dirty {
-					if _, err := apiServer.Controller.Options.Store.UpdateInteraction(ctx, sctx.interaction); err != nil {
+				}
+
+				if sctx.interaction.State == types.InteractionStateWaiting || sctx.dirty {
+					if err := apiServer.Controller.Options.Store.UpdateInteractionStreamingFields(
+						ctx,
+						sctx.interaction.ID,
+						sctx.interaction.GenerationID,
+						sctx.interaction.ResponseMessage,
+						sctx.interaction.ResponseEntries,
+						sctx.interaction.LastZedMessageOffset,
+						sctx.interaction.LastZedMessageID,
+					); err != nil {
 						log.Error().Err(err).
 							Str("interaction_id", sctx.interactionID).
 							Msg("Failed to flush old interaction during transition")
+					}
+				}
+
+				// Auto-complete the old interaction if it's still Waiting.
+				// Claude Code (via the Anthropic API) sometimes starts sending
+				// interrupt tokens BEFORE emitting message_completed for the
+				// cancelled turn. Without this, the cancelled interaction
+				// stays Waiting forever and the E2E ordering check fails
+				// ("interrupt tokens before first message_completed").
+				//
+				// The transition is guarded WHERE state='waiting' so that if
+				// handleTurnCancelled has already moved it to Interrupted (or
+				// handleMessageCompleted moved it to Complete / Error), this
+				// is a no-op — preventing the lost-update that previously
+				// resurrected cancelled turns as falsely "complete".
+				if sctx.interaction.State == types.InteractionStateWaiting {
+					transitioned, err := apiServer.Controller.Options.Store.MarkInteractionCompleteIfWaiting(ctx, sctx.interaction.ID, sctx.interaction.GenerationID)
+					if err != nil {
+						log.Error().Err(err).
+							Str("interaction_id", sctx.interactionID).
+							Msg("Failed to auto-complete old interaction during interrupt transition")
+					} else if transitioned {
+						log.Info().
+							Str("interaction_id", sctx.interactionID).
+							Msg("⚡ [TRANSITION] Auto-completed cancelled interaction (interrupt arrived before message_completed)")
+					} else {
+						log.Debug().
+							Str("interaction_id", sctx.interactionID).
+							Msg("⏭️ [TRANSITION] Skipped auto-complete (DB row is no longer Waiting — another handler already transitioned it)")
 					}
 				}
 			}
@@ -1763,15 +1802,18 @@ func (apiServer *HelixAPIServer) flushAndClearStreamingContext(ctx context.Conte
 					_ = json.Unmarshal(entriesJSON, &sctx.interaction.ResponseEntries)
 				}
 			}
-			// Before flushing, refresh the State field from the store.
-			// Other handlers (e.g. handleTurnCancelled) may have changed
-			// the state while streaming was in progress. We must not
-			// overwrite those state transitions with our stale cached state.
-			freshInteraction, refreshErr := apiServer.Controller.Options.Store.GetInteraction(ctx, sctx.interaction.ID)
-			if refreshErr == nil {
-				sctx.interaction.State = freshInteraction.State
-			}
-			_, err := apiServer.Controller.Options.Store.UpdateInteraction(ctx, sctx.interaction)
+			// Column-scoped write: never touch state/completed/error here,
+			// so a concurrent transition from handleTurnCancelled /
+			// handleMessageCompleted cannot be clobbered by this flush.
+			err := apiServer.Controller.Options.Store.UpdateInteractionStreamingFields(
+				ctx,
+				sctx.interaction.ID,
+				sctx.interaction.GenerationID,
+				sctx.interaction.ResponseMessage,
+				sctx.interaction.ResponseEntries,
+				sctx.interaction.LastZedMessageOffset,
+				sctx.interaction.LastZedMessageID,
+			)
 			if err != nil {
 				log.Error().Err(err).
 					Str("session_id", helixSessionID).

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
+	"gorm.io/datatypes"
 )
 
 // WebSocketSyncSuite tests the individual sync handler methods on HelixAPIServer
@@ -322,11 +323,11 @@ func (s *WebSocketSyncSuite) TestMessageAdded_AssistantFirstMessage() {
 		[]*types.Interaction{existingInteraction}, int64(1), nil,
 	)
 
-	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, interaction *types.Interaction) (*types.Interaction, error) {
-			s.Equal("Hello from AI", interaction.ResponseMessage)
-			s.Equal("msg-1", interaction.LastZedMessageID)
-			return interaction, nil
+	s.store.EXPECT().UpdateInteractionStreamingFields(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, _ int, responseMessage string, _ datatypes.JSON, _ int, lastZedMessageID string) error {
+			s.Equal("Hello from AI", responseMessage)
+			s.Equal("msg-1", lastZedMessageID)
+			return nil
 		},
 	)
 
@@ -372,12 +373,12 @@ func (s *WebSocketSyncSuite) TestMessageAdded_AssistantSameMessageID_StreamingUp
 		[]*types.Interaction{existingInteraction}, int64(1), nil,
 	)
 
-	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, interaction *types.Interaction) (*types.Interaction, error) {
+	s.store.EXPECT().UpdateInteractionStreamingFields(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, _ int, responseMessage string, _ datatypes.JSON, _ int, lastZedMessageID string) error {
 			// Same message_id → content replaced from offset (streaming update)
-			s.Equal("Hello, world!", interaction.ResponseMessage)
-			s.Equal("msg-A", interaction.LastZedMessageID)
-			return interaction, nil
+			s.Equal("Hello, world!", responseMessage)
+			s.Equal("msg-A", lastZedMessageID)
+			return nil
 		},
 	)
 
@@ -423,13 +424,13 @@ func (s *WebSocketSyncSuite) TestMessageAdded_AssistantNewMessageID_MultiEntry()
 		[]*types.Interaction{existingInteraction}, int64(1), nil,
 	)
 
-	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, interaction *types.Interaction) (*types.Interaction, error) {
+	s.store.EXPECT().UpdateInteractionStreamingFields(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, _ int, responseMessage string, _ datatypes.JSON, lastZedMessageOffset int, lastZedMessageID string) error {
 			// New message_id → content appended with \n\n separator
-			s.Equal("First message\n\nSecond message", interaction.ResponseMessage)
-			s.Equal("msg-B", interaction.LastZedMessageID)
-			s.Equal(len("First message")+2, interaction.LastZedMessageOffset)
-			return interaction, nil
+			s.Equal("First message\n\nSecond message", responseMessage)
+			s.Equal("msg-B", lastZedMessageID)
+			s.Equal(len("First message")+2, lastZedMessageOffset)
+			return nil
 		},
 	)
 
@@ -487,14 +488,15 @@ func (s *WebSocketSyncSuite) TestMessageAdded_PriorInteractionMessageIDsAreFilte
 		[]*types.Interaction{priorInteraction, currentInteraction}, int64(2), nil,
 	)
 
-	// UpdateInteraction is the only place the leak would surface. Capture
+	// UpdateInteractionStreamingFields is the only place the leak would
+	// surface (streaming flushes own the response entries column). Capture
 	// every call so we can assert msg-A never appears in int-current's
 	// response_entries.
-	var lastUpdate *types.Interaction
-	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, interaction *types.Interaction) (*types.Interaction, error) {
-			lastUpdate = interaction
-			return interaction, nil
+	var lastEntries datatypes.JSON
+	s.store.EXPECT().UpdateInteractionStreamingFields(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, _ int, _ string, responseEntries datatypes.JSON, _ int, _ string) error {
+			lastEntries = responseEntries
+			return nil
 		},
 	).AnyTimes()
 
@@ -518,9 +520,9 @@ func (s *WebSocketSyncSuite) TestMessageAdded_PriorInteractionMessageIDsAreFilte
 	}
 	s.NoError(s.server.handleMessageAdded("agent-1", replay))
 
-	if lastUpdate != nil && len(lastUpdate.ResponseEntries) > 0 {
+	if len(lastEntries) > 0 {
 		var entries []wsprotocol.ResponseEntry
-		s.NoError(json.Unmarshal(lastUpdate.ResponseEntries, &entries))
+		s.NoError(json.Unmarshal(lastEntries, &entries))
 		for _, e := range entries {
 			s.NotEqual("msg-A", e.MessageID,
 				"msg-A belongs to int-prior and must never be persisted to int-current")
@@ -558,11 +560,13 @@ func (s *WebSocketSyncSuite) TestMessageAdded_WrapperRestartRenumberedMessageIDs
 		[]*types.Interaction{priorInteraction, currentInteraction}, int64(2), nil,
 	)
 
-	var lastUpdate *types.Interaction
-	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, interaction *types.Interaction) (*types.Interaction, error) {
-			lastUpdate = interaction
-			return interaction, nil
+	var lastResponseMessage string
+	var updateCalled bool
+	s.store.EXPECT().UpdateInteractionStreamingFields(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, _ int, responseMessage string, _ datatypes.JSON, _ int, _ string) error {
+			lastResponseMessage = responseMessage
+			updateCalled = true
+			return nil
 		},
 	).AnyTimes()
 
@@ -585,11 +589,9 @@ func (s *WebSocketSyncSuite) TestMessageAdded_WrapperRestartRenumberedMessageIDs
 	s.NoError(s.server.handleMessageAdded("agent-1", newContent))
 
 	// The new content must have landed in int-current.
-	s.NotNil(lastUpdate, "interaction must have been updated")
-	if lastUpdate != nil {
-		s.Contains(lastUpdate.ResponseMessage, "<thinking>",
-			"renumbered new content must be accepted, not silently dropped")
-	}
+	s.True(updateCalled, "interaction must have been updated")
+	s.Contains(lastResponseMessage, "<thinking>",
+		"renumbered new content must be accepted, not silently dropped")
 }
 
 func (s *WebSocketSyncSuite) TestMessageAdded_UserMessage() {
@@ -2124,11 +2126,11 @@ func (s *WebSocketSyncSuite) TestStreamingContextCache_SecondTokenSkipsDBQueries
 	).Times(1)
 
 	// Only FIRST token writes to DB (lastDBWrite is zero, so first always flushes).
-	// Second token within 200ms is throttled — no UpdateInteraction call.
-	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, interaction *types.Interaction) (*types.Interaction, error) {
-			s.Equal("Hello", interaction.ResponseMessage)
-			return interaction, nil
+	// Second token within 200ms is throttled — no streaming-fields call.
+	s.store.EXPECT().UpdateInteractionStreamingFields(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, _ int, responseMessage string, _ datatypes.JSON, _ int, _ string) error {
+			s.Equal("Hello", responseMessage)
+			return nil
 		},
 	).Times(1)
 
@@ -2293,11 +2295,7 @@ func (s *WebSocketSyncSuite) TestStreamingThrottle_DBWriteAfterInterval() {
 	).Times(1)
 
 	// First token writes immediately (lastDBWrite is zero)
-	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, interaction *types.Interaction) (*types.Interaction, error) {
-			return interaction, nil
-		},
-	).Times(1)
+	s.store.EXPECT().UpdateInteractionStreamingFields(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 	// First token
 	syncMsg := &types.SyncMessage{
@@ -2331,10 +2329,10 @@ func (s *WebSocketSyncSuite) TestStreamingThrottle_DBWriteAfterInterval() {
 	sctx.mu.Unlock()
 
 	// Now expect another DB write since interval expired
-	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, interaction *types.Interaction) (*types.Interaction, error) {
-			s.Equal("Token 1 Token 2 Token 3", interaction.ResponseMessage)
-			return interaction, nil
+	s.store.EXPECT().UpdateInteractionStreamingFields(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, _ int, responseMessage string, _ datatypes.JSON, _ int, _ string) error {
+			s.Equal("Token 1 Token 2 Token 3", responseMessage)
+			return nil
 		},
 	).Times(1)
 
@@ -2377,12 +2375,14 @@ func (s *WebSocketSyncSuite) TestStreamingThrottle_DirtyFlushOnMessageCompleted(
 	}
 	s.server.streamingContextsMu.Unlock()
 
-	// flushAndClearStreamingContext should flush the dirty interaction
-	flushUpdate := s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, interaction *types.Interaction) (*types.Interaction, error) {
-			s.Equal("dirty unflushed content", interaction.ResponseMessage)
-			s.Equal(types.InteractionStateWaiting, interaction.State) // Not yet complete
-			return interaction, nil
+	// flushAndClearStreamingContext should flush the dirty interaction.
+	// Column-scoped: only the content fields are written, never state, so
+	// the in-progress state stays Waiting until handleMessageCompleted's
+	// own UpdateInteraction transitions it.
+	flushUpdate := s.store.EXPECT().UpdateInteractionStreamingFields(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, _ int, responseMessage string, _ datatypes.JSON, _ int, _ string) error {
+			s.Equal("dirty unflushed content", responseMessage)
+			return nil
 		},
 	)
 
@@ -2391,16 +2391,15 @@ func (s *WebSocketSyncSuite) TestStreamingThrottle_DirtyFlushOnMessageCompleted(
 	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
 		[]*types.Interaction{existingInteraction}, int64(1), nil,
 	).AnyTimes()
-	// GetInteraction is now called twice: once inside flushAndClearStreamingContext
-	// to refresh the State field (so concurrent state changes from handleTurnCancelled
-	// aren't clobbered), and once inside handleMessageCompleted to reload the latest
-	// response content from the DB.
+	// GetInteraction is called once inside handleMessageCompleted to reload
+	// the latest response content from the DB. The flush no longer reloads
+	// state separately because column-scoped writes can't clobber it.
 	s.store.EXPECT().GetInteraction(gomock.Any(), "int-flush").Return(&types.Interaction{
 		ID:              "int-flush",
 		SessionID:       "ses_flush",
 		State:           types.InteractionStateWaiting,
 		ResponseMessage: "dirty unflushed content", // DB was just flushed
-	}, nil).Times(2)
+	}, nil).Times(1)
 
 	// Final UpdateInteraction to mark complete (must come after flush)
 	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -2453,11 +2452,7 @@ func (s *WebSocketSyncSuite) TestStreamingThrottle_MultiMessageAccumulation() {
 	).Times(1)
 
 	// First message_id writes immediately
-	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, interaction *types.Interaction) (*types.Interaction, error) {
-			return interaction, nil
-		},
-	).Times(1)
+	s.store.EXPECT().UpdateInteractionStreamingFields(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 	// First message_id: assistant text
 	syncMsg := &types.SyncMessage{
@@ -2631,7 +2626,7 @@ func (s *WebSocketSyncSuite) TestStreamingPatch_PreviousEntriesTracked() {
 	// First token: expect DB queries (cache miss) + DB write + publish
 	s.store.EXPECT().GetSession(gomock.Any(), helixSessionID).Return(session, nil).Times(1)
 	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return([]*types.Interaction{interaction}, int64(1), nil).Times(1)
-	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).Return(interaction, nil).AnyTimes()
+	s.store.EXPECT().UpdateInteractionStreamingFields(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	syncMsg := &types.SyncMessage{
 		EventType: "message_added",

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -8,6 +8,7 @@ import (
 	"github.com/helixml/helix/api/pkg/license"
 	"github.com/helixml/helix/api/pkg/pubsub"
 	"github.com/helixml/helix/api/pkg/types"
+	"gorm.io/datatypes"
 )
 
 type ListProjectsQuery struct {
@@ -283,6 +284,20 @@ type Store interface {
 	CreateInteractions(ctx context.Context, interactions ...*types.Interaction) error
 	GetInteraction(ctx context.Context, id string) (*types.Interaction, error)
 	UpdateInteraction(ctx context.Context, interaction *types.Interaction) (*types.Interaction, error)
+	// UpdateInteractionStreamingFields persists only the columns the
+	// websocket streaming layer owns: response content, the Zed message
+	// offset/id pair, and updated. It deliberately does NOT touch state,
+	// completed, or error so that a streaming flush cannot clobber a
+	// concurrent transition written by handleTurnCancelled /
+	// handleMessageCompleted. See the lost-update fix in
+	// websocket_external_agent_sync.go.
+	UpdateInteractionStreamingFields(ctx context.Context, interactionID string, generationID int, responseMessage string, responseEntries datatypes.JSON, lastZedMessageOffset int, lastZedMessageID string) error
+	// MarkInteractionCompleteIfWaiting atomically transitions an interaction
+	// from Waiting → Complete and sets completed=now. Returns true if the row
+	// was transitioned, false if the row was already in a terminal state (no
+	// change made). Used by the streaming transition handler so it cannot
+	// resurrect a cancelled or errored turn as falsely "complete".
+	MarkInteractionCompleteIfWaiting(ctx context.Context, interactionID string, generationID int) (bool, error)
 	UpdateInteractionSummary(ctx context.Context, interactionID string, summary string) error
 	DeleteInteraction(ctx context.Context, id string) error
 	// ListStuckWaitingInteractions returns up to `limit` interactions that

--- a/api/pkg/store/store_interactions.go
+++ b/api/pkg/store/store_interactions.go
@@ -9,6 +9,7 @@ import (
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/helixml/helix/api/pkg/util/sanitize"
 	"github.com/rs/zerolog/log"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -235,6 +236,55 @@ func (s *PostgresStore) UpdateInteraction(ctx context.Context, interaction *type
 	}
 
 	return interaction, nil
+}
+
+// UpdateInteractionStreamingFields persists only the columns the websocket
+// streaming layer owns. State / completed / error are deliberately excluded
+// so a streaming flush cannot clobber a concurrent transition written by
+// handleTurnCancelled or handleMessageCompleted (the lost-update race that
+// turned cancelled turns into spuriously "complete" ones — see
+// websocket_external_agent_sync.go).
+func (s *PostgresStore) UpdateInteractionStreamingFields(ctx context.Context, interactionID string, generationID int, responseMessage string, responseEntries datatypes.JSON, lastZedMessageOffset int, lastZedMessageID string) error {
+	if interactionID == "" {
+		return errors.New("id is required")
+	}
+
+	responseMessage = sanitize.ForPostgres(responseMessage)
+	responseEntries = sanitize.JSONForPostgres(responseEntries)
+
+	return s.gdb.WithContext(ctx).
+		Model(&types.Interaction{}).
+		Where("id = ? AND generation_id = ?", interactionID, generationID).
+		Updates(map[string]interface{}{
+			"response_message":        responseMessage,
+			"response_entries":        responseEntries,
+			"last_zed_message_offset": lastZedMessageOffset,
+			"last_zed_message_id":     lastZedMessageID,
+			"updated":                 time.Now(),
+		}).Error
+}
+
+// MarkInteractionCompleteIfWaiting atomically transitions an interaction from
+// Waiting → Complete. Returns true if the row was transitioned, false if the
+// row was already in a terminal state (Interrupted / Complete / Error). The
+// WHERE clause ensures we cannot clobber a state set by another handler.
+func (s *PostgresStore) MarkInteractionCompleteIfWaiting(ctx context.Context, interactionID string, generationID int) (bool, error) {
+	if interactionID == "" {
+		return false, errors.New("id is required")
+	}
+	now := time.Now()
+	result := s.gdb.WithContext(ctx).
+		Model(&types.Interaction{}).
+		Where("id = ? AND generation_id = ? AND state = ?", interactionID, generationID, types.InteractionStateWaiting).
+		Updates(map[string]interface{}{
+			"state":     types.InteractionStateComplete,
+			"completed": now,
+			"updated":   now,
+		})
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected > 0, nil
 }
 
 // UpdateInteractionSummary updates just the summary field of an interaction

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -18,6 +18,7 @@ import (
 	pubsub "github.com/helixml/helix/api/pkg/pubsub"
 	types "github.com/helixml/helix/api/pkg/types"
 	gomock "go.uber.org/mock/gomock"
+	datatypes "gorm.io/datatypes"
 )
 
 // MockStore is a mock of Store interface.
@@ -5161,6 +5162,21 @@ func (mr *MockStoreMockRecorder) LookupKnowledge(ctx, q any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookupKnowledge", reflect.TypeOf((*MockStore)(nil).LookupKnowledge), ctx, q)
 }
 
+// MarkInteractionCompleteIfWaiting mocks base method.
+func (m *MockStore) MarkInteractionCompleteIfWaiting(ctx context.Context, interactionID string, generationID int) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkInteractionCompleteIfWaiting", ctx, interactionID, generationID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MarkInteractionCompleteIfWaiting indicates an expected call of MarkInteractionCompleteIfWaiting.
+func (mr *MockStoreMockRecorder) MarkInteractionCompleteIfWaiting(ctx, interactionID, generationID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkInteractionCompleteIfWaiting", reflect.TypeOf((*MockStore)(nil).MarkInteractionCompleteIfWaiting), ctx, interactionID, generationID)
+}
+
 // MarkPromptAsCrashed mocks base method.
 func (m *MockStore) MarkPromptAsCrashed(ctx context.Context, promptID, errorMsg string) error {
 	m.ctrl.T.Helper()
@@ -5840,6 +5856,20 @@ func (m *MockStore) UpdateInteraction(ctx context.Context, interaction *types.In
 func (mr *MockStoreMockRecorder) UpdateInteraction(ctx, interaction any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInteraction", reflect.TypeOf((*MockStore)(nil).UpdateInteraction), ctx, interaction)
+}
+
+// UpdateInteractionStreamingFields mocks base method.
+func (m *MockStore) UpdateInteractionStreamingFields(ctx context.Context, interactionID string, generationID int, responseMessage string, responseEntries datatypes.JSON, lastZedMessageOffset int, lastZedMessageID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateInteractionStreamingFields", ctx, interactionID, generationID, responseMessage, responseEntries, lastZedMessageOffset, lastZedMessageID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateInteractionStreamingFields indicates an expected call of UpdateInteractionStreamingFields.
+func (mr *MockStoreMockRecorder) UpdateInteractionStreamingFields(ctx, interactionID, generationID, responseMessage, responseEntries, lastZedMessageOffset, lastZedMessageID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInteractionStreamingFields", reflect.TypeOf((*MockStore)(nil).UpdateInteractionStreamingFields), ctx, interactionID, generationID, responseMessage, responseEntries, lastZedMessageOffset, lastZedMessageID)
 }
 
 // UpdateInteractionSummary mocks base method.


### PR DESCRIPTION
## Summary

When a user interrupts an in-flight turn and immediately sends a follow-up, the cancelled interaction was getting silently flipped from `Interrupted` back to `Complete`, and the agent thread state ended up corrupted (the `[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null` errors users have been hitting). Root cause is a lost-update race in `websocket_external_agent_sync.go`.

- `handleTurnCancelled` does `GetInteraction` → set `State = Interrupted` → `UpdateInteraction`. Correct in isolation.
- The streaming context holds its own `sctx.interaction` pointer with the **stale** in-memory `State = Waiting` from when the turn started. The next `message_added` flush (Zed's in-flight tool_call draining after the cancel ack) writes the full row back through `Store.UpdateInteraction`, overwriting `Interrupted` with `Waiting`.
- `handleMessageCompleted` then reloads, sees `Waiting`, and runs the normal "mark complete" branch.

End result: the cancelled turn shows as `Complete` with the half-finished tool call, claude-code-acp's thread state is half-formed, and the user's next 4 retries all fail with the same `Internal error`. See the trace in https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01krwkwenqp9rhhrahyy9kdcv1 — 17:42:28–29 UTC on 2026-06-02.

## The fix

Switch the three streaming-path writes to a new column-scoped helper that only touches the columns the streaming layer owns:

- `response_message`
- `response_entries`
- `last_zed_message_offset`
- `last_zed_message_id`
- `updated`

`state`, `completed`, and `error` are reserved for the deliberate transitions in `handleTurnCancelled` / `handleMessageCompleted` and can no longer be clobbered by an in-flight streaming flush.

For the transition handler's "auto-complete if still Waiting" intent (the fallback for when Claude Code emits new-turn tokens before `message_completed` for the cancelled turn lands), introduce `MarkInteractionCompleteIfWaiting` — a guarded `WHERE state='waiting'` update that no-ops if another handler has already moved the row.

Removes the prior best-effort `GetInteraction`-then-copy-`State`-into-stale-pointer workaround inside `flushAndClearStreamingContext`, which had a TOCTOU window and didn't cover the other two write sites.

## What is NOT changed

- The interrupt path stays immediate — no extra waits, no extra drains. Cancellation latency is unchanged.
- `handleMessageCompleted`'s two writes (mark-as-error-and-requeue, mark-complete) keep using full-row `UpdateInteraction` because they're intentional state transitions.

## Test plan

- [x] `go build ./api/pkg/store/ ./api/pkg/server/ ./api/pkg/types/ ./api/pkg/controller/`
- [x] `CGO_ENABLED=1 go test ./api/pkg/server/ -count=1` (full server suite, ok)
- [x] `TestWebSocketSyncSuite` (updated 8 expectations to the new mock; all pass)
- [ ] Sanity-watch on `meta.helix.ml` after deploy: send a prompt mid-turn and confirm the prior interaction stays `Interrupted` in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)