### PR TITLE
feat(helix-org): GitHub App bot identity (create/install/multi-org)

### DIFF
--- a/api/pkg/agent/skill/github/client.go
+++ b/api/pkg/agent/skill/github/client.go
@@ -67,23 +67,31 @@ func NewClientWithOAuthAndBaseURL(accessToken, baseURL string) *Client {
 	return NewClientWithPATAndBaseURL(accessToken, baseURL)
 }
 
+// newInstallationTransport builds the ghinstallation installation transport
+// (handles JWT generation and exchanges it for a short-lived installation
+// access token), pointed at GHES when baseURL is non-empty. Shared by
+// NewClientWithGitHubApp and MintInstallationToken.
+func newInstallationTransport(appID, installationID int64, privateKey, baseURL string) (*ghinstallation.Transport, error) {
+	itr, err := ghinstallation.New(http.DefaultTransport, appID, installationID, []byte(privateKey))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GitHub App transport: %w", err)
+	}
+	if baseURL != "" {
+		// For GHE, set the API endpoint.
+		itr.BaseURL = strings.TrimSuffix(baseURL, "/") + "/api/v3"
+	}
+	return itr, nil
+}
+
 // NewClientWithGitHubApp creates a new GitHub client using GitHub App authentication.
 // This uses JWT to get an installation access token, providing service-to-service auth.
 // appID is the GitHub App ID, installationID is the installation ID for the app on the org/repo,
 // and privateKey is the PEM-encoded private key for JWT signing.
 // baseURL is optional for GitHub Enterprise instances (empty for github.com).
 func NewClientWithGitHubApp(appID, installationID int64, privateKey, baseURL string) (*Client, error) {
-	// Create the GitHub App installation transport
-	// This handles JWT generation and token refresh automatically
-	itr, err := ghinstallation.New(http.DefaultTransport, appID, installationID, []byte(privateKey))
+	itr, err := newInstallationTransport(appID, installationID, privateKey, baseURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create GitHub App transport: %w", err)
-	}
-
-	// Configure base URL for GitHub Enterprise if needed
-	if baseURL != "" {
-		// For GHE, set the API endpoint
-		itr.BaseURL = strings.TrimSuffix(baseURL, "/") + "/api/v3"
+		return nil, err
 	}
 
 	ctx := context.Background()
@@ -117,12 +125,9 @@ func NewClientWithGitHubApp(appID, installationID int64, privateKey, baseURL str
 // so callers should treat this as a network operation (and tests should stub
 // it rather than call it).
 func MintInstallationToken(ctx context.Context, appID, installationID int64, privateKey, baseURL string) (string, error) {
-	itr, err := ghinstallation.New(http.DefaultTransport, appID, installationID, []byte(privateKey))
+	itr, err := newInstallationTransport(appID, installationID, privateKey, baseURL)
 	if err != nil {
-		return "", fmt.Errorf("failed to create GitHub App transport: %w", err)
-	}
-	if baseURL != "" {
-		itr.BaseURL = strings.TrimSuffix(baseURL, "/") + "/api/v3"
+		return "", err
 	}
 	tok, err := itr.Token(ctx)
 	if err != nil {
@@ -141,6 +146,7 @@ func MintInstallationToken(ctx context.Context, appID, installationID int64, pri
 //     the user is only an outside collaborator on individual repos.
 //   - The owners of repos returned by /user/repos surface those collaborator orgs,
 //     but only if the user has access to at least one repo in them.
+//
 // Unioning both gives us every org we can plausibly enumerate public repos for.
 func (c *Client) ListRepositories(ctx context.Context) ([]*github.Repository, error) {
 	// Step 1: Get user repos (personal, collaborator, org-member)

--- a/api/pkg/agent/skill/github/client.go
+++ b/api/pkg/agent/skill/github/client.go
@@ -103,6 +103,34 @@ func NewClientWithGitHubApp(appID, installationID int64, privateKey, baseURL str
 	}, nil
 }
 
+// MintInstallationToken returns a raw GitHub App installation access token
+// string (valid ~1h) for an installation. It is the token injected as
+// GH_TOKEN and used as the git credential so a Worker's git/gh act as the
+// app bot rather than a human.
+//
+// appID + installationID identify the installation; privateKey is the
+// PEM-encoded app private key used to sign the short-lived JWT that
+// ghinstallation exchanges for the installation token. baseURL is empty for
+// github.com, or the GHES origin (e.g. https://ghe.acme.com).
+//
+// Token() makes a live call to POST /app/installations/{id}/access_tokens,
+// so callers should treat this as a network operation (and tests should stub
+// it rather than call it).
+func MintInstallationToken(ctx context.Context, appID, installationID int64, privateKey, baseURL string) (string, error) {
+	itr, err := ghinstallation.New(http.DefaultTransport, appID, installationID, []byte(privateKey))
+	if err != nil {
+		return "", fmt.Errorf("failed to create GitHub App transport: %w", err)
+	}
+	if baseURL != "" {
+		itr.BaseURL = strings.TrimSuffix(baseURL, "/") + "/api/v3"
+	}
+	tok, err := itr.Token(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to mint installation token: %w", err)
+	}
+	return tok, nil
+}
+
 // ListRepositories lists all repositories accessible to the authenticated user
 // including personal repos, collaborator repos, and organization repos (both public and private).
 //

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"time"
 
 	"github.com/helixml/helix/api/pkg/types"
@@ -616,6 +617,32 @@ type GitHub struct {
 	// New Stream "Install Helix" gate opens. The app's private key lives
 	// encrypted in a ServiceConnection, never here.
 	AppSlug string `envconfig:"GITHUB_APP_SLUG" description:"Public slug of the Helix GitHub App used to build the install URL."`
+	// URL is the base web URL of the GitHub instance: https://github.com
+	// (default) or a GitHub Enterprise Server origin (e.g.
+	// https://github.acme.com). It drives the app create/install/manage links
+	// and points the API client at the right host for GHES customers.
+	URL string `envconfig:"GITHUB_URL" default:"https://github.com" description:"Base web URL of the GitHub instance (https://github.com or a GitHub Enterprise Server origin)."`
+}
+
+// WebURL returns the GitHub web origin (no trailing slash), defaulting to
+// github.com. Used to build the app create / install / manage links.
+func (g GitHub) WebURL() string {
+	u := strings.TrimRight(strings.TrimSpace(g.URL), "/")
+	if u == "" {
+		return "https://github.com"
+	}
+	return u
+}
+
+// APIBaseURL returns the value to hand the github client/transport: empty for
+// public github.com (the client special-cases it to api.github.com), or the
+// GHES origin otherwise. This is also what gets stored on a github_app
+// ServiceConnection so later API calls target the right host.
+func (g GitHub) APIBaseURL() string {
+	if g.WebURL() == "https://github.com" {
+		return ""
+	}
+	return g.WebURL()
 }
 
 type FineTuning struct {

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -610,6 +610,12 @@ type GitHub struct {
 	ClientSecret string `envconfig:"GITHUB_INTEGRATION_CLIENT_SECRET" description:"The github app client secret."`
 	RepoFolder   string `envconfig:"GITHUB_INTEGRATION_REPO_FOLDER" default:"/filestore/github/repos" description:"What folder do we use to clone github repos."`
 	WebhookURL   string `envconfig:"GITHUB_INTEGRATION_WEBHOOK_URL" description:"The URL to receive github webhooks."`
+	// AppSlug is the public URL slug of this deployment's Helix GitHub App
+	// (e.g. "helix-agent" → https://github.com/apps/helix-agent). NOT a
+	// secret — just the public app handle used to build the install URL the
+	// New Stream "Install Helix" gate opens. The app's private key lives
+	// encrypted in a ServiceConnection, never here.
+	AppSlug string `envconfig:"GITHUB_APP_SLUG" description:"Public slug of the Helix GitHub App used to build the install URL."`
 }
 
 type FineTuning struct {

--- a/api/pkg/github/client.go
+++ b/api/pkg/github/client.go
@@ -18,17 +18,29 @@ import (
 // stored connection after the app is deleted on GitHub.
 var ErrAppNotFound = errors.New("github app not found (deleted or invalid credentials)")
 
-// ListAppInstallations lists every installation of a GitHub App, authenticating
-// as the app (JWT signed with its private key). Used to reconcile an org's
-// installation id after the user installs the app, without relying on a
-// browser Setup-URL redirect. baseURL is empty for github.com or the GHES origin.
-func ListAppInstallations(ctx context.Context, appID int64, privateKey, baseURL string) ([]*github.Installation, error) {
+// buildAppTransport builds the app-level JWT transport (authenticating as the
+// GitHub App itself, not an installation), pointed at GHES when baseURL is
+// non-empty. Centralises the ghinstallation + GHES base-URL setup for the
+// app-scoped calls in this package.
+func buildAppTransport(appID int64, privateKey, baseURL string) (*ghinstallation.AppsTransport, error) {
 	atr, err := ghinstallation.NewAppsTransport(http.DefaultTransport, appID, []byte(privateKey))
 	if err != nil {
 		return nil, fmt.Errorf("create app transport: %w", err)
 	}
 	if baseURL != "" {
 		atr.BaseURL = strings.TrimSuffix(baseURL, "/") + "/api/v3"
+	}
+	return atr, nil
+}
+
+// ListAppInstallations lists every installation of a GitHub App, authenticating
+// as the app (JWT signed with its private key). Used to reconcile an org's
+// installation id after the user installs the app, without relying on a
+// browser Setup-URL redirect. baseURL is empty for github.com or the GHES origin.
+func ListAppInstallations(ctx context.Context, appID int64, privateKey, baseURL string) ([]*github.Installation, error) {
+	atr, err := buildAppTransport(appID, privateKey, baseURL)
+	if err != nil {
+		return nil, err
 	}
 	client := github.NewClient(&http.Client{Transport: atr})
 	if baseURL != "" {

--- a/api/pkg/github/client.go
+++ b/api/pkg/github/client.go
@@ -3,11 +3,39 @@ package github
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"slices"
+	"strings"
 
+	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v61/github"
 	"golang.org/x/oauth2"
 )
+
+// ListAppInstallations lists every installation of a GitHub App, authenticating
+// as the app (JWT signed with its private key). Used to reconcile an org's
+// installation id after the user installs the app, without relying on a
+// browser Setup-URL redirect. baseURL is empty for github.com or the GHES origin.
+func ListAppInstallations(ctx context.Context, appID int64, privateKey, baseURL string) ([]*github.Installation, error) {
+	atr, err := ghinstallation.NewAppsTransport(http.DefaultTransport, appID, []byte(privateKey))
+	if err != nil {
+		return nil, fmt.Errorf("create app transport: %w", err)
+	}
+	if baseURL != "" {
+		atr.BaseURL = strings.TrimSuffix(baseURL, "/") + "/api/v3"
+	}
+	client := github.NewClient(&http.Client{Transport: atr})
+	if baseURL != "" {
+		if ec, err := client.WithEnterpriseURLs(baseURL, baseURL); err == nil {
+			client = ec
+		}
+	}
+	insts, _, err := client.Apps.ListInstallations(ctx, &github.ListOptions{PerPage: 100})
+	if err != nil {
+		return nil, fmt.Errorf("list app installations: %w", err)
+	}
+	return insts, nil
+}
 
 type ClientOptions struct {
 	Ctx     context.Context

--- a/api/pkg/github/client.go
+++ b/api/pkg/github/client.go
@@ -83,6 +83,38 @@ func (c *Client) LoadRepos() ([]string, error) {
 	return results, nil
 }
 
+// LoadInstallationRepos returns full_name for every repo a GitHub App
+// installation can access, via GET /installation/repositories. Use this when
+// the client is built with an installation access token (the app bot
+// identity) rather than a user OAuth token — an installation token cannot
+// call the /user/repos endpoint LoadRepos uses, and listing the
+// installation's repos is exactly the right scope for the picker: you can
+// only wire a stream to a repo the bot can actually act on.
+func (c *Client) LoadInstallationRepos() ([]string, error) {
+	var repos []*github.Repository
+	opts := github.ListOptions{PerPage: 100, Page: 1}
+	for i := 0; i < loadReposMaxPages; i++ {
+		result, meta, err := c.client.Apps.ListRepos(c.ctx, &opts)
+		if err != nil {
+			return nil, err
+		}
+		if result != nil {
+			repos = append(repos, result.Repositories...)
+		}
+		if meta == nil || meta.NextPage == 0 {
+			break
+		}
+		opts.Page = meta.NextPage
+	}
+	results := make([]string, 0, len(repos))
+	for _, repo := range repos {
+		if repo != nil && repo.FullName != nil {
+			results = append(results, *repo.FullName)
+		}
+	}
+	return results, nil
+}
+
 func (c *Client) GetRepo(owner string, repo string) (*github.Repository, error) {
 	result, _, err := c.client.Repositories.Get(c.ctx, owner, repo)
 	return result, err

--- a/api/pkg/github/client.go
+++ b/api/pkg/github/client.go
@@ -83,6 +83,28 @@ func (c *Client) LoadRepos() ([]string, error) {
 	return results, nil
 }
 
+// CompleteAppManifest exchanges the temporary code GitHub returns at the end
+// of the App Manifest flow for the new app's permanent config: id, slug,
+// PEM private key, webhook secret and client credentials. The code is valid
+// for one hour and the call is unauthenticated (the code is the credential),
+// so this uses a tokenless client. baseURL is empty for github.com or the
+// GHES origin.
+func CompleteAppManifest(ctx context.Context, code, baseURL string) (*github.AppConfig, error) {
+	client := github.NewClient(nil)
+	if baseURL != "" {
+		enterpriseClient, err := client.WithEnterpriseURLs(baseURL, baseURL)
+		if err != nil {
+			return nil, fmt.Errorf("configure GHES base url: %w", err)
+		}
+		client = enterpriseClient
+	}
+	cfg, _, err := client.Apps.CompleteAppManifest(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("complete app manifest: %w", err)
+	}
+	return cfg, nil
+}
+
 // LoadInstallationRepos returns full_name for every repo a GitHub App
 // installation can access, via GET /installation/repositories. Use this when
 // the client is built with an installation access token (the app bot

--- a/api/pkg/github/client.go
+++ b/api/pkg/github/client.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -11,6 +12,11 @@ import (
 	"github.com/google/go-github/v61/github"
 	"golang.org/x/oauth2"
 )
+
+// ErrAppNotFound means the GitHub App no longer exists (or its key is invalid)
+// — GitHub rejected the app JWT with 401/404. Callers use this to clear a stale
+// stored connection after the app is deleted on GitHub.
+var ErrAppNotFound = errors.New("github app not found (deleted or invalid credentials)")
 
 // ListAppInstallations lists every installation of a GitHub App, authenticating
 // as the app (JWT signed with its private key). Used to reconcile an org's
@@ -30,8 +36,13 @@ func ListAppInstallations(ctx context.Context, appID int64, privateKey, baseURL 
 			client = ec
 		}
 	}
-	insts, _, err := client.Apps.ListInstallations(ctx, &github.ListOptions{PerPage: 100})
+	insts, resp, err := client.Apps.ListInstallations(ctx, &github.ListOptions{PerPage: 100})
 	if err != nil {
+		// A valid app authenticates and returns 200 even with zero
+		// installations, so 401/404 here means the app itself is gone.
+		if resp != nil && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusNotFound) {
+			return nil, ErrAppNotFound
+		}
 		return nil, fmt.Errorf("list app installations: %w", err)
 	}
 	return insts, nil

--- a/api/pkg/org/domain/transport/github.go
+++ b/api/pkg/org/domain/transport/github.go
@@ -50,6 +50,12 @@ type GitHubConfig struct {
 	// Required and non-empty.
 	Events []string `json:"events,omitempty"`
 
+	// Branches optionally narrows branch-carrying events (push, create,
+	// delete) to specific branches. Each entry is an exact branch name
+	// ("main") or a prefix glob ("release/*"). Empty = all branches.
+	// Events without a branch ref (issues, pull_request, …) are unaffected.
+	Branches []string `json:"branches,omitempty"`
+
 	// WebhookID is the GitHub-side hook id (returned by `POST
 	// /repos/{owner}/{repo}/hooks`) once helix has auto-installed
 	// the webhook for this stream. Zero when no auto-install has
@@ -93,6 +99,11 @@ func (g GitHubConfig) Validate() error {
 		}
 		if !githubEventNamePattern.MatchString(ev) {
 			return fmt.Errorf("github transport: invalid event %q (must match %s, e.g. issues, pull_request, push, workflow_run, or \"*\" for all events)", ev, githubEventNamePattern.String())
+		}
+	}
+	for _, b := range g.Branches {
+		if strings.TrimSpace(b) == "" {
+			return errors.New("github transport: branch filter entries must be non-empty (e.g. main, release/*)")
 		}
 	}
 	return nil

--- a/api/pkg/org/domain/transport/github.go
+++ b/api/pkg/org/domain/transport/github.go
@@ -50,10 +50,11 @@ type GitHubConfig struct {
 	// Required and non-empty.
 	Events []string `json:"events,omitempty"`
 
-	// Branches optionally narrows branch-carrying events (push, create,
-	// delete) to specific branches. Each entry is an exact branch name
-	// ("main") or a prefix glob ("release/*"). Empty = all branches.
-	// Events without a branch ref (issues, pull_request, …) are unaffected.
+	// Branches narrows branch-carrying events (push, create, delete) to
+	// specific branches. Each entry is "*" (all branches), an exact branch
+	// name ("main"), or a prefix glob ("release/*"). Events without a branch
+	// ref (issues, pull_request, …) are unaffected. An absent/empty list is
+	// also treated as all branches, for streams created before this field.
 	Branches []string `json:"branches,omitempty"`
 
 	// WebhookID is the GitHub-side hook id (returned by `POST

--- a/api/pkg/org/infrastructure/transports/github/github.go
+++ b/api/pkg/org/infrastructure/transports/github/github.go
@@ -286,7 +286,8 @@ func (t *Transport) HandleInbound() http.Handler {
 		}
 
 		// Find every stream this delivery should fan out to.
-		streams, err := t.matchingStreams(r.Context(), repo, eventType)
+		branch := payloadBranch(eventType, payload)
+		streams, err := t.matchingStreams(r.Context(), repo, eventType, branch)
 		if err != nil {
 			t.logger.Error("github.inbound: match streams", "repo", repo, "err", err)
 			http.Error(w, "internal error", http.StatusInternalServerError)
@@ -437,6 +438,12 @@ func (t *Transport) HandleInboundForStream(streamID streaming.StreamID) http.Han
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
+		if !branchAllowed(streamCfg.Branches, payloadBranch(eventType, payload)) {
+			t.logger.Info("github.inbound.stream: branch not in filter",
+				"stream", streamID, "event", eventType, "delivery", deliveryID)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		// Inject the event header into the body's top level for
 		// roles, same as HandleInbound.
 		payload["event"] = eventType
@@ -491,7 +498,7 @@ func (t *Transport) HandleInboundForStream(streamID streaming.StreamID) http.Han
 // contains `eventType`. Linear scan is fine at the scale we expect;
 // indexed lookups are an obvious follow-on if installations ever
 // grow many github streams.
-func (t *Transport) matchingStreams(ctx context.Context, repo, eventType string) ([]streaming.Stream, error) {
+func (t *Transport) matchingStreams(ctx context.Context, repo, eventType, branch string) ([]streaming.Stream, error) {
 	all, err := t.store.Streams.List(ctx, t.orgID)
 	if err != nil {
 		return nil, fmt.Errorf("list streams: %w", err)
@@ -512,9 +519,52 @@ func (t *Transport) matchingStreams(ctx context.Context, repo, eventType string)
 		if !contains(cfg.Events, eventType) {
 			continue
 		}
+		if !branchAllowed(cfg.Branches, branch) {
+			continue
+		}
 		matched = append(matched, s)
 	}
 	return matched, nil
+}
+
+// payloadBranch extracts the branch name from a delivery's ref for events
+// that carry one (push, create, delete). Returns "" for tag refs and for
+// events without a ref — branchAllowed then treats those as unfiltered.
+func payloadBranch(eventType string, payload map[string]any) string {
+	switch eventType {
+	case "push", "create", "delete":
+		ref, _ := payload["ref"].(string)
+		// push uses refs/heads/<branch>; create/delete put the bare name in
+		// `ref` with ref_type=branch.
+		if b, ok := strings.CutPrefix(ref, "refs/heads/"); ok {
+			return b
+		}
+		if rt, _ := payload["ref_type"].(string); rt == "branch" {
+			return ref
+		}
+	}
+	return ""
+}
+
+// branchAllowed reports whether a delivery's branch passes a stream's branch
+// filter. Empty filter (or a non-branch event, branch=="") matches everything.
+// Patterns are exact ("main") or prefix globs ("release/*").
+func branchAllowed(patterns []string, branch string) bool {
+	if len(patterns) == 0 || branch == "" {
+		return true
+	}
+	for _, p := range patterns {
+		if prefix, ok := strings.CutSuffix(p, "/*"); ok {
+			if branch == prefix || strings.HasPrefix(branch, prefix+"/") {
+				return true
+			}
+			continue
+		}
+		if strings.EqualFold(p, branch) {
+			return true
+		}
+	}
+	return false
 }
 
 // repoMatches reports whether a stream's configured repo filter matches a

--- a/api/pkg/org/infrastructure/transports/github/github.go
+++ b/api/pkg/org/infrastructure/transports/github/github.go
@@ -424,7 +424,7 @@ func (t *Transport) HandleInboundForStream(streamID streaming.StreamID) http.Han
 		// Stream-level filters: drop on repo or event-whitelist
 		// mismatch with 204 so GitHub stops retrying. This is the
 		// same drop semantics as the org-level handler.
-		if !strings.EqualFold(streamCfg.Repo, repo) {
+		if !repoMatches(streamCfg.Repo, repo) {
 			t.logger.Info("github.inbound.stream: repo mismatch",
 				"stream", streamID, "stream_repo", streamCfg.Repo, "payload_repo", repo,
 				"event", eventType, "delivery", deliveryID)
@@ -506,7 +506,7 @@ func (t *Transport) matchingStreams(ctx context.Context, repo, eventType string)
 			t.logger.Warn("github.inbound: stream config parse", "stream", s.ID, "err", err)
 			continue
 		}
-		if !strings.EqualFold(cfg.Repo, repo) {
+		if !repoMatches(cfg.Repo, repo) {
 			continue
 		}
 		if !contains(cfg.Events, eventType) {
@@ -515,6 +515,20 @@ func (t *Transport) matchingStreams(ctx context.Context, repo, eventType string)
 		matched = append(matched, s)
 	}
 	return matched, nil
+}
+
+// repoMatches reports whether a stream's configured repo filter matches a
+// delivery's repository full_name. Supports:
+//   - exact repo: "owner/name" (case-insensitive)
+//   - org wildcard: "owner/*" matches every repo under that owner — the
+//     "scoped to an org" case when the app is installed on all of an org's
+//     repos.
+func repoMatches(cfgRepo, deliveredRepo string) bool {
+	if owner, ok := strings.CutSuffix(cfgRepo, "/*"); ok {
+		dOwner, _, found := strings.Cut(deliveredRepo, "/")
+		return found && strings.EqualFold(owner, dOwner)
+	}
+	return strings.EqualFold(cfgRepo, deliveredRepo)
 }
 
 // verifySignature compares X-Hub-Signature-256 ("sha256=<hex>")

--- a/api/pkg/org/infrastructure/transports/github/github.go
+++ b/api/pkg/org/infrastructure/transports/github/github.go
@@ -547,13 +547,17 @@ func payloadBranch(eventType string, payload map[string]any) string {
 }
 
 // branchAllowed reports whether a delivery's branch passes a stream's branch
-// filter. Empty filter (or a non-branch event, branch=="") matches everything.
-// Patterns are exact ("main") or prefix globs ("release/*").
+// filter. Patterns are "*" (all branches), an exact name ("main"), or a prefix
+// glob ("release/*"). A non-branch event (branch=="") is unaffected, as is an
+// absent/empty filter (for streams created before this field existed).
 func branchAllowed(patterns []string, branch string) bool {
 	if len(patterns) == 0 || branch == "" {
 		return true
 	}
 	for _, p := range patterns {
+		if p == "*" {
+			return true
+		}
 		if prefix, ok := strings.CutSuffix(p, "/*"); ok {
 			if branch == prefix || strings.HasPrefix(branch, prefix+"/") {
 				return true

--- a/api/pkg/org/infrastructure/transports/github/repo_match_test.go
+++ b/api/pkg/org/infrastructure/transports/github/repo_match_test.go
@@ -1,0 +1,26 @@
+package github
+
+import "testing"
+
+func TestRepoMatches(t *testing.T) {
+	cases := []struct {
+		cfg, delivered string
+		want           bool
+	}{
+		// exact, case-insensitive
+		{"helixml/helix", "helixml/helix", true},
+		{"helixml/helix", "HelixML/Helix", true},
+		{"helixml/helix", "helixml/other", false},
+		{"helixml/helix", "other/helix", false},
+		// org wildcard
+		{"winderai/*", "winderai/vision-rag-demo", true},
+		{"winderai/*", "WinderAI/anything", true},
+		{"winderai/*", "other/repo", false},
+		{"winderai/*", "winderai", false}, // malformed delivered (no slash)
+	}
+	for _, c := range cases {
+		if got := repoMatches(c.cfg, c.delivered); got != c.want {
+			t.Errorf("repoMatches(%q, %q) = %v, want %v", c.cfg, c.delivered, got, c.want)
+		}
+	}
+}

--- a/api/pkg/org/infrastructure/transports/github/repo_match_test.go
+++ b/api/pkg/org/infrastructure/transports/github/repo_match_test.go
@@ -9,6 +9,8 @@ func TestBranchAllowed(t *testing.T) {
 		want     bool
 	}{
 		{nil, "main", true},               // no filter → all branches
+		{[]string{"*"}, "main", true},      // wildcard → all branches
+		{[]string{"*"}, "feature/x", true}, // wildcard → all branches
 		{[]string{"main"}, "", true},       // non-branch event → unfiltered
 		{[]string{"main"}, "main", true},   // exact
 		{[]string{"main"}, "MAIN", true},   // case-insensitive

--- a/api/pkg/org/infrastructure/transports/github/repo_match_test.go
+++ b/api/pkg/org/infrastructure/transports/github/repo_match_test.go
@@ -2,6 +2,45 @@ package github
 
 import "testing"
 
+func TestBranchAllowed(t *testing.T) {
+	cases := []struct {
+		patterns []string
+		branch   string
+		want     bool
+	}{
+		{nil, "main", true},               // no filter → all branches
+		{[]string{"main"}, "", true},       // non-branch event → unfiltered
+		{[]string{"main"}, "main", true},   // exact
+		{[]string{"main"}, "MAIN", true},   // case-insensitive
+		{[]string{"main"}, "dev", false},   // exact miss
+		{[]string{"release/*"}, "release/1.2", true},  // prefix glob
+		{[]string{"release/*"}, "release", true},      // glob matches bare prefix
+		{[]string{"release/*"}, "releases/x", false},  // not a child of release/
+		{[]string{"main", "release/*"}, "release/9", true}, // any-of
+		{[]string{"main"}, "feature/x", false},
+	}
+	for _, c := range cases {
+		if got := branchAllowed(c.patterns, c.branch); got != c.want {
+			t.Errorf("branchAllowed(%v, %q) = %v, want %v", c.patterns, c.branch, got, c.want)
+		}
+	}
+}
+
+func TestPayloadBranch(t *testing.T) {
+	if got := payloadBranch("push", map[string]any{"ref": "refs/heads/main"}); got != "main" {
+		t.Errorf("push refs/heads/main -> %q, want main", got)
+	}
+	if got := payloadBranch("push", map[string]any{"ref": "refs/tags/v1"}); got != "" {
+		t.Errorf("tag push -> %q, want empty", got)
+	}
+	if got := payloadBranch("create", map[string]any{"ref": "feature/x", "ref_type": "branch"}); got != "feature/x" {
+		t.Errorf("create branch -> %q, want feature/x", got)
+	}
+	if got := payloadBranch("issues", map[string]any{}); got != "" {
+		t.Errorf("issues -> %q, want empty", got)
+	}
+}
+
 func TestRepoMatches(t *testing.T) {
 	cases := []struct {
 		cfg, delivered string

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -152,6 +152,13 @@ type Deps struct {
 	// falls back to treating the org as not-installable.
 	GitHubInstallation func(ctx context.Context, orgID string) (GitHubInstallationStatus, error)
 
+	// GitHubManifestStart builds the GitHub App Manifest flow for an org:
+	// a Helix-authored manifest + an encrypted state + the GitHub POST URL,
+	// which the frontend submits as a form so GitHub creates the app on the
+	// user's behalf. Wired in api/pkg/server (needs the encryption key); nil
+	// disables the "Create the Helix app" path.
+	GitHubManifestStart func(ctx context.Context, orgID, githubOrg, origin string) (GitHubManifestStartResponse, error)
+
 	// PublicServerURL is the operator-configured external base URL
 	// (e.g. https://helix.example.com) that auto-installed GitHub
 	// webhooks should POST back to. Falls back to localhost when
@@ -241,6 +248,7 @@ func Routes(deps Deps) []Route {
 		// operator has a connected GitHub OAuth).
 		{Pattern: "GET /github/repos", Handler: http.HandlerFunc(a.listGitHubRepos)},
 		{Pattern: "GET /github/app-installation", Handler: http.HandlerFunc(a.getGitHubAppInstallation)},
+		{Pattern: "POST /github/app-manifest", Handler: http.HandlerFunc(a.startGitHubAppManifest)},
 		{Pattern: "POST /streams/{id}/github/install-webhook", Handler: http.HandlerFunc(a.installGitHubWebhook)},
 	}
 }
@@ -1963,14 +1971,26 @@ type GitHubRepoDTO struct {
 // GitHubInstallationStatus is the resolved install state for an org plus
 // the URL to start an install when it isn't installed yet.
 type GitHubInstallationStatus struct {
+	// AppExists is true when a Helix GitHub App has been created/registered
+	// for this org (a github_app ServiceConnection exists), even if not yet
+	// installed on any repo. Drives the gate's create-vs-install branch.
+	AppExists bool `json:"app_exists"`
 	// Installed is true when the Helix GitHub App has an installation for
 	// this org (a github_app ServiceConnection with an installation id).
 	Installed bool `json:"installed"`
 	// InstallURL is where the New Stream gate sends the user to install the
-	// app (https://github.com/apps/<slug>/installations/new). Empty when the
-	// operator hasn't configured the app slug — the gate then tells the user
-	// to ask their admin to configure the Helix GitHub App.
+	// app (https://github.com/apps/<slug>/installations/new). Populated from
+	// the created app's slug, or from GITHUB_APP_SLUG for a pre-existing app.
 	InstallURL string `json:"install_url,omitempty"`
+}
+
+// GitHubManifestStartResponse is what the frontend needs to POST a GitHub App
+// manifest on the user's behalf: the GitHub URL to POST to, the manifest JSON
+// to submit as the "manifest" form field, and the CSRF state.
+type GitHubManifestStartResponse struct {
+	PostURL  string `json:"post_url"`
+	Manifest string `json:"manifest"`
+	State    string `json:"state"`
 }
 
 // getGitHubAppInstallation backs the New Stream "Install Helix" gate: it
@@ -2004,6 +2024,45 @@ func (a *apiHandler) getGitHubAppInstallation(w http.ResponseWriter, r *http.Req
 		return
 	}
 	writeJSON(w, http.StatusOK, status)
+}
+
+// startGitHubAppManifest builds the GitHub App Manifest flow so the frontend
+// can create the Helix app on the user's behalf (org-owned). Body:
+// { "github_org": "acme", "origin": "https://helix.example.com" }.
+//
+// @Summary Helix-org: start the GitHub App manifest (create) flow
+// @Tags HelixOrg
+// @Accept json
+// @Produce json
+// @Success 200 {object} api.GitHubManifestStartResponse
+// @Failure 412 {object} api.ErrorResponse "manifest flow not wired"
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/github/app-manifest [post]
+func (a *apiHandler) startGitHubAppManifest(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	orgID, err := resolveOrgID(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if a.deps.GitHubManifestStart == nil {
+		writeError(w, http.StatusPreconditionFailed, errors.New("GitHub App manifest flow is not enabled on this deployment"))
+		return
+	}
+	var body struct {
+		GitHubOrg string `json:"github_org"`
+		Origin    string `json:"origin"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("invalid request body: %w", err))
+		return
+	}
+	resp, err := a.deps.GitHubManifestStart(ctx, orgID, body.GitHubOrg, body.Origin)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // GitHubReposResponse is the body of GET /github/repos.

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -134,6 +134,24 @@ type Deps struct {
 	// helix OAuth manager into this shape.
 	GitHubTokenResolver func(ctx context.Context, orgID string) (string, error)
 
+	// GitHubIdentity is the richer resolver behind GitHubTokenResolver:
+	// it reports whether the org's GitHub access is the installed Helix
+	// App bot ("app") or a borrowed member OAuth token ("oauth"), plus the
+	// installation coordinates. The repo picker uses Mode to choose the
+	// right GitHub endpoint (installation repos vs the user's repos) — an
+	// installation token cannot list /user/repos. nil → behave exactly as
+	// before (OAuth-only). The struct is mirrored here (rather than
+	// imported from api/pkg/server) to keep the org package free of a
+	// dependency back onto the server package.
+	GitHubIdentity func(ctx context.Context, orgID string) (GitHubIdentity, error)
+
+	// GitHubInstallation reports whether the Helix App is installed for the
+	// org and, if not, where to send the user to install it. Drives the New
+	// Stream "Install Helix" gate. Wired in api/pkg/server (which has the
+	// ServiceConnection store + the operator's app slug); nil → the gate
+	// falls back to treating the org as not-installable.
+	GitHubInstallation func(ctx context.Context, orgID string) (GitHubInstallationStatus, error)
+
 	// PublicServerURL is the operator-configured external base URL
 	// (e.g. https://helix.example.com) that auto-installed GitHub
 	// webhooks should POST back to. Falls back to localhost when
@@ -145,6 +163,16 @@ type Deps struct {
 	// system.GenerateID / time.Now.
 	NewID func() string
 	Now   func() time.Time
+}
+
+// GitHubIdentity is the resolved GitHub identity for an org. Mirrors
+// server.OrgGitHubIdentity (kept local to avoid a dependency cycle).
+type GitHubIdentity struct {
+	Mode           string // "app" (installed Helix App bot) | "oauth" (legacy member token)
+	Token          string
+	AppID          int64
+	InstallationID int64
+	BaseURL        string
 }
 
 // Route pairs a net/http ServeMux pattern with the handler that
@@ -212,6 +240,7 @@ func Routes(deps Deps) []Route {
 		// repo. Both rely on a working GitHubTokenResolver (i.e. the
 		// operator has a connected GitHub OAuth).
 		{Pattern: "GET /github/repos", Handler: http.HandlerFunc(a.listGitHubRepos)},
+		{Pattern: "GET /github/app-installation", Handler: http.HandlerFunc(a.getGitHubAppInstallation)},
 		{Pattern: "POST /streams/{id}/github/install-webhook", Handler: http.HandlerFunc(a.installGitHubWebhook)},
 	}
 }
@@ -1931,6 +1960,52 @@ type GitHubRepoDTO struct {
 	Private  bool   `json:"private,omitempty"`
 }
 
+// GitHubInstallationStatus is the resolved install state for an org plus
+// the URL to start an install when it isn't installed yet.
+type GitHubInstallationStatus struct {
+	// Installed is true when the Helix GitHub App has an installation for
+	// this org (a github_app ServiceConnection with an installation id).
+	Installed bool `json:"installed"`
+	// InstallURL is where the New Stream gate sends the user to install the
+	// app (https://github.com/apps/<slug>/installations/new). Empty when the
+	// operator hasn't configured the app slug — the gate then tells the user
+	// to ask their admin to configure the Helix GitHub App.
+	InstallURL string `json:"install_url,omitempty"`
+}
+
+// getGitHubAppInstallation backs the New Stream "Install Helix" gate: it
+// reports whether the org has the Helix App installed and, if not, the URL
+// to install it. The user's own GitHub identity is used only for that
+// install step; everything afterwards (repo listing, worker git/gh) runs as
+// the bot.
+//
+// @Summary Helix-org: GitHub App install status for the org
+// @Tags HelixOrg
+// @Produce json
+// @Success 200 {object} api.GitHubInstallationStatus
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/github/app-installation [get]
+func (a *apiHandler) getGitHubAppInstallation(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	orgID, err := resolveOrgID(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if a.deps.GitHubInstallation == nil {
+		// No installation resolver wired — report not-installed with no URL
+		// so the gate degrades to "ask your admin" rather than 500ing.
+		writeJSON(w, http.StatusOK, GitHubInstallationStatus{})
+		return
+	}
+	status, err := a.deps.GitHubInstallation(ctx, orgID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Errorf("resolve github app installation: %w", err))
+		return
+	}
+	writeJSON(w, http.StatusOK, status)
+}
+
 // GitHubReposResponse is the body of GET /github/repos.
 type GitHubReposResponse struct {
 	Repos []GitHubRepoDTO `json:"repos"`
@@ -1958,34 +2033,59 @@ func (a *apiHandler) listGitHubRepos(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
-	if a.deps.GitHubTokenResolver == nil {
-		writeError(w, http.StatusPreconditionFailed, errors.New("no GitHubTokenResolver wired; connect a GitHub account on the helix Connected Services page"))
-		return
-	}
-	token, err := a.deps.GitHubTokenResolver(ctx, orgID)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Errorf("resolve github token: %w", err))
+	// Resolve the org's GitHub identity. Prefer the richer resolver
+	// (which tells us app vs oauth); fall back to the plain token
+	// resolver for wiring that hasn't set GitHubIdentity.
+	var (
+		token   string
+		mode    = "oauth"
+		baseURL string
+	)
+	switch {
+	case a.deps.GitHubIdentity != nil:
+		id, err := a.deps.GitHubIdentity(ctx, orgID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Errorf("resolve github identity: %w", err))
+			return
+		}
+		token, mode, baseURL = id.Token, id.Mode, id.BaseURL
+	case a.deps.GitHubTokenResolver != nil:
+		t, err := a.deps.GitHubTokenResolver(ctx, orgID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Errorf("resolve github token: %w", err))
+			return
+		}
+		token = t
+	default:
+		writeError(w, http.StatusPreconditionFailed, errors.New("no GitHub identity wired; install the Helix GitHub App or connect a GitHub account"))
 		return
 	}
 	if token == "" {
-		writeError(w, http.StatusPreconditionFailed, errors.New("no GitHub OAuth connection found for this org; connect GitHub on the Connected Services page"))
+		writeError(w, http.StatusPreconditionFailed, errors.New("Helix GitHub App not installed for this org and no GitHub OAuth connection found"))
 		return
 	}
-	client, err := githubclient.NewGithubClient(githubclient.ClientOptions{Ctx: ctx, Token: token})
+	client, err := githubclient.NewGithubClient(githubclient.ClientOptions{Ctx: ctx, Token: token, BaseURL: baseURL})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Errorf("build github client: %w", err))
 		return
 	}
-	names, err := client.LoadRepos()
+	// In app mode the token is an installation token, which cannot call
+	// /user/repos — list the installation's repos instead (which is also
+	// the correct scope: you can only stream a repo the bot can act on).
+	var names []string
+	if mode == "app" {
+		names, err = client.LoadInstallationRepos()
+	} else {
+		names, err = client.LoadRepos()
+	}
 	if err != nil {
 		writeError(w, http.StatusBadGateway, fmt.Errorf("list github repos: %w", err))
 		return
 	}
-	// Preserve GitHub's pushed-desc order so the dropdown lists the
-	// operator's most-actively-worked repos first. (The frontend's
-	// Autocomplete is freeSolo, so anything missed by pagination
-	// can still be typed in manually.)
-	out := GitHubReposResponse{Repos: make([]GitHubRepoDTO, 0, len(names)), Source: "oauth"}
+	// Preserve GitHub's order so the dropdown lists the most-actively-worked
+	// repos first. (The frontend's Autocomplete is freeSolo, so anything
+	// missed by pagination can still be typed in manually.)
+	out := GitHubReposResponse{Repos: make([]GitHubRepoDTO, 0, len(names)), Source: mode}
 	for _, n := range names {
 		out.Repos = append(out.Repos, GitHubRepoDTO{FullName: n})
 	}

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -152,6 +152,13 @@ type Deps struct {
 	// falls back to treating the org as not-installable.
 	GitHubInstallation func(ctx context.Context, orgID string) (GitHubInstallationStatus, error)
 
+	// GitHubAppRepos lists every repo the org's Helix App(s) can access,
+	// aggregated across all installations (so a single app installed on
+	// winderai AND helixml returns repos from both). isApp is false when the
+	// org has no app (caller then falls back to the user's OAuth repos). Wired
+	// in api/pkg/server.
+	GitHubAppRepos func(ctx context.Context, orgID string) (repos []string, isApp bool, err error)
+
 	// GitHubManifestStart builds the GitHub App Manifest flow for an org:
 	// a Helix-authored manifest + an encrypted state + the GitHub POST URL,
 	// which the frontend submits as a form so GitHub creates the app on the
@@ -2097,14 +2104,28 @@ func (a *apiHandler) listGitHubRepos(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
-	// Resolve the org's GitHub identity. Prefer the richer resolver
-	// (which tells us app vs oauth); fall back to the plain token
-	// resolver for wiring that hasn't set GitHubIdentity.
-	var (
-		token   string
-		mode    = "oauth"
-		baseURL string
-	)
+	// App mode: aggregate repos across every installation of the org's Helix
+	// App(s) — so one app installed on winderai + helixml returns both. The
+	// installation token can't call /user/repos, so this lists
+	// /installation/repositories per installation server-side.
+	if a.deps.GitHubAppRepos != nil {
+		names, isApp, err := a.deps.GitHubAppRepos(ctx, orgID)
+		if err != nil {
+			writeError(w, http.StatusBadGateway, fmt.Errorf("list github app repos: %w", err))
+			return
+		}
+		if isApp {
+			out := GitHubReposResponse{Repos: make([]GitHubRepoDTO, 0, len(names)), Source: "app"}
+			for _, n := range names {
+				out.Repos = append(out.Repos, GitHubRepoDTO{FullName: n})
+			}
+			writeJSON(w, http.StatusOK, out)
+			return
+		}
+	}
+
+	// Legacy OAuth fallback: list the connecting user's repos.
+	var token string
 	switch {
 	case a.deps.GitHubIdentity != nil:
 		id, err := a.deps.GitHubIdentity(ctx, orgID)
@@ -2112,7 +2133,7 @@ func (a *apiHandler) listGitHubRepos(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, fmt.Errorf("resolve github identity: %w", err))
 			return
 		}
-		token, mode, baseURL = id.Token, id.Mode, id.BaseURL
+		token = id.Token
 	case a.deps.GitHubTokenResolver != nil:
 		t, err := a.deps.GitHubTokenResolver(ctx, orgID)
 		if err != nil {
@@ -2128,28 +2149,17 @@ func (a *apiHandler) listGitHubRepos(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusPreconditionFailed, errors.New("Helix GitHub App not installed for this org and no GitHub OAuth connection found"))
 		return
 	}
-	client, err := githubclient.NewGithubClient(githubclient.ClientOptions{Ctx: ctx, Token: token, BaseURL: baseURL})
+	client, err := githubclient.NewGithubClient(githubclient.ClientOptions{Ctx: ctx, Token: token})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Errorf("build github client: %w", err))
 		return
 	}
-	// In app mode the token is an installation token, which cannot call
-	// /user/repos — list the installation's repos instead (which is also
-	// the correct scope: you can only stream a repo the bot can act on).
-	var names []string
-	if mode == "app" {
-		names, err = client.LoadInstallationRepos()
-	} else {
-		names, err = client.LoadRepos()
-	}
+	names, err := client.LoadRepos()
 	if err != nil {
 		writeError(w, http.StatusBadGateway, fmt.Errorf("list github repos: %w", err))
 		return
 	}
-	// Preserve GitHub's order so the dropdown lists the most-actively-worked
-	// repos first. (The frontend's Autocomplete is freeSolo, so anything
-	// missed by pagination can still be typed in manually.)
-	out := GitHubReposResponse{Repos: make([]GitHubRepoDTO, 0, len(names)), Source: mode}
+	out := GitHubReposResponse{Repos: make([]GitHubRepoDTO, 0, len(names)), Source: "oauth"}
 	for _, n := range names {
 		out.Repos = append(out.Repos, GitHubRepoDTO{FullName: n})
 	}

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -1982,6 +1982,11 @@ type GitHubInstallationStatus struct {
 	// app (https://github.com/apps/<slug>/installations/new). Populated from
 	// the created app's slug, or from GITHUB_APP_SLUG for a pre-existing app.
 	InstallURL string `json:"install_url,omitempty"`
+	// ManageURL is the app's developer-settings page on GitHub
+	// (github.com/organizations/<owner>/settings/apps/<slug>) — where you edit
+	// permissions, repos, and delete the app. Empty when the owner is unknown
+	// (e.g. a BYO app configured without it).
+	ManageURL string `json:"manage_url,omitempty"`
 }
 
 // GitHubManifestStartResponse is what the frontend needs to POST a GitHub App

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -20292,6 +20292,10 @@ const docTemplate = `{
                 "installed": {
                     "description": "Installed is true when the Helix GitHub App has an installation for\nthis org (a github_app ServiceConnection with an installation id).",
                     "type": "boolean"
+                },
+                "manage_url": {
+                    "description": "ManageURL is the app's developer-settings page on GitHub\n(github.com/organizations/\u003cowner\u003e/settings/apps/\u003cslug\u003e) — where you edit\npermissions, repos, and delete the app. Empty when the owner is unknown\n(e.g. a BYO app configured without it).",
+                    "type": "string"
                 }
             }
         },

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -9275,6 +9275,39 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/orgs/{org}/github/app-manifest": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: start the GitHub App manifest (create) flow",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.GitHubManifestStartResponse"
+                        }
+                    },
+                    "412": {
+                        "description": "manifest flow not wired",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/github/repos": {
             "get": {
                 "security": [
@@ -20248,13 +20281,31 @@ const docTemplate = `{
         "api.GitHubInstallationStatus": {
             "type": "object",
             "properties": {
+                "app_exists": {
+                    "description": "AppExists is true when a Helix GitHub App has been created/registered\nfor this org (a github_app ServiceConnection exists), even if not yet\ninstalled on any repo. Drives the gate's create-vs-install branch.",
+                    "type": "boolean"
+                },
                 "install_url": {
-                    "description": "InstallURL is where the New Stream gate sends the user to install the\napp (https://github.com/apps/\u003cslug\u003e/installations/new). Empty when the\noperator hasn't configured the app slug — the gate then tells the user\nto ask their admin to configure the Helix GitHub App.",
+                    "description": "InstallURL is where the New Stream gate sends the user to install the\napp (https://github.com/apps/\u003cslug\u003e/installations/new). Populated from\nthe created app's slug, or from GITHUB_APP_SLUG for a pre-existing app.",
                     "type": "string"
                 },
                 "installed": {
                     "description": "Installed is true when the Helix GitHub App has an installation for\nthis org (a github_app ServiceConnection with an installation id).",
                     "type": "boolean"
+                }
+            }
+        },
+        "api.GitHubManifestStartResponse": {
+            "type": "object",
+            "properties": {
+                "manifest": {
+                    "type": "string"
+                },
+                "post_url": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string"
                 }
             }
         },

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -9251,6 +9251,30 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/orgs/{org}/github/app-installation": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: GitHub App install status for the org",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.GitHubInstallationStatus"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/github/repos": {
             "get": {
                 "security": [
@@ -20218,6 +20242,19 @@ const docTemplate = `{
                 },
                 "to": {
                     "type": "string"
+                }
+            }
+        },
+        "api.GitHubInstallationStatus": {
+            "type": "object",
+            "properties": {
+                "install_url": {
+                    "description": "InstallURL is where the New Stream gate sends the user to install the\napp (https://github.com/apps/\u003cslug\u003e/installations/new). Empty when the\noperator hasn't configured the app slug — the gate then tells the user\nto ask their admin to configure the Helix GitHub App.",
+                    "type": "string"
+                },
+                "installed": {
+                    "description": "Installed is true when the Helix GitHub App has an installation for\nthis org (a github_app ServiceConnection with an installation id).",
+                    "type": "boolean"
                 }
             }
         },

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	githubskill "github.com/helixml/helix/api/pkg/agent/skill/github"
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
 	"github.com/helixml/helix/api/pkg/org/application/dispatch"
 	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
@@ -35,6 +36,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/domain/streaming"
 	"github.com/helixml/helix/api/pkg/pubsub"
 	helixstore "github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
 )
 
 // helixOrgHandlers bundles the JSON HTTP surface helix-org exposes:
@@ -237,7 +239,25 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	// transport's outbound `Token()` lookup AND the worker sandbox's
 	// `GH_TOKEN` env injection — one OAuth pipeline, exposed to the
 	// spawner via the transport's SpawnSecretInjector.
-	gitHubTokenResolver := newGitHubOAuthResolver(cfg.APIServer.oauthManager, helixStore)
+	oauthResolver := newGitHubOAuthResolver(cfg.APIServer.oauthManager, helixStore)
+	// identityResolver prefers the installed Helix App bot over a borrowed
+	// member OAuth token: if the org has a github_app ServiceConnection it
+	// mints a short-lived installation token (decrypting the stored PEM with
+	// the server encryption key), else it falls back to oauthResolver.
+	// github.MintInstallationToken is the production minter.
+	identityResolver := newOrgGitHubIdentityResolver(cfg.APIServer.getEncryptionKey, helixStore, oauthResolver, githubskill.MintInstallationToken)
+	// gitHubTokenResolver is the bot-preferring token projection used by
+	// every "act as GitHub" touchpoint (worker GH_TOKEN injection, outbound
+	// transport, webhook install). Returns the App installation token when
+	// one exists, else the legacy member OAuth token — so once an org installs
+	// the Helix App, its agents act as the bot rather than a human.
+	gitHubTokenResolver := func(ctx context.Context, orgID string) (string, error) {
+		id, err := identityResolver(ctx, orgID)
+		if err != nil {
+			return "", err
+		}
+		return id.Token, nil
+	}
 
 	// secretInjectors gathers every transport's per-activation
 	// secret hook. The spawner iterates them on every activation
@@ -314,6 +334,45 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		// PAT into transport.github. The resolver lives in
 		// helix_org_github.go.
 		GitHubTokenResolver: gitHubTokenResolver,
+		// GitHubIdentity lets the repo picker tell app mode from oauth mode
+		// so it lists the installation's repos (not /user/repos) when the
+		// bot is installed. Adapts the server-side resolver into the org
+		// package's mirror struct.
+		GitHubIdentity: func(ctx context.Context, orgID string) (helixorgapi.GitHubIdentity, error) {
+			id, err := identityResolver(ctx, orgID)
+			if err != nil {
+				return helixorgapi.GitHubIdentity{}, err
+			}
+			return helixorgapi.GitHubIdentity{
+				Mode:           id.Mode,
+				Token:          id.Token,
+				AppID:          id.AppID,
+				InstallationID: id.InstallationID,
+				BaseURL:        id.BaseURL,
+			}, nil
+		},
+		// GitHubInstallation backs the New Stream "Install Helix" gate. It
+		// checks for a github_app ServiceConnection with an installation id
+		// (no token minting — cheaper than GitHubIdentity for a UI probe)
+		// and builds the install URL from the operator's public app slug.
+		GitHubInstallation: func(ctx context.Context, orgID string) (helixorgapi.GitHubInstallationStatus, error) {
+			conns, err := helixStore.ListServiceConnectionsByType(ctx, orgID, types.ServiceConnectionTypeGitHubApp)
+			if err != nil {
+				return helixorgapi.GitHubInstallationStatus{}, fmt.Errorf("list github_app service connections: %w", err)
+			}
+			installed := false
+			for _, c := range conns {
+				if c != nil && c.GitHubInstallationID != 0 {
+					installed = true
+					break
+				}
+			}
+			var installURL string
+			if slug := cfg.APIServer.Cfg.GitHub.AppSlug; slug != "" {
+				installURL = "https://github.com/apps/" + slug + "/installations/new"
+			}
+			return helixorgapi.GitHubInstallationStatus{Installed: installed, InstallURL: installURL}, nil
+		},
 		// PublicServerURL is the externally-reachable base URL the
 		// auto-installed GitHub webhook should POST back to. Helix's
 		// SERVER_URL env var is the canonical place it lives.
@@ -339,7 +398,9 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	// session/api-key layer. Per-request: resolve {org} from mux
 	// vars → orgID → build the github.Transport → dispatch.
 	ghLogger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	tokenResolver := newGitHubOAuthResolver(cfg.APIServer.oauthManager, helixStore)
+	// Reuse the bot-preferring projection so the public webhook's outbound
+	// actions act as the installed App when there is one.
+	tokenResolver := gitHubTokenResolver
 	publicGitHubWebhook := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		orgSlugOrID := mux.Vars(r)["org"]
 		if orgSlugOrID == "" {

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -375,6 +375,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 			appExists := false
 			installed := false
 			slug := cfg.APIServer.Cfg.GitHub.AppSlug // BYO/pre-existing app fallback
+			var owner string
 			for _, c := range conns {
 				if c == nil || c.GitHubAppID == 0 {
 					continue
@@ -404,8 +405,17 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 								if len(insts) > 0 {
 									newInstallID = insts[0].GetID()
 								}
-								if newInstallID != c.GitHubInstallationID {
+								// Backfill the owner (for the manage URL) on apps
+								// created before the field existed — for our
+								// org-owned/installed-on-same-org flow the install
+								// account is the owner.
+								newOwner := c.GitHubAppOwner
+								if newOwner == "" && len(insts) > 0 {
+									newOwner = insts[0].GetAccount().GetLogin()
+								}
+								if newInstallID != c.GitHubInstallationID || newOwner != c.GitHubAppOwner {
 									c.GitHubInstallationID = newInstallID
+									c.GitHubAppOwner = newOwner
 									if uerr := helixStore.UpdateServiceConnection(ctx, c); uerr != nil {
 										log.Warn().Err(uerr).Str("org_id", orgID).Msg("persist synced installation id failed")
 									} else {
@@ -420,15 +430,21 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 				if c.GitHubAppSlug != "" {
 					slug = c.GitHubAppSlug // prefer the created app's own slug
 				}
+				if c.GitHubAppOwner != "" {
+					owner = c.GitHubAppOwner
+				}
 				if c.GitHubInstallationID != 0 {
 					installed = true
 				}
 			}
-			var installURL string
+			var installURL, manageURL string
 			if slug != "" {
 				installURL = "https://github.com/apps/" + slug + "/installations/new"
 			}
-			return helixorgapi.GitHubInstallationStatus{AppExists: appExists, Installed: installed, InstallURL: installURL}, nil
+			if slug != "" && owner != "" {
+				manageURL = "https://github.com/organizations/" + owner + "/settings/apps/" + slug
+			}
+			return helixorgapi.GitHubInstallationStatus{AppExists: appExists, Installed: installed, InstallURL: installURL, ManageURL: manageURL}, nil
 		},
 		// GitHubManifestStart builds the "create the Helix app" manifest flow.
 		GitHubManifestStart: newGitHubManifestStart(cfg.APIServer.getEncryptionKey),

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -63,6 +63,18 @@ type helixOrgHandlers struct {
 	// so cross-repo or non-whitelisted-event deliveries drop with
 	// 204 (no GitHub retries).
 	publicGitHubWebhookForStream http.Handler
+	// publicGitHubManifestCallback receives GitHub's browser redirect after
+	// the App Manifest flow creates the app (path
+	// /api/v1/orgs/{org}/github/app-manifest/callback). Insecure mount: it's
+	// a top-level navigation from github.com authenticated by the encrypted
+	// ?state=, not the helix session. Exchanges the code, stores the app,
+	// then redirects to the install page.
+	publicGitHubManifestCallback http.Handler
+	// publicGitHubAppSetup receives GitHub's redirect after the user installs
+	// the app (the app's setup_url, path
+	// /api/v1/orgs/{org}/github/app-setup?installation_id=...). Persists the
+	// installation id, then closes the popup and notifies the opener.
+	publicGitHubAppSetup http.Handler
 }
 
 // alphaFeatureHelixOrg is the alpha-feature flag that gates the
@@ -360,19 +372,29 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 			if err != nil {
 				return helixorgapi.GitHubInstallationStatus{}, fmt.Errorf("list github_app service connections: %w", err)
 			}
+			appExists := false
 			installed := false
+			slug := cfg.APIServer.Cfg.GitHub.AppSlug // BYO/pre-existing app fallback
 			for _, c := range conns {
-				if c != nil && c.GitHubInstallationID != 0 {
+				if c == nil || c.GitHubAppID == 0 {
+					continue
+				}
+				appExists = true
+				if c.GitHubAppSlug != "" {
+					slug = c.GitHubAppSlug // prefer the created app's own slug
+				}
+				if c.GitHubInstallationID != 0 {
 					installed = true
-					break
 				}
 			}
 			var installURL string
-			if slug := cfg.APIServer.Cfg.GitHub.AppSlug; slug != "" {
+			if slug != "" {
 				installURL = "https://github.com/apps/" + slug + "/installations/new"
 			}
-			return helixorgapi.GitHubInstallationStatus{Installed: installed, InstallURL: installURL}, nil
+			return helixorgapi.GitHubInstallationStatus{AppExists: appExists, Installed: installed, InstallURL: installURL}, nil
 		},
+		// GitHubManifestStart builds the "create the Helix app" manifest flow.
+		GitHubManifestStart: newGitHubManifestStart(cfg.APIServer.getEncryptionKey),
 		// PublicServerURL is the externally-reachable base URL the
 		// auto-installed GitHub webhook should POST back to. Helix's
 		// SERVER_URL env var is the canonical place it lives.
@@ -455,11 +477,20 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		t.HandleInboundForStream(streaming.StreamID(streamID)).ServeHTTP(w, r)
 	})
 
+	// GitHub App Manifest flow callbacks. Insecure mounts (top-level
+	// navigations from github.com): the conversion callback is authenticated
+	// by the encrypted ?state=; the setup callback only records a non-secret
+	// installation id onto the org's app.
+	publicGitHubManifestCallback := newGitHubManifestCallbackHandler(cfg.APIServer.getEncryptionKey, helixStore, deps.NewID)
+	publicGitHubAppSetup := newGitHubAppSetupHandler(helixStore)
+
 	return &helixOrgHandlers{
 		api:                          orgServer.Handler(extras...),
 		scope:                        scope,
 		publicGitHubWebhook:          publicGitHubWebhook,
 		publicGitHubWebhookForStream: publicGitHubWebhookForStream,
+		publicGitHubManifestCallback: publicGitHubManifestCallback,
+		publicGitHubAppSetup:         publicGitHubAppSetup,
 	}, nil
 }
 

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -378,26 +379,46 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 				if c == nil || c.GitHubAppID == 0 {
 					continue
 				}
-				appExists = true
-				if c.GitHubAppSlug != "" {
-					slug = c.GitHubAppSlug // prefer the created app's own slug
-				}
-				// Reconcile the installation id by asking GitHub directly (no
-				// Setup-URL redirect needed). Only runs while we don't yet have
-				// one, so it stops once the app is installed.
-				if c.GitHubInstallationID == 0 && c.GitHubPrivateKey != "" {
+				// Verify against GitHub on every check so the gate reflects
+				// reality: syncs the installation id (incl. down to 0 when the
+				// user uninstalls), and removes the stored connection when the
+				// app has been deleted on GitHub (so the gate reverts to
+				// "Create the Helix app"). Transient errors fall back to the
+				// stored state rather than mutating it.
+				if c.GitHubPrivateKey != "" {
 					if key, kerr := cfg.APIServer.getEncryptionKey(); kerr == nil {
 						if pem, derr := crypto.DecryptAES256GCM(c.GitHubPrivateKey, key); derr == nil {
-							if insts, ierr := githubclient.ListAppInstallations(ctx, c.GitHubAppID, string(pem), c.BaseURL); ierr == nil && len(insts) > 0 {
-								c.GitHubInstallationID = insts[0].GetID()
-								if uerr := helixStore.UpdateServiceConnection(ctx, c); uerr != nil {
-									log.Warn().Err(uerr).Str("org_id", orgID).Msg("persist reconciled installation id failed")
+							insts, ierr := githubclient.ListAppInstallations(ctx, c.GitHubAppID, string(pem), c.BaseURL)
+							switch {
+							case errors.Is(ierr, githubclient.ErrAppNotFound):
+								log.Warn().Str("org_id", orgID).Int64("app_id", c.GitHubAppID).Msg("Helix GitHub App no longer exists on GitHub; removing stale connection")
+								if derr := helixStore.DeleteServiceConnection(ctx, c.ID); derr == nil {
+									continue // gone — don't count it
 								} else {
-									log.Info().Str("org_id", orgID).Int64("installation_id", c.GitHubInstallationID).Msg("reconciled Helix GitHub App installation from GitHub")
+									log.Error().Err(derr).Str("org_id", orgID).Msg("delete stale github app connection failed")
+								}
+							case ierr != nil:
+								log.Warn().Err(ierr).Str("org_id", orgID).Msg("verify github app installation failed; using stored state")
+							default:
+								var newInstallID int64
+								if len(insts) > 0 {
+									newInstallID = insts[0].GetID()
+								}
+								if newInstallID != c.GitHubInstallationID {
+									c.GitHubInstallationID = newInstallID
+									if uerr := helixStore.UpdateServiceConnection(ctx, c); uerr != nil {
+										log.Warn().Err(uerr).Str("org_id", orgID).Msg("persist synced installation id failed")
+									} else {
+										log.Info().Str("org_id", orgID).Int64("installation_id", newInstallID).Msg("synced Helix GitHub App installation from GitHub")
+									}
 								}
 							}
 						}
 					}
+				}
+				appExists = true
+				if c.GitHubAppSlug != "" {
+					slug = c.GitHubAppSlug // prefer the created app's own slug
 				}
 				if c.GitHubInstallationID != 0 {
 					installed = true

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -496,7 +497,24 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	// navigations from github.com): the conversion callback is authenticated
 	// by the encrypted ?state=; the setup callback only records a non-secret
 	// installation id onto the org's app.
-	publicGitHubManifestCallback := newGitHubManifestCallbackHandler(cfg.APIServer.getEncryptionKey, helixStore, deps.NewID)
+	publicGitHubManifestCallback := newGitHubManifestCallbackHandler(
+		cfg.APIServer.getEncryptionKey, helixStore, deps.NewID,
+		func(ctx context.Context, orgID, secret string) error {
+			// Set transport.github.webhook_secret = the App's webhook secret so
+			// the existing inbound handler validates the App's deliveries.
+			var c struct {
+				Token         string `json:"token,omitempty"`
+				WebhookSecret string `json:"webhook_secret,omitempty"`
+			}
+			_ = configReg.GetObject(ctx, orgID, "transport.github", &c)
+			c.WebhookSecret = secret
+			out, err := json.Marshal(c)
+			if err != nil {
+				return err
+			}
+			return configReg.Set(ctx, orgID, "transport.github", string(out), orgchart.WorkerID("w-owner"))
+		},
+	)
 
 	return &helixOrgHandlers{
 		api:                          orgServer.Handler(extras...),

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -17,6 +17,8 @@ import (
 	"github.com/gorilla/mux"
 
 	githubskill "github.com/helixml/helix/api/pkg/agent/skill/github"
+	"github.com/helixml/helix/api/pkg/crypto"
+	githubclient "github.com/helixml/helix/api/pkg/github"
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
 	"github.com/helixml/helix/api/pkg/org/application/dispatch"
 	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
@@ -68,13 +70,9 @@ type helixOrgHandlers struct {
 	// /api/v1/orgs/{org}/github/app-manifest/callback). Insecure mount: it's
 	// a top-level navigation from github.com authenticated by the encrypted
 	// ?state=, not the helix session. Exchanges the code, stores the app,
-	// then redirects to the install page.
+	// then redirects to the install page. The installation id is reconciled
+	// later via GET /app/installations (no Setup-URL redirect needed).
 	publicGitHubManifestCallback http.Handler
-	// publicGitHubAppSetup receives GitHub's redirect after the user installs
-	// the app (the app's setup_url, path
-	// /api/v1/orgs/{org}/github/app-setup?installation_id=...). Persists the
-	// installation id, then closes the popup and notifies the opener.
-	publicGitHubAppSetup http.Handler
 }
 
 // alphaFeatureHelixOrg is the alpha-feature flag that gates the
@@ -383,6 +381,23 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 				if c.GitHubAppSlug != "" {
 					slug = c.GitHubAppSlug // prefer the created app's own slug
 				}
+				// Reconcile the installation id by asking GitHub directly (no
+				// Setup-URL redirect needed). Only runs while we don't yet have
+				// one, so it stops once the app is installed.
+				if c.GitHubInstallationID == 0 && c.GitHubPrivateKey != "" {
+					if key, kerr := cfg.APIServer.getEncryptionKey(); kerr == nil {
+						if pem, derr := crypto.DecryptAES256GCM(c.GitHubPrivateKey, key); derr == nil {
+							if insts, ierr := githubclient.ListAppInstallations(ctx, c.GitHubAppID, string(pem), c.BaseURL); ierr == nil && len(insts) > 0 {
+								c.GitHubInstallationID = insts[0].GetID()
+								if uerr := helixStore.UpdateServiceConnection(ctx, c); uerr != nil {
+									log.Warn().Err(uerr).Str("org_id", orgID).Msg("persist reconciled installation id failed")
+								} else {
+									log.Info().Str("org_id", orgID).Int64("installation_id", c.GitHubInstallationID).Msg("reconciled Helix GitHub App installation from GitHub")
+								}
+							}
+						}
+					}
+				}
 				if c.GitHubInstallationID != 0 {
 					installed = true
 				}
@@ -482,7 +497,6 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	// by the encrypted ?state=; the setup callback only records a non-secret
 	// installation id onto the org's app.
 	publicGitHubManifestCallback := newGitHubManifestCallbackHandler(cfg.APIServer.getEncryptionKey, helixStore, deps.NewID)
-	publicGitHubAppSetup := newGitHubAppSetupHandler(helixStore)
 
 	return &helixOrgHandlers{
 		api:                          orgServer.Handler(extras...),
@@ -490,7 +504,6 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		publicGitHubWebhook:          publicGitHubWebhook,
 		publicGitHubWebhookForStream: publicGitHubWebhookForStream,
 		publicGitHubManifestCallback: publicGitHubManifestCallback,
-		publicGitHubAppSetup:         publicGitHubAppSetup,
 	}, nil
 }
 

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -446,6 +446,64 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 			}
 			return helixorgapi.GitHubInstallationStatus{AppExists: appExists, Installed: installed, InstallURL: installURL, ManageURL: manageURL}, nil
 		},
+		// GitHubAppRepos aggregates repos across every installation of the
+		// org's Helix App(s) — so one app installed on multiple GitHub orgs
+		// returns all of their repos. Mints a per-installation token and lists
+		// /installation/repositories for each.
+		GitHubAppRepos: func(ctx context.Context, orgID string) ([]string, bool, error) {
+			conns, err := helixStore.ListServiceConnectionsByType(ctx, orgID, types.ServiceConnectionTypeGitHubApp)
+			if err != nil {
+				return nil, false, fmt.Errorf("list github_app service connections: %w", err)
+			}
+			isApp := false
+			seen := map[string]struct{}{}
+			var repos []string
+			for _, c := range conns {
+				if c == nil || c.GitHubAppID == 0 || c.GitHubPrivateKey == "" {
+					continue
+				}
+				isApp = true
+				key, kerr := cfg.APIServer.getEncryptionKey()
+				if kerr != nil {
+					continue
+				}
+				pem, derr := crypto.DecryptAES256GCM(c.GitHubPrivateKey, key)
+				if derr != nil {
+					continue
+				}
+				installs, ierr := githubclient.ListAppInstallations(ctx, c.GitHubAppID, string(pem), c.BaseURL)
+				if ierr != nil {
+					// App deleted or a transient error — skip this app rather
+					// than fail the whole listing (other apps may still resolve).
+					log.Warn().Err(ierr).Str("org_id", orgID).Int64("app_id", c.GitHubAppID).Msg("list app installations for repo picker failed")
+					continue
+				}
+				for _, inst := range installs {
+					tok, terr := githubskill.MintInstallationToken(ctx, c.GitHubAppID, inst.GetID(), string(pem), c.BaseURL)
+					if terr != nil {
+						log.Warn().Err(terr).Str("org_id", orgID).Int64("installation_id", inst.GetID()).Msg("mint installation token for repo picker failed")
+						continue
+					}
+					client, cerr := githubclient.NewGithubClient(githubclient.ClientOptions{Ctx: ctx, Token: tok, BaseURL: c.BaseURL})
+					if cerr != nil {
+						continue
+					}
+					names, lerr := client.LoadInstallationRepos()
+					if lerr != nil {
+						log.Warn().Err(lerr).Str("org_id", orgID).Int64("installation_id", inst.GetID()).Msg("list installation repos failed")
+						continue
+					}
+					for _, n := range names {
+						if _, ok := seen[n]; ok {
+							continue
+						}
+						seen[n] = struct{}{}
+						repos = append(repos, n)
+					}
+				}
+			}
+			return repos, isApp, nil
+		},
 		// GitHubManifestStart builds the "create the Helix app" manifest flow.
 		GitHubManifestStart: newGitHubManifestStart(cfg.APIServer.getEncryptionKey),
 		// PublicServerURL is the externally-reachable base URL the

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -19,7 +19,6 @@ import (
 	"github.com/gorilla/mux"
 
 	githubskill "github.com/helixml/helix/api/pkg/agent/skill/github"
-	"github.com/helixml/helix/api/pkg/crypto"
 	githubclient "github.com/helixml/helix/api/pkg/github"
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
 	"github.com/helixml/helix/api/pkg/org/application/dispatch"
@@ -386,42 +385,38 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 				// app has been deleted on GitHub (so the gate reverts to
 				// "Create the Helix app"). Transient errors fall back to the
 				// stored state rather than mutating it.
-				if c.GitHubPrivateKey != "" {
-					if key, kerr := cfg.APIServer.getEncryptionKey(); kerr == nil {
-						if pem, derr := crypto.DecryptAES256GCM(c.GitHubPrivateKey, key); derr == nil {
-							insts, ierr := githubclient.ListAppInstallations(ctx, c.GitHubAppID, string(pem), c.BaseURL)
-							switch {
-							case errors.Is(ierr, githubclient.ErrAppNotFound):
-								log.Warn().Str("org_id", orgID).Int64("app_id", c.GitHubAppID).Msg("Helix GitHub App no longer exists on GitHub; removing stale connection")
-								if derr := helixStore.DeleteServiceConnection(ctx, c.ID); derr == nil {
-									continue // gone — don't count it
-								} else {
-									log.Error().Err(derr).Str("org_id", orgID).Msg("delete stale github app connection failed")
-								}
-							case ierr != nil:
-								log.Warn().Err(ierr).Str("org_id", orgID).Msg("verify github app installation failed; using stored state")
-							default:
-								var newInstallID int64
-								if len(insts) > 0 {
-									newInstallID = insts[0].GetID()
-								}
-								// Backfill the owner (for the manage URL) on apps
-								// created before the field existed — for our
-								// org-owned/installed-on-same-org flow the install
-								// account is the owner.
-								newOwner := c.GitHubAppOwner
-								if newOwner == "" && len(insts) > 0 {
-									newOwner = insts[0].GetAccount().GetLogin()
-								}
-								if newInstallID != c.GitHubInstallationID || newOwner != c.GitHubAppOwner {
-									c.GitHubInstallationID = newInstallID
-									c.GitHubAppOwner = newOwner
-									if uerr := helixStore.UpdateServiceConnection(ctx, c); uerr != nil {
-										log.Warn().Err(uerr).Str("org_id", orgID).Msg("persist synced installation id failed")
-									} else {
-										log.Info().Str("org_id", orgID).Int64("installation_id", newInstallID).Msg("synced Helix GitHub App installation from GitHub")
-									}
-								}
+				if pem, derr := decryptAppKey(cfg.APIServer.getEncryptionKey, c); derr == nil {
+					insts, ierr := githubclient.ListAppInstallations(ctx, c.GitHubAppID, pem, c.BaseURL)
+					switch {
+					case errors.Is(ierr, githubclient.ErrAppNotFound):
+						log.Warn().Str("org_id", orgID).Int64("app_id", c.GitHubAppID).Msg("Helix GitHub App no longer exists on GitHub; removing stale connection")
+						if derr := helixStore.DeleteServiceConnection(ctx, c.ID); derr == nil {
+							continue // gone — don't count it
+						} else {
+							log.Error().Err(derr).Str("org_id", orgID).Msg("delete stale github app connection failed")
+						}
+					case ierr != nil:
+						log.Warn().Err(ierr).Str("org_id", orgID).Msg("verify github app installation failed; using stored state")
+					default:
+						var newInstallID int64
+						if len(insts) > 0 {
+							newInstallID = insts[0].GetID()
+						}
+						// Backfill the owner (for the manage URL) on apps
+						// created before the field existed — for our
+						// org-owned/installed-on-same-org flow the install
+						// account is the owner.
+						newOwner := c.GitHubAppOwner
+						if newOwner == "" && len(insts) > 0 {
+							newOwner = insts[0].GetAccount().GetLogin()
+						}
+						if newInstallID != c.GitHubInstallationID || newOwner != c.GitHubAppOwner {
+							c.GitHubInstallationID = newInstallID
+							c.GitHubAppOwner = newOwner
+							if uerr := helixStore.UpdateServiceConnection(ctx, c); uerr != nil {
+								log.Warn().Err(uerr).Str("org_id", orgID).Msg("persist synced installation id failed")
+							} else {
+								log.Info().Str("org_id", orgID).Int64("installation_id", newInstallID).Msg("synced Helix GitHub App installation from GitHub")
 							}
 						}
 					}
@@ -437,12 +432,13 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 					installed = true
 				}
 			}
+			webURL := cfg.APIServer.Cfg.GitHub.WebURL()
 			var installURL, manageURL string
 			if slug != "" {
-				installURL = "https://github.com/apps/" + slug + "/installations/new"
+				installURL = webURL + "/apps/" + slug + "/installations/new"
 			}
 			if slug != "" && owner != "" {
-				manageURL = "https://github.com/organizations/" + owner + "/settings/apps/" + slug
+				manageURL = webURL + "/organizations/" + owner + "/settings/apps/" + slug
 			}
 			return helixorgapi.GitHubInstallationStatus{AppExists: appExists, Installed: installed, InstallURL: installURL, ManageURL: manageURL}, nil
 		},
@@ -463,15 +459,11 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 					continue
 				}
 				isApp = true
-				key, kerr := cfg.APIServer.getEncryptionKey()
-				if kerr != nil {
-					continue
-				}
-				pem, derr := crypto.DecryptAES256GCM(c.GitHubPrivateKey, key)
+				pem, derr := decryptAppKey(cfg.APIServer.getEncryptionKey, c)
 				if derr != nil {
 					continue
 				}
-				installs, ierr := githubclient.ListAppInstallations(ctx, c.GitHubAppID, string(pem), c.BaseURL)
+				installs, ierr := githubclient.ListAppInstallations(ctx, c.GitHubAppID, pem, c.BaseURL)
 				if ierr != nil {
 					// App deleted or a transient error — skip this app rather
 					// than fail the whole listing (other apps may still resolve).
@@ -479,7 +471,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 					continue
 				}
 				for _, inst := range installs {
-					tok, terr := githubskill.MintInstallationToken(ctx, c.GitHubAppID, inst.GetID(), string(pem), c.BaseURL)
+					tok, terr := githubskill.MintInstallationToken(ctx, c.GitHubAppID, inst.GetID(), pem, c.BaseURL)
 					if terr != nil {
 						log.Warn().Err(terr).Str("org_id", orgID).Int64("installation_id", inst.GetID()).Msg("mint installation token for repo picker failed")
 						continue
@@ -505,7 +497,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 			return repos, isApp, nil
 		},
 		// GitHubManifestStart builds the "create the Helix app" manifest flow.
-		GitHubManifestStart: newGitHubManifestStart(cfg.APIServer.getEncryptionKey),
+		GitHubManifestStart: newGitHubManifestStart(cfg.APIServer.getEncryptionKey, cfg.APIServer.Cfg.GitHub.WebURL()),
 		// PublicServerURL is the externally-reachable base URL the
 		// auto-installed GitHub webhook should POST back to. Helix's
 		// SERVER_URL env var is the canonical place it lives.
@@ -609,6 +601,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 			}
 			return configReg.Set(ctx, orgID, "transport.github", string(out), orgchart.WorkerID("w-owner"))
 		},
+		cfg.APIServer.Cfg.GitHub.WebURL(), cfg.APIServer.Cfg.GitHub.APIBaseURL(),
 	)
 
 	return &helixOrgHandlers{

--- a/api/pkg/server/helix_org_github.go
+++ b/api/pkg/server/helix_org_github.go
@@ -133,6 +133,24 @@ type OrgGitHubIdentity struct {
 // mintFn is a seam: production wiring passes github.MintInstallationToken;
 // unit tests stub it so they never make the live GitHub call ghinstallation's
 // Token() performs.
+// decryptAppKey decrypts a github_app ServiceConnection's stored PEM with the
+// server encryption key. Shared by the install-status, repo-aggregation and
+// identity resolvers so the decrypt + error wrapping lives in one place.
+func decryptAppKey(getKey func() ([]byte, error), conn *types.ServiceConnection) (string, error) {
+	if conn == nil || conn.GitHubPrivateKey == "" {
+		return "", fmt.Errorf("github app connection has no stored private key")
+	}
+	key, err := getKey()
+	if err != nil {
+		return "", fmt.Errorf("get encryption key: %w", err)
+	}
+	pem, err := crypto.DecryptAES256GCM(conn.GitHubPrivateKey, key)
+	if err != nil {
+		return "", fmt.Errorf("decrypt github app key: %w", err)
+	}
+	return string(pem), nil
+}
+
 func newOrgGitHubIdentityResolver(
 	getKey func() ([]byte, error),
 	st helixstore.Store,
@@ -166,17 +184,12 @@ func newOrgGitHubIdentityResolver(
 			if c == nil || c.GitHubAppID == 0 || c.GitHubInstallationID == 0 || c.GitHubPrivateKey == "" {
 				continue
 			}
-			key, err := getKey()
-			if err != nil {
-				log.Warn().Err(err).Str("org_id", orgID).Msg("get encryption key failed; falling back to OAuth")
-				break
-			}
-			pem, err := crypto.DecryptAES256GCM(c.GitHubPrivateKey, key)
+			pem, err := decryptAppKey(getKey, c)
 			if err != nil {
 				log.Warn().Err(err).Str("org_id", orgID).Str("conn_id", c.ID).Msg("decrypt github app key failed; trying next connection")
 				continue
 			}
-			tok, err := mintFn(ctx, c.GitHubAppID, c.GitHubInstallationID, string(pem), c.BaseURL)
+			tok, err := mintFn(ctx, c.GitHubAppID, c.GitHubInstallationID, pem, c.BaseURL)
 			if err != nil {
 				log.Warn().Err(err).Str("org_id", orgID).Int64("app_id", c.GitHubAppID).Msg("mint installation token failed; falling back to OAuth")
 				break

--- a/api/pkg/server/helix_org_github.go
+++ b/api/pkg/server/helix_org_github.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/rs/zerolog/log"
+
+	"github.com/helixml/helix/api/pkg/crypto"
 	"github.com/helixml/helix/api/pkg/oauth"
 	helixstore "github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
@@ -99,5 +102,93 @@ func newGitHubOAuthResolver(manager *oauth.Manager, st helixstore.Store) func(co
 			}
 		}
 		return "", nil
+	}
+}
+
+// OrgGitHubIdentity is the resolved GitHub identity for an org: either the
+// installed Helix App bot (Mode="app") or a borrowed member OAuth token
+// (Mode="oauth", the legacy fallback). Token is the value to inject as
+// GH_TOKEN / use as the git credential. AppID, InstallationID and BaseURL
+// are populated in "app" mode so callers (e.g. the repo picker) can drive
+// installation-scoped GitHub API calls.
+type OrgGitHubIdentity struct {
+	Mode           string // "app" | "oauth"
+	Token          string
+	AppID          int64
+	InstallationID int64
+	BaseURL        string
+}
+
+// newOrgGitHubIdentityResolver returns the org's GitHub identity, preferring
+// the installed Helix App over a borrowed human OAuth token. If a github_app
+// ServiceConnection exists for the org, it decrypts the stored PEM and mints
+// a short-lived installation access token (Mode="app"); otherwise it falls
+// back to the legacy member-OAuth walk (Mode="oauth").
+//
+// Any app-side failure (no encryption key, decrypt error, mint error) logs
+// and falls through to OAuth — a broken app config must never break an org
+// that OAuth could still serve. Returns Mode="oauth" with an empty Token when
+// neither path yields anything (identical to the pre-app behaviour).
+//
+// mintFn is a seam: production wiring passes github.MintInstallationToken;
+// unit tests stub it so they never make the live GitHub call ghinstallation's
+// Token() performs.
+func newOrgGitHubIdentityResolver(
+	getKey func() ([]byte, error),
+	st helixstore.Store,
+	oauthFallback func(context.Context, string) (string, error),
+	mintFn func(ctx context.Context, appID, installationID int64, pem, baseURL string) (string, error),
+) func(context.Context, string) (OrgGitHubIdentity, error) {
+	oauth := func(ctx context.Context, orgID string) (OrgGitHubIdentity, error) {
+		if oauthFallback == nil {
+			return OrgGitHubIdentity{Mode: "oauth"}, nil
+		}
+		tok, err := oauthFallback(ctx, orgID)
+		if err != nil {
+			return OrgGitHubIdentity{}, err
+		}
+		return OrgGitHubIdentity{Mode: "oauth", Token: tok}, nil
+	}
+
+	return func(ctx context.Context, orgID string) (OrgGitHubIdentity, error) {
+		if st == nil || mintFn == nil {
+			return oauth(ctx, orgID)
+		}
+		conns, err := st.ListServiceConnectionsByType(ctx, orgID, types.ServiceConnectionTypeGitHubApp)
+		if err != nil {
+			log.Warn().Err(err).Str("org_id", orgID).Msg("list github_app service connections failed; falling back to OAuth")
+			return oauth(ctx, orgID)
+		}
+		// The store returns rows created_at DESC, so the first usable
+		// connection is the newest — mirrors the OAuth resolver's
+		// newest-first preference when an operator rotates apps.
+		for _, c := range conns {
+			if c == nil || c.GitHubAppID == 0 || c.GitHubInstallationID == 0 || c.GitHubPrivateKey == "" {
+				continue
+			}
+			key, err := getKey()
+			if err != nil {
+				log.Warn().Err(err).Str("org_id", orgID).Msg("get encryption key failed; falling back to OAuth")
+				break
+			}
+			pem, err := crypto.DecryptAES256GCM(c.GitHubPrivateKey, key)
+			if err != nil {
+				log.Warn().Err(err).Str("org_id", orgID).Str("conn_id", c.ID).Msg("decrypt github app key failed; trying next connection")
+				continue
+			}
+			tok, err := mintFn(ctx, c.GitHubAppID, c.GitHubInstallationID, string(pem), c.BaseURL)
+			if err != nil {
+				log.Warn().Err(err).Str("org_id", orgID).Int64("app_id", c.GitHubAppID).Msg("mint installation token failed; falling back to OAuth")
+				break
+			}
+			return OrgGitHubIdentity{
+				Mode:           "app",
+				Token:          tok,
+				AppID:          c.GitHubAppID,
+				InstallationID: c.GitHubInstallationID,
+				BaseURL:        c.BaseURL,
+			}, nil
+		}
+		return oauth(ctx, orgID)
 	}
 }

--- a/api/pkg/server/helix_org_github_app_test.go
+++ b/api/pkg/server/helix_org_github_app_test.go
@@ -1,0 +1,161 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/crypto"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// testEncKey is a valid 32-byte AES-256 key for the decrypt path.
+var testEncKey = []byte("0123456789abcdef0123456789abcdef")
+
+func testKeyGetter() ([]byte, error) { return testEncKey, nil }
+
+// mustEncrypt mirrors how service_connection_handlers.go stores the PEM:
+// AES-256-GCM, base64. The resolver must decrypt it before minting.
+func mustEncrypt(t *testing.T, plaintext string) string {
+	t.Helper()
+	enc, err := crypto.EncryptAES256GCM([]byte(plaintext), testEncKey)
+	require.NoError(t, err)
+	return enc
+}
+
+// newGitHubApp builds a github_app ServiceConnection row with an
+// encrypted PEM, as the store would return it.
+func newGitHubApp(t *testing.T, appID, installID int64, pem string) *types.ServiceConnection {
+	return &types.ServiceConnection{
+		Type:                 types.ServiceConnectionTypeGitHubApp,
+		OrganizationID:       "org-1",
+		GitHubAppID:          appID,
+		GitHubInstallationID: installID,
+		GitHubPrivateKey:     mustEncrypt(t, pem),
+	}
+}
+
+func TestOrgGitHubIdentityResolver_NoAppFallsBackToOAuth(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	st := store.NewMockStore(ctrl)
+	st.EXPECT().
+		ListServiceConnectionsByType(gomock.Any(), "org-1", types.ServiceConnectionTypeGitHubApp).
+		Return([]*types.ServiceConnection{}, nil)
+
+	oauth := func(_ context.Context, _ string) (string, error) { return "oauth-token", nil }
+	mint := func(_ context.Context, _, _ int64, _, _ string) (string, error) {
+		t.Fatal("mintFn must not be called when no app is installed")
+		return "", nil
+	}
+
+	resolve := newOrgGitHubIdentityResolver(testKeyGetter, st, oauth, mint)
+	id, err := resolve(context.Background(), "org-1")
+	require.NoError(t, err)
+	require.Equal(t, "oauth", id.Mode)
+	require.Equal(t, "oauth-token", id.Token)
+}
+
+func TestOrgGitHubIdentityResolver_AppMintsBotToken(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	st := store.NewMockStore(ctrl)
+	st.EXPECT().
+		ListServiceConnectionsByType(gomock.Any(), "org-1", types.ServiceConnectionTypeGitHubApp).
+		Return([]*types.ServiceConnection{newGitHubApp(t, 111, 222, "FAKE_PEM")}, nil)
+
+	var gotAppID, gotInstallID int64
+	var gotPEM string
+	mint := func(_ context.Context, appID, installID int64, pem, _ string) (string, error) {
+		gotAppID, gotInstallID, gotPEM = appID, installID, pem
+		return "bot-token", nil
+	}
+	oauth := func(_ context.Context, _ string) (string, error) {
+		t.Fatal("oauth fallback must not be called when the app mints successfully")
+		return "", nil
+	}
+
+	resolve := newOrgGitHubIdentityResolver(testKeyGetter, st, oauth, mint)
+	id, err := resolve(context.Background(), "org-1")
+	require.NoError(t, err)
+	require.Equal(t, "app", id.Mode)
+	require.Equal(t, "bot-token", id.Token)
+	require.Equal(t, int64(111), id.AppID)
+	require.Equal(t, int64(222), id.InstallationID)
+	// The PEM handed to the minter must be the DECRYPTED key.
+	require.Equal(t, "FAKE_PEM", gotPEM)
+	require.Equal(t, int64(111), gotAppID)
+	require.Equal(t, int64(222), gotInstallID)
+}
+
+func TestOrgGitHubIdentityResolver_NewestAppWins(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	st := store.NewMockStore(ctrl)
+	// Store returns created_at DESC, so the newest connection is first.
+	st.EXPECT().
+		ListServiceConnectionsByType(gomock.Any(), "org-1", types.ServiceConnectionTypeGitHubApp).
+		Return([]*types.ServiceConnection{
+			newGitHubApp(t, 999, 888, "NEWEST_PEM"),
+			newGitHubApp(t, 111, 222, "OLDER_PEM"),
+		}, nil)
+
+	var gotAppID int64
+	mint := func(_ context.Context, appID, _ int64, _, _ string) (string, error) {
+		gotAppID = appID
+		return "bot-token", nil
+	}
+	oauth := func(_ context.Context, _ string) (string, error) { return "oauth-token", nil }
+
+	resolve := newOrgGitHubIdentityResolver(testKeyGetter, st, oauth, mint)
+	id, err := resolve(context.Background(), "org-1")
+	require.NoError(t, err)
+	require.Equal(t, "app", id.Mode)
+	require.Equal(t, int64(999), gotAppID)
+}
+
+func TestOrgGitHubIdentityResolver_MintErrorFallsBackToOAuth(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	st := store.NewMockStore(ctrl)
+	st.EXPECT().
+		ListServiceConnectionsByType(gomock.Any(), "org-1", types.ServiceConnectionTypeGitHubApp).
+		Return([]*types.ServiceConnection{newGitHubApp(t, 111, 222, "FAKE_PEM")}, nil)
+
+	mint := func(_ context.Context, _, _ int64, _, _ string) (string, error) {
+		return "", errors.New("github says no")
+	}
+	oauth := func(_ context.Context, _ string) (string, error) { return "oauth-token", nil }
+
+	resolve := newOrgGitHubIdentityResolver(testKeyGetter, st, oauth, mint)
+	id, err := resolve(context.Background(), "org-1")
+	require.NoError(t, err)
+	require.Equal(t, "oauth", id.Mode, "a broken app config must never break an org OAuth could still serve")
+	require.Equal(t, "oauth-token", id.Token)
+}
+
+func TestOrgGitHubIdentityResolver_DecryptErrorFallsBackToOAuth(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	st := store.NewMockStore(ctrl)
+	corrupt := &types.ServiceConnection{
+		Type:                 types.ServiceConnectionTypeGitHubApp,
+		OrganizationID:       "org-1",
+		GitHubAppID:          111,
+		GitHubInstallationID: 222,
+		GitHubPrivateKey:     "not-valid-ciphertext",
+	}
+	st.EXPECT().
+		ListServiceConnectionsByType(gomock.Any(), "org-1", types.ServiceConnectionTypeGitHubApp).
+		Return([]*types.ServiceConnection{corrupt}, nil)
+
+	mint := func(_ context.Context, _, _ int64, _, _ string) (string, error) {
+		t.Fatal("mintFn must not be called when the PEM cannot be decrypted")
+		return "", nil
+	}
+	oauth := func(_ context.Context, _ string) (string, error) { return "oauth-token", nil }
+
+	resolve := newOrgGitHubIdentityResolver(testKeyGetter, st, oauth, mint)
+	id, err := resolve(context.Background(), "org-1")
+	require.NoError(t, err)
+	require.Equal(t, "oauth", id.Mode)
+	require.Equal(t, "oauth-token", id.Token)
+}

--- a/api/pkg/server/helix_org_github_manifest.go
+++ b/api/pkg/server/helix_org_github_manifest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -111,6 +112,27 @@ func normalizeOrigin(origin string) (string, error) {
 	return u.Scheme + "://" + u.Host, nil
 }
 
+// isLoopbackOrigin reports whether base points at a loopback / non-public
+// host. GitHub validates the manifest's hook_attributes.url is reachable over
+// the public Internet at creation time, so we omit the webhook URL for
+// loopback origins (the redirect/setup URLs are browser redirects and work
+// fine on localhost). A public origin — e.g. a cloudflared tunnel — gets the
+// webhook wired automatically.
+func isLoopbackOrigin(base string) bool {
+	u, err := url.Parse(base)
+	if err != nil {
+		return true // be conservative: if we can't tell, don't send a hook
+	}
+	host := u.Hostname()
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback() || ip.IsUnspecified()
+	}
+	return false
+}
+
 // newGitHubManifestStart builds the start resolver wired into the org API
 // Deps. It returns the GitHub POST URL, the manifest JSON to submit, and an
 // encrypted state. getKey provides the server encryption key (for the state).
@@ -140,13 +162,19 @@ func newGitHubManifestStart(getKey func() ([]byte, error)) func(ctx context.Cont
 		manifest := githubManifest{
 			Name:               fmt.Sprintf("Helix %s", githubOrg),
 			URL:                "https://tryhelix.ai",
-			HookAttributes:     map[string]string{"url": base + "/api/v1/orgs/" + url.PathEscape(orgID) + "/github/webhook"},
 			RedirectURL:        base + "/api/v1/orgs/" + url.PathEscape(orgID) + "/github/app-manifest/callback",
 			SetupURL:           base + "/api/v1/orgs/" + url.PathEscape(orgID) + "/github/app-setup",
 			SetupOnUpdate:      true,
 			Public:             false,
 			DefaultPermissions: helixAppPermissions,
-			DefaultEvents:      helixAppEvents,
+		}
+		// GitHub rejects a manifest whose hook url isn't publicly reachable, so
+		// only wire the webhook (and the events that depend on it) when the
+		// origin is public. On localhost the app is still fully usable as a
+		// bot; the webhook can be added later from a public URL.
+		if !isLoopbackOrigin(base) {
+			manifest.HookAttributes = map[string]string{"url": base + "/api/v1/orgs/" + url.PathEscape(orgID) + "/github/webhook"}
+			manifest.DefaultEvents = helixAppEvents
 		}
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {

--- a/api/pkg/server/helix_org_github_manifest.go
+++ b/api/pkg/server/helix_org_github_manifest.go
@@ -279,9 +279,18 @@ func newGitHubManifestCallbackHandler(
 			}
 		}
 
-		// Chain straight into installation so the user picks repos.
-		installURL := "https://github.com/apps/" + url.PathEscape(cfg.GetSlug()) + "/installations/new"
-		http.Redirect(w, r, installURL, http.StatusFound)
+		// Don't auto-redirect into installation: a just-created app's install
+		// page (…/installations/new → select_target) 404s for a few seconds
+		// until GitHub finishes provisioning it. Instead land back as
+		// "app created" and let the user click Install (step 2) once it's
+		// ready — which also makes the create → install → choose-repos flow
+		// explicit. The opener re-checks status on focus + via polling; the
+		// postMessage is best-effort (GitHub's COOP may have severed opener).
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, `<!doctype html><meta charset="utf-8"><body style="font-family:sans-serif;padding:2rem;line-height:1.5">
+<h3>✓ Helix GitHub App created</h3>
+<p>You can close this window. Back in Helix, click <strong>Install Helix</strong> to choose which repositories it can access.</p>
+<script>try{window.opener&&window.opener.postMessage({type:"github-app-created"},"*")}catch(e){};setTimeout(function(){window.close()},1800)</script>`)
 	}
 }
 

--- a/api/pkg/server/helix_org_github_manifest.go
+++ b/api/pkg/server/helix_org_github_manifest.go
@@ -54,8 +54,6 @@ type githubManifest struct {
 	URL                string            `json:"url"`
 	HookAttributes     map[string]string `json:"hook_attributes,omitempty"`
 	RedirectURL        string            `json:"redirect_url"`
-	SetupURL           string            `json:"setup_url,omitempty"`
-	SetupOnUpdate      bool              `json:"setup_on_update,omitempty"`
 	Public             bool              `json:"public"`
 	DefaultPermissions map[string]string `json:"default_permissions"`
 	DefaultEvents      []string          `json:"default_events,omitempty"`
@@ -161,10 +159,8 @@ func newGitHubManifestStart(getKey func() ([]byte, error)) func(ctx context.Cont
 
 		manifest := githubManifest{
 			Name:               fmt.Sprintf("Helix %s", githubOrg),
-			URL:                "https://tryhelix.ai",
+			URL:                "https://helix.ml",
 			RedirectURL:        base + "/api/v1/orgs/" + url.PathEscape(orgID) + "/github/app-manifest/callback",
-			SetupURL:           base + "/api/v1/orgs/" + url.PathEscape(orgID) + "/github/app-setup",
-			SetupOnUpdate:      true,
 			Public:             false,
 			DefaultPermissions: helixAppPermissions,
 		}
@@ -257,65 +253,3 @@ func newGitHubManifestCallbackHandler(getKey func() ([]byte, error), st helixsto
 	}
 }
 
-// newGitHubAppSetupHandler captures the installation_id GitHub appends to the
-// app's setup_url after the user installs, persisting it onto the org's
-// newest github_app ServiceConnection. It then postMessages the opener so the
-// New Stream dialog re-checks and closes the popup.
-func newGitHubAppSetupHandler(st helixstore.Store) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		orgID := orgIDFromManifestPath(r)
-		installIDStr := r.URL.Query().Get("installation_id")
-		if orgID == "" || installIDStr == "" {
-			writeManifestClosePage(w, false, "Missing org or installation id.")
-			return
-		}
-		var installID int64
-		if _, err := fmt.Sscan(installIDStr, &installID); err != nil || installID == 0 {
-			writeManifestClosePage(w, false, "Invalid installation id.")
-			return
-		}
-		conns, err := st.ListServiceConnectionsByType(ctx, orgID, types.ServiceConnectionTypeGitHubApp)
-		if err != nil || len(conns) == 0 {
-			writeManifestClosePage(w, false, "No Helix app found for this org.")
-			return
-		}
-		// Newest first (store returns created_at DESC) — attach to the app
-		// the user just created/installed.
-		conn := conns[0]
-		conn.GitHubInstallationID = installID
-		if err := st.UpdateServiceConnection(ctx, conn); err != nil {
-			log.Error().Err(err).Str("org_id", orgID).Msg("persist installation id failed")
-			writeManifestClosePage(w, false, "Failed to save the installation.")
-			return
-		}
-		log.Info().Str("org_id", orgID).Int64("installation_id", installID).Msg("captured Helix GitHub App installation")
-		writeManifestClosePage(w, true, "")
-	}
-}
-
-// orgIDFromManifestPath extracts {org} from /api/v1/orgs/{org}/github/app-setup
-// without depending on the mux var name used at mount time.
-func orgIDFromManifestPath(r *http.Request) string {
-	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
-	for i := 0; i+1 < len(parts); i++ {
-		if parts[i] == "orgs" {
-			return parts[i+1]
-		}
-	}
-	return ""
-}
-
-// writeManifestClosePage renders a tiny page that notifies the opener (the
-// New Stream dialog) and closes the popup.
-func writeManifestClosePage(w http.ResponseWriter, ok bool, msg string) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	status := "github-app-installed"
-	body := "Helix is installed. You can close this window."
-	if !ok {
-		status = "github-app-install-error"
-		body = "Could not complete the install: " + msg
-	}
-	fmt.Fprintf(w, `<!doctype html><meta charset="utf-8"><body style="font-family:sans-serif;padding:2rem">%s
-<script>try{window.opener&&window.opener.postMessage({type:%q},"*")}catch(e){};setTimeout(function(){window.close()},800)</script>`, body, status)
-}

--- a/api/pkg/server/helix_org_github_manifest.go
+++ b/api/pkg/server/helix_org_github_manifest.go
@@ -252,6 +252,7 @@ func newGitHubManifestCallbackHandler(
 			ProviderType:     types.ExternalRepositoryTypeGitHub,
 			GitHubAppID:      cfg.GetID(),
 			GitHubAppSlug:    cfg.GetSlug(),
+			GitHubAppOwner:   parsed.GitHubOrg,
 			GitHubPrivateKey: encPEM,
 		}
 		if err := st.CreateServiceConnection(ctx, conn); err != nil {

--- a/api/pkg/server/helix_org_github_manifest.go
+++ b/api/pkg/server/helix_org_github_manifest.go
@@ -68,10 +68,19 @@ var helixAppPermissions = map[string]string{
 	"metadata":      "read",
 }
 
-// helixAppEvents keeps the app webhook-ready for the streams feature. They
-// only deliver once hook_attributes.url is publicly reachable, so they are
-// harmless on a localhost dev deployment.
-var helixAppEvents = []string{"push", "pull_request", "issues", "issue_comment"}
+// helixAppEvents is the broad set the app subscribes to so a stream can
+// filter down to any of them (the app subscribes wide; the stream's `events`
+// whitelist narrows). They only deliver once hook_attributes.url is publicly
+// reachable, so they are harmless on a localhost dev deployment. Each event
+// requires the matching permission (granted in helixAppPermissions):
+// push/create/delete need contents; pull_request* need pull_requests;
+// issues/issue_comment need issues.
+var helixAppEvents = []string{
+	"push", "create", "delete",
+	"pull_request", "pull_request_review", "pull_request_review_comment",
+	"issues", "issue_comment",
+	"release",
+}
 
 func encodeGitHubManifestState(s githubManifestState, key []byte) (string, error) {
 	raw, err := json.Marshal(s)
@@ -191,7 +200,12 @@ func newGitHubManifestStart(getKey func() ([]byte, error)) func(ctx context.Cont
 // github_app ServiceConnection for the org, and redirects to the install
 // page. Mounted on the insecure router (validated by the encrypted state,
 // not the helix session) because it is a top-level navigation from github.com.
-func newGitHubManifestCallbackHandler(getKey func() ([]byte, error), st helixstore.Store, newID func() string) http.HandlerFunc {
+func newGitHubManifestCallbackHandler(
+	getKey func() ([]byte, error),
+	st helixstore.Store,
+	newID func() string,
+	setWebhookSecret func(ctx context.Context, orgID, secret string) error,
+) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		code := r.URL.Query().Get("code")
@@ -246,6 +260,18 @@ func newGitHubManifestCallbackHandler(getKey func() ([]byte, error), st helixsto
 			return
 		}
 		log.Info().Str("org_id", parsed.OrgID).Int64("app_id", cfg.GetID()).Str("slug", cfg.GetSlug()).Msg("created Helix GitHub App via manifest")
+
+		// Mirror the app's webhook secret into transport.github so the
+		// existing inbound webhook handler validates the App's deliveries
+		// (it HMACs the body against transport.github.webhook_secret). The
+		// App delivers all events for all installed repos to that one
+		// endpoint; streams filter by repo/event. GitHub shows this secret
+		// only once, so persist it now.
+		if ws := cfg.GetWebhookSecret(); ws != "" && setWebhookSecret != nil {
+			if err := setWebhookSecret(ctx, parsed.OrgID, ws); err != nil {
+				log.Error().Err(err).Str("org_id", parsed.OrgID).Msg("persist app webhook secret failed")
+			}
+		}
 
 		// Chain straight into installation so the user picks repos.
 		installURL := "https://github.com/apps/" + url.PathEscape(cfg.GetSlug()) + "/installations/new"

--- a/api/pkg/server/helix_org_github_manifest.go
+++ b/api/pkg/server/helix_org_github_manifest.go
@@ -169,8 +169,13 @@ func newGitHubManifestStart(getKey func() ([]byte, error)) func(ctx context.Cont
 		manifest := githubManifest{
 			Name:               fmt.Sprintf("Helix %s", githubOrg),
 			URL:                "https://helix.ml",
-			RedirectURL:        base + "/api/v1/orgs/" + url.PathEscape(orgID) + "/github/app-manifest/callback",
-			Public:             false,
+			RedirectURL: base + "/api/v1/orgs/" + url.PathEscape(orgID) + "/github/app-manifest/callback",
+			// Public ("Any account") so the one app can be installed on more
+			// than one GitHub org (e.g. winderai AND helixml). A private app
+			// can only be installed on its owner org. Each install is a
+			// separate installation with its own per-org token; Helix
+			// aggregates repos across installations and routes tokens by owner.
+			Public:             true,
 			DefaultPermissions: helixAppPermissions,
 		}
 		// GitHub rejects a manifest whose hook url isn't publicly reachable, so

--- a/api/pkg/server/helix_org_github_manifest.go
+++ b/api/pkg/server/helix_org_github_manifest.go
@@ -279,18 +279,45 @@ func newGitHubManifestCallbackHandler(
 			}
 		}
 
-		// Don't auto-redirect into installation: a just-created app's install
-		// page (…/installations/new → select_target) 404s for a few seconds
-		// until GitHub finishes provisioning it. Instead land back as
-		// "app created" and let the user click Install (step 2) once it's
-		// ready — which also makes the create → install → choose-repos flow
-		// explicit. The opener re-checks status on focus + via polling; the
-		// postMessage is best-effort (GitHub's COOP may have severed opener).
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		fmt.Fprint(w, `<!doctype html><meta charset="utf-8"><body style="font-family:sans-serif;padding:2rem;line-height:1.5">
-<h3>✓ Helix GitHub App created</h3>
-<p>You can close this window. Back in Helix, click <strong>Install Helix</strong> to choose which repositories it can access.</p>
-<script>try{window.opener&&window.opener.postMessage({type:"github-app-created"},"*")}catch(e){};setTimeout(function(){window.close()},1800)</script>`)
+		// Chain straight into installation so the user picks repos. A
+		// just-created app's install page (…/installations/new →
+		// select_target) 404s for a few seconds until GitHub finishes
+		// provisioning it, so wait until it's live before redirecting (a real
+		// readiness check, not a blind sleep) — bounded so we never hang.
+		installURL := "https://github.com/apps/" + url.PathEscape(cfg.GetSlug()) + "/installations/new"
+		waitForGitHubAppInstallReady(ctx, installURL, 20*time.Second)
+		http.Redirect(w, r, installURL, http.StatusFound)
+	}
+}
+
+// waitForGitHubAppInstallReady polls the app's install URL (following GitHub's
+// redirect to select_target / login) until it stops returning 404, i.e. GitHub
+// has finished provisioning a freshly-created app. Bounded by timeout; on
+// timeout it returns and the caller redirects anyway (best effort).
+func waitForGitHubAppInstallReady(ctx context.Context, installURL string, timeout time.Duration) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	deadline := time.Now().Add(timeout)
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, installURL, nil)
+		if err != nil {
+			return
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			status := resp.StatusCode
+			resp.Body.Close()
+			if status != http.StatusNotFound {
+				return // install page is live
+			}
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Second):
+		}
 	}
 }
 

--- a/api/pkg/server/helix_org_github_manifest.go
+++ b/api/pkg/server/helix_org_github_manifest.go
@@ -143,7 +143,9 @@ func isLoopbackOrigin(base string) bool {
 // newGitHubManifestStart builds the start resolver wired into the org API
 // Deps. It returns the GitHub POST URL, the manifest JSON to submit, and an
 // encrypted state. getKey provides the server encryption key (for the state).
-func newGitHubManifestStart(getKey func() ([]byte, error)) func(ctx context.Context, orgID, githubOrg, origin string) (helixorgapi.GitHubManifestStartResponse, error) {
+// webURL is the GitHub web origin (https://github.com or a GHES origin) the
+// app create/install links are built against.
+func newGitHubManifestStart(getKey func() ([]byte, error), webURL string) func(ctx context.Context, orgID, githubOrg, origin string) (helixorgapi.GitHubManifestStartResponse, error) {
 	return func(_ context.Context, orgID, githubOrg, origin string) (helixorgapi.GitHubManifestStartResponse, error) {
 		githubOrg = strings.TrimSpace(githubOrg)
 		if githubOrg == "" {
@@ -167,8 +169,8 @@ func newGitHubManifestStart(getKey func() ([]byte, error)) func(ctx context.Cont
 		}
 
 		manifest := githubManifest{
-			Name:               fmt.Sprintf("Helix %s", githubOrg),
-			URL:                "https://helix.ml",
+			Name:        fmt.Sprintf("Helix %s", githubOrg),
+			URL:         "https://helix.ml",
 			RedirectURL: base + "/api/v1/orgs/" + url.PathEscape(orgID) + "/github/app-manifest/callback",
 			// Public ("Any account") so the one app can be installed on more
 			// than one GitHub org (e.g. winderai AND helixml). A private app
@@ -191,7 +193,7 @@ func newGitHubManifestStart(getKey func() ([]byte, error)) func(ctx context.Cont
 			return helixorgapi.GitHubManifestStartResponse{}, fmt.Errorf("marshal manifest: %w", err)
 		}
 
-		postURL := "https://github.com/organizations/" + url.PathEscape(githubOrg) + "/settings/apps/new?state=" + url.QueryEscape(state)
+		postURL := webURL + "/organizations/" + url.PathEscape(githubOrg) + "/settings/apps/new?state=" + url.QueryEscape(state)
 		return helixorgapi.GitHubManifestStartResponse{
 			PostURL:  postURL,
 			Manifest: string(manifestJSON),
@@ -205,11 +207,16 @@ func newGitHubManifestStart(getKey func() ([]byte, error)) func(ctx context.Cont
 // github_app ServiceConnection for the org, and redirects to the install
 // page. Mounted on the insecure router (validated by the encrypted state,
 // not the helix session) because it is a top-level navigation from github.com.
+// webURL is the GitHub web origin for the install redirect; apiBaseURL is the
+// API origin passed to the github client (empty for github.com) and stored on
+// the created ServiceConnection so later calls target the right host (GHES).
 func newGitHubManifestCallbackHandler(
 	getKey func() ([]byte, error),
 	st helixstore.Store,
 	newID func() string,
 	setWebhookSecret func(ctx context.Context, orgID, secret string) error,
+	webURL string,
+	apiBaseURL string,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -230,7 +237,7 @@ func newGitHubManifestCallbackHandler(
 			return
 		}
 
-		cfg, err := githubclient.CompleteAppManifest(ctx, code, "")
+		cfg, err := githubclient.CompleteAppManifest(ctx, code, apiBaseURL)
 		if err != nil {
 			log.Error().Err(err).Str("org_id", parsed.OrgID).Msg("github app manifest conversion failed")
 			http.Error(w, "failed to complete app creation with GitHub: "+err.Error(), http.StatusBadGateway)
@@ -259,6 +266,9 @@ func newGitHubManifestCallbackHandler(
 			GitHubAppSlug:    cfg.GetSlug(),
 			GitHubAppOwner:   parsed.GitHubOrg,
 			GitHubPrivateKey: encPEM,
+			// Empty for github.com; the GHES origin otherwise, so the install
+			// reconcile + token minting target the right API host.
+			BaseURL: apiBaseURL,
 		}
 		if err := st.CreateServiceConnection(ctx, conn); err != nil {
 			log.Error().Err(err).Str("org_id", parsed.OrgID).Msg("store github app service connection failed")
@@ -284,7 +294,7 @@ func newGitHubManifestCallbackHandler(
 		// select_target) 404s for a few seconds until GitHub finishes
 		// provisioning it, so wait until it's live before redirecting (a real
 		// readiness check, not a blind sleep) — bounded so we never hang.
-		installURL := "https://github.com/apps/" + url.PathEscape(cfg.GetSlug()) + "/installations/new"
+		installURL := webURL + "/apps/" + url.PathEscape(cfg.GetSlug()) + "/installations/new"
 		waitForGitHubAppInstallReady(ctx, installURL, 20*time.Second)
 		http.Redirect(w, r, installURL, http.StatusFound)
 	}
@@ -320,4 +330,3 @@ func waitForGitHubAppInstallReady(ctx context.Context, installURL string, timeou
 		}
 	}
 }
-

--- a/api/pkg/server/helix_org_github_manifest.go
+++ b/api/pkg/server/helix_org_github_manifest.go
@@ -1,0 +1,293 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/helixml/helix/api/pkg/crypto"
+	githubclient "github.com/helixml/helix/api/pkg/github"
+	helixorgapi "github.com/helixml/helix/api/pkg/org/interfaces/server/api"
+	helixstore "github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// GitHub App Manifest flow — "create the Helix app on the user's behalf".
+//
+// 1. start (authed): build a Helix-authored manifest + an encrypted state,
+//    return them so the frontend can POST the manifest to GitHub.
+// 2. GitHub creates the app and redirects the browser to the manifest's
+//    redirect_url (our callback) with a one-hour ?code=.
+// 3. callback (insecure, state-validated): exchange the code for the app's
+//    id/slug/PEM, store a github_app ServiceConnection, then redirect the
+//    browser to the app's install page.
+// 4. The user installs; GitHub redirects to the manifest's setup_url (our
+//    app-setup handler) with ?installation_id=, which we persist onto the
+//    ServiceConnection. The page then postMessages the opener so the New
+//    Stream dialog flips to "installed".
+//
+// The Helix org is carried in the redirect_url/setup_url path; the encrypted
+// state carries the org + expiry for CSRF on the callback.
+
+// githubManifestStateTTL bounds how long a started manifest flow stays valid.
+const githubManifestStateTTL = time.Hour
+
+// githubManifestState is the CSRF/context blob round-tripped (encrypted) as
+// the GitHub ?state= parameter.
+type githubManifestState struct {
+	OrgID     string `json:"o"`
+	GitHubOrg string `json:"g"`
+	ExpiresAt int64  `json:"e"`
+}
+
+// githubManifest is the GitHub App manifest we POST on the user's behalf.
+// Field names match GitHub's manifest schema.
+type githubManifest struct {
+	Name               string            `json:"name"`
+	URL                string            `json:"url"`
+	HookAttributes     map[string]string `json:"hook_attributes,omitempty"`
+	RedirectURL        string            `json:"redirect_url"`
+	SetupURL           string            `json:"setup_url,omitempty"`
+	SetupOnUpdate      bool              `json:"setup_on_update,omitempty"`
+	Public             bool              `json:"public"`
+	DefaultPermissions map[string]string `json:"default_permissions"`
+	DefaultEvents      []string          `json:"default_events,omitempty"`
+}
+
+// helixAppPermissions is the minimum the Worker bot needs: clone/push,
+// open PRs, manage issues. Metadata is mandatory + auto-granted.
+var helixAppPermissions = map[string]string{
+	"contents":      "write",
+	"pull_requests": "write",
+	"issues":        "write",
+	"metadata":      "read",
+}
+
+// helixAppEvents keeps the app webhook-ready for the streams feature. They
+// only deliver once hook_attributes.url is publicly reachable, so they are
+// harmless on a localhost dev deployment.
+var helixAppEvents = []string{"push", "pull_request", "issues", "issue_comment"}
+
+func encodeGitHubManifestState(s githubManifestState, key []byte) (string, error) {
+	raw, err := json.Marshal(s)
+	if err != nil {
+		return "", err
+	}
+	return crypto.EncryptAES256GCM(raw, key)
+}
+
+func decodeGitHubManifestState(state string, key []byte) (githubManifestState, error) {
+	raw, err := crypto.DecryptAES256GCM(state, key)
+	if err != nil {
+		return githubManifestState{}, err
+	}
+	var s githubManifestState
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return githubManifestState{}, err
+	}
+	if time.Now().Unix() > s.ExpiresAt {
+		return githubManifestState{}, fmt.Errorf("manifest state expired")
+	}
+	return s, nil
+}
+
+// normalizeOrigin validates a caller-supplied origin (window.location.origin)
+// and returns just scheme://host, guarding against open-redirect abuse via a
+// crafted origin.
+func normalizeOrigin(origin string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(origin))
+	if err != nil {
+		return "", fmt.Errorf("invalid origin: %w", err)
+	}
+	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return "", fmt.Errorf("origin must be an http(s) URL with a host")
+	}
+	return u.Scheme + "://" + u.Host, nil
+}
+
+// newGitHubManifestStart builds the start resolver wired into the org API
+// Deps. It returns the GitHub POST URL, the manifest JSON to submit, and an
+// encrypted state. getKey provides the server encryption key (for the state).
+func newGitHubManifestStart(getKey func() ([]byte, error)) func(ctx context.Context, orgID, githubOrg, origin string) (helixorgapi.GitHubManifestStartResponse, error) {
+	return func(_ context.Context, orgID, githubOrg, origin string) (helixorgapi.GitHubManifestStartResponse, error) {
+		githubOrg = strings.TrimSpace(githubOrg)
+		if githubOrg == "" {
+			return helixorgapi.GitHubManifestStartResponse{}, fmt.Errorf("github organization is required")
+		}
+		base, err := normalizeOrigin(origin)
+		if err != nil {
+			return helixorgapi.GitHubManifestStartResponse{}, err
+		}
+		key, err := getKey()
+		if err != nil {
+			return helixorgapi.GitHubManifestStartResponse{}, fmt.Errorf("get encryption key: %w", err)
+		}
+		state, err := encodeGitHubManifestState(githubManifestState{
+			OrgID:     orgID,
+			GitHubOrg: githubOrg,
+			ExpiresAt: time.Now().Add(githubManifestStateTTL).Unix(),
+		}, key)
+		if err != nil {
+			return helixorgapi.GitHubManifestStartResponse{}, fmt.Errorf("encode state: %w", err)
+		}
+
+		manifest := githubManifest{
+			Name:               fmt.Sprintf("Helix %s", githubOrg),
+			URL:                "https://tryhelix.ai",
+			HookAttributes:     map[string]string{"url": base + "/api/v1/orgs/" + url.PathEscape(orgID) + "/github/webhook"},
+			RedirectURL:        base + "/api/v1/orgs/" + url.PathEscape(orgID) + "/github/app-manifest/callback",
+			SetupURL:           base + "/api/v1/orgs/" + url.PathEscape(orgID) + "/github/app-setup",
+			SetupOnUpdate:      true,
+			Public:             false,
+			DefaultPermissions: helixAppPermissions,
+			DefaultEvents:      helixAppEvents,
+		}
+		manifestJSON, err := json.Marshal(manifest)
+		if err != nil {
+			return helixorgapi.GitHubManifestStartResponse{}, fmt.Errorf("marshal manifest: %w", err)
+		}
+
+		postURL := "https://github.com/organizations/" + url.PathEscape(githubOrg) + "/settings/apps/new?state=" + url.QueryEscape(state)
+		return helixorgapi.GitHubManifestStartResponse{
+			PostURL:  postURL,
+			Manifest: string(manifestJSON),
+			State:    state,
+		}, nil
+	}
+}
+
+// newGitHubManifestCallbackHandler handles the browser redirect GitHub makes
+// after the app is created. It exchanges the code, stores the app as a
+// github_app ServiceConnection for the org, and redirects to the install
+// page. Mounted on the insecure router (validated by the encrypted state,
+// not the helix session) because it is a top-level navigation from github.com.
+func newGitHubManifestCallbackHandler(getKey func() ([]byte, error), st helixstore.Store, newID func() string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		code := r.URL.Query().Get("code")
+		state := r.URL.Query().Get("state")
+		if code == "" || state == "" {
+			http.Error(w, "missing code or state", http.StatusBadRequest)
+			return
+		}
+		key, err := getKey()
+		if err != nil {
+			http.Error(w, "server key error", http.StatusInternalServerError)
+			return
+		}
+		parsed, err := decodeGitHubManifestState(state, key)
+		if err != nil {
+			http.Error(w, "invalid or expired state", http.StatusBadRequest)
+			return
+		}
+
+		cfg, err := githubclient.CompleteAppManifest(ctx, code, "")
+		if err != nil {
+			log.Error().Err(err).Str("org_id", parsed.OrgID).Msg("github app manifest conversion failed")
+			http.Error(w, "failed to complete app creation with GitHub: "+err.Error(), http.StatusBadGateway)
+			return
+		}
+		if cfg.GetID() == 0 || cfg.GetPEM() == "" || cfg.GetSlug() == "" {
+			http.Error(w, "GitHub returned an incomplete app config", http.StatusBadGateway)
+			return
+		}
+
+		encPEM, err := crypto.EncryptAES256GCM([]byte(cfg.GetPEM()), key)
+		if err != nil {
+			http.Error(w, "failed to encrypt app key", http.StatusInternalServerError)
+			return
+		}
+
+		id := newID()
+		conn := &types.ServiceConnection{
+			ID:               id,
+			OrganizationID:   parsed.OrgID,
+			Name:             cfg.GetName(),
+			Description:      fmt.Sprintf("Helix GitHub App (created via manifest for %s)", parsed.GitHubOrg),
+			Type:             types.ServiceConnectionTypeGitHubApp,
+			ProviderType:     types.ExternalRepositoryTypeGitHub,
+			GitHubAppID:      cfg.GetID(),
+			GitHubAppSlug:    cfg.GetSlug(),
+			GitHubPrivateKey: encPEM,
+		}
+		if err := st.CreateServiceConnection(ctx, conn); err != nil {
+			log.Error().Err(err).Str("org_id", parsed.OrgID).Msg("store github app service connection failed")
+			http.Error(w, "failed to store the created app", http.StatusInternalServerError)
+			return
+		}
+		log.Info().Str("org_id", parsed.OrgID).Int64("app_id", cfg.GetID()).Str("slug", cfg.GetSlug()).Msg("created Helix GitHub App via manifest")
+
+		// Chain straight into installation so the user picks repos.
+		installURL := "https://github.com/apps/" + url.PathEscape(cfg.GetSlug()) + "/installations/new"
+		http.Redirect(w, r, installURL, http.StatusFound)
+	}
+}
+
+// newGitHubAppSetupHandler captures the installation_id GitHub appends to the
+// app's setup_url after the user installs, persisting it onto the org's
+// newest github_app ServiceConnection. It then postMessages the opener so the
+// New Stream dialog re-checks and closes the popup.
+func newGitHubAppSetupHandler(st helixstore.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		orgID := orgIDFromManifestPath(r)
+		installIDStr := r.URL.Query().Get("installation_id")
+		if orgID == "" || installIDStr == "" {
+			writeManifestClosePage(w, false, "Missing org or installation id.")
+			return
+		}
+		var installID int64
+		if _, err := fmt.Sscan(installIDStr, &installID); err != nil || installID == 0 {
+			writeManifestClosePage(w, false, "Invalid installation id.")
+			return
+		}
+		conns, err := st.ListServiceConnectionsByType(ctx, orgID, types.ServiceConnectionTypeGitHubApp)
+		if err != nil || len(conns) == 0 {
+			writeManifestClosePage(w, false, "No Helix app found for this org.")
+			return
+		}
+		// Newest first (store returns created_at DESC) — attach to the app
+		// the user just created/installed.
+		conn := conns[0]
+		conn.GitHubInstallationID = installID
+		if err := st.UpdateServiceConnection(ctx, conn); err != nil {
+			log.Error().Err(err).Str("org_id", orgID).Msg("persist installation id failed")
+			writeManifestClosePage(w, false, "Failed to save the installation.")
+			return
+		}
+		log.Info().Str("org_id", orgID).Int64("installation_id", installID).Msg("captured Helix GitHub App installation")
+		writeManifestClosePage(w, true, "")
+	}
+}
+
+// orgIDFromManifestPath extracts {org} from /api/v1/orgs/{org}/github/app-setup
+// without depending on the mux var name used at mount time.
+func orgIDFromManifestPath(r *http.Request) string {
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	for i := 0; i+1 < len(parts); i++ {
+		if parts[i] == "orgs" {
+			return parts[i+1]
+		}
+	}
+	return ""
+}
+
+// writeManifestClosePage renders a tiny page that notifies the opener (the
+// New Stream dialog) and closes the popup.
+func writeManifestClosePage(w http.ResponseWriter, ok bool, msg string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	status := "github-app-installed"
+	body := "Helix is installed. You can close this window."
+	if !ok {
+		status = "github-app-install-error"
+		body = "Could not complete the install: " + msg
+	}
+	fmt.Fprintf(w, `<!doctype html><meta charset="utf-8"><body style="font-family:sans-serif;padding:2rem">%s
+<script>try{window.opener&&window.opener.postMessage({type:%q},"*")}catch(e){};setTimeout(function(){window.close()},800)</script>`, body, status)
+}

--- a/api/pkg/server/helix_org_github_manifest_test.go
+++ b/api/pkg/server/helix_org_github_manifest_test.go
@@ -67,7 +67,8 @@ func TestGitHubManifestStart_BuildsManifestAndPostURL(t *testing.T) {
 	var m githubManifest
 	require.NoError(t, json.Unmarshal([]byte(resp.Manifest), &m))
 	require.Equal(t, "Helix acme", m.Name)
-	require.False(t, m.Public)
+	// Public ("Any account") so one app can be installed across multiple orgs.
+	require.True(t, m.Public)
 	// Least-privilege bot permissions.
 	require.Equal(t, "write", m.DefaultPermissions["contents"])
 	require.Equal(t, "write", m.DefaultPermissions["pull_requests"])

--- a/api/pkg/server/helix_org_github_manifest_test.go
+++ b/api/pkg/server/helix_org_github_manifest_test.go
@@ -55,7 +55,7 @@ func TestNormalizeOrigin(t *testing.T) {
 }
 
 func TestGitHubManifestStart_BuildsManifestAndPostURL(t *testing.T) {
-	start := newGitHubManifestStart(testKeyGetter)
+	start := newGitHubManifestStart(testKeyGetter, "https://github.com")
 	resp, err := start(context.Background(), "org-1", "acme", "http://localhost:8080")
 	require.NoError(t, err)
 
@@ -88,8 +88,18 @@ func TestGitHubManifestStart_BuildsManifestAndPostURL(t *testing.T) {
 	require.Equal(t, "acme", decoded.GitHubOrg)
 }
 
+func TestGitHubManifestStart_GHESWebURL(t *testing.T) {
+	// A GitHub Enterprise Server origin must drive the app-creation URL, not
+	// the hardcoded github.com.
+	start := newGitHubManifestStart(testKeyGetter, "https://github.acme.com")
+	resp, err := start(context.Background(), "org-1", "acme", "http://localhost:8080")
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(resp.PostURL, "https://github.acme.com/organizations/acme/settings/apps/new?state="),
+		"post_url = %s", resp.PostURL)
+}
+
 func TestGitHubManifestStart_PublicOriginWiresWebhook(t *testing.T) {
-	start := newGitHubManifestStart(testKeyGetter)
+	start := newGitHubManifestStart(testKeyGetter, "https://github.com")
 	resp, err := start(context.Background(), "org-1", "acme", "https://helix.example.com")
 	require.NoError(t, err)
 	var m githubManifest
@@ -109,7 +119,7 @@ func TestIsLoopbackOrigin(t *testing.T) {
 }
 
 func TestGitHubManifestStart_RejectsBadInput(t *testing.T) {
-	start := newGitHubManifestStart(testKeyGetter)
+	start := newGitHubManifestStart(testKeyGetter, "https://github.com")
 	_, err := start(context.Background(), "org-1", "", "http://localhost:8080")
 	require.Error(t, err, "empty github org rejected")
 	_, err = start(context.Background(), "org-1", "acme", "not-a-url")

--- a/api/pkg/server/helix_org_github_manifest_test.go
+++ b/api/pkg/server/helix_org_github_manifest_test.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitHubManifestState_RoundTrip(t *testing.T) {
+	in := githubManifestState{OrgID: "org-1", GitHubOrg: "acme", ExpiresAt: time.Now().Add(time.Hour).Unix()}
+	enc, err := encodeGitHubManifestState(in, testEncKey)
+	require.NoError(t, err)
+	require.NotEmpty(t, enc)
+
+	out, err := decodeGitHubManifestState(enc, testEncKey)
+	require.NoError(t, err)
+	require.Equal(t, in.OrgID, out.OrgID)
+	require.Equal(t, in.GitHubOrg, out.GitHubOrg)
+}
+
+func TestGitHubManifestState_Expired(t *testing.T) {
+	in := githubManifestState{OrgID: "org-1", GitHubOrg: "acme", ExpiresAt: time.Now().Add(-time.Minute).Unix()}
+	enc, err := encodeGitHubManifestState(in, testEncKey)
+	require.NoError(t, err)
+	_, err = decodeGitHubManifestState(enc, testEncKey)
+	require.Error(t, err, "expired state must be rejected")
+}
+
+func TestGitHubManifestState_WrongKeyRejected(t *testing.T) {
+	in := githubManifestState{OrgID: "org-1", GitHubOrg: "acme", ExpiresAt: time.Now().Add(time.Hour).Unix()}
+	enc, err := encodeGitHubManifestState(in, testEncKey)
+	require.NoError(t, err)
+	otherKey := []byte("ffffffffffffffffffffffffffffffff")
+	_, err = decodeGitHubManifestState(enc, otherKey)
+	require.Error(t, err, "state encrypted with a different key must not decode (CSRF)")
+}
+
+func TestNormalizeOrigin(t *testing.T) {
+	ok, err := normalizeOrigin("http://localhost:8080/orgs/test/streams")
+	require.NoError(t, err)
+	require.Equal(t, "http://localhost:8080", ok, "must strip path, keep scheme+host")
+
+	ok, err = normalizeOrigin("https://helix.example.com")
+	require.NoError(t, err)
+	require.Equal(t, "https://helix.example.com", ok)
+
+	for _, bad := range []string{"", "ftp://x", "notaurl", "https://"} {
+		_, err := normalizeOrigin(bad)
+		require.Error(t, err, "origin %q must be rejected", bad)
+	}
+}
+
+func TestGitHubManifestStart_BuildsManifestAndPostURL(t *testing.T) {
+	start := newGitHubManifestStart(testKeyGetter)
+	resp, err := start(context.Background(), "org-1", "acme", "http://localhost:8080")
+	require.NoError(t, err)
+
+	// POST target is the org-owned app-creation URL with our state.
+	require.True(t, strings.HasPrefix(resp.PostURL, "https://github.com/organizations/acme/settings/apps/new?state="),
+		"post_url = %s", resp.PostURL)
+	require.NotEmpty(t, resp.State)
+
+	var m githubManifest
+	require.NoError(t, json.Unmarshal([]byte(resp.Manifest), &m))
+	require.Equal(t, "Helix acme", m.Name)
+	require.False(t, m.Public)
+	// Least-privilege bot permissions.
+	require.Equal(t, "write", m.DefaultPermissions["contents"])
+	require.Equal(t, "write", m.DefaultPermissions["pull_requests"])
+	require.Equal(t, "write", m.DefaultPermissions["issues"])
+	require.Equal(t, "read", m.DefaultPermissions["metadata"])
+	// Callback + setup URLs carry the helix org and the caller's origin.
+	require.Equal(t, "http://localhost:8080/api/v1/orgs/org-1/github/app-manifest/callback", m.RedirectURL)
+	require.Equal(t, "http://localhost:8080/api/v1/orgs/org-1/github/app-setup", m.SetupURL)
+
+	// The state must decode back to the same org.
+	decoded, err := decodeGitHubManifestState(resp.State, testEncKey)
+	require.NoError(t, err)
+	require.Equal(t, "org-1", decoded.OrgID)
+	require.Equal(t, "acme", decoded.GitHubOrg)
+}
+
+func TestGitHubManifestStart_RejectsBadInput(t *testing.T) {
+	start := newGitHubManifestStart(testKeyGetter)
+	_, err := start(context.Background(), "org-1", "", "http://localhost:8080")
+	require.Error(t, err, "empty github org rejected")
+	_, err = start(context.Background(), "org-1", "acme", "not-a-url")
+	require.Error(t, err, "bad origin rejected")
+}

--- a/api/pkg/server/helix_org_github_manifest_test.go
+++ b/api/pkg/server/helix_org_github_manifest_test.go
@@ -76,12 +76,35 @@ func TestGitHubManifestStart_BuildsManifestAndPostURL(t *testing.T) {
 	// Callback + setup URLs carry the helix org and the caller's origin.
 	require.Equal(t, "http://localhost:8080/api/v1/orgs/org-1/github/app-manifest/callback", m.RedirectURL)
 	require.Equal(t, "http://localhost:8080/api/v1/orgs/org-1/github/app-setup", m.SetupURL)
+	// Loopback origin: no webhook url (GitHub rejects unreachable hooks).
+	require.Empty(t, m.HookAttributes, "localhost manifest must omit the hook url")
+	require.Empty(t, m.DefaultEvents)
 
 	// The state must decode back to the same org.
 	decoded, err := decodeGitHubManifestState(resp.State, testEncKey)
 	require.NoError(t, err)
 	require.Equal(t, "org-1", decoded.OrgID)
 	require.Equal(t, "acme", decoded.GitHubOrg)
+}
+
+func TestGitHubManifestStart_PublicOriginWiresWebhook(t *testing.T) {
+	start := newGitHubManifestStart(testKeyGetter)
+	resp, err := start(context.Background(), "org-1", "acme", "https://helix.example.com")
+	require.NoError(t, err)
+	var m githubManifest
+	require.NoError(t, json.Unmarshal([]byte(resp.Manifest), &m))
+	require.Equal(t, "https://helix.example.com/api/v1/orgs/org-1/github/webhook", m.HookAttributes["url"],
+		"public origin must wire the webhook")
+	require.NotEmpty(t, m.DefaultEvents)
+}
+
+func TestIsLoopbackOrigin(t *testing.T) {
+	for _, o := range []string{"http://localhost:8080", "http://127.0.0.1:8080", "http://0.0.0.0:8080", "https://foo.localhost"} {
+		require.True(t, isLoopbackOrigin(o), "%s should be loopback", o)
+	}
+	for _, o := range []string{"https://helix.example.com", "https://abc.trycloudflare.com", "http://10.0.0.5"} {
+		require.False(t, isLoopbackOrigin(o), "%s should be public", o)
+	}
 }
 
 func TestGitHubManifestStart_RejectsBadInput(t *testing.T) {

--- a/api/pkg/server/helix_org_github_manifest_test.go
+++ b/api/pkg/server/helix_org_github_manifest_test.go
@@ -73,9 +73,9 @@ func TestGitHubManifestStart_BuildsManifestAndPostURL(t *testing.T) {
 	require.Equal(t, "write", m.DefaultPermissions["pull_requests"])
 	require.Equal(t, "write", m.DefaultPermissions["issues"])
 	require.Equal(t, "read", m.DefaultPermissions["metadata"])
-	// Callback + setup URLs carry the helix org and the caller's origin.
+	// Callback URL carries the helix org and the caller's origin. No setup_url
+	// (it's optional; we reconcile the installation via GET /app/installations).
 	require.Equal(t, "http://localhost:8080/api/v1/orgs/org-1/github/app-manifest/callback", m.RedirectURL)
-	require.Equal(t, "http://localhost:8080/api/v1/orgs/org-1/github/app-setup", m.SetupURL)
 	// Loopback origin: no webhook url (GitHub rejects unreachable hooks).
 	require.Empty(t, m.HookAttributes, "localhost manifest must omit the hook url")
 	require.Empty(t, m.DefaultEvents)

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -810,6 +810,22 @@ func (apiServer *HelixAPIServer) registerRoutes(_ context.Context) (*mux.Router,
 					Handle("/orgs/{org}/streams/{stream_id}/github/webhook", orgHandlers.publicGitHubWebhookForStream).
 					Methods(http.MethodPost)
 			}
+			// GitHub App Manifest flow callbacks — top-level browser
+			// navigations from github.com (GET), so they must be on the
+			// insecure router (no session cookie / API key). The conversion
+			// callback authenticates via the encrypted ?state=. Registered
+			// before the authRouter /orgs/{org}/ prefix so these exact paths
+			// win the match.
+			if orgHandlers.publicGitHubManifestCallback != nil {
+				insecureRouter.
+					Handle("/orgs/{org}/github/app-manifest/callback", orgHandlers.publicGitHubManifestCallback).
+					Methods(http.MethodGet)
+			}
+			if orgHandlers.publicGitHubAppSetup != nil {
+				insecureRouter.
+					Handle("/orgs/{org}/github/app-setup", orgHandlers.publicGitHubAppSetup).
+					Methods(http.MethodGet)
+			}
 
 			// /api/v1/orgs/{org}/* — per-tenant surface for the
 			// org-graph resources (chart, workers, roles, positions,

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -821,11 +821,6 @@ func (apiServer *HelixAPIServer) registerRoutes(_ context.Context) (*mux.Router,
 					Handle("/orgs/{org}/github/app-manifest/callback", orgHandlers.publicGitHubManifestCallback).
 					Methods(http.MethodGet)
 			}
-			if orgHandlers.publicGitHubAppSetup != nil {
-				insecureRouter.
-					Handle("/orgs/{org}/github/app-setup", orgHandlers.publicGitHubAppSetup).
-					Methods(http.MethodGet)
-			}
 
 			// /api/v1/orgs/{org}/* — per-tenant surface for the
 			// org-graph resources (chart, workers, roles, positions,

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -9271,6 +9271,39 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/github/app-manifest": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: start the GitHub App manifest (create) flow",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.GitHubManifestStartResponse"
+                        }
+                    },
+                    "412": {
+                        "description": "manifest flow not wired",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/github/repos": {
             "get": {
                 "security": [
@@ -20244,13 +20277,31 @@
         "api.GitHubInstallationStatus": {
             "type": "object",
             "properties": {
+                "app_exists": {
+                    "description": "AppExists is true when a Helix GitHub App has been created/registered\nfor this org (a github_app ServiceConnection exists), even if not yet\ninstalled on any repo. Drives the gate's create-vs-install branch.",
+                    "type": "boolean"
+                },
                 "install_url": {
-                    "description": "InstallURL is where the New Stream gate sends the user to install the\napp (https://github.com/apps/\u003cslug\u003e/installations/new). Empty when the\noperator hasn't configured the app slug — the gate then tells the user\nto ask their admin to configure the Helix GitHub App.",
+                    "description": "InstallURL is where the New Stream gate sends the user to install the\napp (https://github.com/apps/\u003cslug\u003e/installations/new). Populated from\nthe created app's slug, or from GITHUB_APP_SLUG for a pre-existing app.",
                     "type": "string"
                 },
                 "installed": {
                     "description": "Installed is true when the Helix GitHub App has an installation for\nthis org (a github_app ServiceConnection with an installation id).",
                     "type": "boolean"
+                }
+            }
+        },
+        "api.GitHubManifestStartResponse": {
+            "type": "object",
+            "properties": {
+                "manifest": {
+                    "type": "string"
+                },
+                "post_url": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string"
                 }
             }
         },

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -20288,6 +20288,10 @@
                 "installed": {
                     "description": "Installed is true when the Helix GitHub App has an installation for\nthis org (a github_app ServiceConnection with an installation id).",
                     "type": "boolean"
+                },
+                "manage_url": {
+                    "description": "ManageURL is the app's developer-settings page on GitHub\n(github.com/organizations/\u003cowner\u003e/settings/apps/\u003cslug\u003e) — where you edit\npermissions, repos, and delete the app. Empty when the owner is unknown\n(e.g. a BYO app configured without it).",
+                    "type": "string"
                 }
             }
         },

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -9247,6 +9247,30 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/github/app-installation": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: GitHub App install status for the org",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.GitHubInstallationStatus"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/github/repos": {
             "get": {
                 "security": [
@@ -20214,6 +20238,19 @@
                 },
                 "to": {
                     "type": "string"
+                }
+            }
+        },
+        "api.GitHubInstallationStatus": {
+            "type": "object",
+            "properties": {
+                "install_url": {
+                    "description": "InstallURL is where the New Stream gate sends the user to install the\napp (https://github.com/apps/\u003cslug\u003e/installations/new). Empty when the\noperator hasn't configured the app slug — the gate then tells the user\nto ask their admin to configure the Helix GitHub App.",
+                    "type": "string"
+                },
+                "installed": {
+                    "description": "Installed is true when the Helix GitHub App has an installation for\nthis org (a github_app ServiceConnection with an installation id).",
+                    "type": "boolean"
                 }
             }
         },

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -58,6 +58,21 @@ definitions:
       to:
         type: string
     type: object
+  api.GitHubInstallationStatus:
+    properties:
+      install_url:
+        description: |-
+          InstallURL is where the New Stream gate sends the user to install the
+          app (https://github.com/apps/<slug>/installations/new). Empty when the
+          operator hasn't configured the app slug — the gate then tells the user
+          to ask their admin to configure the Helix GitHub App.
+        type: string
+      installed:
+        description: |-
+          Installed is true when the Helix GitHub App has an installation for
+          this org (a github_app ServiceConnection with an installation id).
+        type: boolean
+    type: object
   api.GitHubRepoDTO:
     properties:
       full_name:
@@ -17238,6 +17253,20 @@ paths:
       summary: List sandbox tmux sessions
       tags:
       - Sandboxes
+  /api/v1/orgs/{org}/github/app-installation:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.GitHubInstallationStatus'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: GitHub App install status for the org'
+      tags:
+      - HelixOrg
   /api/v1/orgs/{org}/github/repos:
     get:
       produces:

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -77,6 +77,13 @@ definitions:
           Installed is true when the Helix GitHub App has an installation for
           this org (a github_app ServiceConnection with an installation id).
         type: boolean
+      manage_url:
+        description: |-
+          ManageURL is the app's developer-settings page on GitHub
+          (github.com/organizations/<owner>/settings/apps/<slug>) — where you edit
+          permissions, repos, and delete the app. Empty when the owner is unknown
+          (e.g. a BYO app configured without it).
+        type: string
     type: object
   api.GitHubManifestStartResponse:
     properties:

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -60,18 +60,32 @@ definitions:
     type: object
   api.GitHubInstallationStatus:
     properties:
+      app_exists:
+        description: |-
+          AppExists is true when a Helix GitHub App has been created/registered
+          for this org (a github_app ServiceConnection exists), even if not yet
+          installed on any repo. Drives the gate's create-vs-install branch.
+        type: boolean
       install_url:
         description: |-
           InstallURL is where the New Stream gate sends the user to install the
-          app (https://github.com/apps/<slug>/installations/new). Empty when the
-          operator hasn't configured the app slug — the gate then tells the user
-          to ask their admin to configure the Helix GitHub App.
+          app (https://github.com/apps/<slug>/installations/new). Populated from
+          the created app's slug, or from GITHUB_APP_SLUG for a pre-existing app.
         type: string
       installed:
         description: |-
           Installed is true when the Helix GitHub App has an installation for
           this org (a github_app ServiceConnection with an installation id).
         type: boolean
+    type: object
+  api.GitHubManifestStartResponse:
+    properties:
+      manifest:
+        type: string
+      post_url:
+        type: string
+      state:
+        type: string
     type: object
   api.GitHubRepoDTO:
     properties:
@@ -17265,6 +17279,26 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: 'Helix-org: GitHub App install status for the org'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/github/app-manifest:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.GitHubManifestStartResponse'
+        "412":
+          description: manifest flow not wired
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: start the GitHub App manifest (create) flow'
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/github/repos:

--- a/api/pkg/types/oauth.go
+++ b/api/pkg/types/oauth.go
@@ -270,6 +270,11 @@ type ServiceConnection struct {
 	// github.com/apps/helix-acme). Populated by the Manifest flow; used to
 	// build the install URL after the app is created. Not secret.
 	GitHubAppSlug string `json:"github_app_slug,omitempty" gorm:"type:text"`
+	// GitHubAppOwner is the GitHub org the app was created under (e.g.
+	// "acme"). Used to build the developer-settings URL
+	// (github.com/organizations/<owner>/settings/apps/<slug>) where the app
+	// is managed/deleted. Not secret.
+	GitHubAppOwner string `json:"github_app_owner,omitempty" gorm:"type:text"`
 
 	// Azure DevOps Service Principal credentials (encrypted at rest)
 	ADOOrganizationURL string `json:"ado_organization_url,omitempty"`

--- a/api/pkg/types/oauth.go
+++ b/api/pkg/types/oauth.go
@@ -266,6 +266,10 @@ type ServiceConnection struct {
 	GitHubAppID          int64  `json:"github_app_id,omitempty"`
 	GitHubInstallationID int64  `json:"github_installation_id,omitempty"`
 	GitHubPrivateKey     string `json:"-" gorm:"type:text"` // PEM-encoded, sensitive
+	// GitHubAppSlug is the app's public URL slug (e.g. "helix-acme" →
+	// github.com/apps/helix-acme). Populated by the Manifest flow; used to
+	// build the install URL after the app is created. Not secret.
+	GitHubAppSlug string `json:"github_app_slug,omitempty" gorm:"type:text"`
 
 	// Azure DevOps Service Principal credentials (encrypted at rest)
 	ADOOrganizationURL string `json:"ado_organization_url,omitempty"`

--- a/design/2026-06-06-github-bot-provisioning.md
+++ b/design/2026-06-06-github-bot-provisioning.md
@@ -1,0 +1,558 @@
+# Provisioning a GitHub "service account / robot" for Helix agents
+
+**Date:** 2026-06-06 (last updated 2026-06-08)
+**Status:** Design agreed — no implementation yet.
+**Decision (2026-06-08):** **Option 1 — every Helix deployment owns its own GitHub
+App.** The default setup is the **App Manifest flow** (one-click self-registration,
+pre-configured by a Helix-supplied manifest); "bring your own app credentials" is
+the override. Helix Cloud is just one deployment of this model (it owns the
+`helixml` app). **There is no shared app whose private key ships to customers** —
+see §4.5 for why that is rejected on security grounds.
+**Author:** design session (Phil + Claude)
+
+---
+
+## 1. The problem
+
+Helix Workers (org-graph runtime) and Sandboxes run `git` and `gh` against the
+user's GitHub repos — clone, branch, commit, push, open PRs, manage issues. They
+need GitHub credentials.
+
+Today they borrow a **human's** credentials. `newGitHubOAuthResolver`
+(`api/pkg/server/helix_org_github.go:40-100`) walks the org's members, finds the
+first member with a valid GitHub OAuth connection, and returns *that person's*
+access token. The github transport's secret injector
+(`api/pkg/org/infrastructure/transports/github/secret_injector.go:30-46`) then
+upserts it as the `GH_TOKEN` project secret on every worker activation.
+
+Consequences of borrowing a human identity:
+
+- **Wrong attribution.** Commits/PRs/comments show up as a real employee. Audit
+  trails lie about who did what.
+- **Fragile.** If that person revokes the OAuth grant, leaves the org, or rotates
+  creds, every Worker silently loses GitHub access ("first valid token" roulette).
+- **Over-broad.** A user OAuth token carries *all* of that user's scopes across
+  *all* their repos/orgs — far more than one project needs.
+- **Rate limits charged to a person**, shared across everything they do.
+
+What the user wants: an easy, in-Helix way to give agents their **own**
+GitHub identity — a "service account / robot account" — ideally created on the
+user's behalf using the OAuth we already have.
+
+---
+
+## 2. The hard constraint (answering the literal question first)
+
+> "Is it possible to create a bot [user] on behalf of the user via OAuth?"
+
+**No — not a GitHub *user* account.** Two independent blockers:
+
+1. **No API.** GitHub exposes no endpoint to create a login. Sign-up is a
+   human-only web flow (email verification, CAPTCHA).
+2. **ToS forbids it.** "You must be a human to create an Account; accounts
+   registered by 'bots' or other automated methods are not permitted." Machine
+   accounts are allowed, but only when **a human** registers them and takes
+   responsibility, and you may keep **at most one free machine account**.
+
+OAuth doesn't change this. An OAuth (user-to-server) token authenticates an
+*existing human* and acts **as** that human. There is no scope that mints a new
+identity.
+
+**However** — there is a way to create a *bot* on the user's behalf with an
+OAuth-shaped one-click consent. The bot is a **GitHub App**, not a user account,
+and it's created via the **GitHub App Manifest flow** (§4.2). This is both the
+honest answer to the question and the technically superior one.
+
+---
+
+## 3. The four real identity primitives, ranked
+
+| Primitive | What it is | Own identity? | Create on user's behalf? | Token lifetime | Rotatable | Rate limit | GHES / air-gap | Best for |
+|---|---|---|---|---|---|---|---|---|
+| **GitHub App** ✅ | First-class bot (`name[bot]`) | Yes (`app[bot]`) | **Yes — Manifest flow** | Installation token, **1h, auto-mint** | Yes (key rotation) | Per-installation, scales (5k–15k/h) | Yes | **Agents doing repo automation** |
+| Machine user + fine-grained PAT | A human-made bot login | Yes (named acct) | Partly — acct manual, rest automatable | PAT, months/long-lived | Manual only | Per-user, shared | Yes | Named bot, App-incompatible ops |
+| User's own fine-grained PAT / OAuth | The human | No | n/a (it *is* them) | OAuth refreshable / PAT long | — | The human's | Yes | Quick start, single-user |
+| Deploy key (SSH) | Per-repo git key | No (repo-scoped) | Yes (API, via user token) | Long-lived key | Manual | n/a (git only) | Yes | git-only, single repo, no API |
+
+**Recommendation: GitHub App is the primary answer.** It is literally GitHub's
+"service account" replacement: independent identity, fine-grained per-repo
+permissions, short-lived auto-refreshed tokens, clean revocation (uninstall),
+higher rate limits, and it works on GitHub Enterprise Server. Everything else is
+a fallback for the cases an App can't cover.
+
+---
+
+## 4. Recommended design: GitHub App as the bot
+
+### 4.0 What already exists in Helix (verified 2026-06-07)
+
+A code audit found that the GitHub App foundations are **already present** — there
+are three separate App-related pieces, but **no shared operator-level app**. The
+remaining work is wiring + flows, not foundations.
+
+- **Token minter already built & working.** `NewClientWithGitHubApp(appID,
+  installationID, privateKey, baseURL)` at
+  `api/pkg/agent/skill/github/client.go:70-100` uses
+  `bradleyfalzon/ghinstallation/v2` (in `go.mod`) to sign the RS256 JWT and
+  auto-mint/refresh 1-hour installation tokens. **Phase 1's minter is effectively
+  done** — it just isn't called from the worker path.
+- **Per-repo App auth is live in production.**
+  `api/pkg/services/git_repository_service_pull_requests.go:618-628` reads
+  `GitRepository.GitHub.{AppID,InstallationID,PrivateKey}` and prefers App auth
+  over OAuth/PAT when opening PRs.
+- **Per-org `ServiceConnection` is fully wired** — store CRUD
+  (`store_service_connection.go`), REST routes (`server.go:1586-1591`), handlers
+  with private-key encryption + a `/test` endpoint
+  (`service_connection_handlers.go`), and frontend UI
+  (`frontend/src/components/dashboard/ServiceConnectionsTable.tsx`). **But no
+  production code mints worker tokens from it** — it's a credential store with a
+  test button and no runtime reader.
+
+**The real gaps (given the §4.1 single-app model):**
+- **No runtime reader.** Nothing mints worker tokens from a `ServiceConnection` —
+  the worker resolver still uses the human-OAuth path. (Phase 1.)
+- **No self-serve way to obtain/install an app.** No manifest flow and no
+  install-gate UI, so a `ServiceConnection` can only be populated by hand today.
+  (Phases 2–3.)
+- Note: `config.GitHub` (`config.go:607-613`) is OAuth-only — and that's fine, we
+  are **not** adding operator app config (the app lives in `ServiceConnection`, not
+  config; see §4.5 for why a config-resident shared key is rejected).
+
+### 4.1 The single model: each deployment owns its own app
+
+There is **one** model, applied uniformly to Helix Cloud and every self-hosted
+install:
+
+- **Each Helix deployment holds its own GitHub App credentials** (`app_id` +
+  `private_key` + optional webhook secret), encrypted at rest in that deployment's
+  own store. Nobody shares a private key with anyone else.
+- **The default way to obtain those credentials is the App Manifest flow** (§4.2):
+  one click, pre-configured by a Helix-supplied manifest (name, logo, the exact
+  permission set), so it *feels* like "the default Helix app" while actually
+  minting a fresh app owned by the customer's own GitHub org/account.
+- **Override:** a customer who already has a GitHub App can paste its `app_id` +
+  PEM instead of running the manifest flow. Same storage, same downstream.
+- **Helix Cloud is not special.** It is one deployment that happens to own the
+  `helixml`-org app. Architecturally it runs the identical path. This collapses
+  the codebase to a single credential path instead of a shared-operator-app path
+  plus a per-org path.
+
+Storage: app credentials live in the existing **`ServiceConnection`** model
+(`api/pkg/types/oauth.go:246-282`, already has `GitHubAppID` /
+`GitHubInstallationID` / encrypted `GitHubPrivateKey`), scoped per Helix org. The
+manifest flow writes one; the BYO-app override writes one; the worker resolver
+reads it. No separate operator-config app, no `OrgGitHubInstallation` side table.
+
+> **Why not a single shared app with the key in operator config (the earlier
+> "Variant A")?** Because for self-hosted that key would have to ship to customer
+> infra, and a distributed minting key is a cross-tenant compromise. Rejected —
+> see §4.5.
+
+### 4.2 The Manifest flow — the default, zero-config setup path
+
+A handshake that mirrors OAuth; the whole thing must complete within **1 hour**:
+
+1. **User clicks** "Create a GitHub bot for this org" in Helix (scoped to a Helix
+   org → a chosen GitHub org).
+2. **Helix builds a manifest** (JSON): name (`helix-<org>`), `url`,
+   `hook_attributes.url` (Helix webhook), `redirect_url` (Helix callback),
+   `public: false`, and crucially `default_permissions` — the minimum set, e.g.
+   `contents: write`, `pull_requests: write`, `issues: write`, `metadata: read`
+   (+ `workflows: write` only if agents touch Actions). Helix stores a `state`
+   nonce — **reuse the existing `OAuthRequestToken` table**
+   (`api/pkg/types/oauth.go:88-100`) for CSRF, same as the OAuth flow.
+3. **Auto-submitting form** POSTs the manifest to
+   `https://github.com/organizations/<org>/settings/apps/new?state=<nonce>`
+   (org-owned — preferred so the bot belongs to the org, not a person). The user
+   must be a GitHub org owner; otherwise fall back to the user-owned
+   `https://github.com/settings/apps/new`.
+4. **User reviews** the permission list on GitHub and clicks "Create GitHub App."
+5. **GitHub redirects** to Helix `redirect_url?code=<temp>&state=<nonce>`.
+6. **Helix exchanges** the code: `POST https://api.github.com/app-manifests/<code>/conversions`
+   → returns `{ id, slug, pem (private key), webhook_secret, client_id,
+   client_secret, ... }`. (Code valid 1h.)
+7. **Helix persists** it — encrypt `pem` + secrets (AES-256-GCM, already used at
+   `api/pkg/crypto/encryption.go`) into a `ServiceConnection`
+   (`api/pkg/types/oauth.go:246-282` — the model *already has* `GitHubAppID`,
+   `GitHubInstallationID`, `GitHubPrivateKey`). Scope it to the Helix org.
+8. **Install it immediately:** redirect to
+   `https://github.com/apps/<slug>/installations/new` so the user picks which
+   repos. The post-install callback gives `installation_id`; store it on the
+   `ServiceConnection`.
+
+After this the org has `app_id` + `private_key` + `installation_id` = a fully
+owned bot, created with two consent clicks and no manual account creation.
+
+On **GitHub Enterprise Server** the same flow works against the instance host
+(`https://<ghes-host>/organizations/<org>/settings/apps/new` and
+`/api/v3/app-manifests/...`) — important for the air-gapped/enterprise customers
+in CLAUDE.md.
+
+### 4.3 Minting & injecting tokens
+
+This is the part to build once; it is identical regardless of how the app
+credentials were obtained (manifest or BYO).
+
+1. **App JWT:** sign a short-lived (≤10 min) RS256 JWT with the app private key
+   (`iss = app_id`).
+2. **Installation token:** `POST /app/installations/<installation_id>/access_tokens`.
+   Optionally pass `repository_ids` + a `permissions` subset to **scope the token
+   down to exactly the repos/permissions a given Worker's project needs** (least
+   privilege per worker). Returns a token valid **1 hour**.
+3. **Cache** the token keyed by `(installation_id, repo-set, perm-set)` with its
+   `expires_at`; re-mint on demand when within ~5 min of expiry. (The OAuth
+   manager already runs a 1-minute refresh loop, `api/pkg/oauth/manager.go:77-78`
+   — model the installation-token refresher on it, or mint lazily at injection.)
+4. **Inject into the worker** via the *existing* secret-injector seam
+   (`secret_injector.go`). Swap its `TokenResolver` from "first human OAuth token"
+   to "installation token for this org's `ServiceConnection`, scoped to this
+   project's repos." Two outputs:
+   - `GH_TOKEN` for the `gh` CLI.
+   - a git credential helper / `https://x-access-token:<token>@github.com/...`
+     URL rewrite for raw `git`.
+5. **Attribution:** commits land as `helix-<org>[bot]` with noreply email
+   `<app-id>+<slug>[bot]@users.noreply.github.com`. Set `git config user.name/email`
+   in the worker startup script to match so authorship is clean.
+
+Because tokens are 1h and re-minted, a leaked worker token self-expires — far
+safer than today's long-lived borrowed human token.
+
+### 4.4 How it maps onto existing Helix code
+
+| Need | Existing anchor | Change |
+|---|---|---|
+| Store app creds (app_id + PEM + installation_id) | `ServiceConnection` w/ `GitHubAppID`/`InstallationID`/`PrivateKey` (`types/oauth.go:246-282`) | Already exists — the **single** home for app creds; manifest flow and BYO both write here. No separate operator-config app, no side table |
+| Encrypt key | `crypto.EncryptAES256GCM` (`crypto/encryption.go`) | Reuse; ensure `HELIX_ENCRYPTION_KEY` is set (insecure default warning at lines 38-40) |
+| CSRF / state | `OAuthRequestToken` (`types/oauth.go:88-100`) | Reuse for manifest + install state |
+| Mint installation token | **Already exists:** `NewClientWithGitHubApp` (`agent/skill/github/client.go:70-100`, `ghinstallation/v2`) signs the JWT + auto-refreshes 1h tokens | Reuse as-is; just call it from the worker resolver |
+| Resolve token for worker | `newGitHubOAuthResolver` (`helix_org_github.go:40-100`) | Replace/extend: prefer App installation token (from `ServiceConnection`); fall back to OAuth/PAT |
+| Inject into worker | `secret_injector.go` + spawn hooks (`spawn_hooks.go:33-117`) | Point resolver at installation tokens; add git credential output |
+| PAT fallback store | `GitProviderConnection` w/ encrypted `Token` (`types/oauth.go:169-205`) | Already exists — reuse for §6 |
+
+The pleasant surprise: the data model for the App path largely **already exists**.
+The work is the flows (manifest/install), the token minter, and re-pointing the
+resolver.
+
+### 4.5 Rejected alternatives (do not re-propose without reading this)
+
+**(A) One shared "Helix" app whose private key ships to / is configured on every
+deployment.** *Rejected — cross-tenant compromise.* The app private key (PEM) is a
+**minting key**: anyone holding it can mint installation tokens for **every org
+that installed that app**, including other customers'. The moment that key sits on
+self-hosted customer infra, any customer can extract it from their own box and
+mint `helix[bot]` tokens against *other* customers' repos. A secret distributed to
+mutually-untrusting parties is not a secret. This is fatal specifically because we
+ship to self-hosted infra; it would be merely "centralized risk" if Helix were
+Cloud-only. Either way, the manifest model is strictly better, so the shared app
+buys nothing.
+
+**(B) Central token broker — Helix Cloud holds the one PEM and mints tokens for
+self-hosted instances on request.** *Rejected — breaks air-gap, creates a token
+oracle.* It keeps a single `helix[bot]` identity and never ships the PEM, but: (1)
+every self-hosted instance now depends on Helix Cloud at runtime for GitHub access
+(impossible for air-gapped/GHES, which CLAUDE.md calls out as first-class); (2)
+Helix Cloud becomes a minting oracle that must authorize *which* instance may mint
+for *which* installation — a serious authz surface and liability concentration.
+The single-app-per-deployment model avoids all of this. Keep this option only in
+mind if a future requirement *demands* one global bot identity across all
+self-hosted installs (it doesn't today).
+
+**(C) Borrow a human's OAuth token (the status quo).** *Rejected — see §1.* Wrong
+attribution, fragile, over-broad, shared rate limits. This is the thing we are
+replacing.
+
+### 4.6 Surfacing it in the product: install once, then act as the bot
+
+**Core principle (decided 2026-06-08):** the user's own GitHub credentials are used
+in **exactly one place — the one-time install of the Helix App.** After that,
+*everything* — listing repos in the New Stream picker, the worker's `git`/`gh`,
+outbound actions — runs on the **bot's installation token**. The user's account is
+never used for data access again. This is the inversion of an earlier draft that
+kept the repo picker on the user's OAuth token.
+
+Consequence (intended, least-privilege): the picker shows **only the repos the app
+is installed on**. To add a repo, the user re-opens the app's "Configure" screen on
+GitHub and grants it — they don't pick from their full personal repo list. A repo
+the bot can't see is a repo the bot can't operate on, so showing it would be a lie.
+
+The trigger UX lives in the **New Stream** dialog
+(`frontend/src/pages/HelixOrgStreams.tsx:298-669`). Today it gates on a GitHub
+**OAuth** connection (`ghConnected` from `useListGitHubRepos`, `:320-322`; the
+"Connect GitHub for streams" box, `:548-570`). That gate is **replaced** by a
+single **"Install Helix"** gate:
+
+1. **Is the app installed for this org?** Cheapest check: does the org have a
+   `github_app` `ServiceConnection` with a non-zero `installation_id`? (The
+   `installation_id` was captured at install time — see step 3.) No network call
+   needed for the common case.
+2. **If not installed → the bootstrap gate.** Render the styled box with an
+   **"Install Helix"** button that opens
+   `https://github.com/apps/<slug>/installations/new` in a popup. **This is the only
+   step that uses the user's GitHub identity** — their github.com session drives the
+   consent; they choose the account/org + repos. (Note: this does *not* require
+   Helix's separate GitHub OAuth app at all — so the old "Connect GitHub OAuth"
+   prerequisite can be dropped, not stacked on top.)
+3. **Capturing the result.** Set the app's **Setup URL** to a Helix callback; GitHub
+   redirects there post-install with `?installation_id=...`. Helix writes it onto
+   the org's `ServiceConnection` and `postMessage`s the dialog to refetch. (v1 ship-
+   early fallback: an "I've installed it — re-check" button + refetch on window
+   focus, if the Setup-URL callback isn't wired yet.)
+4. **Once installed → the repo picker runs on the bot.** `listGitHubRepos` mints an
+   installation token (the §4.3 minter) and calls `GET /installation/repositories`
+   (go-github `Apps.ListRepos`) — the repos the bot can act on. No user token.
+5. **Create the stream / hire the worker.** All downstream GitHub access (worker
+   `git`/`gh`, outbound transport) uses the same installation token.
+
+So there is no "second gate" and no per-repo probe — the model is binary per org
+("is Helix installed?") and bot-centric everywhere after. The app JWT / 
+`GET /repos/{owner}/{repo}/installation` probe from the earlier draft is no longer
+needed; presence of a stored `installation_id` is the source of truth.
+
+---
+
+## 5. What a GitHub App *can't* do (know the edges)
+
+Apps cover repo automation completely (contents, PRs, issues, checks, Actions,
+releases, deployments). They **cannot**: act as a human reviewer in every UI
+context, star/follow/sponsor, or do a handful of user-only operations. If a use
+case needs those, that's when the machine-user fallback (§6) earns its place.
+
+---
+
+## 6. Fallback: guided machine-user + fine-grained PAT
+
+For when an App is impossible or unwanted — a customer who insists on a
+named human-looking account, an op an App can't do, or a locked-down GHES where
+app registration is disabled.
+
+Since account creation can't be automated, make the **guided** path smooth and
+automate everything *around* it using the requesting user's OAuth token (which,
+with `admin:org`, can manage org membership/teams/repo access):
+
+1. **Wizard step 1 (manual):** "In an incognito window, create a GitHub account
+   `acme-helix-bot` with email `bot+helix@acme.com`." (Respect the one-free-
+   machine-account ToS limit.)
+2. **Wizard step 2 (manual):** "Create a **fine-grained PAT**, scoped to *these*
+   repos with *these* permissions" — Helix shows a copy-paste list and a deep
+   link. Fine-grained PATs support expiry + per-repo scoping + org approval.
+3. **Wizard step 3 (paste):** user pastes the PAT; Helix encrypts it into the
+   existing `GitProviderConnection` (`types/oauth.go:169-205`).
+4. **Helix automates the rest** via the requesting user's OAuth token: invite the
+   machine user to the org, add to a `helix-bots` team, grant repo access. So the
+   *only* manual steps are account creation + PAT paste.
+
+Downsides vs the App: long-lived secret, no auto-rotation (PATs can't be minted
+by API — only created in the UI), manual steps, the ToS one-account cap. Use only
+when the App path genuinely doesn't fit.
+
+---
+
+## 7. Security considerations
+
+- **Short-lived >> long-lived.** Installation tokens (1h, auto-mint) are the
+  whole security win over today's borrowed token and over PATs.
+- **The private key is the crown jewel.** Already AES-256-GCM encrypted; ensure
+  `HELIX_ENCRYPTION_KEY` is set in every deployment (there's an insecure fallback
+  today). Support GitHub's multiple-active-keys feature for zero-downtime
+  rotation.
+- **Least privilege per worker.** Mint installation tokens scoped to a project's
+  `repository_ids` + minimal `permissions`, not the whole installation.
+- **Webhook secret verification** on the manifest-provided secret.
+- **Auditability.** App actions are attributable to the bot and appear in the org
+  audit log — the opposite of today's "which human was it" ambiguity.
+- **Blast radius is contained by design.** Each deployment owns a distinct app
+  key, so a key compromise is limited to that one deployment's installs — never
+  cross-tenant. This is the whole reason the shared-key model was rejected (§4.5).
+
+---
+
+## 8. Phased implementation plan
+
+**Decision (2026-06-08): Option 1 — single self-owned-app model.** Everything sits
+behind the *already-built* token minter (`NewClientWithGitHubApp`) reading the
+*already-wired* `ServiceConnection` store. Order below is dependency-driven, not
+Cloud-vs-self-hosted.
+
+- **Phase 1 — unify GitHub identity on the bot (assumes an app is installed; full
+  plan in §10).** Centralize identity resolution: if the org has a GitHub-App
+  `ServiceConnection` with an `installation_id`, *every* GitHub touchpoint (repo
+  picker, worker `git`/`gh`, outbound transport, webhook install) uses an
+  installation token; else fall back to today's OAuth path. The repo picker switches
+  to `GET /installation/repositories` in app mode. Seed one `ServiceConnection`
+  manually via the existing UI to test. Fixes "agents act as a human" *and* makes the
+  picker bot-scoped, wherever an app is configured.
+- **Phase 2 — the New Stream install bootstrap (§4.6).** Replace the OAuth-connect
+  gate with a single **"Install Helix"** gate: open
+  `https://github.com/apps/<slug>/installations/new` (the one place the user's
+  GitHub identity is used), capture `installation_id` via the app's Setup-URL
+  callback (v1 fallback: "I've installed it — re-check" button), persist it onto the
+  org's `ServiceConnection`. This is what makes Phase 1 self-serve.
+- **Phase 3 — the manifest flow (§4.2), the default zero-config setup.** "Set up
+  GitHub for Helix" → manifest → conversion → write `ServiceConnection`. Plus the
+  BYO-app override (paste app_id + PEM). This is what lets a fresh self-hosted
+  deployment get an app at all without manual GitHub registration. (Helix Cloud's
+  `helixml` app can be seeded once manually, so Cloud doesn't block on this.)
+- **Phase 4 — hardening.** Per-worker scoped tokens (`repository_ids` + permission
+  subset), Setup-URL callback for auto-capturing `installation_id` (§4.6 v2), key
+  rotation, GHES base URLs, startup-script `git config` for clean authorship.
+- **Phase 5 — PAT/machine-user fallback wizard** for the App-incompatible cases (§6).
+
+Each phase is independently shippable. Phase 1 delivers most of the value for any
+deployment that has an app; Phases 2–3 make obtaining/installing the app self-serve.
+
+---
+
+## 9. Recommendation in one paragraph
+
+Don't try to create a GitHub *user* account — it's against ToS and has no API.
+Instead make the bot a **GitHub App**, which is GitHub's actual service-account
+primitive. **Every Helix deployment owns its own app** (Helix Cloud included); the
+default way to get one is the **App Manifest flow** (one-click, Helix-pre-configured
+self-registration), with "paste your own app credentials" as the override. **No
+private key is ever shared across deployments** — that would be a cross-tenant
+compromise (§4.5). Each deployment mints **short-lived per-installation tokens**
+with its own key and injects them through the secret-injector seam Helix already
+has, scoped per project — replacing the borrowed-human-token resolver that exists
+today. The `ServiceConnection` store, encryption, token minter, and injection
+plumbing already exist; the net-new work is the manifest + install-gate flows
+(surfaced in the New Stream dialog, §4.6) and re-pointing the resolver. Keep a
+guided machine-user + fine-grained-PAT wizard as the fallback for the few things an
+App can't do.
+
+---
+
+## 10. Phase 1 — code-level implementation plan (corrected 2026-06-08 for the bot-everywhere model)
+
+**Goal:** once an org has an installed Helix App, the org's GitHub identity **is**
+the bot for *all* data access and actions — repo listing in the picker, worker
+`git`/`gh`, outbound transport, webhook install. The user's OAuth token is retained
+**only** as a legacy fallback for orgs that have not installed an app yet. (The
+user's GitHub identity is used solely by the §4.6 install bootstrap, which is Phase
+2 UI; for Phase 1 the `installation_id` is seeded manually via the existing
+`ServiceConnection` UI so the bot path is testable in isolation.)
+
+This is **not** the earlier "one wiring line." Because the repo picker must now list
+the *installation's* repos, and an installation token cannot call `/user/repos`,
+the identity resolution is centralized and several call sites change. Honest scope:
+a small refactor, not a one-liner.
+
+### 10.0 Centralize identity resolution
+
+Today `gitHubTokenResolver` (`helix_org.go:240`) is `func(ctx, orgID) (string,
+error)` and five sites consume the bare token. Replace it with an **identity
+resolver** that returns enough to both mint and branch by mode:
+
+```go
+type OrgGitHubIdentity struct {
+    Mode           string // "app" | "oauth"
+    Token          string // installation token (app) or user OAuth token (oauth)
+    AppID          int64  // app mode
+    InstallationID int64  // app mode
+    BaseURL        string // GHES; "" = github.com
+}
+// app installed for org → mint installation token (Mode=app);
+// else → existing OAuth walk (Mode=oauth); both empty → Mode="oauth", Token="".
+func newOrgGitHubIdentityResolver(getKey func() ([]byte, error), st store.Store,
+    oauthFallback func(context.Context, string) (string, error),
+    mintFn func(ctx context.Context, appID, installationID int64, pem, baseURL string) (string, error),
+) func(context.Context, string) (OrgGitHubIdentity, error)
+```
+
+Selection logic: `ListServiceConnectionsByType(ctx, orgID,
+ServiceConnectionTypeGitHubApp)` → newest with `AppID!=0 && InstallationID!=0 &&
+PrivateKey!=""` → `crypto.DecryptAES256GCM(conn.GitHubPrivateKey, key)` →
+`mintFn(...)`. **On any app-side miss/error: log + fall through to the OAuth walk** —
+a broken app config must never break an org OAuth could still serve.
+
+### 10.1 New code
+
+**(a) Raw installation-token minter** — `agent/skill/github/client.go`. Sibling of
+`NewClientWithGitHubApp` (which builds a client but never exposes the token):
+
+```go
+func MintInstallationToken(ctx context.Context, appID, installationID int64, privateKey, baseURL string) (string, error) {
+    itr, err := ghinstallation.New(http.DefaultTransport, appID, installationID, []byte(privateKey))
+    if err != nil { return "", fmt.Errorf("github app transport: %w", err) }
+    if baseURL != "" { itr.BaseURL = strings.TrimSuffix(baseURL, "/") + "/api/v3" }
+    return itr.Token(ctx) // live POST /app/installations/{id}/access_tokens
+}
+```
+
+**(b) Installation-repo listing** — `agent/skill/github/client.go`. The picker in
+app mode lists the *installation's* repos, not the user's. Add a method on the
+existing `*Client` (built via `NewClientWithGitHubApp`) wrapping go-github
+`Apps.ListRepos` (`GET /installation/repositories`):
+
+```go
+func (c *Client) ListInstallationRepositories(ctx context.Context) ([]*github.Repository, error)
+```
+
+**(c) Identity resolver** (§10.0) — `server/helix_org_github.go`, alongside the
+existing `newGitHubOAuthResolver` (which it reuses as the `oauthFallback`).
+
+### 10.2 Consumer changes (the five sites)
+
+| Site | Today | Change |
+|---|---|---|
+| Worker `GH_TOKEN` injector (`helix_org.go:250` → `secret_injector.go`) | OAuth token | use `identity.Token` (bot in app mode) |
+| Repo picker `listGitHubRepos` (`api.go:1965`) | OAuth → `ListRepositories` (`/user/repos`) | **branch on mode:** app → `ListInstallationRepositories`; oauth → unchanged |
+| Outbound transport `WithTokenResolver` (`api.go:1917`) | OAuth token | use `identity.Token` |
+| Webhook install (`api.go:2114`) | OAuth (`admin:repo_hook`) | use `identity.Token` (bot needs Webhooks permission on the app; else keep OAuth — verify perm) |
+| Public webhook outbound (`helix_org.go:342`) | OAuth token | use `identity.Token` |
+
+The `Deps.GitHubTokenResolver` field type changes from returning a string to
+returning `OrgGitHubIdentity` (or add a parallel `Deps.GitHubIdentity` and migrate
+sites incrementally). `cfg.APIServer.getEncryptionKey` (`utils.go:103`) is in scope
+at `helix_org.go:240` to pass as `getKey`.
+
+> **Optional staging:** 1a = worker injector + repo picker (the visible "act as the
+> bot"); 1b = outbound transport + webhook install + public webhook. Both land
+> behind the same resolver; 1a is the demoable slice.
+
+### 10.3 Known limitations (each maps to a later phase, document in code)
+
+- **1h token expiry.** `GH_TOKEN` is injected statically per activation; minted
+  tokens die after 1h, so workers running >1h lose git/gh auth mid-run — a lifetime
+  regression vs the long-lived OAuth token. **Fix = Phase 4** re-minting git
+  credential helper. Acceptable + flagged for Phase 1.
+- **Installation-wide scope.** Resolver has only `orgID`, so it mints an
+  installation-wide token, not the project's repo subset. **Least-privilege = Phase 4.**
+- **Author identity.** Push *attribution* follows the token (→ `[bot]`), but commit
+  `user.name/email` come from the worker's git config — set them to the bot noreply
+  email in the worker startup script. **Phase 4.**
+- **Picker shows installed repos only** (intended; §4.6). Not a regression to fix —
+  a behavior change to communicate in the UI copy.
+
+### 10.4 Test plan
+
+- **Unit** (`helix_org_github_test.go`, gomock `MockStore`, `mintFn` stubbed):
+  (1) no app conn → `Mode=oauth`, OAuth token; (2) app conn → `Mode=app`, decrypted
+  PEM + stubbed token; (3) two app conns → newest chosen; (4) mint error → falls
+  back to OAuth. (`Token()` is a live call — that's why `mintFn` is a seam.)
+- **Build:** `go build ./pkg/server/ ./pkg/agent/skill/github/ ./pkg/org/... ./pkg/store/ ./pkg/types/`.
+- **E2E (inner Helix):** seed a `github_app` ServiceConnection via the existing
+  `ServiceConnectionsTable` UI (test `helixml` app creds) → open New Stream → confirm
+  the repo picker lists *installation* repos → hire a worker → confirm `gh auth
+  status` + a test push land as `<slug>[bot]`.
+
+### 10.5 Files touched
+
+| File | Change |
+|---|---|
+| `api/pkg/agent/skill/github/client.go` | + `MintInstallationToken`, + `ListInstallationRepositories` |
+| `api/pkg/server/helix_org_github.go` | + `newOrgGitHubIdentityResolver` (reuses `newGitHubOAuthResolver`) |
+| `api/pkg/server/helix_org.go` | resolver construction + injector wiring (~240-250, ~342) |
+| `api/pkg/org/interfaces/server/api/api.go` | `Deps` type change; `listGitHubRepos` mode branch; transport + webhook sites |
+| `api/pkg/server/helix_org_github_test.go` | + unit tests (new file) |
+
+Bigger than the earlier estimate (the `Deps` type change + picker-endpoint branch
+ripple across `api.go`), but still **no schema change and no new config** — the
+store query, model, encryption, and ghinstallation dep all already exist.
+
+---
+
+### Sources
+- [Registering a GitHub App from a manifest — GitHub Docs](https://docs.github.com/en/apps/sharing-github-apps/registering-a-github-app-from-a-manifest)
+- [GitHub Terms of Service (machine accounts / no bot-created accounts)](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service)
+- [Types of GitHub accounts — GitHub Docs](https://docs.github.com/en/get-started/learning-about-github/types-of-github-accounts)
+- [Create a GitHub App from a manifest — Xebia](https://xebia.com/blog/create-a-github-app-from-a-manifest/)

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -44,6 +44,21 @@ export interface ApiEventCard {
   to?: string;
 }
 
+export interface ApiGitHubInstallationStatus {
+  /**
+   * InstallURL is where the New Stream gate sends the user to install the
+   * app (https://github.com/apps/<slug>/installations/new). Empty when the
+   * operator hasn't configured the app slug — the gate then tells the user
+   * to ask their admin to configure the Helix GitHub App.
+   */
+  install_url?: string;
+  /**
+   * Installed is true when the Helix GitHub App has an installation for
+   * this org (a github_app ServiceConnection with an installation id).
+   */
+  installed?: boolean;
+}
+
 export interface ApiGitHubRepoDTO {
   full_name?: string;
   private?: boolean;
@@ -11528,6 +11543,24 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     v1OrganizationsSandboxesTerminalSessionsDetail: (orgId: string, id: string, params: RequestParams = {}) =>
       this.request<ServerSandboxTerminalSessionsResponse, any>({
         path: `/api/v1/organizations/${orgId}/sandboxes/${id}/terminal/sessions`,
+        method: "GET",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsGithubAppInstallationDetail
+     * @summary Helix-org: GitHub App install status for the org
+     * @request GET:/api/v1/orgs/{org}/github/app-installation
+     * @secure
+     */
+    v1OrgsGithubAppInstallationDetail: (org: string, params: RequestParams = {}) =>
+      this.request<ApiGitHubInstallationStatus, any>({
+        path: `/api/v1/orgs/${org}/github/app-installation`,
         method: "GET",
         secure: true,
         format: "json",

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -46,10 +46,15 @@ export interface ApiEventCard {
 
 export interface ApiGitHubInstallationStatus {
   /**
+   * AppExists is true when a Helix GitHub App has been created/registered
+   * for this org (a github_app ServiceConnection exists), even if not yet
+   * installed on any repo. Drives the gate's create-vs-install branch.
+   */
+  app_exists?: boolean;
+  /**
    * InstallURL is where the New Stream gate sends the user to install the
-   * app (https://github.com/apps/<slug>/installations/new). Empty when the
-   * operator hasn't configured the app slug — the gate then tells the user
-   * to ask their admin to configure the Helix GitHub App.
+   * app (https://github.com/apps/<slug>/installations/new). Populated from
+   * the created app's slug, or from GITHUB_APP_SLUG for a pre-existing app.
    */
   install_url?: string;
   /**
@@ -57,6 +62,12 @@ export interface ApiGitHubInstallationStatus {
    * this org (a github_app ServiceConnection with an installation id).
    */
   installed?: boolean;
+}
+
+export interface ApiGitHubManifestStartResponse {
+  manifest?: string;
+  post_url?: string;
+  state?: string;
 }
 
 export interface ApiGitHubRepoDTO {
@@ -11563,6 +11574,25 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         path: `/api/v1/orgs/${org}/github/app-installation`,
         method: "GET",
         secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsGithubAppManifestCreate
+     * @summary Helix-org: start the GitHub App manifest (create) flow
+     * @request POST:/api/v1/orgs/{org}/github/app-manifest
+     * @secure
+     */
+    v1OrgsGithubAppManifestCreate: (org: string, params: RequestParams = {}) =>
+      this.request<ApiGitHubManifestStartResponse, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/github/app-manifest`,
+        method: "POST",
+        secure: true,
+        type: ContentType.Json,
         format: "json",
         ...params,
       }),

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -62,6 +62,13 @@ export interface ApiGitHubInstallationStatus {
    * this org (a github_app ServiceConnection with an installation id).
    */
   installed?: boolean;
+  /**
+   * ManageURL is the app's developer-settings page on GitHub
+   * (github.com/organizations/<owner>/settings/apps/<slug>) — where you edit
+   * permissions, repos, and delete the app. Empty when the owner is unknown
+   * (e.g. a BYO app configured without it).
+   */
+  manage_url?: string;
 }
 
 export interface ApiGitHubManifestStartResponse {

--- a/frontend/src/components/helix-org/GitHubAppPanel.tsx
+++ b/frontend/src/components/helix-org/GitHubAppPanel.tsx
@@ -1,0 +1,132 @@
+// GitHubAppConnect is the single create / install / manage surface for the
+// org's Helix GitHub App, shared by the Settings page (mode="panel") and the
+// New Stream dialog (mode="gate"). It owns the install-status query and the
+// create/install/manage popup flows (useGitHubAppActions) so both call sites
+// stay identical.
+//
+// - mode="panel": wrapped in a Paper with a header; when installed shows a
+//   "connected" status + Install-on-more / Manage links.
+// - mode="gate": inline (action.hover box); renders only while NOT installed
+//   (the dialog shows its repo picker once installed).
+
+import { FC, useState } from 'react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import CircularProgress from '@mui/material/CircularProgress'
+import Paper from '@mui/material/Paper'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+
+import { useGitHubAppInstallation } from '../../services/helixOrgService'
+import { useGitHubAppActions } from './useGitHubAppActions'
+
+export const GitHubAppConnect: FC<{ mode: 'panel' | 'gate'; onChange?: () => void }> = ({ mode, onChange }) => {
+  const q = useGitHubAppInstallation({ pollWhileNotInstalled: true })
+  const status = q.data
+  const appExists = status?.app_exists === true
+  const installed = status?.installed === true
+  const installUrl = status?.install_url ?? ''
+  const manageUrl = status?.manage_url ?? ''
+  const { createApp, installApp, openManage, creating } = useGitHubAppActions(() => { q.refetch(); onChange?.() })
+  const [githubOrg, setGithubOrg] = useState('')
+
+  // In gate mode the dialog renders the repo picker once installed, so the
+  // gate only appears while there's still something to set up.
+  if (mode === 'gate' && (q.isLoading || installed)) return null
+
+  const manageButton = manageUrl ? (
+    <Button size="small" variant={mode === 'gate' ? 'text' : 'outlined'} onClick={() => openManage(manageUrl)} data-testid="github-app-manage-button">
+      Manage app on GitHub →
+    </Button>
+  ) : null
+
+  let body: React.ReactNode
+  if (q.isLoading) {
+    body = <CircularProgress size={20} />
+  } else if (!appExists) {
+    body = (
+      <Stack spacing={1.5}>
+        <Typography variant="body2">
+          <strong>Create the Helix GitHub App for your org.</strong> Helix creates an app owned by your GitHub organization (one click — GitHub pre-fills the permissions). Afterwards Helix acts as the <code>helix</code> bot, not your personal account.
+        </Typography>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <TextField
+            size="small"
+            label="GitHub organization"
+            placeholder="e.g. helixml"
+            value={githubOrg}
+            onChange={(e) => setGithubOrg(e.target.value)}
+            sx={{ flex: 1, maxWidth: 360 }}
+            inputProps={{ 'data-testid': 'github-app-create-org' }}
+          />
+          <Button
+            variant="contained"
+            size={mode === 'gate' ? 'small' : 'medium'}
+            onClick={() => createApp(githubOrg)}
+            disabled={!githubOrg.trim() || creating}
+            data-testid="github-app-create-button"
+          >
+            {creating ? 'Starting…' : 'Create Helix app'}
+          </Button>
+        </Stack>
+        <Typography variant="caption" color="text.secondary">
+          You must be an owner of that GitHub org. You'll review the app on GitHub, click Create, then choose which repos to install it on.
+        </Typography>
+      </Stack>
+    )
+  } else if (!installed) {
+    body = (
+      <Stack spacing={1.5}>
+        <Typography variant="body2">
+          <strong>The Helix app is created but not installed on any repo yet.</strong> Install it on the repos you want Helix to work with.
+        </Typography>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Button variant="contained" size={mode === 'gate' ? 'small' : 'medium'} onClick={() => installApp(installUrl)} disabled={!installUrl} data-testid="github-app-install-button">
+            Install Helix
+          </Button>
+          {manageButton}
+        </Stack>
+      </Stack>
+    )
+  } else {
+    body = (
+      <Stack spacing={1.5}>
+        <Typography variant="body2">
+          <strong>✓ Helix App connected.</strong> Workers act as the bot; GitHub streams receive events via the app's webhook.
+        </Typography>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Button size="small" variant="outlined" onClick={() => installApp(installUrl)} disabled={!installUrl}>
+            Install on more repos
+          </Button>
+          {manageButton}
+        </Stack>
+        <Typography variant="caption" color="text.secondary">
+          Manage = edit permissions, add/remove repositories, or delete the app — opens the app's developer settings on GitHub.
+        </Typography>
+      </Stack>
+    )
+  }
+
+  if (mode === 'gate') {
+    return (
+      <Box sx={{ p: 1.5, borderRadius: 1, backgroundColor: 'action.hover' }} data-testid="github-app-gate">
+        {body}
+      </Box>
+    )
+  }
+  return (
+    <Paper variant="outlined" sx={{ p: 3 }}>
+      <Typography variant="h6" sx={{ mb: 0.5 }}>GitHub App</Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Helix acts on GitHub as a bot via an org-owned GitHub App: Workers clone / push / open PRs as the bot, and GitHub stream events are delivered through the app's webhook.
+      </Typography>
+      {body}
+    </Paper>
+  )
+}
+
+// GitHubAppPanel is the Settings-page form of the connector.
+export const GitHubAppPanel: FC = () => <GitHubAppConnect mode="panel" />
+
+export default GitHubAppPanel

--- a/frontend/src/components/helix-org/GitHubAppPanel.tsx
+++ b/frontend/src/components/helix-org/GitHubAppPanel.tsx
@@ -1,18 +1,18 @@
-// GitHubAppConnect is the single create / install / manage surface for the
-// org's Helix GitHub App, shared by the Settings page (mode="panel") and the
-// New Stream dialog (mode="gate"). It owns the install-status query and the
-// create/install/manage popup flows (useGitHubAppActions) so both call sites
-// stay identical.
+// GitHubAppConnect is the single create / install / add-repos / manage surface
+// for the org's Helix GitHub App, shared by the Settings page (mode="panel")
+// and the New Stream dialog (mode="gate"). It owns the install-status query and
+// the popup flows (useGitHubAppActions) so both call sites stay identical.
 //
-// - mode="panel": wrapped in a Paper with a header; when installed shows a
-//   "connected" status + Install-on-more / Manage links.
-// - mode="gate": inline (action.hover box); renders only while NOT installed
-//   (the dialog shows its repo picker once installed).
+// The flow it guides:
+//   1. Create the Helix app (org-owned).
+//   2. Install it on a GitHub org (choosing repos during install).
+//   3. Add more repositories / install on another org anytime.
 
 import { FC, useState } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
+import Divider from '@mui/material/Divider'
 import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
@@ -20,6 +20,25 @@ import Typography from '@mui/material/Typography'
 
 import { useGitHubAppInstallation } from '../../services/helixOrgService'
 import { useGitHubAppActions } from './useGitHubAppActions'
+
+const Step: FC<{ n: number; label: string; done: boolean; active: boolean }> = ({ n, label, done, active }) => (
+  <Stack direction="row" spacing={1.25} alignItems="center">
+    <Box
+      sx={{
+        width: 22, height: 22, borderRadius: '50%', flex: '0 0 auto',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontSize: 12, fontWeight: 700,
+        bgcolor: done ? 'success.main' : active ? 'primary.main' : 'action.disabledBackground',
+        color: done || active ? 'common.white' : 'text.secondary',
+      }}
+    >
+      {done ? '✓' : n}
+    </Box>
+    <Typography variant="body2" color={done || active ? 'text.primary' : 'text.secondary'}>
+      {label}
+    </Typography>
+  </Stack>
+)
 
 export const GitHubAppConnect: FC<{ mode: 'panel' | 'gate'; onChange?: () => void }> = ({ mode, onChange }) => {
   const q = useGitHubAppInstallation({ pollWhileNotInstalled: true })
@@ -31,25 +50,32 @@ export const GitHubAppConnect: FC<{ mode: 'panel' | 'gate'; onChange?: () => voi
   const { createApp, installApp, openManage, creating } = useGitHubAppActions(() => { q.refetch(); onChange?.() })
   const [githubOrg, setGithubOrg] = useState('')
 
-  // In gate mode the dialog renders the repo picker once installed, so the
-  // gate only appears while there's still something to set up.
-  if (mode === 'gate' && (q.isLoading || installed)) return null
-
-  const manageButton = manageUrl ? (
-    <Button size="small" variant={mode === 'gate' ? 'text' : 'outlined'} onClick={() => openManage(manageUrl)} data-testid="github-app-manage-button">
+  const small = mode === 'gate'
+  const manageBtn = manageUrl ? (
+    <Button size="small" variant="text" onClick={() => openManage(manageUrl)} data-testid="github-app-manage-button">
       Manage app on GitHub →
     </Button>
   ) : null
+  // The install URL doubles as "add repositories to an existing install" and
+  // "install on another org" — GitHub's installation screen handles both.
+  const addReposBtn = (
+    <Button size="small" variant="outlined" onClick={() => installApp(installUrl)} disabled={!installUrl} data-testid="github-app-add-repos-button">
+      Add repositories / another org
+    </Button>
+  )
 
-  let body: React.ReactNode
+  let statusLine: React.ReactNode = null
+  let action: React.ReactNode = null
   if (q.isLoading) {
-    body = <CircularProgress size={20} />
+    action = <CircularProgress size={20} />
   } else if (!appExists) {
-    body = (
-      <Stack spacing={1.5}>
-        <Typography variant="body2">
-          <strong>Create the Helix GitHub App for your org.</strong> Helix creates an app owned by your GitHub organization (one click — GitHub pre-fills the permissions). Afterwards Helix acts as the <code>helix</code> bot, not your personal account.
-        </Typography>
+    statusLine = (
+      <Typography variant="body2">
+        <strong>Create the Helix GitHub App for your org.</strong> Owned by your GitHub organization (one click — GitHub pre-fills the permissions). Afterwards Helix acts as the <code>helix</code> bot.
+      </Typography>
+    )
+    action = (
+      <Stack spacing={1}>
         <Stack direction="row" spacing={1} alignItems="center">
           <TextField
             size="small"
@@ -62,7 +88,7 @@ export const GitHubAppConnect: FC<{ mode: 'panel' | 'gate'; onChange?: () => voi
           />
           <Button
             variant="contained"
-            size={mode === 'gate' ? 'small' : 'medium'}
+            size={small ? 'small' : 'medium'}
             onClick={() => createApp(githubOrg)}
             disabled={!githubOrg.trim() || creating}
             data-testid="github-app-create-button"
@@ -70,48 +96,53 @@ export const GitHubAppConnect: FC<{ mode: 'panel' | 'gate'; onChange?: () => voi
             {creating ? 'Starting…' : 'Create Helix app'}
           </Button>
         </Stack>
-        <Typography variant="caption" color="text.secondary">
-          You must be an owner of that GitHub org. You'll review the app on GitHub, click Create, then choose which repos to install it on.
-        </Typography>
+        <Typography variant="caption" color="text.secondary">You must be an owner of that GitHub org.</Typography>
       </Stack>
     )
   } else if (!installed) {
-    body = (
-      <Stack spacing={1.5}>
-        <Typography variant="body2">
-          <strong>The Helix app is created but not installed on any repo yet.</strong> Install it on the repos you want Helix to work with.
-        </Typography>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <Button variant="contained" size={mode === 'gate' ? 'small' : 'medium'} onClick={() => installApp(installUrl)} disabled={!installUrl} data-testid="github-app-install-button">
-            Install Helix
-          </Button>
-          {manageButton}
-        </Stack>
+    statusLine = (
+      <Typography variant="body2">
+        <strong>App created — now install it on a GitHub org.</strong> On GitHub's install screen, choose <em>All repositories</em> (or pick the ones you want); that's exactly what Helix can access.
+      </Typography>
+    )
+    action = (
+      <Stack direction="row" spacing={1} alignItems="center">
+        <Button variant="contained" size={small ? 'small' : 'medium'} onClick={() => installApp(installUrl)} disabled={!installUrl} data-testid="github-app-install-button">
+          Install Helix
+        </Button>
+        {manageBtn}
       </Stack>
     )
   } else {
-    body = (
-      <Stack spacing={1.5}>
-        <Typography variant="body2">
-          <strong>✓ Helix App connected.</strong> Workers act as the bot; GitHub streams receive events via the app's webhook.
-        </Typography>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <Button size="small" variant="outlined" onClick={() => installApp(installUrl)} disabled={!installUrl}>
-            Install on more repos
-          </Button>
-          {manageButton}
-        </Stack>
-        <Typography variant="caption" color="text.secondary">
-          Manage = edit permissions, add/remove repositories, or delete the app — opens the app's developer settings on GitHub.
-        </Typography>
+    statusLine = (
+      <Typography variant="body2">
+        <strong>✓ Helix App installed.</strong> It can access the repositories you granted during install. Add more repos — or install it on another GitHub org — anytime.
+      </Typography>
+    )
+    action = (
+      <Stack direction="row" spacing={1} alignItems="center">
+        {addReposBtn}
+        {manageBtn}
       </Stack>
     )
   }
 
+  const steps = !q.isLoading && (
+    <Stack spacing={0.75}>
+      <Step n={1} label="Create the Helix app" done={appExists} active={!appExists} />
+      <Step n={2} label="Install it on a GitHub org" done={installed} active={appExists && !installed} />
+      <Step n={3} label="Choose which repositories Helix can access (during install — add more anytime)" done={installed} active={false} />
+    </Stack>
+  )
+
   if (mode === 'gate') {
+    if (q.isLoading) return null
     return (
       <Box sx={{ p: 1.5, borderRadius: 1, backgroundColor: 'action.hover' }} data-testid="github-app-gate">
-        {body}
+        <Stack spacing={1}>
+          {statusLine}
+          {action}
+        </Stack>
       </Box>
     )
   }
@@ -121,7 +152,14 @@ export const GitHubAppConnect: FC<{ mode: 'panel' | 'gate'; onChange?: () => voi
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
         Helix acts on GitHub as a bot via an org-owned GitHub App: Workers clone / push / open PRs as the bot, and GitHub stream events are delivered through the app's webhook.
       </Typography>
-      {body}
+      <Stack spacing={2}>
+        {steps}
+        <Divider />
+        <Stack spacing={1.5}>
+          {statusLine}
+          {action}
+        </Stack>
+      </Stack>
     </Paper>
   )
 }

--- a/frontend/src/components/helix-org/GitHubStreamConfigFields.tsx
+++ b/frontend/src/components/helix-org/GitHubStreamConfigFields.tsx
@@ -1,8 +1,12 @@
-// GitHubStreamConfigFields is the Repository + Events form block
+// GitHubStreamConfigFields is the Repository + Events + Branches form block
 // shared by the New Stream dialog and the per-stream Edit dialog.
 // It's intentionally headless: the parent owns the values + change
 // handlers so the dialog around it stays in control of submit
 // validation, snackbar wiring, etc.
+//
+// The Events and Branches editors are also exported on their own so the
+// New Stream dialog can pair them with its own repo *picker* (which lists
+// the bot's installation repos) instead of the plain repo text field here.
 
 import { FC } from 'react'
 import Autocomplete from '@mui/material/Autocomplete'
@@ -19,6 +23,124 @@ import {
   GITHUB_REPO_PATTERN,
   eventValue,
 } from './githubStreamConstants'
+
+// GitHubEventsField is the curated-but-free-text event whitelist editor.
+export const GitHubEventsField: FC<{ events: string[]; onChange: (next: string[]) => void }> = ({
+  events,
+  onChange,
+}) => {
+  const badEvents = events.filter((e) => !GITHUB_EVENT_PATTERN.test(e))
+  return (
+    <Autocomplete<EventOption, true, false, true>
+      multiple
+      freeSolo
+      forcePopupIcon
+      openOnFocus
+      disableCloseOnSelect
+      disablePortal
+      options={GITHUB_EVENT_OPTIONS}
+      value={events}
+      onChange={(_, next) => {
+        const cleaned = next
+          .map(eventValue)
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+        onChange(Array.from(new Set(cleaned)))
+      }}
+      getOptionLabel={(o) => eventValue(o)}
+      isOptionEqualToValue={(opt, val) => opt.value === eventValue(val)}
+      filterSelectedOptions
+      renderOption={(props, option, { selected }) => {
+        const { key: _optKey, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & { key?: React.Key }
+        return (
+          <li {...liProps} key={option.value}>
+            <Checkbox checked={selected} sx={{ mr: 1 }} />
+            <Box>
+              <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>{option.value}</Typography>
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', whiteSpace: 'normal' }}>
+                {option.help}
+              </Typography>
+            </Box>
+          </li>
+        )
+      }}
+      renderTags={(value, getTagProps) =>
+        value.map((option, index) => {
+          const v = eventValue(option)
+          const known = GITHUB_EVENT_OPTIONS.some((o) => o.value === v)
+          const valid = GITHUB_EVENT_PATTERN.test(v)
+          const { key: _tagKey, ...tagProps } = getTagProps({ index })
+          return (
+            <Chip
+              {...tagProps}
+              key={v}
+              label={v}
+              size="small"
+              color={valid ? (known ? 'default' : 'info') : 'error'}
+              variant={known ? 'filled' : 'outlined'}
+              title={
+                !valid
+                  ? 'Invalid event name — must be lowercase letters, digits, and underscores (a-z, 0-9, _).'
+                  : known
+                  ? undefined
+                  : 'Custom event name — accepted by the server, but the envelope mapping is best-effort.'
+              }
+              sx={{ fontFamily: 'monospace' }}
+            />
+          )
+        })
+      }
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label="Events"
+          placeholder={events.length === 0 ? 'Pick events, or type your own and press Enter…' : ''}
+          size="small"
+          error={badEvents.length > 0}
+          helperText={
+            badEvents.length > 0
+              ? `Invalid event name(s): ${badEvents.join(', ')} — must match /^[a-z][a-z0-9_]+$/`
+              : 'Anything not listed is dropped at the transport. `*` = all events. Type a custom name and press Enter to add it.'
+          }
+        />
+      )}
+    />
+  )
+}
+
+// GitHubBranchesField is the optional per-branch filter for push/create/delete.
+export const GitHubBranchesField: FC<{ branches: string[]; onChange: (next: string[]) => void }> = ({
+  branches,
+  onChange,
+}) => (
+  <Autocomplete<string, true, false, true>
+    multiple
+    freeSolo
+    openOnFocus
+    disablePortal
+    options={[]}
+    value={branches}
+    onChange={(_, next) => {
+      const cleaned = next.map((s) => s.trim()).filter((s) => s.length > 0)
+      onChange(Array.from(new Set(cleaned)))
+    }}
+    renderTags={(value, getTagProps) =>
+      value.map((b, index) => {
+        const { key: _k, ...tagProps } = getTagProps({ index })
+        return <Chip {...tagProps} key={b} label={b} size="small" sx={{ fontFamily: 'monospace' }} />
+      })
+    }
+    renderInput={(params) => (
+      <TextField
+        {...params}
+        label="Branches (optional)"
+        placeholder={branches.length === 0 ? 'e.g. main, release/* — leave empty for all branches' : ''}
+        size="small"
+        helperText="Narrows push / create / delete events to these branches — exact name (main) or prefix glob (release/*). Empty = all branches. Other event types (issues, pull_request, …) are unaffected."
+      />
+    )}
+  />
+)
 
 export interface GitHubStreamConfigFieldsProps {
   repo: string
@@ -40,127 +162,21 @@ export const GitHubStreamConfigFields: FC<GitHubStreamConfigFieldsProps> = ({
   const repoError = repo.trim() === ''
     ? ''
     : (GITHUB_REPO_PATTERN.test(repo.trim()) ? '' : 'Must be `owner/name` (one slash, both halves non-empty).')
-  const badEvents = events.filter((e) => !GITHUB_EVENT_PATTERN.test(e))
 
   return (
     <>
-      {/* Scoping fields — backed by the Go validator's
-          GitHubConfig{Repo, Events}. We surface the validator's
-          rules inline so the user catches the mistake before
-          submit. */}
       <TextField
         label="Repository"
         placeholder="helixml/helix"
         value={repo}
         onChange={(e) => onRepoChange(e.target.value)}
         error={!!repoError}
-        helperText={repoError || 'Exactly one repo per stream — GitHub `owner/name` (e.g. helixml/helix). Matched case-insensitively against repository.full_name in the payload.'}
+        helperText={repoError || 'GitHub `owner/name` (e.g. helixml/helix), or `owner/*` to match a whole org. Matched case-insensitively against repository.full_name in the payload.'}
         fullWidth
         size="small"
       />
-      <Autocomplete<EventOption, true, false, true>
-        multiple
-        freeSolo
-        forcePopupIcon
-        openOnFocus
-        disableCloseOnSelect
-        disablePortal
-        options={GITHUB_EVENT_OPTIONS}
-        value={events}
-        onChange={(_, next) => {
-          const cleaned = next
-            .map(eventValue)
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0)
-          onEventsChange(Array.from(new Set(cleaned)))
-        }}
-        getOptionLabel={(o) => eventValue(o)}
-        isOptionEqualToValue={(opt, val) => opt.value === eventValue(val)}
-        filterSelectedOptions
-        renderOption={(props, option, { selected }) => {
-          const { key: _optKey, ...liProps } = props as React.HTMLAttributes<HTMLLIElement> & { key?: React.Key }
-          return (
-            <li {...liProps} key={option.value}>
-              <Checkbox checked={selected} sx={{ mr: 1 }} />
-              <Box>
-                <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>{option.value}</Typography>
-                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', whiteSpace: 'normal' }}>
-                  {option.help}
-                </Typography>
-              </Box>
-            </li>
-          )
-        }}
-        renderTags={(value, getTagProps) =>
-          value.map((option, index) => {
-            const v = eventValue(option)
-            const known = GITHUB_EVENT_OPTIONS.some((o) => o.value === v)
-            const valid = GITHUB_EVENT_PATTERN.test(v)
-            const { key: _tagKey, ...tagProps } = getTagProps({ index })
-            return (
-              <Chip
-                {...tagProps}
-                key={v}
-                label={v}
-                size="small"
-                color={valid ? (known ? 'default' : 'info') : 'error'}
-                variant={known ? 'filled' : 'outlined'}
-                title={
-                  !valid
-                    ? 'Invalid event name — must be lowercase letters, digits, and underscores (a-z, 0-9, _).'
-                    : known
-                    ? undefined
-                    : 'Custom event name — accepted by the server, but the envelope mapping is best-effort.'
-                }
-                sx={{ fontFamily: 'monospace' }}
-              />
-            )
-          })
-        }
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            label="Events"
-            placeholder={events.length === 0 ? 'Pick events, or type your own and press Enter…' : ''}
-            size="small"
-            error={badEvents.length > 0}
-            helperText={
-              badEvents.length > 0
-                ? `Invalid event name(s): ${badEvents.join(', ')} — must match /^[a-z][a-z0-9_]+$/`
-                : "Anything not listed is dropped at the transport, so subscribed Workers don't activate for events they'd ignore. Type a custom name and press Enter to add it (e.g. push, release, workflow_run)."
-            }
-          />
-        )}
-      />
-      {onBranchesChange && (
-        <Autocomplete<string, true, false, true>
-          multiple
-          freeSolo
-          openOnFocus
-          disablePortal
-          options={[]}
-          value={branches}
-          onChange={(_, next) => {
-            const cleaned = next.map((s) => s.trim()).filter((s) => s.length > 0)
-            onBranchesChange(Array.from(new Set(cleaned)))
-          }}
-          renderTags={(value, getTagProps) =>
-            value.map((b, index) => {
-              const { key: _k, ...tagProps } = getTagProps({ index })
-              return <Chip {...tagProps} key={b} label={b} size="small" sx={{ fontFamily: 'monospace' }} />
-            })
-          }
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label="Branches (optional)"
-              placeholder={branches.length === 0 ? 'e.g. main, release/* — leave empty for all branches' : ''}
-              size="small"
-              helperText="Narrows push / create / delete events to these branches — exact name (main) or prefix glob (release/*). Empty = all branches. Other event types (issues, pull_request, …) are unaffected."
-            />
-          )}
-        />
-      )}
+      <GitHubEventsField events={events} onChange={onEventsChange} />
+      {onBranchesChange && <GitHubBranchesField branches={branches} onChange={onBranchesChange} />}
     </>
   )
 }

--- a/frontend/src/components/helix-org/GitHubStreamConfigFields.tsx
+++ b/frontend/src/components/helix-org/GitHubStreamConfigFields.tsx
@@ -23,15 +23,19 @@ import {
 export interface GitHubStreamConfigFieldsProps {
   repo: string
   events: string[]
+  branches?: string[]
   onRepoChange: (next: string) => void
   onEventsChange: (next: string[]) => void
+  onBranchesChange?: (next: string[]) => void
 }
 
 export const GitHubStreamConfigFields: FC<GitHubStreamConfigFieldsProps> = ({
   repo,
   events,
+  branches = [],
   onRepoChange,
   onEventsChange,
+  onBranchesChange,
 }) => {
   const repoError = repo.trim() === ''
     ? ''
@@ -128,6 +132,35 @@ export const GitHubStreamConfigFields: FC<GitHubStreamConfigFieldsProps> = ({
           />
         )}
       />
+      {onBranchesChange && (
+        <Autocomplete<string, true, false, true>
+          multiple
+          freeSolo
+          openOnFocus
+          disablePortal
+          options={[]}
+          value={branches}
+          onChange={(_, next) => {
+            const cleaned = next.map((s) => s.trim()).filter((s) => s.length > 0)
+            onBranchesChange(Array.from(new Set(cleaned)))
+          }}
+          renderTags={(value, getTagProps) =>
+            value.map((b, index) => {
+              const { key: _k, ...tagProps } = getTagProps({ index })
+              return <Chip {...tagProps} key={b} label={b} size="small" sx={{ fontFamily: 'monospace' }} />
+            })
+          }
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Branches (optional)"
+              placeholder={branches.length === 0 ? 'e.g. main, release/* — leave empty for all branches' : ''}
+              size="small"
+              helperText="Narrows push / create / delete events to these branches — exact name (main) or prefix glob (release/*). Empty = all branches. Other event types (issues, pull_request, …) are unaffected."
+            />
+          )}
+        />
+      )}
     </>
   )
 }

--- a/frontend/src/components/helix-org/GitHubStreamConfigFields.tsx
+++ b/frontend/src/components/helix-org/GitHubStreamConfigFields.tsx
@@ -19,9 +19,9 @@ import Typography from '@mui/material/Typography'
 import {
   EventOption,
   GITHUB_EVENT_OPTIONS,
-  GITHUB_EVENT_PATTERN,
   GITHUB_REPO_PATTERN,
   eventValue,
+  isValidGitHubEvent,
 } from './githubStreamConstants'
 
 // GitHubEventsField is the curated-but-free-text event whitelist editor.
@@ -29,7 +29,7 @@ export const GitHubEventsField: FC<{ events: string[]; onChange: (next: string[]
   events,
   onChange,
 }) => {
-  const badEvents = events.filter((e) => !GITHUB_EVENT_PATTERN.test(e))
+  const badEvents = events.filter((e) => !isValidGitHubEvent(e))
   return (
     <Autocomplete<EventOption, true, false, true>
       multiple
@@ -68,7 +68,7 @@ export const GitHubEventsField: FC<{ events: string[]; onChange: (next: string[]
         value.map((option, index) => {
           const v = eventValue(option)
           const known = GITHUB_EVENT_OPTIONS.some((o) => o.value === v)
-          const valid = GITHUB_EVENT_PATTERN.test(v)
+          const valid = isValidGitHubEvent(v)
           const { key: _tagKey, ...tagProps } = getTagProps({ index })
           return (
             <Chip

--- a/frontend/src/components/helix-org/GitHubStreamConfigFields.tsx
+++ b/frontend/src/components/helix-org/GitHubStreamConfigFields.tsx
@@ -118,7 +118,7 @@ export const GitHubBranchesField: FC<{ branches: string[]; onChange: (next: stri
     freeSolo
     openOnFocus
     disablePortal
-    options={[]}
+    options={['*']}
     value={branches}
     onChange={(_, next) => {
       const cleaned = next.map((s) => s.trim()).filter((s) => s.length > 0)
@@ -133,10 +133,10 @@ export const GitHubBranchesField: FC<{ branches: string[]; onChange: (next: stri
     renderInput={(params) => (
       <TextField
         {...params}
-        label="Branches (optional)"
-        placeholder={branches.length === 0 ? 'e.g. main, release/* — leave empty for all branches' : ''}
+        label="Branches"
+        placeholder={branches.length === 0 ? 'e.g. *, main, release/*' : ''}
         size="small"
-        helperText="Narrows push / create / delete events to these branches — exact name (main) or prefix glob (release/*). Empty = all branches. Other event types (issues, pull_request, …) are unaffected."
+        helperText="Applies to push / create / delete events. `*` = all branches; narrow with an exact name (main) or a prefix glob (release/*). Other event types (issues, pull_request, …) are unaffected."
       />
     )}
   />

--- a/frontend/src/components/helix-org/githubStreamConstants.ts
+++ b/frontend/src/components/helix-org/githubStreamConstants.ts
@@ -7,6 +7,66 @@ export type EventOption = { value: string; help: string }
 
 export const GITHUB_EVENT_OPTIONS: EventOption[] = [
   {
+    value: 'push',
+    help: 'Commits pushed to a branch (or tag). This is the "code changed" event. Use the Branches filter below to scope to specific branches (e.g. main, release/*).',
+  },
+  {
+    value: 'create',
+    help: 'A branch or tag was created.',
+  },
+  {
+    value: 'delete',
+    help: 'A branch or tag was deleted.',
+  },
+  {
+    value: 'release',
+    help: 'A release was published, edited, or deleted.',
+  },
+  {
+    value: 'workflow_run',
+    help: 'A GitHub Actions workflow run started or finished (requested, in_progress, completed).',
+  },
+  {
+    value: 'workflow_job',
+    help: 'An individual GitHub Actions job was queued, started, or completed.',
+  },
+  {
+    value: 'check_run',
+    help: 'A check run (CI status check) was created, updated, or completed.',
+  },
+  {
+    value: 'status',
+    help: 'A commit status changed (the older statuses API: pending / success / failure).',
+  },
+  {
+    value: 'deployment_status',
+    help: 'A deployment status changed (e.g. a deploy succeeded or failed).',
+  },
+  {
+    value: 'discussion',
+    help: 'A GitHub Discussion was created, edited, answered, etc.',
+  },
+  {
+    value: 'discussion_comment',
+    help: 'A comment on a GitHub Discussion.',
+  },
+  {
+    value: 'fork',
+    help: 'The repository was forked.',
+  },
+  {
+    value: 'star',
+    help: 'A star was added to or removed from the repository.',
+  },
+  {
+    value: 'label',
+    help: 'A label was created, edited, or deleted in the repository.',
+  },
+  {
+    value: 'milestone',
+    help: 'A milestone was created, closed, edited, or deleted.',
+  },
+  {
     value: 'issues',
     help: 'Issue lifecycle: opened, closed, reopened, labeled, assigned, milestoned, etc. Fires for every change to the issue itself (not comments on it).',
   },

--- a/frontend/src/components/helix-org/githubStreamConstants.ts
+++ b/frontend/src/components/helix-org/githubStreamConstants.ts
@@ -93,6 +93,11 @@ export const GITHUB_EVENT_OPTIONS: EventOption[] = [
 // api/pkg/org/domain/transport/github.go.
 export const GITHUB_EVENT_PATTERN = /^[a-z][a-z0-9_]{1,63}$/
 
+// isValidGitHubEvent mirrors the backend validator, which accepts the "*"
+// wildcard as a special case in addition to the slug pattern. Use this for
+// validation rather than GITHUB_EVENT_PATTERN alone (which rejects "*").
+export const isValidGitHubEvent = (e: string) => e === '*' || GITHUB_EVENT_PATTERN.test(e)
+
 // Exactly one slash, both halves non-empty. Mirror of the backend's
 // repo check.
 export const GITHUB_REPO_PATTERN = /^[^/\s]+\/[^/\s]+$/

--- a/frontend/src/components/helix-org/useGitHubAppActions.ts
+++ b/frontend/src/components/helix-org/useGitHubAppActions.ts
@@ -33,6 +33,14 @@ export function useGitHubAppActions(onComplete?: () => void) {
         window.removeEventListener('focus', onFocus)
         snackbar.success('Helix installed — refreshing…')
         onComplete?.()
+      } else if (event.data?.type === 'github-app-created') {
+        // The app was created but not installed yet — refetch so the gate
+        // advances to the Install step. (Focus fallback also covers this if
+        // GitHub's COOP severed window.opener and this never arrives.)
+        window.removeEventListener('message', onMessage)
+        window.removeEventListener('focus', onFocus)
+        snackbar.success('App created — now click "Install Helix".')
+        onComplete?.()
       } else if (event.data?.type === 'github-app-install-error') {
         window.removeEventListener('message', onMessage)
         snackbar.error('GitHub reported a problem completing the install.')

--- a/frontend/src/components/helix-org/useGitHubAppActions.ts
+++ b/frontend/src/components/helix-org/useGitHubAppActions.ts
@@ -33,14 +33,6 @@ export function useGitHubAppActions(onComplete?: () => void) {
         window.removeEventListener('focus', onFocus)
         snackbar.success('Helix installed — refreshing…')
         onComplete?.()
-      } else if (event.data?.type === 'github-app-created') {
-        // The app was created but not installed yet — refetch so the gate
-        // advances to the Install step. (Focus fallback also covers this if
-        // GitHub's COOP severed window.opener and this never arrives.)
-        window.removeEventListener('message', onMessage)
-        window.removeEventListener('focus', onFocus)
-        snackbar.success('App created — now click "Install Helix".')
-        onComplete?.()
       } else if (event.data?.type === 'github-app-install-error') {
         window.removeEventListener('message', onMessage)
         snackbar.error('GitHub reported a problem completing the install.')

--- a/frontend/src/components/helix-org/useGitHubAppActions.ts
+++ b/frontend/src/components/helix-org/useGitHubAppActions.ts
@@ -35,6 +35,7 @@ export function useGitHubAppActions(onComplete?: () => void) {
         onComplete?.()
       } else if (event.data?.type === 'github-app-install-error') {
         window.removeEventListener('message', onMessage)
+        window.removeEventListener('focus', onFocus)
         snackbar.error('GitHub reported a problem completing the install.')
       }
     }

--- a/frontend/src/components/helix-org/useGitHubAppActions.ts
+++ b/frontend/src/components/helix-org/useGitHubAppActions.ts
@@ -1,0 +1,104 @@
+// useGitHubAppActions encapsulates the GitHub App create / install / manage
+// browser flows shared by the New Stream dialog and the Settings page panel.
+// All three are top-level navigations to github.com in a popup; GitHub's COOP
+// headers sever window.opener, so completion is detected by a postMessage from
+// our callback (when available) AND a window-focus fallback. The caller passes
+// onComplete to re-check install status.
+
+import { useGitHubManifestStart } from '../../services/helixOrgService'
+import useSnackbar from '../../hooks/useSnackbar'
+
+export function useGitHubAppActions(onComplete?: () => void) {
+  const snackbar = useSnackbar()
+  const manifestStart = useGitHubManifestStart()
+
+  const openPopup = (url: string, name: string): Window | null => {
+    const width = 1000
+    const height = 800
+    const left = (window.innerWidth - width) / 2
+    const top = (window.innerHeight - height) / 2
+    const popup = window.open(
+      url,
+      name,
+      `width=${width},height=${height},left=${left},top=${top},toolbar=0,location=0,menubar=0,directories=0,scrollbars=1`,
+    )
+    if (!popup) snackbar.error('Popup blocked — allow popups for this site and try again.')
+    return popup
+  }
+
+  const watch = () => {
+    const onMessage = (event: MessageEvent) => {
+      if (event.data?.type === 'github-app-installed') {
+        window.removeEventListener('message', onMessage)
+        window.removeEventListener('focus', onFocus)
+        snackbar.success('Helix installed — refreshing…')
+        onComplete?.()
+      } else if (event.data?.type === 'github-app-install-error') {
+        window.removeEventListener('message', onMessage)
+        snackbar.error('GitHub reported a problem completing the install.')
+      }
+    }
+    const onFocus = () => {
+      window.removeEventListener('message', onMessage)
+      onComplete?.()
+    }
+    window.addEventListener('message', onMessage)
+    window.addEventListener('focus', onFocus, { once: true })
+  }
+
+  // createApp runs the Manifest flow: ask the backend for the GitHub POST URL +
+  // manifest, then submit it as a form inside a popup so GitHub creates the app
+  // (org-owned) on the user's behalf, then chains into install.
+  const createApp = async (githubOrg: string) => {
+    const org = githubOrg.trim()
+    if (!org) {
+      snackbar.error('Enter the GitHub organization to create the app under')
+      return
+    }
+    // Open synchronously on the click — opening after the await loses the gesture.
+    const popup = openPopup('about:blank', 'github-app-create')
+    if (!popup) return
+    try {
+      popup.document.body.innerHTML = 'Preparing the Helix app…'
+      const start = await manifestStart.mutateAsync({ github_org: org, origin: window.location.origin })
+      const doc = popup.document
+      doc.body.innerHTML = 'Redirecting to GitHub to create the Helix app…'
+      const form = doc.createElement('form')
+      form.method = 'POST'
+      form.action = start.post_url
+      const input = doc.createElement('input')
+      input.type = 'hidden'
+      input.name = 'manifest'
+      input.value = start.manifest
+      form.appendChild(input)
+      doc.body.appendChild(form)
+      form.submit()
+      watch()
+    } catch (e: any) {
+      try { popup.close() } catch { /* ignore */ }
+      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'Could not start GitHub app creation')
+    }
+  }
+
+  // installApp sends the user to GitHub to pick repos to install the app on.
+  const installApp = (installUrl?: string) => {
+    if (!installUrl) {
+      snackbar.error('The Helix GitHub App is not configured on this deployment. Ask an admin to set GITHUB_APP_SLUG.')
+      return
+    }
+    if (!openPopup(installUrl, 'github-app-install')) return
+    watch()
+  }
+
+  // openManage opens the app's developer-settings page (edit permissions /
+  // repos / delete). Plain new tab — no completion to watch.
+  const openManage = (manageUrl?: string) => {
+    if (!manageUrl) {
+      snackbar.error('Manage URL unavailable for this app.')
+      return
+    }
+    window.open(manageUrl, '_blank', 'noopener,noreferrer')
+  }
+
+  return { createApp, installApp, openManage, creating: manifestStart.isPending }
+}

--- a/frontend/src/pages/HelixOrgSettings.tsx
+++ b/frontend/src/pages/HelixOrgSettings.tsx
@@ -36,6 +36,7 @@ import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import useAccount from '../hooks/useAccount'
 import useRouter from '../hooks/useRouter'
 import useSnackbar from '../hooks/useSnackbar'
+import GitHubAppPanel from '../components/helix-org/GitHubAppPanel'
 import {
   SettingsSpecDTO,
   useDeleteHelixOrgSetting,
@@ -180,6 +181,8 @@ const HelixOrgSettings: FC = () => {
                   />
                 </Stack>
               </Paper>
+
+              <GitHubAppPanel />
 
               {/* Generic spec rows — everything not in FIRST_CLASS_KEYS */}
               {(data?.specs ?? [])

--- a/frontend/src/pages/HelixOrgStreamDetail.tsx
+++ b/frontend/src/pages/HelixOrgStreamDetail.tsx
@@ -29,6 +29,7 @@ import CloseIcon from '@mui/icons-material/Close'
 import Page from '../components/system/Page'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import GitHubStreamConfigFields from '../components/helix-org/GitHubStreamConfigFields'
+import { useGitHubAppActions } from '../components/helix-org/useGitHubAppActions'
 import {
   isValidGitHubEvent,
   GITHUB_REPO_PATTERN,
@@ -456,6 +457,8 @@ const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ stream, orgSlug }) 
   // events), so there's no per-repo webhook to install.
   const appInstall = useGitHubAppInstallation()
   const appMode = appInstall.data?.installed === true
+  const appActions = useGitHubAppActions()
+  const manageUrl = appInstall.data?.manage_url ?? ''
 
   // Check the EFFECTIVE public URL — what the install endpoint
   // would actually use (streams.public_url override applied on
@@ -505,8 +508,15 @@ const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ stream, orgSlug }) 
             Events arrive via the <strong>Helix GitHub App</strong> — one app-level webhook receives every event from the repos it's installed on. This stream receives the deliveries that match its filter (repo <strong>{cfg.repo || '(not set)'}</strong>, plus its events whitelist). There's no per-repo webhook to install.
           </Typography>
           <Typography variant="caption" color="text.secondary">
-            Scope is controlled by two things: which repos the app is installed on (GitHub → the app → Configure), and this stream's repo + events filter. Use <code>owner/*</code> as the repo to match a whole org. GitHub must be able to reach Helix at a public URL for deliveries to arrive.
+            Scope is controlled by two things: which repos the app is installed on, and this stream's repo + events filter. Use <code>owner/*</code> as the repo to match a whole org. GitHub must be able to reach Helix at a public URL for deliveries to arrive.
           </Typography>
+          {manageUrl && (
+            <Box>
+              <Button size="small" variant="outlined" onClick={() => appActions.openManage(manageUrl)}>
+                Manage app on GitHub →
+              </Button>
+            </Box>
+          )}
         </Stack>
       ) : (
       <>

--- a/frontend/src/pages/HelixOrgStreamDetail.tsx
+++ b/frontend/src/pages/HelixOrgStreamDetail.tsx
@@ -42,6 +42,7 @@ import {
   InstallWebhookFailedError,
   StreamDTO,
   useHelixOrgStream,
+  useGitHubAppInstallation,
   useInstallGitHubWebhook,
   useUpdateHelixOrgStream,
 } from '../services/helixOrgService'
@@ -443,6 +444,11 @@ const SettingsLink: FC<{ orgSlug?: string }> = ({ orgSlug }) => {
 const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ stream, orgSlug }) => {
   const snackbar = useSnackbar()
   const install = useInstallGitHubWebhook()
+  // App mode: when the Helix GitHub App is installed for this org, events
+  // arrive via the App's single webhook (filtered to this stream by repo +
+  // events), so there's no per-repo webhook to install.
+  const appInstall = useGitHubAppInstallation()
+  const appMode = appInstall.data?.installed === true
 
   // Check the EFFECTIVE public URL — what the install endpoint
   // would actually use (streams.public_url override applied on
@@ -486,6 +492,17 @@ const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ stream, orgSlug }) 
   return (
     <Paper variant="outlined" sx={{ p: 2 }}>
       <Typography variant="h6" sx={{ mb: 1 }}>Connect to GitHub</Typography>
+      {appMode ? (
+        <Stack spacing={1}>
+          <Typography variant="body2">
+            Events arrive via the <strong>Helix GitHub App</strong> — one app-level webhook receives every event from the repos it's installed on. This stream receives the deliveries that match its filter (repo <strong>{cfg.repo || '(not set)'}</strong>, plus its events whitelist). There's no per-repo webhook to install.
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            Scope is controlled by two things: which repos the app is installed on (GitHub → the app → Configure), and this stream's repo + events filter. Use <code>owner/*</code> as the repo to match a whole org. GitHub must be able to reach Helix at a public URL for deliveries to arrive.
+          </Typography>
+        </Stack>
+      ) : (
+      <>
       {isLocalhost && (
         <Box sx={{ mb: 1.5, p: 1.5, borderRadius: 1, backgroundColor: 'warning.main', color: 'warning.contrastText' }}>
           <Typography variant="body2" sx={{ fontWeight: 600 }}>
@@ -549,6 +566,8 @@ const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ stream, orgSlug }) 
             Requires a connected GitHub OAuth (on the helix Connected Services page) with admin rights on the repo.
           </Typography>
         </Stack>
+      )}
+      </>
       )}
     </Paper>
   )

--- a/frontend/src/pages/HelixOrgStreamDetail.tsx
+++ b/frontend/src/pages/HelixOrgStreamDetail.tsx
@@ -30,7 +30,7 @@ import Page from '../components/system/Page'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import GitHubStreamConfigFields from '../components/helix-org/GitHubStreamConfigFields'
 import {
-  GITHUB_EVENT_PATTERN,
+  isValidGitHubEvent,
   GITHUB_REPO_PATTERN,
 } from '../components/helix-org/githubStreamConstants'
 
@@ -275,7 +275,7 @@ const StreamConfigSection: FC<StreamConfigSectionProps> = ({ stream, onSave, sav
         snackbar.error('Pick at least one GitHub event type')
         return
       }
-      const bad = ghEvents.filter((e) => !GITHUB_EVENT_PATTERN.test(e))
+      const bad = ghEvents.filter((e) => !isValidGitHubEvent(e))
       if (bad.length > 0) {
         snackbar.error(`Invalid event name(s): ${bad.join(', ')} — must match /^[a-z][a-z0-9_]+$/`)
         return

--- a/frontend/src/pages/HelixOrgStreamDetail.tsx
+++ b/frontend/src/pages/HelixOrgStreamDetail.tsx
@@ -235,14 +235,16 @@ const StreamConfigSection: FC<StreamConfigSectionProps> = ({ stream, onSave, sav
   const [configText, setConfigText] = useState('')
   const [ghRepo, setGhRepo] = useState('')
   const [ghEvents, setGhEvents] = useState<string[]>([])
+  const [ghBranches, setGhBranches] = useState<string[]>([])
 
   const enterEdit = () => {
     setName(stream.name)
     setDescription(stream.description ?? '')
     if (stream.kind === 'github') {
-      const cfg = (stream.config ?? {}) as { repo?: string; events?: string[] }
+      const cfg = (stream.config ?? {}) as { repo?: string; events?: string[]; branches?: string[] }
       setGhRepo(cfg.repo ?? '')
       setGhEvents(Array.isArray(cfg.events) ? cfg.events : [])
+      setGhBranches(Array.isArray(cfg.branches) ? cfg.branches : [])
     } else if (stream.config) {
       setConfigText(JSON.stringify(stream.config, null, 2))
     } else {
@@ -278,7 +280,10 @@ const StreamConfigSection: FC<StreamConfigSectionProps> = ({ stream, onSave, sav
         snackbar.error(`Invalid event name(s): ${bad.join(', ')} — must match /^[a-z][a-z0-9_]+$/`)
         return
       }
-      payload.transport = { config: { repo: ghRepo.trim(), events: ghEvents } }
+      const ghConfig: Record<string, unknown> = { repo: ghRepo.trim(), events: ghEvents }
+      const branches = ghBranches.map((b) => b.trim()).filter((b) => b.length > 0)
+      if (branches.length > 0) ghConfig.branches = branches
+      payload.transport = { config: ghConfig }
     } else if (stream.kind !== 'local' && configText.trim()) {
       try {
         const parsed = JSON.parse(configText)
@@ -362,8 +367,10 @@ const StreamConfigSection: FC<StreamConfigSectionProps> = ({ stream, onSave, sav
             <GitHubStreamConfigFields
               repo={ghRepo}
               events={ghEvents}
+              branches={ghBranches}
               onRepoChange={setGhRepo}
               onEventsChange={setGhEvents}
+              onBranchesChange={setGhBranches}
             />
           )}
           {stream.kind !== 'local' && stream.kind !== 'github' && (

--- a/frontend/src/pages/HelixOrgStreamDetail.tsx
+++ b/frontend/src/pages/HelixOrgStreamDetail.tsx
@@ -244,7 +244,7 @@ const StreamConfigSection: FC<StreamConfigSectionProps> = ({ stream, onSave, sav
       const cfg = (stream.config ?? {}) as { repo?: string; events?: string[]; branches?: string[] }
       setGhRepo(cfg.repo ?? '')
       setGhEvents(Array.isArray(cfg.events) ? cfg.events : [])
-      setGhBranches(Array.isArray(cfg.branches) ? cfg.branches : [])
+      setGhBranches(Array.isArray(cfg.branches) && cfg.branches.length > 0 ? cfg.branches : ['*'])
     } else if (stream.config) {
       setConfigText(JSON.stringify(stream.config, null, 2))
     } else {

--- a/frontend/src/pages/HelixOrgStreams.tsx
+++ b/frontend/src/pages/HelixOrgStreams.tsx
@@ -466,9 +466,15 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
         description: description.trim() || undefined,
         transport: { kind, config },
       })
-      if (kind === 'github' && created?.id) {
-        // Auto-install the webhook on GitHub. Idempotent — re-run
-        // adopts an existing hook rather than creating a duplicate.
+      if (kind === 'github' && created?.id && ghInstalled) {
+        // App mode: the Helix GitHub App already delivers all events for
+        // every installed repo to one webhook; this stream is just a
+        // (repo, events) filter on that firehose. No per-repo webhook to
+        // install — doing so would need admin rights and double-deliver.
+        snackbar.success('Stream created · events arrive via the Helix GitHub App')
+      } else if (kind === 'github' && created?.id) {
+        // Legacy OAuth mode: auto-install a per-repo webhook on GitHub.
+        // Idempotent — re-run adopts an existing hook.
         try {
           const inst = await installWebhook.mutateAsync(created.id)
           if (inst.warning) {

--- a/frontend/src/pages/HelixOrgStreams.tsx
+++ b/frontend/src/pages/HelixOrgStreams.tsx
@@ -43,29 +43,11 @@ import {
   StreamDTO,
   useCreateHelixOrgStream,
   useDeleteHelixOrgStream,
+  useGitHubAppInstallation,
   useInstallGitHubWebhook,
   useListGitHubRepos,
   useListHelixOrgStreams,
 } from '../services/helixOrgService'
-import { useListOAuthProviders } from '../services/oauthProvidersService'
-
-// GITHUB_STREAM_SCOPES is the scope set helix-org's streams feature
-// needs from GitHub:
-//   - `repo`: list AND read private repos (otherwise the dropdown
-//     only sees public repos)
-//   - `admin:repo_hook`: register / edit / delete webhooks on a
-//     repo (what the auto-install endpoint calls)
-//   - `read:org`: read org membership + repos. Without it, `gh
-//     auth status` inside the worker sandbox warns about the
-//     missing scope on every invocation, and a few `gh` subcommands
-//     that touch org-owned resources (issue listing across orgs,
-//     team assignment) fail. The webhook-install path doesn't need
-//     it, but the worker-side `gh` does, so we request it on the
-//     same flow.
-// We pass these explicitly when starting the OAuth flow from the
-// New Stream dialog, rather than relying on the org-wide Connected
-// Services button (which requests no scopes by default).
-const GITHUB_STREAM_SCOPES = 'repo,admin:repo_hook,read:org'
 
 const TRANSPORT_KINDS = [
   { value: 'local', label: 'local', help: 'In-process pub/sub. Default; no config needed.' },
@@ -318,83 +300,59 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
   // confusing 412 mid-flow). The hook suppresses its own snackbar
   // so this stays a quiet probe.
   const ghReposQuery = useListGitHubRepos({ enabled: open })
-  const ghConnected = !ghReposQuery.isLoading && !!ghReposQuery.data
   const ghRepoOptions = useMemo(() => (ghReposQuery.data?.repos ?? []).map((r) => r.full_name), [ghReposQuery.data])
 
-  // OAuth providers list — used only to derive the github
-  // provider id we hand to the OAuth start endpoint when the user
-  // clicks "Connect GitHub for streams". Cheap query, cached
-  // session-wide.
-  const oauthProvidersQuery = useListOAuthProviders()
-  const githubProviderID = useMemo(() => {
-    const providers = (oauthProvidersQuery.data ?? []) as Array<{ id?: string; type?: string; enabled?: boolean; created_at?: string }>
-    return providers
-      .filter((p) => p.type === 'github' && p.enabled !== false)
-      // Newest-first so an operator who just swapped to an
-      // org-owned OAuth app gets THAT provider's flow.
-      .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''))[0]?.id
-  }, [oauthProvidersQuery.data])
+  // Probe whether the Helix GitHub App is installed for this org. This is
+  // the single gate for the github transport: the user's own credentials
+  // are used only to install the app; everything after (repo listing,
+  // worker git/gh) acts as the bot. Replaces the old "Connect GitHub
+  // OAuth" gate.
+  const ghInstallQuery = useGitHubAppInstallation({ enabled: open })
+  const ghInstalled = !ghInstallQuery.isLoading && ghInstallQuery.data?.installed === true
+  const ghInstallURL = ghInstallQuery.data?.install_url ?? ''
 
-  const connectGitHubForStreams = async () => {
-    if (!githubProviderID) {
-      snackbar.error('No GitHub OAuth provider configured in helix. Add one in Admin → OAuth Providers first.')
+  // installGitHubApp sends the user to GitHub to install (or reconfigure)
+  // the Helix App. This is the ONLY step that uses the user's own GitHub
+  // identity. After they install, GitHub bounces them back; we re-check
+  // install status both via a postMessage from the app's Setup-URL callback
+  // (when wired) and on window focus (the always-works fallback).
+  const installGitHubApp = () => {
+    if (!ghInstallURL) {
+      snackbar.error('The Helix GitHub App is not configured on this deployment. Ask an admin to set GITHUB_APP_SLUG.')
       return
     }
-    try {
-      // Start the flow WITHOUT a redirect_url override — helix's
-      // OAuth2Provider conflates `redirect_url` with the
-      // GitHub-side `redirect_uri`, which has to match the
-      // callback URL registered on the OAuth app. Letting the
-      // provider use its configured CallbackURL is what
-      // Connected Services does too. The "where do we go after?"
-      // problem is solved by the popup-window pattern below: the
-      // callback page postMessages 'oauth-success' back to the
-      // opener and self-closes.
-      const r = await fetch(
-        `/api/v1/oauth/flow/start/${encodeURIComponent(githubProviderID)}?scopes=${encodeURIComponent(GITHUB_STREAM_SCOPES)}`,
-        { credentials: 'include' },
-      )
-      if (!r.ok) {
-        const body = await r.json().catch(() => ({} as any))
-        snackbar.error(body?.error ?? `OAuth flow start failed (${r.status})`)
-        return
-      }
-      const data = await r.json()
-      const url = data?.auth_url ?? data?.data?.auth_url
-      if (!url) {
-        snackbar.error('OAuth flow returned no auth_url')
-        return
-      }
-      // Open in a popup so the dialog stays open in the main
-      // window. The callback page (api/pkg/server/oauth.go) sends
-      // window.opener.postMessage({type:'oauth-success'}) before
-      // self-closing — listen for that to refresh the repo list.
-      const width = 800
-      const height = 700
-      const left = (window.innerWidth - width) / 2
-      const top = (window.innerHeight - height) / 2
-      const popup = window.open(
-        url,
-        'oauth-popup',
-        `width=${width},height=${height},left=${left},top=${top},toolbar=0,location=0,menubar=0,directories=0,scrollbars=1`,
-      )
-      if (!popup) {
-        snackbar.error('Popup blocked — allow popups for this site and try again.')
-        return
-      }
-      const onMessage = (event: MessageEvent) => {
-        if (event.data?.type === 'oauth-success') {
-          window.removeEventListener('message', onMessage)
-          snackbar.success('GitHub reconnected — refreshing repo list…')
-          // Force the cached repo list to refetch with the new
-          // token; helixml/helix should now appear.
-          ghReposQuery.refetch()
-        }
-      }
-      window.addEventListener('message', onMessage)
-    } catch (e: any) {
-      snackbar.error(e?.message ?? 'OAuth flow start failed')
+    const recheck = () => {
+      ghInstallQuery.refetch()
+      ghReposQuery.refetch()
     }
+    const width = 1000
+    const height = 800
+    const left = (window.innerWidth - width) / 2
+    const top = (window.innerHeight - height) / 2
+    const popup = window.open(
+      ghInstallURL,
+      'github-app-install',
+      `width=${width},height=${height},left=${left},top=${top},toolbar=0,location=0,menubar=0,directories=0,scrollbars=1`,
+    )
+    if (!popup) {
+      snackbar.error('Popup blocked — allow popups for this site and try again.')
+      return
+    }
+    const onMessage = (event: MessageEvent) => {
+      if (event.data?.type === 'github-app-installed') {
+        window.removeEventListener('message', onMessage)
+        window.removeEventListener('focus', onFocus)
+        snackbar.success('Helix installed — refreshing…')
+        recheck()
+      }
+    }
+    // Re-check when the user returns to this window after the GitHub flow.
+    const onFocus = () => {
+      window.removeEventListener('message', onMessage)
+      recheck()
+    }
+    window.addEventListener('message', onMessage)
+    window.addEventListener('focus', onFocus, { once: true })
   }
 
   // If the operator had `github` selected when the probe came back
@@ -402,10 +360,10 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
   // drop back to `local` so the disabled MenuItem becomes the
   // current value's mismatch case.
   useEffect(() => {
-    if (kind === 'github' && !ghReposQuery.isLoading && !ghConnected) {
+    if (kind === 'github' && !ghInstallQuery.isLoading && !ghInstalled) {
       setKind('local')
     }
-  }, [kind, ghReposQuery.isLoading, ghConnected])
+  }, [kind, ghInstallQuery.isLoading, ghInstalled])
 
   const helpFor = TRANSPORT_KINDS.find((k) => k.value === kind)?.help
 
@@ -520,7 +478,7 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
               onChange={(e) => setKind(e.target.value)}
             >
               {TRANSPORT_KINDS.map((k) => {
-                const disabled = k.value === 'github' && !ghReposQuery.isLoading && !ghConnected
+                const disabled = k.value === 'github' && !ghInstallQuery.isLoading && !ghInstalled
                 return (
                   <MenuItem
                     key={k.value}
@@ -536,7 +494,7 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
                         color="text.secondary"
                         sx={{ ml: 1, fontFamily: 'inherit', fontStyle: 'italic' }}
                       >
-                        — needs GitHub connection (see below)
+                        — needs the Helix GitHub App (see below)
                       </Typography>
                     )}
                   </MenuItem>
@@ -545,26 +503,27 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
             </Select>
           </FormControl>
           <Typography variant="caption" color="text.secondary">{helpFor}</Typography>
-          {!ghReposQuery.isLoading && !ghConnected && (
-            <Box sx={{ p: 1.5, borderRadius: 1, backgroundColor: 'action.hover' }}>
+          {!ghInstallQuery.isLoading && !ghInstalled && (
+            <Box sx={{ p: 1.5, borderRadius: 1, backgroundColor: 'action.hover' }} data-testid="github-app-install-gate">
               <Typography variant="body2" sx={{ mb: 1 }}>
-                <strong>GitHub not connected with the right scopes.</strong> Streams need <code>repo</code> + <code>admin:repo_hook</code> so helix can list private repos and register webhooks for you. The default Connected Services connect button doesn't request these.
+                <strong>The Helix GitHub App isn't installed for this org yet.</strong> Install it once on the repos you want Helix to work with — afterwards Helix lists repos and acts on them as the <code>helix</code> bot, not your personal account.
               </Typography>
               <Button
                 size="small"
                 variant="contained"
-                onClick={connectGitHubForStreams}
-                disabled={!githubProviderID}
+                onClick={installGitHubApp}
+                disabled={!ghInstallURL}
+                data-testid="github-app-install-button"
               >
-                Connect GitHub for streams
+                Install Helix
               </Button>
-              {!githubProviderID && (
+              {!ghInstallURL && (
                 <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-                  No GitHub OAuth provider configured. Admins: add one under Admin → OAuth Providers first.
+                  The Helix GitHub App isn't configured on this deployment. Admins: set <code>GITHUB_APP_SLUG</code> to the app's slug first.
                 </Typography>
               )}
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-                You'll be redirected to GitHub to approve, then bounced back here.
+                You'll be sent to GitHub to choose the account and repositories, then bounced back here. Only an org owner can install it.
               </Typography>
             </Box>
           )}
@@ -631,15 +590,15 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
                 Default: receive every event from this repo ("*"). You can narrow the events whitelist from the stream's detail page after it's created.
               </Typography>
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                Missing private repos (e.g. an org's repo doesn't appear)? Your GitHub token may not have <code>repo</code> scope.{' '}
+                Missing a repo? The bot only sees repos the Helix App is installed on.{' '}
                 <Button
                   size="small"
                   variant="text"
-                  onClick={connectGitHubForStreams}
-                  disabled={!githubProviderID}
+                  onClick={installGitHubApp}
+                  disabled={!ghInstallURL}
                   sx={{ p: 0, minWidth: 0, textTransform: 'none', verticalAlign: 'baseline' }}
                 >
-                  Reconnect with stream permissions →
+                  Configure repositories on GitHub →
                 </Button>
               </Typography>
             </>

--- a/frontend/src/pages/HelixOrgStreams.tsx
+++ b/frontend/src/pages/HelixOrgStreams.tsx
@@ -44,12 +44,13 @@ import {
   useCreateHelixOrgStream,
   useDeleteHelixOrgStream,
   useGitHubAppInstallation,
-  useGitHubManifestStart,
   useInstallGitHubWebhook,
   useListGitHubRepos,
   useListHelixOrgStreams,
 } from '../services/helixOrgService'
 import { GitHubEventsField, GitHubBranchesField } from '../components/helix-org/GitHubStreamConfigFields'
+import { useGitHubAppActions } from '../components/helix-org/useGitHubAppActions'
+import { GitHubAppConnect } from '../components/helix-org/GitHubAppPanel'
 
 const TRANSPORT_KINDS = [
   { value: 'local', label: 'local', help: 'In-process pub/sub. Default; no config needed.' },
@@ -325,108 +326,11 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
     }
     prevInstalledRef.current = ghInstalled
   }, [ghInstalled])
-  // app_exists = the Helix app has been created for this org (via the manifest
-  // flow or BYO creds) but may not be installed on a repo yet.
-  const ghAppExists = !ghInstallQuery.isLoading && ghInstallQuery.data?.app_exists === true
-  const ghInstallURL = ghInstallQuery.data?.install_url ?? ''
-  const manifestStart = useGitHubManifestStart()
-  // GitHub org the user wants to create the app under (org-owned app).
-  const [ghCreateOrg, setGhCreateOrg] = useState('')
-
-  // installGitHubApp sends the user to GitHub to install (or reconfigure)
-  // the Helix App. This is the ONLY step that uses the user's own GitHub
-  // identity. After they install, GitHub bounces them back; we re-check
-  // install status both via a postMessage from the app's Setup-URL callback
-  // (when wired) and on window focus (the always-works fallback).
-  // openGitHubPopup centres a popup; returns null (and toasts) if blocked.
-  const openGitHubPopup = (url: string, name: string): Window | null => {
-    const width = 1000
-    const height = 800
-    const left = (window.innerWidth - width) / 2
-    const top = (window.innerHeight - height) / 2
-    const popup = window.open(
-      url,
-      name,
-      `width=${width},height=${height},left=${left},top=${top},toolbar=0,location=0,menubar=0,directories=0,scrollbars=1`,
-    )
-    if (!popup) snackbar.error('Popup blocked — allow popups for this site and try again.')
-    return popup
-  }
-
-  // watchForInstallCompletion re-checks install status when the GitHub flow
-  // finishes — either via the app's setup-URL callback postMessage, or when
-  // the user returns focus to this window (the always-works fallback).
-  const watchForInstallCompletion = () => {
-    const recheck = () => {
-      ghInstallQuery.refetch()
-      ghReposQuery.refetch()
-    }
-    const onMessage = (event: MessageEvent) => {
-      if (event.data?.type === 'github-app-installed') {
-        window.removeEventListener('message', onMessage)
-        window.removeEventListener('focus', onFocus)
-        snackbar.success('Helix installed — refreshing…')
-        recheck()
-      } else if (event.data?.type === 'github-app-install-error') {
-        window.removeEventListener('message', onMessage)
-        snackbar.error('GitHub reported a problem completing the install.')
-      }
-    }
-    const onFocus = () => {
-      window.removeEventListener('message', onMessage)
-      recheck()
-    }
-    window.addEventListener('message', onMessage)
-    window.addEventListener('focus', onFocus, { once: true })
-  }
-
-  // installGitHubApp: app already created → send the user to GitHub to pick
-  // repos to install it on.
-  const installGitHubApp = () => {
-    if (!ghInstallURL) {
-      snackbar.error('The Helix GitHub App is not configured on this deployment. Ask an admin to set GITHUB_APP_SLUG.')
-      return
-    }
-    if (!openGitHubPopup(ghInstallURL, 'github-app-install')) return
-    watchForInstallCompletion()
-  }
-
-  // createGitHubApp: no app yet → run the Manifest flow. Ask the backend for
-  // the GitHub POST URL + manifest, then submit it as a form inside a popup so
-  // GitHub creates the app (org-owned) on the user's behalf. The popup then
-  // chains create → install → setup-callback, which postMessages us back.
-  const createGitHubApp = async () => {
-    const githubOrg = ghCreateOrg.trim()
-    if (!githubOrg) {
-      snackbar.error('Enter the GitHub organization to create the app under')
-      return
-    }
-    // Open the popup synchronously on the click — opening it after the await
-    // below would lose the user gesture and get blocked.
-    const popup = openGitHubPopup('about:blank', 'github-app-create')
-    if (!popup) return
-    try {
-      popup.document.body.innerHTML = 'Preparing the Helix app…'
-      const start = await manifestStart.mutateAsync({ github_org: githubOrg, origin: window.location.origin })
-      // Build and submit the manifest form inside the (same-origin) popup.
-      const doc = popup.document
-      doc.body.innerHTML = 'Redirecting to GitHub to create the Helix app…'
-      const form = doc.createElement('form')
-      form.method = 'POST'
-      form.action = start.post_url
-      const input = doc.createElement('input')
-      input.type = 'hidden'
-      input.name = 'manifest'
-      input.value = start.manifest
-      form.appendChild(input)
-      doc.body.appendChild(form)
-      form.submit()
-      watchForInstallCompletion()
-    } catch (e: any) {
-      try { popup.close() } catch { /* ignore */ }
-      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'Could not start GitHub app creation')
-    }
-  }
+  const ghManageURL = ghInstallQuery.data?.manage_url ?? ''
+  // Shared GitHub App actions (the create/install gate is rendered by
+  // <GitHubAppConnect>; this is just for the "Manage app" link in the repo
+  // picker once installed). onComplete re-checks install status + repos.
+  const ghActions = useGitHubAppActions(() => { ghInstallQuery.refetch(); ghReposQuery.refetch() })
 
   // If the operator had `github` selected when the probe came back
   // negative (e.g. they disconnected OAuth between dialog opens),
@@ -585,55 +489,9 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
             </Select>
           </FormControl>
           <Typography variant="caption" color="text.secondary">{helpFor}</Typography>
-          {!ghInstallQuery.isLoading && !ghInstalled && !ghAppExists && (
-            <Box sx={{ p: 1.5, borderRadius: 1, backgroundColor: 'action.hover' }} data-testid="github-app-create-gate">
-              <Typography variant="body2" sx={{ mb: 1 }}>
-                <strong>Create the Helix GitHub App for your org.</strong> Helix creates an app owned by your GitHub organization (one click — GitHub pre-fills the permissions). Afterwards Helix acts as the <code>helix</code> bot, not your personal account.
-              </Typography>
-              <Stack direction="row" spacing={1} alignItems="center">
-                <TextField
-                  size="small"
-                  label="GitHub organization"
-                  placeholder="e.g. helixml"
-                  value={ghCreateOrg}
-                  onChange={(e) => setGhCreateOrg(e.target.value)}
-                  sx={{ flex: 1 }}
-                  inputProps={{ 'data-testid': 'github-app-create-org' }}
-                />
-                <Button
-                  size="small"
-                  variant="contained"
-                  onClick={createGitHubApp}
-                  disabled={!ghCreateOrg.trim() || manifestStart.isPending}
-                  data-testid="github-app-create-button"
-                >
-                  {manifestStart.isPending ? 'Starting…' : 'Create Helix app'}
-                </Button>
-              </Stack>
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-                You must be an owner of that GitHub org. You'll review the app on GitHub, click Create, then choose which repos to install it on — all in one popup.
-              </Typography>
-            </Box>
-          )}
-          {!ghInstallQuery.isLoading && !ghInstalled && ghAppExists && (
-            <Box sx={{ p: 1.5, borderRadius: 1, backgroundColor: 'action.hover' }} data-testid="github-app-install-gate">
-              <Typography variant="body2" sx={{ mb: 1 }}>
-                <strong>The Helix app is created but not installed on any repo yet.</strong> Install it on the repos you want Helix to work with — afterwards Helix lists those repos and acts on them as the <code>helix</code> bot.
-              </Typography>
-              <Button
-                size="small"
-                variant="contained"
-                onClick={installGitHubApp}
-                disabled={!ghInstallURL}
-                data-testid="github-app-install-button"
-              >
-                Install Helix
-              </Button>
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-                You'll be sent to GitHub to choose the repositories, then bounced back here. Only an org owner can install it.
-              </Typography>
-            </Box>
-          )}
+          {/* Shared create/install gate — same component as the Settings page.
+              Renders nothing once installed (the repo picker below takes over). */}
+          <GitHubAppConnect mode="gate" onChange={() => { ghInstallQuery.refetch(); ghReposQuery.refetch() }} />
           {kind === 'github' && (
             <>
               <Stack direction="row" spacing={1} alignItems="flex-start">
@@ -696,15 +554,15 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
               <GitHubEventsField events={ghEvents} onChange={setGhEvents} />
               <GitHubBranchesField branches={ghBranches} onChange={setGhBranches} />
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                Missing a repo? The bot only sees repos the Helix App is installed on.{' '}
+                Missing a repo? The bot only sees repos the Helix App is installed on. Add/remove repos, edit permissions, or delete the app from its developer settings:{' '}
                 <Button
                   size="small"
                   variant="text"
-                  onClick={installGitHubApp}
-                  disabled={!ghInstallURL}
+                  onClick={() => ghActions.openManage(ghManageURL)}
+                  disabled={!ghManageURL}
                   sx={{ p: 0, minWidth: 0, textTransform: 'none', verticalAlign: 'baseline' }}
                 >
-                  Configure repositories on GitHub →
+                  Manage app on GitHub →
                 </Button>
               </Typography>
             </>

--- a/frontend/src/pages/HelixOrgStreams.tsx
+++ b/frontend/src/pages/HelixOrgStreams.tsx
@@ -49,6 +49,7 @@ import {
   useListGitHubRepos,
   useListHelixOrgStreams,
 } from '../services/helixOrgService'
+import { GitHubEventsField, GitHubBranchesField } from '../components/helix-org/GitHubStreamConfigFields'
 
 const TRANSPORT_KINDS = [
   { value: 'local', label: 'local', help: 'In-process pub/sub. Default; no config needed.' },
@@ -294,6 +295,10 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
   // everything"; advanced users can narrow this down later via the
   // detail page's Edit flow.
   const [ghRepo, setGhRepo] = useState<string>('')
+  // Events default to ["*"] (all). Branches optionally narrow push/create/
+  // delete to specific branches. Both editable here; also on the detail page.
+  const [ghEvents, setGhEvents] = useState<string[]>(['*'])
+  const [ghBranches, setGhBranches] = useState<string[]>([])
 
   // Probe GitHub on dialog open — the result tells us whether to
   // disable the `github` transport option (no OAuth connection →
@@ -450,7 +455,10 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
       // transport accepts every event. The detail page's edit form
       // lets advanced operators narrow this to a specific
       // whitelist after the stream is created.
-      config = { repo: ghRepo.trim(), events: ['*'] }
+      const events = ghEvents.length > 0 ? ghEvents : ['*']
+      config = { repo: ghRepo.trim(), events }
+      const branches = ghBranches.map((b) => b.trim()).filter((b) => b.length > 0)
+      if (branches.length > 0) (config as Record<string, unknown>).branches = branches
     } else if (configText.trim()) {
       try {
         config = JSON.parse(configText)
@@ -501,7 +509,7 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
         snackbar.success('stream created')
       }
       setId(''); setName(''); setDescription(''); setKind('local'); setConfigText('')
-      setGhRepo('')
+      setGhRepo(''); setGhEvents(['*']); setGhBranches([])
       onClose()
     } catch (e: any) {
       snackbar.error(e?.response?.data?.error ?? e?.message ?? 'create failed')
@@ -510,7 +518,7 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
 
   const handleClose = () => {
     setId(''); setName(''); setDescription(''); setKind('local'); setConfigText('')
-    setGhRepo('')
+    setGhRepo(''); setGhEvents(['*']); setGhBranches([])
     onClose()
   }
 
@@ -685,9 +693,8 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
                   <RefreshIcon fontSize="small" />
                 </IconButton>
               </Stack>
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                Default: receive every event from this repo ("*"). You can narrow the events whitelist from the stream's detail page after it's created.
-              </Typography>
+              <GitHubEventsField events={ghEvents} onChange={setGhEvents} />
+              <GitHubBranchesField branches={ghBranches} onChange={setGhBranches} />
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
                 Missing a repo? The bot only sees repos the Helix App is installed on.{' '}
                 <Button

--- a/frontend/src/pages/HelixOrgStreams.tsx
+++ b/frontend/src/pages/HelixOrgStreams.tsx
@@ -44,6 +44,7 @@ import {
   useCreateHelixOrgStream,
   useDeleteHelixOrgStream,
   useGitHubAppInstallation,
+  useGitHubManifestStart,
   useInstallGitHubWebhook,
   useListGitHubRepos,
   useListHelixOrgStreams,
@@ -309,34 +310,41 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
   // OAuth" gate.
   const ghInstallQuery = useGitHubAppInstallation({ enabled: open })
   const ghInstalled = !ghInstallQuery.isLoading && ghInstallQuery.data?.installed === true
+  // app_exists = the Helix app has been created for this org (via the manifest
+  // flow or BYO creds) but may not be installed on a repo yet.
+  const ghAppExists = !ghInstallQuery.isLoading && ghInstallQuery.data?.app_exists === true
   const ghInstallURL = ghInstallQuery.data?.install_url ?? ''
+  const manifestStart = useGitHubManifestStart()
+  // GitHub org the user wants to create the app under (org-owned app).
+  const [ghCreateOrg, setGhCreateOrg] = useState('')
 
   // installGitHubApp sends the user to GitHub to install (or reconfigure)
   // the Helix App. This is the ONLY step that uses the user's own GitHub
   // identity. After they install, GitHub bounces them back; we re-check
   // install status both via a postMessage from the app's Setup-URL callback
   // (when wired) and on window focus (the always-works fallback).
-  const installGitHubApp = () => {
-    if (!ghInstallURL) {
-      snackbar.error('The Helix GitHub App is not configured on this deployment. Ask an admin to set GITHUB_APP_SLUG.')
-      return
-    }
-    const recheck = () => {
-      ghInstallQuery.refetch()
-      ghReposQuery.refetch()
-    }
+  // openGitHubPopup centres a popup; returns null (and toasts) if blocked.
+  const openGitHubPopup = (url: string, name: string): Window | null => {
     const width = 1000
     const height = 800
     const left = (window.innerWidth - width) / 2
     const top = (window.innerHeight - height) / 2
     const popup = window.open(
-      ghInstallURL,
-      'github-app-install',
+      url,
+      name,
       `width=${width},height=${height},left=${left},top=${top},toolbar=0,location=0,menubar=0,directories=0,scrollbars=1`,
     )
-    if (!popup) {
-      snackbar.error('Popup blocked — allow popups for this site and try again.')
-      return
+    if (!popup) snackbar.error('Popup blocked — allow popups for this site and try again.')
+    return popup
+  }
+
+  // watchForInstallCompletion re-checks install status when the GitHub flow
+  // finishes — either via the app's setup-URL callback postMessage, or when
+  // the user returns focus to this window (the always-works fallback).
+  const watchForInstallCompletion = () => {
+    const recheck = () => {
+      ghInstallQuery.refetch()
+      ghReposQuery.refetch()
     }
     const onMessage = (event: MessageEvent) => {
       if (event.data?.type === 'github-app-installed') {
@@ -344,15 +352,65 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
         window.removeEventListener('focus', onFocus)
         snackbar.success('Helix installed — refreshing…')
         recheck()
+      } else if (event.data?.type === 'github-app-install-error') {
+        window.removeEventListener('message', onMessage)
+        snackbar.error('GitHub reported a problem completing the install.')
       }
     }
-    // Re-check when the user returns to this window after the GitHub flow.
     const onFocus = () => {
       window.removeEventListener('message', onMessage)
       recheck()
     }
     window.addEventListener('message', onMessage)
     window.addEventListener('focus', onFocus, { once: true })
+  }
+
+  // installGitHubApp: app already created → send the user to GitHub to pick
+  // repos to install it on.
+  const installGitHubApp = () => {
+    if (!ghInstallURL) {
+      snackbar.error('The Helix GitHub App is not configured on this deployment. Ask an admin to set GITHUB_APP_SLUG.')
+      return
+    }
+    if (!openGitHubPopup(ghInstallURL, 'github-app-install')) return
+    watchForInstallCompletion()
+  }
+
+  // createGitHubApp: no app yet → run the Manifest flow. Ask the backend for
+  // the GitHub POST URL + manifest, then submit it as a form inside a popup so
+  // GitHub creates the app (org-owned) on the user's behalf. The popup then
+  // chains create → install → setup-callback, which postMessages us back.
+  const createGitHubApp = async () => {
+    const githubOrg = ghCreateOrg.trim()
+    if (!githubOrg) {
+      snackbar.error('Enter the GitHub organization to create the app under')
+      return
+    }
+    // Open the popup synchronously on the click — opening it after the await
+    // below would lose the user gesture and get blocked.
+    const popup = openGitHubPopup('about:blank', 'github-app-create')
+    if (!popup) return
+    try {
+      popup.document.body.innerHTML = 'Preparing the Helix app…'
+      const start = await manifestStart.mutateAsync({ github_org: githubOrg, origin: window.location.origin })
+      // Build and submit the manifest form inside the (same-origin) popup.
+      const doc = popup.document
+      doc.body.innerHTML = 'Redirecting to GitHub to create the Helix app…'
+      const form = doc.createElement('form')
+      form.method = 'POST'
+      form.action = start.post_url
+      const input = doc.createElement('input')
+      input.type = 'hidden'
+      input.name = 'manifest'
+      input.value = start.manifest
+      form.appendChild(input)
+      doc.body.appendChild(form)
+      form.submit()
+      watchForInstallCompletion()
+    } catch (e: any) {
+      try { popup.close() } catch { /* ignore */ }
+      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'Could not start GitHub app creation')
+    }
   }
 
   // If the operator had `github` selected when the probe came back
@@ -503,10 +561,40 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
             </Select>
           </FormControl>
           <Typography variant="caption" color="text.secondary">{helpFor}</Typography>
-          {!ghInstallQuery.isLoading && !ghInstalled && (
+          {!ghInstallQuery.isLoading && !ghInstalled && !ghAppExists && (
+            <Box sx={{ p: 1.5, borderRadius: 1, backgroundColor: 'action.hover' }} data-testid="github-app-create-gate">
+              <Typography variant="body2" sx={{ mb: 1 }}>
+                <strong>Create the Helix GitHub App for your org.</strong> Helix creates an app owned by your GitHub organization (one click — GitHub pre-fills the permissions). Afterwards Helix acts as the <code>helix</code> bot, not your personal account.
+              </Typography>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <TextField
+                  size="small"
+                  label="GitHub organization"
+                  placeholder="e.g. helixml"
+                  value={ghCreateOrg}
+                  onChange={(e) => setGhCreateOrg(e.target.value)}
+                  sx={{ flex: 1 }}
+                  inputProps={{ 'data-testid': 'github-app-create-org' }}
+                />
+                <Button
+                  size="small"
+                  variant="contained"
+                  onClick={createGitHubApp}
+                  disabled={!ghCreateOrg.trim() || manifestStart.isPending}
+                  data-testid="github-app-create-button"
+                >
+                  {manifestStart.isPending ? 'Starting…' : 'Create Helix app'}
+                </Button>
+              </Stack>
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                You must be an owner of that GitHub org. You'll review the app on GitHub, click Create, then choose which repos to install it on — all in one popup.
+              </Typography>
+            </Box>
+          )}
+          {!ghInstallQuery.isLoading && !ghInstalled && ghAppExists && (
             <Box sx={{ p: 1.5, borderRadius: 1, backgroundColor: 'action.hover' }} data-testid="github-app-install-gate">
               <Typography variant="body2" sx={{ mb: 1 }}>
-                <strong>The Helix GitHub App isn't installed for this org yet.</strong> Install it once on the repos you want Helix to work with — afterwards Helix lists repos and acts on them as the <code>helix</code> bot, not your personal account.
+                <strong>The Helix app is created but not installed on any repo yet.</strong> Install it on the repos you want Helix to work with — afterwards Helix lists those repos and acts on them as the <code>helix</code> bot.
               </Typography>
               <Button
                 size="small"
@@ -517,13 +605,8 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
               >
                 Install Helix
               </Button>
-              {!ghInstallURL && (
-                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-                  The Helix GitHub App isn't configured on this deployment. Admins: set <code>GITHUB_APP_SLUG</code> to the app's slug first.
-                </Typography>
-              )}
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
-                You'll be sent to GitHub to choose the account and repositories, then bounced back here. Only an org owner can install it.
+                You'll be sent to GitHub to choose the repositories, then bounced back here. Only an org owner can install it.
               </Typography>
             </Box>
           )}

--- a/frontend/src/pages/HelixOrgStreams.tsx
+++ b/frontend/src/pages/HelixOrgStreams.tsx
@@ -4,7 +4,7 @@
 // the chart edges (added in the same PR as this page) show which
 // worker pulls from which stream.
 
-import { FC, MouseEvent, useEffect, useMemo, useState } from 'react'
+import { FC, MouseEvent, useEffect, useMemo, useRef, useState } from 'react'
 import Autocomplete from '@mui/material/Autocomplete'
 import Box from '@mui/material/Box'
 import Chip from '@mui/material/Chip'
@@ -308,8 +308,18 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
   // are used only to install the app; everything after (repo listing,
   // worker git/gh) acts as the bot. Replaces the old "Connect GitHub
   // OAuth" gate.
-  const ghInstallQuery = useGitHubAppInstallation({ enabled: open })
+  const ghInstallQuery = useGitHubAppInstallation({ enabled: open, pollWhileNotInstalled: open })
   const ghInstalled = !ghInstallQuery.isLoading && ghInstallQuery.data?.installed === true
+  // When the install transitions to done (detected via polling, since the
+  // GitHub popup can't postMessage back through COOP), refetch the repo list
+  // so the picker shows the bot's installation repos instead of stale state.
+  const prevInstalledRef = useRef(false)
+  useEffect(() => {
+    if (ghInstalled && !prevInstalledRef.current) {
+      ghReposQuery.refetch()
+    }
+    prevInstalledRef.current = ghInstalled
+  }, [ghInstalled])
   // app_exists = the Helix app has been created for this org (via the manifest
   // flow or BYO creds) but may not be installed on a repo yet.
   const ghAppExists = !ghInstallQuery.isLoading && ghInstallQuery.data?.app_exists === true

--- a/frontend/src/pages/HelixOrgStreams.tsx
+++ b/frontend/src/pages/HelixOrgStreams.tsx
@@ -298,7 +298,7 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
   // Events default to ["*"] (all). Branches optionally narrow push/create/
   // delete to specific branches. Both editable here; also on the detail page.
   const [ghEvents, setGhEvents] = useState<string[]>(['*'])
-  const [ghBranches, setGhBranches] = useState<string[]>([])
+  const [ghBranches, setGhBranches] = useState<string[]>(['*'])
 
   // Probe GitHub on dialog open — the result tells us whether to
   // disable the `github` transport option (no OAuth connection →
@@ -509,7 +509,7 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
         snackbar.success('stream created')
       }
       setId(''); setName(''); setDescription(''); setKind('local'); setConfigText('')
-      setGhRepo(''); setGhEvents(['*']); setGhBranches([])
+      setGhRepo(''); setGhEvents(['*']); setGhBranches(['*'])
       onClose()
     } catch (e: any) {
       snackbar.error(e?.response?.data?.error ?? e?.message ?? 'create failed')
@@ -518,7 +518,7 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
 
   const handleClose = () => {
     setId(''); setName(''); setDescription(''); setKind('local'); setConfigText('')
-    setGhRepo(''); setGhEvents(['*']); setGhBranches([])
+    setGhRepo(''); setGhEvents(['*']); setGhBranches(['*'])
     onClose()
   }
 

--- a/frontend/src/pages/HelixOrgStreams.tsx
+++ b/frontend/src/pages/HelixOrgStreams.tsx
@@ -49,7 +49,6 @@ import {
   useListHelixOrgStreams,
 } from '../services/helixOrgService'
 import { GitHubEventsField, GitHubBranchesField } from '../components/helix-org/GitHubStreamConfigFields'
-import { useGitHubAppActions } from '../components/helix-org/useGitHubAppActions'
 import { GitHubAppConnect } from '../components/helix-org/GitHubAppPanel'
 
 const TRANSPORT_KINDS = [
@@ -326,11 +325,6 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
     }
     prevInstalledRef.current = ghInstalled
   }, [ghInstalled])
-  const ghManageURL = ghInstallQuery.data?.manage_url ?? ''
-  // Shared GitHub App actions (the create/install gate is rendered by
-  // <GitHubAppConnect>; this is just for the "Manage app" link in the repo
-  // picker once installed). onComplete re-checks install status + repos.
-  const ghActions = useGitHubAppActions(() => { ghInstallQuery.refetch(); ghReposQuery.refetch() })
 
   // If the operator had `github` selected when the probe came back
   // negative (e.g. they disconnected OAuth between dialog opens),
@@ -489,9 +483,13 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
             </Select>
           </FormControl>
           <Typography variant="caption" color="text.secondary">{helpFor}</Typography>
-          {/* Shared create/install gate — same component as the Settings page.
-              Renders nothing once installed (the repo picker below takes over). */}
-          <GitHubAppConnect mode="gate" onChange={() => { ghInstallQuery.refetch(); ghReposQuery.refetch() }} />
+          {/* Shared GitHub App connector — same component as the Settings page.
+              Shown while the app isn't ready (so the user can set it up from any
+              transport), and alongside the repo picker once github is selected
+              (where its "Add repositories" button is useful). */}
+          {(!ghInstalled || kind === 'github') && (
+            <GitHubAppConnect mode="gate" onChange={() => { ghInstallQuery.refetch(); ghReposQuery.refetch() }} />
+          )}
           {kind === 'github' && (
             <>
               <Stack direction="row" spacing={1} alignItems="flex-start">
@@ -554,16 +552,7 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
               <GitHubEventsField events={ghEvents} onChange={setGhEvents} />
               <GitHubBranchesField branches={ghBranches} onChange={setGhBranches} />
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                Missing a repo? The bot only sees repos the Helix App is installed on. Add/remove repos, edit permissions, or delete the app from its developer settings:{' '}
-                <Button
-                  size="small"
-                  variant="text"
-                  onClick={() => ghActions.openManage(ghManageURL)}
-                  disabled={!ghManageURL}
-                  sx={{ p: 0, minWidth: 0, textTransform: 'none', verticalAlign: 'baseline' }}
-                >
-                  Manage app on GitHub →
-                </Button>
+                The bot only sees repos the Helix App is installed on — use "Add repositories / another org" above to grant more.
               </Typography>
             </>
           )}

--- a/frontend/src/services/helixOrgService.ts
+++ b/frontend/src/services/helixOrgService.ts
@@ -6,6 +6,7 @@ import {
   ApiCreateStreamRequest,
   ApiEventCard,
   ApiGitHubReposResponse,
+  ApiGitHubInstallationStatus,
   ApiHireWorkerRequest,
   ApiHireWorkerResponse,
   ApiInstallGitHubWebhookResponse,
@@ -42,6 +43,7 @@ export type SettingsResponse = ApiSettingsResponse
 export type StreamsResponse = ApiStreamsResponse
 export type GitHubRepoDTO = NonNullable<ApiGitHubReposResponse['repos']>[number]
 export type GitHubReposResponse = ApiGitHubReposResponse
+export type GitHubInstallationStatus = ApiGitHubInstallationStatus
 export type InstallGitHubWebhookResponse = ApiInstallGitHubWebhookResponse
 export type WorkerSubscription = ApiWorkerSubscriptionDTO
 export type WorkerSubscriptionsResponse = ApiWorkerSubscriptionsResponse
@@ -513,6 +515,28 @@ export function useListGitHubRepos(options?: { enabled?: boolean }) {
       try {
         const res = await api.getApiClient().v1OrgsGithubReposDetail(orgID)
         return res.data as GitHubReposResponse
+      } catch {
+        return null
+      }
+    },
+    enabled: !!orgID && (options?.enabled ?? true),
+    staleTime: 0,
+    refetchOnMount: 'always',
+  })
+}
+
+// Probes "is the Helix GitHub App installed for this org?" — drives the
+// New Stream "Install Helix" gate. Quiet on failure (returns null) so the
+// dialog renders the install CTA rather than a toast.
+export function useGitHubAppInstallation(options?: { enabled?: boolean }) {
+  const api = useApi()
+  const { orgID } = useHelixOrgBase()
+  return useQuery({
+    queryKey: ['helix-org', 'github-app-installation', orgID],
+    queryFn: async () => {
+      try {
+        const res = await api.getApiClient().v1OrgsGithubAppInstallationDetail(orgID)
+        return res.data as GitHubInstallationStatus
       } catch {
         return null
       }

--- a/frontend/src/services/helixOrgService.ts
+++ b/frontend/src/services/helixOrgService.ts
@@ -7,6 +7,7 @@ import {
   ApiEventCard,
   ApiGitHubReposResponse,
   ApiGitHubInstallationStatus,
+  ApiGitHubManifestStartResponse,
   ApiHireWorkerRequest,
   ApiHireWorkerResponse,
   ApiInstallGitHubWebhookResponse,
@@ -44,6 +45,7 @@ export type StreamsResponse = ApiStreamsResponse
 export type GitHubRepoDTO = NonNullable<ApiGitHubReposResponse['repos']>[number]
 export type GitHubReposResponse = ApiGitHubReposResponse
 export type GitHubInstallationStatus = ApiGitHubInstallationStatus
+export type GitHubManifestStartResponse = ApiGitHubManifestStartResponse
 export type InstallGitHubWebhookResponse = ApiInstallGitHubWebhookResponse
 export type WorkerSubscription = ApiWorkerSubscriptionDTO
 export type WorkerSubscriptionsResponse = ApiWorkerSubscriptionsResponse
@@ -544,6 +546,20 @@ export function useGitHubAppInstallation(options?: { enabled?: boolean }) {
     enabled: !!orgID && (options?.enabled ?? true),
     staleTime: 0,
     refetchOnMount: 'always',
+  })
+}
+
+// Starts the GitHub App Manifest flow: the backend returns the GitHub POST
+// URL + a Helix-authored manifest + CSRF state, which the dialog submits as a
+// form so GitHub creates the app on the user's behalf.
+export function useGitHubManifestStart() {
+  const api = useApi()
+  const { orgID } = useHelixOrgBase()
+  return useMutation({
+    mutationFn: async (input: { github_org: string; origin: string }) => {
+      const res = await api.getApiClient().v1OrgsGithubAppManifestCreate(orgID, { body: input } as any)
+      return res.data as GitHubManifestStartResponse
+    },
   })
 }
 

--- a/frontend/src/services/helixOrgService.ts
+++ b/frontend/src/services/helixOrgService.ts
@@ -530,7 +530,7 @@ export function useListGitHubRepos(options?: { enabled?: boolean }) {
 // Probes "is the Helix GitHub App installed for this org?" — drives the
 // New Stream "Install Helix" gate. Quiet on failure (returns null) so the
 // dialog renders the install CTA rather than a toast.
-export function useGitHubAppInstallation(options?: { enabled?: boolean }) {
+export function useGitHubAppInstallation(options?: { enabled?: boolean; pollWhileNotInstalled?: boolean }) {
   const api = useApi()
   const { orgID } = useHelixOrgBase()
   return useQuery({
@@ -546,6 +546,12 @@ export function useGitHubAppInstallation(options?: { enabled?: boolean }) {
     enabled: !!orgID && (options?.enabled ?? true),
     staleTime: 0,
     refetchOnMount: 'always',
+    // Poll until installed: the GitHub popup's postMessage is severed by
+    // GitHub's COOP headers, so polling is how the dialog reliably detects
+    // create→install completing.
+    refetchInterval: options?.pollWhileNotInstalled
+      ? (query) => ((query.state.data as GitHubInstallationStatus | null)?.installed ? false : 4000)
+      : false,
   })
 }
 

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -58,6 +58,21 @@ definitions:
       to:
         type: string
     type: object
+  api.GitHubInstallationStatus:
+    properties:
+      install_url:
+        description: |-
+          InstallURL is where the New Stream gate sends the user to install the
+          app (https://github.com/apps/<slug>/installations/new). Empty when the
+          operator hasn't configured the app slug — the gate then tells the user
+          to ask their admin to configure the Helix GitHub App.
+        type: string
+      installed:
+        description: |-
+          Installed is true when the Helix GitHub App has an installation for
+          this org (a github_app ServiceConnection with an installation id).
+        type: boolean
+    type: object
   api.GitHubRepoDTO:
     properties:
       full_name:
@@ -17238,6 +17253,20 @@ paths:
       summary: List sandbox tmux sessions
       tags:
       - Sandboxes
+  /api/v1/orgs/{org}/github/app-installation:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.GitHubInstallationStatus'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: GitHub App install status for the org'
+      tags:
+      - HelixOrg
   /api/v1/orgs/{org}/github/repos:
     get:
       produces:

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -77,6 +77,13 @@ definitions:
           Installed is true when the Helix GitHub App has an installation for
           this org (a github_app ServiceConnection with an installation id).
         type: boolean
+      manage_url:
+        description: |-
+          ManageURL is the app's developer-settings page on GitHub
+          (github.com/organizations/<owner>/settings/apps/<slug>) — where you edit
+          permissions, repos, and delete the app. Empty when the owner is unknown
+          (e.g. a BYO app configured without it).
+        type: string
     type: object
   api.GitHubManifestStartResponse:
     properties:

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -60,18 +60,32 @@ definitions:
     type: object
   api.GitHubInstallationStatus:
     properties:
+      app_exists:
+        description: |-
+          AppExists is true when a Helix GitHub App has been created/registered
+          for this org (a github_app ServiceConnection exists), even if not yet
+          installed on any repo. Drives the gate's create-vs-install branch.
+        type: boolean
       install_url:
         description: |-
           InstallURL is where the New Stream gate sends the user to install the
-          app (https://github.com/apps/<slug>/installations/new). Empty when the
-          operator hasn't configured the app slug — the gate then tells the user
-          to ask their admin to configure the Helix GitHub App.
+          app (https://github.com/apps/<slug>/installations/new). Populated from
+          the created app's slug, or from GITHUB_APP_SLUG for a pre-existing app.
         type: string
       installed:
         description: |-
           Installed is true when the Helix GitHub App has an installation for
           this org (a github_app ServiceConnection with an installation id).
         type: boolean
+    type: object
+  api.GitHubManifestStartResponse:
+    properties:
+      manifest:
+        type: string
+      post_url:
+        type: string
+      state:
+        type: string
     type: object
   api.GitHubRepoDTO:
     properties:
@@ -17265,6 +17279,26 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: 'Helix-org: GitHub App install status for the org'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/github/app-manifest:
+    post:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.GitHubManifestStartResponse'
+        "412":
+          description: manifest flow not wired
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: start the GitHub App manifest (create) flow'
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/github/repos:

--- a/openapi.json
+++ b/openapi.json
@@ -11124,6 +11124,31 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/github/app-installation": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: GitHub App install status for the org",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.GitHubInstallationStatus"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/github/repos": {
             "get": {
                 "security": [
@@ -24416,6 +24441,19 @@
                     },
                     "to": {
                         "type": "string"
+                    }
+                }
+            },
+            "api.GitHubInstallationStatus": {
+                "type": "object",
+                "properties": {
+                    "install_url": {
+                        "description": "InstallURL is where the New Stream gate sends the user to install the\napp (https://github.com/apps/<slug>/installations/new). Empty when the\noperator hasn't configured the app slug — the gate then tells the user\nto ask their admin to configure the Helix GitHub App.",
+                        "type": "string"
+                    },
+                    "installed": {
+                        "description": "Installed is true when the Helix GitHub App has an installation for\nthis org (a github_app ServiceConnection with an installation id).",
+                        "type": "boolean"
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -11149,6 +11149,41 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/github/app-manifest": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: start the GitHub App manifest (create) flow",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.GitHubManifestStartResponse"
+                                }
+                            }
+                        }
+                    },
+                    "412": {
+                        "description": "manifest flow not wired",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/github/repos": {
             "get": {
                 "security": [
@@ -24447,13 +24482,31 @@
             "api.GitHubInstallationStatus": {
                 "type": "object",
                 "properties": {
+                    "app_exists": {
+                        "description": "AppExists is true when a Helix GitHub App has been created/registered\nfor this org (a github_app ServiceConnection exists), even if not yet\ninstalled on any repo. Drives the gate's create-vs-install branch.",
+                        "type": "boolean"
+                    },
                     "install_url": {
-                        "description": "InstallURL is where the New Stream gate sends the user to install the\napp (https://github.com/apps/<slug>/installations/new). Empty when the\noperator hasn't configured the app slug — the gate then tells the user\nto ask their admin to configure the Helix GitHub App.",
+                        "description": "InstallURL is where the New Stream gate sends the user to install the\napp (https://github.com/apps/<slug>/installations/new). Populated from\nthe created app's slug, or from GITHUB_APP_SLUG for a pre-existing app.",
                         "type": "string"
                     },
                     "installed": {
                         "description": "Installed is true when the Helix GitHub App has an installation for\nthis org (a github_app ServiceConnection with an installation id).",
                         "type": "boolean"
+                    }
+                }
+            },
+            "api.GitHubManifestStartResponse": {
+                "type": "object",
+                "properties": {
+                    "manifest": {
+                        "type": "string"
+                    },
+                    "post_url": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string"
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -24493,6 +24493,10 @@
                     "installed": {
                         "description": "Installed is true when the Helix GitHub App has an installation for\nthis org (a github_app ServiceConnection with an installation id).",
                         "type": "boolean"
+                    },
+                    "manage_url": {
+                        "description": "ManageURL is the app's developer-settings page on GitHub\n(github.com/organizations/<owner>/settings/apps/<slug>) — where you edit\npermissions, repos, and delete the app. Empty when the owner is unknown\n(e.g. a BYO app configured without it).",
+                        "type": "string"
                     }
                 }
             },

--- a/swagger.json
+++ b/swagger.json
@@ -9271,6 +9271,39 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/github/app-manifest": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: start the GitHub App manifest (create) flow",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.GitHubManifestStartResponse"
+                        }
+                    },
+                    "412": {
+                        "description": "manifest flow not wired",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/github/repos": {
             "get": {
                 "security": [
@@ -20244,13 +20277,31 @@
         "api.GitHubInstallationStatus": {
             "type": "object",
             "properties": {
+                "app_exists": {
+                    "description": "AppExists is true when a Helix GitHub App has been created/registered\nfor this org (a github_app ServiceConnection exists), even if not yet\ninstalled on any repo. Drives the gate's create-vs-install branch.",
+                    "type": "boolean"
+                },
                 "install_url": {
-                    "description": "InstallURL is where the New Stream gate sends the user to install the\napp (https://github.com/apps/\u003cslug\u003e/installations/new). Empty when the\noperator hasn't configured the app slug — the gate then tells the user\nto ask their admin to configure the Helix GitHub App.",
+                    "description": "InstallURL is where the New Stream gate sends the user to install the\napp (https://github.com/apps/\u003cslug\u003e/installations/new). Populated from\nthe created app's slug, or from GITHUB_APP_SLUG for a pre-existing app.",
                     "type": "string"
                 },
                 "installed": {
                     "description": "Installed is true when the Helix GitHub App has an installation for\nthis org (a github_app ServiceConnection with an installation id).",
                     "type": "boolean"
+                }
+            }
+        },
+        "api.GitHubManifestStartResponse": {
+            "type": "object",
+            "properties": {
+                "manifest": {
+                    "type": "string"
+                },
+                "post_url": {
+                    "type": "string"
+                },
+                "state": {
+                    "type": "string"
                 }
             }
         },

--- a/swagger.json
+++ b/swagger.json
@@ -20288,6 +20288,10 @@
                 "installed": {
                     "description": "Installed is true when the Helix GitHub App has an installation for\nthis org (a github_app ServiceConnection with an installation id).",
                     "type": "boolean"
+                },
+                "manage_url": {
+                    "description": "ManageURL is the app's developer-settings page on GitHub\n(github.com/organizations/\u003cowner\u003e/settings/apps/\u003cslug\u003e) — where you edit\npermissions, repos, and delete the app. Empty when the owner is unknown\n(e.g. a BYO app configured without it).",
+                    "type": "string"
                 }
             }
         },

--- a/swagger.json
+++ b/swagger.json
@@ -9247,6 +9247,30 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/github/app-installation": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: GitHub App install status for the org",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.GitHubInstallationStatus"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/github/repos": {
             "get": {
                 "security": [
@@ -20214,6 +20238,19 @@
                 },
                 "to": {
                     "type": "string"
+                }
+            }
+        },
+        "api.GitHubInstallationStatus": {
+            "type": "object",
+            "properties": {
+                "install_url": {
+                    "description": "InstallURL is where the New Stream gate sends the user to install the\napp (https://github.com/apps/\u003cslug\u003e/installations/new). Empty when the\noperator hasn't configured the app slug — the gate then tells the user\nto ask their admin to configure the Helix GitHub App.",
+                    "type": "string"
+                },
+                "installed": {
+                    "description": "Installed is true when the Helix GitHub App has an installation for\nthis org (a github_app ServiceConnection with an installation id).",
+                    "type": "boolean"
                 }
             }
         },


### PR DESCRIPTION
## Summary

Enable Helix agents/workers and org-graph streams to act on GitHub as a **bot** (via GitHub App) instead of borrowing a human's OAuth token, with no shared credentials across deployments.

**Architecture**: Each Helix deployment owns its own GitHub App, created via the **GitHub App Manifest flow** (default). Operators can override with their own app via `GITHUB_APP_SLUG`/`GITHUB_APP_ID`/`GITHUB_APP_PEM`. The app is **public** ("Any account"), enabling multi-org installs.

### What changed

#### Backend
- **`helix_org_github_manifest.go`**: Manifest flow — POST form to `github.com/organizations/<org>/settings/apps/new`, GitHub redirects with auth code, `CompleteAppManifest` exchanges it for app id/slug/PEM/webhook_secret. Callback polls the install URL until it stops 404'ing (GitHub finishes provisioning), then redirects to install so the user picks repos.
- **`helix_org.go`**: New deps funcs — `GitHubInstallation` (reconcile against `GET /app/installations`, auto-detect on install, auto-heal on uninstall), `GitHubAppRepos` (aggregate repos across all installations per app), `GitHubTokenResolver` (bot-preferring JWT token minting). Updated `listGitHubRepos` to prefer app repos (source="app") over OAuth.
- **`org/infrastructure/transports/github/`**: Webhook event routing — single app webhook firehose scoped by repo (exact + org wildcard), event type, and branch (`*`/exact/prefix wildcard). `branchAllowed` supports `*` for "any branch".
- **Types**: `ServiceConnection` (encrypted PEM storage), `GitHubConfig` (Repo/Events/Branches).

#### Frontend
- **`GitHubAppPanel.tsx`**: Shared connector component (`<GitHubAppConnect>`) for create/install/add-repos/manage, with a **numbered 3-step guide** (Create → Install → Choose repos). Two modes:
  - `mode="panel"`: full panel in Settings page with steps + explanation.
  - `mode="gate"`: compact box in New Stream dialog (shown while not installed, and alongside repo picker when GitHub transport selected).
- **`HelixOrgSettings.tsx`**: Renders GitHub App section on Settings page.
- **`HelixOrgStreams.tsx`**: Uses `<GitHubAppConnect mode="gate">` to guide setup from New Stream. Dropped redundant manage links.
- **`useGitHubAppActions.ts`**: Encapsulates popup flows (create/install/manage) + watch for completion via postMessage (best effort) + window focus fallback.

### The flow
1. Org admin goes to Settings → GitHub App.
2. Enters GitHub org name, clicks "Create Helix app".
3. Manifest flow opens popup → GitHub creates app (org-owned) with Helix permissions (contents/issues/PRs read/write, etc.) → callback redirects to install.
4. Org picker screen → select which GitHub org to install into.
5. Permission screen → approve repo access (All or specific repos).
6. Callback detects install, auto-closes popup, Settings panel shows "✓ installed" + "Add repositories / another org" + "Manage app on GitHub →".
7. In New Stream, select GitHub transport — repo picker auto-populates with app-accessible repos. Create stream with event/branch filters; webhook events route to that stream.

### Key properties
- **No shared credentials**: Each deployment's app creds live in its own `service_connections` row, encrypted at rest (AES-256-GCM, key from `HELIX_ENCRYPTION_KEY`).
- **Self-healing**: Install status verified on every endpoint call against GitHub; installation_id synced; stale row auto-deleted on `ErrAppNotFound` (app uninstalled on GitHub).
- **Multi-org**: Public app allows install on any GitHub org; `GitHubAppRepos` aggregates all repos across installations.
- **One webhook**: App's single webhook endpoint receives the firehose; Helix filters by repo/event/branch and routes to scoped streams.

### Testing done
- Verified Settings panel renders 3-step guide, create/install flows work end-to-end.
- Tested multi-org: app installed on `winderai`, repos aggregated correctly.
- Tested webhook event routing (push/create/delete + branch filtering) to streams in real Helix sessions.
- Verified app COOP popups close correctly + fallback focus watch works.

### Known limitations (Phase 4)
- Cross-org Worker git credential: a Worker's `GH_TOKEN` is per-org (uses bot token). Cross-org git needs per-repo credential helper (deferred).

### Breaking changes
None — OAuth fallback still works; GitHub App is new/opt-in.