### PR TITLE
fix(store/memorystore): add GetUser stub returning ErrNotFound

### DIFF
--- a/api/pkg/store/memorystore/memorystore.go
+++ b/api/pkg/store/memorystore/memorystore.go
@@ -349,6 +349,13 @@ func (m *MemoryStore) GetSpecTaskExternalAgentByID(_ context.Context, _ string) 
 	return nil, store.ErrNotFound
 }
 
+// GetUser: handlers call this to hydrate a project's owner; returning
+// ErrNotFound lets them log a warn and continue rather than panic on
+// the embedded nil store.Store.
+func (m *MemoryStore) GetUser(_ context.Context, _ *store.GetUserQuery) (*types.User, error) {
+	return nil, store.ErrNotFound
+}
+
 func (m *MemoryStore) GetApp(_ context.Context, id string) (*types.App, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()


### PR DESCRIPTION
## Summary
- Cross-merge collision between #2516 (helix-org redesign, added `TestInProcProjectService_GetProject_Found_ReturnsProject`) and 9a322cdc9 (\`fix(projects): show owner in manage access\`, added `populateProjectOwners` calling `Store.GetUser`).
- Both passed CI on their own branches; on main the test's `GetProject` call now panics with SIGSEGV inside the autogenerated nil-method of MemoryStore's embedded `store.Store` interface.
- Adds a `GetUser` stub returning `ErrNotFound`. The handler's existing `err != nil` path logs a warn and continues — projects in the in-process adapter tests come up without a hydrated owner, which is correct because they don't assert on it.

## Repro
\`\`\`
CGO_ENABLED=1 go test -count=1 -run TestInProcProjectService_GetProject_Found_ReturnsProject ./api/pkg/server/
\`\`\`
Before: SIGSEGV in `MemoryStore.GetUser` via `populateProjectOwners` via `getProject`.
After: \`ok\`.

## Test plan
- [ ] `go test ./api/pkg/server/...` green on this branch.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)