### PR TITLE
fix(helix-org): UI tweaks — settings, streams, role, chart, worker detail

### DIFF
--- a/api/pkg/org/QA.md
+++ b/api/pkg/org/QA.md
@@ -168,12 +168,32 @@ surface lives at `…/helix-org/streams`.
 
 ## §7. GitHub streams — one-click setup
 
-Pre-conditions: GitHub OAuth connected with `repo,
-admin:repo_hook, read:org`. `SERVER_URL` is a public host
+Pre-conditions: the Helix GitHub App installed for the org (the repo
+picker lists its installable repos). `SERVER_URL` is a public host
 (loopback refused).
 
 Create → pick repo → submit → webhook installed end-to-end.
 Detail page exposes **Edit on GitHub →** and **Re-install**.
+
+- **Shared repo picker.** Both the New Stream dialog and the per-stream
+  Edit form use the same `GitHubRepoPicker` (autocomplete over
+  installable repos + free-text fallback + refresh). The Edit form's
+  Repository field is the picker, not a plain text input.
+- **Events live on GitHub, not Helix.** The event-type whitelist is
+  offered only at **creation** (Helix installs the webhook with those
+  events). The post-creation Edit form does NOT show an events editor —
+  a caption points the operator at the GitHub webhook UI. Editing the
+  repo/branches and saving must PRESERVE the existing `events`,
+  `webhook_id`, and `webhook_html_url` (the prior bug rebuilt the
+  config from `{repo, events, branches}` only, wiping the managed
+  fields and silently failing `GitHubConfig.Validate` on an empty
+  events list). Confirm a save round-trips: `org_streams` config still
+  has the original `events` and `webhook_id` after editing only the
+  repo.
+- **Settings.** The `transport.github` row is no longer shown on the
+  Settings page — the GitHub App provisions the webhook secret itself,
+  so there is nothing to paste. (The registry key still exists; it's
+  just not operator-facing.)
 
 ## §8. Worker-anchored subscriptions
 
@@ -229,14 +249,18 @@ reconciles after the row is gone; there is no inline stream delete).
    zero rows. `w-cleanup-rep` survives, keeping its own
    `s-activations-w-cleanup-rep`.
 
-## §10. Chat: inline transcript + Human Desktop
+## §10. Chat: inline transcript
 
 The worker detail page renders the worker's conversation inline using
 the same transcript view the spec-task page uses (`EmbeddedSessionView`
 + `RobustPromptInput`), reading the per-Worker project's long-lived
-"Human Desktop" exploratory session. The operator should NOT have to
-click out to the external desktop tab just to see what the worker is
-doing. The desktop launch stays available for the full Zed GUI / video.
+"Human Desktop" exploratory session. The inline transcript is the chat
+surface — there are no "Open Human Desktop" / "Restart Desktop" buttons
+on the page (removed); session (re)provisioning is handled by the
+worker's activation flow and the Advanced → Restart agent session
+action (§14). The embedded transcript defaults to auto-scroll ON
+(`autoScrollOnMount`), so live output follows to the bottom without the
+operator un-pausing it.
 
 1. **Inline transcript auto-loads.** Open a worker that has already
    been chatted with (`…/helix-org/workers/<id>` with a `project_id`).
@@ -247,8 +271,8 @@ doing. The desktop launch stays available for the full Zed GUI / video.
    `GET …/projects/<pid>/exploratory-session`, no create/resume POST).
 2. **No-session empty state.** A freshly-hired worker that has never
    been chatted with (no `project_id`, or project with no exploratory
-   session — the GET returns 204) shows "No conversation yet — launch
-   the Human Desktop to start one", not a crash or a spinner.
+   session — the GET returns 204) shows "No conversation yet for this
+   worker", not a crash or a spinner.
 3. **Send a message and verify the worker responds.** This is the
    load-bearing test — the worker chat is useless if messages don't
    actually reach the agent. With the transcript shown, type a prompt
@@ -284,11 +308,10 @@ doing. The desktop launch stays available for the full Zed GUI / video.
      `SELECT state, prompt_message FROM interactions WHERE session_id =
      '<sid>' ORDER BY created DESC LIMIT 2;` shows the user prompt and a
      `complete` assistant turn.
-4. **Open Human Desktop** still lands on
-   `…/projects/<project_id>/desktop/<session_id>` in a new tab — the
-   full GUI surface, NOT the bare composer at `/agent/<id>`. After
-   launch, the inline transcript on the worker page reflects the same
-   session.
+4. **No desktop-launch buttons.** The page must NOT render "Open Human
+   Desktop", "Restart Desktop", or a topbar "Start new chat" button —
+   all removed. Chat happens inline; the only restart affordance is the
+   Advanced accordion (§14).
 
 ## §11. Worker sandbox: Zed launch, per-Worker tools, stale-session recovery
 
@@ -421,6 +444,52 @@ manager (of `w-sub`).
    `dm` tool does NOT mint one. (Confirm the refusal wrote nothing:
    `SELECT id FROM org_streams WHERE id='s-dm-w-mgr-w-sub'` → zero rows.)
 
+## §14. Breadcrumbs (all helix-org pages)
+
+Every helix-org page builds its breadcrumb trail from the shared
+`useHelixOrgBreadcrumbs(section?)` hook (`components/helix-org/`), so the
+trail is consistent and the leading org-name crumb is always a link to
+the chart. No page uses the old `orgBreadcrumbs={true}` plain-text org
+crumb, and the detail pages have NO standalone "back" button — the
+breadcrumb is the back-nav.
+
+1. **List pages.** On `…/helix-org/roles`, `…/workers`, `…/streams`
+   the trail is `<org name> / <Section>` (e.g. `test / Streams`). The
+   org-name crumb is a clickable link → navigates to
+   `…/helix-org/chart`. The section word is the current (leaf) crumb,
+   not a link.
+2. **Detail pages.** On a role/worker/stream detail page the trail is
+   `<org name> / <Section> / <leaf id>` (e.g. `test / Workers / w-ai-1`).
+   Both `<org name>` (→ chart) and `<Section>` (→ the list page) are
+   links. There is no separate "Roles" / "Streams" / "Workers" back
+   button anywhere.
+3. **Settings.** `…/helix-org/settings` shows `test / Settings`; the
+   org crumb links to the chart.
+4. The org link works from **every** page above, not just settings —
+   this is the regression that motivated the shared hook (the list
+   pages previously rendered the org name as plain text).
+
+## §15. Worker detail surfaces: identity, links, Advanced
+
+Beyond the inline chat (§10), the worker detail page exposes an
+editable identity, deep links into Helix, and a guarded restart.
+
+1. **Editable identity.** The Identity section is a Monaco markdown
+   editor (not a read-only block) with a **Save** button. Edit the
+   text → Save is enabled → click (or Cmd/Ctrl+S) → snackbar
+   `identity saved`; `POST …/workers/<id>/identity` returns 2xx. The
+   Spawner projects the new content into `identity.md` on the next
+   activation.
+2. **Right-rail links.** In the right panel, the **Project** id is a
+   link → `…/projects/<project_id>/specs` (the project's board), and an
+   **Agent** row links to `…/agent/<agent_app_id>`. Both render only
+   when the worker has been provisioned (has a project / agent app).
+3. **Advanced → Restart agent session.** A collapsed **Advanced**
+   accordion at the bottom of the page expands to a **Restart agent
+   session** button with a caption warning that in-progress work is
+   lost. Clicking re-activates the worker (`POST …/workers/<id>/activate`)
+   → snackbar confirming the restart was queued.
+
 ## Pass criteria
 
 - §1 — bootstrap creates one Worker (`w-owner` with `role_id =
@@ -459,11 +528,19 @@ manager (of `w-sub`).
   non-reporting worker is refused and mints nothing.
 - §10 — the worker page shows the conversation inline (transcript +
   tool calls + composer) when a session exists, GET-only on load (no
-  container spin-up); the empty state shows otherwise. Sending a
-  message dispatches via `POST …/sessions/chat` (the composer does NOT
-  get stuck on "Message queue (saved locally)") and the worker's agent
-  replies live in the transcript. "Open Human Desktop" lands on
-  `…/projects/<pid>/desktop/<sid>`, never on `…/agent/<id>`.
+  container spin-up), auto-scroll defaulting ON; the empty state shows
+  otherwise. Sending a message dispatches via `POST …/sessions/chat`
+  (the composer does NOT get stuck on "Message queue (saved locally)")
+  and the worker's agent replies live in the transcript. No
+  desktop-launch / "Start new chat" buttons remain on the page.
+- §14 — every helix-org page's breadcrumb comes from the shared hook;
+  the org-name crumb links to the chart from every page (list, detail,
+  settings), and detail pages carry an org / Section / leaf trail with
+  no standalone back button.
+- §15 — worker identity is an editable Monaco field saved via
+  `POST …/workers/<id>/identity`; the right-rail Project and Agent ids
+  link into Helix; the Advanced accordion's "Restart agent session"
+  re-activates the worker with a data-loss warning.
 - §11 — fresh sandbox: Zed launches; per-Worker `gh`
   startupScript installs cleanly; `gh auth status` green.
 - No console errors beyond the three Vite WS errors at startup.

--- a/frontend/src/components/helix-org/GitHubRepoPicker.tsx
+++ b/frontend/src/components/helix-org/GitHubRepoPicker.tsx
@@ -1,0 +1,117 @@
+// GitHubRepoPicker is the shared `owner/name` repository selector for
+// helix-org. It lists the repos the Helix GitHub App can see (via
+// useListGitHubRepos) in an Autocomplete, falls back to free-text entry
+// for repos that aren't listed yet, and exposes a refresh button so the
+// operator can re-pull after granting the App access to a new org.
+//
+// It is intentionally the single source of truth for "pick a GitHub
+// repo" across helix-org — the New Stream dialog and the per-stream
+// Edit form both render it, so the picker behaves identically wherever a
+// repository is configured. The parent owns the value + onChange; this
+// component owns the fetching, loading state, and validation hint.
+
+import { FC } from 'react'
+import Autocomplete from '@mui/material/Autocomplete'
+import CircularProgress from '@mui/material/CircularProgress'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import RefreshIcon from '@mui/icons-material/Refresh'
+
+import { useListGitHubRepos } from '../../services/helixOrgService'
+import { GITHUB_REPO_PATTERN } from './githubStreamConstants'
+
+export interface GitHubRepoPickerProps {
+  value: string
+  onChange: (next: string) => void
+  // enabled gates the underlying repo fetch — pass the dialog's `open`
+  // so closed dialogs don't poll GitHub. Defaults to true for always-on
+  // surfaces (e.g. the inline stream-edit form).
+  enabled?: boolean
+  label?: string
+  // helperOverride replaces the default count/hint helper text when set.
+  helperOverride?: string
+}
+
+const GitHubRepoPicker: FC<GitHubRepoPickerProps> = ({
+  value,
+  onChange,
+  enabled = true,
+  label = 'Repository',
+  helperOverride,
+}) => {
+  const reposQuery = useListGitHubRepos({ enabled })
+  const options = (reposQuery.data?.repos ?? []).map((r) => r.full_name)
+  const loading = reposQuery.isLoading || reposQuery.isRefetching
+
+  const trimmed = value.trim()
+  const repoError = trimmed === ''
+    ? ''
+    : (GITHUB_REPO_PATTERN.test(trimmed) ? '' : 'Must be `owner/name` (one slash, both halves non-empty).')
+
+  const helper = repoError
+    ? repoError
+    : (helperOverride ?? (
+        options.length >= 1000
+          ? `Showing the ${options.length} most-recently-pushed repos. Type the full owner/name if the one you want isn't listed.`
+          : `Pick a repo, or type owner/name directly. Helix registers the webhook on GitHub for you — no manual setup. ${options.length} repos loaded.`
+      ))
+
+  return (
+    <Stack direction="row" spacing={1} alignItems="flex-start">
+      <Autocomplete
+        freeSolo
+        autoSelect
+        selectOnFocus
+        fullWidth
+        options={options}
+        value={value || null}
+        onChange={(_, v) => onChange((v ?? '').trim())}
+        onInputChange={(_, v, reason) => {
+          // Sync typed text into the value so callers see what the
+          // operator typed even if they never picked a dropdown row.
+          if (reason === 'input') onChange(v)
+        }}
+        loading={loading}
+        disablePortal
+        noOptionsText={
+          reposQuery.isError
+            ? 'Could not load repos — connect a GitHub account on Connected Services first.'
+            : loading
+              ? 'Loading…'
+              : 'No matches — type the full owner/name and press Enter.'
+        }
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label={label}
+            placeholder="search or type owner/name…"
+            size="small"
+            error={!!repoError}
+            InputProps={{
+              ...params.InputProps,
+              endAdornment: (
+                <>
+                  {loading && <CircularProgress size={16} sx={{ mr: 1 }} />}
+                  {params.InputProps.endAdornment}
+                </>
+              ),
+            }}
+            helperText={helper}
+          />
+        )}
+      />
+      <IconButton
+        size="small"
+        onClick={() => reposQuery.refetch()}
+        disabled={reposQuery.isFetching}
+        title="Re-fetch repos from GitHub (use this after granting the Helix App access to a new org)"
+        sx={{ mt: 0.5 }}
+      >
+        <RefreshIcon fontSize="small" />
+      </IconButton>
+    </Stack>
+  )
+}
+
+export default GitHubRepoPicker

