### PR TITLE
fix(spectask): stop spinner flicker when chatting an idle desktop

### DIFF
--- a/api/pkg/server/auto_wake_stuck_interactions.go
+++ b/api/pkg/server/auto_wake_stuck_interactions.go
@@ -664,6 +664,22 @@ func (apiServer *HelixAPIServer) maybeKickColdStart(ctx context.Context, stuck *
 				Msg("[AUTO_WAKE] Failed to mark cold-start-exhausted interaction as error")
 			return
 		}
+		// Revert any sync-time "starting" mark left behind by
+		// syncPromptHistory's markCanonicalSessionStartingForSync. Without
+		// this, the spec-task detail page sits on a perpetual
+		// "Starting Desktop..." spinner instead of reverting to
+		// "Desktop Paused". Targeted JSONB merge gated on
+		// status='starting' so we don't clobber a status that hydra has
+		// since updated. See spec design/tasks/002047_yet-again-sending-a/.
+		if cleared, clearErr := apiServer.Store.ClearSessionStartingStatus(ctx, stuck.SessionID); clearErr != nil {
+			log.Warn().Err(clearErr).
+				Str("session_id", stuck.SessionID).
+				Msg("[AUTO_WAKE] Failed to clear sync-time starting status on cold-start exhaustion")
+		} else if cleared {
+			log.Info().
+				Str("session_id", stuck.SessionID).
+				Msg("[AUTO_WAKE] Cleared sync-time starting status after cold-start exhaustion — spinner will return to paused")
+		}
 		log.Warn().
 			Str("interaction_id", stuck.ID).
 			Str("session_id", stuck.SessionID).

--- a/api/pkg/server/auto_wake_stuck_interactions_test.go
+++ b/api/pkg/server/auto_wake_stuck_interactions_test.go
@@ -259,6 +259,11 @@ func (s *AutoWakeColdStartSuite) TestMarksAsErrorAfterMaxRetries() {
 		},
 	).Times(1)
 
+	// After marking the interaction as error, the worker also reverts any
+	// sync-time "starting" mark left by syncPromptHistory so the spinner
+	// returns to "Desktop Paused". Spec 002047_yet-again-sending-a.
+	s.store.EXPECT().ClearSessionStartingStatus(gomock.Any(), "ses_exhausted").Return(false, nil).Times(1)
+
 	// IncrementInteractionAutoWakeCount must NOT be called — we're past the cap.
 	// StartDesktop must NOT be called either. gomock fails on unexpected calls.
 
@@ -267,6 +272,26 @@ func (s *AutoWakeColdStartSuite) TestMarksAsErrorAfterMaxRetries() {
 	s.Require().NotNil(captured)
 	s.Equal(types.InteractionStateError, captured.State)
 	s.Contains(captured.Error, "helixml/helix#2397")
+}
+
+// TestClearsStartingStatusOnExhaustion: when the worker exhausts cold-start
+// retries on a session that was sync-marked "starting" by syncPromptHistory,
+// it must also revert the status so the UI spinner returns to paused.
+func (s *AutoWakeColdStartSuite) TestClearsStartingStatusOnExhaustion() {
+	stuck := stuckInteraction("int-exh-clear", "ses_exh_clear", autoWakeMaxRetries)
+
+	session := &types.Session{
+		ID: "ses_exh_clear",
+		Metadata: types.SessionMetadata{
+			AgentType: "zed_external",
+		},
+	}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_exh_clear").Return(session, nil).Times(1)
+	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).Return(stuck, nil).Times(1)
+	// Worker found a "starting" mark and cleared it.
+	s.store.EXPECT().ClearSessionStartingStatus(gomock.Any(), "ses_exh_clear").Return(true, nil).Times(1)
+
+	s.server.maybeAutoWake(context.Background(), stuck)
 }
 
 // TestSkipsWhenInteractionIsYoung: stuck row younger than threshold must

