### PR TITLE
feat(helix-org): restore ReactFlow org chart (worker-in-role model)

### DIFF
--- a/api/pkg/org/QA.md
+++ b/api/pkg/org/QA.md
@@ -26,8 +26,13 @@ of repeating steps.
   (specialisation) or only the on-call subset of a Role wake up on
   an event (load patterns).
 
-The chart UI is gone. The Overview tab groups Workers by Role
-(role cards, click a Role to edit, click a Worker to open detail).
+The Chart tab is a ReactFlow canvas. Roles are group frames that
+contain their Workers (a Role can hold many Workers). Worker → Worker
+edges are reporting lines derived from `worker.parent_id`; drag from a
+manager's bottom handle to a subordinate to set it, delete the edge to
+clear it. Streams hang off the right; drag from a Worker's right handle
+to a Stream to subscribe. Click a Role header to edit it, a Worker to
+open its detail page.
 
 ## Setup
 
@@ -37,11 +42,11 @@ sidebar. Tests run against `…/orgs/<org>/helix-org/*`.
 
 ## §1. Bootstrap + sidebar
 
-1. Land on `…/helix-org/overview`. Middle sidebar shows highlighted
-   **Overview** plus **Roles / Workers / Streams / Settings**.
-2. Overview shows one Role card: `r-owner` with one Worker badge
+1. Land on `…/helix-org/chart`. Middle sidebar shows highlighted
+   **Chart** plus **Roles / Workers / Streams / Settings**.
+2. Chart shows one Role frame: `r-owner` containing one Worker node
    `w-owner`. No other roles, no other workers.
-3. Network tab: `/overview /workers /roles /streams` requests all
+3. Network tab: `/workers /roles /streams` requests all
    2xx in parallel (bootstrap-race regression — see §1 in prior
    plan: first request used to win, the rest 500-ed with
    `create owner role: already exists`).
@@ -85,8 +90,8 @@ in that Role on their next MCP request.
 Pins the AI-hire path, the owner protections, and the cascade
 dialogs.
 
-1. **+ New Worker** (the Workers tab grew a primary action button
-   now that the chart canvas is gone). Form: `id`, `kind`,
+1. **+ New Worker** (the Workers tab primary action button; the Chart
+   also hires via the per-Role hire icon). Form: `id`, `kind`,
    `role_id` (dropdown), `parent_id` (optional, defaults to
    `w-owner`), `identity_content`.
 2. Submit kind `ai`, id `w-ai-1`, role `r-test-dm`,
@@ -108,7 +113,7 @@ dialogs.
 
 ## §4. Cross-org isolation, persistence, theme
 
-1. Switch to a second org via the top-left selector. Overview
+1. Switch to a second org via the top-left selector. The Chart
    shows the fresh `r-owner / w-owner` baseline — no leakage from
    the first org. Hire something in the second org and switch
    back: first org unchanged.
@@ -116,7 +121,7 @@ dialogs.
    `ResetSchema=true` on production wiring used to drop every
    `org_*` table on boot).
 3. Toggle the top-right sun/moon. Both modes render the
-   overview cards cleanly.
+   Chart canvas (role frames, worker nodes, stream nodes) cleanly.
 
 ## §5. Workers list
 
@@ -219,6 +224,41 @@ the worker detail page → lands on
 (Unchanged. Position-removal did not touch the sandbox /
 spawner pipeline. Procedures in the prior QA.md history.)
 
