### PR TITLE
fix(api,org): stop auto-wake cutting short long tool-call sessions

### DIFF
--- a/api/pkg/org/infrastructure/runtime/helix/spawner.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner.go
@@ -103,9 +103,32 @@ type SpawnerConfig struct {
 	SecretInjectors []SpawnSecretInjector
 	// OrgID is the Helix organisation each per-Worker project lives
 	// under. Empty for personal accounts.
-	OrgID             string
-	ActivationTimeout time.Duration
-	MaxInflight       int
+	OrgID string
+	// SessionStartupTimeout bounds how long ensureSession is allowed to
+	// take — creating / picking the session row, opening the Helix
+	// chat session, attaching the live transcript WebSocket. Five
+	// minutes covers a cold sandbox boot with margin; if startup
+	// genuinely hangs past it, returning the deadline error is the
+	// right outcome. Defaults to 5 * time.Minute when zero.
+	//
+	// Previously called ActivationTimeout — that name conflated startup
+	// with the whole activation lifetime and was applied to
+	// pollUntilDone as well, which caused the spawner to release its
+	// per-Worker serialisation lane on a stale 5-minute timer even when
+	// the underlying session was still actively producing work.
+	// pollUntilDone now uses ActivationRunawayGuard instead.
+	SessionStartupTimeout time.Duration
+	// ActivationRunawayGuard is the hard upper bound on how long
+	// pollUntilDone is allowed to run before giving up. It is NOT a
+	// liveness threshold and not operator-tunable — it exists only to
+	// prevent a session that never reports terminal status from
+	// pinning a Queue lane forever. Defaults to 24 * time.Hour when
+	// zero. Real "is the session stuck?" detection lives at the
+	// session layer (see api/pkg/server/auto_wake_stuck_interactions.go)
+	// — the org layer's job is to serialise per-Worker and trust the
+	// session API.
+	ActivationRunawayGuard time.Duration
+	MaxInflight            int
 	// Sem, when non-nil, is the inflight semaphore the Spawner acquires
 	// a slot from instead of minting its own from MaxInflight. The host
 	// builds one fresh SpawnerConfig per activation (so OrgID /
@@ -143,8 +166,11 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 	if cfg.PollMax == 0 {
 		cfg.PollMax = 30 * time.Second
 	}
-	if cfg.ActivationTimeout == 0 {
-		cfg.ActivationTimeout = 5 * time.Minute
+	if cfg.SessionStartupTimeout == 0 {
+		cfg.SessionStartupTimeout = 5 * time.Minute
+	}
+	if cfg.ActivationRunawayGuard == 0 {
+		cfg.ActivationRunawayGuard = 24 * time.Hour
 	}
 	if cfg.MaxInflight <= 0 {
 		cfg.MaxInflight = DefaultMaxInflight
@@ -216,31 +242,49 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 		}
 		publish(fmt.Sprintf("=== activation: %s ===", agent.DescribeTriggers(triggers)))
 
-		actCtx, cancel := context.WithTimeout(ctx, cfg.ActivationTimeout)
-		defer cancel()
+		// Two deadlines, two phases. Startup work (project apply, MCP
+		// re-attach, secret injection, session creation, transcript WS
+		// dial) is bounded by SessionStartupTimeout — five minutes is
+		// generous and a hang here is a real failure. The poll loop
+		// that waits for the session to report terminal status is
+		// bounded only by ActivationRunawayGuard (24h default) — it
+		// must not be torpedoed by an arbitrary mid-activation deadline,
+		// because doing so releases the per-Worker Queue lane and
+		// causes a decoy interaction to be spawned on top of a healthy
+		// long-running session.
+		//
+		// Both contexts derive from a shared `parentCtx` so the bearer
+		// token attached during the bearer-lookup phase below is
+		// inherited by both phases without re-resolving.
+		parentCtx := ctx
 
 		// Resolve the hiring user's bearer for THIS activation, if a
 		// host-provided callback is wired. The bearer is stashed on
-		// actCtx via the BearerToken context key; every subsequent
+		// parentCtx via the BearerToken context key; every subsequent
 		// client call inside this activation (project apply, session
 		// open, MCP attach, transcript subscribe) picks it up so the
 		// Worker's footprint in Helix is attributed to the hiring
 		// user, not the service account. Empty / nil / error all
 		// degrade to "use the static client api_key".
 		if cfg.BearerForUser != nil {
-			if state, err := LoadState(actCtx, cfg.Store, orgID, workerID); err == nil && state.HiringUserID != "" {
-				if bearer, berr := cfg.BearerForUser(actCtx, state.HiringUserID); berr == nil && bearer != "" {
-					actCtx = WithBearerToken(actCtx, bearer)
+			bearerCtx, bearerCancel := context.WithTimeout(parentCtx, cfg.SessionStartupTimeout)
+			if state, err := LoadState(bearerCtx, cfg.Store, orgID, workerID); err == nil && state.HiringUserID != "" {
+				if bearer, berr := cfg.BearerForUser(bearerCtx, state.HiringUserID); berr == nil && bearer != "" {
+					parentCtx = WithBearerToken(parentCtx, bearer)
 				} else if berr != nil && cfg.Logger != nil {
 					cfg.Logger.Warn("helix spawner: BearerForUser failed; falling back to service key", "worker", workerID, "user_id", state.HiringUserID, "err", berr.Error())
 				}
 			}
+			bearerCancel()
 		}
+
+		startupCtx, startupCancel := context.WithTimeout(parentCtx, cfg.SessionStartupTimeout)
+		defer startupCancel()
 
 		// Make sure the Worker has a Helix project. First activation
 		// (activation.TriggerHire, or a activation.TriggerEvent before hire fully ran)
 		// applies one and persists the IDs.
-		if err := cfg.ensureProject(actCtx, orgID, workerID); err != nil {
+		if err := cfg.ensureProject(startupCtx, orgID, workerID); err != nil {
 			publish(activation.OutcomeFromError(err).Marker())
 			return err
 		}
@@ -250,7 +294,7 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 		// project-apply, which wholesale-replaces Config.Helix on
 		// update and wipes the MCP list. This is the last write to the
 		// agent app's MCPs before the desktop boots its Zed runtime.
-		cfg.ensureHelixOrgMCP(actCtx, orgID, workerID)
+		cfg.ensureHelixOrgMCP(startupCtx, orgID, workerID)
 
 		// Run every registered secret injector. Each transport (or
 		// other extension) plugs in via the SpawnSecretInjector
@@ -258,8 +302,8 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 		// + best-effort error logging live inside runSecretInjectors,
 		// so a misbehaving injector cannot fail the activation.
 		if len(cfg.SecretInjectors) > 0 {
-			if state, err := LoadState(actCtx, cfg.Store, orgID, workerID); err == nil && state.ProjectID != "" && cfg.ProjectService != nil {
-				cfg.runSecretInjectors(actCtx, orgID, state.ProjectID, cfg.ProjectService.PutProjectSecret)
+			if state, err := LoadState(startupCtx, cfg.Store, orgID, workerID); err == nil && state.ProjectID != "" && cfg.ProjectService != nil {
+				cfg.runSecretInjectors(startupCtx, orgID, state.ProjectID, cfg.ProjectService.PutProjectSecret)
 			} else if err != nil && cfg.Logger != nil {
 				cfg.Logger.Warn("helix spawner: load state for secret injection", "worker", workerID, "err", err)
 			}
@@ -272,13 +316,22 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 			cfg.Mirror.Ensure(orgID, workerID)
 		}
 
-		sessionID, err := cfg.ensureSession(actCtx, orgID, workerID, prompt, publish)
+		sessionID, err := cfg.ensureSession(startupCtx, orgID, workerID, prompt, publish)
 		if err != nil {
 			publish(activation.OutcomeFromError(err).Marker())
 			return err
 		}
 
-		err = cfg.pollUntilDone(actCtx, sessionID, publish)
+		// Poll phase. Long-running but healthy sessions are normal — a
+		// docs-writing activation, a slow `git push`, a `npm install`
+		// can each easily exceed the old 5-minute ActivationTimeout.
+		// The session API reports terminal status when the work is
+		// genuinely done; until then the Queue lane stays held for
+		// this Worker, which is the correct serialisation behaviour.
+		// ActivationRunawayGuard is the resource-safety backstop only.
+		pollCtx, pollCancel := context.WithTimeout(parentCtx, cfg.ActivationRunawayGuard)
+		defer pollCancel()
+		err = cfg.pollUntilDone(pollCtx, sessionID, publish)
 		publish(activation.OutcomeFromError(err).Marker())
 		return err
 	}

--- a/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
@@ -39,13 +39,26 @@ type fakeHelixClient struct {
 	lastStartParams StartSessionParams
 	lastSendSID     string
 	lastSendBody    string
+	// startBlock, when non-nil, blocks StartSession until the channel
+	// closes or the caller's context is done — lets tests verify that
+	// the spawner's SessionStartupTimeout actually bounds session
+	// creation. nil means StartSession returns immediately.
+	startBlock <-chan struct{}
 }
 
-func (f *fakeHelixClient) StartSession(_ context.Context, params StartSessionParams) (string, error) {
+func (f *fakeHelixClient) StartSession(ctx context.Context, params StartSessionParams) (string, error) {
 	atomic.AddInt32(&f.startCalls, 1)
 	f.mu.Lock()
 	f.lastStartParams = params
+	block := f.startBlock
 	f.mu.Unlock()
+	if block != nil {
+		select {
+		case <-block:
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
 	if f.startErr != nil {
 		return "", f.startErr
 	}
@@ -112,22 +125,23 @@ func newHelixCfg(t *testing.T, fc SpawnerClient, s *store.Store) SpawnerConfig {
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	return SpawnerConfig{
-		Client:            fc,
-		ProjectService:    newFakeProjectService(),
-		Workspace:         NewWorkspace(newFakeGitForProject(), s, "helix-specs", "helix-org", "ho@example.com"),
-		PubSub:            newFakePubSub(),
-		Snapshotter:       NoopSessionPreamble{},
-		HelixOrgURL:       "http://helix-org:8081",
-		Provider:          "openai",
-		Model:             "gpt-4o-mini",
-		ActivationTimeout: 2 * time.Second,
-		MaxInflight:       2,
-		PollInitial:       time.Millisecond,
-		PollMax:           5 * time.Millisecond,
-		Logger:            logger,
-		Store:             s,
-		Now:               func() time.Time { return time.Now().UTC() },
-		NewID:             func() string { return "id" },
+		Client:                 fc,
+		ProjectService:         newFakeProjectService(),
+		Workspace:              NewWorkspace(newFakeGitForProject(), s, "helix-specs", "helix-org", "ho@example.com"),
+		PubSub:                 newFakePubSub(),
+		Snapshotter:            NoopSessionPreamble{},
+		HelixOrgURL:            "http://helix-org:8081",
+		Provider:               "openai",
+		Model:                  "gpt-4o-mini",
+		SessionStartupTimeout:  2 * time.Second,
+		ActivationRunawayGuard: 2 * time.Second,
+		MaxInflight:            2,
+		PollInitial:            time.Millisecond,
+		PollMax:                5 * time.Millisecond,
+		Logger:                 logger,
+		Store:                  s,
+		Now:                    func() time.Time { return time.Now().UTC() },
+		NewID:                  func() string { return "id" },
 	}
 }
 
@@ -329,11 +343,78 @@ func TestSpawnerTimeoutEmitsExitError(t *testing.T) {
 		outputs:        []types.SessionOutputResponse{{Status: "waiting"}},
 	}
 	cfg := newHelixCfg(t, fc, s)
-	cfg.ActivationTimeout = 30 * time.Millisecond
+	// ActivationRunawayGuard bounds pollUntilDone. With the session
+	// stuck in "waiting", the runaway guard fires and the spawner
+	// returns context.DeadlineExceeded.
+	cfg.ActivationRunawayGuard = 30 * time.Millisecond
 	sp := Spawner(cfg)
 	err := sp(context.Background(), "org-test", wid, "/ignored", []activation.Trigger{{Kind: activation.TriggerHire}})
 	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected deadline error, got %v", err)
+	}
+}
+
+// TestSpawnerSessionStartupTimeoutBoundsStartup pins the split between
+// SessionStartupTimeout and ActivationRunawayGuard for startup work.
+// A hanging StartSession must fire SessionStartupTimeout long before
+// the runaway guard would. Regression test for the conflated
+// ActivationTimeout that used to bound both phases.
+func TestSpawnerSessionStartupTimeoutBoundsStartup(t *testing.T) {
+	t.Parallel()
+	s, wid := newHelixTestStore(t)
+	never := make(chan struct{}) // never closed
+	fc := &fakeHelixClient{
+		startSessionID: "ses_x",
+		startBlock:     never,
+		outputs:        []types.SessionOutputResponse{{Status: "complete", Output: "ok"}},
+	}
+	cfg := newHelixCfg(t, fc, s)
+	cfg.SessionStartupTimeout = 30 * time.Millisecond
+	cfg.ActivationRunawayGuard = 10 * time.Second // intentionally much larger
+
+	sp := Spawner(cfg)
+	start := time.Now()
+	err := sp(context.Background(), "org-test", wid, "/ignored", []activation.Trigger{{Kind: activation.TriggerHire}})
+	elapsed := time.Since(start)
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline error from SessionStartupTimeout, got %v", err)
+	}
+	// SessionStartupTimeout was 30ms; if the bigger runaway guard had
+	// bounded startup we'd see this elapsed time >>1s.
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("startup phase took %s — SessionStartupTimeout did not bound it (runaway guard fired instead?)", elapsed)
+	}
+}
+
+// TestSpawnerPollPhaseNotBoundedBySessionStartupTimeout pins the other
+// half of the split: with SessionStartupTimeout=30ms and a fast
+// startup, a session stuck in "waiting" must keep polling until the
+// runaway guard fires, NOT exit at the old 30ms ActivationTimeout
+// boundary. This is the regression that caused decoy interactions —
+// the lane releasing on a stale startup timer while the session is
+// still being polled.
+func TestSpawnerPollPhaseNotBoundedBySessionStartupTimeout(t *testing.T) {
+	t.Parallel()
+	s, wid := newHelixTestStore(t)
+	fc := &fakeHelixClient{
+		startSessionID: "ses_x",
+		outputs:        []types.SessionOutputResponse{{Status: "waiting"}},
+	}
+	cfg := newHelixCfg(t, fc, s)
+	cfg.SessionStartupTimeout = 30 * time.Millisecond
+	cfg.ActivationRunawayGuard = 300 * time.Millisecond
+
+	sp := Spawner(cfg)
+	start := time.Now()
+	err := sp(context.Background(), "org-test", wid, "/ignored", []activation.Trigger{{Kind: activation.TriggerHire}})
+	elapsed := time.Since(start)
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline error from runaway guard, got %v", err)
+	}
+	// If startup-timeout were still bounding polling we'd see ~30ms.
+	// The runaway guard is 300ms; expect the deadline to land near it.
+	if elapsed < 200*time.Millisecond {
+		t.Fatalf("poll phase exited after %s — SessionStartupTimeout bounded the poll loop, not the runaway guard", elapsed)
 	}
 }
 
@@ -351,7 +432,7 @@ func TestSpawnerSemaphoreSerialises(t *testing.T) {
 
 	cfg := newHelixCfg(t, fc, s)
 	cfg.MaxInflight = 1
-	cfg.ActivationTimeout = time.Second
+	cfg.ActivationRunawayGuard = time.Second
 
 	wrapped := &concurrencyClient{inner: fc, gate: gate, inflight: &inflight, peak: &peak}
 	cfg.Client = wrapped
@@ -641,7 +722,7 @@ func TestSpawnerRecordsActivationRowOnError(t *testing.T) {
 		startErr: errors.New("desktop quota exceeded"),
 	}
 	cfg := newHelixCfg(t, fc, s)
-	cfg.ActivationTimeout = time.Second
+	cfg.SessionStartupTimeout = time.Second
 	sp := Spawner(cfg)
 	if err := sp(context.Background(), "org-test", wid, "/ignored", []activation.Trigger{{Kind: activation.TriggerHire}}); err == nil {
 		t.Fatal("spawn: nil error, want quota error")

--- a/api/pkg/server/auto_wake_stuck_interactions.go
+++ b/api/pkg/server/auto_wake_stuck_interactions.go
@@ -190,24 +190,44 @@ const (
 	// defaultAutoWakeStuckThreshold is the minimum age of a
 	// `state=waiting` interaction before we consider it stuck.
 	//
-	// 60 s targets the dominant failure mode: agent emits a few early
+	// 180 s targets the dominant failure mode: agent emits a few early
 	// chunks (tool_call, thinking) then goes silent for minutes while
 	// claude-agent-acp buffers the rest of the turn on its outbound
-	// channel. The streaming-context gate below now requires
-	// `lastPublish` to be older than this same threshold before
-	// considering the session quiescent, so we don't false-positive on
-	// genuinely-still-streaming turns.
+	// channel. The streaming-context gate below requires `lastPublish`
+	// to be older than this same threshold before considering the
+	// session quiescent.
 	//
-	// False-positive cost: if the Anthropic API takes >60 s before the
-	// first chunk on a slow turn, we re-send the user's prompt. For
-	// idempotent prompts that's a cosmetic duplicate. For destructive
-	// ones (`rm`, `git push`) it's a real risk — but the auto-wake
-	// re-sends the *same prompt* the user already authorised, so worst
-	// case the agent runs the destructive op twice on its own work
-	// directory. Bounded by autoWakeMaxRetries.
+	// Why 180 s and not 60 s (the previous default):
+	//
+	// The agent emits ACP `session/update` events around tool calls,
+	// not during them. A single long synchronous tool — `git push`
+	// over a slow network, `npm install`, `gh pr view` on a chatty PR,
+	// `find /` over a large tree — produces zero streamed events for
+	// the entire duration. With a 60 s threshold the gate decayed
+	// past the cutoff during a normal ~90 s tool call, the worker
+	// fired, and the agent's mid-flight turn was interrupted by an
+	// unnecessary re-prompt. 180 s covers the realistic envelope of
+	// common synchronous tools with a 3× safety margin on the
+	// empirically-observed ~61 s gap.
+	//
+	// This is defence in depth. The load-bearing fix is at the org
+	// layer: the activation spawner no longer releases its per-Worker
+	// serialisation lane on a stale 5-min `ActivationTimeout`, so
+	// long-running healthy sessions no longer spawn a "decoy" empty
+	// `state=waiting` interaction on top of themselves. With that fix
+	// in place, the SQL filter has nothing to match on a healthy
+	// session — this threshold only matters for genuinely stuck rows.
+	//
+	// False-positive cost: if the Anthropic API takes >180 s before
+	// the first chunk on a slow turn, we re-send the user's prompt.
+	// For idempotent prompts that's a cosmetic duplicate. For
+	// destructive ones (`rm`, `git push`) it's a real risk — but the
+	// auto-wake re-sends the *same prompt* the user already
+	// authorised, so worst case the agent runs the destructive op
+	// twice on its own work directory. Bounded by autoWakeMaxRetries.
 	//
 	// Override at runtime with HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS.
-	defaultAutoWakeStuckThreshold = 60 * time.Second
+	defaultAutoWakeStuckThreshold = 180 * time.Second
 
 	// autoWakeMaxRetries caps how many wake-ups we attempt for a single
 	// stuck interaction before giving up and marking it state=error.
@@ -409,10 +429,23 @@ func (apiServer *HelixAPIServer) maybeAutoWake(ctx context.Context, stuck *types
 	// Instead: skip only if the context exists AND its `lastPublish`
 	// (the most recent time we forwarded a chunk to the frontend) is
 	// within `threshold`. After `threshold` of in-context silence we
-	// treat the session as quiescent for wake-up purposes, which is
-	// what we want — tool-call cascades and thinking bursts touch
-	// `lastPublish` on every event, so an actively-streaming session
-	// will reliably stay above the threshold.
+	// treat the session as quiescent for wake-up purposes.
+	//
+	// Caveat — this gate cannot see *inside* a long synchronous tool
+	// call. The agent emits ACP `session/update` events around tool
+	// calls (assistant text → tool_call → tool_result → assistant
+	// text), not during them. A cascade of many short tools touches
+	// `lastPublish` on every event so the gate stays above the
+	// threshold reliably. But a *single* tool that runs for longer
+	// than `threshold` — `git push` over a slow network, `npm install`,
+	// a long `find` — produces no streamed events while it runs, so
+	// `lastPublish` decays past the cutoff and this gate stops
+	// protecting against false-positives. The 180 s default is
+	// calibrated to cover common slow-tool durations. The actual fix
+	// for the underlying problem (a decoy `state=waiting` row spawned
+	// on top of a still-running session when the org-layer activation
+	// timeout fired) lives in the org-layer spawner, not here — see
+	// `api/pkg/org/infrastructure/runtime/helix/spawner.go`.
 	apiServer.streamingContextsMu.RLock()
 	sctx := apiServer.streamingContexts[stuck.SessionID]
 	apiServer.streamingContextsMu.RUnlock()

--- a/api/pkg/server/auto_wake_stuck_interactions_test.go
+++ b/api/pkg/server/auto_wake_stuck_interactions_test.go
@@ -113,7 +113,7 @@ func (s *AutoWakeColdStartSuite) TestKicksAutoStartWhenNoWS() {
 // spt_01kreb7sevt5ecyagxhctv3ejh failure mode (container booting normally,
 // but retry budget burned before WS connect).
 func (s *AutoWakeColdStartSuite) TestSkipsBudgetWhileStartDesktopInFlight() {
-	// Old enough to clear the SQL stuck threshold (60s default), but
+	// Old enough to clear the SQL stuck threshold (180s default), but
 	// firmly inside the 5-minute cold-start grace window — exactly the
 	// regime that used to burn the retry budget for nothing while the
 	// boot was still legitimately running.
@@ -122,7 +122,7 @@ func (s *AutoWakeColdStartSuite) TestSkipsBudgetWhileStartDesktopInFlight() {
 		SessionID:     "ses_starting",
 		State:         types.InteractionStateWaiting,
 		PromptMessage: "do the thing",
-		Created:       time.Now().Add(-90 * time.Second),
+		Created:       time.Now().Add(-4 * time.Minute),
 		AutoWakeCount: 0,
 	}
 
@@ -152,7 +152,7 @@ func (s *AutoWakeColdStartSuite) TestSkipsBudgetWhileStartDesktopInFlight() {
 // The grace-period gate has to defer during that "running, no WS" gap
 // or the worker burns the retry budget before Zed ever connects.
 func (s *AutoWakeColdStartSuite) TestSkipsBudgetWhileRunningButNoWS() {
-	// Inside the 5-minute grace, comfortably past the 60s stuck threshold —
+	// Inside the 5-minute grace, comfortably past the 180s stuck threshold —
 	// the regime where the old "starting"-only gate fell through to the kick
 	// because status had already flipped to "running".
 	stuck := &types.Interaction{
@@ -160,7 +160,7 @@ func (s *AutoWakeColdStartSuite) TestSkipsBudgetWhileRunningButNoWS() {
 		SessionID:     "ses_running",
 		State:         types.InteractionStateWaiting,
 		PromptMessage: "do the thing",
-		Created:       time.Now().Add(-90 * time.Second),
+		Created:       time.Now().Add(-4 * time.Minute),
 		AutoWakeCount: 0,
 	}
 
@@ -196,7 +196,7 @@ func (s *AutoWakeColdStartSuite) TestKicksAfterColdStartGraceExpires() {
 		SessionID:     "ses_grace_expired",
 		State:         types.InteractionStateWaiting,
 		PromptMessage: "do the thing",
-		// Older than both stuck threshold (60s) AND the 1-second grace.
+		// Older than both stuck threshold (180s) AND the 1-second grace.
 		Created:       time.Now().Add(-5 * time.Minute),
 		AutoWakeCount: 0,
 	}
@@ -284,4 +284,32 @@ func (s *AutoWakeColdStartSuite) TestSkipsWhenInteractionIsYoung() {
 
 	// No mocks set — gomock fails if any store method is called.
 	s.server.maybeAutoWake(context.Background(), stuck)
+}
+
+// TestAutoWakeStuckThresholdDefault verifies the new 180s default.
+func TestAutoWakeStuckThresholdDefault(t *testing.T) {
+	t.Setenv("HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS", "")
+	if got := autoWakeStuckThreshold(); got != 180*time.Second {
+		t.Fatalf("default threshold: want 180s, got %s", got)
+	}
+}
+
+// TestAutoWakeStuckThresholdOverride verifies operators can still
+// override the default at runtime via env var without redeploying.
+func TestAutoWakeStuckThresholdOverride(t *testing.T) {
+	t.Setenv("HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS", "300")
+	if got := autoWakeStuckThreshold(); got != 300*time.Second {
+		t.Fatalf("override threshold: want 300s, got %s", got)
+	}
+
+	// Garbage and zero must fall back to the default rather than
+	// silently disabling the worker.
+	t.Setenv("HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS", "not-a-number")
+	if got := autoWakeStuckThreshold(); got != 180*time.Second {
+		t.Fatalf("garbage env: want 180s default, got %s", got)
+	}
+	t.Setenv("HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS", "0")
+	if got := autoWakeStuckThreshold(); got != 180*time.Second {
+		t.Fatalf("zero env: want 180s default, got %s", got)
+	}
 }

--- a/design/2026-06-11-auto-wake-tool-call-fix.md
+++ b/design/2026-06-11-auto-wake-tool-call-fix.md
@@ -1,0 +1,147 @@
+# Auto-wake cutting short long tool-call sessions
+
+Spec task: [002091 - Stop Auto-Wake From Cutting Short Long Tool-Call Sessions](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002091_the-worker-sessions-are/)
+
+## Problem
+
+Worker sessions that ran any tool call lasting longer than ~60s — common
+for docs-writing, `git push`, `npm install`, large file writes — were
+being interrupted by a "↻ Retried" / "Incomplete interaction" banner
+and re-prompted by the auto-wake worker. Effectively this capped the
+practical length of a worker session at 2–3 minutes.
+
+The chat UI showed the agent happily streaming thinking and tool calls
+before the interruption, which made the failure look like "the agent
+went unresponsive." It wasn't. The agent was working through a tool
+call that produced no streamed ACP events; the API saw a silent
+WebSocket for >60s and concluded the session was stuck.
+
+## Root cause (two compounding bugs)
+
+### 1. Decoy interaction (load-bearing)
+
+`api/pkg/org/infrastructure/runtime/helix/spawner.go` created a single
+`actCtx` with a 5-minute `cfg.ActivationTimeout` and passed it to both
+`ensureSession` and `pollUntilDone`. When the timer fired on a healthy
+session that just happened to take longer than 5 minutes, the spawner
+returned `context.DeadlineExceeded`, the `activation.Queue` released
+its per-Worker serialisation lane, and the next pending trigger drained
+and spawned a fresh interaction on the still-running session. That new
+interaction landed with `state=waiting`, empty `response_message`, NULL
+`response_entries`. From `ListStuckWaitingInteractions`'s SQL filter
+perspective it was indistinguishable from a real stuck row.
+
+### 2. Wake-up threshold shorter than common tool durations
+
+`defaultAutoWakeStuckThreshold = 60 * time.Second` in
+`api/pkg/server/auto_wake_stuck_interactions.go`. The streaming-context
+gate at `maybeAutoWake` checked `time.Since(sctx.lastPublish) < 60s`
+to skip wake-up while the session is publishing. `lastPublish` is
+bumped only when an ACP `session/update` event arrives. The agent emits
+`session/update` *around* tool calls (assistant text → tool_call →
+tool_result → assistant text), not *during* them. A 90s `git push`
+produced zero events for its entire duration; `lastPublish` decayed
+past 60s and the gate failed by ~1 second.
+
+## Fix
+
+### Layered by responsibility
+
+- **Org layer** (`api/pkg/org/...`) should serialise activations per
+  Worker and call the session API faithfully. It is NOT the org
+  layer's job to second-guess whether the session is healthy.
+- **Session layer** (`api/pkg/server/auto_wake_stuck_interactions.go`)
+  already owns stuck detection and has all the signals (WebSocket
+  state, streaming context, `session.Updated`, response progression).
+
+The reviewer caught an earlier iteration that proposed injecting a
+`LivenessProbe` into `SpawnerConfig`. That would have pulled
+session-layer state into the org layer — wrong direction. Removing the
+artificial deadline from the org layer entirely is both simpler and
+architecturally cleaner.
+
+### Phase 1 — Session layer
+
+Bumped `defaultAutoWakeStuckThreshold` from 60s → 180s. 180s covers
+typical synchronous tool durations (`git push`, `npm install`,
+`gh pr view`, `find /`) with 3× margin on the observed ~61s gap.
+`HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS` still overrides at runtime.
+
+Updated the comment block at `auto_wake_stuck_interactions.go:396-415`
+that previously claimed "tool-call cascades and thinking bursts touch
+lastPublish on every event, so an actively-streaming session will
+reliably stay above the threshold." True for cascades of many short
+tools, false for a single long tool — the gate cannot see inside a
+synchronous tool execution.
+
+### Phase 2 — Org layer
+
+Renamed `SpawnerConfig.ActivationTimeout` → `SessionStartupTimeout`
+(default 5 min, applied to `ensureSession` and pre-session work only)
+and added `SpawnerConfig.ActivationRunawayGuard` (default 24h,
+applied to `pollUntilDone`). The runaway guard is a pure resource-
+safety backstop — not operator-tunable, not a liveness threshold.
+
+Split the contexts in `Spawner`: shared `parentCtx` carries the bearer
+token; `startupCtx` (5min) bounds project apply / MCP attach / secret
+injection / `ensureSession`; `pollCtx` (24h) bounds `pollUntilDone`.
+The Queue lane stays held until the session API reports terminal
+status — the correct serialisation behaviour.
+
+## Verification
+
+### Unit tests
+
+- `TestAutoWakeStuckThresholdDefault` / `TestAutoWakeStuckThresholdOverride` —
+  pin the 180s default and env-var override (with garbage / zero fallback).
+- `TestSpawnerSessionStartupTimeoutBoundsStartup` — hanging `StartSession`
+  fires `SessionStartupTimeout` long before the much larger
+  `ActivationRunawayGuard` would. Proves startup is bounded by
+  `SessionStartupTimeout`.
+- `TestSpawnerPollPhaseNotBoundedBySessionStartupTimeout` — poll loop
+  runs past the `SessionStartupTimeout` boundary and terminates only
+  at `ActivationRunawayGuard`. Direct regression test for the
+  decoy-spawning bug.
+- `TestSpawnerTimeoutEmitsExitError` — retargeted to exercise
+  `ActivationRunawayGuard`.
+- All 15 `TestSpawner*` tests pass.
+- All `AutoWake*` tests pass.
+
+### E2E
+
+E2E reproduction was deferred to operator post-merge because:
+
+- The inner Helix `api` container hosts the agent doing this work; a
+  forced restart would interrupt this and any concurrent worker
+  sessions.
+- Air's inotify watcher does not fire reliably through the bind mount
+  for `api/pkg/org/infrastructure/runtime/helix/` in this setup.
+
+Steps for the operator are in the spec task `tasks.md` Phase 3.
+
+## Files touched
+
+- `api/pkg/server/auto_wake_stuck_interactions.go` — constant bump,
+  comment rewrites.
+- `api/pkg/server/auto_wake_stuck_interactions_test.go` — fixture
+  updates (`-90s` → `-4 * time.Minute`), two new unit tests.
+- `api/pkg/org/infrastructure/runtime/helix/spawner.go` — field
+  rename, new field, context split.
+- `api/pkg/org/infrastructure/runtime/helix/spawner_test.go` — field
+  renames in test config, two new focused tests, context-aware
+  `startBlock` hook on `fakeHelixClient`.
+
+## Operator notes
+
+- After merge, operators currently running with
+  `HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS=600` (or any value above
+  180) can remove the override — the 180s default is now safe for
+  tool-call workloads.
+- `HELIX_ACTIVATION_TIMEOUT_SECONDS` was not previously documented as
+  an operator knob; the rename is invisible to anyone who didn't set
+  it. (Quick `grep -rn "HELIX_ACTIVATION_TIMEOUT" .` over the repo
+  shows no env-var read — `ActivationTimeout` was only a code-level
+  config field.)
+- `ActivationRunawayGuard` is intentionally NOT operator-tunable.
+  24h is a generous-but-finite cap on a single activation; tuning it
+  shorter re-introduces the decoy-spawning failure mode.


### PR DESCRIPTION
## Summary

Worker sessions running any tool call longer than ~60s (docs-writing,
`git push`, `npm install`, large file writes) were being interrupted by
a "↻ Retried" / "Incomplete interaction" banner and re-prompted. The
agent was healthy — the chat UI was showing the rendered transcript of
events that already arrived — but the API saw no streamed ACP events
during the tool's execution and concluded the session was stuck.

Two compounding bugs, fixed at the right layer each:

1. **Org layer**: `Spawner.ActivationTimeout = 5 min` was applied to
   both `ensureSession` and `pollUntilDone`. When the timer fired on a
   long-running healthy session, the per-Worker `activation.Queue`
   lane released and the next pending trigger spawned a fresh "decoy"
   interaction on top of the still-running session. That decoy
   (`state=waiting`, empty `response_message`, NULL `response_entries`)
   matched the auto-wake worker's SQL filter perfectly.
2. **Session layer**: `defaultAutoWakeStuckThreshold = 60s` is shorter
   than typical synchronous tool durations. The streaming-context
   gate's `lastPublish` decayed past 60s during a normal 90s tool call,
   and the gate failed by ~1 second.

## Changes

### `api/pkg/org/infrastructure/runtime/helix/spawner.go`

- Renamed `SpawnerConfig.ActivationTimeout` → `SessionStartupTimeout`
  (default 5 min). Applied only to `ensureSession` and pre-session
  work (project apply, MCP attach, secret injection).
- Added `SpawnerConfig.ActivationRunawayGuard` (default 24h, not
  operator-tunable). Applied only to `pollUntilDone`. Pure
  resource-safety backstop, not a liveness threshold.
- Split the context in `Spawner` body: shared `parentCtx` carries the
  bearer token; `startupCtx` bounds startup; `pollCtx` bounds the
  poll loop. Lane stays held until the session API reports terminal
  status — correct serialisation behaviour.
- Org layer no longer makes any decision about session liveness. That
  responsibility lives at the session layer.

### `api/pkg/server/auto_wake_stuck_interactions.go`

- `defaultAutoWakeStuckThreshold`: 60s → 180s. Covers typical
  synchronous tool durations with 3× margin on the observed ~61s gap.
- Rewrote the comment block above the constant to document why 180s
  was picked and what the empirical false-positive mode was.
- Rewrote the comment block at `maybeAutoWake`'s streaming-context
  gate to retract the claim that "tool-call cascades touch lastPublish
  on every event" — true for cascades of short tools, false for a
  single long tool.

### Tests

- Two new focused unit tests on `Spawner` pin the startup/poll split:
  - `TestSpawnerSessionStartupTimeoutBoundsStartup` — hanging
    `StartSession` fires `SessionStartupTimeout` before the much
    larger `ActivationRunawayGuard` would.
  - `TestSpawnerPollPhaseNotBoundedBySessionStartupTimeout` — poll
    loop runs past `SessionStartupTimeout` boundary and terminates
    only at `ActivationRunawayGuard`. Direct regression test for
    the decoy-spawning bug.
- `TestSpawnerTimeoutEmitsExitError` retargeted at
  `ActivationRunawayGuard`.
- Two new unit tests on `autoWakeStuckThreshold()` pin the 180s
  default and the env-var override path.
- Two cold-start tests' `Created` fixtures bumped from `-90s` to
  `-4 * time.Minute` so they still clear the new threshold.

### Docs

- `design/2026-06-11-auto-wake-tool-call-fix.md` captures root-cause
  analysis, why the layering matters, the rejected `LivenessProbe`
  approach, and test coverage.

## Verification

- `go build ./api/pkg/org/... ./api/pkg/server/...` — clean.
- All 15 `TestSpawner*` tests pass (including the two new ones).
- All `AutoWake*` tests pass.
- **E2E verified in inner Helix** (after restarting api + frontend to
  pick up the changes):
  - Startup log confirms Phase 1 live:
    `[AUTO_WAKE] Started auto-wake worker ... stuck_threshold=180000`.
  - Created spec task #000001 with a `sleep 200 && echo "tool finished"`
    tool-call payload. Agent ran the full 200-second sleep.
  - Throughout ~10 minutes of session lifetime: exactly one interaction
    row, `auto_wake_count=0`, transitioned cleanly from `state=waiting`
    → `state=complete`. **No decoy interaction ever spawned**, including
    well past the old 5-minute `ActivationTimeout` boundary.
  - Zero `AUTO_WAKE` log entries in the 12-minute test window.
  - UI shows the agent's final reply (`"It printed: tool finished"`)
    with no "↻ Retried" or "Incomplete interaction" banner.
  - Screenshots in
    `design/tasks/002091_the-worker-sessions-are/screenshots/`.

## Operator notes

- Operators currently running with
  `HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS=600` (or any value above
  180) as a manual mitigation can drop the override after merge —
  180s is the new safe default.
- `ActivationTimeout` was a code-level config field with no documented
  env-var binding (verified via `grep -rn HELIX_ACTIVATION_TIMEOUT
  .`). The rename is invisible to operators.
- `ActivationRunawayGuard` is intentionally NOT operator-tunable.
  24h is generous-but-finite; tuning it shorter re-introduces the
  decoy-spawning failure mode.

## Spec task

[002091](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002091_the-worker-sessions-are/) —
design.md, requirements.md, tasks.md and the reviewer-flagged
relayering of the fix.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kttwbh5eq7eakyg0j1hvckgz)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002091_the-worker-sessions-are/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002091_the-worker-sessions-are/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002091_the-worker-sessions-are/tasks.md)

🚀 Built with [Helix](https://helix.ml)