### PR TITLE
feat(helix-org): add manual activation endpoint for worker desktop restart

### DIFF
--- a/api/pkg/org/application/agent/prompt.go
+++ b/api/pkg/org/application/agent/prompt.go
@@ -38,6 +38,8 @@ func BuildPrompt(workerID orgchart.WorkerID, mandate string, triggers []activati
 			ctx.WriteString("You have just been hired. This is your first activation. Complete any one-time setup your role describes, then exit. The runtime will re-activate you when an event arrives on a Stream you subscribe to.\n")
 		case activation.TriggerEvent:
 			ctx.WriteString(renderTrigger(t))
+		case activation.TriggerManual:
+			ctx.WriteString("An operator manually woke you up from the worker UI. Re-read your role and identity (per the mandate above), summarise your current state, and stand by — the operator will follow up with instructions on the next message.\n")
 		default:
 			fmt.Fprintf(&ctx, "Activation kind: %q.\n", t.Kind)
 		}
@@ -139,6 +141,8 @@ func DescribeTrigger(t activation.Trigger) string {
 		return "hire"
 	case activation.TriggerEvent:
 		return fmt.Sprintf("event %s on %s from %s", t.EventID, t.StreamID, t.Source)
+	case activation.TriggerManual:
+		return "manual"
 	default:
 		return string(t.Kind)
 	}

--- a/api/pkg/org/application/agent/prompt_test.go
+++ b/api/pkg/org/application/agent/prompt_test.go
@@ -159,3 +159,22 @@ func TestBuildPromptIncludesEnvelope(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildPromptManualTrigger pins the operator-driven activation path.
+// The prompt body must be operator-aware so the Worker doesn't treat the
+// activation as either a hire (first-time setup) or an event (no event
+// envelope to read). Standard wrapper still renders the mandate so the
+// Worker re-reads its role / identity per the helix-specs branch.
+func TestBuildPromptManualTrigger(t *testing.T) {
+	t.Parallel()
+	prompt := BuildPrompt("w-eng", "[mandate]", []activation.Trigger{{Kind: activation.TriggerManual}})
+	if !strings.Contains(prompt, "operator manually woke you up") {
+		t.Errorf("manual trigger body missing\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "[mandate]") {
+		t.Errorf("mandate wrapper missing\n%s", prompt)
+	}
+	if got := DescribeTrigger(activation.Trigger{Kind: activation.TriggerManual}); got != "manual" {
+		t.Errorf("DescribeTrigger(manual) = %q, want %q", got, "manual")
+	}
+}

--- a/api/pkg/org/application/dispatch/auto_spawn_test.go
+++ b/api/pkg/org/application/dispatch/auto_spawn_test.go
@@ -113,3 +113,32 @@ func TestDispatchHireEnqueuesSpawn(t *testing.T) {
 		t.Fatalf("ActivationID = %q, want %q", got[0].Triggers[0].ActivationID, activation.ID("a-hire-1"))
 	}
 }
+
+// TestDispatchManualEnqueuesSpawn pins the manual-activation wiring:
+// the worker UI's "Start Desktop" button hits POST /workers/{id}/activate,
+// which calls Dispatcher.DispatchManual; the dispatcher must enqueue a
+// TriggerManual activation against the worker's per-Worker queue with
+// the caller-supplied pre-allocated audit-row ID. Without this, the
+// activate endpoint becomes a no-op and the desktop stays in whatever
+// MCP-clobbered state it was already in.
+func TestDispatchManualEnqueuesSpawn(t *testing.T) {
+	t.Parallel()
+	d, s, rec := newDispatcherWithSpawner(t)
+	seedAIWorker(t, s, "w-manual")
+
+	d.DispatchManual(context.Background(), "org-test", "w-manual", "/tmp/env-manual", activation.ID("a-manual-1"))
+
+	got := drainActivations(t, rec, 500*time.Millisecond)
+	if len(got) != 1 {
+		t.Fatalf("activations = %d, want 1 (DispatchManual must spawn the worker); got %+v", len(got), got)
+	}
+	if got[0].WorkerID != "w-manual" {
+		t.Fatalf("spawned worker = %q, want %q", got[0].WorkerID, "w-manual")
+	}
+	if len(got[0].Triggers) != 1 || got[0].Triggers[0].Kind != activation.TriggerManual {
+		t.Fatalf("trigger kind = %+v, want one TriggerManual", got[0].Triggers)
+	}
+	if got[0].Triggers[0].ActivationID != activation.ID("a-manual-1") {
+		t.Fatalf("ActivationID = %q, want %q", got[0].Triggers[0].ActivationID, activation.ID("a-manual-1"))
+	}
+}

--- a/api/pkg/org/application/dispatch/dispatcher.go
+++ b/api/pkg/org/application/dispatch/dispatcher.go
@@ -114,6 +114,26 @@ func (d *Dispatcher) DispatchHire(_ context.Context, orgID string, workerID orgc
 	})
 }
 
+// DispatchManual fires an operator-driven activation. Used by the
+// worker UI's "Start Desktop" button to put the per-Worker project
+// through the full activation pipeline (ensureProject → AttachHelixOrgMCP
+// → ensureSession), which re-attaches the helix-org MCP entry that
+// applyProject's wholesale Config.Helix replace wipes between
+// activations. Without this path, restarting a paused desktop via
+// /sessions/{id}/resume alone leaves the desktop without the helix-org
+// MCP until the next AI activation or owner-chat call.
+//
+// Returns immediately; the activation runs on the per-Worker queue
+// goroutine. activationID semantics match DispatchHire — callers that
+// pre-allocate the audit row pass its ID through; empty means the
+// Spawner mints its own. No-op if the Spawner is nil.
+func (d *Dispatcher) DispatchManual(_ context.Context, orgID string, workerID orgchart.WorkerID, envPath string, activationID activation.ID) {
+	d.queue.Enqueue(orgID, workerID, envPath, activation.Trigger{
+		Kind:         activation.TriggerManual,
+		ActivationID: activationID,
+	})
+}
+
 // Dispatch fans an Event out to every AI Worker subscribed to its
 // Stream (skipping the Worker that sourced the event) and emits an
 // outbound webhook POST if the Stream's Transport is configured for

--- a/api/pkg/org/domain/activation/trigger.go
+++ b/api/pkg/org/domain/activation/trigger.go
@@ -31,6 +31,15 @@ const (
 	// TriggerEvent fires whenever a Worker receives an event on a
 	// Stream they subscribe to.
 	TriggerEvent TriggerKind = "event"
+
+	// TriggerManual fires when an operator manually wakes a Worker
+	// from the UI (the worker page's "Start Desktop" button).
+	// Functionally identical to TriggerHire in terms of the activation
+	// pipeline — ensureProject + AttachHelixOrgMCP + ensureSession —
+	// just with a different label so the audit row + activation marker
+	// distinguish "operator clicked the button" from "Worker was just
+	// hired" or "Stream event arrived".
+	TriggerManual TriggerKind = "manual"
 )
 
 // Trigger is the per-activation context the runtime gives to the