--- a/api/pkg/server/prompt_history_handlers.go
+++ b/api/pkg/server/prompt_history_handlers.go
@@ -60,11 +60,66 @@ func (apiServer *HelixAPIServer) syncPromptHistory(_ http.ResponseWriter, req *h
 		Int("total_entries", len(response.Entries)).
 		Msg("Synced prompt history")
 
+	// Synchronously mark the canonical session as "starting" if it's idle and
+	// has no live WebSocket. This closes the race that caused the
+	// "Starting Desktop..." spinner to flicker off: the frontend's first
+	// refetch after the optimistic cache write would otherwise overwrite
+	// "starting" with the still-stale "stopped" backend row, because the
+	// wake goroutine below has not yet had time to call StartDesktop and
+	// have hydra write status=starting to the DB. See spec
+	// design/tasks/002047_yet-again-sending-a/design.md.
+	apiServer.markCanonicalSessionStartingForSync(ctx, syncReq.SpecTaskID)
+
 	// Process pending prompts in the background
 	// This runs on EVERY sync to catch prompts that may have been missed
 	go apiServer.processPendingPromptsForIdleSessions(context.Background(), syncReq.SpecTaskID)
 
 	return response, nil
+}
+
+// markCanonicalSessionStartingForSync flips the canonical planning session's
+// external_agent_status to "starting" when its desktop is genuinely idle (no
+// live WebSocket connection to the external agent). No-op when the session is
+// already "starting" / "running", or when a WS is alive (the existing socket
+// will deliver the prompt without any boot). Failures are logged but never
+// surfaced to the caller — the synchronous mark is a UX optimisation, not a
+// correctness requirement; the async wake goroutine that fires next still
+// works as before.
+func (apiServer *HelixAPIServer) markCanonicalSessionStartingForSync(ctx context.Context, specTaskID string) {
+	if specTaskID == "" {
+		return
+	}
+	specTask, err := apiServer.Store.GetSpecTask(ctx, specTaskID)
+	if err != nil || specTask == nil {
+		log.Debug().Err(err).Str("spec_task_id", specTaskID).Msg("[PROMPT-SYNC] cannot resolve spec task for sync-time mark; skipping")
+		return
+	}
+	sessionID := specTask.PlanningSessionID
+	if sessionID == "" {
+		return
+	}
+	if conn, connected := apiServer.externalAgentWSManager.getConnection(sessionID); connected && conn != nil {
+		return
+	}
+	updated, err := apiServer.Store.MarkSessionStartingIfIdle(ctx, sessionID)
+	if err != nil {
+		log.Warn().Err(err).
+			Str("spec_task_id", specTaskID).
+			Str("session_id", sessionID).
+			Msg("[PROMPT-SYNC] failed to mark session starting; spinner may flicker")
+		return
+	}
+	if updated {
+		log.Info().
+			Str("spec_task_id", specTaskID).
+			Str("session_id", sessionID).
+			Msg("[PROMPT-SYNC] marked idle session as starting (no live WS)")
+	} else {
+		log.Debug().
+			Str("spec_task_id", specTaskID).
+			Str("session_id", sessionID).
+			Msg("[PROMPT-SYNC] session already starting/running; no mark needed")
+	}
 }
 
 // processPendingPromptsForIdleSessions checks the database for any pending prompts

--- a/api/pkg/server/prompt_history_handlers_test.go
+++ b/api/pkg/server/prompt_history_handlers_test.go
@@ -202,3 +202,79 @@ func (s *PromptHistoryHandlersSuite) TestProcessPendingPromptsForIdleSessions_Bu
 
 	s.server.processPendingPromptsForIdleSessions(context.Background(), "task-789")
 }
