### PR TITLE
fix(helix-org): PutProjectSecret upsert + QA.md §12b per-Worker startupScript model

### DIFF
--- a/api/pkg/org/QA.md
+++ b/api/pkg/org/QA.md
@@ -287,30 +287,84 @@ bare composer at `/agent/<id>`.
    shows the project id. Re-click the button to navigate
    straight to the desktop (Ensure fast-paths).
 
-## §12. Worker sandbox: Zed launch, `gh` auth, stale-session recovery
+## §12. Worker sandbox: Zed launch, per-Worker tools, stale-session recovery
 
 Pins the chain `desktop click → fresh container → Zed launches
-→ WebSocket connects → Claude responds → gh works`.
+→ WebSocket connects → Claude responds → per-Worker startup
+script runs → tooling works`. The base desktop image stays
+lean; anything a particular Worker needs (e.g. `gh`) is
+operator-configurable per project via `configure_worker_project`
+(§12b).
 
-**§12a. Zed launches in a fresh container** (regression: build-time
-`gh --version` left `/home/retro/.local/` root-owned, blocking Zed's
-`~/.local/share/zed/extensions` mkdir, so the agent never came up
-and chat queued forever). Hire a fresh AI worker; once the
-container appears, the desktop viewer renders the GNOME shell + Zed
-pane. API logs show `External agent added message … role=assistant`
-as Claude processes the hire-time activation. No
-`no external agent WebSocket connection` warnings for this session.
+**§12a. Zed launches in a fresh container.** Hire a fresh AI
+worker; once the container appears, the desktop viewer renders
+the GNOME shell + Zed pane. API logs show `External agent added
+message … role=assistant` as Claude processes the hire-time
+activation. No `no external agent WebSocket connection` warnings
+for this session. `/home/retro/.local/` is `retro`-owned (any
+build-time tool that touches `${HOME}` as root will poison it
+and stop Zed from creating `~/.local/share/zed/extensions` —
+the desktop image must not invoke such tools during build).
 
-**§12b. `gh` is installed + GH_TOKEN auto-injected.** Open a
-terminal inside the desktop:
+**§12b. `gh` is available + GH_TOKEN auto-injected.** Tools
+beyond the base image are a **per-Worker concern**, set on the
+Worker's helix project via the `configure_worker_project` MCP
+tool (`startupScript` field) — NOT baked into the desktop image
+or wired into the image-level startup scripts. `GH_TOKEN` is
+plumbed by the helix-org spawner on every activation from the
+org's connected GitHub OAuth (`SpawnSecretInjector` →
+`PutProjectSecret("GH_TOKEN")` → env var on next container
+boot); no operator step is needed for the token itself.
+
+Pre-conditions:
+- At least one org member has connected GitHub on Connected
+  Services with `repo, admin:repo_hook, read:org` scopes. The
+  `Reconnect with stream permissions →` flow in §8 grants them.
+  Without a connected member the resolver returns "" and
+  `GH_TOKEN` stays unset (soft skip — not an error).
+- The Worker's project `startupScript` installs `gh`. From the
+  hiring manager prompt (or an operator's MCP call):
+  ```
+  configure_worker_project(
+    workerId: "w-…",
+    startupScript: """
+      #!/bin/bash
+      set -e
+      type -p gh >/dev/null || {
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+          | sudo dd of=/etc/apt/keyrings/githubcli-archive-keyring.gpg
+        sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+          | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+        sudo apt-get update && sudo apt-get install -y gh
+      }
+    """
+  )
+  ```
+  Re-running is a no-op (the `type -p gh` guard short-circuits
+  once gh is present). The script runs as `retro` on every
+  fresh container start.
+
+Open a terminal inside the desktop and verify:
+- `gh --version` resolves (installed by the startupScript).
 - `gh auth status` reports `✓ Logged in to github.com account
   <login> (GH_TOKEN)` with scopes `repo, admin:repo_hook,
   read:org`. (If `read:org` is missing, re-auth via §8's
-  "Reconnect with stream permissions →".)
+  `Reconnect with stream permissions →`.)
 - `gh issue comment <number> --repo <owner>/<repo> --body "from
   helix-org worker"` succeeds. Comment lands on the issue under
   the operator's GitHub identity (the org's OAuth token is what
   signs the call).
+
+Server-side cross-checks if the env var is missing:
+- `SELECT name, owner FROM secrets WHERE name='GH_TOKEN' AND
+  owner=<worker-project's user_id>;` — secret row present means
+  the SpawnSecretInjector ran. Absent means the resolver
+  returned "" (no member with GitHub OAuth — fix the
+  pre-condition).
+- Secret present but env empty means the project-secret →
+  container-env projection broke. That's a runtime regression,
+  not a §12b config error.
 
 **§12c. Stale-session recovery after `./stack build-ubuntu`.**
 Image rebuilds leave every pre-existing exploratory session row
