### PR TITLE
Reinstate Role/Identity File Republish on Worker Activation

### DIFF
--- a/api/pkg/org/infrastructure/runtime/helix/project.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project.go
@@ -220,16 +220,15 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 			// flipped to api_key mode but w-owner's agent app still
 			// thought it was in subscription mode.
 			//
-			// We do NOT re-push canonical files (role.md / identity.md
-			// / agent.md): republishing on every activation clobbers
-			// any external edits the Worker has made on the
-			// helix-specs branch since the last apply. Canonical-
-			// content updates flow through Workspace.MirrorFile
-			// explicitly; that's the only path that touches these
-			// files outside first-activation provisioning.
 			if _, err := a.Service.ApplyProject(ctx, applyReq); err != nil {
 				return "", "", "", fmt.Errorf("refresh project spec for %s: %w", workerID, err)
 			}
+			// Re-publish canonical files so DB edits to role / identity /
+			// agent.md propagate to the helix-specs branch on every
+			// activation — that's the contract DefaultHelixSpecsMandate
+			// promises every Worker. Idempotent and cheap: CreateBranch
+			// and CreateOrUpdateFileContents both no-op on unchanged input.
+			a.republishWorkerFiles(ctx, workerID, state.RepoID, roleContent, worker.IdentityContent())
 			return state.ProjectID, state.AgentAppID, state.RepoID, nil
 		}
 	}

