### PR TITLE
fix(helix-org): inline validation error when Identity content is empty on hire

### DIFF
--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -983,10 +983,13 @@ const HireDrawer: FC<{ positionId: string; onClose: () => void }> = ({ positionI
   const [id, setId] = useState('')
   const [kind, setKind] = useState<'ai' | 'human'>('human')
   const [identity, setIdentity] = useState('')
+  const [identityTouched, setIdentityTouched] = useState(false)
+
+  const identityError = identityTouched && !identity.trim()
 
   const submit = async () => {
+    setIdentityTouched(true)
     if (!identity.trim()) {
-      snackbar.error('identity content is required')
       return
     }
     const body: HireWorkerRequest = {
@@ -998,7 +1001,7 @@ const HireDrawer: FC<{ positionId: string; onClose: () => void }> = ({ positionI
     try {
       const res = await hire.mutateAsync(body)
       snackbar.success(`hired ${res.id}`)
-      setId(''); setIdentity(''); onClose()
+      setId(''); setIdentity(''); setIdentityTouched(false); onClose()
     } catch (err: any) {
       snackbar.error(err?.response?.data?.error ?? err?.message ?? 'hire failed')
     }
@@ -1032,9 +1035,13 @@ const HireDrawer: FC<{ positionId: string; onClose: () => void }> = ({ positionI
         <TextField
           size="small"
           label="Identity content"
+          required
           placeholder="Short persona / profile in markdown."
           value={identity}
           onChange={(e) => setIdentity(e.target.value)}
+          onBlur={() => setIdentityTouched(true)}
+          error={identityError}
+          helperText={identityError ? 'Identity content is required' : undefined}
           multiline
           minRows={6}
           fullWidth


### PR DESCRIPTION
## Summary

Fixes #2523 — HIRE button silently no-ops when Identity content is empty.

### Root cause
The `HireDrawer` submit handler validated `identity_content` and called `snackbar.error(...)`, but the toast was not reliably visible inside the right-side MUI Drawer (the Drawer's backdrop/stacking context obscured it). The button returned early (no API call) but gave no visible feedback.

### Fix
Replace the invisible-toast approach with **inline field validation**:

- `identityTouched` state prevents false positives on drawer open
- On submit with empty field: `setIdentityTouched(true)` makes the error appear immediately
- `onBlur` shows the error pre-emptively if the user tabs past the field  
- The TextField now has `required`, `error`, and `helperText` — red border + inline "Identity content is required" message renders directly on the field, guaranteed visible regardless of z-index

### Behaviour after fix
| Action | Before | After |
|--------|--------|-------|
| Click HIRE, empty identity | Silently returns, nothing shown | Red border + "Identity content is required" below the field |
| Tab out of empty identity field | Nothing | Red border + helperText appears |
| Type into field after error | N/A | Error clears immediately |
| Successful hire | Snackbar `hired w-x` | Snackbar `hired w-x` (unchanged) |

## Test plan
- [ ] Open Hire drawer on any position
- [ ] Click HIRE with empty Identity content → red field border + "Identity content is required" helperText appears
- [ ] Tab away from empty Identity content field → same inline error
- [ ] Type something in Identity content → error clears
- [ ] Fill Identity content and click HIRE → normal hire succeeds, snackbar shows `hired <id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)