+
+// TestMarkCanonicalSessionStartingForSync_NoWS_MarksStarting verifies that
+// when a chat is sent to a session whose desktop has no live WebSocket,
+// syncPromptHistory's helper flips external_agent_status to "starting"
+// synchronously before the wake goroutine fires — so the frontend's first
+// refetch returns a row that agrees with the optimistic cache write.
+// Spec: design/tasks/002047_yet-again-sending-a/.
+func (s *PromptHistoryHandlersSuite) TestMarkCanonicalSessionStartingForSync_NoWS_MarksStarting() {
+	sessionID := "ses_no_ws"
+	specTaskID := "spt_idle"
+
+	s.store.EXPECT().
+		GetSpecTask(gomock.Any(), specTaskID).
+		Return(&types.SpecTask{ID: specTaskID, PlanningSessionID: sessionID}, nil)
+
+	// No WS registered for this session — manager returns (nil, false).
+	// MarkSessionStartingIfIdle must then be called and return true (row was idle).
+	s.store.EXPECT().
+		MarkSessionStartingIfIdle(gomock.Any(), sessionID).
+		Return(true, nil).Times(1)
+
+	s.server.markCanonicalSessionStartingForSync(context.Background(), specTaskID)
+}
+
+// TestMarkCanonicalSessionStartingForSync_LiveWS_SkipsMark verifies that
+// when a WS is already live the helper does not touch the row — the
+// existing socket will deliver the prompt without any boot.
+func (s *PromptHistoryHandlersSuite) TestMarkCanonicalSessionStartingForSync_LiveWS_SkipsMark() {
+	sessionID := "ses_live_ws"
+	specTaskID := "spt_live"
+
+	s.store.EXPECT().
+		GetSpecTask(gomock.Any(), specTaskID).
+		Return(&types.SpecTask{ID: specTaskID, PlanningSessionID: sessionID}, nil)
+
+	// Register a live WS for the session. Pass a non-nil placeholder
+	// connection so the registration sticks.
+	s.server.externalAgentWSManager.registerConnection(sessionID, &ExternalAgentWSConnection{})
+
+	// MarkSessionStartingIfIdle must NOT be called — gomock enforces.
+	s.server.markCanonicalSessionStartingForSync(context.Background(), specTaskID)
+}
+
+// TestMarkCanonicalSessionStartingForSync_NoPlanningSession_NoOp verifies that
+// the helper bails cleanly when the spec task has no planning session yet
+// (typical right after creation, before the planning session is wired up).
+func (s *PromptHistoryHandlersSuite) TestMarkCanonicalSessionStartingForSync_NoPlanningSession_NoOp() {
+	specTaskID := "spt_no_planning"
+
+	s.store.EXPECT().
+		GetSpecTask(gomock.Any(), specTaskID).
+		Return(&types.SpecTask{ID: specTaskID, PlanningSessionID: ""}, nil)
+
+	// MarkSessionStartingIfIdle must NOT be called.
+	s.server.markCanonicalSessionStartingForSync(context.Background(), specTaskID)
+}
+
+// TestMarkCanonicalSessionStartingForSync_AlreadyStarting_NoUpdate verifies that
+// the helper still calls MarkSessionStartingIfIdle (which is a no-op at the
+// DB level because of its WHERE guard) and logs the no-update outcome.
+func (s *PromptHistoryHandlersSuite) TestMarkCanonicalSessionStartingForSync_AlreadyStarting_NoUpdate() {
+	sessionID := "ses_already_starting"
+	specTaskID := "spt_already"
+
+	s.store.EXPECT().
+		GetSpecTask(gomock.Any(), specTaskID).
+		Return(&types.SpecTask{ID: specTaskID, PlanningSessionID: sessionID}, nil)
+
+	// Helper falls into the no-update branch when the WHERE guard skipped
+	// the row.
+	s.store.EXPECT().
+		MarkSessionStartingIfIdle(gomock.Any(), sessionID).
+		Return(false, nil).Times(1)
+
+	s.server.markCanonicalSessionStartingForSync(context.Background(), specTaskID)
+}

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -278,6 +278,18 @@ type Store interface {
 	UpdateSessionMeta(ctx context.Context, data types.SessionMetaUpdate) (*types.Session, error)
 	DeleteSession(ctx context.Context, id string) (*types.Session, error)
 	ClearStaleStartingSessions(ctx context.Context) (int64, error)
+	// MarkSessionStartingIfIdle atomically flips external_agent_status to
+	// "starting" + status_message to "Starting Desktop..." for a session,
+	// but only if its current status is neither "starting" nor "running".
+	// Targeted JSONB merge so it cannot race with the streaming path's
+	// full-row writes. Returns true when a row was updated.
+	MarkSessionStartingIfIdle(ctx context.Context, sessionID string) (bool, error)
+	// ClearSessionStartingStatus reverts a "starting" session back to empty
+	// status + empty message, but only when the current status is
+	// "starting". Used by the auto-wake worker on retry exhaustion so the
+	// spinner reverts to "Desktop Paused" instead of staying on
+	// "Starting Desktop..." forever.
+	ClearSessionStartingStatus(ctx context.Context, sessionID string) (bool, error)
 	ListSessionsBySandbox(ctx context.Context, sandboxID string) ([]*types.Session, error) // For cleanup on sandbox disconnect
 	ListSessionsByOwner(ctx context.Context, ownerID string) ([]*types.Session, error)     // All non-deleted sessions for a user (any org, any model_name) — used to fan out user-scoped events
 	ListIdleDesktops(ctx context.Context, idleSince time.Time) ([]*types.Session, error)   // Returns one session per desktop that has had no interaction since idleSince

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -132,6 +132,21 @@ func (mr *MockStoreMockRecorder) CleanupStaleAgentRunners(ctx, staleThreshold an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupStaleAgentRunners", reflect.TypeOf((*MockStore)(nil).CleanupStaleAgentRunners), ctx, staleThreshold)
 }
 
+// ClearSessionStartingStatus mocks base method.
+func (m *MockStore) ClearSessionStartingStatus(ctx context.Context, sessionID string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClearSessionStartingStatus", ctx, sessionID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ClearSessionStartingStatus indicates an expected call of ClearSessionStartingStatus.
+func (mr *MockStoreMockRecorder) ClearSessionStartingStatus(ctx, sessionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearSessionStartingStatus", reflect.TypeOf((*MockStore)(nil).ClearSessionStartingStatus), ctx, sessionID)
+}
+
 // ClearStaleStartingSessions mocks base method.
 func (m *MockStore) ClearStaleStartingSessions(ctx context.Context) (int64, error) {
 	m.ctrl.T.Helper()
@@ -145,6 +160,21 @@ func (m *MockStore) ClearStaleStartingSessions(ctx context.Context) (int64, erro
 func (mr *MockStoreMockRecorder) ClearStaleStartingSessions(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearStaleStartingSessions", reflect.TypeOf((*MockStore)(nil).ClearStaleStartingSessions), ctx)
+}
+
+// MarkSessionStartingIfIdle mocks base method.
+func (m *MockStore) MarkSessionStartingIfIdle(ctx context.Context, sessionID string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkSessionStartingIfIdle", ctx, sessionID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MarkSessionStartingIfIdle indicates an expected call of MarkSessionStartingIfIdle.
+func (mr *MockStoreMockRecorder) MarkSessionStartingIfIdle(ctx, sessionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkSessionStartingIfIdle", reflect.TypeOf((*MockStore)(nil).MarkSessionStartingIfIdle), ctx, sessionID)
 }
 
 // ConsumePendingInvitations mocks base method.

--- a/api/pkg/store/store_sessions.go
+++ b/api/pkg/store/store_sessions.go
@@ -343,6 +343,62 @@ func (s *PostgresStore) ClearStaleStartingSessions(ctx context.Context) (int64, 
 	return result.RowsAffected, result.Error
 }
 
+// MarkSessionStartingIfIdle atomically flips external_agent_status to "starting"
+// and status_message to "Starting Desktop..." for the named session, but ONLY
+// if the current external_agent_status is neither "starting" nor "running".
+// Targeted JSONB merge — does NOT use GORM Save, so it can't race with the
+// streaming path's full-row writes (see auto_wake_stuck_interactions.go header
+// at lines 75-86 for the original incident this pattern guards against).
+//
+// Returns true when the row was updated. False (with err=nil) means the row
+// already showed "starting" or "running" — caller can log a no-op and move on.
+//
+// Used by syncPromptHistory to close the cache-vs-backend race that causes
+// the "Starting Desktop..." spinner to flicker off when chatting to an idle
+// spec-task session: by marking the row synchronously before firing the
+// async wake goroutine, the frontend's first refetch sees "starting" and
+// agrees with the optimistic React Query cache write. See spec
+// design/tasks/002047_yet-again-sending-a/design.md.
+func (s *PostgresStore) MarkSessionStartingIfIdle(ctx context.Context, sessionID string) (bool, error) {
+	if sessionID == "" {
+		return false, errors.New("session_id is required")
+	}
+	result := s.gdb.WithContext(ctx).
+		Model(&types.Session{}).
+		Where("id = ?", sessionID).
+		Where("COALESCE(config->>'external_agent_status', '') NOT IN ('starting', 'running')").
+		Updates(map[string]interface{}{
+			"config": gorm.Expr(`config || '{"external_agent_status":"starting","status_message":"Starting Desktop..."}'::jsonb`),
+		})
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected > 0, nil
+}
+
+// ClearSessionStartingStatus reverts external_agent_status from "starting"
+// back to empty (and clears status_message), but ONLY if the current status
+// is "starting". Used by the auto-wake worker after retry exhaustion so the
+// frontend spinner returns to "Desktop Paused" instead of sitting on
+// "Starting Desktop..." forever. Targeted JSONB merge for the same race
+// reasons as MarkSessionStartingIfIdle.
+func (s *PostgresStore) ClearSessionStartingStatus(ctx context.Context, sessionID string) (bool, error) {
+	if sessionID == "" {
+		return false, errors.New("session_id is required")
+	}
+	result := s.gdb.WithContext(ctx).
+		Model(&types.Session{}).
+		Where("id = ?", sessionID).
+		Where("config->>'external_agent_status' = ?", "starting").
+		Updates(map[string]interface{}{
+			"config": gorm.Expr(`config || '{"external_agent_status":"","status_message":""}'::jsonb`),
+		})
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected > 0, nil
+}
+
 // ListSessionsBySandbox returns all sessions associated with a specific sandbox
 // Used to clean up session metadata when a sandbox disconnects
 func (s *PostgresStore) ListSessionsBySandbox(ctx context.Context, sandboxID string) ([]*types.Session, error) {

--- a/frontend/src/utils/optimisticSessionStarting.test.ts
+++ b/frontend/src/utils/optimisticSessionStarting.test.ts
@@ -115,13 +115,26 @@ describe('optimisticallyMarkSessionStarting', () => {
     expect(data.config.external_agent_status).toBe('starting')
   })
 
-  it('fires invalidateQueries on the prefix key to nudge the next poll', () => {
+  it('does NOT call invalidateQueries (would race the async backend wake)', () => {
+    // See spec 002047_yet-again-sending-a/design.md: the previous belt-and-braces
+    // invalidate fired a refetch that overwrote the optimistic "starting" with the
+    // still-stale "stopped" backend row, causing a visible spinner flicker.
     const qc = new QueryClient()
+    seed(qc, 'absent', 'full')
     const spy = vi.spyOn(qc, 'invalidateQueries')
     optimisticallyMarkSessionStarting(qc, SESSION_ID)
-    expect(spy).toHaveBeenCalledWith({
-      queryKey: GET_SESSION_QUERY_KEY(SESSION_ID),
-    })
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('optimistic state is not marked stale (so the 3s poll, not an immediate refetch, reconciles)', () => {
+    const qc = new QueryClient()
+    seed(qc, 'absent', 'full')
+    optimisticallyMarkSessionStarting(qc, SESSION_ID)
+    const state = qc.getQueryState(fullKey)
+    // Query was never observed (no useGetSession mounted in this unit test),
+    // so isInvalidated should remain false — confirms we did not nudge React Query
+    // into kicking off a refetch.
+    expect(state?.isInvalidated).not.toBe(true)
   })
 
   it('returns immediately on empty sessionId', () => {

--- a/frontend/src/utils/optimisticSessionStarting.ts
+++ b/frontend/src/utils/optimisticSessionStarting.ts
@@ -9,9 +9,16 @@ import { GET_SESSION_QUERY_KEY } from '../services/sessionService'
 const QUERY_VARIANTS = ['full', 'skip'] as const
 
 // Synchronously flip the cached session config to external_agent_status="starting"
-// when the user submits a chat to a paused desktop. The next 3s poll brings the
-// authoritative backend value, harmlessly overwriting this optimistic state to
-// "starting" (boot in flight), "running" (already up), or "absent" (failed).
+// when the user submits a chat to a paused desktop. The next useSandboxState 3s
+// poll reconciles to the authoritative backend value — by which point the
+// backend's synchronous syncPromptHistory mark has already written "starting"
+// to the DB row, so the optimistic patch and the refetch agree.
+//
+// We deliberately do NOT call invalidateQueries here: an immediate refetch
+// races the asynchronous wake goroutine on the backend and overwrites the
+// optimistic write with a still-stale "stopped" row, causing the spinner to
+// flicker off before the 3s poll catches up. See spec
+// 002047_yet-again-sending-a/design.md for the full race analysis.
 //
 // No-op when the cache already shows "starting" or "running" (avoids stomping
 // fresher state from a poll that landed between the user's keystrokes and the
@@ -47,8 +54,4 @@ export function optimisticallyMarkSessionStarting(
       },
     )
   }
-  // Belt-and-braces: a prefix-matching invalidate kicks the next poll a bit
-  // earlier than waiting for the 3s tick. The optimistic state above already
-  // shows the spinner; this just shortens the time until it's confirmed.
-  queryClient.invalidateQueries({ queryKey: GET_SESSION_QUERY_KEY(sessionId) })
 }


### PR DESCRIPTION
Closes the race that made the "Starting Desktop..." spinner
flicker off when sending a chat message to an idle spec-task
session on the detail page. Third attempt at this UX bug — full
root-cause analysis in spec
`design/tasks/002047_yet-again-sending-a/`.

## Why the previous attempts didn't stick

Three prior commits each closed *part* of this gap:
- `e43acefdb` (Apr 2026): made `useSandboxState` poll
  unconditionally. Reduced the worst case from "never" to
  "within 3 s" — but didn't make the transition immediate.
- `bea5d6ae1` (May 2026): added
  `optimisticallyMarkSessionStarting` + `onWillSend` to push
  the spinner up synchronously. Same helper also called
  `queryClient.invalidateQueries(...)` "as belt-and-braces".
  That invalidate triggered an immediate refetch.
- spec `001995_…` (May 2026): generalised
  `autoStartDevContainerForSession` so the backend *eventually*
  wakes the desktop on `/messages`. The wake is async.

The bug: the immediate refetch (from `invalidateQueries`) wins
against the async backend wake. The refetch returns the still
`stopped` row and overwrites the optimistic "starting" in the
React Query cache. The spinner flickers off, then ~3 s later the
regular poll catches the goroutine's eventual DB write and the
spinner returns. Users perceive this as "the spinner never
showed" and click send a second time.

## The fix (two prongs)

**Frontend** — `frontend/src/utils/optimisticSessionStarting.ts`:
remove the `invalidateQueries` call. The 3 s poll reconciles
naturally, and the backend now writes "starting" synchronously
(see backend prong) so even an unrelated refetch returns the
right value.

**Backend** —
`api/pkg/server/prompt_history_handlers.go`: before firing the
async wake goroutine, `syncPromptHistory` now calls a new
helper `markCanonicalSessionStartingForSync` that
column-updates the canonical planning session's
`external_agent_status` to `"starting"` and `status_message` to
`"Starting Desktop..."`, gated on the session having no live
WebSocket and not already being in `starting`/`running`.

**Failure-mode UX** —
`api/pkg/server/auto_wake_stuck_interactions.go`: on cold-start
retry exhaustion, the worker now also reverts the sync-time
"starting" mark so the spinner returns to "Desktop Paused"
instead of sitting on a perpetual spinner.

## Changes

- `frontend/src/utils/optimisticSessionStarting.ts` — delete
  `queryClient.invalidateQueries` at line 53; update the
  comment block to describe the new contract.
- `frontend/src/utils/optimisticSessionStarting.test.ts` —
  replace the "fires invalidateQueries" assertion with two new
  tests that assert (a) `invalidateQueries` is NOT called and
  (b) the cache entry's `isInvalidated` stays false. Existing
  11 tests still pass.
- `api/pkg/store/store_sessions.go` — two new helpers:
  `MarkSessionStartingIfIdle` (atomic JSONB merge gated on
  `status NOT IN ('starting','running')`) and
  `ClearSessionStartingStatus` (atomic JSONB merge gated on
  `status = 'starting'`). Both follow the existing
  `ClearStaleStartingSessions` pattern.
- `api/pkg/store/store.go` — interface additions for the two
  helpers, plus prose comments.
- `api/pkg/store/store_mocks.go` — generated-style mock entries
  for both new helpers.
- `api/pkg/server/prompt_history_handlers.go` — new
  `markCanonicalSessionStartingForSync` helper; called from
  `syncPromptHistory` before the wake goroutine fires.
- `api/pkg/server/auto_wake_stuck_interactions.go` — in the
  cold-start exhaustion branch, call
  `ClearSessionStartingStatus` to revert the sync-time mark.
- `api/pkg/server/prompt_history_handlers_test.go` — four new
  tests for the sync-time mark (no-WS marks, live-WS skips,
  no planning session no-ops, already-starting no-update).
- `api/pkg/server/auto_wake_stuck_interactions_test.go` — extend
  `TestMarksAsErrorAfterMaxRetries` to assert the clear call;
  new `TestClearsStartingStatusOnExhaustion` for the
  "something was cleared" branch.

## Test plan

- [x] `cd api && CGO_ENABLED=1 go test ./pkg/server/ -count=1`
      — full server suite green (9.9 s).
- [x] `cd api && CGO_ENABLED=1 go test ./pkg/server/ -run
      'PromptHistory|AutoWake' -count=1` — focused suites green.
- [x] `cd api && CGO_ENABLED=1 go build ./pkg/server/
      ./pkg/store/ ./pkg/store/memorystore/ ./pkg/external-agent/`
      — clean.
- [x] `cd frontend && yarn test --run optimisticSessionStarting`
      — 11/11 pass.
- [x] `cd frontend && yarn tsc` — clean. `yarn build` blocked
      by a pre-existing root-owned `frontend/dist` bind mount,
      not by these changes (CLAUDE.md warns "NEVER `rm -rf
      frontend/dist`").
- [ ] Manual E2E in inner Helix (deferred — no inner Helix
      reachable in this sandbox; sufficient unit coverage above).
- [ ] CI (Drone) — to be checked after push.

## Out of scope

- Refactor of `resumeSession` to share code with
  `startDevContainerForSession` (deferred in spec #001995,
  still deferred here).
- Splitting `prompt-history/sync` into multiple endpoints.
- Frontend WebSocket session_update handling — already preserves
  config per `streaming.tsx:307-327`.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01ks77aamawsn3c3peb7xwehj1)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002047_yet-again-sending-a/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002047_yet-again-sending-a/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002047_yet-again-sending-a/tasks.md)

🚀 Built with [Helix](https://helix.ml)