### PR TITLE
fix(api): preserve design_doc_path when resetting task to backlog

### DIFF
--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -1017,7 +1017,6 @@ func (s *HelixAPIServer) updateSpecTask(w http.ResponseWriter, r *http.Request) 
 			task.TechnicalDesign = ""
 			task.ImplementationPlan = ""
 			task.DesignDocsPushedAt = nil
-			task.DesignDocPath = ""
 			task.SpecApprovedBy = ""
 			task.SpecApprovedAt = nil
 			task.SpecApproval = nil


### PR DESCRIPTION
## Summary
- Stop clearing `DesignDocPath` in the Backlog-reset block of `updateSpecTask`.
- The path is derived from `name + task_number` (both stable across restarts), so it's safe to keep — and resetting it breaks the restart flow.

## Why
Repro: send a task back to Backlog, then restart it. Observed on `spt_01kt41cqsmcxpry0sjrzb2mw7h` (task 2068) — the UI shows **Specs Folder: N/A** and the DB row's `design_doc_path` is empty even though `task_number=2068` and `branch_name=feature/002068-repurpose-tessl-ai` are set.

What was happening:
1. `updateSpecTask` (`spec_driven_task_handlers.go:1020`) cleared `DesignDocPath` along with `RequirementsSpec`, `BranchName`, `PlanningSessionID`, etc.
2. On restart, `StartSpecGeneration` skipped regeneration based on a stale comment: *"design doc path is now assigned at creation time … so they should always be set by this point"*.
3. The orchestrator fell through to the backwards-compat branch in `spec_task_orchestrator.go:1250-1254` and used `task.ID` as the directory name — so the agent wrote specs to `tasks/spt_01.../` instead of `tasks/002068_repurpose-tessl-ai/`.
4. Push detection in `git_http_server.go:1586-1596` filters by `DesignDocPath`, so it couldn't match the pushed dir back to the task either.

Other `done` tasks created via the same backlog→restart path show the same symptom (e.g. task 2070).

## Test plan
- [ ] Existing task: send to Backlog → restart → confirm `design_doc_path` is preserved and UI still shows the human-readable folder.
- [ ] New task: create → restart from Backlog → confirm `design_doc_path` is still populated.
- [ ] Spec push from agent lands under `tasks/NNNNNN_shortname/` and is matched back to the task by push detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)