### PR TITLE
fix(api): address CodeQL critical alerts (SSRF + unsafe JSON)

### DIFF
--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1840,10 +1842,13 @@ func (s *HelixAPIServer) downloadAndExtractZipToKnowledge(ctx context.Context, z
 		Str("destination_path", knowledgeStorePath).
 		Msg("Starting zip file download and extraction")
 
-	// Download the zip file with a timeout
-	client := &http.Client{
-		Timeout: 10 * time.Minute, // Allow up to 10 minutes for large zip files
+	if err := validateSeedZipURL(zipURL); err != nil {
+		return fmt.Errorf("rejected seed zip URL: %w", err)
 	}
+
+	// Use the SSRF-safe client so any DNS rebind or redirect to a blocked
+	// address is rejected at dial time, not just at the URL string level.
+	client := newSafeFetchClient(10 * time.Minute)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", zipURL, nil)
 	if err != nil {
@@ -2111,4 +2116,91 @@ func (s *HelixAPIServer) deleteAppMemory(_ http.ResponseWriter, r *http.Request)
 	return &types.Memory{
 		ID: memoryID,
 	}, nil
+}
+
+// validateSeedZipURL does the cheap up-front URL checks: parseable, scheme is
+// http(s), host is present. The real SSRF defence is at dial time - see
+// newSafeFetchClient. Doing only the cheap checks here keeps the error path
+// fast for obviously-bad input (file://, empty host) without duplicating the
+// IP block list that the dialer enforces anyway.
+func validateSeedZipURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("parse url: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("scheme %q not allowed (only http/https)", u.Scheme)
+	}
+	if u.Hostname() == "" {
+		return fmt.Errorf("missing host")
+	}
+	return nil
+}
+
+// newSafeFetchClient returns an http.Client that refuses to dial loopback,
+// link-local, or cloud-instance-metadata addresses. Knowledge seed URLs come
+// from caller-supplied app config; without this guard, a tenant could point
+// the API process at `127.0.0.1` (probe internal services) or
+// `169.254.169.254` (exfiltrate IAM credentials on cloud-hosted Helix).
+//
+// We deliberately allow other RFC1918 ranges - downloadAndExtractZipToKnowledge
+// is documented as supporting air-gapped deployments seeding from internal
+// mirrors. If an operator needs stricter egress control, that belongs at the
+// network layer.
+//
+// Enforcement is at dial time, not URL parse time, so it survives:
+//   - DNS rebinding (each Dial does its own resolution)
+//   - HTTP redirects to blocked addresses (each followed redirect dials)
+//   - Obscure IPv4 literals like 2130706433 or 0x7f.0.0.1 (the resolved IP is
+//     checked, not the literal string in the URL)
+func newSafeFetchClient(timeout time.Duration) *http.Client {
+	dialer := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+			if err != nil {
+				return nil, err
+			}
+			// Reject if ANY resolved address is unsafe - a multi-A-record
+			// hostname that includes a blocked IP gets rejected outright
+			// rather than trying to pick a "safe" one (which would still
+			// leak DNS to the attacker).
+			for _, ip := range ips {
+				if !isSafeFetchIP(ip.IP) {
+					return nil, fmt.Errorf("blocked dial: host %s resolves to %s", host, ip.IP)
+				}
+			}
+			// Pin to the first resolved IP we already checked - prevents the
+			// http stack from doing its own second lookup that could return
+			// a different (unsafe) IP between our check and the actual dial.
+			return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+		},
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+}
+
+// isSafeFetchIP returns false for any address the seed-zip fetcher must not
+// reach. Centralised so the deny set is one list, not scattered.
+func isSafeFetchIP(ip net.IP) bool {
+	if ip.IsLoopback() || ip.IsUnspecified() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast() {
+		return false
+	}
+	// Cloud instance metadata endpoints. 169.254.169.254 is already covered
+	// by IsLinkLocalUnicast on most stacks but we match explicitly so the
+	// intent is greppable, and to cover the IPv4-mapped IPv6 form.
+	if ip.Equal(net.ParseIP("169.254.169.254")) {
+		return false
+	}
+	if ip.Equal(net.ParseIP("fd00:ec2::254")) {
+		return false
+	}
+	return true
 }

--- a/api/pkg/server/sandboxes_api_handlers.go
+++ b/api/pkg/server/sandboxes_api_handlers.go
@@ -567,14 +567,14 @@ echo "tmux not available — falling back to bash (session will not persist acro
 exec /bin/bash -l
 `)
 		if err := client.WriteSandboxFile(r.Context(), sb.ID, scriptPath, scriptBody, 0o755); err != nil {
-			wsConn.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"failed to install attach script: `+jsonEscapeString(err.Error())+`"}`))
+			writeWSError(wsConn, "failed to install attach script: "+err.Error())
 			return
 		}
 		shell = scriptPath
 	}
 	hydraConn, err := client.OpenSandboxTerminal(r.Context(), sb.ID, shell)
 	if err != nil {
-		wsConn.WriteMessage(websocket.TextMessage, []byte(`{"type":"error","message":"`+jsonEscapeString(err.Error())+`"}`))
+		writeWSError(wsConn, err.Error())
 		return
 	}
 	defer hydraConn.Close()
@@ -958,14 +958,18 @@ func writeJSON(rw http.ResponseWriter, status int, body interface{}) {
 	_ = json.NewEncoder(rw).Encode(body)
 }
 
