### PR TITLE
nits - drop meaningless "Running Sandboxes" stat on sandbox detail view

### DIFF
--- a/frontend/src/components/admin/AgentSandboxes.tsx
+++ b/frontend/src/components/admin/AgentSandboxes.tsx
@@ -831,18 +831,24 @@ const AgentSandboxes: FC<AgentSandboxesProps> = ({ selectedSandboxId }) => {
         </Alert>
       )}
 
-      {/* Summary Stats */}
+      {/* Summary Stats. "Running Sandboxes" only makes sense in the
+          all-sandboxes aggregate view - when a specific sandbox is
+          selected, the filter scope is a single row and the count is
+          always 1, which is noise. Hide it in the detail view and
+          rebalance the remaining two cards to fill the row. */}
       <Grid container spacing={2} sx={{ mb: 3 }}>
-        <Grid item xs={12} sm={4}>
-          <Paper sx={{ p: 2, textAlign: 'center' }}>
-            <ComputerIcon sx={{ fontSize: 40, color: 'primary.main', mb: 1 }} />
-            <Typography variant="h4">{runningSandboxes}</Typography>
-            <Typography variant="body2" color="text.secondary">
-              Running Sandboxes
-            </Typography>
-          </Paper>
-        </Grid>
-        <Grid item xs={12} sm={4}>
+        {!selectedSandboxId && (
+          <Grid item xs={12} sm={4}>
+            <Paper sx={{ p: 2, textAlign: 'center' }}>
+              <ComputerIcon sx={{ fontSize: 40, color: 'primary.main', mb: 1 }} />
+              <Typography variant="h4">{runningSandboxes}</Typography>
+              <Typography variant="body2" color="text.secondary">
+                Running Sandboxes
+              </Typography>
+            </Paper>
+          </Grid>
+        )}
+        <Grid item xs={12} sm={selectedSandboxId ? 6 : 4}>
           <Paper sx={{ p: 2, textAlign: 'center' }}>
             <DesktopWindowsIcon sx={{ fontSize: 40, color: 'success.main', mb: 1 }} />
             <Typography variant="h4">{runningContainers}</Typography>
@@ -851,7 +857,7 @@ const AgentSandboxes: FC<AgentSandboxesProps> = ({ selectedSandboxId }) => {
             </Typography>
           </Paper>
         </Grid>
-        <Grid item xs={12} sm={4}>
+        <Grid item xs={12} sm={selectedSandboxId ? 6 : 4}>
           <Paper sx={{ p: 2, textAlign: 'center' }}>
             <PersonIcon sx={{ fontSize: 40, color: 'info.main', mb: 1 }} />
             <Typography variant="h4">{totalClients}</Typography>


### PR DESCRIPTION
## Summary

Small nit on the admin Agent Sandboxes page. When a specific sandbox is selected from the dropdown, the page shows three stat cards: Running Sandboxes / Dev Containers / Connected Users. The latter two are sandbox-specific and meaningful; the first is noise.

## Why "Running Sandboxes" is noise on the detail view

`runningSandboxes` is computed as:

```tsx
const runningSandboxes = filteredSandboxes.filter((s) => s.status === 'online').length
```

When `selectedSandboxId` is set, `filteredSandboxes` is a list of one row (the selected sandbox), so the count is always 0 or 1. The page already says `Sandbox: <id>` in the heading; reading "1 Running Sandbox" below it adds nothing.

Worse: mid-refetch the filter can briefly contain two rows (the previously-selected and the newly-selected), so the card sometimes flips to 2, which actively misleads.

## Fix

Wrap the "Running Sandboxes" card in `{!selectedSandboxId && (...)}` so it only renders on the all-sandboxes aggregate view (where it correctly counts global online sandboxes). When a specific sandbox is selected, widen Dev Containers + Connected Users from `sm={4}` to `sm={6}` so the row stays balanced.

## Before / after

- **Aggregate view** (`selectedSandboxId` null): unchanged - 3 cards in a row, each `sm={4}`.
- **Detail view** (`selectedSandboxId` set): 2 cards in a row, each `sm={6}`. Running Sandboxes card gone.

## Test plan

- [ ] Aggregate view still shows 3 cards.
- [ ] Detail view shows 2 cards, balanced 50/50.
- [ ] No layout shift on filter change.