### PR TITLE
Keep host responsive during rust builds + make golden builds survive long runs

### DIFF
--- a/Dockerfile.sway-helix
+++ b/Dockerfile.sway-helix
@@ -122,7 +122,7 @@ COPY desktop/gst-pipewire-zerocopy ./gst-pipewire-zerocopy/
 # Builds with CUDA support on both amd64 and arm64 platforms
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cd gst-pipewire-zerocopy && \
-    cargo build --release && \
+    nice -n 19 cargo build --release && \
     cp target/release/libgstpipewirezerocopy.so /libgstpipewirezerocopy.so
 
 # (CUDA libraries are downloaded directly in main stage when needed)

--- a/Dockerfile.ubuntu-helix
+++ b/Dockerfile.ubuntu-helix
@@ -140,7 +140,7 @@ if [ "${TARGETARCH}" = "arm64" ]; then
 
     # Build pipewirezerocopysrc (DMA-BUF passthrough for virtio-gpu)
     cd /build/gst-pipewire-zerocopy && \
-        cargo build --locked --release && \
+        nice -n 19 cargo build --locked --release && \
         cp target/release/libgstpipewirezerocopy.so /libgstpipewirezerocopy.so
     echo "pipewirezerocopysrc built"
 else
@@ -153,7 +153,7 @@ else
 
     # Build pipewirezerocopysrc with CUDA support
     cd /build/gst-pipewire-zerocopy && \
-        cargo build --locked --release && \
+        nice -n 19 cargo build --locked --release && \
         cp target/release/libgstpipewirezerocopy.so /libgstpipewirezerocopy.so
     echo "pipewirezerocopysrc built (amd64)"
 
@@ -227,7 +227,7 @@ RUN git clone https://github.com/aaif-goose/goose.git . && \
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/build/target \
-    cargo build --release -p goose-cli --bin goose && \
+    nice -n 19 cargo build --release -p goose-cli --bin goose && \
     cp target/release/goose /goose-binary && \
     strip /goose-binary
 

--- a/Dockerfile.zed-build
+++ b/Dockerfile.zed-build
@@ -105,7 +105,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     CARGO_TARGET_DIR=target-ubuntu25-v4 \
     ZED_COMMIT_SHA=${ZED_COMMIT_SHA} \
     RUSTFLAGS='-C link-arg=-s' \
-    cargo build \
+    nice -n 19 cargo build \
         $(if [ "$BUILD_TYPE" = "release" ]; then echo "--release"; else echo ""; fi) \
         --features external_websocket_sync \
     && CARGO_OUT_DIR=$(if [ "$BUILD_TYPE" = "release" ]; then echo "release"; else echo "debug"; fi) \

--- a/api/pkg/services/golden_build_service.go
+++ b/api/pkg/services/golden_build_service.go
@@ -12,6 +12,16 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// goldenBuildTimeout bounds a single golden build's wall-clock duration. A cold
+// `build-zed release` + `build-sandbox` under heavy CPU contention can take
+// hours (especially after a zed bump invalidates the cargo cache), so this
+// ceiling is deliberately generous. It doubles as the staleness threshold for
+// the in-memory `building` map: an entry older than this with no live monitor
+// goroutine (e.g. an API restart that recovery missed) is treated as dead, so a
+// fresh build is allowed. On timeout the build is marked failed AND its
+// container is stopped, so a blown build doesn't keep compiling and burning CPU.
+const goldenBuildTimeout = 6 * time.Hour
+
 // GoldenBuildService manages golden Docker cache builds for projects.
 // When a merge to main happens and the project has AutoWarmDockerCache enabled,
 // it triggers a golden build session that runs the startup script to populate