--- a/api/pkg/org/infrastructure/runtime/helix/mcp.go
+++ b/api/pkg/org/infrastructure/runtime/helix/mcp.go
@@ -1,0 +1,98 @@
+package helix
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// HelixOrgMCPName is the AssistantMCP.Name slot the helix-org MCP entry
+// occupies on a Worker's agent app. Upsert is keyed on this string —
+// keep it stable across the codebase.
+const HelixOrgMCPName = "helix"
+
+// AttachHelixOrgMCP idempotently writes the helix-org MCP entry onto
+// the per-Worker agent app's first assistant.
+//
+// Why this isn't done inside the project-apply path: applyProject
+// (api/pkg/server/project_handlers.go) wholesale-replaces
+// agentApp.Config.Helix when an agent app already exists, so anything
+// attached previously is wiped on every re-apply. Re-attaching after
+// the apply lands is the invariant that keeps the helix-org MCP
+// present across activations. Both call sites — the Spawner (per AI
+// Worker activation) and dynamicProjectApplier (per owner-chat
+// ensureWorker call) — invoke this; the function is the single source
+// of truth for what the MCP entry looks like.
+//
+// Upsert is keyed on HelixOrgMCPName: an existing entry with the same
+// name is overwritten in place, otherwise appended. The bearer is
+// picked from ctx first (per-activation user attribution via
+// WithBearerToken / HelixIdentity), falling back to fallbackBearer
+// (the service api_key). Empty bearer means no Authorization header
+// is sent — fine for standalone deployments where the MCP route is
+// not auth-gated.
+func AttachHelixOrgMCP(
+	ctx context.Context,
+	svc ProjectService,
+	appID string,
+	helixOrgURL string,
+	workerID orgchart.WorkerID,
+	fallbackBearer string,
+) error {
+	if svc == nil {
+		return errors.New("AttachHelixOrgMCP: ProjectService is nil")
+	}
+	if appID == "" {
+		return errors.New("AttachHelixOrgMCP: appID is empty")
+	}
+	if helixOrgURL == "" {
+		return errors.New("AttachHelixOrgMCP: helixOrgURL is empty")
+	}
+	if workerID == "" {
+		return errors.New("AttachHelixOrgMCP: workerID is empty")
+	}
+
+	cfg, err := svc.GetAppConfig(ctx, appID)
+	if err != nil {
+		return fmt.Errorf("get app config: %w", err)
+	}
+	if len(cfg.Helix.Assistants) == 0 {
+		return errors.New("AttachHelixOrgMCP: app has no assistants")
+	}
+
+	bearer := BearerFromContext(ctx)
+	if bearer == "" {
+		bearer = fallbackBearer
+	}
+	var headers map[string]string
+	if bearer != "" {
+		headers = map[string]string{"Authorization": "Bearer " + bearer}
+	}
+	entry := types.AssistantMCP{
+		Name:      HelixOrgMCPName,
+		Transport: "http",
+		URL:       strings.TrimRight(helixOrgURL, "/") + "/workers/" + string(workerID) + "/mcp",
+		Headers:   headers,
+	}
+
+	asst := &cfg.Helix.Assistants[0]
+	replaced := false
+	for i := range asst.MCPs {
+		if asst.MCPs[i].Name == entry.Name {
+			asst.MCPs[i] = entry
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		asst.MCPs = append(asst.MCPs, entry)
+	}
+	if err := svc.UpdateAppConfig(ctx, appID, cfg); err != nil {
+		return fmt.Errorf("update app config: %w", err)
+	}
+	return nil
+}

--- a/api/pkg/org/infrastructure/runtime/helix/mcp_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/mcp_test.go
@@ -1,0 +1,227 @@
+package helix
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// findMCP returns the AssistantMCP named `name` on assistants[0], or
+// nil if not present.
+func findMCP(cfg types.AppConfig, name string) *types.AssistantMCP {
+	if len(cfg.Helix.Assistants) == 0 {
+		return nil
+	}
+	for i := range cfg.Helix.Assistants[0].MCPs {
+		if cfg.Helix.Assistants[0].MCPs[i].Name == name {
+			return &cfg.Helix.Assistants[0].MCPs[i]
+		}
+	}
+	return nil
+}
+
+// TestAttachHelixOrgMCPAppends writes a fresh entry when no MCP with
+// HelixOrgMCPName exists yet.
+func TestAttachHelixOrgMCPAppends(t *testing.T) {
+	t.Parallel()
+	svc := newFakeProjectService()
+	err := AttachHelixOrgMCP(context.Background(), svc, "app_test", "http://helix-org:8081", orgchart.WorkerID("w-eng"), "k_service")
+	if err != nil {
+		t.Fatalf("AttachHelixOrgMCP: %v", err)
+	}
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	if svc.getAppCalls != 1 || svc.updateAppCalls != 1 {
+		t.Fatalf("expected one GetAppConfig + one UpdateAppConfig; got get=%d update=%d", svc.getAppCalls, svc.updateAppCalls)
+	}
+	mcp := findMCP(svc.updateAppLastCfg, HelixOrgMCPName)
+	if mcp == nil {
+		t.Fatalf("UpdateApp config missing %q MCP entry: %+v", HelixOrgMCPName, svc.updateAppLastCfg)
+	}
+	if mcp.Transport != "http" {
+		t.Errorf("Transport = %q, want http", mcp.Transport)
+	}
+	if !strings.HasSuffix(mcp.URL, "/workers/w-eng/mcp") {
+		t.Errorf("URL = %q, want suffix /workers/w-eng/mcp", mcp.URL)
+	}
+	if mcp.Headers["Authorization"] != "Bearer k_service" {
+		t.Errorf("Headers[Authorization] = %q, want %q", mcp.Headers["Authorization"], "Bearer k_service")
+	}
+}
+
+// TestAttachHelixOrgMCPUpsertReplacesExisting pins the idempotency
+// contract — re-attaching with a different bearer overwrites the
+// entry in place instead of appending a duplicate.
+func TestAttachHelixOrgMCPUpsertReplacesExisting(t *testing.T) {
+	t.Parallel()
+	svc := newFakeProjectService()
+	svc.appConfig.Helix.Assistants[0].MCPs = []types.AssistantMCP{
+		{Name: HelixOrgMCPName, Transport: "http", URL: "http://old/workers/w-eng/mcp", Headers: map[string]string{"Authorization": "Bearer old"}},
+		{Name: "other", URL: "http://other/mcp"},
+	}
+	if err := AttachHelixOrgMCP(context.Background(), svc, "app_test", "http://helix-org:8081", orgchart.WorkerID("w-eng"), "k_new"); err != nil {
+		t.Fatalf("AttachHelixOrgMCP: %v", err)
+	}
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	asst := svc.updateAppLastCfg.Helix.Assistants[0]
+	if got := len(asst.MCPs); got != 2 {
+		t.Fatalf("MCP entries = %d, want 2 (upsert must not append a duplicate); got %+v", got, asst.MCPs)
+	}
+	helix := findMCP(svc.updateAppLastCfg, HelixOrgMCPName)
+	if helix == nil {
+		t.Fatalf("helix MCP entry missing")
+	}
+	if helix.Headers["Authorization"] != "Bearer k_new" {
+		t.Errorf("upsert did not refresh bearer; got %q", helix.Headers["Authorization"])
+	}
+	if !strings.HasSuffix(helix.URL, "/workers/w-eng/mcp") {
+		t.Errorf("URL not rewritten; got %q", helix.URL)
+	}
+}
+
+// TestAttachHelixOrgMCPBearerFromContextOverridesFallback pins the
+// per-activation user-attribution path: when a bearer is on ctx
+// (via WithBearerToken / HelixIdentity), it wins over the fallback
+// service api_key. Used by the Spawner so per-Worker projects are
+// owned by the hiring user, not the service account.
+func TestAttachHelixOrgMCPBearerFromContextOverridesFallback(t *testing.T) {
+	t.Parallel()
+	svc := newFakeProjectService()
+	ctx := WithBearerToken(context.Background(), "k_user")
+	if err := AttachHelixOrgMCP(ctx, svc, "app_test", "http://helix-org:8081", orgchart.WorkerID("w-eng"), "k_service"); err != nil {
+		t.Fatalf("AttachHelixOrgMCP: %v", err)
+	}
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	mcp := findMCP(svc.updateAppLastCfg, HelixOrgMCPName)
+	if mcp == nil || mcp.Headers["Authorization"] != "Bearer k_user" {
+		t.Errorf("ctx bearer must override fallback; got %+v", mcp)
+	}
+}
+
+// TestAttachHelixOrgMCPEmptyBearerOmitsHeader pins the standalone-
+// deployment shape: when neither ctx nor fallback carry a bearer, no
+// Authorization header is written. The standalone helix-org MCP is
+// not auth-gated so an empty header is correct.
+func TestAttachHelixOrgMCPEmptyBearerOmitsHeader(t *testing.T) {
+	t.Parallel()
+	svc := newFakeProjectService()
+	if err := AttachHelixOrgMCP(context.Background(), svc, "app_test", "http://helix-org:8081", orgchart.WorkerID("w-eng"), ""); err != nil {
+		t.Fatalf("AttachHelixOrgMCP: %v", err)
+	}
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	mcp := findMCP(svc.updateAppLastCfg, HelixOrgMCPName)
+	if mcp == nil {
+		t.Fatalf("MCP entry missing")
+	}
+	if mcp.Headers != nil {
+		t.Errorf("Headers must be nil when no bearer is set; got %+v", mcp.Headers)
+	}
+}
+
+// TestAttachHelixOrgMCPRejectsMissingInputs pins the up-front
+// validation. Each failure mode returns a clear error rather than
+// nil-derefing or writing a malformed entry.
+func TestAttachHelixOrgMCPRejectsMissingInputs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		svc     ProjectService
+		appID   string
+		url     string
+		worker  orgchart.WorkerID
+		errFrag string
+	}{
+		{"nil service", nil, "app_test", "http://helix-org", "w-eng", "ProjectService is nil"},
+		{"empty appID", newFakeProjectService(), "", "http://helix-org", "w-eng", "appID is empty"},
+		{"empty URL", newFakeProjectService(), "app_test", "", "w-eng", "helixOrgURL is empty"},
+		{"empty workerID", newFakeProjectService(), "app_test", "http://helix-org", "", "workerID is empty"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := AttachHelixOrgMCP(context.Background(), tc.svc, tc.appID, tc.url, tc.worker, "")
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.errFrag)
+			}
+			if !strings.Contains(err.Error(), tc.errFrag) {
+				t.Errorf("err = %q, want contains %q", err.Error(), tc.errFrag)
+			}
+		})
+	}
+}
+
+// TestAttachHelixOrgMCPRequiresAssistant pins the contract on the
+// agent app shape: a project's auto-provisioned agent app always
+// has a [0]th assistant; if it doesn't, attach refuses rather than
+// silently appending into a zero-length slice.
+func TestAttachHelixOrgMCPRequiresAssistant(t *testing.T) {
+	t.Parallel()
+	svc := newFakeProjectService()
+	svc.appConfig = types.AppConfig{} // no assistants
+	err := AttachHelixOrgMCP(context.Background(), svc, "app_test", "http://helix-org", orgchart.WorkerID("w-eng"), "")
+	if err == nil || !strings.Contains(err.Error(), "no assistants") {
+		t.Errorf("expected 'no assistants' error, got %v", err)
+	}
+}
+
+// TestAttachHelixOrgMCPPropagatesGetError pins the error path: a
+// failure from GetAppConfig surfaces (wrapped) rather than crashing
+// or writing garbage.
+func TestAttachHelixOrgMCPPropagatesGetError(t *testing.T) {
+	t.Parallel()
+	svc := &failingProjectService{getErr: errors.New("boom")}
+	err := AttachHelixOrgMCP(context.Background(), svc, "app_test", "http://helix-org", orgchart.WorkerID("w-eng"), "")
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Errorf("expected wrapped GetAppConfig error, got %v", err)
+	}
+}
+
+// failingProjectService stubs ProjectService so the GetAppConfig
+// error-path test can isolate failure-mode behaviour without
+// touching the fake's other state.
+type failingProjectService struct {
+	noopProjectService
+	getErr error
+}
+
+func (f *failingProjectService) GetAppConfig(_ context.Context, _ string) (types.AppConfig, error) {
+	return types.AppConfig{}, f.getErr
+}
+
+// noopProjectService satisfies ProjectService with no-op
+// implementations so test stand-ins can embed it and override only
+// the method under test.
+type noopProjectService struct{}
+
+func (noopProjectService) WhoAmI(_ context.Context) (string, error) { return "u-test", nil }
+func (noopProjectService) ApplyProject(_ context.Context, _ types.ProjectApplyRequest) (types.ProjectApplyResponse, error) {
+	return types.ProjectApplyResponse{}, nil
+}
+func (noopProjectService) GetProject(_ context.Context, _ string) (types.Project, error) {
+	return types.Project{}, nil
+}
+func (noopProjectService) UpdateProject(_ context.Context, _ string, _ types.ProjectUpdateRequest) (types.Project, error) {
+	return types.Project{}, nil
+}
+func (noopProjectService) PutProjectSecret(_ context.Context, _, _, _ string) error { return nil }
+func (noopProjectService) CreateGitRepo(_ context.Context, _ types.GitRepositoryCreateRequest) (types.GitRepository, error) {
+	return types.GitRepository{}, nil
+}
+func (noopProjectService) AttachRepoToProject(_ context.Context, _, _ string, _ bool) error {
+	return nil
+}
+func (noopProjectService) CreateBranch(_ context.Context, _, _, _ string) error { return nil }
+func (noopProjectService) GetAppConfig(_ context.Context, _ string) (types.AppConfig, error) {
+	return types.AppConfig{}, nil
+}
+func (noopProjectService) UpdateAppConfig(_ context.Context, _ string, _ types.AppConfig) error {
+	return nil
+}
+func (noopProjectService) DeleteProject(_ context.Context, _ string) error { return nil }
+func (noopProjectService) DeleteApp(_ context.Context, _ string) error     { return nil }

