### PR TITLE
fix(inference): route runner-profile models over RevDial, expose them to chat

### DIFF
--- a/api/pkg/hydra/server.go
+++ b/api/pkg/hydra/server.go
@@ -187,6 +187,12 @@ func (s *Server) registerRoutes(router *mux.Router) {
 	// Port proxy - forward HTTP requests to a port on the desktop container's network
 	api.PathPrefix("/dev-containers/{session_id}/proxy/{port}").HandlerFunc(s.handleDevContainerProxy)
 
+	// Inference proxy - forward OpenAI requests (chat/embeddings) to the local
+	// inference-proxy, which routes to the active profile's model containers.
+	// The API reaches this over the sandbox's outbound RevDial tunnel, so the
+	// sandbox needs no inbound network reachability.
+	api.PathPrefix("/inference/").HandlerFunc(s.handleInferenceProxy)
+
 	// Golden cache management
 	api.HandleFunc("/dev-containers/{session_id}/blkio", s.handleGetDevContainerBlkio).Methods("GET")
 
@@ -588,6 +594,84 @@ func (s *Server) handleDevContainerProxy(w http.ResponseWriter, r *http.Request)
 		if n > 0 {
 			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
 				break
+			}
+		}
+		if readErr != nil {
+			break
+		}
+	}
+}
+
+// inferenceProxyAddr is the host:port of the local inference-proxy process
+// (same sandbox container). inference-proxy listens on 0.0.0.0:8090 by default;
+// hydra reaches it over loopback. Overridable for non-default deployments.
+func inferenceProxyAddr() string {
+	if v := strings.TrimSpace(os.Getenv("HELIX_INFERENCE_PROXY_ADDR")); v != "" {
+		return v
+	}
+	return "127.0.0.1:8090"
+}
+
+// handleInferenceProxy forwards an OpenAI request (arriving over the RevDial
+// tunnel under /api/v1/inference/*) to the local inference-proxy, streaming the
+// response back so SSE chat completions stream chunk-by-chunk. The API server
+// reaches this endpoint via the sandbox's outbound tunnel, so the sandbox needs
+// no inbound reachability.
+func (s *Server) handleInferenceProxy(w http.ResponseWriter, r *http.Request) {
+	const prefix = "/api/v1/inference"
+	upstreamPath := strings.TrimPrefix(r.URL.Path, prefix)
+	if upstreamPath == "" {
+		upstreamPath = "/"
+	}
+
+	targetURL := fmt.Sprintf("http://%s%s", inferenceProxyAddr(), upstreamPath)
+	if r.URL.RawQuery != "" {
+		targetURL += "?" + r.URL.RawQuery
+	}
+
+	proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, targetURL, r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to create inference proxy request: %s", err), http.StatusInternalServerError)
+		return
+	}
+	for key, values := range r.Header {
+		switch strings.ToLower(key) {
+		case "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
+			"te", "trailers", "transfer-encoding", "upgrade":
+			continue
+		}
+		for _, value := range values {
+			proxyReq.Header.Add(key, value)
+		}
+	}
+
+	// No client timeout: inference (especially streaming) can run for minutes.
+	// The request context (propagated from the tunnel) bounds the lifetime.
+	resp, err := http.DefaultClient.Do(proxyReq)
+	if err != nil {
+		log.Warn().Err(err).Str("target_url", targetURL).Msg("Failed to proxy inference request")
+		http.Error(w, fmt.Sprintf("failed to connect to inference-proxy: %s", err), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	for key, values := range resp.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+
+	flusher, _ := w.(http.Flusher)
+	buf := make([]byte, 32*1024)
+	for {
+		n, readErr := resp.Body.Read(buf)
+		if n > 0 {
+			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
+				break
+			}
+			if flusher != nil {
+				flusher.Flush() // push each SSE chunk to the tunnel immediately
 			}
 		}
 		if readErr != nil {

--- a/api/pkg/hydra/server.go
+++ b/api/pkg/hydra/server.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -613,71 +615,30 @@ func inferenceProxyAddr() string {
 }
 
 // handleInferenceProxy forwards an OpenAI request (arriving over the RevDial
-// tunnel under /api/v1/inference/*) to the local inference-proxy, streaming the
-// response back so SSE chat completions stream chunk-by-chunk. The API server
+// tunnel under /api/v1/inference/*) to the local inference-proxy. The API server
 // reaches this endpoint via the sandbox's outbound tunnel, so the sandbox needs
 // no inbound reachability.
+//
+// FlushInterval -1 streams each write immediately, so SSE chat completions
+// arrive chunk-by-chunk rather than being buffered — important in this
+// double-proxy path (API -> hydra -> inference-proxy), matching how
+// anthropic.Proxy streams. Cancellation is bounded by r.Context(): when the API
+// side closes the tunnel conn (e.g. its dispatch deadline fires), this request's
+// context is cancelled and ReverseProxy aborts the upstream call.
 func (s *Server) handleInferenceProxy(w http.ResponseWriter, r *http.Request) {
 	const prefix = "/api/v1/inference"
-	upstreamPath := strings.TrimPrefix(r.URL.Path, prefix)
-	if upstreamPath == "" {
-		upstreamPath = "/"
+	r.URL.Path = strings.TrimPrefix(r.URL.Path, prefix)
+	if r.URL.Path == "" {
+		r.URL.Path = "/"
 	}
 
-	targetURL := fmt.Sprintf("http://%s%s", inferenceProxyAddr(), upstreamPath)
-	if r.URL.RawQuery != "" {
-		targetURL += "?" + r.URL.RawQuery
-	}
-
-	proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, targetURL, r.Body)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("failed to create inference proxy request: %s", err), http.StatusInternalServerError)
-		return
-	}
-	for key, values := range r.Header {
-		switch strings.ToLower(key) {
-		case "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
-			"te", "trailers", "transfer-encoding", "upgrade":
-			continue
-		}
-		for _, value := range values {
-			proxyReq.Header.Add(key, value)
-		}
-	}
-
-	// No client timeout: inference (especially streaming) can run for minutes.
-	// The request context (propagated from the tunnel) bounds the lifetime.
-	resp, err := http.DefaultClient.Do(proxyReq)
-	if err != nil {
-		log.Warn().Err(err).Str("target_url", targetURL).Msg("Failed to proxy inference request")
+	proxy := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: "http", Host: inferenceProxyAddr()})
+	proxy.FlushInterval = -1
+	proxy.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
+		log.Warn().Err(err).Str("path", req.URL.Path).Msg("Failed to proxy inference request")
 		http.Error(w, fmt.Sprintf("failed to connect to inference-proxy: %s", err), http.StatusBadGateway)
-		return
 	}