-// jsonEscapeString returns a JSON-safe inner string (no surrounding quotes).
-func jsonEscapeString(s string) string {
-	b, err := json.Marshal(s)
+// writeWSError sends a structured error frame on the websocket. We marshal a
+// struct rather than splicing strings into a JSON literal so the message field
+// is always validly escaped - error strings from upstream callers can contain
+// quotes, backslashes, or control characters that would otherwise break out of
+// the surrounding JSON.
+func writeWSError(wsConn *websocket.Conn, message string) {
+	b, err := json.Marshal(struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	}{Type: "error", Message: message})
 	if err != nil {
-		return ""
+		return
 	}
-	if len(b) < 2 {
-		return ""
-	}
-	return string(b[1 : len(b)-1])
+	_ = wsConn.WriteMessage(websocket.TextMessage, b)
 }


### PR DESCRIPTION
## Summary

Triage of the 7 critical-severity CodeQL alerts. 3 are fixed in code, 4 will be dismissed via the API after merge with documented rationale.

Follow-up to https://github.com/helixml/helix/pull/2590 (CodeQL ruleset narrowing).

## Code changes

### 1. SSRF guard on knowledge seed-zip downloads
`api/pkg/server/app_handlers.go` - addresses alert #972 (`go/request-forgery`)

`downloadAndExtractZipToKnowledge` accepts a URL from caller-supplied app config (a tenant could point at `127.0.0.1` to probe internal services, or `169.254.169.254` to exfiltrate IAM credentials on cloud-hosted Helix).

Defence is at **dial time**, not URL parse time:
- `validateSeedZipURL` does only the cheap up-front checks (parseable, http(s) scheme, host present).
- `newSafeFetchClient` returns an `http.Client` whose `Transport.DialContext` resolves the hostname, runs every resolved IP through `isSafeFetchIP`, rejects the dial outright if any IP is unsafe, then pins to the already-checked IP.
- Because the dialer runs on every connection, this catches DNS rebinding (each dial re-resolves), follow-on redirects to blocked addresses (each redirect re-dials), and obscure IPv4 literals like `2130706433` (the resolved IP is checked, not the literal string).

Deny set: loopback, unspecified, link-local unicast/multicast, multicast, `169.254.169.254`, `fd00:ec2::254`.

### 2. Unsafe JSON construction in sandbox ws error frames
`api/pkg/server/sandboxes_api_handlers.go` - addresses alerts #991, #992 (`go/unsafe-quoting`)

Replaced `jsonEscapeString` (marshal-then-strip-outer-quotes) with `writeWSError` that marshals a struct directly. CodeQL can see the escape, and the code is no longer doing brittle string surgery on JSON output.

## Known limitation (deliberate)

**RFC1918 ranges (10.x, 172.16-31.x, 192.168.x) are still allowed.** The function is documented as supporting air-gapped deployments seeding from internal mirrors, so blocking private ranges would break the air-gapped use case. This means in a cloud-SaaS scenario, a tenant could still aim at internal-only services in the VPC via private IPs.

Three ways to close that gap if/when needed (out of scope here):
1. Env-flag `HELIX_FETCH_ALLOW_PRIVATE_NETWORKS=true` for air-gapped, default-block otherwise.
2. Operator-side egress forward proxy (smokescreen / squid) with allowlist.
3. Network policy / namespace constraining the API container.

Recommend (1) if Helix the product moves further toward multi-tenant SaaS.

## Will be dismissed via API after merge (not code changes)

| # | Alert | Rationale |
|---|---|---|
| 984, 983 | `go/command-injection` in `api/pkg/desktop/exec.go:104,127` | Endpoint runs inside the user's own sandbox container, has an explicit allowlist (`vkcube`, `glxgears`, `claude`, ...) and per-binary scoping for `git`. The whole point of the endpoint is to invoke specific external binaries. Removing the call removes the feature. |
| 971 | `go/request-forgery` in `api/pkg/agent/skill/bitbucket/client.go:68` | URL is `c.baseURL` (set once at integration setup) + constant API paths. Same shape as any third-party API client. Not user-controllable per-request. |
| 970 | `go/request-forgery` in `api/pkg/agent/skill/azure_devops/client.go:164` | Same shape as Bitbucket - `c.organizationURL` is integration config, used with constant API paths. |

One-liner I'll run after merge:
```bash
for N in 970 971 983 984; do
  gh api -X PATCH repos/helixml/helix/code-scanning/alerts/$N \
    -f state=dismissed -f dismissed_reason="won't fix" \
    -f dismissed_comment="See PR for rationale"
done
```

## Follow-up SSRF surfaces (out of scope, flagged for triage)

The review agent flagged these as similar SSRF shapes elsewhere in the codebase. Not touching them here - each needs its own policy decision:
- `api/pkg/tools/tools_api.go` (tool API URL from app config)
- `api/pkg/agent/skill/mcp/mcp_client.go` (MCP server URL from config)
- `api/pkg/notification/notification_webhook.go` (user-supplied callback URL)
- `api/pkg/oauth/manager.go`, `api/pkg/oauth/oauth2.go` (OAuth provider URLs)
- `api/pkg/trigger/teams/*` (tokenURL / sendURL from Teams config)

## Test plan

- [ ] CI passes (build + existing tests)
- [ ] Manual: confirm a public-URL seed zip still downloads (regression check)
- [ ] Manual: confirm `http://127.0.0.1/x` is rejected with a clear error
- [ ] Manual: confirm `http://169.254.169.254/x` is rejected
- [ ] Next CodeQL scan: alert count for criticals drops from 7 to 0 (3 fixed in code + 4 dismissed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)