--- a/api/pkg/org/infrastructure/runtime/helix/project.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/org/domain/store"
@@ -132,11 +131,7 @@ type WorkerProject struct {
 	// `.context/agent.md` on every Worker's helix-specs branch. Empty
 	// string skips the push.
 	AgentMD string
-	// MCPAuthBearer is added as an `Authorization: Bearer <value>`
-	// header on the helix-org MCP entry attached to each Worker's
-	// agent app.
-	MCPAuthBearer string
-	Logger        *slog.Logger
+	Logger  *slog.Logger
 }
 
 // Ensure applies a Helix project for the given Worker if one
@@ -290,28 +285,12 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 		}
 	}
 	a.republishWorkerFiles(ctx, workerID, repoID, roleContent, worker.IdentityContent())
-	// Attach helix-org's MCP server to the auto-provisioned Agent App.
-	if resp.AgentAppID != "" && a.HelixOrgURL != "" {
-		mcpURL := strings.TrimRight(a.HelixOrgURL, "/") + "/workers/" + string(workerID) + "/mcp"
-		// Prefer the per-request bearer from ctx so the attached MCP
-		// entry authenticates as the actual user who triggered this
-		// project apply.
-		bearer := BearerFromContext(ctx)
-		if bearer == "" {
-			bearer = a.MCPAuthBearer
-		}
-		var headers map[string]string
-		if bearer != "" {
-			headers = map[string]string{"Authorization": "Bearer " + bearer}
-		}
-		if err := a.attachMCPToApp(ctx, resp.AgentAppID, "helix", "http", mcpURL, headers); err != nil {
-			if a.Logger != nil {
-				a.Logger.Warn("attach MCP to agent app", "worker", workerID, "app", resp.AgentAppID, "err", err)
-			}
-		} else if a.Logger != nil {
-			a.Logger.Info("helix mcp attached", "worker", workerID, "app", resp.AgentAppID, "mcp", mcpURL)
-		}
-	}
+	// NB: helix-org MCP attachment is NOT done here. applyProject
+	// (helix project handler) wholesale-replaces agentApp.Config.Helix
+	// on update, so anything we attach now is clobbered on the next
+	// re-apply. The Spawner and dynamicProjectApplier call
+	// AttachHelixOrgMCP themselves *after* this Ensure returns — that's
+	// the single place MCP mutation lives.
 	if err := SaveProject(ctx, a.Store, orgID, workerID, resp.ProjectID, resp.AgentAppID, repoID); err != nil {
 		return "", "", "", fmt.Errorf("persist helix project IDs: %w", err)
 	}
@@ -358,41 +337,3 @@ func (a *WorkerProject) republishWorkerFiles(ctx context.Context, workerID orgch
 	}
 }
 
-// attachMCPToApp upserts an MCP entry on the first assistant of the
-// given app, identified by name. Works against typed
-// types.AssistantMCP / types.AppConfig rather than raw JSON so the
-// shape Helix expects is checked at compile time.
-func (a *WorkerProject) attachMCPToApp(ctx context.Context, appID, name, transport, mcpURL string, headers map[string]string) error {
-	if appID == "" {
-		return errors.New("attachMCPToApp: appID is empty")
-	}
-	cfg, err := a.Service.GetAppConfig(ctx, appID)
-	if err != nil {
-		return fmt.Errorf("get app: %w", err)
-	}
-	if len(cfg.Helix.Assistants) == 0 {
-		return errors.New("attachMCPToApp: app has no assistants")
-	}
-	asst := &cfg.Helix.Assistants[0]
-	entry := types.AssistantMCP{
-		Name:      name,
-		Transport: transport,
-		URL:       mcpURL,
-		Headers:   headers,
-	}
-	replaced := false
-	for i := range asst.MCPs {
-		if asst.MCPs[i].Name == name {
-			asst.MCPs[i] = entry
-			replaced = true
-			break
-		}
-	}
-	if !replaced {
-		asst.MCPs = append(asst.MCPs, entry)
-	}
-	if err := a.Service.UpdateAppConfig(ctx, appID, cfg); err != nil {
-		return fmt.Errorf("update app: %w", err)
-	}
-	return nil
-}

--- a/api/pkg/org/infrastructure/runtime/helix/project_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_test.go
@@ -545,9 +545,19 @@ func TestEnsureGetProjectErrorIsFatal(t *testing.T) {
 	}
 }
 
