### PR TITLE
refactor(admin): consolidate runner admin pages into a single master-detail Runners view

### DIFF
--- a/frontend/src/components/admin/AdminPanelSidebar.tsx
+++ b/frontend/src/components/admin/AdminPanelSidebar.tsx
@@ -8,7 +8,6 @@ import LinkIcon from '@mui/icons-material/Link'
 import DirectionsRunIcon from '@mui/icons-material/DirectionsRun'
 import ModelTrainingIcon from '@mui/icons-material/ModelTraining'
 import SettingsIcon from '@mui/icons-material/Settings'
-import DeveloperBoardIcon from '@mui/icons-material/DeveloperBoard'
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney'
 import CodeIcon from '@mui/icons-material/Code'
 import QueueIcon from '@mui/icons-material/Queue'
@@ -69,17 +68,10 @@ const AdminPanelSidebar: FC<AdminPanelSidebarProps> = ({ activeTab = 'llm_calls'
         },
         {
           id: 'runners',
-          label: 'GPU Runners',
+          label: 'Runners',
           icon: <DirectionsRunIcon />,
           isActive: currentTab === 'runners',
           onClick: () => handleNavigationClick('runners')
-        },
-        {
-          id: 'agent_sandboxes',
-          label: 'Agent Sandboxes',
-          icon: <DeveloperBoardIcon />,
-          isActive: currentTab === 'agent_sandboxes',
-          onClick: () => handleNavigationClick('agent_sandboxes')
         }
       ]
     },
