### PR TITLE
feat(frontend): hover-to-delete × on org chart connections

### DIFF
--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -19,8 +19,12 @@ import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined'
 import dagre from 'dagre'
 import {
   Background,
+  BaseEdge,
   Controls,
   Edge,
+  EdgeLabelRenderer,
+  EdgeProps,
+  getStraightPath,
   Handle,
   MiniMap,
   Node,
@@ -626,7 +630,7 @@ const buildGraph = (
       id: `report:${parentId}->${wk.id}`,
       source: `worker:${parentId}`,
       target: `worker:${wk.id}`,
-      type: 'default',
+      type: 'deletable',
       animated: false,
       data: { kind: 'report', childWorkerId: wk.id, parentWorkerId: parentId },
       style: {
@@ -748,7 +752,7 @@ const buildGraph = (
           source: `worker:${wid}`,
           sourceHandle: 'stream',
           target: `stream:${s.id}`,
-          type: 'default',
+          type: 'deletable',
           animated: false,
           data: { kind: 'sub', workerId: wid, streamId: s.id },
           style: {
@@ -787,6 +791,95 @@ const ConfirmDeleteDialog: FC<{
     </DialogActions>
   </Dialog>
 )
+
+// ---- Custom edge: deletable on hover -----------------------------------
+//
+// Wraps the default straight edge with a hover affordance: a small × button
+// appears at the edge midpoint while the pointer is over the edge (or the
+// button), and clicking it routes through ReactFlow's deleteElements API so
+// the existing onEdgesDelete dispatch fires unchanged. A transparent wider
+// stroke overlay widens the hover hit-area to ~20px so the 1.25–1.5px
+// visible line is not the only target.
+const DeletableEdge: FC<EdgeProps> = ({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  style,
+  markerEnd,
+  data,
+  selected,
+}) => {
+  const [hover, setHover] = useState(false)
+  const { deleteElements } = useReactFlow()
+  const [edgePath, labelX, labelY] = getStraightPath({ sourceX, sourceY, targetX, targetY })
+  const kind = (data as { kind?: string } | undefined)?.kind
+  const ariaLabel = kind === 'sub' ? 'Remove subscription' : 'Remove reporting line'
+  const show = hover || selected
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} style={style} markerEnd={markerEnd} interactionWidth={20} />
+      {/* invisible wider hit-area; must NOT inherit strokeDasharray or hover
+          becomes spotty between dashes on subscription edges */}
+      <path
+        d={edgePath}
+        fill="none"
+        stroke="transparent"
+        strokeWidth={20}
+        strokeDasharray="none"
+        style={{ cursor: 'pointer' }}
+        onMouseEnter={() => setHover(true)}
+        onMouseLeave={() => setHover(false)}
+      />
+      {show && (
+        <EdgeLabelRenderer>
+          <button
+            type="button"
+            aria-label={ariaLabel}
+            title={ariaLabel}
+            onMouseEnter={() => setHover(true)}
+            onMouseLeave={() => setHover(false)}
+            onClick={(e) => {
+              e.stopPropagation()
+              deleteElements({ edges: [{ id }] })
+            }}
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+              pointerEvents: 'all',
+              width: 18,
+              height: 18,
+              borderRadius: '50%',
+              border: '1px solid rgba(0,0,0,0.2)',
+              background: '#ffffff',
+              color: '#444',
+              padding: 0,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              cursor: 'pointer',
+              boxShadow: '0 1px 2px rgba(0,0,0,0.15)',
+              fontSize: 14,
+              lineHeight: 1,
+            }}
+            onFocus={(e) => {
+              e.currentTarget.style.outline = '2px solid #1976d2'
+            }}
+            onBlur={(e) => {
+              e.currentTarget.style.outline = 'none'
+            }}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            ×
+          </button>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  )
+}
+
+const edgeTypes = { deletable: DeletableEdge }
 
 // ---- ReactFlow canvas --------------------------------------------------
 
@@ -886,6 +979,7 @@ const ChartCanvas: FC<{
       onConnect={onConnect}
       onEdgesDelete={onEdgesDelete}
       nodeTypes={nodeTypes}
+      edgeTypes={edgeTypes}
       fitView
       fitViewOptions={{ padding: 0.2 }}
       proOptions={{ hideAttribution: true }}


### PR DESCRIPTION
## Summary

Adds a hover-only × button at the midpoint of every connection in the org
chart (`HelixOrgChart`). Today the only way to remove a subscription or a
reporting line from the chart view is to click the edge to select it and
press `Backspace`/`Delete` — undiscoverable for users who don't know that
keyboard shortcut. This change surfaces a visible affordance without
adding visual noise (the × appears on hover, disappears on mouse-leave).

## Changes

- `frontend/src/pages/HelixOrgChart.tsx`:
  - New `DeletableEdge` React-Flow custom edge using `BaseEdge` + `EdgeLabelRenderer` from `@xyflow/react` v12; renders a transparent stroke-20 overlay path for a usable hover hit-area (the visible line is only 1.25–1.5px) and a small × button at the edge midpoint while hovered or selected.
  - The × `onClick` routes through `useReactFlow().deleteElements({ edges: [{ id }] })` so the existing `onEdgesDelete` dispatch (subscription → `DELETE /workers/{id}/subscriptions/{stream_id}`, reporting → `DELETE /workers/{id}/parents/{parent_id}`) fires unchanged. No new backend endpoints, no service-layer changes, no duplicated mutation logic.
  - Both `edges.push(...)` call-sites now set `type: 'deletable'`; new `edgeTypes={{ deletable: DeletableEdge }}` prop on `<ReactFlow>`.
  - `aria-label` differentiates the two edge kinds ("Remove subscription" / "Remove reporting line"); button is a real `<button type="button">` with a visible focus ring.
  - Existing keyboard delete (`Backspace`/`Delete` on selected edge) is preserved — same `onEdgesDelete` handles both paths.

## Verification

Tested end-to-end in the inner Helix at `http://localhost:8080`:

- Hovering a subscription edge shows the ×; click fires `DELETE /workers/w-owner/subscriptions/s-activations-w-owner → 204`; edge disappears; persists on page reload.
- Hovering a reporting edge shows the ×; click fires `DELETE /workers/w-alice/parents/w-owner → 204`; edge disappears.
- Keyboard delete (click edge to select, press `Delete`) still removes the edge.
- `yarn tsc --noEmit` clean. `yarn build` clean.

## Screenshots

![Chart with both edge kinds](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002085_the-current-connections/screenshots/04-chart-with-both-edge-kinds.png)

Hovering a **subscription** edge shows "Remove subscription":

![Hover × on subscription edge](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002085_the-current-connections/screenshots/03-hover-x-on-subscription-edge.png)

Hovering a **reporting** edge shows "Remove reporting line":

![Hover × on reporting edge](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002085_the-current-connections/screenshots/05-hover-x-on-reporting-edge.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01ktrgqft0wcnhc3tc7n46ky02)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002085_the-current-connections/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002085_the-current-connections/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002085_the-current-connections/tasks.md)

🚀 Built with [Helix](https://helix.ml)