### PR TITLE
ci: restore CodeQL scanning of first-party code

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly catch-all so main keeps a fresh scan even with no pushes.
+    - cron: '23 4 * * 1'
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        # Our first-party code. Container-image CVEs are intentionally
+        # out of scope here (Trivy image scanning was retired in e83b08285).
+        language: [go, javascript-typescript, python]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Why

The code-scanning tab showed a "Code Scanning results may be out of date" banner. Root cause: two scanners both stopped running against `main`.

- **CodeQL** ran via GitHub *default setup* (no workflow file in-repo). Its last run on `main` was 2025-08-14; default setup is now `not-configured`, so our own code hasn't been analysed in ~10 months.
- **Trivy** image scanning (`.github/workflows/trivy.yml`) was intentionally removed in `e83b08285` (2026-02-27).

That left **225 stale open alerts**: 221 Trivy base-image CVEs (pgvector/postgres/keycloak/gosu/etc. - third-party images, not our code) and 4 CodeQL (3 path-injection in `api/pkg/runner/files.go`, which was since **deleted** in `5d9abe3fc`, plus 1 in a test fixture).

## What this does

- Adds an explicit, version-controlled `codeql.yml` covering first-party **Go / TypeScript / Python** on push, PR, and a weekly schedule. Preferred over default setup: reviewable and runs on every change.
- Container-image CVE scanning stays retired (Trivy was deliberately removed). The 221 inherited base-image alerts were **bulk-dismissed as won't-fix** out-of-band, and the test-fixture alert dismissed as used-in-tests. The 3 path-injection findings auto-resolve once CodeQL re-runs, since that file is gone.

## Notes

- Rust is in the repo but excluded here to keep the build green and low-maintenance; can be added later if wanted.
- First run on merge re-baselines the tab against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)