-// TestEnsureAttachesMCPToAgentApp verifies the GetApp + UpdateApp pair
-// runs and the config carries the /workers/<id>/mcp URL.
-func TestEnsureAttachesMCPToAgentApp(t *testing.T) {
+// TestEnsureDoesNotTouchAgentAppMCPs pins the new contract: MCP
+// attachment is NOT WorkerProject.Ensure's responsibility. It moved
+// out into runtimehelix.AttachHelixOrgMCP, called explicitly by the
+// Spawner (per-activation) and dynamicProjectApplier (per owner-chat
+// ensureWorker). Ensure mutates the project + repo + helix-specs
+// files only.
+//
+// Why this matters: the helix project-apply path wholesale-replaces
+// agentApp.Config.Helix on update, so any MCP attached during Ensure
+// is clobbered on the next re-apply. Keeping MCP attachment outside
+// Ensure means there's exactly one place that writes the MCP entry,
+// and it's the last write before the desktop boots.
+func TestEnsureDoesNotTouchAgentAppMCPs(t *testing.T) {
 	t.Parallel()
 	st, wid := newProjectTestStore(t, "# Role")
 	svc := newFakeProjectService()
@@ -559,50 +569,11 @@ func TestEnsureAttachesMCPToAgentApp(t *testing.T) {
 	}
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
-	if svc.getAppCalls < 1 || svc.updateAppCalls < 1 {
-		t.Fatalf("MCP attach must call GetApp+UpdateApp; got get=%d update=%d", svc.getAppCalls, svc.updateAppCalls)
+	if svc.getAppCalls != 0 {
+		t.Errorf("Ensure must not read agent app config; GetAppConfig calls = %d", svc.getAppCalls)
 	}
-	mcp := findMCP(svc.updateAppLastCfg, "helix")
-	if mcp == nil {
-		t.Fatalf("UpdateApp config missing 'helix' MCP entry: %+v", svc.updateAppLastCfg)
-	}
-	if !strings.Contains(mcp.URL, "/workers/w-eng/mcp") {
-		t.Errorf("MCP URL = %q, want contains /workers/w-eng/mcp", mcp.URL)
-	}
-}
-
-// findMCP returns the AssistantMCP named `name` on assistants[0], or
-// nil if not present.
-func findMCP(cfg types.AppConfig, name string) *types.AssistantMCP {
-	if len(cfg.Helix.Assistants) == 0 {
-		return nil
-	}
-	for i := range cfg.Helix.Assistants[0].MCPs {
-		if cfg.Helix.Assistants[0].MCPs[i].Name == name {
-			return &cfg.Helix.Assistants[0].MCPs[i]
-		}
-	}
-	return nil
-}
-
-// TestEnsureMCPAttachUsesBearerFromContext pins the per-call bearer
-// behaviour.
-func TestEnsureMCPAttachUsesBearerFromContext(t *testing.T) {
-	t.Parallel()
-	st, wid := newProjectTestStore(t, "# Role")
-	svc := newFakeProjectService()
-	git := newFakeGitForProject()
-	a := newApplierGit(svc, git, st)
-
-	ctx := WithBearerToken(context.Background(), "k_bob")
-	if _, _, _, err := a.Ensure(ctx, "org-test", wid); err != nil {
-		t.Fatalf("Ensure: %v", err)
-	}
-	svc.mu.Lock()
-	defer svc.mu.Unlock()
-	mcp := findMCP(svc.updateAppLastCfg, "helix")
-	if mcp == nil || mcp.Headers["Authorization"] != "Bearer k_bob" {
-		t.Errorf("MCP entry missing Authorization=Bearer k_bob; got %+v", mcp)
+	if svc.updateAppCalls != 0 {
+		t.Errorf("Ensure must not write agent app config; UpdateAppConfig calls = %d", svc.updateAppCalls)
 	}
 }
 

--- a/api/pkg/org/infrastructure/runtime/helix/spawner.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner.go
@@ -51,10 +51,12 @@ type SpawnerConfig struct {
 	// branch. The spawner's activation prompt tells every Worker to
 	// read it first. Embedded by main.go from agent/policy.md.
 	AgentMD string
-	// MCPAuthBearer is forwarded to WorkerProject so the helix-org
-	// MCP entry on each Worker's agent app carries an Authorization
-	// header. Used when HelixOrgURL routes through an auth-gated
-	// proxy (embedded SaaS alpha). Empty in standalone mode.
+	// MCPAuthBearer is the fallback bearer the spawner passes to
+	// AttachHelixOrgMCP when no per-activation user bearer is on ctx.
+	// It ends up as the `Authorization: Bearer <value>` header on the
+	// helix-org MCP entry attached to each Worker's agent app. Used
+	// when HelixOrgURL routes through an auth-gated proxy (embedded
+	// SaaS alpha). Empty in standalone mode.
 	MCPAuthBearer string
 	// SpecsMandate is the activation-prompt directive that tells the
 	// agent how to find role.md / identity.md / agent.md on the
@@ -220,6 +222,13 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 			return err
 		}
 
+		// Re-attach the helix-org MCP entry. ensureProject (and the
+		// dynamic applier that may have run before us) calls helix
+		// project-apply, which wholesale-replaces Config.Helix on
+		// update and wipes the MCP list. This is the last write to the
+		// agent app's MCPs before the desktop boots its Zed runtime.
+		cfg.ensureHelixOrgMCP(actCtx, orgID, workerID)
+
 		// Run every registered secret injector. Each transport (or
 		// other extension) plugs in via the SpawnSecretInjector
 		// interface; the spawner stays transport-agnostic. Soft-skips
@@ -327,21 +336,51 @@ After meaningful work, persist state on helix-specs:
 // must be wired by the embedding host (api/pkg/server/helix_org.go).
 func (c SpawnerConfig) ensureProject(ctx context.Context, orgID string, workerID orgchart.WorkerID) error {
 	a := &WorkerProject{
-		Service:       c.ProjectService,
-		Workspace:     c.Workspace,
-		Store:         c.Store,
-		HelixOrgURL:   c.HelixOrgURL,
-		OrgID:         c.OrgID,
-		Runtime:       c.Runtime,
-		Provider:      c.Provider,
-		Model:         c.Model,
-		Credentials:   c.Credentials,
-		AgentMD:       c.AgentMD,
-		MCPAuthBearer: c.MCPAuthBearer,
-		Logger:        c.Logger,
+		Service:     c.ProjectService,
+		Workspace:   c.Workspace,
+		Store:       c.Store,
+		HelixOrgURL: c.HelixOrgURL,
+		OrgID:       c.OrgID,
+		Runtime:     c.Runtime,
+		Provider:    c.Provider,
+		Model:       c.Model,
+		Credentials: c.Credentials,
+		AgentMD:     c.AgentMD,
+		Logger:      c.Logger,
 	}
 	_, _, _, err := a.Ensure(ctx, orgID, workerID)
 	return err
+}
+
+// ensureHelixOrgMCP re-attaches the helix-org MCP entry to the
+// Worker's agent app on every activation. Best-effort: a failure here
+// surfaces in the desktop as "no helix-org tools", which is a
+// degraded but bootable state — failing the activation would be
+// worse. The attach is idempotent (upsert by name), so re-running on
+// every activation is safe.
+//
+// Why it runs here and not inside WorkerProject.Ensure: the project-
+// apply path on the helix side wholesale-replaces Config.Helix when
+// the agent app already exists, blowing away whatever MCPs were
+// attached on the previous activation. Re-attaching after Ensure
+// returns keeps the MCP present.
+func (c SpawnerConfig) ensureHelixOrgMCP(ctx context.Context, orgID string, workerID orgchart.WorkerID) {
+	if c.ProjectService == nil || c.HelixOrgURL == "" {
+		return
+	}
+	state, err := LoadState(ctx, c.Store, orgID, workerID)
+	if err != nil {
+		if c.Logger != nil {
+			c.Logger.Warn("helix spawner: load state for MCP attach", "worker", workerID, "err", err)
+		}
+		return
+	}
+	if state.AgentAppID == "" {
+		return
+	}
+	if err := AttachHelixOrgMCP(ctx, c.ProjectService, state.AgentAppID, c.HelixOrgURL, workerID, c.MCPAuthBearer); err != nil && c.Logger != nil {
+		c.Logger.Warn("helix spawner: attach helix-org MCP", "worker", workerID, "app", state.AgentAppID, "err", err)
+	}
 }
 
 // ensureSession dispatches the activation prompt to the Worker's

--- a/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
@@ -141,6 +141,51 @@ func TestSpawnerStartsFreshAndPersistsSession(t *testing.T) {
 	}
 }
 
+// TestSpawnerAttachesHelixOrgMCPEveryActivation pins the bug-fix
+// invariant: the helix-org MCP is re-attached to the Worker's agent
+// app on every activation, after ensureProject runs. helix's project-
+// apply path wholesale-replaces Config.Helix on update, so without
+// this re-attach the MCP is gone from the second activation onward
+// and the desktop runtime boots without the helix-org tools — the
+// regression behind /workers/<id>/mcp not appearing in Zed.
+func TestSpawnerAttachesHelixOrgMCPEveryActivation(t *testing.T) {
+	t.Parallel()
+	s, wid := newHelixTestStore(t)
+	fc := &fakeHelixClient{
+		startSessionID: "ses_new",
+		outputs:        []types.SessionOutputResponse{{Status: "complete", Output: "ok"}},
+	}
+	cfg := newHelixCfg(t, fc, s)
+	cfg.MCPAuthBearer = "k_service"
+	sp := Spawner(cfg)
+	if err := sp(context.Background(), "org-test", wid, "/ignored", []activation.Trigger{{Kind: activation.TriggerHire}}); err != nil {
+		t.Fatalf("spawn 1: %v", err)
+	}
+	if err := sp(context.Background(), "org-test", wid, "/ignored", []activation.Trigger{{Kind: activation.TriggerEvent}}); err != nil {
+		t.Fatalf("spawn 2: %v", err)
+	}
+	svc := cfg.ProjectService.(*fakeProjectService)
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	// Two activations should mean two UpdateAppConfig calls for the
+	// MCP attach (one per activation, after ensureProject). The
+	// helix-side apply path clobbers the MCP list each time so this
+	// must NOT be debounced.
+	if svc.updateAppCalls != 2 {
+		t.Errorf("UpdateAppConfig calls = %d, want 2 (one MCP re-attach per activation)", svc.updateAppCalls)
+	}
+	mcp := findMCP(svc.updateAppLastCfg, HelixOrgMCPName)
+	if mcp == nil {
+		t.Fatalf("last UpdateApp missing helix MCP entry: %+v", svc.updateAppLastCfg)
+	}
+	if !strings.HasSuffix(mcp.URL, "/workers/w-eng/mcp") {
+		t.Errorf("MCP URL = %q, want /workers/w-eng/mcp suffix", mcp.URL)
+	}
+	if mcp.Headers["Authorization"] != "Bearer k_service" {
+		t.Errorf("MCP fallback bearer not applied; Authorization = %q", mcp.Headers["Authorization"])
+	}
+}
+
 // TestBridgeRendersEntryPatchEvents verifies that the bridge's
 // EntryStream callback produces the same line shapes the claude
 // bridge emits — assistant text, tool_use, tool_result.

--- a/api/pkg/org/interfaces/server/api/activate_worker_test.go
+++ b/api/pkg/org/interfaces/server/api/activate_worker_test.go
@@ -1,0 +1,258 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/org/domain/activation"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+	orgapi "github.com/helixml/helix/api/pkg/org/interfaces/server/api"
+)
+
+// fakeEnsurer captures the ProjectEnsurer.Ensure call and returns
+// the seeded IDs. Errors come from `err` if non-nil.
+type fakeEnsurer struct {
+	mu        sync.Mutex
+	calls     int
+	lastOrgID string
+	lastWid   orgchart.WorkerID
+	projectID string
+	agentApp  string
+	repoID    string
+	err       error
+}
+
+func (f *fakeEnsurer) Ensure(_ context.Context, orgID string, wid orgchart.WorkerID) (string, string, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.lastOrgID = orgID
+	f.lastWid = wid
+	return f.projectID, f.agentApp, f.repoID, f.err
+}
+
+// fakeDispatcher records DispatchManual / Dispatch calls so the
+// handler test can assert exactly what was enqueued.
+type fakeDispatcher struct {
+	mu              sync.Mutex
+	manualCalls     int
+	lastOrgID       string
+	lastWorkerID    orgchart.WorkerID
+	lastEnvPath     string
+	lastActivation  activation.ID
+	dispatchedEvent *streaming.Event
+}
+
+func (f *fakeDispatcher) Dispatch(_ context.Context, ev streaming.Event) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.dispatchedEvent = &ev
+}
+
+func (f *fakeDispatcher) DispatchManual(_ context.Context, orgID string, wid orgchart.WorkerID, envPath string, actID activation.ID) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.manualCalls++
+	f.lastOrgID = orgID
+	f.lastWorkerID = wid
+	f.lastEnvPath = envPath
+	f.lastActivation = actID
+}
+
+// TestActivateWorker_HappyPath pins the bug-fix contract: POST
+// /workers/{id}/activate runs the ensureProject pipeline (which
+// re-attaches the helix-org MCP), enqueues a manual activation, and
+// returns a 202 carrying the project + agent app IDs plus the
+// pre-allocated activation ID. This is what the worker UI's
+// "Start Desktop" button hits instead of the generic
+// /sessions/{id}/resume, so that the desktop boots with the
+// helix-org MCP in Zed's context_servers map.
+func TestActivateWorker_HappyPath(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	ctx := context.Background()
+	seedOwnerPosition(t, st, ctx)
+	mustCreateAIWorker(t, st, ctx, "w-alice", "p-root", "alice identity")
+
+	ensurer := &fakeEnsurer{projectID: "prj_alice", agentApp: "app_alice", repoID: "repo_alice"}
+	disp := &fakeDispatcher{}
+	deps.ProjectEnsurer = ensurer
+	deps.Dispatcher = disp
+	deps.EnvsDir = "/tmp/helix-org-envs"
+
+	h := orgapi.Handler(deps)
+	rec := do(t, h, "POST", "/workers/w-alice/activate", nil)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", rec.Code, rec.Body)
+	}
+
+	var resp orgapi.WorkerActivateDTO
+	decode(t, rec, &resp)
+	if resp.ProjectID != "prj_alice" || resp.AgentAppID != "app_alice" {
+		t.Errorf("IDs = (%q,%q), want (prj_alice, app_alice)", resp.ProjectID, resp.AgentAppID)
+	}
+	if resp.ActivationID == "" {
+		t.Errorf("ActivationID must be pre-allocated; got empty")
+	}
+
+	if ensurer.calls != 1 {
+		t.Errorf("Ensure calls = %d, want 1 (sync ensureProject before enqueue)", ensurer.calls)
+	}
+	if ensurer.lastWid != "w-alice" || ensurer.lastOrgID != "org-test" {
+		t.Errorf("Ensure called with (%q, %q), want (org-test, w-alice)", ensurer.lastOrgID, ensurer.lastWid)
+	}
+
+	if disp.manualCalls != 1 {
+		t.Errorf("DispatchManual calls = %d, want 1", disp.manualCalls)
+	}
+	if disp.lastActivation == "" {
+		t.Errorf("DispatchManual must carry the pre-allocated activation id; got empty")
+	}
+	if string(disp.lastActivation) != resp.ActivationID {
+		t.Errorf("DispatchManual activation id (%q) does not match response (%q)", disp.lastActivation, resp.ActivationID)
+	}
+	if disp.lastEnvPath != "/tmp/helix-org-envs/w-alice" {
+		t.Errorf("envPath = %q, want /tmp/helix-org-envs/w-alice", disp.lastEnvPath)
+	}
+
+	// Audit row must be persisted with the same ID so the Spawner
+	// picks it up and Completes it instead of writing a sibling.
+	row, err := st.Activations.Get(ctx, "org-test", activation.ID(resp.ActivationID))
+	if err != nil {
+		t.Fatalf("activation row missing: %v", err)
+	}
+	if row.WorkerID != "w-alice" {
+		t.Errorf("activation row WorkerID = %q, want w-alice", row.WorkerID)
+	}
+	if len(row.Triggers) != 1 || row.Triggers[0].Kind != activation.TriggerManual {
+		t.Errorf("activation row triggers = %+v, want [manual]", row.Triggers)
+	}
+}
+
+// TestActivateWorker_AllowsHumanWorker pins the no-kind-gating
+// contract: every identity in helix-org (owner + hired humans + AI
+// workers) has a chat agent and a desktop, and Restart Desktop must
+// work uniformly across all of them. The endpoint runs the same
+// pipeline regardless of kind — ensureProject (which re-attaches the
+// helix-org MCP) and a TriggerManual enqueue.
+func TestActivateWorker_AllowsHumanWorker(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	ctx := context.Background()
+	seedOwnerPosition(t, st, ctx)
+	human, err := orgchart.NewHumanWorker("w-human", "p-root", "human identity", "org-test")
+	if err != nil {
+		t.Fatalf("NewHumanWorker: %v", err)
+	}
+	if err := st.Workers.Create(ctx, human); err != nil {
+		t.Fatalf("create human worker: %v", err)
+	}
+
+	ensurer := &fakeEnsurer{projectID: "prj_human", agentApp: "app_human"}
+	disp := &fakeDispatcher{}
+	deps.ProjectEnsurer = ensurer
+	deps.Dispatcher = disp
+	h := orgapi.Handler(deps)
+
+	rec := do(t, h, "POST", "/workers/w-human/activate", nil)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", rec.Code, rec.Body)
+	}
+	if ensurer.calls != 1 {
+		t.Errorf("Ensure must run for human worker; got %d calls", ensurer.calls)
+	}
+	if disp.manualCalls != 1 {
+		t.Errorf("DispatchManual must run for human worker; got %d calls", disp.manualCalls)
+	}
+}
+
+// TestActivateWorker_EnsureFailureDoesNotEnqueue pins the synchronous-
+// ensureProject contract. If the MCP-attaching step fails, we must
+// surface the error to the operator (500) and skip the enqueue —
+// queueing an activation against a missing project leaves a dangling
+// audit row and confuses the worker's activation timeline.
+func TestActivateWorker_EnsureFailureDoesNotEnqueue(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	ctx := context.Background()
+	seedOwnerPosition(t, st, ctx)
+	mustCreateAIWorker(t, st, ctx, "w-alice", "p-root", "alice identity")
+
+	ensurer := &fakeEnsurer{err: errors.New("apply project failed")}
+	disp := &fakeDispatcher{}
+	deps.ProjectEnsurer = ensurer
+	deps.Dispatcher = disp
+	h := orgapi.Handler(deps)
+
+	rec := do(t, h, "POST", "/workers/w-alice/activate", nil)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", rec.Code, rec.Body)
+	}
+	if disp.manualCalls != 0 {
+		t.Errorf("DispatchManual must not run when ensureProject failed; got %d", disp.manualCalls)
+	}
+
+	// No audit row should have been written either — the
+	// pre-allocation happens after the ensureProject step.
+	rows, err := st.Activations.ListForWorker(ctx, "org-test", "w-alice", 10)
+	if err != nil {
+		t.Fatalf("list activations: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("activation rows = %d, want 0", len(rows))
+	}
+}
+
+// TestActivateWorker_404OnUnknownWorker pins the not-found path so a
+// stale UI link returns a useful 404 rather than a 500 from the
+// ensurer (the ProjectEnsurer needs a worker row to do its work).
+func TestActivateWorker_404OnUnknownWorker(t *testing.T) {
+	deps, _, _ := newDeps(t)
+	deps.ProjectEnsurer = &fakeEnsurer{}
+	deps.Dispatcher = &fakeDispatcher{}
+	h := orgapi.Handler(deps)
+
+	rec := do(t, h, "POST", "/workers/w-ghost/activate", nil)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", rec.Code, rec.Body)
+	}
+}
+
+// TestActivateWorker_NotImplementedWithoutDeps pins the wiring
+// failure mode: if either ProjectEnsurer or Dispatcher is nil in
+// Deps (e.g. helix-org disabled by feature flag), the endpoint
+// returns 501 instead of nil-derefing.
+func TestActivateWorker_NotImplementedWithoutDeps(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		setup func(d *orgapi.Deps)
+	}{
+		{"no ProjectEnsurer", func(d *orgapi.Deps) { d.Dispatcher = &fakeDispatcher{} }},
+		{"no Dispatcher", func(d *orgapi.Deps) { d.ProjectEnsurer = &fakeEnsurer{} }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			deps, st, _ := newDeps(t)
+			ctx := context.Background()
+			seedOwnerPosition(t, st, ctx)
+			mustCreateAIWorker(t, st, ctx, "w-alice", "p-root", "")
+			tc.setup(&deps)
+			h := orgapi.Handler(deps)
+			rec := do(t, h, "POST", "/workers/w-alice/activate", nil)
+			if rec.Code != http.StatusNotImplemented {
+				t.Fatalf("status = %d, want 501; body=%s", rec.Code, rec.Body)
+			}
+		})
+	}
+}
+
+// silence unused-import warnings if a later test removes the only
+// reference to one of these.
+var (
+	_ = json.Marshal
+	_ = httptest.NewRecorder
+	_ = store.ErrNotFound
+)

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -20,6 +20,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
 	"github.com/helixml/helix/api/pkg/org/application/streamhub"
 	"github.com/helixml/helix/api/pkg/org/application/tools"