@@ -25,7 +35,7 @@ type GoldenBuildService struct {
 
 	// Track running golden builds to prevent duplicates.
 	// Key: "projectID/sandboxID" -> build start time.
-	// Entries older than 30 min are treated as stale.
+	// Entries older than goldenBuildTimeout are treated as stale.
 	mu       sync.Mutex
 	building map[string]time.Time
 
@@ -234,7 +244,7 @@ func (g *GoldenBuildService) TriggerManualGoldenBuild(ctx context.Context, proje
 		key := buildKey(project.ID, sb.ID)
 		g.mu.Lock()
 		if startedAt, ok := g.building[key]; ok {
-			if time.Since(startedAt) < 30*time.Minute {
+			if time.Since(startedAt) < goldenBuildTimeout {
 				// Manual trigger while build running — queue rebuild
 				g.pendingRebuild[key] = project
 				g.mu.Unlock()
@@ -334,7 +344,7 @@ func (g *GoldenBuildService) fanOutBuilds(ctx context.Context, project *types.Pr
 
 		g.mu.Lock()
 		if startedAt, ok := g.building[key]; ok {
-			if time.Since(startedAt) < 30*time.Minute {
+			if time.Since(startedAt) < goldenBuildTimeout {
 				// Build already running — queue a rebuild for when it finishes.
 				// This ensures rapid merges don't leave the cache stale.
 				g.pendingRebuild[key] = project
@@ -344,7 +354,7 @@ func (g *GoldenBuildService) fanOutBuilds(ctx context.Context, project *types.Pr
 				continue
 			}
 			log.Warn().Str("project_id", project.ID).Str("sandbox_id", sb.ID).
-				Msg("Golden build entry is stale (>30min), starting new build")
+				Msg("Golden build entry is stale (no live monitor), starting new build")
 			delete(g.building, key)
 		}
 		g.building[key] = time.Now()
@@ -379,7 +389,7 @@ func (g *GoldenBuildService) runGoldenBuildOnSandbox(parentCtx context.Context, 
 		})
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), goldenBuildTimeout)
 	defer cancel()
 
 	// Get project repositories
@@ -559,10 +569,19 @@ func (g *GoldenBuildService) waitForGoldenBuildCompletion(ctx context.Context, p
 		select {
 		case <-ctx.Done():
 			log.Warn().Str("project_id", projectID).Str("sandbox_id", sandboxID).Str("session_id", sessionID).
-				Msg("Golden build: timed out waiting for completion")
+				Dur("timeout", goldenBuildTimeout).
+				Msg("Golden build: timed out waiting for completion, stopping container")
+			// Stop the container so a blown build doesn't keep compiling and
+			// burning CPU. ctx is already cancelled, so use a fresh context.
+			stopCtx, stopCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			if err := g.containerExecutor.StopDesktop(stopCtx, sessionID); err != nil {
+				log.Warn().Err(err).Str("session_id", sessionID).Str("sandbox_id", sandboxID).
+					Msg("Golden build: failed to stop timed-out container (may have already exited)")
+			}
+			stopCancel()
 			g.updateSandboxCacheStatus(context.Background(), projectID, sandboxID, func(s *types.SandboxCacheState) {
 				s.Status = "failed"
-				s.Error = "Build timed out (30 min)"
+				s.Error = fmt.Sprintf("Build timed out (%s)", goldenBuildTimeout)
 				s.BuildSessionID = ""
 			})
 			return

--- a/stack
+++ b/stack
@@ -308,19 +308,6 @@ function build-runner-image() {
     .
 }
 
-# Background helper used by build-zed (and other long Rust builds) to keep
-# the helix-api container and sandbox-nvidia streaming pipeline responsive
-# when the host is under CPU contention. Watches for compiler/linker
-# processes spawned inside BuildKit's runc containers and renices them down.
-# Renice is idempotent, so re-running on already-niced PIDs is harmless.
-_nice_rust_workers() {
-  while true; do
-    sudo pgrep -f 'rustc|cc1plus|cc1|lld|mold' 2>/dev/null \
-      | xargs -r sudo renice -n 19 -p >/dev/null 2>&1
-    sleep 2
-  done
-}
-
 function build-zed() {
   # ====================================================================
   # Build Zed inside Docker with BuildKit cache mounts
@@ -393,10 +380,11 @@ EIGNORE
 
   echo "🚀 Starting Docker build (cached after first run)..."
 
-  # Background-nice rustc/cc1/lld so helix-api and sandbox-nvidia stay
-  # responsive while this build saturates the host. See _nice_rust_workers.
-  _nice_rust_workers &
-  local _NICE_PID=$!
+  # rustc/cc1/lld run at nice 19 — set via `nice -n 19 cargo build` in
+  # Dockerfile.zed-build so the build stays low-priority no matter how it's
+  # launched (./stack, startup.sh, CI, manual). This survives the foreground
+  # process disconnecting, unlike a host-side renice watcher, because BuildKit
+  # keeps compiling inside buildkitd after `docker buildx build` returns.
 
   # Build using Dockerfile.zed-build with the Zed source as context
   # --output extracts just the binary from the scratch final stage
@@ -410,9 +398,6 @@ EIGNORE
     "$ZED_SOURCE_DIR"
 
   local BUILD_EXIT=$?
-
-  kill $_NICE_PID 2>/dev/null || true
-  wait $_NICE_PID 2>/dev/null || true
 
   # Clean up temporary .dockerignore (unless it existed before)
   if [ "$DOCKERIGNORE_EXISTED" = "false" ]; then


### PR DESCRIPTION
## Why

Investigation into `meta.helix.ml` feeling sluggish: the box was CPU-saturated (load 73 on 48 cores, ~5% idle, only ~3% iowait — **not** disk-bound). The dominant consumer was an inner-Helix **golden Docker cache build** running `./stack build-zed release` — rustc grabbing ~37 of 48 cores at normal priority, starving everything else.

Two related problems fell out of that, fixed here.

## 1. `perf(build)`: nice the rust builds

The old approach — a host-side `_nice_rust_workers` watcher spawned by `build-zed` — only reniced while the foreground `docker buildx build` was connected. BuildKit keeps compiling inside `buildkitd` after that process returns/disconnects, so the long tail ran at normal priority (and the watcher often wasn't running at all — observed rustc at `NI 0`).

Now `nice -n 19` is set directly on the `cargo build` line in every Dockerfile (`Dockerfile.zed-build`, `Dockerfile.ubuntu-helix` ×3, `Dockerfile.sway-helix`). It's intrinsic to the build:
- holds however it's launched (`./stack`, `.helix/startup.sh`, CI, manual);
- survives the foreground process disconnecting;
- needs no sudo / `CAP_SYS_NICE` (lowering priority is always allowed);
- child rustc inherit it.

Removed the now-redundant watcher from `stack`.

## 2. `fix(golden)`: 6h timeout + kill-on-timeout

A cold golden build (`build-zed release` + `build-sandbox` via `.helix/startup.sh`) routinely exceeds the old **30-minute** timeout — especially after a zed bump invalidates the cargo cache, and more so now that builds are niced (lower priority → longer wall-clock under contention). On timeout the monitor marked the build `failed` but **left the container running**, so cargo kept compiling and burning CPU with no promotion to a golden snapshot.

- Timeout 30m → **6h** via a named `goldenBuildTimeout` constant, reused for the in-memory `building` staleness threshold so a legitimately long build isn't treated as stale and duplicated.
- **Stop the desktop container on timeout** (fresh context, since the build ctx is already cancelled).

## Testing

- `go build ./pkg/services/` ✓
- `go test ./pkg/services/ -run Golden` ✓ (30s)
- Dockerfile `nice` prefixes are a standard, low-risk change but **not yet exercised through a full image build** — will confirm on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)