+## §12. Chart canvas: reporting + subscription drag (regression: position-less reparent)
+
+The Chart is a ReactFlow canvas keyed entirely off `worker.parent_id`
+and worker-anchored subscriptions — there are no Position rows. This
+pins the drag interactions and the `POST /workers/{id}/parent` endpoint.
+
+1. On `…/helix-org/chart`, hire two AI workers into a new role
+   `r-eng` via the role frame's hire icon: `w-alice`, `w-bob`. Both
+   appear as Worker nodes inside the `r-eng` frame with no reporting
+   edges (top-level orphans).
+2. Drag from `w-owner`'s **bottom** handle to `w-alice`'s **top**
+   handle. A solid reporting edge appears; snackbar `w-alice now
+   reports to w-owner`. DB: `SELECT parent_id FROM org_workers WHERE
+   id='w-alice'` → `w-owner`. The `r-owner` frame now sits above
+   `r-eng` (dagre lays the role tree out from the cross-role edge).
+3. Drag from `w-alice`'s bottom handle to `w-bob`'s top handle →
+   `w-bob` reports to `w-alice` (intra-role edge; both stay in
+   `r-eng`).
+4. **Cycle guard**: drag from `w-bob`'s bottom handle to `w-alice`'s
+   top handle (would make alice→bob→alice). API returns 409; snackbar
+   surfaces the cycle error; no edge added. DB unchanged.
+5. Select the `w-owner → w-alice` edge, press **Delete** (and retest
+   with **Backspace**). Edge gone; snackbar `w-alice no longer
+   reports to anyone`; `parent_id` cleared in DB.
+6. Create a stream `s-test` (Streams tab). It appears as a dashed
+   node to the right of the tree. Drag from `w-alice`'s **right**
+   (amber) handle to `s-test` → dashed subscription edge; snackbar
+   `w-alice now consumes s-test`. `GET /streams` shows `w-alice` in
+   subscribers.
+7. Delete the subscription edge → `w-alice` drops from the stream's
+   subscriber list (worker-anchored unsubscribe).
+8. Fire `w-alice` from her node's trash icon → confirm dialog lists
+   that her one direct report (`w-bob`) loses its manager. Confirm;
+   node gone, `w-bob`'s edge to her removed.
+
 ## Pass criteria
 
 - §1 — bootstrap creates one Worker (`w-owner` with `role_id =
@@ -251,7 +291,6 @@ spawner pipeline. Procedures in the prior QA.md history.)
 - A Worker's `parent_id` points at at most one other Worker.
   Hierarchy is a tree (no co-managers in the current model).
 - `w-owner` / `r-owner` are protected at the API; UI hides the
-  trash affordance and surfaces a friendly 409.
-- The Overview tab does not currently visualise the reporting
-  tree (parent_id chains). It groups by Role. Future iteration
-  can layer a tree view on the same data.
+  trash/fire affordance and surfaces a friendly 409.
+- Reparenting is cycle-guarded server-side: dragging a manager edge
+  that would close a reporting loop is rejected with a 409.

--- a/api/pkg/org/domain/orgchart/worker.go
+++ b/api/pkg/org/domain/orgchart/worker.go
@@ -23,6 +23,11 @@ type Worker interface {
 	IdentityContent() string
 	OrganizationID() string
 	WithIdentityContent(content string) Worker
+	// WithParentID returns a copy of the Worker reporting to parent.
+	// A nil parent makes the Worker top-level (no manager); the chart
+	// UI uses this when an edge is deleted. Returns an error if the
+	// parent is the Worker itself or an empty (non-nil) id.
+	WithParentID(parent *WorkerID) (Worker, error)
 	isWorker()
 }
 
@@ -64,6 +69,13 @@ func (h *HumanWorker) OrganizationID() string  { return h.orgID }
 func (h *HumanWorker) WithIdentityContent(content string) Worker {
 	return &HumanWorker{id: h.id, roleID: h.roleID, parentID: cloneParent(h.parentID), identityContent: content, orgID: h.orgID}
 }
+func (h *HumanWorker) WithParentID(parent *WorkerID) (Worker, error) {
+	p, err := validateParent(h.id, parent)
+	if err != nil {
+		return nil, err
+	}
+	return &HumanWorker{id: h.id, roleID: h.roleID, parentID: p, identityContent: h.identityContent, orgID: h.orgID}, nil
+}
 func (h *HumanWorker) isWorker() {}
 
 // AIWorker represents a software agent inside the organisation.
@@ -101,6 +113,13 @@ func (a *AIWorker) IdentityContent() string { return a.identityContent }
 func (a *AIWorker) OrganizationID() string  { return a.orgID }
 func (a *AIWorker) WithIdentityContent(content string) Worker {
 	return &AIWorker{id: a.id, roleID: a.roleID, parentID: cloneParent(a.parentID), identityContent: content, orgID: a.orgID}
+}
+func (a *AIWorker) WithParentID(parent *WorkerID) (Worker, error) {
+	p, err := validateParent(a.id, parent)
+	if err != nil {
+		return nil, err
+	}
+	return &AIWorker{id: a.id, roleID: a.roleID, parentID: p, identityContent: a.identityContent, orgID: a.orgID}, nil
 }
 func (a *AIWorker) isWorker() {}
 

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -176,6 +176,7 @@ func Routes(deps Deps) []Route {
 		{Pattern: "POST /workers/{id}/activate", Handler: http.HandlerFunc(a.activateWorker)},
 		{Pattern: "POST /workers/{id}/role", Handler: http.HandlerFunc(a.updateWorkerRole)},
 		{Pattern: "POST /workers/{id}/identity", Handler: http.HandlerFunc(a.updateWorkerIdentity)},
+		{Pattern: "POST /workers/{id}/parent", Handler: http.HandlerFunc(a.reparentWorker)},
 		{Pattern: "GET /tools", Handler: http.HandlerFunc(a.listTools)},
 		{Pattern: "GET /settings", Handler: http.HandlerFunc(a.listSettings)},
 		{Pattern: "PUT /settings/{key}", Handler: http.HandlerFunc(a.setSetting)},
@@ -780,6 +781,97 @@ func (a *apiHandler) updateWorkerIdentity(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if err := a.deps.Store.Workers.Update(ctx, existing.WithIdentityContent(req.Identity)); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Errorf("update worker: %w", err))
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// reparentWorker sets (or clears) the Worker this one reports to. The
+// chart UI calls it when an accountability edge is drawn between two
+// Worker nodes (set parent) or deleted (clear parent, empty body).
+//
+// Validation beyond the domain's self-parent check:
+//   - a non-empty parent must reference a Worker that exists in the org
+//   - the new parent must not be a descendant of this Worker, which
+//     would create a reporting cycle
+//
+// @Summary Helix-org: set worker parent (reporting line)
+// @Tags HelixOrg
+// @Accept json
+// @Param id path string true "Worker ID"
+// @Param payload body api.UpdateWorkerParentRequest true "New parent worker id ('' to clear)"
+// @Success 204
+// @Failure 400 {object} api.ErrorResponse
+// @Failure 404 {object} api.ErrorResponse
+// @Failure 409 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/workers/{id}/parent [post]
+func (a *apiHandler) reparentWorker(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	orgID, err := resolveOrgID(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	id := orgchart.WorkerID(r.PathValue("id"))
+	if id == "" {
+		writeError(w, http.StatusBadRequest, errors.New("worker id is required"))
+		return
+	}
+	var req UpdateWorkerParentRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	existing, err := a.deps.Store.Workers.Get(ctx, orgID, id)
+	if err != nil {
+		writeError(w, errStatus(err), fmt.Errorf("get worker %s: %w", id, err))
+		return
+	}
+
+	var parent *orgchart.WorkerID
+	parentID := strings.TrimSpace(req.ParentID)
+	if parentID != "" {
+		pid := orgchart.WorkerID(parentID)
+		// The parent must exist before we wire to it.
+		if _, err := a.deps.Store.Workers.Get(ctx, orgID, pid); err != nil {
+			writeError(w, errStatus(err), fmt.Errorf("get parent worker %s: %w", pid, err))
+			return
+		}
+		// Cycle guard: walk up from the proposed parent via parent_id.
+		// If we reach this Worker, the edge would close a loop. We load
+		// the full set once and chase pointers in memory rather than
+		// issuing a Get per hop.
+		all, err := a.deps.Store.Workers.List(ctx, orgID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Errorf("list workers: %w", err))
+			return
+		}
+		byID := make(map[orgchart.WorkerID]orgchart.Worker, len(all))
+		for _, wk := range all {
+			byID[wk.ID()] = wk
+		}
+		for cursor := &pid; cursor != nil; {
+			if *cursor == id {
+				writeError(w, http.StatusConflict, fmt.Errorf("reparenting %s under %s would create a reporting cycle", id, pid))
+				return
+			}
+			wk, ok := byID[*cursor]
+			if !ok {
+				break
+			}
+			cursor = wk.ParentID()
+		}
+		parent = &pid
+	}
+
+	updated, err := existing.WithParentID(parent)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := a.deps.Store.Workers.Update(ctx, updated); err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Errorf("update worker: %w", err))
 		return
 	}

--- a/api/pkg/org/interfaces/server/api/api_test.go
+++ b/api/pkg/org/interfaces/server/api/api_test.go
@@ -246,6 +246,70 @@ func TestPostWorkerRole_UpdatesRoleAssignment(t *testing.T) {
 	}
 }
 
+// TestPostWorkerParent_SetClearCycle pins the chart's drag-to-reparent
+// endpoint: setting a parent persists, an empty body clears it, an
+// unknown parent 404s, and an edge that would close a reporting loop is
+// rejected with 409 (the cycle guard).
+func TestPostWorkerParent_SetClearCycle(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	h := orgapi.Handler(deps)
+	ctx := context.Background()
+
+	seedOwnerPosition(t, st, ctx)
+	mustCreateAIWorker(t, st, ctx, "w-owner", "r-owner", "owner identity")
+	mustCreateAIWorker(t, st, ctx, "w-alice", "r-owner", "alice identity")
+	mustCreateAIWorker(t, st, ctx, "w-bob", "r-owner", "bob identity")
+
+	parentOf := func(id string) string {
+		rec := do(t, h, "GET", "/workers/"+id, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET %s status: got %d, want 200; body=%s", id, rec.Code, rec.Body)
+		}
+		var detail orgapi.WorkerDetailDTO
+		decode(t, rec, &detail)
+		return detail.Worker.ParentID
+	}
+
+	// Set: w-alice reports to w-owner.
+	rec := do(t, h, "POST", "/workers/w-alice/parent", orgapi.UpdateWorkerParentRequest{ParentID: "w-owner"})
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("set parent status: got %d, want 204; body=%s", rec.Code, rec.Body)
+	}
+	if got := parentOf("w-alice"); got != "w-owner" {
+		t.Fatalf("w-alice parent: got %q, want w-owner", got)
+	}
+
+	// Chain: w-bob reports to w-alice.
+	rec = do(t, h, "POST", "/workers/w-bob/parent", orgapi.UpdateWorkerParentRequest{ParentID: "w-alice"})
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("chain parent status: got %d, want 204; body=%s", rec.Code, rec.Body)
+	}
+
+	// Cycle guard: w-alice → w-bob would close w-alice→w-bob→w-alice.
+	rec = do(t, h, "POST", "/workers/w-alice/parent", orgapi.UpdateWorkerParentRequest{ParentID: "w-bob"})
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("cycle status: got %d, want 409; body=%s", rec.Code, rec.Body)
+	}
+	if got := parentOf("w-alice"); got != "w-owner" {
+		t.Fatalf("w-alice parent after rejected cycle: got %q, want unchanged w-owner", got)
+	}
+
+	// Unknown parent → 404.
+	rec = do(t, h, "POST", "/workers/w-alice/parent", orgapi.UpdateWorkerParentRequest{ParentID: "w-ghost"})
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown parent status: got %d, want 404; body=%s", rec.Code, rec.Body)
+	}
+
+	// Clear: empty body makes w-alice top-level again.
+	rec = do(t, h, "POST", "/workers/w-alice/parent", orgapi.UpdateWorkerParentRequest{ParentID: ""})
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("clear parent status: got %d, want 204; body=%s", rec.Code, rec.Body)
+	}
+	if got := parentOf("w-alice"); got != "" {
+		t.Fatalf("w-alice parent after clear: got %q, want empty", got)
+	}
+}
+
 // seedOwnerPosition creates the canonical r-owner / p-root pair that
 // tests hire workers under. Mirrors bootstrap.Run's first two writes
 // without dragging in the bootstrap package's environment-dir

--- a/api/pkg/org/interfaces/server/api/dto.go
+++ b/api/pkg/org/interfaces/server/api/dto.go
@@ -127,6 +127,14 @@ type UpdateWorkerRoleRequest struct {
 	Content string `json:"content"`
 }
 
+// UpdateWorkerParentRequest is the body of POST /workers/{id}/parent.
+// ParentID is the Worker this one now reports to; an empty string
+// clears the manager (the Worker becomes top-level). The chart UI
+// posts this when an accountability edge is drawn or deleted.
+type UpdateWorkerParentRequest struct {
+	ParentID string `json:"parent_id"`
+}
+
 // SettingsSpecDTO is one row in GET /settings.
 type SettingsSpecDTO struct {
 	Key         string `json:"key"`

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -10311,6 +10311,63 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/orgs/{org}/workers/{id}/parent": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: set worker parent (reporting line)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New parent worker id ('' to clear)",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.UpdateWorkerParentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/workers/{id}/role": {
             "post": {
                 "security": [
@@ -20466,6 +20523,14 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "identity": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.UpdateWorkerParentRequest": {
+            "type": "object",
+            "properties": {
+                "parent_id": {
                     "type": "string"
                 }
             }

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -10307,6 +10307,63 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/workers/{id}/parent": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: set worker parent (reporting line)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New parent worker id ('' to clear)",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.UpdateWorkerParentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/workers/{id}/role": {
             "post": {
                 "security": [
@@ -20462,6 +20519,14 @@
             "type": "object",
             "properties": {
                 "identity": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.UpdateWorkerParentRequest": {
+            "type": "object",
+            "properties": {
+                "parent_id": {
                     "type": "string"
                 }
             }

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -294,6 +294,11 @@ definitions:
       identity:
         type: string
     type: object
+  api.UpdateWorkerParentRequest:
+    properties:
+      parent_id:
+        type: string
+    type: object
   api.UpdateWorkerRoleRequest:
     properties:
       content:
@@ -17892,6 +17897,42 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: 'Helix-org: update worker identity'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/workers/{id}/parent:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Worker ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: New parent worker id ('' to clear)
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/api.UpdateWorkerParentRequest'
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: set worker parent (reporting line)'
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/workers/{id}/role:

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -185,6 +185,10 @@ export interface ApiUpdateWorkerIdentityRequest {
   identity?: string;
 }
 
+export interface ApiUpdateWorkerParentRequest {
+  parent_id?: string;
+}
+
 export interface ApiUpdateWorkerRoleRequest {
   content?: string;
 }
@@ -12025,6 +12029,30 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     ) =>
       this.request<void, ApiErrorResponse>({
         path: `/api/v1/orgs/${org}/workers/${id}/identity`,
+        method: "POST",
+        body: payload,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsWorkersParentCreate
+     * @summary Helix-org: set worker parent (reporting line)
+     * @request POST:/api/v1/orgs/{org}/workers/{id}/parent
+     * @secure
+     */
+    v1OrgsWorkersParentCreate: (
+      id: string,
+      org: string,
+      payload: ApiUpdateWorkerParentRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<void, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/workers/${id}/parent`,
         method: "POST",
         body: payload,
         secure: true,

--- a/frontend/src/components/orgs/HelixOrgSidebar.tsx
+++ b/frontend/src/components/orgs/HelixOrgSidebar.tsx
@@ -32,8 +32,8 @@ const HelixOrgSidebar: FC = () => {
     {
       items: [
         {
-          id: 'overview',
-          label: 'Overview',
+          id: 'chart',
+          label: 'Chart',
           icon: <Network size={18} />,
           isActive: currentRouteName === 'helix_org_chart' || currentRouteName === 'helix_org_root',
           onClick: () => navigateTo('helix_org_chart'),

--- a/frontend/src/components/orgs/UserOrgSelector.tsx
+++ b/frontend/src/components/orgs/UserOrgSelector.tsx
@@ -400,7 +400,7 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
       // Projects so it sits with the other primary org-level surfaces.
       ...(helixOrgEnabled ? [{
         icon: <Network size={NAV_BUTTON_SIZE} />,
-        tooltip: "View org overview",
+        tooltip: "View org chart",
         isActive: router.name.startsWith('helix_org'),
         onClick: handleHelixOrgClick,
         label: "Org",

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -1,138 +1,1249 @@
-// HelixOrgChart renders the helix-org overview: every Role with the
-// Workers currently holding it. Replaces the old position-tree canvas
-// after Positions were removed from the domain. The route name
-// `helix_org_chart` is kept so existing deep links keep resolving.
-
-import { FC } from 'react'
+import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
-import Card from '@mui/material/Card'
-import CardContent from '@mui/material/CardContent'
-import Chip from '@mui/material/Chip'
-import Container from '@mui/material/Container'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogContentText from '@mui/material/DialogContentText'
+import DialogTitle from '@mui/material/DialogTitle'
+import Divider from '@mui/material/Divider'
+import Drawer from '@mui/material/Drawer'
+import IconButton from '@mui/material/IconButton'
+import MenuItem from '@mui/material/MenuItem'
 import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
+import AddIcon from '@mui/icons-material/Add'
+import PersonAddOutlinedIcon from '@mui/icons-material/PersonAddOutlined'
+import CloseIcon from '@mui/icons-material/Close'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline'
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined'
 
+import dagre from 'dagre'
+import {
+  Background,
+  Controls,
+  Edge,
+  Handle,
+  MiniMap,
+  Node,
+  NodeProps,
+  Position as RFPosition,
+  ReactFlow,
+  ReactFlowProvider,
+  useEdgesState,
+  useNodesState,
+  useReactFlow,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+
 import Page from '../components/system/Page'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
+import useLightTheme from '../hooks/useLightTheme'
 import useRouter from '../hooks/useRouter'
+import useSnackbar from '../hooks/useSnackbar'
 import {
-  useHelixOrgOverview,
-  WorkerBadge,
+  HireWorkerRequest,
+  WorkerDTO,
+  useCreateHelixOrgRole,
+  useDeleteHelixOrgRole,
+  useDeleteHelixOrgStream,
+  useFireHelixOrgWorker,
+  useHireHelixOrgWorker,
+  useListHelixOrgRoles,
+  useListHelixOrgStreams,
+  useListHelixOrgWorkers,
+  useReparentWorker,
+  useSubscribeWorkerAtChart,
+  useUnsubscribeWorkerAtChart,
 } from '../services/helixOrgService'
 
-const HelixOrgChart: FC = () => {
-  const router = useRouter()
-  const orgSlug = router.params.org_id as string | undefined
-  const { data, isLoading } = useHelixOrgOverview()
+// The chart visualises the org as a ReactFlow subflow. After Positions
+// were removed from the domain, a Role groups Workers directly:
+//
+//   ┌─[Role: r-owner]──────────────────┐
+//   │  [w-owner]                       │
+//   └────────│───────────────────────────┘
+//            ↓ (worker-to-worker reporting edge, from worker.parent_id)
+//   ┌─[Role: r-engineer]───────────────────────────┐
+//   │  [w-alice]  [w-bob]  [w-carol]               │
+//   └───────────────────────────────────────────────┘
+//
+// Roles are parent group nodes that VISUALLY CONTAIN their Worker child
+// nodes. A Role can hold many Workers. Edges link Worker → Worker based
+// on the worker.parent_id chain (which crosses role boundaries), so the
+// edge reads as a manager → subordinate reporting line. Streams hang off
+// the right of the tree; an edge from a Worker to a Stream is a
+// subscription.
+//
+// Layout: dagre runs over the role tree (edges derived from cross-role
+// parent_id links) to get global (x, y) for each Role. Workers sit in a
+// horizontal row inside their Role's frame.
 
-  const groups = data?.groups ?? []
+const OWNER_ROLE = 'r-owner'
+const OWNER_WORKER = 'w-owner'
 
-  const openWorker = (workerId: string) => {
-    if (!orgSlug) return
-    router.navigate('helix_org_worker_detail', { org_id: orgSlug, worker_id: workerId })
+const WORKER_W = 220
+const WORKER_H = 96
+const WORKER_GAP_X = 32
+const WORKER_GAP_Y = 90
+const ROLE_PAD_X = 24
+const ROLE_PAD_TOP = 56
+const ROLE_PAD_BOTTOM = 24
+
+// ---- Flatten + group ---------------------------------------------------
+
+type FlatWorker = {
+  id: string
+  kind: string
+  roleId: string
+  parentId: string
+}
+
+type RoleGroup = { roleId: string; workers: FlatWorker[] }
+
+const groupByRole = (workers: FlatWorker[], knownRoles: string[]): RoleGroup[] => {
+  const byRole = new Map<string, FlatWorker[]>()
+  for (const r of knownRoles) {
+    if (!byRole.has(r)) byRole.set(r, [])
   }
-  const openRole = (roleId: string) => {
-    if (!orgSlug) return
-    router.navigate('helix_org_role_detail', { org_id: orgSlug, role_id: roleId })
+  for (const wk of workers) {
+    const list = byRole.get(wk.roleId) ?? []
+    list.push(wk)
+    byRole.set(wk.roleId, list)
+  }
+  const out: RoleGroup[] = []
+  byRole.forEach((ws, roleId) => {
+    out.push({
+      roleId,
+      workers: ws.slice().sort((a, b) => a.id.localeCompare(b.id)),
+    })
+  })
+  out.sort((a, b) => {
+    if (a.roleId === OWNER_ROLE) return -1
+    if (b.roleId === OWNER_ROLE) return 1
+    return a.roleId.localeCompare(b.roleId)
+  })
+  return out
+}
+
+// ---- Node renderers ----------------------------------------------------
+
+type RoleNodeData = {
+  roleId: string
+  workerCount: number
+  isOwner: boolean
+  onSelectRole: (roleId: string) => void
+  onHire: (roleId: string) => void
+  onDeleteRole: (roleId: string) => void
+}
+
+type WorkerNodeData = {
+  workerId: string
+  kind: string
+  isOwner: boolean
+  onSelectWorker: (workerId: string) => void
+  onFireWorker: (workerId: string) => void
+}
+
+// StreamNodeData drives the small pseudo-nodes the chart renders for
+// each Stream beside the org tree. Edges from Workers to these nodes
+// (subscriptions) are styled distinctly from the accountability edges
+// between Workers.
+type StreamNodeData = {
+  streamId: string
+  name: string
+  kind: string
+  subscriberCount: number
+  onSelectStream: (streamId: string) => void
+  onDeleteStream: (streamId: string) => void
+}
+
+// ReactFlow uses these CSS class names internally — children of a node
+// that carry `nodrag` won't start a node-drag, and `nopan` won't pan
+// the canvas. The combination is the documented way to make buttons,
+// menus and form inputs inside custom nodes work correctly. See
+// https://reactflow.dev/learn/customization/custom-nodes#interactive-children.
+const NO_DRAG_NO_PAN = 'nodrag nopan'
+
+// RoleNode is a parent group — ReactFlow renders the child Worker nodes
+// inside its rect. The Box fills the node's frame and paints the header
+// band along the top edge with the role id + the hire / delete-role
+// affordances.
+const RoleNode: FC<NodeProps<Node<RoleNodeData>>> = ({ data }) => {
+  const lightTheme = useLightTheme()
+  const muted = lightTheme.isLight ? 'rgba(0,0,0,0.6)' : 'rgba(255,255,255,0.6)'
+  const titleColor = lightTheme.isLight ? 'rgba(0,0,0,0.85)' : 'rgba(255,255,255,0.9)'
+
+  return (
+    <Box sx={{ position: 'relative', width: '100%', height: '100%' }}>
+      <Box
+        className={NO_DRAG_NO_PAN}
+        onClick={(e) => { e.stopPropagation(); data.onSelectRole(data.roleId) }}
+        sx={{
+          position: 'absolute',
+          top: 0, left: 0, right: 0,
+          height: ROLE_PAD_TOP - 8,
+          px: 2,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          cursor: 'pointer',
+          borderTopLeftRadius: 12,
+          borderTopRightRadius: 12,
+          '&:hover': {
+            backgroundColor: lightTheme.isLight ? 'rgba(0,0,0,0.025)' : 'rgba(255,255,255,0.03)',
+          },
+        }}
+      >
+        <Stack direction="row" alignItems="baseline" spacing={1.5} sx={{ minWidth: 0, flex: 1 }}>
+          <Typography
+            variant="subtitle1"
+            sx={{
+              fontWeight: 700,
+              color: titleColor,
+              fontFamily: 'monospace',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {data.roleId}
+          </Typography>
+          <Typography variant="caption" sx={{ color: muted, whiteSpace: 'nowrap' }}>
+            {data.workerCount} {data.workerCount === 1 ? 'worker' : 'workers'}
+          </Typography>
+        </Stack>
+        <Stack direction="row" spacing={0.25}>
+          <Tooltip title="Hire a worker into this role">
+            <IconButton
+              className={NO_DRAG_NO_PAN}
+              size="small"
+              onClick={(e) => { e.stopPropagation(); data.onHire(data.roleId) }}
+              sx={{ color: muted }}
+            >
+              <PersonAddOutlinedIcon sx={{ fontSize: 18 }} />
+            </IconButton>
+          </Tooltip>
+          {!data.isOwner && (
+            <Tooltip title="Delete role (fires every Worker holding it)">
+              <IconButton
+                className={NO_DRAG_NO_PAN}
+                size="small"
+                onClick={(e) => { e.stopPropagation(); data.onDeleteRole(data.roleId) }}
+                sx={{ color: muted }}
+              >
+                <DeleteOutlineIcon sx={{ fontSize: 18 }} />
+              </IconButton>
+            </Tooltip>
+          )}
+        </Stack>
+      </Box>
+      {data.workerCount === 0 && (
+        <Box
+          sx={{
+            position: 'absolute',
+            top: ROLE_PAD_TOP,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: muted,
+            fontStyle: 'italic',
+            fontSize: '0.85rem',
+            px: 2,
+            textAlign: 'center',
+          }}
+        >
+          No workers yet — click the hire icon to add one
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+const WorkerNode: FC<NodeProps<Node<WorkerNodeData>>> = ({ data }) => {
+  const lightTheme = useLightTheme()
+  const muted = lightTheme.isLight ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.55)'
+  const border = lightTheme.isLight ? 'rgba(0,0,0,0.14)' : 'rgba(255,255,255,0.18)'
+  const bg = lightTheme.isLight ? '#fff' : 'rgba(255,255,255,0.05)'
+  const hoverBg = lightTheme.isLight ? 'rgba(0,0,0,0.02)' : 'rgba(255,255,255,0.08)'
+  const handleColor = lightTheme.isLight ? 'rgba(0,0,0,0.35)' : 'rgba(255,255,255,0.35)'
+
+  return (
+    <Box
+      className={NO_DRAG_NO_PAN}
+      onClick={(e) => { e.stopPropagation(); data.onSelectWorker(data.workerId) }}
+      sx={{
+        width: WORKER_W,
+        height: WORKER_H,
+        border: `1px solid ${border}`,
+        borderRadius: 1.5,
+        backgroundColor: bg,
+        boxShadow: lightTheme.isLight ? '0 1px 2px rgba(0,0,0,0.04)' : 'none',
+        p: 1.5,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1,
+        cursor: 'pointer',
+        '&:hover': { backgroundColor: hoverBg },
+      }}
+    >
+      {/* Target handle = where a manager's edge LANDS, marking this
+          worker as the subordinate. Source handle = where the user drags
+          FROM when this worker becomes the manager. */}
+      <Handle
+        type="target"
+        position={RFPosition.Top}
+        style={{ background: handleColor, width: 12, height: 12 }}
+      />
+      <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+        <Stack direction="row" alignItems="center" spacing={1} sx={{ minWidth: 0 }}>
+          {data.kind === 'ai' ? (
+            <SmartToyOutlinedIcon sx={{ fontSize: 18, color: muted }} />
+          ) : (
+            <PersonOutlineIcon sx={{ fontSize: 18, color: muted }} />
+          )}
+          <Typography
+            variant="body2"
+            sx={{ fontFamily: 'monospace', fontSize: '0.85rem', fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          >
+            {data.workerId}
+          </Typography>
+        </Stack>
+        {!data.isOwner && (
+          <Tooltip title="Fire worker">
+            <IconButton
+              className={NO_DRAG_NO_PAN}
+              size="small"
+              onClick={(e) => { e.stopPropagation(); data.onFireWorker(data.workerId) }}
+              sx={{ p: 0.25, color: muted }}
+            >
+              <DeleteOutlineIcon sx={{ fontSize: 16 }} />
+            </IconButton>
+          </Tooltip>
+        )}
+      </Stack>
+      <Typography variant="caption" sx={{ color: muted, fontSize: '0.65rem', mt: 'auto' }}>
+        {data.kind === 'ai' ? 'AI agent' : 'Human'}
+      </Typography>
+      <Handle
+        type="source"
+        position={RFPosition.Bottom}
+        style={{ background: handleColor, width: 12, height: 12 }}
+      />
+      {/* Dedicated source handle for stream/subscription edges, anchored
+          on the right side of the card. Decoupling stream edges from the
+          bottom-center reporting handle means a subscription edge and a
+          manager → subordinate edge can never share the same geometry.
+          id="stream" is what buildGraph passes as sourceHandle when
+          emitting subscription edges. */}
+      <Handle
+        id="stream"
+        type="source"
+        position={RFPosition.Right}
+        isConnectable
+        style={{ background: 'rgba(180,100,0,0.5)', border: 'none', width: 8, height: 8 }}
+      />
+    </Box>
+  )
+}
+
+// StreamNode is a small pseudo-node — narrower than a Worker card —
+// rendered beside the org tree to anchor subscription edges. Clicking
+// the body navigates to the per-stream detail page; the trash icon
+// deletes the Stream row (irreversible).
+const STREAM_W = 180
+const STREAM_H = 80
+const StreamNode: FC<NodeProps<Node<StreamNodeData>>> = ({ data }) => {
+  const lightTheme = useLightTheme()
+  const accent = lightTheme.isLight ? 'rgba(180,100,0,0.85)' : 'rgba(255,180,80,0.85)'
+  const bg = 'rgba(255,180,80,0.06)'
+  const muted = lightTheme.isLight ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.55)'
+  const handleColor = lightTheme.isLight ? 'rgba(180,100,0,0.55)' : 'rgba(255,180,80,0.55)'
+  return (
+    <Box
+      onClick={(e) => { e.stopPropagation(); data.onSelectStream(data.streamId) }}
+      sx={{
+        width: STREAM_W,
+        height: STREAM_H,
+        border: `1px dashed ${accent}`,
+        borderRadius: 1.5,
+        backgroundColor: bg,
+        p: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 0.25,
+        cursor: 'pointer',
+        position: 'relative',
+        '&:hover': { backgroundColor: 'rgba(255,180,80,0.12)' },
+      }}
+    >
+      <Handle type="target" position={RFPosition.Left} style={{ background: handleColor, width: 8, height: 8 }} />
+      <Tooltip title="Delete stream">
+        <IconButton
+          className={NO_DRAG_NO_PAN}
+          size="small"
+          onClick={(e) => { e.stopPropagation(); data.onDeleteStream(data.streamId) }}
+          sx={{ position: 'absolute', top: 2, right: 2, p: 0.25, color: muted }}
+        >
+          <DeleteOutlineIcon sx={{ fontSize: 14 }} />
+        </IconButton>
+      </Tooltip>
+      <Typography variant="caption" sx={{ fontFamily: 'monospace', fontSize: '0.7rem', color: muted, pr: 2 }}>
+        {data.streamId}
+      </Typography>
+      <Typography variant="body2" sx={{ fontSize: '0.8rem', fontWeight: 600, color: accent, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {data.name}
+      </Typography>
+      <Typography variant="caption" sx={{ fontSize: '0.65rem', color: muted, mt: 'auto' }}>
+        {data.kind} · {data.subscriberCount} sub{data.subscriberCount === 1 ? '' : 's'}
+      </Typography>
+    </Box>
+  )
+}
+
+const nodeTypes = { role: RoleNode, worker: WorkerNode, stream: StreamNode }
+
+// ---- dagre layout ------------------------------------------------------
+
+type StreamSummary = {
+  id: string
+  name: string
+  kind: string
+  created_by?: string
+  subscribers?: string[]
+}
+
+// buildGraph computes nodes + edges for the chart. Roles are laid out by
+// dagre over a role-level graph whose edges come from worker.parent_id
+// links that cross role boundaries. Workers sit in a horizontal row
+// inside their role's frame. Worker → Worker reporting edges and Worker
+// → Stream subscription edges are drawn on top.
+const buildGraph = (
+  groups: RoleGroup[],
+  flat: FlatWorker[],
+  handlers: {
+    onSelectWorker: (workerId: string) => void
+    onSelectRole: (roleId: string) => void
+    onHire: (roleId: string) => void
+    onDeleteRole: (roleId: string) => void
+    onFireWorker: (workerId: string) => void
+    onSelectStream: (streamId: string) => void
+    onDeleteStream: (streamId: string) => void
+  },
+  isLight: boolean,
+  streams: StreamSummary[],
+): { nodes: Node[]; edges: Edge[] } => {
+  const flatByID = new Map<string, FlatWorker>()
+  for (const wk of flat) flatByID.set(wk.id, wk)
+
+  const workerToRole = new Map<string, string>()
+  for (const group of groups) {
+    for (const wk of group.workers) workerToRole.set(wk.id, group.roleId)
+  }
+
+  // 1. Size each role frame from its worker count. Empty roles get a
+  //    one-slot-wide placeholder so they're still discoverable.
+  type Size = { w: number; h: number }
+  const roleSize = new Map<string, Size>()
+  for (const group of groups) {
+    const n = Math.max(1, group.workers.length)
+    roleSize.set(group.roleId, {
+      w: n * WORKER_W + (n - 1) * WORKER_GAP_X + 2 * ROLE_PAD_X,
+      h: WORKER_H + ROLE_PAD_TOP + ROLE_PAD_BOTTOM,
+    })
+  }
+
+  // 2. Role-level dagre graph. Edges: any worker.parent_id that crosses
+  //    a role boundary contributes a role → role edge.
+  const g = new dagre.graphlib.Graph()
+  g.setGraph({
+    rankdir: 'TB',
+    nodesep: WORKER_GAP_X,
+    ranksep: WORKER_GAP_Y,
+    marginx: 0,
+    marginy: 0,
+  })
+  g.setDefaultEdgeLabel(() => ({}))
+  for (const group of groups) {
+    const sz = roleSize.get(group.roleId)!
+    g.setNode(`role:${group.roleId}`, { width: sz.w, height: sz.h })
+  }
+  const seenEdge = new Set<string>()
+  for (const wk of flat) {
+    if (!wk.parentId || !flatByID.has(wk.parentId)) continue
+    const childRole = workerToRole.get(wk.id)
+    const parentRole = workerToRole.get(wk.parentId)
+    if (!childRole || !parentRole || childRole === parentRole) continue
+    const key = `${parentRole}->${childRole}`
+    if (seenEdge.has(key)) continue
+    seenEdge.add(key)
+    g.setEdge(`role:${parentRole}`, `role:${childRole}`)
+  }
+  dagre.layout(g)
+
+  // 3. Emit nodes — role parents first, then their worker children.
+  const nodes: Node[] = []
+  const roleStyle = {
+    backgroundColor: isLight ? 'rgba(0,0,0,0.025)' : 'rgba(255,255,255,0.03)',
+    border: `1px solid ${isLight ? 'rgba(0,0,0,0.1)' : 'rgba(255,255,255,0.12)'}`,
+    borderRadius: 12,
+    boxShadow: isLight ? '0 1px 2px rgba(0,0,0,0.04)' : 'none',
+  }
+  type RoleOrigin = { x: number; y: number; w: number; h: number }
+  const roleOrigin = new Map<string, RoleOrigin>()
+  for (const group of groups) {
+    const ln = g.node(`role:${group.roleId}`)
+    const sz = roleSize.get(group.roleId)!
+    if (!ln) continue
+    roleOrigin.set(group.roleId, {
+      x: ln.x - sz.w / 2,
+      y: ln.y - sz.h / 2,
+      w: sz.w,
+      h: sz.h,
+    })
+  }
+
+  for (const group of groups) {
+    const ro = roleOrigin.get(group.roleId)
+    if (!ro) continue
+    nodes.push({
+      id: `role:${group.roleId}`,
+      type: 'role',
+      position: { x: ro.x, y: ro.y },
+      style: { ...roleStyle, width: ro.w, height: ro.h },
+      data: {
+        roleId: group.roleId,
+        workerCount: group.workers.length,
+        isOwner: group.roleId === OWNER_ROLE,
+        onSelectRole: handlers.onSelectRole,
+        onHire: handlers.onHire,
+        onDeleteRole: handlers.onDeleteRole,
+      } as RoleNodeData,
+      // selectable: true keeps the role's pointer-events on so the
+      // header controls stay clickable; draggable is off (dagre owns
+      // layout). The canvas-level elementsSelectable still applies.
+      draggable: false,
+      selectable: true,
+    })
+  }
+  for (const group of groups) {
+    const ro = roleOrigin.get(group.roleId)
+    if (!ro) continue
+    group.workers.forEach((wk, i) => {
+      nodes.push({
+        id: `worker:${wk.id}`,
+        type: 'worker',
+        position: {
+          x: ro.x + ROLE_PAD_X + i * (WORKER_W + WORKER_GAP_X),
+          y: ro.y + ROLE_PAD_TOP,
+        },
+        data: {
+          workerId: wk.id,
+          kind: wk.kind,
+          isOwner: wk.id === OWNER_WORKER,
+          onSelectWorker: handlers.onSelectWorker,
+          onFireWorker: handlers.onFireWorker,
+        } as WorkerNodeData,
+        draggable: false,
+        connectable: true,
+      })
+    })
+  }
+
+  // 4. Reporting edges: manager → subordinate, derived from
+  //    worker.parent_id. Bezier (the default) gives every pair its own
+  //    arc so multiple reports from one manager never overlap.
+  const edges: Edge[] = []
+  for (const wk of flat) {
+    if (!wk.parentId || !flatByID.has(wk.parentId)) continue
+    edges.push({
+      id: `report:${wk.parentId}->${wk.id}`,
+      source: `worker:${wk.parentId}`,
+      target: `worker:${wk.id}`,
+      type: 'default',
+      animated: false,
+      data: { kind: 'report', childWorkerId: wk.id },
+      style: {
+        stroke: isLight ? 'rgba(0,0,0,0.3)' : 'rgba(255,255,255,0.35)',
+        strokeWidth: 1.5,
+      },
+    })
+  }
+
+  // 5. Stream pseudo-nodes + subscription edges. Subscriptions are
+  //    worker-anchored, so subscribers carries Worker ids — one dashed
+  //    edge per subscribed Worker. Streams sit in a column to the right
+  //    of the org tree. Each stream is vertically anchored to the
+  //    "subject" Worker: for activation streams (`s-activations-<id>`)
+  //    that's the encoded worker; otherwise created_by. Streams whose
+  //    subject isn't on the chart park in an orphan strip below.
+  if (streams.length > 0) {
+    const ACTIVATION_PREFIX = 's-activations-'
+    const workerAbs = new Map<string, { x: number; y: number }>()
+    for (const group of groups) {
+      const ro = roleOrigin.get(group.roleId)
+      if (!ro) continue
+      group.workers.forEach((wk, i) => {
+        workerAbs.set(wk.id, {
+          x: ro.x + ROLE_PAD_X + i * (WORKER_W + WORKER_GAP_X),
+          y: ro.y + ROLE_PAD_TOP,
+        })
+      })
+    }
+
+    let maxY = 0
+    let minLeft = Infinity, maxRight = -Infinity
+    for (const ro of roleOrigin.values()) {
+      const bottom = ro.y + ro.h
+      if (bottom > maxY) maxY = bottom
+      if (ro.x < minLeft) minLeft = ro.x
+      if (ro.x + ro.w > maxRight) maxRight = ro.x + ro.w
+    }
+    if (!isFinite(minLeft)) minLeft = 0
+    if (!isFinite(maxRight)) maxRight = 0
+
+    const STREAM_VERTICAL_GAP = 16
+    const STREAM_COLUMN_GAP = 120
+    const STREAM_GAP_X = 32
+    const ORPHAN_VERTICAL_GAP = 120
+    const streamColumnX = maxRight + STREAM_COLUMN_GAP
+    const stackByYRow = new Map<number, number>()
+
+    const resolved: { stream: StreamSummary; subjectWorker: string | null }[] = []
+    for (const s of streams) {
+      let subjectWorker: string | undefined
+      if (s.id.startsWith(ACTIVATION_PREFIX)) {
+        subjectWorker = s.id.slice(ACTIVATION_PREFIX.length)
+      } else if (s.created_by) {
+        subjectWorker = s.created_by
+      }
+      const onChart = subjectWorker && workerAbs.has(subjectWorker) ? subjectWorker : null
+      resolved.push({ stream: s, subjectWorker: onChart })
+    }
+    const orphans = resolved.filter((r) => !r.subjectWorker)
+    let orphanCursorX = (minLeft + maxRight) / 2
+    if (orphans.length > 0) {
+      const stripWidth = orphans.length * STREAM_W + (orphans.length - 1) * STREAM_GAP_X
+      orphanCursorX = (minLeft + maxRight) / 2 - stripWidth / 2
+    }
+
+    for (const { stream: s, subjectWorker } of resolved) {
+      let x: number
+      let y: number
+      if (subjectWorker) {
+        const anchor = workerAbs.get(subjectWorker)!
+        const yRow = Math.round(anchor.y)
+        const stackIndex = stackByYRow.get(yRow) ?? 0
+        x = streamColumnX
+        y = anchor.y + stackIndex * (STREAM_H + STREAM_VERTICAL_GAP)
+        stackByYRow.set(yRow, stackIndex + 1)
+      } else {
+        x = orphanCursorX
+        y = maxY + ORPHAN_VERTICAL_GAP
+        orphanCursorX += STREAM_W + STREAM_GAP_X
+      }
+      nodes.push({
+        id: `stream:${s.id}`,
+        type: 'stream',
+        position: { x, y },
+        data: {
+          streamId: s.id,
+          name: s.name,
+          kind: s.kind,
+          subscriberCount: s.subscribers?.length ?? 0,
+          onSelectStream: handlers.onSelectStream,
+          onDeleteStream: handlers.onDeleteStream,
+        } as StreamNodeData,
+        draggable: false,
+        connectable: true,
+        selectable: true,
+      })
+      const subscribingWorkers = (s.subscribers ?? []).filter((wid) => workerAbs.has(wid))
+      for (const wid of subscribingWorkers) {
+        edges.push({
+          id: `sub:${wid}->${s.id}`,
+          source: `worker:${wid}`,
+          sourceHandle: 'stream',
+          target: `stream:${s.id}`,
+          type: 'default',
+          animated: false,
+          data: { kind: 'sub', workerId: wid, streamId: s.id },
+          style: {
+            stroke: isLight ? 'rgba(180,100,0,0.7)' : 'rgba(255,180,80,0.7)',
+            strokeWidth: 1.25,
+            strokeDasharray: '6 4',
+          },
+        })
+      }
+    }
+  }
+
+  return { nodes, edges }
+}
+
+// ---- Dialogs (Create role, Confirm delete) -----------------------------
+
+const CreateRoleDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onClose }) => {
+  const snackbar = useSnackbar()
+  const create = useCreateHelixOrgRole()
+  const [id, setId] = useState('')
+  const [content, setContent] = useState('')
+
+  const submit = async () => {
+    const trimmedId = id.trim()
+    if (!trimmedId) {
+      snackbar.error('Role ID is required')
+      return
+    }
+    try {
+      await create.mutateAsync({ id: trimmedId, content })
+      snackbar.success(`role ${trimmedId} created`)
+      setId(''); setContent(''); onClose()
+    } catch (err: any) {
+      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'create role failed')
+    }
   }
 
   return (
-    <Page breadcrumbTitle="Overview">
-      <Container maxWidth="xl" sx={{ mb: 4, pt: 3 }}>
-        <Stack spacing={2}>
-          <Box>
-            <Typography variant="h5" sx={{ mb: 1 }}>Overview</Typography>
-            <Typography variant="body2" color="text.secondary">
-              Roles in this org, with the Workers currently holding each one.
-              Click a Role to edit its prompt and tool set, or a Worker to
-              open its detail page.
-            </Typography>
-          </Box>
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>New role</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ pt: 1 }}>
+          <TextField
+            label="Role ID"
+            placeholder="r-engineer"
+            value={id}
+            onChange={(e) => setId(e.target.value)}
+            helperText="Convention: r-<kebab-case>. Stays as-is — the LLM and operator both refer to roles by this handle."
+            autoFocus
+            fullWidth
+          />
+          <TextField
+            label="Content (markdown)"
+            placeholder="# Engineer&#10;Builds and ships software."
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            multiline
+            minRows={6}
+            fullWidth
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={submit} variant="contained" disabled={create.isPending}>
+          {create.isPending ? 'Creating…' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
 
+const ConfirmDeleteDialog: FC<{
+  open: boolean
+  title: string
+  body: string
+  onConfirm: () => Promise<void> | void
+  onClose: () => void
+  pending: boolean
+}> = ({ open, title, body, onConfirm, onClose, pending }) => (
+  <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+    <DialogTitle>{title}</DialogTitle>
+    <DialogContent>
+      <DialogContentText sx={{ whiteSpace: 'pre-wrap' }}>{body}</DialogContentText>
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={onClose}>Cancel</Button>
+      <Button onClick={() => onConfirm()} color="error" variant="contained" disabled={pending}>
+        {pending ? 'Deleting…' : 'Delete'}
+      </Button>
+    </DialogActions>
+  </Dialog>
+)
+
+// ---- Hire drawer -------------------------------------------------------
+
+const HireDrawer: FC<{ roleId: string; onClose: () => void }> = ({ roleId, onClose }) => {
+  const snackbar = useSnackbar()
+  const hire = useHireHelixOrgWorker()
+  const [id, setId] = useState('')
+  const [kind, setKind] = useState<'ai' | 'human'>('human')
+  const [identity, setIdentity] = useState('')
+
+  const submit = async () => {
+    if (!identity.trim()) {
+      snackbar.error('identity content is required')
+      return
+    }
+    const body: HireWorkerRequest = {
+      role_id: roleId,
+      kind,
+      identity_content: identity,
+    }
+    if (id.trim()) body.id = id.trim()
+    try {
+      const res = await hire.mutateAsync(body)
+      snackbar.success(`hired ${res.id} — drag an edge from a manager to set who they report to`)
+      setId(''); setIdentity(''); onClose()
+    } catch (err: any) {
+      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'hire failed')
+    }
+  }
+
+  return (
+    <Box sx={{ p: 2.5, width: 380 }}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+        <Typography variant="h6">Hire worker</Typography>
+        <IconButton size="small" onClick={onClose}><CloseIcon /></IconButton>
+      </Stack>
+      <Stack spacing={1.5}>
+        <Box>
+          <Typography variant="caption" color="text.secondary">Role</Typography>
+          <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>{roleId}</Typography>
+        </Box>
+        <Divider sx={{ my: 1 }} />
+        <TextField select size="small" label="Kind" value={kind} onChange={(e) => setKind(e.target.value as 'ai' | 'human')} fullWidth>
+          <MenuItem value="human">Human</MenuItem>
+          <MenuItem value="ai">AI</MenuItem>
+        </TextField>
+        <TextField
+          size="small"
+          label="Handle (optional)"
+          placeholder="w-alice"
+          helperText="Lowercase first name, prefixed with w-. Leave blank to auto-assign."
+          value={id}
+          onChange={(e) => setId(e.target.value)}
+          fullWidth
+        />
+        <TextField
+          size="small"
+          label="Identity content"
+          placeholder="Short persona / profile in markdown."
+          value={identity}
+          onChange={(e) => setIdentity(e.target.value)}
+          multiline
+          minRows={6}
+          fullWidth
+        />
+        <Stack direction="row" spacing={1} sx={{ pt: 1 }}>
+          <Button variant="contained" onClick={submit} disabled={hire.isPending}>
+            {hire.isPending ? 'Hiring…' : 'Hire'}
+          </Button>
+          <Button variant="text" onClick={onClose}>Cancel</Button>
+        </Stack>
+      </Stack>
+    </Box>
+  )
+}
+
+// ---- ReactFlow canvas --------------------------------------------------
+
+const ChartCanvas: FC<{
+  groups: RoleGroup[]
+  flat: FlatWorker[]
+  handlers: {
+    onSelectWorker: (workerId: string) => void
+    onSelectRole: (roleId: string) => void
+    onHire: (roleId: string) => void
+    onDeleteRole: (roleId: string) => void
+    onFireWorker: (workerId: string) => void
+    onSelectStream: (streamId: string) => void
+    onDeleteStream: (streamId: string) => void
+  }
+  // onSetParent fires when the user wires manager → subordinate (an
+  // onConnect); onClearParent fires when they delete a reporting edge.
+  onSetParent: (childWorkerId: string, newParentWorkerId: string) => void
+  onClearParent: (childWorkerId: string) => void
+  // onSubscribeWorker fires when the user wires a Worker node → a stream
+  // pseudo-node; onUnsubscribeWorker fires when they delete that edge.
+  onSubscribeWorker: (workerId: string, streamId: string) => void
+  onUnsubscribeWorker: (workerId: string, streamId: string) => void
+  streams: StreamSummary[]
+}> = ({ groups, flat, handlers, onSetParent, onClearParent, onSubscribeWorker, onUnsubscribeWorker, streams }) => {
+  const lightTheme = useLightTheme()
+  const { fitView } = useReactFlow()
+
+  const { nodes: computedNodes, edges: computedEdges } = useMemo(
+    () => buildGraph(groups, flat, handlers, lightTheme.isLight, streams),
+    [groups, flat, handlers, lightTheme.isLight, streams],
+  )
+  const [nodes, setNodes, onNodesChange] = useNodesState(computedNodes)
+  const [edges, setEdges, onEdgesChange] = useEdgesState(computedEdges)
+
+  useEffect(() => {
+    setNodes(computedNodes)
+    setEdges(computedEdges)
+    requestAnimationFrame(() => fitView({ padding: 0.2, duration: 250 }))
+  }, [computedNodes, computedEdges, fitView, setNodes, setEdges])
+
+  // onConnect handles both wire shapes:
+  //   - worker→worker: manager wires their report. Source = manager,
+  //     target = subordinate. Persists by PATCHing parent_id.
+  //   - worker→stream:  the worker consumes a stream. Persists by
+  //     POSTing a (worker, stream) subscription.
+  const onConnect = useCallback(
+    ({ source, target }: { source: string | null; target: string | null }) => {
+      if (!source || !target) return
+      if (!source.startsWith('worker:')) return
+      const sourceId = source.replace(/^worker:/, '')
+      if (!sourceId) return
+      if (target.startsWith('stream:')) {
+        const streamId = target.replace(/^stream:/, '')
+        if (!streamId) return
+        onSubscribeWorker(sourceId, streamId)
+        return
+      }
+      if (target.startsWith('worker:')) {
+        const targetId = target.replace(/^worker:/, '')
+        if (!targetId || sourceId === targetId) return
+        onSetParent(targetId, sourceId)
+      }
+    },
+    [onSetParent, onSubscribeWorker],
+  )
+
+  // onEdgesDelete severs whatever the edge represented: a reporting edge
+  // clears the subordinate's parent_id; a subscription edge drops the
+  // (worker, stream) row.
+  const onEdgesDelete = useCallback(
+    (deleted: Edge[]) => {
+      for (const e of deleted) {
+        const d = e.data as { kind?: string; childWorkerId?: string; workerId?: string; streamId?: string } | undefined
+        if (d?.kind === 'sub' && d.workerId && d.streamId) {
+          onUnsubscribeWorker(d.workerId, d.streamId)
+          continue
+        }
+        const childId = d?.childWorkerId ?? (e.target ?? '').replace(/^worker:/, '')
+        if (childId && (e.target ?? '').startsWith('worker:')) onClearParent(childId)
+      }
+    },
+    [onClearParent, onUnsubscribeWorker],
+  )
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      onConnect={onConnect}
+      onEdgesDelete={onEdgesDelete}
+      nodeTypes={nodeTypes}
+      fitView
+      fitViewOptions={{ padding: 0.2 }}
+      proOptions={{ hideAttribution: true }}
+      colorMode={lightTheme.isLight ? 'light' : 'dark'}
+      nodesConnectable
+      elementsSelectable
+      // @xyflow/react v12's deleteKeyCode defaults to Backspace only, so
+      // Linux/Windows users hitting Delete on a selected edge get
+      // nothing. Accept both.
+      deleteKeyCode={['Backspace', 'Delete']}
+      panOnDrag
+      zoomOnScroll
+    >
+      <Background gap={20} size={1} />
+      <Controls showInteractive={false} />
+      <MiniMap pannable zoomable maskColor={lightTheme.isLight ? 'rgba(0,0,0,0.06)' : 'rgba(0,0,0,0.6)'} />
+    </ReactFlow>
+  )
+}
+
+// ---- Page --------------------------------------------------------------
+
+type Selection =
+  | { kind: 'none' }
+  | { kind: 'hire'; roleId: string }
+
+const HelixOrgChart: FC = () => {
+  const lightTheme = useLightTheme()
+  const snackbar = useSnackbar()
+  const router = useRouter()
+  const { data: workersData, isLoading } = useListHelixOrgWorkers()
+  const { data: rolesData } = useListHelixOrgRoles()
+  const { data: streamsData } = useListHelixOrgStreams()
+  const deleteRole = useDeleteHelixOrgRole()
+  const deleteStream = useDeleteHelixOrgStream()
+  const fireWorker = useFireHelixOrgWorker()
+  const reparent = useReparentWorker()
+  const subscribe = useSubscribeWorkerAtChart()
+  const unsubscribe = useUnsubscribeWorkerAtChart()
+
+  const flat = useMemo<FlatWorker[]>(
+    () => (workersData ?? []).map((w: WorkerDTO) => ({
+      id: w.id ?? '',
+      kind: w.kind ?? 'human',
+      roleId: w.role_id ?? '',
+      parentId: w.parent_id ?? '',
+    })),
+    [workersData],
+  )
+  const knownRoles = useMemo(() => (rolesData ?? []).map((r) => r.id ?? ''), [rolesData])
+  const groups = useMemo(() => groupByRole(flat, knownRoles), [flat, knownRoles])
+  const streams = useMemo<StreamSummary[]>(
+    () => (streamsData?.streams ?? []).map((s) => ({
+      id: s.id ?? '',
+      name: s.name ?? '',
+      kind: s.kind ?? '',
+      created_by: s.created_by,
+      subscribers: s.subscribers,
+    })),
+    [streamsData],
+  )
+
+  const [selection, setSelection] = useState<Selection>({ kind: 'none' })
+  const [roleDialogOpen, setRoleDialogOpen] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState<
+    | { kind: 'role'; id: string }
+    | { kind: 'worker'; id: string }
+    | { kind: 'stream'; id: string }
+    | null
+  >(null)
+
+  const titleColor = lightTheme.isLight ? 'rgba(0,0,0,0.87)' : 'rgba(255,255,255,0.95)'
+  const subtitleColor = lightTheme.isLight ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.55)'
+  const canvasBorder = lightTheme.isLight ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.08)'
+  const canvasBg = lightTheme.isLight ? '#fafafa' : 'rgba(255,255,255,0.02)'
+
+  const orgSlug = (router.params.org_id as string | undefined) ?? ''
+  const onSelectWorker = useCallback(
+    (workerId: string) => {
+      if (!orgSlug) return
+      router.navigate('helix_org_worker_detail', { org_id: orgSlug, worker_id: workerId })
+    },
+    [router, orgSlug],
+  )
+  const onSelectRole = useCallback(
+    (roleId: string) => {
+      if (!orgSlug) return
+      router.navigate('helix_org_role_detail', { org_id: orgSlug, role_id: roleId })
+    },
+    [router, orgSlug],
+  )
+  const onHire = useCallback((roleId: string) => setSelection({ kind: 'hire', roleId }), [])
+  const onDeleteRole = useCallback((roleId: string) => setConfirmDelete({ kind: 'role', id: roleId }), [])
+  const onFireWorker = useCallback((workerId: string) => setConfirmDelete({ kind: 'worker', id: workerId }), [])
+  const onSelectStream = useCallback(
+    (streamId: string) => {
+      if (!orgSlug) return
+      router.navigate('helix_org_stream_detail', { org_id: orgSlug, stream_id: streamId })
+    },
+    [router, orgSlug],
+  )
+  const onDeleteStream = useCallback((streamId: string) => setConfirmDelete({ kind: 'stream', id: streamId }), [])
+  const handlers = useMemo(
+    () => ({ onSelectWorker, onSelectRole, onHire, onDeleteRole, onFireWorker, onSelectStream, onDeleteStream }),
+    [onSelectWorker, onSelectRole, onHire, onDeleteRole, onFireWorker, onSelectStream, onDeleteStream],
+  )
+
+  const onSetParent = useCallback(
+    async (childWorkerId: string, newParentWorkerId: string) => {
+      try {
+        await reparent.mutateAsync({ workerID: childWorkerId, parentID: newParentWorkerId })
+        snackbar.success(`${childWorkerId} now reports to ${newParentWorkerId}`)
+      } catch (err: any) {
+        snackbar.error(err?.response?.data?.error ?? err?.message ?? 'reparent failed')
+      }
+    },
+    [reparent, snackbar],
+  )
+
+  const onClearParent = useCallback(
+    async (childWorkerId: string) => {
+      try {
+        await reparent.mutateAsync({ workerID: childWorkerId, parentID: '' })
+        snackbar.success(`${childWorkerId} no longer reports to anyone`)
+      } catch (err: any) {
+        snackbar.error(err?.response?.data?.error ?? err?.message ?? 'clear parent failed')
+      }
+    },
+    [reparent, snackbar],
+  )
+
+  const onSubscribeWorker = useCallback(
+    async (workerId: string, streamId: string) => {
+      try {
+        await subscribe.mutateAsync({ workerID: workerId, streamID: streamId })
+        snackbar.success(`${workerId} now consumes ${streamId}`)
+      } catch (err: any) {
+        snackbar.error(err?.response?.data?.error ?? err?.message ?? 'subscribe failed')
+      }
+    },
+    [subscribe, snackbar],
+  )
+
+  const onUnsubscribeWorker = useCallback(
+    async (workerId: string, streamId: string) => {
+      try {
+        await unsubscribe.mutateAsync({ workerID: workerId, streamID: streamId })
+        snackbar.success(`${workerId} no longer consumes ${streamId}`)
+      } catch (err: any) {
+        snackbar.error(err?.response?.data?.error ?? err?.message ?? 'unsubscribe failed')
+      }
+    },
+    [unsubscribe, snackbar],
+  )
+
+  const handleConfirmDelete = async () => {
+    if (!confirmDelete) return
+    try {
+      if (confirmDelete.kind === 'role') {
+        await deleteRole.mutateAsync(confirmDelete.id)
+        snackbar.success(`deleted role ${confirmDelete.id}`)
+      } else if (confirmDelete.kind === 'stream') {
+        await deleteStream.mutateAsync(confirmDelete.id)
+        snackbar.success(`deleted stream ${confirmDelete.id}`)
+      } else {
+        await fireWorker.mutateAsync(confirmDelete.id)
+        snackbar.success(`fired worker ${confirmDelete.id}`)
+      }
+      setConfirmDelete(null)
+    } catch (err: any) {
+      const status = err?.response?.status
+      const msg = err?.response?.data?.error ?? err?.message ?? 'delete failed'
+      if (status === 409) {
+        snackbar.error(`${confirmDelete.kind} is protected and cannot be deleted`)
+      } else {
+        snackbar.error(msg)
+      }
+    }
+  }
+
+  const confirmBody = useMemo(() => {
+    if (!confirmDelete) return ''
+    if (confirmDelete.kind === 'role') {
+      const group = groups.find((g) => g.roleId === confirmDelete.id)
+      const workers = (group?.workers ?? []).map((w) => w.id)
+      return [
+        `Deleting role ${confirmDelete.id} will cascade:`,
+        `  • fires ${workers.length} worker${workers.length === 1 ? '' : 's'} (${workers.join(', ') || 'none'})`,
+        '',
+        'This is irreversible.',
+      ].join('\n')
+    }
+    if (confirmDelete.kind === 'stream') {
+      const s = (streamsData?.streams ?? []).find((x) => x.id === confirmDelete.id)
+      const subs = s?.subscribers ?? []
+      return [
+        `Deleting stream ${confirmDelete.id}:`,
+        `  • removes the Stream row`,
+        `  • drops ${subs.length} subscription${subs.length === 1 ? '' : 's'}${subs.length > 0 ? ' (' + subs.join(', ') + ')' : ''}`,
+        `  • events on this stream survive as an audit trail`,
+        '',
+        'This is irreversible.',
+      ].join('\n')
+    }
+    const reports = flat.filter((w) => w.parentId === confirmDelete.id).map((w) => w.id)
+    return [
+      `Firing worker ${confirmDelete.id} will cascade:`,
+      `  • stops sessions, deletes its project + agent app, drops its subscriptions`,
+      reports.length > 0
+        ? `  • ${reports.length} direct report${reports.length === 1 ? '' : 's'} (${reports.join(', ')}) lose their manager`
+        : `  • no direct reports`,
+      '',
+      'This is irreversible.',
+    ].join('\n')
+  }, [confirmDelete, groups, flat, streamsData])
+
+  return (
+    <Page breadcrumbTitle="Chart">
+      <Box sx={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 64px)', minHeight: 0 }}>
+        <Box sx={{ px: 4, pt: 4, pb: 2 }}>
+          <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+            <Box>
+              <Typography
+                variant="h4"
+                sx={{ fontWeight: 700, mb: 1, color: titleColor, letterSpacing: '-0.02em' }}
+              >
+                Chart
+              </Typography>
+              <Typography variant="body2" sx={{ color: subtitleColor }}>
+                Roles group Workers. Hire Workers into a Role, then drag from a manager's
+                bottom handle to a subordinate to set who reports to whom, or from a
+                Worker's right handle to a Stream to subscribe.
+              </Typography>
+            </Box>
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={() => setRoleDialogOpen(true)}
+            >
+              New role
+            </Button>
+          </Stack>
+        </Box>
+
+        <Box
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            mx: 4,
+            mb: 4,
+            position: 'relative',
+            border: `1px solid ${canvasBorder}`,
+            borderRadius: 1,
+            backgroundColor: canvasBg,
+            overflow: 'hidden',
+          }}
+        >
           {isLoading ? (
-            <LoadingSpinner />
+            <Box sx={{ p: 4 }}><LoadingSpinner /></Box>
           ) : groups.length === 0 ? (
-            <Box sx={{ textAlign: 'center', py: 8 }}>
-              <Typography variant="body1" color="text.secondary">
-                No roles yet. Create one from the Roles tab.
+            <Box sx={{ p: 4 }}>
+              <Typography variant="body1" sx={{ color: subtitleColor }}>
+                No roles yet. Click <strong>New role</strong> to get started.
               </Typography>
             </Box>
           ) : (
-            <Box
-              sx={{
-                display: 'grid',
-                gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
-                gap: 2,
-              }}
-            >
-              {groups.map((g) => (
-                <Card
-                  key={g.role_id}
-                  variant="outlined"
-                  sx={{
-                    borderRadius: 1,
-                    boxShadow: 'none',
-                    border: '1px solid rgba(0, 0, 0, 0.08)',
-                    height: '100%',
-                    display: 'flex',
-                    flexDirection: 'column',
-                  }}
-                >
-                  <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
-                    <Stack spacing={1.5}>
-                      <Button
-                        variant="text"
-                        onClick={() => openRole(g.role_id!)}
-                        sx={{
-                          alignSelf: 'flex-start',
-                          fontFamily: 'monospace',
-                          textTransform: 'none',
-                          fontSize: '0.95rem',
-                          fontWeight: 600,
-                          p: 0,
-                          minWidth: 0,
-                        }}
-                      >
-                        {g.role_id}
-                      </Button>
-                      <Typography variant="caption" color="text.secondary">
-                        {(g.workers ?? []).length === 0
-                          ? 'No Workers yet'
-                          : `${(g.workers ?? []).length} Worker${(g.workers ?? []).length === 1 ? '' : 's'}`}
-                      </Typography>
-                      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
-                        {(g.workers ?? []).map((w: WorkerBadge) => (
-                          <Chip
-                            key={w.id}
-                            label={w.id}
-                            icon={
-                              w.kind === 'ai' ? (
-                                <SmartToyOutlinedIcon sx={{ fontSize: 14 }} />
-                              ) : (
-                                <PersonOutlineIcon sx={{ fontSize: 14 }} />
-                              )
-                            }
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              openWorker(w.id!)
-                            }}
-                            size="small"
-                            sx={{ fontFamily: 'monospace' }}
-                            clickable
-                          />
-                        ))}
-                      </Stack>
-                    </Stack>
-                  </CardContent>
-                </Card>
-              ))}
-            </Box>
+            <ReactFlowProvider>
+              <ChartCanvas
+                groups={groups}
+                flat={flat}
+                handlers={handlers}
+                onSetParent={onSetParent}
+                onClearParent={onClearParent}
+                onSubscribeWorker={onSubscribeWorker}
+                onUnsubscribeWorker={onUnsubscribeWorker}
+                streams={streams}
+              />
+            </ReactFlowProvider>
           )}
-        </Stack>
-      </Container>
+        </Box>
+      </Box>
+
+      <CreateRoleDialog open={roleDialogOpen} onClose={() => setRoleDialogOpen(false)} />
+      <ConfirmDeleteDialog
+        open={confirmDelete !== null}
+        title={
+          confirmDelete?.kind === 'role' ? 'Delete role?' :
+          confirmDelete?.kind === 'stream' ? 'Delete stream?' :
+          'Fire worker?'
+        }
+        body={confirmBody}
+        onConfirm={handleConfirmDelete}
+        onClose={() => setConfirmDelete(null)}
+        pending={deleteRole.isPending || deleteStream.isPending || fireWorker.isPending}
+      />
+
+      <Drawer
+        anchor="right"
+        open={selection.kind !== 'none'}
+        onClose={() => setSelection({ kind: 'none' })}
+        PaperProps={{ sx: { backgroundImage: 'none' } }}
+      >
+        {selection.kind === 'hire' && (
+          <HireDrawer
+            roleId={selection.roleId}
+            onClose={() => setSelection({ kind: 'none' })}
+          />
+        )}
+      </Drawer>
     </Page>
   )
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -555,8 +555,8 @@ const routes: IApplicationRoute[] = [
   },
 }, {
   name: 'helix_org_chart',
-  path: '/orgs/:org_id/helix-org/overview',
-  meta: { drawer: true, title: 'Helix Org · Overview' },
+  path: '/orgs/:org_id/helix-org/chart',
+  meta: { drawer: true, title: 'Helix Org · Chart' },
   render: () => <HelixOrgChart />,
 }, {
   name: 'helix_org_roles',

--- a/frontend/src/services/helixOrgService.ts
+++ b/frontend/src/services/helixOrgService.ts
@@ -222,6 +222,65 @@ export function useHireHelixOrgWorker() {
   })
 }
 
+// useReparentWorker rewires who a Worker reports to. parentID === ''
+// clears the manager (Worker becomes top-level). Drives the chart's
+// drag-to-reparent: dragging manager → subordinate sets parent_id,
+// deleting the edge clears it. Invalidates overview + the worker list
+// so the new accountability edge renders on the next refetch.
+export function useReparentWorker() {
+  const api = useApi()
+  const qc = useQueryClient()
+  const { orgID } = useHelixOrgBase()
+  return useMutation({
+    mutationFn: async ({ workerID, parentID }: { workerID: string; parentID: string }) => {
+      await api.getApiClient().v1OrgsWorkersParentCreate(workerID, orgID, { parent_id: parentID })
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.overview(orgID) })
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.workers(orgID) })
+    },
+  })
+}
+
+// useSubscribeWorkerAtChart drives the chart's drag-to-subscribe flow.
+// Each call carries its own (workerID, streamID) because the chart
+// wires arbitrary Workers to arbitrary streams; useSubscribeWorker is
+// bound to a single workerID and so doesn't fit the canvas's onConnect.
+export function useSubscribeWorkerAtChart() {
+  const api = useApi()
+  const qc = useQueryClient()
+  const { orgID } = useHelixOrgBase()
+  return useMutation({
+    mutationFn: async ({ workerID, streamID }: { workerID: string; streamID: string }) => {
+      await api.getApiClient().v1OrgsWorkersSubscriptionsCreate(workerID, orgID, { stream_id: streamID })
+    },
+    onSuccess: (_data, { workerID }) => {
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.workerSubs(orgID, workerID) })
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.streams(orgID) })
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.overview(orgID) })
+    },
+  })
+}
+
+// useUnsubscribeWorkerAtChart is the chart-scoped counterpart of
+// useSubscribeWorkerAtChart — it drops a (worker, stream) subscription
+// when the user deletes a subscription edge on the canvas.
+export function useUnsubscribeWorkerAtChart() {
+  const api = useApi()
+  const qc = useQueryClient()
+  const { orgID } = useHelixOrgBase()
+  return useMutation({
+    mutationFn: async ({ workerID, streamID }: { workerID: string; streamID: string }) => {
+      await api.getApiClient().v1OrgsWorkersSubscriptionsDelete(workerID, streamID, orgID)
+    },
+    onSuccess: (_data, { workerID }) => {
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.workerSubs(orgID, workerID) })
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.streams(orgID) })
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.overview(orgID) })
+    },
+  })
+}
+
 export function useFireHelixOrgWorker() {
   const api = useApi()
   const qc = useQueryClient()

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -294,6 +294,11 @@ definitions:
       identity:
         type: string
     type: object
+  api.UpdateWorkerParentRequest:
+    properties:
+      parent_id:
+        type: string
+    type: object
   api.UpdateWorkerRoleRequest:
     properties:
       content:
@@ -17892,6 +17897,42 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: 'Helix-org: update worker identity'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/workers/{id}/parent:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Worker ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: New parent worker id ('' to clear)
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/api.UpdateWorkerParentRequest'
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: set worker parent (reporting line)'
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/workers/{id}/role:

--- a/openapi.json
+++ b/openapi.json
@@ -12365,6 +12365,76 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/workers/{id}/parent": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: set worker parent (reporting line)",
+                "parameters": [
+                    {
+                        "description": "Worker ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.UpdateWorkerParentRequest"
+                            }
+                        }
+                    },
+                    "description": "New parent worker id ('' to clear)",
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/workers/{id}/role": {
             "post": {
                 "security": [
@@ -24639,6 +24709,14 @@
                 "type": "object",
                 "properties": {
                     "identity": {
+                        "type": "string"
+                    }
+                }
+            },
+            "api.UpdateWorkerParentRequest": {
+                "type": "object",
+                "properties": {
+                    "parent_id": {
                         "type": "string"
                     }
                 }

--- a/swagger.json
+++ b/swagger.json
@@ -10307,6 +10307,63 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/workers/{id}/parent": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: set worker parent (reporting line)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New parent worker id ('' to clear)",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.UpdateWorkerParentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/workers/{id}/role": {
             "post": {
                 "security": [
@@ -20462,6 +20519,14 @@
             "type": "object",
             "properties": {
                 "identity": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.UpdateWorkerParentRequest": {
+            "type": "object",
+            "properties": {
+                "parent_id": {
                     "type": "string"
                 }
             }


### PR DESCRIPTION
## Summary

The org chart canvas was swapped for a static role-grouped overview when Positions were removed from the domain (#2527). This brings back the **ReactFlow chart**, rebuilt for the position-less **Worker-in-Role** model rather than a literal revert (a revert would have reintroduced Positions).

### Frontend — [HelixOrgChart.tsx](frontend/src/pages/HelixOrgChart.tsx)
- Role frames contain **Worker nodes directly** (a Role can hold many Workers). Reporting edges are **Worker → Worker**, derived from `worker.parent_id` instead of the old Position parent chain.
- **Drag** a manager's bottom handle → a subordinate's top handle to set who reports to whom; select the edge + **Delete/Backspace** to clear it.
- **Drag** a Worker's right handle → a Stream to subscribe (dashed amber edge); delete to unsubscribe.
- Per-Role hire icon, fire-worker per node, delete-role / delete-stream — all with cascade-confirm dialogs. `dagre` lays out the role tree from the cross-role `parent_id` edges.
- Restored **"Chart"** naming (sidebar, org-selector tooltip, `/helix-org/chart` path). Route name `helix_org_chart` is unchanged so existing deep links keep resolving.

### Backend — new reparent primitive
There was no way to re-point an existing Worker's manager (Positions used to own that), so:
- `orgchart.Worker.WithParentID` for re-pointing a Worker's manager.
- `POST /workers/{id}/parent` (`reparentWorker`): sets/clears `parent_id`, validates the parent exists, and **guards against reporting cycles** (409). Empty body clears the manager.
- Service hooks `useReparentWorker` / `useSubscribeWorkerAtChart` / `useUnsubscribeWorkerAtChart`; regenerated OpenAPI client.

## Testing
- `go build ./pkg/org/... ./pkg/server/...` + `go test ./pkg/org/...` green. New `TestPostWorkerParent_SetClearCycle` covers set / clear / cycle-409 / not-found-404.
- `tsc --noEmit` clean; full `yarn build` succeeds.
- **End-to-end in a live stack** (org `test`): chart renders → hired a worker into a role via the hire icon → **dragged a reporting edge** (DB `parent_id` confirmed, layout reflowed) → **deleted the edge** (parent cleared) → **fired the worker** from its node (cascade dialog correct, org back to baseline). Activation stream stayed correctly anchored throughout.
- QA.md updated: the "chart UI is gone" note removed; new **§12** pins the drag interactions and cycle guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)