--- a/frontend/src/components/helix-org/GitHubStreamConfigFields.tsx
+++ b/frontend/src/components/helix-org/GitHubStreamConfigFields.tsx
@@ -1,12 +1,9 @@
-// GitHubStreamConfigFields is the Repository + Events + Branches form block
-// shared by the New Stream dialog and the per-stream Edit dialog.
-// It's intentionally headless: the parent owns the values + change
-// handlers so the dialog around it stays in control of submit
-// validation, snackbar wiring, etc.
-//
-// The Events and Branches editors are also exported on their own so the
-// New Stream dialog can pair them with its own repo *picker* (which lists
-// the bot's installation repos) instead of the plain repo text field here.
+// GitHub stream-config field building blocks. The Events and Branches
+// editors are headless (the parent owns values + change handlers) and
+// are composed alongside the shared GitHubRepoPicker by both the New
+// Stream dialog and the per-stream Edit form. Repository selection lives
+// in GitHubRepoPicker; event-type selection only appears at creation
+// (afterwards events are managed on GitHub's own webhook UI).
 
 import { FC } from 'react'
 import Autocomplete from '@mui/material/Autocomplete'
@@ -19,7 +16,6 @@ import Typography from '@mui/material/Typography'
 import {
   EventOption,
   GITHUB_EVENT_OPTIONS,
-  GITHUB_REPO_PATTERN,
   eventValue,
   isValidGitHubEvent,
 } from './githubStreamConstants'
@@ -141,44 +137,3 @@ export const GitHubBranchesField: FC<{ branches: string[]; onChange: (next: stri
     )}
   />
 )
-
-export interface GitHubStreamConfigFieldsProps {
-  repo: string
-  events: string[]
-  branches?: string[]
-  onRepoChange: (next: string) => void
-  onEventsChange: (next: string[]) => void
-  onBranchesChange?: (next: string[]) => void
-}
-
-export const GitHubStreamConfigFields: FC<GitHubStreamConfigFieldsProps> = ({
-  repo,
-  events,
-  branches = [],
-  onRepoChange,
-  onEventsChange,
-  onBranchesChange,
-}) => {
-  const repoError = repo.trim() === ''
-    ? ''
-    : (GITHUB_REPO_PATTERN.test(repo.trim()) ? '' : 'Must be `owner/name` (one slash, both halves non-empty).')
-
-  return (
-    <>
-      <TextField
-        label="Repository"
-        placeholder="helixml/helix"
-        value={repo}
-        onChange={(e) => onRepoChange(e.target.value)}
-        error={!!repoError}
-        helperText={repoError || 'GitHub `owner/name` (e.g. helixml/helix), or `owner/*` to match a whole org. Matched case-insensitively against repository.full_name in the payload.'}
-        fullWidth
-        size="small"
-      />
-      <GitHubEventsField events={events} onChange={onEventsChange} />
-      {onBranchesChange && <GitHubBranchesField branches={branches} onChange={onBranchesChange} />}
-    </>
-  )
-}
-
-export default GitHubStreamConfigFields

