### PR TITLE
fix(helix-org): close cross-tenant leaks in the org-graph runtime

### DIFF
--- a/api/pkg/org/application/agent/activations.go
+++ b/api/pkg/org/application/agent/activations.go
@@ -66,7 +66,7 @@ func PublishActivationEvent(
 		return "", err
 	}
 	if bc != nil {
-		bc.Notify(streamID)
+		bc.Notify(orgID, streamID)
 	}
 	return event.ID, nil
 }

--- a/api/pkg/org/application/dispatch/multitenant_harness_test.go
+++ b/api/pkg/org/application/dispatch/multitenant_harness_test.go
@@ -1,0 +1,249 @@
+package dispatch_test
+
+// Multi-tenant isolation gate for the org-graph service layer.
+//
+// WHY THIS FILE EXISTS
+// --------------------
+// The org store is keyed by composite (id, org_id) PKs, so the store
+// layer is tenant-safe by construction (proved in
+// infrastructure/persistence/gorm/multitenant_test.go). Every
+// multi-tenancy bug we've actually shipped lived one layer UP, in the
+// long-lived in-memory structures that sit above the store and were
+// keyed by an id that is unique only WITHIN an org:
+//
+//   - the per-Worker spawner config (frozen to the first org)
+//   - the activation Queue's serialisation lanes (keyed by workerID)
+//   - the transcript Mirror's tracker map (keyed by workerID)
+//   - the streamhub wake topics (keyed by streamID)
+//
+// Every org's owner is "w-owner"; user-named streams like "s-general"
+// collide trivially. So the canonical trigger for this whole bug class
+// is: TWO orgs holding the SAME ids. This file drives that trigger
+// through the real Dispatcher → Queue → Spawner wiring and asserts an
+// event for one org never activates the other org's identically-named
+// Worker.
+//
+// WHEN YOU ADD A NEW PROCESS-WIDE SINGLETON / CACHE to the org runtime,
+// add its colliding-id isolation assertion here (or, for a leaf
+// component, alongside it — see the siblings below) so the gate keeps
+// pace:
+//   - activation:  TestQueueIsolatesSameWorkerIDAcrossOrgs
+//   - helix:       TestMirrorIsolatesSameWorkerIDAcrossOrgs,
+//                  TestSpawnerHonorsSharedSemaphore,
+//                  TestEnsureScopesProjectToParamOrg_NotStructOrgID
+//   - streamhub:   TestNotify_IsolatedAcrossOrgs,
+//                  TestSubscribeAll_IsolatedAcrossOrgs
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/application/dispatch"
+	"github.com/helixml/helix/api/pkg/org/domain/activation"
+	"github.com/helixml/helix/api/pkg/org/domain/environment"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+	"github.com/helixml/helix/api/pkg/org/domain/transport"
+	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
+)
+
+// orgActivation captures one Spawner invocation WITH its org, which is
+// the field the bug class corrupts (the leaf recordedActivation in
+// dispatcher_test.go deliberately drops orgID).
+type orgActivation struct {
+	OrgID    string
+	WorkerID orgchart.WorkerID
+}
+
+// seedTenant provisions one org with a worker + stream + subscription,
+// all using caller-supplied ids. Call it twice with the SAME ids and
+// different orgs to set up a collision.
+func seedTenant(t *testing.T, s *store.Store, orgID string, workerID orgchart.WorkerID, streamID streaming.StreamID) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	role, err := orgchart.NewRole("r-shared", "# Role: shared\nIdentical id across orgs.", nil, nil, now, orgID)
+	if err != nil {
+		t.Fatalf("[%s] new role: %v", orgID, err)
+	}
+	if err := s.Roles.Create(ctx, role); err != nil {
+		t.Fatalf("[%s] create role: %v", orgID, err)
+	}
+	w, err := orgchart.NewAIWorker(workerID, "r-shared", "# "+string(workerID), orgID)
+	if err != nil {
+		t.Fatalf("[%s] new worker: %v", orgID, err)
+	}
+	if err := s.Workers.Create(ctx, w); err != nil {
+		t.Fatalf("[%s] create worker: %v", orgID, err)
+	}
+	env, err := environment.New(workerID, t.TempDir(), now, orgID)
+	if err != nil {
+		t.Fatalf("[%s] new env: %v", orgID, err)
+	}
+	if err := s.Environments.Create(ctx, env); err != nil {
+		t.Fatalf("[%s] create env: %v", orgID, err)
+	}
+	// A local stream (no outbound) so Dispatch's only effect is the
+	// subscriber activation we're asserting on.
+	stream, err := streaming.NewStream(streamID, string(streamID), "", workerID, now, transport.LocalTransport(), orgID)
+	if err != nil {
+		t.Fatalf("[%s] new stream: %v", orgID, err)
+	}
+	if err := s.Streams.Create(ctx, stream); err != nil {
+		t.Fatalf("[%s] create stream: %v", orgID, err)
+	}
+	sub, err := streaming.NewSubscription(string(workerID), streamID, now, orgID)
+	if err != nil {
+		t.Fatalf("[%s] new subscription: %v", orgID, err)
+	}
+	if err := s.Subscriptions.Create(ctx, sub); err != nil {
+		t.Fatalf("[%s] create subscription: %v", orgID, err)
+	}
+}
+
+// TestDispatch_IsolatesCollidingIDsAcrossOrgs is the integration leg of
+// the gate: two orgs with the SAME worker id ("w-owner") subscribed to
+// the SAME stream id ("s-general"). An event for org-a must activate
+// ONLY org-a's worker, under org-a — never org-b's identically-named
+// worker. This exercises the real Dispatcher.Dispatch →
+// Subscriptions.ListForStream(org) → Queue.Enqueue(org) → Spawner(org)
+// path, catching any call site that drops or crosses the org.
+func TestDispatch_IsolatesCollidingIDsAcrossOrgs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := orggorm.GetOrgTestDB(t)
+
+	const (
+		workerID = orgchart.WorkerID("w-owner")    // identical across orgs
+		streamID = streaming.StreamID("s-general") // identical across orgs
+	)
+	seedTenant(t, s, "org-a", workerID, streamID)
+	seedTenant(t, s, "org-b", workerID, streamID)
+
+	rec := make(chan orgActivation, 16)
+	spawner := runtime.Spawner(func(_ context.Context, orgID string, wid orgchart.WorkerID, _ string, _ []activation.Trigger) error {
+		rec <- orgActivation{OrgID: orgID, WorkerID: wid}
+		return nil
+	})
+	d := dispatch.New(s, spawner, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	drain := func(window time.Duration) []orgActivation {
+		deadline := time.After(window)
+		var got []orgActivation
+		for {
+			select {
+			case r := <-rec:
+				got = append(got, r)
+			case <-deadline:
+				sort.Slice(got, func(i, j int) bool { return got[i].OrgID < got[j].OrgID })
+				return got
+			}
+		}
+	}
+
+	// Event for org-a only. NewMessageEvent encodes the canonical
+	// Message envelope the dispatcher parses before fan-out.
+	eA, err := streaming.NewMessageEvent("e-a-1", streamID, "external",
+		streaming.Message{From: "external", Body: "for org-a"}, time.Now().UTC(), "org-a")
+	if err != nil {
+		t.Fatalf("new event a: %v", err)
+	}
+	d.Dispatch(ctx, eA)
+
+	got := drain(500 * time.Millisecond)
+	if len(got) != 1 {
+		t.Fatalf("org-a event produced %d activations, want exactly 1: %+v — a colliding-id worker in another org must not be activated", len(got), got)
+	}
+	if got[0].OrgID != "org-a" || got[0].WorkerID != workerID {
+		t.Fatalf("org-a event activated %+v, want {org-a w-owner} — the activation crossed tenants", got[0])
+	}
+
+	// Now org-b: must activate org-b's worker, under org-b.
+	eB, err := streaming.NewMessageEvent("e-b-1", streamID, "external",
+		streaming.Message{From: "external", Body: "for org-b"}, time.Now().UTC(), "org-b")
+	if err != nil {
+		t.Fatalf("new event b: %v", err)
+	}
+	d.Dispatch(ctx, eB)
+
+	got = drain(500 * time.Millisecond)
+	if len(got) != 1 {
+		t.Fatalf("org-b event produced %d activations, want exactly 1: %+v", len(got), got)
+	}
+	if got[0].OrgID != "org-b" || got[0].WorkerID != workerID {
+		t.Fatalf("org-b event activated %+v, want {org-b w-owner}", got[0])
+	}
+}
+
+// TestDispatch_CollidingIDsActivateConcurrently deterministically pins
+// the activation-queue half of the bug class at the integration level.
+// Two orgs' identically-named "w-owner" must serialise INDEPENDENTLY:
+// an in-flight activation for org-a's w-owner must not block org-b's.
+//
+// The spawner blocks until released. We dispatch to both orgs and
+// require BOTH activations to enter the spawner concurrently. If the
+// queue keyed its lanes by workerID alone (the shipped bug), both orgs'
+// w-owner would share one lane and the second would queue behind the
+// first — only one entry would arrive while blocked and this test would
+// time out.
+func TestDispatch_CollidingIDsActivateConcurrently(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := orggorm.GetOrgTestDB(t)
+
+	const (
+		workerID = orgchart.WorkerID("w-owner")
+		streamID = streaming.StreamID("s-general")
+	)
+	seedTenant(t, s, "org-a", workerID, streamID)
+	seedTenant(t, s, "org-b", workerID, streamID)
+
+	entered := make(chan string, 2) // orgID of each activation that started
+	release := make(chan struct{})
+	spawner := runtime.Spawner(func(_ context.Context, orgID string, _ orgchart.WorkerID, _ string, _ []activation.Trigger) error {
+		entered <- orgID
+		<-release
+		return nil
+	})
+	d := dispatch.New(s, spawner, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	mkEvent := func(id streaming.EventID, org string) streaming.Event {
+		e, err := streaming.NewMessageEvent(id, streamID, "external",
+			streaming.Message{From: "external", Body: "x"}, time.Now().UTC(), org)
+		if err != nil {
+			t.Fatalf("new event: %v", err)
+		}
+		return e
+	}
+	d.Dispatch(ctx, mkEvent("e-a", "org-a"))
+	d.Dispatch(ctx, mkEvent("e-b", "org-b"))
+
+	// Both must enter concurrently — collect two distinct orgs before
+	// releasing either. A shared lane would deliver only one here.
+	got := map[string]struct{}{}
+	deadline := time.After(2 * time.Second)
+	for len(got) < 2 {
+		select {
+		case org := <-entered:
+			got[org] = struct{}{}
+		case <-deadline:
+			close(release)
+			t.Fatalf("only %d/2 colliding-id activations ran concurrently: %v — org-a's w-owner is blocking org-b's (shared lane, cross-tenant)", len(got), got)
+		}
+	}
+	close(release)
+
+	if _, ok := got["org-a"]; !ok {
+		t.Fatal("org-a's w-owner never activated")
+	}
+	if _, ok := got["org-b"]; !ok {
+		t.Fatal("org-b's w-owner never activated")
+	}
+}

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -121,7 +121,7 @@ func (s *Service) Fire(ctx context.Context, orgID string, id orgchart.WorkerID) 
 	state, _ := helix.LoadState(ctx, s.Store, orgID, id)
 
 	if s.Mirror != nil {
-		s.Mirror.Stop(id)
+		s.Mirror.Stop(orgID, id)
 	}
 
 	if s.Helix != nil && state.ProjectID != "" {

--- a/api/pkg/org/application/streamhub/streamhub.go
+++ b/api/pkg/org/application/streamhub/streamhub.go
@@ -33,23 +33,33 @@ import (
 )
 
 // topicPrefix is the NATS subject prefix every wake topic shares.
-// Concrete topics are "<prefix>.<streamID>". The wildcard form
-// "<prefix>.>" matches every per-stream topic, used by SubscribeAll.
+// Concrete topics are "<prefix>.<orgID>.<streamID>". The org segment is
+// REQUIRED: stream IDs are unique only within an org (the store keys
+// streams by the composite (id, org_id)), so two orgs routinely share a
+// stream id — every org's owner activation stream is
+// `s-activations-w-owner`, and user-named streams like `s-general`
+// collide trivially. Without the org token, one org's Notify would wake
+// the other org's subscribers on a colliding id. The per-org wildcard
+// form "<prefix>.<orgID>.>" matches every per-stream topic in one org,
+// used by SubscribeAll.
 //
-// Stream IDs are kebab-case (`s-activations-w-alice` etc.) so they
-// never contain NATS-special characters (`.`, `*`, `>`, whitespace);
-// passing them as a single subject token is safe.
+// Org IDs (`org_…`) and stream IDs (`s-activations-w-alice` etc.) are
+// kebab/underscore tokens that never contain NATS-special characters
+// (`.`, `*`, `>`, whitespace), so passing each as a single subject
+// token is safe.
 const topicPrefix = "helix-org.stream-updates"
 
-// topicFor returns the NATS subject this stream's wake notifications
-// publish to.
-func topicFor(sid streaming.StreamID) string {
-	return topicPrefix + "." + string(sid)
+// topicFor returns the NATS subject this org's stream publishes wake
+// notifications to.
+func topicFor(orgID string, sid streaming.StreamID) string {
+	return topicPrefix + "." + orgID + "." + string(sid)
 }
 
-// wildcardTopic is the NATS-wildcard subscription that matches every
-// per-stream topic — used by SubscribeAll.
-const wildcardTopic = topicPrefix + ".>"
+// wildcardTopicFor is the NATS-wildcard subscription that matches every
+// per-stream topic within one org — used by SubscribeAll.
+func wildcardTopicFor(orgID string) string {
+	return topicPrefix + "." + orgID + ".>"
+}
 
 // Hub is safe for concurrent use. The zero value is not usable; use
 // New.
@@ -96,7 +106,7 @@ func signal(ch chan struct{}) {
 // they are done, typically via defer. Subscribing with an empty list
 // returns a never-woken channel — equivalent to the broadcast
 // behaviour.
-func (h *Hub) Subscribe(streamIDs []streaming.StreamID) chan struct{} {
+func (h *Hub) Subscribe(orgID string, streamIDs []streaming.StreamID) chan struct{} {
 	ch := make(chan struct{}, 1)
 	if len(streamIDs) == 0 {
 		// Track the channel so Unsubscribe is still a no-op (rather
@@ -112,7 +122,7 @@ func (h *Hub) Subscribe(streamIDs []streaming.StreamID) chan struct{} {
 	}
 	pubsubSubs := make([]pubsub.Subscription, 0, len(streamIDs))
 	for _, sid := range streamIDs {
-		sub, err := h.ps.Subscribe(context.Background(), topicFor(sid), handler)
+		sub, err := h.ps.Subscribe(context.Background(), topicFor(orgID, sid), handler)
 		if err != nil {
 			// Tear down partial state to avoid leaking subscriptions.
 			for _, s := range pubsubSubs {
@@ -169,13 +179,14 @@ func (h *Hub) Unsubscribe(streamIDs []streaming.StreamID, ch chan struct{}) {
 // specific stream selected) to refresh whenever any worker writes
 // anywhere. Caller MUST defer UnsubscribeAll.
 //
-// Backed by a NATS wildcard subscription (`helix-org.stream-updates.>`)
-// so it matches every per-stream topic published via Notify. Both the
-// real NATS provider and the in-memory test provider honour wildcard
-// subscriptions.
-func (h *Hub) SubscribeAll() chan struct{} {
+// Backed by a per-org NATS wildcard subscription
+// (`helix-org.stream-updates.<orgID>.>`) so it matches every per-stream
+// topic published via Notify within that org — and ONLY that org. Both
+// the real NATS provider and the in-memory test provider honour
+// wildcard subscriptions.
+func (h *Hub) SubscribeAll(orgID string) chan struct{} {
 	ch := make(chan struct{}, 1)
-	sub, err := h.ps.Subscribe(context.Background(), wildcardTopic, func(_ []byte) error {
+	sub, err := h.ps.Subscribe(context.Background(), wildcardTopicFor(orgID), func(_ []byte) error {
 		signal(ch)
 		return nil
 	})
@@ -211,9 +222,9 @@ func (h *Hub) UnsubscribeAll(ch chan struct{}) {
 // the wake handler uses select/default, so a subscriber whose channel
 // buffer is full simply drops the signal (coalesced — the subscriber
 // is expected to re-query after waking).
-func (h *Hub) Notify(streamID streaming.StreamID) {
+func (h *Hub) Notify(orgID string, streamID streaming.StreamID) {
 	// Publish payload is nil — this is a pure wake signal. Ignoring
 	// publish errors matches broadcast's contract: Notify was a
 	// best-effort wake-only call with no return value.
-	_ = h.ps.Publish(context.Background(), topicFor(streamID), nil)
+	_ = h.ps.Publish(context.Background(), topicFor(orgID, streamID), nil)
 }

--- a/api/pkg/org/application/streamhub/streamhub_test.go
+++ b/api/pkg/org/application/streamhub/streamhub_test.go
@@ -63,9 +63,9 @@ func TestSubscribeAndNotify_WakesMatchingSubscriber(t *testing.T) { // B1
 	t.Parallel()
 
 	h := newHub(t)
-	ch := h.Subscribe([]streaming.StreamID{"s-a", "s-b"})
+	ch := h.Subscribe("org-test", []streaming.StreamID{"s-a", "s-b"})
 	time.Sleep(subInstall)
-	h.Notify("s-a")
+	h.Notify("org-test", "s-a")
 	select {
 	case <-ch:
 	case <-time.After(waitForWake):
@@ -77,9 +77,9 @@ func TestNotify_IgnoresOtherStreams(t *testing.T) { // B2
 	t.Parallel()
 
 	h := newHub(t)
-	ch := h.Subscribe([]streaming.StreamID{"s-a"})
+	ch := h.Subscribe("org-test", []streaming.StreamID{"s-a"})
 	time.Sleep(subInstall)
-	h.Notify("s-b")
+	h.Notify("org-test", "s-b")
 	select {
 	case <-ch:
 		t.Fatalf("subscriber woke on unrelated stream")
@@ -91,10 +91,10 @@ func TestNotify_CoalescesBurstyNotifications(t *testing.T) { // B3
 	t.Parallel()
 
 	h := newHub(t)
-	ch := h.Subscribe([]streaming.StreamID{"s-a"})
+	ch := h.Subscribe("org-test", []streaming.StreamID{"s-a"})
 	time.Sleep(subInstall)
 	for i := 0; i < 100; i++ {
-		h.Notify("s-a")
+		h.Notify("org-test", "s-a")
 	}
 	// Drain the first wake-up. With pubsub-backed delivery this may
 	// take a few ms to appear; the 1 s wake timeout absorbs that.
@@ -125,10 +125,10 @@ func TestUnsubscribe_StopsDelivery(t *testing.T) { // B4
 	t.Parallel()
 
 	h := newHub(t)
-	ch := h.Subscribe([]streaming.StreamID{"s-a"})
+	ch := h.Subscribe("org-test", []streaming.StreamID{"s-a"})
 	time.Sleep(subInstall)
 	h.Unsubscribe([]streaming.StreamID{"s-a"}, ch)
-	h.Notify("s-a")
+	h.Notify("org-test", "s-a")
 	select {
 	case <-ch:
 		t.Fatalf("woke after unsubscribe")
@@ -144,7 +144,7 @@ func TestNotify_WakesEveryMatchingSubscriber(t *testing.T) { // B5
 	var wg sync.WaitGroup
 	channels := make([]chan struct{}, n)
 	for i := range channels {
-		channels[i] = h.Subscribe([]streaming.StreamID{"s-a"})
+		channels[i] = h.Subscribe("org-test", []streaming.StreamID{"s-a"})
 	}
 	time.Sleep(subInstall)
 	for i := range channels {
@@ -158,7 +158,7 @@ func TestNotify_WakesEveryMatchingSubscriber(t *testing.T) { // B5
 			}
 		}(channels[i])
 	}
-	h.Notify("s-a")
+	h.Notify("org-test", "s-a")
 	wg.Wait()
 }
 
@@ -168,11 +168,11 @@ func TestSubscriber_RegisteredForMultipleStreams_WakesOnAny(t *testing.T) { // B
 	t.Parallel()
 
 	h := newHub(t)
-	ch := h.Subscribe([]streaming.StreamID{"s-a", "s-b", "s-c"})
+	ch := h.Subscribe("org-test", []streaming.StreamID{"s-a", "s-b", "s-c"})
 	time.Sleep(subInstall)
 
 	// Notify on s-b — the middle one — to prove order doesn't matter.
-	h.Notify("s-b")
+	h.Notify("org-test", "s-b")
 	select {
 	case <-ch:
 	case <-time.After(waitForWake):
@@ -180,7 +180,7 @@ func TestSubscriber_RegisteredForMultipleStreams_WakesOnAny(t *testing.T) { // B
 	}
 
 	// And again on s-c after draining.
-	h.Notify("s-c")
+	h.Notify("org-test", "s-c")
 	select {
 	case <-ch:
 	case <-time.After(waitForWake):
@@ -192,11 +192,11 @@ func TestSubscribeAll_WakesOnAnyNotify(t *testing.T) { // B7
 	t.Parallel()
 
 	h := newHub(t)
-	ch := h.SubscribeAll()
+	ch := h.SubscribeAll("org-test")
 	time.Sleep(subInstall)
 
 	// No registration for a specific stream, yet any Notify wakes it.
-	h.Notify("s-anything")
+	h.Notify("org-test", "s-anything")
 	select {
 	case <-ch:
 	case <-time.After(waitForWake):
@@ -204,7 +204,7 @@ func TestSubscribeAll_WakesOnAnyNotify(t *testing.T) { // B7
 	}
 
 	// A second, unrelated stream — same listener wakes again.
-	h.Notify("s-different")
+	h.Notify("org-test", "s-different")
 	select {
 	case <-ch:
 	case <-time.After(waitForWake):
@@ -216,11 +216,11 @@ func TestUnsubscribeAll_StopsDelivery(t *testing.T) { // B8
 	t.Parallel()
 
 	h := newHub(t)
-	ch := h.SubscribeAll()
+	ch := h.SubscribeAll("org-test")
 	time.Sleep(subInstall)
 	h.UnsubscribeAll(ch)
 
-	h.Notify("s-x")
+	h.Notify("org-test", "s-x")
 	select {
 	case <-ch:
 		t.Fatalf("SubscribeAll listener woke after UnsubscribeAll")
@@ -235,17 +235,17 @@ func TestNotify_NonBlockingOnFullSubscriberChannel(t *testing.T) { // B9
 	// Subscribe but never drain the channel — the second notify must
 	// not block. If Notify weren't non-blocking, this test would hang
 	// past the timeout and fail.
-	ch := h.Subscribe([]streaming.StreamID{"s-a"})
+	ch := h.Subscribe("org-test", []streaming.StreamID{"s-a"})
 	_ = ch // not draining intentionally
 	time.Sleep(subInstall)
 
 	// First Notify fills the channel.
-	h.Notify("s-a")
+	h.Notify("org-test", "s-a")
 	// Subsequent Notifies must coalesce silently — none of them block.
 	done := make(chan struct{})
 	go func() {
 		for i := 0; i < 1000; i++ {
-			h.Notify("s-a")
+			h.Notify("org-test", "s-a")
 		}
 		close(done)
 	}()
@@ -260,7 +260,7 @@ func TestUnsubscribe_EmptyStreamListIsNoop(t *testing.T) { // B10
 	t.Parallel()
 
 	h := newHub(t)
-	ch := h.Subscribe([]streaming.StreamID{"s-a"})
+	ch := h.Subscribe("org-test", []streaming.StreamID{"s-a"})
 	time.Sleep(subInstall)
 
 	// Calling Unsubscribe with an empty list MUST NOT panic and MUST
@@ -269,7 +269,7 @@ func TestUnsubscribe_EmptyStreamListIsNoop(t *testing.T) { // B10
 	h.Unsubscribe(nil, ch)
 	h.Unsubscribe([]streaming.StreamID{}, ch)
 
-	h.Notify("s-a")
+	h.Notify("org-test", "s-a")
 	select {
 	case <-ch:
 	case <-time.After(waitForWake):
@@ -290,7 +290,7 @@ func TestConcurrent_SubscribeNotifyUnsubscribe_RaceFree(t *testing.T) { // B11
 
 	// One durable subscriber registered before any Notify — guaranteed
 	// to observe at least one wake.
-	durable := h.Subscribe([]streaming.StreamID{"s-shared"})
+	durable := h.Subscribe("org-test", []streaming.StreamID{"s-shared"})
 	time.Sleep(subInstall)
 
 	var wg sync.WaitGroup
@@ -303,7 +303,7 @@ func TestConcurrent_SubscribeNotifyUnsubscribe_RaceFree(t *testing.T) { // B11
 			defer wg.Done()
 			<-start
 			for i := 0; i < iterations; i++ {
-				h.Notify("s-shared")
+				h.Notify("org-test", "s-shared")
 			}
 		}()
 	}
@@ -317,7 +317,7 @@ func TestConcurrent_SubscribeNotifyUnsubscribe_RaceFree(t *testing.T) { // B11
 			defer wg.Done()
 			<-start
 			for i := 0; i < iterations; i++ {
-				ch := h.Subscribe([]streaming.StreamID{"s-shared"})
+				ch := h.Subscribe("org-test", []streaming.StreamID{"s-shared"})
 				h.Unsubscribe([]streaming.StreamID{"s-shared"}, ch)
 			}
 		}()
@@ -334,5 +334,60 @@ func TestConcurrent_SubscribeNotifyUnsubscribe_RaceFree(t *testing.T) { // B11
 	case <-durable:
 	case <-time.After(waitForWake):
 		t.Fatalf("durable subscriber did not observe a wake across %d notifies", goroutines*iterations)
+	}
+}
+
+// TestNotify_IsolatedAcrossOrgs is the regression test for the
+// cross-tenant wake leak (design/2026-06-09-org-multitenancy-spawner-leak.md).
+//
+// Stream IDs are unique only within an org, so two orgs share ids like
+// `s-general` and `s-activations-w-owner`. The wake topic must include
+// the org, otherwise one org's Notify wakes the other org's subscriber
+// on a colliding id. Here both orgs subscribe to the SAME id; a Notify
+// for org-a must wake only org-a.
+func TestNotify_IsolatedAcrossOrgs(t *testing.T) {
+	t.Parallel()
+
+	h := newHub(t)
+	chA := h.Subscribe("org-a", []streaming.StreamID{"s-general"})
+	chB := h.Subscribe("org-b", []streaming.StreamID{"s-general"})
+	time.Sleep(subInstall)
+
+	h.Notify("org-a", "s-general")
+
+	select {
+	case <-chA:
+	case <-time.After(waitForWake):
+		t.Fatalf("org-a subscriber did not wake on its own org's Notify")
+	}
+	select {
+	case <-chB:
+		t.Fatalf("org-b subscriber woke on org-a's Notify for a colliding stream id — cross-tenant wake leak")
+	case <-time.After(waitForNonWake):
+	}
+}
+
+// TestSubscribeAll_IsolatedAcrossOrgs pins that the wildcard live-view
+// subscription is org-scoped: SubscribeAll for org-a must not fire on
+// org-b's Notify.
+func TestSubscribeAll_IsolatedAcrossOrgs(t *testing.T) {
+	t.Parallel()
+
+	h := newHub(t)
+	ch := h.SubscribeAll("org-a")
+	time.Sleep(subInstall)
+
+	h.Notify("org-b", "s-anything")
+	select {
+	case <-ch:
+		t.Fatalf("org-a SubscribeAll woke on org-b's Notify — wildcard is not org-scoped")
+	case <-time.After(waitForNonWake):
+	}
+
+	h.Notify("org-a", "s-anything")
+	select {
+	case <-ch:
+	case <-time.After(waitForWake):
+		t.Fatalf("org-a SubscribeAll did not wake on its own org's Notify")
 	}
 }

--- a/api/pkg/org/application/tools/dm.go
+++ b/api/pkg/org/application/tools/dm.go
@@ -117,7 +117,7 @@ func (t *DM) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, 
 		return nil, err
 	}
 	if t.deps.Hub != nil {
-		t.deps.Hub.Notify(streamID)
+		t.deps.Hub.Notify(orgID, streamID)
 	}
 	if t.deps.Dispatcher != nil {
 		t.deps.Dispatcher.Dispatch(ctx, event)

--- a/api/pkg/org/application/tools/publish.go
+++ b/api/pkg/org/application/tools/publish.go
@@ -104,7 +104,7 @@ func (t *Publish) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMess
 	}
 	// Wake long-poll observers (read_events with wait>0).
 	if t.deps.Hub != nil {
-		t.deps.Hub.Notify(streamID)
+		t.deps.Hub.Notify(orgID, streamID)
 	}
 	// Activate every subscribed AI Worker. Background; returns immediately.
 	if t.deps.Dispatcher != nil {

--- a/api/pkg/org/application/tools/read_events.go
+++ b/api/pkg/org/application/tools/read_events.go
@@ -173,7 +173,7 @@ func (t *ReadEvents) Invoke(ctx context.Context, inv tool.Invocation) (json.RawM
 	for _, sub := range subs {
 		streamIDs = append(streamIDs, sub.StreamID)
 	}
-	wake := t.deps.Hub.Subscribe(streamIDs)
+	wake := t.deps.Hub.Subscribe(orgID, streamIDs)
 	defer t.deps.Hub.Unsubscribe(streamIDs, wake)
 
 	timer := time.NewTimer(time.Duration(wait) * time.Second)

--- a/api/pkg/org/application/tools/worker_log.go
+++ b/api/pkg/org/application/tools/worker_log.go
@@ -185,7 +185,7 @@ func (t *WorkerLog) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMe
 		return marshalEvents(fresh), nil
 	}
 
-	wake := t.deps.Hub.Subscribe([]streaming.StreamID{streamID})
+	wake := t.deps.Hub.Subscribe(orgID, []streaming.StreamID{streamID})
 	defer t.deps.Hub.Unsubscribe([]streaming.StreamID{streamID}, wake)
 
 	timer := time.NewTimer(time.Duration(wait) * time.Second)

--- a/api/pkg/org/domain/activation/queue.go
+++ b/api/pkg/org/domain/activation/queue.go
@@ -37,7 +37,20 @@ type Spawn func(ctx context.Context, orgID string, workerID orgchart.WorkerID, e
 type Queue struct {
 	spawn  Spawn
 	logger *slog.Logger
-	lanes  sync.Map // map[orgchart.WorkerID]*workerLane
+	lanes  sync.Map // map[laneKey]*workerLane
+}
+
+// laneKey identifies a serialisation lane. It MUST include orgID:
+// Worker IDs are only unique within an org (the store keys workers by
+// the composite (org_id, id)), so the owner of every org shares the id
+// "w-owner". Keying lanes by workerID alone collapses every org's
+// w-owner into one lane — their triggers coalesce into a single batch
+// and lane.orgID becomes last-writer-wins, so one org's activation runs
+// under another org's context (wrong project, MCP URL, secrets). The
+// composite key keeps each tenant's lane separate.
+type laneKey struct {
+	orgID    string
+	workerID orgchart.WorkerID
 }
 
 // NewQueue returns a Queue that calls spawn per coalesced batch. spawn
@@ -73,7 +86,7 @@ func (q *Queue) Enqueue(orgID string, workerID orgchart.WorkerID, envPath string
 	if q.spawn == nil {
 		return
 	}
-	lane := q.laneFor(workerID)
+	lane := q.laneFor(orgID, workerID)
 	lane.mu.Lock()
 	lane.pending = append(lane.pending, trigger)
 	lane.envPath = envPath // last writer wins; stable in practice
@@ -136,7 +149,7 @@ func (q *Queue) activate(ctx context.Context, orgID string, workerID orgchart.Wo
 	)
 }
 
-func (q *Queue) laneFor(workerID orgchart.WorkerID) *workerLane {
-	got, _ := q.lanes.LoadOrStore(workerID, &workerLane{})
+func (q *Queue) laneFor(orgID string, workerID orgchart.WorkerID) *workerLane {
+	got, _ := q.lanes.LoadOrStore(laneKey{orgID: orgID, workerID: workerID}, &workerLane{})
 	return got.(*workerLane)
 }

--- a/api/pkg/org/domain/activation/queue_test.go
+++ b/api/pkg/org/domain/activation/queue_test.go
@@ -156,3 +156,53 @@ func TestQueueNilSpawnerIsNoop(t *testing.T) {
 	// No goroutine started, no panic; nothing to assert beyond
 	// "didn't crash" and the test returning normally.
 }
+
+// TestQueueIsolatesSameWorkerIDAcrossOrgs is the regression test for the
+// cross-tenant activation leak
+// (design/2026-06-09-org-multitenancy-spawner-leak.md).
+//
+// Worker IDs are unique only within an org — every org's owner is
+// "w-owner". The lane key must therefore include the org. When it
+// didn't, two orgs' "w-owner" shared one lane: the second Enqueue
+// folded into the first's pending list (no parallel runner) and
+// overwrote lane.orgID, so activations ran under the wrong tenant.
+//
+// Here both orgs enqueue the SAME worker id and block in spawn. If they
+// share a lane only one spawn starts and the second test-loop receive
+// times out. With per-(org,worker) lanes both run in parallel, each
+// under its own org.
+func TestQueueIsolatesSameWorkerIDAcrossOrgs(t *testing.T) {
+	t.Parallel()
+	type call struct {
+		org string
+		w   orgchart.WorkerID
+	}
+	started := make(chan call, 2)
+	release := make(chan struct{})
+
+	spawn := func(_ context.Context, org string, w orgchart.WorkerID, _ string, _ []activation.Trigger) error {
+		started <- call{org: org, w: w}
+		<-release
+		return nil
+	}
+
+	q := activation.NewQueue(spawn, nil)
+	q.Enqueue("org-a", "w-owner", "/env/a", activation.Trigger{Kind: activation.TriggerHire})
+	q.Enqueue("org-b", "w-owner", "/env/b", activation.Trigger{Kind: activation.TriggerHire})
+
+	deadline := time.After(2 * time.Second)
+	got := map[string]orgchart.WorkerID{}
+	for len(got) < 2 {
+		select {
+		case c := <-started:
+			got[c.org] = c.w
+		case <-deadline:
+			t.Fatalf("same worker id in two orgs did not run in parallel — they share a lane (cross-tenant); got %+v", got)
+		}
+	}
+	close(release)
+
+	if got["org-a"] != "w-owner" || got["org-b"] != "w-owner" {
+		t.Fatalf("activations not delivered per-org: %+v", got)
+	}
+}

--- a/api/pkg/org/infrastructure/runtime/helix/mirror.go
+++ b/api/pkg/org/infrastructure/runtime/helix/mirror.go
@@ -51,7 +51,19 @@ type Mirror struct {
 	cfg  MirrorConfig
 
 	mu      sync.Mutex
-	tracked map[orgchart.WorkerID]context.CancelFunc
+	tracked map[mirrorKey]context.CancelFunc
+}
+
+// mirrorKey identifies a tracked worker. It MUST include orgID: worker
+// IDs are unique only within an org (the store keys workers by the
+// composite (org_id, id)), so every org's owner shares the id
+// "w-owner". Keying trackers by workerID alone collapses every org's
+// w-owner into one entry — the second org's Ensure sees the key already
+// present and no-ops, so that org's transcript is never mirrored, and
+// Stop tears down whichever org happens to hold the slot.
+type mirrorKey struct {
+	orgID    string
+	workerID orgchart.WorkerID
 }
 
 // NewMirror constructs a Mirror. base bounds every tracker (typically
@@ -63,7 +75,7 @@ func NewMirror(base context.Context, cfg MirrorConfig) *Mirror {
 	return &Mirror{
 		base:    base,
 		cfg:     cfg,
-		tracked: map[orgchart.WorkerID]context.CancelFunc{},
+		tracked: map[mirrorKey]context.CancelFunc{},
 	}
 }
 
@@ -81,13 +93,14 @@ func (m *Mirror) Ensure(orgID string, workerID orgchart.WorkerID) {
 	if m == nil || m.cfg.PubSub == nil {
 		return
 	}
+	key := mirrorKey{orgID: orgID, workerID: workerID}
 	m.mu.Lock()
-	if _, ok := m.tracked[workerID]; ok {
+	if _, ok := m.tracked[key]; ok {
 		m.mu.Unlock()
 		return
 	}
 	ctx, cancel := context.WithCancel(m.base)
-	m.tracked[workerID] = cancel
+	m.tracked[key] = cancel
 	m.mu.Unlock()
 	go m.track(ctx, orgID, workerID)
 }
@@ -111,16 +124,19 @@ func (m *Mirror) EnsureAll(ctx context.Context, orgID string) {
 	}
 }
 
-// Stop stops tracking a worker (on fire).
-func (m *Mirror) Stop(workerID orgchart.WorkerID) {
+// Stop stops tracking a worker (on fire). orgID is required — trackers
+// are keyed per (org, worker), so a bare workerID would tear down the
+// wrong tenant's tracker when two orgs share the id.
+func (m *Mirror) Stop(orgID string, workerID orgchart.WorkerID) {
 	if m == nil {
 		return
 	}
+	key := mirrorKey{orgID: orgID, workerID: workerID}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if cancel, ok := m.tracked[workerID]; ok {
+	if cancel, ok := m.tracked[key]; ok {
 		cancel()
-		delete(m.tracked, workerID)
+		delete(m.tracked, key)
 	}
 }
 

--- a/api/pkg/org/infrastructure/runtime/helix/mirror_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/mirror_test.go
@@ -228,8 +228,47 @@ func TestMirrorStop(t *testing.T) {
 	if !waitForHandlers(ps, topic, 1) {
 		t.Fatal("mirror never subscribed")
 	}
-	m.Stop(wid)
+	m.Stop("org-test", wid)
 	if !waitForHandlers(ps, topic, 0) {
 		t.Fatal("Stop did not drop the subscription")
+	}
+}
+
+// TestMirrorIsolatesSameWorkerIDAcrossOrgs is the regression test for the
+// cross-tenant tracker collision (design/2026-06-09-org-multitenancy-spawner-leak.md).
+//
+// The Mirror is a process-wide singleton keyed per worker. Worker IDs
+// are unique only within an org — every org's owner is "w-owner" — so
+// keying trackers by workerID alone collapses two orgs into one entry:
+// the second org's Ensure no-ops (its transcript never mirrors) and a
+// Stop tears down whichever org holds the slot. Trackers must be keyed
+// by (org, worker).
+func TestMirrorIsolatesSameWorkerIDAcrossOrgs(t *testing.T) {
+	t.Parallel()
+	s, wid := newHelixTestStore(t)
+	ps := newFakePubSub()
+	m, _ := newTestMirror(t, s, ps, "u-owner")
+
+	m.Ensure("org-a", wid)
+	m.Ensure("org-b", wid) // same worker id, different org
+
+	count := func() int { m.mu.Lock(); defer m.mu.Unlock(); return len(m.tracked) }
+	has := func(org string) bool {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		_, ok := m.tracked[mirrorKey{orgID: org, workerID: wid}]
+		return ok
+	}
+
+	if count() != 2 {
+		t.Fatalf("tracked = %d, want 2 — same worker id in two orgs must track separately (cross-tenant)", count())
+	}
+	// Stopping one org must leave the other's tracker intact.
+	m.Stop("org-a", wid)
+	if has("org-a") {
+		t.Fatal("org-a tracker should be gone after its own Stop")
+	}
+	if !has("org-b") {
+		t.Fatal("org-b tracker was torn down by org-a's Stop — Stop is org-blind (cross-tenant)")
 	}
 }

--- a/api/pkg/org/infrastructure/runtime/helix/project.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project.go
@@ -173,7 +173,12 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 		runtime = Runtime
 	}
 	applyReq := types.ProjectApplyRequest{
-		OrganizationID: a.OrgID,
+		// Scope the project to the org this Ensure call was invoked for,
+		// not the struct's OrgID field. They are normally equal, but a
+		// caller that reuses a WorkerProject across orgs (or stamps OrgID
+		// from frozen config) must not be able to apply one org's project
+		// into another — the org parameter is the authority here.
+		OrganizationID: orgID,
 		Name:           string(workerID),
 		Spec: types.ProjectSpec{
 			Description: worker.IdentityContent(),

--- a/api/pkg/org/infrastructure/runtime/helix/project_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_test.go
@@ -629,3 +629,36 @@ func TestEnsureLogsButDoesNotFailOnPutFileError(t *testing.T) {
 		t.Fatalf("Ensure must not fail on PutFile error; got %v", err)
 	}
 }
+
+// TestEnsureScopesProjectToParamOrg_NotStructOrgID is the unit-level
+// pin for the cross-tenant leak fix
+// (design/2026-06-09-org-multitenancy-spawner-leak.md).
+//
+// WorkerProject.Ensure takes an orgID parameter AND carries an OrgID
+// struct field. They are normally equal, but the production spawner
+// used to freeze one org's identity onto a process-wide SpawnerConfig
+// and replay it for every org — so a WorkerProject built for org A
+// would .Ensure() worker activations for org B. If Ensure stamps the
+// project with the struct field (a.OrgID) instead of the orgID it was
+// invoked for, org B's worker project lands in org A — the root of the
+// leak. This test forces the two apart and asserts the parameter wins.
+func TestEnsureScopesProjectToParamOrg_NotStructOrgID(t *testing.T) {
+	t.Parallel()
+	// Worker exists in org-test (newProjectTestStore seeds there).
+	st, wid := newProjectTestStore(t, "# Role: engineer")
+	svc := newFakeProjectService()
+	git := newFakeGitForProject()
+	a := newApplierGit(svc, git, st)
+	// Frozen, WRONG org on the struct — simulates a reused/cached config.
+	a.OrgID = "org-OTHER-TENANT"
+
+	if _, _, _, err := a.Ensure(context.Background(), "org-test", wid); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	if svc.lastApplyReq.OrganizationID != "org-test" {
+		t.Fatalf("ApplyProject OrganizationID = %q, want org-test — Ensure must scope to the org it was invoked for, not the struct's frozen OrgID (cross-tenant leak)", svc.lastApplyReq.OrganizationID)
+	}
+}

--- a/api/pkg/org/infrastructure/runtime/helix/spawner.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner.go
@@ -26,6 +26,11 @@ import (
 // ProjectID of its own — every AI Worker gets its own Helix project,
 // applied at hire time and persisted in the WorkerRuntimeState
 // sidecar under the "helix" backend.
+// DefaultMaxInflight bounds concurrent activations when a SpawnerConfig
+// doesn't set MaxInflight. The host also uses it to size the shared
+// semaphore it injects via SpawnerConfig.Sem.
+const DefaultMaxInflight = 8
+
 type SpawnerConfig struct {
 	Client         SpawnerClient
 	ProjectService ProjectService
@@ -101,7 +106,15 @@ type SpawnerConfig struct {
 	OrgID             string
 	ActivationTimeout time.Duration
 	MaxInflight       int
-	PollInitial       time.Duration // default 250ms
+	// Sem, when non-nil, is the inflight semaphore the Spawner acquires
+	// a slot from instead of minting its own from MaxInflight. The host
+	// builds one fresh SpawnerConfig per activation (so OrgID /
+	// HelixOrgURL stay scoped to the activating org — never frozen to
+	// whichever org activated first), and shares a single Sem across all
+	// of them to keep one process-wide inflight cap. Nil falls back to a
+	// per-config semaphore of size MaxInflight.
+	Sem         chan struct{}
+	PollInitial time.Duration // default 250ms
 	PollMax           time.Duration // default 30s
 	Logger            *slog.Logger
 	Store             *store.Store
@@ -134,9 +147,15 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 		cfg.ActivationTimeout = 5 * time.Minute
 	}
 	if cfg.MaxInflight <= 0 {
-		cfg.MaxInflight = 8
+		cfg.MaxInflight = DefaultMaxInflight
 	}
-	sem := make(chan struct{}, cfg.MaxInflight)
+	// Prefer a host-supplied shared semaphore so multiple per-org
+	// SpawnerConfigs enforce one global inflight cap; otherwise mint one
+	// sized to this config's MaxInflight.
+	sem := cfg.Sem
+	if sem == nil {
+		sem = make(chan struct{}, cfg.MaxInflight)
+	}
 	return func(ctx context.Context, orgID string, workerID orgchart.WorkerID, _ string, triggers []activation.Trigger) (retErr error) {
 		if len(triggers) == 0 {
 			return errors.New("spawner invoked with no triggers")

--- a/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
@@ -664,3 +664,50 @@ func TestSpawnerRecordsActivationRowOnError(t *testing.T) {
 		t.Error("Outcome.Error empty on error path")
 	}
 }
+
+// TestSpawnerHonorsSharedSemaphore pins the mechanism that replaced the
+// cross-tenant-leaking cached spawner
+// (design/2026-06-09-org-multitenancy-spawner-leak.md).
+//
+// The old host wrapper cached ONE inner Spawner (and so one org's
+// frozen OrgID/HelixOrgURL) to share a single inflight cap. The fix
+// rebuilds a per-org SpawnerConfig every activation and instead shares
+// the cap via SpawnerConfig.Sem. If Spawner ignores cfg.Sem and mints
+// its own semaphore from MaxInflight, the global cap is silently lost.
+//
+// Here we inject a shared semaphore whose only slot is already taken.
+// A correct Spawner blocks on it and returns the context error without
+// starting a session; a Spawner that ignored cfg.Sem would sail past
+// and call StartChat.
+func TestSpawnerHonorsSharedSemaphore(t *testing.T) {
+	t.Parallel()
+	s, wid := newHelixTestStore(t)
+	fc := &fakeHelixClient{
+		startSessionID: "ses_new",
+		outputs:        []types.SessionOutputResponse{{Status: "complete", Output: "ok"}},
+	}
+	cfg := newHelixCfg(t, fc, s)
+	sem := make(chan struct{}, 1)
+	sem <- struct{}{} // occupy the only slot — no inflight budget left
+	cfg.Sem = sem
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	err := Spawner(cfg)(ctx, "org-test", wid, "", []activation.Trigger{{Kind: activation.TriggerHire}})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded while the shared semaphore is full, got %v", err)
+	}
+	if got := atomic.LoadInt32(&fc.startCalls); got != 0 {
+		t.Fatalf("StartChat fired %d times despite a full shared semaphore — Spawner ignored cfg.Sem and the global inflight cap is lost", got)
+	}
+
+	// Free the slot; the next activation must now proceed to completion,
+	// proving the gate was the semaphore and nothing else.
+	<-sem
+	if err := Spawner(cfg)(context.Background(), "org-test", wid, "", []activation.Trigger{{Kind: activation.TriggerHire}}); err != nil {
+		t.Fatalf("activation with a free shared-semaphore slot must succeed, got %v", err)
+	}
+	if got := atomic.LoadInt32(&fc.startCalls); got != 1 {
+		t.Fatalf("StartChat calls = %d, want 1 after the slot freed", got)
+	}
+}

--- a/api/pkg/org/infrastructure/streamcron/scheduler.go
+++ b/api/pkg/org/infrastructure/streamcron/scheduler.go
@@ -320,7 +320,7 @@ func (c *Scheduler) fire(ctx context.Context, orgID string, streamID streaming.S
 		return fmt.Errorf("append event: %w", err)
 	}
 	if c.hub != nil {
-		c.hub.Notify(streamID)
+		c.hub.Notify(orgID, streamID)
 	}
 	c.dispatcher.Dispatch(ctx, event)
 	return nil

--- a/api/pkg/org/infrastructure/transports/github/github.go
+++ b/api/pkg/org/infrastructure/transports/github/github.go
@@ -342,7 +342,7 @@ func (t *Transport) HandleInbound() http.Handler {
 				continue
 			}
 			if t.broadcaster != nil {
-				t.broadcaster.Notify(s.ID)
+				t.broadcaster.Notify(t.orgID, s.ID)
 			}
 			if t.dispatcher != nil {
 				t.dispatcher.Dispatch(r.Context(), event)
@@ -481,7 +481,7 @@ func (t *Transport) HandleInboundForStream(streamID streaming.StreamID) http.Han
 			return
 		}
 		if t.broadcaster != nil {
-			t.broadcaster.Notify(stream.ID)
+			t.broadcaster.Notify(t.orgID, stream.ID)
 		}
 		if t.dispatcher != nil {
 			t.dispatcher.Dispatch(r.Context(), event)

--- a/api/pkg/org/infrastructure/transports/postmark/postmark.go
+++ b/api/pkg/org/infrastructure/transports/postmark/postmark.go
@@ -311,7 +311,7 @@ func (t *Transport) HandleInbound() http.Handler {
 			return
 		}
 		if t.broadcaster != nil {
-			t.broadcaster.Notify(stream.ID)
+			t.broadcaster.Notify(t.orgID, stream.ID)
 		}
 		if t.dispatcher != nil {
 			t.dispatcher.Dispatch(r.Context(), event)

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -1644,7 +1644,7 @@ func (a *apiHandler) streamEventsSSE(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, errors.New("stream id is required"))
 		return
 	}
-	wake := a.deps.Hub.Subscribe([]streaming.StreamID{streaming.StreamID(streamID)})
+	wake := a.deps.Hub.Subscribe(orgID, []streaming.StreamID{streaming.StreamID(streamID)})
 	defer a.deps.Hub.Unsubscribe([]streaming.StreamID{streaming.StreamID(streamID)}, wake)
 
 	w.Header().Set("Content-Type", "text/event-stream")
@@ -1769,7 +1769,7 @@ func (a *apiHandler) publishToStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if a.deps.Hub != nil {
-		a.deps.Hub.Notify(streamID)
+		a.deps.Hub.Notify(orgID, streamID)
 	}
 	if a.deps.Dispatcher != nil {
 		a.deps.Dispatcher.Dispatch(ctx, ev)

--- a/api/pkg/org/interfaces/server/webhook.go
+++ b/api/pkg/org/interfaces/server/webhook.go
@@ -98,7 +98,7 @@ func (s *Server) webhookHandler() http.Handler {
 		}
 
 		if s.broadcaster != nil {
-			s.broadcaster.Notify(streamID)
+			s.broadcaster.Notify(orgID, streamID)
 		}
 		if s.dispatcher != nil {
 			s.dispatcher.Dispatch(r.Context(), event)

--- a/api/pkg/org/interfaces/server/webhook_test.go
+++ b/api/pkg/org/interfaces/server/webhook_test.go
@@ -99,7 +99,7 @@ func TestWebhookPostAppendsEvent(t *testing.T) {
 	srv, s, bc := newWebhookServer(t, rd)
 	seedStream(t, s, "s-inbox", transport.KindWebhook)
 
-	wake := bc.Subscribe([]streaming.StreamID{"s-inbox"})
+	wake := bc.Subscribe("org-test", []streaming.StreamID{"s-inbox"})
 	t.Cleanup(func() { bc.Unsubscribe([]streaming.StreamID{"s-inbox"}, wake) })
 	// streamhub is pubsub-backed (NATS); the SUB has to round-trip to
 	// the embedded server before Publish can route to us. Give it a

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -913,27 +912,33 @@ func buildHelixOrgSpawnerConfig(
 	}, nil
 }
 
-// lazyHelixOrgSpawner returns an runtime.Spawner that defers building
-// the underlying SpawnerConfig (and the wrapped helix.Spawner closure)
-// until the first activation arrives. Subsequent activations reuse
-// the same built Spawner — semaphore + MaxInflight live on the
-// inner closure, so they're shared across calls.
+// lazyHelixOrgSpawner returns a runtime.Spawner that builds a fresh
+// SpawnerConfig, scoped to the activating org, on every activation.
 //
-// Re-reads SpawnerConfig only if the first attempt failed; this lets
-// "pick an agent" flow seamlessly after API boot without restart.
+// It MUST NOT cache a single inner Spawner across orgs. SpawnerConfig
+// carries tenant-specific identity — OrgID and HelixOrgURL
+// (`/api/v1/mcp/helix-org/<orgID>`) — which the inner spawner stamps
+// onto every Worker's project (applyReq.OrganizationID, the
+// HELIX_ORG_URL project secret) and, critically, onto the helix-org
+// MCP entry it re-attaches to the Worker's agent app on every
+// activation. A cached spawner freezes the *first* activating org's
+// identity and replays it for every other org, so org B's owner ends
+// up with an MCP pointing at org A's gateway — and create_role /
+// hire_worker land in org A. (Root cause of the cross-tenant leak; see
+// design/2026-06-09-org-multitenancy-spawner-leak.md.)
 //
-// Worker.* drift handling: once the inner Spawner is built, its
-// captured SpawnerConfig.Runtime/Provider/Model/Credentials are frozen
-// for the life of the process. Those fields are only consumed inside
-// the spawner's own ensureProject call, so we run the dynamic applier
-// first — it re-reads worker.* on every activation and materialises
-// (or fast-paths) the per-Worker project with current settings. The
-// spawner's internal ensureProject then fast-paths against the project
-// our wrapper just touched, and the frozen fields are dead weight.
-// Net effect: changing worker.runtime / credentials / provider / model
-// via the settings page takes effect on the next activation, without
-// disturbing the shared MaxInflight semaphore inside the cached
-// spawner.
+// Building per activation is cheap (a handful of config-registry
+// reads) and also keeps worker.runtime/credentials/provider/model
+// current without any "drift" handling. The one thing the old cache
+// legitimately provided — a single process-wide inflight cap — is
+// preserved by minting one shared semaphore here and injecting it into
+// each per-activation config via SpawnerConfig.Sem.
+//
+// The dynamic applier still runs first: it provisions (or fast-paths)
+// the per-Worker project and attaches the MCP for owner-chat's benefit.
+// The inner spawner re-attaches the MCP after its own ensureProject
+// (ApplyProject wipes Config.Helix), so both must use the correct
+// per-org URL — which they now do.
 func lazyHelixOrgSpawner(
 	cfg *configregistry.Registry,
 	helixStore helixstore.Store,
@@ -949,44 +954,33 @@ func lazyHelixOrgSpawner(
 	now func() time.Time,
 	mirror *runtimehelix.Mirror,
 ) runtime.Spawner {
-	var (
-		mu      sync.Mutex
-		spawner runtime.Spawner
-	)
+	// One inflight cap shared across every per-org spawner config.
+	sem := make(chan struct{}, runtimehelix.DefaultMaxInflight)
 	return func(ctx context.Context, orgID string, workerID orgchart.WorkerID, envPath string, triggers []activation.Trigger) error {
 		// Apply (or fast-path) the per-Worker project with the current
-		// worker.* settings before delegating. Without this, the cached
-		// spawner's first activation bakes whatever worker.* values
-		// were live at boot into the project; later edits via the
-		// settings page never propagate.
+		// worker.* settings before delegating.
 		if applier != nil {
 			if _, _, _, err := applier.Ensure(ctx, orgID, workerID); err != nil {
 				return fmt.Errorf("helix-org spawner: pre-apply project for %s: %w", workerID, err)
 			}
 		}
-		mu.Lock()
-		current := spawner
-		mu.Unlock()
-		if current == nil {
-			cfgVal, err := buildHelixOrgSpawnerConfig(ctx, orgID, cfg, helixStore, spawnerClient, projectSvc, orgStore, bc, ps, logger, secretInjectors, newID, now)
-			if err != nil {
-				return fmt.Errorf("helix-org spawner not configured: %w", err)
-			}
-			cfgVal.Mirror = mirror // shared singleton; not per-org config
-			built := runtimehelix.Spawner(cfgVal)
-			mu.Lock()
-			if spawner == nil {
-				spawner = built
-			}
-			current = spawner
-			mu.Unlock()
-			log.Info().
-				Str("helix_org_url", cfgVal.HelixOrgURL).
-				Str("runtime", cfgVal.Runtime).
-				Str("credentials", cfgVal.Credentials).
-				Msg("helix-org spawner built (zed_external workers)")
+		// Rebuild the SpawnerConfig for THIS org on every activation —
+		// never reuse another org's config. The shared semaphore keeps
+		// the global inflight cap intact.
+		cfgVal, err := buildHelixOrgSpawnerConfig(ctx, orgID, cfg, helixStore, spawnerClient, projectSvc, orgStore, bc, ps, logger, secretInjectors, newID, now)
+		if err != nil {
+			return fmt.Errorf("helix-org spawner not configured: %w", err)
 		}
-		return current(ctx, orgID, workerID, envPath, triggers)
+		cfgVal.Mirror = mirror // process-wide singleton; not per-org config
+		cfgVal.Sem = sem
+		log.Trace().
+			Str("org_id", orgID).
+			Str("worker_id", string(workerID)).
+			Str("helix_org_url", cfgVal.HelixOrgURL).
+			Str("runtime", cfgVal.Runtime).
+			Str("credentials", cfgVal.Credentials).
+			Msg("helix-org spawner: per-org activation")
+		return runtimehelix.Spawner(cfgVal)(ctx, orgID, workerID, envPath, triggers)
 	}
 }
 

--- a/design/2026-06-09-org-multitenancy-spawner-leak.md
+++ b/design/2026-06-09-org-multitenancy-spawner-leak.md
@@ -130,6 +130,21 @@ correctness anyway: topics are now `…stream-updates.<orgID>.<streamID>` and
 `SubscribeAll` uses a per-org wildcard. `Notify`/`Subscribe`/`SubscribeAll`
 gained an `orgID` parameter; all ~10 call sites pass their operating org.
 
+### 4. Transcript Mirror trackers keyed by workerID alone (found on rebase)
+
+`api/pkg/org/infrastructure/runtime/helix/mirror.go`. The session-layer
+`Mirror` (added by the `session-layer transcript mirror` feature on main) is a
+process-wide singleton whose `tracked map[orgchart.WorkerID]context.CancelFunc`
+was keyed by workerID. Identical defect class to #2: every org's `w-owner`
+collapses into one entry, so `Ensure(orgB, "w-owner")` sees the slot occupied
+and silently no-ops (orgB's transcript never mirrors), and `Stop` cancels the
+wrong tenant. Fixed by keying `mirrorKey{orgID, workerID}`; `Stop` now takes
+`orgID`.
+
+This one is instructive: the bug class (org-blind singleton keyed by a
+non-unique id) **reappeared in brand-new code** the moment a singleton was
+added, which is the basis for the systematic-audit recommendation below.
+
 ## Regression tests
 
 - `project_test.go::TestEnsureScopesProjectToParamOrg_NotStructOrgID` — Ensure

--- a/design/2026-06-09-org-multitenancy-spawner-leak.md
+++ b/design/2026-06-09-org-multitenancy-spawner-leak.md
@@ -1,0 +1,151 @@
+# Cross-tenant leak: helix-org spawner freezes the first org's identity
+
+**Date:** 2026-06-09
+**Branch:** `fix/org-multitenancy-leak` (off `main`)
+**Severity:** Critical — cross-tenant data write. Roles/workers created by one
+org's owner land in a *different* org.
+
+## Symptom (reported)
+
+> Created a new org, configured the Helix Org feature for it, asked the owner
+> of that org to create a new role and hire a worker. The role and worker were
+> created in a **different** org.
+
+## Root cause
+
+`lazyHelixOrgSpawner` (`api/pkg/server/helix_org.go`) caches **one**
+process-wide `runtime.Spawner`, built from the **first** org that ever
+activates a worker:
+
+```go
+var spawner runtime.Spawner            // package-lifetime singleton
+...
+if current == nil {
+    cfgVal, _ := buildHelixOrgSpawnerConfig(ctx, orgID, ...) // orgID = FIRST org
+    spawner = runtimehelix.Spawner(cfgVal)                   // OrgID + HelixOrgURL frozen
+}
+return current(ctx, orgID, workerID, ...)                    // reused for EVERY org
+```
+
+`buildHelixOrgSpawnerConfig` bakes two **tenant-specific** values into that
+frozen config:
+
+- `SpawnerConfig.OrgID = orgID`
+- `SpawnerConfig.HelixOrgURL = baseURL + "/api/v1/mcp/helix-org/" + orgID`
+
+Every later activation, for **any** org, reuses the first org's frozen config.
+The frozen values are then actively used (they are NOT "dead weight" as the old
+comment claimed):
+
+1. `SpawnerConfig.ensureProject` (`spawner.go`) builds
+   `WorkerProject{OrgID: c.OrgID, HelixOrgURL: c.HelixOrgURL}` — first org.
+2. `WorkerProject.Ensure` (`project.go:176`) sends
+   `applyReq.OrganizationID = a.OrgID` and (`:236`) writes
+   `HELIX_ORG_URL = a.HelixOrgURL` as a project secret — first org.
+3. `SpawnerConfig.ensureHelixOrgMCP` (`spawner.go:381`) calls
+   `AttachHelixOrgMCP(c.HelixOrgURL, ...)` — first org. **This is the kill
+   shot.** It runs on *every* activation and re-attaches the worker's
+   helix-org MCP entry pointing at the **first org's** gateway URL.
+
+## Attack path (matches the report exactly)
+
+1. Owner clicks *Start Desktop* → `apiHandler.activateWorker`.
+2. Step 1 `dynamicProjectApplier.Ensure(orgB, w-owner)` is **correct** — it
+   rebuilds per-org and attaches the MCP at orgB's URL.
+3. Step 4 `Dispatcher.DispatchManual(orgB, ...)` → `lazyHelixOrgSpawner`.
+4. The cached inner spawner (frozen to orgA, the first org to ever activate)
+   runs `ensureHelixOrgMCP` → re-attaches w-owner's MCP at
+   `/api/v1/mcp/helix-org/<orgA>`, **clobbering** the correct orgB entry.
+5. orgB's owner desktop boots Zed, reads the agent-app config → MCP URL = orgA.
+6. Owner chats "create a role / hire a worker" → MCP call hits
+   `HelixOrgMCPBackend` with orgA in the path → `lookupOrg` resolves orgA →
+   `create_role` / `hire_worker` write into **orgA**.
+
+The MCP gateway, store layer, and tools are all correctly org-scoped (they read
+`org` from the request URL and use composite `(org_id, id)` PKs). The leak is
+purely that the worker's MCP URL is stamped with the wrong org by the frozen
+spawner.
+
+## Fix
+
+Make the spawner genuinely multi-tenant. The host wrapper is the only place
+with per-org config (the `configregistry.Registry`), so it must build the
+SpawnerConfig **per activation**, scoped to the activation's org — never cache
+one org's config and reuse it.
+
+1. `lazyHelixOrgSpawner`: drop the frozen-singleton cache. Build a fresh
+   per-org `SpawnerConfig` on every activation. Preserve the one thing the
+   cache legitimately provided — a single process-wide inflight cap — by
+   creating one shared semaphore and injecting it into each per-activation
+   config.
+2. `SpawnerConfig.Sem` (new, optional): when set, `Spawner()` uses it instead
+   of minting its own. Lets the host share one global semaphore across all
+   per-org spawner instances.
+3. `WorkerProject.Ensure`: use the `orgID` **parameter** for
+   `applyReq.OrganizationID`, not the struct field `a.OrgID`. The function is
+   handed an `orgID`; mixing it with a struct field was the latent
+   inconsistency that let the frozen field leak through. Defence in depth.
+
+Worker.* drift handling is unaffected: `dynamicProjectApplier.Ensure` still
+runs first and re-reads `worker.*` per activation; rebuilding the spawner
+config per activation just means its own copy of those values is now also
+current instead of frozen.
+
+## Two further leaks found during the review
+
+The brief was "review the org-based multi-tenancy," so I swept for other
+process-wide state that should be per-tenant. Two more real leaks:
+
+### 2. Activation queue lane keyed by workerID alone (CRITICAL — second
+root cause of the same symptom)
+
+`api/pkg/org/domain/activation/queue.go`. The dispatcher holds one
+process-wide `Queue`; its serialisation lanes were keyed by `workerID`:
+
+```go
+lanes sync.Map // map[orgchart.WorkerID]*workerLane
+func (q *Queue) laneFor(workerID orgchart.WorkerID) *workerLane { ... }
+```
+
+Worker IDs are unique only within an org — **every** org's owner is
+`w-owner`. So all orgs' `w-owner` shared one lane: a second org's `Enqueue`
+folded its trigger into the first's `pending` and overwrote
+`lane.orgID` (last-writer-wins, queue.go:80). The lane runner then read that
+overwritten `orgID` (queue.go:105) and ran one org's activation under another
+org's context — wrong project, MCP URL, secrets. This independently produces
+the reported symptom.
+
+**Fix:** key lanes by `laneKey{orgID, workerID}`.
+
+### 3. Streamhub wake topics not org-scoped (LOW — spurious wakes, not a
+data leak)
+
+`api/pkg/org/application/streamhub/streamhub.go`. Wake topics were
+`helix-org.stream-updates.<streamID>`. Stream IDs collide across orgs
+(`s-activations-w-owner`, named streams like `s-general`), so one org's
+`Notify` woke another org's subscribers on a colliding id. The hub is
+**wake-only** (nil payload; subscribers re-query their own org-scoped store),
+so this leaks no data — the impact is spurious cross-org wakeups. Fixed for
+correctness anyway: topics are now `…stream-updates.<orgID>.<streamID>` and
+`SubscribeAll` uses a per-org wildcard. `Notify`/`Subscribe`/`SubscribeAll`
+gained an `orgID` parameter; all ~10 call sites pass their operating org.
+
+## Regression tests
+
+- `project_test.go::TestEnsureScopesProjectToParamOrg_NotStructOrgID` — Ensure
+  scopes the project to its `orgID` arg, not the struct's frozen `OrgID`.
+- `spawner_test.go::TestSpawnerHonorsSharedSemaphore` — the inner spawner uses
+  the host-supplied shared `Sem` (the global cap that replaced the cache).
+- `queue_test.go::TestQueueIsolatesSameWorkerIDAcrossOrgs` — two orgs' `w-owner`
+  run in parallel under their own org, not one shared lane.
+- `streamhub_test.go::TestNotify_IsolatedAcrossOrgs` /
+  `TestSubscribeAll_IsolatedAcrossOrgs` — one org's Notify never wakes another
+  org's subscriber on a colliding stream id.
+
+## Not fixed (verified correct during the sweep)
+
+MCP gateway org resolution (`mcp_backend_helix_org.go` reads `org` from the
+URL, `lookupOrg`, `authorizeOrgMember`), the config registry, the tool
+registry, store lookups (composite `(org_id, id)` PKs), the in-proc client
+(service-account scoped; `ApplyProject` honours `req.OrganizationID`), and the
+Workspace (org-agnostic; methods take `orgID` per call).


### PR DESCRIPTION
## Summary

A new org's owner Worker created a Role and hired a Worker **into a different org**. Root-caused to a class of multi-tenancy bugs in the org-graph runtime: process-lifetime in-memory state keyed by an identifier that is only unique *within* an org (every org's owner is `w-owner`; user-named streams like `s-general` collide trivially), or a per-org config frozen into a process-wide singleton.

The store layer is tenant-safe by construction (composite `(id, org_id)` PKs); **every** leak lived one layer up. This PR fixes all of them and adds a colliding-IDs gate so the class can't silently return.

Full write-up: `design/2026-06-09-org-multitenancy-spawner-leak.md`.

## The leaks (and fixes)

1. **Per-Worker spawner frozen to the first org** *(primary cause of the reported bug).* `lazyHelixOrgSpawner` cached one process-wide `Spawner` built from the first org to activate, baking that org's `OrgID` + `HelixOrgURL` (`/api/v1/mcp/helix-org/<orgID>`) into every later org's activations. The inner spawner re-attaches each Worker's helix-org MCP entry at that frozen URL on every activation — so org B's owner desktop booted with an MCP pointing at org A, and `create_role`/`hire_worker` landed in org A. **Fix:** rebuild the `SpawnerConfig` per activation, scoped to the activating org; share the global inflight cap via a new `SpawnerConfig.Sem`. Also hardened `WorkerProject.Ensure` to scope the project to its `orgID` argument, not the struct field.

2. **Activation queue lanes keyed by `workerID` alone** *(independent second cause).* All orgs' `w-owner` shared one serialisation lane; a second org's enqueue folded into the first's batch and overwrote `lane.orgID` (last-writer-wins), running one org's activation under another's context. **Fix:** key lanes by `{orgID, workerID}`.

3. **Transcript Mirror trackers keyed by `workerID` alone** *(surfaced on rebase onto the new session-layer-mirror feature — same defect class, in brand-new code).* The second org's `Ensure` saw the slot occupied and no-op'd (its transcript never mirrored); `Stop` cancelled the wrong tenant. **Fix:** key trackers by `{orgID, workerID}`; `Stop` now takes `orgID`.

4. **Streamhub wake topics not org-scoped** *(low severity — no data leak).* Topics were `…stream-updates.<streamID>`, which collide across orgs, so one org's `Notify` spuriously woke another's subscribers. It's wake-only (subscribers re-query their own org-scoped store), so nothing leaked, but it's still wrong. **Fix:** topics are now `…stream-updates.<orgID>.<streamID>`; `Notify`/`Subscribe`/`SubscribeAll` take an `orgID`, threaded from each call site.

## Verification — static sweep

Enumerated every long-lived/shared structure in the org runtime and confirmed the four above were the complete set. Verified safe (with reasons in the design doc): streamcron scheduler (composite `streamKey`), memorystore (`orgKey`/`lineKey`/`runtimeKey`/`subKey` all include org), the dispatcher (stateless, threads `orgID` per call), github/postmark transports (constructed per-request with the request's org), the tool/prompt/config registries (org-agnostic schema; values are per-org in the store), and workspace `repoLocks` (globally-unique repoID).

## Regression coverage

Per-component colliding-id tests:
- `queue_test.go::TestQueueIsolatesSameWorkerIDAcrossOrgs`
- `mirror_test.go::TestMirrorIsolatesSameWorkerIDAcrossOrgs`
- `spawner_test.go::TestSpawnerHonorsSharedSemaphore`, `project_test.go::TestEnsureScopesProjectToParamOrg_NotStructOrgID`
- `streamhub_test.go::TestNotify_IsolatedAcrossOrgs`, `TestSubscribeAll_IsolatedAcrossOrgs`

Plus a durable integration gate — `dispatch/multitenant_harness_test.go` — driving the real Dispatcher → Queue → Spawner path with two orgs holding identical ids, asserting an event for org-a activates only org-a's `w-owner` (under org-a), and that both orgs' `w-owner` activate **concurrently** (independent lanes, deterministically catching the shared-lane regression). Its header documents the invariant and is the anchor for covering future singletons.

## Testing

`go build ./pkg/org/... ./pkg/server/` clean; all affected suites green (`pkg/org/...`, `pkg/server` helix-org/spawner/inproc). Not yet exercised end-to-end in a running two-org stack — verification is build + unit/integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)