### PR TITLE
refactor(helix-org): drop grant terminology, tool surface is Role.Tools

### DIFF
--- a/api/pkg/org/QA.md
+++ b/api/pkg/org/QA.md
@@ -12,8 +12,8 @@ the why.
 
 - **Role** — the job description. Carries the markdown a Worker
   reads at activation plus the tool list that becomes the Worker's
-  live MCP surface. There is no separate per-Worker grants table —
-  capability is the Role's responsibility.
+  live MCP surface. There is no separate per-Worker tool record —
+  the Role's tool list is the whole story.
 - **Worker** — a human or AI agent. Holds a single `role_id` (the
   capability binding). Who reports to whom is a separate many-to-many
   relation (see Reporting line), not a field on the Worker.
@@ -86,8 +86,8 @@ in that Role on their next MCP request.
    (§3.2). Add `publish` via the dropdown + Save. Hit the
    Worker's MCP endpoint
    (`/api/v1/mcp/helix-org/<org>/workers/<id>/mcp` → `tools/list`):
-   `publish` is now in the list without any `hire_worker`,
-   `grant_tool`, or session restart. Remove + Save: next
+   `publish` is now in the list without any `hire_worker` call,
+   tool-assignment step, or session restart. Remove + Save: next
    `tools/list` no longer includes it.
 
 ## §3. Hire workers + cascade semantics
@@ -391,7 +391,7 @@ Worker's surface — call them via `tools/call` at
 uses for `tools/list`). The owner Role and every Role drafted via
 `/role` carry `managers` + `reports`.
 
-Setup: in a fresh role that grants `managers`, `reports`, hire AI
+Setup: in a fresh role that lists `managers`, `reports`, hire AI
 `w-mgr` (parent `w-owner`), AI `w-rep` (parent `w-mgr`), and AI `w-sub`
 (parent `w-rep`) — so `w-rep` is both a report (of `w-mgr`) and a
 manager (of `w-sub`).

--- a/api/pkg/org/application/agent/worker-policy.md
+++ b/api/pkg/org/application/agent/worker-policy.md
@@ -118,7 +118,7 @@ hierarchy, not a limitation to work around.
 
 ## Errors and exits
 
