### PR TITLE
fix(helix-org): run ReconcileAll at bootstrap to catch pre-topology hires

### DIFF
--- a/api/pkg/org/application/topology/reconciler.go
+++ b/api/pkg/org/application/topology/reconciler.go
@@ -146,6 +146,30 @@ func (r *Reconciler) Reconcile(ctx context.Context, orgID string, affected ...or
 	return nil
 }
 
+// ReconcileAll converges the full topology for every Worker in the org.
+// Call at server startup so Workers hired before the reconciler was
+// wired (or before a new topology rule was added) get their activation,
+// team, and DM Streams created or corrected idempotently. Internally
+// loads every Worker ID and delegates to Reconcile so the scoping and
+// create/delete/subscribe logic stays in one place.
+func (r *Reconciler) ReconcileAll(ctx context.Context, orgID string) error {
+	if r == nil || r.Store == nil {
+		return nil
+	}
+	workers, err := r.Store.Workers.List(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("topology: ReconcileAll list workers: %w", err)
+	}
+	if len(workers) == 0 {
+		return nil
+	}
+	ids := make([]orgchart.WorkerID, len(workers))
+	for i, w := range workers {
+		ids[i] = w.ID()
+	}
+	return r.Reconcile(ctx, orgID, ids...)
+}
+
 // ensureStream converges one managed Stream: create it if missing,
 // subscribe every desired member, and unsubscribe anyone the desired
 // set no longer includes (the load-bearing half — this is what fixes

--- a/api/pkg/org/application/topology/reconciler_test.go
+++ b/api/pkg/org/application/topology/reconciler_test.go
@@ -123,7 +123,39 @@ func TestReconcile_LeavesForeignStreamsUntouched(t *testing.T) {
 	}
 }
 
-// TestReconcile_ScopedToAffectedSubtree: reconciling one manager's
+// TestReconcileAll_CatchesUpMissingTeamStream simulates the case where
+// Workers were hired before the topology reconciler was wired: the
+// reporting lines and Workers exist in the store but no team stream was
+// ever created. ReconcileAll must converge all Streams idempotently,
+// including the team stream for a manager who already has direct
+// reports.
+func TestReconcileAll_CatchesUpMissingTeamStream(t *testing.T) {
+	rec, st := newRec(t)
+	ctx := context.Background()
+
+	// Seed the org graph directly (bypassing hire_worker) to simulate
+	// Workers hired before the reconciler was wired — no streams exist.
+	seedWorker(t, st, human("w-owner"))
+	seedWorker(t, st, ai("w-alice"))
+	seedWorker(t, st, ai("w-qa-1"))
+	addLine(t, st, "w-owner", "w-alice")
+	addLine(t, st, "w-owner", "w-qa-1")
+
+	// ReconcileAll must create the team stream and subscribe all members.
+	if err := rec.ReconcileAll(ctx, orgID); err != nil {
+		t.Fatalf("ReconcileAll: %v", err)
+	}
+
+	team := TeamStreamID("w-owner")
+	if !streamExists(t, st, team) {
+		t.Fatalf("s-team-w-owner should exist after ReconcileAll")
+	}
+	if got := streamMembers(t, st, team); !eq(got, []orgchart.WorkerID{"w-alice", "w-owner", "w-qa-1"}) {
+		t.Fatalf("s-team-w-owner members = %v, want [w-alice w-owner w-qa-1]", got)
+	}
+}
+
+// TestReconcileAll_ScopedToAffectedSubtree: reconciling one manager's
 // subtree leaves an unrelated manager's team stream untouched.
 func TestReconcile_ScopedToAffectedSubtree(t *testing.T) {
 	rec, st := newRec(t)

--- a/api/pkg/server/helix_org_middleware.go
+++ b/api/pkg/server/helix_org_middleware.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/helixml/helix/api/pkg/org/application/bootstrap"
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+	"github.com/helixml/helix/api/pkg/org/application/topology"
 	helixorgstore "github.com/helixml/helix/api/pkg/org/domain/store"
 	helixorgserver "github.com/helixml/helix/api/pkg/org/interfaces/server"
 	helixstore "github.com/helixml/helix/api/pkg/store"
@@ -115,6 +116,18 @@ func (s *helixOrgScope) ensureBootstrap(ctx context.Context, orgID string) error
 		// for the idempotency story.
 		if _, err := ensureHelixOrgServiceAPIKey(ctx, orgID, s.helixStore, s.configs); err != nil {
 			log.Warn().Err(err).Str("org_id", orgID).Msg("helix-org service api key not provisioned")
+		}
+
+		// Converge the full topology for this org. Best-effort: a
+		// failure is logged but does not break the request — the org
+		// is still accessible and future hire/reparent/fire mutations
+		// will re-run Reconcile on the affected Workers. This catches
+		// Workers hired before the topology reconciler was wired
+		// (e.g. orgs upgraded from an older server version that
+		// lacked team-stream auto-creation).
+		rec := &topology.Reconciler{Store: s.orgStore}
+		if err := rec.ReconcileAll(ctx, orgID); err != nil {
+			log.Warn().Err(err).Str("org_id", orgID).Msg("helix-org topology reconcile-all failed")
 		}
 
 		s.mu.Lock()


### PR DESCRIPTION
## Summary

- Adds `ReconcileAll` to `topology.Reconciler` — loads all Worker IDs and delegates to the existing `Reconcile` diff so team/activation/DM streams for all workers are converged in one pass
- Calls `ReconcileAll` inside `ensureBootstrap` (once per org per server boot) so orgs upgraded from a pre-topology server version fix up missing streams automatically on first request
- Adds a regression test `TestReconcileAll_CatchesUpMissingTeamStream` that seeds workers + reporting lines without any streams, then asserts `ReconcileAll` creates `s-team-w-owner` with the correct subscribers

## Root cause

The topology reconciler (which auto-creates `s-team-<managerID>` streams) was added in commit 795323d (2026-06-08T08:53). Workers `w-alice` and `w-qa-1` were hired under `w-owner` before that commit, so `hire_worker` never ran `Reconcile` for their edge — the team stream was never created.

Fixes https://github.com/helixml/helix/issues/2540

## Test plan

- [x] `go test ./api/pkg/org/application/topology/...` — all tests pass including new `TestReconcileAll_CatchesUpMissingTeamStream`
- [x] `go build ./api/pkg/org/application/topology/... ./api/pkg/server/...` — compiles clean
- [x] Manually applied immediate fix to helix-org: `s-team-w-owner` now has subscribers `[w-owner, w-alice, w-qa-1]` (confirmed via API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)