### PR TITLE
fix(api): populate project context when worker starts first session

### DIFF
--- a/api/pkg/server/attach_project_context_test.go
+++ b/api/pkg/server/attach_project_context_test.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// Regression test for the worker-hire bug: StartExternalAgentSession must
+// populate ProjectID, RepositoryIDs, and PrimaryRepositoryID on the
+// DesktopAgent. Without it, HELIX_REPOSITORIES is empty in the container
+// and helix-workspace-setup.sh aborts.
+func TestAttachProjectContext_PopulatesAgentFromStore(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockStore.EXPECT().
+		ListGitRepositories(gomock.Any(), &types.ListGitRepositoriesRequest{ProjectID: "prj_x"}).
+		Return([]*types.GitRepository{
+			{ID: "repo_a"},
+			{ID: "repo_b"},
+		}, nil)
+	mockStore.EXPECT().
+		GetProject(gomock.Any(), "prj_x").
+		Return(&types.Project{ID: "prj_x", DefaultRepoID: "repo_b"}, nil)
+
+	s := &HelixAPIServer{Store: mockStore}
+	agent := &types.DesktopAgent{}
+	err := s.attachProjectContext(context.Background(), agent, "prj_x")
+	require.NoError(t, err)
+	require.Equal(t, "prj_x", agent.ProjectID)
+	require.Equal(t, []string{"repo_a", "repo_b"}, agent.RepositoryIDs)
+	require.Equal(t, "repo_b", agent.PrimaryRepositoryID)
+}
+
+func TestAttachProjectContext_EmptyProjectIDIsNoOp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	// No store calls expected.
+
+	s := &HelixAPIServer{Store: mockStore}
+	agent := &types.DesktopAgent{}
+	err := s.attachProjectContext(context.Background(), agent, "")
+	require.NoError(t, err)
+	require.Empty(t, agent.ProjectID)
+	require.Empty(t, agent.RepositoryIDs)
+	require.Empty(t, agent.PrimaryRepositoryID)
+}
+
+func TestAttachProjectContext_NoReposLeavesRepoFieldsUnset(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockStore.EXPECT().
+		ListGitRepositories(gomock.Any(), gomock.Any()).
+		Return(nil, nil)
+	// GetProject is not called when there are no repos (no work to do).
+
+	s := &HelixAPIServer{Store: mockStore}
+	agent := &types.DesktopAgent{}
+	err := s.attachProjectContext(context.Background(), agent, "prj_empty")
+	require.NoError(t, err)
+	require.Equal(t, "prj_empty", agent.ProjectID)
+	require.Empty(t, agent.RepositoryIDs)
+	require.Empty(t, agent.PrimaryRepositoryID)
+}
+
+func TestAttachProjectContext_ListReposErrorIsReturned(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockStore.EXPECT().
+		ListGitRepositories(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("db boom"))
+
+	s := &HelixAPIServer{Store: mockStore}
+	agent := &types.DesktopAgent{}
+	err := s.attachProjectContext(context.Background(), agent, "prj_x")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "db boom")
+}
+
+func TestAttachProjectContext_GetProjectErrorTolerated_FirstRepoWins(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// If GetProject fails (e.g., briefly racy lookup), we still want repos
+	// attached — the worst case is PrimaryRepositoryID falls back to the
+	// first repo. This matches the pre-refactor behaviour of the
+	// startDevContainerForSession path.
+	mockStore := store.NewMockStore(ctrl)
+	mockStore.EXPECT().
+		ListGitRepositories(gomock.Any(), gomock.Any()).
+		Return([]*types.GitRepository{{ID: "repo_first"}}, nil)
+	mockStore.EXPECT().
+		GetProject(gomock.Any(), "prj_x").
+		Return(nil, errors.New("transient"))
+
+	s := &HelixAPIServer{Store: mockStore}
+	agent := &types.DesktopAgent{}
+	err := s.attachProjectContext(context.Background(), agent, "prj_x")
+	require.NoError(t, err)
+	require.Equal(t, []string{"repo_first"}, agent.RepositoryIDs)
+	require.Equal(t, "repo_first", agent.PrimaryRepositoryID)
+}

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -1983,27 +1983,15 @@ func (s *HelixAPIServer) resumeSessionInternal(ctx context.Context, user *types.
 		agent.OrganizationID = session.OrganizationID
 	}
 
