### PR TITLE
fix(helix-org): restore per-repo webhooks with live status checking

### DIFF
--- a/api/pkg/github/client.go
+++ b/api/pkg/github/client.go
@@ -221,6 +221,24 @@ func (c *Client) AddWebhookToRepo(
 type WebhookSummary struct {
 	ID     int64
 	Events []string
+	Active bool
+}
+
+// FindWebhook returns the repo webhook whose payload URL matches `url`.
+// found=false with a nil error means the repo has no hook pointing there
+// (i.e. it needs installing) — distinct from a non-nil error, which means we
+// couldn't determine the state (auth/permission/transport failure).
+func (c *Client) FindWebhook(owner, repo, url string) (WebhookSummary, bool, error) {
+	hooks, _, err := c.client.Repositories.ListHooks(c.ctx, owner, repo, nil)
+	if err != nil {
+		return WebhookSummary{}, false, err
+	}
+	for _, hook := range hooks {
+		if hook.Config != nil && hook.Config.URL != nil && *hook.Config.URL == url {
+			return summarizeHook(hook), true, nil
+		}
+	}
+	return WebhookSummary{}, false, nil
 }
 
 // UpsertWebhook creates a webhook on the repo if none points at `url`,
@@ -302,6 +320,9 @@ func summarizeHook(h *github.Hook) WebhookSummary {
 	out := WebhookSummary{Events: h.Events}
 	if h.ID != nil {
 		out.ID = *h.ID
+	}
+	if h.Active != nil {
+		out.Active = *h.Active
 	}
 	return out
 }

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -257,6 +257,7 @@ func Routes(deps Deps) []Route {
 		{Pattern: "GET /github/app-installation", Handler: http.HandlerFunc(a.getGitHubAppInstallation)},
 		{Pattern: "POST /github/app-manifest", Handler: http.HandlerFunc(a.startGitHubAppManifest)},
 		{Pattern: "POST /streams/{id}/github/install-webhook", Handler: http.HandlerFunc(a.installGitHubWebhook)},
+		{Pattern: "GET /streams/{id}/github/webhook-status", Handler: http.HandlerFunc(a.getGitHubWebhookStatus)},
 	}
 }
 
@@ -2180,6 +2181,26 @@ type InstallGitHubWebhookResponse struct {
 	Warning string `json:"warning,omitempty"`
 }
 
+// GitHubWebhookStatusResponse is the body of GET
+// /streams/{id}/github/webhook-status. It reports the LIVE state of the
+// stream's repo webhook as seen on GitHub (not the stored config), so the
+// detail page can show a link when the hook really exists and a re-install
+// button when it doesn't — and self-correct stale stored ids.
+type GitHubWebhookStatusResponse struct {
+	// State is one of:
+	//   "installed" — a webhook for this stream's payload URL exists on the repo
+	//   "missing"   — GitHub was reachable and has no such webhook (needs install)
+	//   "unknown"   — couldn't determine (no repo / no public URL / no creds /
+	//                 GitHub error); see Detail. The UI falls back to stored state.
+	State          string `json:"state"`
+	WebhookID      int64  `json:"webhook_id,omitempty"`
+	WebhookHTMLURL string `json:"webhook_html_url,omitempty"`
+	Active         bool   `json:"active,omitempty"`
+	PayloadURL     string `json:"payload_url,omitempty"`
+	// Detail explains a "unknown" state (and is empty otherwise).
+	Detail string `json:"detail,omitempty"`
+}
+
 // installGitHubWebhook calls the GitHub REST API on behalf of the
 // operator to register a webhook on the stream's repo pointing at
 // helix's per-stream payload URL. Idempotent: if a webhook with