--- a/api/pkg/org/infrastructure/runtime/helix/project_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_test.go
@@ -365,19 +365,22 @@ func TestEnsureRequiresRepoToBeAttached(t *testing.T) {
 //
 // The fast path must:
 //
-//   - return the stored IDs (no fresh provisioning)
-//   - NOT create a new repo or re-publish canonical files (those
-//     would clobber any external edits the operator has made on the
-//     helix-specs branch since the last apply — canonical-content
-//     updates flow through Workspace.MirrorFile)
-//
-// It MUST re-call ApplyProject with the current Runtime/Provider/
-// Model/Credentials, so a change in worker.* via the Settings page
-// propagates to existing workers on the next activation. ApplyProject
-// is upsert-by-name and idempotent — calling it on every Ensure with
-// the fresh spec is the single mechanism that auto-applies settings
-// drift to pre-existing workers. See
-// TestEnsureFastPathRefreshesAgentSpec for the spec assertion.
+//   - return the stored IDs (no fresh provisioning — no
+//     CreateGitRepo / AttachRepoToProject calls)
+//   - re-call ApplyProject with the current Runtime/Provider/Model/
+//     Credentials so worker.* edits via the Settings page propagate
+//     to existing workers on the next activation. ApplyProject is
+//     upsert-by-name and idempotent. See
+//     TestEnsureFastPathRefreshesAgentSpec for the spec assertion.
+//   - re-publish canonical files (agent.md / role.md / identity.md)
+//     from the DB to the helix-specs branch so DB edits that don't
+//     go through update_role / update_identity (e.g. direct store
+//     mutation, role-reconciler reseeding) still reach Workers
+//     without a fire+re-hire round trip. That contract is what
+//     DefaultHelixSpecsMandate promises every Worker; the original
+//     feature lived at commit 4a6cb33c51, regressed at 4f7837ac0c.
+//     See TestEnsureFastPathPropagatesRoleEdits for the propagation
+//     assertion.
 func TestEnsureWithPersistedProjectFastPaths(t *testing.T) {
 	t.Parallel()
 	st, wid := newProjectTestStore(t, "# Role v1")
@@ -407,21 +410,29 @@ func TestEnsureWithPersistedProjectFastPaths(t *testing.T) {
 	if svc.getProjectCalls < 1 {
 		t.Errorf("GetProject calls = %d, want >=1", svc.getProjectCalls)
 	}
-	// Fast path must NOT create a new repo, change branches, or re-push
-	// canonical files. Repo + files are first-activation provisioning.
+	// Fast path must NOT create a new repo. Repo creation is
+	// first-activation provisioning.
 	if svc.createGitRepoCalls != 0 {
 		t.Errorf("fast path must not create a new repo; got %d", svc.createGitRepoCalls)
 	}
 	if svc.attachRepoCalls != 0 {
 		t.Errorf("fast path must not attach a repo; got %d", svc.attachRepoCalls)
 	}
-	if atomic.LoadInt32(&git.branchCalls) != 0 {
-		t.Errorf("fast path must not create-branch; got %d", atomic.LoadInt32(&git.branchCalls))
+	// Fast path MUST ensure-branch + republish canonical files so DB
+	// edits propagate to the helix-specs branch on every activation.
+	if atomic.LoadInt32(&git.branchCalls) == 0 {
+		t.Errorf("fast path MUST ensure helix-specs branch exists before republish; got 0 CreateBranch calls")
 	}
 	git.mu.Lock()
 	defer git.mu.Unlock()
-	if _, ok := git.putFileByPath["workers/w-eng/.context/role.md"]; ok {
-		t.Errorf("fast path must not republish role.md (would clobber external edits)")
+	if got := git.putFileByPath["workers/w-eng/.context/role.md"]; got != "# Role v1" {
+		t.Errorf("fast path MUST republish role.md from DB; got %q, want %q", got, "# Role v1")
+	}
+	if got := git.putFileByPath["workers/w-eng/.context/identity.md"]; got != "# Identity content" {
+		t.Errorf("fast path MUST republish identity.md from DB; got %q, want %q", got, "# Identity content")
+	}
+	if got := git.putFileByPath[".context/agent.md"]; got != "# Org policy" {
+		t.Errorf("fast path MUST republish agent.md from AgentMD; got %q, want %q", got, "# Org policy")
 	}
 }
 
@@ -478,6 +489,66 @@ func TestEnsureFastPathRefreshesAgentSpec(t *testing.T) {
 	}
 	if got.Model != "anthropic/claude-3-haiku" {
 		t.Errorf("Model = %q, want anthropic/claude-3-haiku", got.Model)
+	}
+}
+
+// TestEnsureFastPathPropagatesRoleEdits pins live-edit propagation: a
+// role.Content mutation made directly in the store (bypassing the
+// update_role MCP tool's MirrorFile push) must reach the helix-specs
+// branch on the next activation, without a fire+re-hire.
+//
+// This is the contract DefaultHelixSpecsMandate promises every Worker
+// and the contract the original feature commit 4a6cb33c51 validated
+// end-to-end. It silently regressed in commit 4f7837ac0c when the
+// fast-path republish was removed.
+func TestEnsureFastPathPropagatesRoleEdits(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st, wid := newProjectTestStore(t, "# Role v1")
+	if err := SaveProject(ctx, st, "org-test", wid, "prj_existing", "app_existing", "repo_existing"); err != nil {
+		t.Fatalf("save project: %v", err)
+	}
+	svc := newFakeProjectService()
+	svc.getProjectResp = types.Project{ID: "prj_existing", DefaultRepoID: "repo_existing"}
+	git := newFakeGitForProject()
+	a := newApplierGit(svc, git, st)
+
+	// First activation: republishes v1 to the branch.
+	if _, _, _, err := a.Ensure(ctx, "org-test", wid); err != nil {
+		t.Fatalf("first Ensure: %v", err)
+	}
+	git.mu.Lock()
+	if got := git.putFileByPath["workers/w-eng/.context/role.md"]; got != "# Role v1" {
+		git.mu.Unlock()
+		t.Fatalf("after first Ensure, role.md on branch = %q, want %q", got, "# Role v1")
+	}
+	// Reset capture so the second-call assertion only sees the second
+	// activation's push.
+	git.putFileByPath = map[string]string{}
+	git.mu.Unlock()
+
+	// Mutate the role's Content in the store, simulating any edit path
+	// that bypasses update_role/MirrorFile (direct DB edit,
+	// RoleReconciler reseed, restore-from-backup, …). The DB is the
+	// source of truth; the branch must reflect it on next activation.
+	existing, err := st.Roles.Get(ctx, "org-test", "r-eng")
+	if err != nil {
+		t.Fatalf("get role: %v", err)
+	}
+	existing.Content = "# Role v2"
+	existing.UpdatedAt = time.Now().UTC()
+	if err := st.Roles.Update(ctx, existing); err != nil {
+		t.Fatalf("update role: %v", err)
+	}
+
+	// Second activation: must republish v2.
+	if _, _, _, err := a.Ensure(ctx, "org-test", wid); err != nil {
+		t.Fatalf("second Ensure: %v", err)
+	}
+	git.mu.Lock()
+	defer git.mu.Unlock()
+	if got := git.putFileByPath["workers/w-eng/.context/role.md"]; got != "# Role v2" {
+		t.Errorf("after second Ensure, role.md on branch = %q, want %q — live-edit did not propagate", got, "# Role v2")
 	}
 }
 


### PR DESCRIPTION
I think there might have been a regression somewhere where the role files and identity files and things are not pushed to the Helix specs branch like the prompt indicates. I thought Helix was responsible for doing that. It might have got deleted at some point. Please search the commit history to see if it ever got deleted and why, and then think about reinstating it. 

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kts7zed3fe0wmadwb5wv0xzy)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002089_i-think-there-might-have/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002089_i-think-there-might-have/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002089_i-think-there-might-have/tasks.md)

🚀 Built with [Helix](https://helix.ml)