### PR TITLE
feat(yellowdog): discover WorkerTag from YD nodes at boot

### DIFF
--- a/api/pkg/sandbox/compute/bootstrap/bootstrap.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap.go
@@ -6,8 +6,10 @@
 package bootstrap
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/data"
@@ -121,17 +123,23 @@ func deriveDeploymentTag(cfg config.Compute) string {
 func buildProvider(cfg config.Compute, serverURL, runnerToken string) (compute.Provider, error) {
 	switch cfg.Provider {
 	case "yellowdog":
-		// Auto-derive WorkerTag from Namespace when unset, matching
-		// the yd-provision POC convention (`worker_tag = "worker-<tag>"`).
-		// Operator who set up their pool per the POC docs gets a
-		// working default; anyone with a custom pool naming scheme
-		// overrides via HELIX_YD_WORKER_TAG.
-		workerTag := cfg.Yellowdog.WorkerTag
-		if workerTag == "" && cfg.Yellowdog.Namespace != "" {
-			workerTag = "worker-" + cfg.Yellowdog.Namespace
-			log.Info().
-				Str("worker_tag", workerTag).
-				Msg("compute: HELIX_YD_WORKER_TAG auto-derived from namespace; override if your YD worker pool advertises a different tag")
+		// WorkerTag resolution order:
+		//   1. HELIX_YD_WORKER_TAG explicit  -> use verbatim
+		//   2. Discover from YD nodes        -> query GET /workerPools/nodes,
+		//                                       use the unique tag if there
+		//                                       is exactly one across all
+		//                                       online nodes
+		//   3. Namespace-derived fallback    -> "worker-<namespace>"
+		//
+		// (2) replaces blind (3) as the primary path. The 2026-06-10 E2E
+		// run showed that the POC's `worker_tag = "worker-{{username}}"`
+		// convention is incompatible with naive namespace derivation: a
+		// pool registered as `worker-psamuel` would silently never accept
+		// WRs Helix submitted with `worker-development`. Discovery reads
+		// the truth from the running pool.
+		workerTag, err := resolveWorkerTag(cfg.Yellowdog)
+		if err != nil {
+			return nil, err
 		}
 		sandboxImage, err := helixSandboxImage()
 		if err != nil {
@@ -184,6 +192,72 @@ var sentinelVersions = map[string]bool{
 
 func helixSandboxImage() (string, error) {
 	return helixSandboxImageFor(data.GetHelixVersion())
+}
+
+// resolveWorkerTag picks the YD WorkerTag for the Provider, preferring
+// an explicit operator override, then discovery from online nodes, then
+// a namespace-derived fallback.
+//
+// Returns (tag, err). err is non-nil only when the operator MUST act:
+// either Namespace is missing (no possible default) or discovery saw
+// multiple distinct tags in scope (ambiguous - pick one).
+//
+// Discovery transport errors fall through to the namespace-derived
+// fallback rather than failing boot: a transient YD outage shouldn't
+// prevent Helix from starting, and if the fallback turns out wrong the
+// operator will see WRs sit PENDING and can fix it.
+//
+// The discoverFn parameter is injectable for tests.
+var discoverFn = yellowdog.DiscoverOnlineWorkerTags
+
+func resolveWorkerTag(yd config.Yellowdog) (string, error) {
+	if yd.WorkerTag != "" {
+		log.Info().
+			Str("worker_tag", yd.WorkerTag).
+			Msg("compute: HELIX_YD_WORKER_TAG provided by operator")
+		return yd.WorkerTag, nil
+	}
+	if yd.Namespace == "" {
+		return "", errors.New(
+			"compute: HELIX_YD_NAMESPACE is required (cannot derive WorkerTag without it; alternatively set HELIX_YD_WORKER_TAG explicitly)",
+		)
+	}
+
+	// Discovery: query YD for the unique workerTag(s) currently visible
+	// to this API key. Bounded timeout so a hung YD doesn't pin boot.
+	discoverCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	tags, err := discoverFn(discoverCtx, yellowdog.Config{
+		APIKeyID:  yd.APIKeyID,
+		APISecret: yd.APISecret,
+		BaseURL:   yd.BaseURL,
+	})
+
+	fallback := "worker-" + yd.Namespace
+
+	switch {
+	case err != nil:
+		log.Warn().
+			Err(err).
+			Str("worker_tag", fallback).
+			Msg("compute: WorkerTag discovery failed; falling back to namespace-derived default. Set HELIX_YD_WORKER_TAG explicitly to override if WRs sit PENDING.")
+		return fallback, nil
+	case len(tags) == 1:
+		log.Info().
+			Str("worker_tag", tags[0]).
+			Msg("compute: WorkerTag auto-discovered from online YD nodes")
+		return tags[0], nil
+	case len(tags) == 0:
+		log.Warn().
+			Str("worker_tag", fallback).
+			Msg("compute: no online YD nodes visible for discovery; falling back to namespace-derived default. If your pool advertises a different tag and is currently offline, set HELIX_YD_WORKER_TAG explicitly.")
+		return fallback, nil
+	default:
+		return "", fmt.Errorf(
+			"compute: discovery found multiple distinct YD workerTags %v - cannot pick one automatically. Set HELIX_YD_WORKER_TAG explicitly to disambiguate.",
+			tags,
+		)
+	}
 }
 
 // helixSandboxImageFor is the testable inner. Tests inject specific

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/data"
 	"github.com/helixml/helix/api/pkg/sandbox/compute"
+	"github.com/helixml/helix/api/pkg/sandbox/compute/yellowdog"
 	"github.com/helixml/helix/api/pkg/types"
 )
 
@@ -17,11 +19,33 @@ import (
 // global so tests that construct a Manager via Bootstrap don't trip
 // the helixSandboxImage sentinel-rejection. Tests of the rejection
 // itself call helixSandboxImageFor directly with their own values.
+//
+// Also stubs discoverFn so unit tests never reach out to the real YD
+// portal during boot. The default stub returns no tags (zero-online-nodes
+// branch), which causes resolveWorkerTag to fall back to the namespace
+// derivation - the same shape the original tests assumed.
+// Tests that want to exercise the discovery branches override
+// discoverFn locally via withDiscoverFn.
 func TestMain(m *testing.M) {
-	orig := data.Version
+	origVersion := data.Version
 	data.Version = "0.0.0-test"
-	defer func() { data.Version = orig }()
+	origDiscover := discoverFn
+	discoverFn = func(context.Context, yellowdog.Config) ([]string, error) {
+		return nil, nil
+	}
+	defer func() {
+		data.Version = origVersion
+		discoverFn = origDiscover
+	}()
 	os.Exit(m.Run())
+}
+
+// withDiscoverFn temporarily replaces the package's discoverFn for the
+// scope of a single test. Returns a cleanup func tests should defer.
+func withDiscoverFn(stub func(context.Context, yellowdog.Config) ([]string, error)) func() {
+	prev := discoverFn
+	discoverFn = stub
+	return func() { discoverFn = prev }
 }
 
 // nullStore is a no-op SandboxStore so we can construct Bootstrap
@@ -188,10 +212,10 @@ func TestBootstrapUnknownProviderErrors(t *testing.T) {
 }
 
 func TestBootstrapDerivesWorkerTagFromNamespace(t *testing.T) {
-	// Omitting HELIX_YD_WORKER_TAG should auto-derive "worker-<namespace>"
-	// per the yd-provision POC convention. Bootstrap completes without
-	// error using only Namespace; yellowdog.NewProvider will reject
-	// the build if WorkerTag is still empty after derivation.
+	// 0-tags branch: discovery returns no online nodes (the TestMain
+	// default stub), so resolveWorkerTag falls back to the
+	// namespace-derived default `worker-<namespace>`. Bootstrap
+	// completes without error.
 	cfg := config.Compute{
 		Provider:                "yellowdog",
 		ReconcileInterval:       time.Second,
@@ -213,6 +237,128 @@ func TestBootstrapDerivesWorkerTagFromNamespace(t *testing.T) {
 	}
 	if mgr == nil {
 		t.Fatal("expected non-nil Manager")
+	}
+}
+
+func TestResolveWorkerTagExplicitWins(t *testing.T) {
+	// Explicit-tag branch: HELIX_YD_WORKER_TAG set -> discoverFn is
+	// never called and the operator's value passes through verbatim.
+	called := false
+	defer withDiscoverFn(func(context.Context, yellowdog.Config) ([]string, error) {
+		called = true
+		return []string{"unrelated-tag"}, nil
+	})()
+
+	got, err := resolveWorkerTag(config.Yellowdog{
+		APIKeyID:  "k",
+		APISecret: "s",
+		Namespace: "development",
+		WorkerTag: "operator-override",
+	})
+	if err != nil {
+		t.Fatalf("resolveWorkerTag returned error: %v", err)
+	}
+	if got != "operator-override" {
+		t.Fatalf("explicit tag should win; got %q", got)
+	}
+	if called {
+		t.Fatal("discoverFn should NOT be called when WorkerTag is explicit")
+	}
+}
+
+func TestResolveWorkerTagOneTagDiscoveredUsedAsIs(t *testing.T) {
+	// 1-tag branch: discovery returns exactly one tag -> use it
+	// verbatim. This is the happy path that fixes the POC
+	// `worker-<username>` vs `worker-<namespace>` mismatch.
+	defer withDiscoverFn(func(context.Context, yellowdog.Config) ([]string, error) {
+		return []string{"worker-psamuel"}, nil
+	})()
+
+	got, err := resolveWorkerTag(config.Yellowdog{
+		APIKeyID:  "k",
+		APISecret: "s",
+		Namespace: "development",
+	})
+	if err != nil {
+		t.Fatalf("resolveWorkerTag returned error: %v", err)
+	}
+	if got != "worker-psamuel" {
+		t.Fatalf("discovered tag should pass through; got %q", got)
+	}
+}
+
+func TestResolveWorkerTagMultipleTagsRefusesToStart(t *testing.T) {
+	// N-tags branch: discovery finds >1 distinct tag in scope ->
+	// fail fast with an actionable error. Silent picking of one
+	// would route WRs to an arbitrary pool.
+	defer withDiscoverFn(func(context.Context, yellowdog.Config) ([]string, error) {
+		return []string{"worker-prod", "worker-staging"}, nil
+	})()
+
+	_, err := resolveWorkerTag(config.Yellowdog{
+		APIKeyID:  "k",
+		APISecret: "s",
+		Namespace: "development",
+	})
+	if err == nil {
+		t.Fatal("expected error when discovery returns multiple distinct tags")
+	}
+	if !strings.Contains(err.Error(), "multiple distinct") {
+		t.Fatalf("error should mention ambiguity, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "HELIX_YD_WORKER_TAG") {
+		t.Fatalf("error should name the env var to set, got %q", err.Error())
+	}
+	for _, tag := range []string{"worker-prod", "worker-staging"} {
+		if !strings.Contains(err.Error(), tag) {
+			t.Fatalf("error should list each candidate tag (missing %q): %q", tag, err.Error())
+		}
+	}
+}
+
+func TestResolveWorkerTagDiscoveryErrorFallsBack(t *testing.T) {
+	// Transport-error branch: a network or auth blip during discovery
+	// should NOT block Helix boot. Fall back to the namespace-derived
+	// default and warn; the WR-PENDING diagnostic will surface a real
+	// mismatch later if the default was wrong.
+	defer withDiscoverFn(func(context.Context, yellowdog.Config) ([]string, error) {
+		return nil, errors.New("yellowdog: HTTP 503")
+	})()
+
+	got, err := resolveWorkerTag(config.Yellowdog{
+		APIKeyID:  "k",
+		APISecret: "s",
+		Namespace: "development",
+	})
+	if err != nil {
+		t.Fatalf("transport error in discovery should not fail boot, got: %v", err)
+	}
+	if got != "worker-development" {
+		t.Fatalf("expected fallback worker-development, got %q", got)
+	}
+}
+
+func TestResolveWorkerTagNamespaceRequiredWhenNoExplicitTag(t *testing.T) {
+	// Without explicit WorkerTag AND without Namespace, there's no
+	// way to compute even the fallback. resolveWorkerTag returns an
+	// actionable error rather than calling discovery with no
+	// fall-back basis.
+	defer withDiscoverFn(func(context.Context, yellowdog.Config) ([]string, error) {
+		t.Fatal("discoverFn should not be reached when Namespace is empty")
+		return nil, nil
+	})()
+
+	_, err := resolveWorkerTag(config.Yellowdog{
+		APIKeyID:  "k",
+		APISecret: "s",
+		Namespace: "",
+		WorkerTag: "",
+	})
+	if err == nil {
+		t.Fatal("expected error when both Namespace and WorkerTag are empty")
+	}
+	if !strings.Contains(err.Error(), "HELIX_YD_NAMESPACE") {
+		t.Fatalf("error should name HELIX_YD_NAMESPACE, got %q", err.Error())
 	}
 }
 

--- a/api/pkg/sandbox/compute/yellowdog/node_discovery.go
+++ b/api/pkg/sandbox/compute/yellowdog/node_discovery.go
@@ -1,0 +1,104 @@
+package yellowdog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+// node mirrors the YD scheduler `Node` entity returned by
+// GET /workerPools/nodes. We only decode the fields we use.
+type node struct {
+	ID      string      `json:"id"`
+	Status  string      `json:"status"`
+	Details nodeDetails `json:"details"`
+}
+
+type nodeDetails struct {
+	WorkerTag string `json:"workerTag"`
+}
+
+// sliceNode is the paginated envelope YD returns. We only read the
+// first page: WorkerTag discovery doesn't need full pagination since
+// healthy deployments routinely have <10 online nodes, well under the
+// 200 page size we request.
+type sliceNode struct {
+	Items []node `json:"items"`
+}
+
+// DiscoverOnlineWorkerTags queries the YD scheduler API for the set of
+// distinct workerTags advertised by currently-online (RUNNING) nodes
+// visible to the configured API key.
+//
+// Bootstrap callers use this to populate HELIX_YD_WORKER_TAG from the
+// operator's pre-existing pool, instead of guessing `worker-<namespace>`
+// (which silently mismatches whenever the pool was set up with a
+// different convention - the YD POC `config.toml`, for example, derives
+// its tag from `{{username}}` not `{{namespace}}`).
+//
+// Returns a sorted list of distinct non-empty tags. Empty list means
+// "no online nodes visible to this key" (likely no pool provisioned
+// yet); caller decides whether that's an error or whether to fall back
+// to a default.
+//
+// Assumption: this API key's visibility scope is one Helix install's
+// pool(s). YD scopes by key, not by namespace path; an operator who
+// uses one key across multiple Helix deployments' namespaces will get
+// the union of all tags and must set HELIX_YD_WORKER_TAG explicitly to
+// disambiguate (see bootstrap's >1-tag handling).
+func DiscoverOnlineWorkerTags(ctx context.Context, cfg Config) ([]string, error) {
+	creds := credentials{keyID: cfg.APIKeyID, secret: cfg.APISecret}
+	if !creds.valid() {
+		return nil, errors.New("yellowdog: discovery requires APIKeyID and APISecret")
+	}
+	base := cfg.BaseURL
+	if base == "" {
+		base = defaultBaseURL
+	}
+	if !cfg.AllowInsecureBaseURL && !strings.HasPrefix(base, "https://") {
+		return nil, fmt.Errorf("yellowdog: discovery BaseURL must use https:// (got %q)", base)
+	}
+	httpc := cfg.HTTPClient
+	if httpc == nil {
+		httpc = &http.Client{
+			Timeout: 30 * time.Second,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+	}
+
+	// nodeSearch and sliceReference are both *required* query params on
+	// GET /workerPools/nodes per the scheduler OpenAPI; the server 400s
+	// without them. Both serialise as URL-encoded JSON strings, matching
+	// the convention searchWorkRequirements already uses for
+	// /work/requirements.
+	q := url.Values{}
+	q.Set("nodeSearch", `{"statuses":["RUNNING"]}`)
+	q.Set("sliceReference", `{"size":200}`)
+
+	var out sliceNode
+	if err := doJSON(ctx, httpc, creds, base, http.MethodGet, "/workerPools/nodes", q, nil, &out, retryConfig{maxAttempts: 3}); err != nil {
+		return nil, fmt.Errorf("yellowdog: query nodes: %w", err)
+	}
+
+	seen := map[string]struct{}{}
+	for _, n := range out.Items {
+		tag := strings.TrimSpace(n.Details.WorkerTag)
+		if tag == "" {
+			continue
+		}
+		seen[tag] = struct{}{}
+	}
+	tags := make([]string, 0, len(seen))
+	for t := range seen {
+		tags = append(tags, t)
+	}
+	sort.Strings(tags)
+	return tags, nil
+}

--- a/api/pkg/sandbox/compute/yellowdog/node_discovery_test.go
+++ b/api/pkg/sandbox/compute/yellowdog/node_discovery_test.go
@@ -1,0 +1,137 @@
+package yellowdog
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDiscoverOnlineWorkerTags(t *testing.T) {
+	cases := []struct {
+		name     string
+		response string
+		want     []string
+	}{
+		{
+			name:     "no nodes",
+			response: `{"items":[]}`,
+			want:     []string{},
+		},
+		{
+			name: "single tag across multiple nodes is deduplicated",
+			response: `{"items":[
+				{"id":"n1","status":"RUNNING","details":{"workerTag":"worker-psamuel"}},
+				{"id":"n2","status":"RUNNING","details":{"workerTag":"worker-psamuel"}}
+			]}`,
+			want: []string{"worker-psamuel"},
+		},
+		{
+			name: "multiple distinct tags returned sorted",
+			response: `{"items":[
+				{"id":"n1","status":"RUNNING","details":{"workerTag":"worker-staging"}},
+				{"id":"n2","status":"RUNNING","details":{"workerTag":"worker-prod"}}
+			]}`,
+			want: []string{"worker-prod", "worker-staging"},
+		},
+		{
+			name: "empty workerTag fields are dropped",
+			response: `{"items":[
+				{"id":"n1","status":"RUNNING","details":{"workerTag":""}},
+				{"id":"n2","status":"RUNNING","details":{"workerTag":"worker-real"}}
+			]}`,
+			want: []string{"worker-real"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeServer(t)
+			f.handler = func(w http.ResponseWriter, r *http.Request) {
+				// Must hit the right endpoint with the right query
+				// shape. If this assertion ever fails it means we
+				// regressed away from the public OpenAPI contract.
+				if r.URL.Path != "/workerPools/nodes" {
+					t.Errorf("path = %q, want /workerPools/nodes", r.URL.Path)
+				}
+				if r.Method != http.MethodGet {
+					t.Errorf("method = %q, want GET", r.Method)
+				}
+				q := r.URL.Query()
+				if q.Get("nodeSearch") == "" {
+					t.Error("nodeSearch query param missing - YD will 400")
+				}
+				if q.Get("sliceReference") == "" {
+					t.Error("sliceReference query param missing - YD will 400")
+				}
+				// Only RUNNING nodes should be requested.
+				if !strings.Contains(q.Get("nodeSearch"), "RUNNING") {
+					t.Errorf("nodeSearch should filter to RUNNING, got %q", q.Get("nodeSearch"))
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.response))
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			got, err := DiscoverOnlineWorkerTags(ctx, Config{
+				APIKeyID:             "k",
+				APISecret:            "s",
+				BaseURL:              f.srv.URL,
+				HTTPClient:           f.srv.Client(),
+				AllowInsecureBaseURL: true,
+			})
+			if err != nil {
+				t.Fatalf("DiscoverOnlineWorkerTags: %v", err)
+			}
+			// Treat nil and empty slice as equivalent for this comparison.
+			if got == nil {
+				got = []string{}
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDiscoverOnlineWorkerTagsRequiresCreds(t *testing.T) {
+	_, err := DiscoverOnlineWorkerTags(context.Background(), Config{
+		BaseURL: "https://portal.yellowdog.co/api",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing APIKeyID/APISecret")
+	}
+}
+
+func TestDiscoverOnlineWorkerTagsRefusesPlaintextURL(t *testing.T) {
+	_, err := DiscoverOnlineWorkerTags(context.Background(), Config{
+		APIKeyID:  "k",
+		APISecret: "s",
+		BaseURL:   "http://example.com/api",
+	})
+	if err == nil {
+		t.Fatal("expected error for non-https BaseURL without AllowInsecureBaseURL")
+	}
+}
+
+func TestDiscoverOnlineWorkerTagsPropagatesServerError(t *testing.T) {
+	f := newFakeServer(t)
+	f.handler = func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := DiscoverOnlineWorkerTags(ctx, Config{
+		APIKeyID:             "k",
+		APISecret:            "s",
+		BaseURL:              f.srv.URL,
+		HTTPClient:           f.srv.Client(),
+		AllowInsecureBaseURL: true,
+	})
+	if err == nil {
+		t.Fatal("expected error when YD returns 500")
+	}
+}
+


### PR DESCRIPTION
## Summary

Closes a silent-misroute gotcha the 2026-06-10 E2E run exposed: when the YD operator's pool was registered with worker tag `worker-psamuel` (POC `worker_tag = worker-{{username}}` convention), Helix would auto-derive `worker-development` from `HELIX_YD_NAMESPACE` and submit WRs that no worker would ever match. WR sits PENDING indefinitely with no surfaced error.

Discovery reads the truth from the running pool instead of guessing.

## How it works

`resolveWorkerTag` in `bootstrap.go` resolves in this order:

| Order | Source | When taken |
|---|---|---|
| 1 | `HELIX_YD_WORKER_TAG` explicit | operator override |
| 2 | `GET /workerPools/nodes` | exactly one distinct tag across online nodes |
| 3 | `worker-<namespace>` fallback | discovery returns 0 nodes OR a transport error |

**Failure mode**: discovery finds >1 distinct tag → refuse to boot with an actionable error naming each candidate tag and pointing at `HELIX_YD_WORKER_TAG`. Silent disambiguation could route to the wrong pool — operator must choose.

**Boot resilience**: discovery transport errors (network, auth, 5xx) fall through to (3) rather than failing boot. A flapping YD shouldn't take Helix offline; if the fallback is wrong, the WR-PENDING diagnostic surfaces it later. (Bounded 15s context to keep boot quick if YD is unreachable.)

## What's covered

- `DiscoverOnlineWorkerTags(ctx, Config)` in `yellowdog/node_discovery.go` — calls `GET /workerPools/nodes` with the OpenAPI-required `nodeSearch={statuses:[\"RUNNING\"]}` + `sliceReference={size:200}` params, decodes the SliceNode response, returns distinct non-empty tags sorted.
- `resolveWorkerTag` in `bootstrap/bootstrap.go` — wires discovery into the existing buildProvider yellowdog arm.
- `discoverFn` package var — injectable for tests so the unit suite never reaches out to `portal.yellowdog.co`.

## Tests

`yellowdog/node_discovery_test.go` (new, against an httptest fake server):
- happy path: returns the unique tag
- dedup: same tag on multiple nodes → one entry
- multi: distinct tags returned sorted
- empty workerTag fields dropped
- creds required
- HTTPS required (escape hatch: `AllowInsecureBaseURL`)
- server 5xx propagates as error
- asserts the actual URL path + required query params (so a refactor can't silently regress the OpenAPI contract)

`bootstrap/bootstrap_test.go` (5 new tests):
- explicit WorkerTag bypasses discovery (`discoverFn` not called)
- 1 tag discovered → used verbatim
- >1 tag → refuse to start, error names both candidates AND `HELIX_YD_WORKER_TAG`
- transport error → fall back to namespace-derived, no boot failure
- empty Namespace + empty WorkerTag → fail fast with named env var

`TestMain` now stubs `discoverFn` to return no tags. The existing `TestBootstrapDerivesWorkerTagFromNamespace` is reframed as the 0-tags fallback branch.

## Operator-visible change

After this lands, operators who previously set `HELIX_YD_WORKER_TAG` explicitly can drop it when discovery finds exactly one online tag. Helix will discover and log the resolved tag on boot.

## Validation

- `go test ./api/pkg/sandbox/compute/yellowdog/... ./api/pkg/sandbox/compute/bootstrap/...` — all green, zero network calls
- `go vet ./api/pkg/sandbox/compute/bootstrap/...` — clean
- Live YD validation pending on next deploy

## Test plan

- [x] Unit tests green
- [ ] CI green
- [ ] Live: redeploy without `HELIX_YD_WORKER_TAG`, confirm log line `WorkerTag auto-discovered from online YD nodes worker_tag=worker-psamuel`
- [ ] Live: bring up a second pool with a different tag, confirm boot fails with the ambiguity error naming both tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)