### PR TITLE
feat(helix-org): add inline worker chat transcript + fix queue pump + session authz

### DIFF
--- a/api/pkg/org/QA.md
+++ b/api/pkg/org/QA.md
@@ -197,14 +197,66 @@ Firing a worker removes its `s-activations-<workerID>` stream.
    Events on that stream survive in `org_events` as an audit
    trail.
 
-## §10. Chat → Human Desktop
+## §10. Chat: inline transcript + Human Desktop
 
-Chat MUST happen inside the per-Worker project's Human Desktop
-session — same surface a normal project uses — not the bare
-composer at `/agent/<id>`.
+The worker detail page renders the worker's conversation inline using
+the same transcript view the spec-task page uses (`EmbeddedSessionView`
++ `RobustPromptInput`), reading the per-Worker project's long-lived
+"Human Desktop" exploratory session. The operator should NOT have to
+click out to the external desktop tab just to see what the worker is
+doing. The desktop launch stays available for the full Zed GUI / video.
 
-Click **Open Human Desktop** on the worker detail page → lands on
-`…/projects/<project_id>/desktop/<session_id>` in a new tab.
+1. **Inline transcript auto-loads.** Open a worker that has already
+   been chatted with (`…/helix-org/workers/<id>` with a `project_id`).
+   The Chat panel shows the conversation inline — user turns, the
+   agent's responses, and its MCP tool calls (collapsible) — without
+   any click. The resolve is GET-only: opening the page must NOT spin
+   up a desktop container (Network tab: one
+   `GET …/projects/<pid>/exploratory-session`, no create/resume POST).
+2. **No-session empty state.** A freshly-hired worker that has never
+   been chatted with (no `project_id`, or project with no exploratory
+   session — the GET returns 204) shows "No conversation yet — launch
+   the Human Desktop to start one", not a crash or a spinner.
+3. **Send a message and verify the worker responds.** This is the
+   load-bearing test — the worker chat is useless if messages don't
+   actually reach the agent. With the transcript shown, type a prompt
+   the agent must visibly act on (e.g. "Reply with the single word
+   PONG and nothing else") and send.
+   - **The message must dispatch, not park.** The composer must NOT get
+     stuck showing a queue header reading **"Message queue (saved
+     locally)"** with the message sitting under it forever. That header
+     means the prompt was written to local storage but never sent — the
+     symptom of the 53b336e01 regression where the client-side queue
+     pump was deleted. For a worker/Human-Desktop session (no
+     `spec_task_id`) the composer pumps its own queue via
+     `onSend → streaming.NewInference`; the queued item should clear
+     within ~1s, not persist.
+   - **Network:** sending fires `POST …/sessions/chat` for the worker's
+     session id (NOT `POST …/prompt-history/sync`, which is the
+     spec-task-only path and 400s without a `spec_task_id`). It must
+     return 2xx, NOT **401** — the worker's "Human Desktop" session is
+     owned by whoever bootstrapped the org, not necessarily the operator
+     driving the worker, so the chat endpoint authorizes via org/project
+     RBAC (`authorizeUserToSession`, `ActionUpdate`), not strict
+     owner-equality. An operator who can see the transcript (read) but
+     lacks write access on the project is correctly refused; a read-only
+     org member should not be able to drive the agent.
+   - **The user turn appears** inline immediately.
+   - **The agent replies** — a new assistant interaction streams into
+     the transcript live (the WebSocket is subscribed to the session),
+     ending with the expected output (e.g. `PONG`). If the desktop was
+     paused, the first send wakes it (spinner, then the reply). No
+     navigation required.
+   - **DB cross-check** (optional): the new interactions land against
+     the worker's session —
+     `SELECT state, prompt_message FROM interactions WHERE session_id =
+     '<sid>' ORDER BY created DESC LIMIT 2;` shows the user prompt and a
+     `complete` assistant turn.
+4. **Open Human Desktop** still lands on
+   `…/projects/<project_id>/desktop/<session_id>` in a new tab — the
+   full GUI surface, NOT the bare composer at `/agent/<id>`. After
+   launch, the inline transcript on the worker page reflects the same
+   session.
 
 ## §11. Worker sandbox: Zed launch, per-Worker tools, stale-session recovery
 
@@ -267,8 +319,13 @@ pins the drag interactions and the `POST /workers/{id}/parent` endpoint.
   hires do NOT inherit; two workers in the same role can hold
   disjoint subscription sets.
 - §9 — fire removes the worker's activation stream (no orphans).
-- §10 — chat button lands on `…/projects/<pid>/desktop/<sid>`,
-  never on `…/agent/<id>`.
+- §10 — the worker page shows the conversation inline (transcript +
+  tool calls + composer) when a session exists, GET-only on load (no
+  container spin-up); the empty state shows otherwise. Sending a
+  message dispatches via `POST …/sessions/chat` (the composer does NOT
+  get stuck on "Message queue (saved locally)") and the worker's agent
+  replies live in the transcript. "Open Human Desktop" lands on
+  `…/projects/<pid>/desktop/<sid>`, never on `…/agent/<id>`.
 - §11 — fresh sandbox: Zed launches; per-Worker `gh`
   startupScript installs cleanly; `gh auth status` green.
 - No console errors beyond the three Vite WS errors at startup.

--- a/api/pkg/org/QA.md
+++ b/api/pkg/org/QA.md
@@ -15,8 +15,13 @@ the why.
   live MCP surface. There is no separate per-Worker grants table —
   capability is the Role's responsibility.
 - **Worker** — a human or AI agent. Holds a single `role_id` (the
-  capability binding) and an optional `parent_id` (the Worker it
-  reports to). The owner Worker `w-owner` has no parent.
+  capability binding). Who reports to whom is a separate many-to-many
+  relation (see Reporting line), not a field on the Worker.
+- **Reporting line** — an `org_reporting_lines` `(org, manager,
+  report)` row meaning *report* reports to *manager*. A Worker may
+  report to several managers; the owner Worker `w-owner` has none.
+  Worker deletion drops every line that references it via
+  `ON DELETE CASCADE` foreign keys. The graph is a cycle-guarded DAG.
 - **Subscription** — a `(org, worker, stream)` row. Worker-anchored:
   firing a Worker drops the row, and a new hire into the same Role
   does NOT automatically inherit. The hiring playbook re-subscribes
@@ -27,11 +32,11 @@ the why.
 
 The Chart tab is a ReactFlow canvas. Roles are group frames that
 contain their Workers (a Role can hold many Workers). Worker → Worker
-edges are reporting lines derived from `worker.parent_id`; drag from a
-manager's bottom handle to a subordinate to set it, delete the edge to
-clear it. Streams hang off the right; drag from a Worker's right handle
-to a Stream to subscribe. Click a Role header to edit it, a Worker to
-open its detail page.
+edges are reporting lines (`org_reporting_lines` rows); drag from a
+manager's bottom handle to a subordinate to add one, delete an edge to
+remove that line (a Worker can have several). Streams hang off the
+right; drag from a Worker's right handle to a Stream to subscribe.
+Click a Role header to edit it, a Worker to open its detail page.
 
 ## Setup
 
@@ -49,10 +54,13 @@ sidebar. Tests run against `…/orgs/<org>/helix-org/*`.
    2xx in parallel.
 4. Confirm DB:
    ```sql
-   SELECT id, role_id, parent_id FROM org_workers;
+   SELECT id, role_id FROM org_workers WHERE id = 'w-owner';
    ```
-   One row: `(w-owner, r-owner, NULL)`. No `org_positions` table
-   exists (`SELECT to_regclass('org_positions')` → NULL).
+   One row: `(w-owner, r-owner)`. There is no `parent_id` column —
+   reporting lives in `org_reporting_lines`; confirm it's empty:
+   `SELECT * FROM org_reporting_lines WHERE org_id = '<org>'` returns
+   zero rows. No `org_positions` table exists
+   (`SELECT to_regclass('org_positions')` → NULL).
 
 ## §2. Roles list + tool editor
 
@@ -89,8 +97,8 @@ dialogs.
 
 1. **+ New Worker** (the Workers tab primary action button; the Chart
    also hires via the per-Role hire icon). Form: `id`, `kind`,
-   `role_id` (dropdown), `parent_id` (optional, defaults to
-   `w-owner`), `identity_content`.
+   `role_id` (dropdown), `parent_id` (optional — the new hire's initial
+   manager; creates one reporting line), `identity_content`.
 2. Submit kind `ai`, id `w-ai-1`, role `r-test-dm`,
    parent `w-owner`. Row appears in the Workers table — Role
    column shows `r-test-dm`, Reports to shows `w-owner`.
@@ -266,28 +274,42 @@ Worker's Role tools are present in the sandbox MCP surface.
 
 ## §12. Chart canvas: reporting + subscription drag
 
-The Chart is a ReactFlow canvas keyed entirely off `worker.parent_id`
+The Chart is a ReactFlow canvas keyed off the `org_reporting_lines`
+join table (many-to-many: a Worker may report to several managers)
 and worker-anchored subscriptions — there are no Position rows. This
-pins the drag interactions and the `POST /workers/{id}/parent` endpoint.
+pins the drag interactions and the `POST /workers/{id}/parents` /
+`DELETE /workers/{id}/parents/{parent_id}` endpoints.
 
-1. On `…/helix-org/chart`, hire two AI workers into a new role
-   `r-eng` via the role frame's hire icon: `w-alice`, `w-bob`. Both
-   appear as Worker nodes inside the `r-eng` frame with no reporting
-   edges (top-level orphans).
+1. On `…/helix-org/chart`, hire three AI workers into a new role
+   `r-eng` via the role frame's hire icon: `w-alice`, `w-bob`,
+   `w-carol`. All appear as Worker nodes inside the `r-eng` frame with
+   no reporting edges (top-level orphans).
 2. Drag from `w-owner`'s **bottom** handle to `w-alice`'s **top**
    handle. A solid reporting edge appears; snackbar `w-alice now
-   reports to w-owner`. DB: `SELECT parent_id FROM org_workers WHERE
-   id='w-alice'` → `w-owner`. The `r-owner` frame now sits above
-   `r-eng` (dagre lays the role tree out from the cross-role edge).
+   reports to w-owner`. DB: `SELECT manager_id FROM org_reporting_lines
+   WHERE report_id='w-alice' AND org_id='<org>'` → `{w-owner}`. The
+   `r-owner` frame now sits above `r-eng` (dagre lays the role tree out
+   from the cross-role edge).
 3. Drag from `w-alice`'s bottom handle to `w-bob`'s top handle →
    `w-bob` reports to `w-alice` (intra-role edge; both stay in
    `r-eng`).
+3a. **Multi-manager.** Drag from `w-carol`'s bottom handle to
+   `w-alice`'s top handle. A second reporting edge appears; snackbar
+   `w-alice now reports to w-carol`. `GET /workers/w-alice →
+   .parent_ids` returns `[w-owner, w-carol]` (order may vary). DB:
+   `SELECT manager_id FROM org_reporting_lines WHERE
+   report_id='w-alice'` → two rows. Then select **only** the
+   `w-carol → w-alice` edge and press **Delete**: snackbar `w-alice no
+   longer reports to w-carol`; the `w-owner → w-alice` edge survives;
+   `parent_ids` is back to `[w-owner]`.
 4. **Cycle guard**: drag from `w-bob`'s bottom handle to `w-alice`'s
    top handle (would make alice→bob→alice). API returns 409; snackbar
    surfaces the cycle error; no edge added. DB unchanged.
 5. Select the `w-owner → w-alice` edge, press **Delete** (and retest
-   with **Backspace**). Edge gone; snackbar `w-alice no longer
-   reports to anyone`; `parent_id` cleared in DB.
+   with **Backspace**, re-adding the edge between the two). Edge gone;
+   snackbar `w-alice no longer reports to w-owner`; the
+   `org_reporting_lines` row for `(w-owner, w-alice)` is gone (no row
+   where `report_id='w-alice'`).
 6. Create a stream `s-test` (Streams tab). It appears as a dashed
    node to the right of the tree. Drag from `w-alice`'s **right**
    (amber) handle to `s-test` → dashed subscription edge; snackbar
@@ -302,7 +324,7 @@ pins the drag interactions and the `POST /workers/{id}/parent` endpoint.
 ## Pass criteria
 
 - §1 — bootstrap creates one Worker (`w-owner` with `role_id =
-  r-owner`, `parent_id = NULL`); no `org_positions` table.
+  r-owner`); `org_reporting_lines` is empty; no `org_positions` table.
 - §2 — `r-owner` has a non-empty tool set (position tools absent);
   multi-select adds/removes a tool; refresh persists; an edit
   propagates to every Worker in the role on the next MCP
@@ -333,9 +355,10 @@ pins the drag interactions and the `POST /workers/{id}/parent` endpoint.
 ## Known limitations
 
 - A Worker holds at most one Role.
-- A Worker's `parent_id` points at at most one other Worker.
-  Hierarchy is a tree (no co-managers in the current model).
+- A Worker's reporting lines are many-to-many (one `org_reporting_lines`
+  row per manager–report pair). A Worker may report to several managers
+  simultaneously; the graph is a cycle-guarded DAG, not a tree.
 - `w-owner` / `r-owner` are protected at the API; UI hides the
   trash/fire affordance and surfaces a friendly 409.
-- Reparenting is cycle-guarded server-side: dragging a manager edge
-  that would close a reporting loop is rejected with a 409.
+- Adding a reporting line is cycle-guarded server-side: dragging a
+  manager edge that would close a reporting loop is rejected with a 409.

--- a/api/pkg/org/application/bootstrap/bootstrap.go
+++ b/api/pkg/org/application/bootstrap/bootstrap.go
@@ -107,7 +107,7 @@ func Run(ctx context.Context, s *store.Store, params Params) (Result, error) {
 
 	ownerIdentity := "# Owner\n\nThe person running this org. Edit this from /helix-org to " +
 		"introduce yourself — your name, voice, and how you want subordinates to address you.\n"
-	owner, err := orgchart.NewHumanWorker(orgchart.WorkerID("w-owner"), ownerRole.ID, nil, ownerIdentity, params.OrganizationID)
+	owner, err := orgchart.NewHumanWorker(orgchart.WorkerID("w-owner"), ownerRole.ID, ownerIdentity, params.OrganizationID)
 	if err != nil {
 		return Result{}, err
 	}

--- a/api/pkg/org/application/dispatch/dispatcher_test.go
+++ b/api/pkg/org/application/dispatch/dispatcher_test.go
@@ -155,7 +155,7 @@ func seedAIWorker(t *testing.T, s *store.Store, workerID orgchart.WorkerID) {
 			t.Fatalf("create role: %v", err)
 		}
 	}
-	w, err := orgchart.NewAIWorker(workerID, roleID, nil, "# "+string(workerID)+"\nTest persona.", "org-test")
+	w, err := orgchart.NewAIWorker(workerID, roleID, "# "+string(workerID)+"\nTest persona.", "org-test")
 	if err != nil {
 		t.Fatalf("new worker: %v", err)
 	}

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -114,9 +114,11 @@ func (s *Service) Fire(ctx context.Context, orgID string, id orgchart.WorkerID) 
 		}
 	}
 
-	// Subscriptions (worker-anchored) and the direct reports' parent_id
-	// are cascaded structurally by Workers.Delete below — see
-	// gorm/worker.go. Nothing to drop explicitly here.
+	// The worker's subscriptions and every reporting line that
+	// references it are cascaded structurally when the worker row is
+	// deleted below (Workers.Delete drops the subs; the
+	// org_reporting_lines ON DELETE CASCADE foreign keys drop the
+	// lines). Nothing to drop explicitly here.
 
 	if env, err := s.Store.Environments.Get(ctx, orgID, id); err == nil {
 		if env.Path != "" {

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -114,21 +114,9 @@ func (s *Service) Fire(ctx context.Context, orgID string, id orgchart.WorkerID) 
 		}
 	}
 
