### PR TITLE
docs(org): add mint_credential backstop to worker-policy

### DIFF
--- a/api/pkg/org/application/agent/worker-policy.md
+++ b/api/pkg/org/application/agent/worker-policy.md
@@ -116,6 +116,26 @@ across the org, escalate to a manager or brief through your team stream
 and let the chain of command carry it — that's the point of the
 hierarchy, not a limitation to work around.
 
+## External-provider credentials
+
+Your shell has no provider tokens by default. Anything that needs to
+authenticate to an external system — `gh`, `git push`/`git fetch`
+against a private remote, `curl` to an authenticated endpoint — will
+fail unless you mint a credential first.
+
+- **Before** the first authenticated command in an activation, call
+  `mint_credential` with the provider name (e.g. `"github"`) and
+  `export` the returned token into your shell:
+  `export GH_TOKEN=$(...)`. The minted token is short-lived (~1 hour).
+- **On any 401 / 403** from a command that should have worked, assume
+  the token has expired. Call `mint_credential` again, re-export,
+  retry once. Do not abandon the task on a stale token; expired
+  tokens are expected on any session that runs longer than ~1 hour.
+
+Your Role describes *which* providers and *which* commands apply.
+This section is the rule that holds even if the Role text predates
+the `mint_credential` flow.
+
 ## Errors and exits
 
 If you cannot make progress (missing tool, ambiguous request,

--- a/api/pkg/org/application/bootstrap/templates/owner_role.md
+++ b/api/pkg/org/application/bootstrap/templates/owner_role.md
@@ -100,31 +100,3 @@ can see no MCP tools at all and will fall back to writing files
 instead of publishing/DMing, which is wrong. A Worker hired without
 their streams subscribed is half-hired — they have nothing to listen
 to. Don't skip step 1's tools list or step 3.
-
-## External-provider credentials: `mint_credential`
-
-The baseline rule lives in `worker-policy.md`'s "External-provider
-credentials" section — every Worker reads it on every activation. The
-Role-prompt paragraph described below is the workflow specialisation an
-owner adds for Roles whose Workers actually run authenticated commands.
-
-External-provider tokens (GitHub today, Slack next) are **not** in the
-Worker's environment by default. To run `gh`, `git`, or authenticated
-`curl`, the Worker calls `mint_credential` to obtain a fresh ~1h token,
-exports it into its shell, and uses it. Tokens minted this way expire,
-so the same flow is also the recovery path: any 401/403 means the token
-is stale and the Worker should mint a fresh one and retry.
-
-`mint_credential` is part of the baseline tool set every Role gets, so
-you do not need to add it to a Role's `tools` list. What you **do** need
-to do, for any Role whose Worker will run `gh`/`git`/authenticated
-`curl`: include a paragraph in the Role prompt telling the Worker to
-call `mint_credential` **before its first authenticated command**,
-`export` the returned token into its shell (e.g.
-`export GH_TOKEN=$(...)`), and **mint again on any 401/403**. Without
-that paragraph the Worker has the tool but no signal for when to reach
-for it.
-
-You can call `mint_credential` yourself too — it returns
-`{ token, expires_at, usage }` for any provider configured on the
-server.

--- a/api/pkg/org/application/bootstrap/templates/owner_role.md
+++ b/api/pkg/org/application/bootstrap/templates/owner_role.md
@@ -103,6 +103,11 @@ to. Don't skip step 1's tools list or step 3.
 
 ## External-provider credentials: `mint_credential`
 
+The baseline rule lives in `worker-policy.md`'s "External-provider
+credentials" section — every Worker reads it on every activation. The
+Role-prompt paragraph described below is the workflow specialisation an
+owner adds for Roles whose Workers actually run authenticated commands.
+
 External-provider tokens (GitHub today, Slack next) are **not** in the
 Worker's environment by default. To run `gh`, `git`, or authenticated
 `curl`, the Worker calls `mint_credential` to obtain a fresh ~1h token,


### PR DESCRIPTION
## Summary

Adds a short "External-provider credentials" section to
`worker-policy.md` — the org-wide policy every AI Worker reads on
every activation. After #2586 (task 002092) removed the boot-time
`GH_TOKEN` `SecretInjector`, the mint-then-export contract was
documented only in `mint_credential`'s tool description and in
`owner_role.md`. Every other existing Role still describes
authenticated shell commands as if `GH_TOKEN` were present at boot,
so a Worker on one of those Roles silently burns its activation
when `gh`/`git`/auth-`curl` fails.

worker-policy.md is the right altitude for the rule — it reaches
every Worker on next activation without hand-editing five-plus
Roles. The cost asymmetry justifies the few extra lines for Roles
that don't use credentials: trivial unused context vs. a wasted
activation.

## Changes

- `api/pkg/org/application/agent/worker-policy.md` — new section
  between "Chain of command" and "Errors and exits" stating that
  the shell has no provider tokens by default, that
  `mint_credential` must be called before the first authenticated
  command (with the `export GH_TOKEN=$(...)` pattern), and that any
  401/403 means re-mint and retry once.
- `api/pkg/org/application/bootstrap/templates/owner_role.md` —
  the "External-provider credentials: `mint_credential`" section
  is deleted in full. With worker-policy.md carrying the rule,
  owners no longer need to write a credential paragraph into Roles
  they create. One source of truth, no duplication for owners to
  keep in sync.

## Verification

- `go build ./pkg/org/...` — green (confirms the `//go:embed
  worker-policy.md` directive in `policy.go` still resolves).
- `go test ./pkg/org/application/agent/ -count=1` — green
  (`prompt_test.go` passes; no test asserts the literal `Policy`
  string, so the edit is text-only).
- `grep -n "mint_credential" api/pkg/org/application/agent/worker-policy.md`
  — three hits in the new section.

## Related

- Parent task: 002092 (`mint_credential` MCP tool +
  `SecretInjector` removal).
- Design doc: `helix-specs` branch,
  `design/tasks/002094_2-backstop-in-worker/`.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01ktv9t8ecjwrv5a6xhh67qbmk)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002094_2-backstop-in-worker/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002094_2-backstop-in-worker/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002094_2-backstop-in-worker/tasks.md)

🚀 Built with [Helix](https://helix.ml)