### PR TITLE
chore(ci): narrow CodeQL ruleset to security signal only

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,35 @@
+name: "Helix CodeQL config"
+
+# Use the focused security suite. The default suite is broad; `security-extended`
+# adds higher-recall security queries without the maintainability/quality noise
+# that the `security-and-quality` suite drags in (unused-variable, etc).
+queries:
+  - uses: security-extended
+
+# Strip out anything that is not a security finding. CodeQL tags every query;
+# excluding by tag removes whole noise classes in one go regardless of language.
+query-filters:
+  - exclude:
+      tags contain: maintainability
+  - exclude:
+      tags contain: quality
+
+# Skip generated, vendored, and third-party code. These dominate alert counts
+# and we do not own the fixes.
+paths-ignore:
+  - "**/*_test.go"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "**/testdata/**"
+  - "**/mocks/**"
+  - "**/*_mock.go"
+  - "**/mock_*.go"
+  - "api/pkg/openapi/**"
+  - "frontend/src/api/api.ts"
+  - "frontend/dist/**"
+  - "frontend/node_modules/**"
+  - "vendor/**"
+  - "**/*.generated.go"
+  - "**/*.pb.go"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3


### PR DESCRIPTION
## Summary

- Switch CodeQL from `security-and-quality` suite to `security-extended` + a config file that excludes `maintainability` and `quality` tagged queries
- Add `paths-ignore` for tests, mocks, generated, and vendored code
- Workflow change is one line; the rest is the new config file

## Why

We have 728 open CodeQL alerts. ~520 of those are maintainability findings, not security:

| Count | Rule |
|---|---|
| 460 | `js/unused-local-variable` |
| 19 | `js/automatic-semicolon-insertion` |
| 13 | `go/unhandled-writable-file-close` |
| 7 | `js/useless-assignment-to-local` |
| 7 | `js/trivial-conditional` |
| ~14 | other style/lint |

At that volume the queue is not actionable. After this change, future scans should report ~210 alerts, all security-relevant. The `security-extended` suite is a slight superset of `security` for higher recall on real findings.

## What this does NOT change

- No branch-protection / required-check changes. CodeQL stays informational.
- Existing 520 maintainability alerts are not touched - they need a one-shot bulk dismissal via the API after merge (one-liner in the design notes).

## Follow-ups (separate work)

- Bulk-dismiss the 520 existing maintainability alerts with `dismissed_reason="won't fix"` and a comment pointing at the config file.
- Triage the 7 critical-severity alerts (2 unsafe-quoting, 2 command-injection, 3 SSRF).
- Sample the 78 `go/path-injection` findings - initial read is mostly false positives (internal `filepath.Join` calls), but a handful in `git_repository_service_contents.go` look real.

## Test plan

- [ ] Merge to main, wait for first scheduled scan (or trigger manually via the Actions tab)
- [ ] Verify the new run completes against all four... three language jobs (go, javascript-typescript, python)
- [ ] Confirm alert count on `main` drops from ~728 toward ~210 once the dismissal one-liner is run
- [ ] Spot-check that test files no longer appear in alert paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)