### PR TITLE
fix(frontend): de-flake HelixOrgWorkerDetail inline-transcript test

### DIFF
--- a/frontend/src/pages/HelixOrgWorkerDetail.test.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.test.tsx
@@ -106,11 +106,16 @@ describe('HelixOrgWorkerDetail inline transcript', () => {
 
     renderPage()
 
+    // chatSessionId flips null -> 'ses_abc' after the exploratory-session
+    // promise resolves. The useEffect that calls setCurrentSessionId runs
+    // after the re-render; the embedded-session DOM update is visible
+    // before the effect's next tick fires, so the spy assertion must
+    // poll alongside the DOM ones rather than running once after.
     await waitFor(() => {
       expect(screen.getByTestId('embedded-session')).toHaveTextContent('ses_abc')
+      expect(screen.getByTestId('prompt-input')).toHaveTextContent('ses_abc')
+      expect(mockSetCurrentSessionId).toHaveBeenCalledWith('ses_abc')
     })
-    expect(screen.getByTestId('prompt-input')).toHaveTextContent('ses_abc')
-    expect(mockSetCurrentSessionId).toHaveBeenCalledWith('ses_abc')
   })
 
   it('shows the empty state and never creates a session on load', async () => {


### PR DESCRIPTION
## Summary

The \`HelixOrgWorkerDetail inline transcript > mounts the transcript + subscribes the socket when a session exists\` test in \`frontend/src/pages/HelixOrgWorkerDetail.test.tsx\` has been intermittently failing on main since shortly after #2534 introduced it. **Approximately 30% pass rate** over the last two weeks of CI runs.

Recent main builds: 1888 ✓, 1899 ✗, 1900 ✓, 1904 ✗, 1905 ✗, 1913 ✗, 1915 ✓, 1920 ✗, 1921 ✗.

## Root cause

The component has a single effect at \`HelixOrgWorkerDetail.tsx:139\` that calls \`streaming.setCurrentSessionId(chatSessionId)\` on every render. The test flow:

1. Mount: \`chatSessionId = null\`, effect runs, spy receives \`null\`.
2. Exploratory-session promise resolves, \`chatSessionId\` flips to \`'ses_abc'\`.
3. React re-renders. The DOM updates with the new value.
4. The effect fires its cleanup with the previous closure (\`null\`) and re-runs with \`'ses_abc'\`.

The existing \`waitFor\` block polls until the embedded-session DOM node has the \`'ses_abc'\` text, which happens at step 3 - **before** the effect tick at step 4. The next assertion line \`expect(mockSetCurrentSessionId).toHaveBeenCalledWith('ses_abc')\` then runs against a spy that still only has the initial \`null\` call.

## Fix

Move the spy assertion (and the prompt-input DOM assertion next to it) inside the same \`waitFor\` block. \`waitFor\` will keep retrying until all three pass, which gives the effect tick time to fire.

## Verification

Locally ran the test 5 consecutive times after the fix - all 5 passed (3/3 tests each):

\`\`\`
=== run 1-5 ===
 ✓ src/pages/HelixOrgWorkerDetail.test.tsx (3 tests) 128ms
 Test Files  1 passed (1)
\`\`\`

\`npx tsc --noEmit -p tsconfig.json\` clean.

## Out of scope

The production component is fine - the spurious \`null\` call to \`setCurrentSessionId\` is the correct cleanup behaviour and any downstream subscriber should tolerate it. No prod change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)