### PR TITLE
fix(session): scrolling back to bottom re-enables auto-scroll

### DIFF
--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -141,6 +141,13 @@ const EmbeddedSessionView = forwardRef<
   // Touch state for tracking finger-drag direction.
   const touchStartYRef = useRef<number | null>(null);
   const lastTouchYRef = useRef<number | null>(null);
+  // Last scrollTop observed in handleScroll. Used to distinguish
+  // "user actively scrolled toward the bottom" (delta > 0) from
+  // "content shrank and the viewport happens to be near the bottom now"
+  // (delta == 0). Pre-recorded after every programmatic scrollTop write
+  // so the resulting onScroll event sees no delta and doesn't falsely
+  // re-enable auto-scroll.
+  const lastScrollTopRef = useRef(0);
 
   // Pagination state: track which page we've loaded up to (page 0 = newest)
   const [oldestPageLoaded, setOldestPageLoaded] = useState(0);
@@ -158,13 +165,32 @@ const EmbeddedSessionView = forwardRef<
     return scrollTop + clientHeight >= scrollHeight - AUTO_SCROLL_NEAR_BOTTOM_PX;
   }, []);
 
-  // Only used to clear the pill when the user scrolls back to the bottom.
-  // We deliberately do NOT track "is the user at the bottom" for auto-scroll
-  // decisions — auto-scroll is purely driven by the preference toggle.
+  // Clears the pill when the user scrolls back to the bottom, and re-enables
+  // auto-scroll when the user actively scrolls down into the near-bottom zone.
+  // We detect "user actively scrolled down" via a strictly-increasing
+  // scrollTop delta — content reflow (e.g. a tool-call below the viewport
+  // collapsing) leaves scrollTop unchanged, so we won't re-engage auto-scroll
+  // without a user signal. Programmatic scroll writes elsewhere in this file
+  // pre-record lastScrollTopRef so the resulting onScroll sees no delta.
   const handleScroll = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const prevScrollTop = lastScrollTopRef.current;
+    const currScrollTop = container.scrollTop;
+    lastScrollTopRef.current = currScrollTop;
+
     if (autoScrollRef.current) return;
-    if (isNearBottom()) setHasNewBelow(false);
-  }, [isNearBottom]);
+    if (!isNearBottom()) return;
+
+    setHasNewBelow(false);
+
+    if (currScrollTop > prevScrollTop) {
+      setAutoScroll(true);
+      autoScrollRef.current = true;
+      upwardAccumRef.current = 0;
+    }
+  }, [isNearBottom, setAutoScroll]);
 
   // Scroll to bottom. Respects the auto-scroll preference unless `force` is set
   // (force is only used for initial mount, session change, and the
@@ -178,6 +204,7 @@ const EmbeddedSessionView = forwardRef<
       if (!force && container.scrollHeight === lastScrolledHeightRef.current) return;
       container.scrollTop = container.scrollHeight;
       lastScrolledHeightRef.current = container.scrollHeight;
+      lastScrollTopRef.current = container.scrollHeight;
       setHasNewBelow(false);
       onScrollToBottom?.();
     },
@@ -277,6 +304,7 @@ const EmbeddedSessionView = forwardRef<
       lastWheelTsRef.current = 0;
       touchStartYRef.current = null;
       lastTouchYRef.current = null;
+      lastScrollTopRef.current = 0;
       setHasNewBelow(false);
       setOldestPageLoaded(0);
       setOlderInteractions([]);
@@ -335,6 +363,7 @@ const EmbeddedSessionView = forwardRef<
       if (autoScrollRef.current) {
         container.scrollTop = container.scrollHeight;
         lastScrolledHeightRef.current = container.scrollHeight;
+        lastScrollTopRef.current = container.scrollHeight;
         setHasNewBelow(false);
       } else if (!isNearBottom()) {
         setHasNewBelow(true);
@@ -481,6 +510,7 @@ const EmbeddedSessionView = forwardRef<
       if (containerRef.current) {
         const newScrollHeight = containerRef.current.scrollHeight;
         containerRef.current.scrollTop += newScrollHeight - prevScrollHeight;
+        lastScrollTopRef.current = containerRef.current.scrollTop;
       }
     });
   }, [api, sessionId, oldestPageLoaded, isLoadingOlder]);