@@ -367,7 +421,8 @@ container from the current image, and chat works.
   and from the streams list (no orphans).
 - §11 — chat button lands on `…/projects/<pid>/desktop/<sid>`,
   never on `…/agent/<id>`.
-- §12 — fresh sandbox: Zed launches; `gh auth status` green;
+- §12 — fresh sandbox: Zed launches; with a `configure_worker_project`
+  startupScript that installs `gh`, `gh auth status` green;
   `gh issue comment` round-trips. Stale-session recovery
   procedure unblocks all pre-existing workers after a desktop
   rebuild.

--- a/api/pkg/org/QA.md
+++ b/api/pkg/org/QA.md
@@ -374,12 +374,11 @@ token:
   `agent.Env` on container create. If this line is missing for
   a session whose secret row exists, the projection path is
   broken (runtime regression).
-- WARN `put project secret failed … already exists for this
-  project` is **expected** on every activation after the first
-  for now (PutProjectSecret is not idempotent against existing
-  secrets). The first-activation token sticks; OAuth rotation
-  does NOT propagate — re-hire the worker, or delete + recreate
-  the secret manually, to refresh.
+- `PutProjectSecret` upserts: every activation overwrites
+  `GH_TOKEN` with whatever the resolver returns. OAuth rotation
+  propagates on the next session without re-hiring. No WARN
+  `put project secret failed … already exists` should appear in
+  steady state; if it does, the upsert path regressed.
 
 **§12c. Stale-session recovery after `./stack build-ubuntu`.**
 Image rebuilds leave every pre-existing exploratory session row

--- a/api/pkg/org/QA.md
+++ b/api/pkg/org/QA.md
@@ -356,15 +356,30 @@ Open a terminal inside the desktop and verify:
   the operator's GitHub identity (the org's OAuth token is what
   signs the call).
 
-Server-side cross-checks if the env var is missing:
-- `SELECT name, owner FROM secrets WHERE name='GH_TOKEN' AND
-  owner=<worker-project's user_id>;` — secret row present means
-  the SpawnSecretInjector ran. Absent means the resolver
+Verifying the env var: open a terminal in the desktop and run
+`env | grep GH_TOKEN` (NOT `su - retro -c …` — a login shell
+strips the inherited env and will lie). The token is injected
+on docker create, so any non-login shell inside the container
+sees it.
+
+Server-side cross-checks if `gh auth status` still says no
+token:
+- `SELECT id, name, project_id FROM secrets WHERE name='GH_TOKEN'
+  AND project_id=<worker's project_id>;` — secret row present
+  means the SpawnSecretInjector ran. Absent means the resolver
   returned "" (no member with GitHub OAuth — fix the
   pre-condition).
-- Secret present but env empty means the project-secret →
-  container-env projection broke. That's a runtime regression,
-  not a §12b config error.
+- `grep "Injected project secrets into desktop env" api-logs |
+  grep <session_id>` — present means the env actually reached
+  `agent.Env` on container create. If this line is missing for
+  a session whose secret row exists, the projection path is
+  broken (runtime regression).
+- WARN `put project secret failed … already exists for this
+  project` is **expected** on every activation after the first
+  for now (PutProjectSecret is not idempotent against existing
+  secrets). The first-activation token sticks; OAuth rotation
+  does NOT propagate — re-hire the worker, or delete + recreate
+  the secret manually, to refresh.
 
 **§12c. Stale-session recovery after `./stack build-ubuntu`.**
 Image rebuilds leave every pre-existing exploratory session row

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -191,17 +191,67 @@ func (c *inProcHelixClient) UpdateProject(ctx context.Context, id string, patch 
 	return *resp, nil
 }
 
