### PR TITLE
Fix Chrome auto-relaunch on session resume

### DIFF
--- a/desktop/sway-config/startup-app.sh
+++ b/desktop/sway-config/startup-app.sh
@@ -587,19 +587,24 @@ while true; do
             # Settings sync daemon only needs to start once
             /usr/local/bin/start-settings-sync-daemon.sh &
 
-            # Chrome auto-relaunch: if Chrome was running at the end of the
-            # previous session (marker touched by the heartbeat loop below),
-            # bring it back up so the user's tabs are visible immediately.
-            # Stale marker (> 5 min old) means Chrome was deliberately closed,
-            # so don't relaunch. Profile persistence is set up by
+            # Chrome auto-relaunch: if Chrome was running when the previous
+            # container stopped (marker file present, maintained by the
+            # heartbeat loop below), bring it back up so the user's tabs are
+            # visible immediately. The heartbeat removes the marker as soon as
+            # Chrome stops, so a missing marker means the user closed Chrome
+            # before the session ended. Profile persistence is set up by
             # helix-workspace-setup.sh; restore-on-startup policy lives in
-            # the Dockerfile.
+            # the Dockerfile. Works for both Chrome (amd64) and Chromium
+            # (arm64) — google-chrome-stable is symlinked to chromium on arm64.
             CHROME_MARKER="/home/retro/work/.chrome-state/.was-running"
-            if [ -f "$CHROME_MARKER" ] && [ $(($(date +%s) - $(stat -c %Y "$CHROME_MARKER"))) -lt 300 ]; then
+            CHROME_LOG="/tmp/chrome-autolaunch.log"
+            if [ -f "$CHROME_MARKER" ]; then
                 # Hard container kill can leave singleton locks behind.
                 rm -f /home/retro/work/.chrome-state/Singleton* 2>/dev/null || true
-                echo "[sway-session] Auto-launching Chrome (was running at end of previous session)"
-                WAYLAND_DISPLAY=wayland-1 google-chrome-stable >/dev/null 2>&1 &
+                echo "[$(date -Is)] [sway-session] Auto-launching Chrome (marker present from previous session)" | tee -a "$CHROME_LOG"
+                WAYLAND_DISPLAY=wayland-1 google-chrome-stable >>"$CHROME_LOG" 2>&1 &
+            else
+                echo "[$(date -Is)] [sway-session] Skipping Chrome auto-launch (no marker; was closed or never opened)" >> "$CHROME_LOG"
             fi
 
             # Heartbeat: while Chrome is running, refresh the marker; when it

--- a/desktop/ubuntu-config/startup-app.sh
+++ b/desktop/ubuntu-config/startup-app.sh
@@ -307,21 +307,28 @@ fi
 # Chrome auto-relaunch + heartbeat. Mirrors the sway-session.sh logic — see
 # helix-workspace-setup.sh for the persistent profile symlink and the
 # Dockerfile for the RestoreOnStartup=1 policy that makes tabs come back.
