### PR TITLE
fix(yellowdog): clean up container on YD task abort

### DIFF
--- a/api/pkg/sandbox/compute/yellowdog/bash_script.sh
+++ b/api/pkg/sandbox/compute/yellowdog/bash_script.sh
@@ -52,7 +52,34 @@ echo "container_name=$CONTAINER_NAME"
 echo "sandbox_id=$SANDBOX_ID"
 echo "gpu_vendor=$GPU_VENDOR gpu_flags=$GPU_FLAGS device_flags=$DEVICE_FLAGS max_sandboxes=$MAX_SANDBOXES"
 
-exec sudo docker run --rm --name "$CONTAINER_NAME" \
+# Cleanup on task abort or normal exit. Without this, a YD task cancel
+# (CANCELLING transition - YD agent sends SIGTERM to this script) leaves
+# the helix-sandbox container running, which holds the GPU slot and
+# prevents the next task on this worker from launching. Patterned after
+# YD's own docker-run.sh userdata script. Docker --rm alone isn't enough:
+# it covers clean exits but not abort-by-signal, and not SIGKILL at all.
+cleanup() {
+  echo "=== Cleanup: stopping container $CONTAINER_NAME ==="
+  sudo docker stop -t 10 "$CONTAINER_NAME" 2>/dev/null || true
+  sudo docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+}
+trap cleanup EXIT
+# Re-raise on signal so the EXIT trap fires AND the right exit code is
+# reported back to the YD agent (143 = 128+SIGTERM, 130 = 128+SIGINT).
+trap 'exit 143' TERM
+trap 'exit 130' INT
+
+# Pre-flight: remove any stale container with the same name from a
+# previous task on this worker that died without firing its EXIT trap
+# (e.g. killed by SIGKILL, OOM, or worker host reboot). Without this,
+# `docker run --name` will fail with "container name already in use"
+# and the new task will never start.
+sudo docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+
+# Run docker in the foreground (NOT exec) so this bash process stays
+# alive and owns signal handling. With `exec`, bash is replaced by
+# docker and the trap above never fires.
+sudo docker run --rm --name "$CONTAINER_NAME" \
   --privileged $GPU_FLAGS $DEVICE_FLAGS \
   -v /var/lib/docker \
   -e HELIX_API_URL="$HELIX_URL" \


### PR DESCRIPTION
## Summary

Fixes an orphaned-container bug in the YD bash task launcher. Without this, an aborted YD task leaves the helix-sandbox container running on the worker, holding the GPU slot and preventing the next task on that worker from launching.

Flagged by Peter (YD): if you stick with task type bash you need to do your own container cleanup, like YD's own `docker-run.sh` userdata script does.

## What was wrong

`bash_script.sh` used `exec sudo docker run --rm ...`. `exec` replaces the bash process with docker, so:

- When YD transitions a task to CANCELLING (which `Provider.Deprovision` does on Helix's behalf), the YD agent sends SIGTERM to the task PID. That PID is now docker, not bash. `docker --rm` usually stops the container, but it's not bulletproof under load.
- SIGKILL is untrappable. The container survives, holding the GPU slot.

## Fix

- Drop `exec` so bash stays alive as the parent process and owns signal handling
- `trap cleanup EXIT` runs `docker stop -t 10` + `docker rm -f` by container name on any exit path
- `trap 'exit 143' TERM` / `'exit 130' INT` re-raise so YD records the right exit code (128+signum)
- Pre-flight `docker rm -f` clears any stale container from a prior task that died without firing its EXIT trap (SIGKILL, OOM, worker reboot). Without this, the next `docker run --name` would fail with "name already in use" and the task would never start.

## Behaviour matrix

| Path | Result |
|---|---|
| Normal exit | `--rm` cleans up; EXIT trap is a no-op |
| YD CANCELLING -> SIGTERM | bash catches TERM, runs cleanup, container stops + removed, exit code 143 |
| SIGKILL (untrappable) | container orphaned, but the next task's preflight `docker rm -f` clears it |

## Test plan

- [x] `bash -n` syntax check
- [ ] End-to-end on yd.helix.ml: provoke an abort (`Provider.Deprovision` -> CANCELLING) mid-task and verify the worker is ready to accept a new task immediately afterwards
- [ ] Verify the next task on the same worker succeeds even when the prior task was SIGKILLed (simulate via `docker kill -s KILL` of the bash PID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)