-If you cannot make progress (missing tool grant, ambiguous request,
+If you cannot make progress (missing tool, ambiguous request,
 broken environment), say so once — briefly — and exit. Do not loop,
 retry, or compose long apologies. A short failure note in `helix-log.md` is
 enough.

--- a/api/pkg/org/application/bootstrap/bootstrap.go
+++ b/api/pkg/org/application/bootstrap/bootstrap.go
@@ -1,7 +1,7 @@
 // Package bootstrap creates the per-org initial owner Role (with the
 // structural tool list) and the owner Worker. The Worker's MCP surface
 // is derived live from r-owner.Tools — there is no separate per-Worker
-// grants step. Run once per helix.Organization; subsequent calls for
+// tool-assignment step. Run once per helix.Organization; subsequent calls for
 // the same org return ErrAlreadyInitialised, leaving other orgs free
 // to bootstrap independently.
 package bootstrap

--- a/api/pkg/org/application/bootstrap/templates/owner_role.md
+++ b/api/pkg/org/application/bootstrap/templates/owner_role.md
@@ -58,8 +58,8 @@ When you hire — directly or via `/role` — chain the steps without
 asking permission between them:
 
 1. Save the Role (`create_role`) with its `tools` list populated. The
-   Role's tools are the MCP surface every Worker holding this Role
-   gets — there is no separate per-Worker grant step. List **every
+   Role's tools are the MCP surface every Worker filling this Role
+   gets — there is no separate per-Worker tool-assignment step. List **every
    MCP tool the Role's prompt expects to use** (typically `subscribe`,
    `unsubscribe`, `read_events`, `publish`, `dm`, `list_streams`,
    `stream_members`, `managers`, `reports`, plus anything specific to
@@ -67,13 +67,13 @@ asking permission between them:
    reporting lines live — escalate up to a manager, brief down to its
    reports. If you later
    realise the Role needs more or fewer tools, call `update_role` and
-   every Worker holding that Role sees the change on their next MCP
+   every Worker filling that Role sees the change on their next MCP
    request.
 2. Hire the Worker (`hire_worker`) — kind `ai`, id
    `w-<lowercase-firstname>` (e.g. `w-mark`, `w-priya`), `roleId`
    pointing at the Role you just saved, and `parentId` set to the
    manager Worker (default: `w-owner`). The Worker's MCP tool surface
-   is read live from Role.tools, so `hire_worker` takes no `grants`
+   is read live from Role.tools, so `hire_worker` takes no `tools`
    parameter.
 
    Example shape:

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -86,7 +86,7 @@ var ErrOwnerRoleProtected = errors.New("cannot delete the owner role")
 // the hiring playbook explicitly re-subscribes.
 //
 // Tool capability is derived from Role.Tools, so there is no
-// per-Worker grants cascade.
+// per-Worker tool cascade to clean up.
 //
 // Activation events themselves are intentionally left behind as an
 // audit trail; only the Stream row is dropped.

--- a/api/pkg/org/application/lifecycle/lifecycle_test.go
+++ b/api/pkg/org/application/lifecycle/lifecycle_test.go
@@ -17,7 +17,7 @@ import (
 // TestFire_RemovesWorkersActivationStream pins the regression behind
 // "we still see s-activations-w-ai-1 and s-activations-w-test-ai
 // even though those workers are gone": the Fire cascade tore down
-// subscriptions, grants, environment, runtime state, and the worker
+// subscriptions, environment, runtime state, and the worker
 // row — but left the per-Worker activation Stream
 // (s-activations-<workerID>) lying around, so the Streams page kept
 // rendering ghost rows for workers that no longer existed and the

--- a/api/pkg/org/application/prompts/help.go
+++ b/api/pkg/org/application/prompts/help.go
@@ -42,8 +42,8 @@ func (Help) Description() string {
 func (Help) Arguments() []Argument { return nil }
 
 // RequiresTool returns the empty string so every Worker sees `/help`
-// regardless of grants. There is no tool to gate against — `/help`
-// reads the registry, never mutates anything.
+// regardless of their Role's tools. There is no tool to gate against —
+// `/help` reads the registry, never mutates anything.
 func (Help) RequiresTool() tool.Name { return "" }
 
 func (h Help) Render(_ context.Context, _ map[string]string) ([]Message, error) {

--- a/api/pkg/org/application/prompts/prompt.go
+++ b/api/pkg/org/application/prompts/prompt.go
@@ -45,8 +45,8 @@ type Prompt interface {
 	Description() string
 	Arguments() []Argument
 
-	// RequiresTool gates visibility: only Workers holding a grant for
-	// the named tool see this prompt. The empty string means visible
+	// RequiresTool gates visibility: only Workers whose Role lists the
+	// named tool see this prompt. The empty string means visible
 	// to every Worker. Gating exists because prompts that end in a
 	// tool call are useless to a Worker who can't make that call —
 	// surfacing the slash command would just produce a 403 at the end.

--- a/api/pkg/org/application/prompts/role.go
+++ b/api/pkg/org/application/prompts/role.go
@@ -42,9 +42,9 @@ func (Role) Arguments() []Argument {
 	}}
 }
 
-// RequiresTool gates the prompt on the create_role grant: a Worker
-// without it can't save the result, so surfacing the slash command
-// would only produce a dead-end at the very last step.
+// RequiresTool gates the prompt on the create_role tool: a Worker whose
+// Role doesn't list it can't save the result, so surfacing the slash
+// command would only produce a dead-end at the very last step.
 func (Role) RequiresTool() tool.Name { return tools.CreateRoleName }
 
 func (Role) Render(_ context.Context, args map[string]string) ([]Message, error) {

--- a/api/pkg/org/application/prompts/role_test.go
+++ b/api/pkg/org/application/prompts/role_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/tools"
 )
 
-func TestRoleRequiresCreateRoleGrant(t *testing.T) {
+func TestRoleRequiresCreateRoleTool(t *testing.T) {
 	t.Parallel()
 	if got := (prompts.Role{}).RequiresTool(); got != tools.CreateRoleName {
 		t.Fatalf("RequiresTool = %q, want %q", got, tools.CreateRoleName)

--- a/api/pkg/org/application/prompts/templates/role.md
+++ b/api/pkg/org/application/prompts/templates/role.md
@@ -62,8 +62,8 @@ Default tools: pick from what the org has — typically `subscribe`,
 `publish`, `read_events`, `dm`, `managers`, `reports`. `managers` and
 `reports` let the Worker resolve its reporting lines live — escalate up
 to a manager (`managers` + `dm`), brief down to its reports (`reports` +
-`publish` to the team stream). Grant both to any Role that sits in a
-hierarchy. Don't grant `hire_worker` or `create_role` unless the title
+`publish` to the team stream). List both on any Role that sits in a
+hierarchy. Don't list `hire_worker` or `create_role` unless the title
 implies seniority.
 
 ## Step 2 — Save it. **Don't ask permission.**
@@ -102,7 +102,7 @@ person, then chain:
 1. `hire_worker` — kind `ai`, id `w-<lowercase-firstname>`, `roleId`
    pointing at the Role you just saved, `parentId` set to the manager
    Worker (default `w-owner`). The Worker's MCP tools come live from
-   the Role you just saved; no `grants` parameter is needed (or
+   the Role you just saved; no `tools` parameter is needed (or
    accepted).
 2. **Stand up their streams.** For each stream the Role's Streams
    section lists:

--- a/api/pkg/org/application/tools/builtins_test.go
+++ b/api/pkg/org/application/tools/builtins_test.go
@@ -29,7 +29,7 @@ import (
 //
 // Owner is pre-seeded. Owner creates a #general Stream, subscribes
 // themselves, defines a CEO Role (markdown content), creates a Position,
-// then hires the CEO with inline grants and an identityContent. The
+// then hires the CEO with an identityContent. The
 // Worker's IdentityContent is stored in the domain alongside the Role —
 // no env files are written at hire (the spawner projects them at
 // activation). Owner publishes; CEO sees it.
@@ -50,7 +50,7 @@ func TestDemoOwnerHiresCEO(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Seed owner directly: role, position, worker, environment, structural grants.
+	// Seed owner directly: role (with the structural tool list), worker, environment.
 	now := time.Now().UTC()
 	ownerRole, err := orgchart.NewRole(
 		"r-owner",
@@ -465,12 +465,10 @@ func TestDM(t *testing.T) {
 
 	ctx := context.Background()
 	now := time.Now().UTC()
-	// Alice and Bob share a Role with both dm + read_events. In the
-	// old grants model they had slightly different sets (Bob had only
-	// dm); under Role.Tools both get both, which is fine — Bob simply
-	// never calls read_events in this test.
-	// Alice and Bob share a Role with both dm + read_events. Subscriptions
-	// are worker-anchored, so the DM subscribes each worker independently.
+	// Alice and Bob share a Role with both dm + read_events. Because the
+	// tool surface is the Role's, both get both, which is fine — Bob
+	// simply never calls read_events in this test. Subscriptions are
+	// worker-anchored, so the DM subscribes each worker independently.
 	memberRole, _ := orgchart.NewRole(
 		"r-member",
 		"# Member",
@@ -574,8 +572,8 @@ func TestDM(t *testing.T) {
 	}
 }
 
-// TestReadsOverMCP exercises the new read tools: an Owner with the
-// full builtin grant set lists workers, lists streams, and reads back
+// TestReadsOverMCP exercises the read tools: an Owner with the
+// full builtin tool set lists workers, lists streams, and reads back
 // events on subscribed streams, all over MCP.
 func TestReadsOverMCP(t *testing.T) {
 	t.Parallel()

--- a/api/pkg/org/application/tools/hire_worker.go
+++ b/api/pkg/org/application/tools/hire_worker.go
@@ -28,10 +28,10 @@ import (
 // tomorrow) without touching the tools.
 //
 // A Worker's MCP tool surface is derived live from Role.Tools: change
-// the Role and every Worker holding it sees the new tool set on the
-// next MCP request. There is no per-Worker grants table and no
-// `grants` parameter on this tool — capability is the Role's
-// responsibility.
+// the Role and every Worker filling it sees the new tool set on the
+// next MCP request. There is no per-Worker tool record and no
+// `tools` parameter on this tool — the Role's tool list is the whole
+// story.
 //
 // hire_worker does not subscribe to Streams; the hiring Worker does
 // that explicitly after the Worker is alive, typically via the Worker's

--- a/api/pkg/org/application/tools/hire_worker_test.go
+++ b/api/pkg/org/application/tools/hire_worker_test.go
@@ -80,7 +80,7 @@ func newHireTestEnv(t *testing.T) (Deps, *fakeDispatcher, string, orgchart.Worke
 	deps.EnvsDir = envsDir
 	deps.Dispatcher = dispatcher
 	deps.Now = func() time.Time { return now }
-	// Deterministic IDs make assertions on stream + grant IDs feasible.
+	// Deterministic IDs make assertions on stream IDs feasible.
 	var counter int
 	deps.NewID = func() string {
 		counter++

--- a/api/pkg/org/application/tools/registry.go
+++ b/api/pkg/org/application/tools/registry.go
@@ -47,7 +47,7 @@ func (r *Registry) Get(name tool.Name) (tool.Tool, error) {
 
 // List returns every registered tool, sorted by name for stable
 // rendering. Used by the chart UI's role editor to populate the
-// "Tools" multi-select with the catalogue of available grants.
+// "Tools" multi-select with the catalogue of available tools.
 func (r *Registry) List() []tool.Tool {
 	out := make([]tool.Tool, 0, len(r.tools))
 	for _, t := range r.tools {

--- a/api/pkg/org/application/tools/schema.go
+++ b/api/pkg/org/application/tools/schema.go
@@ -40,7 +40,7 @@ var schemaOpts = &jsonschema.ForOptions{
 
 // enumSchema builds an "enum-constrained string" schema for a
 // string-typed domain enum. Centralising this means new enum domains
-// (e.g. a future GrantScope) get the right shape automatically.
+// (e.g. a future transport kind) get the right shape automatically.
 func enumSchema[T ~string](vals []T, description string) *jsonschema.Schema {
 	out := make([]any, len(vals))
 	for i, v := range vals {

--- a/api/pkg/org/application/tools/update_identity.go
+++ b/api/pkg/org/application/tools/update_identity.go
@@ -16,7 +16,7 @@ import (
 // write; the new content takes effect on the Worker's next activation,
 // when the Spawner projects identity into the Environment.
 //
-// Identity is owner-managed: subordinate Workers don't get this grant.
+// Identity is owner-managed: subordinate Workers don't get this tool.
 // The identity supplied at hire time stays in place until rewritten.
 type UpdateIdentity struct {
 	deps Deps

--- a/api/pkg/org/domain/orgchart/role_test.go
+++ b/api/pkg/org/domain/orgchart/role_test.go
@@ -70,8 +70,8 @@ func TestNew_RejectsZeroTime(t *testing.T) {
 func TestNew_NilToolsAndStreamsAreValid(t *testing.T) {
 	t.Parallel()
 	// A Role with no declared tools or streams is valid — the hiring
-	// caller's prompt is responsible for figuring out what to grant
-	// and subscribe from Content alone.
+	// caller's prompt is responsible for figuring out which tools to list
+	// and streams to subscribe from Content alone.
 	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
 	r, err := orgchart.NewRole("r-minimal", "# Minimal", nil, nil, now, "org-test")
 	if err != nil {

--- a/api/pkg/org/domain/tool/tool.go
+++ b/api/pkg/org/domain/tool/tool.go
@@ -1,8 +1,9 @@
-// Package tool owns the Tool concept: a capability the MCP gateway
-// exposes to a calling Worker, gated by Grants. The package carries
-// the Name typed identifier (used both in `grants` rows and as the
-// MCP tool name advertised to LLM callers), the Tool interface every
-// implementation satisfies, and the Invocation envelope passed to
+// Package tool owns the Tool concept: an MCP tool the gateway exposes
+// to a calling Worker. Which tools a Worker sees is derived live from
+// their Role.Tools list; there is no per-Worker permission record. The
+// package carries the Name typed identifier (used both in Role.Tools and
+// as the MCP tool name advertised to LLM callers), the Tool interface
+// every implementation satisfies, and the Invocation envelope passed to
 // Tool.Invoke.
 //
 // Lifted from api/pkg/org/tool and api/pkg/org/domain/tool.go in the
@@ -24,8 +25,8 @@ import (
 	"github.com/google/jsonschema-go/jsonschema"
 )
 
-// Name is the stable identifier for a Tool — used both in `grants`
-// rows and as the MCP tool name advertised to LLM callers. Convention
+// Name is the stable identifier for a Tool — used both in Role.Tools
+// and as the MCP tool name advertised to LLM callers. Convention
 // is snake_case (e.g. `hire_worker`, `read_events`, `publish`).
 type Name = string
 
@@ -40,7 +41,7 @@ type Worker interface {
 }
 
 // Invocation bundles the per-call data passed to Tool.Invoke. The
-// pipeline populates it from the caller's grant; tools parse Args
+// pipeline populates Caller from the MCP request; tools parse Args
 // according to their own input schema.
 type Invocation struct {
 	Caller Worker
@@ -53,7 +54,7 @@ type Invocation struct {
 // owner-defined tools, and any future MCP-shaped tools all implement
 // this interface.
 type Tool interface {
-	// Name is the stable identifier used in grants and MCP tool calls.
+	// Name is the stable identifier used in Role.Tools and MCP tool calls.
 	Name() Name
 
 	// Description is a human-readable summary the LLM sees when
@@ -64,8 +65,8 @@ type Tool interface {
 	// clients to validate calls and by LLMs to understand the call shape.
 	InputSchema() *jsonschema.Schema
 
-	// Invoke executes the tool. Holding the grant is the entire
-	// authorisation — the tool does not re-check the caller's scope
-	// because there is no scope.
+	// Invoke executes the tool. The tool appearing in the caller's
+	// Role.Tools is the entire authorisation — the tool does not
+	// re-check the caller's scope because there is no scope.
 	Invoke(ctx context.Context, inv Invocation) (json.RawMessage, error)
 }

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -95,7 +95,7 @@ type Deps struct {
 
 	// Tools is the same tools registry the MCP server exposes — used
 	// by GET /tools so the chart UI's role-editor multi-select can
-	// render the catalogue of available grants. nil = endpoint
+	// render the catalogue of available tools. nil = endpoint
 	// returns an empty list (degrade gracefully on test wirings that
 	// don't bother building a registry).
 	Tools *tools.Registry
@@ -332,8 +332,8 @@ func buildOverview(workers []orgchart.Worker, roles []orgchart.Role) OrgOverview
 
 // ---- Roles / Workers ----------------------------------------------------
 
-// listTools returns the catalogue of available MCP tools the org
-// can grant to its roles. Powers the role editor's multi-select.
+// listTools returns the catalogue of available MCP tools that can be
+// listed on a Role. Powers the role editor's multi-select.
 //
 // @Summary Helix-org: list available MCP tools
 // @Tags HelixOrg
@@ -544,7 +544,7 @@ func (a *apiHandler) hireWorker(w http.ResponseWriter, r *http.Request) {
 // 409 if the target is the owner.
 //
 // @Summary Helix-org: fire worker
-// @Description Delete a Worker. Cascades: stops sessions, deletes the Helix project + agent app, clears runtime state, deletes subscriptions + grants + env dir + env row, then the worker row. Activations are preserved as audit.
+// @Description Delete a Worker. Cascades: stops sessions, deletes the Helix project + agent app, clears runtime state, deletes subscriptions + env dir + env row, then the worker row. Activations are preserved as audit.
 // @Tags HelixOrg
 // @Param id path string true "Worker ID"
 // @Success 204
@@ -579,7 +579,7 @@ func (a *apiHandler) fireWorker(w http.ResponseWriter, r *http.Request) {
 }
 
 // workerDTO converts a orgchart.Worker to its wire form. tools may be
-// nil — callers populating per-worker grants pass the sorted list.
+// nil — callers that want to surface the Role's tools pass the sorted list.
 // parentIDs are the managers this Worker reports to (from the reporting
 // lines); nil for a top-level Worker.
 func workerDTO(wk orgchart.Worker, tools []string, parentIDs []string) WorkerDTO {

--- a/api/pkg/org/interfaces/server/api/dto.go
+++ b/api/pkg/org/interfaces/server/api/dto.go
@@ -34,8 +34,8 @@ type OrgOverview struct {
 	Groups []RoleGroup `json:"groups"`
 }
 
-// ToolDTO is one entry in GET /tools — the catalogue of every grant
-// the org can hand to a Role. Powers the chart-UI role editor's
+// ToolDTO is one entry in GET /tools — the catalogue of every tool
+// that can be listed on a Role. Powers the chart-UI role editor's
 // multi-select. Description is the human-readable one-liner the
 // underlying tool surfaces to LLM callers via MCP.
 type ToolDTO struct {

--- a/api/pkg/org/interfaces/server/mcp.go
+++ b/api/pkg/org/interfaces/server/mcp.go
@@ -17,7 +17,7 @@ import (
 // mcpHandler returns an http.Handler that speaks MCP over the Streamable
 // HTTP transport. It is mounted at /workers/{id}/mcp; the worker ID in
 // the URL identifies the caller, and the server exposes only the tools
-// that worker holds grants for.
+// listed in that worker's Role.
 //
 // Stateless mode is used: each request stands on its own. The server has
 // no need to push notifications to clients, so session state buys us
@@ -60,9 +60,9 @@ func (s *Server) mcpHandler() http.Handler {
 
 // buildMCPServer assembles a fresh *mcp.Server tailored to the worker in
 // the request URL. The advertised tools are derived live from the
-// Worker's Role.Tools: changing the Role updates every Worker holding
-// it. There is no per-Worker grants table — capability is the Role's
-// responsibility.
+// Worker's Role.Tools: changing the Role updates every Worker filling
+// it. There is no per-Worker tool record — the Role's tool list is the
+// whole story.
 //
 // Returning nil causes the SDK to respond 400 Bad Request.
 func (s *Server) buildMCPServer(r *http.Request) *mcp.Server {
@@ -94,9 +94,9 @@ func (s *Server) buildMCPServer(r *http.Request) *mcp.Server {
 		Version: "0.1.0",
 	}, nil)
 
-	heldTools := make(map[tool.Name]bool, len(role.Tools))
+	roleTools := make(map[tool.Name]bool, len(role.Tools))
 	for _, toolName := range role.Tools {
-		heldTools[toolName] = true
+		roleTools[toolName] = true
 		t, err := s.registry.Get(toolName)
 		if err != nil {
 			// Role lists a tool the server doesn't know about. Skip
@@ -109,7 +109,7 @@ func (s *Server) buildMCPServer(r *http.Request) *mcp.Server {
 
 	if s.prompts != nil {
 		for _, p := range s.prompts.All() {
-			if req := p.RequiresTool(); req != "" && !heldTools[req] {
+			if req := p.RequiresTool(); req != "" && !roleTools[req] {
 				continue
 			}
 			registerPromptForWorker(srv, p, s.logger.With("worker", workerID, "prompt", p.Name()))
@@ -123,7 +123,7 @@ func (s *Server) buildMCPServer(r *http.Request) *mcp.Server {
 // server. The handler closes over the caller so each invocation
 // dispatches with the right Invocation without re-querying the store.
 // Authorisation is by virtue of the tool appearing in the Worker's
-// Role.Tools; there is no grant object to consult at call time.
+// Role.Tools; there is no per-Worker tool record to consult at call time.
 func registerToolForWorker(srv *mcp.Server, t tool.Tool, caller orgchart.Worker, logger interface {
 	Info(msg string, args ...any)
 }) {

--- a/api/pkg/org/interfaces/server/server.go
+++ b/api/pkg/org/interfaces/server/server.go
@@ -1,6 +1,6 @@
 // Package server exposes the HTTP surface. There is exactly one
 // endpoint: /workers/{id}/mcp — every Worker is its own MCP server,
-// scoped to the tools that Worker holds grants for, and used for both
+// scoped to the tools listed in that Worker's Role, and used for both
 // reads and mutations of the org graph. The CLI bootstraps by opening
 // the store directly; there is no other HTTP write path.
 package server

--- a/api/pkg/org/interfaces/server/server_test.go
+++ b/api/pkg/org/interfaces/server/server_test.go
@@ -72,10 +72,10 @@ func connectMCP(t *testing.T, baseURL string, workerID orgchart.WorkerID) *mcp.C
 }
 
 // newTestServerRoleDerived seeds a Worker whose MCP surface comes from
-// Role.Tools rather than per-Worker grants. The Role lists ping; no rows
-// are inserted into org_grants. Asserting that ping appears on the
-// Worker's MCP endpoint pins the new "Role.Tools is the live source of
-// truth" contract — see feat/org-role-tools-as-source-of-truth.
+// Role.Tools rather than a per-Worker tool record. The Role lists ping.
+// Asserting that ping appears on the Worker's MCP endpoint pins the
+// "Role.Tools is the live source of truth" contract — see
+// feat/org-role-tools-as-source-of-truth.
 func newTestServerRoleDerived(t *testing.T) (*httptest.Server, orgchart.WorkerID) {
 	t.Helper()
 	s := orggorm.GetOrgTestDB(t)
@@ -107,10 +107,10 @@ func newTestServerRoleDerived(t *testing.T) (*httptest.Server, orgchart.WorkerID
 	return srv, "w-ceo"
 }
 
-// TestMCPListToolsFromRole pins the new contract: a Worker's MCP surface
-// is derived live from their Position's Role.Tools, with no grants rows
+// TestMCPListToolsFromRole pins the contract: a Worker's MCP surface
+// is derived live from their Role.Tools, with no per-Worker tool record
 // involved. Hiring a Worker into a Role with `ping` listed must make
-// ping appear on the MCP endpoint without any explicit grant call.
+// ping appear on the MCP endpoint without any explicit tool-assignment call.
 func TestMCPListToolsFromRole(t *testing.T) {
 	t.Parallel()
 	srv, workerID := newTestServerRoleDerived(t)
@@ -158,8 +158,8 @@ func TestMCPListTools(t *testing.T) {
 	}
 }
 
-// TestMCPInvokePing exercises a granted tool over MCP end-to-end: the
-// CEO holds a ping grant, so calling tools/call should succeed and echo
+// TestMCPInvokePing exercises a tool over MCP end-to-end: the CEO's
+// Role lists ping, so calling tools/call should succeed and echo
 // the message back along with the caller ID.
 func TestMCPInvokePing(t *testing.T) {
 	t.Parallel()
@@ -195,11 +195,11 @@ func TestMCPInvokePing(t *testing.T) {
 	}
 }
 
-// TestMCPUngrantedToolHidden confirms that a tool not listed in the
+// TestMCPToolNotInRoleHidden confirms that a tool not listed in the
 // Worker's Role.Tools isn't visible. Calling a hidden tool surfaces as
 // a protocol-level "tool not found", not a 403 — the LLM never sees
 // tools its Role doesn't carry.
-func TestMCPUngrantedToolHidden(t *testing.T) {
+func TestMCPToolNotInRoleHidden(t *testing.T) {
 	t.Parallel()
 	srv, workerID := newTestServer(t)
 	session := connectMCP(t, srv.URL, workerID)
@@ -209,7 +209,7 @@ func TestMCPUngrantedToolHidden(t *testing.T) {
 		Arguments: map[string]any{"id": "r-x", "title": "X"},
 	})
 	if err == nil {
-		t.Fatalf("expected error for ungranted tool, got nil")
+		t.Fatalf("expected error for tool not in Role, got nil")
 	}
 }
 
@@ -249,9 +249,9 @@ func newTestServerWithPrompts(t *testing.T, includeCreateRole bool) (*httptest.S
 	return srv, "w-ceo"
 }
 
-// TestMCPListPromptsVisibleWithGrant confirms that a prompt gated on a
-// tool shows up exactly when the worker's Role.Tools includes it.
-func TestMCPListPromptsVisibleWithGrant(t *testing.T) {
+// TestMCPListPromptsVisibleWhenRoleHasTool confirms that a prompt gated
+// on a tool shows up exactly when the worker's Role.Tools includes it.
+func TestMCPListPromptsVisibleWhenRoleHasTool(t *testing.T) {
 	t.Parallel()
 	srv, workerID := newTestServerWithPrompts(t, true)
 	session := connectMCP(t, srv.URL, workerID)
@@ -269,10 +269,10 @@ func TestMCPListPromptsVisibleWithGrant(t *testing.T) {
 	}
 }
 
-// TestMCPListPromptsHiddenWithoutGrant confirms the gating: a worker
+// TestMCPListPromptsHiddenWhenRoleLacksTool confirms the gating: a worker
 // whose Role doesn't list create_role does NOT see the new_role
 // prompt, because the final tool call would fail anyway.
-func TestMCPListPromptsHiddenWithoutGrant(t *testing.T) {
+func TestMCPListPromptsHiddenWhenRoleLacksTool(t *testing.T) {
 	t.Parallel()
 	srv, workerID := newTestServerWithPrompts(t, false)
 	session := connectMCP(t, srv.URL, workerID)
@@ -283,7 +283,7 @@ func TestMCPListPromptsHiddenWithoutGrant(t *testing.T) {
 	}
 	for _, p := range res.Prompts {
 		if p.Name == string(prompts.RoleName) {
-			t.Errorf("new_role visible without create_role grant: %+v", p)
+			t.Errorf("new_role visible without create_role tool: %+v", p)
 		}
 	}
 }

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -10239,7 +10239,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Delete a Worker. Cascades: stops sessions, deletes the Helix project + agent app, clears runtime state, deletes subscriptions + grants + env dir + env row, then the worker row. Activations are preserved as audit.",
+                "description": "Delete a Worker. Cascades: stops sessions, deletes the Helix project + agent app, clears runtime state, deletes subscriptions + env dir + env row, then the worker row. Activations are preserved as audit.",
                 "tags": [
                     "HelixOrg"
                 ],

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -10235,7 +10235,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Delete a Worker. Cascades: stops sessions, deletes the Helix project + agent app, clears runtime state, deletes subscriptions + grants + env dir + env row, then the worker row. Activations are preserved as audit.",
+                "description": "Delete a Worker. Cascades: stops sessions, deletes the Helix project + agent app, clears runtime state, deletes subscriptions + env dir + env row, then the worker row. Activations are preserved as audit.",
                 "tags": [
                     "HelixOrg"
                 ],

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -17919,7 +17919,7 @@ paths:
   /api/v1/orgs/{org}/workers/{id}:
     delete:
       description: 'Delete a Worker. Cascades: stops sessions, deletes the Helix project
-        + agent app, clears runtime state, deletes subscriptions + grants + env dir
+        + agent app, clears runtime state, deletes subscriptions + env dir
         + env row, then the worker row. Activations are preserved as audit.'
       parameters:
       - description: Worker ID

--- a/frontend/src/pages/HelixOrgRoleDetail.tsx
+++ b/frontend/src/pages/HelixOrgRoleDetail.tsx
@@ -1,5 +1,5 @@
 // HelixOrgRoleDetail edits a single role end-to-end: markdown content,
-// tools (MCP grants), streams (inbound subscriptions). Lives at
+// tools (the role's MCP tool list), streams (inbound subscriptions). Lives at
 // `/orgs/:org_id/helix-org/roles/:role_id` and is the destination
 // both the chart's role drawer and the Roles list link to.
 //
@@ -79,11 +79,11 @@ const HelixOrgRoleDetail: FC = () => {
 
   const streams = useMemo(() => parseList(streamsText), [streamsText])
 
-  // The Autocomplete needs Option objects, but the role's grant
-  // shape is just a string[] of names. We render every catalogue
-  // entry plus any role-held names the catalogue didn't return
-  // (defensive — if a tool was unregistered but the grant still
-  // exists, we keep showing it as selected so the operator can
+  // The Autocomplete needs Option objects, but the role's tool list
+  // is just a string[] of names. We render every catalogue
+  // entry plus any role-listed names the catalogue didn't return
+  // (defensive — if a tool was unregistered but the role still
+  // lists it, we keep showing it as selected so the operator can
   // explicitly remove it).
   const toolOptions = useMemo<ToolDTO[]>(() => {
     const cat = toolCatalogue ?? []
@@ -256,7 +256,7 @@ const HelixOrgRoleDetail: FC = () => {
                     renderInput={(params) => (
                       <TextField
                         {...params}
-                        placeholder={tools.length === 0 ? 'Pick the tools to grant to workers in this role' : ''}
+                        placeholder={tools.length === 0 ? 'Pick the tools for workers in this role' : ''}
                         helperText="MCP tools the Workers in this role can call. Empty = no tools (workers can still receive owner-chat)."
                       />
                     )}

--- a/frontend/src/pages/HelixOrgRoles.tsx
+++ b/frontend/src/pages/HelixOrgRoles.tsx
@@ -154,8 +154,8 @@ const HelixOrgRoles: FC = () => {
             <Typography variant="h5" sx={{ mb: 1 }}>Roles</Typography>
             <Typography variant="body2" color="text.secondary">
               A Role defines a job description: the markdown content tells a Worker what they're for, the
-              tools list grants MCP access, and the streams list flags which inbound events the Role's
-              prompt expects. Workers hold a Role directly — capability and prompt come from here.
+              tools list is the Worker's MCP tool surface, and the streams list flags which inbound events the Role's
+              prompt expects. Workers hold a Role directly — tools and prompt come from here.
             </Typography>
           </Box>
 

--- a/frontend/src/pages/HelixOrgWorkerDetail.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.tsx
@@ -510,7 +510,7 @@ const HelixOrgWorkerDetail: FC = () => {
         >
           <Typography variant="body1">
             Firing worker <b style={{ fontFamily: 'monospace' }}>{workerId}</b> tears down its
-            per-worker Helix project + agent app and removes its grants. This is irreversible.
+            per-worker Helix project + agent app and clears its runtime state. This is irreversible.
           </Typography>
         </DeleteConfirmWindow>
       )}

--- a/frontend/src/pages/HelixOrgWorkers.tsx
+++ b/frontend/src/pages/HelixOrgWorkers.tsx
@@ -228,7 +228,7 @@ const HelixOrgWorkers: FC = () => {
         >
           <Typography variant="body1">
             Firing worker <b style={{ fontFamily: 'monospace' }}>{firing.id}</b> tears down its
-            per-worker Helix project + agent app and removes its grants. This is irreversible.
+            per-worker Helix project + agent app and clears its runtime state. This is irreversible.
           </Typography>
         </DeleteConfirmWindow>
       )}

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -17919,7 +17919,7 @@ paths:
   /api/v1/orgs/{org}/workers/{id}:
     delete:
       description: 'Delete a Worker. Cascades: stops sessions, deletes the Helix project
-        + agent app, clears runtime state, deletes subscriptions + grants + env dir
+        + agent app, clears runtime state, deletes subscriptions + env dir
         + env row, then the worker row. Activations are preserved as audit.'
       parameters:
       - description: Worker ID

--- a/openapi.json
+++ b/openapi.json
@@ -12256,7 +12256,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Delete a Worker. Cascades: stops sessions, deletes the Helix project + agent app, clears runtime state, deletes subscriptions + grants + env dir + env row, then the worker row. Activations are preserved as audit.",
+                "description": "Delete a Worker. Cascades: stops sessions, deletes the Helix project + agent app, clears runtime state, deletes subscriptions + env dir + env row, then the worker row. Activations are preserved as audit.",
                 "tags": [
                     "HelixOrg"
                 ],

--- a/swagger.json
+++ b/swagger.json
@@ -10235,7 +10235,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Delete a Worker. Cascades: stops sessions, deletes the Helix project + agent app, clears runtime state, deletes subscriptions + grants + env dir + env row, then the worker row. Activations are preserved as audit.",
+                "description": "Delete a Worker. Cascades: stops sessions, deletes the Helix project + agent app, clears runtime state, deletes subscriptions + env dir + env row, then the worker row. Activations are preserved as audit.",
                 "tags": [
                     "HelixOrg"
                 ],


### PR DESCRIPTION
## Summary

The org-graph grant mechanism was already removed (table dropped, types deleted, CRUD tools gone). This cleans up the lingering grant *language* throughout comments, docs, prompt templates, test names, and the frontend.

After this change, the model reads consistently everywhere: **a Role lists MCP tools; every Worker filling that Role gets exactly those tools, derived live on each MCP request. There is no per-Worker tool record.**

## Changes

- **Core domain** (`tool.go`, `mcp.go`, `server.go`, `prompt.go`): Reword "gated by Grants" / "holds grants for" / "holding the grant is the authorisation" to point at `Role.Tools`
- **Speculative reference**: `schema.go` "a future GrantScope" → "a future transport kind"
- **Application code**: `bootstrap.go`, `lifecycle.go`, `hire_worker.go`, `registry.go`, `update_identity.go`, plus prompts and API comments
- **Behavioral docs**: `QA.md`, `worker-policy.md`, `owner_role.md`, `role.md` — "grant X" → "list X on Role"
- **Tests**: Rename `TestMCPUngrantedToolHidden` → `TestMCPToolNotInRoleHidden`, `…WithGrant` → `…WhenRoleHasTool`, `…WithoutGrant` → `…WhenRoleLacksTool`, `…CreateRoleGrant` → `…CreateRoleTool`
- **Frontend**: Role/worker pages, role editor placeholder, fire-confirmation dialogs
- **Generated OpenAPI**: Sync description string for cascading delete (no full `update_openapi`)

## Verification

- `go build ./pkg/org/...` ✅
- `go build ./pkg/server/...` ✅  
- `go vet ./pkg/org/...` ✅
- Unit + MCP server tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)