@@ -2291,7 +2312,7 @@ func (a *apiHandler) installGitHubWebhook(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if token == "" {
-		writeError(w, http.StatusPreconditionFailed, errors.New("no GitHub OAuth connection found for this org; connect GitHub on the Connected Services page"))
+		writeError(w, http.StatusPreconditionFailed, errors.New("no GitHub credentials for this org: install the Helix GitHub App (preferred) or connect GitHub OAuth on the Connected Services page"))
 		return
 	}
 	secret, err := ensureGitHubWebhookSecret(ctx, a.deps.Configs, orgID)
@@ -2334,6 +2355,118 @@ func (a *apiHandler) installGitHubWebhook(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, InstallGitHubWebhookResponse{
 		WebhookID:      hook.ID,
 		WebhookHTMLURL: htmlURL,
+		PayloadURL:     payloadURL,
+	})
+}
+
+// getGitHubWebhookStatus reports the LIVE state of a github stream's repo
+// webhook by listing the repo's hooks (as the bot) and matching this stream's
+// payload URL. Read-only: it never creates, edits, or persists. Returns
+// state="unknown" (rather than an HTTP error) for every "can't tell" case so
+// the detail page can degrade to stored config instead of showing a scary
+// failure for an ordinarily-fine condition (e.g. no public URL configured yet).
+//
+// @Summary Helix-org: live webhook status for a github stream
+// @Tags HelixOrg
+// @Param id path string true "Stream ID"
+// @Produce json
+// @Success 200 {object} api.GitHubWebhookStatusResponse
+// @Failure 400 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/streams/{id}/github/webhook-status [get]
+func (a *apiHandler) getGitHubWebhookStatus(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	orgID, err := resolveOrgID(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	streamID := streaming.StreamID(r.PathValue("id"))
+	if streamID == "" {
+		writeError(w, http.StatusBadRequest, errors.New("stream id is required"))
+		return
+	}
+	s, err := a.deps.Store.Streams.Get(ctx, orgID, streamID)
+	if err != nil {
+		writeError(w, errStatus(err), fmt.Errorf("get stream %s: %w", streamID, err))
+		return
+	}
+	if s.Transport.Kind != transport.KindGitHub {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("stream %s is not a github transport (kind=%s)", streamID, s.Transport.Kind))
+		return
+	}
+	cfg, err := s.Transport.GitHubConfig()
+	if err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("parse github config: %w", err))
+		return
+	}
+
+	unknown := func(detail string) {
+		writeJSON(w, http.StatusOK, GitHubWebhookStatusResponse{State: "unknown", Detail: detail})
+	}
+	if cfg.Repo == "" {
+		unknown("stream has no repo set")
+		return
+	}
+	repoParts := strings.SplitN(cfg.Repo, "/", 2)
+	if len(repoParts) != 2 {
+		unknown(fmt.Sprintf("malformed repo %q", cfg.Repo))
+		return
+	}
+	owner, repoName := repoParts[0], repoParts[1]
+
+	// Same payload-URL resolution as install (streams.public_url override on top
+	// of SERVER_URL). Without a public URL we can't compute the URL GitHub would
+	// hold, so we can't match a hook — report unknown.
+	publicURL := strings.TrimSpace(a.deps.PublicServerURL)
+	if a.deps.Configs != nil {
+		if override, err := a.deps.Configs.GetString(ctx, orgID, "streams.public_url"); err == nil && strings.TrimSpace(override) != "" {
+			publicURL = strings.TrimSpace(override)
+		}
+	}
+	if publicURL == "" {
+		unknown("no public URL configured for helix")
+		return
+	}
+	payloadURL := strings.TrimRight(publicURL, "/") +
+		"/api/v1/orgs/" + url.PathEscape(orgID) +
+		"/streams/" + url.PathEscape(string(streamID)) + "/github/webhook"
+
+	if a.deps.GitHubTokenResolver == nil {
+		unknown("no GitHubTokenResolver wired")
+		return
+	}
+	token, err := a.deps.GitHubTokenResolver(ctx, orgID)
+	if err != nil {
+		unknown(fmt.Sprintf("resolve github token: %v", err))
+		return
+	}
+	if token == "" {
+		unknown("no GitHub credentials for this org (install the Helix GitHub App or connect GitHub OAuth)")
+		return
+	}
+	client, err := githubclient.NewGithubClient(githubclient.ClientOptions{Ctx: ctx, Token: token})
+	if err != nil {
+		unknown(fmt.Sprintf("build github client: %v", err))
+		return
+	}
+	hook, found, err := client.FindWebhook(owner, repoName, payloadURL)
+	if err != nil {
+		// GitHub reachable-but-errored (e.g. missing repository_hooks
+		// permission, 404 on a repo the bot can't see). Can't assert
+		// "missing", so report unknown with the reason.
+		unknown(fmt.Sprintf("list webhooks on %s: %v", cfg.Repo, err))
+		return
+	}
+	if !found {
+		writeJSON(w, http.StatusOK, GitHubWebhookStatusResponse{State: "missing", PayloadURL: payloadURL})
+		return
+	}
+	writeJSON(w, http.StatusOK, GitHubWebhookStatusResponse{
+		State:          "installed",
+		WebhookID:      hook.ID,
+		WebhookHTMLURL: githubclient.WebhookSettingsURL(owner, repoName, hook.ID),
+		Active:         hook.Active,
 		PayloadURL:     payloadURL,
 	})
 }

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -9996,6 +9996,45 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/orgs/{org}/streams/{id}/github/webhook-status": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: live webhook status for a github stream",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Stream ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.GitHubWebhookStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/streams/{id}/publish": {
             "post": {
                 "security": [
@@ -20336,6 +20375,31 @@ const docTemplate = `{
                 "source": {
                     "description": "Source identifies which token paid for this list — useful\nwhen debugging \"I can't see repo X\" reports.",
                     "type": "string"
+                }
+            }
+        },
+        "api.GitHubWebhookStatusResponse": {
+            "type": "object",
+            "properties": {
+                "active": {
+                    "type": "boolean"
+                },
+                "detail": {
+                    "description": "Detail explains a \"unknown\" state (and is empty otherwise).",
+                    "type": "string"
+                },
+                "payload_url": {
+                    "type": "string"
+                },
+                "state": {
+                    "description": "State is one of:\n  \"installed\" — a webhook for this stream's payload URL exists on the repo\n  \"missing\"   — GitHub was reachable and has no such webhook (needs install)\n  \"unknown\"   — couldn't determine (no repo / no public URL / no creds /\n                GitHub error); see Detail. The UI falls back to stored state.",
+                    "type": "string"
+                },
+                "webhook_html_url": {
+                    "type": "string"
+                },
+                "webhook_id": {
+                    "type": "integer"
                 }
             }
         },
@@ -31661,6 +31725,10 @@ const docTemplate = `{
                     "description": "Sandbox capacity",
                     "type": "integer"
                 },
+                "compute_state": {
+                    "description": "ComputeState tracks the provider's view of the host's provisioning\nlifecycle. Distinct from Status (which is the heartbeat-derived\nonline/offline/degraded view). Values: \"provisioning\" | \"ready\" |\n\"terminating\" | \"terminated\" | \"failed\". See compute.State for\nthe canonical enum. Empty for self-registered hosts.",
+                    "type": "string"
+                },
                 "created": {
                     "type": "string"
                 },
@@ -31721,6 +31789,25 @@ const docTemplate = `{
                 },
                 "profile_status": {
                     "description": "ProfileStatus tracks the compose stack lifecycle:\n\"\" | \"assigning\" | \"pulling\" | \"starting\" | \"running\" | \"failed\".",
+                    "type": "string"
+                },
+                "provider": {
+                    "description": "Provider is the Name() of the compute.Provider that owns this host.\nE.g. \"yellowdog\", \"gcp\", \"lambda\". Empty for self-registered hosts.",
+                    "type": "string"
+                },
+                "provider_id": {
+                    "description": "ProviderID is the upstream system's opaque identifier for this\nhost (e.g. a YellowDog work-requirement YDID). Forms a composite\nindex with Provider so the reconciler can look hosts up cheaply.",
+                    "type": "string"
+                },
+                "provider_metadata": {
+                    "description": "ProviderMetadata is provider-specific opaque data for\nreconciliation, debugging, and admin display. Examples for YD:\nworker-pool ID, compute requirement ID, region, public IP.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "provisioned_at": {
+                    "description": "ProvisionedAt is when Helix asked the provider to bring this host\nup. Earlier than Created (which is the first heartbeat). Nil for\nself-registered hosts.",
                     "type": "string"
                 },
                 "render_node": {

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -586,21 +585,6 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	// installation id onto the org's app.
 	publicGitHubManifestCallback := newGitHubManifestCallbackHandler(
 		cfg.APIServer.getEncryptionKey, helixStore, deps.NewID,
-		func(ctx context.Context, orgID, secret string) error {
-			// Set transport.github.webhook_secret = the App's webhook secret so
-			// the existing inbound handler validates the App's deliveries.
-			var c struct {
-				Token         string `json:"token,omitempty"`
-				WebhookSecret string `json:"webhook_secret,omitempty"`
-			}
-			_ = configReg.GetObject(ctx, orgID, "transport.github", &c)
-			c.WebhookSecret = secret
-			out, err := json.Marshal(c)
-			if err != nil {
-				return err
-			}
-			return configReg.Set(ctx, orgID, "transport.github", string(out), orgchart.WorkerID("w-owner"))
-		},
 		cfg.APIServer.Cfg.GitHub.WebURL(), cfg.APIServer.Cfg.GitHub.APIBaseURL(),
 	)
 

--- a/api/pkg/server/helix_org_github_manifest.go
+++ b/api/pkg/server/helix_org_github_manifest.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -52,34 +51,21 @@ type githubManifestState struct {
 type githubManifest struct {
 	Name               string            `json:"name"`
 	URL                string            `json:"url"`
-	HookAttributes     map[string]string `json:"hook_attributes,omitempty"`
 	RedirectURL        string            `json:"redirect_url"`
 	Public             bool              `json:"public"`
 	DefaultPermissions map[string]string `json:"default_permissions"`
-	DefaultEvents      []string          `json:"default_events,omitempty"`
 }
 
 // helixAppPermissions is the minimum the Worker bot needs: clone/push,
-// open PRs, manage issues. Metadata is mandatory + auto-granted.
+// open PRs, manage issues, plus repository_hooks so the bot can install the
+// per-repo webhook for a github Stream (delivery is per-repo, not via an
+// app-level firehose). Metadata is mandatory + auto-granted.
 var helixAppPermissions = map[string]string{
-	"contents":      "write",
-	"pull_requests": "write",
-	"issues":        "write",
-	"metadata":      "read",
-}
-
-// helixAppEvents is the broad set the app subscribes to so a stream can
-// filter down to any of them (the app subscribes wide; the stream's `events`
-// whitelist narrows). They only deliver once hook_attributes.url is publicly
-// reachable, so they are harmless on a localhost dev deployment. Each event
-// requires the matching permission (granted in helixAppPermissions):
-// push/create/delete need contents; pull_request* need pull_requests;
-// issues/issue_comment need issues.
-var helixAppEvents = []string{
-	"push", "create", "delete",
-	"pull_request", "pull_request_review", "pull_request_review_comment",
-	"issues", "issue_comment",
-	"release",
+	"contents":         "write",
+	"pull_requests":    "write",
+	"issues":           "write",
+	"repository_hooks": "write",
+	"metadata":         "read",
 }
 
 func encodeGitHubManifestState(s githubManifestState, key []byte) (string, error) {
@@ -117,27 +103,6 @@ func normalizeOrigin(origin string) (string, error) {
 		return "", fmt.Errorf("origin must be an http(s) URL with a host")
 	}
 	return u.Scheme + "://" + u.Host, nil
-}
-
-// isLoopbackOrigin reports whether base points at a loopback / non-public
-// host. GitHub validates the manifest's hook_attributes.url is reachable over
-// the public Internet at creation time, so we omit the webhook URL for
-// loopback origins (the redirect/setup URLs are browser redirects and work
-// fine on localhost). A public origin — e.g. a cloudflared tunnel — gets the
-// webhook wired automatically.
-func isLoopbackOrigin(base string) bool {
-	u, err := url.Parse(base)
-	if err != nil {
-		return true // be conservative: if we can't tell, don't send a hook
-	}
-	host := u.Hostname()
-	if host == "localhost" || strings.HasSuffix(host, ".localhost") {
-		return true
-	}
-	if ip := net.ParseIP(host); ip != nil {
-		return ip.IsLoopback() || ip.IsUnspecified()
-	}
-	return false
 }
 
 // newGitHubManifestStart builds the start resolver wired into the org API
@@ -180,14 +145,10 @@ func newGitHubManifestStart(getKey func() ([]byte, error), webURL string) func(c
 			Public:             true,
 			DefaultPermissions: helixAppPermissions,
 		}
-		// GitHub rejects a manifest whose hook url isn't publicly reachable, so
-		// only wire the webhook (and the events that depend on it) when the
-		// origin is public. On localhost the app is still fully usable as a
-		// bot; the webhook can be added later from a public URL.
-		if !isLoopbackOrigin(base) {
-			manifest.HookAttributes = map[string]string{"url": base + "/api/v1/orgs/" + url.PathEscape(orgID) + "/github/webhook"}
-			manifest.DefaultEvents = helixAppEvents
-		}
+		// No app-level webhook: event delivery is per-repo. The bot installs a
+		// repo webhook (via repository_hooks permission) for each github Stream,
+		// pointed at /streams/{id}/github/webhook. So the manifest deliberately
+		// omits hook_attributes/default_events.
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			return helixorgapi.GitHubManifestStartResponse{}, fmt.Errorf("marshal manifest: %w", err)
@@ -214,7 +175,6 @@ func newGitHubManifestCallbackHandler(
 	getKey func() ([]byte, error),
 	st helixstore.Store,
 	newID func() string,
-	setWebhookSecret func(ctx context.Context, orgID, secret string) error,
 	webURL string,
 	apiBaseURL string,
 ) http.HandlerFunc {
@@ -277,17 +237,10 @@ func newGitHubManifestCallbackHandler(
 		}
 		log.Info().Str("org_id", parsed.OrgID).Int64("app_id", cfg.GetID()).Str("slug", cfg.GetSlug()).Msg("created Helix GitHub App via manifest")
 
-		// Mirror the app's webhook secret into transport.github so the
-		// existing inbound webhook handler validates the App's deliveries
-		// (it HMACs the body against transport.github.webhook_secret). The
-		// App delivers all events for all installed repos to that one
-		// endpoint; streams filter by repo/event. GitHub shows this secret
-		// only once, so persist it now.
-		if ws := cfg.GetWebhookSecret(); ws != "" && setWebhookSecret != nil {
-			if err := setWebhookSecret(ctx, parsed.OrgID, ws); err != nil {
-				log.Error().Err(err).Str("org_id", parsed.OrgID).Msg("persist app webhook secret failed")
-			}
-		}
+		// No app-level webhook secret to persist: the app has no webhook.
+		// Per-repo webhooks (installed by the bot for each github Stream) use
+		// the per-org transport.github.webhook_secret minted by
+		// ensureGitHubWebhookSecret at install time.
 
 		// Chain straight into installation so the user picks repos. A
 		// just-created app's install page (…/installations/new →

--- a/api/pkg/server/helix_org_github_manifest_test.go
+++ b/api/pkg/server/helix_org_github_manifest_test.go
@@ -73,13 +73,12 @@ func TestGitHubManifestStart_BuildsManifestAndPostURL(t *testing.T) {
 	require.Equal(t, "write", m.DefaultPermissions["contents"])
 	require.Equal(t, "write", m.DefaultPermissions["pull_requests"])
 	require.Equal(t, "write", m.DefaultPermissions["issues"])
+	// repository_hooks lets the bot install the per-repo webhook for a Stream.
+	require.Equal(t, "write", m.DefaultPermissions["repository_hooks"])
 	require.Equal(t, "read", m.DefaultPermissions["metadata"])
 	// Callback URL carries the helix org and the caller's origin. No setup_url
 	// (it's optional; we reconcile the installation via GET /app/installations).
 	require.Equal(t, "http://localhost:8080/api/v1/orgs/org-1/github/app-manifest/callback", m.RedirectURL)
-	// Loopback origin: no webhook url (GitHub rejects unreachable hooks).
-	require.Empty(t, m.HookAttributes, "localhost manifest must omit the hook url")
-	require.Empty(t, m.DefaultEvents)
 
 	// The state must decode back to the same org.
 	decoded, err := decodeGitHubManifestState(resp.State, testEncKey)
@@ -98,25 +97,9 @@ func TestGitHubManifestStart_GHESWebURL(t *testing.T) {
 		"post_url = %s", resp.PostURL)
 }
 
-func TestGitHubManifestStart_PublicOriginWiresWebhook(t *testing.T) {
-	start := newGitHubManifestStart(testKeyGetter, "https://github.com")
-	resp, err := start(context.Background(), "org-1", "acme", "https://helix.example.com")
-	require.NoError(t, err)
-	var m githubManifest
-	require.NoError(t, json.Unmarshal([]byte(resp.Manifest), &m))
-	require.Equal(t, "https://helix.example.com/api/v1/orgs/org-1/github/webhook", m.HookAttributes["url"],
-		"public origin must wire the webhook")
-	require.NotEmpty(t, m.DefaultEvents)
-}
-
-func TestIsLoopbackOrigin(t *testing.T) {
-	for _, o := range []string{"http://localhost:8080", "http://127.0.0.1:8080", "http://0.0.0.0:8080", "https://foo.localhost"} {
-		require.True(t, isLoopbackOrigin(o), "%s should be loopback", o)
-	}
-	for _, o := range []string{"https://helix.example.com", "https://abc.trycloudflare.com", "http://10.0.0.5"} {
-		require.False(t, isLoopbackOrigin(o), "%s should be public", o)
-	}
-}
+// The manifest never wires an app-level webhook (delivery is per-repo via the
+// bot's repository_hooks permission), so hook_attributes/default_events are
+// always absent regardless of origin — covered by the BuildsManifest test.
 
 func TestGitHubManifestStart_RejectsBadInput(t *testing.T) {
 	start := newGitHubManifestStart(testKeyGetter, "https://github.com")

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -9992,6 +9992,45 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/streams/{id}/github/webhook-status": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: live webhook status for a github stream",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Stream ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.GitHubWebhookStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/streams/{id}/publish": {
             "post": {
                 "security": [
@@ -20332,6 +20371,31 @@
                 "source": {
                     "description": "Source identifies which token paid for this list — useful\nwhen debugging \"I can't see repo X\" reports.",
                     "type": "string"
+                }
+            }
+        },
+        "api.GitHubWebhookStatusResponse": {
+            "type": "object",
+            "properties": {
+                "active": {
+                    "type": "boolean"
+                },
+                "detail": {
+                    "description": "Detail explains a \"unknown\" state (and is empty otherwise).",
+                    "type": "string"
+                },
+                "payload_url": {
+                    "type": "string"
+                },
+                "state": {
+                    "description": "State is one of:\n  \"installed\" — a webhook for this stream's payload URL exists on the repo\n  \"missing\"   — GitHub was reachable and has no such webhook (needs install)\n  \"unknown\"   — couldn't determine (no repo / no public URL / no creds /\n                GitHub error); see Detail. The UI falls back to stored state.",
+                    "type": "string"
+                },
+                "webhook_html_url": {
+                    "type": "string"
+                },
+                "webhook_id": {
+                    "type": "integer"
                 }
             }
         },
@@ -31657,6 +31721,10 @@
                     "description": "Sandbox capacity",
                     "type": "integer"
                 },
+                "compute_state": {
+                    "description": "ComputeState tracks the provider's view of the host's provisioning\nlifecycle. Distinct from Status (which is the heartbeat-derived\nonline/offline/degraded view). Values: \"provisioning\" | \"ready\" |\n\"terminating\" | \"terminated\" | \"failed\". See compute.State for\nthe canonical enum. Empty for self-registered hosts.",
+                    "type": "string"
+                },
                 "created": {
                     "type": "string"
                 },
@@ -31717,6 +31785,25 @@
                 },
                 "profile_status": {
                     "description": "ProfileStatus tracks the compose stack lifecycle:\n\"\" | \"assigning\" | \"pulling\" | \"starting\" | \"running\" | \"failed\".",
+                    "type": "string"
+                },
+                "provider": {
+                    "description": "Provider is the Name() of the compute.Provider that owns this host.\nE.g. \"yellowdog\", \"gcp\", \"lambda\". Empty for self-registered hosts.",
+                    "type": "string"
+                },
+                "provider_id": {
+                    "description": "ProviderID is the upstream system's opaque identifier for this\nhost (e.g. a YellowDog work-requirement YDID). Forms a composite\nindex with Provider so the reconciler can look hosts up cheaply.",
+                    "type": "string"
+                },
+                "provider_metadata": {
+                    "description": "ProviderMetadata is provider-specific opaque data for\nreconciliation, debugging, and admin display. Examples for YD:\nworker-pool ID, compute requirement ID, region, public IP.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "provisioned_at": {
+                    "description": "ProvisionedAt is when Helix asked the provider to bring this host\nup. Earlier than Created (which is the first heartbeat). Nil for\nself-registered hosts.",
                     "type": "string"
                 },
                 "render_node": {

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -113,6 +113,28 @@ definitions:
           when debugging "I can't see repo X" reports.
         type: string
     type: object
+  api.GitHubWebhookStatusResponse:
+    properties:
+      active:
+        type: boolean
+      detail:
+        description: Detail explains a "unknown" state (and is empty otherwise).
+        type: string
+      payload_url:
+        type: string
+      state:
+        description: |-
+          State is one of:
+            "installed" — a webhook for this stream's payload URL exists on the repo
+            "missing"   — GitHub was reachable and has no such webhook (needs install)
+            "unknown"   — couldn't determine (no repo / no public URL / no creds /
+                          GitHub error); see Detail. The UI falls back to stored state.
+        type: string
+      webhook_html_url:
+        type: string
+      webhook_id:
+        type: integer
+    type: object
   api.HireWorkerRequest:
     properties:
       id:
@@ -8142,6 +8164,14 @@ definitions:
       active_sandboxes:
         description: Sandbox capacity
         type: integer
+      compute_state:
+        description: |-
+          ComputeState tracks the provider's view of the host's provisioning
+          lifecycle. Distinct from Status (which is the heartbeat-derived
+          online/offline/degraded view). Values: "provisioning" | "ready" |
+          "terminating" | "terminated" | "failed". See compute.State for
+          the canonical enum. Empty for self-registered hosts.
+        type: string
       created:
         type: string
       desktop_versions:
@@ -8200,6 +8230,31 @@ definitions:
         description: |-
           ProfileStatus tracks the compose stack lifecycle:
           "" | "assigning" | "pulling" | "starting" | "running" | "failed".
+        type: string
+      provider:
+        description: |-
+          Provider is the Name() of the compute.Provider that owns this host.
+          E.g. "yellowdog", "gcp", "lambda". Empty for self-registered hosts.
+        type: string
+      provider_id:
+        description: |-
+          ProviderID is the upstream system's opaque identifier for this
+          host (e.g. a YellowDog work-requirement YDID). Forms a composite
+          index with Provider so the reconciler can look hosts up cheaply.
+        type: string
+      provider_metadata:
+        additionalProperties:
+          type: string
+        description: |-
+          ProviderMetadata is provider-specific opaque data for
+          reconciliation, debugging, and admin display. Examples for YD:
+          worker-pool ID, compute requirement ID, region, public IP.
+        type: object
+      provisioned_at:
+        description: |-
+          ProvisionedAt is when Helix asked the provider to bring this host
+          up. Earlier than Created (which is the first heartbeat). Nil for
+          self-registered hosts.
         type: string
       render_node:
         description: /dev/dri/renderD128 or SOFTWARE
@@ -17734,6 +17789,30 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: 'Helix-org: auto-install the webhook for a github stream'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/streams/{id}/github/webhook-status:
+    get:
+      parameters:
+      - description: Stream ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.GitHubWebhookStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: live webhook status for a github stream'
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/streams/{id}/publish:

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -91,6 +91,23 @@ export interface ApiGitHubReposResponse {
   source?: string;
 }
 
+export interface ApiGitHubWebhookStatusResponse {
+  active?: boolean;
+  /** Detail explains a "unknown" state (and is empty otherwise). */
+  detail?: string;
+  payload_url?: string;
+  /**
+   * State is one of:
+   *   "installed" — a webhook for this stream's payload URL exists on the repo
+   *   "missing"   — GitHub was reachable and has no such webhook (needs install)
+   *   "unknown"   — couldn't determine (no repo / no public URL / no creds /
+   *                 GitHub error); see Detail. The UI falls back to stored state.
+   */
+  state?: string;
+  webhook_html_url?: string;
+  webhook_id?: number;
+}
+
 export interface ApiHireWorkerRequest {
   id?: string;
   identity_content?: string;
@@ -5010,6 +5027,14 @@ export interface TypesSandboxInstance {
   active_profile_id?: string;
   /** Sandbox capacity */
   active_sandboxes?: number;
+  /**
+   * ComputeState tracks the provider's view of the host's provisioning
+   * lifecycle. Distinct from Status (which is the heartbeat-derived
+   * online/offline/degraded view). Values: "provisioning" | "ready" |
+   * "terminating" | "terminated" | "failed". See compute.State for
+   * the canonical enum. Empty for self-registered hosts.
+   */
+  compute_state?: string;
   created?: string;
   /**
    * Desktop image versions available on this sandbox
@@ -5052,6 +5077,29 @@ export interface TypesSandboxInstance {
    * "" | "assigning" | "pulling" | "starting" | "running" | "failed".
    */
   profile_status?: string;
+  /**
+   * Provider is the Name() of the compute.Provider that owns this host.
+   * E.g. "yellowdog", "gcp", "lambda". Empty for self-registered hosts.
+   */
+  provider?: string;
+  /**
+   * ProviderID is the upstream system's opaque identifier for this
+   * host (e.g. a YellowDog work-requirement YDID). Forms a composite
+   * index with Provider so the reconciler can look hosts up cheaply.
+   */
+  provider_id?: string;
+  /**
+   * ProviderMetadata is provider-specific opaque data for
+   * reconciliation, debugging, and admin display. Examples for YD:
+   * worker-pool ID, compute requirement ID, region, public IP.
+   */
+  provider_metadata?: Record<string, string>;
+  /**
+   * ProvisionedAt is when Helix asked the provider to bring this host
+   * up. Earlier than Created (which is the first heartbeat). Nil for
+   * self-registered hosts.
+   */
+  provisioned_at?: string;
   /** /dev/dri/renderD128 or SOFTWARE */
   render_node?: string;
   /**
@@ -11930,6 +11978,24 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       this.request<ApiInstallGitHubWebhookResponse, ApiErrorResponse>({
         path: `/api/v1/orgs/${org}/streams/${id}/github/install-webhook`,
         method: "POST",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsStreamsGithubWebhookStatusDetail
+     * @summary Helix-org: live webhook status for a github stream
+     * @request GET:/api/v1/orgs/{org}/streams/{id}/github/webhook-status
+     * @secure
+     */
+    v1OrgsStreamsGithubWebhookStatusDetail: (id: string, org: string, params: RequestParams = {}) =>
+      this.request<ApiGitHubWebhookStatusResponse, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/streams/${id}/github/webhook-status`,
+        method: "GET",
         secure: true,
         format: "json",
         ...params,

--- a/frontend/src/pages/HelixOrgStreamDetail.tsx
+++ b/frontend/src/pages/HelixOrgStreamDetail.tsx
@@ -15,6 +15,7 @@ import { FC, useEffect, useMemo, useRef, useState } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
+import CircularProgress from '@mui/material/CircularProgress'
 import Container from '@mui/material/Container'
 import Divider from '@mui/material/Divider'
 import Paper from '@mui/material/Paper'
@@ -29,7 +30,6 @@ import CloseIcon from '@mui/icons-material/Close'
 import Page from '../components/system/Page'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import GitHubStreamConfigFields from '../components/helix-org/GitHubStreamConfigFields'
-import { useGitHubAppActions } from '../components/helix-org/useGitHubAppActions'
 import {
   isValidGitHubEvent,
   GITHUB_REPO_PATTERN,
@@ -43,7 +43,7 @@ import {
   InstallWebhookFailedError,
   StreamDTO,
   useHelixOrgStream,
-  useGitHubAppInstallation,
+  useGitHubWebhookStatus,
   useInstallGitHubWebhook,
   useUpdateHelixOrgStream,
 } from '../services/helixOrgService'
@@ -452,13 +452,11 @@ const SettingsLink: FC<{ orgSlug?: string }> = ({ orgSlug }) => {
 const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ stream, orgSlug }) => {
   const snackbar = useSnackbar()
   const install = useInstallGitHubWebhook()
-  // App mode: when the Helix GitHub App is installed for this org, events
-  // arrive via the App's single webhook (filtered to this stream by repo +
-  // events), so there's no per-repo webhook to install.
-  const appInstall = useGitHubAppInstallation()
-  const appMode = appInstall.data?.installed === true
-  const appActions = useGitHubAppActions()
-  const manageUrl = appInstall.data?.manage_url ?? ''
+  // Live truth from GitHub: does a webhook for this stream's payload URL
+  // actually exist on the repo? This is the source of truth for the link vs
+  // re-install decision — the stored config can be stale (hook deleted on
+  // GitHub, or installed before we tracked the id).
+  const status = useGitHubWebhookStatus(stream.id)
 
   // Check the EFFECTIVE public URL — what the install endpoint
   // would actually use (streams.public_url override applied on
@@ -473,7 +471,36 @@ const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ stream, orgSlug }) 
   const isLocalhost = /(localhost|127\.0\.0\.1|0\.0\.0\.0)/i.test(effectivePublicURL)
 
   const cfg = (stream.config ?? {}) as { repo?: string; webhook_id?: number; webhook_html_url?: string }
-  const installed = !!cfg.webhook_id
+
+  // Resolve the live status into a concrete view. "unknown" (couldn't reach
+  // GitHub / no creds / no public URL) falls back to the stored config so the
+  // panel still works degraded instead of always claiming "missing".
+  const live = status.data
+  let view: 'loading' | 'installed' | 'missing' = 'missing'
+  let webhookHtmlUrl = ''
+  let webhookId: number | undefined
+  let active = true
+  let unknownNote = ''
+  if (status.isLoading) {
+    view = 'loading'
+  } else if (live?.state === 'installed') {
+    view = 'installed'
+    webhookHtmlUrl = live.webhook_html_url || cfg.webhook_html_url || ''
+    webhookId = live.webhook_id
+    active = live.active ?? true
+  } else if (live?.state === 'missing') {
+    view = 'missing'
+  } else {
+    // "unknown" or a query error — degrade to stored config.
+    unknownNote = live?.detail || (status.error as any)?.message || ''
+    if (cfg.webhook_id) {
+      view = 'installed'
+      webhookHtmlUrl = cfg.webhook_html_url || ''
+      webhookId = cfg.webhook_id
+    } else {
+      view = 'missing'
+    }
+  }
 
   const reinstall = async () => {
     try {
@@ -502,24 +529,6 @@ const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ stream, orgSlug }) 
   return (
     <Paper variant="outlined" sx={{ p: 2 }}>
       <Typography variant="h6" sx={{ mb: 1 }}>Connect to GitHub</Typography>
-      {appMode ? (
-        <Stack spacing={1}>
-          <Typography variant="body2">
-            Events arrive via the <strong>Helix GitHub App</strong> — one app-level webhook receives every event from the repos it's installed on. This stream receives the deliveries that match its filter (repo <strong>{cfg.repo || '(not set)'}</strong>, plus its events whitelist). There's no per-repo webhook to install.
-          </Typography>
-          <Typography variant="caption" color="text.secondary">
-            Scope is controlled by two things: which repos the app is installed on, and this stream's repo + events filter. Use <code>owner/*</code> as the repo to match a whole org. GitHub must be able to reach Helix at a public URL for deliveries to arrive.
-          </Typography>
-          {manageUrl && (
-            <Box>
-              <Button size="small" variant="outlined" onClick={() => appActions.openManage(manageUrl)}>
-                Manage app on GitHub →
-              </Button>
-            </Box>
-          )}
-        </Stack>
-      ) : (
-      <>
       {isLocalhost && (
         <Box sx={{ mb: 1.5, p: 1.5, borderRadius: 1, backgroundColor: 'warning.main', color: 'warning.contrastText' }}>
           <Typography variant="body2" sx={{ fontWeight: 600 }}>
@@ -533,23 +542,30 @@ const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ stream, orgSlug }) 
           <SettingsLink orgSlug={orgSlug} />
         </Box>
       )}
-      {installed ? (
+      {view === 'loading' ? (
+        <Stack direction="row" spacing={1} alignItems="center">
+          <CircularProgress size={16} />
+          <Typography variant="body2" color="text.secondary">
+            Checking GitHub for this stream's webhook…
+          </Typography>
+        </Stack>
+      ) : view === 'installed' ? (
         <Stack spacing={1}>
           <Typography variant="body2">
-            Helix has registered a webhook on <strong>{cfg.repo}</strong> (id <code>{cfg.webhook_id}</code>).
-            Deliveries flow into this stream automatically — no manual setup.
+            Webhook registered on <strong>{cfg.repo}</strong>{webhookId ? <> (id <code>{webhookId}</code>)</> : null}.
+            {active ? ' Deliveries flow into this stream automatically.' : ' ⚠ It is currently disabled on GitHub, so no deliveries arrive — re-install to re-enable.'}
           </Typography>
           <Stack direction="row" spacing={1} alignItems="center">
-            {cfg.webhook_html_url && (
+            {webhookHtmlUrl && (
               <Button
                 size="small"
                 variant="outlined"
                 component="a"
-                href={cfg.webhook_html_url}
+                href={webhookHtmlUrl}
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Edit on GitHub →
+                View on GitHub →
               </Button>
             )}
             <Button
@@ -561,6 +577,11 @@ const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ stream, orgSlug }) 
               {install.isPending ? 'Re-installing…' : 'Re-install'}
             </Button>
           </Stack>
+          {unknownNote && (
+            <Typography variant="caption" color="text.secondary">
+              Couldn't confirm against GitHub ({unknownNote}); showing last-known state.
+            </Typography>
+          )}
           <Typography variant="caption" color="text.secondary">
             Tweak the events whitelist (or any other webhook settings) directly on GitHub's UI. Helix routes deliveries by repo + stream id, so as long as the payload URL stays intact your changes take effect immediately.
           </Typography>
@@ -568,7 +589,7 @@ const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ stream, orgSlug }) 
       ) : (
         <Stack spacing={1.5}>
           <Typography variant="body2">
-            No webhook registered yet for <strong>{cfg.repo || '(repo not set)'}</strong>. Helix can install it for you — one click, no copying URLs.
+            No webhook found on GitHub for <strong>{cfg.repo || '(repo not set)'}</strong>. Helix can install it for you — one click, no copying URLs.
           </Typography>
           <Box>
             <Button
@@ -579,12 +600,15 @@ const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ stream, orgSlug }) 
               {install.isPending ? 'Installing…' : 'Install webhook on GitHub'}
             </Button>
           </Box>
+          {unknownNote && (
+            <Typography variant="caption" color="text.secondary">
+              Note: couldn't verify against GitHub ({unknownNote}).
+            </Typography>
+          )}
           <Typography variant="caption" color="text.secondary">
-            Requires a connected GitHub OAuth (on the helix Connected Services page) with admin rights on the repo.
+            Installed as the Helix GitHub App bot when it's installed on this repo (no human admin needed); otherwise falls back to a connected GitHub OAuth (on the helix Connected Services page) with admin rights on the repo.
           </Typography>
         </Stack>
-      )}
-      </>
       )}
     </Paper>
   )

