### PR TITLE
fix(frontend): patch EventSource for embed-token SSE auth

### DIFF
--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -155,6 +155,39 @@ if (embedToken) {
     })
     window.WebSocket = PatchedWebSocket
   }
+
+  // EventSource (SSE) also cannot carry custom headers. Append ?access_token=
+  // for same-origin connections so the helix-org SSE endpoint authenticates
+  // correctly when the page is loaded via the ?access_token= embed flow.
+  if (typeof window !== 'undefined' && typeof window.EventSource === 'function') {
+    const OrigEventSource = window.EventSource
+    const PatchedEventSource = function (
+      this: EventSource,
+      url: string | URL,
+      init?: EventSourceInit,
+    ) {
+      let finalUrl: string | URL = url
+      try {
+        const urlStr = typeof url === 'string' ? url : url.toString()
+        const u = new URL(urlStr, window.location.origin)
+        const sameHost = u.host === window.location.host
+        if (sameHost && !u.searchParams.has('access_token')) {
+          u.searchParams.set('access_token', embedToken)
+          finalUrl = u.toString()
+        }
+      } catch {
+        // ignore — pass through unmodified
+      }
+      return new OrigEventSource(finalUrl, init)
+    } as unknown as typeof EventSource
+    PatchedEventSource.prototype = OrigEventSource.prototype
+    Object.defineProperties(PatchedEventSource, {
+      CONNECTING: { value: OrigEventSource.CONNECTING },
+      OPEN: { value: OrigEventSource.OPEN },
+      CLOSED: { value: OrigEventSource.CLOSED },
+    })
+    window.EventSource = PatchedEventSource
+  }
 }
 
 // Add interceptors to the Api client's axios instance

--- a/frontend/src/pages/HelixOrgStreamDetail.tsx
+++ b/frontend/src/pages/HelixOrgStreamDetail.tsx
@@ -63,10 +63,13 @@ const HelixOrgStreamDetail: FC = () => {
   const [liveEvents, setLiveEvents] = useState<EventCard[] | null>(null)
   const events = liveEvents ?? stream?.recent_events ?? []
 
-  // SSE wiring. EventSource sends `Cookie` automatically, so the
-  // browser session auth flows through without extra headers. The
-  // server emits `event: message` frames with a JSON-array payload of
-  // up to 50 events newest-first; we replace state on each.
+  // SSE wiring. For normal browser sessions EventSource sends the
+  // helix_session cookie automatically. For embed-token flows
+  // (pages loaded with ?access_token=…) the EventSource constructor
+  // is patched in useApi.ts to append ?access_token= to same-origin
+  // URLs — see the embedToken block there. The server emits
+  // `event: message` frames with a JSON-array payload of up to 50
+  // events newest-first; we replace state on each.
   const orgID = account.organizationTools.organization?.id || orgSlug || ''
   const sseUrlRef = useRef<string | null>(null)
   useEffect(() => {


### PR DESCRIPTION
## Summary

- `useApi.ts` already patches `axios`, `window.fetch`, and `window.WebSocket` to forward the embed bearer token (`?access_token=` URL param) for same-origin requests
- `EventSource` was not patched — SSE connections from QA agents or embed-page users got 401 because browsers cannot send custom headers on `EventSource` and no `helix_session` cookie is present in embed mode
- Adds an `EventSource` constructor patch (matching the existing WebSocket pattern) that appends `?access_token=<embedToken>` to same-origin SSE URLs
- `getRequestToken()` in `auth_utils.go` already accepts `?access_token=` as a valid auth source — no server changes needed

Fixes #2541.

## Test plan

- [ ] Load stream detail page normally (browser session) — SSE connects and streams events as before
- [ ] Load stream detail page with `?access_token=<worker-api-key>` — SSE now connects (previously 401)
- [ ] Confirm QA agent regression in #2541 no longer reproduces

🤖 Generated with [Claude Code](https://claude.com/claude-code)