### PR DESCRIPTION
## Summary

When the user manually scrolls the chat back down to the bottom of an
`EmbeddedSessionView`, auto-scroll now re-engages automatically. Before
this change, scrolling back to the bottom would clear the "Jump to
latest" pill but leave the auto-scroll preference OFF — the user had to
also click the pill or the toggle button to resume following new
content.

This applies to every input modality (wheel, finger-drag, scrollbar
handle, Page Down / End keys, iOS momentum) because the detection
lives in `handleScroll`, which fires for every form of scrolling.

## Changes

`frontend/src/components/session/EmbeddedSessionView.tsx`:

- Added a `lastScrollTopRef` to track the prior `scrollTop` observed in
  `handleScroll`. The delta lets us distinguish "user actively scrolled
  downward" from "content reflow drifted the viewport into the
  near-bottom zone" (which must NOT re-engage).
- Extended `handleScroll`: when `autoScroll` is OFF and the user
  scrolls into the `AUTO_SCROLL_NEAR_BOTTOM_PX` zone via a strictly
  increasing `scrollTop`, flip the preference back to ON (via the same
  `useAutoScrollPreference` setter the pill click uses, so localStorage
  + cross-tab broadcast happens for free) and reset
  `upwardAccumRef` so the next gesture starts clean.
- Pre-record `lastScrollTopRef` at three programmatic-write sites so
  the resulting `onScroll` events see no delta and don't falsely
  re-enable:
  - `scrollToBottom` (covers initial mount with off-preference and the
    pill click)
  - ResizeObserver's auto-scroll-on-growth branch
  - `handleLoadOlder`'s viewport-preserve scrollTop bump
- Added `lastScrollTopRef.current = 0` to the existing session-change
  reset block.

Net: ~30 lines added, one file, no new dependencies.

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| Pause, wheel back down to bottom | stays paused | auto-resumes |
| Pause, drag scrollbar to bottom | stays paused | auto-resumes |
| Pause, press End | stays paused | auto-resumes |
| Pause mid-conversation; tool-call below collapses | stays paused | stays paused (correct — no user signal) |
| Initial mount, `helix.autoScroll = "false"` persisted | scrolls to bottom; stays paused | scrolls to bottom; stays paused (preference respected) |
| Pause, click "Show N older messages" | stays paused | stays paused |
| Re-enable cycle, then wheel up ≥100px | re-engages OFF | re-engages OFF |

## Verification

Confirmed end-to-end on the real spec-task detail page
(`/orgs/.../projects/.../tasks/spt_…`), which mounts the actual
`EmbeddedSessionView` via `SpecTaskDetailContent.tsx`. Drove a
scrollTop=0 → scrollTop=scrollHeight cycle on the live `.css-1vgswcs`
container — `localStorage.helix.autoScroll` flipped from `"false"` to
`"true"` and the toggle button changed from `"Resume auto-scroll"`
(outlined ghost) to `"Pause auto-scroll" pressed` (filled primary).

Also: state-machine reproduction of the updated callbacks (run in the
live browser via `evaluate_script`) covers all five critical ACs
deterministically — AC-1 re-enable, AC-2 localStorage, AC-3 content
shrink stays-off, AC-4 initial-mount stays-off, AC-5 pagination
stays-off. Details in
`design/tasks/002045_scrolling-back-to-the/design.md`.

## Screenshots

Before (auto-scroll OFF, button reads "Resume auto-scroll"):
![Before](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002045_scrolling-back-to-the/screenshots/01-before-scroll-autoscroll-off.png)

After scrolling back to bottom (auto-scroll ON, button reads "Pause auto-scroll"):
![After](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002045_scrolling-back-to-the/screenshots/02-after-scroll-to-bottom-autoscroll-on.png)

## Spec task

[002045](https://github.com/helixml/helix/tree/helix-specs/design/tasks/002045_scrolling-back-to-the)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01ks6949a3mggh1b1x4xrq4n2d)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002045_scrolling-back-to-the/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002045_scrolling-back-to-the/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002045_scrolling-back-to-the/tasks.md)

🚀 Built with [Helix](https://helix.ml)