### PR TITLE
fix(api): atomic claim of planning_session_id prevents duplicate desktops

### DIFF
--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -411,17 +411,16 @@ func (s *SpecDrivenTaskService) StartSpecGeneration(ctx context.Context, task *t
 		OwnerType:      types.OwnerTypeUser,
 	}
 
-	// Guard against duplicate session creation (issue #10 from ZFS deployment).
-	// Two concurrent requests can both reach this point before either has written
-	// planning_session_id to the DB. Re-read the task to see if a sibling already won the race.
-	if freshTask, readErr := s.store.GetSpecTask(ctx, task.ID); readErr == nil && freshTask.PlanningSessionID != "" {
-		log.Info().
-			Str("task_id", task.ID).
-			Str("existing_session_id", freshTask.PlanningSessionID).
-			Msg("Planning session already created by concurrent request — skipping duplicate creation")
-		return
-	}
-
+	// Create the session first so we have a real session ID to claim with. If
+	// we lose the atomic claim below, we delete this orphan and return — the
+	// winning caller's session is the one that ends up driving the desktop.
+	//
+	// This is more wasteful than a pre-claim (we burn a session row when we
+	// lose) but avoids the rollback footgun: if we claimed first and
+	// CreateSession failed, planning_session_id would point at a non-existent
+	// session and future retries would silently noop on the read-then-write
+	// guard. With this ordering, the claim is the single source of truth and
+	// no retry path can be left in a half-claimed state.
 	session, err = s.store.CreateSession(ctx, *session)
 	if err != nil {
 		log.Error().Err(err).Str("task_id", task.ID).Msg("Failed to create spec generation session")
@@ -429,16 +428,39 @@ func (s *SpecDrivenTaskService) StartSpecGeneration(ctx context.Context, task *t
 		return
 	}
 
-	// Update task with session ID
-	log.Debug().Str("task_id", task.ID).Str("session_id", session.ID).Msg("DEBUG: About to update task with session ID")
-	task.PlanningSessionID = session.ID
-	err = s.store.UpdateSpecTask(ctx, task)
+	// Atomically claim the planning_session_id slot. Two concurrent callers
+	// (orchestrator ticker + status-change subscription firing on the same
+	// task within milliseconds) each get to here with their own session, but
+	// only one wins this single-statement UPDATE. The loser deletes its
+	// orphan session and returns BEFORE reaching StartDesktop — preventing
+	// the workspace-volume race that corrupts the spec-task's git clone.
+	// Replaces the read-then-write TOCTOU guard that issue #10 of the
+	// 2026-03-18 ZFS deployment design doc attempted to close.
+	claimed, err := s.store.SetPlanningSessionIDIfEmpty(ctx, task.ID, session.ID)
 	if err != nil {
-		log.Error().Err(err).Str("task_id", task.ID).Msg("Failed to update task with session ID")
-		s.markTaskFailed(ctx, task, fmt.Sprintf("Failed to update task with session ID: %v", err))
+		log.Error().Err(err).Str("task_id", task.ID).Str("session_id", session.ID).Msg("Failed to claim planning_session_id; rolling back session")
+		if _, delErr := s.store.DeleteSession(ctx, session.ID); delErr != nil {
+			log.Warn().Err(delErr).Str("session_id", session.ID).Msg("Failed to delete orphan session after claim error")
+		}
+		s.markTaskFailed(ctx, task, fmt.Sprintf("Failed to claim planning_session_id: %v", err))
 		return
 	}
-	log.Debug().Str("task_id", task.ID).Msg("DEBUG: Task updated with session ID")
+	if !claimed {
+		log.Info().
+			Str("task_id", task.ID).
+			Str("orphan_session_id", session.ID).
+			Msg("Lost race to claim planning_session_id; deleting orphan session and bailing before StartDesktop")
+		if _, delErr := s.store.DeleteSession(ctx, session.ID); delErr != nil {
+			log.Warn().Err(delErr).Str("session_id", session.ID).Msg("Failed to delete orphan session after losing claim")
+		}
+		return
+	}
+
+	// We won the claim. Mirror the DB write into the in-memory task struct so
+	// the rest of this function (env var building, audit logging) sees the
+	// canonical planning_session_id.
+	log.Debug().Str("task_id", task.ID).Str("session_id", session.ID).Msg("DEBUG: Claimed planning_session_id atomically")
+	task.PlanningSessionID = session.ID
 
 	// Kick off git-identity sync in the background. The desktop container
 	// isn't up yet; the async helper polls until it can reach the container,

--- a/api/pkg/services/spec_driven_task_service_race_test.go
+++ b/api/pkg/services/spec_driven_task_service_race_test.go
@@ -1,0 +1,157 @@
+package services
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	external_agent "github.com/helixml/helix/api/pkg/external-agent"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+// TestSpecDrivenTaskService_StartSpecGeneration_NoDoubleStartDesktopOnConcurrency
+// pins the fix for the orchestrator double-fire race that ships two dev containers
+// against the same spec-task workspace and corrupts its git clone.
+//
+// In production, SpecTaskOrchestrator has two dispatch paths: a 10s ticker that
+// iterates active tasks, and a subscription that fires on every status change.
+// Both can land on a task in QueuedSpecGeneration within milliseconds of each
+// other and each spawn a goroutine that calls StartSpecGeneration. The old guard
+// at spec_driven_task_service.go:414-423 was a read-then-write TOCTOU — both
+// callers read PlanningSessionID=="", both passed, both went on to CreateSession
+// and StartDesktop. Real-world evidence of this failure: planning session
+// ses_01kts7zgv54067bgkdyjv3kj2x for task spt_01kts7zed3fe0wmadwb5wv0xzy on
+// 2026-06-10, where two containers (01kts7zgv0znfte5dr3nq6stbs +
+// 01kts7zgv54067bgkdyjv3kj2x) raced the same workspace volume and one ended up
+// with a half-written /home/retro/work/helix whose `git fetch origin --prune`
+// returned only `* branch HEAD -> FETCH_HEAD`.
+//
+// The fix: SetPlanningSessionIDIfEmpty does the claim atomically at the store
+// layer; the loser deletes its orphan session and returns BEFORE StartDesktop.
+func TestSpecDrivenTaskService_StartSpecGeneration_NoDoubleStartDesktopOnConcurrency(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockExecutor := external_agent.NewMockExecutor(ctrl)
+
+	project := &types.Project{
+		ID:                "project-race",
+		OrganizationID:    "org-1",
+		DefaultHelixAppID: "app-race",
+	}
+	app := &types.App{ID: "app-race"}
+	baseTask := &types.SpecTask{
+		ID:         "task-race",
+		ProjectID:  "project-race",
+		HelixAppID: "app-race",
+		Status:     types.TaskStatusQueuedSpecGeneration,
+		CreatedBy:  "user-1",
+		BranchMode: types.BranchModeNew,
+		BaseBranch: "main",
+		Name:       "racing task",
+	}
+
+	// All read-side store calls happen on both goroutines; allow any number.
+	mockStore.EXPECT().GetProject(gomock.Any(), "project-race").Return(project, nil).AnyTimes()
+	mockStore.EXPECT().GetApp(gomock.Any(), "app-race").Return(app, nil).AnyTimes()
+	mockStore.EXPECT().GetOrganization(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	// The TOCTOU read at spec_driven_task_service.go:417. We force it to ALWAYS
+	// return an empty planning_session_id so both concurrent callers pass the
+	// read-then-write guard. This is the canonical setup for the race.
+	mockStore.EXPECT().GetSpecTask(gomock.Any(), "task-race").Return(&types.SpecTask{
+		ID:                "task-race",
+		PlanningSessionID: "",
+	}, nil).AnyTimes()
+
+	mockStore.EXPECT().UpdateSpecTask(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	// CreateSession echoes the input (preserves any pre-generated ID).
+	mockStore.EXPECT().CreateSession(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, s types.Session) (*types.Session, error) {
+			sCopy := s
+			return &sCopy, nil
+		}).AnyTimes()
+
+	// The orphan-cleanup path the fix uses on the losing branch. Without the
+	// fix this is never called (the loser proceeds to StartDesktop instead).
+	mockStore.EXPECT().DeleteSession(gomock.Any(), gomock.Any()).
+		Return(&types.Session{}, nil).AnyTimes()
+
+	// The atomic gate that replaces the TOCTOU guard. The DoAndReturn body is
+	// the in-test simulation of the postgres single-statement UPDATE: the
+	// first caller wins, the rest lose. Without the fix this is never called.
+	var claimAttempts int32
+	mockStore.EXPECT().SetPlanningSessionIDIfEmpty(gomock.Any(), "task-race", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string) (bool, error) {
+			return atomic.AddInt32(&claimAttempts, 1) == 1, nil
+		}).AnyTimes()
+
+	mockStore.EXPECT().CreateInteraction(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, i *types.Interaction) (*types.Interaction, error) {
+			return i, nil
+		}).AnyTimes()
+
+	mockStore.EXPECT().ListGitRepositories(gomock.Any(), gomock.Any()).
+		Return([]*types.GitRepository{}, nil).AnyTimes()
+
+	mockStore.EXPECT().ListSpecTaskAttachments(gomock.Any(), gomock.Any()).
+		Return([]*types.SpecTaskAttachment{}, nil).AnyTimes()
+
+	// The assertion this whole test exists for: even with two concurrent
+	// StartSpecGeneration callers seeing the same empty PlanningSessionID,
+	// exactly one of them must reach StartDesktop. The other must bail.
+	var startDesktopCount int32
+	mockExecutor.EXPECT().StartDesktop(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *types.DesktopAgent) (*types.DesktopAgentResponse, error) {
+			atomic.AddInt32(&startDesktopCount, 1)
+			return &types.DesktopAgentResponse{
+				DevContainerID: "dev-test",
+				ContainerName:  "container-test",
+			}, nil
+		}).AnyTimes()
+
+	// Real GitRepositoryService — SyncBaseBranchForTask iterates zero repos
+	// (we mock ListGitRepositories to []), so no remote calls happen.
+	gitRepoService := NewGitRepositoryService(mockStore, t.TempDir(), "http://test", "test", "test@test")
+
+	service := NewSpecDrivenTaskService(
+		mockStore,
+		nil, // notifier
+		"test-helix-agent",
+		[]string{"test-zed-agent"},
+		nil, // pubsub
+		mockExecutor,
+		gitRepoService,
+		nil, // RegisterRequestMapping
+		NewDisabledKoditService(),
+	)
+	service.SetTestMode(true)
+
+	ctx := context.Background()
+
+	// Two callers, mirroring orchestrator ticker + subscription firing within
+	// milliseconds of each other on the same task.
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Each goroutine gets an independent task copy so they don't
+			// trample shared in-memory fields. (Same as production: the
+			// orchestrator passes a fresh *types.SpecTask per dispatch.)
+			taskCopy := *baseTask
+			service.StartSpecGeneration(ctx, &taskCopy)
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&startDesktopCount),
+		"StartDesktop must fire exactly once per task even when two StartSpecGeneration goroutines race; got %d calls",
+		atomic.LoadInt32(&startDesktopCount))
+}

