### PR TITLE
fix(stack): run yarn install before yarn build

### DIFF
--- a/stack
+++ b/stack
@@ -1936,7 +1936,7 @@ function build-frontend() {
 	fi
 
 	(
-		cd "$DIR/frontend" && yarn build
+		cd "$DIR/frontend" && yarn install --frozen-lockfile && yarn build
 	) || {
 		echo "❌ Frontend build failed"
 		return 1


### PR DESCRIPTION
## Summary
- `build-frontend` rebuilt the bundle whenever `package.json` changed but never refreshed `node_modules` — after a pull that added a new dep, vite blew up with `Rollup failed to resolve import 'dagre'` because the package was in the lockfile but not on disk. Add `yarn install --frozen-lockfile && yarn build` so deps are synced before the bundle is produced (and a drifted lockfile fails fast instead of mutating itself).

## Repro
Pre-fix, on a system that pulled the helix-org-redesign merge without running `yarn install` first:
```
./stack start
…
✗ Build failed in 567ms
error during build:
[vite]: Rollup failed to resolve import "dagre" from "frontend/src/pages/HelixOrgChart.tsx".
```

## Test plan
- [ ] `./stack start` on a system with a stale `node_modules` succeeds (installs the new deps, then builds).
- [ ] `./stack start` on a system with up-to-date `node_modules` re-runs install (cheap, integrity check) and then builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)