--- a/frontend/src/pages/HelixOrgStreams.tsx
+++ b/frontend/src/pages/HelixOrgStreams.tsx
@@ -372,15 +372,11 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
         description: description.trim() || undefined,
         transport: { kind, config },
       })
-      if (kind === 'github' && created?.id && ghInstalled) {
-        // App mode: the Helix GitHub App already delivers all events for
-        // every installed repo to one webhook; this stream is just a
-        // (repo, events) filter on that firehose. No per-repo webhook to
-        // install — doing so would need admin rights and double-deliver.
-        snackbar.success('Stream created · events arrive via the Helix GitHub App')
-      } else if (kind === 'github' && created?.id) {
-        // Legacy OAuth mode: auto-install a per-repo webhook on GitHub.
-        // Idempotent — re-run adopts an existing hook.
+      if (kind === 'github' && created?.id) {
+        // Auto-install a per-repo webhook on GitHub. The backend uses the
+        // installed Helix App's installation token (repository_hooks
+        // permission) when the app is present, falling back to a member's
+        // OAuth token otherwise. Idempotent — re-run adopts an existing hook.
         try {
           const inst = await installWebhook.mutateAsync(created.id)
           if (inst.warning) {

--- a/frontend/src/services/helixOrgService.ts
+++ b/frontend/src/services/helixOrgService.ts
@@ -11,6 +11,7 @@ import {
   ApiHireWorkerRequest,
   ApiHireWorkerResponse,
   ApiInstallGitHubWebhookResponse,
+  ApiGitHubWebhookStatusResponse,
   ApiOrgOverview,
   ApiRoleDTO,
   ApiRoleGroup,
@@ -47,6 +48,7 @@ export type GitHubReposResponse = ApiGitHubReposResponse
 export type GitHubInstallationStatus = ApiGitHubInstallationStatus
 export type GitHubManifestStartResponse = ApiGitHubManifestStartResponse
 export type InstallGitHubWebhookResponse = ApiInstallGitHubWebhookResponse
+export type GitHubWebhookStatusResponse = ApiGitHubWebhookStatusResponse
 export type WorkerSubscription = ApiWorkerSubscriptionDTO
 export type WorkerSubscriptionsResponse = ApiWorkerSubscriptionsResponse
 export type OrgOverview = ApiOrgOverview
@@ -82,6 +84,7 @@ export const QUERY_KEYS = {
   modelsForProvider: (provider: string) => ['helix-org', 'models', provider] as const,
   streams: (orgID: string) => ['helix-org', orgID, 'streams'] as const,
   stream: (orgID: string, id: string) => ['helix-org', orgID, 'streams', id] as const,
+  webhookStatus: (orgID: string, id: string) => ['helix-org', orgID, 'streams', id, 'webhook-status'] as const,
   workerSubs: (orgID: string, workerID: string) => ['helix-org', orgID, 'workers', workerID, 'subscriptions'] as const,
 }
 
@@ -489,6 +492,24 @@ export function useHelixOrgStream(streamId: string | undefined, options?: { enab
   })
 }
 
+// useGitHubWebhookStatus reports the LIVE state of a github stream's repo
+// webhook as seen on GitHub (state: "installed" | "missing" | "unknown"), so
+// the detail page can link to the real hook or offer a re-install. Read-only;
+// safe to refetch. Invalidate QUERY_KEYS.webhookStatus after an install.
+export function useGitHubWebhookStatus(streamId: string | undefined, options?: { enabled?: boolean }) {
+  const api = useApi()
+  const { orgID } = useHelixOrgBase()
+  return useQuery({
+    queryKey: QUERY_KEYS.webhookStatus(orgID, streamId ?? ''),
+    queryFn: async () => {
+      if (!streamId) return null
+      const res = await api.getApiClient().v1OrgsStreamsGithubWebhookStatusDetail(streamId, orgID)
+      return res.data as GitHubWebhookStatusResponse
+    },
+    enabled: !!orgID && !!streamId && (options?.enabled ?? true),
+  })
+}
+
 export function useCreateHelixOrgStream() {
   const api = useApi()
   const qc = useQueryClient()
@@ -589,6 +610,7 @@ export function useInstallGitHubWebhook() {
     onSuccess: (_data, streamId) => {
       qc.invalidateQueries({ queryKey: QUERY_KEYS.stream(orgID, streamId) })
       qc.invalidateQueries({ queryKey: QUERY_KEYS.streams(orgID) })
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.webhookStatus(orgID, streamId) })
     },
   })
 }

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -113,6 +113,28 @@ definitions:
           when debugging "I can't see repo X" reports.
         type: string
     type: object
+  api.GitHubWebhookStatusResponse:
+    properties:
+      active:
+        type: boolean
+      detail:
+        description: Detail explains a "unknown" state (and is empty otherwise).
+        type: string
+      payload_url:
+        type: string
+      state:
+        description: |-
+          State is one of:
+            "installed" — a webhook for this stream's payload URL exists on the repo
+            "missing"   — GitHub was reachable and has no such webhook (needs install)
+            "unknown"   — couldn't determine (no repo / no public URL / no creds /
+                          GitHub error); see Detail. The UI falls back to stored state.
+        type: string
+      webhook_html_url:
+        type: string
+      webhook_id:
+        type: integer
+    type: object
   api.HireWorkerRequest:
     properties:
       id:
