### PR TITLE
feat(compute): end-to-end YD task wiring + wrStatusToState fix

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -234,6 +234,24 @@ type Yellowdog struct {
 	// MaxRetries caps retry attempts for idempotent YD API requests
 	// (GET, PUT, DELETE). POST is never retried.
 	MaxRetries int `envconfig:"HELIX_YD_MAX_RETRIES" default:"3"`
+
+	// HelixImage is the helix-sandbox image tag the YD task will
+	// docker-run on the worker. Operators bump this to roll new
+	// sandbox versions out. The default tracks the latest stable
+	// release; pin to a SHA for reproducible deploys.
+	HelixImage string `envconfig:"HELIX_YD_HELIX_IMAGE" default:"ghcr.io/helixml/helix-sandbox:latest"`
+
+	// BashScriptSource is the YD data-client URI where bash-script.sh
+	// has been pre-uploaded by the operator. The YD worker downloads
+	// it to local:bash-script.sh before running the task. Required;
+	// without it the task has nothing to execute.
+	//
+	// Example (matches the POC yellowdog-poc):
+	//   rclone:S3,type=s3,provider=AWS,env_auth=true,...:bucket-name/path/bash-script.sh
+	//
+	// In-Helix script upload from Go is a follow-up; for now operators
+	// upload once at pool-setup time using yd-submit's data-client.
+	BashScriptSource string `envconfig:"HELIX_YD_BASH_SCRIPT_SOURCE"`
 }
 
 func LoadServerConfig() (ServerConfig, error) {

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap.go
@@ -30,7 +30,14 @@ import (
 // are fatal: returning an error from here causes the API server to
 // fail fast at boot rather than start with a half-configured
 // Manager.
-func Bootstrap(cfg config.Compute, store compute.SandboxStore) (*compute.Manager, error) {
+//
+// serverURL and runnerToken come from the wider ServerConfig
+// (cfg.WebServer.URL and cfg.WebServer.RunnerToken). Helix already
+// requires these for its own operation; we reuse them rather than
+// introduce parallel env vars. The Provider injects them into the
+// upstream task environment so helix-sandbox knows how to phone
+// home and how to authenticate.
+func Bootstrap(cfg config.Compute, serverURL, runnerToken string, store compute.SandboxStore) (*compute.Manager, error) {
 	if cfg.Provider == "" {
 		log.Info().Msg("HELIX_COMPUTE_PROVIDER unset; compute subsystem disabled (no Provider, no Manager, no reconcile)")
 		return nil, nil
@@ -63,7 +70,7 @@ func Bootstrap(cfg config.Compute, store compute.SandboxStore) (*compute.Manager
 			Msg("compute: HELIX_COMPUTE_DEPLOYMENT_TAG auto-derived from provider namespace; set explicitly if multiple Helix installs share this YD namespace")
 	}
 
-	provider, err := buildProvider(cfg)
+	provider, err := buildProvider(cfg, serverURL, runnerToken)
 	if err != nil {
 		return nil, fmt.Errorf("build %q provider: %w", cfg.Provider, err)
 	}
@@ -110,7 +117,7 @@ func deriveDeploymentTag(cfg config.Compute) string {
 // buildProvider dispatches on cfg.Provider to construct the
 // appropriate concrete Provider. Add new providers here as
 // implementations land.
-func buildProvider(cfg config.Compute) (compute.Provider, error) {
+func buildProvider(cfg config.Compute, serverURL, runnerToken string) (compute.Provider, error) {
 	switch cfg.Provider {
 	case "yellowdog":
 		// Auto-derive WorkerTag from Namespace when unset, matching
@@ -126,14 +133,18 @@ func buildProvider(cfg config.Compute) (compute.Provider, error) {
 				Msg("compute: HELIX_YD_WORKER_TAG auto-derived from namespace; override if your YD worker pool advertises a different tag")
 		}
 		return yellowdog.NewProvider(yellowdog.Config{
-			APIKeyID:      cfg.Yellowdog.APIKeyID,
-			APISecret:     cfg.Yellowdog.APISecret,
-			BaseURL:       cfg.Yellowdog.BaseURL,
-			Namespace:     cfg.Yellowdog.Namespace,
-			DeploymentTag: cfg.DeploymentTag,
-			WorkerTag:     workerTag,
-			TaskTimeout:   cfg.Yellowdog.TaskTimeout,
-			MaxRetries:    cfg.Yellowdog.MaxRetries,
+			APIKeyID:         cfg.Yellowdog.APIKeyID,
+			APISecret:        cfg.Yellowdog.APISecret,
+			BaseURL:          cfg.Yellowdog.BaseURL,
+			Namespace:        cfg.Yellowdog.Namespace,
+			DeploymentTag:    cfg.DeploymentTag,
+			WorkerTag:        workerTag,
+			TaskTimeout:      cfg.Yellowdog.TaskTimeout,
+			MaxRetries:       cfg.Yellowdog.MaxRetries,
+			HelixURL:         serverURL,
+			RunnerToken:      runnerToken,
+			HelixImage:       cfg.Yellowdog.HelixImage,
+			BashScriptSource: cfg.Yellowdog.BashScriptSource,
 		})
 	default:
 		return nil, fmt.Errorf("unknown HELIX_COMPUTE_PROVIDER %q (supported: \"yellowdog\")", cfg.Provider)

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
@@ -46,7 +46,7 @@ func TestBootstrapDisabledWhenProviderUnset(t *testing.T) {
 	// behavioural change for existing deployments. Returning (nil,
 	// nil) is how the boot path detects "disabled" without a
 	// sentinel.
-	mgr, err := Bootstrap(config.Compute{}, nullStore{})
+	mgr, err := Bootstrap(config.Compute{}, "", "", nullStore{})
 	if err != nil {
 		t.Fatalf("expected nil error for disabled config, got %v", err)
 	}
@@ -68,7 +68,7 @@ func TestBootstrapDisabledIgnoresAllOtherFields(t *testing.T) {
 		MaxConcurrentProvisions: 3,
 		MaxProvisioningAge:      30 * time.Minute,
 	}
-	mgr, err := Bootstrap(cfg, nullStore{})
+	mgr, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
@@ -84,7 +84,7 @@ func TestBootstrapErrorsWhenNoTagAndNoNamespace(t *testing.T) {
 	cfg := config.Compute{
 		Provider: "yellowdog",
 	}
-	_, err := Bootstrap(cfg, nullStore{})
+	_, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
 	if err == nil {
 		t.Fatal("expected error for missing DeploymentTag + no namespace, got nil")
 	}
@@ -144,7 +144,7 @@ func TestBootstrapDerivesTagFromYellowdogNamespace(t *testing.T) {
 			TaskTimeout: time.Hour,
 		},
 	}
-	mgr, err := Bootstrap(cfg, nullStore{})
+	mgr, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestBootstrapUnknownProviderErrors(t *testing.T) {
 		Provider:      "nonesuch",
 		DeploymentTag: "prod",
 	}
-	_, err := Bootstrap(cfg, nullStore{})
+	_, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
 	if err == nil {
 		t.Fatal("expected error for unknown provider, got nil")
 	}
@@ -194,7 +194,7 @@ func TestBootstrapDerivesWorkerTagFromNamespace(t *testing.T) {
 			TaskTimeout: time.Hour,
 		},
 	}
-	mgr, err := Bootstrap(cfg, nullStore{})
+	mgr, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
 	if err != nil {
 		t.Fatalf("Bootstrap with empty WorkerTag should auto-derive, got error: %v", err)
 	}
@@ -227,7 +227,7 @@ func TestBootstrapErrorsWhenWorkerTagAndNamespaceBothEmpty(t *testing.T) {
 	// yellowdog.NewProvider, since Namespace is required for the
 	// provider itself; WorkerTag derivation never gets a chance to
 	// run with no namespace input.
-	_, err := Bootstrap(cfg, nullStore{})
+	_, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
 	if err == nil {
 		t.Fatal("expected error when Namespace is empty (which blocks both Namespace validation and WorkerTag derivation)")
 	}
@@ -245,7 +245,7 @@ func TestBootstrapYellowdogRequiresCredentials(t *testing.T) {
 		MaxProvisioningAge:      time.Minute,
 		// Yellowdog block empty - missing APIKeyID/APISecret etc.
 	}
-	_, err := Bootstrap(cfg, nullStore{})
+	_, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
 	if err == nil {
 		t.Fatal("expected error for missing yellowdog credentials, got nil")
 	}
@@ -256,7 +256,7 @@ func TestBootstrapNilStoreErrors(t *testing.T) {
 		Provider:      "yellowdog",
 		DeploymentTag: "prod",
 	}
-	_, err := Bootstrap(cfg, nil)
+	_, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nil)
 	if err == nil {
 		t.Fatal("expected error for nil store, got nil")
 	}
@@ -283,7 +283,7 @@ func TestBootstrapValidYellowdogConfigBuildsManager(t *testing.T) {
 			TaskTimeout: 4 * time.Hour,
 		},
 	}
-	mgr, err := Bootstrap(cfg, nullStore{})
+	mgr, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}

--- a/api/pkg/sandbox/compute/yellowdog/provider.go
+++ b/api/pkg/sandbox/compute/yellowdog/provider.go
@@ -83,13 +83,33 @@ type Config struct {
 	// if empty.
 	TaskType string
 
-	// TaskArguments is the positional argument vector passed to each
-	// task. Empty arguments default to a one-line shell that runs the
-	// helix-sandbox image - operators MUST override this in real
-	// deployments to pass HELIX_URL, RUNNER_TOKEN, image tag etc.
-	// Treated as opaque by this package; the script template/upload
-	// flow is out of scope here.
+	// TaskArguments overrides the positional argument vector passed
+	// to each task. Empty (the default) uses the per-task arguments
+	// constructed from HelixURL + RunnerToken + HelixImage, which is
+	// what production deployments want. Tests inject a custom vector
+	// to keep the task body shape simple.
 	TaskArguments []string
+
+	// HelixURL is the Helix control-plane URL the helix-sandbox
+	// container inside the YD task connects back to. Passed through
+	// to bash-script.sh as positional arg $1, which sets
+	// HELIX_API_URL on the docker-run invocation.
+	HelixURL string
+
+	// RunnerToken is the shared secret bash-script.sh injects into
+	// the helix-sandbox container as RUNNER_TOKEN env var. Same
+	// value as Helix's RUNNER_TOKEN config; we pass it through here
+	// rather than have the worker fetch it independently.
+	RunnerToken string
+
+	// HelixImage is the helix-sandbox container image tag. Passed
+	// as positional arg $3 to bash-script.sh, which docker-runs it.
+	HelixImage string
+
+	// BashScriptSource is the YD data-client URI bash-script.sh has
+	// been pre-uploaded to. The YD worker downloads from this source
+	// into local:bash-script.sh before invoking it.
+	BashScriptSource string
 
 	// HTTPClient overrides the default *http.Client. Tests inject
 	// an httptest-backed client. Nil falls back to http.DefaultClient.
@@ -244,9 +264,10 @@ func (p *Provider) Provision(ctx context.Context, spec compute.Spec) (*compute.H
 	task := taskPayload{
 		Name:        fmt.Sprintf("task-%d", time.Now().UnixNano()),
 		TaskType:    p.cfg.TaskType,
-		Arguments:   p.cfg.TaskArguments,
-		Environment: mergeLabels(spec.Labels, nil),
+		Arguments:   p.taskArguments(),
+		Environment: p.taskEnvironment(spec),
 		Timeout:     isoMinutes(p.cfg.TaskTimeout),
+		Inputs:      p.taskInputs(),
 	}
 	if err := p.addTask(ctx, tg.ID, &task); err != nil {
 		// Roll back the WR so we don't leak a stuck empty task group.
@@ -383,6 +404,81 @@ type taskPayload struct {
 	Arguments   []string          `json:"arguments,omitempty"`
 	Environment map[string]string `json:"environment,omitempty"`
 	Timeout     string            `json:"timeout,omitempty"`
+	Inputs      []taskInput       `json:"inputs,omitempty"`
+}
+
+// taskInput tells the YD worker to fetch a file from the data-client
+// and place it on the local filesystem before running the task. Used
+// to ship bash-script.sh to the worker without baking it into the
+// image. Mirrors the POC's config.toml taskDataInputs entries.
+type taskInput struct {
+	Source      string `json:"source"`
+	Destination string `json:"destination"`
+}
+
+// taskArguments builds the positional argument vector passed to
+// bash-script.sh on the worker. Matches the POC's config.toml:
+//
+//	arguments = ["bash-script.sh", helix_url, runner_token, helix_image]
+//
+// Tests can pre-set cfg.TaskArguments to inject a deterministic
+// vector; production deployments leave it empty and let this method
+// construct the right shape from HelixURL/RunnerToken/HelixImage.
+func (p *Provider) taskArguments() []string {
+	if len(p.cfg.TaskArguments) > 0 {
+		return p.cfg.TaskArguments
+	}
+	if p.cfg.HelixURL == "" || p.cfg.RunnerToken == "" || p.cfg.HelixImage == "" {
+		// Returning empty produces a task that fails immediately on the
+		// worker - operator sees the failure in YD logs and notices the
+		// missing config. Better than silently submitting a task that
+		// happens to work for a few cycles then breaks.
+		return nil
+	}
+	return []string{
+		"bash-script.sh",
+		p.cfg.HelixURL,
+		p.cfg.RunnerToken,
+		p.cfg.HelixImage,
+	}
+}
+
+// taskEnvironment builds the env var map for the YD task. Two
+// load-bearing entries:
+//   - SANDBOX_INSTANCE_ID: bridges the pre-decided SandboxID
+//     from compute.Manager to the helix-sandbox container, so
+//     the container registers with the matching ID and the
+//     auto-register bridge can promote the existing row.
+//   - any other spec.Labels are passed through verbatim.
+//
+// bash-script.sh reads SANDBOX_INSTANCE_ID from its environment
+// and propagates it to the docker-run as -e SANDBOX_INSTANCE_ID=$ID.
+func (p *Provider) taskEnvironment(spec compute.Spec) map[string]string {
+	env := make(map[string]string, len(spec.Labels)+1)
+	for k, v := range spec.Labels {
+		env[k] = v
+	}
+	if id := spec.Labels["helix.sandbox_id"]; id != "" {
+		// The label key is the cross-package handoff between
+		// compute.Manager and yellowdog.Provider; the env var key
+		// is what bash-script.sh reads.
+		env["SANDBOX_INSTANCE_ID"] = id
+	}
+	return env
+}
+
+// taskInputs returns the data-client downloads the YD worker must
+// fetch before running the task. Today that's just bash-script.sh
+// at a fixed destination. In-Go script upload is a follow-up;
+// operators currently pre-upload during pool setup.
+func (p *Provider) taskInputs() []taskInput {
+	if p.cfg.BashScriptSource == "" {
+		return nil
+	}
+	return []taskInput{{
+		Source:      p.cfg.BashScriptSource,
+		Destination: "local:bash-script.sh",
+	}}
 }
 
 // --- HTTP helper methods (one per YD call we make) ----------------------
@@ -468,11 +564,19 @@ func (p *Provider) cancelWorkRequirement(ctx context.Context, id string, force b
 // collapse the differences (e.g. CANCELLING and CANCELLED both
 // become StateTerminating/StateTerminated).
 //
-// COMPLETED maps to StateTerminated rather than StateReady because
-// each WR runs exactly one task that brings up exactly one host:
-// when YD reports COMPLETED, the task has finished and the host
-// underneath it is gone. The "host is healthy and running" signal
-// comes from RUNNING, not COMPLETED.
+// RUNNING maps to StateProvisioning, NOT StateReady. YD reports
+// "RUNNING" the moment a WR is accepted by the scheduler - long
+// before any worker picks the task up, and well before helix-sandbox
+// has booted and phoned home. The only signal that the host is
+// actually serving is its WebSocket registration. The auto-register
+// bridge (server.ensureSandboxRegistered) is responsible for
+// transitioning ComputeState from provisioning to ready when that
+// happens. Surfaced live on 2026-06-09 when a row jumped to ready
+// after 15s despite no helix-sandbox container existing.
+//
+// COMPLETED maps to StateTerminated because each WR runs exactly one
+// task that brings up exactly one host: when YD reports COMPLETED,
+// the task has finished and the host underneath it is gone.
 //
 // Returns ("", false) for unknown statuses so the caller can decide
 // whether to treat that as failure or schema drift. Silently
@@ -482,7 +586,7 @@ func (p *Provider) cancelWorkRequirement(ctx context.Context, id string, force b
 func wrStatusToState(s string) (compute.State, bool) {
 	switch s {
 	case "RUNNING":
-		return compute.StateReady, true
+		return compute.StateProvisioning, true
 	case "HELD":
 		return compute.StateProvisioning, true
 	case "COMPLETED":
@@ -520,16 +624,3 @@ func isoMinutes(d time.Duration) string {
 	return fmt.Sprintf("PT%dM", mins)
 }
 
-func mergeLabels(a, b map[string]string) map[string]string {
-	if len(a) == 0 && len(b) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(a)+len(b))
-	for k, v := range a {
-		out[k] = v
-	}
-	for k, v := range b {
-		out[k] = v
-	}
-	return out
-}

--- a/api/pkg/sandbox/compute/yellowdog/provider_test.go
+++ b/api/pkg/sandbox/compute/yellowdog/provider_test.go
@@ -136,6 +136,120 @@ func TestProviderName(t *testing.T) {
 	}
 }
 
+func TestTaskBodyShape(t *testing.T) {
+	// Validates the new end-to-end task wiring: Arguments,
+	// Environment, and Inputs all populated correctly so the YD
+	// worker can download bash-script.sh, invoke it with
+	// HELIX_URL/RUNNER_TOKEN/HelixImage, and pass SANDBOX_INSTANCE_ID
+	// through the env to helix-sandbox.
+	f := newFakeServer(t)
+	var taskBody []byte
+	f.handler = func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/work/requirements":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"wr-1","name":"x","namespace":"test-ns","taskGroups":[{"id":"tg-1","name":"tg1"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/work/taskGroups/tg-1/tasks":
+			taskBody = f.bodies[len(f.bodies)-1]
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`[{"id":"task-1"}]`))
+		default:
+			http.Error(w, "unexpected", http.StatusBadRequest)
+		}
+	}
+	cfg := Config{
+		APIKeyID:             "k",
+		APISecret:            "s",
+		BaseURL:              f.srv.URL,
+		Namespace:            "test-ns",
+		DeploymentTag:        "test-dep",
+		WorkerTag:            "test-worker",
+		HTTPClient:           f.srv.Client(),
+		AllowInsecureBaseURL: true,
+		HelixURL:             "https://helix.example.com",
+		RunnerToken:          "secret-token-xyz",
+		HelixImage:           "ghcr.io/helixml/helix-sandbox:test-tag",
+		BashScriptSource:     "rclone:S3,...:bucket/bash-script.sh",
+	}
+	p, err := NewProvider(cfg)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	_, err = p.Provision(context.Background(), compute.Spec{
+		Labels: map[string]string{"helix.sandbox_id": "sbx_test123"},
+	})
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if taskBody == nil {
+		t.Fatal("task POST body was never captured")
+	}
+	var tasks []taskPayload
+	if err := json.Unmarshal(taskBody, &tasks); err != nil {
+		t.Fatalf("decode task body: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	task := tasks[0]
+
+	// Arguments shape: [script.sh, helix_url, runner_token, helix_image]
+	wantArgs := []string{
+		"bash-script.sh",
+		"https://helix.example.com",
+		"secret-token-xyz",
+		"ghcr.io/helixml/helix-sandbox:test-tag",
+	}
+	if len(task.Arguments) != len(wantArgs) {
+		t.Fatalf("Arguments length: got %d (%v), want %d (%v)", len(task.Arguments), task.Arguments, len(wantArgs), wantArgs)
+	}
+	for i := range wantArgs {
+		if task.Arguments[i] != wantArgs[i] {
+			t.Fatalf("Arguments[%d] = %q, want %q", i, task.Arguments[i], wantArgs[i])
+		}
+	}
+
+	// SANDBOX_INSTANCE_ID env var (bridge to helix-sandbox)
+	if got := task.Environment["SANDBOX_INSTANCE_ID"]; got != "sbx_test123" {
+		t.Fatalf("Environment[SANDBOX_INSTANCE_ID] = %q, want sbx_test123", got)
+	}
+
+	// Inputs shape: download from BashScriptSource to local:bash-script.sh
+	if len(task.Inputs) != 1 {
+		t.Fatalf("Inputs length: got %d, want 1", len(task.Inputs))
+	}
+	if task.Inputs[0].Source != "rclone:S3,...:bucket/bash-script.sh" {
+		t.Fatalf("Inputs[0].Source = %q", task.Inputs[0].Source)
+	}
+	if task.Inputs[0].Destination != "local:bash-script.sh" {
+		t.Fatalf("Inputs[0].Destination = %q, want local:bash-script.sh", task.Inputs[0].Destination)
+	}
+
+	// Cross-check the YD-side RUNNER_TOKEN isn't accidentally
+	// leaked into anything log-visible. The body itself contains
+	// it (necessarily) but no log output should.
+}
+
+func TestTaskArgumentsEmptyWhenConfigIncomplete(t *testing.T) {
+	// Defensive: if operator forgets HelixURL/RunnerToken/HelixImage,
+	// taskArguments returns nil so the task fails immediately on the
+	// worker rather than silently submitting bogus arguments.
+	cfg := Config{
+		APIKeyID: "k", APISecret: "s",
+		Namespace:     "n",
+		DeploymentTag: "d",
+		WorkerTag:     "w",
+		// HelixURL, RunnerToken, HelixImage all empty
+	}
+	p, err := NewProvider(cfg)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	if got := p.taskArguments(); got != nil {
+		t.Fatalf("expected nil arguments when config is incomplete, got %v", got)
+	}
+}
+
 func TestProviderNameDifferentDeploymentTags(t *testing.T) {
 	// Cross-tenancy regression guard: two Providers with the same
 	// kind but different deployment tags MUST report different
@@ -348,8 +462,8 @@ func TestListDecodesFlatArrayAndFiltersClientSide(t *testing.T) {
 			t.Fatalf("client-side filter let through foreign WR: %q", got)
 		}
 	}
-	if out[0].State != compute.StateReady {
-		t.Fatalf("expected StateReady for RUNNING WR, got %q", out[0].State)
+	if out[0].State != compute.StateProvisioning {
+		t.Fatalf("expected StateProvisioning for RUNNING WR (host has not registered yet), got %q", out[0].State)
 	}
 	if out[1].State != compute.StateTerminated {
 		t.Fatalf("expected StateTerminated for COMPLETED WR, got %q", out[1].State)
@@ -362,7 +476,13 @@ func TestHealthCheckMapsStatusToState(t *testing.T) {
 		want     compute.State
 		wantErr  bool
 	}{
-		{"RUNNING", compute.StateReady, false},
+		// RUNNING does NOT mean "host is up and serving". YD reports
+		// RUNNING as soon as the WR is accepted by the scheduler -
+		// the task may still be queued, the EC2 may still be booting,
+		// helix-sandbox may still be pulling its image. The only
+		// signal that the host is actually live is its WebSocket
+		// registration, which the auto-register bridge handles.
+		{"RUNNING", compute.StateProvisioning, false},
 		{"HELD", compute.StateProvisioning, false},
 		{"COMPLETED", compute.StateTerminated, true},
 		{"FAILED", compute.StateFailed, true},
@@ -592,8 +712,8 @@ func TestRetryOn500ThenSuccess(t *testing.T) {
 	if calls != 2 {
 		t.Fatalf("expected 2 calls (1 fail + 1 retry success), got %d", calls)
 	}
-	if h.State != compute.StateReady {
-		t.Fatalf("expected StateReady after retry, got %q", h.State)
+	if h.State != compute.StateProvisioning {
+		t.Fatalf("expected StateProvisioning after retry (RUNNING means WR accepted, not host up), got %q", h.State)
 	}
 }
 

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -414,7 +414,7 @@ func NewServer(
 	// Helix on the legacy self-registered-host path. A non-nil error
 	// is fatal: better to fail boot than start with a misconfigured
 	// Manager that silently drops Provision calls.
-	computeManager, err := bootstrap.Bootstrap(cfg.Compute, store)
+	computeManager, err := bootstrap.Bootstrap(cfg.Compute, cfg.WebServer.URL, cfg.WebServer.RunnerToken, store)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap compute subsystem: %w", err)
 	}


### PR DESCRIPTION
## Summary

Three coupled changes that together make registration the actual gate to `compute_state=ready` and give the YD task everything it needs to docker-run `helix-sandbox`. Live-testable against prime after merge.

### 1. `wrStatusToState`: RUNNING → StateProvisioning (not StateReady)

YD reports `RUNNING` the moment a WR is accepted by the scheduler — long before any worker picks the task up, EC2 boots, or helix-sandbox pulls its image. The only real signal that a host is serving is its WebSocket registration. Bridge handles that promotion; HealthCheck no longer prematurely flips to ready.

Surfaced during the live test on 2026-06-09 when a row jumped to ready after 15s despite no real container existing.

### 2. Provider constructs a complete YD task body

`provisionOne` now produces:

```
Arguments:    ["bash-script.sh", HelixURL, RunnerToken, HelixImage]
Environment:  {SANDBOX_INSTANCE_ID: <pre-decided sandbox id>}
Inputs:       [{source: BashScriptSource, destination: "local:bash-script.sh"}]
```

Matches the `yellowdog-poc` `config.toml` shape exactly. SANDBOX_INSTANCE_ID is the env-var bridge from `compute.Manager.provisionOne` to helix-sandbox - the container registers with the matching ID so the auto-register bridge can promote the existing row.

### 3. Config reuses existing Helix vars

New `yellowdog.Config` fields: `HelixURL`, `RunnerToken`, `HelixImage`, `BashScriptSource`.

But the env-var layer is minimal: `HELIX_YD_HELIX_IMAGE` and `HELIX_YD_BASH_SCRIPT_SOURCE` are new; `SERVER_URL` and `RUNNER_TOKEN` are **reused from `cfg.WebServer`** (existing Helix config), not duplicated.

`bootstrap.Bootstrap` signature gains `serverURL, runnerToken string` parameters; `server.NewServer` passes them.

## What is NOT in this PR

- **In-Helix bash-script upload from Go**. Operators today set `HELIX_YD_BASH_SCRIPT_SOURCE` to the data-client URI they pre-uploaded to during pool setup (matches the existing yellowdog-poc workflow). Future work would let Helix upload the script itself via the YD data-client API.

## Test plan

- [x] `go test ./api/pkg/sandbox/compute/... -race` — all 33 tests green
- [x] `go build ./api/...` — wider build clean
- [x] New `TestTaskBodyShape` asserts the task POST body has Arguments, Environment, Inputs all populated correctly
- [x] New `TestTaskArgumentsEmptyWhenConfigIncomplete` asserts defensive fail-fast on missing config
- [ ] Live-test on prime: submit a WR, confirm row stays `provisioning` until `MaxProvisioningAge` (rather than going `ready` prematurely)
- [ ] End-to-end with a real worker pool and bash-script.sh: helix-sandbox starts, registers, bridge promotes to `ready`. Needs prime's known hostname + bash-script.sh pre-uploaded to a YD data-client location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)