### PR TITLE
fix(cli): org-awareness for project list and spectask list-agents

### DIFF
--- a/api/pkg/cli/project/list.go
+++ b/api/pkg/cli/project/list.go
@@ -4,27 +4,53 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/spf13/cobra"
+
+	"github.com/helixml/helix/api/pkg/cli"
+	"github.com/helixml/helix/api/pkg/client"
 )
 
 func newListCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:     "list",
-		Short:   "List all projects",
+	var orgFlag string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List projects in an organization",
+		Long: `List projects in an organization.
+
+Projects are organization-scoped. If --org is omitted and you belong to a
+single org, that org is used; if you belong to multiple, you will be
+prompted. The HELIX_ORG environment variable is also honoured.`,
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			apiClient, err := client.NewClientFromEnv()
+			if err != nil {
+				return fmt.Errorf("failed to create API client: %w", err)
+			}
+
+			orgID, err := cli.ResolveOrganizationInteractive(ctx, apiClient, orgFlag)
+			if err != nil {
+				return err
+			}
+
 			apiURL := getAPIURL()
 			token := getToken()
 
-			req, err := http.NewRequest("GET", apiURL+"/api/v1/projects", nil)
+			q := url.Values{}
+			q.Set("organization_id", orgID)
+			endpoint := apiURL + "/api/v1/projects?" + q.Encode()
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 			if err != nil {
 				return fmt.Errorf("failed to create request: %w", err)
 			}
 			req.Header.Set("Authorization", "Bearer "+token)
 
-			client := &http.Client{}
-			resp, err := client.Do(req)
+			httpClient := &http.Client{}
+			resp, err := httpClient.Do(req)
 			if err != nil {
 				return fmt.Errorf("failed to list projects: %w", err)
 			}