-	// Subscriptions are worker-anchored — drop them. Best-effort +
-	// logged: a half-torn worker with leftover sub rows would
-	// dispatch events into a void, but the worker row delete below
-	// is the user-visible truth.
-	if s.Store.Subscriptions != nil {
-		if subs, err := s.Store.Subscriptions.ListForWorker(ctx, orgID, id); err == nil {
-			for _, sub := range subs {
-				if err := s.Store.Subscriptions.Delete(ctx, orgID, id, sub.StreamID); err != nil {
-					s.logger().Warn("fire: drop subscription", "worker", id, "stream", sub.StreamID, "err", err)
-				}
-			}
-		} else {
-			s.logger().Warn("fire: list subscriptions", "worker", id, "err", err)
-		}
-	}
+	// Subscriptions (worker-anchored) and the direct reports' parent_id
+	// are cascaded structurally by Workers.Delete below — see
+	// gorm/worker.go. Nothing to drop explicitly here.
 
 	if env, err := s.Store.Environments.Get(ctx, orgID, id); err == nil {
 		if env.Path != "" {

--- a/api/pkg/org/application/lifecycle/lifecycle_test.go
+++ b/api/pkg/org/application/lifecycle/lifecycle_test.go
@@ -40,7 +40,7 @@ func TestFire_RemovesWorkersActivationStream(t *testing.T) {
 	if err := st.Roles.Create(ctx, role); err != nil {
 		t.Fatalf("create role: %v", err)
 	}
-	worker, err := orgchart.NewAIWorker("w-ghost", role.ID, nil, "# Ghost", orgID)
+	worker, err := orgchart.NewAIWorker("w-ghost", role.ID, "# Ghost", orgID)
 	if err != nil {
 		t.Fatalf("new worker: %v", err)
 	}
@@ -76,19 +76,17 @@ func TestFire_RemovesWorkersActivationStream(t *testing.T) {
 	}
 }
 
-// TestFire_CascadesParentAndSubscriptions pins the two cascade bugs
-// found in the 2026-06-06 QA run:
+// TestFire_CascadesReportingLinesAndSubscriptions pins the two cascade
+// bugs found in the 2026-06-06 QA run, now handled structurally by the
+// store:
 //
-//   - F8: firing a manager left their direct reports' parent_id
-//     pointing at the now-deleted worker (dangling reference; the fire
-//     dialog promised "loses their manager" but the data kept it).
+//   - F8: firing a manager left their direct reports pointing at the
+//     now-deleted worker. With reporting lines, firing the manager must
+//     drop every line that references it (the gorm store does this with
+//     ON DELETE CASCADE; the memory store mirrors it).
 //   - F5: firing a worker deleted its s-activations-<id> stream but
-//     left OTHER workers' subscriptions to that stream behind, pointing
-//     at a stream that no longer exists.
-//
-// Both are now cascaded structurally by Workers.Delete /
-// Streams.Delete, so Fire just has to delete the worker.
-func TestFire_CascadesParentAndSubscriptions(t *testing.T) {
+//     left OTHER workers' subscriptions to that stream behind.
+func TestFire_CascadesReportingLinesAndSubscriptions(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	st := orggorm.GetOrgTestDB(t)
@@ -102,20 +100,27 @@ func TestFire_CascadesParentAndSubscriptions(t *testing.T) {
 		t.Fatalf("create role: %v", err)
 	}
 
-	mgr, err := orgchart.NewAIWorker("w-mgr", role.ID, nil, "# Mgr", orgID)
+	mgr, err := orgchart.NewAIWorker("w-mgr", role.ID, "# Mgr", orgID)
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
 	}
 	if err := st.Workers.Create(ctx, mgr); err != nil {
 		t.Fatalf("create manager: %v", err)
 	}
-	mgrID := mgr.ID()
-	report, err := orgchart.NewAIWorker("w-report", role.ID, &mgrID, "# Report", orgID)
+	report, err := orgchart.NewAIWorker("w-report", role.ID, "# Report", orgID)
 	if err != nil {
 		t.Fatalf("new report: %v", err)
 	}
 	if err := st.Workers.Create(ctx, report); err != nil {
 		t.Fatalf("create report: %v", err)
+	}
+	// w-report reports to w-mgr.
+	line, err := orgchart.NewReportingLine(orgID, "w-mgr", "w-report")
+	if err != nil {
+		t.Fatalf("new reporting line: %v", err)
+	}
+	if err := st.ReportingLines.Add(ctx, line); err != nil {
+		t.Fatalf("add reporting line: %v", err)
 	}
 
 	// The manager's activation stream + an outside subscriber (mirrors
@@ -141,13 +146,13 @@ func TestFire_CascadesParentAndSubscriptions(t *testing.T) {
 		t.Fatalf("Fire: %v", err)
 	}
 
-	// F8: the report must no longer claim w-mgr as its manager.
-	got, err := st.Workers.Get(ctx, orgID, "w-report")
+	// F8: no reporting line may reference the deleted manager.
+	managers, err := st.ReportingLines.ListManagers(ctx, orgID, "w-report")
 	if err != nil {
-		t.Fatalf("get report after fire: %v", err)
+		t.Fatalf("list managers after fire: %v", err)
 	}
-	if p := got.ParentID(); p != nil {
-		t.Fatalf("report parent_id = %q after firing manager, want nil (F8 dangling-parent regression)", *p)
+	if len(managers) != 0 {
+		t.Fatalf("w-report still reports to %v after firing its manager, want none (F8 dangling-line regression)", managers)
 	}
 
 	// F5: no subscription may reference the deleted activation stream.

--- a/api/pkg/org/application/lifecycle/lifecycle_test.go
+++ b/api/pkg/org/application/lifecycle/lifecycle_test.go
@@ -75,3 +75,87 @@ func TestFire_RemovesWorkersActivationStream(t *testing.T) {
 		t.Fatalf("activation stream %q still exists after Fire — orphan regression", streamID)
 	}
 }
+
+// TestFire_CascadesParentAndSubscriptions pins the two cascade bugs
+// found in the 2026-06-06 QA run:
+//
+//   - F8: firing a manager left their direct reports' parent_id
+//     pointing at the now-deleted worker (dangling reference; the fire
+//     dialog promised "loses their manager" but the data kept it).
+//   - F5: firing a worker deleted its s-activations-<id> stream but
+//     left OTHER workers' subscriptions to that stream behind, pointing
+//     at a stream that no longer exists.
+//
+// Both are now cascaded structurally by Workers.Delete /
+// Streams.Delete, so Fire just has to delete the worker.
+func TestFire_CascadesParentAndSubscriptions(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := orggorm.GetOrgTestDB(t)
+	const orgID = "org-cascade"
+
+	role, err := orgchart.NewRole("r-owner", "# Owner", nil, nil, time.Now().UTC(), orgID)
+	if err != nil {
+		t.Fatalf("new role: %v", err)
+	}
+	if err := st.Roles.Create(ctx, role); err != nil {
+		t.Fatalf("create role: %v", err)
+	}
+
+	mgr, err := orgchart.NewAIWorker("w-mgr", role.ID, nil, "# Mgr", orgID)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	if err := st.Workers.Create(ctx, mgr); err != nil {
+		t.Fatalf("create manager: %v", err)
+	}
+	mgrID := mgr.ID()
+	report, err := orgchart.NewAIWorker("w-report", role.ID, &mgrID, "# Report", orgID)
+	if err != nil {
+		t.Fatalf("new report: %v", err)
+	}
+	if err := st.Workers.Create(ctx, report); err != nil {
+		t.Fatalf("create report: %v", err)
+	}
+
+	// The manager's activation stream + an outside subscriber (mirrors
+	// the hiring caller auto-subscribed to a new hire's activations).
+	mgrStream := activation.StreamID(mgr.ID())
+	stream, err := streaming.NewStream(mgrStream, "Activations: w-mgr", "test", mgr.ID(), time.Now().UTC(), transport.Transport{}, orgID)
+	if err != nil {
+		t.Fatalf("new stream: %v", err)
+	}
+	if err := st.Streams.Create(ctx, stream); err != nil {
+		t.Fatalf("create stream: %v", err)
+	}
+	sub, err := streaming.NewSubscription("w-report", mgrStream, time.Now().UTC(), orgID)
+	if err != nil {
+		t.Fatalf("new subscription: %v", err)
+	}
+	if err := st.Subscriptions.Create(ctx, sub); err != nil {
+		t.Fatalf("create subscription: %v", err)
+	}
+
+	svc := &lifecycle.Service{Store: st, Owner: "w-owner"}
+	if err := svc.Fire(ctx, orgID, mgr.ID()); err != nil {
+		t.Fatalf("Fire: %v", err)
+	}
+
+	// F8: the report must no longer claim w-mgr as its manager.
+	got, err := st.Workers.Get(ctx, orgID, "w-report")
+	if err != nil {
+		t.Fatalf("get report after fire: %v", err)
+	}
+	if p := got.ParentID(); p != nil {
+		t.Fatalf("report parent_id = %q after firing manager, want nil (F8 dangling-parent regression)", *p)
+	}
+
+	// F5: no subscription may reference the deleted activation stream.
+	subs, err := st.Subscriptions.ListForStream(ctx, orgID, mgrStream)
+	if err != nil {
+		t.Fatalf("list subscriptions for stream: %v", err)
+	}
+	if len(subs) != 0 {
+		t.Fatalf("found %d subscription(s) to deleted stream %q, want 0 (F5 orphan-subscription regression)", len(subs), mgrStream)
+	}
+}

--- a/api/pkg/org/application/tools/builtins_test.go
+++ b/api/pkg/org/application/tools/builtins_test.go
@@ -71,7 +71,7 @@ func TestDemoOwnerHiresCEO(t *testing.T) {
 		t.Fatalf("seed role: %v", err)
 	}
 	mustCreate(t, s.Roles.Create(ctx, ownerRole))
-	owner, _ := orgchart.NewHumanWorker("w-owner", "r-owner", nil, "", "org-test")
+	owner, _ := orgchart.NewHumanWorker("w-owner", "r-owner", "", "org-test")
 	mustCreate(t, s.Workers.Create(ctx, owner))
 	ownerEnvPath := filepath.Join(envsDir, "w-owner")
 	if err := os.MkdirAll(ownerEnvPath, 0o750); err != nil {
@@ -208,7 +208,7 @@ func TestUpdateRoleAndIdentityAreDomainWrites(t *testing.T) {
 		"org-test",
 	)
 	mustCreate(t, s.Roles.Create(ctx, ownerRole))
-	owner, _ := orgchart.NewHumanWorker("w-owner", "r-owner", nil, "", "org-test")
+	owner, _ := orgchart.NewHumanWorker("w-owner", "r-owner", "", "org-test")
 	mustCreate(t, s.Workers.Create(ctx, owner))
 
 	ownerSession := connectMCP(t, srv.URL, "w-owner")
@@ -326,9 +326,9 @@ func TestStreamMembers(t *testing.T) {
 		"org-test",
 	)
 	mustCreate(t, s.Roles.Create(ctx, listenerRole))
-	owner, _ := orgchart.NewHumanWorker("w-owner", "r-owner", nil, "", "org-test")
+	owner, _ := orgchart.NewHumanWorker("w-owner", "r-owner", "", "org-test")
 	mustCreate(t, s.Workers.Create(ctx, owner))
-	worker, _ := orgchart.NewAIWorker("w-listener", "r-listener", nil, "", "org-test")
+	worker, _ := orgchart.NewAIWorker("w-listener", "r-listener", "", "org-test")
 	mustCreate(t, s.Workers.Create(ctx, worker))
 
 	ownerSession := connectMCP(t, srv.URL, "w-owner")
@@ -390,11 +390,11 @@ func TestInviteWorkers(t *testing.T) {
 	// is fine.
 	memberRole, _ := orgchart.NewRole("r-member", "# Member", nil, nil, now, "org-test")
 	mustCreate(t, s.Roles.Create(ctx, memberRole))
-	owner, _ := orgchart.NewHumanWorker("w-owner", "r-owner", nil, "", "org-test")
+	owner, _ := orgchart.NewHumanWorker("w-owner", "r-owner", "", "org-test")
 	mustCreate(t, s.Workers.Create(ctx, owner))
-	alice, _ := orgchart.NewAIWorker("w-alice", "r-member", nil, "", "org-test")
+	alice, _ := orgchart.NewAIWorker("w-alice", "r-member", "", "org-test")
 	mustCreate(t, s.Workers.Create(ctx, alice))
-	bob, _ := orgchart.NewAIWorker("w-bob", "r-member", nil, "", "org-test")
+	bob, _ := orgchart.NewAIWorker("w-bob", "r-member", "", "org-test")
 	mustCreate(t, s.Workers.Create(ctx, bob))
 
 	ownerSession := connectMCP(t, srv.URL, "w-owner")
@@ -480,9 +480,9 @@ func TestDM(t *testing.T) {
 		"org-test",
 	)
 	mustCreate(t, s.Roles.Create(ctx, memberRole))
-	alice, _ := orgchart.NewHumanWorker("w-alice", "r-member", nil, "", "org-test")
+	alice, _ := orgchart.NewHumanWorker("w-alice", "r-member", "", "org-test")
 	mustCreate(t, s.Workers.Create(ctx, alice))
-	bob, _ := orgchart.NewAIWorker("w-bob", "r-member", nil, "", "org-test")
+	bob, _ := orgchart.NewAIWorker("w-bob", "r-member", "", "org-test")
 	mustCreate(t, s.Workers.Create(ctx, bob))
 
 	aliceSession := connectMCP(t, srv.URL, "w-alice")
@@ -602,7 +602,7 @@ func TestReadsOverMCP(t *testing.T) {
 		"org-test",
 	)
 	mustCreate(t, s.Roles.Create(ctx, ownerRole))
-	owner, _ := orgchart.NewHumanWorker("w-owner", "r-owner", nil, "", "org-test")
+	owner, _ := orgchart.NewHumanWorker("w-owner", "r-owner", "", "org-test")
 	mustCreate(t, s.Workers.Create(ctx, owner))
 
 	ownerSession := connectMCP(t, srv.URL, "w-owner")
@@ -714,9 +714,9 @@ func TestWorkerLog(t *testing.T) {
 		"org-test",
 	)
 	mustCreate(t, s.Roles.Create(ctx, ownerRole))
-	owner, _ := orgchart.NewHumanWorker("w-owner", "r-owner", nil, "", "org-test")
+	owner, _ := orgchart.NewHumanWorker("w-owner", "r-owner", "", "org-test")
 	mustCreate(t, s.Workers.Create(ctx, owner))
-	bot, _ := orgchart.NewAIWorker("w-bot", "r-owner", nil, "", "org-test")
+	bot, _ := orgchart.NewAIWorker("w-bot", "r-owner", "", "org-test")
 	mustCreate(t, s.Workers.Create(ctx, bot))
 
 	// Pre-create the activation stream + seed a couple of events. In
@@ -827,9 +827,9 @@ func TestWorkerLogFiltersByActivationID(t *testing.T) {
 		"org-test",
 	)
 	mustCreate(t, s.Roles.Create(ctx, ownerRole))
-	owner, _ := orgchart.NewHumanWorker("w-owner", "r-owner", nil, "", "org-test")
+	owner, _ := orgchart.NewHumanWorker("w-owner", "r-owner", "", "org-test")
 	mustCreate(t, s.Workers.Create(ctx, owner))
-	bot, _ := orgchart.NewAIWorker("w-bot", "r-owner", nil, "", "org-test")
+	bot, _ := orgchart.NewAIWorker("w-bot", "r-owner", "", "org-test")
 	mustCreate(t, s.Workers.Create(ctx, bot))
 
 	streamID := activation.StreamID("w-bot")
@@ -941,7 +941,7 @@ func TestWorkerLogFiltersByActivationID(t *testing.T) {
 	// activationId belonging to a *different* Worker is rejected too —
 	// no cross-Worker leakage even if the caller knows another
 	// Worker's activation IDs.
-	other, _ := orgchart.NewAIWorker("w-other", "r-owner", nil, "", "org-test")
+	other, _ := orgchart.NewAIWorker("w-other", "r-owner", "", "org-test")
 	mustCreate(t, s.Workers.Create(ctx, other))
 	otherStream, _ := streaming.NewStream(activation.StreamID("w-other"), "Activations: w-other", "", "w-owner", base, transport.Transport{}, "org-test")
 	mustCreate(t, s.Streams.Create(ctx, otherStream))

--- a/api/pkg/org/application/tools/hire_worker.go
+++ b/api/pkg/org/application/tools/hire_worker.go
@@ -133,13 +133,13 @@ func (t *HireWorker) Invoke(ctx context.Context, inv tool.Invocation) (json.RawM
 	var wkr orgchart.Worker
 	switch args.Kind {
 	case orgchart.WorkerKindHuman:
-		w, err := orgchart.NewHumanWorker(id, roleID, parent, args.IdentityContent, orgID)
+		w, err := orgchart.NewHumanWorker(id, roleID, args.IdentityContent, orgID)
 		if err != nil {
 			return nil, err
 		}
 		wkr = w
 	case orgchart.WorkerKindAI:
-		w, err := orgchart.NewAIWorker(id, roleID, parent, args.IdentityContent, orgID)
+		w, err := orgchart.NewAIWorker(id, roleID, args.IdentityContent, orgID)
 		if err != nil {
 			return nil, err
 		}
@@ -155,6 +155,20 @@ func (t *HireWorker) Invoke(ctx context.Context, inv tool.Invocation) (json.RawM
 
 	if err := t.deps.Store.Workers.Create(ctx, wkr); err != nil {
 		return nil, err
+	}
+
+	// Wire the initial reporting line (the new hire reports to parent)
+	// now that both Worker rows exist. Reporting is a many-to-many
+	// relation — more managers can be added later via the add-parent
+	// endpoint.
+	if parent != nil && t.deps.Store.ReportingLines != nil {
+		line, err := orgchart.NewReportingLine(orgID, *parent, id)
+		if err != nil {
+			return nil, err
+		}
+		if err := t.deps.Store.ReportingLines.Add(ctx, line); err != nil {
+			return nil, fmt.Errorf("add reporting line: %w", err)
+		}
 	}
 
 	env, err := environment.New(id, envPath, t.deps.Now(), orgID)

--- a/api/pkg/org/application/tools/hire_worker_test.go
+++ b/api/pkg/org/application/tools/hire_worker_test.go
@@ -69,7 +69,7 @@ func newHireTestEnv(t *testing.T) (Deps, *fakeDispatcher, string, orgchart.Worke
 	if err := st.Roles.Create(ctx, ownerRole); err != nil {
 		t.Fatalf("create role: %v", err)
 	}
-	caller, _ := orgchart.NewHumanWorker("w-owner", "r-owner", nil, "", "org-test")
+	caller, _ := orgchart.NewHumanWorker("w-owner", "r-owner", "", "org-test")
 	if err := st.Workers.Create(ctx, caller); err != nil {
 		t.Fatalf("create owner worker: %v", err)
 	}

--- a/api/pkg/org/application/tools/publish_test.go
+++ b/api/pkg/org/application/tools/publish_test.go
@@ -38,7 +38,7 @@ func TestPublishRejectsGitHubStream(t *testing.T) {
 	if err := st.Streams.Create(ctx, stream); err != nil {
 		t.Fatalf("create stream: %v", err)
 	}
-	caller, _ := orgchart.NewHumanWorker("w-owner", "r-owner", nil, "", "org-test")
+	caller, _ := orgchart.NewHumanWorker("w-owner", "r-owner", "", "org-test")
 
 	deps := DefaultDeps(st)
 	tl := &Publish{deps: deps}
@@ -82,7 +82,7 @@ func TestPublishLocalStreamStillWorks(t *testing.T) {
 	if err := st.Streams.Create(ctx, stream); err != nil {
 		t.Fatalf("create stream: %v", err)
 	}
-	caller, _ := orgchart.NewHumanWorker("w-owner", "r-owner", nil, "", "org-test")
+	caller, _ := orgchart.NewHumanWorker("w-owner", "r-owner", "", "org-test")
 
 	deps := DefaultDeps(st)
 	tl := &Publish{deps: deps}

--- a/api/pkg/org/application/tools/read_workers.go
+++ b/api/pkg/org/application/tools/read_workers.go
@@ -13,14 +13,14 @@ import (
 )
 
 type workerView struct {
-	ID       orgchart.WorkerID   `json:"id"`
-	Kind     orgchart.WorkerKind `json:"kind"`
-	RoleID   orgchart.RoleID     `json:"roleId,omitempty"`
-	ParentID *orgchart.WorkerID  `json:"parentId,omitempty"`
+	ID        orgchart.WorkerID   `json:"id"`
+	Kind      orgchart.WorkerKind `json:"kind"`
+	RoleID    orgchart.RoleID     `json:"roleId,omitempty"`
+	ParentIDs []orgchart.WorkerID `json:"parentIds,omitempty"`
 }
 
-func workerViewOf(w orgchart.Worker) workerView {
-	return workerView{ID: w.ID(), Kind: w.Kind(), RoleID: w.RoleID(), ParentID: w.ParentID()}
+func workerViewOf(w orgchart.Worker, managers []orgchart.WorkerID) workerView {
+	return workerView{ID: w.ID(), Kind: w.Kind(), RoleID: w.RoleID(), ParentIDs: managers}
 }
 
 // ListWorkers returns every Worker — humans and AIs.
@@ -49,9 +49,21 @@ func (t *ListWorkers) Invoke(ctx context.Context, inv tool.Invocation) (json.Raw
 	if err != nil {
 		return nil, fmt.Errorf("list workers: %w", err)
 	}
+	// One List call builds the report → managers index, so we don't
+	// issue a ListManagers per worker.
+	managersByReport := map[orgchart.WorkerID][]orgchart.WorkerID{}
+	if t.deps.Store.ReportingLines != nil {
+		lines, err := t.deps.Store.ReportingLines.List(ctx, orgID)
+		if err != nil {
+			return nil, fmt.Errorf("list reporting lines: %w", err)
+		}
+		for _, l := range lines {
+			managersByReport[l.ReportID] = append(managersByReport[l.ReportID], l.ManagerID)
+		}
+	}
 	out := make([]workerView, 0, len(workers))
 	for _, w := range workers {
-		out = append(out, workerViewOf(w))
+		out = append(out, workerViewOf(w, managersByReport[w.ID()]))
 	}
 	return json.Marshal(map[string]any{"workers": out})
 }
@@ -91,7 +103,14 @@ func (t *GetWorker) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMe
 	if err != nil {
 		return nil, fmt.Errorf("get worker %q: %w", args.ID, err)
 	}
-	return json.Marshal(workerViewOf(w))
+	var managers []orgchart.WorkerID
+	if t.deps.Store.ReportingLines != nil {
+		managers, err = t.deps.Store.ReportingLines.ListManagers(ctx, orgID, w.ID())
+		if err != nil {
+			return nil, fmt.Errorf("list managers for %q: %w", args.ID, err)
+		}
+	}
+	return json.Marshal(workerViewOf(w, managers))
 }
 
 // GetWorkerEnvironment returns the on-disk Environment record for a Worker.

--- a/api/pkg/org/domain/orgchart/ids.go
+++ b/api/pkg/org/domain/orgchart/ids.go
@@ -1,9 +1,10 @@
-// Package orgchart owns the org-chart aggregate: Role and Worker
-// (interface plus HumanWorker / AIWorker). Role lists Tool names and
-// Stream IDs; Worker carries a RoleID (its capability binding) and an
-// optional ParentID (the Worker it reports to). Collapsing both
-// entities into one Go package resolves the cycle that per-entity
-// packages produced.
+// Package orgchart owns the org-chart aggregate: Role, Worker
+// (interface plus HumanWorker / AIWorker), and ReportingLine. Role
+// lists Tool names and Stream IDs; Worker carries a RoleID (its
+// capability binding); who reports to whom is a separate many-to-many
+// relation (ReportingLine), not a field on the Worker. Collapsing
+// these entities into one Go package resolves the cycle that
+// per-entity packages produced.
 //
 // The ID types are Go type aliases (`type WorkerID = string`) rather
 // than distinct named types. This is deliberate: orgchart's Role

--- a/api/pkg/org/domain/orgchart/reporting.go
+++ b/api/pkg/org/domain/orgchart/reporting.go
@@ -1,0 +1,37 @@
+package orgchart
+
+import "errors"
+
+// ReportingLine is one edge of the org's reporting graph: ReportID
+// reports to ManagerID. The relationship is many-to-many — a Worker
+// may report to several managers and a manager may have many reports —
+// so reporting lives in its own relation rather than as a column on
+// the Worker. Deleting either endpoint Worker drops every line that
+// references it (the store enforces this structurally).
+//
+// The graph is a DAG: cycles are rejected when a line is added (see the
+// add-parent handler's ancestor walk).
+type ReportingLine struct {
+	OrgID     string
+	ManagerID WorkerID
+	ReportID  WorkerID
+}
+
+// NewReportingLine validates and constructs a ReportingLine. Both
+// endpoints are required, must differ, and orgID must be set. A Worker
+// cannot report to itself.
+func NewReportingLine(orgID string, managerID, reportID WorkerID) (ReportingLine, error) {
+	if orgID == "" {
+		return ReportingLine{}, errors.New("reporting line orgID is empty")
+	}
+	if managerID == "" {
+		return ReportingLine{}, errors.New("reporting line managerID is empty")
+	}
+	if reportID == "" {
+		return ReportingLine{}, errors.New("reporting line reportID is empty")
+	}
+	if managerID == reportID {
+		return ReportingLine{}, errors.New("worker cannot report to itself")
+	}
+	return ReportingLine{OrgID: orgID, ManagerID: managerID, ReportID: reportID}, nil
+}

--- a/api/pkg/org/domain/orgchart/worker.go
+++ b/api/pkg/org/domain/orgchart/worker.go
@@ -7,9 +7,10 @@ import "errors"
 // implementations; the unexported marker method keeps the set closed.
 //
 // Each Worker carries a Role (the capability binding — the live source
-// of truth for the Worker's MCP surface) and an optional ParentID (the
-// Worker this one reports to). The owner Worker (`w-owner`) has nil
-// ParentID. A person who serves two roles is two Workers.
+// of truth for the Worker's MCP surface). Reporting lines are a
+// separate many-to-many relation (see ReportingLine) rather than a
+// field on the Worker, so a Worker can report to several managers. A
+// person who serves two roles is two Workers.
 //
 // IdentityContent is the per-Worker Identity description. It lives
 // in the domain — never on disk — so it survives any change in env
@@ -19,15 +20,9 @@ type Worker interface {
 	ID() WorkerID
 	Kind() WorkerKind
 	RoleID() RoleID
-	ParentID() *WorkerID
 	IdentityContent() string
 	OrganizationID() string
 	WithIdentityContent(content string) Worker
-	// WithParentID returns a copy of the Worker reporting to parent.
-	// A nil parent makes the Worker top-level (no manager); the chart
-	// UI uses this when an edge is deleted. Returns an error if the
-	// parent is the Worker itself or an empty (non-nil) id.
-	WithParentID(parent *WorkerID) (Worker, error)
 	isWorker()
 }
 
@@ -35,15 +30,13 @@ type Worker interface {
 type HumanWorker struct {
 	id              WorkerID
 	roleID          RoleID
-	parentID        *WorkerID
 	identityContent string
 	orgID           string
 }
 
-// NewHumanWorker validates and constructs a HumanWorker. orgID and
-// roleID are required. parentID may be nil for the owner; passing a
-// non-nil empty string is rejected. A worker may not be its own parent.
-func NewHumanWorker(id WorkerID, roleID RoleID, parentID *WorkerID, identityContent, orgID string) (*HumanWorker, error) {
+// NewHumanWorker validates and constructs a HumanWorker. id, roleID
+// and orgID are required.
+func NewHumanWorker(id WorkerID, roleID RoleID, identityContent, orgID string) (*HumanWorker, error) {
 	if id == "" {
 		return nil, errors.New("worker id is empty")
 	}
@@ -53,28 +46,16 @@ func NewHumanWorker(id WorkerID, roleID RoleID, parentID *WorkerID, identityCont
 	if orgID == "" {
 		return nil, errors.New("worker orgID is empty")
 	}
-	parent, err := validateParent(id, parentID)
-	if err != nil {
-		return nil, err
-	}
-	return &HumanWorker{id: id, roleID: roleID, parentID: parent, identityContent: identityContent, orgID: orgID}, nil
+	return &HumanWorker{id: id, roleID: roleID, identityContent: identityContent, orgID: orgID}, nil
 }
 
 func (h *HumanWorker) ID() WorkerID            { return h.id }
 func (h *HumanWorker) Kind() WorkerKind        { return WorkerKindHuman }
 func (h *HumanWorker) RoleID() RoleID          { return h.roleID }
-func (h *HumanWorker) ParentID() *WorkerID     { return cloneParent(h.parentID) }
 func (h *HumanWorker) IdentityContent() string { return h.identityContent }
 func (h *HumanWorker) OrganizationID() string  { return h.orgID }
 func (h *HumanWorker) WithIdentityContent(content string) Worker {
-	return &HumanWorker{id: h.id, roleID: h.roleID, parentID: cloneParent(h.parentID), identityContent: content, orgID: h.orgID}
-}
-func (h *HumanWorker) WithParentID(parent *WorkerID) (Worker, error) {
-	p, err := validateParent(h.id, parent)
-	if err != nil {
-		return nil, err
-	}
-	return &HumanWorker{id: h.id, roleID: h.roleID, parentID: p, identityContent: h.identityContent, orgID: h.orgID}, nil
+	return &HumanWorker{id: h.id, roleID: h.roleID, identityContent: content, orgID: h.orgID}
 }
 func (h *HumanWorker) isWorker() {}
 
@@ -82,13 +63,12 @@ func (h *HumanWorker) isWorker() {}
 type AIWorker struct {
 	id              WorkerID
 	roleID          RoleID
-	parentID        *WorkerID
 	identityContent string
 	orgID           string
 }
 
 // NewAIWorker validates and constructs an AIWorker.
-func NewAIWorker(id WorkerID, roleID RoleID, parentID *WorkerID, identityContent, orgID string) (*AIWorker, error) {
+func NewAIWorker(id WorkerID, roleID RoleID, identityContent, orgID string) (*AIWorker, error) {
 	if id == "" {
 		return nil, errors.New("worker id is empty")
 	}
@@ -98,49 +78,15 @@ func NewAIWorker(id WorkerID, roleID RoleID, parentID *WorkerID, identityContent
 	if orgID == "" {
 		return nil, errors.New("worker orgID is empty")
 	}
-	parent, err := validateParent(id, parentID)
-	if err != nil {
-		return nil, err
-	}
-	return &AIWorker{id: id, roleID: roleID, parentID: parent, identityContent: identityContent, orgID: orgID}, nil
+	return &AIWorker{id: id, roleID: roleID, identityContent: identityContent, orgID: orgID}, nil
 }
 
 func (a *AIWorker) ID() WorkerID            { return a.id }
 func (a *AIWorker) Kind() WorkerKind        { return WorkerKindAI }
 func (a *AIWorker) RoleID() RoleID          { return a.roleID }
-func (a *AIWorker) ParentID() *WorkerID     { return cloneParent(a.parentID) }
 func (a *AIWorker) IdentityContent() string { return a.identityContent }
 func (a *AIWorker) OrganizationID() string  { return a.orgID }
 func (a *AIWorker) WithIdentityContent(content string) Worker {
-	return &AIWorker{id: a.id, roleID: a.roleID, parentID: cloneParent(a.parentID), identityContent: content, orgID: a.orgID}
-}
-func (a *AIWorker) WithParentID(parent *WorkerID) (Worker, error) {
-	p, err := validateParent(a.id, parent)
-	if err != nil {
-		return nil, err
-	}
-	return &AIWorker{id: a.id, roleID: a.roleID, parentID: p, identityContent: a.identityContent, orgID: a.orgID}, nil
+	return &AIWorker{id: a.id, roleID: a.roleID, identityContent: content, orgID: a.orgID}
 }
 func (a *AIWorker) isWorker() {}
-
-func validateParent(self WorkerID, parent *WorkerID) (*WorkerID, error) {
-	if parent == nil {
-		return nil, nil
-	}
-	if *parent == "" {
-		return nil, errors.New("parent worker id is empty")
-	}
-	if *parent == self {
-		return nil, errors.New("worker cannot be its own parent")
-	}
-	p := *parent
-	return &p, nil
-}
-
-func cloneParent(parent *WorkerID) *WorkerID {
-	if parent == nil {
-		return nil
-	}
-	p := *parent
-	return &p
-}

--- a/api/pkg/org/domain/orgchart/worker_test.go
+++ b/api/pkg/org/domain/orgchart/worker_test.go
@@ -6,11 +6,6 @@ import (
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 )
 
-func ptr(s string) *orgchart.WorkerID {
-	v := orgchart.WorkerID(s)
-	return &v
-}
-
 func TestNewHumanWorker(t *testing.T) {
 	t.Parallel()
 
@@ -18,22 +13,19 @@ func TestNewHumanWorker(t *testing.T) {
 		name     string
 		id       orgchart.WorkerID
 		role     orgchart.RoleID
-		parent   *orgchart.WorkerID
 		identity string
 		wantErr  bool
 	}{
-		{"valid", "w-1", "r-ceo", nil, "i am the ceo", false},
-		{"valid with parent", "w-1", "r-eng", ptr("w-owner"), "i am the eng", false},
-		{"valid empty identity", "w-1", "r-ceo", nil, "", false},
-		{"empty id", "", "r-ceo", nil, "", true},
-		{"empty role", "w-1", "", nil, "", true},
-		{"self parent", "w-1", "r-ceo", ptr("w-1"), "", true},
+		{"valid", "w-1", "r-ceo", "i am the ceo", false},
+		{"valid empty identity", "w-1", "r-ceo", "", false},
+		{"empty id", "", "r-ceo", "", true},
+		{"empty role", "w-1", "", "", true},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			w, err := orgchart.NewHumanWorker(tc.id, tc.role, tc.parent, tc.identity, "org-test")
+			w, err := orgchart.NewHumanWorker(tc.id, tc.role, tc.identity, "org-test")
 			gotErr := err != nil
 			if gotErr != tc.wantErr {
 				t.Fatalf("orgchart.NewHumanWorker error = %v, wantErr = %v", err, tc.wantErr)
@@ -59,8 +51,7 @@ func TestNewHumanWorker(t *testing.T) {
 func TestNewAIWorker(t *testing.T) {
 	t.Parallel()
 
-	parent := orgchart.WorkerID("w-owner")
-	w, err := orgchart.NewAIWorker("w-ai", "r-docs", &parent, "you are the docs editor", "org-test")
+	w, err := orgchart.NewAIWorker("w-ai", "r-docs", "you are the docs editor", "org-test")
 	if err != nil {
 		t.Fatalf("orgchart.NewAIWorker: %v", err)
 	}
@@ -70,9 +61,6 @@ func TestNewAIWorker(t *testing.T) {
 	if got := w.RoleID(); got != "r-docs" {
 		t.Fatalf("RoleID = %q, want r-docs", got)
 	}
-	if got := w.ParentID(); got == nil || *got != "w-owner" {
-		t.Fatalf("ParentID = %v, want w-owner", got)
-	}
 	if w.IdentityContent() != "you are the docs editor" {
 		t.Fatalf("IdentityContent = %q", w.IdentityContent())
 	}
@@ -81,7 +69,7 @@ func TestNewAIWorker(t *testing.T) {
 func TestWorkerWithIdentityContent(t *testing.T) {
 	t.Parallel()
 
-	w, err := orgchart.NewAIWorker("w-1", "r-eng", nil, "old", "org-test")
+	w, err := orgchart.NewAIWorker("w-1", "r-eng", "old", "org-test")
 	if err != nil {
 		t.Fatalf("orgchart.NewAIWorker: %v", err)
 	}
@@ -112,7 +100,7 @@ var (
 // TestWorkerOrganizationIDFromConstructor: the OrganizationID accessor
 // returns the orgID supplied at construction time.
 func TestWorkerOrganizationIDFromConstructor(t *testing.T) {
-	ai, err := orgchart.NewAIWorker("w-bot", "r-eng", nil, "# bot", "org-acme")
+	ai, err := orgchart.NewAIWorker("w-bot", "r-eng", "# bot", "org-acme")
 	if err != nil {
 		t.Fatalf("orgchart.NewAIWorker: %v", err)
 	}
@@ -120,7 +108,7 @@ func TestWorkerOrganizationIDFromConstructor(t *testing.T) {
 		t.Errorf("AIWorker.OrganizationID() = %q, want org-acme", got)
 	}
 
-	hu, err := orgchart.NewHumanWorker("w-alice", "r-eng", nil, "# alice", "org-acme")
+	hu, err := orgchart.NewHumanWorker("w-alice", "r-eng", "# alice", "org-acme")
 	if err != nil {
 		t.Fatalf("orgchart.NewHumanWorker: %v", err)
 	}

--- a/api/pkg/org/domain/store/store.go
+++ b/api/pkg/org/domain/store/store.go
@@ -45,16 +45,37 @@ type Roles interface {
 // is the per-Worker description; the system holds it in the domain
 // rather than on disk so it survives any change in env layout.
 //
-// Delete removes the worker row. Callers are expected to have already
-// torn down dependent rows (subscriptions, grants, environment,
-// runtime state) — the store does not cascade. See the lifecycle
-// service in api/pkg/org/lifecycle for the canonical cascade.
+// Delete removes the worker row and structurally cascades the rows
+// that reference it: its subscriptions (worker-anchored) and every
+// reporting line where it is the manager or the report. See the gorm
+// and memory implementations.
 type Workers interface {
 	Create(ctx context.Context, worker orgchart.Worker) error
 	Get(ctx context.Context, orgID string, id orgchart.WorkerID) (orgchart.Worker, error)
 	List(ctx context.Context, orgID string) ([]orgchart.Worker, error)
 	Update(ctx context.Context, worker orgchart.Worker) error
 	Delete(ctx context.Context, orgID string, id orgchart.WorkerID) error
+}
+
+// ReportingLines persists the org's many-to-many reporting graph:
+// each row says ReportID reports to ManagerID. Worker-anchored on both
+// ends — deleting either endpoint Worker drops the line (the gorm
+// store enforces this with ON DELETE CASCADE foreign keys; the memory
+// store mirrors it). The graph is a DAG; cycle prevention lives in the
+// add-parent handler, not here.
+type ReportingLines interface {
+	// Add inserts a (manager, report) line. Idempotent: re-adding an
+	// existing line is a no-op (no error).
+	Add(ctx context.Context, line orgchart.ReportingLine) error
+	// Remove drops the (report → manager) line. Returns ErrNotFound
+	// when no such line exists.
+	Remove(ctx context.Context, orgID string, reportID, managerID orgchart.WorkerID) error
+	// List returns every reporting line in the org.
+	List(ctx context.Context, orgID string) ([]orgchart.ReportingLine, error)
+	// ListManagers returns the managers the given report reports to.
+	ListManagers(ctx context.Context, orgID string, reportID orgchart.WorkerID) ([]orgchart.WorkerID, error)
+	// ListReports returns the direct reports of the given manager.
+	ListReports(ctx context.Context, orgID string, managerID orgchart.WorkerID) ([]orgchart.WorkerID, error)
 }
 
 // WorkerRuntimeState is a sidecar key/value store keyed by
@@ -153,6 +174,7 @@ type Configs interface {
 type Store struct {
 	Roles              Roles
 	Workers            Workers
+	ReportingLines     ReportingLines
 	WorkerRuntimeState WorkerRuntimeState
 	Streams            Streams
 	Subscriptions      Subscriptions

--- a/api/pkg/org/infrastructure/persistence/gorm/gorm.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/gorm.go
@@ -20,6 +20,7 @@ import (
 var orgRowTypes = []any{
 	&roleRow{},
 	&workerRow{},
+	&reportingLineRow{},
 	&workerRuntimeStateRow{},
 	&streamRow{},
 	&subscriptionRow{},
@@ -32,12 +33,13 @@ var orgRowTypes = []any{
 // orgTableNames returns the SQL table names for orgRowTypes. Used by
 // the FK installer. The legacy `org_grants` and `org_positions`
 // tables are intentionally absent — capability is derived from
-// Role.Tools and Workers hold their own role/parent directly. Those
-// tables are no longer migrated; any pre-existing rows are simply
-// orphaned (left in place, never read).
+// Role.Tools, and reporting is its own org_reporting_lines relation.
+// Those tables are no longer migrated; any pre-existing rows are
+// simply orphaned (left in place, never read).
 var orgTableNames = []string{
 	"org_roles",
 	"org_workers",
+	"org_reporting_lines",
 	"org_worker_runtime_state",
 	"org_streams",
 	"org_subscriptions",
@@ -76,10 +78,19 @@ func OpenWithDB(db *gorm.DB, opts Options) (*store.Store, error) {
 		}
 	}
 
+	// The reporting-line cascade FKs reference org_workers (always
+	// migrated above), not organizations, so they install regardless of
+	// InstallOrganizationFK — they're what make worker deletion drop
+	// reporting lines structurally instead of via app code.
+	if err := installReportingLineFKs(db); err != nil {
+		return nil, fmt.Errorf("install reporting-line FKs: %w", err)
+	}
+
 	workers := newWorkersRepo(db)
 	return &store.Store{
 		Roles:              newRolesRepo(db),
 		Workers:            workers,
+		ReportingLines:     newReportingLinesRepo(db),
 		WorkerRuntimeState: newWorkerRuntimeStateRepo(db),
 		Streams:            newStreamsRepo(db),
 		Subscriptions:      newSubscriptionsRepo(db),
@@ -88,6 +99,42 @@ func OpenWithDB(db *gorm.DB, opts Options) (*store.Store, error) {
 		Configs:            newConfigsRepo(db),
 		Activations:        newActivationsRepo(db),
 	}, nil
+}
+
+// installReportingLineFKs adds the two ON DELETE CASCADE foreign keys
+// that make org_reporting_lines self-clean when a Worker is deleted:
+// (org_id, manager_id) and (org_id, report_id) both reference
+// org_workers(org_id, id). Idempotent — re-adding an existing
+// constraint is a no-op. Postgres-specific (our production target);
+// unit tests run against the in-memory store and never reach here.
+func installReportingLineFKs(db *gorm.DB) error {
+	if !db.Migrator().HasTable("org_reporting_lines") || !db.Migrator().HasTable("org_workers") {
+		return nil
+	}
+	type fk struct{ name, cols string }
+	for _, f := range []fk{
+		{"fk_org_reporting_lines_manager", "org_id, manager_id"},
+		{"fk_org_reporting_lines_report", "org_id, report_id"},
+	} {
+		stmt := fmt.Sprintf(
+			`DO $$ BEGIN
+				IF NOT EXISTS (
+					SELECT 1 FROM pg_constraint WHERE conname = '%s'
+				) THEN
+					ALTER TABLE org_reporting_lines
+						ADD CONSTRAINT %s
+						FOREIGN KEY (%s)
+						REFERENCES org_workers(org_id, id)
+						ON DELETE CASCADE;
+				END IF;
+			END $$;`,
+			f.name, f.name, f.cols,
+		)
+		if err := db.Exec(stmt).Error; err != nil {
+			return fmt.Errorf("add FK %s: %w", f.name, err)
+		}
+	}
+	return nil
 }
 
 // installOrganizationFKs adds the FK constraint

--- a/api/pkg/org/infrastructure/persistence/gorm/gorm_test.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/gorm_test.go
@@ -81,8 +81,8 @@ func TestRolesNotFound(t *testing.T) {
 	}
 }
 
-// TestWorkerReportingHierarchy round-trips Worker.ParentID through the
-// store. Workers replace Positions for tree structure.
+// TestWorkerReportingHierarchy round-trips a reporting line through the
+// store and confirms deleting the manager cascades the line away.
 func TestWorkerReportingHierarchy(t *testing.T) {
 	t.Parallel()
 	s := newStore(t)
@@ -96,23 +96,40 @@ func TestWorkerReportingHierarchy(t *testing.T) {
 	if err := s.Roles.Create(ctx, role); err != nil {
 		t.Fatalf("Create role: %v", err)
 	}
-	owner, _ := orgchart.NewHumanWorker("w-owner", role.ID, nil, "", "org-test")
+	owner, _ := orgchart.NewHumanWorker("w-owner", role.ID, "", "org-test")
 	if err := s.Workers.Create(ctx, owner); err != nil {
 		t.Fatalf("Create owner: %v", err)
 	}
-	ownerID := orgchart.WorkerID("w-owner")
-	child, _ := orgchart.NewAIWorker("w-ceo", role.ID, &ownerID, "", "org-test")
+	child, _ := orgchart.NewAIWorker("w-ceo", role.ID, "", "org-test")
 	if err := s.Workers.Create(ctx, child); err != nil {
 		t.Fatalf("Create child: %v", err)
 	}
-
-	got, err := s.Workers.Get(ctx, "org-test", "w-ceo")
+	line, err := orgchart.NewReportingLine("org-test", "w-owner", "w-ceo")
 	if err != nil {
-		t.Fatalf("Get: %v", err)
+		t.Fatalf("NewReportingLine: %v", err)
 	}
-	parent := got.ParentID()
-	if parent == nil || *parent != "w-owner" {
-		t.Fatalf("ParentID = %v, want w-owner", parent)
+	if err := s.ReportingLines.Add(ctx, line); err != nil {
+		t.Fatalf("Add reporting line: %v", err)
+	}
+
+	managers, err := s.ReportingLines.ListManagers(ctx, "org-test", "w-ceo")
+	if err != nil {
+		t.Fatalf("ListManagers: %v", err)
+	}
+	if len(managers) != 1 || managers[0] != "w-owner" {
+		t.Fatalf("managers = %v, want [w-owner]", managers)
+	}
+
+	// Deleting the manager cascades the line away.
+	if err := s.Workers.Delete(ctx, "org-test", "w-owner"); err != nil {
+		t.Fatalf("Delete owner: %v", err)
+	}
+	managers, err = s.ReportingLines.ListManagers(ctx, "org-test", "w-ceo")
+	if err != nil {
+		t.Fatalf("ListManagers after delete: %v", err)
+	}
+	if len(managers) != 0 {
+		t.Fatalf("managers = %v after deleting manager, want none (cascade)", managers)
 	}
 }
 
@@ -121,7 +138,7 @@ func TestWorkersHumanAndAI(t *testing.T) {
 	s := newStore(t)
 	ctx := context.Background()
 
-	human, err := orgchart.NewHumanWorker("w-owner", "r-owner", nil, "i am the owner", "org-test")
+	human, err := orgchart.NewHumanWorker("w-owner", "r-owner", "i am the owner", "org-test")
 	if err != nil {
 		t.Fatalf("NewHumanWorker: %v", err)
 	}
@@ -133,7 +150,7 @@ func TestWorkersHumanAndAI(t *testing.T) {
 	if err := s.Roles.Create(ctx, ownerRole); err != nil {
 		t.Fatalf("Create ceo role: %v", err)
 	}
-	ai, err := orgchart.NewAIWorker("w-ceo", "r-ceo", nil, "you are the ceo", "org-test")
+	ai, err := orgchart.NewAIWorker("w-ceo", "r-ceo", "you are the ceo", "org-test")
 	if err != nil {
 		t.Fatalf("NewAIWorker: %v", err)
 	}
@@ -170,7 +187,7 @@ func TestWorkerOrganizationIDRoundTrip(t *testing.T) {
 	s := newStore(t)
 	ctx := context.Background()
 
-	scoped, err := orgchart.NewAIWorker("w-acme-bot", "r-eng", nil, "# bot", "org-acme")
+	scoped, err := orgchart.NewAIWorker("w-acme-bot", "r-eng", "# bot", "org-acme")
 	if err != nil {
 		t.Fatalf("NewAIWorker: %v", err)
 	}

--- a/api/pkg/org/infrastructure/persistence/gorm/multitenant_test.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/multitenant_test.go
@@ -41,7 +41,7 @@ func TestWorkers_SameIDAcrossOrgs(t *testing.T) {
 		if err := s.Roles.Create(ctx, r); err != nil {
 			t.Fatalf("Roles.Create(%s): %v", org, err)
 		}
-		w, err := orgchart.NewHumanWorker("w-owner", "r-owner", nil, "# Owner identity", org)
+		w, err := orgchart.NewHumanWorker("w-owner", "r-owner", "# Owner identity", org)
 		if err != nil {
 			t.Fatalf("NewHumanWorker(%s): %v", org, err)
 		}
@@ -156,7 +156,7 @@ func mustSeedOwner(t *testing.T, s *store.Store, orgID string) {
 	if err := s.Roles.Create(ctx, r); err != nil {
 		t.Fatalf("Roles.Create(%s): %v", orgID, err)
 	}
-	w, err := orgchart.NewHumanWorker("w-owner", "r-owner", nil, "# Owner", orgID)
+	w, err := orgchart.NewHumanWorker("w-owner", "r-owner", "# Owner", orgID)
 	if err != nil {
 		t.Fatalf("NewHumanWorker: %v", err)
 	}

--- a/api/pkg/org/infrastructure/persistence/gorm/reporting_line.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/reporting_line.go
@@ -1,0 +1,114 @@
+package gorm
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+)
+
+// reportingLineRow is one edge of the org's reporting graph: ReportID
+// reports to ManagerID. Composite PK (org_id, manager_id, report_id).
+// Both (org_id, manager_id) and (org_id, report_id) carry an
+// ON DELETE CASCADE FK to org_workers(org_id, id), installed in
+// OpenWithDB — so deleting either endpoint Worker drops the line with
+// no app code involved.
+type reportingLineRow struct {
+	OrgID     string `gorm:"primaryKey;type:text;index"`
+	ManagerID string `gorm:"primaryKey;type:text;index"`
+	ReportID  string `gorm:"primaryKey;type:text;index"`
+	CreatedAt time.Time
+}
+
+func (reportingLineRow) TableName() string { return "org_reporting_lines" }
+
+type reportingLinesRepo struct {
+	db *gorm.DB
+}
+
+func newReportingLinesRepo(db *gorm.DB) *reportingLinesRepo {
+	return &reportingLinesRepo{db: db}
+}
+
+func (r *reportingLinesRepo) Add(ctx context.Context, line orgchart.ReportingLine) error {
+	row := reportingLineRow{
+		OrgID:     line.OrgID,
+		ManagerID: string(line.ManagerID),
+		ReportID:  string(line.ReportID),
+	}
+	// Idempotent: re-adding an existing (manager, report) edge is a
+	// no-op rather than a PK-violation error.
+	if err := r.db.WithContext(ctx).
+		Clauses(clause.OnConflict{DoNothing: true}).
+		Create(&row).Error; err != nil {
+		return fmt.Errorf("add reporting line: %w", err)
+	}
+	return nil
+}
+
+func (r *reportingLinesRepo) Remove(ctx context.Context, orgID string, reportID, managerID orgchart.WorkerID) error {
+	res := r.db.WithContext(ctx).
+		Where("org_id = ? AND manager_id = ? AND report_id = ?", orgID, string(managerID), string(reportID)).
+		Delete(&reportingLineRow{})
+	if res.Error != nil {
+		return fmt.Errorf("remove reporting line: %w", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("reporting line: %w", store.ErrNotFound)
+	}
+	return nil
+}
+
+func (r *reportingLinesRepo) List(ctx context.Context, orgID string) ([]orgchart.ReportingLine, error) {
+	var rows []reportingLineRow
+	if err := r.db.WithContext(ctx).
+		Where("org_id = ?", orgID).
+		Order("manager_id ASC, report_id ASC").
+		Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("list reporting lines: %w", err)
+	}
+	out := make([]orgchart.ReportingLine, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, orgchart.ReportingLine{
+			OrgID:     row.OrgID,
+			ManagerID: orgchart.WorkerID(row.ManagerID),
+			ReportID:  orgchart.WorkerID(row.ReportID),
+		})
+	}
+	return out, nil
+}
+
+func (r *reportingLinesRepo) ListManagers(ctx context.Context, orgID string, reportID orgchart.WorkerID) ([]orgchart.WorkerID, error) {
+	var rows []reportingLineRow
+	if err := r.db.WithContext(ctx).
+		Where("org_id = ? AND report_id = ?", orgID, string(reportID)).
+		Order("manager_id ASC").
+		Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("list managers: %w", err)
+	}
+	out := make([]orgchart.WorkerID, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, orgchart.WorkerID(row.ManagerID))
+	}
+	return out, nil
+}
+
+func (r *reportingLinesRepo) ListReports(ctx context.Context, orgID string, managerID orgchart.WorkerID) ([]orgchart.WorkerID, error) {
+	var rows []reportingLineRow
+	if err := r.db.WithContext(ctx).
+		Where("org_id = ? AND manager_id = ?", orgID, string(managerID)).
+		Order("report_id ASC").
+		Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("list reports: %w", err)
+	}
+	out := make([]orgchart.WorkerID, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, orgchart.WorkerID(row.ReportID))
+	}
+	return out, nil
+}

--- a/api/pkg/org/infrastructure/persistence/gorm/stream.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/stream.go
@@ -3,6 +3,7 @@ package gorm
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"gorm.io/gorm"
@@ -99,6 +100,24 @@ func (r *streamsRepo) Update(ctx context.Context, s streaming.Stream) error {
 	)
 }
 
+// Delete removes the stream row and structurally cascades the
+// subscriptions that reference it: every worker-anchored row for this
+// stream is dropped in the same transaction, so firing a worker (which
+// deletes its s-activations-<id> stream) can't leave other workers'
+// subscriptions pointing at a stream that no longer exists.
 func (r *streamsRepo) Delete(ctx context.Context, orgID string, id streaming.StreamID) error {
-	return r.Repository.Delete(ctx, store.WithOrg(orgID), store.WithID(string(id)))
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("org_id = ? AND stream_id = ?", orgID, string(id)).
+			Delete(&subscriptionRow{}).Error; err != nil {
+			return fmt.Errorf("delete stream: drop subscriptions: %w", err)
+		}
+		res := tx.Where("org_id = ? AND id = ?", orgID, string(id)).Delete(&streamRow{})
+		if res.Error != nil {
+			return fmt.Errorf("delete stream: %w", res.Error)
+		}
+		if res.RowsAffected == 0 {
+			return fmt.Errorf("stream: %w", store.ErrNotFound)
+		}
+		return nil
+	})
 }

--- a/api/pkg/org/infrastructure/persistence/gorm/streams_and_events_test.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/streams_and_events_test.go
@@ -84,7 +84,7 @@ func TestEventsListForWorkerViaSubscriptions(t *testing.T) {
 	if err := s.Roles.Create(ctx, role); err != nil {
 		t.Fatalf("Create role: %v", err)
 	}
-	worker, err := orgchart.NewAIWorker("w-1", "r-test", nil, "# w-1", "org-test")
+	worker, err := orgchart.NewAIWorker("w-1", "r-test", "# w-1", "org-test")
 	if err != nil {
 		t.Fatalf("new worker: %v", err)
 	}

--- a/api/pkg/org/infrastructure/persistence/gorm/worker.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/worker.go
@@ -2,6 +2,7 @@ package gorm
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"gorm.io/gorm"
@@ -81,8 +82,42 @@ func (r *workersRepo) List(ctx context.Context, orgID string) ([]orgchart.Worker
 	return r.Find(ctx, store.WithOrg(orgID), store.WithOrderAsc("id"))
 }
 
+// Delete removes the worker row and structurally cascades the two
+// relationships that reference it, so deletion can never leave a
+// dangling pointer:
+//
+//   - direct reports: any worker whose parent_id is this worker has
+//     it cleared to NULL (they become top-level). A composite
+//     self-referential FK with ON DELETE SET NULL can't express this
+//     — Postgres would also null the org_id half of (org_id,
+//     parent_id), which is a NOT NULL PK column — so the cascade
+//     lives here in the store, the one place every delete funnels
+//     through.
+//   - subscriptions: worker-anchored rows for this worker are
+//     dropped so none outlive the worker row.
+//
+// All three writes run in one transaction so a partial cascade can't
+// leave the graph half-torn.
 func (r *workersRepo) Delete(ctx context.Context, orgID string, id orgchart.WorkerID) error {
-	return r.Repository.Delete(ctx, store.WithOrg(orgID), store.WithID(string(id)))
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&workerRow{}).
+			Where("org_id = ? AND parent_id = ?", orgID, string(id)).
+			Update("parent_id", gorm.Expr("NULL")).Error; err != nil {
+			return fmt.Errorf("delete worker: clear child parent_id: %w", err)
+		}
+		if err := tx.Where("org_id = ? AND worker_id = ?", orgID, string(id)).
+			Delete(&subscriptionRow{}).Error; err != nil {
+			return fmt.Errorf("delete worker: drop subscriptions: %w", err)
+		}
+		res := tx.Where("org_id = ? AND id = ?", orgID, string(id)).Delete(&workerRow{})
+		if res.Error != nil {
+			return fmt.Errorf("delete worker: %w", res.Error)
+		}
+		if res.RowsAffected == 0 {
+			return fmt.Errorf("worker: %w", store.ErrNotFound)
+		}
+		return nil
+	})
 }
 
 func (r *workersRepo) Update(ctx context.Context, w orgchart.Worker) error {

--- a/api/pkg/org/infrastructure/persistence/gorm/worker.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/worker.go
@@ -17,14 +17,14 @@ import (
 // added out-of-band in OpenWithDB because GORM tag-driven FK creation
 // to a table owned by another package is fragile.
 //
-// RoleID is the live capability binding. ParentID is the reporting
-// line (nullable; the owner has no parent).
+// RoleID is the live capability binding. Reporting lines (who reports
+// to whom) are a separate many-to-many relation — see
+// reportingLineRow — so a Worker carries no parent column.
 type workerRow struct {
-	ID              string  `gorm:"primaryKey;type:text"`
-	OrgID           string  `gorm:"primaryKey;type:text;index"`
-	Kind            string  `gorm:"not null"` // "human" or "ai"
-	RoleID          string  `gorm:"not null;index"`
-	ParentID        *string `gorm:"index"`
+	ID              string `gorm:"primaryKey;type:text"`
+	OrgID           string `gorm:"primaryKey;type:text;index"`
+	Kind            string `gorm:"not null"` // "human" or "ai"
+	RoleID          string `gorm:"not null;index"`
 	IdentityContent string
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
@@ -35,32 +35,21 @@ func (workerRow) TableName() string { return "org_workers" }
 type workerMapper struct{}
 
 func (workerMapper) ToRow(w orgchart.Worker) (workerRow, error) {
-	var parent *string
-	if p := w.ParentID(); p != nil {
-		s := string(*p)
-		parent = &s
-	}
 	return workerRow{
 		ID:              string(w.ID()),
 		OrgID:           w.OrganizationID(),
 		Kind:            string(w.Kind()),
 		RoleID:          string(w.RoleID()),
-		ParentID:        parent,
 		IdentityContent: w.IdentityContent(),
 	}, nil
 }
 
 func (workerMapper) ToDomain(row workerRow) (orgchart.Worker, error) {
-	var parent *orgchart.WorkerID
-	if row.ParentID != nil {
-		p := orgchart.WorkerID(*row.ParentID)
-		parent = &p
-	}
 	switch orgchart.WorkerKind(row.Kind) {
 	case orgchart.WorkerKindHuman:
-		return orgchart.NewHumanWorker(orgchart.WorkerID(row.ID), orgchart.RoleID(row.RoleID), parent, row.IdentityContent, row.OrgID)
+		return orgchart.NewHumanWorker(orgchart.WorkerID(row.ID), orgchart.RoleID(row.RoleID), row.IdentityContent, row.OrgID)
 	case orgchart.WorkerKindAI:
-		return orgchart.NewAIWorker(orgchart.WorkerID(row.ID), orgchart.RoleID(row.RoleID), parent, row.IdentityContent, row.OrgID)
+		return orgchart.NewAIWorker(orgchart.WorkerID(row.ID), orgchart.RoleID(row.RoleID), row.IdentityContent, row.OrgID)
 	default:
 		return nil, errUnknownWorkerKind(row.Kind)
 	}
@@ -82,29 +71,14 @@ func (r *workersRepo) List(ctx context.Context, orgID string) ([]orgchart.Worker
 	return r.Find(ctx, store.WithOrg(orgID), store.WithOrderAsc("id"))
 }
 
-// Delete removes the worker row and structurally cascades the two
-// relationships that reference it, so deletion can never leave a
-// dangling pointer:
-//
-//   - direct reports: any worker whose parent_id is this worker has
-//     it cleared to NULL (they become top-level). A composite
-//     self-referential FK with ON DELETE SET NULL can't express this
-//     — Postgres would also null the org_id half of (org_id,
-//     parent_id), which is a NOT NULL PK column — so the cascade
-//     lives here in the store, the one place every delete funnels
-//     through.
-//   - subscriptions: worker-anchored rows for this worker are
-//     dropped so none outlive the worker row.
-//
-// All three writes run in one transaction so a partial cascade can't
-// leave the graph half-torn.
+// Delete removes the worker row and drops its worker-anchored
+// subscriptions in the same transaction. The reporting lines that
+// reference this worker (as manager or report) are removed by the
+// ON DELETE CASCADE foreign keys on org_reporting_lines (installed in
+// OpenWithDB), so no app code clears them — that's the whole point of
+// the association table.
 func (r *workersRepo) Delete(ctx context.Context, orgID string, id orgchart.WorkerID) error {
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Model(&workerRow{}).
-			Where("org_id = ? AND parent_id = ?", orgID, string(id)).
-			Update("parent_id", gorm.Expr("NULL")).Error; err != nil {
-			return fmt.Errorf("delete worker: clear child parent_id: %w", err)
-		}
 		if err := tx.Where("org_id = ? AND worker_id = ?", orgID, string(id)).
 			Delete(&subscriptionRow{}).Error; err != nil {
 			return fmt.Errorf("delete worker: drop subscriptions: %w", err)
@@ -131,7 +105,6 @@ func (r *workersRepo) Update(ctx context.Context, w orgchart.Worker) error {
 		store.WithUpdates(map[string]any{
 			"identity_content": row.IdentityContent,
 			"role_id":          row.RoleID,
-			"parent_id":        row.ParentID,
 			"kind":             row.Kind,
 		}),
 	)

--- a/api/pkg/org/infrastructure/persistence/memory/memorystore.go
+++ b/api/pkg/org/infrastructure/persistence/memory/memorystore.go
@@ -33,11 +33,13 @@ import (
 // for tests and dev paths that don't need Postgres.
 func New() *store.Store {
 	subs := &subscriptionsRepo{rows: map[subKey]streaming.Subscription{}}
-	workers := &workersRepo{rows: map[orgKey]orgchart.Worker{}, subs: subs}
+	lines := &reportingLinesRepo{rows: map[lineKey]struct{}{}}
+	workers := &workersRepo{rows: map[orgKey]orgchart.Worker{}, subs: subs, lines: lines}
 	streams := &streamsRepo{rows: map[orgKey]streaming.Stream{}, subs: subs}
 	return &store.Store{
 		Roles:              &rolesRepo{rows: map[orgKey]orgchart.Role{}},
 		Workers:            workers,
+		ReportingLines:     lines,
 		WorkerRuntimeState: &runtimeStateRepo{rows: map[runtimeKey]string{}},
 		Streams:            streams,
 		Subscriptions:      subs,
@@ -123,9 +125,12 @@ func (r *rolesRepo) Delete(_ context.Context, orgID string, id orgchart.RoleID) 
 type workersRepo struct {
 	mu   sync.RWMutex
 	rows map[orgKey]orgchart.Worker
-	// subs is held by reference so Delete can cascade: a deleted
-	// worker's own subscriptions are dropped, mirroring the gorm store.
-	subs *subscriptionsRepo
+	// subs and lines are held by reference so Delete can cascade: a
+	// deleted worker's own subscriptions and every reporting line that
+	// references it (as manager or report) are dropped, mirroring the
+	// gorm store's ON DELETE CASCADE foreign keys.
+	subs  *subscriptionsRepo
+	lines *reportingLinesRepo
 }
 
 func (w *workersRepo) Create(_ context.Context, wk orgchart.Worker) error {
@@ -172,11 +177,9 @@ func (w *workersRepo) Update(_ context.Context, wk orgchart.Worker) error {
 	return nil
 }
 
-// Delete removes the worker and cascades the relationships that point
-// at it, matching the gorm store: direct reports have their parent_id
-// cleared (they become top-level) and the worker's own subscriptions
-// are dropped. Without this a fired manager would leave reports with a
-// parent_id referencing a row that no longer exists.
+// Delete removes the worker and cascades the rows that reference it,
+// matching the gorm store: the worker's own subscriptions and every
+// reporting line where it is the manager or the report are dropped.
 func (w *workersRepo) Delete(_ context.Context, orgID string, id orgchart.WorkerID) error {
 	w.mu.Lock()
 	k := orgKey{OrgID: orgID, ID: string(id)}
@@ -184,42 +187,107 @@ func (w *workersRepo) Delete(_ context.Context, orgID string, id orgchart.Worker
 		w.mu.Unlock()
 		return fmt.Errorf("worker %q in org %q: %w", id, orgID, store.ErrNotFound)
 	}
-	// Cascade: null any direct report's parent_id.
-	for ck, child := range w.rows {
-		if ck.OrgID != orgID {
-			continue
-		}
-		if p := child.ParentID(); p != nil && *p == id {
-			reparented, err := withClearedParent(child)
-			if err != nil {
-				w.mu.Unlock()
-				return fmt.Errorf("clear child %q parent: %w", child.ID(), err)
-			}
-			w.rows[ck] = reparented
-		}
-	}
 	delete(w.rows, k)
 	w.mu.Unlock()
-	// Cascade: drop the worker's own subscriptions (held under a
-	// separate mutex, so release ours first to avoid lock ordering
-	// hazards).
+	// Cascade under the dependent repos' own mutexes — release ours
+	// first to avoid lock-ordering hazards.
 	if w.subs != nil {
 		w.subs.deleteAllForWorker(orgID, id)
+	}
+	if w.lines != nil {
+		w.lines.deleteAllForWorker(orgID, id)
 	}
 	return nil
 }
 
-// withClearedParent returns a copy of w with no reporting parent,
-// preserving every other field. Workers are immutable domain values,
-// so clearing parent_id means reconstructing the worker.
-func withClearedParent(w orgchart.Worker) (orgchart.Worker, error) {
-	switch w.Kind() {
-	case orgchart.WorkerKindHuman:
-		return orgchart.NewHumanWorker(w.ID(), w.RoleID(), nil, w.IdentityContent(), w.OrganizationID())
-	case orgchart.WorkerKindAI:
-		return orgchart.NewAIWorker(w.ID(), w.RoleID(), nil, w.IdentityContent(), w.OrganizationID())
-	default:
-		return nil, fmt.Errorf("unknown worker kind %q", w.Kind())
+// ---- ReportingLines ----------------------------------------------------
+
+// lineKey is the composite (org, manager, report) PK the memory repo
+// keys on — mirrors the gorm reportingLineRow composite PK.
+type lineKey struct {
+	OrgID     string
+	ManagerID string
+	ReportID  string
+}
+
+type reportingLinesRepo struct {
+	mu   sync.RWMutex
+	rows map[lineKey]struct{}
+}
+
+func (r *reportingLinesRepo) Add(_ context.Context, line orgchart.ReportingLine) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Idempotent: re-adding an existing edge is a no-op.
+	r.rows[lineKey{OrgID: line.OrgID, ManagerID: string(line.ManagerID), ReportID: string(line.ReportID)}] = struct{}{}
+	return nil
+}
+
+func (r *reportingLinesRepo) Remove(_ context.Context, orgID string, reportID, managerID orgchart.WorkerID) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	k := lineKey{OrgID: orgID, ManagerID: string(managerID), ReportID: string(reportID)}
+	if _, ok := r.rows[k]; !ok {
+		return fmt.Errorf("reporting line %q→%q in org %q: %w", reportID, managerID, orgID, store.ErrNotFound)
+	}
+	delete(r.rows, k)
+	return nil
+}
+
+func (r *reportingLinesRepo) List(_ context.Context, orgID string) ([]orgchart.ReportingLine, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]orgchart.ReportingLine, 0)
+	for k := range r.rows {
+		if k.OrgID == orgID {
+			out = append(out, orgchart.ReportingLine{OrgID: k.OrgID, ManagerID: orgchart.WorkerID(k.ManagerID), ReportID: orgchart.WorkerID(k.ReportID)})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ManagerID != out[j].ManagerID {
+			return out[i].ManagerID < out[j].ManagerID
+		}
+		return out[i].ReportID < out[j].ReportID
+	})
+	return out, nil
+}
+
+func (r *reportingLinesRepo) ListManagers(_ context.Context, orgID string, reportID orgchart.WorkerID) ([]orgchart.WorkerID, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]orgchart.WorkerID, 0)
+	for k := range r.rows {
+		if k.OrgID == orgID && k.ReportID == string(reportID) {
+			out = append(out, orgchart.WorkerID(k.ManagerID))
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out, nil
+}
+
+func (r *reportingLinesRepo) ListReports(_ context.Context, orgID string, managerID orgchart.WorkerID) ([]orgchart.WorkerID, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]orgchart.WorkerID, 0)
+	for k := range r.rows {
+		if k.OrgID == orgID && k.ManagerID == string(managerID) {
+			out = append(out, orgchart.WorkerID(k.ReportID))
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out, nil
+}
+
+// deleteAllForWorker drops every reporting line where the worker is the
+// manager or the report. Used by workersRepo.Delete to cascade — the
+// memory-store analogue of the gorm ON DELETE CASCADE foreign keys.
+func (r *reportingLinesRepo) deleteAllForWorker(orgID string, workerID orgchart.WorkerID) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for k := range r.rows {
+		if k.OrgID == orgID && (k.ManagerID == string(workerID) || k.ReportID == string(workerID)) {
+			delete(r.rows, k)
+		}
 	}
 }
 

--- a/api/pkg/org/infrastructure/persistence/memory/memorystore.go
+++ b/api/pkg/org/infrastructure/persistence/memory/memorystore.go
@@ -33,12 +33,13 @@ import (
 // for tests and dev paths that don't need Postgres.
 func New() *store.Store {
 	subs := &subscriptionsRepo{rows: map[subKey]streaming.Subscription{}}
-	workers := &workersRepo{rows: map[orgKey]orgchart.Worker{}}
+	workers := &workersRepo{rows: map[orgKey]orgchart.Worker{}, subs: subs}
+	streams := &streamsRepo{rows: map[orgKey]streaming.Stream{}, subs: subs}
 	return &store.Store{
 		Roles:              &rolesRepo{rows: map[orgKey]orgchart.Role{}},
 		Workers:            workers,
 		WorkerRuntimeState: &runtimeStateRepo{rows: map[runtimeKey]string{}},
-		Streams:            &streamsRepo{rows: map[orgKey]streaming.Stream{}},
+		Streams:            streams,
 		Subscriptions:      subs,
 		Events:             &eventsRepo{rows: []streaming.Event{}, subs: subs, workers: workers},
 		Environments:       &environmentsRepo{rows: map[orgKey]environment.Environment{}},
@@ -122,6 +123,9 @@ func (r *rolesRepo) Delete(_ context.Context, orgID string, id orgchart.RoleID) 
 type workersRepo struct {
 	mu   sync.RWMutex
 	rows map[orgKey]orgchart.Worker
+	// subs is held by reference so Delete can cascade: a deleted
+	// worker's own subscriptions are dropped, mirroring the gorm store.
+	subs *subscriptionsRepo
 }
 
 func (w *workersRepo) Create(_ context.Context, wk orgchart.Worker) error {
@@ -168,15 +172,55 @@ func (w *workersRepo) Update(_ context.Context, wk orgchart.Worker) error {
 	return nil
 }
 
+// Delete removes the worker and cascades the relationships that point
+// at it, matching the gorm store: direct reports have their parent_id
+// cleared (they become top-level) and the worker's own subscriptions
+// are dropped. Without this a fired manager would leave reports with a
+// parent_id referencing a row that no longer exists.
 func (w *workersRepo) Delete(_ context.Context, orgID string, id orgchart.WorkerID) error {
 	w.mu.Lock()
-	defer w.mu.Unlock()
 	k := orgKey{OrgID: orgID, ID: string(id)}
 	if _, ok := w.rows[k]; !ok {
+		w.mu.Unlock()
 		return fmt.Errorf("worker %q in org %q: %w", id, orgID, store.ErrNotFound)
 	}
+	// Cascade: null any direct report's parent_id.
+	for ck, child := range w.rows {
+		if ck.OrgID != orgID {
+			continue
+		}
+		if p := child.ParentID(); p != nil && *p == id {
+			reparented, err := withClearedParent(child)
+			if err != nil {
+				w.mu.Unlock()
+				return fmt.Errorf("clear child %q parent: %w", child.ID(), err)
+			}
+			w.rows[ck] = reparented
+		}
+	}
 	delete(w.rows, k)
+	w.mu.Unlock()
+	// Cascade: drop the worker's own subscriptions (held under a
+	// separate mutex, so release ours first to avoid lock ordering
+	// hazards).
+	if w.subs != nil {
+		w.subs.deleteAllForWorker(orgID, id)
+	}
 	return nil
+}
+
+// withClearedParent returns a copy of w with no reporting parent,
+// preserving every other field. Workers are immutable domain values,
+// so clearing parent_id means reconstructing the worker.
+func withClearedParent(w orgchart.Worker) (orgchart.Worker, error) {
+	switch w.Kind() {
+	case orgchart.WorkerKindHuman:
+		return orgchart.NewHumanWorker(w.ID(), w.RoleID(), nil, w.IdentityContent(), w.OrganizationID())
+	case orgchart.WorkerKindAI:
+		return orgchart.NewAIWorker(w.ID(), w.RoleID(), nil, w.IdentityContent(), w.OrganizationID())
+	default:
+		return nil, fmt.Errorf("unknown worker kind %q", w.Kind())
+	}
 }
 
 // ---- WorkerRuntimeState ------------------------------------------------
@@ -237,6 +281,10 @@ func (r *runtimeStateRepo) Clear(_ context.Context, orgID string, workerID orgch
 type streamsRepo struct {
 	mu   sync.RWMutex
 	rows map[orgKey]streaming.Stream
+	// subs is held by reference so Delete can cascade: every
+	// subscription to a deleted stream is dropped, mirroring the gorm
+	// store.
+	subs *subscriptionsRepo
 }
 
 func (s *streamsRepo) Create(_ context.Context, st streaming.Stream) error {
@@ -307,14 +355,21 @@ func (s *streamsRepo) Update(_ context.Context, st streaming.Stream) error {
 	return nil
 }
 
+// Delete removes the stream and cascades its subscriptions, matching
+// the gorm store: every worker-anchored row for this stream is dropped
+// so none dangle past the stream row.
 func (s *streamsRepo) Delete(_ context.Context, orgID string, id streaming.StreamID) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	key := orgKey{OrgID: orgID, ID: string(id)}
 	if _, ok := s.rows[key]; !ok {
+		s.mu.Unlock()
 		return fmt.Errorf("stream %q in org %q: %w", id, orgID, store.ErrNotFound)
 	}
 	delete(s.rows, key)
+	s.mu.Unlock()
+	if s.subs != nil {
+		s.subs.deleteAllForStream(orgID, id)
+	}
 	return nil
 }
 
@@ -351,6 +406,32 @@ func (s *subscriptionsRepo) Delete(_ context.Context, orgID string, workerID org
 	}
 	delete(s.rows, k)
 	return nil
+}
+
+// deleteAllForWorker drops every subscription held by the given
+// worker. Used by workersRepo.Delete to cascade — idempotent, no error
+// when the worker has none.
+func (s *subscriptionsRepo) deleteAllForWorker(orgID string, workerID orgchart.WorkerID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for k := range s.rows {
+		if k.OrgID == orgID && k.WorkerID == string(workerID) {
+			delete(s.rows, k)
+		}
+	}
+}
+
+// deleteAllForStream drops every subscription to the given stream.
+// Used by streamsRepo.Delete to cascade — idempotent, no error when
+// the stream has no subscribers.
+func (s *subscriptionsRepo) deleteAllForStream(orgID string, streamID streaming.StreamID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for k := range s.rows {
+		if k.OrgID == orgID && k.StreamID == string(streamID) {
+			delete(s.rows, k)
+		}
+	}
 }
 
 func (s *subscriptionsRepo) Find(_ context.Context, orgID string, workerID orgchart.WorkerID, streamID streaming.StreamID) (streaming.Subscription, error) {

--- a/api/pkg/org/infrastructure/runtime/helix/hire_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/hire_test.go
@@ -12,7 +12,7 @@ import (
 func TestHireRecorderPersistsHiringUser(t *testing.T) {
 	t.Parallel()
 	st := orggorm.GetOrgTestDB(t)
-	w, _ := orgchart.NewAIWorker("w-alice", "r-x", nil, "# Alice", "org-test")
+	w, _ := orgchart.NewAIWorker("w-alice", "r-x", "# Alice", "org-test")
 	if err := st.Workers.Create(context.Background(), w); err != nil {
 		t.Fatalf("create worker: %v", err)
 	}
@@ -33,7 +33,7 @@ func TestHireRecorderPersistsHiringUser(t *testing.T) {
 func TestHireRecorderEmptyUserIDIsNoop(t *testing.T) {
 	t.Parallel()
 	st := orggorm.GetOrgTestDB(t)
-	w, _ := orgchart.NewAIWorker("w-alice", "r-x", nil, "# Alice", "org-test")
+	w, _ := orgchart.NewAIWorker("w-alice", "r-x", "# Alice", "org-test")
 	if err := st.Workers.Create(context.Background(), w); err != nil {
 		t.Fatalf("create worker: %v", err)
 	}

--- a/api/pkg/org/infrastructure/runtime/helix/project_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_test.go
@@ -197,7 +197,7 @@ func newProjectTestStore(t *testing.T, roleContent string) (*store.Store, orgcha
 	if err := st.Roles.Create(ctx, r); err != nil {
 		t.Fatalf("create role: %v", err)
 	}
-	w, err := orgchart.NewAIWorker("w-eng", "r-eng", nil, "# Identity content", "org-test")
+	w, err := orgchart.NewAIWorker("w-eng", "r-eng", "# Identity content", "org-test")
 	if err != nil {
 		t.Fatalf("new worker: %v", err)
 	}
@@ -595,7 +595,7 @@ func TestEnsureRolePropagatesFromFirstPosition(t *testing.T) {
 func TestEnsureSkipsRolePushIfRoleMissing(t *testing.T) {
 	t.Parallel()
 	st := orggorm.GetOrgTestDB(t)
-	w, _ := orgchart.NewAIWorker("w-orphan", "r-missing", nil, "# I am alone", "org-test")
+	w, _ := orgchart.NewAIWorker("w-orphan", "r-missing", "# I am alone", "org-test")
 	if err := st.Workers.Create(context.Background(), w); err != nil {
 		t.Fatalf("create worker: %v", err)
 	}

--- a/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
@@ -70,7 +70,7 @@ func newHelixTestStore(t *testing.T) (*store.Store, orgchart.WorkerID) {
 	if err := s.Roles.Create(ctx, role); err != nil {
 		t.Fatalf("role: %v", err)
 	}
-	worker, _ := orgchart.NewAIWorker("w-eng", "r-eng", nil, "# Persona", "org-test")
+	worker, _ := orgchart.NewAIWorker("w-eng", "r-eng", "# Persona", "org-test")
 	if err := s.Workers.Create(ctx, worker); err != nil {
 		t.Fatalf("worker: %v", err)
 	}

--- a/api/pkg/org/infrastructure/runtime/helix/workspace_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/workspace_test.go
@@ -44,7 +44,7 @@ func newSeededStore(t *testing.T, repoID string) (*store.Store, orgchart.WorkerI
 	ctx := context.Background()
 	r, _ := orgchart.NewRole("r-eng", "# Role", nil, nil, time.Now().UTC(), "org-test")
 	_ = s.Roles.Create(ctx, r)
-	w, _ := orgchart.NewAIWorker("w-eng", "r-eng", nil, "# Persona", "org-test")
+	w, _ := orgchart.NewAIWorker("w-eng", "r-eng", "# Persona", "org-test")
 	_ = s.Workers.Create(ctx, w)
 	if repoID != "" {
 		_ = SaveProject(ctx, s, "org-test", w.ID(), "prj_x", "app_x", repoID)

--- a/api/pkg/org/interfaces/server/api/activate_worker_test.go
+++ b/api/pkg/org/interfaces/server/api/activate_worker_test.go
@@ -145,7 +145,7 @@ func TestActivateWorker_AllowsHumanWorker(t *testing.T) {
 	deps, st, _ := newDeps(t)
 	ctx := context.Background()
 	seedOwnerPosition(t, st, ctx)
-	human, err := orgchart.NewHumanWorker("w-human", "r-owner", nil, "human identity", "org-test")
+	human, err := orgchart.NewHumanWorker("w-human", "r-owner", "human identity", "org-test")
 	if err != nil {
 		t.Fatalf("NewHumanWorker: %v", err)
 	}

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -176,7 +176,10 @@ func Routes(deps Deps) []Route {
 		{Pattern: "POST /workers/{id}/activate", Handler: http.HandlerFunc(a.activateWorker)},
 		{Pattern: "POST /workers/{id}/role", Handler: http.HandlerFunc(a.updateWorkerRole)},
 		{Pattern: "POST /workers/{id}/identity", Handler: http.HandlerFunc(a.updateWorkerIdentity)},
-		{Pattern: "POST /workers/{id}/parent", Handler: http.HandlerFunc(a.reparentWorker)},
+		// Reporting lines are many-to-many — add/remove individual
+		// manager edges rather than replacing a single parent.
+		{Pattern: "POST /workers/{id}/parents", Handler: http.HandlerFunc(a.addWorkerParent)},
+		{Pattern: "DELETE /workers/{id}/parents/{parent_id}", Handler: http.HandlerFunc(a.removeWorkerParent)},
 		{Pattern: "GET /tools", Handler: http.HandlerFunc(a.listTools)},
 		{Pattern: "GET /settings", Handler: http.HandlerFunc(a.listSettings)},
 		{Pattern: "PUT /settings/{key}", Handler: http.HandlerFunc(a.setSetting)},
@@ -361,6 +364,19 @@ func (a *apiHandler) listWorkers(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, fmt.Errorf("list workers: %w", err))
 		return
 	}
+	// One List call builds the report → managers index so each worker's
+	// parent_ids don't cost a query.
+	managersByReport := map[orgchart.WorkerID][]string{}
+	if a.deps.Store.ReportingLines != nil {
+		lines, err := a.deps.Store.ReportingLines.List(ctx, orgID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Errorf("list reporting lines: %w", err))
+			return
+		}
+		for _, l := range lines {
+			managersByReport[l.ReportID] = append(managersByReport[l.ReportID], string(l.ManagerID))
+		}
+	}
 	// Resolve each worker's tools via Role.Tools. Cache by role so a
 	// org with many workers in the same role only pays for the
 	// lookup once.
@@ -379,7 +395,7 @@ func (a *apiHandler) listWorkers(w http.ResponseWriter, r *http.Request) {
 			}
 			roleCache[rid] = tools
 		}
-		out = append(out, workerDTO(wk, tools))
+		out = append(out, workerDTO(wk, tools, managersByReport[wk.ID()]))
 	}
 	writeJSON(w, http.StatusOK, out)
 }
@@ -511,19 +527,37 @@ func (a *apiHandler) fireWorker(w http.ResponseWriter, r *http.Request) {
 
 // workerDTO converts a orgchart.Worker to its wire form. tools may be
 // nil — callers populating per-worker grants pass the sorted list.
-func workerDTO(wk orgchart.Worker, tools []string) WorkerDTO {
-	dto := WorkerDTO{
+// parentIDs are the managers this Worker reports to (from the reporting
+// lines); nil for a top-level Worker.
+func workerDTO(wk orgchart.Worker, tools []string, parentIDs []string) WorkerDTO {
+	return WorkerDTO{
 		ID:              string(wk.ID()),
 		Kind:            string(wk.Kind()),
 		RoleID:          string(wk.RoleID()),
+		ParentIDs:       parentIDs,
 		IdentityContent: wk.IdentityContent(),
 		OrganizationID:  wk.OrganizationID(),
 		Tools:           tools,
 	}
-	if p := wk.ParentID(); p != nil {
-		dto.ParentID = string(*p)
+}
+
+// managerIDs returns the ids of the managers the given worker reports
+// to, as strings, for embedding in a WorkerDTO. Returns nil on any
+// store error — the reporting graph is best-effort context, never a
+// reason to fail the whole worker read.
+func (a *apiHandler) managerIDs(ctx context.Context, orgID string, id orgchart.WorkerID) []string {
+	if a.deps.Store.ReportingLines == nil {
+		return nil
 	}
-	return dto
+	managers, err := a.deps.Store.ReportingLines.ListManagers(ctx, orgID, id)
+	if err != nil || len(managers) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(managers))
+	for _, m := range managers {
+		out = append(out, string(m))
+	}
+	return out
 }
 
 // getWorker returns a Worker + the role/position it fills.
@@ -572,7 +606,7 @@ func (a *apiHandler) getWorker(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	detail := WorkerDetailDTO{Worker: workerDTO(wk, toolNames)}
+	detail := WorkerDetailDTO{Worker: workerDTO(wk, toolNames, a.managerIDs(ctx, orgID, id))}
 	detail.Role = roDTO
 	// Populate the agent app id + project id from the helix-runtime
 	// sidecar so the chart UI can deep-link "chat with worker" to the
@@ -787,27 +821,31 @@ func (a *apiHandler) updateWorkerIdentity(w http.ResponseWriter, r *http.Request
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// reparentWorker sets (or clears) the Worker this one reports to. The
+// addWorkerParent adds a reporting line: the Worker at {id} now also
+// reports to the manager in the body. Reporting is many-to-many, so
+// this is additive — a Worker can report to several managers. The
 // chart UI calls it when an accountability edge is drawn between two
-// Worker nodes (set parent) or deleted (clear parent, empty body).
+// Worker nodes.
 //
-// Validation beyond the domain's self-parent check:
-//   - a non-empty parent must reference a Worker that exists in the org
-//   - the new parent must not be a descendant of this Worker, which
-//     would create a reporting cycle
+// Validation:
+//   - the manager must reference a Worker that exists in the org
+//   - the manager must not already be a descendant of {id}, which
+//     would close a reporting cycle (the graph is a DAG)
 //
-// @Summary Helix-org: set worker parent (reporting line)
+// Idempotent: re-adding an existing line returns 204.
+//
+// @Summary Helix-org: add a worker reporting line (manager)
 // @Tags HelixOrg
 // @Accept json
-// @Param id path string true "Worker ID"
-// @Param payload body api.UpdateWorkerParentRequest true "New parent worker id ('' to clear)"
+// @Param id path string true "Worker ID (the report)"
+// @Param payload body api.AddWorkerParentRequest true "Manager worker id"
 // @Success 204
 // @Failure 400 {object} api.ErrorResponse
 // @Failure 404 {object} api.ErrorResponse
 // @Failure 409 {object} api.ErrorResponse
 // @Security ApiKeyAuth
-// @Router /api/v1/orgs/{org}/workers/{id}/parent [post]
-func (a *apiHandler) reparentWorker(w http.ResponseWriter, r *http.Request) {
+// @Router /api/v1/orgs/{org}/workers/{id}/parents [post]
+func (a *apiHandler) addWorkerParent(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	orgID, err := resolveOrgID(r)
 	if err != nil {
@@ -819,60 +857,104 @@ func (a *apiHandler) reparentWorker(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, errors.New("worker id is required"))
 		return
 	}
-	var req UpdateWorkerParentRequest
+	var req AddWorkerParentRequest
 	if err := decodeJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
-	existing, err := a.deps.Store.Workers.Get(ctx, orgID, id)
-	if err != nil {
+	managerID := orgchart.WorkerID(strings.TrimSpace(req.ParentID))
+	if managerID == "" {
+		writeError(w, http.StatusBadRequest, errors.New("parent_id is required"))
+		return
+	}
+	if a.deps.Store.ReportingLines == nil {
+		writeError(w, http.StatusNotImplemented, errors.New("reporting lines not wired"))
+		return
+	}
+	// Both endpoints must exist before we wire them.
+	if _, err := a.deps.Store.Workers.Get(ctx, orgID, id); err != nil {
 		writeError(w, errStatus(err), fmt.Errorf("get worker %s: %w", id, err))
 		return
 	}
-
-	var parent *orgchart.WorkerID
-	parentID := strings.TrimSpace(req.ParentID)
-	if parentID != "" {
-		pid := orgchart.WorkerID(parentID)
-		// The parent must exist before we wire to it.
-		if _, err := a.deps.Store.Workers.Get(ctx, orgID, pid); err != nil {
-			writeError(w, errStatus(err), fmt.Errorf("get parent worker %s: %w", pid, err))
-			return
-		}
-		// Cycle guard: walk up from the proposed parent via parent_id.
-		// If we reach this Worker, the edge would close a loop. We load
-		// the full set once and chase pointers in memory rather than
-		// issuing a Get per hop.
-		all, err := a.deps.Store.Workers.List(ctx, orgID)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, fmt.Errorf("list workers: %w", err))
-			return
-		}
-		byID := make(map[orgchart.WorkerID]orgchart.Worker, len(all))
-		for _, wk := range all {
-			byID[wk.ID()] = wk
-		}
-		for cursor := &pid; cursor != nil; {
-			if *cursor == id {
-				writeError(w, http.StatusConflict, fmt.Errorf("reparenting %s under %s would create a reporting cycle", id, pid))
-				return
-			}
-			wk, ok := byID[*cursor]
-			if !ok {
-				break
-			}
-			cursor = wk.ParentID()
-		}
-		parent = &pid
+	if _, err := a.deps.Store.Workers.Get(ctx, orgID, managerID); err != nil {
+		writeError(w, errStatus(err), fmt.Errorf("get manager %s: %w", managerID, err))
+		return
 	}
 
-	updated, err := existing.WithParentID(parent)
+	line, err := orgchart.NewReportingLine(orgID, managerID, id)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
-	if err := a.deps.Store.Workers.Update(ctx, updated); err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Errorf("update worker: %w", err))
+
+	// Cycle guard over the DAG: if {id} is already an ancestor of the
+	// proposed manager, adding manager → {id} closes a loop. Walk up
+	// from the manager via all reporting lines (BFS) and reject if we
+	// reach {id}.
+	lines, err := a.deps.Store.ReportingLines.List(ctx, orgID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Errorf("list reporting lines: %w", err))
+		return
+	}
+	managersOf := map[orgchart.WorkerID][]orgchart.WorkerID{}
+	for _, l := range lines {
+		managersOf[l.ReportID] = append(managersOf[l.ReportID], l.ManagerID)
+	}
+	seen := map[orgchart.WorkerID]bool{}
+	queue := []orgchart.WorkerID{managerID}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		if cur == id {
+			writeError(w, http.StatusConflict, fmt.Errorf("making %s report to %s would create a reporting cycle", id, managerID))
+			return
+		}
+		if seen[cur] {
+			continue
+		}
+		seen[cur] = true
+		queue = append(queue, managersOf[cur]...)
+	}
+
+	if err := a.deps.Store.ReportingLines.Add(ctx, line); err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Errorf("add reporting line: %w", err))
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// removeWorkerParent drops one reporting line: the Worker at {id} no
+// longer reports to {parent_id}. The chart UI calls it when an
+// accountability edge is deleted. Returns 404 when no such line exists.
+//
+// @Summary Helix-org: remove a worker reporting line (manager)
+// @Tags HelixOrg
+// @Param id path string true "Worker ID (the report)"
+// @Param parent_id path string true "Manager worker id"
+// @Success 204
+// @Failure 400 {object} api.ErrorResponse
+// @Failure 404 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/workers/{id}/parents/{parent_id} [delete]
+func (a *apiHandler) removeWorkerParent(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	orgID, err := resolveOrgID(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	id := orgchart.WorkerID(r.PathValue("id"))
+	managerID := orgchart.WorkerID(r.PathValue("parent_id"))
+	if id == "" || managerID == "" {
+		writeError(w, http.StatusBadRequest, errors.New("worker id and parent_id are required"))
+		return
+	}
+	if a.deps.Store.ReportingLines == nil {
+		writeError(w, http.StatusNotImplemented, errors.New("reporting lines not wired"))
+		return
+	}
+	if err := a.deps.Store.ReportingLines.Remove(ctx, orgID, id, managerID); err != nil {
+		writeError(w, errStatus(err), fmt.Errorf("remove reporting line %s→%s: %w", id, managerID, err))
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/api/pkg/org/interfaces/server/api/api_test.go
+++ b/api/pkg/org/interfaces/server/api/api_test.go
@@ -246,11 +246,12 @@ func TestPostWorkerRole_UpdatesRoleAssignment(t *testing.T) {
 	}
 }
 
-// TestPostWorkerParent_SetClearCycle pins the chart's drag-to-reparent
-// endpoint: setting a parent persists, an empty body clears it, an
-// unknown parent 404s, and an edge that would close a reporting loop is
-// rejected with 409 (the cycle guard).
-func TestPostWorkerParent_SetClearCycle(t *testing.T) {
+// TestWorkerParents_AddRemoveCycleMulti pins the chart's reporting-line
+// endpoints: adding a manager persists, a Worker can hold multiple
+// managers, removing one drops just that line, an unknown manager 404s,
+// and an edge that would close a reporting loop is rejected with 409
+// (the DAG cycle guard).
+func TestWorkerParents_AddRemoveCycleMulti(t *testing.T) {
 	deps, st, _ := newDeps(t)
 	h := orgapi.Handler(deps)
 	ctx := context.Background()
@@ -260,53 +261,71 @@ func TestPostWorkerParent_SetClearCycle(t *testing.T) {
 	mustCreateAIWorker(t, st, ctx, "w-alice", "r-owner", "alice identity")
 	mustCreateAIWorker(t, st, ctx, "w-bob", "r-owner", "bob identity")
 
-	parentOf := func(id string) string {
+	parentsOf := func(id string) []string {
 		rec := do(t, h, "GET", "/workers/"+id, nil)
 		if rec.Code != http.StatusOK {
 			t.Fatalf("GET %s status: got %d, want 200; body=%s", id, rec.Code, rec.Body)
 		}
 		var detail orgapi.WorkerDetailDTO
 		decode(t, rec, &detail)
-		return detail.Worker.ParentID
+		return detail.Worker.ParentIDs
+	}
+	hasParent := func(id, parent string) bool {
+		for _, p := range parentsOf(id) {
+			if p == parent {
+				return true
+			}
+		}
+		return false
 	}
 
-	// Set: w-alice reports to w-owner.
-	rec := do(t, h, "POST", "/workers/w-alice/parent", orgapi.UpdateWorkerParentRequest{ParentID: "w-owner"})
+	// Add: w-alice reports to w-owner.
+	rec := do(t, h, "POST", "/workers/w-alice/parents", orgapi.AddWorkerParentRequest{ParentID: "w-owner"})
 	if rec.Code != http.StatusNoContent {
-		t.Fatalf("set parent status: got %d, want 204; body=%s", rec.Code, rec.Body)
+		t.Fatalf("add parent status: got %d, want 204; body=%s", rec.Code, rec.Body)
 	}
-	if got := parentOf("w-alice"); got != "w-owner" {
-		t.Fatalf("w-alice parent: got %q, want w-owner", got)
+	if !hasParent("w-alice", "w-owner") {
+		t.Fatalf("w-alice parents: got %v, want to include w-owner", parentsOf("w-alice"))
 	}
 
-	// Chain: w-bob reports to w-alice.
-	rec = do(t, h, "POST", "/workers/w-bob/parent", orgapi.UpdateWorkerParentRequest{ParentID: "w-alice"})
+	// Multi-manager: w-alice also reports to w-bob.
+	rec = do(t, h, "POST", "/workers/w-alice/parents", orgapi.AddWorkerParentRequest{ParentID: "w-bob"})
 	if rec.Code != http.StatusNoContent {
-		t.Fatalf("chain parent status: got %d, want 204; body=%s", rec.Code, rec.Body)
+		t.Fatalf("add second parent status: got %d, want 204; body=%s", rec.Code, rec.Body)
+	}
+	if got := parentsOf("w-alice"); len(got) != 2 {
+		t.Fatalf("w-alice parents after second add: got %v, want 2", got)
 	}
 
-	// Cycle guard: w-alice → w-bob would close w-alice→w-bob→w-alice.
-	rec = do(t, h, "POST", "/workers/w-alice/parent", orgapi.UpdateWorkerParentRequest{ParentID: "w-bob"})
+	// Cycle guard: w-bob → w-alice would close w-alice→...→w-bob→w-alice
+	// (w-bob is already a manager of w-alice).
+	rec = do(t, h, "POST", "/workers/w-bob/parents", orgapi.AddWorkerParentRequest{ParentID: "w-alice"})
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("cycle status: got %d, want 409; body=%s", rec.Code, rec.Body)
 	}
-	if got := parentOf("w-alice"); got != "w-owner" {
-		t.Fatalf("w-alice parent after rejected cycle: got %q, want unchanged w-owner", got)
-	}
 
-	// Unknown parent → 404.
-	rec = do(t, h, "POST", "/workers/w-alice/parent", orgapi.UpdateWorkerParentRequest{ParentID: "w-ghost"})
+	// Unknown manager → 404.
+	rec = do(t, h, "POST", "/workers/w-alice/parents", orgapi.AddWorkerParentRequest{ParentID: "w-ghost"})
 	if rec.Code != http.StatusNotFound {
-		t.Fatalf("unknown parent status: got %d, want 404; body=%s", rec.Code, rec.Body)
+		t.Fatalf("unknown manager status: got %d, want 404; body=%s", rec.Code, rec.Body)
 	}
 
-	// Clear: empty body makes w-alice top-level again.
-	rec = do(t, h, "POST", "/workers/w-alice/parent", orgapi.UpdateWorkerParentRequest{ParentID: ""})
+	// Remove: drop just the w-owner line; w-bob remains.
+	rec = do(t, h, "DELETE", "/workers/w-alice/parents/w-owner", nil)
 	if rec.Code != http.StatusNoContent {
-		t.Fatalf("clear parent status: got %d, want 204; body=%s", rec.Code, rec.Body)
+		t.Fatalf("remove parent status: got %d, want 204; body=%s", rec.Code, rec.Body)
 	}
-	if got := parentOf("w-alice"); got != "" {
-		t.Fatalf("w-alice parent after clear: got %q, want empty", got)
+	if hasParent("w-alice", "w-owner") {
+		t.Fatalf("w-alice still reports to w-owner after remove: %v", parentsOf("w-alice"))
+	}
+	if !hasParent("w-alice", "w-bob") {
+		t.Fatalf("w-alice should still report to w-bob: %v", parentsOf("w-alice"))
+	}
+
+	// Removing a line that doesn't exist → 404.
+	rec = do(t, h, "DELETE", "/workers/w-alice/parents/w-owner", nil)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("remove missing line status: got %d, want 404; body=%s", rec.Code, rec.Body)
 	}
 }
 
@@ -327,7 +346,7 @@ func seedOwnerPosition(t *testing.T, st *store.Store, ctx context.Context) {
 
 func mustCreateAIWorker(t *testing.T, st *store.Store, ctx context.Context, id, role, identity string) {
 	t.Helper()
-	w, err := orgchart.NewAIWorker(orgchart.WorkerID(id), orgchart.RoleID(role), nil, identity, "org-test")
+	w, err := orgchart.NewAIWorker(orgchart.WorkerID(id), orgchart.RoleID(role), identity, "org-test")
 	if err != nil {
 		t.Fatalf("NewAIWorker: %v", err)
 	}

--- a/api/pkg/org/interfaces/server/api/dto.go
+++ b/api/pkg/org/interfaces/server/api/dto.go
@@ -55,15 +55,16 @@ type RoleDTO struct {
 }
 
 // WorkerDTO is one row in GET /workers and the body of GET
-// /workers/{id}. RoleID is the live capability binding; ParentID is
-// the Worker this one reports to (empty for the owner).
+// /workers/{id}. RoleID is the live capability binding; ParentIDs are
+// the Workers this one reports to (empty for the owner). Reporting is
+// many-to-many — a Worker may report to several managers.
 // IdentityContent is the per-Worker persona markdown (the Spawner
 // projects it into identity.md at activation time).
 type WorkerDTO struct {
 	ID              string   `json:"id"`
 	Kind            string   `json:"kind"`
 	RoleID          string   `json:"role_id,omitempty"`
-	ParentID        string   `json:"parent_id,omitempty"`
+	ParentIDs       []string `json:"parent_ids,omitempty"`
 	IdentityContent string   `json:"identity_content"`
 	OrganizationID  string   `json:"organization_id,omitempty"`
 	Tools           []string `json:"tools,omitempty"`
@@ -127,11 +128,12 @@ type UpdateWorkerRoleRequest struct {
 	Content string `json:"content"`
 }
 
-// UpdateWorkerParentRequest is the body of POST /workers/{id}/parent.
-// ParentID is the Worker this one now reports to; an empty string
-// clears the manager (the Worker becomes top-level). The chart UI
-// posts this when an accountability edge is drawn or deleted.
-type UpdateWorkerParentRequest struct {
+// AddWorkerParentRequest is the body of POST /workers/{id}/parents.
+// ParentID is a manager the Worker should now report to. Reporting is
+// many-to-many, so this ADDS a line rather than replacing — the chart
+// UI posts it when an accountability edge is drawn; deleting an edge
+// hits DELETE /workers/{id}/parents/{parent_id}.
+type AddWorkerParentRequest struct {
 	ParentID string `json:"parent_id"`
 }
 

--- a/api/pkg/org/interfaces/server/server_test.go
+++ b/api/pkg/org/interfaces/server/server_test.go
@@ -47,7 +47,7 @@ func newTestServer(t *testing.T) (*httptest.Server, orgchart.WorkerID) {
 	if err := s.Roles.Create(ctx, role); err != nil {
 		t.Fatalf("seed role: %v", err)
 	}
-	ai, _ := orgchart.NewAIWorker("w-ceo", "r-ceo", nil, "", "org-test")
+	ai, _ := orgchart.NewAIWorker("w-ceo", "r-ceo", "", "org-test")
 	if err := s.Workers.Create(ctx, ai); err != nil {
 		t.Fatalf("seed worker: %v", err)
 	}
@@ -100,7 +100,7 @@ func newTestServerRoleDerived(t *testing.T) (*httptest.Server, orgchart.WorkerID
 	if err := s.Roles.Create(ctx, role); err != nil {
 		t.Fatalf("seed role: %v", err)
 	}
-	ai, _ := orgchart.NewAIWorker("w-ceo", "r-ceo", nil, "", "org-test")
+	ai, _ := orgchart.NewAIWorker("w-ceo", "r-ceo", "", "org-test")
 	if err := s.Workers.Create(ctx, ai); err != nil {
 		t.Fatalf("seed worker: %v", err)
 	}
@@ -244,7 +244,7 @@ func newTestServerWithPrompts(t *testing.T, includeCreateRole bool) (*httptest.S
 	}
 	role, _ := orgchart.NewRole("r-ceo", "# CEO", roleTools, nil, time.Now().UTC(), "org-test")
 	_ = s.Roles.Create(ctx, role)
-	ai, _ := orgchart.NewAIWorker("w-ceo", "r-ceo", nil, "", "org-test")
+	ai, _ := orgchart.NewAIWorker("w-ceo", "r-ceo", "", "org-test")
 	_ = s.Workers.Create(ctx, ai)
 	return srv, "w-ceo"
 }

--- a/api/pkg/server/authz_test.go
+++ b/api/pkg/server/authz_test.go
@@ -666,3 +666,143 @@ func (s *AuthzAppSuite) TestWithOrg_AdminAllowed() {
 	err := s.server.authorizeUserToApp(context.Background(), user, app, types.ActionGet)
 	s.NoError(err)
 }
+
+// AuthzSessionSuite pins authorizeUserToSession, which startChatSessionHandler
+// uses to gate POST /sessions/chat on an existing session. The regression this
+// guards: the chat handler used a strict `session.Owner != user.ID` check, so an
+// org owner (or project grantee) who was NOT the literal session owner got a 401
+// when chatting into an org-shared session — e.g. a helix-org Worker's "Human
+// Desktop" session, which is owned by whoever bootstrapped the org, not the
+// operator driving the worker. The read path always used this RBAC; the write
+// path now matches it (with ActionUpdate so read-only members can't drive the
+// agent).
+type AuthzSessionSuite struct {
+	suite.Suite
+	ctrl      *gomock.Controller
+	mockStore *store.MockStore
+	server    *HelixAPIServer
+
+	orgID  string
+	userID string
+}
+
+func TestAuthzSessionSuite(t *testing.T) {
+	suite.Run(t, new(AuthzSessionSuite))
+}
+
+func (s *AuthzSessionSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.mockStore = store.NewMockStore(s.ctrl)
+	s.orgID = "org1"
+	s.userID = "user1"
+
+	s.server = &HelixAPIServer{
+		Cfg:   &config.ServerConfig{},
+		Store: s.mockStore,
+	}
+}
+
+func (s *AuthzSessionSuite) expectOrgMember(role types.OrganizationRole) {
+	s.mockStore.EXPECT().GetOrganizationMembership(gomock.Any(), &store.GetOrganizationMembershipQuery{
+		OrganizationID: s.orgID,
+		UserID:         s.userID,
+	}).Return(&types.OrganizationMembership{
+		OrganizationID: s.orgID,
+		UserID:         s.userID,
+		Role:           role,
+	}, nil).AnyTimes()
+}
+
+func (s *AuthzSessionSuite) expectProjectGrant(projectID string, action types.Action) {
+	s.mockStore.EXPECT().ListTeams(gomock.Any(), &store.ListTeamsQuery{
+		OrganizationID: s.orgID,
+		UserID:         s.userID,
+	}).Return([]*types.Team{}, nil)
+	s.mockStore.EXPECT().ListAccessGrants(gomock.Any(), &store.ListAccessGrantsQuery{
+		OrganizationID: s.orgID,
+		UserID:         s.userID,
+		ResourceID:     projectID,
+	}).Return([]*types.AccessGrant{
+		{
+			Roles: []types.Role{{
+				Config: types.Config{Rules: []types.Rule{{
+					Resources: []types.Resource{types.ResourceProject},
+					Actions:   []types.Action{action},
+					Effect:    types.EffectAllow,
+				}}},
+			}},
+		},
+	}, nil)
+}
+
+func (s *AuthzSessionSuite) expectNoProjectGrant(projectID string) {
+	s.mockStore.EXPECT().ListTeams(gomock.Any(), &store.ListTeamsQuery{
+		OrganizationID: s.orgID,
+		UserID:         s.userID,
+	}).Return([]*types.Team{}, nil)
+	s.mockStore.EXPECT().ListAccessGrants(gomock.Any(), &store.ListAccessGrantsQuery{
+		OrganizationID: s.orgID,
+		UserID:         s.userID,
+		ResourceID:     projectID,
+	}).Return([]*types.AccessGrant{}, nil)
+}
+
+// The literal session owner can always write to their session.
+func (s *AuthzSessionSuite) TestSessionOwnerAllowed() {
+	session := &types.Session{ID: "ses1", Owner: s.userID, OrganizationID: s.orgID, ProjectID: "prj1"}
+	user := &types.User{ID: s.userID}
+
+	s.expectOrgMember(types.OrganizationRoleMember)
+
+	err := s.server.authorizeUserToSession(context.Background(), user, session, types.ActionUpdate)
+	s.NoError(err)
+}
+
+// THE regression: org owner chatting into a session owned by another member
+// (e.g. a helix-org Worker "Human Desktop") must be allowed for ActionUpdate.
+func (s *AuthzSessionSuite) TestOrgOwnerCanUpdateOthersSession() {
+	session := &types.Session{ID: "ses1", Owner: "someone_else", OrganizationID: s.orgID, ProjectID: "prj1"}
+	user := &types.User{ID: s.userID}
+
+	s.expectOrgMember(types.OrganizationRoleOwner)
+
+	err := s.server.authorizeUserToSession(context.Background(), user, session, types.ActionUpdate)
+	s.NoError(err)
+}
+
+// A plain member with a project update grant can drive the session.
+func (s *AuthzSessionSuite) TestMemberWithProjectGrantAllowed() {
+	session := &types.Session{ID: "ses1", Owner: "someone_else", OrganizationID: s.orgID, ProjectID: "prj1"}
+	user := &types.User{ID: s.userID}
+
+	s.expectOrgMember(types.OrganizationRoleMember)
+	s.expectProjectGrant("prj1", types.ActionUpdate)
+
+	err := s.server.authorizeUserToSession(context.Background(), user, session, types.ActionUpdate)
+	s.NoError(err)
+}
+
+// A member without a grant on the session's project is denied — ActionUpdate
+// keeps read-only members from driving someone else's agent.
+func (s *AuthzSessionSuite) TestMemberWithoutGrantDenied() {
+	session := &types.Session{ID: "ses1", Owner: "someone_else", OrganizationID: s.orgID, ProjectID: "prj1"}
+	user := &types.User{ID: s.userID}
+
+	s.expectOrgMember(types.OrganizationRoleMember)
+	s.expectNoProjectGrant("prj1")
+
+	err := s.server.authorizeUserToSession(context.Background(), user, session, types.ActionUpdate)
+	s.Error(err)
+}
+
+// A non-member of the org is denied outright.
+func (s *AuthzSessionSuite) TestNonMemberDenied() {
+	session := &types.Session{ID: "ses1", Owner: "someone_else", OrganizationID: s.orgID, ProjectID: "prj1"}
+	user := &types.User{ID: s.userID}
+
+	s.mockStore.EXPECT().GetOrganizationMembership(gomock.Any(), gomock.Any()).
+		Return(nil, store.ErrNotFound)
+
+	err := s.server.authorizeUserToSession(context.Background(), user, session, types.ActionUpdate)
+	s.Error(err)
+}

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -10311,7 +10311,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/v1/orgs/{org}/workers/{id}/parent": {
+        "/api/v1/orgs/{org}/workers/{id}/parents": {
             "post": {
                 "security": [
                     {
@@ -10324,22 +10324,22 @@ const docTemplate = `{
                 "tags": [
                     "HelixOrg"
                 ],
-                "summary": "Helix-org: set worker parent (reporting line)",
+                "summary": "Helix-org: add a worker reporting line (manager)",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Worker ID",
+                        "description": "Worker ID (the report)",
                         "name": "id",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "New parent worker id ('' to clear)",
+                        "description": "Manager worker id",
                         "name": "payload",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.UpdateWorkerParentRequest"
+                            "$ref": "#/definitions/api.AddWorkerParentRequest"
                         }
                     }
                 ],
@@ -10361,6 +10361,52 @@ const docTemplate = `{
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/workers/{id}/parents/{parent_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: remove a worker reporting line (manager)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker ID (the report)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Manager worker id",
+                        "name": "parent_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorResponse"
                         }
@@ -20084,6 +20130,14 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "api.AddWorkerParentRequest": {
+            "type": "object",
+            "properties": {
+                "parent_id": {
+                    "type": "string"
+                }
+            }
+        },
         "api.CreateRoleRequest": {
             "type": "object",
             "properties": {
@@ -20527,14 +20581,6 @@ const docTemplate = `{
                 }
             }
         },
-        "api.UpdateWorkerParentRequest": {
-            "type": "object",
-            "properties": {
-                "parent_id": {
-                    "type": "string"
-                }
-            }
-        },
         "api.UpdateWorkerRoleRequest": {
             "type": "object",
             "properties": {
@@ -20597,8 +20643,11 @@ const docTemplate = `{
                 "organization_id": {
                     "type": "string"
                 },
-                "parent_id": {
-                    "type": "string"
+                "parent_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "role_id": {
                     "type": "string"

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -524,8 +524,16 @@ If the user asks for information about Helix or installing Helix, refer them to 
 			return
 		}
 
-		if session.Owner != user.ID {
-			http.Error(rw, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		// Authorize via the unified session RBAC (org owner / project owner /
+		// project grant), NOT a strict owner-equality check. The read path
+		// (getSessionHandler) already uses authorizeUserToSession for ActionGet,
+		// so an org member who can VIEW a session could not chat into it — the
+		// inconsistency that left org-shared sessions (helix-org Worker "Human
+		// Desktop", team desktops) un-chattable by anyone but the literal owner,
+		// surfacing as a repeated 401 on POST /sessions/chat. ActionUpdate keeps
+		// read-only members from driving the agent.
+		if err := s.authorizeUserToSession(ctx, user, session, types.ActionUpdate); err != nil {
+			http.Error(rw, err.Error(), http.StatusForbidden)
 			return
 		}
 

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -10307,7 +10307,7 @@
                 }
             }
         },
-        "/api/v1/orgs/{org}/workers/{id}/parent": {
+        "/api/v1/orgs/{org}/workers/{id}/parents": {
             "post": {
                 "security": [
                     {
@@ -10320,22 +10320,22 @@
                 "tags": [
                     "HelixOrg"
                 ],
-                "summary": "Helix-org: set worker parent (reporting line)",
+                "summary": "Helix-org: add a worker reporting line (manager)",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Worker ID",
+                        "description": "Worker ID (the report)",
                         "name": "id",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "New parent worker id ('' to clear)",
+                        "description": "Manager worker id",
                         "name": "payload",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.UpdateWorkerParentRequest"
+                            "$ref": "#/definitions/api.AddWorkerParentRequest"
                         }
                     }
                 ],
@@ -10357,6 +10357,52 @@
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/workers/{id}/parents/{parent_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: remove a worker reporting line (manager)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker ID (the report)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Manager worker id",
+                        "name": "parent_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorResponse"
                         }
@@ -20080,6 +20126,14 @@
         }
     },
     "definitions": {
+        "api.AddWorkerParentRequest": {
+            "type": "object",
+            "properties": {
+                "parent_id": {
+                    "type": "string"
+                }
+            }
+        },
         "api.CreateRoleRequest": {
             "type": "object",
             "properties": {
@@ -20523,14 +20577,6 @@
                 }
             }
         },
-        "api.UpdateWorkerParentRequest": {
-            "type": "object",
-            "properties": {
-                "parent_id": {
-                    "type": "string"
-                }
-            }
-        },
         "api.UpdateWorkerRoleRequest": {
             "type": "object",
             "properties": {
@@ -20593,8 +20639,11 @@
                 "organization_id": {
                     "type": "string"
                 },
-                "parent_id": {
-                    "type": "string"
+                "parent_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "role_id": {
                     "type": "string"

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -1,4 +1,9 @@
 definitions:
+  api.AddWorkerParentRequest:
+    properties:
+      parent_id:
+        type: string
+    type: object
   api.CreateRoleRequest:
     properties:
       content:
@@ -294,11 +299,6 @@ definitions:
       identity:
         type: string
     type: object
-  api.UpdateWorkerParentRequest:
-    properties:
-      parent_id:
-        type: string
-    type: object
   api.UpdateWorkerRoleRequest:
     properties:
       content:
@@ -339,8 +339,10 @@ definitions:
         type: string
       organization_id:
         type: string
-      parent_id:
-        type: string
+      parent_ids:
+        items:
+          type: string
+        type: array
       role_id:
         type: string
       tools:
@@ -17899,22 +17901,22 @@ paths:
       summary: 'Helix-org: update worker identity'
       tags:
       - HelixOrg
-  /api/v1/orgs/{org}/workers/{id}/parent:
+  /api/v1/orgs/{org}/workers/{id}/parents:
     post:
       consumes:
       - application/json
       parameters:
-      - description: Worker ID
+      - description: Worker ID (the report)
         in: path
         name: id
         required: true
         type: string
-      - description: New parent worker id ('' to clear)
+      - description: Manager worker id
         in: body
         name: payload
         required: true
         schema:
-          $ref: '#/definitions/api.UpdateWorkerParentRequest'
+          $ref: '#/definitions/api.AddWorkerParentRequest'
       responses:
         "204":
           description: No Content
@@ -17932,7 +17934,36 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - ApiKeyAuth: []
-      summary: 'Helix-org: set worker parent (reporting line)'
+      summary: 'Helix-org: add a worker reporting line (manager)'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/workers/{id}/parents/{parent_id}:
+    delete:
+      parameters:
+      - description: Worker ID (the report)
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Manager worker id
+        in: path
+        name: parent_id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: remove a worker reporting line (manager)'
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/workers/{id}/role:

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -9,6 +9,10 @@
  * ---------------------------------------------------------------
  */
 
+export interface ApiAddWorkerParentRequest {
+  parent_id?: string;
+}
+
 export interface ApiCreateRoleRequest {
   content?: string;
   id?: string;
@@ -185,10 +189,6 @@ export interface ApiUpdateWorkerIdentityRequest {
   identity?: string;
 }
 
-export interface ApiUpdateWorkerParentRequest {
-  parent_id?: string;
-}
-
 export interface ApiUpdateWorkerRoleRequest {
   content?: string;
 }
@@ -215,7 +215,7 @@ export interface ApiWorkerDTO {
   identity_content?: string;
   kind?: string;
   organization_id?: string;
-  parent_id?: string;
+  parent_ids?: string[];
   role_id?: string;
   tools?: string[];
 }
@@ -12040,23 +12040,40 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * No description
      *
      * @tags HelixOrg
-     * @name V1OrgsWorkersParentCreate
-     * @summary Helix-org: set worker parent (reporting line)
-     * @request POST:/api/v1/orgs/{org}/workers/{id}/parent
+     * @name V1OrgsWorkersParentsCreate
+     * @summary Helix-org: add a worker reporting line (manager)
+     * @request POST:/api/v1/orgs/{org}/workers/{id}/parents
      * @secure
      */
-    v1OrgsWorkersParentCreate: (
+    v1OrgsWorkersParentsCreate: (
       id: string,
       org: string,
-      payload: ApiUpdateWorkerParentRequest,
+      payload: ApiAddWorkerParentRequest,
       params: RequestParams = {},
     ) =>
       this.request<void, ApiErrorResponse>({
-        path: `/api/v1/orgs/${org}/workers/${id}/parent`,
+        path: `/api/v1/orgs/${org}/workers/${id}/parents`,
         method: "POST",
         body: payload,
         secure: true,
         type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsWorkersParentsDelete
+     * @summary Helix-org: remove a worker reporting line (manager)
+     * @request DELETE:/api/v1/orgs/{org}/workers/{id}/parents/{parent_id}
+     * @secure
+     */
+    v1OrgsWorkersParentsDelete: (id: string, parentId: string, org: string, params: RequestParams = {}) =>
+      this.request<void, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/workers/${id}/parents/${parentId}`,
+        method: "DELETE",
+        secure: true,
         ...params,
       }),
 

--- a/frontend/src/components/common/RobustPromptInput.test.tsx
+++ b/frontend/src/components/common/RobustPromptInput.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
 import { PromptHistoryEntry } from '../../hooks/usePromptHistory'
 import RobustPromptInput from './RobustPromptInput'
 
@@ -117,4 +117,45 @@ describe('RobustPromptInput empty-Enter promotes most-recent queued to interrupt
     expect(saveToHistory).not.toHaveBeenCalled()
   })
 
+})
+
+// Regression for 53b336e01: the client-side queue pump was deleted, so any
+// composer without a spec_task_id (project Human Desktop, org-worker chat)
+// silently parked messages as "saved locally" and never dispatched them. The
+// pump must run when backend queue processing is NOT enabled, and must stay
+// out of the way when it is (spec tasks).
+describe('RobustPromptInput client-side queue pump', () => {
+  beforeEach(() => {
+    saveToHistory.mockClear()
+    pendingPrompts = []
+  })
+
+  it('dispatches a pending message via onSend when there is no spec task', async () => {
+    pendingPrompts = [mkEntry('a', 1000, { content: 'hello worker' })]
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    render(
+      <RobustPromptInput sessionId="ses_test" projectId="prj_1" onSend={onSend} />
+    )
+    await waitFor(
+      () => expect(onSend).toHaveBeenCalledWith('hello worker', false),
+      { timeout: 2000 },
+    )
+  })
+
+  it('does NOT pump the queue when the backend queue is enabled (spec task)', async () => {
+    pendingPrompts = [mkEntry('a', 1000)]
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    render(
+      <RobustPromptInput
+        sessionId="ses_test"
+        specTaskId="task_1"
+        projectId="prj_1"
+        apiClient={{} as any}
+        onSend={onSend}
+      />
+    )
+    // Give the pump's 500ms/300ms timers room to (not) fire.
+    await new Promise((r) => setTimeout(r, 800))
+    expect(onSend).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -584,6 +584,84 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
   // Track previous appendText to detect changes
   const prevAppendTextRef = useRef<string | undefined>(undefined)
 
+  // Re-entrancy guard for the client-side queue pump below.
+  const processingRef = useRef(false)
+
+  // Backend queue processing only kicks in for spec-task composers: that path
+  // persists prompts via usePromptHistory and the server dispatches them once
+  // synced (keyed on spec_task_id). Plain external-agent sessions — the
+  // project "Human Desktop" (TeamDesktopPage) and org-worker chat — have no
+  // spec_task_id, so the composer must pump the queue itself by calling
+  // onSend, which the parent routes to streaming.NewInference → the running
+  // Zed agent. Without this fallback every queued message just sits forever as
+  // "Message queue (saved locally)" and the agent never sees it. (Regression
+  // from 53b336e01, which deleted the client-side pump on the assumption that
+  // the backend queue was always enabled.)
+  const backendQueueEnabled = !!(specTaskId && projectId && apiClient)
+
+  const processQueue = useCallback(async () => {
+    // Spec-task sessions: the backend owns dispatch after sync.
+    if (backendQueueEnabled) return
+    // Prevent concurrent processing.
+    if (processingRef.current || !isOnline || disabled) return
+
+    // Interrupt-mode messages first, then queue-mode, each oldest-first.
+    const sortedQueue = [...failedPrompts, ...pendingPrompts].sort((a, b) => {
+      const aInterrupt = a.interrupt !== false
+      const bInterrupt = b.interrupt !== false
+      if (aInterrupt && !bInterrupt) return -1
+      if (!aInterrupt && bInterrupt) return 1
+      return a.timestamp - b.timestamp
+    })
+
+    // If editing, block the edited message and everything after it so ordering
+    // is preserved while the user revises.
+    let editingIndex = -1
+    if (editingId) {
+      editingIndex = sortedQueue.findIndex(m => m.id === editingId)
+    }
+
+    const nextToSend = sortedQueue.find((m, index) => {
+      if (m.id === sendingId) return false
+      if (m.status === 'sent') return false
+      if (editingIndex !== -1 && index >= editingIndex) return false
+      return true
+    })
+
+    if (!nextToSend) return
+
+    processingRef.current = true
+    setSendingId(nextToSend.id)
+
+    try {
+      // interrupt=true interrupts the agent's current turn; false queues after.
+      await onSend(nextToSend.content, nextToSend.interrupt !== false)
+      markAsSent(nextToSend.id)
+    } catch (error) {
+      console.error('Failed to send message:', error)
+      markAsFailed(nextToSend.id)
+    } finally {
+      setSendingId(null)
+      processingRef.current = false
+    }
+  }, [backendQueueEnabled, isOnline, disabled, failedPrompts, pendingPrompts, sendingId, editingId, onSend, markAsSent, markAsFailed])
+
+  // Pump the queue when messages are pending and we're online.
+  useEffect(() => {
+    if (isOnline && (pendingPrompts.length > 0 || failedPrompts.length > 0) && !processingRef.current) {
+      const timer = setTimeout(processQueue, 500)
+      return () => clearTimeout(timer)
+    }
+  }, [isOnline, pendingPrompts.length, failedPrompts.length, processQueue])
+
+  // Continue pumping after each send completes.
+  useEffect(() => {
+    if (!sendingId && isOnline && (pendingPrompts.length > 0 || failedPrompts.length > 0)) {
+      const timer = setTimeout(processQueue, 300)
+      return () => clearTimeout(timer)
+    }
+  }, [sendingId, isOnline, pendingPrompts.length, failedPrompts.length, processQueue])
+
   // Handle prepending text from parent (e.g., uploaded file paths)
   useEffect(() => {
     if (appendText && appendText !== prevAppendTextRef.current) {

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -341,13 +341,20 @@ const WorkerNode: FC<NodeProps<Node<WorkerNodeData>>> = ({ data }) => {
           bottom-center reporting handle means a subscription edge and a
           manager → subordinate edge can never share the same geometry.
           id="stream" is what buildGraph passes as sourceHandle when
-          emitting subscription edges. */}
+          emitting subscription edges.
+
+          Unlike the top/bottom reporting handles (which sit clear above
+          and below the card), this one lands at the card's vertical
+          centre — right where the name/caption Typography rows are. It
+          must be large enough to grab and explicitly stacked above that
+          content (zIndex), or the label intercepts the pointer and the
+          subscription drag can't start. */}
       <Handle
         id="stream"
         type="source"
         position={RFPosition.Right}
         isConnectable
-        style={{ background: 'rgba(180,100,0,0.5)', border: 'none', width: 8, height: 8 }}
+        style={{ background: 'rgba(180,100,0,0.85)', border: 'none', width: 14, height: 14, zIndex: 5 }}
       />
     </Box>
   )

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -55,7 +55,8 @@ import {
   useListHelixOrgRoles,
   useListHelixOrgStreams,
   useListHelixOrgWorkers,
-  useReparentWorker,
+  useAddWorkerParent,
+  useRemoveWorkerParent,
   useSubscribeWorkerAtChart,
   useUnsubscribeWorkerAtChart,
 } from '../services/helixOrgService'
@@ -66,20 +67,20 @@ import {
 //   ┌─[Role: r-owner]──────────────────┐
 //   │  [w-owner]                       │
 //   └────────│───────────────────────────┘
-//            ↓ (worker-to-worker reporting edge, from worker.parent_id)
+//            ↓ (worker-to-worker reporting edge, from a reporting line)
 //   ┌─[Role: r-engineer]───────────────────────────┐
 //   │  [w-alice]  [w-bob]  [w-carol]               │
 //   └───────────────────────────────────────────────┘
 //
 // Roles are parent group nodes that VISUALLY CONTAIN their Worker child
-// nodes. A Role can hold many Workers. Edges link Worker → Worker based
-// on the worker.parent_id chain (which crosses role boundaries), so the
-// edge reads as a manager → subordinate reporting line. Streams hang off
-// the right of the tree; an edge from a Worker to a Stream is a
+// nodes. A Role can hold many Workers. Reporting is a many-to-many
+// relation: each (manager → report) reporting line becomes a Worker →
+// Worker edge (a Worker may have several incoming edges). Streams hang
+// off the right of the tree; an edge from a Worker to a Stream is a
 // subscription.
 //
 // Layout: dagre runs over the role tree (edges derived from cross-role
-// parent_id links) to get global (x, y) for each Role. Workers sit in a
+// reporting lines) to get global (x, y) for each Role. Workers sit in a
 // horizontal row inside their Role's frame.
 
 const OWNER_ROLE = 'r-owner'
@@ -99,7 +100,8 @@ type FlatWorker = {
   id: string
   kind: string
   roleId: string
-  parentId: string
+  // Reporting is many-to-many: a Worker may report to several managers.
+  parentIds: string[]
 }
 
 type RoleGroup = { roleId: string; workers: FlatWorker[] }
@@ -427,10 +429,10 @@ type StreamSummary = {
 }
 
 // buildGraph computes nodes + edges for the chart. Roles are laid out by
-// dagre over a role-level graph whose edges come from worker.parent_id
-// links that cross role boundaries. Workers sit in a horizontal row
-// inside their role's frame. Worker → Worker reporting edges and Worker
-// → Stream subscription edges are drawn on top.
+// dagre over a role-level graph whose edges come from reporting lines
+// that cross role boundaries. Workers sit in a horizontal row inside
+// their role's frame. Worker → Worker reporting edges and Worker →
+// Stream subscription edges are drawn on top.
 const buildGraph = (
   groups: RoleGroup[],
   flat: FlatWorker[],
@@ -466,7 +468,7 @@ const buildGraph = (
     })
   }
 
-  // 2. Role-level dagre graph. Edges: any worker.parent_id that crosses
+  // 2. Role-level dagre graph. Edges: any reporting line that crosses
   //    a role boundary contributes a role → role edge.
   const g = new dagre.graphlib.Graph()
   g.setGraph({
@@ -483,14 +485,16 @@ const buildGraph = (
   }
   const seenEdge = new Set<string>()
   for (const wk of flat) {
-    if (!wk.parentId || !flatByID.has(wk.parentId)) continue
+    for (const parentId of wk.parentIds) {
+    if (!parentId || !flatByID.has(parentId)) continue
     const childRole = workerToRole.get(wk.id)
-    const parentRole = workerToRole.get(wk.parentId)
+    const parentRole = workerToRole.get(parentId)
     if (!childRole || !parentRole || childRole === parentRole) continue
     const key = `${parentRole}->${childRole}`
     if (seenEdge.has(key)) continue
     seenEdge.add(key)
     g.setEdge(`role:${parentRole}`, `role:${childRole}`)
+    }
   }
   dagre.layout(g)
 
@@ -563,24 +567,26 @@ const buildGraph = (
     })
   }
 
-  // 4. Reporting edges: manager → subordinate, derived from
-  //    worker.parent_id. Bezier (the default) gives every pair its own
+  // 4. Reporting edges: manager → subordinate, one per reporting line
+  //    (a Worker may report to several). Bezier (the default) gives every pair its own
   //    arc so multiple reports from one manager never overlap.
   const edges: Edge[] = []
   for (const wk of flat) {
-    if (!wk.parentId || !flatByID.has(wk.parentId)) continue
+    for (const parentId of wk.parentIds) {
+    if (!parentId || !flatByID.has(parentId)) continue
     edges.push({
-      id: `report:${wk.parentId}->${wk.id}`,
-      source: `worker:${wk.parentId}`,
+      id: `report:${parentId}->${wk.id}`,
+      source: `worker:${parentId}`,
       target: `worker:${wk.id}`,
       type: 'default',
       animated: false,
-      data: { kind: 'report', childWorkerId: wk.id },
+      data: { kind: 'report', childWorkerId: wk.id, parentWorkerId: parentId },
       style: {
         stroke: isLight ? 'rgba(0,0,0,0.3)' : 'rgba(255,255,255,0.35)',
         strokeWidth: 1.5,
       },
     })
+    }
   }
 
   // 5. Stream pseudo-nodes + subscription edges. Subscriptions are
@@ -863,16 +869,17 @@ const ChartCanvas: FC<{
     onSelectStream: (streamId: string) => void
     onDeleteStream: (streamId: string) => void
   }
-  // onSetParent fires when the user wires manager → subordinate (an
-  // onConnect); onClearParent fires when they delete a reporting edge.
-  onSetParent: (childWorkerId: string, newParentWorkerId: string) => void
-  onClearParent: (childWorkerId: string) => void
+  // onAddParent fires when the user wires manager → subordinate (an
+  // onConnect); onRemoveParent fires when they delete a reporting edge,
+  // and carries the specific manager since a Worker may have several.
+  onAddParent: (childWorkerId: string, newParentWorkerId: string) => void
+  onRemoveParent: (childWorkerId: string, parentWorkerId: string) => void
   // onSubscribeWorker fires when the user wires a Worker node → a stream
   // pseudo-node; onUnsubscribeWorker fires when they delete that edge.
   onSubscribeWorker: (workerId: string, streamId: string) => void
   onUnsubscribeWorker: (workerId: string, streamId: string) => void
   streams: StreamSummary[]
-}> = ({ groups, flat, handlers, onSetParent, onClearParent, onSubscribeWorker, onUnsubscribeWorker, streams }) => {
+}> = ({ groups, flat, handlers, onAddParent, onRemoveParent, onSubscribeWorker, onUnsubscribeWorker, streams }) => {
   const lightTheme = useLightTheme()
   const { fitView } = useReactFlow()
 
@@ -891,7 +898,7 @@ const ChartCanvas: FC<{
 
   // onConnect handles both wire shapes:
   //   - worker→worker: manager wires their report. Source = manager,
-  //     target = subordinate. Persists by PATCHing parent_id.
+  //     target = subordinate. Persists by adding a reporting line.
   //   - worker→stream:  the worker consumes a stream. Persists by
   //     POSTing a (worker, stream) subscription.
   const onConnect = useCallback(
@@ -909,28 +916,32 @@ const ChartCanvas: FC<{
       if (target.startsWith('worker:')) {
         const targetId = target.replace(/^worker:/, '')
         if (!targetId || sourceId === targetId) return
-        onSetParent(targetId, sourceId)
+        onAddParent(targetId, sourceId)
       }
     },
-    [onSetParent, onSubscribeWorker],
+    [onAddParent, onSubscribeWorker],
   )
 
   // onEdgesDelete severs whatever the edge represented: a reporting edge
-  // clears the subordinate's parent_id; a subscription edge drops the
-  // (worker, stream) row.
+  // drops that one (manager → report) line; a subscription edge drops
+  // the (worker, stream) row.
   const onEdgesDelete = useCallback(
     (deleted: Edge[]) => {
       for (const e of deleted) {
-        const d = e.data as { kind?: string; childWorkerId?: string; workerId?: string; streamId?: string } | undefined
+        const d = e.data as { kind?: string; childWorkerId?: string; parentWorkerId?: string; workerId?: string; streamId?: string } | undefined
         if (d?.kind === 'sub' && d.workerId && d.streamId) {
           onUnsubscribeWorker(d.workerId, d.streamId)
           continue
         }
+        // Reporting edge: remove the specific manager line. Fall back to
+        // parsing "report:<parent>-><child>" from the edge id when data
+        // is missing (e.g. an edge synthesised by ReactFlow).
         const childId = d?.childWorkerId ?? (e.target ?? '').replace(/^worker:/, '')
-        if (childId && (e.target ?? '').startsWith('worker:')) onClearParent(childId)
+        const parentId = d?.parentWorkerId ?? (e.source ?? '').replace(/^worker:/, '')
+        if (childId && parentId && (e.target ?? '').startsWith('worker:')) onRemoveParent(childId, parentId)
       }
     },
-    [onClearParent, onUnsubscribeWorker],
+    [onRemoveParent, onUnsubscribeWorker],
   )
 
   return (
@@ -978,7 +989,8 @@ const HelixOrgChart: FC = () => {
   const deleteRole = useDeleteHelixOrgRole()
   const deleteStream = useDeleteHelixOrgStream()
   const fireWorker = useFireHelixOrgWorker()
-  const reparent = useReparentWorker()
+  const addParent = useAddWorkerParent()
+  const removeParent = useRemoveWorkerParent()
   const subscribe = useSubscribeWorkerAtChart()
   const unsubscribe = useUnsubscribeWorkerAtChart()
 
@@ -987,7 +999,7 @@ const HelixOrgChart: FC = () => {
       id: w.id ?? '',
       kind: w.kind ?? 'human',
       roleId: w.role_id ?? '',
-      parentId: w.parent_id ?? '',
+      parentIds: w.parent_ids ?? [],
     })),
     [workersData],
   )
@@ -1049,28 +1061,28 @@ const HelixOrgChart: FC = () => {
     [onSelectWorker, onSelectRole, onHire, onDeleteRole, onFireWorker, onSelectStream, onDeleteStream],
   )
 
-  const onSetParent = useCallback(
+  const onAddParent = useCallback(
     async (childWorkerId: string, newParentWorkerId: string) => {
       try {
-        await reparent.mutateAsync({ workerID: childWorkerId, parentID: newParentWorkerId })
+        await addParent.mutateAsync({ workerID: childWorkerId, parentID: newParentWorkerId })
         snackbar.success(`${childWorkerId} now reports to ${newParentWorkerId}`)
       } catch (err: any) {
-        snackbar.error(err?.response?.data?.error ?? err?.message ?? 'reparent failed')
+        snackbar.error(err?.response?.data?.error ?? err?.message ?? 'add reporting line failed')
       }
     },
-    [reparent, snackbar],
+    [addParent, snackbar],
   )
 
-  const onClearParent = useCallback(
-    async (childWorkerId: string) => {
+  const onRemoveParent = useCallback(
+    async (childWorkerId: string, parentWorkerId: string) => {
       try {
-        await reparent.mutateAsync({ workerID: childWorkerId, parentID: '' })
-        snackbar.success(`${childWorkerId} no longer reports to anyone`)
+        await removeParent.mutateAsync({ workerID: childWorkerId, parentID: parentWorkerId })
+        snackbar.success(`${childWorkerId} no longer reports to ${parentWorkerId}`)
       } catch (err: any) {
-        snackbar.error(err?.response?.data?.error ?? err?.message ?? 'clear parent failed')
+        snackbar.error(err?.response?.data?.error ?? err?.message ?? 'remove reporting line failed')
       }
     },
-    [reparent, snackbar],
+    [removeParent, snackbar],
   )
 
   const onSubscribeWorker = useCallback(
@@ -1146,7 +1158,7 @@ const HelixOrgChart: FC = () => {
         'This is irreversible.',
       ].join('\n')
     }
-    const reports = flat.filter((w) => w.parentId === confirmDelete.id).map((w) => w.id)
+    const reports = flat.filter((w) => w.parentIds.includes(confirmDelete.id)).map((w) => w.id)
     return [
       `Firing worker ${confirmDelete.id} will cascade:`,
       `  • stops sessions, deletes its project + agent app, drops its subscriptions`,
@@ -1213,8 +1225,8 @@ const HelixOrgChart: FC = () => {
                 groups={groups}
                 flat={flat}
                 handlers={handlers}
-                onSetParent={onSetParent}
-                onClearParent={onClearParent}
+                onAddParent={onAddParent}
+                onRemoveParent={onRemoveParent}
                 onSubscribeWorker={onSubscribeWorker}
                 onUnsubscribeWorker={onUnsubscribeWorker}
                 streams={streams}

--- a/frontend/src/pages/HelixOrgRoleDetail.tsx
+++ b/frontend/src/pages/HelixOrgRoleDetail.tsx
@@ -10,7 +10,7 @@
 // beats a multi-select for the alpha; we can swap to a real
 // autocomplete once the catalogue stabilises.
 
-import { FC, useEffect, useMemo, useState } from 'react'
+import { FC, Key, useEffect, useMemo, useState } from 'react'
 import Autocomplete from '@mui/material/Autocomplete'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
@@ -213,36 +213,45 @@ const HelixOrgRoleDetail: FC = () => {
                     onChange={(_e, value) => setTools(value.map((v) => v.name))}
                     getOptionLabel={(o) => o.name}
                     isOptionEqualToValue={(a, b) => a.name === b.name}
-                    renderOption={(props, option, { selected }) => (
-                      <li {...props} key={option.name}>
-                        <Checkbox
-                          icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
-                          checkedIcon={<CheckBoxIcon fontSize="small" />}
-                          style={{ marginRight: 8 }}
-                          checked={selected}
-                        />
-                        <Box sx={{ minWidth: 0 }}>
-                          <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
-                            {option.name}
-                          </Typography>
-                          {option.description && (
-                            <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                              {option.description}
+                    renderOption={(props, option, { selected }) => {
+                      // Pass key explicitly rather than via the props
+                      // spread — React 18.3 warns when a spread object
+                      // carries a key.
+                      const { key, ...liProps } = props as typeof props & { key?: Key }
+                      return (
+                        <li key={key ?? option.name} {...liProps}>
+                          <Checkbox
+                            icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
+                            checkedIcon={<CheckBoxIcon fontSize="small" />}
+                            style={{ marginRight: 8 }}
+                            checked={selected}
+                          />
+                          <Box sx={{ minWidth: 0 }}>
+                            <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                              {option.name}
                             </Typography>
-                          )}
-                        </Box>
-                      </li>
-                    )}
+                            {option.description && (
+                              <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                                {option.description}
+                              </Typography>
+                            )}
+                          </Box>
+                        </li>
+                      )
+                    }}
                     renderTags={(value, getTagProps) =>
-                      value.map((option, index) => (
-                        <Chip
-                          {...getTagProps({ index })}
-                          key={option.name}
-                          label={option.name}
-                          size="small"
-                          sx={{ fontFamily: 'monospace' }}
-                        />
-                      ))
+                      value.map((option, index) => {
+                        const { key, ...tagProps } = getTagProps({ index })
+                        return (
+                          <Chip
+                            key={key ?? option.name}
+                            {...tagProps}
+                            label={option.name}
+                            size="small"
+                            sx={{ fontFamily: 'monospace' }}
+                          />
+                        )
+                      })
                     }
                     renderInput={(params) => (
                       <TextField

--- a/frontend/src/pages/HelixOrgRoles.tsx
+++ b/frontend/src/pages/HelixOrgRoles.tsx
@@ -9,7 +9,6 @@
 
 import { FC, MouseEvent, useMemo, useState } from 'react'
 import Box from '@mui/material/Box'
-import Button from '@mui/material/Button'
 import Container from '@mui/material/Container'
 import IconButton from '@mui/material/IconButton'
 import Menu from '@mui/material/Menu'
@@ -17,7 +16,6 @@ import MenuItem from '@mui/material/MenuItem'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import useTheme from '@mui/material/styles/useTheme'
-import AddIcon from '@mui/icons-material/Add'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
@@ -32,15 +30,9 @@ import useRouter from '../hooks/useRouter'
 import useSnackbar from '../hooks/useSnackbar'
 import {
   RoleDTO,
-  useCreateHelixOrgRole,
   useDeleteHelixOrgRole,
   useListHelixOrgRoles,
 } from '../services/helixOrgService'
-import Dialog from '@mui/material/Dialog'
-import DialogActions from '@mui/material/DialogActions'
-import DialogContent from '@mui/material/DialogContent'
-import DialogTitle from '@mui/material/DialogTitle'
-import TextField from '@mui/material/TextField'
 
 const OWNER_ROLE = 'r-owner'
 
@@ -53,10 +45,8 @@ const HelixOrgRoles: FC = () => {
 
   const { data, isLoading } = useListHelixOrgRoles()
   const deleteRole = useDeleteHelixOrgRole()
-  const createRole = useCreateHelixOrgRole()
 
   const roles = data ?? []
-  const [createOpen, setCreateOpen] = useState(false)
   const [deleting, setDeleting] = useState<RoleDTO | undefined>()
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [currentRole, setCurrentRole] = useState<RoleDTO | null>(null)
@@ -157,16 +147,6 @@ const HelixOrgRoles: FC = () => {
       breadcrumbTitle="Roles"
       orgBreadcrumbs={true}
       organizationId={account.organizationTools.organization?.id}
-      topbarContent={(
-        <Button
-          variant="contained"
-          color="secondary"
-          startIcon={<AddIcon />}
-          onClick={() => setCreateOpen(true)}
-        >
-          New Role
-        </Button>
-      )}
     >
       <Container maxWidth="xl" sx={{ mb: 4, pt: 3 }}>
         <Stack spacing={2}>
@@ -186,15 +166,9 @@ const HelixOrgRoles: FC = () => {
               <Typography variant="body1" color="text.secondary" gutterBottom>
                 No roles defined yet.
               </Typography>
-              <Button
-                variant="contained"
-                color="secondary"
-                startIcon={<AddIcon />}
-                onClick={() => setCreateOpen(true)}
-                sx={{ mt: 1 }}
-              >
-                Create your first role
-              </Button>
+              <Typography variant="body2" color="text.secondary">
+                Create roles from the Chart — use “New role” on the org chart canvas.
+              </Typography>
             </Box>
           ) : (
             <SimpleTable
@@ -251,91 +225,7 @@ const HelixOrgRoles: FC = () => {
           </Typography>
         </DeleteConfirmWindow>
       )}
-
-      <NewRoleDialog
-        open={createOpen}
-        onClose={() => setCreateOpen(false)}
-        onCreated={(id) => {
-          setCreateOpen(false)
-          snackbar.success(`role ${id} created`)
-          openRole(id)
-        }}
-        creating={createRole.isPending}
-        create={async (payload) => {
-          await createRole.mutateAsync(payload)
-        }}
-      />
     </Page>
-  )
-}
-
-// NewRoleDialog is a small two-field form: id + markdown content.
-// Inline rather than imported from HelixOrgChart so the two surfaces
-// can evolve independently — e.g. the Roles page could grow tool /
-// stream selectors that the chart's quick-create doesn't need.
-const NewRoleDialog: FC<{
-  open: boolean
-  creating: boolean
-  onClose: () => void
-  onCreated: (id: string) => void
-  create: (payload: { id: string; content: string }) => Promise<void>
-}> = ({ open, creating, onClose, onCreated, create }) => {
-  const snackbar = useSnackbar()
-  const [id, setId] = useState('')
-  const [content, setContent] = useState('')
-
-  const submit = async () => {
-    const trimmed = id.trim()
-    if (!trimmed) {
-      snackbar.error('Role ID is required')
-      return
-    }
-    try {
-      await create({ id: trimmed, content })
-      setId(''); setContent('')
-      onCreated(trimmed)
-    } catch (err: any) {
-      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'create role failed')
-    }
-  }
-
-  const handleClose = () => {
-    setId(''); setContent('')
-    onClose()
-  }
-
-  return (
-    <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
-      <DialogTitle>New role</DialogTitle>
-      <DialogContent>
-        <Stack spacing={2} sx={{ pt: 1 }}>
-          <TextField
-            label="Role ID"
-            placeholder="r-engineer"
-            value={id}
-            onChange={(e) => setId(e.target.value)}
-            helperText="Convention: r-<kebab-case>. Stays as-is — the LLM and operator both refer to roles by this handle."
-            autoFocus
-            fullWidth
-          />
-          <TextField
-            label="Content (markdown)"
-            placeholder="# Engineer&#10;Builds and ships software."
-            value={content}
-            onChange={(e) => setContent(e.target.value)}
-            multiline
-            minRows={6}
-            fullWidth
-          />
-        </Stack>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleClose}>Cancel</Button>
-        <Button onClick={submit} variant="contained" disabled={creating}>
-          {creating ? 'Creating…' : 'Create'}
-        </Button>
-      </DialogActions>
-    </Dialog>
   )
 }
 

--- a/frontend/src/pages/HelixOrgWorkerDetail.test.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { forwardRef } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import HelixOrgWorkerDetail from './HelixOrgWorkerDetail'
+
+// Verifies the inline-transcript wiring added to the worker detail page:
+// when the worker's project already has an exploratory ("Human Desktop")
+// session, the page mounts EmbeddedSessionView against it and subscribes
+// the WebSocket via streaming.setCurrentSessionId — so the operator sees
+// the worker's conversation without clicking out to the desktop tab.
+
+const mockSetCurrentSessionId = vi.fn()
+const mockGetExploratorySession = vi.fn()
+
+vi.mock('../contexts/streaming', () => ({
+  useStreaming: () => ({
+    setCurrentSessionId: mockSetCurrentSessionId,
+    NewInference: vi.fn(),
+  }),
+}))
+
+vi.mock('../hooks/useApi', () => ({
+  default: () => ({
+    getApiClient: () => ({
+      v1ProjectsExploratorySessionDetail: mockGetExploratorySession,
+      v1ProjectsExploratorySessionCreate: vi.fn(),
+      v1SessionsResumeCreate: vi.fn(),
+    }),
+  }),
+}))
+
+const mockUseHelixOrgWorker = vi.fn()
+vi.mock('../services/helixOrgService', () => ({
+  useHelixOrgWorker: (id: string | undefined) => mockUseHelixOrgWorker(id),
+  useFireHelixOrgWorker: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useEnsureWorkerChat: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useActivateWorker: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useListHelixOrgStreams: () => ({ data: { streams: [] }, isLoading: false }),
+  useListWorkerSubscriptions: () => ({ data: { subscriptions: [] }, isLoading: false }),
+  useSubscribeWorker: () => ({ mutateAsync: vi.fn() }),
+  useUnsubscribeWorker: () => ({ mutateAsync: vi.fn() }),
+}))
+
+vi.mock('../hooks/useAccount', () => ({
+  default: () => ({ organizationTools: { organization: { id: 'org_1' } } }),
+}))
+
+vi.mock('../hooks/useRouter', () => ({
+  default: () => ({
+    params: { org_id: 'acme', worker_id: 'w-ai-1' },
+    navigate: vi.fn(),
+  }),
+}))
+
+vi.mock('../hooks/useSnackbar', () => ({
+  default: () => ({ error: vi.fn(), success: vi.fn(), info: vi.fn() }),
+}))
+
+vi.mock('../components/system/Page', () => ({
+  default: ({ children, topbarContent }: any) => (
+    <div>{topbarContent}{children}</div>
+  ),
+}))
+vi.mock('../components/widgets/LoadingSpinner', () => ({ default: () => null }))
+vi.mock('../components/widgets/DeleteConfirmWindow', () => ({ default: () => null }))
+vi.mock('../components/common/RobustPromptInput', () => ({
+  default: ({ sessionId }: any) => <div data-testid="prompt-input">{sessionId}</div>,
+}))
+vi.mock('../components/session/EmbeddedSessionView', () => ({
+  __esModule: true,
+  default: forwardRef(({ sessionId }: any, _ref) => (
+    <div data-testid="embedded-session">{sessionId}</div>
+  )),
+}))
+
+const renderPage = () =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <HelixOrgWorkerDetail />
+    </QueryClientProvider>,
+  )
+
+const worker = {
+  id: 'w-ai-1',
+  kind: 'ai',
+  role_id: 'r-test',
+  organization_id: 'org_1',
+  identity_content: '',
+}
+
+describe('HelixOrgWorkerDetail inline transcript', () => {
+  beforeEach(() => {
+    mockSetCurrentSessionId.mockReset()
+    mockGetExploratorySession.mockReset()
+    mockUseHelixOrgWorker.mockReset()
+  })
+
+  it('mounts the transcript + subscribes the socket when a session exists', async () => {
+    mockUseHelixOrgWorker.mockReturnValue({
+      data: { worker, project_id: 'prj_1' },
+      isLoading: false,
+    })
+    mockGetExploratorySession.mockResolvedValue({ data: { id: 'ses_abc' } })
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('embedded-session')).toHaveTextContent('ses_abc')
+    })
+    expect(screen.getByTestId('prompt-input')).toHaveTextContent('ses_abc')
+    expect(mockSetCurrentSessionId).toHaveBeenCalledWith('ses_abc')
+  })
+
+  it('shows the empty state and never creates a session on load', async () => {
+    mockUseHelixOrgWorker.mockReturnValue({
+      data: { worker, project_id: 'prj_1' },
+      isLoading: false,
+    })
+    // 204 No Content → adapter maps to null → no transcript.
+    mockGetExploratorySession.mockRejectedValue({ response: { status: 204 } })
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/No conversation yet/i)).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('embedded-session')).toBeNull()
+  })
+
+  it('does not resolve a session when the worker has no project', async () => {
+    mockUseHelixOrgWorker.mockReturnValue({
+      data: { worker, project_id: undefined },
+      isLoading: false,
+    })
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/No conversation yet/i)).toBeInTheDocument()
+    })
+    expect(mockGetExploratorySession).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/HelixOrgWorkerDetail.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.tsx
@@ -13,7 +13,7 @@
 //     tab, for when the operator needs the desktop, not just the chat.
 //   - "Restart Desktop": a fresh manual activation (re-attaches MCP).
 
-import { FC, useEffect, useMemo, useRef, useState } from 'react'
+import { FC, Key, useEffect, useMemo, useRef, useState } from 'react'
 import Autocomplete from '@mui/material/Autocomplete'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
@@ -74,8 +74,13 @@ const HelixOrgWorkerDetail: FC = () => {
   const orgSlug = router.params.org_id as string | undefined
   const workerId = router.params.worker_id as string | undefined
 
-  const { data, isLoading } = useHelixOrgWorker(workerId)
   const fire = useFireHelixOrgWorker()
+  // Stop polling/refetching this worker once a fire is in flight or
+  // done — the row is being torn down, so a refetch would only hit a
+  // 404 (QA F3). The page navigates to the workers list on success.
+  const { data, isLoading } = useHelixOrgWorker(workerId, {
+    enabled: !fire.isPending && !fire.isSuccess,
+  })
   const ensureChat = useEnsureWorkerChat()
   const activate = useActivateWorker()
   const streaming = useStreaming()
@@ -571,19 +576,24 @@ const SubscriptionsPanel: FC<{ workerID?: string }> = ({ workerID }) => {
         onChange={handleChange}
         getOptionLabel={(s) => s.id}
         isOptionEqualToValue={(a, b) => a.id === b.id}
-        renderOption={(props, option, { selected }) => (
-          <li {...props}>
-            <Checkbox checked={selected} sx={{ mr: 1 }} />
-            <Box>
-              <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>{option.id}</Typography>
-              {option.description && (
-                <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                  {option.description}
-                </Typography>
-              )}
-            </Box>
-          </li>
-        )}
+        renderOption={(props, option, { selected }) => {
+          // Pass key explicitly rather than via the props spread —
+          // React 18.3 warns when a spread object carries a key.
+          const { key, ...liProps } = props as typeof props & { key?: Key }
+          return (
+            <li key={key ?? option.id} {...liProps}>
+              <Checkbox checked={selected} sx={{ mr: 1 }} />
+              <Box>
+                <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>{option.id}</Typography>
+                {option.description && (
+                  <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                    {option.description}
+                  </Typography>
+                )}
+              </Box>
+            </li>
+          )
+        }}
         renderInput={(params) => (
           <TextField
             {...params}
@@ -593,15 +603,18 @@ const SubscriptionsPanel: FC<{ workerID?: string }> = ({ workerID }) => {
           />
         )}
         renderTags={(value, getTagProps) =>
-          value.map((option, index) => (
-            <Chip
-              {...getTagProps({ index })}
-              key={option.id}
-              label={option.id}
-              size="small"
-              sx={{ fontFamily: 'monospace' }}
-            />
-          ))
+          value.map((option, index) => {
+            const { key, ...tagProps } = getTagProps({ index })
+            return (
+              <Chip
+                key={key ?? option.id}
+                {...tagProps}
+                label={option.id}
+                size="small"
+                sx={{ fontFamily: 'monospace' }}
+              />
+            )
+          })
         }
       />
       <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>

--- a/frontend/src/pages/HelixOrgWorkerDetail.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.tsx
@@ -1,17 +1,19 @@
 // HelixOrgWorkerDetail shows a single worker and lets the operator
-// chat to it in a fresh session. "Fresh" matters — the user explicitly
-// asked for no session history on this page; clicking the chat button
-// always opens a new conversation against the worker's per-Worker
-// agent app.
+// watch and drive its conversation inline — the same transcript view
+// the spec-task page uses (EmbeddedSessionView), reading the worker's
+// per-Worker project "Human Desktop" session. The point is to avoid
+// forcing the operator to click out to the external desktop tab just
+// to see what the worker is doing.
 //
-// Implementation: each "Start new chat" click navigates to the agent
-// app's chat page (/orgs/<org>/agent/<app_id>) WITHOUT a session_id
-// query param. The agent page's default behaviour for a missing
-// session id is to show an empty composer ready for a new session.
-// By avoiding any session_id pinning we guarantee no transcript bleed
-// across worker visits.
+// Surfaces, in order of weight:
+//   - Inline transcript (EmbeddedSessionView + RobustPromptInput):
+//     auto-shown when the worker's project already has an exploratory
+//     session. GET-only on load — never spins up infra by itself.
+//   - "Open Human Desktop": the full Zed GUI / video stream in a new
+//     tab, for when the operator needs the desktop, not just the chat.
+//   - "Restart Desktop": a fresh manual activation (re-attaches MCP).
 
-import { FC, useMemo, useState } from 'react'
+import { FC, useEffect, useMemo, useRef, useState } from 'react'
 import Autocomplete from '@mui/material/Autocomplete'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
@@ -35,11 +37,17 @@ import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined'
 import Page from '../components/system/Page'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import DeleteConfirmWindow from '../components/widgets/DeleteConfirmWindow'
+import EmbeddedSessionView, {
+  EmbeddedSessionViewHandle,
+} from '../components/session/EmbeddedSessionView'
+import RobustPromptInput from '../components/common/RobustPromptInput'
 
 import useAccount from '../hooks/useAccount'
 import useApi from '../hooks/useApi'
 import useRouter from '../hooks/useRouter'
 import useSnackbar from '../hooks/useSnackbar'
+import { useStreaming } from '../contexts/streaming'
+import { SESSION_TYPE_TEXT } from '../types'
 import {
   useActivateWorker,
   useEnsureWorkerChat,
@@ -50,6 +58,11 @@ import {
   useSubscribeWorker,
   useUnsubscribeWorker,
 } from '../services/helixOrgService'
+import {
+  WorkerChatApi,
+  ensureRunningWorkerSession,
+  fetchExistingWorkerSession,
+} from '../services/workerChatSession'
 
 const OWNER_WORKER = 'w-owner'
 
@@ -65,11 +78,63 @@ const HelixOrgWorkerDetail: FC = () => {
   const fire = useFireHelixOrgWorker()
   const ensureChat = useEnsureWorkerChat()
   const activate = useActivateWorker()
+  const streaming = useStreaming()
   const [confirmingFire, setConfirmingFire] = useState(false)
 
   const isOwner = workerId === OWNER_WORKER
   const worker = data?.worker
   const projectID = data?.project_id
+
+  // chatSessionId is the worker's long-lived "Human Desktop" exploratory
+  // session — the transcript we render inline. Null until we've resolved
+  // one (or there isn't one yet).
+  const [chatSessionId, setChatSessionId] = useState<string | null>(null)
+  const sessionViewRef = useRef<EmbeddedSessionViewHandle>(null)
+
+  // chatApi adapts the generated client to the injected shape the
+  // workerChatSession helpers expect. The exploratory-session GET returns
+  // 204 No Content when the project has no session yet — map that to null
+  // rather than letting it surface as an error.
+  const chatApi: WorkerChatApi = useMemo(() => ({
+    getExploratorySession: async (pid: string) => {
+      try {
+        const resp = await api.getApiClient().v1ProjectsExploratorySessionDetail(pid)
+        return resp.data ?? null
+      } catch (err: any) {
+        if (err?.response?.status === 204) return null
+        throw err
+      }
+    },
+    createExploratorySession: async (pid: string) =>
+      (await api.getApiClient().v1ProjectsExploratorySessionCreate(pid)).data,
+    resumeSession: async (sid: string) =>
+      api.getApiClient().v1SessionsResumeCreate(sid),
+  }), [api])
+
+  // Auto-load the inline transcript when the worker already has a project.
+  // GET-only — we never create a session just because the operator opened
+  // this page; the "Open Human Desktop" / provision buttons own that.
+  useEffect(() => {
+    let cancelled = false
+    if (!projectID) {
+      setChatSessionId(null)
+      return
+    }
+    fetchExistingWorkerSession(projectID, chatApi)
+      .then((sid) => { if (!cancelled) setChatSessionId(sid) })
+      .catch(() => { if (!cancelled) setChatSessionId(null) })
+    return () => { cancelled = true }
+    // chatApi is stable (memoised on the singleton api client); keying on
+    // projectID alone follows the "only primitives in deps" rule.
+  }, [projectID])
+
+  // Subscribe the WebSocket to the inline session so in-flight turns stream
+  // live (mirrors SpecTaskDetailContent, which likewise omits the streaming
+  // context object from deps). Clear on unmount / session change.
+  useEffect(() => {
+    streaming.setCurrentSessionId(chatSessionId)
+    return () => { streaming.setCurrentSessionId(null) }
+  }, [chatSessionId])
 
   // launching covers the whole openChat flow, not just the
   // ensureChat mutation. The user-facing "5 seconds of nothing"
@@ -117,30 +182,13 @@ const HelixOrgWorkerDetail: FC = () => {
         return
       }
 
-      const apiClient = api.getApiClient()
-      let session: { id?: string; config?: { external_agent_status?: string } } | null = null
-      try {
-        const resp = await apiClient.v1ProjectsExploratorySessionDetail(pid)
-        session = resp.data ?? null
-      } catch (err: any) {
-        if (err?.response?.status !== 204) {
-          snackbar.error(err?.response?.data?.error ?? err?.message ?? 'failed to open Human Desktop')
-          return
-        }
-      }
-      if (!session?.id) {
-        const created = await apiClient.v1ProjectsExploratorySessionCreate(pid)
-        session = created.data
-      } else if (session.config?.external_agent_status === 'stopped') {
-        // Paused desktop — kick it back to running before navigating so
-        // the user doesn't land on a dead viewer.
-        await apiClient.v1SessionsResumeCreate(session.id)
-      }
-      if (!session?.id) {
-        snackbar.error('failed to open Human Desktop session')
-        return
-      }
-      const url = `/orgs/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(pid)}/desktop/${encodeURIComponent(session.id)}`
+      // ensureRunningWorkerSession does the GET → create-if-missing →
+      // resume-if-paused dance so the operator never lands on a dead
+      // viewer. Surface the resolved session inline too so the transcript
+      // shows on this page once the desktop is up.
+      const sessionID = await ensureRunningWorkerSession(pid, chatApi)
+      setChatSessionId(sessionID)
+      const url = `/orgs/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(pid)}/desktop/${encodeURIComponent(sessionID)}`
       window.open(url, '_blank', 'noopener,noreferrer')
     } catch (err: any) {
       snackbar.error(err?.response?.data?.error ?? err?.message ?? 'failed to open Human Desktop')
@@ -241,18 +289,20 @@ const HelixOrgWorkerDetail: FC = () => {
                   </Stack>
                 </Box>
 
-                {/* Chat panel — no transcript, just the call to action. The
-                    user asked for "no previous sessions"; the agent chat page
-                    is where the actual transcript lives. */}
+                {/* Chat panel — inline transcript (same view the spec-task
+                    page uses) plus the desktop launch buttons. The
+                    transcript auto-loads when the worker already has a
+                    session; otherwise the call to action provisions one. */}
                 <Paper variant="outlined" sx={{ p: 3 }}>
                   <Stack spacing={2} alignItems="flex-start">
                     <Typography variant="subtitle1">Chat with this worker</Typography>
                     <Typography variant="body2" color="text.secondary">
-                      Opens the worker's Human Desktop in a new tab. The first click on
-                      a never-chatted-with worker provisions the agent app + project on
-                      the fly (takes a few seconds — the button shows a spinner and the
-                      label flips to "Launching Human Desktop…"); subsequent clicks open
-                      the same session immediately.
+                      The conversation below is the worker's Human Desktop session —
+                      the same transcript you'd see in the desktop tab, including its
+                      MCP tool calls. Send a message to drive it from here, or open the
+                      full desktop (Zed GUI + video) in a new tab. The first launch on a
+                      never-chatted-with worker provisions the agent app + project on the
+                      fly (takes a few seconds).
                     </Typography>
                     <Stack direction="row" spacing={1} flexWrap="wrap">
                       <Button
@@ -288,6 +338,52 @@ const HelixOrgWorkerDetail: FC = () => {
                     {!projectID && (
                       <Typography variant="caption" color="text.secondary">
                         Restart Desktop is available after the first "Open Human Desktop".
+                      </Typography>
+                    )}
+
+                    {/* Inline transcript. EmbeddedSessionView self-fetches
+                        the session + interactions and live-streams in-flight
+                        turns; it needs a bounded, flex-column container to
+                        scroll within. RobustPromptInput drives the same
+                        session via streaming.NewInference. */}
+                    {chatSessionId ? (
+                      <Box
+                        sx={{
+                          width: '100%',
+                          height: 520,
+                          display: 'flex',
+                          flexDirection: 'column',
+                          border: (theme) =>
+                            `1px solid ${theme.palette.mode === 'light' ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.08)'}`,
+                          borderRadius: 1,
+                          overflow: 'hidden',
+                        }}
+                      >
+                        <EmbeddedSessionView
+                          ref={sessionViewRef}
+                          sessionId={chatSessionId}
+                        />
+                        <Box sx={{ p: 1.5, flexShrink: 0 }}>
+                          <RobustPromptInput
+                            sessionId={chatSessionId}
+                            projectId={projectID}
+                            apiClient={api.getApiClient()}
+                            onSend={async (message: string, interrupt?: boolean) => {
+                              await streaming.NewInference({
+                                type: SESSION_TYPE_TEXT,
+                                message,
+                                sessionId: chatSessionId,
+                                interrupt: interrupt ?? true,
+                              })
+                            }}
+                            onHeightChange={() => sessionViewRef.current?.scrollToBottom()}
+                            placeholder="Send message to agent..."
+                          />
+                        </Box>
+                      </Box>
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">
+                        No conversation yet — launch the Human Desktop to start one.
                       </Typography>
                     )}
                   </Stack>

--- a/frontend/src/pages/HelixOrgWorkerDetail.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.tsx
@@ -448,11 +448,11 @@ const HelixOrgWorkerDetail: FC = () => {
                     <Typography variant="caption" color="text.secondary">Kind</Typography>
                     <Typography variant="body2">{worker.kind}</Typography>
                   </Box>
-                  {worker?.parent_id && (
+                  {(worker?.parent_ids ?? []).length > 0 && (
                     <Box>
                       <Typography variant="caption" color="text.secondary">Reports to</Typography>
                       <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
-                        {worker.parent_id}
+                        {(worker?.parent_ids ?? []).join(', ')}
                       </Typography>
                     </Box>
                   )}

--- a/frontend/src/pages/HelixOrgWorkers.tsx
+++ b/frontend/src/pages/HelixOrgWorkers.tsx
@@ -118,7 +118,7 @@ const HelixOrgWorkers: FC = () => {
     ),
     reportsTo: (
       <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
-        {w.parent_id || '—'}
+        {(w.parent_ids ?? []).join(', ') || '—'}
       </Typography>
     ),
     identityPreview: (

--- a/frontend/src/services/helixOrgService.ts
+++ b/frontend/src/services/helixOrgService.ts
@@ -289,9 +289,20 @@ export function useFireHelixOrgWorker() {
     mutationFn: async (workerId: string) => {
       await api.getApiClient().v1OrgsWorkersDelete(workerId, orgID)
     },
-    onSuccess: () => {
+    onSuccess: (_data, workerId) => {
+      // Evict the fired worker's own queries (the worker key prefix-
+      // matches its subscriptions key, so this drops both) and cancel
+      // any in-flight fetch. Without this the worker detail page would
+      // refetch a now-deleted worker and log a 404 (the QA F3 finding).
+      qc.removeQueries({ queryKey: QUERY_KEYS.worker(orgID, workerId) })
       qc.invalidateQueries({ queryKey: QUERY_KEYS.overview(orgID) })
-      qc.invalidateQueries({ queryKey: QUERY_KEYS.workers(orgID) })
+      // Exact: refresh the list itself without prefix-matching (and so
+      // refetching) the worker/subscriptions queries we just removed.
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.workers(orgID), exact: true })
+      // Firing cascades away the worker's s-activations-<id> stream and
+      // its direct reports' parent edge — refresh the Streams list (QA
+      // F6) and any open stream detail.
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.streams(orgID) })
     },
   })
 }
@@ -339,6 +350,11 @@ export function useDeleteHelixOrgRole() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: QUERY_KEYS.overview(orgID) })
       qc.invalidateQueries({ queryKey: QUERY_KEYS.roles(orgID) })
+      // Deleting a role fires every Worker holding it, which tears down
+      // their activation streams — refresh both lists so neither shows
+      // ghost rows (QA F6).
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.workers(orgID), exact: true })
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.streams(orgID) })
     },
   })
 }

--- a/frontend/src/services/helixOrgService.ts
+++ b/frontend/src/services/helixOrgService.ts
@@ -222,18 +222,36 @@ export function useHireHelixOrgWorker() {
   })
 }
 
-// useReparentWorker rewires who a Worker reports to. parentID === ''
-// clears the manager (Worker becomes top-level). Drives the chart's
-// drag-to-reparent: dragging manager → subordinate sets parent_id,
-// deleting the edge clears it. Invalidates overview + the worker list
-// so the new accountability edge renders on the next refetch.
-export function useReparentWorker() {
+// useAddWorkerParent adds a reporting line — the Worker now also
+// reports to parentID. Reporting is many-to-many, so this is additive.
+// Drives the chart's drag-to-report: dragging manager → subordinate
+// adds the line. Invalidates overview + the worker list so the new
+// accountability edge renders on the next refetch.
+export function useAddWorkerParent() {
   const api = useApi()
   const qc = useQueryClient()
   const { orgID } = useHelixOrgBase()
   return useMutation({
     mutationFn: async ({ workerID, parentID }: { workerID: string; parentID: string }) => {
-      await api.getApiClient().v1OrgsWorkersParentCreate(workerID, orgID, { parent_id: parentID })
+      await api.getApiClient().v1OrgsWorkersParentsCreate(workerID, orgID, { parent_id: parentID })
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.overview(orgID) })
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.workers(orgID) })
+    },
+  })
+}
+
+// useRemoveWorkerParent drops one reporting line — the Worker no longer
+// reports to parentID. Drives the chart's delete-edge flow; only the
+// dragged edge's line is removed, leaving any other managers intact.
+export function useRemoveWorkerParent() {
+  const api = useApi()
+  const qc = useQueryClient()
+  const { orgID } = useHelixOrgBase()
+  return useMutation({
+    mutationFn: async ({ workerID, parentID }: { workerID: string; parentID: string }) => {
+      await api.getApiClient().v1OrgsWorkersParentsDelete(workerID, parentID, orgID)
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: QUERY_KEYS.overview(orgID) })

--- a/frontend/src/services/workerChatSession.test.ts
+++ b/frontend/src/services/workerChatSession.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import {
+  fetchExistingWorkerSession,
+  ensureRunningWorkerSession,
+} from './workerChatSession'
+
+// These two helpers split the worker chat-session resolution into the
+// side-effect-free read (used to auto-show the inline transcript on the
+// worker detail page) and the infra-spinning ensure (used by "Open Human
+// Desktop"). Keeping them pure + injected makes the ensure→create→resume
+// branching unit-testable without an axios client.
+
+describe('fetchExistingWorkerSession', () => {
+  it('returns the existing session id without creating anything', async () => {
+    const getExploratorySession = vi.fn().mockResolvedValue({ id: 'ses_existing' })
+    const id = await fetchExistingWorkerSession('prj_1', { getExploratorySession })
+    expect(id).toBe('ses_existing')
+    expect(getExploratorySession).toHaveBeenCalledWith('prj_1')
+  })
+
+  it('returns null when no session exists yet', async () => {
+    const getExploratorySession = vi.fn().mockResolvedValue(null)
+    expect(
+      await fetchExistingWorkerSession('prj_1', { getExploratorySession }),
+    ).toBeNull()
+  })
+
+  it('returns null when the session has no id', async () => {
+    const getExploratorySession = vi.fn().mockResolvedValue({ config: {} })
+    expect(
+      await fetchExistingWorkerSession('prj_1', { getExploratorySession }),
+    ).toBeNull()
+  })
+})
+
+describe('ensureRunningWorkerSession', () => {
+  it('returns a running session id without creating or resuming', async () => {
+    const api = {
+      getExploratorySession: vi
+        .fn()
+        .mockResolvedValue({ id: 'ses_run', config: { external_agent_status: 'running' } }),
+      createExploratorySession: vi.fn(),
+      resumeSession: vi.fn(),
+    }
+    const id = await ensureRunningWorkerSession('prj_1', api)
+    expect(id).toBe('ses_run')
+    expect(api.createExploratorySession).not.toHaveBeenCalled()
+    expect(api.resumeSession).not.toHaveBeenCalled()
+  })
+
+  it('creates a session when none exists', async () => {
+    const api = {
+      getExploratorySession: vi.fn().mockResolvedValue(null),
+      createExploratorySession: vi.fn().mockResolvedValue({ id: 'ses_new' }),
+      resumeSession: vi.fn(),
+    }
+    const id = await ensureRunningWorkerSession('prj_1', api)
+    expect(id).toBe('ses_new')
+    expect(api.createExploratorySession).toHaveBeenCalledWith('prj_1')
+    expect(api.resumeSession).not.toHaveBeenCalled()
+  })
+
+  it('resumes a stopped (paused) session before returning it', async () => {
+    const api = {
+      getExploratorySession: vi
+        .fn()
+        .mockResolvedValue({ id: 'ses_paused', config: { external_agent_status: 'stopped' } }),
+      createExploratorySession: vi.fn(),
+      resumeSession: vi.fn().mockResolvedValue(undefined),
+    }
+    const id = await ensureRunningWorkerSession('prj_1', api)
+    expect(id).toBe('ses_paused')
+    expect(api.resumeSession).toHaveBeenCalledWith('ses_paused')
+    expect(api.createExploratorySession).not.toHaveBeenCalled()
+  })
+
+  it('throws when create yields no session id', async () => {
+    const api = {
+      getExploratorySession: vi.fn().mockResolvedValue(null),
+      createExploratorySession: vi.fn().mockResolvedValue({}),
+      resumeSession: vi.fn(),
+    }
+    await expect(ensureRunningWorkerSession('prj_1', api)).rejects.toThrow()
+  })
+})

--- a/frontend/src/services/workerChatSession.ts
+++ b/frontend/src/services/workerChatSession.ts
@@ -1,0 +1,60 @@
+// workerChatSession resolves a Worker's per-Worker project "Human Desktop"
+// session — the single long-lived exploratory session that IS the chat
+// surface (Zed ⇄ Claude Code). Two entry points, deliberately split by
+// their side effects:
+//
+//   - fetchExistingWorkerSession: GET-only. Never spins up infra. Safe to
+//     call on page load to auto-show the inline transcript when a session
+//     already exists.
+//   - ensureRunningWorkerSession: GET → create-if-missing → resume-if-paused.
+//     Spins up the desktop container. Used by the "Open / Provision Human
+//     Desktop" actions.
+//
+// Both take their API calls injected so the branching is unit-testable
+// without an axios client (see workerChatSession.test.ts).
+
+export interface ExploratorySession {
+  id?: string
+  config?: { external_agent_status?: string }
+}
+
+export interface WorkerChatReader {
+  // Returns the project's existing exploratory session, or null when none
+  // exists. Implementations map the API's 204 No Content to null.
+  getExploratorySession: (projectID: string) => Promise<ExploratorySession | null>
+}
+
+export interface WorkerChatApi extends WorkerChatReader {
+  createExploratorySession: (projectID: string) => Promise<ExploratorySession>
+  resumeSession: (sessionID: string) => Promise<unknown>
+}
+
+// fetchExistingWorkerSession returns the id of the project's long-lived
+// exploratory session if one already exists, else null. No side effects.
+export async function fetchExistingWorkerSession(
+  projectID: string,
+  api: WorkerChatReader,
+): Promise<string | null> {
+  const session = await api.getExploratorySession(projectID)
+  return session?.id ?? null
+}
+
+// ensureRunningWorkerSession returns a running exploratory session id,
+// creating one if the project has none and resuming it if it was paused
+// (external_agent_status === 'stopped') so the caller never lands on a
+// dead desktop.
+export async function ensureRunningWorkerSession(
+  projectID: string,
+  api: WorkerChatApi,
+): Promise<string> {
+  let session = await api.getExploratorySession(projectID)
+  if (!session?.id) {
+    session = await api.createExploratorySession(projectID)
+  } else if (session.config?.external_agent_status === 'stopped') {
+    await api.resumeSession(session.id)
+  }
+  if (!session?.id) {
+    throw new Error('failed to open Human Desktop session')
+  }
+  return session.id
+}

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -1,4 +1,9 @@
 definitions:
+  api.AddWorkerParentRequest:
+    properties:
+      parent_id:
+        type: string
+    type: object
   api.CreateRoleRequest:
     properties:
       content:
@@ -294,11 +299,6 @@ definitions:
       identity:
         type: string
     type: object
-  api.UpdateWorkerParentRequest:
-    properties:
-      parent_id:
-        type: string
-    type: object
   api.UpdateWorkerRoleRequest:
     properties:
       content:
@@ -339,8 +339,10 @@ definitions:
         type: string
       organization_id:
         type: string
-      parent_id:
-        type: string
+      parent_ids:
+        items:
+          type: string
+        type: array
       role_id:
         type: string
       tools:
@@ -17899,22 +17901,22 @@ paths:
       summary: 'Helix-org: update worker identity'
       tags:
       - HelixOrg
-  /api/v1/orgs/{org}/workers/{id}/parent:
+  /api/v1/orgs/{org}/workers/{id}/parents:
     post:
       consumes:
       - application/json
       parameters:
-      - description: Worker ID
+      - description: Worker ID (the report)
         in: path
         name: id
         required: true
         type: string
-      - description: New parent worker id ('' to clear)
+      - description: Manager worker id
         in: body
         name: payload
         required: true
         schema:
-          $ref: '#/definitions/api.UpdateWorkerParentRequest'
+          $ref: '#/definitions/api.AddWorkerParentRequest'
       responses:
         "204":
           description: No Content
@@ -17932,7 +17934,36 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - ApiKeyAuth: []
-      summary: 'Helix-org: set worker parent (reporting line)'
+      summary: 'Helix-org: add a worker reporting line (manager)'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/workers/{id}/parents/{parent_id}:
+    delete:
+      parameters:
+      - description: Worker ID (the report)
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Manager worker id
+        in: path
+        name: parent_id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: remove a worker reporting line (manager)'
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/workers/{id}/role:

--- a/openapi.json
+++ b/openapi.json
@@ -12365,7 +12365,7 @@
                 }
             }
         },
-        "/api/v1/orgs/{org}/workers/{id}/parent": {
+        "/api/v1/orgs/{org}/workers/{id}/parents": {
             "post": {
                 "security": [
                     {
@@ -12375,10 +12375,10 @@
                 "tags": [
                     "HelixOrg"
                 ],
-                "summary": "Helix-org: set worker parent (reporting line)",
+                "summary": "Helix-org: add a worker reporting line (manager)",
                 "parameters": [
                     {
-                        "description": "Worker ID",
+                        "description": "Worker ID (the report)",
                         "name": "id",
                         "in": "path",
                         "required": true,
@@ -12391,11 +12391,11 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/api.UpdateWorkerParentRequest"
+                                "$ref": "#/components/schemas/api.AddWorkerParentRequest"
                             }
                         }
                     },
-                    "description": "New parent worker id ('' to clear)",
+                    "description": "Manager worker id",
                     "required": true
                 },
                 "responses": {
@@ -12424,6 +12424,64 @@
                     },
                     "409": {
                         "description": "Conflict",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/workers/{id}/parents/{parent_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: remove a worker reporting line (manager)",
+                "parameters": [
+                    {
+                        "description": "Worker ID (the report)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Manager worker id",
+                        "name": "parent_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "content": {
                             "*/*": {
                                 "schema": {
@@ -24270,6 +24328,14 @@
             }
         },
         "schemas": {
+            "api.AddWorkerParentRequest": {
+                "type": "object",
+                "properties": {
+                    "parent_id": {
+                        "type": "string"
+                    }
+                }
+            },
             "api.CreateRoleRequest": {
                 "type": "object",
                 "properties": {
@@ -24713,14 +24779,6 @@
                     }
                 }
             },
-            "api.UpdateWorkerParentRequest": {
-                "type": "object",
-                "properties": {
-                    "parent_id": {
-                        "type": "string"
-                    }
-                }
-            },
             "api.UpdateWorkerRoleRequest": {
                 "type": "object",
                 "properties": {
@@ -24783,8 +24841,11 @@
                     "organization_id": {
                         "type": "string"
                     },
-                    "parent_id": {
-                        "type": "string"
+                    "parent_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "role_id": {
                         "type": "string"

--- a/swagger.json
+++ b/swagger.json
@@ -10307,7 +10307,7 @@
                 }
             }
         },
-        "/api/v1/orgs/{org}/workers/{id}/parent": {
+        "/api/v1/orgs/{org}/workers/{id}/parents": {
             "post": {
                 "security": [
                     {
@@ -10320,22 +10320,22 @@
                 "tags": [
                     "HelixOrg"
                 ],
-                "summary": "Helix-org: set worker parent (reporting line)",
+                "summary": "Helix-org: add a worker reporting line (manager)",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Worker ID",
+                        "description": "Worker ID (the report)",
                         "name": "id",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "New parent worker id ('' to clear)",
+                        "description": "Manager worker id",
                         "name": "payload",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.UpdateWorkerParentRequest"
+                            "$ref": "#/definitions/api.AddWorkerParentRequest"
                         }
                     }
                 ],
@@ -10357,6 +10357,52 @@
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/workers/{id}/parents/{parent_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: remove a worker reporting line (manager)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker ID (the report)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Manager worker id",
+                        "name": "parent_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/api.ErrorResponse"
                         }
@@ -20080,6 +20126,14 @@
         }
     },
     "definitions": {
+        "api.AddWorkerParentRequest": {
+            "type": "object",
+            "properties": {
+                "parent_id": {
+                    "type": "string"
+                }
+            }
+        },
         "api.CreateRoleRequest": {
             "type": "object",
             "properties": {
@@ -20523,14 +20577,6 @@
                 }
             }
         },
-        "api.UpdateWorkerParentRequest": {
-            "type": "object",
-            "properties": {
-                "parent_id": {
-                    "type": "string"
-                }
-            }
-        },
         "api.UpdateWorkerRoleRequest": {
             "type": "object",
             "properties": {
@@ -20593,8 +20639,11 @@
                 "organization_id": {
                     "type": "string"
                 },
-                "parent_id": {
-                    "type": "string"
+                "parent_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "role_id": {
                     "type": "string"


### PR DESCRIPTION
## Summary

Three stacked bugs, all now fixed and tested:

1. **Worker detail inline transcript** — embed EmbeddedSessionView + RobustPromptInput so operators see the worker's conversation without clicking out to the desktop tab. Auto-resolves existing sessions (GET-only on load, no container spin-up); empty state when none exists.

2. **RobustPromptInput queue pump regression** (53b336e01) — client-side queue pump was deleted, so every non-spec-task composer (TeamDesktopPage, worker chat) silently parked messages as 'saved locally' forever. Restored the pump, gated on `backendQueueEnabled` so spec-task (backend queue) and plain (frontend queue) paths don't double-send.

3. **Session chat handler authz inconsistency** — the chat POST used strict owner-equality check while GET/UPDATE/DELETE used proper RBAC, so org members (even owners) couldn't chat into org-shared sessions like worker Human Desktops — hit repeated 401. Now uses `authorizeUserToSession(ActionUpdate)` consistently.

## Testing

- Frontend TDD: `workerChatSession.test.ts` (7 unit tests), `HelixOrgWorkerDetail.test.tsx` (3 render tests), `RobustPromptInput.test.tsx` (2 regression tests for queue pump)
- Backend: `AuthzSessionSuite` (5 cases) pinning the org-owner-can-update case
- Full suite: 210 tests pass; vite build green; API builds clean

## QA

Updated `api/pkg/org/QA.md` §10 with explicit send-and-verify steps including authorization and response verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)