+	"github.com/helixml/helix/api/pkg/org/domain/activation"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/org/domain/store"
 	"github.com/helixml/helix/api/pkg/org/domain/streaming"
@@ -28,6 +29,8 @@ import (
 	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
 	githubtransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/github"
 	helixorgserver "github.com/helixml/helix/api/pkg/org/interfaces/server"
+
+	"path/filepath"
 )
 
 // resolveOrgID returns the orgID stashed on ctx by the helix-org
@@ -47,6 +50,11 @@ func resolveOrgID(r *http.Request) (string, error) {
 // one-directional — server/api is below server, not next to it.
 type Dispatcher interface {
 	Dispatch(ctx context.Context, ev streaming.Event)
+	// DispatchManual enqueues an operator-driven activation for the
+	// given Worker. Called by activateWorker after the synchronous
+	// ensureProject step. activationID is the pre-allocated audit-row
+	// ID; empty means the Spawner mints its own.
+	DispatchManual(ctx context.Context, orgID string, workerID orgchart.WorkerID, envPath string, activationID activation.ID)
 }
 
 // ProjectEnsurer provisions (or fast-paths) the per-Worker Helix
@@ -172,6 +180,7 @@ func Routes(deps Deps) []Route {
 		{Pattern: "GET /workers/{id}", Handler: http.HandlerFunc(a.getWorker)},
 		{Pattern: "DELETE /workers/{id}", Handler: http.HandlerFunc(a.fireWorker)},
 		{Pattern: "POST /workers/{id}/chat", Handler: http.HandlerFunc(a.ensureWorkerChat)},
+		{Pattern: "POST /workers/{id}/activate", Handler: http.HandlerFunc(a.activateWorker)},
 		{Pattern: "POST /workers/{id}/role", Handler: http.HandlerFunc(a.updateWorkerRole)},
 		{Pattern: "POST /workers/{id}/identity", Handler: http.HandlerFunc(a.updateWorkerIdentity)},
 		{Pattern: "GET /tools", Handler: http.HandlerFunc(a.listTools)},
@@ -706,6 +715,119 @@ func (a *apiHandler) ensureWorkerChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, WorkerChatDTO{AgentAppID: agentAppID, ProjectID: projectID})
+}
+
+// activateWorker manually triggers an activation for a Worker. The
+// worker page's "Start Desktop" button hits this endpoint instead of
+// /sessions/{id}/resume so the full activation pipeline runs:
+// ensureProject → AttachHelixOrgMCP → ensureSession → Helix spins
+// up the desktop container as part of the session start. This is the
+// path that guarantees the helix-org MCP entry is present on the
+// agent app when Zed reads /sessions/{id}/zed-config inside the
+// container — plain resume reads but doesn't write Config.Helix, so
+// it can't fix an MCP-clobbered agent app on its own.
+//
+// Synchronous up to ensureProject so the response carries the
+// project + agent_app IDs the UI needs to navigate the user to the
+// desktop. The session-start work runs async on the per-Worker
+// queue inside the dispatcher.
+//
+// @Summary Helix-org: manually trigger a worker activation
+// @Tags HelixOrg
+// @Param id path string true "Worker ID"
+// @Success 202 {object} api.WorkerActivateDTO
+// @Failure 404 {object} api.ErrorResponse
+// @Failure 501 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/workers/{id}/activate [post]
+func (a *apiHandler) activateWorker(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if a.deps.ProjectEnsurer == nil {
+		writeError(w, http.StatusNotImplemented, errors.New("project ensurer not wired"))
+		return
+	}
+	if a.deps.Dispatcher == nil {
+		writeError(w, http.StatusNotImplemented, errors.New("dispatcher not wired"))
+		return
+	}
+	orgID, err := resolveOrgID(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	id := orgchart.WorkerID(r.PathValue("id"))
+	if id == "" {
+		writeError(w, http.StatusBadRequest, errors.New("worker id is required"))
+		return
+	}
+	if _, err := a.deps.Store.Workers.Get(ctx, orgID, id); err != nil {
+		writeError(w, errStatus(err), fmt.Errorf("get worker %s: %w", id, err))
+		return
+	}
+	// Every identity in helix-org (human or AI, owner or hired) has a
+	// chat agent and a desktop; activation runs the same pipeline for
+	// all of them. No kind gating — the UI calls this for any worker
+	// the operator clicks Restart Desktop on.
+
+	// 1. Synchronously ensure the project + MCP attach. Side effect:
+	// dynamicProjectApplier.Ensure re-attaches the helix-org MCP on
+	// the agent app, which is the immediate user-visible fix the
+	// operator clicked Start Desktop for.
+	projectID, agentAppID, _, err := a.deps.ProjectEnsurer.Ensure(ctx, orgID, id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Errorf("ensure project for %s: %w", id, err))
+		return
+	}
+
+	// 2. Look up the persisted session id (may be empty if this is
+	// the first activation). The UI uses it to navigate straight to
+	// the desktop viewer; on first activation, it'll wait for the
+	// next state refresh.
+	var sessionID string
+	if state, err := runtimehelix.LoadState(ctx, a.deps.Store, orgID, id); err == nil {
+		sessionID = state.SessionID
+	}
+
+	// 3. Pre-allocate the audit row so the response can carry the
+	// activation_id synchronously. Mirrors hire_worker's pattern —
+	// the Spawner picks the row up (matched by Trigger.ActivationID)
+	// and Completes it when the activation finishes, rather than
+	// minting a sibling.
+	var activationID activation.ID
+	if a.deps.Store.Activations != nil && a.deps.NewID != nil && a.deps.Now != nil {
+		activationID = activation.ID("a-" + a.deps.NewID())
+		act, err := activation.New(
+			activationID,
+			id,
+			[]activation.Trigger{{Kind: activation.TriggerManual}},
+			a.deps.Now(),
+			orgID,
+		)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Errorf("build manual activation: %w", err))
+			return
+		}
+		if err := a.deps.Store.Activations.Create(ctx, act); err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Errorf("persist manual activation: %w", err))
+			return
+		}
+	}
+
+	// 4. Enqueue. The dispatcher's per-Worker queue coalesces with
+	// any in-flight activation, so a double-click on Start Desktop
+	// folds into a single follow-up rather than two parallel runs.
+	envPath := ""
+	if a.deps.EnvsDir != "" {
+		envPath = filepath.Join(a.deps.EnvsDir, string(id))
+	}
+	a.deps.Dispatcher.DispatchManual(ctx, orgID, id, envPath, activationID)
+
+	writeJSON(w, http.StatusAccepted, WorkerActivateDTO{
+		ActivationID: string(activationID),
+		ProjectID:    projectID,
+		AgentAppID:   agentAppID,
+		SessionID:    sessionID,
+	})
 }
 
 // updateWorkerIdentity rewrites a Worker's IdentityContent. The