@@ -8142,6 +8164,14 @@ definitions:
       active_sandboxes:
         description: Sandbox capacity
         type: integer
+      compute_state:
+        description: |-
+          ComputeState tracks the provider's view of the host's provisioning
+          lifecycle. Distinct from Status (which is the heartbeat-derived
+          online/offline/degraded view). Values: "provisioning" | "ready" |
+          "terminating" | "terminated" | "failed". See compute.State for
+          the canonical enum. Empty for self-registered hosts.
+        type: string
       created:
         type: string
       desktop_versions:
@@ -8200,6 +8230,31 @@ definitions:
         description: |-
           ProfileStatus tracks the compose stack lifecycle:
           "" | "assigning" | "pulling" | "starting" | "running" | "failed".
+        type: string
+      provider:
+        description: |-
+          Provider is the Name() of the compute.Provider that owns this host.
+          E.g. "yellowdog", "gcp", "lambda". Empty for self-registered hosts.
+        type: string
+      provider_id:
+        description: |-
+          ProviderID is the upstream system's opaque identifier for this
+          host (e.g. a YellowDog work-requirement YDID). Forms a composite
+          index with Provider so the reconciler can look hosts up cheaply.
+        type: string
+      provider_metadata:
+        additionalProperties:
+          type: string
+        description: |-
+          ProviderMetadata is provider-specific opaque data for
+          reconciliation, debugging, and admin display. Examples for YD:
+          worker-pool ID, compute requirement ID, region, public IP.
+        type: object
+      provisioned_at:
+        description: |-
+          ProvisionedAt is when Helix asked the provider to bring this host
+          up. Earlier than Created (which is the first heartbeat). Nil for
+          self-registered hosts.
         type: string
       render_node:
         description: /dev/dri/renderD128 or SOFTWARE
