### PR TITLE
feat(frontend): disable human worker kind in hire form

### DIFF
--- a/frontend/src/components/helix-org/HireWorkerDrawer.tsx
+++ b/frontend/src/components/helix-org/HireWorkerDrawer.tsx
@@ -44,7 +44,9 @@ const HireWorkerDrawer: FC<HireWorkerDrawerProps> = ({ open, onClose, presetRole
   const { data: workersData } = useListHelixOrgWorkers({ enabled: open })
 
   const [id, setId] = useState('')
-  const [kind, setKind] = useState<'ai' | 'human'>('human')
+  // Human workers aren't supported yet — default to AI and disable the
+  // Human option below.
+  const [kind, setKind] = useState<'ai' | 'human'>('ai')
   const [identity, setIdentity] = useState('')
   const [roleId, setRoleId] = useState(presetRoleId ?? '')
   const [parentId, setParentId] = useState('')
@@ -54,7 +56,7 @@ const HireWorkerDrawer: FC<HireWorkerDrawerProps> = ({ open, onClose, presetRole
   useEffect(() => {
     if (!open) return
     setId('')
-    setKind('human')
+    setKind('ai')
     setIdentity('')
     setRoleId(presetRoleId ?? '')
     setParentId('')
@@ -138,8 +140,9 @@ const HireWorkerDrawer: FC<HireWorkerDrawerProps> = ({ open, onClose, presetRole
             value={kind}
             onChange={(e) => setKind(e.target.value as 'ai' | 'human')}
             fullWidth
+            helperText="Human workers aren't supported yet."
           >
-            <MenuItem value="human">Human</MenuItem>
+            <MenuItem value="human" disabled>Human</MenuItem>
             <MenuItem value="ai">AI</MenuItem>
           </TextField>
           <TextField


### PR DESCRIPTION
## Summary

Greys out the **Human** option in the Hire worker form's _Kind_ selector, since human workers aren't supported yet. UI-only change.

Changes in [HireWorkerDrawer.tsx](frontend/src/components/helix-org/HireWorkerDrawer.tsx):
- `<MenuItem value="human">` now has `disabled` — renders greyed out and can't be selected.
- Default `kind` flipped from `'human'` to `'ai'` (initial `useState` + the on-open reset effect), so the form doesn't sit pinned to a now-unselectable value.
- Added helper text under the selector: "Human workers aren't supported yet."

No backend/service changes — the `kind: 'human' | 'ai'` type and API request shape are untouched.

## Testing

⚠️ **Not built/tested** — the fresh worktree had no `node_modules`, so `yarn build`/`tsc` weren't run. The edits use only standard MUI props (`disabled` on `MenuItem`, `helperText` on `TextField`) and a string-literal default, so they are type-safe by inspection, but have not been compiled or verified in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)