### PR TITLE
feat(frontend): shared hire-worker + new-role components across helix-org pages

### DIFF
--- a/frontend/src/components/helix-org/HireWorkerDrawer.tsx
+++ b/frontend/src/components/helix-org/HireWorkerDrawer.tsx
@@ -1,0 +1,193 @@
+// HireWorkerDrawer is the shared hire form rendered from three places:
+//   - the Chart canvas's per-role + icon (presetRoleId set; Role field
+//     is read-only),
+//   - the Workers tab's "+ New Worker" button (presetRoleId omitted; a
+//     Role <select> is rendered and required),
+//   - any future entry point that wants to hire (same API).
+//
+// Form fields: Role, Kind, Handle (optional), Reports to (optional),
+// Identity content. parent_id is already part of HireWorkerRequest, so
+// no service-layer change is needed to wire the new selector.
+
+import { FC, useEffect, useState } from 'react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Divider from '@mui/material/Divider'
+import Drawer from '@mui/material/Drawer'
+import IconButton from '@mui/material/IconButton'
+import MenuItem from '@mui/material/MenuItem'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+import CloseIcon from '@mui/icons-material/Close'
+
+import useSnackbar from '../../hooks/useSnackbar'
+import {
+  HireWorkerRequest,
+  useHireHelixOrgWorker,
+  useListHelixOrgRoles,
+  useListHelixOrgWorkers,
+} from '../../services/helixOrgService'
+
+export type HireWorkerDrawerProps = {
+  open: boolean
+  onClose: () => void
+  // When set, the Role field is rendered read-only and prefilled. When
+  // omitted, a required Role <select> is rendered.
+  presetRoleId?: string
+}
+
+const HireWorkerDrawer: FC<HireWorkerDrawerProps> = ({ open, onClose, presetRoleId }) => {
+  const snackbar = useSnackbar()
+  const hire = useHireHelixOrgWorker()
+  const { data: rolesData } = useListHelixOrgRoles({ enabled: open && !presetRoleId })
+  const { data: workersData } = useListHelixOrgWorkers({ enabled: open })
+
+  const [id, setId] = useState('')
+  const [kind, setKind] = useState<'ai' | 'human'>('human')
+  const [identity, setIdentity] = useState('')
+  const [roleId, setRoleId] = useState(presetRoleId ?? '')
+  const [parentId, setParentId] = useState('')
+
+  // Reset form on each open so reopening doesn't show stale state from
+  // a previous hire.
+  useEffect(() => {
+    if (!open) return
+    setId('')
+    setKind('human')
+    setIdentity('')
+    setRoleId(presetRoleId ?? '')
+    setParentId('')
+  }, [open, presetRoleId])
+
+  const roles = rolesData ?? []
+  const workers = workersData ?? []
+
+  const canSubmit = Boolean(identity.trim()) && Boolean(roleId)
+
+  const submit = async () => {
+    if (!identity.trim()) {
+      snackbar.error('identity content is required')
+      return
+    }
+    if (!roleId) {
+      snackbar.error('role is required')
+      return
+    }
+    const body: HireWorkerRequest = {
+      role_id: roleId,
+      kind,
+      identity_content: identity,
+    }
+    if (id.trim()) body.id = id.trim()
+    if (parentId) body.parent_id = parentId
+    try {
+      const res = await hire.mutateAsync(body)
+      if (parentId) {
+        snackbar.success(`hired ${res.id} reporting to ${parentId}`)
+      } else {
+        snackbar.success(`hired ${res.id} — drag an edge from a manager to set who they report to`)
+      }
+      onClose()
+    } catch (err: any) {
+      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'hire failed')
+    }
+  }
+
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      PaperProps={{ sx: { backgroundImage: 'none' } }}
+    >
+      <Box sx={{ p: 2.5, width: 380 }}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+          <Typography variant="h6">Hire worker</Typography>
+          <IconButton size="small" onClick={onClose}><CloseIcon /></IconButton>
+        </Stack>
+        <Stack spacing={1.5}>
+          {presetRoleId ? (
+            <Box>
+              <Typography variant="caption" color="text.secondary">Role</Typography>
+              <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>{presetRoleId}</Typography>
+            </Box>
+          ) : (
+            <TextField
+              select
+              size="small"
+              label="Role"
+              value={roleId}
+              onChange={(e) => setRoleId(e.target.value)}
+              fullWidth
+              required
+              helperText={roles.length === 0 ? 'No roles defined yet — create one first.' : 'Job description + MCP tools the worker holds.'}
+            >
+              {roles.map((r) => (
+                <MenuItem key={r.id} value={r.id ?? ''} sx={{ fontFamily: 'monospace' }}>
+                  {r.id}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
+          <Divider sx={{ my: 1 }} />
+          <TextField
+            select
+            size="small"
+            label="Kind"
+            value={kind}
+            onChange={(e) => setKind(e.target.value as 'ai' | 'human')}
+            fullWidth
+          >
+            <MenuItem value="human">Human</MenuItem>
+            <MenuItem value="ai">AI</MenuItem>
+          </TextField>
+          <TextField
+            size="small"
+            label="Handle (optional)"
+            placeholder="w-alice"
+            helperText="Lowercase first name, prefixed with w-. Leave blank to auto-assign."
+            value={id}
+            onChange={(e) => setId(e.target.value)}
+            fullWidth
+          />
+          <TextField
+            select
+            size="small"
+            label="Reports to (optional)"
+            value={parentId}
+            onChange={(e) => setParentId(e.target.value)}
+            fullWidth
+            helperText="Manager this worker reports to. Leave blank and wire later by dragging an edge in the Chart."
+          >
+            <MenuItem value="">(none)</MenuItem>
+            {workers.map((w) => (
+              <MenuItem key={w.id} value={w.id ?? ''} sx={{ fontFamily: 'monospace' }}>
+                {w.id}{w.role_id ? ` — ${w.role_id}` : ''}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            size="small"
+            label="Identity content"
+            placeholder="Short persona / profile in markdown."
+            value={identity}
+            onChange={(e) => setIdentity(e.target.value)}
+            multiline
+            minRows={6}
+            fullWidth
+            required
+          />
+          <Stack direction="row" spacing={1} sx={{ pt: 1 }}>
+            <Button variant="contained" onClick={submit} disabled={hire.isPending || !canSubmit}>
+              {hire.isPending ? 'Hiring…' : 'Hire'}
+            </Button>
+            <Button variant="text" onClick={onClose}>Cancel</Button>
+          </Stack>
+        </Stack>
+      </Box>
+    </Drawer>
+  )
+}
+
+export default HireWorkerDrawer

--- a/frontend/src/components/helix-org/NewRoleDialog.tsx
+++ b/frontend/src/components/helix-org/NewRoleDialog.tsx
@@ -1,0 +1,85 @@
+// NewRoleDialog is the shared "create role" dialog used by the Chart
+// canvas's floating top-right button and the Roles tab's "+ New Role"
+// header action. Lifted from HelixOrgChart.tsx so both call sites get
+// the same form, validation, and error handling.
+
+import { FC, useEffect, useState } from 'react'
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
+
+import useSnackbar from '../../hooks/useSnackbar'
+import { useCreateHelixOrgRole } from '../../services/helixOrgService'
+
+export type NewRoleDialogProps = {
+  open: boolean
+  onClose: () => void
+}
+
+const NewRoleDialog: FC<NewRoleDialogProps> = ({ open, onClose }) => {
+  const snackbar = useSnackbar()
+  const create = useCreateHelixOrgRole()
+  const [id, setId] = useState('')
+  const [content, setContent] = useState('')
+
+  useEffect(() => {
+    if (!open) return
+    setId('')
+    setContent('')
+  }, [open])
+
+  const submit = async () => {
+    const trimmedId = id.trim()
+    if (!trimmedId) {
+      snackbar.error('Role ID is required')
+      return
+    }
+    try {
+      await create.mutateAsync({ id: trimmedId, content })
+      snackbar.success(`role ${trimmedId} created`)
+      onClose()
+    } catch (err: any) {
+      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'create role failed')
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>New role</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ pt: 1 }}>
+          <TextField
+            label="Role ID"
+            placeholder="r-engineer"
+            value={id}
+            onChange={(e) => setId(e.target.value)}
+            helperText="Convention: r-<kebab-case>. Stays as-is — the LLM and operator both refer to roles by this handle."
+            autoFocus
+            fullWidth
+          />
+          <TextField
+            label="Content (markdown)"
+            placeholder="# Engineer&#10;Builds and ships software."
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            multiline
+            minRows={6}
+            fullWidth
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={submit} variant="contained" disabled={create.isPending}>
+          {create.isPending ? 'Creating…' : 'Create'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default NewRoleDialog

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -6,17 +6,12 @@ import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import DialogContentText from '@mui/material/DialogContentText'
 import DialogTitle from '@mui/material/DialogTitle'
-import Divider from '@mui/material/Divider'
-import Drawer from '@mui/material/Drawer'
 import IconButton from '@mui/material/IconButton'
-import MenuItem from '@mui/material/MenuItem'
 import Stack from '@mui/material/Stack'
-import TextField from '@mui/material/TextField'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import AddIcon from '@mui/icons-material/Add'
 import PersonAddOutlinedIcon from '@mui/icons-material/PersonAddOutlined'
-import CloseIcon from '@mui/icons-material/Close'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline'
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined'
@@ -41,17 +36,16 @@ import '@xyflow/react/dist/style.css'
 
 import Page from '../components/system/Page'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
+import HireWorkerDrawer from '../components/helix-org/HireWorkerDrawer'
+import NewRoleDialog from '../components/helix-org/NewRoleDialog'
 import useLightTheme from '../hooks/useLightTheme'
 import useRouter from '../hooks/useRouter'
 import useSnackbar from '../hooks/useSnackbar'
 import {
-  HireWorkerRequest,
   WorkerDTO,
-  useCreateHelixOrgRole,
   useDeleteHelixOrgRole,
   useDeleteHelixOrgStream,
   useFireHelixOrgWorker,
-  useHireHelixOrgWorker,
   useListHelixOrgRoles,
   useListHelixOrgStreams,
   useListHelixOrgWorkers,
@@ -770,63 +764,7 @@ const buildGraph = (
   return { nodes, edges }
 }
 
-// ---- Dialogs (Create role, Confirm delete) -----------------------------
-
-const CreateRoleDialog: FC<{ open: boolean; onClose: () => void }> = ({ open, onClose }) => {
-  const snackbar = useSnackbar()
-  const create = useCreateHelixOrgRole()
-  const [id, setId] = useState('')
-  const [content, setContent] = useState('')
-
-  const submit = async () => {
-    const trimmedId = id.trim()
-    if (!trimmedId) {
-      snackbar.error('Role ID is required')
-      return
-    }
-    try {
-      await create.mutateAsync({ id: trimmedId, content })
-      snackbar.success(`role ${trimmedId} created`)
-      setId(''); setContent(''); onClose()
-    } catch (err: any) {
-      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'create role failed')
-    }
-  }
-
-  return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
-      <DialogTitle>New role</DialogTitle>
-      <DialogContent>
-        <Stack spacing={2} sx={{ pt: 1 }}>
-          <TextField
-            label="Role ID"
-            placeholder="r-engineer"
-            value={id}
-            onChange={(e) => setId(e.target.value)}
-            helperText="Convention: r-<kebab-case>. Stays as-is — the LLM and operator both refer to roles by this handle."
-            autoFocus
-            fullWidth
-          />
-          <TextField
-            label="Content (markdown)"
-            placeholder="# Engineer&#10;Builds and ships software."
-            value={content}
-            onChange={(e) => setContent(e.target.value)}
-            multiline
-            minRows={6}
-            fullWidth
-          />
-        </Stack>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
-        <Button onClick={submit} variant="contained" disabled={create.isPending}>
-          {create.isPending ? 'Creating…' : 'Create'}
-        </Button>
-      </DialogActions>
-    </Dialog>
-  )
-}
+// ---- Dialogs (Confirm delete) -----------------------------------------
 
 const ConfirmDeleteDialog: FC<{
   open: boolean
@@ -849,81 +787,6 @@ const ConfirmDeleteDialog: FC<{
     </DialogActions>
   </Dialog>
 )
-
-// ---- Hire drawer -------------------------------------------------------
-
-const HireDrawer: FC<{ roleId: string; onClose: () => void }> = ({ roleId, onClose }) => {
-  const snackbar = useSnackbar()
-  const hire = useHireHelixOrgWorker()
-  const [id, setId] = useState('')
-  const [kind, setKind] = useState<'ai' | 'human'>('human')
-  const [identity, setIdentity] = useState('')
-
-  const submit = async () => {
-    if (!identity.trim()) {
-      snackbar.error('identity content is required')
-      return
-    }
-    const body: HireWorkerRequest = {
-      role_id: roleId,
-      kind,
-      identity_content: identity,
-    }
-    if (id.trim()) body.id = id.trim()
-    try {
-      const res = await hire.mutateAsync(body)
-      snackbar.success(`hired ${res.id} — drag an edge from a manager to set who they report to`)
-      setId(''); setIdentity(''); onClose()
-    } catch (err: any) {
-      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'hire failed')
-    }
-  }
-
-  return (
-    <Box sx={{ p: 2.5, width: 380 }}>
-      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
-        <Typography variant="h6">Hire worker</Typography>
-        <IconButton size="small" onClick={onClose}><CloseIcon /></IconButton>
-      </Stack>
-      <Stack spacing={1.5}>
-        <Box>
-          <Typography variant="caption" color="text.secondary">Role</Typography>
-          <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>{roleId}</Typography>
-        </Box>
-        <Divider sx={{ my: 1 }} />
-        <TextField select size="small" label="Kind" value={kind} onChange={(e) => setKind(e.target.value as 'ai' | 'human')} fullWidth>
-          <MenuItem value="human">Human</MenuItem>
-          <MenuItem value="ai">AI</MenuItem>
-        </TextField>
-        <TextField
-          size="small"
-          label="Handle (optional)"
-          placeholder="w-alice"
-          helperText="Lowercase first name, prefixed with w-. Leave blank to auto-assign."
-          value={id}
-          onChange={(e) => setId(e.target.value)}
-          fullWidth
-        />
-        <TextField
-          size="small"
-          label="Identity content"
-          placeholder="Short persona / profile in markdown."
-          value={identity}
-          onChange={(e) => setIdentity(e.target.value)}
-          multiline
-          minRows={6}
-          fullWidth
-        />
-        <Stack direction="row" spacing={1} sx={{ pt: 1 }}>
-          <Button variant="contained" onClick={submit} disabled={hire.isPending}>
-            {hire.isPending ? 'Hiring…' : 'Hire'}
-          </Button>
-          <Button variant="text" onClick={onClose}>Cancel</Button>
-        </Stack>
-      </Stack>
-    </Box>
-  )
-}
 
 // ---- ReactFlow canvas --------------------------------------------------
 
@@ -1310,7 +1173,7 @@ const HelixOrgChart: FC = () => {
         </Box>
       </Box>
 
-      <CreateRoleDialog open={roleDialogOpen} onClose={() => setRoleDialogOpen(false)} />
+      <NewRoleDialog open={roleDialogOpen} onClose={() => setRoleDialogOpen(false)} />
       <ConfirmDeleteDialog
         open={confirmDelete !== null}
         title={
@@ -1324,19 +1187,11 @@ const HelixOrgChart: FC = () => {
         pending={deleteRole.isPending || deleteStream.isPending || fireWorker.isPending}
       />
 
-      <Drawer
-        anchor="right"
-        open={selection.kind !== 'none'}
+      <HireWorkerDrawer
+        open={selection.kind === 'hire'}
         onClose={() => setSelection({ kind: 'none' })}
-        PaperProps={{ sx: { backgroundImage: 'none' } }}
-      >
-        {selection.kind === 'hire' && (
-          <HireDrawer
-            roleId={selection.roleId}
-            onClose={() => setSelection({ kind: 'none' })}
-          />
-        )}
-      </Drawer>
+        presetRoleId={selection.kind === 'hire' ? selection.roleId : undefined}
+      />
     </Page>
   )
 }

--- a/frontend/src/pages/HelixOrgRoles.tsx
+++ b/frontend/src/pages/HelixOrgRoles.tsx
@@ -9,6 +9,7 @@
 
 import { FC, MouseEvent, useMemo, useState } from 'react'
 import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
 import Container from '@mui/material/Container'
 import IconButton from '@mui/material/IconButton'
 import Menu from '@mui/material/Menu'
@@ -16,11 +17,13 @@ import MenuItem from '@mui/material/MenuItem'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import useTheme from '@mui/material/styles/useTheme'
+import AddIcon from '@mui/icons-material/Add'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 
 import Page from '../components/system/Page'
+import NewRoleDialog from '../components/helix-org/NewRoleDialog'
 import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import SimpleTable from '../components/widgets/SimpleTable'
@@ -52,6 +55,7 @@ const HelixOrgRoles: FC = () => {
   const [deleting, setDeleting] = useState<RoleDTO | undefined>()
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [currentRole, setCurrentRole] = useState<RoleDTO | null>(null)
+  const [newRoleOpen, setNewRoleOpen] = useState(false)
 
   const openRole = (roleId: string) => {
     if (!orgSlug) return
@@ -152,14 +156,24 @@ const HelixOrgRoles: FC = () => {
     >
       <Container maxWidth="xl" sx={{ mb: 4, pt: 3 }}>
         <Stack spacing={2}>
-          <Box>
-            <Typography variant="h5" sx={{ mb: 1 }}>Roles</Typography>
-            <Typography variant="body2" color="text.secondary">
-              A Role defines a job description: the markdown content tells a Worker what they're for, the
-              tools list is the Worker's MCP tool surface, and the streams list flags which inbound events the Role's
-              prompt expects. Workers hold a Role directly — tools and prompt come from here.
-            </Typography>
-          </Box>
+          <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={2}>
+            <Box sx={{ flex: 1 }}>
+              <Typography variant="h5" sx={{ mb: 1 }}>Roles</Typography>
+              <Typography variant="body2" color="text.secondary">
+                A Role defines a job description: the markdown content tells a Worker what they're for, the
+                tools list is the Worker's MCP tool surface, and the streams list flags which inbound events the Role's
+                prompt expects. Workers hold a Role directly — tools and prompt come from here.
+              </Typography>
+            </Box>
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={() => setNewRoleOpen(true)}
+              sx={{ flexShrink: 0, mt: 0.5 }}
+            >
+              New Role
+            </Button>
+          </Stack>
 
           {isLoading ? (
             <LoadingSpinner />
@@ -168,9 +182,14 @@ const HelixOrgRoles: FC = () => {
               <Typography variant="body1" color="text.secondary" gutterBottom>
                 No roles defined yet.
               </Typography>
-              <Typography variant="body2" color="text.secondary">
-                Create roles from the Chart — use “New role” on the org chart canvas.
-              </Typography>
+              <Button
+                variant="contained"
+                startIcon={<AddIcon />}
+                onClick={() => setNewRoleOpen(true)}
+                sx={{ mt: 1 }}
+              >
+                New Role
+              </Button>
             </Box>
           ) : (
             <SimpleTable
@@ -227,6 +246,8 @@ const HelixOrgRoles: FC = () => {
           </Typography>
         </DeleteConfirmWindow>
       )}
+
+      <NewRoleDialog open={newRoleOpen} onClose={() => setNewRoleOpen(false)} />
     </Page>
   )
 }

--- a/frontend/src/pages/HelixOrgWorkers.tsx
+++ b/frontend/src/pages/HelixOrgWorkers.tsx
@@ -6,20 +6,24 @@
 
 import { FC, MouseEvent, useMemo, useState } from 'react'
 import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
 import Container from '@mui/material/Container'
 import IconButton from '@mui/material/IconButton'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import Stack from '@mui/material/Stack'
+import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import useTheme from '@mui/material/styles/useTheme'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import PersonAddOutlinedIcon from '@mui/icons-material/PersonAddOutlined'
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline'
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined'
 
 import Page from '../components/system/Page'
+import HireWorkerDrawer from '../components/helix-org/HireWorkerDrawer'
 import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import SimpleTable from '../components/widgets/SimpleTable'
@@ -31,6 +35,7 @@ import useSnackbar from '../hooks/useSnackbar'
 import {
   WorkerDTO,
   useFireHelixOrgWorker,
+  useListHelixOrgRoles,
   useListHelixOrgWorkers,
 } from '../services/helixOrgService'
 
@@ -45,12 +50,29 @@ const HelixOrgWorkers: FC = () => {
   const orgSlug = router.params.org_id as string | undefined
 
   const { data, isLoading } = useListHelixOrgWorkers()
+  const { data: rolesData } = useListHelixOrgRoles()
   const fire = useFireHelixOrgWorker()
 
   const workers = data ?? []
+  const roles = rolesData ?? []
   const [firing, setFiring] = useState<WorkerDTO | undefined>()
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [currentWorker, setCurrentWorker] = useState<WorkerDTO | null>(null)
+  const [hireOpen, setHireOpen] = useState(false)
+
+  // Role filter — persisted in the URL (?role=r-…) so a filtered view
+  // is shareable and survives refresh. URL only, not localStorage:
+  // a filter is per-task context, not a per-user preference.
+  const roleFilter = (router.params.role as string | undefined) ?? ''
+  const setRoleFilter = (value: string) => {
+    if (value) router.mergeParams({ role: value })
+    else router.removeParams(['role'])
+  }
+
+  const filteredWorkers = useMemo(
+    () => (roleFilter ? workers.filter((w) => w.role_id === roleFilter) : workers),
+    [workers, roleFilter],
+  )
 
   const openWorker = (workerId: string) => {
     if (!orgSlug) return
@@ -84,7 +106,7 @@ const HelixOrgWorkers: FC = () => {
     }
   }
 
-  const tableData = useMemo(() => workers.map((w) => ({
+  const tableData = useMemo(() => filteredWorkers.map((w) => ({
     id: w.id,
     _data: w,
     name: (
@@ -142,7 +164,7 @@ const HelixOrgWorkers: FC = () => {
         {w.tools?.length ?? 0}
       </Typography>
     ),
-  })), [workers, theme])
+  })), [filteredWorkers, theme])
 
   const getActions = (row: any) => {
     const w = row._data as WorkerDTO
@@ -161,22 +183,64 @@ const HelixOrgWorkers: FC = () => {
     >
       <Container maxWidth="xl" sx={{ mb: 4, pt: 3 }}>
         <Stack spacing={2}>
-          <Box>
-            <Typography variant="h5" sx={{ mb: 1 }}>Workers</Typography>
-            <Typography variant="body2" color="text.secondary">
-              Workers are the people and AI agents in the org. Each holds a Role
-              (the source of their MCP capabilities) and reports to another
-              Worker. Click a worker to open its detail page — chat to it in a
-              fresh session, inspect its identity, manage its subscriptions.
-            </Typography>
-          </Box>
+          <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={2}>
+            <Box sx={{ flex: 1 }}>
+              <Typography variant="h5" sx={{ mb: 1 }}>Workers</Typography>
+              <Typography variant="body2" color="text.secondary">
+                Workers are the people and AI agents in the org. Each holds a Role
+                (the source of their MCP capabilities) and reports to another
+                Worker. Click a worker to open its detail page — chat to it in a
+                fresh session, inspect its identity, manage its subscriptions.
+              </Typography>
+            </Box>
+            <Button
+              variant="contained"
+              startIcon={<PersonAddOutlinedIcon />}
+              onClick={() => setHireOpen(true)}
+              sx={{ flexShrink: 0, mt: 0.5 }}
+            >
+              New Worker
+            </Button>
+          </Stack>
+
+          <Stack direction="row" alignItems="center" spacing={2}>
+            <TextField
+              select
+              size="small"
+              label="Role"
+              value={roleFilter}
+              onChange={(e) => setRoleFilter(e.target.value)}
+              sx={{ minWidth: 220 }}
+            >
+              <MenuItem value="">All roles</MenuItem>
+              {roles.map((r) => (
+                <MenuItem key={r.id} value={r.id ?? ''} sx={{ fontFamily: 'monospace' }}>
+                  {r.id}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Stack>
 
           {isLoading ? (
             <LoadingSpinner />
           ) : workers.length === 0 ? (
             <Box sx={{ textAlign: 'center', py: 8 }}>
               <Typography variant="body1" color="text.secondary" gutterBottom>
-                No workers yet. Hire one from the chart.
+                No workers yet.
+              </Typography>
+              <Button
+                variant="contained"
+                startIcon={<PersonAddOutlinedIcon />}
+                onClick={() => setHireOpen(true)}
+                sx={{ mt: 1 }}
+              >
+                New Worker
+              </Button>
+            </Box>
+          ) : filteredWorkers.length === 0 ? (
+            <Box sx={{ textAlign: 'center', py: 8 }}>
+              <Typography variant="body1" color="text.secondary">
+                No workers match this role.
               </Typography>
             </Box>
           ) : (
@@ -196,6 +260,8 @@ const HelixOrgWorkers: FC = () => {
           )}
         </Stack>
       </Container>
+
+      <HireWorkerDrawer open={hireOpen} onClose={() => setHireOpen(false)} />
 
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleMenuClose}>
         <MenuItem


### PR DESCRIPTION
## Summary

Bundles three QA regressions on the helix-org UI that all live in the
same two files (`HelixOrgWorkers.tsx`, `HelixOrgChart.tsx`) and have
overlapping mechanics. Extracts the hire form and new-role dialog into
two shared components under `frontend/src/components/helix-org/`, so
Workers, Roles and the Chart canvas can all open the same drawer/dialog.

Closes
- https://github.com/helixml/helix/issues/2537
- https://github.com/helixml/helix/issues/2538
- https://github.com/helixml/helix/issues/2539

## Changes

- **`+ New Worker` button on the Workers tab** (#2537) — primary action
  in the page header and a second one in the empty state. Opens the new
  `<HireWorkerDrawer>`.
- **`Reports to` (parent_id) selector on the hire form** (#2538) —
  populated from `useListHelixOrgWorkers()`, sent as `parent_id` in the
  hire request body (`HireWorkerRequest.parent_id` was already on the
  type; only the input + body wiring were missing). Success toast
  becomes `hired X reporting to Y` when set.
- **Role filter on the Workers list** (#2539) — `<TextField select>`
  above the table, options come from `useListHelixOrgRoles()`. Selection
  persists in the URL (`?role=…`) via `router.mergeParams` /
  `router.removeParams`, so a filtered view is shareable and
  refresh-safe. Client-side filter.
- **`+ New Role` button on the Roles tab** — parity with Workers; opens
  the shared `<NewRoleDialog>`. The Chart's existing floating "New role"
  button now uses the same component.
- **Role selector in the drawer when no preset role is given** — needed
  so the Workers tab's `+ New Worker` flow can pick a role. When the
  drawer is opened from the Chart's per-role hire icon, `presetRoleId`
  is set and the field is rendered as read-only text (mirrors the prior
  Chart drawer behaviour).
- **Two new files:**
  - `frontend/src/components/helix-org/HireWorkerDrawer.tsx`
  - `frontend/src/components/helix-org/NewRoleDialog.tsx`
- **`HelixOrgChart.tsx`** drops its inline `HireDrawer` + `CreateRoleDialog`
  (and the now-unused `Drawer` / `TextField` / `MenuItem` / `Divider` /
  `CloseIcon` imports); both call sites switch to the shared components.

No backend changes, no generated API client regen.

## Test plan

- [x] `cd frontend && yarn build` — clean TypeScript build.
- [x] Inner-Helix browser test: register, create org, navigate to
      Workers → `+ New Worker` → drawer shows Role + Reports-to
      selectors → hire with both set → table row shows
      `Role=r-engineer, Reports to=w-owner` (not `—`); toast reads
      `hired w-alice reporting to w-owner`.
- [x] Inner-Helix browser test: Workers → Role filter narrows table,
      URL gains `?role=r-engineer`, filter survives a full page reload.
- [x] Inner-Helix browser test: Roles → `+ New Role` → dialog opens,
      creates role, row appears.
- [x] Inner-Helix browser test: Chart → per-role hire icon → drawer
      opens with Role rendered as read-only `r-engineer` text and
      Reports-to selector present.
- [x] Inner-Helix browser test: Chart → floating `+ New role` → same
      shared dialog opens.

## Screenshots

![Workers tab — empty with NEW WORKER button](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002084_group-a-frontend/screenshots/01-workers-tab-empty.png)

![Hire drawer from Workers tab — Role + Reports-to selectors](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002084_group-a-frontend/screenshots/02-hire-drawer-from-workers-tab.png)

![Roles tab — NEW ROLE button](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002084_group-a-frontend/screenshots/03-roles-tab-with-new-role-button.png)

![NEW ROLE created — r-engineer row](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002084_group-a-frontend/screenshots/04-role-created.png)

![Workers tab with role+filter row](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002084_group-a-frontend/screenshots/05-workers-tab-with-owner.png)

![Hire drawer filled out](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002084_group-a-frontend/screenshots/06-hire-drawer-filled.png)

![After hire — Reports-to column populated](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002084_group-a-frontend/screenshots/07-hire-success-with-parent.png)

![Role filter applied — only r-engineer rows visible](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002084_group-a-frontend/screenshots/08-role-filter-applied.png)

![Chart after hire — w-alice under w-owner](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002084_group-a-frontend/screenshots/09-chart-after-hire.png)

![Chart's per-role hire icon — preset role read-only](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002084_group-a-frontend/screenshots/10-chart-hire-drawer-preset-role.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01ktrg8ar8n6brm0qnqnaf476k)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002084_group-a-frontend/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002084_group-a-frontend/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002084_group-a-frontend/tasks.md)

🚀 Built with [Helix](https://helix.ml)