@@ -92,13 +84,6 @@ const AdminPanelSidebar: FC<AdminPanelSidebarProps> = ({ activeTab = 'llm_calls'
           icon: <ModelTrainingIcon />,
           isActive: currentTab === 'helix_models',
           onClick: () => handleNavigationClick('helix_models')
-        },
-        {
-          id: 'runner_profiles',
-          label: 'Runner Profiles',
-          icon: <ModelTrainingIcon />,
-          isActive: currentTab === 'runner_profiles',
-          onClick: () => handleNavigationClick('runner_profiles')
         },
         {
           id: 'pricing',

--- a/frontend/src/components/admin/AdminPanelSidebar.tsx
+++ b/frontend/src/components/admin/AdminPanelSidebar.tsx
@@ -86,6 +86,13 @@ const AdminPanelSidebar: FC<AdminPanelSidebarProps> = ({ activeTab = 'llm_calls'
           onClick: () => handleNavigationClick('helix_models')
         },
         {
+          id: 'runner_profiles',
+          label: 'Runner Profiles',
+          icon: <ModelTrainingIcon />,
+          isActive: currentTab === 'runner_profiles',
+          onClick: () => handleNavigationClick('runner_profiles')
+        },
+        {
           id: 'pricing',
           label: 'Pricing',
           icon: <AttachMoneyIcon />,

--- a/frontend/src/components/admin/Runners.tsx
+++ b/frontend/src/components/admin/Runners.tsx
@@ -858,15 +858,14 @@ const Runners: FC = () => {
                 renderValue={(value) => {
                   const inst = sandboxes.find((s) => s.id === value)
                   if (!inst) return value
-                  const label = inst.hostname || inst.id
                   const bits = [inst.status]
                   if (inst.active_profile_id) bits.push(`profile: ${inst.active_profile_id}`)
-                  return `${label}  (${bits.join(', ')})`
+                  return `${inst.id}  (${bits.join(', ')})`
                 }}
               >
                 {sandboxes.map((sb) => (
                   <MenuItem key={sb.id} value={sb.id}>
-                    {sb.hostname || sb.id}
+                    {sb.id}
                     {sb.active_profile_id && ` — ${sb.active_profile_id}`}
                     {' '}({sb.status})
                   </MenuItem>

--- a/frontend/src/components/admin/Runners.tsx
+++ b/frontend/src/components/admin/Runners.tsx
@@ -782,13 +782,7 @@ const Runners: FC = () => {
 
   return (
     <Box sx={{ p: 3 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-        <Box>
-          <Typography variant="h5">Runners</Typography>
-          <Typography variant="body2" color="text.secondary">
-            Aggregate view of all Helix Runners
-          </Typography>
-        </Box>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', mb: 1 }}>
         <IconButton onClick={() => refetch()} disabled={isLoading} sx={{ color: 'primary.main' }}>
           {isLoading ? <CircularProgress size={24} /> : <RefreshIcon />}
         </IconButton>

--- a/frontend/src/components/admin/Runners.tsx
+++ b/frontend/src/components/admin/Runners.tsx
@@ -31,9 +31,8 @@ import DesktopWindowsIcon from '@mui/icons-material/DesktopWindows'
 import PersonIcon from '@mui/icons-material/Person'
 import ThermostatIcon from '@mui/icons-material/Thermostat'
 import VideocamIcon from '@mui/icons-material/Videocam'
-import DescriptionIcon from '@mui/icons-material/Description'
 
-import RunnerProfilesTable from '../dashboard/RunnerProfilesTable'
+import RunnerLogs from './RunnerLogs'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAccount } from '../../contexts/account'
 import useApi from '../../hooks/useApi'
@@ -245,21 +244,6 @@ const SandboxProfileCard: FC<{ sandbox: SandboxInstanceInfo }> = ({ sandbox }) =
         {!isOnline && (
           <Chip label={sandbox.status} size="small" variant="outlined" color="default" />
         )}
-        <Box sx={{ flexGrow: 1 }} />
-        <Tooltip title="Open live-tail logs in a new tab">
-          <Button
-            size="small"
-            variant="text"
-            startIcon={<DescriptionIcon sx={{ fontSize: 16 }} />}
-            component="a"
-            href={`/admin/runner-logs/${encodeURIComponent(sandbox.id)}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            sx={{ minWidth: 'auto', px: 1 }}
-          >
-            Logs
-          </Button>
-        </Tooltip>
       </Box>
       {profileID && (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
@@ -717,22 +701,21 @@ const DevContainerCard: FC<DevContainerCardProps> = ({ container, onStop, isStop
   )
 }
 
-// SubTab is one of three lenses on the same underlying dataset:
-//   overview  – aggregate stats + GPU panel + per-host runner cards
-//               (all of "what runners do I have, how are they doing" in
-//               one place; the host list was briefly a sibling sub-tab
-//               but felt redundant - operators want the totals + the
-//               list on the same view)
+// SubTab is one of two lenses on the same underlying dataset:
+//   overview  – stats + GPU panel + runner picker + selected-runner detail
+//               (master-detail; the picker drives an inline live-tail log
+//               + profile card for the chosen runner)
 //   sandboxes – user-facing dev containers (was "Dev Containers")
-//   profiles  – inference-profile config (was the standalone Runner Profiles
-//               admin tab; absorbed here because Profiles only make sense
-//               in the context of the runners that consume them)
-type SubTab = 'overview' | 'sandboxes' | 'profiles'
+//
+// Runner Profiles used to live here as a third sub-tab but it's
+// conceptually a standalone catalog, not a lens on running compute,
+// so it's promoted back to its own admin-sidebar entry.
+type SubTab = 'overview' | 'sandboxes'
 
 const SUBTAB_LS_KEY = 'admin-runners-subtab'
 
 function isSubTab(v: string | null): v is SubTab {
-  return v === 'overview' || v === 'sandboxes' || v === 'profiles'
+  return v === 'overview' || v === 'sandboxes'
 }
 
 const Runners: FC = () => {
@@ -755,6 +738,12 @@ const Runners: FC = () => {
     if (typeof window === 'undefined') return
     window.localStorage.setItem(SUBTAB_LS_KEY, subTab)
   }, [subTab])
+
+  // Selected runner for the Overview master-detail view. Auto-selects the
+  // first available runner so a single-runner deployment shows its detail
+  // without a manual pick. Resets if the current selection drops off the
+  // list (e.g. runner taken offline by the reaper).
+  const [selectedRunnerId, setSelectedRunnerId] = useState<string>('')
 
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: ['agent-sandboxes-debug'],
@@ -796,6 +785,23 @@ const Runners: FC = () => {
     a.session_id.localeCompare(b.session_id)
   )
 
+  // Keep the picker's selection consistent with the live data:
+  //   - Reset to '' if the list goes empty
+  //   - Reset to the first runner if the current selection has dropped off
+  //   - Auto-select the first runner on initial load (single-runner UX)
+  useEffect(() => {
+    if (sandboxes.length === 0) {
+      if (selectedRunnerId !== '') setSelectedRunnerId('')
+      return
+    }
+    const stillExists = sandboxes.some((s) => s.id === selectedRunnerId)
+    if (!stillExists) {
+      setSelectedRunnerId(sandboxes[0].id)
+    }
+  }, [sandboxes, selectedRunnerId])
+
+  const selectedRunner = sandboxes.find((s) => s.id === selectedRunnerId)
+
   // Aggregate stats - "online" not "running" (sandbox status enum).
   const runningRunners = sandboxes.filter((s) => s.status === 'online').length
   const runningContainers = sortedContainers.filter((c) => c.status === 'running').length
@@ -828,7 +834,6 @@ const Runners: FC = () => {
       >
         <Tab value="overview" label="Overview" />
         <Tab value="sandboxes" label="Sandboxes" />
-        <Tab value="profiles" label="Profiles" />
       </Tabs>
 
       {subTab === 'overview' && (
@@ -864,14 +869,14 @@ const Runners: FC = () => {
             </Grid>
           </Grid>
 
-          {/* Middle: GPU telemetry strip. */}
+          {/* GPU telemetry strip. */}
           {gpus.length > 0 && (
             <Box sx={{ mb: 3 }}>
               <GPUStatsCard gpus={gpus} />
             </Box>
           )}
 
-          {/* Bottom: one card per runner host. */}
+          {/* Master-detail: picker on top, selected-runner detail below. */}
           {sandboxes.length === 0 ? (
             <Box sx={{ textAlign: 'center', py: 6 }}>
               <ComputerIcon sx={{ fontSize: 60, color: 'text.secondary', mb: 2 }} />
@@ -883,13 +888,67 @@ const Runners: FC = () => {
               </Typography>
             </Box>
           ) : (
-            <Grid container spacing={2}>
-              {sandboxes.map((sb) => (
-                <Grid item xs={12} md={6} lg={4} key={sb.id}>
-                  <SandboxProfileCard sandbox={sb} />
-                </Grid>
-              ))}
-            </Grid>
+            <Box>
+              {/* Runner picker. Shown even when there's only one runner so
+                  the operator always sees which one they're looking at. */}
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2, flexWrap: 'wrap' }}>
+                <FormControl size="small" sx={{ minWidth: 360, flexGrow: 1, maxWidth: 600 }}>
+                  <InputLabel id="runner-picker-label" shrink>Runner</InputLabel>
+                  <Select
+                    labelId="runner-picker-label"
+                    value={selectedRunnerId}
+                    label="Runner"
+                    onChange={(e) => setSelectedRunnerId(e.target.value)}
+                    renderValue={(value) => {
+                      const inst = sandboxes.find((s) => s.id === value)
+                      if (!inst) return value
+                      const label = inst.hostname || inst.id
+                      const bits = [inst.status]
+                      if (inst.active_profile_id) bits.push(`profile: ${inst.active_profile_id}`)
+                      return `${label}  (${bits.join(', ')})`
+                    }}
+                  >
+                    {sandboxes.map((sb) => (
+                      <MenuItem key={sb.id} value={sb.id}>
+                        {sb.hostname || sb.id}
+                        {sb.active_profile_id && ` — ${sb.active_profile_id}`}
+                        {' '}({sb.status})
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+                {selectedRunner && (
+                  <Tooltip title="Open the live-tail log stream in a new tab">
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      component="a"
+                      href={`/admin/runner-logs/${encodeURIComponent(selectedRunner.id)}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Open logs
+                    </Button>
+                  </Tooltip>
+                )}
+              </Box>
+
+              {/* Selected runner detail: profile assignment + inline logs. */}
+              {selectedRunner && (
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                  <SandboxProfileCard sandbox={selectedRunner} />
+                  <Card>
+                    <CardHeader
+                      title="Runner Logs"
+                      subheader="Live tail (control-plane + inner desktop containers, aggregated)"
+                    />
+                    <CardContent>
+                      <RunnerLogs runnerId={selectedRunner.id} compact />
+                    </CardContent>
+                  </Card>
+                </Box>
+              )}
+            </Box>
           )}
         </Box>
       )}
@@ -919,12 +978,6 @@ const Runners: FC = () => {
               </Typography>
             </Box>
           )}
-        </Box>
-      )}
-
-      {subTab === 'profiles' && (
-        <Box>
-          <RunnerProfilesTable />
         </Box>
       )}
     </Box>

--- a/frontend/src/components/admin/Runners.tsx
+++ b/frontend/src/components/admin/Runners.tsx
@@ -704,19 +704,18 @@ const DevContainerCard: FC<DevContainerCardProps> = ({ container, onStop, isStop
 
 // SubTab is one of four lenses on the same underlying dataset:
 //   overview  – aggregate stats + GPU panel (was the "Aggregate View" cards)
-//   fleet     – the list of runners themselves, one card per runner showing
-//               status + profile assignment (links into the runner-detail
-//               page for logs)
+//   hosts     – the list of runner hosts themselves, one card per runner
+//               showing status + profile assignment
 //   sandboxes – user-facing dev containers (was "Dev Containers")
 //   profiles  – inference-profile config (was the standalone Runner Profiles
 //               admin tab; absorbed here because Profiles only make sense
 //               in the context of the runners that consume them)
-type SubTab = 'overview' | 'fleet' | 'sandboxes' | 'profiles'
+type SubTab = 'overview' | 'hosts' | 'sandboxes' | 'profiles'
 
 const SUBTAB_LS_KEY = 'admin-runners-subtab'
 
 function isSubTab(v: string | null): v is SubTab {
-  return v === 'overview' || v === 'fleet' || v === 'sandboxes' || v === 'profiles'
+  return v === 'overview' || v === 'hosts' || v === 'sandboxes' || v === 'profiles'
 }
 
 const Runners: FC = () => {
@@ -788,7 +787,7 @@ const Runners: FC = () => {
     a.session_id.localeCompare(b.session_id)
   )
 
-  // Decide whether the Profiles assignment panel inside Fleet should render.
+  // Decide whether the Profiles assignment panel inside Hosts should render.
   // Visible when at least one Runner Profile is configured OR when any runner
   // already has a profile assigned (so deleting the last catalogue entry
   // mid-interaction doesn't hide a "Clear" button from the operator).
@@ -830,7 +829,7 @@ const Runners: FC = () => {
         sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}
       >
         <Tab value="overview" label="Overview" />
-        <Tab value="fleet" label="Fleet" />
+        <Tab value="hosts" label="Hosts" />
         <Tab value="sandboxes" label="Sandboxes" />
         <Tab value="profiles" label="Profiles" />
       </Tabs>
@@ -878,7 +877,7 @@ const Runners: FC = () => {
         </Box>
       )}
 
-      {subTab === 'fleet' && (
+      {subTab === 'hosts' && (
         <Box>
           {showInferenceProfilesPanel && sandboxes.length > 0 ? (
             <Grid container spacing={2}>

--- a/frontend/src/components/admin/Runners.tsx
+++ b/frontend/src/components/admin/Runners.tsx
@@ -40,7 +40,6 @@ import {
   useAssignRunnerProfile,
   useClearRunnerProfile,
   useListCompatibleRunnerProfiles,
-  useListRunnerProfiles,
 } from '../../services/runnerProfilesService'
 
 // Types matching the backend response
@@ -702,20 +701,22 @@ const DevContainerCard: FC<DevContainerCardProps> = ({ container, onStop, isStop
   )
 }
 
-// SubTab is one of four lenses on the same underlying dataset:
-//   overview  – aggregate stats + GPU panel (was the "Aggregate View" cards)
-//   hosts     – the list of runner hosts themselves, one card per runner
-//               showing status + profile assignment
+// SubTab is one of three lenses on the same underlying dataset:
+//   overview  – aggregate stats + GPU panel + per-host runner cards
+//               (all of "what runners do I have, how are they doing" in
+//               one place; the host list was briefly a sibling sub-tab
+//               but felt redundant - operators want the totals + the
+//               list on the same view)
 //   sandboxes – user-facing dev containers (was "Dev Containers")
 //   profiles  – inference-profile config (was the standalone Runner Profiles
 //               admin tab; absorbed here because Profiles only make sense
 //               in the context of the runners that consume them)
-type SubTab = 'overview' | 'hosts' | 'sandboxes' | 'profiles'
+type SubTab = 'overview' | 'sandboxes' | 'profiles'
 
 const SUBTAB_LS_KEY = 'admin-runners-subtab'
 
 function isSubTab(v: string | null): v is SubTab {
-  return v === 'overview' || v === 'hosts' || v === 'sandboxes' || v === 'profiles'
+  return v === 'overview' || v === 'sandboxes' || v === 'profiles'
 }
 
 const Runners: FC = () => {
@@ -738,14 +739,6 @@ const Runners: FC = () => {
     if (typeof window === 'undefined') return
     window.localStorage.setItem(SUBTAB_LS_KEY, subTab)
   }, [subTab])
-
-  // Inference profile catalogue. Polled on the same 5s cadence as the debug
-  // query below so the Profiles sub-tab tracks additions / deletions made
-  // elsewhere without manual refresh.
-  const {
-    data: runnerProfiles,
-    isLoading: isLoadingRunnerProfiles,
-  } = useListRunnerProfiles({ refetchInterval: 5000 })
 
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: ['agent-sandboxes-debug'],
@@ -787,17 +780,6 @@ const Runners: FC = () => {
     a.session_id.localeCompare(b.session_id)
   )
 
-  // Decide whether the Profiles assignment panel inside Hosts should render.
-  // Visible when at least one Runner Profile is configured OR when any runner
-  // already has a profile assigned (so deleting the last catalogue entry
-  // mid-interaction doesn't hide a "Clear" button from the operator).
-  const anySandboxHasProfileAssigned = sandboxes.some((s) => !!s.active_profile_id)
-  const hasRunnerProfiles = (runnerProfiles?.length ?? 0) > 0
-  const showInferenceProfilesPanel =
-    isLoadingRunnerProfiles ||
-    hasRunnerProfiles ||
-    anySandboxHasProfileAssigned
-
   // Aggregate stats - "online" not "running" (sandbox status enum).
   const runningRunners = sandboxes.filter((s) => s.status === 'online').length
   const runningContainers = sortedContainers.filter((c) => c.status === 'running').length
@@ -829,13 +811,13 @@ const Runners: FC = () => {
         sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}
       >
         <Tab value="overview" label="Overview" />
-        <Tab value="hosts" label="Hosts" />
         <Tab value="sandboxes" label="Sandboxes" />
         <Tab value="profiles" label="Profiles" />
       </Tabs>
 
       {subTab === 'overview' && (
         <Box>
+          {/* Top: aggregate stats. */}
           <Grid container spacing={2} sx={{ mb: 3 }}>
             <Grid item xs={12} sm={4}>
               <Paper sx={{ p: 2, textAlign: 'center' }}>
@@ -866,28 +848,15 @@ const Runners: FC = () => {
             </Grid>
           </Grid>
 
-          {gpus.length > 0 && <GPUStatsCard gpus={gpus} />}
-          {gpus.length === 0 && (
-            <Box sx={{ textAlign: 'center', py: 4 }}>
-              <Typography variant="body2" color="text.secondary">
-                No GPU stats reported. Bring up a runner to see GPU telemetry.
-              </Typography>
+          {/* Middle: GPU telemetry strip. */}
+          {gpus.length > 0 && (
+            <Box sx={{ mb: 3 }}>
+              <GPUStatsCard gpus={gpus} />
             </Box>
           )}
-        </Box>
-      )}
 
-      {subTab === 'hosts' && (
-        <Box>
-          {showInferenceProfilesPanel && sandboxes.length > 0 ? (
-            <Grid container spacing={2}>
-              {sandboxes.map((sb) => (
-                <Grid item xs={12} md={6} lg={4} key={sb.id}>
-                  <SandboxProfileCard sandbox={sb} />
-                </Grid>
-              ))}
-            </Grid>
-          ) : sandboxes.length === 0 ? (
+          {/* Bottom: one card per runner host. */}
+          {sandboxes.length === 0 ? (
             <Box sx={{ textAlign: 'center', py: 6 }}>
               <ComputerIcon sx={{ fontSize: 60, color: 'text.secondary', mb: 2 }} />
               <Typography variant="body1" color="text.secondary">

--- a/frontend/src/components/admin/Runners.tsx
+++ b/frontend/src/components/admin/Runners.tsx
@@ -20,8 +20,6 @@ import {
   InputLabel,
   MenuItem,
   Select,
-  Tab,
-  Tabs,
 } from '@mui/material'
 import RefreshIcon from '@mui/icons-material/Refresh'
 import CloseIcon from '@mui/icons-material/Close'
@@ -701,47 +699,16 @@ const DevContainerCard: FC<DevContainerCardProps> = ({ container, onStop, isStop
   )
 }
 
-// SubTab is one of two lenses on the same underlying dataset:
-//   overview  – stats + GPU panel + runner picker + selected-runner detail
-//               (master-detail; the picker drives an inline live-tail log
-//               + profile card for the chosen runner)
-//   sandboxes – user-facing dev containers (was "Dev Containers")
-//
-// Runner Profiles used to live here as a third sub-tab but it's
-// conceptually a standalone catalog, not a lens on running compute,
-// so it's promoted back to its own admin-sidebar entry.
-type SubTab = 'overview' | 'sandboxes'
-
-const SUBTAB_LS_KEY = 'admin-runners-subtab'
-
-function isSubTab(v: string | null): v is SubTab {
-  return v === 'overview' || v === 'sandboxes'
-}
-
 const Runners: FC = () => {
   const api = useApi()
   const apiClient = api.getApiClient()
   const queryClient = useQueryClient()
   const [stoppingIds, setStoppingIds] = useState<Set<string>>(new Set())
 
-  // Sub-tab state with localStorage persistence. URL-syncing would be nicer
-  // for deep-linking but the admin shell controls the top-level `dialog_tab`
-  // param and doesn't currently expose a nested-param hook; localStorage gets
-  // us 90% of the way (same operator returns to the same lens) without
-  // touching the shell.
-  const [subTab, setSubTab] = useState<SubTab>(() => {
-    if (typeof window === 'undefined') return 'overview'
-    const stored = window.localStorage.getItem(SUBTAB_LS_KEY)
-    return isSubTab(stored) ? stored : 'overview'
-  })
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    window.localStorage.setItem(SUBTAB_LS_KEY, subTab)
-  }, [subTab])
-
-  // Selected runner for the Overview master-detail view. Auto-selects the
-  // first available runner so a single-runner deployment shows its detail
-  // without a manual pick. Resets if the current selection drops off the
+  // Selected runner for the master-detail view. Auto-selects the first
+  // ONLINE runner so a single-runner deployment shows useful detail
+  // immediately and offline historical rows don't trap the operator on
+  // a broken log stream. Resets if the current selection drops off the
   // list (e.g. runner taken offline by the reaper).
   const [selectedRunnerId, setSelectedRunnerId] = useState<string>('')
 
@@ -833,157 +800,151 @@ const Runners: FC = () => {
         </Alert>
       )}
 
-      <Tabs
-        value={subTab}
-        onChange={(_, v) => setSubTab(v as SubTab)}
-        sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}
-      >
-        <Tab value="overview" label="Overview" />
-        <Tab value="sandboxes" label="Sandboxes" />
-      </Tabs>
+      {/* Top: aggregate stats - always global across all runners. */}
+      <Grid container spacing={2} sx={{ mb: 3 }}>
+        <Grid item xs={12} sm={4}>
+          <Paper sx={{ p: 2, textAlign: 'center' }}>
+            <ComputerIcon sx={{ fontSize: 40, color: 'primary.main', mb: 1 }} />
+            <Typography variant="h4">{runningRunners}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Online Runners
+            </Typography>
+          </Paper>
+        </Grid>
+        <Grid item xs={12} sm={4}>
+          <Paper sx={{ p: 2, textAlign: 'center' }}>
+            <DesktopWindowsIcon sx={{ fontSize: 40, color: 'success.main', mb: 1 }} />
+            <Typography variant="h4">{runningContainers}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Active Sandboxes
+            </Typography>
+          </Paper>
+        </Grid>
+        <Grid item xs={12} sm={4}>
+          <Paper sx={{ p: 2, textAlign: 'center' }}>
+            <PersonIcon sx={{ fontSize: 40, color: 'info.main', mb: 1 }} />
+            <Typography variant="h4">{totalClients}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Connected Users
+            </Typography>
+          </Paper>
+        </Grid>
+      </Grid>
 
-      {subTab === 'overview' && (
-        <Box>
-          {/* Top: aggregate stats. */}
-          <Grid container spacing={2} sx={{ mb: 3 }}>
-            <Grid item xs={12} sm={4}>
-              <Paper sx={{ p: 2, textAlign: 'center' }}>
-                <ComputerIcon sx={{ fontSize: 40, color: 'primary.main', mb: 1 }} />
-                <Typography variant="h4">{runningRunners}</Typography>
-                <Typography variant="body2" color="text.secondary">
-                  Online Runners
-                </Typography>
-              </Paper>
-            </Grid>
-            <Grid item xs={12} sm={4}>
-              <Paper sx={{ p: 2, textAlign: 'center' }}>
-                <DesktopWindowsIcon sx={{ fontSize: 40, color: 'success.main', mb: 1 }} />
-                <Typography variant="h4">{runningContainers}</Typography>
-                <Typography variant="body2" color="text.secondary">
-                  Active Sandboxes
-                </Typography>
-              </Paper>
-            </Grid>
-            <Grid item xs={12} sm={4}>
-              <Paper sx={{ p: 2, textAlign: 'center' }}>
-                <PersonIcon sx={{ fontSize: 40, color: 'info.main', mb: 1 }} />
-                <Typography variant="h4">{totalClients}</Typography>
-                <Typography variant="body2" color="text.secondary">
-                  Connected Users
-                </Typography>
-              </Paper>
-            </Grid>
-          </Grid>
-
-          {/* GPU telemetry strip. */}
-          {gpus.length > 0 && (
-            <Box sx={{ mb: 3 }}>
-              <GPUStatsCard gpus={gpus} />
-            </Box>
-          )}
-
-          {/* Master-detail: picker on top, selected-runner detail below. */}
-          {sandboxes.length === 0 ? (
-            <Box sx={{ textAlign: 'center', py: 6 }}>
-              <ComputerIcon sx={{ fontSize: 60, color: 'text.secondary', mb: 2 }} />
-              <Typography variant="body1" color="text.secondary">
-                No runners registered
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                Provision one via YellowDog, or self-register a runner pointing at this control plane.
-              </Typography>
-            </Box>
-          ) : (
-            <Box>
-              {/* Runner picker. Shown even when there's only one runner so
-                  the operator always sees which one they're looking at. */}
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2, flexWrap: 'wrap' }}>
-                <FormControl size="small" sx={{ minWidth: 360, flexGrow: 1, maxWidth: 600 }}>
-                  <InputLabel id="runner-picker-label" shrink>Runner</InputLabel>
-                  <Select
-                    labelId="runner-picker-label"
-                    value={selectedRunnerId}
-                    label="Runner"
-                    onChange={(e) => setSelectedRunnerId(e.target.value)}
-                    renderValue={(value) => {
-                      const inst = sandboxes.find((s) => s.id === value)
-                      if (!inst) return value
-                      const label = inst.hostname || inst.id
-                      const bits = [inst.status]
-                      if (inst.active_profile_id) bits.push(`profile: ${inst.active_profile_id}`)
-                      return `${label}  (${bits.join(', ')})`
-                    }}
-                  >
-                    {sandboxes.map((sb) => (
-                      <MenuItem key={sb.id} value={sb.id}>
-                        {sb.hostname || sb.id}
-                        {sb.active_profile_id && ` — ${sb.active_profile_id}`}
-                        {' '}({sb.status})
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-                {selectedRunner && (
-                  <Tooltip title="Open the live-tail log stream in a new tab">
-                    <Button
-                      size="small"
-                      variant="outlined"
-                      component="a"
-                      href={`/admin/runner-logs/${encodeURIComponent(selectedRunner.id)}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Open logs
-                    </Button>
-                  </Tooltip>
-                )}
-              </Box>
-
-              {/* Selected runner detail: profile assignment + inline logs. */}
-              {selectedRunner && (
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                  <SandboxProfileCard sandbox={selectedRunner} />
-                  <Card>
-                    <CardHeader
-                      title="Runner Logs"
-                      subheader="Live tail (control-plane + inner desktop containers, aggregated)"
-                    />
-                    <CardContent>
-                      <RunnerLogs runnerId={selectedRunner.id} compact />
-                    </CardContent>
-                  </Card>
-                </Box>
-              )}
-            </Box>
-          )}
+      {/* GPU telemetry strip - global across all runners. */}
+      {gpus.length > 0 && (
+        <Box sx={{ mb: 3 }}>
+          <GPUStatsCard gpus={gpus} />
         </Box>
       )}
 
-      {subTab === 'sandboxes' && (
+      {/* Master-detail: picker on top, selected-runner detail below. */}
+      {sandboxes.length === 0 ? (
+        <Box sx={{ textAlign: 'center', py: 6 }}>
+          <ComputerIcon sx={{ fontSize: 60, color: 'text.secondary', mb: 2 }} />
+          <Typography variant="body1" color="text.secondary">
+            No runners registered
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Provision one via YellowDog, or self-register a runner pointing at this control plane.
+          </Typography>
+        </Box>
+      ) : (
         <Box>
-          {sortedContainers.length > 0 ? (
-            <Grid container spacing={2}>
-              {sortedContainers.map((container) => (
-                <Grid item xs={12} md={6} lg={4} key={`${container.sandbox_id}-${container.session_id}`}>
-                  <DevContainerCard
-                    container={container}
-                    onStop={handleStopContainer}
-                    isStopping={stoppingIds.has(container.session_id)}
+          {/* Runner picker. Shown even when there's only one runner so
+              the operator always sees which one they're looking at. */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2, flexWrap: 'wrap' }}>
+            <FormControl size="small" sx={{ minWidth: 360, flexGrow: 1, maxWidth: 600 }}>
+              <InputLabel id="runner-picker-label" shrink>Runner</InputLabel>
+              <Select
+                labelId="runner-picker-label"
+                value={selectedRunnerId}
+                label="Runner"
+                onChange={(e) => setSelectedRunnerId(e.target.value)}
+                renderValue={(value) => {
+                  const inst = sandboxes.find((s) => s.id === value)
+                  if (!inst) return value
+                  const label = inst.hostname || inst.id
+                  const bits = [inst.status]
+                  if (inst.active_profile_id) bits.push(`profile: ${inst.active_profile_id}`)
+                  return `${label}  (${bits.join(', ')})`
+                }}
+              >
+                {sandboxes.map((sb) => (
+                  <MenuItem key={sb.id} value={sb.id}>
+                    {sb.hostname || sb.id}
+                    {sb.active_profile_id && ` — ${sb.active_profile_id}`}
+                    {' '}({sb.status})
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            {selectedRunner && (
+              <Tooltip title="Open the live-tail log stream in a new tab">
+                <Button
+                  size="small"
+                  variant="outlined"
+                  component="a"
+                  href={`/admin/runner-logs/${encodeURIComponent(selectedRunner.id)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Open logs
+                </Button>
+              </Tooltip>
+            )}
+          </Box>
+
+          {/* Selected runner detail: profile assignment + inline logs +
+              this runner's sandboxes (filtered from the global container
+              list by sandbox_id). */}
+          {selectedRunner && (() => {
+            const containersForRunner = sortedContainers.filter(
+              (c) => c.sandbox_id === selectedRunner.id,
+            )
+            return (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <SandboxProfileCard sandbox={selectedRunner} />
+                <Card>
+                  <CardHeader
+                    title="Runner Logs"
+                    subheader="Live tail (control-plane + inner desktop containers, aggregated)"
                   />
-                </Grid>
-              ))}
-            </Grid>
-          ) : (
-            <Box sx={{ textAlign: 'center', py: 6 }}>
-              <DesktopWindowsIcon sx={{ fontSize: 60, color: 'text.secondary', mb: 2 }} />
-              <Typography variant="body1" color="text.secondary">
-                No dev containers running
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                Start a task to launch a desktop sandbox.
-              </Typography>
-            </Box>
-          )}
+                  <CardContent>
+                    <RunnerLogs runnerId={selectedRunner.id} compact />
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardHeader
+                    title="Sandboxes"
+                    subheader={`${containersForRunner.length} active on this runner`}
+                  />
+                  <CardContent>
+                    {containersForRunner.length > 0 ? (
+                      <Grid container spacing={2}>
+                        {containersForRunner.map((container) => (
+                          <Grid item xs={12} md={6} lg={4} key={`${container.sandbox_id}-${container.session_id}`}>
+                            <DevContainerCard
+                              container={container}
+                              onStop={handleStopContainer}
+                              isStopping={stoppingIds.has(container.session_id)}
+                            />
+                          </Grid>
+                        ))}
+                      </Grid>
+                    ) : (
+                      <Box sx={{ textAlign: 'center', py: 3 }}>
+                        <DesktopWindowsIcon sx={{ fontSize: 40, color: 'text.secondary', mb: 1 }} />
+                        <Typography variant="body2" color="text.secondary">
+                          No active sandboxes on this runner
+                        </Typography>
+                      </Box>
+                    )}
+                  </CardContent>
+                </Card>
+              </Box>
+            )
+          })()}
         </Box>
       )}
     </Box>

--- a/frontend/src/components/admin/Runners.tsx
+++ b/frontend/src/components/admin/Runners.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 import {
   Box,
   Grid,
@@ -16,10 +16,8 @@ import {
   AvatarGroup,
   LinearProgress,
   Button,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
+  Tab,
+  Tabs,
 } from '@mui/material'
 import RefreshIcon from '@mui/icons-material/Refresh'
 import CloseIcon from '@mui/icons-material/Close'
@@ -29,9 +27,8 @@ import DesktopWindowsIcon from '@mui/icons-material/DesktopWindows'
 import PersonIcon from '@mui/icons-material/Person'
 import ThermostatIcon from '@mui/icons-material/Thermostat'
 import VideocamIcon from '@mui/icons-material/Videocam'
-import DescriptionIcon from '@mui/icons-material/Description'
 
-import RunnerLogs from './RunnerLogs'
+import RunnerProfilesTable from '../dashboard/RunnerProfilesTable'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useAccount } from '../../contexts/account'
 import useApi from '../../hooks/useApi'
@@ -701,19 +698,47 @@ const DevContainerCard: FC<DevContainerCardProps> = ({ container, onStop, isStop
   )
 }
 
-interface AgentSandboxesProps {
-  selectedSandboxId?: string
+// SubTab is one of four lenses on the same underlying dataset:
+//   overview  – aggregate stats + GPU panel (was the "Aggregate View" cards)
+//   fleet     – the list of runners themselves, one card per runner showing
+//               status + profile assignment (links into the runner-detail
+//               page for logs)
+//   sandboxes – user-facing dev containers (was "Dev Containers")
+//   profiles  – inference-profile config (was the standalone Runner Profiles
+//               admin tab; absorbed here because Profiles only make sense
+//               in the context of the runners that consume them)
+type SubTab = 'overview' | 'fleet' | 'sandboxes' | 'profiles'
+
+const SUBTAB_LS_KEY = 'admin-runners-subtab'
+
+function isSubTab(v: string | null): v is SubTab {
+  return v === 'overview' || v === 'fleet' || v === 'sandboxes' || v === 'profiles'
 }
 
-const AgentSandboxes: FC<AgentSandboxesProps> = ({ selectedSandboxId }) => {
+const Runners: FC = () => {
   const api = useApi()
   const apiClient = api.getApiClient()
   const queryClient = useQueryClient()
   const [stoppingIds, setStoppingIds] = useState<Set<string>>(new Set())
 
-  // Inference profile catalogue. Polled on the same 5s cadence as the
-  // debug query below so the card visibility tracks profile additions /
-  // deletions made in another tab without manual refresh.
+  // Sub-tab state with localStorage persistence. URL-syncing would be nicer
+  // for deep-linking but the admin shell controls the top-level `dialog_tab`
+  // param and doesn't currently expose a nested-param hook; localStorage gets
+  // us 90% of the way (same operator returns to the same lens) without
+  // touching the shell.
+  const [subTab, setSubTab] = useState<SubTab>(() => {
+    if (typeof window === 'undefined') return 'overview'
+    const stored = window.localStorage.getItem(SUBTAB_LS_KEY)
+    return isSubTab(stored) ? stored : 'overview'
+  })
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    window.localStorage.setItem(SUBTAB_LS_KEY, subTab)
+  }, [subTab])
+
+  // Inference profile catalogue. Polled on the same 5s cadence as the debug
+  // query below so the Profiles sub-tab tracks additions / deletions made
+  // elsewhere without manual refresh.
   const {
     data: runnerProfiles,
     isLoading: isLoadingRunnerProfiles,
@@ -728,7 +753,7 @@ const AgentSandboxes: FC<AgentSandboxesProps> = ({ selectedSandboxId }) => {
     refetchInterval: 5000,
   })
 
-  // Stop session mutation
+  // Stop session mutation - kills a dev container.
   const stopMutation = useMutation({
     mutationFn: async (sessionId: string) => {
       setStoppingIds((prev) => new Set(prev).add(sessionId))
@@ -750,74 +775,38 @@ const AgentSandboxes: FC<AgentSandboxesProps> = ({ selectedSandboxId }) => {
     stopMutation.mutate(sessionId)
   }
 
-  const allGpus = data?.gpus || []
-  const devContainers = data?.dev_containers || []
+  const gpus = data?.gpus || []
   const sandboxes = data?.sandboxes || []
+  const devContainers = data?.dev_containers || []
 
-  // Filter by selected sandbox if specified. Every GPU in the API response
-  // is tagged with its owning sandbox_id (see agent_sandboxes_handlers.go),
-  // so untagged GPUs under the current selection are dropped — they're
-  // either orphans or evidence of a backend bug worth flagging in the
-  // console rather than silently rendering under every Runner.
-  const gpus = selectedSandboxId
-    ? allGpus.filter((g) => {
-        if (!g.sandbox_id) {
-          // eslint-disable-next-line no-console
-          console.warn('[AgentSandboxes] dropping untagged GPU under specific-Runner filter', g)
-          return false
-        }
-        return g.sandbox_id === selectedSandboxId
-      })
-    : allGpus
-
-  const filteredContainers = selectedSandboxId
-    ? devContainers.filter((c) => c.sandbox_id === selectedSandboxId)
-    : devContainers
-
-  // Sort containers by session_id for stable ordering
-  const sortedContainers = [...filteredContainers].sort((a, b) =>
+  // Sort containers by session_id for stable rendering across refetches.
+  const sortedContainers = [...devContainers].sort((a, b) =>
     a.session_id.localeCompare(b.session_id)
   )
 
-  // Filter sandboxes too for consistency
-  const filteredSandboxes = selectedSandboxId
-    ? sandboxes.filter((s) => s.id === selectedSandboxId)
-    : sandboxes
-
-  // Decide whether to render the Inference Profiles card. Visible when
-  // at least one Runner Profile is configured OR when any sandbox in the
-  // current view has a profile already assigned (so deleting the last
-  // catalogue entry mid-interaction doesn't hide a "Clear" button from
-  // the operator). During the initial load of the profiles query, keep
-  // the card mounted to avoid a flash-of-hidden-card on first paint —
-  // it'll hide on the next render if the load resolves to empty.
-  const anySandboxHasProfileAssigned = filteredSandboxes.some(
-    (s) => !!s.active_profile_id,
-  )
+  // Decide whether the Profiles assignment panel inside Fleet should render.
+  // Visible when at least one Runner Profile is configured OR when any runner
+  // already has a profile assigned (so deleting the last catalogue entry
+  // mid-interaction doesn't hide a "Clear" button from the operator).
+  const anySandboxHasProfileAssigned = sandboxes.some((s) => !!s.active_profile_id)
   const hasRunnerProfiles = (runnerProfiles?.length ?? 0) > 0
-  const showInferenceProfilesCard =
+  const showInferenceProfilesPanel =
     isLoadingRunnerProfiles ||
     hasRunnerProfiles ||
     anySandboxHasProfileAssigned
 
-  // Summary stats should reflect the current filter
-  // Note: sandbox status is "online"/"offline"/"degraded", not "running"
-  const runningSandboxes = filteredSandboxes.filter((s) => s.status === 'online').length
+  // Aggregate stats - "online" not "running" (sandbox status enum).
+  const runningRunners = sandboxes.filter((s) => s.status === 'online').length
   const runningContainers = sortedContainers.filter((c) => c.status === 'running').length
   const totalClients = sortedContainers.reduce((sum, c) => sum + (c.clients?.length || 0), 0)
 
   return (
     <Box sx={{ p: 3 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
         <Box>
-          <Typography variant="h5">
-            {selectedSandboxId ? `Sandbox: ${selectedSandboxId}` : 'All Agent Sandboxes'}
-          </Typography>
+          <Typography variant="h5">Runners</Typography>
           <Typography variant="body2" color="text.secondary">
-            {selectedSandboxId
-              ? 'Dev containers and streaming stats for this sandbox'
-              : 'Aggregate view of all Hydra-managed dev containers'
-            }
+            Aggregate view of all Helix Runners
           </Typography>
         </Box>
         <IconButton onClick={() => refetch()} disabled={isLoading} sx={{ color: 'primary.main' }}>
@@ -827,143 +816,131 @@ const AgentSandboxes: FC<AgentSandboxesProps> = ({ selectedSandboxId }) => {
 
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>
-          {error instanceof Error ? error.message : 'Failed to fetch sandbox data'}
+          {error instanceof Error ? error.message : 'Failed to fetch runner data'}
         </Alert>
       )}
 
-      {/* Summary Stats. "Running Sandboxes" only makes sense in the
-          all-sandboxes aggregate view - when a specific sandbox is
-          selected, the filter scope is a single row and the count is
-          always 1, which is noise. Hide it in the detail view and
-          rebalance the remaining two cards to fill the row. */}
-      <Grid container spacing={2} sx={{ mb: 3 }}>
-        {!selectedSandboxId && (
-          <Grid item xs={12} sm={4}>
-            <Paper sx={{ p: 2, textAlign: 'center' }}>
-              <ComputerIcon sx={{ fontSize: 40, color: 'primary.main', mb: 1 }} />
-              <Typography variant="h4">{runningSandboxes}</Typography>
+      <Tabs
+        value={subTab}
+        onChange={(_, v) => setSubTab(v as SubTab)}
+        sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}
+      >
+        <Tab value="overview" label="Overview" />
+        <Tab value="fleet" label="Fleet" />
+        <Tab value="sandboxes" label="Sandboxes" />
+        <Tab value="profiles" label="Profiles" />
+      </Tabs>
+
+      {subTab === 'overview' && (
+        <Box>
+          <Grid container spacing={2} sx={{ mb: 3 }}>
+            <Grid item xs={12} sm={4}>
+              <Paper sx={{ p: 2, textAlign: 'center' }}>
+                <ComputerIcon sx={{ fontSize: 40, color: 'primary.main', mb: 1 }} />
+                <Typography variant="h4">{runningRunners}</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Online Runners
+                </Typography>
+              </Paper>
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <Paper sx={{ p: 2, textAlign: 'center' }}>
+                <DesktopWindowsIcon sx={{ fontSize: 40, color: 'success.main', mb: 1 }} />
+                <Typography variant="h4">{runningContainers}</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Active Sandboxes
+                </Typography>
+              </Paper>
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <Paper sx={{ p: 2, textAlign: 'center' }}>
+                <PersonIcon sx={{ fontSize: 40, color: 'info.main', mb: 1 }} />
+                <Typography variant="h4">{totalClients}</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Connected Users
+                </Typography>
+              </Paper>
+            </Grid>
+          </Grid>
+
+          {gpus.length > 0 && <GPUStatsCard gpus={gpus} />}
+          {gpus.length === 0 && (
+            <Box sx={{ textAlign: 'center', py: 4 }}>
               <Typography variant="body2" color="text.secondary">
-                Running Sandboxes
+                No GPU stats reported. Bring up a runner to see GPU telemetry.
               </Typography>
-            </Paper>
-          </Grid>
-        )}
-        <Grid item xs={12} sm={selectedSandboxId ? 6 : 4}>
-          <Paper sx={{ p: 2, textAlign: 'center' }}>
-            <DesktopWindowsIcon sx={{ fontSize: 40, color: 'success.main', mb: 1 }} />
-            <Typography variant="h4">{runningContainers}</Typography>
-            <Typography variant="body2" color="text.secondary">
-              Dev Containers
-            </Typography>
-          </Paper>
-        </Grid>
-        <Grid item xs={12} sm={selectedSandboxId ? 6 : 4}>
-          <Paper sx={{ p: 2, textAlign: 'center' }}>
-            <PersonIcon sx={{ fontSize: 40, color: 'info.main', mb: 1 }} />
-            <Typography variant="h4">{totalClients}</Typography>
-            <Typography variant="body2" color="text.secondary">
-              Connected Users
-            </Typography>
-          </Paper>
-        </Grid>
-      </Grid>
+            </Box>
+          )}
+        </Box>
+      )}
 
-      <Grid container spacing={3}>
-        {/* GPU Stats */}
-        {gpus.length > 0 && (
-          <Grid item xs={12}>
-            <GPUStatsCard gpus={gpus} />
-          </Grid>
-        )}
-
-        {/* Inference Profile state per sandbox. See showInferenceProfilesCard
-            above for the visibility decision (configured profile, mid-load,
-            or any sandbox already assigned). */}
-        {showInferenceProfilesCard && filteredSandboxes.length > 0 && (
-          <Grid item xs={12}>
-            <Card>
-              <CardHeader
-                avatar={<MemoryIcon />}
-                title="Inference Profiles"
-                subheader="Per-sandbox assignment, compose stack lifecycle, and model-weights download progress"
-              />
-              <CardContent>
-                <Grid container spacing={2}>
-                  {filteredSandboxes.map((sb) => (
-                    <Grid item xs={12} md={6} lg={4} key={sb.id}>
-                      <SandboxProfileCard sandbox={sb} />
-                    </Grid>
-                  ))}
+      {subTab === 'fleet' && (
+        <Box>
+          {showInferenceProfilesPanel && sandboxes.length > 0 ? (
+            <Grid container spacing={2}>
+              {sandboxes.map((sb) => (
+                <Grid item xs={12} md={6} lg={4} key={sb.id}>
+                  <SandboxProfileCard sandbox={sb} />
                 </Grid>
-              </CardContent>
-            </Card>
-          </Grid>
-        )}
-
-        {/* Runner Logs: live-tail hydra-aggregated logs from the selected
-            Runner. Requires a specific Runner selection — the stream is
-            per-Runner so "All Sandboxes" shows a prompt. */}
-        <Grid item xs={12}>
-          <Card>
-            <CardHeader
-              avatar={<DescriptionIcon />}
-              title="Runner Logs"
-              subheader="Live tail of hydra-aggregated logs (Runner stdout + inner desktop containers)"
-            />
-            <CardContent>
-              {selectedSandboxId ? (
-                <RunnerLogs runnerId={selectedSandboxId} compact />
-              ) : (
-                <Box sx={{ textAlign: 'center', py: 4 }}>
-                  <DescriptionIcon sx={{ fontSize: 48, color: 'text.secondary', mb: 2 }} />
-                  <Typography variant="body2" color="text.secondary">
-                    Pick a Runner from the selector above to live-tail its logs.
-                  </Typography>
-                </Box>
-              )}
-            </CardContent>
-          </Card>
-        </Grid>
-
-        {/* Dev Containers */}
-        <Grid item xs={12}>
-          <Card>
-            <CardHeader
-              avatar={<DesktopWindowsIcon />}
-              title="Dev Containers"
-              subheader={`${sortedContainers.length} container${sortedContainers.length !== 1 ? 's' : ''}`}
-            />
-            <CardContent>
-              {sortedContainers.length > 0 ? (
-                <Grid container spacing={2}>
-                  {sortedContainers.map((container) => (
-                    <Grid item xs={12} md={6} lg={4} key={`${container.sandbox_id}-${container.session_id}`}>
-                      <DevContainerCard
-                        container={container}
-                        onStop={handleStopContainer}
-                        isStopping={stoppingIds.has(container.session_id)}
-                      />
-                    </Grid>
-                  ))}
+              ))}
+            </Grid>
+          ) : sandboxes.length === 0 ? (
+            <Box sx={{ textAlign: 'center', py: 6 }}>
+              <ComputerIcon sx={{ fontSize: 60, color: 'text.secondary', mb: 2 }} />
+              <Typography variant="body1" color="text.secondary">
+                No runners registered
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Provision one via YellowDog, or self-register a runner pointing at this control plane.
+              </Typography>
+            </Box>
+          ) : (
+            <Grid container spacing={2}>
+              {sandboxes.map((sb) => (
+                <Grid item xs={12} md={6} lg={4} key={sb.id}>
+                  <SandboxProfileCard sandbox={sb} />
                 </Grid>
-              ) : (
-                <Box sx={{ textAlign: 'center', py: 4 }}>
-                  <DesktopWindowsIcon sx={{ fontSize: 60, color: 'text.secondary', mb: 2 }} />
-                  <Typography variant="body1" color="text.secondary">
-                    No dev containers running
-                  </Typography>
-                  <Typography variant="body2" color="text.secondary">
-                    Start a task to launch a desktop sandbox
-                  </Typography>
-                </Box>
-              )}
-            </CardContent>
-          </Card>
-        </Grid>
+              ))}
+            </Grid>
+          )}
+        </Box>
+      )}
 
-      </Grid>
+      {subTab === 'sandboxes' && (
+        <Box>
+          {sortedContainers.length > 0 ? (
+            <Grid container spacing={2}>
+              {sortedContainers.map((container) => (
+                <Grid item xs={12} md={6} lg={4} key={`${container.sandbox_id}-${container.session_id}`}>
+                  <DevContainerCard
+                    container={container}
+                    onStop={handleStopContainer}
+                    isStopping={stoppingIds.has(container.session_id)}
+                  />
+                </Grid>
+              ))}
+            </Grid>
+          ) : (
+            <Box sx={{ textAlign: 'center', py: 6 }}>
+              <DesktopWindowsIcon sx={{ fontSize: 60, color: 'text.secondary', mb: 2 }} />
+              <Typography variant="body1" color="text.secondary">
+                No dev containers running
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Start a task to launch a desktop sandbox.
+              </Typography>
+            </Box>
+          )}
+        </Box>
+      )}
+
+      {subTab === 'profiles' && (
+        <Box>
+          <RunnerProfilesTable />
+        </Box>
+      )}
     </Box>
   )
 }
 
-export default AgentSandboxes
+export default Runners

--- a/frontend/src/components/admin/Runners.tsx
+++ b/frontend/src/components/admin/Runners.tsx
@@ -787,8 +787,13 @@ const Runners: FC = () => {
 
   // Keep the picker's selection consistent with the live data:
   //   - Reset to '' if the list goes empty
-  //   - Reset to the first runner if the current selection has dropped off
-  //   - Auto-select the first runner on initial load (single-runner UX)
+  //   - When picking automatically, prefer the first ONLINE runner so the
+  //     operator doesn't land on a stale offline row by default (which is
+  //     useless: the log stream errors immediately). Fall through to the
+  //     first runner overall only if every runner is offline (rare, but
+  //     better than showing an empty picker)
+  //   - If the operator explicitly picked an offline runner, leave it
+  //     alone - they're presumably debugging it
   useEffect(() => {
     if (sandboxes.length === 0) {
       if (selectedRunnerId !== '') setSelectedRunnerId('')
@@ -796,7 +801,8 @@ const Runners: FC = () => {
     }
     const stillExists = sandboxes.some((s) => s.id === selectedRunnerId)
     if (!stillExists) {
-      setSelectedRunnerId(sandboxes[0].id)
+      const firstOnline = sandboxes.find((s) => s.status === 'online')
+      setSelectedRunnerId((firstOnline ?? sandboxes[0]).id)
     }
   }, [sandboxes, selectedRunnerId])
 

--- a/frontend/src/components/admin/Runners.tsx
+++ b/frontend/src/components/admin/Runners.tsx
@@ -31,6 +31,7 @@ import DesktopWindowsIcon from '@mui/icons-material/DesktopWindows'
 import PersonIcon from '@mui/icons-material/Person'
 import ThermostatIcon from '@mui/icons-material/Thermostat'
 import VideocamIcon from '@mui/icons-material/Videocam'
+import DescriptionIcon from '@mui/icons-material/Description'
 
 import RunnerProfilesTable from '../dashboard/RunnerProfilesTable'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -244,6 +245,21 @@ const SandboxProfileCard: FC<{ sandbox: SandboxInstanceInfo }> = ({ sandbox }) =
         {!isOnline && (
           <Chip label={sandbox.status} size="small" variant="outlined" color="default" />
         )}
+        <Box sx={{ flexGrow: 1 }} />
+        <Tooltip title="Open live-tail logs in a new tab">
+          <Button
+            size="small"
+            variant="text"
+            startIcon={<DescriptionIcon sx={{ fontSize: 16 }} />}
+            component="a"
+            href={`/admin/runner-logs/${encodeURIComponent(sandbox.id)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{ minWidth: 'auto', px: 1 }}
+          >
+            Logs
+          </Button>
+        </Tooltip>
       </Box>
       {profileID && (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>

--- a/frontend/src/components/admin/Runners.tsx
+++ b/frontend/src/components/admin/Runners.tsx
@@ -16,6 +16,10 @@ import {
   AvatarGroup,
   LinearProgress,
   Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
   Tab,
   Tabs,
 } from '@mui/material'

--- a/frontend/src/components/dashboard/profileBlocks.ts
+++ b/frontend/src/components/dashboard/profileBlocks.ts
@@ -363,7 +363,7 @@ export const blockDesktopReserve: ProfileBlock = {
   id: "desktop-reserve",
   name: "Desktop session headroom",
   category: "budget",
-  description: "Reserves the unclaimed portion of the GPU for Hydra to spawn agent desktop sessions on. No compose service — informational. The math just works: anything the LLM blocks above don't claim is available to Hydra.",
+  description: "Reserves the unclaimed portion of the GPU for agent desktop sessions to spawn on. No compose service — informational. The math just works: anything the LLM blocks above don't claim is available for agent desktops.",
   pros: [
     "Lets one GPU host both inference and 1–2 agent desktop sessions",
     "Useful for dev hosts with one card",
@@ -419,7 +419,7 @@ export const curatedProfiles: CuratedProfile[] = [
   {
     id: "dev-shared-tiny",
     name: "Dev box: tiny LLM + desktops",
-    description: "Single GPU shared between a tiny chat model and Hydra agent desktops. The LLM claims only 20% of VRAM, leaving the rest for Wolf/sway desktop sessions.",
+    description: "Single GPU shared between a tiny chat model and agent desktops. The LLM claims only 20% of VRAM, leaving the rest for the desktop sessions.",
     pros: [
       "Works on a single 16 GiB consumer card",
       "Both inference and one or two agent desktop sessions can coexist",
@@ -511,7 +511,7 @@ export const curatedProfiles: CuratedProfile[] = [
   {
     id: "8xrtx6000pro-vllm",
     name: "8×RTX PRO 6000 Blackwell — multi-model stack",
-    description: "Full multi-model stack on 8× RTX PRO 6000 Blackwell (96 GB each). Two embedding models share GPU 0 at 45% util each, qwen3.5-35b on GPU 1, minimax-m2.7 tensor-parallel-4 on GPUs 2-5, gemma-4-26b on GPU 6 — and **GPU 7 left free for Hydra-spawned agent desktops on the same node** (Decision 15: spawn with `gpu_index: 7`). The canonical multi-tenant layout for this hardware.",
+    description: "Full multi-model stack on 8× RTX PRO 6000 Blackwell (96 GB each). Two embedding models share GPU 0 at 45% util each, qwen3.5-35b on GPU 1, minimax-m2.7 tensor-parallel-4 on GPUs 2-5, gemma-4-26b on GPU 6 — and **GPU 7 left free for agent desktops on the same node** (Decision 15: spawn with `gpu_index: 7`). The canonical multi-tenant layout for this hardware.",
     pros: [
       "5 models running concurrently on one node (incl. text + vision embeddings, mid-size chat, large MoE chat, long-context chat)",
       "Desktop sessions on the same physical box as inference (GPU 7 reserved)",
@@ -706,7 +706,7 @@ export const curatedProfiles: CuratedProfile[] = [
   {
     id: "4xa100-vllm",
     name: "4×A100 80GB — multi-model stack",
-    description: "4× A100 80GB. Embeddings + GLM-4.7-Flash + Qwen3.6-35B-A3B MoE on GPUs 0-2; **GPU 3 reserved for Hydra desktops, software-encoded only** (Decision 15: spawn with `gpu_index: 3`). A100 has no NVENC and no display engine — Mutter renders via the nvidia DRM/KMS path and GStreamer falls back to libx264 (CPU-bound; fine for 1-2 concurrent sessions). For hardware-accelerated desktops on the same hardware tier, prefer L40S.",
+    description: "4× A100 80GB. Embeddings + GLM-4.7-Flash + Qwen3.6-35B-A3B MoE on GPUs 0-2; **GPU 3 reserved for agent desktops, software-encoded only** (Decision 15: spawn with `gpu_index: 3`). A100 has no NVENC and no display engine — Mutter renders via the nvidia DRM/KMS path and GStreamer falls back to libx264 (CPU-bound; fine for 1-2 concurrent sessions). For hardware-accelerated desktops on the same hardware tier, prefer L40S.",
     pros: [
       "Mid-tier inference + agent desktops on the same node",
       "GLM-4.7-Flash 31B + Qwen3.6-35B-A3B MoE = top-tier reasoning + tool calling",
@@ -764,7 +764,7 @@ services:
   {
     id: "4xl40s-vllm",
     name: "4×L40S 48GB — multi-model (round-robin fleet)",
-    description: "4× L40S 48GB. Designed to be deployed identically on multiple nodes; the inference router round-robins across the sandboxes that serve the same model names. Embeddings + Qwen3.5-27B + Qwen3.6-35B-A3B on GPUs 0-2; **GPU 3 reserved for Hydra desktops with full NVENC hardware encoding**.",
+    description: "4× L40S 48GB. Designed to be deployed identically on multiple nodes; the inference router round-robins across the sandboxes that serve the same model names. Embeddings + Qwen3.5-27B + Qwen3.6-35B-A3B on GPUs 0-2; **GPU 3 reserved for agent desktops with full NVENC hardware encoding**.",
     pros: [
       "Fleet-friendly: deploy identically across N nodes; inference router round-robins",
       "Full hardware-accelerated desktop video (NVENC + display engine)",

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,18 +1,13 @@
 import ClearIcon from "@mui/icons-material/Clear";
-import StorageIcon from "@mui/icons-material/Storage";
 import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Container from "@mui/material/Container";
 import Divider from "@mui/material/Divider";
-import FormControl from "@mui/material/FormControl";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormGroup from "@mui/material/FormGroup";
 import Grid from "@mui/material/Grid";
 import IconButton from "@mui/material/IconButton";
-import InputLabel from "@mui/material/InputLabel";
-import MenuItem from "@mui/material/MenuItem";
-import Select from "@mui/material/Select";
 import Switch from "@mui/material/Switch";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
@@ -38,11 +33,10 @@ import {
 import ProviderEndpointsTable from "../components/dashboard/ProviderEndpointsTable";
 import OAuthProvidersTable from "../components/dashboard/OAuthProvidersTable";
 import HelixModelsTable from "../components/dashboard/HelixModelsTable";
-import RunnerProfilesTable from "../components/dashboard/RunnerProfilesTable";
 import PricingTable from "../components/dashboard/PricingTable";
 import SystemSettingsTable from "../components/dashboard/SystemSettingsTable";
 import ServiceConnectionsTable from "../components/dashboard/ServiceConnectionsTable";
-import AgentSandboxes from "../components/admin/AgentSandboxes";
+import Runners from "../components/admin/Runners";
 import AdminOrgsTable from "../components/dashboard/AdminOrgsTable";
 import UsersTable from "../components/dashboard/UsersTable";
 import UserDetailPanel from "../components/dashboard/UserDetailPanel";
@@ -70,7 +64,6 @@ const Dashboard: FC<DashboardProps> = ({ tab = "llm_calls", initialSessionFilter
     const [viewingSession, setViewingSession] = useState<TypesSession>();
     const [active, setActive] = useState(START_ACTIVE);
     const [sessionFilter, setSessionFilter] = useState("");
-    const [selectedSandboxId, setSelectedSandboxId] = useState<string>("");
     const [sessionIdParam, setSessionIdParam] = useState<string>("");
     const [repoId, setRepoId] = useState<string>("");
     const [selectedUserId, setSelectedUserId] = useState<string>("");
@@ -78,45 +71,24 @@ const Dashboard: FC<DashboardProps> = ({ tab = "llm_calls", initialSessionFilter
 
     const session_id = sessionIdParam;
 
-    // Fetch list of registered sandbox instances for the agent_sandboxes tab.
-    // v1SandboxesList returns every row including offline ones (good for
-    // /admin/runners/.../assignment use-cases that want history). The
-    // dropdown filters to online-only below so the operator only sees
-    // Runners that can actually be inspected.
-    const { data: allSandboxInstances, isLoading: isLoadingSandboxes } = useQuery({
+    // Fetch list of registered sandbox instances for the Runners tab.
+    // Used solely for the version-mismatch alert that surfaces when any
+    // online runner reports a helix_version different from the control
+    // plane. Tab-gated and only refetched while the tab is open.
+    const { data: allSandboxInstances } = useQuery({
         queryKey: ["sandbox-instances"],
         queryFn: async () => {
             const response = await apiClient.v1SandboxesList();
             return response.data;
         },
-        enabled: tab === "agent_sandboxes",
+        enabled: tab === "runners",
         refetchInterval: 10000,
     });
 
-    // Online-only view for the dropdown + downstream AgentSandboxes filter.
-    // The reaper flips stale rows to status="offline"; we hide those from
-    // the picker so the operator isn't confronted with dead-yesterday
-    // Runners they can't actually do anything with. If we ever need the
-    // full historical list (e.g. for an "include offline" toggle), the
-    // raw allSandboxInstances is still available above.
     const sandboxInstances = useMemo(
         () => allSandboxInstances?.filter((i) => i.status === "online"),
         [allSandboxInstances],
     );
-
-    // Don't auto-select — default to "All Sandboxes" view for aggregate monitoring.
-    // BUT if the currently-selected Runner has disappeared from the list (reaper
-    // flipped it to offline, then it dropped out of the API response, or it was
-    // deleted), reset to empty so the dropdown doesn't render an opaque sbx_…
-    // id with no hostname/icon and the downstream panel doesn't render empty
-    // arrays under a stale id.
-    useEffect(() => {
-        if (!selectedSandboxId || !sandboxInstances) return;
-        const stillExists = sandboxInstances.some((i) => i.id === selectedSandboxId);
-        if (!stillExists) {
-            setSelectedSandboxId("");
-        }
-    }, [sandboxInstances, selectedSandboxId]);
 
     const onViewSession = useCallback((session_id: string) => {
         setSessionIdParam(session_id);
@@ -267,23 +239,6 @@ const Dashboard: FC<DashboardProps> = ({ tab = "llm_calls", initialSessionFilter
                     </Box>
                 )}
 
-                {tab === "runners" && (
-                    <Box sx={{ width: "100%", p: 3 }}>
-                        <Typography variant="h5" gutterBottom>GPU Runners</Typography>
-                        <Typography variant="body1" color="text.secondary" paragraph>
-                            The legacy runner / scheduler / slot dashboard has been retired in
-                            the sandbox-absorbs-runner pivot. What you used to see here now
-                            lives in:
-                        </Typography>
-                        <ul>
-                            <li><strong>Agent Sandboxes</strong> — connected sandboxes with their
-                            GPU inventory, active profile, and per-service health.</li>
-                            <li><strong>Runner Profiles</strong> — define and assign compose-based
-                            profiles to sandboxes.</li>
-                        </ul>
-                    </Box>
-                )}
-
                 {tab === "helix_models" && (
                     <Box
                         sx={{
@@ -291,12 +246,6 @@ const Dashboard: FC<DashboardProps> = ({ tab = "llm_calls", initialSessionFilter
                         }}
                     >
                         <HelixModelsTable />
-                    </Box>
-                )}
-
-                {tab === "runner_profiles" && account.admin && (
-                    <Box sx={{ width: "100%", p: 2 }}>
-                        <RunnerProfilesTable />
                     </Box>
                 )}
 
@@ -321,91 +270,43 @@ const Dashboard: FC<DashboardProps> = ({ tab = "llm_calls", initialSessionFilter
                     </Box>
                 )}
 
-                {tab === "agent_sandboxes" && account.admin && (
+                {tab === "runners" && account.admin && (
                     <Box sx={{ width: "100%" }}>
-                        {/* Version Mismatch Alert - skip for dev builds (SHA1 hashes or unknown) */}
+                        {/* Version Mismatch Alert - skip for dev builds (SHA1 hashes or unknown).
+                            Kept at this layer (not inside Runners.tsx) so it's visible across
+                            every sub-tab, not just Overview. */}
                         {(() => {
                             const controlPlaneVersion = account.serverConfig?.version;
                             if (!controlPlaneVersion || !sandboxInstances) return null;
-                            
-                            // Skip alert for dev builds: <unknown> or SHA1 hash (40 hex chars)
+
                             if (controlPlaneVersion === "<unknown>") return null;
                             const isSha1Hash = /^[a-f0-9]{40}$/i.test(controlPlaneVersion);
                             if (isSha1Hash) return null;
-                            
-                            const mismatchedSandboxes = sandboxInstances.filter(
+
+                            const mismatched = sandboxInstances.filter(
                                 (s) => s.helix_version && s.status === "online" && s.helix_version !== controlPlaneVersion
                             );
-                            
-                            if (mismatchedSandboxes.length === 0) return null;
-                            
-                            const formatVersion = (v: string) => v.length > 7 ? v.substring(0, 7) : v;
-                            
+                            if (mismatched.length === 0) return null;
+
+                            const fmt = (v: string) => v.length > 7 ? v.substring(0, 7) : v;
                             return (
-                                <Alert 
-                                    severity="warning" 
+                                <Alert
+                                    severity="warning"
                                     icon={<WarningAmberIcon />}
-                                    sx={{ mb: 2 }}
+                                    sx={{ m: 2, mb: 0 }}
                                 >
-                                    <strong>Version Mismatch:</strong> {mismatchedSandboxes.length} sandbox{mismatchedSandboxes.length > 1 ? "es" : ""} running different version than control plane (v{formatVersion(controlPlaneVersion)}):
+                                    <strong>Version Mismatch:</strong> {mismatched.length} runner{mismatched.length > 1 ? "s" : ""} on a different version than control plane (v{fmt(controlPlaneVersion)}):
                                     {" "}
-                                    {mismatchedSandboxes.map((s, i) => (
+                                    {mismatched.map((s, i) => (
                                         <span key={s.id}>
                                             {i > 0 && ", "}
-                                            <strong>{s.hostname || s.id}</strong> (v{formatVersion(s.helix_version || "unknown")})
+                                            <strong>{s.hostname || s.id}</strong> (v{fmt(s.helix_version || "unknown")})
                                         </span>
                                     ))}
                                 </Alert>
                             );
                         })()}
-                        {/* Sandbox Selector */}
-                        <Box sx={{ mb: 3, display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap" }}>
-                            <FormControl size="small" sx={{ minWidth: 400 }}>
-                                <InputLabel id="sandbox-selector-label" shrink>Agent Sandbox</InputLabel>
-                                <Select
-                                    labelId="sandbox-selector-label"
-                                    value={selectedSandboxId}
-                                    label="Agent Sandbox"
-                                    displayEmpty
-                                    onChange={(e) => setSelectedSandboxId(e.target.value)}
-                                    disabled={isLoadingSandboxes || !sandboxInstances?.length}
-                                    startAdornment={<StorageIcon sx={{ mr: 1, color: "text.secondary" }} />}
-                                    renderValue={(value) => {
-                                        if (!value) return <em>All Sandboxes</em>
-                                        const inst = sandboxInstances?.find((i) => i.id === value)
-                                        if (!inst) return value
-                                        return `${inst.gpu_vendor ? "🖥️" : "💻"} ${inst.hostname || inst.id}`
-                                    }}
-                                >
-                                    <MenuItem value="">
-                                        <em>All Sandboxes</em>
-                                    </MenuItem>
-                                    {sandboxInstances?.map((instance) => {
-                                        const version = instance.helix_version;
-                                        const shortVersion = version && version.length > 7 ? version.substring(0, 7) : version;
-                                        return (
-                                            <MenuItem key={instance.id} value={instance.id}>
-                                                {instance.gpu_vendor ? "🖥️" : "💻"}{" "}
-                                                {instance.hostname || instance.id}
-                                                {shortVersion && ` (v${shortVersion})`}
-                                                {" "}- {instance.active_sandboxes || 0}/{instance.max_sandboxes || 10} sessions
-                                            </MenuItem>
-                                        );
-                                    })}
-                                </Select>
-                            </FormControl>
-                            {sandboxInstances && sandboxInstances.length > 0 && (
-                                <Typography variant="body2" color="text.secondary">
-                                    {sandboxInstances.length} sandbox{sandboxInstances.length !== 1 ? "es" : ""} registered
-                                </Typography>
-                            )}
-                            {!isLoadingSandboxes && (!sandboxInstances || sandboxInstances.length === 0) && (
-                                <Typography variant="body2" color="warning.main">
-                                    No agent sandboxes registered
-                                </Typography>
-                            )}
-                        </Box>
-                        <AgentSandboxes selectedSandboxId={selectedSandboxId} />
+                        <Runners />
                     </Box>
                 )}
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -37,6 +37,7 @@ import PricingTable from "../components/dashboard/PricingTable";
 import SystemSettingsTable from "../components/dashboard/SystemSettingsTable";
 import ServiceConnectionsTable from "../components/dashboard/ServiceConnectionsTable";
 import Runners from "../components/admin/Runners";
+import RunnerProfilesTable from "../components/dashboard/RunnerProfilesTable";
 import AdminOrgsTable from "../components/dashboard/AdminOrgsTable";
 import UsersTable from "../components/dashboard/UsersTable";
 import UserDetailPanel from "../components/dashboard/UserDetailPanel";
@@ -246,6 +247,12 @@ const Dashboard: FC<DashboardProps> = ({ tab = "llm_calls", initialSessionFilter
                         }}
                     >
                         <HelixModelsTable />
+                    </Box>
+                )}
+
+                {tab === "runner_profiles" && account.admin && (
+                    <Box sx={{ width: "100%", p: 2 }}>
+                        <RunnerProfilesTable />
                     </Box>
                 )}
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -15,7 +15,6 @@ import React, { FC, useCallback, useEffect, useMemo, useRef, useState } from "re
 import { useQuery } from "@tanstack/react-query";
 import LLMCallsTable from "../components/dashboard/LLMCallsTable";
 import Interaction from "../components/session/Interaction";
-import SessionBadgeKey from "../components/session/SessionBadgeKey";
 import SessionToolbar from "../components/session/SessionToolbar";
 import SessionSummary from "../components/session/SessionSummary";
 // Page wrapper removed - Dashboard is now rendered inside FullScreenDialog
@@ -166,7 +165,6 @@ const Dashboard: FC<DashboardProps> = ({ tab = "llm_calls", initialSessionFilter
                         justifyContent: "flex-end",
                     }}
                 >
-                    {tab === "runners" && <SessionBadgeKey />}
                 </Box>
             </Box>
             <Container


### PR DESCRIPTION
## Summary

The admin panel had three separate tabs for runner-related concerns - an empty \"GPU Runners\" placeholder, \"Agent Sandboxes\" with five cards on one scroll, and a standalone \"Runner Profiles\" tab. Vocabulary across them was inconsistent (Runner / Sandbox / Dev Container all overlapping). This PR consolidates them into one **Runners** admin tab structured as a single master-detail view, plus restores Runner Profiles to its own sidebar entry.

## Final shape

**Sidebar:**
- ...
- **Runners** (was \"Agent Sandboxes\"; old empty \"GPU Runners\" tab killed)
- ...
- **Runner Profiles** (restored to sidebar - it's a standalone catalog, not a lens on running compute)

**Inside Runners** (one page, top-to-bottom, no sub-tabs):
1. Stats row - Online Runners / Active Sandboxes / Connected Users (global)
2. GPU statistics panel (global across all runners)
3. **Runner picker** dropdown - auto-selects first online runner; offline historical rows stay in the picker for debugging but won't be picked by default
4. Per-runner detail (when a runner is selected):
   - Profile assignment card (assign / clear / show errors)
   - Live-tail logs (RunnerLogs, compact) inline
   - Active sandboxes ON THIS runner (filtered DevContainerCards)
5. \"Open logs\" button next to the picker for popping the live-tail into a new tab

**Runner Profiles** (own sidebar entry, same RunnerProfilesTable as before)

## Why this shape

Earlier iterations tried sub-tabs (Overview / Fleet / Sandboxes / Profiles). The user feedback was that sub-tabs-inside-a-floating-admin-dialog felt visually busy, and Profiles is conceptually standalone (a catalog), not another lens on running compute. Sandboxes are inherently scoped to which runner is hosting them - splitting them into their own sub-tab forced operators to mentally re-correlate \"which sandbox is on which runner\". Folding them under the picked runner makes that obvious.

## Other tweaks in this PR

- Dropped \"Hydra\" from five user-facing template descriptions in `profileBlocks.ts` (internal-component name leaking into the \"New runner profile from template\" gallery)
- Removed the orphan `SessionBadgeKey` legend (Ollama / VLLM / Axolotl / Diffusers colored badges) that rendered at the topbar when `tab === \"runners\"` - it was a legend for a row-rendering shape that no longer exists
- Removed the in-page \"Runners / Aggregate view of all Helix Runners\" header (sidebar already labels the tab)
- Dropped the page-header sandbox-selector dropdown that scoped every card to one runner (replaced by the picker inside the master-detail layout)

## Validation

- `yarn build` clean
- Tested live on prime via SSH + Playwright auth: dropdown picks online runner by default, switching surfaces correct profile + logs + per-runner sandboxes
- One fixup commit en route (`fix(admin): restore Select imports SandboxProfileCard needs`) caught at runtime - SandboxProfileCard's per-runner profile picker also uses MUI Select primitives that an earlier dead-code removal dropped. yarn build TS-compiled clean both before and after, so this slipped past type-checking; lesson noted

## Diff

```
 AdminPanelSidebar.tsx       |  10 +-
 Runners.tsx (renamed)       | 359 +++++++++++++++++--------
 profileBlocks.ts            |  10 +-
 Dashboard.tsx               | 144 ++--------
 4 files changed, 200 insertions(+), 323 deletions(-)
```

## Test plan

- [x] Live-tested on prime localhost:8080
- [ ] Confirm Runners admin tab loads, picker defaults to online runner, logs stream
- [ ] Confirm Runner Profiles sidebar entry navigates to the catalog as before
- [ ] Confirm the old `?dialog_tab=agent_sandboxes` and `?dialog_tab=runner_profiles` URLs - any deep links from elsewhere will break; this PR doesn't add redirects since admin URLs aren't shared externally

🤖 Generated with [Claude Code](https://claude.com/claude-code)