### PR TITLE
fix(frontend): show field-level error on HireDrawer when identity is empty

### DIFF
--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -983,10 +983,11 @@ const HireDrawer: FC<{ positionId: string; onClose: () => void }> = ({ positionI
   const [id, setId] = useState('')
   const [kind, setKind] = useState<'ai' | 'human'>('human')
   const [identity, setIdentity] = useState('')
+  const [identityError, setIdentityError] = useState(false)
 
   const submit = async () => {
     if (!identity.trim()) {
-      snackbar.error('identity content is required')
+      setIdentityError(true)
       return
     }
     const body: HireWorkerRequest = {
@@ -1034,10 +1035,13 @@ const HireDrawer: FC<{ positionId: string; onClose: () => void }> = ({ positionI
           label="Identity content"
           placeholder="Short persona / profile in markdown."
           value={identity}
-          onChange={(e) => setIdentity(e.target.value)}
+          onChange={(e) => { setIdentity(e.target.value); if (e.target.value.trim()) setIdentityError(false) }}
           multiline
           minRows={6}
           fullWidth
+          required
+          error={identityError}
+          helperText={identityError ? 'Identity content is required' : undefined}
         />
         <Stack direction="row" spacing={1} sx={{ pt: 1 }}>
           <Button variant="contained" onClick={submit} disabled={hire.isPending}>


### PR DESCRIPTION
## Summary

Fixes https://github.com/helixml/helix/issues/2523

The HIRE button in the Hire Worker drawer silently returned early when **Identity content** was blank — no API call, no visible error message, no field highlight. The previous code called `snackbar.error()` but the snackbar is rendered in the Layout Portal and isn't reliably visible while a Drawer panel is open.

**Root cause**: `HireDrawer` had no field-level validation state. `submit()` called `snackbar.error()` then returned, but with no visual feedback on the field itself the user had no cue that the field was required.

**Fix**: Replace the snackbar-only path with inline field validation:
- Add `identityError` state (boolean).
- On HIRE click with an empty field: set `identityError=true` (shows red border + helper text "Identity content is required"), do **not** call the API.
- Clear the error as soon as the user starts typing a non-whitespace character.
- Add `required` prop to the TextField so the label shows the `*` indicator.

## Test plan

- [ ] Open the org chart → click **Hire worker** on any position slot.
- [ ] Leave **Identity content** blank → click **HIRE**. The field turns red with "Identity content is required" below it. No network request is made.
- [ ] Type any character into Identity content → red border clears immediately.
- [ ] Fill the field → click **HIRE** → worker is created (201) and chip appears.