--- a/api/pkg/org/interfaces/server/api/dto.go
+++ b/api/pkg/org/interfaces/server/api/dto.go
@@ -92,6 +92,21 @@ type WorkerChatDTO struct {
 	ProjectID  string `json:"project_id,omitempty"`
 }
 
+// WorkerActivateDTO is the POST /workers/{id}/activate response. The
+// handler runs ensureProject synchronously (so ProjectID and
+// AgentAppID are always populated on a 202) then enqueues the manual
+// activation. SessionID is the persisted per-Worker chat session id
+// from WorkerRuntimeState; empty until the first activation has run
+// at least once. ActivationID is the pre-allocated audit-row id so
+// the UI can poll activation progress without a follow-up listing
+// round-trip.
+type WorkerActivateDTO struct {
+	ActivationID string `json:"activation_id,omitempty"`
+	ProjectID    string `json:"project_id,omitempty"`
+	AgentAppID   string `json:"agent_app_id,omitempty"`
+	SessionID    string `json:"session_id,omitempty"`
+}
+
 // WorkerDetailDTO is the full GET /workers/{id} response — Worker
 // fields plus the surrounding context the UI's detail pane needs
 // (the role markdown of the Position the Worker fills, sibling worker

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -10526,6 +10526,48 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/orgs/{org}/workers/{id}/activate": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: manually trigger a worker activation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/api.WorkerActivateDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/workers/{id}/chat": {
             "post": {
                 "security": [
@@ -20742,6 +20784,23 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "content": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.WorkerActivateDTO": {
+            "type": "object",
+            "properties": {
+                "activation_id": {
+                    "type": "string"
+                },
+                "agent_app_id": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "session_id": {
                     "type": "string"
                 }
             }

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -429,12 +429,28 @@ type dynamicProjectApplier struct {
 // runtimehelix.WorkerProject from the current registry state and
 // delegates. WorkerProject.Ensure is itself idempotent — first call
 // applies, subsequent calls fast-path on the existing project.
+//
+// After Ensure succeeds, re-attaches the helix-org MCP entry on the
+// per-Worker agent app. ApplyProject (called inside WorkerProject.Ensure)
+// wholesale-replaces Config.Helix on update, so any MCPs we attached
+// previously are wiped — we re-attach here to keep the MCP present.
+// The Spawner does the same on its own activations; owner-chat goes
+// through this path only.
 func (d *dynamicProjectApplier) Ensure(ctx context.Context, orgID string, workerID orgchart.WorkerID) (projectID, agentAppID, repoID string, err error) {
-	applier, err := buildHelixOrgProjectApplier(ctx, orgID, d.cfg, d.projectSvc, d.Store, d.logger)
+	applier, mcpBearer, err := buildHelixOrgProjectApplier(ctx, orgID, d.cfg, d.projectSvc, d.Store, d.logger)
 	if err != nil {
 		return "", "", "", err
 	}
-	return applier.Ensure(ctx, orgID, workerID)
+	projectID, agentAppID, repoID, err = applier.Ensure(ctx, orgID, workerID)
+	if err != nil {
+		return "", "", "", err
+	}
+	if agentAppID != "" && applier.HelixOrgURL != "" {
+		if attachErr := runtimehelix.AttachHelixOrgMCP(ctx, d.projectSvc, agentAppID, applier.HelixOrgURL, workerID, mcpBearer); attachErr != nil && d.logger != nil {
+			d.logger.Warn("dynamic project applier: attach helix-org MCP", "worker", workerID, "app", agentAppID, "err", attachErr)
+		}
+	}
+	return projectID, agentAppID, repoID, nil
 }
 
 // buildHelixOrgProjectApplier constructs the WorkerProject that
@@ -450,6 +466,12 @@ func (d *dynamicProjectApplier) Ensure(ctx context.Context, orgID string, worker
 // (worker.runtime/credentials/provider/model, helix.url/api_key)
 // take effect immediately. The struct it returns is cheap to build
 // and short-lived — one apply call, then discarded.
+//
+// Also returns the service api_key as a separate value (mcpBearer)
+// for the caller to feed into runtimehelix.AttachHelixOrgMCP as the
+// fallback bearer when no per-request bearer is on ctx. The bearer
+// is no longer carried on WorkerProject because Ensure doesn't touch
+// MCPs — MCP attachment is a separate, explicit step.
 func buildHelixOrgProjectApplier(
 	ctx context.Context,
 	orgID string,
@@ -457,30 +479,35 @@ func buildHelixOrgProjectApplier(
 	projectSvc runtimehelix.ProjectService,
 	orgStore *helixorgstore.Store,
 	logger *slog.Logger,
-) (*runtimehelix.WorkerProject, error) {
+) (*runtimehelix.WorkerProject, string, error) {
 	apiKey, _ := cfg.GetString(ctx, orgID, "helix.api_key")
 	if apiKey == "" {
-		return nil, fmt.Errorf("helix.api_key not set")
+		return nil, "", fmt.Errorf("helix.api_key not set")
 	}
 	baseURL, err := cfg.GetString(ctx, orgID, "helix.url")
 	if err != nil {
-		return nil, fmt.Errorf("read helix.url: %w", err)
+		return nil, "", fmt.Errorf("read helix.url: %w", err)
 	}
 	runtime, credentials, provider, model := resolveWorkerAgentConfig(ctx, orgID, cfg)
-	helixOrgURL := strings.TrimRight(baseURL, "/") + "/api/v1/mcp/helix-org"
+	// HelixOrgMCPBackend.ServeHTTP parses `<org>/workers/<id>/mcp`
+	// from the suffix path, so the org segment is required in the
+	// URL Zed will dial. The previous form
+	// `/api/v1/mcp/helix-org/workers/<id>/mcp` made the backend read
+	// "workers" as the org slug and 404 every request — the helix-org
+	// MCP was effectively unreachable from inside the sandbox.
+	helixOrgURL := strings.TrimRight(baseURL, "/") + "/api/v1/mcp/helix-org/" + orgID
 	return &runtimehelix.WorkerProject{
-		Service:       projectSvc,
-		Workspace:     helixOrgWorkspaceRef,
-		Store:         orgStore,
-		HelixOrgURL:   helixOrgURL,
-		OrgID:         orgID,
-		Runtime:       runtime,
-		Credentials:   credentials,
-		Provider:      provider,
-		Model:         model,
-		MCPAuthBearer: apiKey,
-		Logger:        logger,
-	}, nil
+		Service:     projectSvc,
+		Workspace:   helixOrgWorkspaceRef,
+		Store:       orgStore,
+		HelixOrgURL: helixOrgURL,
+		OrgID:       orgID,
+		Runtime:     runtime,
+		Credentials: credentials,
+		Provider:    provider,
+		Model:       model,
+		Logger:      logger,
+	}, apiKey, nil
 }
 
 // helixOrgWorkspaceRef is the production Workspace, set at
@@ -611,7 +638,13 @@ func buildHelixOrgSpawnerConfig(
 	}
 
 	runtime, credentials, provider, model := resolveWorkerAgentConfig(ctx, orgID, cfg)
-	helixOrgURL := strings.TrimRight(baseURL, "/") + "/api/v1/mcp/helix-org"
+	// HelixOrgMCPBackend.ServeHTTP parses `<org>/workers/<id>/mcp`
+	// from the suffix path, so the org segment is required in the
+	// URL Zed will dial. The previous form
+	// `/api/v1/mcp/helix-org/workers/<id>/mcp` made the backend read
+	// "workers" as the org slug and 404 every request — the helix-org
+	// MCP was effectively unreachable from inside the sandbox.
+	helixOrgURL := strings.TrimRight(baseURL, "/") + "/api/v1/mcp/helix-org/" + orgID
 	specsMandate, _ := cfg.GetString(ctx, orgID, "worker.specs_mandate")
 	return runtimehelix.SpawnerConfig{
 		Client:         spawnerClient,

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -245,7 +245,14 @@ func (c *inProcHelixClient) PutProjectSecret(ctx context.Context, projectID, nam
 		return nil
 	}
 
-	updateBody := types.Secret{Value: []byte(value)}
+	// updateSecret decodes the body into a fresh types.Secret and
+	// preserves Owner/ProjectID/AppID from the existing row — but NOT
+	// Name. If we omit Name here it gets blanked to "", and
+	// GetProjectSecretsAsEnvVars later emits an env var "=<value>",
+	// which Docker rejects as `invalid environment variable: =<value>`
+	// at container-create time. Always pass Name so the row keeps its
+	// identity.
+	updateBody := types.Secret{Name: name, Value: []byte(value)}
 	r, err := c.newRequest(ctx, http.MethodPut, "/api/v1/secrets/"+existingID, updateBody, map[string]string{"id": existingID})
 	if err != nil {
 		return err
@@ -323,7 +330,7 @@ func (c *inProcHelixClient) CreateBranch(ctx context.Context, repoID, branch, ba
 }
 
 // GetAppConfig returns the typed config for an App. Used by
-// WorkerProject.attachMCPToApp to round-trip MCP entries.
+// runtimehelix.AttachHelixOrgMCP to round-trip MCP entries.
 func (c *inProcHelixClient) GetAppConfig(ctx context.Context, id string) (types.AppConfig, error) {
 	r, err := c.newRequest(ctx, http.MethodGet, "/api/v1/apps/"+id, nil, map[string]string{"id": id})
 	if err != nil {

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -10522,6 +10522,48 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/workers/{id}/activate": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: manually trigger a worker activation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/api.WorkerActivateDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/workers/{id}/chat": {
             "post": {
                 "security": [
@@ -20738,6 +20780,23 @@
             "type": "object",
             "properties": {
                 "content": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.WorkerActivateDTO": {
+            "type": "object",
+            "properties": {
+                "activation_id": {
+                    "type": "string"
+                },
+                "agent_app_id": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "session_id": {
                     "type": "string"
                 }
             }

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -379,6 +379,17 @@ definitions:
       content:
         type: string
     type: object
+  api.WorkerActivateDTO:
+    properties:
+      activation_id:
+        type: string
+      agent_app_id:
+        type: string
+      project_id:
+        type: string
+      session_id:
+        type: string
+    type: object
   api.WorkerBadge:
     properties:
       id:
@@ -18095,6 +18106,32 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: 'Helix-org: get worker detail'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/workers/{id}/activate:
+    post:
+      parameters:
+      - description: Worker ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/api.WorkerActivateDTO'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: manually trigger a worker activation'
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/workers/{id}/chat:

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -251,6 +251,13 @@ export interface ApiUpdateWorkerRoleRequest {
   content?: string;
 }
 
+export interface ApiWorkerActivateDTO {
+  activation_id?: string;
+  agent_app_id?: string;
+  project_id?: string;
+  session_id?: string;
+}
+
 export interface ApiWorkerBadge {
   id?: string;
   kind?: string;
@@ -12184,6 +12191,23 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         method: "GET",
         secure: true,
         format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsWorkersActivateCreate
+     * @summary Helix-org: manually trigger a worker activation
+     * @request POST:/api/v1/orgs/{org}/workers/{id}/activate
+     * @secure
+     */
+    v1OrgsWorkersActivateCreate: (id: string, org: string, params: RequestParams = {}) =>
+      this.request<ApiWorkerActivateDTO, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/workers/${id}/activate`,
+        method: "POST",
+        secure: true,
         ...params,
       }),
 

--- a/frontend/src/pages/HelixOrgWorkerDetail.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.tsx
@@ -29,6 +29,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline'
+import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew'
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined'
 
 import Page from '../components/system/Page'
@@ -40,6 +41,7 @@ import useApi from '../hooks/useApi'
 import useRouter from '../hooks/useRouter'
 import useSnackbar from '../hooks/useSnackbar'
 import {
+  useActivateWorker,
   useEnsureWorkerChat,
   useFireHelixOrgWorker,
   useHelixOrgWorker,
@@ -62,6 +64,7 @@ const HelixOrgWorkerDetail: FC = () => {
   const { data, isLoading } = useHelixOrgWorker(workerId)
   const fire = useFireHelixOrgWorker()
   const ensureChat = useEnsureWorkerChat()
+  const activate = useActivateWorker()
   const [confirmingFire, setConfirmingFire] = useState(false)
 
   const isOwner = workerId === OWNER_WORKER
@@ -146,6 +149,31 @@ const HelixOrgWorkerDetail: FC = () => {
     }
   }
 
+  // handleRestartDesktop manually triggers a fresh activation for this
+  // Worker. The /activate endpoint runs ensureProject synchronously
+  // (which re-attaches the helix-org MCP that helix's project-apply
+  // wipes on update), then enqueues a manual trigger; the spawner
+  // picks it up, opens or resumes the per-Worker chat session, and
+  // helix spins the desktop container back up as part of session
+  // start. The intended use case: the operator stopped the desktop
+  // ("reset it") and wants it back online with the MCP correctly
+  // attached. Plain "resume" doesn't re-attach because it only
+  // restarts the container — Config.Helix isn't touched.
+  //
+  // We stay on this page rather than navigating: the user's desktop
+  // tab may already be open in another window; if not, "Open Human
+  // Desktop" above is one click away.
+  const handleRestartDesktop = async () => {
+    if (!workerId) return
+    if (activate.isPending) return
+    try {
+      await activate.mutateAsync(workerId)
+      snackbar.success('Activation queued — desktop will come up shortly')
+    } catch (err: any) {
+      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'activate failed')
+    }
+  }
+
   const handleFire = async () => {
     if (!workerId) return
     try {
@@ -226,17 +254,42 @@ const HelixOrgWorkerDetail: FC = () => {
                       label flips to "Launching Human Desktop…"); subsequent clicks open
                       the same session immediately.
                     </Typography>
-                    <Button
-                      variant="contained"
-                      color="secondary"
-                      startIcon={launching ? <CircularProgress size={16} color="inherit" /> : <ChatBubbleOutlineIcon />}
-                      onClick={openChat}
-                      disabled={launching}
-                    >
-                      {launching
-                        ? 'Launching Human Desktop…'
-                        : (projectID ? 'Open Human Desktop' : 'Provision + open Human Desktop')}
-                    </Button>
+                    <Stack direction="row" spacing={1} flexWrap="wrap">
+                      <Button
+                        variant="contained"
+                        color="secondary"
+                        startIcon={launching ? <CircularProgress size={16} color="inherit" /> : <ChatBubbleOutlineIcon />}
+                        onClick={openChat}
+                        disabled={launching}
+                      >
+                        {launching
+                          ? 'Launching Human Desktop…'
+                          : (projectID ? 'Open Human Desktop' : 'Provision + open Human Desktop')}
+                      </Button>
+                      {/* Restart Desktop kicks a fresh manual
+                          activation. Re-attaches the helix-org MCP
+                          and brings the container back up after a
+                          manual stop. Every identity has the same
+                          chat+desktop surface, so the button shows
+                          for all workers — human and AI — once the
+                          worker has been provisioned at least once
+                          (no agent app to activate against
+                          otherwise). */}
+                      <Button
+                        variant="outlined"
+                        color="secondary"
+                        startIcon={activate.isPending ? <CircularProgress size={16} color="inherit" /> : <PowerSettingsNewIcon />}
+                        onClick={handleRestartDesktop}
+                        disabled={activate.isPending || !projectID}
+                      >
+                        {activate.isPending ? 'Activating…' : 'Restart Desktop'}
+                      </Button>
+                    </Stack>
+                    {!projectID && (
+                      <Typography variant="caption" color="text.secondary">
+                        Restart Desktop is available after the first "Open Human Desktop".
+                      </Typography>
+                    )}
                   </Stack>
                 </Paper>
 

--- a/frontend/src/services/helixOrgService.ts
+++ b/frontend/src/services/helixOrgService.ts
@@ -23,6 +23,7 @@ import {
   ApiStreamsResponse,
   ApiToolDTO,
   ApiUpdateStreamRequest,
+  ApiWorkerActivateDTO,
   ApiWorkerBadge,
   ApiWorkerChatDTO,
   ApiWorkerDTO,
@@ -116,6 +117,28 @@ export function useEnsureWorkerChat() {
     },
     onSuccess: (_data, workerId) => {
       qc.invalidateQueries({ queryKey: QUERY_KEYS.worker(orgID, workerId) })
+    },
+  })
+}
+
+// useActivateWorker manually triggers an activation for a Worker.
+// Wired to the worker page's "Start Desktop" button so the click goes
+// through the full activation pipeline (ensureProject → AttachHelixOrgMCP
+// → ensureSession → container start) instead of the generic
+// /sessions/{id}/resume — which doesn't re-attach the helix-org MCP
+// and so leaves the desktop without the org-graph tools.
+//
+// The accepts an orgID override so callers that aren't running inside
+// the helix-org base context (e.g. TeamDesktopPage opened in a new
+// tab from the worker detail page) can pass the org slug explicitly.
+export function useActivateWorker(orgIDOverride?: string) {
+  const api = useApi()
+  const { orgID: baseOrgID } = useHelixOrgBase()
+  const orgID = orgIDOverride ?? baseOrgID
+  return useMutation({
+    mutationFn: async (workerId: string) => {
+      const res = await api.getApiClient().v1OrgsWorkersActivateCreate(workerId, orgID)
+      return res.data as ApiWorkerActivateDTO
     },
   })
 }

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -379,6 +379,17 @@ definitions:
       content:
         type: string
     type: object
+  api.WorkerActivateDTO:
+    properties:
+      activation_id:
+        type: string
+      agent_app_id:
+        type: string
+      project_id:
+        type: string
+      session_id:
+        type: string
+    type: object
   api.WorkerBadge:
     properties:
       id:
@@ -18095,6 +18106,32 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: 'Helix-org: get worker detail'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/workers/{id}/activate:
+    post:
+      parameters:
+      - description: Worker ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/api.WorkerActivateDTO'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: manually trigger a worker activation'
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/workers/{id}/chat:

--- a/openapi.json
+++ b/openapi.json
@@ -12620,6 +12620,62 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/workers/{id}/activate": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: manually trigger a worker activation",
+                "parameters": [
+                    {
+                        "description": "Worker ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.WorkerActivateDTO"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/workers/{id}/chat": {
             "post": {
                 "security": [
@@ -24940,6 +24996,23 @@
                 "type": "object",
                 "properties": {
                     "content": {
+                        "type": "string"
+                    }
+                }
+            },
+            "api.WorkerActivateDTO": {
+                "type": "object",
+                "properties": {
+                    "activation_id": {
+                        "type": "string"
+                    },
+                    "agent_app_id": {
+                        "type": "string"
+                    },
+                    "project_id": {
+                        "type": "string"
+                    },
+                    "session_id": {
                         "type": "string"
                     }
                 }

--- a/swagger.json
+++ b/swagger.json
@@ -10522,6 +10522,48 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/workers/{id}/activate": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: manually trigger a worker activation",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/api.WorkerActivateDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/workers/{id}/chat": {
             "post": {
                 "security": [
@@ -20738,6 +20780,23 @@
             "type": "object",
             "properties": {
                 "content": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.WorkerActivateDTO": {
+            "type": "object",
+            "properties": {
+                "activation_id": {
+                    "type": "string"
+                },
+                "agent_app_id": {
+                    "type": "string"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "session_id": {
                     "type": "string"
                 }
             }


### PR DESCRIPTION
## Summary
- Implements manual worker activation endpoint allowing operators to restart paused desktops and re-attach helix-org MCP server
- All worker identities (human, AI, owner) follow uniform activation behavior with no kind-based gating
- Fixes MCP disappearance on session restart by re-attaching after config updates
- Fixes multi-tenant routing for helix-org MCP server
- Fixes secret injection issue where empty Name field caused invalid environment variables

## Testing
- End-to-end tested with Playwright: clicked "Restart Desktop" button on human and AI workers
- Verified activations through API logs
- Confirmed MCP server appears in Zed and connects successfully
- Verified uniform behavior across all worker types without kind checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)