--- a/frontend/src/components/helix-org/useHelixOrgBreadcrumbs.ts
+++ b/frontend/src/components/helix-org/useHelixOrgBreadcrumbs.ts
@@ -1,0 +1,52 @@
+// useHelixOrgBreadcrumbs is the single source of truth for the breadcrumb
+// trail on helix-org pages. It returns the leading crumbs to hand to
+// Page's `breadcrumbs` prop: the org name (linking to the chart) followed
+// by an optional section crumb (linking to that section's list page). The
+// page supplies the leaf via `breadcrumbTitle`.
+//
+// Every crumb navigates via the plain router (useOrgRouter: false).
+// helix-org routes are named `helix_org_*`, which account.orgNavigate
+// would mangle by prepending `org_` (turning `helix_org_chart` into the
+// non-existent `org_helix_org_chart`) — so the org router must not be used.
+//
+// Because this hook supplies the org crumb itself, pages using it should
+// NOT also set `orgBreadcrumbs` (which would inject a second, plain-text
+// org crumb).
+
+import { IPageBreadcrumb } from '../../types'
+import useAccount from '../../hooks/useAccount'
+import useRouter from '../../hooks/useRouter'
+
+export interface HelixOrgBreadcrumbSection {
+  // Display label, e.g. "Roles".
+  title: string
+  // Route name of the section's list page, e.g. "helix_org_roles".
+  routeName: string
+}
+
+export function useHelixOrgBreadcrumbs(section?: HelixOrgBreadcrumbSection): IPageBreadcrumb[] {
+  const account = useAccount()
+  const { params } = useRouter()
+  const orgSlug = (params.org_id as string) || ''
+  const orgName = account.organizationTools.organization?.name || orgSlug
+
+  const crumbs: IPageBreadcrumb[] = [
+    {
+      title: orgName,
+      routeName: 'helix_org_chart',
+      params: { org_id: orgSlug },
+      useOrgRouter: false,
+    },
+  ]
+  if (section) {
+    crumbs.push({
+      title: section.title,
+      routeName: section.routeName,
+      params: { org_id: orgSlug },
+      useOrgRouter: false,
+    })
+  }
+  return crumbs
+}
+
+export default useHelixOrgBreadcrumbs

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -54,6 +54,12 @@ import { SESSION_TYPE_TEXT } from "../../types";
 interface EmbeddedSessionViewProps {
   sessionId: string;
   onScrollToBottom?: () => void;
+  // When true, force the (otherwise persisted, globally-shared)
+  // auto-scroll preference ON when this view mounts. Surfaces that want
+  // the transcript to follow live output by default — e.g. the helix-org
+  // worker detail chat — opt in so a previously-toggled-OFF value doesn't
+  // leave the chat opening paused.
+  autoScrollOnMount?: boolean;
 }
 
 export interface EmbeddedSessionViewHandle {
@@ -86,7 +92,7 @@ export interface EmbeddedSessionViewHandle {
 const EmbeddedSessionView = forwardRef<
   EmbeddedSessionViewHandle,
   EmbeddedSessionViewProps
->(({ sessionId, onScrollToBottom }, ref) => {
+>(({ sessionId, onScrollToBottom, autoScrollOnMount }, ref) => {
   const account = useAccount();
   const api = useApi();
   const lightTheme = useLightTheme();
@@ -100,6 +106,18 @@ const EmbeddedSessionView = forwardRef<
   useEffect(() => {
     autoScrollRef.current = autoScroll;
   }, [autoScroll]);
+
+  // Opt-in surfaces (autoScrollOnMount) want the transcript to follow
+  // live output regardless of a previously-persisted OFF value. Force
+  // the preference ON once on mount. Runs once — after that the toggle
+  // and scroll-up unlock behave normally.
+  useEffect(() => {
+    if (autoScrollOnMount && !autoScrollRef.current) {
+      autoScrollRef.current = true;
+      setAutoScroll(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // True when auto-scroll is OFF and new content has landed below the viewport.
   // Drives the "Jump to latest" pill.

--- a/frontend/src/components/system/Page.tsx
+++ b/frontend/src/components/system/Page.tsx
@@ -38,6 +38,12 @@ const Page: React.FC<{
   breadcrumbs?: IPageBreadcrumb[],
   // this means to use the org router for the breadcrumbs
   orgBreadcrumbs?: boolean,
+  // when orgBreadcrumbs is on, the leading "org name" crumb is plain
+  // text by default. Pass these to turn it into a link (e.g. point it at
+  // the helix-org chart from the detail pages). Navigates via the plain
+  // router (not orgNavigate).
+  orgBreadcrumbRouteName?: string,
+  orgBreadcrumbRouteParams?: Record<string, any>,
   headerContent?: ReactNode,
   footerContent?: ReactNode,
   showDrawerButton?: boolean,
@@ -61,6 +67,8 @@ const Page: React.FC<{
   breadcrumbParent,
   breadcrumbs = [],
   orgBreadcrumbs = false,
+  orgBreadcrumbRouteName,
+  orgBreadcrumbRouteParams,
   headerContent = null,
   footerContent = null,
   showDrawerButton = true,
@@ -107,6 +115,10 @@ const Page: React.FC<{
     if(orgBreadcrumbs && account.organizationTools.organization) {
       useBreadcrumbTitles.unshift({
         title: account.organizationTools.organization?.name || '',
+        routeName: orgBreadcrumbRouteName,
+        params: orgBreadcrumbRouteParams,
+        // Navigate via the plain router when a route is supplied.
+        useOrgRouter: orgBreadcrumbRouteName ? false : undefined,
       })
     }
     // Only add parent breadcrumb if explicitly provided

--- a/frontend/src/components/system/Page.tsx
+++ b/frontend/src/components/system/Page.tsx
@@ -38,12 +38,6 @@ const Page: React.FC<{
   breadcrumbs?: IPageBreadcrumb[],
   // this means to use the org router for the breadcrumbs
   orgBreadcrumbs?: boolean,
-  // when orgBreadcrumbs is on, the leading "org name" crumb is plain
-  // text by default. Pass these to turn it into a link (e.g. point it at
-  // the helix-org chart from the detail pages). Navigates via the plain
-  // router (not orgNavigate).
-  orgBreadcrumbRouteName?: string,
-  orgBreadcrumbRouteParams?: Record<string, any>,
   headerContent?: ReactNode,
   footerContent?: ReactNode,
   showDrawerButton?: boolean,
@@ -67,8 +61,6 @@ const Page: React.FC<{
   breadcrumbParent,
   breadcrumbs = [],
   orgBreadcrumbs = false,
-  orgBreadcrumbRouteName,
-  orgBreadcrumbRouteParams,
   headerContent = null,
   footerContent = null,
   showDrawerButton = true,
@@ -115,10 +107,6 @@ const Page: React.FC<{
     if(orgBreadcrumbs && account.organizationTools.organization) {
       useBreadcrumbTitles.unshift({
         title: account.organizationTools.organization?.name || '',
-        routeName: orgBreadcrumbRouteName,
-        params: orgBreadcrumbRouteParams,
-        // Navigate via the plain router when a route is supplied.
-        useOrgRouter: orgBreadcrumbRouteName ? false : undefined,
       })
     }
     // Only add parent breadcrumb if explicitly provided

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -1174,28 +1174,19 @@ const HelixOrgChart: FC = () => {
     <Page breadcrumbTitle="Chart">
       <Box sx={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 64px)', minHeight: 0 }}>
         <Box sx={{ px: 4, pt: 4, pb: 2 }}>
-          <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
-            <Box>
-              <Typography
-                variant="h4"
-                sx={{ fontWeight: 700, mb: 1, color: titleColor, letterSpacing: '-0.02em' }}
-              >
-                Chart
-              </Typography>
-              <Typography variant="body2" sx={{ color: subtitleColor }}>
-                Roles group Workers. Hire Workers into a Role, then drag from a manager's
-                bottom handle to a subordinate to set who reports to whom, or from a
-                Worker's right handle to a Stream to subscribe.
-              </Typography>
-            </Box>
-            <Button
-              variant="contained"
-              startIcon={<AddIcon />}
-              onClick={() => setRoleDialogOpen(true)}
+          <Box>
+            <Typography
+              variant="h4"
+              sx={{ fontWeight: 700, mb: 1, color: titleColor, letterSpacing: '-0.02em' }}
             >
-              New role
-            </Button>
-          </Stack>
+              Chart
+            </Typography>
+            <Typography variant="body2" sx={{ color: subtitleColor }}>
+              Roles group Workers. Hire Workers into a Role, then drag from a manager's
+              bottom handle to a subordinate to set who reports to whom, or from a
+              Worker's right handle to a Stream to subscribe.
+            </Typography>
+          </Box>
         </Box>
 
         <Box
@@ -1211,6 +1202,19 @@ const HelixOrgChart: FC = () => {
             overflow: 'hidden',
           }}
         >
+          {/* New role lives on the canvas (floating top-right) rather than
+              in the page header — it reads as a canvas action, and keeps
+              the header to title + description. zIndex sits above the
+              ReactFlow surface / controls. */}
+          <Button
+            variant="contained"
+            startIcon={<AddIcon />}
+            onClick={() => setRoleDialogOpen(true)}
+            sx={{ position: 'absolute', top: 12, right: 12, zIndex: 5 }}
+          >
+            New role
+          </Button>
+
           {isLoading ? (
             <Box sx={{ p: 4 }}><LoadingSpinner /></Box>
           ) : groups.length === 0 ? (

--- a/frontend/src/pages/HelixOrgRoleDetail.tsx
+++ b/frontend/src/pages/HelixOrgRoleDetail.tsx
@@ -25,7 +25,6 @@ import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
-import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import CheckBoxIcon from '@mui/icons-material/CheckBox'
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
@@ -137,15 +136,17 @@ const HelixOrgRoleDetail: FC = () => {
     <Page
       breadcrumbTitle={roleId ?? 'Role'}
       orgBreadcrumbs={true}
+      orgBreadcrumbRouteName="helix_org_chart"
+      orgBreadcrumbRouteParams={{ org_id: orgSlug ?? '' }}
+      breadcrumbs={[{
+        title: 'Roles',
+        routeName: 'helix_org_roles',
+        params: { org_id: orgSlug ?? '' },
+        useOrgRouter: false,
+      }]}
       organizationId={account.organizationTools.organization?.id}
       topbarContent={(
         <Stack direction="row" spacing={1}>
-          <Button
-            startIcon={<ArrowBackIcon />}
-            onClick={() => orgSlug && router.navigate('helix_org_roles', { org_id: orgSlug })}
-          >
-            Roles
-          </Button>
           <Button
             variant="contained"
             color="secondary"

--- a/frontend/src/pages/HelixOrgRoleDetail.tsx
+++ b/frontend/src/pages/HelixOrgRoleDetail.tsx
@@ -34,6 +34,7 @@ import Page from '../components/system/Page'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import MonacoEditor from '../components/widgets/MonacoEditor'
 import DeleteConfirmWindow from '../components/widgets/DeleteConfirmWindow'
+import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
 
 import useAccount from '../hooks/useAccount'
 import useRouter from '../hooks/useRouter'
@@ -54,6 +55,7 @@ const HelixOrgRoleDetail: FC = () => {
   const snackbar = useSnackbar()
   const orgSlug = router.params.org_id as string | undefined
   const roleId = router.params.role_id as string | undefined
+  const breadcrumbs = useHelixOrgBreadcrumbs({ title: 'Roles', routeName: 'helix_org_roles' })
 
   const { data, isLoading } = useHelixOrgRole(roleId)
   const { data: toolCatalogue } = useListHelixOrgTools()
@@ -135,15 +137,7 @@ const HelixOrgRoleDetail: FC = () => {
   return (
     <Page
       breadcrumbTitle={roleId ?? 'Role'}
-      orgBreadcrumbs={true}
-      orgBreadcrumbRouteName="helix_org_chart"
-      orgBreadcrumbRouteParams={{ org_id: orgSlug ?? '' }}
-      breadcrumbs={[{
-        title: 'Roles',
-        routeName: 'helix_org_roles',
-        params: { org_id: orgSlug ?? '' },
-        useOrgRouter: false,
-      }]}
+      breadcrumbs={breadcrumbs}
       organizationId={account.organizationTools.organization?.id}
       topbarContent={(
         <Stack direction="row" spacing={1}>

--- a/frontend/src/pages/HelixOrgRoleDetail.tsx
+++ b/frontend/src/pages/HelixOrgRoleDetail.tsx
@@ -1,14 +1,16 @@
-// HelixOrgRoleDetail edits a single role end-to-end: markdown content,
-// tools (the role's MCP tool list), streams (inbound subscriptions). Lives at
+// HelixOrgRoleDetail edits a single role end-to-end: markdown content
+// and tools (the role's MCP tool list). Lives at
 // `/orgs/:org_id/helix-org/roles/:role_id` and is the destination
 // both the chart's role drawer and the Roles list link to.
 //
+// Stream subscriptions are NOT edited here — subscriptions are
+// worker-anchored (they live on the Worker, die when it's fired, and
+// aren't inherited by a new hire into the same Role), so they're
+// managed on the Worker detail page, not the Role.
+//
 // Markdown editing uses the in-tree Monaco editor (loaded everywhere
-// else via `components/widgets/MonacoEditor`). Tools and streams are
-// edited as comma-separated chips — the underlying API takes
-// `string[]` and the registry is small enough that a freeform input
-// beats a multi-select for the alpha; we can swap to a real
-// autocomplete once the catalogue stabilises.
+// else via `components/widgets/MonacoEditor`). Tools are edited via a
+// multi-select over the tool catalogue.
 
 import { FC, Key, useEffect, useMemo, useState } from 'react'
 import Autocomplete from '@mui/material/Autocomplete'
@@ -47,11 +49,6 @@ import {
 
 const OWNER_ROLE = 'r-owner'
 
-// parseList turns "foo, bar, baz" into ["foo", "bar", "baz"], dropping
-// empty entries. Used for both tools and streams.
-const parseList = (s: string): string[] =>
-  s.split(/[,\n]/).map((t) => t.trim()).filter((t) => t !== '')
-
 const HelixOrgRoleDetail: FC = () => {
   const router = useRouter()
   const account = useAccount()
@@ -66,7 +63,6 @@ const HelixOrgRoleDetail: FC = () => {
 
   const [content, setContent] = useState('')
   const [tools, setTools] = useState<string[]>([])
-  const [streamsText, setStreamsText] = useState('')
   const [confirmingDelete, setConfirmingDelete] = useState(false)
 
   // Seed local state when the role loads or the route changes.
@@ -74,10 +70,7 @@ const HelixOrgRoleDetail: FC = () => {
     if (!data) return
     setContent(data.content ?? '')
     setTools(data.tools ?? [])
-    setStreamsText((data.streams ?? []).join(', '))
   }, [data])
-
-  const streams = useMemo(() => parseList(streamsText), [streamsText])
 
   // The Autocomplete needs Option objects, but the role's tool list
   // is just a string[] of names. We render every catalogue
@@ -98,18 +91,19 @@ const HelixOrgRoleDetail: FC = () => {
     if (!data) return false
     if ((data.content ?? '') !== content) return true
     if ((data.tools ?? []).join(',') !== tools.join(',')) return true
-    if ((data.streams ?? []).join(',') !== streams.join(',')) return true
     return false
-  }, [data, content, tools, streams])
+  }, [data, content, tools])
 
   const handleSave = async () => {
     if (!roleId) return
     try {
+      // Streams are intentionally omitted — they're worker-anchored and
+      // managed on the Worker detail page. The backend preserves a
+      // Role's existing streams when the field is absent.
       await updateRole.mutateAsync({
         id: roleId,
         content,
         tools,
-        streams,
       })
       snackbar.success(`role ${roleId} saved`)
     } catch (err: any) {
@@ -263,25 +257,6 @@ const HelixOrgRoleDetail: FC = () => {
                   />
                 </Box>
 
-                <Box>
-                  <Typography variant="subtitle2" sx={{ mb: 1 }}>Streams</Typography>
-                  <TextField
-                    fullWidth
-                    value={streamsText}
-                    onChange={(e) => setStreamsText(e.target.value)}
-                    placeholder="s-github-webhooks, s-postmark-inbound, … (comma- or newline-separated)"
-                    helperText="Inbound event streams the Workers in this role subscribe to."
-                    multiline
-                    minRows={2}
-                  />
-                  {streams.length > 0 && (
-                    <Stack direction="row" flexWrap="wrap" gap={0.5} sx={{ mt: 1 }}>
-                      {streams.map((s) => (
-                        <Chip key={s} label={s} size="small" sx={{ fontFamily: 'monospace' }} />
-                      ))}
-                    </Stack>
-                  )}
-                </Box>
               </Stack>
             </Grid>
 

--- a/frontend/src/pages/HelixOrgRoles.tsx
+++ b/frontend/src/pages/HelixOrgRoles.tsx
@@ -21,6 +21,7 @@ import MoreVertIcon from '@mui/icons-material/MoreVert'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 
 import Page from '../components/system/Page'
+import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import SimpleTable from '../components/widgets/SimpleTable'
 import DeleteConfirmWindow from '../components/widgets/DeleteConfirmWindow'
@@ -39,6 +40,7 @@ const OWNER_ROLE = 'r-owner'
 const HelixOrgRoles: FC = () => {
   const router = useRouter()
   const account = useAccount()
+  const breadcrumbs = useHelixOrgBreadcrumbs()
   const snackbar = useSnackbar()
   const theme = useTheme()
   const orgSlug = router.params.org_id as string | undefined
@@ -145,7 +147,7 @@ const HelixOrgRoles: FC = () => {
   return (
     <Page
       breadcrumbTitle="Roles"
-      orgBreadcrumbs={true}
+      breadcrumbs={breadcrumbs}
       organizationId={account.organizationTools.organization?.id}
     >
       <Container maxWidth="xl" sx={{ mb: 4, pt: 3 }}>

--- a/frontend/src/pages/HelixOrgSettings.tsx
+++ b/frontend/src/pages/HelixOrgSettings.tsx
@@ -141,6 +141,8 @@ const HelixOrgSettings: FC = () => {
     <Page
       breadcrumbTitle="Settings"
       orgBreadcrumbs={true}
+      orgBreadcrumbRouteName="helix_org_chart"
+      orgBreadcrumbRouteParams={{ org_id: orgSlug ?? '' }}
       organizationId={account.organizationTools.organization?.id}
     >
       <Container maxWidth="md" sx={{ mb: 4, pt: 3 }}>

--- a/frontend/src/pages/HelixOrgSettings.tsx
+++ b/frontend/src/pages/HelixOrgSettings.tsx
@@ -55,6 +55,15 @@ const FIRST_CLASS_KEYS = new Set<string>([
   'worker.model',
 ])
 
+// Keys we deliberately hide from the settings surface. transport.github
+// is auto-managed now: the Helix GitHub App provisions the webhook
+// secret (and the access token comes from the App installation), so
+// there's nothing for an operator to paste here. The key still exists
+// in the registry — it's just self-configured, not operator-facing.
+const HIDDEN_KEYS = new Set<string>([
+  'transport.github',
+])
+
 // Allowed values for the two dropdown-only knobs. The server
 // validates against the same set in
 // api/pkg/server/helix_org.go::resolveWorkerAgentConfig.
@@ -184,9 +193,9 @@ const HelixOrgSettings: FC = () => {
 
               <GitHubAppPanel />
 
-              {/* Generic spec rows — everything not in FIRST_CLASS_KEYS */}
+              {/* Generic spec rows — everything not first-class or hidden */}
               {(data?.specs ?? [])
-                .filter((s) => !FIRST_CLASS_KEYS.has(s.key))
+                .filter((s) => !FIRST_CLASS_KEYS.has(s.key) && !HIDDEN_KEYS.has(s.key))
                 .map((s) => <GenericSettingRow key={s.key} spec={s} />)}
             </>
           )}
@@ -388,8 +397,8 @@ const ModelRow: FC<{
 
 // GenericSettingRow renders any registry spec we don't have a
 // dedicated control for (helix.url, helix.api_key, worker.specs_mandate,
-// transport.github, …). Plain text input. Secrets are shown redacted
-// and must be re-entered to update.
+// …) and isn't in HIDDEN_KEYS. Plain text input. Secrets are shown
+// redacted and must be re-entered to update.
 const GenericSettingRow: FC<{ spec: SettingsSpecDTO }> = ({ spec }) => {
   const setMut = useSetHelixOrgSetting()
   const delMut = useDeleteHelixOrgSetting()

--- a/frontend/src/pages/HelixOrgSettings.tsx
+++ b/frontend/src/pages/HelixOrgSettings.tsx
@@ -37,6 +37,7 @@ import useAccount from '../hooks/useAccount'
 import useRouter from '../hooks/useRouter'
 import useSnackbar from '../hooks/useSnackbar'
 import GitHubAppPanel from '../components/helix-org/GitHubAppPanel'
+import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
 import {
   SettingsSpecDTO,
   useDeleteHelixOrgSetting,
@@ -98,6 +99,7 @@ const HelixOrgSettings: FC = () => {
   const router = useRouter()
   const account = useAccount()
   const orgSlug = router.params.org_id as string | undefined
+  const breadcrumbs = useHelixOrgBreadcrumbs()
 
   const { data, isLoading } = useHelixOrgSettings()
   const { data: providers } = useHelixProviders()
@@ -140,9 +142,7 @@ const HelixOrgSettings: FC = () => {
   return (
     <Page
       breadcrumbTitle="Settings"
-      orgBreadcrumbs={true}
-      orgBreadcrumbRouteName="helix_org_chart"
-      orgBreadcrumbRouteParams={{ org_id: orgSlug ?? '' }}
+      breadcrumbs={breadcrumbs}
       organizationId={account.organizationTools.organization?.id}
     >
       <Container maxWidth="md" sx={{ mb: 4, pt: 3 }}>

--- a/frontend/src/pages/HelixOrgStreamDetail.tsx
+++ b/frontend/src/pages/HelixOrgStreamDetail.tsx
@@ -30,6 +30,7 @@ import Page from '../components/system/Page'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import { GitHubBranchesField } from '../components/helix-org/GitHubStreamConfigFields'
 import GitHubRepoPicker from '../components/helix-org/GitHubRepoPicker'
+import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
 import { GITHUB_REPO_PATTERN } from '../components/helix-org/githubStreamConstants'
 
 import useAccount from '../hooks/useAccount'
@@ -51,6 +52,7 @@ const HelixOrgStreamDetail: FC = () => {
   const snackbar = useSnackbar()
   const orgSlug = router.params.org_id as string | undefined
   const streamId = router.params.stream_id as string | undefined
+  const breadcrumbs = useHelixOrgBreadcrumbs({ title: 'Streams', routeName: 'helix_org_streams' })
 
   const { data: stream, isLoading } = useHelixOrgStream(streamId)
   const updateStream = useUpdateHelixOrgStream()
@@ -104,15 +106,7 @@ const HelixOrgStreamDetail: FC = () => {
   return (
     <Page
       breadcrumbTitle={stream?.name || streamId || 'Stream'}
-      orgBreadcrumbs={true}
-      orgBreadcrumbRouteName="helix_org_chart"
-      orgBreadcrumbRouteParams={{ org_id: orgSlug ?? '' }}
-      breadcrumbs={[{
-        title: 'Streams',
-        routeName: 'helix_org_streams',
-        params: { org_id: orgSlug ?? '' },
-        useOrgRouter: false,
-      }]}
+      breadcrumbs={breadcrumbs}
       organizationId={account.organizationTools.organization?.id}
     >
       <Container maxWidth="xl" sx={{ mb: 4, pt: 3 }}>

--- a/frontend/src/pages/HelixOrgStreamDetail.tsx
+++ b/frontend/src/pages/HelixOrgStreamDetail.tsx
@@ -22,7 +22,6 @@ import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
-import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import EditIcon from '@mui/icons-material/Edit'
 import SaveIcon from '@mui/icons-material/Save'
 import CloseIcon from '@mui/icons-material/Close'
@@ -95,10 +94,6 @@ const HelixOrgStreamDetail: FC = () => {
 
   const subscribers = stream?.subscribers ?? []
 
-  const backToList = () => {
-    if (orgSlug) router.navigate('helix_org_streams', { org_id: orgSlug })
-  }
-
   const formatTimestamp = (iso: string) => {
     if (!iso) return ''
     const d = new Date(iso)
@@ -110,16 +105,18 @@ const HelixOrgStreamDetail: FC = () => {
     <Page
       breadcrumbTitle={stream?.name || streamId || 'Stream'}
       orgBreadcrumbs={true}
+      orgBreadcrumbRouteName="helix_org_chart"
+      orgBreadcrumbRouteParams={{ org_id: orgSlug ?? '' }}
+      breadcrumbs={[{
+        title: 'Streams',
+        routeName: 'helix_org_streams',
+        params: { org_id: orgSlug ?? '' },
+        useOrgRouter: false,
+      }]}
       organizationId={account.organizationTools.organization?.id}
     >
       <Container maxWidth="xl" sx={{ mb: 4, pt: 3 }}>
         <Stack spacing={2}>
-          <Stack direction="row" alignItems="center" spacing={1}>
-            <Button startIcon={<ArrowBackIcon />} variant="text" onClick={backToList}>
-              Streams
-            </Button>
-          </Stack>
-
           {isLoading ? (
             <LoadingSpinner />
           ) : !stream ? (

--- a/frontend/src/pages/HelixOrgStreamDetail.tsx
+++ b/frontend/src/pages/HelixOrgStreamDetail.tsx
@@ -29,11 +29,9 @@ import CloseIcon from '@mui/icons-material/Close'
 
 import Page from '../components/system/Page'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
-import GitHubStreamConfigFields from '../components/helix-org/GitHubStreamConfigFields'
-import {
-  isValidGitHubEvent,
-  GITHUB_REPO_PATTERN,
-} from '../components/helix-org/githubStreamConstants'
+import { GitHubBranchesField } from '../components/helix-org/GitHubStreamConfigFields'
+import GitHubRepoPicker from '../components/helix-org/GitHubRepoPicker'
+import { GITHUB_REPO_PATTERN } from '../components/helix-org/githubStreamConstants'
 
 import useAccount from '../hooks/useAccount'
 import useRouter from '../hooks/useRouter'
@@ -235,17 +233,22 @@ const StreamConfigSection: FC<StreamConfigSectionProps> = ({ stream, onSave, sav
   const [description, setDescription] = useState(stream.description ?? '')
   const [configText, setConfigText] = useState('')
   const [ghRepo, setGhRepo] = useState('')
-  const [ghEvents, setGhEvents] = useState<string[]>([])
   const [ghBranches, setGhBranches] = useState<string[]>([])
+  // The full github config as it was on the server when edit opened.
+  // We overlay only the operator-editable fields (repo, branches) on
+  // top of this at save time so server-managed fields — events (now
+  // owned by GitHub's webhook UI), webhook_id, webhook_html_url —
+  // survive the round-trip instead of being wiped.
+  const [ghOriginalConfig, setGhOriginalConfig] = useState<Record<string, unknown>>({})
 
   const enterEdit = () => {
     setName(stream.name)
     setDescription(stream.description ?? '')
     if (stream.kind === 'github') {
-      const cfg = (stream.config ?? {}) as { repo?: string; events?: string[]; branches?: string[] }
-      setGhRepo(cfg.repo ?? '')
-      setGhEvents(Array.isArray(cfg.events) ? cfg.events : [])
-      setGhBranches(Array.isArray(cfg.branches) && cfg.branches.length > 0 ? cfg.branches : ['*'])
+      const cfg = (stream.config ?? {}) as Record<string, unknown>
+      setGhOriginalConfig(cfg)
+      setGhRepo(typeof cfg.repo === 'string' ? cfg.repo : '')
+      setGhBranches(Array.isArray(cfg.branches) && cfg.branches.length > 0 ? (cfg.branches as string[]) : ['*'])
     } else if (stream.config) {
       setConfigText(JSON.stringify(stream.config, null, 2))
     } else {
@@ -272,18 +275,18 @@ const StreamConfigSection: FC<StreamConfigSectionProps> = ({ stream, onSave, sav
         snackbar.error('GitHub repo is required and must be owner/name')
         return
       }
-      if (ghEvents.length === 0) {
-        snackbar.error('Pick at least one GitHub event type')
-        return
-      }
-      const bad = ghEvents.filter((e) => !isValidGitHubEvent(e))
-      if (bad.length > 0) {
-        snackbar.error(`Invalid event name(s): ${bad.join(', ')} — must match /^[a-z][a-z0-9_]+$/`)
-        return
-      }
-      const ghConfig: Record<string, unknown> = { repo: ghRepo.trim(), events: ghEvents }
+      // Overlay the editable fields onto the original config so
+      // events (managed on GitHub now), webhook_id and webhook_html_url
+      // are preserved. The server's GitHubConfig.Validate requires a
+      // non-empty events list — dropping it here is what used to make
+      // the save silently fail.
+      const ghConfig: Record<string, unknown> = { ...ghOriginalConfig, repo: ghRepo.trim() }
       const branches = ghBranches.map((b) => b.trim()).filter((b) => b.length > 0)
-      if (branches.length > 0) ghConfig.branches = branches
+      if (branches.length > 0) {
+        ghConfig.branches = branches
+      } else {
+        delete ghConfig.branches
+      }
       payload.transport = { config: ghConfig }
     } else if (stream.kind !== 'local' && configText.trim()) {
       try {
@@ -365,14 +368,14 @@ const StreamConfigSection: FC<StreamConfigSectionProps> = ({ stream, onSave, sav
             fullWidth
           />
           {stream.kind === 'github' && (
-            <GitHubStreamConfigFields
-              repo={ghRepo}
-              events={ghEvents}
-              branches={ghBranches}
-              onRepoChange={setGhRepo}
-              onEventsChange={setGhEvents}
-              onBranchesChange={setGhBranches}
-            />
+            <>
+              <GitHubRepoPicker value={ghRepo} onChange={setGhRepo} />
+              <GitHubBranchesField branches={ghBranches} onChange={setGhBranches} />
+              <Typography variant="caption" color="text.secondary">
+                Which GitHub event types this webhook delivers is configured on GitHub,
+                not here — open the webhook on GitHub (below) to change it.
+              </Typography>
+            </>
           )}
           {stream.kind !== 'local' && stream.kind !== 'github' && (
             <TextField

--- a/frontend/src/pages/HelixOrgStreams.tsx
+++ b/frontend/src/pages/HelixOrgStreams.tsx
@@ -5,11 +5,9 @@
 // worker pulls from which stream.
 
 import { FC, MouseEvent, useEffect, useMemo, useRef, useState } from 'react'
-import Autocomplete from '@mui/material/Autocomplete'
 import Box from '@mui/material/Box'
 import Chip from '@mui/material/Chip'
 import Button from '@mui/material/Button'
-import CircularProgress from '@mui/material/CircularProgress'
 import Container from '@mui/material/Container'
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
@@ -28,7 +26,6 @@ import useTheme from '@mui/material/styles/useTheme'
 import AddIcon from '@mui/icons-material/Add'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
-import RefreshIcon from '@mui/icons-material/Refresh'
 
 import Page from '../components/system/Page'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
@@ -49,6 +46,7 @@ import {
   useListHelixOrgStreams,
 } from '../services/helixOrgService'
 import { GitHubEventsField, GitHubBranchesField } from '../components/helix-org/GitHubStreamConfigFields'
+import GitHubRepoPicker from '../components/helix-org/GitHubRepoPicker'
 import { GitHubAppConnect } from '../components/helix-org/GitHubAppPanel'
 
 const TRANSPORT_KINDS = [
@@ -305,8 +303,10 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
   // operator gets a "Connect GitHub for streams" CTA instead of a
   // confusing 412 mid-flow). The hook suppresses its own snackbar
   // so this stays a quiet probe.
+  // Kept for the refetch side-effects (App install completing,
+  // GitHubAppConnect's onChange). GitHubRepoPicker fetches the list
+  // itself via the same React Query key, so both stay in sync.
   const ghReposQuery = useListGitHubRepos({ enabled: open })
-  const ghRepoOptions = useMemo(() => (ghReposQuery.data?.repos ?? []).map((r) => r.full_name), [ghReposQuery.data])
 
   // Probe whether the Helix GitHub App is installed for this org. This is
   // the single gate for the github transport: the user's own credentials
@@ -488,63 +488,7 @@ const NewStreamDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onC
           )}
           {kind === 'github' && (
             <>
-              <Stack direction="row" spacing={1} alignItems="flex-start">
-                <Autocomplete
-                  freeSolo
-                  autoSelect
-                  selectOnFocus
-                  fullWidth
-                  options={ghRepoOptions}
-                  value={ghRepo || null}
-                  onChange={(_, v) => setGhRepo((v ?? '').trim())}
-                  onInputChange={(_, v, reason) => {
-                    // Sync typed text into ghRepo so the submit
-                    // handler sees what the operator typed even if
-                    // they never picked a dropdown row.
-                    if (reason === 'input') setGhRepo(v)
-                  }}
-                  loading={ghReposQuery.isLoading || ghReposQuery.isRefetching}
-                  disablePortal
-                  noOptionsText={
-                    ghReposQuery.isError
-                      ? 'Could not load repos — connect a GitHub account on Connected Services first.'
-                      : (ghReposQuery.isLoading || ghReposQuery.isRefetching)
-                        ? 'Loading…'
-                        : 'No matches — type the full owner/name and press Enter.'
-                  }
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      label="Repository"
-                      placeholder="search or type owner/name…"
-                      size="small"
-                      InputProps={{
-                        ...params.InputProps,
-                        endAdornment: (
-                          <>
-                            {(ghReposQuery.isLoading || ghReposQuery.isRefetching) && <CircularProgress size={16} sx={{ mr: 1 }} />}
-                            {params.InputProps.endAdornment}
-                          </>
-                        ),
-                      }}
-                      helperText={
-                        ghRepoOptions.length >= 1000
-                          ? `Showing the ${ghRepoOptions.length} most-recently-pushed repos. Type the full owner/name if the one you want isn't listed.`
-                          : `Pick a repo, or type owner/name directly. Helix will register the webhook on GitHub for you — no manual setup. ${ghRepoOptions.length} repos loaded.`
-                      }
-                    />
-                  )}
-                />
-                <IconButton
-                  size="small"
-                  onClick={() => ghReposQuery.refetch()}
-                  disabled={ghReposQuery.isFetching}
-                  title="Re-fetch repos from GitHub (use this after granting the helix OAuth app access to a new org)"
-                  sx={{ mt: 0.5 }}
-                >
-                  <RefreshIcon fontSize="small" />
-                </IconButton>
-              </Stack>
+              <GitHubRepoPicker value={ghRepo} onChange={setGhRepo} enabled={open} />
               <GitHubEventsField events={ghEvents} onChange={setGhEvents} />
               <GitHubBranchesField branches={ghBranches} onChange={setGhBranches} />
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>

--- a/frontend/src/pages/HelixOrgStreams.tsx
+++ b/frontend/src/pages/HelixOrgStreams.tsx
@@ -28,6 +28,7 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 
 import Page from '../components/system/Page'
+import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import SimpleTable from '../components/widgets/SimpleTable'
 import DeleteConfirmWindow from '../components/widgets/DeleteConfirmWindow'
@@ -72,6 +73,7 @@ const HIGHLIGHT_DURATION_MS = 2400
 const HelixOrgStreams: FC = () => {
   const account = useAccount()
   const router = useRouter()
+  const breadcrumbs = useHelixOrgBreadcrumbs()
   const snackbar = useSnackbar()
   const theme = useTheme()
 
@@ -185,7 +187,7 @@ const HelixOrgStreams: FC = () => {
   return (
     <Page
       breadcrumbTitle="Streams"
-      orgBreadcrumbs={true}
+      breadcrumbs={breadcrumbs}
       organizationId={account.organizationTools.organization?.id}
       topbarContent={(
         <Button

--- a/frontend/src/pages/HelixOrgWorkerDetail.test.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.test.tsx
@@ -36,6 +36,7 @@ vi.mock('../services/helixOrgService', () => ({
   useHelixOrgWorker: (id: string | undefined) => mockUseHelixOrgWorker(id),
   useFireHelixOrgWorker: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useUpdateWorkerIdentity: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useActivateWorker: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useListHelixOrgStreams: () => ({ data: { streams: [] }, isLoading: false }),
   useListWorkerSubscriptions: () => ({ data: { subscriptions: [] }, isLoading: false }),
   useSubscribeWorker: () => ({ mutateAsync: vi.fn() }),

--- a/frontend/src/pages/HelixOrgWorkerDetail.test.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.test.tsx
@@ -35,8 +35,7 @@ const mockUseHelixOrgWorker = vi.fn()
 vi.mock('../services/helixOrgService', () => ({
   useHelixOrgWorker: (id: string | undefined) => mockUseHelixOrgWorker(id),
   useFireHelixOrgWorker: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useEnsureWorkerChat: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useActivateWorker: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateWorkerIdentity: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useListHelixOrgStreams: () => ({ data: { streams: [] }, isLoading: false }),
   useListWorkerSubscriptions: () => ({ data: { subscriptions: [] }, isLoading: false }),
   useSubscribeWorker: () => ({ mutateAsync: vi.fn() }),
@@ -64,6 +63,9 @@ vi.mock('../components/system/Page', () => ({
   ),
 }))
 vi.mock('../components/widgets/LoadingSpinner', () => ({ default: () => null }))
+vi.mock('../components/widgets/MonacoEditor', () => ({
+  default: ({ value }: any) => <div data-testid="monaco">{value}</div>,
+}))
 vi.mock('../components/widgets/DeleteConfirmWindow', () => ({ default: () => null }))
 vi.mock('../components/common/RobustPromptInput', () => ({
   default: ({ sessionId }: any) => <div data-testid="prompt-input">{sessionId}</div>,

--- a/frontend/src/pages/HelixOrgWorkerDetail.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.tsx
@@ -5,20 +5,19 @@
 // forcing the operator to click out to the external desktop tab just
 // to see what the worker is doing.
 //
-// Surfaces, in order of weight:
-//   - Inline transcript (EmbeddedSessionView + RobustPromptInput):
-//     auto-shown when the worker's project already has an exploratory
-//     session. GET-only on load — never spins up infra by itself.
-//   - "Open Human Desktop": the full Zed GUI / video stream in a new
-//     tab, for when the operator needs the desktop, not just the chat.
-//   - "Restart Desktop": a fresh manual activation (re-attaches MCP).
+// The inline transcript (EmbeddedSessionView + RobustPromptInput) is
+// auto-shown when the worker's project already has an exploratory
+// session. GET-only on load — never spins up infra by itself; sessions
+// are provisioned by the worker's activation flow.
+//
+// The worker's identity markdown is editable here (Monaco + Save),
+// persisted via the workers/{id}/identity endpoint.
 
 import { FC, Key, useEffect, useMemo, useRef, useState } from 'react'
 import Autocomplete from '@mui/material/Autocomplete'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Checkbox from '@mui/material/Checkbox'
-import CircularProgress from '@mui/material/CircularProgress'
 import Chip from '@mui/material/Chip'
 import Container from '@mui/material/Container'
 import Divider from '@mui/material/Divider'
@@ -27,10 +26,8 @@ import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
-import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline'
-import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew'
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined'
 
 import Page from '../components/system/Page'
@@ -48,8 +45,6 @@ import useSnackbar from '../hooks/useSnackbar'
 import { useStreaming } from '../contexts/streaming'
 import { SESSION_TYPE_TEXT } from '../types'
 import {
-  useActivateWorker,
-  useEnsureWorkerChat,
   useFireHelixOrgWorker,
   useHelixOrgWorker,
   useListHelixOrgStreams,
@@ -58,8 +53,7 @@ import {
   useUnsubscribeWorker,
 } from '../services/helixOrgService'
 import {
-  WorkerChatApi,
-  ensureRunningWorkerSession,
+  WorkerChatReader,
   fetchExistingWorkerSession,
 } from '../services/workerChatSession'
 
@@ -80,8 +74,6 @@ const HelixOrgWorkerDetail: FC = () => {
   const { data, isLoading } = useHelixOrgWorker(workerId, {
     enabled: !fire.isPending && !fire.isSuccess,
   })
-  const ensureChat = useEnsureWorkerChat()
-  const activate = useActivateWorker()
   const streaming = useStreaming()
   const [confirmingFire, setConfirmingFire] = useState(false)
 
@@ -95,11 +87,12 @@ const HelixOrgWorkerDetail: FC = () => {
   const [chatSessionId, setChatSessionId] = useState<string | null>(null)
   const sessionViewRef = useRef<EmbeddedSessionViewHandle>(null)
 
-  // chatApi adapts the generated client to the injected shape the
-  // workerChatSession helpers expect. The exploratory-session GET returns
-  // 204 No Content when the project has no session yet — map that to null
-  // rather than letting it surface as an error.
-  const chatApi: WorkerChatApi = useMemo(() => ({
+  // chatApi adapts the generated client to the read-only shape the
+  // workerChatSession helper expects (we only GET the existing session
+  // here — provisioning is owned by the worker's activation flow). The
+  // exploratory-session GET returns 204 No Content when the project has
+  // no session yet — map that to null rather than surfacing an error.
+  const chatApi: WorkerChatReader = useMemo(() => ({
     getExploratorySession: async (pid: string) => {
       try {
         const resp = await api.getApiClient().v1ProjectsExploratorySessionDetail(pid)
@@ -109,15 +102,11 @@ const HelixOrgWorkerDetail: FC = () => {
         throw err
       }
     },
-    createExploratorySession: async (pid: string) =>
-      (await api.getApiClient().v1ProjectsExploratorySessionCreate(pid)).data,
-    resumeSession: async (sid: string) =>
-      api.getApiClient().v1SessionsResumeCreate(sid),
   }), [api])
 
   // Auto-load the inline transcript when the worker already has a project.
   // GET-only — we never create a session just because the operator opened
-  // this page; the "Open Human Desktop" / provision buttons own that.
+  // this page; sessions are provisioned by the worker's activation flow.
   useEffect(() => {
     let cancelled = false
     if (!projectID) {
@@ -139,92 +128,6 @@ const HelixOrgWorkerDetail: FC = () => {
     streaming.setCurrentSessionId(chatSessionId)
     return () => { streaming.setCurrentSessionId(null) }
   }, [chatSessionId])
-
-  // launching covers the whole openChat flow, not just the
-  // ensureChat mutation. The user-facing "5 seconds of nothing"
-  // before was because ensureChat.isPending only spans the
-  // /workers/{id}/chat call; the remaining work (GET exploratory
-  // session, optional POST create, optional POST resume, finally
-  // the window.open) all ran while the button looked idle. Now the
-  // button stays disabled with a spinner from the first click
-  // through to the new tab opening.
-  const [launching, setLaunching] = useState(false)
-
-  // openChat takes the operator to the Human Desktop for the Worker's
-  // per-Worker Helix project, matching how chat works for regular
-  // projects in the rest of the app (the desktop session IS the chat
-  // surface — Zed talks to Claude Code inside it). The owner Worker
-  // has no project on bootstrap (the spawner provisions one only on
-  // AI-Worker activation), so the first click POSTs /workers/{id}/chat
-  // to fast-path through WorkerProject.Ensure and get the project_id
-  // back; later clicks already have it from the worker detail fetch.
-  //
-  // The exploratory session is the project's single long-lived "Human
-  // Desktop" — we start it on demand (idempotent server-side when
-  // already running) and resume from a paused state if needed, then
-  // open /orgs/<org>/projects/<projectID>/desktop/<sessionID> in a
-  // NEW TAB so the operator keeps the worker detail page as the
-  // home base they can fire / inspect from while the desktop is
-  // up.
-  const openChat = async () => {
-    if (!orgSlug || !workerId) return
-    if (launching) return
-    setLaunching(true)
-    try {
-      let pid = projectID
-      if (!pid) {
-        try {
-          const resp = await ensureChat.mutateAsync(workerId)
-          pid = resp.project_id
-        } catch (err: any) {
-          snackbar.error(err?.response?.data?.error ?? err?.message ?? 'provisioning chat failed')
-          return
-        }
-      }
-      if (!pid) {
-        snackbar.error('no project id returned for worker')
-        return
-      }
-
-      // ensureRunningWorkerSession does the GET → create-if-missing →
-      // resume-if-paused dance so the operator never lands on a dead
-      // viewer. Surface the resolved session inline too so the transcript
-      // shows on this page once the desktop is up.
-      const sessionID = await ensureRunningWorkerSession(pid, chatApi)
-      setChatSessionId(sessionID)
-      const url = `/orgs/${encodeURIComponent(orgSlug)}/projects/${encodeURIComponent(pid)}/desktop/${encodeURIComponent(sessionID)}`
-      window.open(url, '_blank', 'noopener,noreferrer')
-    } catch (err: any) {
-      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'failed to open Human Desktop')
-    } finally {
-      setLaunching(false)
-    }
-  }
-
-  // handleRestartDesktop manually triggers a fresh activation for this
-  // Worker. The /activate endpoint runs ensureProject synchronously
-  // (which re-attaches the helix-org MCP that helix's project-apply
-  // wipes on update), then enqueues a manual trigger; the spawner
-  // picks it up, opens or resumes the per-Worker chat session, and
-  // helix spins the desktop container back up as part of session
-  // start. The intended use case: the operator stopped the desktop
-  // ("reset it") and wants it back online with the MCP correctly
-  // attached. Plain "resume" doesn't re-attach because it only
-  // restarts the container — Config.Helix isn't touched.
-  //
-  // We stay on this page rather than navigating: the user's desktop
-  // tab may already be open in another window; if not, "Open Human
-  // Desktop" above is one click away.
-  const handleRestartDesktop = async () => {
-    if (!workerId) return
-    if (activate.isPending) return
-    try {
-      await activate.mutateAsync(workerId)
-      snackbar.success('Activation queued — desktop will come up shortly')
-    } catch (err: any) {
-      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'activate failed')
-    }
-  }
 
   const handleFire = async () => {
     if (!workerId) return
@@ -290,47 +193,8 @@ const HelixOrgWorkerDetail: FC = () => {
                     <Typography variant="body2" color="text.secondary">
                       The conversation below is the worker's Human Desktop session —
                       the same transcript you'd see in the desktop tab, including its
-                      MCP tool calls. Send a message to drive it from here, or open the
-                      full desktop (Zed GUI + video) in a new tab. The first launch on a
-                      never-chatted-with worker provisions the agent app + project on the
-                      fly (takes a few seconds).
+                      MCP tool calls. Send a message to drive it from here.
                     </Typography>
-                    <Stack direction="row" spacing={1} flexWrap="wrap">
-                      <Button
-                        variant="contained"
-                        color="secondary"
-                        startIcon={launching ? <CircularProgress size={16} color="inherit" /> : <ChatBubbleOutlineIcon />}
-                        onClick={openChat}
-                        disabled={launching}
-                      >
-                        {launching
-                          ? 'Launching Human Desktop…'
-                          : (projectID ? 'Open Human Desktop' : 'Provision + open Human Desktop')}
-                      </Button>
-                      {/* Restart Desktop kicks a fresh manual
-                          activation. Re-attaches the helix-org MCP
-                          and brings the container back up after a
-                          manual stop. Every identity has the same
-                          chat+desktop surface, so the button shows
-                          for all workers — human and AI — once the
-                          worker has been provisioned at least once
-                          (no agent app to activate against
-                          otherwise). */}
-                      <Button
-                        variant="outlined"
-                        color="secondary"
-                        startIcon={activate.isPending ? <CircularProgress size={16} color="inherit" /> : <PowerSettingsNewIcon />}
-                        onClick={handleRestartDesktop}
-                        disabled={activate.isPending || !projectID}
-                      >
-                        {activate.isPending ? 'Activating…' : 'Restart Desktop'}
-                      </Button>
-                    </Stack>
-                    {!projectID && (
-                      <Typography variant="caption" color="text.secondary">
-                        Restart Desktop is available after the first "Open Human Desktop".
-                      </Typography>
-                    )}
 
                     {/* Inline transcript. EmbeddedSessionView self-fetches
                         the session + interactions and live-streams in-flight
@@ -374,7 +238,7 @@ const HelixOrgWorkerDetail: FC = () => {
                       </Box>
                     ) : (
                       <Typography variant="body2" color="text.secondary">
-                        No conversation yet — launch the Human Desktop to start one.
+                        No conversation yet for this worker.
                       </Typography>
                     )}
                   </Stack>

--- a/frontend/src/pages/HelixOrgWorkerDetail.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.tsx
@@ -14,11 +14,15 @@
 // persisted via the workers/{id}/identity endpoint.
 
 import { FC, Key, useEffect, useMemo, useRef, useState } from 'react'
+import Accordion from '@mui/material/Accordion'
+import AccordionDetails from '@mui/material/AccordionDetails'
+import AccordionSummary from '@mui/material/AccordionSummary'
 import Autocomplete from '@mui/material/Autocomplete'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Checkbox from '@mui/material/Checkbox'
 import Chip from '@mui/material/Chip'
+import CircularProgress from '@mui/material/CircularProgress'
 import Container from '@mui/material/Container'
 import Divider from '@mui/material/Divider'
 import Grid from '@mui/material/Grid'
@@ -27,7 +31,9 @@ import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline'
+import RestartAltIcon from '@mui/icons-material/RestartAlt'
 import SaveIcon from '@mui/icons-material/Save'
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined'
 
@@ -47,6 +53,7 @@ import useSnackbar from '../hooks/useSnackbar'
 import { useStreaming } from '../contexts/streaming'
 import { SESSION_TYPE_TEXT } from '../types'
 import {
+  useActivateWorker,
   useFireHelixOrgWorker,
   useHelixOrgWorker,
   useListHelixOrgStreams,
@@ -79,11 +86,13 @@ const HelixOrgWorkerDetail: FC = () => {
   })
   const streaming = useStreaming()
   const updateIdentity = useUpdateWorkerIdentity()
+  const activate = useActivateWorker()
   const [confirmingFire, setConfirmingFire] = useState(false)
 
   const isOwner = workerId === OWNER_WORKER
   const worker = data?.worker
   const projectID = data?.project_id
+  const agentAppID = data?.agent_app_id
 
   // Editable identity markdown. Seeded from the worker every time it
   // loads/refreshes so a cancelled edit re-syncs to server state.
@@ -100,6 +109,20 @@ const HelixOrgWorkerDetail: FC = () => {
       snackbar.success('identity saved')
     } catch (err: any) {
       snackbar.error(err?.response?.data?.error ?? err?.message ?? 'save identity failed')
+    }
+  }
+
+  // handleRestartSession re-activates the Worker: the /activate endpoint
+  // re-attaches the helix-org MCP and brings a fresh agent session up.
+  // Destructive to in-flight work, so it's tucked behind the Advanced
+  // accordion with an explicit warning.
+  const handleRestartSession = async () => {
+    if (!workerId || activate.isPending) return
+    try {
+      await activate.mutateAsync(workerId)
+      snackbar.success('Agent session restart queued — it will come back up shortly')
+    } catch (err: any) {
+      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'restart failed')
     }
   }
 
@@ -175,6 +198,8 @@ const HelixOrgWorkerDetail: FC = () => {
     <Page
       breadcrumbTitle={workerId ?? 'Worker'}
       orgBreadcrumbs={true}
+      orgBreadcrumbRouteName="helix_org_chart"
+      orgBreadcrumbRouteParams={{ org_id: orgSlug ?? '' }}
       breadcrumbs={[{
         title: 'Workers',
         routeName: 'helix_org_workers',
@@ -187,6 +212,7 @@ const HelixOrgWorkerDetail: FC = () => {
         {isLoading || !worker ? (
           <LoadingSpinner />
         ) : (
+          <>
           <Grid container spacing={3}>
             <Grid item xs={12} md={9}>
               <Stack spacing={3}>
@@ -355,10 +381,28 @@ const HelixOrgWorkerDetail: FC = () => {
                   )}
                   {projectID && (
                     <Box>
-                      <Typography variant="caption" color="text.secondary">Project</Typography>
-                      <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.7rem', wordBreak: 'break-all' }}>
+                      <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>Project</Typography>
+                      <Button
+                        size="small"
+                        variant="text"
+                        onClick={() => orgSlug && router.navigate('org_project-specs', { org_id: orgSlug, id: projectID })}
+                        sx={{ fontFamily: 'monospace', fontSize: '0.7rem', textTransform: 'none', justifyContent: 'flex-start', p: 0, minWidth: 0, wordBreak: 'break-all', textAlign: 'left' }}
+                      >
                         {projectID}
-                      </Typography>
+                      </Button>
+                    </Box>
+                  )}
+                  {agentAppID && (
+                    <Box>
+                      <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>Agent</Typography>
+                      <Button
+                        size="small"
+                        variant="text"
+                        onClick={() => orgSlug && router.navigate('org_agent', { org_id: orgSlug, app_id: agentAppID })}
+                        sx={{ fontFamily: 'monospace', fontSize: '0.7rem', textTransform: 'none', justifyContent: 'flex-start', p: 0, minWidth: 0, wordBreak: 'break-all', textAlign: 'left' }}
+                      >
+                        {agentAppID}
+                      </Button>
                     </Box>
                   )}
                   <Divider />
@@ -380,6 +424,42 @@ const HelixOrgWorkerDetail: FC = () => {
               </Paper>
             </Grid>
           </Grid>
+
+          {/* Advanced — collapsed by default. Houses destructive
+              maintenance actions kept out of the main flow. */}
+          <Accordion
+            disableGutters
+            elevation={0}
+            sx={{
+              mt: 3,
+              border: (theme) => `1px solid ${theme.palette.mode === 'light' ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.08)'}`,
+              borderRadius: 1,
+              '&:before': { display: 'none' },
+              backgroundImage: 'none',
+            }}
+          >
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Typography variant="subtitle2">Advanced</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Stack spacing={1.5} alignItems="flex-start">
+                <Button
+                  variant="outlined"
+                  color="warning"
+                  startIcon={activate.isPending ? <CircularProgress size={16} color="inherit" /> : <RestartAltIcon />}
+                  onClick={handleRestartSession}
+                  disabled={activate.isPending}
+                >
+                  {activate.isPending ? 'Restarting…' : 'Restart agent session'}
+                </Button>
+                <Typography variant="caption" color="text.secondary">
+                  Restarts the worker's agent session from scratch. Any in-progress work in
+                  the current session will be lost.
+                </Typography>
+              </Stack>
+            </AccordionDetails>
+          </Accordion>
+          </>
         )}
       </Container>
 

--- a/frontend/src/pages/HelixOrgWorkerDetail.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.tsx
@@ -27,7 +27,6 @@ import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
-import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline'
@@ -251,15 +250,15 @@ const HelixOrgWorkerDetail: FC = () => {
     <Page
       breadcrumbTitle={workerId ?? 'Worker'}
       orgBreadcrumbs={true}
+      breadcrumbs={[{
+        title: 'Workers',
+        routeName: 'helix_org_workers',
+        params: { org_id: orgSlug ?? '' },
+        useOrgRouter: false,
+      }]}
       organizationId={account.organizationTools.organization?.id}
       topbarContent={(
         <Stack direction="row" spacing={1}>
-          <Button
-            startIcon={<ArrowBackIcon />}
-            onClick={() => orgSlug && router.navigate('helix_org_workers', { org_id: orgSlug })}
-          >
-            Workers
-          </Button>
           <Button
             variant="contained"
             color="secondary"

--- a/frontend/src/pages/HelixOrgWorkerDetail.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.tsx
@@ -28,10 +28,12 @@ import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline'
+import SaveIcon from '@mui/icons-material/Save'
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined'
 
 import Page from '../components/system/Page'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
+import MonacoEditor from '../components/widgets/MonacoEditor'
 import DeleteConfirmWindow from '../components/widgets/DeleteConfirmWindow'
 import EmbeddedSessionView, {
   EmbeddedSessionViewHandle,
@@ -51,6 +53,7 @@ import {
   useListWorkerSubscriptions,
   useSubscribeWorker,
   useUnsubscribeWorker,
+  useUpdateWorkerIdentity,
 } from '../services/helixOrgService'
 import {
   WorkerChatReader,
@@ -75,11 +78,30 @@ const HelixOrgWorkerDetail: FC = () => {
     enabled: !fire.isPending && !fire.isSuccess,
   })
   const streaming = useStreaming()
+  const updateIdentity = useUpdateWorkerIdentity()
   const [confirmingFire, setConfirmingFire] = useState(false)
 
   const isOwner = workerId === OWNER_WORKER
   const worker = data?.worker
   const projectID = data?.project_id
+
+  // Editable identity markdown. Seeded from the worker every time it
+  // loads/refreshes so a cancelled edit re-syncs to server state.
+  const [identityContent, setIdentityContent] = useState('')
+  useEffect(() => {
+    setIdentityContent(worker?.identity_content ?? '')
+  }, [worker?.identity_content])
+  const identityDirty = identityContent !== (worker?.identity_content ?? '')
+
+  const handleSaveIdentity = async () => {
+    if (!workerId) return
+    try {
+      await updateIdentity.mutateAsync({ workerId, identity: identityContent })
+      snackbar.success('identity saved')
+    } catch (err: any) {
+      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'save identity failed')
+    }
+  }
 
   // chatSessionId is the worker's long-lived "Human Desktop" exploratory
   // session — the transcript we render inline. Null until we've resolved
@@ -244,26 +266,35 @@ const HelixOrgWorkerDetail: FC = () => {
                   </Stack>
                 </Paper>
 
-                {worker.identity_content && (
-                  <Box>
-                    <Typography variant="subtitle2" sx={{ mb: 1 }}>Identity</Typography>
-                    <Box
-                      component="pre"
-                      sx={{
-                        p: 1.5,
-                        borderRadius: 1,
-                        backgroundColor: (theme) => theme.palette.mode === 'light' ? 'rgba(0,0,0,0.04)' : 'rgba(255,255,255,0.04)',
-                        fontSize: '0.8rem',
-                        whiteSpace: 'pre-wrap',
-                        fontFamily: 'monospace',
-                        maxHeight: 360,
-                        overflow: 'auto',
-                      }}
+                <Box>
+                  <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1 }}>
+                    <Typography variant="subtitle2">Identity</Typography>
+                    <Button
+                      size="small"
+                      variant="contained"
+                      color="secondary"
+                      startIcon={<SaveIcon />}
+                      disabled={!identityDirty || updateIdentity.isPending}
+                      onClick={handleSaveIdentity}
                     >
-                      {worker.identity_content}
-                    </Box>
-                  </Box>
-                )}
+                      {updateIdentity.isPending ? 'Saving…' : 'Save'}
+                    </Button>
+                  </Stack>
+                  <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+                    The worker's persona markdown. Projected into its identity.md on the next
+                    activation. Cmd/Ctrl+S inside the editor saves.
+                  </Typography>
+                  <MonacoEditor
+                    value={identityContent}
+                    onChange={setIdentityContent}
+                    onSave={handleSaveIdentity}
+                    language="markdown"
+                    minHeight={240}
+                    maxHeight={600}
+                    autoHeight={true}
+                    theme="helix-dark"
+                  />
+                </Box>
 
                 {worker.tools && worker.tools.length > 0 && (
                   <Box>

--- a/frontend/src/pages/HelixOrgWorkerDetail.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.tsx
@@ -45,6 +45,7 @@ import EmbeddedSessionView, {
   EmbeddedSessionViewHandle,
 } from '../components/session/EmbeddedSessionView'
 import RobustPromptInput from '../components/common/RobustPromptInput'
+import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
 
 import useAccount from '../hooks/useAccount'
 import useApi from '../hooks/useApi'
@@ -76,6 +77,7 @@ const HelixOrgWorkerDetail: FC = () => {
   const api = useApi()
   const orgSlug = router.params.org_id as string | undefined
   const workerId = router.params.worker_id as string | undefined
+  const breadcrumbs = useHelixOrgBreadcrumbs({ title: 'Workers', routeName: 'helix_org_workers' })
 
   const fire = useFireHelixOrgWorker()
   // Stop polling/refetching this worker once a fire is in flight or
@@ -197,15 +199,7 @@ const HelixOrgWorkerDetail: FC = () => {
   return (
     <Page
       breadcrumbTitle={workerId ?? 'Worker'}
-      orgBreadcrumbs={true}
-      orgBreadcrumbRouteName="helix_org_chart"
-      orgBreadcrumbRouteParams={{ org_id: orgSlug ?? '' }}
-      breadcrumbs={[{
-        title: 'Workers',
-        routeName: 'helix_org_workers',
-        params: { org_id: orgSlug ?? '' },
-        useOrgRouter: false,
-      }]}
+      breadcrumbs={breadcrumbs}
       organizationId={account.organizationTools.organization?.id}
     >
       <Container maxWidth="xl" sx={{ mb: 4, pt: 3 }}>

--- a/frontend/src/pages/HelixOrgWorkerDetail.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.tsx
@@ -239,6 +239,7 @@ const HelixOrgWorkerDetail: FC = () => {
                         <EmbeddedSessionView
                           ref={sessionViewRef}
                           sessionId={chatSessionId}
+                          autoScrollOnMount
                         />
                         <Box sx={{ p: 1.5, flexShrink: 0 }}>
                           <RobustPromptInput

--- a/frontend/src/pages/HelixOrgWorkerDetail.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.tsx
@@ -257,19 +257,6 @@ const HelixOrgWorkerDetail: FC = () => {
         useOrgRouter: false,
       }]}
       organizationId={account.organizationTools.organization?.id}
-      topbarContent={(
-        <Stack direction="row" spacing={1}>
-          <Button
-            variant="contained"
-            color="secondary"
-            startIcon={launching ? <CircularProgress size={16} color="inherit" /> : <ChatBubbleOutlineIcon />}
-            onClick={openChat}
-            disabled={launching}
-          >
-            {launching ? 'Launching Human Desktop…' : 'Start new chat'}
-          </Button>
-        </Stack>
-      )}
     >
       <Container maxWidth="xl" sx={{ mb: 4, pt: 3 }}>
         {isLoading || !worker ? (

--- a/frontend/src/pages/HelixOrgWorkers.tsx
+++ b/frontend/src/pages/HelixOrgWorkers.tsx
@@ -20,6 +20,7 @@ import PersonOutlineIcon from '@mui/icons-material/PersonOutline'
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined'
 
 import Page from '../components/system/Page'
+import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import SimpleTable from '../components/widgets/SimpleTable'
 import DeleteConfirmWindow from '../components/widgets/DeleteConfirmWindow'
@@ -38,6 +39,7 @@ const OWNER_WORKER = 'w-owner'
 const HelixOrgWorkers: FC = () => {
   const router = useRouter()
   const account = useAccount()
+  const breadcrumbs = useHelixOrgBreadcrumbs()
   const snackbar = useSnackbar()
   const theme = useTheme()
   const orgSlug = router.params.org_id as string | undefined
@@ -154,7 +156,7 @@ const HelixOrgWorkers: FC = () => {
   return (
     <Page
       breadcrumbTitle="Workers"
-      orgBreadcrumbs={true}
+      breadcrumbs={breadcrumbs}
       organizationId={account.organizationTools.organization?.id}
     >
       <Container maxWidth="xl" sx={{ mb: 4, pt: 3 }}>

--- a/frontend/src/services/helixOrgService.ts
+++ b/frontend/src/services/helixOrgService.ts
@@ -172,6 +172,25 @@ export function useHelixOrgWorker(workerId: string | undefined, options?: { enab
   })
 }
 
+// useUpdateWorkerIdentity rewrites a Worker's identity markdown. The
+// Spawner projects the new content into the Worker's identity.md on the
+// next activation. Drives the editable Identity panel on the worker
+// detail page.
+export function useUpdateWorkerIdentity() {
+  const api = useApi()
+  const qc = useQueryClient()
+  const { orgID } = useHelixOrgBase()
+  return useMutation({
+    mutationFn: async ({ workerId, identity }: { workerId: string; identity: string }) => {
+      await api.getApiClient().v1OrgsWorkersIdentityCreate(workerId, orgID, { identity })
+    },
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.worker(orgID, vars.workerId) })
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.workers(orgID) })
+    },
+  })
+}
+
 export function useListHelixOrgTools(options?: { enabled?: boolean }) {
   const api = useApi()
   const { orgID } = useHelixOrgBase()


### PR DESCRIPTION
A batch of small helix-org UI fixes, each as its own commit.

### Settings
- **Stop exposing `transport.github`** — the GitHub App now provisions the webhook secret itself, so there's nothing for an operator to paste. Hidden via a new `HIDDEN_KEYS` filter; the registry key still exists (self-configured).

### Streams
- **Shared `GitHubRepoPicker`** — extracted the repo selector out of the New Stream dialog into a reusable component, now used in the dialog *and* the per-stream Edit form (the repository is no longer a plain text field there).
- **Stream-config save fix** — the Edit form rebuilt the github config from only `{repo, events, branches}`, dropping the server-managed `webhook_id`/`webhook_html_url` and (with an empty events list) failing `GitHubConfig.Validate` silently. Now overlays only the editable fields onto the original config.
- **Event selection moved to GitHub** — the event-type whitelist is only offered at creation (where Helix installs the webhook with those events). After the fact it's managed on GitHub's own webhook UI, so it's removed from the post-creation edit surface (existing events are preserved on save).

### Role detail
- **Removed the streams list** — subscriptions are worker-anchored, so they're managed on the Worker detail page, not the Role. Save omits `streams`; the backend preserves existing ones.

### Chart
- **New role button moved onto the canvas** (floating top-right) instead of sitting outside the box in the page header.

### Worker detail
- **Breadcrumb** now reads `org / Workers / worker-id`; the standalone "Workers" back button is gone.
- **Removed** the top-right "Start new chat" button and the "Open Human Desktop" / "Restart Desktop" buttons (plus the now-dead handlers/imports).
- **Editable identity** — the identity markdown is now a Monaco editor with Save (was read-only `<pre>`), persisted via the existing `workers/{id}/identity` endpoint.
- **Auto-scroll defaults ON** for the embedded chat via a new opt-in `autoScrollOnMount` prop.

### Note
With both the topbar "Start new chat" and the in-panel desktop buttons removed as requested, the worker detail page no longer has an in-page button to *create* a session — the inline transcript + prompt input only appear once a session exists (provisioned by the worker's activation flow). Flagging in case you want a different chat-initiation path here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)