### PR TITLE
feat(yellowdog): cloud-provision sandbox hosts via YD (end-to-end)

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -240,18 +240,6 @@ type Yellowdog struct {
 	// sandbox versions out. The default tracks the latest stable
 	// release; pin to a SHA for reproducible deploys.
 	HelixImage string `envconfig:"HELIX_YD_HELIX_IMAGE" default:"ghcr.io/helixml/helix-sandbox:latest"`
-
-	// BashScriptSource is the YD data-client URI where bash-script.sh
-	// has been pre-uploaded by the operator. The YD worker downloads
-	// it to local:bash-script.sh before running the task. Required;
-	// without it the task has nothing to execute.
-	//
-	// Example (matches the POC yellowdog-poc):
-	//   rclone:S3,type=s3,provider=AWS,env_auth=true,...:bucket-name/path/bash-script.sh
-	//
-	// In-Helix script upload from Go is a follow-up; for now operators
-	// upload once at pool-setup time using yd-submit's data-client.
-	BashScriptSource string `envconfig:"HELIX_YD_BASH_SCRIPT_SOURCE"`
 }
 
 func LoadServerConfig() (ServerConfig, error) {

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -234,9 +234,6 @@ type Yellowdog struct {
 	// MaxRetries caps retry attempts for idempotent YD API requests
 	// (GET, PUT, DELETE). POST is never retried.
 	MaxRetries int `envconfig:"HELIX_YD_MAX_RETRIES" default:"3"`
-
-	// (helix-sandbox image is auto-derived from the Helix build
-	// version - see bootstrap.helixSandboxImage. No env var to set.)
 }
 
 func LoadServerConfig() (ServerConfig, error) {

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -234,6 +234,24 @@ type Yellowdog struct {
 	// MaxRetries caps retry attempts for idempotent YD API requests
 	// (GET, PUT, DELETE). POST is never retried.
 	MaxRetries int `envconfig:"HELIX_YD_MAX_RETRIES" default:"3"`
+
+	// HelixImage is the helix-sandbox image tag the YD task will
+	// docker-run on the worker. Operators bump this to roll new
+	// sandbox versions out. The default tracks the latest stable
+	// release; pin to a SHA for reproducible deploys.
+	HelixImage string `envconfig:"HELIX_YD_HELIX_IMAGE" default:"ghcr.io/helixml/helix-sandbox:latest"`
+
+	// BashScriptSource is the YD data-client URI where bash-script.sh
+	// has been pre-uploaded by the operator. The YD worker downloads
+	// it to local:bash-script.sh before running the task. Required;
+	// without it the task has nothing to execute.
+	//
+	// Example (matches the POC yellowdog-poc):
+	//   rclone:S3,type=s3,provider=AWS,env_auth=true,...:bucket-name/path/bash-script.sh
+	//
+	// In-Helix script upload from Go is a follow-up; for now operators
+	// upload once at pool-setup time using yd-submit's data-client.
+	BashScriptSource string `envconfig:"HELIX_YD_BASH_SCRIPT_SOURCE"`
 }
 
 func LoadServerConfig() (ServerConfig, error) {

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -235,11 +235,8 @@ type Yellowdog struct {
 	// (GET, PUT, DELETE). POST is never retried.
 	MaxRetries int `envconfig:"HELIX_YD_MAX_RETRIES" default:"3"`
 
-	// HelixImage is the helix-sandbox image tag the YD task will
-	// docker-run on the worker. Operators bump this to roll new
-	// sandbox versions out. The default tracks the latest stable
-	// release; pin to a SHA for reproducible deploys.
-	HelixImage string `envconfig:"HELIX_YD_HELIX_IMAGE" default:"ghcr.io/helixml/helix-sandbox:latest"`
+	// (helix-sandbox image is auto-derived from the Helix build
+	// version - see bootstrap.helixSandboxImage. No env var to set.)
 }
 
 func LoadServerConfig() (ServerConfig, error) {

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap.go
@@ -30,7 +30,14 @@ import (
 // are fatal: returning an error from here causes the API server to
 // fail fast at boot rather than start with a half-configured
 // Manager.
-func Bootstrap(cfg config.Compute, store compute.SandboxStore) (*compute.Manager, error) {
+//
+// serverURL and runnerToken come from the wider ServerConfig
+// (cfg.WebServer.URL and cfg.WebServer.RunnerToken). Helix already
+// requires these for its own operation; we reuse them rather than
+// introduce parallel env vars. The Provider injects them into the
+// upstream task environment so helix-sandbox knows how to phone
+// home and how to authenticate.
+func Bootstrap(cfg config.Compute, serverURL, runnerToken string, store compute.SandboxStore) (*compute.Manager, error) {
 	if cfg.Provider == "" {
 		log.Info().Msg("HELIX_COMPUTE_PROVIDER unset; compute subsystem disabled (no Provider, no Manager, no reconcile)")
 		return nil, nil
@@ -63,7 +70,7 @@ func Bootstrap(cfg config.Compute, store compute.SandboxStore) (*compute.Manager
 			Msg("compute: HELIX_COMPUTE_DEPLOYMENT_TAG auto-derived from provider namespace; set explicitly if multiple Helix installs share this YD namespace")
 	}
 
-	provider, err := buildProvider(cfg)
+	provider, err := buildProvider(cfg, serverURL, runnerToken)
 	if err != nil {
 		return nil, fmt.Errorf("build %q provider: %w", cfg.Provider, err)
 	}
@@ -110,7 +117,7 @@ func deriveDeploymentTag(cfg config.Compute) string {
 // buildProvider dispatches on cfg.Provider to construct the
 // appropriate concrete Provider. Add new providers here as
 // implementations land.
-func buildProvider(cfg config.Compute) (compute.Provider, error) {
+func buildProvider(cfg config.Compute, serverURL, runnerToken string) (compute.Provider, error) {
 	switch cfg.Provider {
 	case "yellowdog":
 		// Auto-derive WorkerTag from Namespace when unset, matching
@@ -126,14 +133,18 @@ func buildProvider(cfg config.Compute) (compute.Provider, error) {
 				Msg("compute: HELIX_YD_WORKER_TAG auto-derived from namespace; override if your YD worker pool advertises a different tag")
 		}
 		return yellowdog.NewProvider(yellowdog.Config{
-			APIKeyID:      cfg.Yellowdog.APIKeyID,
-			APISecret:     cfg.Yellowdog.APISecret,
-			BaseURL:       cfg.Yellowdog.BaseURL,
-			Namespace:     cfg.Yellowdog.Namespace,
-			DeploymentTag: cfg.DeploymentTag,
-			WorkerTag:     workerTag,
-			TaskTimeout:   cfg.Yellowdog.TaskTimeout,
-			MaxRetries:    cfg.Yellowdog.MaxRetries,
+			APIKeyID:         cfg.Yellowdog.APIKeyID,
+			APISecret:        cfg.Yellowdog.APISecret,
+			BaseURL:          cfg.Yellowdog.BaseURL,
+			Namespace:        cfg.Yellowdog.Namespace,
+			DeploymentTag:    cfg.DeploymentTag,
+			WorkerTag:        workerTag,
+			TaskTimeout:      cfg.Yellowdog.TaskTimeout,
+			MaxRetries:       cfg.Yellowdog.MaxRetries,
+			HelixURL:         serverURL,
+			RunnerToken:      runnerToken,
+			HelixImage:       cfg.Yellowdog.HelixImage,
+			BashScriptSource: cfg.Yellowdog.BashScriptSource,
 		})
 	default:
 		return nil, fmt.Errorf("unknown HELIX_COMPUTE_PROVIDER %q (supported: \"yellowdog\")", cfg.Provider)

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap.go
@@ -8,7 +8,6 @@ package bootstrap
 import (
 	"errors"
 	"fmt"
-	"regexp"
 
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/data"
@@ -134,6 +133,10 @@ func buildProvider(cfg config.Compute, serverURL, runnerToken string) (compute.P
 				Str("worker_tag", workerTag).
 				Msg("compute: HELIX_YD_WORKER_TAG auto-derived from namespace; override if your YD worker pool advertises a different tag")
 		}
+		sandboxImage, err := helixSandboxImage()
+		if err != nil {
+			return nil, err
+		}
 		return yellowdog.NewProvider(yellowdog.Config{
 			APIKeyID:      cfg.Yellowdog.APIKeyID,
 			APISecret:     cfg.Yellowdog.APISecret,
@@ -145,7 +148,7 @@ func buildProvider(cfg config.Compute, serverURL, runnerToken string) (compute.P
 			MaxRetries:    cfg.Yellowdog.MaxRetries,
 			HelixURL:      serverURL,
 			RunnerToken:   runnerToken,
-			HelixImage:    helixSandboxImage(),
+			HelixImage:    sandboxImage,
 		})
 	default:
 		return nil, fmt.Errorf("unknown HELIX_COMPUTE_PROVIDER %q (supported: \"yellowdog\")", cfg.Provider)
@@ -157,33 +160,43 @@ func buildProvider(cfg config.Compute, serverURL, runnerToken string) (compute.P
 // the sandbox image always matches the control plane that's
 // dispatching it - no version skew, no operator config knob.
 //
-// In production, data.GetHelixVersion() returns the release tag
-// (e.g. "2.11.14") that was baked into the controlplane image via
-// ldflags. Sandbox images are published with the same tag on every
-// release. So the auto-derived ref pulls cleanly.
+// data.GetHelixVersion() returns whatever was baked into the
+// controlplane image at build time via ldflags - release tags
+// ("2.11.14"), release candidates ("2.11.14-rc1"), and per-PR
+// short-SHA tags are all valid. Sandbox images are published at
+// the same tag for every Helix build, so any non-sentinel value
+// has a matching pullable image.
 //
-// In dev / non-release builds, data.GetHelixVersion() returns
-// "<unknown>", a git revision, or "v0.0.0+dev" - none of which have
-// a corresponding published sandbox image. We fall back to "latest"
-// with a loud log line so the operator notices.
-//
-// Pattern: strict X.Y.Z or vX.Y.Z, no pre-release suffix, no build
-// metadata. Rejects "v0.0.0+dev", "<unknown>", git shas, and any
-// "-rc1"-style suffix.
-var releaseTagPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
+// We refuse to proceed when data.GetHelixVersion() returns one of
+// its sentinel values ("<unknown>", empty string) or the dummy
+// dev-default ("v0.0.0+dev", "v0.0.0", "0.0.0"). Those mean the
+// build didn't pin a version and we have no way to know which
+// sandbox image is correct. Fail loudly at boot so the operator
+// fixes the build rather than discovering the mismatch later when
+// YD tasks ERROR on docker pull.
+var sentinelVersions = map[string]bool{
+	"":          true,
+	"<unknown>": true,
+	"v0.0.0":    true,
+	"0.0.0":     true,
+	"v0.0.0+dev": true,
+}
 
-func helixSandboxImage() string {
+func helixSandboxImage() (string, error) {
 	return helixSandboxImageFor(data.GetHelixVersion())
 }
 
 // helixSandboxImageFor is the testable inner. Tests inject specific
 // version strings; the production wrapper above reads from data.
-func helixSandboxImageFor(version string) string {
-	if !releaseTagPattern.MatchString(version) || version == "v0.0.0" || version == "0.0.0" {
-		log.Warn().
-			Str("helix_version", version).
-			Msg("compute: Helix build is not a tagged release; falling back to helix-sandbox:latest. YD tasks may pull a sandbox version that does not match this control plane.")
-		return "ghcr.io/helixml/helix-sandbox:latest"
+func helixSandboxImageFor(version string) (string, error) {
+	if sentinelVersions[version] {
+		return "", fmt.Errorf(
+			"compute: cannot derive helix-sandbox image tag - Helix build version %q is a placeholder, not a real version. "+
+				"YD compute requires a versioned Helix build so the sandbox image (ghcr.io/helixml/helix-sandbox:<version>) "+
+				"matches the control plane. Build with -ldflags=\"-X github.com/helixml/helix/api/pkg/data.Version=X.Y.Z\" "+
+				"or run a tagged release.",
+			version,
+		)
 	}
-	return "ghcr.io/helixml/helix-sandbox:" + version
+	return "ghcr.io/helixml/helix-sandbox:" + version, nil
 }

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap.go
@@ -8,8 +8,10 @@ package bootstrap
 import (
 	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/data"
 	"github.com/helixml/helix/api/pkg/sandbox/compute"
 	"github.com/helixml/helix/api/pkg/sandbox/compute/yellowdog"
 	"github.com/rs/zerolog/log"
@@ -143,9 +145,45 @@ func buildProvider(cfg config.Compute, serverURL, runnerToken string) (compute.P
 			MaxRetries:    cfg.Yellowdog.MaxRetries,
 			HelixURL:      serverURL,
 			RunnerToken:   runnerToken,
-			HelixImage:    cfg.Yellowdog.HelixImage,
+			HelixImage:    helixSandboxImage(),
 		})
 	default:
 		return nil, fmt.Errorf("unknown HELIX_COMPUTE_PROVIDER %q (supported: \"yellowdog\")", cfg.Provider)
 	}
+}
+
+// helixSandboxImage returns the helix-sandbox image tag the YD task
+// should docker-run. Auto-derived from the Helix build version so
+// the sandbox image always matches the control plane that's
+// dispatching it - no version skew, no operator config knob.
+//
+// In production, data.GetHelixVersion() returns the release tag
+// (e.g. "2.11.14") that was baked into the controlplane image via
+// ldflags. Sandbox images are published with the same tag on every
+// release. So the auto-derived ref pulls cleanly.
+//
+// In dev / non-release builds, data.GetHelixVersion() returns
+// "<unknown>", a git revision, or "v0.0.0+dev" - none of which have
+// a corresponding published sandbox image. We fall back to "latest"
+// with a loud log line so the operator notices.
+//
+// Pattern: strict X.Y.Z or vX.Y.Z, no pre-release suffix, no build
+// metadata. Rejects "v0.0.0+dev", "<unknown>", git shas, and any
+// "-rc1"-style suffix.
+var releaseTagPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
+
+func helixSandboxImage() string {
+	return helixSandboxImageFor(data.GetHelixVersion())
+}
+
+// helixSandboxImageFor is the testable inner. Tests inject specific
+// version strings; the production wrapper above reads from data.
+func helixSandboxImageFor(version string) string {
+	if !releaseTagPattern.MatchString(version) || version == "v0.0.0" || version == "0.0.0" {
+		log.Warn().
+			Str("helix_version", version).
+			Msg("compute: Helix build is not a tagged release; falling back to helix-sandbox:latest. YD tasks may pull a sandbox version that does not match this control plane.")
+		return "ghcr.io/helixml/helix-sandbox:latest"
+	}
+	return "ghcr.io/helixml/helix-sandbox:" + version
 }

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap.go
@@ -133,18 +133,17 @@ func buildProvider(cfg config.Compute, serverURL, runnerToken string) (compute.P
 				Msg("compute: HELIX_YD_WORKER_TAG auto-derived from namespace; override if your YD worker pool advertises a different tag")
 		}
 		return yellowdog.NewProvider(yellowdog.Config{
-			APIKeyID:         cfg.Yellowdog.APIKeyID,
-			APISecret:        cfg.Yellowdog.APISecret,
-			BaseURL:          cfg.Yellowdog.BaseURL,
-			Namespace:        cfg.Yellowdog.Namespace,
-			DeploymentTag:    cfg.DeploymentTag,
-			WorkerTag:        workerTag,
-			TaskTimeout:      cfg.Yellowdog.TaskTimeout,
-			MaxRetries:       cfg.Yellowdog.MaxRetries,
-			HelixURL:         serverURL,
-			RunnerToken:      runnerToken,
-			HelixImage:       cfg.Yellowdog.HelixImage,
-			BashScriptSource: cfg.Yellowdog.BashScriptSource,
+			APIKeyID:      cfg.Yellowdog.APIKeyID,
+			APISecret:     cfg.Yellowdog.APISecret,
+			BaseURL:       cfg.Yellowdog.BaseURL,
+			Namespace:     cfg.Yellowdog.Namespace,
+			DeploymentTag: cfg.DeploymentTag,
+			WorkerTag:     workerTag,
+			TaskTimeout:   cfg.Yellowdog.TaskTimeout,
+			MaxRetries:    cfg.Yellowdog.MaxRetries,
+			HelixURL:      serverURL,
+			RunnerToken:   runnerToken,
+			HelixImage:    cfg.Yellowdog.HelixImage,
 		})
 	default:
 		return nil, fmt.Errorf("unknown HELIX_COMPUTE_PROVIDER %q (supported: \"yellowdog\")", cfg.Provider)

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
@@ -46,7 +46,7 @@ func TestBootstrapDisabledWhenProviderUnset(t *testing.T) {
 	// behavioural change for existing deployments. Returning (nil,
 	// nil) is how the boot path detects "disabled" without a
 	// sentinel.
-	mgr, err := Bootstrap(config.Compute{}, nullStore{})
+	mgr, err := Bootstrap(config.Compute{}, "", "", nullStore{})
 	if err != nil {
 		t.Fatalf("expected nil error for disabled config, got %v", err)
 	}
@@ -68,7 +68,7 @@ func TestBootstrapDisabledIgnoresAllOtherFields(t *testing.T) {
 		MaxConcurrentProvisions: 3,
 		MaxProvisioningAge:      30 * time.Minute,
 	}
-	mgr, err := Bootstrap(cfg, nullStore{})
+	mgr, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
@@ -84,7 +84,7 @@ func TestBootstrapErrorsWhenNoTagAndNoNamespace(t *testing.T) {
 	cfg := config.Compute{
 		Provider: "yellowdog",
 	}
-	_, err := Bootstrap(cfg, nullStore{})
+	_, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
 	if err == nil {
 		t.Fatal("expected error for missing DeploymentTag + no namespace, got nil")
 	}
@@ -144,7 +144,7 @@ func TestBootstrapDerivesTagFromYellowdogNamespace(t *testing.T) {
 			TaskTimeout: time.Hour,
 		},
 	}
-	mgr, err := Bootstrap(cfg, nullStore{})
+	mgr, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestBootstrapUnknownProviderErrors(t *testing.T) {
 		Provider:      "nonesuch",
 		DeploymentTag: "prod",
 	}
-	_, err := Bootstrap(cfg, nullStore{})
+	_, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
 	if err == nil {
 		t.Fatal("expected error for unknown provider, got nil")
 	}
@@ -194,7 +194,7 @@ func TestBootstrapDerivesWorkerTagFromNamespace(t *testing.T) {
 			TaskTimeout: time.Hour,
 		},
 	}
-	mgr, err := Bootstrap(cfg, nullStore{})
+	mgr, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
 	if err != nil {
 		t.Fatalf("Bootstrap with empty WorkerTag should auto-derive, got error: %v", err)
 	}
@@ -227,7 +227,7 @@ func TestBootstrapErrorsWhenWorkerTagAndNamespaceBothEmpty(t *testing.T) {
 	// yellowdog.NewProvider, since Namespace is required for the
 	// provider itself; WorkerTag derivation never gets a chance to
 	// run with no namespace input.
-	_, err := Bootstrap(cfg, nullStore{})
+	_, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
 	if err == nil {
 		t.Fatal("expected error when Namespace is empty (which blocks both Namespace validation and WorkerTag derivation)")
 	}
@@ -245,7 +245,7 @@ func TestBootstrapYellowdogRequiresCredentials(t *testing.T) {
 		MaxProvisioningAge:      time.Minute,
 		// Yellowdog block empty - missing APIKeyID/APISecret etc.
 	}
-	_, err := Bootstrap(cfg, nullStore{})
+	_, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
 	if err == nil {
 		t.Fatal("expected error for missing yellowdog credentials, got nil")
 	}
@@ -256,7 +256,7 @@ func TestBootstrapNilStoreErrors(t *testing.T) {
 		Provider:      "yellowdog",
 		DeploymentTag: "prod",
 	}
-	_, err := Bootstrap(cfg, nil)
+	_, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nil)
 	if err == nil {
 		t.Fatal("expected error for nil store, got nil")
 	}
@@ -283,7 +283,7 @@ func TestBootstrapValidYellowdogConfigBuildsManager(t *testing.T) {
 			TaskTimeout: 4 * time.Hour,
 		},
 	}
-	mgr, err := Bootstrap(cfg, nullStore{})
+	mgr, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
@@ -2,14 +2,27 @@ package bootstrap
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/data"
 	"github.com/helixml/helix/api/pkg/sandbox/compute"
 	"github.com/helixml/helix/api/pkg/types"
 )
+
+// TestMain sets a plausible release version on the data package
+// global so tests that construct a Manager via Bootstrap don't trip
+// the helixSandboxImage sentinel-rejection. Tests of the rejection
+// itself call helixSandboxImageFor directly with their own values.
+func TestMain(m *testing.M) {
+	orig := data.Version
+	data.Version = "0.0.0-test"
+	defer func() { data.Version = orig }()
+	os.Exit(m.Run())
+}
 
 // nullStore is a no-op SandboxStore so we can construct Bootstrap
 // without standing up a real Postgres or even an in-memory fake.
@@ -300,36 +313,69 @@ func TestBootstrapValidYellowdogConfigBuildsManager(t *testing.T) {
 }
 
 func TestHelixSandboxImageFor(t *testing.T) {
-	// Auto-derived sandbox image tag. Production must pull
-	// ghcr.io/helixml/helix-sandbox:<version> matching the running
-	// control plane; dev/non-release builds fall back to :latest so
-	// they don't try to pull a tag that was never published.
-	cases := []struct {
-		in   string
-		want string
-	}{
-		// Release shapes -> use the version verbatim
-		{"2.11.14", "ghcr.io/helixml/helix-sandbox:2.11.14"},
-		{"v2.11.14", "ghcr.io/helixml/helix-sandbox:v2.11.14"},
-		{"1.0.0", "ghcr.io/helixml/helix-sandbox:1.0.0"},
-		// Dev / unset / unrecognised -> fall back to :latest
-		{"v0.0.0+dev", "ghcr.io/helixml/helix-sandbox:latest"},
-		{"v0.0.0", "ghcr.io/helixml/helix-sandbox:latest"},
-		{"0.0.0", "ghcr.io/helixml/helix-sandbox:latest"},
-		{"<unknown>", "ghcr.io/helixml/helix-sandbox:latest"},
-		{"", "ghcr.io/helixml/helix-sandbox:latest"},
-		// Git sha (when no Version baked in, GetHelixVersion can return vcs.revision)
-		{"a1b2c3d4e5f6", "ghcr.io/helixml/helix-sandbox:latest"},
-		// Pre-release / build-metadata shapes -> fall back rather than guess
-		{"2.11.14-rc1", "ghcr.io/helixml/helix-sandbox:latest"},
-		{"2.11.14+build.42", "ghcr.io/helixml/helix-sandbox:latest"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.in, func(t *testing.T) {
-			if got := helixSandboxImageFor(tc.in); got != tc.want {
-				t.Fatalf("helixSandboxImageFor(%q) = %q, want %q", tc.in, got, tc.want)
-			}
-		})
-	}
+	// The Helix build process publishes a sandbox image at the same
+	// tag as whatever data.Version was set to - release tags, RCs,
+	// per-PR short SHAs all valid. We trust the build process and
+	// pass the version through verbatim. The only thing we reject
+	// is sentinel/placeholder values that mean "Version wasn't
+	// actually baked in" - because there's no corresponding image
+	// for those.
+	t.Run("valid versions are passed through verbatim", func(t *testing.T) {
+		cases := []struct {
+			in   string
+			want string
+		}{
+			// Release tags
+			{"2.11.14", "ghcr.io/helixml/helix-sandbox:2.11.14"},
+			{"v2.11.14", "ghcr.io/helixml/helix-sandbox:v2.11.14"},
+			{"1.0.0", "ghcr.io/helixml/helix-sandbox:1.0.0"},
+			// Release candidates (Helix publishes -rc tags)
+			{"2.11.14-rc1", "ghcr.io/helixml/helix-sandbox:2.11.14-rc1"},
+			{"2.12.0-beta.3", "ghcr.io/helixml/helix-sandbox:2.12.0-beta.3"},
+			// Per-PR short SHAs (Helix publishes these too)
+			{"a1b2c3d", "ghcr.io/helixml/helix-sandbox:a1b2c3d"},
+			// Build metadata - trust the build process
+			{"2.11.14+build.42", "ghcr.io/helixml/helix-sandbox:2.11.14+build.42"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.in, func(t *testing.T) {
+				got, err := helixSandboxImageFor(tc.in)
+				if err != nil {
+					t.Fatalf("unexpected error for %q: %v", tc.in, err)
+				}
+				if got != tc.want {
+					t.Fatalf("helixSandboxImageFor(%q) = %q, want %q", tc.in, got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("sentinel values are rejected loudly", func(t *testing.T) {
+		// These are the values data.GetHelixVersion() returns when
+		// Version wasn't baked in via ldflags - no published image
+		// corresponds, so we error rather than silently producing a
+		// ref that will fail at docker pull on the worker.
+		sentinels := []string{
+			"",
+			"<unknown>",
+			"v0.0.0",
+			"0.0.0",
+			"v0.0.0+dev",
+		}
+		for _, s := range sentinels {
+			t.Run(s, func(t *testing.T) {
+				_, err := helixSandboxImageFor(s)
+				if err == nil {
+					t.Fatalf("expected error for sentinel version %q, got nil", s)
+				}
+				if !strings.Contains(err.Error(), "Helix build version") {
+					t.Fatalf("error should explain why; got %q", err.Error())
+				}
+				if !strings.Contains(err.Error(), "-ldflags") {
+					t.Fatalf("error should tell operator how to fix; got %q", err.Error())
+				}
+			})
+		}
+	})
 	_ = compute.Manager{} // keep the compute import used even if signature simplifies later
 }

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
@@ -297,5 +297,39 @@ func TestBootstrapValidYellowdogConfigBuildsManager(t *testing.T) {
 		Run(context.Context) error
 		Reconcile(context.Context) error
 	} = mgr
+}
+
+func TestHelixSandboxImageFor(t *testing.T) {
+	// Auto-derived sandbox image tag. Production must pull
+	// ghcr.io/helixml/helix-sandbox:<version> matching the running
+	// control plane; dev/non-release builds fall back to :latest so
+	// they don't try to pull a tag that was never published.
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// Release shapes -> use the version verbatim
+		{"2.11.14", "ghcr.io/helixml/helix-sandbox:2.11.14"},
+		{"v2.11.14", "ghcr.io/helixml/helix-sandbox:v2.11.14"},
+		{"1.0.0", "ghcr.io/helixml/helix-sandbox:1.0.0"},
+		// Dev / unset / unrecognised -> fall back to :latest
+		{"v0.0.0+dev", "ghcr.io/helixml/helix-sandbox:latest"},
+		{"v0.0.0", "ghcr.io/helixml/helix-sandbox:latest"},
+		{"0.0.0", "ghcr.io/helixml/helix-sandbox:latest"},
+		{"<unknown>", "ghcr.io/helixml/helix-sandbox:latest"},
+		{"", "ghcr.io/helixml/helix-sandbox:latest"},
+		// Git sha (when no Version baked in, GetHelixVersion can return vcs.revision)
+		{"a1b2c3d4e5f6", "ghcr.io/helixml/helix-sandbox:latest"},
+		// Pre-release / build-metadata shapes -> fall back rather than guess
+		{"2.11.14-rc1", "ghcr.io/helixml/helix-sandbox:latest"},
+		{"2.11.14+build.42", "ghcr.io/helixml/helix-sandbox:latest"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := helixSandboxImageFor(tc.in); got != tc.want {
+				t.Fatalf("helixSandboxImageFor(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
 	_ = compute.Manager{} // keep the compute import used even if signature simplifies later
 }

--- a/api/pkg/sandbox/compute/yellowdog/bash_script.sh
+++ b/api/pkg/sandbox/compute/yellowdog/bash_script.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Embedded helix-sandbox launcher for YellowDog workers.
+#
+# Shipped inline in the YD task arguments via `bash -c <this body>`
+# rather than uploaded to S3 separately. The Helix Go binary embeds
+# this file via go:embed; the Provider sends it to YD as the body
+# of a bash task.
+#
+# Invocation (set by yellowdog.Provider.taskArguments):
+#   /bin/bash -c <this body> "yd-inline" $helix_url $runner_token $helix_image
+#
+# That makes $0="yd-inline", $1=helix_url, $2=runner_token, $3=helix_image
+# inside this script - matching the existing yellowdog-poc bash-script.sh
+# convention so SANDBOX_INSTANCE_ID, container naming, etc. all behave
+# identically.
+#
+# Hardware-specific bits (--gpus all, NVIDIA device paths,
+# MAX_SANDBOXES=2) stay here for now. When Helix grows multi-profile
+# support these become first-class Provider.Spec fields and this
+# script becomes a Go template. See
+# titan/helix/design/2026-06-09-yd-bash-script-alternatives.md.
+set -euo pipefail
+
+HELIX_URL="${1:?missing arg 1: control plane URL}"
+RUNNER_TOK="${2:?missing arg 2: runner token}"
+IMG="${3:?missing arg 3: helix-sandbox image}"
+
+WORKER_TAG="${YD_WORKER_SLOT:-default}"
+CONTAINER_NAME="yd-helix-runner-${WORKER_TAG}"
+SANDBOX_ID="${SANDBOX_INSTANCE_ID:-yd-inline-$(date -u +%Y%m%d-%H%M%S)-w${WORKER_TAG}}"
+
+echo "=== Helix runner $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo "helix_url=$HELIX_URL"
+echo "image=$IMG"
+echo "container_name=$CONTAINER_NAME"
+echo "sandbox_id=$SANDBOX_ID"
+
+exec sudo docker run --rm --name "$CONTAINER_NAME" \
+  --privileged --gpus all \
+  --device /dev/dri/renderD128 \
+  --device /dev/dri/card1 \
+  -v /var/lib/docker \
+  -e HELIX_API_URL="$HELIX_URL" \
+  -e RUNNER_TOKEN="$RUNNER_TOK" \
+  -e SANDBOX_INSTANCE_ID="$SANDBOX_ID" \
+  -e GPU_VENDOR=nvidia \
+  -e MAX_SANDBOXES=2 \
+  "$IMG"

--- a/api/pkg/sandbox/compute/yellowdog/bash_script.sh
+++ b/api/pkg/sandbox/compute/yellowdog/bash_script.sh
@@ -14,11 +14,20 @@
 # convention so SANDBOX_INSTANCE_ID, container naming, etc. all behave
 # identically.
 #
-# Hardware-specific bits (--gpus all, NVIDIA device paths,
-# MAX_SANDBOXES=2) stay here for now. When Helix grows multi-profile
-# support these become first-class Provider.Spec fields and this
-# script becomes a Go template. See
-# titan/helix/design/2026-06-09-yd-bash-script-alternatives.md.
+# Hardware-specific bits are parameterised via task Environment so a
+# pool with non-NVIDIA GPUs (or no GPU at all) can override them at
+# task-submit time without forking this script. The defaults match the
+# NVIDIA POC pool so existing deployments keep working unchanged.
+#
+# Overridable via task Environment (defaults in parens):
+#   GPU_VENDOR     - container env var passed to helix-sandbox (nvidia)
+#   GPU_FLAGS      - docker run hardware flags (--gpus all)
+#   DEVICE_FLAGS   - docker run --device flags (NVIDIA DRI nodes)
+#   MAX_SANDBOXES  - per-runner sandbox cap (2)
+#
+# When Helix grows multi-profile support these become first-class
+# Provider.Spec fields and the Provider populates the task Environment
+# from the profile. See titan/helix/design/2026-06-09-yd-bash-script-alternatives.md.
 set -euo pipefail
 
 HELIX_URL="${1:?missing arg 1: control plane URL}"
@@ -29,20 +38,26 @@ WORKER_TAG="${YD_WORKER_SLOT:-default}"
 CONTAINER_NAME="yd-helix-runner-${WORKER_TAG}"
 SANDBOX_ID="${SANDBOX_INSTANCE_ID:-yd-inline-$(date -u +%Y%m%d-%H%M%S)-w${WORKER_TAG}}"
 
+GPU_VENDOR="${GPU_VENDOR:-nvidia}"
+MAX_SANDBOXES="${MAX_SANDBOXES:-2}"
+# GPU_FLAGS / DEVICE_FLAGS are unquoted on use - operator-provided
+# strings are tokenised by the shell to become individual docker run args.
+GPU_FLAGS="${GPU_FLAGS:---gpus all}"
+DEVICE_FLAGS="${DEVICE_FLAGS:---device /dev/dri/renderD128 --device /dev/dri/card1}"
+
 echo "=== Helix runner $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
 echo "helix_url=$HELIX_URL"
 echo "image=$IMG"
 echo "container_name=$CONTAINER_NAME"
 echo "sandbox_id=$SANDBOX_ID"
+echo "gpu_vendor=$GPU_VENDOR gpu_flags=$GPU_FLAGS device_flags=$DEVICE_FLAGS max_sandboxes=$MAX_SANDBOXES"
 
 exec sudo docker run --rm --name "$CONTAINER_NAME" \
-  --privileged --gpus all \
-  --device /dev/dri/renderD128 \
-  --device /dev/dri/card1 \
+  --privileged $GPU_FLAGS $DEVICE_FLAGS \
   -v /var/lib/docker \
   -e HELIX_API_URL="$HELIX_URL" \
   -e RUNNER_TOKEN="$RUNNER_TOK" \
   -e SANDBOX_INSTANCE_ID="$SANDBOX_ID" \
-  -e GPU_VENDOR=nvidia \
-  -e MAX_SANDBOXES=2 \
+  -e GPU_VENDOR="$GPU_VENDOR" \
+  -e MAX_SANDBOXES="$MAX_SANDBOXES" \
   "$IMG"

--- a/api/pkg/sandbox/compute/yellowdog/provider.go
+++ b/api/pkg/sandbox/compute/yellowdog/provider.go
@@ -83,13 +83,33 @@ type Config struct {
 	// if empty.
 	TaskType string
 
-	// TaskArguments is the positional argument vector passed to each
-	// task. Empty arguments default to a one-line shell that runs the
-	// helix-sandbox image - operators MUST override this in real
-	// deployments to pass HELIX_URL, RUNNER_TOKEN, image tag etc.
-	// Treated as opaque by this package; the script template/upload
-	// flow is out of scope here.
+	// TaskArguments overrides the positional argument vector passed
+	// to each task. Empty (the default) uses the per-task arguments
+	// constructed from HelixURL + RunnerToken + HelixImage, which is
+	// what production deployments want. Tests inject a custom vector
+	// to keep the task body shape simple.
 	TaskArguments []string
+
+	// HelixURL is the Helix control-plane URL the helix-sandbox
+	// container inside the YD task connects back to. Passed through
+	// to bash-script.sh as positional arg $1, which sets
+	// HELIX_API_URL on the docker-run invocation.
+	HelixURL string
+
+	// RunnerToken is the shared secret bash-script.sh injects into
+	// the helix-sandbox container as RUNNER_TOKEN env var. Same
+	// value as Helix's RUNNER_TOKEN config; we pass it through here
+	// rather than have the worker fetch it independently.
+	RunnerToken string
+
+	// HelixImage is the helix-sandbox container image tag. Passed
+	// as positional arg $3 to bash-script.sh, which docker-runs it.
+	HelixImage string
+
+	// BashScriptSource is the YD data-client URI bash-script.sh has
+	// been pre-uploaded to. The YD worker downloads from this source
+	// into local:bash-script.sh before invoking it.
+	BashScriptSource string
 
 	// HTTPClient overrides the default *http.Client. Tests inject
 	// an httptest-backed client. Nil falls back to http.DefaultClient.
@@ -244,9 +264,10 @@ func (p *Provider) Provision(ctx context.Context, spec compute.Spec) (*compute.H
 	task := taskPayload{
 		Name:        fmt.Sprintf("task-%d", time.Now().UnixNano()),
 		TaskType:    p.cfg.TaskType,
-		Arguments:   p.cfg.TaskArguments,
-		Environment: mergeLabels(spec.Labels, nil),
+		Arguments:   p.taskArguments(),
+		Environment: p.taskEnvironment(spec),
 		Timeout:     isoMinutes(p.cfg.TaskTimeout),
+		Inputs:      p.taskInputs(),
 	}
 	if err := p.addTask(ctx, tg.ID, &task); err != nil {
 		// Roll back the WR so we don't leak a stuck empty task group.
@@ -383,6 +404,81 @@ type taskPayload struct {
 	Arguments   []string          `json:"arguments,omitempty"`
 	Environment map[string]string `json:"environment,omitempty"`
 	Timeout     string            `json:"timeout,omitempty"`
+	Inputs      []taskInput       `json:"inputs,omitempty"`
+}
+
+// taskInput tells the YD worker to fetch a file from the data-client
+// and place it on the local filesystem before running the task. Used
+// to ship bash-script.sh to the worker without baking it into the
+// image. Mirrors the POC's config.toml taskDataInputs entries.
+type taskInput struct {
+	Source      string `json:"source"`
+	Destination string `json:"destination"`
+}
+
+// taskArguments builds the positional argument vector passed to
+// bash-script.sh on the worker. Matches the POC's config.toml:
+//
+//	arguments = ["bash-script.sh", helix_url, runner_token, helix_image]
+//
+// Tests can pre-set cfg.TaskArguments to inject a deterministic
+// vector; production deployments leave it empty and let this method
+// construct the right shape from HelixURL/RunnerToken/HelixImage.
+func (p *Provider) taskArguments() []string {
+	if len(p.cfg.TaskArguments) > 0 {
+		return p.cfg.TaskArguments
+	}
+	if p.cfg.HelixURL == "" || p.cfg.RunnerToken == "" || p.cfg.HelixImage == "" {
+		// Returning empty produces a task that fails immediately on the
+		// worker - operator sees the failure in YD logs and notices the
+		// missing config. Better than silently submitting a task that
+		// happens to work for a few cycles then breaks.
+		return nil
+	}
+	return []string{
+		"bash-script.sh",
+		p.cfg.HelixURL,
+		p.cfg.RunnerToken,
+		p.cfg.HelixImage,
+	}
+}
+
+// taskEnvironment builds the env var map for the YD task. Two
+// load-bearing entries:
+//   - SANDBOX_INSTANCE_ID: bridges the pre-decided SandboxID
+//     from compute.Manager to the helix-sandbox container, so
+//     the container registers with the matching ID and the
+//     auto-register bridge can promote the existing row.
+//   - any other spec.Labels are passed through verbatim.
+//
+// bash-script.sh reads SANDBOX_INSTANCE_ID from its environment
+// and propagates it to the docker-run as -e SANDBOX_INSTANCE_ID=$ID.
+func (p *Provider) taskEnvironment(spec compute.Spec) map[string]string {
+	env := make(map[string]string, len(spec.Labels)+1)
+	for k, v := range spec.Labels {
+		env[k] = v
+	}
+	if id := spec.Labels["helix.sandbox_id"]; id != "" {
+		// The label key is the cross-package handoff between
+		// compute.Manager and yellowdog.Provider; the env var key
+		// is what bash-script.sh reads.
+		env["SANDBOX_INSTANCE_ID"] = id
+	}
+	return env
+}
+
+// taskInputs returns the data-client downloads the YD worker must
+// fetch before running the task. Today that's just bash-script.sh
+// at a fixed destination. In-Go script upload is a follow-up;
+// operators currently pre-upload during pool setup.
+func (p *Provider) taskInputs() []taskInput {
+	if p.cfg.BashScriptSource == "" {
+		return nil
+	}
+	return []taskInput{{
+		Source:      p.cfg.BashScriptSource,
+		Destination: "local:bash-script.sh",
+	}}
 }
 
 // --- HTTP helper methods (one per YD call we make) ----------------------
@@ -468,11 +564,19 @@ func (p *Provider) cancelWorkRequirement(ctx context.Context, id string, force b
 // collapse the differences (e.g. CANCELLING and CANCELLED both
 // become StateTerminating/StateTerminated).
 //
-// COMPLETED maps to StateTerminated rather than StateReady because
-// each WR runs exactly one task that brings up exactly one host:
-// when YD reports COMPLETED, the task has finished and the host
-// underneath it is gone. The "host is healthy and running" signal
-// comes from RUNNING, not COMPLETED.
+// RUNNING maps to StateProvisioning, NOT StateReady. YD reports
+// "RUNNING" the moment a WR is accepted by the scheduler - long
+// before any worker picks the task up, and well before helix-sandbox
+// has booted and phoned home. The only signal that the host is
+// actually serving is its WebSocket registration. The auto-register
+// bridge (server.ensureSandboxRegistered) is responsible for
+// transitioning ComputeState from provisioning to ready when that
+// happens. Surfaced live on 2026-06-09 when a row jumped to ready
+// after 15s despite no helix-sandbox container existing.
+//
+// COMPLETED maps to StateTerminated because each WR runs exactly one
+// task that brings up exactly one host: when YD reports COMPLETED,
+// the task has finished and the host underneath it is gone.
 //
 // Returns ("", false) for unknown statuses so the caller can decide
 // whether to treat that as failure or schema drift. Silently
@@ -482,7 +586,7 @@ func (p *Provider) cancelWorkRequirement(ctx context.Context, id string, force b
 func wrStatusToState(s string) (compute.State, bool) {
 	switch s {
 	case "RUNNING":
-		return compute.StateReady, true
+		return compute.StateProvisioning, true
 	case "HELD":
 		return compute.StateProvisioning, true
 	case "COMPLETED":
@@ -520,16 +624,3 @@ func isoMinutes(d time.Duration) string {
 	return fmt.Sprintf("PT%dM", mins)
 }
 
-func mergeLabels(a, b map[string]string) map[string]string {
-	if len(a) == 0 && len(b) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(a)+len(b))
-	for k, v := range a {
-		out[k] = v
-	}
-	for k, v := range b {
-		out[k] = v
-	}
-	return out
-}

--- a/api/pkg/sandbox/compute/yellowdog/provider.go
+++ b/api/pkg/sandbox/compute/yellowdog/provider.go
@@ -18,6 +18,7 @@ package yellowdog
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"net/http"
@@ -171,7 +172,7 @@ func NewProvider(cfg Config) (*Provider, error) {
 		return nil, errors.New("yellowdog: WorkerTag is required")
 	}
 	if cfg.TaskType == "" {
-		cfg.TaskType = "docker"
+		cfg.TaskType = "bash"
 	}
 	base := cfg.BaseURL
 	if base == "" {
@@ -264,7 +265,7 @@ func (p *Provider) Provision(ctx context.Context, spec compute.Spec) (*compute.H
 	task := taskPayload{
 		Name:        fmt.Sprintf("task-%d", time.Now().UnixNano()),
 		TaskType:    p.cfg.TaskType,
-		Arguments:   p.taskArguments(spec),
+		Arguments:   p.taskArguments(),
 		Environment: p.taskEnvironment(spec),
 		Timeout:     isoMinutes(p.cfg.TaskTimeout),
 	}
@@ -405,25 +406,29 @@ type taskPayload struct {
 	Timeout     string            `json:"timeout,omitempty"`
 }
 
-// taskArguments builds the docker run argument vector passed to YD's
-// docker task type handler. The handler invokes:
+// embeddedBashScript is the helix-sandbox launcher we ship inline to
+// every YD task. The YD 'bash' task type handler is `/bin/bash` plus
+// task arguments, so by sending ["-c", <body>, "yd-inline", url, token,
+// image] we get the body executed with $0=yd-inline, $1=url, $2=token,
+// $3=image - matching the existing yellowdog-poc bash-script.sh
+// convention.
 //
-//	docker run --rm --name yd-container-$$ --stop-signal SIGTERM \
-//	  --env YD_WORKING=/yd_working -v $(pwd):/yd_working "$@"
+//go:embed bash_script.sh
+var embeddedBashScript string
+
+// taskArguments builds the positional argument vector for the YD
+// task. YD's bash task type handler is /bin/bash, so YD invokes:
 //
-// Where "$@" is what we return here. We append:
-//   - hardware flags (--privileged, --gpus, --device, -v /var/lib/docker)
-//   - env vars (-e HELIX_API_URL, RUNNER_TOKEN, SANDBOX_INSTANCE_ID, ...)
-//   - the helix-sandbox image
+//	/bin/bash <task.Arguments...>
 //
-// Tests inject cfg.TaskArguments to skip the auto-build.
+// We use the "bash -c <body> <argv>" form: arguments[0]="-c",
+// arguments[1]=<embedded script body>, and arguments[2..] become $0,
+// $1, $2... inside the body. The embedded script reads $1, $2, $3
+// for helix_url, runner_token, helix_image (matching the original
+// yellowdog-poc bash-script.sh).
 //
-// HARDWARE-SPECIFIC: the --gpus / --device / -e GPU_VENDOR / -e
-// MAX_SANDBOXES values are hardcoded here for NVIDIA + the POC's
-// EC2 g5.xlarge layout. When Helix grows multi-profile support
-// (different instance types, vendors), these become per-Spec fields.
-// Tracked in design/2026-06-09-yd-bash-script-alternatives.md.
-func (p *Provider) taskArguments(spec compute.Spec) []string {
+// Tests can inject cfg.TaskArguments to skip the auto-build.
+func (p *Provider) taskArguments() []string {
 	if len(p.cfg.TaskArguments) > 0 {
 		return p.cfg.TaskArguments
 	}
@@ -434,48 +439,43 @@ func (p *Provider) taskArguments(spec compute.Spec) []string {
 		// submitting a task that "almost works."
 		return nil
 	}
-	sandboxID := spec.Labels["helix.sandbox_id"]
 	return []string{
-		// Container runtime flags.
-		"--privileged",
-		"--gpus", "all",
-		"--device", "/dev/dri/renderD128",
-		"--device", "/dev/dri/card1",
-		"-v", "/var/lib/docker",
-		// Env vars consumed by helix-sandbox at startup.
-		"-e", "HELIX_API_URL=" + p.cfg.HelixURL,
-		"-e", "RUNNER_TOKEN=" + p.cfg.RunnerToken,
-		"-e", "SANDBOX_INSTANCE_ID=" + sandboxID,
-		"-e", "GPU_VENDOR=nvidia",
-		"-e", "MAX_SANDBOXES=2",
-		// Image to run (last positional - everything before is a flag).
+		"-c",
+		embeddedBashScript,
+		// $0 (conventionally the "script name" under bash -c)
+		"yd-inline",
+		// $1, $2, $3 — consumed by the embedded script
+		p.cfg.HelixURL,
+		p.cfg.RunnerToken,
 		p.cfg.HelixImage,
 	}
 }
 
-// taskEnvironment builds the env var map attached to the YD task
-// itself (read by the YD task handler script, NOT the helix-sandbox
-// container). For our docker-task-type flow, the helix-sandbox env
-// vars travel as docker -e flags inside taskArguments above.
+// taskEnvironment builds the env var map attached to the YD task.
+// The YD bash task type's handler is `/bin/bash` - whatever we set
+// here lands in the bash process's environment, visible to the
+// embedded script as $VAR.
 //
-// This map can carry:
-//   - YD_STOP_SIGNAL / YD_STOP_TIMEOUT: graceful-shutdown tuning
-//     read by the docker task handler.
-//   - DOCKER_USERNAME / DOCKER_PASSWORD / DOCKER_REGISTRY: private
-//     registry auth (unused today since helix-sandbox is on public
-//     ghcr.io).
-//   - Any spec.Labels the operator wants to surface in YD's UI.
+// One load-bearing entry: SANDBOX_INSTANCE_ID. The embedded
+// bash_script.sh reads it (matching the existing yellowdog-poc
+// convention) and propagates it to helix-sandbox via docker -e.
+// That's the cross-package bridge between compute.Manager (which
+// generated the sandbox id) and the helix-sandbox container
+// (which will register with that id so the auto-register bridge
+// can promote the existing row).
 //
-// We do NOT set SANDBOX_INSTANCE_ID here - it flows to the
-// helix-sandbox container via the docker -e flag in taskArguments,
-// not via the YD task environment.
+// Any other spec.Labels are passed through verbatim - useful for
+// operator-supplied YD-side tagging / debugging.
 func (p *Provider) taskEnvironment(spec compute.Spec) map[string]string {
-	if len(spec.Labels) == 0 {
-		return nil
-	}
-	env := make(map[string]string, len(spec.Labels))
+	env := make(map[string]string, len(spec.Labels)+1)
 	for k, v := range spec.Labels {
 		env[k] = v
+	}
+	if id := spec.Labels["helix.sandbox_id"]; id != "" {
+		env["SANDBOX_INSTANCE_ID"] = id
+	}
+	if len(env) == 0 {
+		return nil
 	}
 	return env
 }

--- a/api/pkg/sandbox/compute/yellowdog/provider.go
+++ b/api/pkg/sandbox/compute/yellowdog/provider.go
@@ -79,37 +79,37 @@ type Config struct {
 	TaskTimeout time.Duration
 
 	// TaskType is the worker task-type handler name (registered on
-	// each worker by install-agent.sh in the POC). Defaults to "bash"
-	// if empty.
+	// each worker via the operator's userdata scripts). Defaults to
+	// "docker" if empty - YD's docker task type handler
+	// (add-docker-run-script.sh) reads the task's Arguments as
+	// docker run flags and invokes the container directly. The
+	// older "bash" path is still supported for backwards compat
+	// but is being phased out (no need to ship + maintain a
+	// separate bash script).
 	TaskType string
 
 	// TaskArguments overrides the positional argument vector passed
-	// to each task. Empty (the default) uses the per-task arguments
-	// constructed from HelixURL + RunnerToken + HelixImage, which is
-	// what production deployments want. Tests inject a custom vector
-	// to keep the task body shape simple.
+	// to each task. Empty (the default) uses the auto-built docker
+	// run argument vector constructed from HelixURL + RunnerToken +
+	// HelixImage + the hardware-specific flags. Tests inject a
+	// custom vector to keep assertion shape simple.
 	TaskArguments []string
 
 	// HelixURL is the Helix control-plane URL the helix-sandbox
-	// container inside the YD task connects back to. Passed through
-	// to bash-script.sh as positional arg $1, which sets
-	// HELIX_API_URL on the docker-run invocation.
+	// container connects back to. Auto-built docker run args
+	// include "-e HELIX_API_URL=<HelixURL>".
 	HelixURL string
 
-	// RunnerToken is the shared secret bash-script.sh injects into
-	// the helix-sandbox container as RUNNER_TOKEN env var. Same
-	// value as Helix's RUNNER_TOKEN config; we pass it through here
-	// rather than have the worker fetch it independently.
+	// RunnerToken is the shared secret helix-sandbox uses to
+	// authenticate against the Helix control plane. Auto-built
+	// docker run args include "-e RUNNER_TOKEN=<RunnerToken>".
+	// Same value as Helix's WebServer.RunnerToken; passed through
+	// here rather than having the worker fetch it independently.
 	RunnerToken string
 
-	// HelixImage is the helix-sandbox container image tag. Passed
-	// as positional arg $3 to bash-script.sh, which docker-runs it.
+	// HelixImage is the helix-sandbox container image the YD worker
+	// will docker-run. Last positional in the docker run args.
 	HelixImage string
-
-	// BashScriptSource is the YD data-client URI bash-script.sh has
-	// been pre-uploaded to. The YD worker downloads from this source
-	// into local:bash-script.sh before invoking it.
-	BashScriptSource string
 
 	// HTTPClient overrides the default *http.Client. Tests inject
 	// an httptest-backed client. Nil falls back to http.DefaultClient.
@@ -171,7 +171,7 @@ func NewProvider(cfg Config) (*Provider, error) {
 		return nil, errors.New("yellowdog: WorkerTag is required")
 	}
 	if cfg.TaskType == "" {
-		cfg.TaskType = "bash"
+		cfg.TaskType = "docker"
 	}
 	base := cfg.BaseURL
 	if base == "" {
@@ -264,10 +264,9 @@ func (p *Provider) Provision(ctx context.Context, spec compute.Spec) (*compute.H
 	task := taskPayload{
 		Name:        fmt.Sprintf("task-%d", time.Now().UnixNano()),
 		TaskType:    p.cfg.TaskType,
-		Arguments:   p.taskArguments(),
+		Arguments:   p.taskArguments(spec),
 		Environment: p.taskEnvironment(spec),
 		Timeout:     isoMinutes(p.cfg.TaskTimeout),
-		Inputs:      p.taskInputs(),
 	}
 	if err := p.addTask(ctx, tg.ID, &task); err != nil {
 		// Roll back the WR so we don't leak a stuck empty task group.
@@ -404,81 +403,81 @@ type taskPayload struct {
 	Arguments   []string          `json:"arguments,omitempty"`
 	Environment map[string]string `json:"environment,omitempty"`
 	Timeout     string            `json:"timeout,omitempty"`
-	Inputs      []taskInput       `json:"inputs,omitempty"`
 }
 
-// taskInput tells the YD worker to fetch a file from the data-client
-// and place it on the local filesystem before running the task. Used
-// to ship bash-script.sh to the worker without baking it into the
-// image. Mirrors the POC's config.toml taskDataInputs entries.
-type taskInput struct {
-	Source      string `json:"source"`
-	Destination string `json:"destination"`
-}
-
-// taskArguments builds the positional argument vector passed to
-// bash-script.sh on the worker. Matches the POC's config.toml:
+// taskArguments builds the docker run argument vector passed to YD's
+// docker task type handler. The handler invokes:
 //
-//	arguments = ["bash-script.sh", helix_url, runner_token, helix_image]
+//	docker run --rm --name yd-container-$$ --stop-signal SIGTERM \
+//	  --env YD_WORKING=/yd_working -v $(pwd):/yd_working "$@"
 //
-// Tests can pre-set cfg.TaskArguments to inject a deterministic
-// vector; production deployments leave it empty and let this method
-// construct the right shape from HelixURL/RunnerToken/HelixImage.
-func (p *Provider) taskArguments() []string {
+// Where "$@" is what we return here. We append:
+//   - hardware flags (--privileged, --gpus, --device, -v /var/lib/docker)
+//   - env vars (-e HELIX_API_URL, RUNNER_TOKEN, SANDBOX_INSTANCE_ID, ...)
+//   - the helix-sandbox image
+//
+// Tests inject cfg.TaskArguments to skip the auto-build.
+//
+// HARDWARE-SPECIFIC: the --gpus / --device / -e GPU_VENDOR / -e
+// MAX_SANDBOXES values are hardcoded here for NVIDIA + the POC's
+// EC2 g5.xlarge layout. When Helix grows multi-profile support
+// (different instance types, vendors), these become per-Spec fields.
+// Tracked in design/2026-06-09-yd-bash-script-alternatives.md.
+func (p *Provider) taskArguments(spec compute.Spec) []string {
 	if len(p.cfg.TaskArguments) > 0 {
 		return p.cfg.TaskArguments
 	}
 	if p.cfg.HelixURL == "" || p.cfg.RunnerToken == "" || p.cfg.HelixImage == "" {
-		// Returning empty produces a task that fails immediately on the
-		// worker - operator sees the failure in YD logs and notices the
-		// missing config. Better than silently submitting a task that
-		// happens to work for a few cycles then breaks.
+		// Returning empty produces a task that fails immediately on
+		// the worker - operator sees the failure in YD logs and
+		// notices the missing config. Better than silently
+		// submitting a task that "almost works."
 		return nil
 	}
+	sandboxID := spec.Labels["helix.sandbox_id"]
 	return []string{
-		"bash-script.sh",
-		p.cfg.HelixURL,
-		p.cfg.RunnerToken,
+		// Container runtime flags.
+		"--privileged",
+		"--gpus", "all",
+		"--device", "/dev/dri/renderD128",
+		"--device", "/dev/dri/card1",
+		"-v", "/var/lib/docker",
+		// Env vars consumed by helix-sandbox at startup.
+		"-e", "HELIX_API_URL=" + p.cfg.HelixURL,
+		"-e", "RUNNER_TOKEN=" + p.cfg.RunnerToken,
+		"-e", "SANDBOX_INSTANCE_ID=" + sandboxID,
+		"-e", "GPU_VENDOR=nvidia",
+		"-e", "MAX_SANDBOXES=2",
+		// Image to run (last positional - everything before is a flag).
 		p.cfg.HelixImage,
 	}
 }
 
-// taskEnvironment builds the env var map for the YD task. Two
-// load-bearing entries:
-//   - SANDBOX_INSTANCE_ID: bridges the pre-decided SandboxID
-//     from compute.Manager to the helix-sandbox container, so
-//     the container registers with the matching ID and the
-//     auto-register bridge can promote the existing row.
-//   - any other spec.Labels are passed through verbatim.
+// taskEnvironment builds the env var map attached to the YD task
+// itself (read by the YD task handler script, NOT the helix-sandbox
+// container). For our docker-task-type flow, the helix-sandbox env
+// vars travel as docker -e flags inside taskArguments above.
 //
-// bash-script.sh reads SANDBOX_INSTANCE_ID from its environment
-// and propagates it to the docker-run as -e SANDBOX_INSTANCE_ID=$ID.
+// This map can carry:
+//   - YD_STOP_SIGNAL / YD_STOP_TIMEOUT: graceful-shutdown tuning
+//     read by the docker task handler.
+//   - DOCKER_USERNAME / DOCKER_PASSWORD / DOCKER_REGISTRY: private
+//     registry auth (unused today since helix-sandbox is on public
+//     ghcr.io).
+//   - Any spec.Labels the operator wants to surface in YD's UI.
+//
+// We do NOT set SANDBOX_INSTANCE_ID here - it flows to the
+// helix-sandbox container via the docker -e flag in taskArguments,
+// not via the YD task environment.
 func (p *Provider) taskEnvironment(spec compute.Spec) map[string]string {
-	env := make(map[string]string, len(spec.Labels)+1)
+	if len(spec.Labels) == 0 {
+		return nil
+	}
+	env := make(map[string]string, len(spec.Labels))
 	for k, v := range spec.Labels {
 		env[k] = v
 	}
-	if id := spec.Labels["helix.sandbox_id"]; id != "" {
-		// The label key is the cross-package handoff between
-		// compute.Manager and yellowdog.Provider; the env var key
-		// is what bash-script.sh reads.
-		env["SANDBOX_INSTANCE_ID"] = id
-	}
 	return env
-}
-
-// taskInputs returns the data-client downloads the YD worker must
-// fetch before running the task. Today that's just bash-script.sh
-// at a fixed destination. In-Go script upload is a follow-up;
-// operators currently pre-upload during pool setup.
-func (p *Provider) taskInputs() []taskInput {
-	if p.cfg.BashScriptSource == "" {
-		return nil
-	}
-	return []taskInput{{
-		Source:      p.cfg.BashScriptSource,
-		Destination: "local:bash-script.sh",
-	}}
 }
 
 // --- HTTP helper methods (one per YD call we make) ----------------------

--- a/api/pkg/sandbox/compute/yellowdog/provider_test.go
+++ b/api/pkg/sandbox/compute/yellowdog/provider_test.go
@@ -119,8 +119,8 @@ func TestNewProviderDefaults(t *testing.T) {
 	if p.baseURL != defaultBaseURL {
 		t.Fatalf("expected default baseURL, got %q", p.baseURL)
 	}
-	if p.cfg.TaskType != "bash" {
-		t.Fatalf("expected TaskType default 'bash', got %q", p.cfg.TaskType)
+	if p.cfg.TaskType != "docker" {
+		t.Fatalf("expected TaskType default 'docker', got %q", p.cfg.TaskType)
 	}
 }
 
@@ -136,12 +136,13 @@ func TestProviderName(t *testing.T) {
 	}
 }
 
-func TestTaskBodyShape(t *testing.T) {
-	// Validates the new end-to-end task wiring: Arguments,
-	// Environment, and Inputs all populated correctly so the YD
-	// worker can download bash-script.sh, invoke it with
-	// HELIX_URL/RUNNER_TOKEN/HelixImage, and pass SANDBOX_INSTANCE_ID
-	// through the env to helix-sandbox.
+func TestTaskBodyShape_DockerTaskType(t *testing.T) {
+	// Validates the YD task wiring: TaskType=docker so YD's
+	// docker-run.sh handler invokes the container directly with our
+	// arguments as docker run flags. Asserts the docker run argv
+	// shape, that SANDBOX_INSTANCE_ID flows via "-e" (not via Task
+	// environment), and that no taskInputs are emitted (the
+	// bash-script + S3 upload path is gone).
 	f := newFakeServer(t)
 	var taskBody []byte
 	f.handler = func(w http.ResponseWriter, r *http.Request) {
@@ -169,7 +170,6 @@ func TestTaskBodyShape(t *testing.T) {
 		HelixURL:             "https://helix.example.com",
 		RunnerToken:          "secret-token-xyz",
 		HelixImage:           "ghcr.io/helixml/helix-sandbox:test-tag",
-		BashScriptSource:     "rclone:S3,...:bucket/bash-script.sh",
 	}
 	p, err := NewProvider(cfg)
 	if err != nil {
@@ -193,11 +193,24 @@ func TestTaskBodyShape(t *testing.T) {
 	}
 	task := tasks[0]
 
-	// Arguments shape: [script.sh, helix_url, runner_token, helix_image]
+	// TaskType must be "docker" (the new default) so YD invokes its
+	// docker-run.sh handler rather than the bash one.
+	if task.TaskType != "docker" {
+		t.Fatalf("TaskType = %q, want docker", task.TaskType)
+	}
+
+	// Arguments are docker run flags, ending with the image.
 	wantArgs := []string{
-		"bash-script.sh",
-		"https://helix.example.com",
-		"secret-token-xyz",
+		"--privileged",
+		"--gpus", "all",
+		"--device", "/dev/dri/renderD128",
+		"--device", "/dev/dri/card1",
+		"-v", "/var/lib/docker",
+		"-e", "HELIX_API_URL=https://helix.example.com",
+		"-e", "RUNNER_TOKEN=secret-token-xyz",
+		"-e", "SANDBOX_INSTANCE_ID=sbx_test123",
+		"-e", "GPU_VENDOR=nvidia",
+		"-e", "MAX_SANDBOXES=2",
 		"ghcr.io/helixml/helix-sandbox:test-tag",
 	}
 	if len(task.Arguments) != len(wantArgs) {
@@ -209,25 +222,16 @@ func TestTaskBodyShape(t *testing.T) {
 		}
 	}
 
-	// SANDBOX_INSTANCE_ID env var (bridge to helix-sandbox)
-	if got := task.Environment["SANDBOX_INSTANCE_ID"]; got != "sbx_test123" {
-		t.Fatalf("Environment[SANDBOX_INSTANCE_ID] = %q, want sbx_test123", got)
+	// helix-sandbox container env vars must flow via docker -e flags
+	// in Arguments (verified above), NOT via task Environment. The
+	// task Environment is for the docker-run.sh handler itself
+	// (DOCKER_USERNAME, YD_STOP_SIGNAL, etc.) - kept minimal here.
+	if got := task.Environment["SANDBOX_INSTANCE_ID"]; got != "" {
+		t.Fatalf("SANDBOX_INSTANCE_ID must NOT appear in task Environment (it goes via docker -e in Arguments); got %q", got)
 	}
-
-	// Inputs shape: download from BashScriptSource to local:bash-script.sh
-	if len(task.Inputs) != 1 {
-		t.Fatalf("Inputs length: got %d, want 1", len(task.Inputs))
+	if got := task.Environment["HELIX_API_URL"]; got != "" {
+		t.Fatalf("HELIX_API_URL must NOT appear in task Environment; got %q", got)
 	}
-	if task.Inputs[0].Source != "rclone:S3,...:bucket/bash-script.sh" {
-		t.Fatalf("Inputs[0].Source = %q", task.Inputs[0].Source)
-	}
-	if task.Inputs[0].Destination != "local:bash-script.sh" {
-		t.Fatalf("Inputs[0].Destination = %q, want local:bash-script.sh", task.Inputs[0].Destination)
-	}
-
-	// Cross-check the YD-side RUNNER_TOKEN isn't accidentally
-	// leaked into anything log-visible. The body itself contains
-	// it (necessarily) but no log output should.
 }
 
 func TestTaskArgumentsEmptyWhenConfigIncomplete(t *testing.T) {
@@ -245,7 +249,7 @@ func TestTaskArgumentsEmptyWhenConfigIncomplete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProvider: %v", err)
 	}
-	if got := p.taskArguments(); got != nil {
+	if got := p.taskArguments(compute.Spec{}); got != nil {
 		t.Fatalf("expected nil arguments when config is incomplete, got %v", got)
 	}
 }

--- a/api/pkg/sandbox/compute/yellowdog/provider_test.go
+++ b/api/pkg/sandbox/compute/yellowdog/provider_test.go
@@ -136,6 +136,120 @@ func TestProviderName(t *testing.T) {
 	}
 }
 
+func TestTaskBodyShape(t *testing.T) {
+	// Validates the new end-to-end task wiring: Arguments,
+	// Environment, and Inputs all populated correctly so the YD
+	// worker can download bash-script.sh, invoke it with
+	// HELIX_URL/RUNNER_TOKEN/HelixImage, and pass SANDBOX_INSTANCE_ID
+	// through the env to helix-sandbox.
+	f := newFakeServer(t)
+	var taskBody []byte
+	f.handler = func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/work/requirements":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"wr-1","name":"x","namespace":"test-ns","taskGroups":[{"id":"tg-1","name":"tg1"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/work/taskGroups/tg-1/tasks":
+			taskBody = f.bodies[len(f.bodies)-1]
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`[{"id":"task-1"}]`))
+		default:
+			http.Error(w, "unexpected", http.StatusBadRequest)
+		}
+	}
+	cfg := Config{
+		APIKeyID:             "k",
+		APISecret:            "s",
+		BaseURL:              f.srv.URL,
+		Namespace:            "test-ns",
+		DeploymentTag:        "test-dep",
+		WorkerTag:            "test-worker",
+		HTTPClient:           f.srv.Client(),
+		AllowInsecureBaseURL: true,
+		HelixURL:             "https://helix.example.com",
+		RunnerToken:          "secret-token-xyz",
+		HelixImage:           "ghcr.io/helixml/helix-sandbox:test-tag",
+		BashScriptSource:     "rclone:S3,...:bucket/bash-script.sh",
+	}
+	p, err := NewProvider(cfg)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	_, err = p.Provision(context.Background(), compute.Spec{
+		Labels: map[string]string{"helix.sandbox_id": "sbx_test123"},
+	})
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if taskBody == nil {
+		t.Fatal("task POST body was never captured")
+	}
+	var tasks []taskPayload
+	if err := json.Unmarshal(taskBody, &tasks); err != nil {
+		t.Fatalf("decode task body: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	task := tasks[0]
+
+	// Arguments shape: [script.sh, helix_url, runner_token, helix_image]
+	wantArgs := []string{
+		"bash-script.sh",
+		"https://helix.example.com",
+		"secret-token-xyz",
+		"ghcr.io/helixml/helix-sandbox:test-tag",
+	}
+	if len(task.Arguments) != len(wantArgs) {
+		t.Fatalf("Arguments length: got %d (%v), want %d (%v)", len(task.Arguments), task.Arguments, len(wantArgs), wantArgs)
+	}
+	for i := range wantArgs {
+		if task.Arguments[i] != wantArgs[i] {
+			t.Fatalf("Arguments[%d] = %q, want %q", i, task.Arguments[i], wantArgs[i])
+		}
+	}
+
+	// SANDBOX_INSTANCE_ID env var (bridge to helix-sandbox)
+	if got := task.Environment["SANDBOX_INSTANCE_ID"]; got != "sbx_test123" {
+		t.Fatalf("Environment[SANDBOX_INSTANCE_ID] = %q, want sbx_test123", got)
+	}
+
+	// Inputs shape: download from BashScriptSource to local:bash-script.sh
+	if len(task.Inputs) != 1 {
+		t.Fatalf("Inputs length: got %d, want 1", len(task.Inputs))
+	}
+	if task.Inputs[0].Source != "rclone:S3,...:bucket/bash-script.sh" {
+		t.Fatalf("Inputs[0].Source = %q", task.Inputs[0].Source)
+	}
+	if task.Inputs[0].Destination != "local:bash-script.sh" {
+		t.Fatalf("Inputs[0].Destination = %q, want local:bash-script.sh", task.Inputs[0].Destination)
+	}
+
+	// Cross-check the YD-side RUNNER_TOKEN isn't accidentally
+	// leaked into anything log-visible. The body itself contains
+	// it (necessarily) but no log output should.
+}
+
+func TestTaskArgumentsEmptyWhenConfigIncomplete(t *testing.T) {
+	// Defensive: if operator forgets HelixURL/RunnerToken/HelixImage,
+	// taskArguments returns nil so the task fails immediately on the
+	// worker rather than silently submitting bogus arguments.
+	cfg := Config{
+		APIKeyID: "k", APISecret: "s",
+		Namespace:     "n",
+		DeploymentTag: "d",
+		WorkerTag:     "w",
+		// HelixURL, RunnerToken, HelixImage all empty
+	}
+	p, err := NewProvider(cfg)
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	if got := p.taskArguments(); got != nil {
+		t.Fatalf("expected nil arguments when config is incomplete, got %v", got)
+	}
+}
+
 func TestProviderNameDifferentDeploymentTags(t *testing.T) {
 	// Cross-tenancy regression guard: two Providers with the same
 	// kind but different deployment tags MUST report different
@@ -348,8 +462,8 @@ func TestListDecodesFlatArrayAndFiltersClientSide(t *testing.T) {
 			t.Fatalf("client-side filter let through foreign WR: %q", got)
 		}
 	}
-	if out[0].State != compute.StateReady {
-		t.Fatalf("expected StateReady for RUNNING WR, got %q", out[0].State)
+	if out[0].State != compute.StateProvisioning {
+		t.Fatalf("expected StateProvisioning for RUNNING WR (host has not registered yet), got %q", out[0].State)
 	}
 	if out[1].State != compute.StateTerminated {
 		t.Fatalf("expected StateTerminated for COMPLETED WR, got %q", out[1].State)
@@ -362,7 +476,13 @@ func TestHealthCheckMapsStatusToState(t *testing.T) {
 		want     compute.State
 		wantErr  bool
 	}{
-		{"RUNNING", compute.StateReady, false},
+		// RUNNING does NOT mean "host is up and serving". YD reports
+		// RUNNING as soon as the WR is accepted by the scheduler -
+		// the task may still be queued, the EC2 may still be booting,
+		// helix-sandbox may still be pulling its image. The only
+		// signal that the host is actually live is its WebSocket
+		// registration, which the auto-register bridge handles.
+		{"RUNNING", compute.StateProvisioning, false},
 		{"HELD", compute.StateProvisioning, false},
 		{"COMPLETED", compute.StateTerminated, true},
 		{"FAILED", compute.StateFailed, true},
@@ -592,8 +712,8 @@ func TestRetryOn500ThenSuccess(t *testing.T) {
 	if calls != 2 {
 		t.Fatalf("expected 2 calls (1 fail + 1 retry success), got %d", calls)
 	}
-	if h.State != compute.StateReady {
-		t.Fatalf("expected StateReady after retry, got %q", h.State)
+	if h.State != compute.StateProvisioning {
+		t.Fatalf("expected StateProvisioning after retry (RUNNING means WR accepted, not host up), got %q", h.State)
 	}
 }
 

--- a/api/pkg/sandbox/compute/yellowdog/provider_test.go
+++ b/api/pkg/sandbox/compute/yellowdog/provider_test.go
@@ -119,8 +119,8 @@ func TestNewProviderDefaults(t *testing.T) {
 	if p.baseURL != defaultBaseURL {
 		t.Fatalf("expected default baseURL, got %q", p.baseURL)
 	}
-	if p.cfg.TaskType != "docker" {
-		t.Fatalf("expected TaskType default 'docker', got %q", p.cfg.TaskType)
+	if p.cfg.TaskType != "bash" {
+		t.Fatalf("expected TaskType default 'bash', got %q", p.cfg.TaskType)
 	}
 }
 
@@ -136,13 +136,13 @@ func TestProviderName(t *testing.T) {
 	}
 }
 
-func TestTaskBodyShape_DockerTaskType(t *testing.T) {
-	// Validates the YD task wiring: TaskType=docker so YD's
-	// docker-run.sh handler invokes the container directly with our
-	// arguments as docker run flags. Asserts the docker run argv
-	// shape, that SANDBOX_INSTANCE_ID flows via "-e" (not via Task
-	// environment), and that no taskInputs are emitted (the
-	// bash-script + S3 upload path is gone).
+func TestTaskBodyShape_BashInline(t *testing.T) {
+	// Validates the YD task wiring: TaskType=bash so YD's default
+	// /bin/bash handler is invoked with our arguments. We use the
+	// "bash -c <body> argv..." form so the embedded script body
+	// runs with $1, $2, $3 as helix_url, runner_token, helix_image.
+	// SANDBOX_INSTANCE_ID flows via the task Environment because
+	// the script reads $SANDBOX_INSTANCE_ID from its env.
 	f := newFakeServer(t)
 	var taskBody []byte
 	f.handler = func(w http.ResponseWriter, r *http.Request) {
@@ -193,44 +193,45 @@ func TestTaskBodyShape_DockerTaskType(t *testing.T) {
 	}
 	task := tasks[0]
 
-	// TaskType must be "docker" (the new default) so YD invokes its
-	// docker-run.sh handler rather than the bash one.
-	if task.TaskType != "docker" {
-		t.Fatalf("TaskType = %q, want docker", task.TaskType)
+	// TaskType must be "bash" - we no longer use the docker task
+	// type because YD agent registration is one-shot and adding
+	// docker via post-install userdata is fragile (see
+	// design/2026-06-09-yd-bash-script-alternatives.md).
+	if task.TaskType != "bash" {
+		t.Fatalf("TaskType = %q, want bash", task.TaskType)
 	}
 
-	// Arguments are docker run flags, ending with the image.
-	wantArgs := []string{
-		"--privileged",
-		"--gpus", "all",
-		"--device", "/dev/dri/renderD128",
-		"--device", "/dev/dri/card1",
-		"-v", "/var/lib/docker",
-		"-e", "HELIX_API_URL=https://helix.example.com",
-		"-e", "RUNNER_TOKEN=secret-token-xyz",
-		"-e", "SANDBOX_INSTANCE_ID=sbx_test123",
-		"-e", "GPU_VENDOR=nvidia",
-		"-e", "MAX_SANDBOXES=2",
-		"ghcr.io/helixml/helix-sandbox:test-tag",
+	// Argument shape: -c, <embedded body>, "yd-inline" ($0),
+	// helix_url ($1), runner_token ($2), helix_image ($3).
+	if len(task.Arguments) != 6 {
+		t.Fatalf("expected 6 arguments [-c body $0 $1 $2 $3], got %d: %v", len(task.Arguments), task.Arguments)
 	}
-	if len(task.Arguments) != len(wantArgs) {
-		t.Fatalf("Arguments length: got %d (%v), want %d (%v)", len(task.Arguments), task.Arguments, len(wantArgs), wantArgs)
+	if task.Arguments[0] != "-c" {
+		t.Fatalf("Arguments[0] = %q, want -c", task.Arguments[0])
 	}
-	for i := range wantArgs {
-		if task.Arguments[i] != wantArgs[i] {
-			t.Fatalf("Arguments[%d] = %q, want %q", i, task.Arguments[i], wantArgs[i])
-		}
+	// Arguments[1] is the embedded script body. Spot-check that it
+	// references the positional args we'll pass.
+	if !strings.Contains(task.Arguments[1], "HELIX_URL=\"${1") {
+		t.Fatalf("embedded script body doesn't reference $1 as expected")
+	}
+	if task.Arguments[2] != "yd-inline" {
+		t.Fatalf("Arguments[2] = %q, want yd-inline ($0)", task.Arguments[2])
+	}
+	if task.Arguments[3] != "https://helix.example.com" {
+		t.Fatalf("Arguments[3] = %q, want helix URL ($1)", task.Arguments[3])
+	}
+	if task.Arguments[4] != "secret-token-xyz" {
+		t.Fatalf("Arguments[4] = %q, want runner token ($2)", task.Arguments[4])
+	}
+	if task.Arguments[5] != "ghcr.io/helixml/helix-sandbox:test-tag" {
+		t.Fatalf("Arguments[5] = %q, want image ($3)", task.Arguments[5])
 	}
 
-	// helix-sandbox container env vars must flow via docker -e flags
-	// in Arguments (verified above), NOT via task Environment. The
-	// task Environment is for the docker-run.sh handler itself
-	// (DOCKER_USERNAME, YD_STOP_SIGNAL, etc.) - kept minimal here.
-	if got := task.Environment["SANDBOX_INSTANCE_ID"]; got != "" {
-		t.Fatalf("SANDBOX_INSTANCE_ID must NOT appear in task Environment (it goes via docker -e in Arguments); got %q", got)
-	}
-	if got := task.Environment["HELIX_API_URL"]; got != "" {
-		t.Fatalf("HELIX_API_URL must NOT appear in task Environment; got %q", got)
+	// SANDBOX_INSTANCE_ID must be in the task Environment - the
+	// embedded script reads $SANDBOX_INSTANCE_ID from its process
+	// env to name the container + propagate to helix-sandbox.
+	if got := task.Environment["SANDBOX_INSTANCE_ID"]; got != "sbx_test123" {
+		t.Fatalf("Environment[SANDBOX_INSTANCE_ID] = %q, want sbx_test123", got)
 	}
 }
 
@@ -249,7 +250,7 @@ func TestTaskArgumentsEmptyWhenConfigIncomplete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewProvider: %v", err)
 	}
-	if got := p.taskArguments(compute.Spec{}); got != nil {
+	if got := p.taskArguments(); got != nil {
 		t.Fatalf("expected nil arguments when config is incomplete, got %v", got)
 	}
 }

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -414,7 +414,7 @@ func NewServer(
 	// Helix on the legacy self-registered-host path. A non-nil error
 	// is fatal: better to fail boot than start with a misconfigured
 	// Manager that silently drops Provision calls.
-	computeManager, err := bootstrap.Bootstrap(cfg.Compute, store)
+	computeManager, err := bootstrap.Bootstrap(cfg.Compute, cfg.WebServer.URL, cfg.WebServer.RunnerToken, store)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap compute subsystem: %w", err)
 	}


### PR DESCRIPTION
## Summary

Wires Helix's ComputeManager to YellowDog so the control plane can dispatch sandbox hosts via YD's REST API. Combines what was originally split across two PRs (#2565 + #2571) into a single review unit after some mid-flight churn around how the sandbox launcher gets to the worker.

**Disabled by default.** Without `HELIX_COMPUTE_PROVIDER` set, nothing in this PR changes runtime behaviour. The bash task type, the docker run, the auto-register bridge - none of it fires.

## What lands

### YD client (api/pkg/sandbox/compute/yellowdog)

- `Provider` wraps the YD REST API (POST work-requirement, GET status, PUT transition CANCELLING, GET search). Auto-derives WorkerTag from Namespace ("worker-<namespace>") when unset; matches the yd-provision POC convention.
- `bash_script.sh` is the helix-sandbox launcher, embedded into the Helix Go binary via `//go:embed`. Shipped inline as `bash -c <body> args...` so YD's default `bash` task type runs it directly - no S3 upload, no extra userdata script, no docker task type registration.
- `Provider.Provision` constructs the WR + task with: `TaskType=bash`, `Arguments=["-c", <embedded body>, "yd-inline", helix_url, runner_token, helix_image]`, `Environment={SANDBOX_INSTANCE_ID: <pre-decided sandbox id>}`.

### Auto-derived helix-sandbox image (no env var)

- `helixSandboxImage()` reads `data.GetHelixVersion()` and produces `ghcr.io/helixml/helix-sandbox:<version>`. Trusts the build process: release tags, RCs, per-PR short SHAs all valid.
- Rejects sentinel placeholders (`""`, `"<unknown>"`, `"v0.0.0+dev"`, `"v0.0.0"`, `"0.0.0"`) with an explicit error pointing at the `-ldflags` fix.
- No `HELIX_YD_HELIX_IMAGE` env var. Version-pin via the standard Helix build process.

### wrStatusToState fix

YD reports `RUNNING` the moment a WR is accepted by the scheduler - long before any worker picks the task up, EC2 boots, or helix-sandbox pulls its image. Previously we mapped YD-`RUNNING` to `StateReady`, which prematurely promoted rows to ready before helix-sandbox could phone home. Now maps to `StateProvisioning` - the auto-register bridge handles the actual promotion when helix-sandbox registers via WebSocket.

### Auto-register bridge

`server.ensureSandboxRegistered` now transitions a Manager-provisioned row (matching pre-decided SandboxID) from `provisioning -> ready` when helix-sandbox phones home. Uses targeted column updates (compute_state, status, network) instead of a full-row Save to avoid clobbering concurrent heartbeat writes. Also recovers `failed` rows that later come online.

### SERVER_URL and RUNNER_TOKEN

Plumbed through from `cfg.WebServer.URL` / `cfg.WebServer.RunnerToken` - reuses existing Helix config, no parallel env vars.

## What is NOT in this PR

- `compute.D3` (on-demand scaling) and `compute.D4` (idle deprovision) - separate follow-ups
- Per-row bridge attestation secret - tracked as a security follow-up
- Multi-profile / multi-instance-type support - bigger workstream after the POC

## Test plan

- [x] `go test ./api/pkg/sandbox/compute/... -race` - all tests green
- [x] `go build ./api/...` - wider build clean
- [x] Live-tested on prime: Helix-to-YD direction validated end-to-end (WR submission, worker matching, bash execution, docker run, helix-sandbox container start). Only step that didn't complete is sandbox phoning home, because prime's SERVER_URL is localhost (the YD worker can't reach it).
- [ ] End-to-end on yd.helix.ml (real public URL) - merge-blocker for the full demo loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)