--- a/api/pkg/store/memorystore/memorystore.go
+++ b/api/pkg/store/memorystore/memorystore.go
@@ -29,7 +29,11 @@ type MemoryStore struct {
 	interactions map[string]*types.Interaction
 	apps         map[string]*types.App
 	projects     map[string]*types.Project
-	mu           sync.RWMutex
+	// planningSessionClaims tracks the atomic claim set by
+	// SetPlanningSessionIDIfEmpty; keyed by taskID, value is the winning
+	// sessionID. Allocated lazily.
+	planningSessionClaims map[string]string
+	mu                    sync.RWMutex
 
 	// OnInteractionUpdated is called after every UpdateInteraction call.
 	// Test binaries use this to detect completion events.
@@ -390,6 +394,25 @@ func (m *MemoryStore) GetSpecTask(_ context.Context, _ string) (*types.SpecTask,
 
 func (m *MemoryStore) TransitionSpecTaskStatus(_ context.Context, _ string, _ []types.SpecTaskStatus, _ types.SpecTaskStatus, _ map[string]any) (bool, error) {
 	return false, nil
+}
+
+// SetPlanningSessionIDIfEmpty mirrors the postgres CAS — first caller wins, rest
+// lose. No persistence; just a per-task atomic gate keyed by taskID so tests can
+// exercise the race without a real DB.
+func (m *MemoryStore) SetPlanningSessionIDIfEmpty(_ context.Context, taskID string, sessionID string) (bool, error) {
+	if taskID == "" || sessionID == "" {
+		return false, nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.planningSessionClaims == nil {
+		m.planningSessionClaims = make(map[string]string)
+	}
+	if existing := m.planningSessionClaims[taskID]; existing != "" {
+		return false, nil
+	}
+	m.planningSessionClaims[taskID] = sessionID
+	return true, nil
 }
 
 func (m *MemoryStore) GetSpecTaskZedThreadByZedThreadID(_ context.Context, _ string) (*types.SpecTaskZedThread, error) {

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -557,6 +557,13 @@ type Store interface {
 	GetSpecTask(ctx context.Context, id string) (*types.SpecTask, error)
 	UpdateSpecTask(ctx context.Context, task *types.SpecTask) error
 	TransitionSpecTaskStatus(ctx context.Context, taskID string, fromStatuses []types.SpecTaskStatus, newStatus types.SpecTaskStatus, extraFields map[string]any) (bool, error)
+	// SetPlanningSessionIDIfEmpty atomically claims a spec task's planning_session_id
+	// slot. Returns true if this caller won the claim (row updated), false if another
+	// caller had already set planning_session_id to a non-empty value. The single SQL
+	// statement closes the TOCTOU window that a read-then-write guard leaves open and
+	// is the primary defence against two concurrent StartSpecGeneration calls each
+	// creating a session and spawning a dev container against the same workspace.
+	SetPlanningSessionIDIfEmpty(ctx context.Context, taskID string, sessionID string) (bool, error)
 	DeleteSpecTask(ctx context.Context, id string) error
 	ListSpecTasks(ctx context.Context, filters *types.SpecTaskFilters) ([]*types.SpecTask, error)
 	ListProjectLabels(ctx context.Context, projectID string) ([]string, error)

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -5526,6 +5526,21 @@ func (mr *MockStoreMockRecorder) SetLicenseKey(ctx, licenseKey any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLicenseKey", reflect.TypeOf((*MockStore)(nil).SetLicenseKey), ctx, licenseKey)
 }
 
+// SetPlanningSessionIDIfEmpty mocks base method.
+func (m *MockStore) SetPlanningSessionIDIfEmpty(ctx context.Context, taskID, sessionID string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetPlanningSessionIDIfEmpty", ctx, taskID, sessionID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetPlanningSessionIDIfEmpty indicates an expected call of SetPlanningSessionIDIfEmpty.
+func (mr *MockStoreMockRecorder) SetPlanningSessionIDIfEmpty(ctx, taskID, sessionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPlanningSessionIDIfEmpty", reflect.TypeOf((*MockStore)(nil).SetPlanningSessionIDIfEmpty), ctx, taskID, sessionID)
+}
+
 // SetProjectPrimaryRepository mocks base method.
 func (m *MockStore) SetProjectPrimaryRepository(ctx context.Context, projectID, repoID string) error {
 	m.ctrl.T.Helper()

--- a/api/pkg/store/store_spec_tasks.go
+++ b/api/pkg/store/store_spec_tasks.go
@@ -206,6 +206,38 @@ func (s *PostgresStore) TransitionSpecTaskStatus(
 	return true, nil
 }
 
+// SetPlanningSessionIDIfEmpty atomically writes planning_session_id only when the
+// existing column is empty (NULL or ''). Returns true if this caller claimed the
+// slot, false if another caller had already populated it.
+//
+// This is the single source of truth for "who owns the planning session?" — every
+// caller in StartSpecGeneration must use it instead of the read-check-write pattern
+// at line 414-423 of spec_driven_task_service.go (which lets two concurrent goroutines
+// each see an empty value and each go on to create a session and spawn a dev
+// container against the shared workspace, corrupting the git clone).
+func (s *PostgresStore) SetPlanningSessionIDIfEmpty(ctx context.Context, taskID string, sessionID string) (bool, error) {
+	if taskID == "" {
+		return false, fmt.Errorf("task ID is required")
+	}
+	if sessionID == "" {
+		return false, fmt.Errorf("session ID is required")
+	}
+
+	now := time.Now()
+	result := s.gdb.WithContext(ctx).
+		Model(&types.SpecTask{}).
+		Where("id = ? AND (planning_session_id IS NULL OR planning_session_id = '')", taskID).
+		Updates(map[string]any{
+			"planning_session_id": sessionID,
+			"updated_at":          now,
+		})
+
+	if result.Error != nil {
+		return false, fmt.Errorf("failed to claim planning_session_id: %w", result.Error)
+	}
+	return result.RowsAffected > 0, nil
+}
+
 func syncSpecTaskDependsOn(ctx context.Context, tx *gorm.DB, task *types.SpecTask) error {
 	if task.DependsOn == nil {
 		return nil


### PR DESCRIPTION
## Summary

- `SpecTaskOrchestrator` has two dispatch paths (10s ticker + status-change subscription) that can fire on the same `QueuedSpecGeneration` task within milliseconds. The old TOCTOU guard in `StartSpecGeneration` (`spec_driven_task_service.go:414-423`, added for issue #10 of the 2026-03-18 ZFS deployment doc) let both goroutines through, so two sessions and **two dev containers** spawned against the same `/data/workspaces/spec-tasks/<id>/` volume and raced on `git clone`. The loser's clone ended up with only `HEAD` as a ref, and `helix-workspace-setup.sh` failed with `Base branch not found on remote: main`.
- This PR adds `Store.SetPlanningSessionIDIfEmpty(ctx, taskID, sessionID) (bool, error)`: a single-statement `UPDATE … WHERE planning_session_id IS NULL OR ''`. `StartSpecGeneration` now creates the session, attempts the claim, and **the loser deletes its orphan session and returns before `StartDesktop`** — at most one desktop per task, no matter how the orchestrator dispatches.

## Why CreateSession-then-claim (not claim-then-CreateSession)

Claiming first would mean a `CreateSession` failure leaves `planning_session_id` pointing at a non-existent session, and the old retry path (any guard reading the field as "already claimed") would silently noop forever. Wasting a session row on the losing branch is the lesser evil, and the claim becomes the unambiguous source of truth.

## Real-world evidence (what triggered the investigation)

Task `spt_01kts7zed3fe0wmadwb5wv0xzy`, 2026-06-10 17:06:18Z:

- Two sessions created within ~5µs: `ses_01kts7zgv0znfte5dr3nq6stbs` + `ses_01kts7zgv54067bgkdyjv3kj2x`.
- Two API log lines: `DEBUG: StartSpecGeneration entered` for the same task at the same second.
- Two parallel `info/refs` requests for `prj_…-helix-4` at 17:06:43Z.
- The losing container's `.helix-setup-failed` sentinel surfaced via auto-wake: `* branch HEAD -> FETCH_HEAD` → `FATAL: Base branch not found on remote: main`.
- The bare repo on the API side was healthy (full history, all branches present). The corruption was strictly in the in-container clone, caused by two `git clone`s racing into the same `/home/retro/work/helix` directory.

A colleague initially diagnosed this as the bare repo being empty and proposed seeding `main` from the script — that "fix" would have force-pushed an orphan commit over real `helixml/helix` history. Refuted with `git -C … rev-parse refs/heads/main` returning `75e82b14b…` and `git branch -a` listing the full ref set.

## Test plan

- [x] **TDD red**: `TestSpecDrivenTaskService_StartSpecGeneration_NoDoubleStartDesktopOnConcurrency` fires two goroutines at one task with `GetSpecTask` mocked to always return empty `planning_session_id` (the canonical TOCTOU setup). On the unfixed code it fails with `expected: 1, actual: 2` `StartDesktop` calls.
- [x] **TDD green**: Same test passes after the CAS lands. Trace shows the winner reaching `StartDesktop` and the loser logging `Lost race to claim planning_session_id; deleting orphan session and bailing before StartDesktop`.
- [x] `go test ./pkg/services/ ./pkg/store/ ./pkg/store/memorystore/` — all green.
- [ ] Drone CI (full suite + store integration tests against postgres).
- [ ] Manual verification: kick off a new spec task on the helix project in the inner Helix, confirm exactly one `ubuntu-external-*` container spawns per task.

## Follow-ups (not in this PR)

- `StartJustDoItMode` (`spec_driven_task_service.go:801`) has the same TOCTOU shape. Same fix mechanically applies — separate PR to keep the diff focused and bisectable.
- Belt-and-braces: `SpecTaskOrchestrator.handleQueuedSpecGeneration` could acquire a per-task mutex before spawning the goroutine, to avoid wasting the loser's `CreateSession` work. The CAS is sufficient for correctness; the mutex would just be a micro-optimisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)