-	defer resp.Body.Close()
-
-	for key, values := range resp.Header {
-		for _, value := range values {
-			w.Header().Add(key, value)
-		}
-	}
-	w.WriteHeader(resp.StatusCode)
-
-	flusher, _ := w.(http.Flusher)
-	buf := make([]byte, 32*1024)
-	for {
-		n, readErr := resp.Body.Read(buf)
-		if n > 0 {
-			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
-				break
-			}
-			if flusher != nil {
-				flusher.Flush() // push each SSE chunk to the tunnel immediately
-			}
-		}
-		if readErr != nil {
-			break
-		}
-	}
+	proxy.ServeHTTP(w, r)
 }
 
 // handleDevContainerWebSocketProxy handles WebSocket upgrade requests to dev container ports

--- a/api/pkg/inferencerouter/router.go
+++ b/api/pkg/inferencerouter/router.go
@@ -29,8 +29,7 @@ import (
 // RunnerState is what the router knows about one connected runner
 // (a Helix sandbox post-absorption). Populated from sandbox HTTP heartbeats.
 type RunnerState struct {
-	ID            string
-	URL           string               // e.g. "http://10.0.0.5:8081" — where to forward inference
+	ID            string               // sandbox id; dispatch reaches it over its RevDial tunnel
 	Status        string               // "running" | "starting" | "pulling" | "assigning" | "failed" | ""
 	ActiveProfile *types.RunnerProfile // nil if no profile assigned
 	GPUs          []types.GPUStatus    // per-GPU inventory (vendor, arch, total VRAM, ...)

--- a/api/pkg/inferencerouter/router_test.go
+++ b/api/pkg/inferencerouter/router_test.go
@@ -20,7 +20,7 @@ func runningProfile(modelNames ...string) *types.RunnerProfile {
 func TestRouter_PickRunner_HappyPath(t *testing.T) {
 	r := NewRouter()
 	r.SetRunnerState(&RunnerState{
-		ID: "runner-a", URL: "http://a:8081", Status: "running",
+		ID: "runner-a", Status: "running",
 		ActiveProfile: runningProfile("qwen-7b"), LastSeen: time.Now(),
 	})
 	got, err := r.PickRunner("qwen-7b")

--- a/api/pkg/openai/helix_openai_server.go
+++ b/api/pkg/openai/helix_openai_server.go
@@ -263,7 +263,12 @@ func (c *InternalHelixServer) dispatchAndPublish(req *types.RunnerLLMInferenceRe
 	publishErr := func(msg string) {
 		log.Warn().Str("request_id", req.RequestID).Str("sandbox_id", sandboxID).Str("err", msg).Msg("dispatch inference -> sandbox failed")
 		reply, _ := json.Marshal(&types.RunnerNatsReplyResponse{Error: msg})
-		_ = c.pubsub.Publish(ctx, pubsub.GetRunnerResponsesQueue(req.OwnerID, req.RequestID), reply)
+		// Use a fresh context: the dispatch ctx may already be cancelled/expired
+		// (that is often *why* we are publishing an error), and the caller must
+		// still receive the failure rather than hang until its own timeout.
+		pubCtx, pubCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer pubCancel()
+		_ = c.pubsub.Publish(pubCtx, pubsub.GetRunnerResponsesQueue(req.OwnerID, req.RequestID), reply)
 	}
 
 	// Open a connection back to the sandbox over its RevDial tunnel. The
@@ -277,6 +282,15 @@ func (c *InternalHelixServer) dispatchAndPublish(req *types.RunnerLLMInferenceRe
 		return
 	}
 	defer conn.Close()
+	// A raw RevDial conn does not honor ctx once dialed, so a sandbox that never
+	// finishes the response (hung upstream, half-open tunnel) would block the
+	// reads below forever and leak this goroutine + the connection. Close the
+	// conn when the 5-minute budget expires so the reads unblock — this restores
+	// the bound the previous http.Client{Timeout} gave us.
+	go func() {
+		<-ctx.Done()
+		_ = conn.Close()
+	}()
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://hydra/api/v1/inference"+path, bytes.NewReader(body))
 	if err != nil {

--- a/api/pkg/openai/helix_openai_server.go
+++ b/api/pkg/openai/helix_openai_server.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -19,6 +20,15 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// RevDialer opens a connection to a sandbox over its outbound RevDial tunnel,
+// keyed by device id. Implemented by connman.ConnectionManager. Kept as a
+// narrow interface here to avoid importing connman (and to keep this package
+// testable). The sandbox is never addressed by network host - only by id -
+// so dispatch works regardless of where the sandbox runs (NAT, other network).
+type RevDialer interface {
+	Dial(ctx context.Context, key string) (net.Conn, error)
+}
+
 type HelixServer interface {
 	// ProcessRunnerResponse is called by the HTTP handler when the runner sends a response over the websocket
 	ProcessRunnerResponse(ctx context.Context, resp *types.RunnerLLMInferenceResponse) error
@@ -30,8 +40,9 @@ var _ HelixServer = &InternalHelixServer{}
 // purpose is to power internal tools
 type InternalHelixServer struct {
 	cfg             *config.ServerConfig
-	pubsub          pubsub.PubSub // Used to get responses from the runners
+	pubsub          pubsub.PubSub           // Used to get responses from the runners
 	inferenceRouter *inferencerouter.Router // Sandbox-absorbs-runner pivot: replaces scheduler for routing
+	dialer          RevDialer               // dispatches inference to a sandbox over its RevDial tunnel
 	store           store.Store
 }
 
@@ -56,6 +67,12 @@ func (c *InternalHelixServer) SetInferenceRouter(r *inferencerouter.Router) {
 	c.inferenceRouter = r
 }
 
+// SetDialer wires the RevDial connection manager used to reach sandboxes.
+// Called once during apiServer construction.
+func (c *InternalHelixServer) SetDialer(d RevDialer) {
+	c.dialer = d
+}
+
 func (c *InternalHelixServer) ListModels(ctx context.Context) ([]types.OpenAIModel, error) {
 	helixModels, err := c.store.ListModels(ctx, &store.ListModelsQuery{})
 	if err != nil {
@@ -66,6 +83,7 @@ func (c *InternalHelixServer) ListModels(ctx context.Context) ([]types.OpenAIMod
 	availableModels := c.getAvailableModelsFromRunners()
 
 	var models []types.OpenAIModel
+	served := make(map[string]bool) // model IDs already in the response
 	for _, model := range helixModels {
 		// Skip embedding models as they should not appear in chat model pickers
 		if model.Type == types.ModelTypeEmbed {
@@ -114,6 +132,27 @@ func (c *InternalHelixServer) ListModels(ctx context.Context) ([]types.OpenAIMod
 			Msg("Serving model to API")
 
 		models = append(models, openAIModel)
+		served[model.ID] = true
+	}
+
+	// Sandbox-absorbs-runner pivot: a model served by a running profile is
+	// first-class even when it has no row in the `models` table. The profile's
+	// compose YAML is the source of truth for these, so they only exist in the
+	// inference router. Union them in so the OpenAI surface (and the model
+	// validation in controller.assertProviderServesModel) can see them.
+	for id := range availableModels {
+		if served[id] {
+			continue
+		}
+		models = append(models, types.OpenAIModel{
+			ID:      id,
+			Object:  "model",
+			OwnedBy: "helix",
+			Name:    id,
+			Type:    string(types.ModelTypeChat),
+			Enabled: true,
+		})
+		served[id] = true
 	}
 	return models, nil
 }
@@ -161,27 +200,32 @@ func (c *InternalHelixServer) enqueueRequest(req *types.RunnerLLMInferenceReques
 	if err != nil {
 		return err
 	}
-	return c.dispatchHTTPToRunner(req, state.URL)
+	return c.dispatchToSandbox(req, state.ID)
 }
 
-// dispatchHTTPToRunner forwards an inference request over HTTP to a
-// sandbox's inference-proxy, then publishes the response back through the
-// existing pubsub queue so callers (CreateChatCompletion / Stream /
-// CreateEmbeddings) receive it via the same code path they already wait
-// on. Returning nil here means "request accepted, response will arrive
-// asynchronously via pubsub" — the same contract as the scheduler path.
+// dispatchToSandbox forwards an inference request to a sandbox's inference-proxy
+// over the sandbox's outbound RevDial tunnel (keyed by sandbox id), then
+// publishes the response back through the existing pubsub queue so callers
+// (CreateChatCompletion / Stream / CreateEmbeddings) receive it via the same
+// code path they already wait on. Returning nil here means "request accepted,
+// response will arrive asynchronously via pubsub" — the same contract as the
+// scheduler path.
+//
+// The sandbox is addressed only by id, never by network host: the GPU sandbox
+// may be on a different network / behind NAT and reachable only via the tunnel
+// it dialed out to us. hydra (in the sandbox) proxies /api/v1/inference/* to
+// the local inference-proxy.
 //
 // Streaming is handled by reading the SSE stream from the sandbox and
 // publishing each chunk to the same pubsub queue with the same shape the
 // runner used to publish.
-func (c *InternalHelixServer) dispatchHTTPToRunner(req *types.RunnerLLMInferenceRequest, runnerURL string) error {
-	if runnerURL == "" {
-		return fmt.Errorf("dispatchHTTPToRunner: runner URL is empty")
+func (c *InternalHelixServer) dispatchToSandbox(req *types.RunnerLLMInferenceRequest, sandboxID string) error {
+	if c.dialer == nil {
+		return fmt.Errorf("dispatchToSandbox: RevDial dialer not initialised")
 	}
-	// inference-proxy listens on port 8090 inside the sandbox by default.
-	// runnerURL from refreshInferenceRouterFromHeartbeat is "http://<ip>"
-	// (no port). Append.
-	target := runnerURL + ":8090"
+	if sandboxID == "" {
+		return fmt.Errorf("dispatchToSandbox: sandbox id is empty")
+	}
 
 	// Pick the upstream path based on what the request carries.
 	var path string
@@ -203,7 +247,7 @@ func (c *InternalHelixServer) dispatchHTTPToRunner(req *types.RunnerLLMInference
 		return fmt.Errorf("marshal request body: %w", err)
 	}
 
-	go c.dispatchAndPublish(req, target+path, body)
+	go c.dispatchAndPublish(req, sandboxID, path, body)
 	return nil
 }
 
@@ -212,27 +256,43 @@ func (c *InternalHelixServer) dispatchHTTPToRunner(req *types.RunnerLLMInference
 // scheduler-based path uses. Errors are wrapped into a
 // RunnerNatsReplyResponse with the Error field set so callers see them
 // through their existing subscribe-and-wait code.
-func (c *InternalHelixServer) dispatchAndPublish(req *types.RunnerLLMInferenceRequest, url string, body []byte) {
+func (c *InternalHelixServer) dispatchAndPublish(req *types.RunnerLLMInferenceRequest, sandboxID, path string, body []byte) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	publishErr := func(msg string) {
-		log.Warn().Str("request_id", req.RequestID).Str("url", url).Str("err", msg).Msg("dispatch HTTP -> sandbox failed")
+		log.Warn().Str("request_id", req.RequestID).Str("sandbox_id", sandboxID).Str("err", msg).Msg("dispatch inference -> sandbox failed")
 		reply, _ := json.Marshal(&types.RunnerNatsReplyResponse{Error: msg})
 		_ = c.pubsub.Publish(ctx, pubsub.GetRunnerResponsesQueue(req.OwnerID, req.RequestID), reply)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	// Open a connection back to the sandbox over its RevDial tunnel. The
+	// hydra HTTP server in the sandbox serves /api/v1/inference/* and proxies
+	// to the local inference-proxy. We speak HTTP/1.1 directly over the conn
+	// (no http.Client) so the response body streams as it arrives — required
+	// for SSE chat completions.
+	conn, err := c.dialer.Dial(ctx, "hydra-"+sandboxID)
+	if err != nil {
+		publishErr("dial sandbox via RevDial: " + err.Error())
+		return
+	}
+	defer conn.Close()
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://hydra/api/v1/inference"+path, bytes.NewReader(body))
 	if err != nil {
 		publishErr("build request: " + err.Error())
 		return
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: 5 * time.Minute}
-	resp, err := client.Do(httpReq)
+	if err := httpReq.Write(conn); err != nil {
+		publishErr("write request to tunnel: " + err.Error())
+		return
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), httpReq)
 	if err != nil {
-		publishErr("HTTP roundtrip: " + err.Error())
+		publishErr("read response from tunnel: " + err.Error())
 		return
 	}
 	defer resp.Body.Close()

--- a/api/pkg/server/runner_assignment_handlers.go
+++ b/api/pkg/server/runner_assignment_handlers.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -17,14 +15,6 @@ import (
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 )
-
-// envFallback is a tiny helper: returns the env var value or fallback.
-func envFallback(key, fallback string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return fallback
-}
 
 // refreshInferenceRouterFromHeartbeat is called after a sandbox heartbeat
 // is processed. It pushes the latest inference-relevant state into the
@@ -46,34 +36,12 @@ func (apiServer *HelixAPIServer) refreshInferenceRouterFromHeartbeat(ctx context
 			activeProfile = p
 		}
 	}
-	// URL the API server uses to reach this sandbox's inference-proxy.
-	// dispatchHTTPToRunner appends :8090.
-	//
-	// For dev mode (HELIX_DEV_SANDBOX_HOST set), use that. Otherwise prefer
-	// the sandbox's registered Hostname (resolvable inside the docker
-	// network), falling back to IPAddress with any embedded source port
-	// stripped.
-	//
-	// TODO(multi-sandbox): for production with multiple sandboxes we need
-	// a discovery mechanism more robust than the registered hostname —
-	// the sandbox's own /etc/hostname is the random Docker container ID,
-	// which isn't resolvable from elsewhere.
-	url := ""
-	if devHost := strings.TrimSpace(envFallback("HELIX_DEV_SANDBOX_HOST", "")); devHost != "" {
-		url = "http://" + devHost
-	} else if inst, err := apiServer.Store.GetSandboxInstance(ctx, sandboxID); err == nil && inst != nil {
-		host := inst.Hostname
-		if host == "" {
-			host = inst.IPAddress
-			if i := strings.Index(host, ":"); i >= 0 {
-				host = host[:i]
-			}
-		}
-		url = "http://" + host
-	}
+	// No network address is stored: inference is dispatched to the sandbox over
+	// its outbound RevDial tunnel (keyed by sandbox id), so the API never needs
+	// to resolve or route to a sandbox host. This works for sandboxes on any
+	// network, including behind NAT. See dispatchToSandbox in helix_openai_server.go.
 	apiServer.inferenceRouter.SetRunnerState(&inferencerouter.RunnerState{
 		ID:            sandboxID,
-		URL:           url,
 		Status:        hb.ProfileStatus,
 		ActiveProfile: activeProfile,
 		GPUs:          hb.GPUs,

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -405,6 +405,10 @@ func NewServer(
 	// ErrNoRunner and enqueueRequest falls back to the scheduler path.
 	if apiServer.inferenceServer != nil {
 		apiServer.inferenceServer.SetInferenceRouter(apiServer.inferenceRouter)
+		// Inference is dispatched to a sandbox over its RevDial tunnel, keyed
+		// by sandbox id — never by network host. Works for sandboxes on any
+		// network, including behind NAT.
+		apiServer.inferenceServer.SetDialer(apiServer.connman)
 	}
 
 	contextMappings := &controller.ExternalAgentRequestContextMappings{

--- a/design/2026-06-04-runner-profile-inference-routing.md
+++ b/design/2026-06-04-runner-profile-inference-routing.md
@@ -51,13 +51,13 @@ Fix: dispatch over RevDial, addressed by sandbox ID, never by network address.
 - `RunnerState.URL` and all hostname/IP derivation are deleted - the router
   routes by sandbox ID alone.
 
-### Bug C - heartbeat delivery (to verify)
+### Bug C - heartbeat delivery (resolved: not a bug)
 
 During debugging the in-memory router was empty until a heartbeat with
-`profile_status=running` was POSTed. The router is in-memory and is wiped on
-every API restart; it repopulates only on the next 30s heartbeat. Need to
-confirm the daemon's heartbeats actually land in steady state (no code change
-unless a delivery gap is found).
+`profile_status=running` was POSTed. This was an artifact of an API-restart
+window: the router is in-memory and is wiped on restart, repopulating on the
+next 30s heartbeat. Verified in steady state the daemon's heartbeats land and
+keep the model listed with no manual poke. No code change.
 
 ## Files touched
 
@@ -72,3 +72,11 @@ unless a delivery gap is found).
 
 API changes hot-reload via Air. The hydra route is a sandbox-side change and
 requires `./stack build-sandbox` + a new session before end-to-end test.
+
+## Verified (prime, 2026-06-04)
+
+- Unprefixed `POST /v1/chat/completions` for `qwen2.5-0.5b` returns a normal
+  completion (Bug A).
+- `stream:true` streams SSE chunks end-to-end: API -> RevDial tunnel -> hydra
+  /api/v1/inference/* -> inference-proxy -> vLLM (Bug B; flush works).
+- Model stays listed via the live daemon heartbeats with no manual poke (Bug C).

--- a/design/2026-06-04-runner-profile-inference-routing.md
+++ b/design/2026-06-04-runner-profile-inference-routing.md
@@ -1,0 +1,74 @@
+# Runner-profile inference routing: cross-network dispatch + model discovery
+
+Date: 2026-06-04
+Branch: fix/runner-profile-inference-routing
+
+## Symptom
+
+Operator created a runner profile ("tiny LLM", serves `qwen2.5-0.5b` via vLLM),
+assigned it to a sandbox. Profile pulled, vLLM came up healthy, admin panel
+showed `running`. But chat completions for the model failed:
+
+    model "qwen2.5-0.5b" is not configured in the default provider "helix"
+
+## Root causes (three independent bugs)
+
+### Bug A - chat path can't see profile-served models
+
+`InternalHelixServer.ListModels` (`api/pkg/openai/helix_openai_server.go`) builds
+its list by iterating the `models` DB table and keeping only rows that are also
+present on a runner. A profile-served model exists only in the inference
+router's `AvailableModels()`, never in the `models` table, so it is filtered
+out. The OpenAI chat path validates the requested model via this same
+`ListModels` (`assertProviderServesModel` in `controller/inference.go`), so the
+request is rejected before routing.
+
+Fix: in `ListModels`, union the router's `AvailableModels()` into the result.
+Models served by a running profile are first-class, even with no `models` row.
+
+### Bug B - dispatch used a direct HTTP dial to the sandbox host
+
+`refreshInferenceRouterFromHeartbeat` derived a URL from the sandbox's
+registered hostname / IP and stored it on `RunnerState.URL`;
+`dispatchHTTPToRunner` then did `http.Client.Do("http://<host>:8090/...")`.
+
+This can only work when the API can route to the sandbox by address. In a real
+deployment the GPU sandbox is on a different network / behind NAT and is NOT
+directly reachable - it only has an outbound RevDial WebSocket to the API
+(the same tunnel hydra uses for exec/files/terminal). The stored hostname
+(`sandbox-local`) was unresolvable, so dispatch failed with
+`dial tcp: lookup sandbox-local: server misbehaving`.
+
+The design doc's own cloud smoke test (`design/2026-04-28-cloud-gpu-smoke-results.md`)
+records inference being proxied "via the Hydra RevDial WebSocket" - the
+direct-HTTP code was a regression from the intended design.
+
+Fix: dispatch over RevDial, addressed by sandbox ID, never by network address.
+- hydra (sandbox side) gains an inference proxy route that forwards to the
+  local inference-proxy (`localhost:8090`) with SSE streaming.
+- the API dials `hydra-<sandboxID>` via connman and speaks HTTP over the
+  tunnel, streaming the response back into the existing pubsub queue.
+- `RunnerState.URL` and all hostname/IP derivation are deleted - the router
+  routes by sandbox ID alone.
+
+### Bug C - heartbeat delivery (to verify)
+
+During debugging the in-memory router was empty until a heartbeat with
+`profile_status=running` was POSTed. The router is in-memory and is wiped on
+every API restart; it repopulates only on the next 30s heartbeat. Need to
+confirm the daemon's heartbeats actually land in steady state (no code change
+unless a delivery gap is found).
+
+## Files touched
+
+- `api/pkg/hydra/server.go` - inference proxy route + streaming handler (sandbox side; needs `./stack build-sandbox`)
+- `api/pkg/hydra/client.go` - n/a (API speaks the tunnel directly from openai pkg)
+- `api/pkg/openai/helix_openai_server.go` - ListModels union (Bug A); RevDial dispatch (Bug B); dialer wiring
+- `api/pkg/inferencerouter/router.go` - drop `RunnerState.URL`
+- `api/pkg/server/runner_assignment_handlers.go` - drop URL derivation in refresh
+- `api/pkg/server/server.go` - wire connman dialer into the inference server
+
+## Deploy
+
+API changes hot-reload via Air. The hydra route is a sandbox-side change and
+requires `./stack build-sandbox` + a new session before end-to-end test.


### PR DESCRIPTION
## Problem

Assigning a runner profile that serves a model (e.g. vLLM `qwen2.5-0.5b`) brought the profile up healthy, but chat completions for the model failed with:

```
model "qwen2.5-0.5b" is not configured in the default provider "helix"
```

Root-caused to three independent bugs on the inference request path (the assignment, pull, and profile startup all worked correctly).

## Fixes

**1. Chat path couldn't see profile-served models.** The helix provider's `ListModels` only returned rows from the `models` DB table, filtering out profile-served models that live only in the inference router. The chat path validates the requested model against this list (`controller.assertProviderServesModel`), so requests were rejected. Now `ListModels` unions the router's `AvailableModels()` - a model served by a running profile is first-class even with no `models` row.

**2. Dispatch used a direct HTTP dial to the sandbox host.** It derived a URL from the sandbox's registered hostname/IP and did `http.Client.Do("http://<host>:8090/...")`. This cannot work when the GPU sandbox is on a different network / behind NAT - it only has an outbound RevDial tunnel. Restored the intended design (see `design/2026-04-28-cloud-gpu-smoke-results.md`): dispatch over the sandbox's RevDial tunnel, addressed by sandbox id. hydra gains an `/api/v1/inference/*` route that stream-proxies (SSE) to the local inference-proxy.

**3. Removed `RunnerState.URL`** and all hostname/IP derivation - the router routes by sandbox id alone, so no host resolution is ever needed.

`design/2026-06-04-runner-profile-inference-routing.md` has the full write-up.

## Robustness (from code review)

- **Bounded dispatch lifetime.** A raw RevDial conn does not honor its context once dialed, so a hung upstream / half-open tunnel would block the response reads forever and leak the goroutine + connection. A watchdog closes the conn when the 5-minute budget expires (restoring the bound the old `http.Client{Timeout}` gave us). Error replies now publish on a fresh context so a timeout reaches the caller instead of hanging it.
- **Reuse over hand-rolled proxy.** `handleInferenceProxy` uses `httputil.ReverseProxy` with `FlushInterval: -1` (same pattern as `anthropic.Proxy`) for correct SSE streaming through the double-proxy path, instead of a custom header-copy + flush loop.

## Testing

Verified end-to-end on prime with a real profile (`qwen2.5-0.5b` via vLLM):

- Unprefixed `POST /v1/chat/completions` returns a normal completion (fix 1).
- `stream:true` streams SSE chunks end-to-end: API -> RevDial tunnel -> hydra -> inference-proxy -> vLLM (fix 2).
- Model stays listed via the live daemon heartbeats with no manual poke.

Unit tests pass (`inferencerouter`, `openai`); full `go build ./...` clean.

> Note: hydra is a sandbox-side change - CI's `build-sandbox` bakes it into the image on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)