### PR TITLE
fix(frontend): label playout buffer "no jitter detected" vs "interactive"

### DIFF
--- a/frontend/src/components/external-agent/DesktopStreamViewer.tsx
+++ b/frontend/src/components/external-agent/DesktopStreamViewer.tsx
@@ -2884,6 +2884,7 @@ const DesktopStreamViewer: React.FC<DesktopStreamViewerProps> = ({
           receiveIntervalSamples: wsStats.receiveIntervalSamples,
           renderIntervalSamples: wsStats.renderIntervalSamples,
           playoutBufferMs: wsStats.playoutBufferMs,
+          playoutState: wsStats.playoutState,
           // Debug flags
           usingSoftwareDecoder: wsStats.usingSoftwareDecoder,
           // Decoder health

--- a/frontend/src/components/external-agent/DesktopStreamViewer.types.ts
+++ b/frontend/src/components/external-agent/DesktopStreamViewer.types.ts
@@ -61,7 +61,8 @@ export interface VideoStats {
   avgRenderIntervalMs?: number;      // Average render interval
   receiveIntervalSamples?: number[]; // Rolling window of inter-arrival intervals (sparkline/burst)
   renderIntervalSamples?: number[];  // Rolling window of inter-render intervals (sparkline/burst)
-  playoutBufferMs?: number;          // Adaptive playout buffer depth (0 while interacting)
+  playoutBufferMs?: number;          // Adaptive playout buffer depth (0 while interacting / no jitter)
+  playoutState?: 'smoothing' | 'interactive' | 'idle'; // why the buffer is at its current depth
   // Debug flags
   usingSoftwareDecoder?: boolean;    // True if software decoding was forced (?softdecode=1)
   // Decoder health

--- a/frontend/src/components/external-agent/StatsOverlay.tsx
+++ b/frontend/src/components/external-agent/StatsOverlay.tsx
@@ -427,15 +427,18 @@ const StatsOverlay: React.FC<StatsOverlayProps> = ({
                   )}
                 </div>
               )}
-              {/* Adaptive playout buffer depth (0 while interacting, grows when
-                  idle to absorb network/WiFi jitter). */}
+              {/* Adaptive playout buffer depth. Grows when idle to absorb
+                  network/WiFi jitter; 0 either because we're interacting (kept
+                  low for latency) or because there's no jitter worth buffering. */}
               {stats.video.playoutBufferMs !== undefined && (
                 <div>
                   <strong>Playout Buffer:</strong> {stats.video.playoutBufferMs} ms
-                  {stats.video.playoutBufferMs === 0 ? (
+                  {stats.video.playoutBufferMs > 0 ? (
+                    <span style={{ color: '#888' }}> (smoothing)</span>
+                  ) : stats.video.playoutState === 'interactive' ? (
                     <span style={{ color: '#4caf50' }}> (interactive)</span>
                   ) : (
-                    <span style={{ color: '#888' }}> (smoothing)</span>
+                    <span style={{ color: '#888' }}> (no jitter detected)</span>
                   )}
                 </div>
               )}

--- a/frontend/src/lib/helix-stream/stream/websocket-stream.ts
+++ b/frontend/src/lib/helix-stream/stream/websocket-stream.ts
@@ -2213,7 +2213,8 @@ export class WebSocketStream {
     avgRenderIntervalMs: number      // Average render interval
     receiveIntervalSamples: number[] // Rolling window of inter-arrival intervals (for sparkline/burst)
     renderIntervalSamples: number[]  // Rolling window of inter-render intervals (for sparkline/burst)
-    playoutBufferMs: number          // Current adaptive playout buffer depth (0 while interacting)
+    playoutBufferMs: number          // Current adaptive playout buffer depth (0 while interacting / no jitter)
+    playoutState: 'smoothing' | 'interactive' | 'idle' // why the buffer is at its current depth
     // FPS timestamp
     fpsUpdatedAt: number             // Wall clock timestamp of last FPS update
     // Debug flags
@@ -2296,6 +2297,12 @@ export class WebSocketStream {
       receiveIntervalSamples: this.receiveIntervalSamples.slice(),
       renderIntervalSamples: this.renderIntervalSamples.slice(),
       playoutBufferMs: Math.round(this.playoutDelayMs),
+      // Why the buffer is at its current depth: 'smoothing' (engaged), or one of
+      // the two zero cases — 'interactive' (collapsed for low latency on recent
+      // input) vs 'idle' (no jitter worth buffering).
+      playoutState: this.playoutDelayMs > 0
+        ? 'smoothing'
+        : (performance.now() - this.lastInputMs < this.PLAYOUT_IDLE_RAMP_MS ? 'interactive' : 'idle'),
       // Debug flags
       usingSoftwareDecoder: this.forceSoftwareDecoding,
       // Frame health monitoring (for iOS Safari stall detection)


### PR DESCRIPTION
The "Playout Buffer" row in Stats for Nerds labelled any 0 ms depth as **(interactive)**. But the buffer is also 0 when idle on a clean connection — i.e. there is simply no jitter worth buffering. Calling that "interactive" is misleading.

Expose the actual playout state from `websocket-stream.ts` (where input recency and target depth are known) as `smoothing | interactive | idle`, and render:
- `> 0 ms` → **(smoothing)**
- `0 ms` + recent input → **(interactive)**
- `0 ms` + idle → **(no jitter detected)**

Frontend-only; `yarn build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)