@@ -17734,6 +17789,30 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: 'Helix-org: auto-install the webhook for a github stream'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/streams/{id}/github/webhook-status:
+    get:
+      parameters:
+      - description: Stream ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.GitHubWebhookStatusResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: live webhook status for a github stream'
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/streams/{id}/publish:

--- a/openapi.json
+++ b/openapi.json
@@ -11981,6 +11981,52 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/streams/{id}/github/webhook-status": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: live webhook status for a github stream",
+                "parameters": [
+                    {
+                        "description": "Stream ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.GitHubWebhookStatusResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/streams/{id}/publish": {
             "post": {
                 "security": [
@@ -24540,6 +24586,31 @@
                     }
                 }
             },
+            "api.GitHubWebhookStatusResponse": {
+                "type": "object",
+                "properties": {
+                    "active": {
+                        "type": "boolean"
+                    },
+                    "detail": {
+                        "description": "Detail explains a \"unknown\" state (and is empty otherwise).",
+                        "type": "string"
+                    },
+                    "payload_url": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "description": "State is one of:\n  \"installed\" — a webhook for this stream's payload URL exists on the repo\n  \"missing\"   — GitHub was reachable and has no such webhook (needs install)\n  \"unknown\"   — couldn't determine (no repo / no public URL / no creds /\n                GitHub error); see Detail. The UI falls back to stored state.",
+                        "type": "string"
+                    },
+                    "webhook_html_url": {
+                        "type": "string"
+                    },
+                    "webhook_id": {
+                        "type": "integer"
+                    }
+                }
+            },
             "api.HireWorkerRequest": {
                 "type": "object",
                 "properties": {
@@ -35862,6 +35933,10 @@
                         "description": "Sandbox capacity",
                         "type": "integer"
                     },
+                    "compute_state": {
+                        "description": "ComputeState tracks the provider's view of the host's provisioning\nlifecycle. Distinct from Status (which is the heartbeat-derived\nonline/offline/degraded view). Values: \"provisioning\" | \"ready\" |\n\"terminating\" | \"terminated\" | \"failed\". See compute.State for\nthe canonical enum. Empty for self-registered hosts.",
+                        "type": "string"
+                    },
                     "created": {
                         "type": "string"
                     },
@@ -35922,6 +35997,25 @@
                     },
                     "profile_status": {
                         "description": "ProfileStatus tracks the compose stack lifecycle:\n\"\" | \"assigning\" | \"pulling\" | \"starting\" | \"running\" | \"failed\".",
+                        "type": "string"
+                    },
+                    "provider": {
+                        "description": "Provider is the Name() of the compute.Provider that owns this host.\nE.g. \"yellowdog\", \"gcp\", \"lambda\". Empty for self-registered hosts.",
+                        "type": "string"
+                    },
+                    "provider_id": {
+                        "description": "ProviderID is the upstream system's opaque identifier for this\nhost (e.g. a YellowDog work-requirement YDID). Forms a composite\nindex with Provider so the reconciler can look hosts up cheaply.",
+                        "type": "string"
+                    },
+                    "provider_metadata": {
+                        "description": "ProviderMetadata is provider-specific opaque data for\nreconciliation, debugging, and admin display. Examples for YD:\nworker-pool ID, compute requirement ID, region, public IP.",
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "provisioned_at": {
+                        "description": "ProvisionedAt is when Helix asked the provider to bring this host\nup. Earlier than Created (which is the first heartbeat). Nil for\nself-registered hosts.",
                         "type": "string"
                     },
                     "render_node": {

--- a/swagger.json
+++ b/swagger.json
@@ -9992,6 +9992,45 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/streams/{id}/github/webhook-status": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: live webhook status for a github stream",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Stream ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.GitHubWebhookStatusResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/streams/{id}/publish": {
             "post": {
                 "security": [
@@ -20332,6 +20371,31 @@
                 "source": {
                     "description": "Source identifies which token paid for this list — useful\nwhen debugging \"I can't see repo X\" reports.",
                     "type": "string"
+                }
+            }
+        },
+        "api.GitHubWebhookStatusResponse": {
+            "type": "object",
+            "properties": {
+                "active": {
+                    "type": "boolean"
+                },
+                "detail": {
+                    "description": "Detail explains a \"unknown\" state (and is empty otherwise).",
+                    "type": "string"
+                },
+                "payload_url": {
+                    "type": "string"
+                },
+                "state": {
+                    "description": "State is one of:\n  \"installed\" — a webhook for this stream's payload URL exists on the repo\n  \"missing\"   — GitHub was reachable and has no such webhook (needs install)\n  \"unknown\"   — couldn't determine (no repo / no public URL / no creds /\n                GitHub error); see Detail. The UI falls back to stored state.",
+                    "type": "string"
+                },
+                "webhook_html_url": {
+                    "type": "string"
+                },
+                "webhook_id": {
+                    "type": "integer"
                 }
             }
         },
@@ -31657,6 +31721,10 @@
                     "description": "Sandbox capacity",
                     "type": "integer"
                 },
+                "compute_state": {
+                    "description": "ComputeState tracks the provider's view of the host's provisioning\nlifecycle. Distinct from Status (which is the heartbeat-derived\nonline/offline/degraded view). Values: \"provisioning\" | \"ready\" |\n\"terminating\" | \"terminated\" | \"failed\". See compute.State for\nthe canonical enum. Empty for self-registered hosts.",
+                    "type": "string"
+                },
                 "created": {
                     "type": "string"
                 },
@@ -31717,6 +31785,25 @@
                 },
                 "profile_status": {
                     "description": "ProfileStatus tracks the compose stack lifecycle:\n\"\" | \"assigning\" | \"pulling\" | \"starting\" | \"running\" | \"failed\".",
+                    "type": "string"
+                },
+                "provider": {
+                    "description": "Provider is the Name() of the compute.Provider that owns this host.\nE.g. \"yellowdog\", \"gcp\", \"lambda\". Empty for self-registered hosts.",
+                    "type": "string"
+                },
+                "provider_id": {
+                    "description": "ProviderID is the upstream system's opaque identifier for this\nhost (e.g. a YellowDog work-requirement YDID). Forms a composite\nindex with Provider so the reconciler can look hosts up cheaply.",
+                    "type": "string"
+                },
+                "provider_metadata": {
+                    "description": "ProviderMetadata is provider-specific opaque data for\nreconciliation, debugging, and admin display. Examples for YD:\nworker-pool ID, compute requirement ID, region, public IP.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "provisioned_at": {
+                    "description": "ProvisionedAt is when Helix asked the provider to bring this host\nup. Earlier than Created (which is the first heartbeat). Nil for\nself-registered hosts.",
                     "type": "string"
                 },
                 "render_node": {


### PR DESCRIPTION
## Summary
Restores webhook creation that regressed in #2550 by reverting to per-repo webhooks using GitHub App bot credentials instead of app-level firehose. Adds a live webhook-status endpoint and UI component to display real webhook state from GitHub.

## Changes
- **Backend**: Add `repository_hooks:write` permission to app manifest; implement `FindWebhook()` helper and new `GET /streams/{id}/github/webhook-status` endpoint with three-state logic (installed/missing/unknown)
- **Frontend**: Add live webhook status component on stream detail page with Install/View buttons; gracefully degrade to stored config when GitHub unreachable
- **Tests**: Removed obsolete tests for app-level webhook wiring

## Why
Commit 9f1f01c09 shifted to app-level firehose webhooks, but the app was created on localhost without webhook capability or events subscription. Per-repo webhooks are the correct approach and allow users to control webhook behavior per stream.

## Known Limitation
Existing GitHub Apps lack `repository_hooks` permission (cannot be added via API). Users must:
1. Go to GitHub Settings > Developer settings > GitHub Apps > helix-winderai
2. Edit Permissions > Repository permissions > Webhooks: set to "Read & write"
3. Reinstall the app on their organization

After that, the Install button on stream detail pages will create webhooks on demand.

## Test Plan
- [x] API builds without errors
- [x] Frontend builds without errors
- [ ] Create new stream in inner Helix and verify webhook appears on GitHub
- [ ] Check webhook status component displays correctly (installed/missing states)
- [ ] Test re-install button when webhook is missing