-	project, err := s.Controller.Options.Store.GetProject(ctx, agent.ProjectID)
-	if err != nil {
+	// Resume path: project must exist (return 500 if it doesn't). The repo
+	// loading below tolerates a missing project, but this code path is the
+	// one that owns the "project must be present" contract for the session.
+	if _, err := s.Controller.Options.Store.GetProject(ctx, agent.ProjectID); err != nil {
 		return nil, fmt.Errorf("failed to get project '%s': %w", agent.ProjectID, err)
 	}
 
-	projectRepos, err := s.Controller.Options.Store.ListGitRepositories(ctx, &types.ListGitRepositoriesRequest{
-		ProjectID: agent.ProjectID,
-	})
-	if err == nil && len(projectRepos) > 0 {
-		agent.RepositoryIDs = make([]string, 0, len(projectRepos))
-		for _, repo := range projectRepos {
-			if repo.ID != "" {
-				agent.RepositoryIDs = append(agent.RepositoryIDs, repo.ID)
-			}
-		}
-
-		primaryRepoID := project.DefaultRepoID
-		if primaryRepoID == "" {
-			primaryRepoID = projectRepos[0].ID
-		}
-		agent.PrimaryRepositoryID = primaryRepoID
+	if err := s.attachProjectContext(ctx, agent, agent.ProjectID); err != nil {
+		return nil, fmt.Errorf("attach project context: %w", err)
 	}
 
 	if session.ParentApp != "" {
@@ -2398,6 +2386,35 @@ func (s *HelixAPIServer) restartCrashedAgentThread(_ http.ResponseWriter, r *htt
 	}, nil
 }
 
+// attachProjectContext sets agent.ProjectID and loads the project's
+// repositories, populating agent.RepositoryIDs and agent.PrimaryRepositoryID
+// via DesktopAgent.SetRepoContext. No-op when projectID is empty.
+//
+// All desktop-launch sites in this package must call this before handing the
+// agent to externalAgentExecutor.StartDesktop, otherwise HELIX_REPOSITORIES
+// will be empty in the container and helix-workspace-setup.sh will abort.
+func (s *HelixAPIServer) attachProjectContext(ctx context.Context, agent *types.DesktopAgent, projectID string) error {
+	if projectID == "" {
+		return nil
+	}
+	agent.ProjectID = projectID
+
+	repos, err := s.Store.ListGitRepositories(ctx, &types.ListGitRepositoriesRequest{ProjectID: projectID})
+	if err != nil {
+		return fmt.Errorf("list git repositories for project %s: %w", projectID, err)
+	}
+	if len(repos) == 0 {
+		return nil
+	}
+
+	var defaultRepoID string
+	if project, err := s.Store.GetProject(ctx, projectID); err == nil && project != nil {
+		defaultRepoID = project.DefaultRepoID
+	}
+	agent.SetRepoContext(repos, defaultRepoID)
+	return nil
+}
+
 // getSessionOutput godoc
 // StartExternalAgentSession creates a new external agent session programmatically.
 // This implements cron.ExternalAgentStarter for use by the cron trigger system.
@@ -2477,6 +2494,13 @@ func (s *HelixAPIServer) StartExternalAgentSession(ctx context.Context, req *typ
 		UserID:         userID,
 		Input:          "Initialize Zed development environment",
 		ProjectPath:    "workspace",
+	}
+
+	// Load the project's repos so HELIX_REPOSITORIES is populated in the
+	// container. Without this, helix-workspace-setup.sh aborts and
+	// start-zed-helix.sh loops on the setup-failed marker forever.
+	if err := s.attachProjectContext(ctx, zedAgent, session.ProjectID); err != nil {
+		return nil, fmt.Errorf("attach project context: %w", err)
 	}
 
 	zedAgent.OnBeforeCreate = func(hookCtx context.Context, a *types.DesktopAgent) error {

--- a/api/pkg/server/spec_task_design_review_handlers.go
+++ b/api/pkg/server/spec_task_design_review_handlers.go
@@ -964,22 +964,8 @@ func (s *HelixAPIServer) startDevContainerForSession(ctx context.Context, sessio
 	}
 
 	// Load project repositories.
-	projectRepos, err := s.Store.ListGitRepositories(ctx, &types.ListGitRepositoriesRequest{
-		ProjectID: agent.ProjectID,
-	})
-	if err == nil && len(projectRepos) > 0 {
-		agent.RepositoryIDs = make([]string, 0, len(projectRepos))
-		for _, repo := range projectRepos {
-			if repo.ID != "" {
-				agent.RepositoryIDs = append(agent.RepositoryIDs, repo.ID)
-			}
-		}
-		project, err := s.Store.GetProject(ctx, agent.ProjectID)
-		if err == nil && project != nil && project.DefaultRepoID != "" {
-			agent.PrimaryRepositoryID = project.DefaultRepoID
-		} else if len(projectRepos) > 0 {
-			agent.PrimaryRepositoryID = projectRepos[0].ID
-		}
+	if err := s.attachProjectContext(ctx, agent, agent.ProjectID); err != nil {
+		return fmt.Errorf("attach project context: %w", err)
 	}
 
 	// Get display settings from app config.

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -519,20 +519,8 @@ func (s *SpecDrivenTaskService) StartSpecGeneration(ctx context.Context, task *t
 		return
 	}
 
-	// Build list of all repository IDs to clone from project
-	repositoryIDs := []string{}
-	for _, repo := range projectRepos {
-		if repo.ID != "" {
-			repositoryIDs = append(repositoryIDs, repo.ID)
-		}
-	}
-
-	// Determine primary repository from project configuration
-	primaryRepoID := project.DefaultRepoID
-	if primaryRepoID == "" && len(projectRepos) > 0 {
-		// Use first project repo as fallback if no default set
-		primaryRepoID = projectRepos[0].ID
-	}
+	// Repository fields are populated below via zedAgent.SetRepoContext after
+	// the agent struct is constructed.
 
 	// API key creation is deferred to OnBeforeCreate hook (inside StartDesktop's
 	// session lock) to prevent races with concurrent StopDesktop.
@@ -600,21 +588,20 @@ func (s *SpecDrivenTaskService) StartSpecGeneration(ctx context.Context, task *t
 	}
 
 	zedAgent := &types.DesktopAgent{
-		OrganizationID:      orgID,
-		SessionID:           session.ID,
-		UserID:              task.CreatedBy,
-		Input:               "Initialize Zed development environment for spec generation",
-		ProjectID:           task.ProjectID, // For golden Docker cache overlay
-		ProjectPath:         "workspace",    // Use relative path
-		SpecTaskID:          task.ID,        // For task-scoped workspace
-		PrimaryRepositoryID: primaryRepoID,  // Primary repo to open in Zed
-		RepositoryIDs:       repositoryIDs,  // ALL project repos to checkout
-		DisplayWidth:        displayWidth,
-		DisplayHeight:       displayHeight,
-		DisplayRefreshRate:  displayRefreshRate,
-		Resolution:          resolution,
-		ZoomLevel:           zoomLevel,
-		DesktopType:         desktopType,
+		OrganizationID: orgID,
+		SessionID:      session.ID,
+		UserID:         task.CreatedBy,
+		Input:          "Initialize Zed development environment for spec generation",
+		ProjectID:      task.ProjectID, // For golden Docker cache overlay
+		ProjectPath:    "workspace",    // Use relative path
+		SpecTaskID:     task.ID,        // For task-scoped workspace
+		// RepositoryIDs / PrimaryRepositoryID set by SetRepoContext below.
+		DisplayWidth:       displayWidth,
+		DisplayHeight:      displayHeight,
+		DisplayRefreshRate: displayRefreshRate,
+		Resolution:         resolution,
+		ZoomLevel:          zoomLevel,
+		DesktopType:        desktopType,
 		Env: envVars,
 		OnBeforeCreate: func(hookCtx context.Context, a *types.DesktopAgent) error {
 			apiKey, err := s.GetOrCreateSessionAPIKey(hookCtx, &SessionAPIKeyRequest{
@@ -633,6 +620,7 @@ func (s *SpecDrivenTaskService) StartSpecGeneration(ctx context.Context, task *t
 		BaseBranch:    task.BaseBranch,
 		WorkingBranch: task.BranchName, // For existing mode: checkout this; for new mode: create this
 	}
+	zedAgent.SetRepoContext(projectRepos, project.DefaultRepoID)
 	log.Debug().Str("task_id", task.ID).Str("session_id", session.ID).Msg("DEBUG: Created ZedAgent struct")
 
 	// Check if executor is nil

--- a/api/pkg/types/desktop_agent_repo_context_test.go
+++ b/api/pkg/types/desktop_agent_repo_context_test.go
@@ -1,0 +1,61 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDesktopAgent_SetRepoContext_EmptyReposIsNoOp(t *testing.T) {
+	a := &DesktopAgent{
+		RepositoryIDs:       []string{"preserved"},
+		PrimaryRepositoryID: "preserved",
+	}
+	a.SetRepoContext(nil, "")
+	require.Equal(t, []string{"preserved"}, a.RepositoryIDs)
+	require.Equal(t, "preserved", a.PrimaryRepositoryID)
+}
+
+func TestDesktopAgent_SetRepoContext_DefaultRepoIDWins(t *testing.T) {
+	repos := []*GitRepository{
+		{ID: "repo_a"},
+		{ID: "repo_b"},
+	}
+	a := &DesktopAgent{}
+	a.SetRepoContext(repos, "repo_b")
+	require.Equal(t, []string{"repo_a", "repo_b"}, a.RepositoryIDs)
+	require.Equal(t, "repo_b", a.PrimaryRepositoryID)
+}
+
+func TestDesktopAgent_SetRepoContext_NoDefaultUsesFirstRepo(t *testing.T) {
+	repos := []*GitRepository{
+		{ID: "repo_a"},
+		{ID: "repo_b"},
+	}
+	a := &DesktopAgent{}
+	a.SetRepoContext(repos, "")
+	require.Equal(t, []string{"repo_a", "repo_b"}, a.RepositoryIDs)
+	require.Equal(t, "repo_a", a.PrimaryRepositoryID)
+}
+
+func TestDesktopAgent_SetRepoContext_FiltersEmptyIDsAndNils(t *testing.T) {
+	repos := []*GitRepository{
+		nil,
+		{ID: ""},
+		{ID: "repo_real"},
+	}
+	a := &DesktopAgent{}
+	a.SetRepoContext(repos, "")
+	require.Equal(t, []string{"repo_real"}, a.RepositoryIDs)
+	require.Equal(t, "repo_real", a.PrimaryRepositoryID)
+}
+
+func TestDesktopAgent_SetRepoContext_AllFilteredIsNoOp(t *testing.T) {
+	a := &DesktopAgent{
+		RepositoryIDs:       []string{"preserved"},
+		PrimaryRepositoryID: "preserved",
+	}
+	a.SetRepoContext([]*GitRepository{nil, {ID: ""}}, "")
+	require.Equal(t, []string{"preserved"}, a.RepositoryIDs)
+	require.Equal(t, "preserved", a.PrimaryRepositoryID)
+}

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -1913,6 +1913,31 @@ func (z *DesktopAgent) GetEffectiveResolution() (width, height, refreshRate int)
 	return width, height, refreshRate
 }
 
+// SetRepoContext populates RepositoryIDs and PrimaryRepositoryID from the
+// given project repos. defaultRepoID is the project's preferred repo
+// (typically Project.DefaultRepoID); when empty the first repo wins.
+// No-op when repos is empty — caller-set values are preserved.
+func (z *DesktopAgent) SetRepoContext(repos []*GitRepository, defaultRepoID string) {
+	if len(repos) == 0 {
+		return
+	}
+	ids := make([]string, 0, len(repos))
+	for _, repo := range repos {
+		if repo != nil && repo.ID != "" {
+			ids = append(ids, repo.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return
+	}
+	z.RepositoryIDs = ids
+	if defaultRepoID != "" {
+		z.PrimaryRepositoryID = defaultRepoID
+	} else {
+		z.PrimaryRepositoryID = ids[0]
+	}
+}
+
 // DesktopAgentAPIEnvVars returns the standard API-related environment variables
 // that desktop agents need for LLM access and Git operations.
 // This function ensures consistent env var names across all code paths.


### PR DESCRIPTION
## Summary

When a Helix-OR worker is hired and its first session is launched, the
desktop container never finishes initializing — `HELIX_REPOSITORIES`
lands empty, `helix-workspace-setup.sh` aborts, the
`/home/retro/.helix-setup-failed` marker is written, and
`start-zed-helix.sh` loops on the setup-waiting check forever.

Root cause: `StartExternalAgentSession` (the worker-hire entry point)
built a `DesktopAgent` without `ProjectID`, `RepositoryIDs`, or
`PrimaryRepositoryID`. Two near-identical lookups already existed at
`startDevContainerForSession` and the exploratory-resume path, plus a
slight variant in the spec-task service — all of which worked correctly.
Only the worker-hire site had been missed.

Auto-wake retries didn't recover the stuck session because hydra
short-circuits with "Dev container already running, returning existing
session" before re-applying env vars. The fix has to be at the caller.

## Changes

- New pure method `(*types.DesktopAgent).SetRepoContext(repos, defaultRepoID)`
  in `api/pkg/types/types.go` — no I/O, callable from any package.
- New `(s *HelixAPIServer).attachProjectContext(ctx, agent, projectID)` in
  `api/pkg/server/session_handlers.go` — does the `ListGitRepositories` +
  `GetProject` lookups and delegates to `SetRepoContext`.
- `StartExternalAgentSession` now calls `attachProjectContext` after
  constructing the `DesktopAgent` (the bug fix).
- `startDevContainerForSession` (`spec_task_design_review_handlers.go:967`)
  and the exploratory-resume path (`session_handlers.go:1991`) both
  replaced with the helper. The exploratory-resume path keeps its
  separate `GetProject` 500-on-missing check as a precondition.
- `spec_driven_task_service.go` uses `SetRepoContext` directly (it already
  has `projectRepos` loaded for `SyncBaseBranchForTask`, so no extra DB
  call is needed).
- Surfaced `ListGitRepositories` errors loudly — the old inline code
  silently swallowed them and launched a broken container.

## Tests

- 5 pure-value tests for `SetRepoContext` (empty repos no-op, default
  wins, fallback to first repo, nil/empty-id filtering, all-filtered no-op).
- 5 `MockStore`-driven tests for `attachProjectContext` (happy path,
  empty `projectID` no-op, no repos leaves repo fields unset,
  `ListGitRepositories` error returned, `GetProject` error tolerated
  with first-repo fallback).
- Full `go build ./api/...` clean.

## Test plan

- [ ] CI green (Drone)
- [ ] Hire a Helix-OR worker against a project with attached repos, watch
      first session start, confirm `HELIX_REPOSITORIES` is populated in the
      container env and Zed launches without the
      `/home/retro/.helix-setup-failed` marker appearing.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01ktry0kgz0ax4s1322a0y5cy2)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002088_very-odd-bug-when/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002088_very-odd-bug-when/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002088_very-odd-bug-when/tasks.md)

🚀 Built with [Helix](https://helix.ml)