-// PutProjectSecret upserts a project-scoped secret. Routes through
-// HelixAPIServer.createProjectSecret. Helix's underlying store does an
-// upsert on (project_id, name) so re-calling with the same name updates.
+// PutProjectSecret upserts a project-scoped secret.
+//
+// The underlying store does NOT upsert: store.CreateSecret rejects
+// duplicates on (owner, name, project_id, app_id) with "already
+// exists", and the public POST handler exposes that error verbatim
+// (intentional — UI users editing secrets get duplicate-name form
+// validation). Plain "POST create" therefore breaks the spawner,
+// which runs on every activation and needs idempotent write +
+// in-place value refresh so a rotated OAuth token actually
+// propagates to the next session without re-hiring.
+//
+// So here we list-then-create-or-update:
+//   - GET /api/v1/projects/<id>/secrets and find any secret named
+//     `name`. listProjectSecrets strips Value (we only need the ID).
+//   - If none, POST /api/v1/projects/<id>/secrets to create.
+//   - If one exists, PUT /api/v1/secrets/<existing-id> to overwrite
+//     the value in place. updateSecret preserves owner / project_id
+//     / app_id so the row stays project-scoped.
+//
+// Race note: two concurrent activations for the same project +
+// name could both see "no existing" and both POST — the second
+// would hit the duplicate-name error. The spawner already logs
+// (and tolerates) PutProjectSecret errors as best-effort, and
+// activations for the same worker serialize at the spawner level,
+// so the race window is theoretical for current callers.
 func (c *inProcHelixClient) PutProjectSecret(ctx context.Context, projectID, name, value string) error {
-	body := types.CreateSecretRequest{Name: name, Value: value}
-	r, err := c.newRequest(ctx, http.MethodPost, "/api/v1/projects/"+projectID+"/secrets", body, map[string]string{"id": projectID})
+	listReq, err := c.newRequest(ctx, http.MethodGet, "/api/v1/projects/"+projectID+"/secrets", nil, map[string]string{"id": projectID})
 	if err != nil {
 		return err
 	}
-	if _, herr := c.server.createProjectSecret(nil, r); herr != nil {
-		return fmt.Errorf("put project secret: %s", herr.Error())
+	existing, herr := c.server.listProjectSecrets(nil, listReq)
+	if herr != nil {
+		return fmt.Errorf("put project secret (list): %s", herr.Error())
+	}
+	var existingID string
+	for _, s := range existing {
+		if s != nil && s.Name == name {
+			existingID = s.ID
+			break
+		}
+	}
+
+	if existingID == "" {
+		body := types.CreateSecretRequest{Name: name, Value: value}
+		r, err := c.newRequest(ctx, http.MethodPost, "/api/v1/projects/"+projectID+"/secrets", body, map[string]string{"id": projectID})
+		if err != nil {
+			return err
+		}
+		if _, herr := c.server.createProjectSecret(nil, r); herr != nil {
+			return fmt.Errorf("put project secret: %s", herr.Error())
+		}
+		return nil
+	}
+
+	updateBody := types.Secret{Value: []byte(value)}
+	r, err := c.newRequest(ctx, http.MethodPut, "/api/v1/secrets/"+existingID, updateBody, map[string]string{"id": existingID})
+	if err != nil {
+		return err
+	}
+	if _, herr := c.server.updateSecret(nil, r); herr != nil {
+		return fmt.Errorf("put project secret (update): %s", herr.Error())
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- **Fix `inProcHelixClient.PutProjectSecret` to actually upsert** — the function's name + docstring promised upsert but routed to `store.CreateSecret` which rejects duplicates on `(owner, name, project_id, app_id)`. Result: helix-org's spawner WARN'd on every activation after the first (`helix spawner: put project secret failed … already exists for this project`), and the stored OAuth token never refreshed, defeating the documented "re-issued OAuth tokens take effect on the next session without re-hiring" guarantee. Same freeze hit `HELIX_ORG_URL` / `HELIX_WORKER_ID`. Fix lists project secrets, PUTs `/api/v1/secrets/<id>` if name exists, POSTs `/api/v1/projects/<id>/secrets` otherwise — public POST endpoint keeps its strict duplicate-name validation for UI form users.
- **Rewrite QA.md §12b around the per-Worker `configure_worker_project` startupScript model** — `gh` is operator-configurable per project via the MCP tool's `startupScript` field, not baked into `Dockerfile.ubuntu-helix` and not set in image-level startup scripts. §12a's regression note generalized from a specific gh-during-build incident to the underlying invariant (no build-time tool may write `\${HOME}` as root). §12b's verification guidance corrected: `su - retro -c` is a login shell that strips inherited container env and will lie about `GH_TOKEN` absence — use a non-login shell (`env | grep GH_TOKEN` via `docker exec`).

## Verification

End-to-end against fresh DB state on inner Helix:
- New project's `secrets` table has exactly 3 rows (`GH_TOKEN`, `HELIX_ORG_URL`, `HELIX_WORKER_ID`), no duplicates.
- No `put project secret failed … already exists for this project` WARN in API logs across hire + activation.
- `GH_TOKEN=gho_…` visible in fresh container env via \`docker exec ubuntu-external-<sid> env | grep GH_TOKEN\` — confirming the upserted secret reaches \`agent.Env\` on container create.
- Claude executed hire-time activation end-to-end (pulled helix-specs, read role/identity, checkpointed) — \`External agent added message role=assistant\` confirmed.

## Test plan

- [ ] Hire a fresh AI worker against an org that has a connected GitHub OAuth member; confirm GH_TOKEN env is set in the container without manual intervention.
- [ ] Open the worker's Human Desktop a second time; confirm API logs show no new `put project secret failed … already exists` WARN (upsert path taken).
- [ ] Set the worker's `startupScript` via `configure_worker_project` to install gh, re-open the desktop, confirm `gh auth status` reports the GH_TOKEN-backed login.
- [ ] Check the public POST `/api/v1/projects/{id}/secrets` still returns duplicate-name error from the UI (public contract preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)