### PR TITLE
Fix Ugly Bright Blue Org Switcher Hover Color in Dark Mode

### DIFF
--- a/frontend/src/components/orgs/UserOrgSelector.tsx
+++ b/frontend/src/components/orgs/UserOrgSelector.tsx
@@ -1241,7 +1241,7 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
                       ? 'transparent'
                       : currentOrgSlug === org.name
                         ? 'rgba(0, 229, 255, 0.15)'
-                        : lightTheme.highlightColor,
+                        : 'rgba(0, 229, 255, 0.08)',
                 },
               }}
             >


### PR DESCRIPTION
When we implemented dark mode, We accidentally made the on-hover colour for the org switcher in dark mode a bright blue that looks ugly 

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kt7ehyg58w91jevatggmxcdf)

🚀 Built with [Helix](https://helix.ml)