### PR TITLE
feat(frontend): open worker right-rail links in new tab

### DIFF
--- a/frontend/src/pages/HelixOrgWorkerDetail.tsx
+++ b/frontend/src/pages/HelixOrgWorkerDetail.tsx
@@ -26,12 +26,14 @@ import CircularProgress from '@mui/material/CircularProgress'
 import Container from '@mui/material/Container'
 import Divider from '@mui/material/Divider'
 import Grid from '@mui/material/Grid'
+import Link from '@mui/material/Link'
 import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline'
 import RestartAltIcon from '@mui/icons-material/RestartAlt'
 import SaveIcon from '@mui/icons-material/Save'
@@ -47,6 +49,7 @@ import EmbeddedSessionView, {
 import RobustPromptInput from '../components/common/RobustPromptInput'
 import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
 
+import router5 from '../router'
 import useAccount from '../hooks/useAccount'
 import useApi from '../hooks/useApi'
 import useRouter from '../hooks/useRouter'
@@ -363,40 +366,58 @@ const HelixOrgWorkerDetail: FC = () => {
                       <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
                         Role
                       </Typography>
-                      <Button
-                        size="small"
-                        variant="text"
-                        onClick={() => orgSlug && router.navigate('helix_org_role_detail', { org_id: orgSlug, role_id: data.role!.id })}
-                        sx={{ fontFamily: 'monospace', textTransform: 'none', justifyContent: 'flex-start', p: 0, minWidth: 0 }}
-                      >
-                        {data.role.id}
-                      </Button>
+                      {orgSlug ? (
+                        <Link
+                          href={router5.buildPath('helix_org_role_detail', { org_id: orgSlug, role_id: data.role.id })}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          underline="hover"
+                          sx={{ fontFamily: 'monospace', display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
+                        >
+                          {data.role.id}
+                          <OpenInNewIcon sx={{ fontSize: 14 }} />
+                        </Link>
+                      ) : (
+                        <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>{data.role.id}</Typography>
+                      )}
                     </Box>
                   )}
                   {projectID && (
                     <Box>
                       <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>Project</Typography>
-                      <Button
-                        size="small"
-                        variant="text"
-                        onClick={() => orgSlug && router.navigate('org_project-specs', { org_id: orgSlug, id: projectID })}
-                        sx={{ fontFamily: 'monospace', fontSize: '0.7rem', textTransform: 'none', justifyContent: 'flex-start', p: 0, minWidth: 0, wordBreak: 'break-all', textAlign: 'left' }}
-                      >
-                        {projectID}
-                      </Button>
+                      {orgSlug ? (
+                        <Link
+                          href={router5.buildPath('org_project-specs', { org_id: orgSlug, id: projectID })}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          underline="hover"
+                          sx={{ fontFamily: 'monospace', fontSize: '0.7rem', display: 'inline-flex', alignItems: 'center', gap: 0.5, wordBreak: 'break-all' }}
+                        >
+                          {projectID}
+                          <OpenInNewIcon sx={{ fontSize: 14, flexShrink: 0 }} />
+                        </Link>
+                      ) : (
+                        <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.7rem', wordBreak: 'break-all' }}>{projectID}</Typography>
+                      )}
                     </Box>
                   )}
                   {agentAppID && (
                     <Box>
                       <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>Agent</Typography>
-                      <Button
-                        size="small"
-                        variant="text"
-                        onClick={() => orgSlug && router.navigate('org_agent', { org_id: orgSlug, app_id: agentAppID })}
-                        sx={{ fontFamily: 'monospace', fontSize: '0.7rem', textTransform: 'none', justifyContent: 'flex-start', p: 0, minWidth: 0, wordBreak: 'break-all', textAlign: 'left' }}
-                      >
-                        {agentAppID}
-                      </Button>
+                      {orgSlug ? (
+                        <Link
+                          href={router5.buildPath('org_agent', { org_id: orgSlug, app_id: agentAppID })}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          underline="hover"
+                          sx={{ fontFamily: 'monospace', fontSize: '0.7rem', display: 'inline-flex', alignItems: 'center', gap: 0.5, wordBreak: 'break-all' }}
+                        >
+                          {agentAppID}
+                          <OpenInNewIcon sx={{ fontSize: 14, flexShrink: 0 }} />
+                        </Link>
+                      ) : (
+                        <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.7rem', wordBreak: 'break-all' }}>{agentAppID}</Typography>
+                      )}
                     </Box>
                   )}
                   <Divider />


### PR DESCRIPTION
## Summary

On the Helix-OR Worker Detail page (`HelixOrgWorkerDetail.tsx`), the
Role / Project / Agent links in the right-hand rail used to navigate
the user away in the same tab. Operators almost always want to peek at
those without losing their place on the worker view, so this PR rewrites
them as real anchors that open in a new browser tab, with the
conventional "open in new" icon (square + arrow) next to each value.

## Changes

- Replace the three `<Button onClick={router.navigate}>` blocks (Role,
  Project, Agent) with MUI `<Link href target="_blank"
  rel="noopener noreferrer">` elements whose `href` is generated via
  `router.buildPath(routeName, params)` — so the route table stays the
  single source of truth.
- Append `<OpenInNewIcon sx={{ fontSize: 14 }} />` inside each link to
  signal the new-tab behaviour before the click.
- Preserve the existing per-link sizing (Role at body2, Project/Agent
  at `0.7rem` monospace with `wordBreak: 'break-all'`).
- Fall back to plain `<Typography>` when `orgSlug` is missing — the
  prior behaviour was a button with a no-op onClick, which was worse
  UX.
- Import the default router as `router5` to avoid shadowing the
  existing `const router = useRouter()` local in the component.

Because we're using a native `<a>` (via MUI `<Link>`), middle-click /
Cmd-click / right-click → "Open link in new tab" work natively without
any JS interception.

## Files changed

- `frontend/src/pages/HelixOrgWorkerDetail.tsx`

No backend, route, or API changes.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01ktrx0hjqe57t1jjw2f366drn)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002087_in-the-helix-or-worker/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002087_in-the-helix-or-worker/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002087_in-the-helix-or-worker/tasks.md)

🚀 Built with [Helix](https://helix.ml)