### PR TITLE
fix(store/memorystore): add UpdateInteractionStreamingFields + MarkInteractionCompleteIfWaiting stubs

### DIFF
--- a/api/pkg/store/memorystore/memorystore.go
+++ b/api/pkg/store/memorystore/memorystore.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"gorm.io/datatypes"
+
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/types"
@@ -233,6 +235,59 @@ func (m *MemoryStore) UpdateInteraction(_ context.Context, interaction *types.In
 		cb(&cp)
 	}
 	return &cp, nil
+}
+
+// UpdateInteractionStreamingFields mirrors the Postgres column-scoped write
+// from the streaming flush path. It only touches response content / Zed
+// offset+id, so a concurrent state transition (cancel / complete) is never
+// clobbered. Matches the lost-update fix in websocket_external_agent_sync.go.
+func (m *MemoryStore) UpdateInteractionStreamingFields(_ context.Context, interactionID string, generationID int, responseMessage string, responseEntries datatypes.JSON, lastZedMessageOffset int, lastZedMessageID string) error {
+	m.mu.Lock()
+	existing, ok := m.interactions[interactionID]
+	if !ok || existing.GenerationID != generationID {
+		m.mu.Unlock()
+		return nil
+	}
+	existing.ResponseMessage = responseMessage
+	existing.ResponseEntries = responseEntries
+	existing.LastZedMessageOffset = lastZedMessageOffset
+	existing.LastZedMessageID = lastZedMessageID
+	existing.Updated = time.Now()
+	cp := *existing
+	cb := m.OnInteractionUpdated
+	m.mu.Unlock()
+
+	if cb != nil {
+		cb(&cp)
+	}
+	return nil
+}
+
+// MarkInteractionCompleteIfWaiting transitions Waiting → Complete atomically.
+// Returns true only if the row was actually transitioned, so a streaming flush
+// cannot resurrect a cancelled or errored turn as "complete".
+func (m *MemoryStore) MarkInteractionCompleteIfWaiting(_ context.Context, interactionID string, generationID int) (bool, error) {
+	m.mu.Lock()
+	existing, ok := m.interactions[interactionID]
+	if !ok || existing.GenerationID != generationID {
+		m.mu.Unlock()
+		return false, nil
+	}
+	if existing.State != types.InteractionStateWaiting {
+		m.mu.Unlock()
+		return false, nil
+	}
+	existing.State = types.InteractionStateComplete
+	existing.Completed = time.Now()
+	existing.Updated = time.Now()
+	cp := *existing
+	cb := m.OnInteractionUpdated
+	m.mu.Unlock()
+
+	if cb != nil {
+		cb(&cp)
+	}
+	return true, nil
 }
 
 func (m *MemoryStore) ListInteractions(_ context.Context, query *types.ListInteractionsQuery) ([]*types.Interaction, int64, error) {


### PR DESCRIPTION
## Summary

The zed-e2e-test step in CI has been failing since PR #2509 (which added streaming-scoped writes to the store interface) because memorystore was missing two new methods. When called, the embedded nil store.Store panics with 'invalid memory address or nil pointer dereference'.

Root cause: PR #2509 added UpdateInteractionStreamingFields and MarkInteractionCompleteIfWaiting to the store interface, but memorystore (used by the test harness) was not updated with implementations. The embedded nil interface panics on unimplemented methods, and every zed-e2e-test run hits these code paths.

Affected builds (all failures with the same nil panic): 1860, 1865, 1866, 1870, 1876.

## Changes

- UpdateInteractionStreamingFields: column-scoped write that updates response content / Zed offsets without touching state, so concurrent transitions (cancel/complete) are never clobbered. Matches the lost-update fix from websocket_external_agent_sync.go.
- MarkInteractionCompleteIfWaiting: atomic state transition from Waiting → Complete, returns false if the row was already in a terminal state (preventing resurrections).

Both methods are thread-safe, update the Updated timestamp, and fire the OnInteractionUpdated callback so tests can observe completion events.

Closes https://github.com/helixml/helix/issues/2521