-# A heartbeat loop touches the marker every 30s while Chrome is up; on next
-# session start we relaunch only if the marker is fresh (< 5 min old),
-# meaning Chrome was running when the previous session ended.
+# A heartbeat loop touches the marker every 30s while Chrome is up and removes
+# it as soon as Chrome stops. We relaunch on next session start iff the marker
+# exists, meaning Chrome was still running when the previous container stopped.
+# Works for both Chrome (amd64) and Chromium (arm64) — google-chrome-stable is
+# symlinked to chromium on arm64.
 (
     CHROME_MARKER="/home/retro/work/.chrome-state/.was-running"
+    CHROME_LOG="/tmp/chrome-autolaunch.log"
     # Wait for wayland-0 so Chrome can connect to the compositor.
     for i in \$(seq 1 60); do
         [ -S "\${XDG_RUNTIME_DIR}/wayland-0" ] && break
         sleep 1
     done
-    if [ -f "\$CHROME_MARKER" ] && [ \$((\$(date +%s) - \$(stat -c %Y "\$CHROME_MARKER"))) -lt 300 ]; then
+    if [ -f "\$CHROME_MARKER" ]; then
         # Hard container kill can leave singleton locks behind.
         rm -f /home/retro/work/.chrome-state/Singleton* 2>/dev/null || true
-        gow_log "[start] Auto-launching Chrome (was running at end of previous session)"
-        WAYLAND_DISPLAY=wayland-0 google-chrome-stable >/dev/null 2>&1 &
+        gow_log "[start] Auto-launching Chrome (marker present from previous session)"
+        echo "[\$(date -Is)] Auto-launching Chrome (marker present)" >> "\$CHROME_LOG"
+        WAYLAND_DISPLAY=wayland-0 google-chrome-stable >>"\$CHROME_LOG" 2>&1 &
+    else
+        gow_log "[start] Skipping Chrome auto-launch (no marker; was closed or never opened)"
+        echo "[\$(date -Is)] Skipping Chrome auto-launch (no marker)" >> "\$CHROME_LOG"
     fi
     while true; do
         if pgrep -x chrome >/dev/null 2>&1 || pgrep -x chromium >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Feature [002027](https://github.com/helixml/helix/pull/2452) shipped two things: Chrome
profile persistence (works) and auto-relaunch of Chrome on the next session if
it was running when the previous session ended (broken). After 002027, profiles
persist correctly but Chrome never auto-reopens, so users have to launch it by
hand every time.

This PR makes auto-relaunch actually fire.

## Why it was broken

The marker file (`/home/retro/work/.chrome-state/.was-running`) is touched
every 30 s by a heartbeat loop while Chrome is running and removed as soon as
Chrome stops. The auto-relaunch check was:

```bash
if [ -f "$CHROME_MARKER" ] && [ $(($(date +%s) - $(stat -c %Y "$CHROME_MARKER"))) -lt 300 ]; then
```

The heartbeat only runs while the container is alive, so on container stop the
marker's `mtime` freezes at "moment before stop". On resume, `now - mtime` is
the sandbox's off-time, which is almost always > 5 minutes — so the freshness
branch is effectively dead and Chrome is never relaunched. The 5-minute window
only works if the user resumes within five minutes of stopping, which is not
how Helix sandboxes are used.

The correct semantics — already implemented by the heartbeat — is "marker
exists ⇒ Chrome was up when the heartbeat last ran ⇒ relaunch; marker absent
⇒ Chrome was closed ⇒ skip". The freshness check adds no signal, only filters
out the cases we want to trigger on.

## Changes

- **`desktop/sway-config/startup-app.sh`** — replace `[ ... -lt 300 ]` with a
  plain `[ -f "$CHROME_MARKER" ]`. Route the auto-launch decision and Chrome's
  own stdout/stderr to `/tmp/chrome-autolaunch.log` so a silent failure can be
  diagnosed by tailing one file. Heartbeat block underneath is untouched.

- **`desktop/ubuntu-config/startup-app.sh`** — same change inside the
  `<<GNOME_EOF` heredoc that builds the gnome start script, preserving the
  `\$` / `\${...}` / `\$(...)` heredoc escapes. Emits both a `gow_log` line
  (lands in the standard start log) and a line to `/tmp/chrome-autolaunch.log`
  in each branch (launching / skipping).

## Arch coverage

Single code path for both architectures, no branching:

- `google-chrome-stable` is already symlinked to `chromium-browser` on arm64
  by the Dockerfiles (002027).
- The persistence symlink set up in `helix-workspace-setup.sh` covers both
  `~/.config/google-chrome` and `~/.config/chromium`.
- The unchanged heartbeat block already checks `pgrep -x chrome || pgrep -x
  chromium`, so the marker is maintained correctly for either binary.
- Both the Chrome and Chromium managed policies were set to
  `RestoreOnStartup: 1` in 002027.

Net effect: this one-line change makes auto-relaunch start working on amd64
(Chrome) and arm64 (Chromium) sandboxes alike.

## Tested

- `bash -n` on both modified scripts passes.
- For the Ubuntu file: extracted the `<<GNOME_EOF` heredoc body, applied the
  `\$` → `$` unescaping that bash does at heredoc-write time, and `bash -n`
  on the resulting `start_gnome` script passes.

End-to-end verification (open Chrome → stop session → wait > 5 min → resume
→ see tabs) requires `./stack build-ubuntu` (and the sway equivalent) plus a
fresh session, which would terminate the spec-task agent that authored this
PR — reviewer to run those checks. See
`design/tasks/002071_since-feature002027/design.md` for the rationale.

## Notes for reviewers

- The risk surface is tiny: this change strictly broadens the conditions
  under which Chrome auto-launches. Anywhere the old code launched, the new
  code still launches; anywhere the old code skipped because of staleness,
  the new code now launches — and that's exactly the fix.
- A small race remains by design: the heartbeat samples every 30 s, so if
  the user closes Chrome < 30 s before the container stops, the marker is
  left stale-positive and Chrome will auto-launch once on next resume. This
  is acceptable (one stray launch is much smaller harm than "never launches")
  and the alternative (wrapping Chrome with an EXIT trap) was already
  rejected in 002027 because crashes would lose the marker that the user
  actually wants restored.
- New diagnostic log: `/tmp/chrome-autolaunch.log` inside the desktop
  container. Captures one line per session start indicating whether the
  relaunch fired, plus Chrome's own stdout/stderr if it did.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kt7m5vj2b3yv6649e8p41zss)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002071_since-feature002027/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002071_since-feature002027/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002071_since-feature002027/tasks.md)

🚀 Built with [Helix](https://helix.ml)