@@ -61,6 +87,9 @@ func newListCommand() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&orgFlag, "org", "o", "", "Organization name or ID (defaults to $HELIX_ORG, then your only org, or prompts)")
+	return cmd
 }
 
 type Project struct {

--- a/api/pkg/cli/spectask/spectask.go
+++ b/api/pkg/cli/spectask/spectask.go
@@ -18,6 +18,9 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/spf13/cobra"
+
+	"github.com/helixml/helix/api/pkg/cli"
+	"github.com/helixml/helix/api/pkg/client"
 )
 
 func New() *cobra.Command {
@@ -595,22 +598,53 @@ type AppsResponse struct {
 }
 
 func newListAgentsCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:     "list-agents",
-		Short:   "List available Helix agents/apps",
+	var (
+		orgFlag        string
+		zedExternalOnly bool
+	)
+	cmd := &cobra.Command{
+		Use:   "list-agents",
+		Short: "List agents (apps) in an organization",
+		Long: `List agents in an organization.
+
+Agents are organization-scoped. If --org is omitted and you belong to a
+single org, that org is used; if you belong to multiple, you will be
+prompted. The HELIX_ORG environment variable is also honoured.
+
+By default every agent the user has access to in the org is listed, with
+the assistant type shown so it is obvious which can be launched with
+"helix spectask start" (zed_external) vs other agent kinds. Pass
+--zed-external-only to restore the old behaviour and hide non-spec-task
+agents.`,
 		Aliases: []string{"agents"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			apiClient, err := client.NewClientFromEnv()
+			if err != nil {
+				return fmt.Errorf("failed to create API client: %w", err)
+			}
+
+			orgID, err := cli.ResolveOrganizationInteractive(ctx, apiClient, orgFlag)
+			if err != nil {
+				return err
+			}
+
 			apiURL := getAPIURL()
 			token := getToken()
 
-			req, err := http.NewRequest("GET", apiURL+"/api/v1/apps", nil)
+			q := url.Values{}
+			q.Set("organization_id", orgID)
+			endpoint := apiURL + "/api/v1/apps?" + q.Encode()
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 			if err != nil {
 				return err
 			}
 			req.Header.Set("Authorization", "Bearer "+token)
 
-			client := &http.Client{}
-			resp, err := client.Do(req)
+			httpClient := &http.Client{}
+			resp, err := httpClient.Do(req)
 			if err != nil {
 				return err
 			}
@@ -621,41 +655,75 @@ func newListAgentsCommand() *cobra.Command {
 				return fmt.Errorf("failed to parse apps: %w", err)
 			}
 
-			fmt.Println("Available Agents (Apps with zed_external assistants):")
+			fmt.Println("Available Agents:")
 			fmt.Println()
 
-			count := 0
+			shown := 0
 			for _, app := range apps {
-				// Find zed_external assistants
-				for _, assistant := range app.Config.Helix.Assistants {
+				// Surface the most relevant assistant per app: prefer zed_external
+				// (the only kind launchable via `spectask start` today), fall back
+				// to the first assistant otherwise so non-spec-task agents are
+				// still visible to the user.
+				var primary *Assistant
+				for i, assistant := range app.Config.Helix.Assistants {
 					if assistant.AgentType == "zed_external" {
-						count++
-						fmt.Printf("App: %s\n", app.Name)
-						fmt.Printf("  ID: %s\n", app.ID)
-						fmt.Printf("  Assistant: %s\n", assistant.Name)
-						if assistant.CodeAgentRuntime != "" {
-							fmt.Printf("  Runtime: %s\n", assistant.CodeAgentRuntime)
-						}
-						if assistant.Model != "" {
-							fmt.Printf("  Model: %s\n", assistant.Model)
-						}
-						fmt.Printf("  Usage: helix spectask start --project <prj_id> --agent %s -n \"Task name\"\n", app.ID)
-						fmt.Println()
+						primary = &app.Config.Helix.Assistants[i]
 						break
 					}
 				}
+				if primary == nil && len(app.Config.Helix.Assistants) > 0 {
+					if zedExternalOnly {
+						continue
+					}
+					primary = &app.Config.Helix.Assistants[0]
+				}
+				if primary == nil {
+					// App with no assistants at all - skip.
+					continue
+				}
+
+				shown++
+				usable := primary.AgentType == "zed_external"
+				marker := " (not launchable via spectask start)"
+				if usable {
+					marker = ""
+				}
+
+				fmt.Printf("App: %s%s\n", app.Name, marker)
+				fmt.Printf("  ID: %s\n", app.ID)
+				fmt.Printf("  Assistant: %s\n", primary.Name)
+				if primary.AgentType != "" {
+					fmt.Printf("  Agent type: %s\n", primary.AgentType)
+				}
+				if primary.CodeAgentRuntime != "" {
+					fmt.Printf("  Runtime: %s\n", primary.CodeAgentRuntime)
+				}
+				if primary.Model != "" {
+					fmt.Printf("  Model: %s\n", primary.Model)
+				}
+				if usable {
+					fmt.Printf("  Usage: helix spectask start --project <prj_id> --agent %s -n \"Task name\"\n", app.ID)
+				}
+				fmt.Println()
 			}
 
-			if count == 0 {
-				fmt.Println("No agents with zed_external assistants found.")
-				fmt.Println("Create an agent with a zed_external assistant in the Helix UI first.")
-			} else {
-				fmt.Printf("Found %d agent(s) with external assistant support.\n", count)
+			switch {
+			case shown == 0 && zedExternalOnly:
+				fmt.Println("No agents with zed_external assistants found in this org.")
+				fmt.Println("Create one in the Helix UI, or drop --zed-external-only to see all agents.")
+			case shown == 0:
+				fmt.Println("No agents found in this org. Create one in the Helix UI first.")
+			default:
+				fmt.Printf("Found %d agent(s) in this org.\n", shown)
 			}
 
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&orgFlag, "org", "o", "", "Organization name or ID (defaults to $HELIX_ORG, then your only org, or prompts)")
+	cmd.Flags().BoolVar(&zedExternalOnly, "zed-external-only", false, "Hide agents whose assistant is not zed_external (the only kind launchable via spectask start today)")
+	return cmd
 }
 
 func formatBytes(b int64) string {


### PR DESCRIPTION
## Summary

The Helix CLI was last updated before organisations were introduced. Today every multi-org install hits two visible CLI bugs because both commands query the user-scoped endpoint and get back empty results when the actual data lives under an org. This PR fixes both.

Closes T-3 and T-4 from the obsidian backlog.

### `helix project list` (T-3)

Hit `/api/v1/projects` without `?organization_id=` and gets `📁 Projects (0)` against any control plane where projects exist under an org (e.g. `https://yd.helix.ml/orgs/helix/projects/...`).

Fix:
- Add `--org` / `-o` flag with `$HELIX_ORG` env fallback.
- Use the existing `cli.ResolveOrganizationInteractive` helper: prompts if you belong to multiple orgs, auto-picks if you belong to one, errors if you have none.
- Pass `?organization_id=<id>` through to `/api/v1/projects`.

Same UX pattern that `helix sandbox` already uses (`api/pkg/cli/sandbox/sandbox.go`).

### `helix spectask list-agents` (T-4)

Two problems compounding:

1. Same missing `organization_id` on `/api/v1/apps`, so freshly created agents in an org are invisible.
2. The command then hard-filtered `assistant.AgentType == "zed_external"` and printed `No agents with zed_external assistants found.` when the org has agents of other kinds. The user had no way to see what they had.

Fix:
- Add `--org` flag (same pattern as above).
- List every agent the user has access to in the org. Surface the assistant kind and mark `zed_external` agents as launchable via `spectask start` so the affordance is unambiguous.
- `--zed-external-only` flag restores the old behaviour for anyone who relied on the filter.

### `helix org list`

Already exists at `api/pkg/cli/organization/list.go` and the server handler `listOrganizations` (`api/pkg/server/organization_handlers.go:60`) filters to memberships for non-admins. So it already returns "orgs the current user is a member of" today - no change needed in this PR.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/cli/project/ ./pkg/cli/spectask/`
- [x] `helix project list --help` shows the new `--org` flag and updated long description
- [x] `helix spectask list-agents --help` shows `--org` and `--zed-external-only` with updated long description
- [x] `helix org list --help` unchanged
- [ ] Live: `HELIX_URL=https://yd.helix.ml HELIX_API_KEY=... ./helix org list` (lists memberships)
- [ ] Live: `helix project list --org helix` (returns the YD POC projects we know exist there)
- [ ] Live: `helix spectask list-agents --org helix` (returns the agent created via UI, which was previously hidden because it isn't zed_external)
- [ ] Drone CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)