### PR TITLE
refactor(org): process worker activation triggers one at a time

### DIFF
--- a/api/pkg/org/application/dispatch/dispatcher.go
+++ b/api/pkg/org/application/dispatch/dispatcher.go
@@ -2,7 +2,7 @@
 // subscribed AI Worker. The server is the event bus; Workers are
 // reactors. Each activation is a single fresh run of the Spawner — no
 // long-running agent loops, no in-process state per worker beyond a
-// per-Worker queue that coalesces overlapping events.
+// per-Worker queue that serialises overlapping events.
 //
 // Lifecycle:
 //   - hire_worker calls DispatchHire to fire a TriggerHire activation
@@ -12,12 +12,14 @@
 //
 // Both calls return immediately; activations run on goroutines. Each
 // Worker has a single runner goroutine that drains a per-Worker
-// queue: new triggers arriving while an activation is in flight are
-// appended and processed as one coalesced batch when the current
-// activation finishes. This collapses webhook cascades (e.g. five
-// GitHub events fired by the worker's own action against a shared
-// auth token) into a single follow-up activation, which keeps cost
-// bounded under burst traffic.
+// queue: new triggers arriving while an activation is in flight wait
+// in the queue and are processed one at a time, in arrival order, as
+// the current activation finishes. Triggers are not coalesced — each
+// activation carries exactly one trigger so that a busy Stream (e.g. a
+// GitHub Stream firing an event per commit, CI run and issue) can't
+// fold its backlog into one oversized activation that exhausts the
+// Worker's context window. The trade-off is more (sequential)
+// activations under burst traffic.
 package dispatch
 
 import (
@@ -38,8 +40,8 @@ import (
 // (webhook, email, …) — but it knows nothing about how each transport
 // delivers; that lives behind the streaming.Outbound port.
 //
-// The per-Worker coalescing logic (one in-flight Spawn per Worker,
-// bursts folded into the next batch) moved out to
+// The per-Worker serialisation logic (one in-flight Spawn per Worker,
+// queued triggers drained one at a time in arrival order) moved out to
 // activation.Queue in B5.10; Dispatcher delegates Enqueue to its
 // embedded Queue and focuses on the event-side fan-out.
 type Dispatcher struct {
@@ -122,9 +124,10 @@ func (d *Dispatcher) DispatchManual(_ context.Context, orgID string, workerID or
 // runs on its own goroutine with its own background context, so a
 // slow target never stalls the publish that triggered Dispatch.
 //
-// Returns immediately. A per-Worker queue serialises and coalesces
-// overlapping subscriber activations within a Worker; outbound POSTs
-// have no such ordering guarantee.
+// Returns immediately. A per-Worker queue serialises overlapping
+// subscriber activations within a Worker, draining them one trigger at
+// a time in arrival order; outbound POSTs have no such ordering
+// guarantee.
 func (d *Dispatcher) Dispatch(ctx context.Context, e streaming.Event) {
 	orgID := e.OrganizationID
 	d.emitOutbound(ctx, e)

--- a/api/pkg/org/application/dispatch/dispatcher_test.go
+++ b/api/pkg/org/application/dispatch/dispatcher_test.go
@@ -573,18 +573,18 @@ func TestDispatchAttachesSourceKind(t *testing.T) {
 	}
 }
 
-// TestDispatchCoalescesEvents pins the cost-saving rule that drove this
-// design: while one activation is in flight for a Worker, any further
-// events that arrive on Streams that Worker subscribes to are
-// appended to a per-Worker queue and delivered to the Spawner as one
-// batched activation when the current one finishes — not five
-// separate fresh-claude runs.
+// TestDispatchDeliversEventsOneAtATime pins the context-bounding rule
+// that drove this design: while one activation is in flight for a
+// Worker, any further events that arrive on Streams that Worker
+// subscribes to are appended to a per-Worker queue and delivered to
+// the Spawner one trigger per activation, in arrival order — never
+// folded into one oversized batch that would blow the Worker's context
+// budget.
 //
 // Shape of the test: the spawner blocks on the very first call so we
 // can publish more events behind it, then we release it and assert
-// the second Spawner call receives all the events that queued during
-// the block as one slice.
-func TestDispatchCoalescesEvents(t *testing.T) {
+// each queued event drains in its own Spawner call, FIFO.
+func TestDispatchDeliversEventsOneAtATime(t *testing.T) {
 	t.Parallel()
 
 	s := orggorm.GetOrgTestDB(t)
@@ -636,9 +636,9 @@ func TestDispatchCoalescesEvents(t *testing.T) {
 	publish("e-1", "first")
 	<-started
 
-	// Three more events while activation #1 is held. These should NOT
-	// each trigger a fresh Spawner call — they should pool in the queue
-	// and be drained as one batch when activation #1 returns.
+	// Three more events while activation #1 is held. Each should drain
+	// in its own Spawner call once activation #1 returns — never pooled
+	// into one batch.
 	publish("e-2", "two")
 	publish("e-3", "three")
 	publish("e-4", "four")
@@ -648,41 +648,38 @@ func TestDispatchCoalescesEvents(t *testing.T) {
 	// goroutines that resolve subs/env can still be in flight.
 	time.Sleep(100 * time.Millisecond)
 
-	// Release the first activation; the runner now drains the batch.
+	// Release the first activation; the runner now drains the queue one
+	// trigger at a time.
 	close(release)
 
-	// Two Spawner calls total: one with [e-1], one with [e-2, e-3, e-4].
-	a1 := waitForActivation(t, rec, 2*time.Second)
-	a2 := waitForActivation(t, rec, 2*time.Second)
-
-	if len(a1.Triggers) != 1 || a1.Triggers[0].EventID != "e-1" {
-		t.Fatalf("activation #1 = %d trigger(s) %+v, want [e-1]", len(a1.Triggers), eventIDs(a1.Triggers))
-	}
-	if len(a2.Triggers) != 3 {
-		t.Fatalf("activation #2 = %d triggers %+v, want 3", len(a2.Triggers), eventIDs(a2.Triggers))
-	}
-	wantIDs := []streaming.EventID{"e-2", "e-3", "e-4"}
+	// Four Spawner calls total, each carrying a single event in FIFO
+	// order: [e-1], [e-2], [e-3], [e-4].
+	wantIDs := []streaming.EventID{"e-1", "e-2", "e-3", "e-4"}
 	for i, want := range wantIDs {
-		if a2.Triggers[i].EventID != want {
-			t.Fatalf("activation #2 trigger order = %+v, want %+v", eventIDs(a2.Triggers), wantIDs)
+		a := waitForActivation(t, rec, 2*time.Second)
+		if len(a.Triggers) != 1 {
+			t.Fatalf("activation #%d = %d triggers %+v, want exactly 1", i+1, len(a.Triggers), eventIDs(a.Triggers))
+		}
+		if a.Triggers[0].EventID != want {
+			t.Fatalf("activation #%d event = %q, want %q (FIFO order broken)", i+1, a.Triggers[0].EventID, want)
 		}
 	}
 
-	// And no third activation is fired — the runner exits cleanly when
+	// And no fifth activation is fired — the runner exits cleanly when
 	// the queue drains.
 	select {
 	case extra := <-rec:
-		t.Fatalf("unexpected third activation: %+v", extra)
+		t.Fatalf("unexpected fifth activation: %+v", extra)
 	case <-time.After(150 * time.Millisecond):
 	}
 
-	if got := calls.Load(); got != 2 {
-		t.Fatalf("Spawner calls = %d, want 2", got)
+	if got := calls.Load(); got != 4 {
+		t.Fatalf("Spawner calls = %d, want 4 (one per event)", got)
 	}
 }
 
 // waitForActivation pulls one recordedActivation off rec or fails the
-// test on timeout. Centralised so the coalescing test reads cleanly.
+// test on timeout. Centralised so the one-at-a-time test reads cleanly.
 func waitForActivation(t *testing.T, rec <-chan recordedActivation, timeout time.Duration) recordedActivation {
 	t.Helper()
 	select {

--- a/api/pkg/org/domain/activation/queue.go
+++ b/api/pkg/org/domain/activation/queue.go
@@ -9,10 +9,12 @@ import (
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 )
 
-// Spawn is the callback Queue fires per coalesced batch. The shape
-// is identical to runtime.Spawner; the activation package doesn't
-// import runtime to avoid the cycle (runtime already imports
-// activation for Trigger). Callers convert their runtime.Spawner via
+// Spawn is the callback Queue fires once per trigger. The shape takes
+// a []Trigger slice — kept for compatibility with runtime.Spawner —
+// but the Queue always passes exactly one trigger; the slice is never
+// longer than one element. The activation package doesn't import
+// runtime to avoid the cycle (runtime already imports activation for
+// Trigger). Callers convert their runtime.Spawner via
 // `activation.Spawn(rs)`.
 //
 // A nil Spawn turns Enqueue into a no-op — useful for tests / event-
@@ -21,13 +23,21 @@ import (
 type Spawn func(ctx context.Context, orgID string, workerID orgchart.WorkerID, triggers []Trigger) error
 
 // Queue holds the per-Worker pending-trigger lists and the lifecycle
-// state that turns bursts of arrivals into a single Spawn call. The
+// state that drains arrivals one at a time into Spawn calls. The
 // invariants it owns (05 §3):
 //
 //   - at most one in-flight Spawn per Worker;
 //   - every trigger that arrives while a Worker's spawn is running
-//     waits in pending and is delivered as part of the next batch;
+//     waits in pending and is delivered, one per activation, in
+//     arrival (FIFO) order;
 //   - distinct Workers run independently.
+//
+// Triggers are NOT coalesced: a busy Stream (e.g. a GitHub Stream
+// emitting an event per commit, CI run and issue) used to fold its
+// whole backlog into one follow-up activation, producing an oversized
+// prompt that exhausted the Worker's context window. Draining one
+// trigger per activation bounds the context each activation carries,
+// at the cost of more (sequential) activations.
 //
 // Lifted out of helix-org/dispatch.Dispatcher in B5.10 because the
 // queueing logic isn't specific to Event/transport fan-out — every
@@ -44,8 +54,8 @@ type Queue struct {
 // Worker IDs are only unique within an org (the store keys workers by
 // the composite (org_id, id)), so the owner of every org shares the id
 // "w-owner". Keying lanes by workerID alone collapses every org's
-// w-owner into one lane — their triggers coalesce into a single batch
-// and lane.orgID becomes last-writer-wins, so one org's activation runs
+// w-owner into one lane — their triggers share a pending list and
+// lane.orgID becomes last-writer-wins, so one org's activation runs
 // under another org's context (wrong project, MCP URL, secrets). The
 // composite key keeps each tenant's lane separate.
 type laneKey struct {
@@ -53,7 +63,7 @@ type laneKey struct {
 	workerID orgchart.WorkerID
 }
 
-// NewQueue returns a Queue that calls spawn per coalesced batch. spawn
+// NewQueue returns a Queue that calls spawn once per trigger. spawn
 // may be nil — Enqueue then no-ops, which keeps tests that don't
 // exercise the runtime green. logger may be nil; falls back to
 // slog.Default.
@@ -66,8 +76,8 @@ func NewQueue(spawn Spawn, logger *slog.Logger) *Queue {
 
 // workerLane is the per-Worker state. New triggers arriving while
 // running == true are appended to pending; the runner picks them up
-// at the top of its next loop iteration and feeds them to spawn as
-// one coalesced batch.
+// one at a time at the top of its next loop iteration, in arrival
+// order.
 type workerLane struct {
 	mu      sync.Mutex
 	pending []Trigger
@@ -96,10 +106,13 @@ func (q *Queue) Enqueue(orgID string, workerID orgchart.WorkerID, trigger Trigge
 	go q.run(workerID, lane)
 }
 
-// run drains the Worker's lane, calling spawn once per drain with
-// however many triggers accumulated. Exits when an iteration finds
-// the lane empty under the lock — at which point any later Enqueue
-// will see running == false and start a fresh runner.
+// run drains the Worker's lane one trigger per iteration, calling
+// spawn once per trigger in arrival order. Triggers are not coalesced:
+// any that piled up while the previous activation ran are worked off
+// sequentially, one activation each, so no single activation carries
+// more than one trigger's worth of context. Exits when an iteration
+// finds the lane empty under the lock — at which point any later
+// Enqueue will see running == false and start a fresh runner.
 func (q *Queue) run(workerID orgchart.WorkerID, lane *workerLane) {
 	for {
 		lane.mu.Lock()
@@ -108,12 +121,12 @@ func (q *Queue) run(workerID orgchart.WorkerID, lane *workerLane) {
 			lane.mu.Unlock()
 			return
 		}
-		batch := lane.pending
-		lane.pending = nil
+		trigger := lane.pending[0]
+		lane.pending = lane.pending[1:]
 		orgID := lane.orgID
 		lane.mu.Unlock()
 
-		q.activate(context.Background(), orgID, workerID, batch)
+		q.activate(context.Background(), orgID, workerID, []Trigger{trigger})
 	}
 }
 

--- a/api/pkg/org/domain/activation/queue_test.go
+++ b/api/pkg/org/domain/activation/queue_test.go
@@ -13,10 +13,9 @@ import (
 
 // TestQueueSerializesPerWorker is the core invariant the Spawner
 // relies on: at most one in-flight Spawn per Worker. The number of
-// Spawn calls is NOT asserted — coalescing is racy by design (a
-// trigger arriving while a batch is mid-claim gets folded in), so
-// the count varies between 1 and len(Enqueues). What must hold is
-// that no two Spawn calls ever overlap for the same Worker.
+// Spawn calls is NOT asserted here (one-per-trigger is covered by
+// TestQueueDrainsTriggersOneAtATime); what must hold is that no two
+// Spawn calls ever overlap for the same Worker.
 func TestQueueSerializesPerWorker(t *testing.T) {
 	t.Parallel()
 	var inflight, peak int32
@@ -66,15 +65,17 @@ func TestQueueSerializesPerWorker(t *testing.T) {
 	}
 }
 
-// TestQueueCoalescesBurstIntoOneBatch — two triggers landing
-// while the first activation is running become ONE batch on the next
-// drain, not two separate Spawner calls.
-func TestQueueCoalescesBurstIntoOneBatch(t *testing.T) {
+// TestQueueDrainsTriggersOneAtATime — two triggers landing while the
+// first activation is running are NOT coalesced. Each is delivered in
+// its own Spawner call, one trigger per call, in arrival (FIFO) order.
+// This is the context-bounding behaviour: a busy Stream can never fold
+// its backlog into one oversized activation.
+func TestQueueDrainsTriggersOneAtATime(t *testing.T) {
 	t.Parallel()
 	var batches [][]activation.Trigger
 	var mu sync.Mutex
 	var done sync.WaitGroup
-	done.Add(2) // first batch + the coalesced follow-up
+	done.Add(3) // hire + e-1 + e-2, each its own activation
 	holdFirst := make(chan struct{})
 
 	spawn := func(_ context.Context, _ string, _ orgchart.WorkerID, triggers []activation.Trigger) error {
@@ -93,7 +94,7 @@ func TestQueueCoalescesBurstIntoOneBatch(t *testing.T) {
 
 	c := activation.NewQueue(spawn, nil)
 	c.Enqueue("org-test", "w-a", activation.Trigger{Kind: activation.TriggerHire})
-	// Two more triggers arrive while batch 0 is blocked.
+	// Two more triggers arrive while the first activation is blocked.
 	time.Sleep(20 * time.Millisecond)
 	c.Enqueue("org-test", "w-a", activation.Trigger{Kind: activation.TriggerEvent, EventID: "e-1"})
 	c.Enqueue("org-test", "w-a", activation.Trigger{Kind: activation.TriggerEvent, EventID: "e-2"})
@@ -103,14 +104,23 @@ func TestQueueCoalescesBurstIntoOneBatch(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
-	if len(batches) != 2 {
-		t.Fatalf("batches = %d, want 2 (the burst coalesces)", len(batches))
+	if len(batches) != 3 {
+		t.Fatalf("activations = %d, want 3 (one per trigger, no coalescing)", len(batches))
 	}
-	if len(batches[0]) != 1 {
-		t.Errorf("first batch size = %d, want 1", len(batches[0]))
+	for i, b := range batches {
+		if len(b) != 1 {
+			t.Errorf("activation %d carried %d triggers, want exactly 1", i, len(b))
+		}
 	}
-	if len(batches[1]) != 2 {
-		t.Errorf("second batch size = %d, want 2 (e-1 + e-2 coalesced)", len(batches[1]))
+	// FIFO order: hire, then e-1, then e-2.
+	if batches[0][0].Kind != activation.TriggerHire {
+		t.Errorf("activation 0 kind = %q, want hire", batches[0][0].Kind)
+	}
+	if batches[1][0].EventID != "e-1" {
+		t.Errorf("activation 1 event = %q, want e-1", batches[1][0].EventID)
+	}
+	if batches[2][0].EventID != "e-2" {
+		t.Errorf("activation 2 event = %q, want e-2", batches[2][0].EventID)
 	}
 }
 


### PR DESCRIPTION
## Summary

In production, busy Streams overwhelm an AI Worker's context window. A real
example: a GitHub Stream emits an event for every commit, CI action, and issue.
While a Worker was mid-activation, the activation Queue **coalesced** the entire
backlog into a single follow-up activation — handing the Worker's next run dozens
of triggers at once, a huge prompt that exhausted the context budget.

This change stops coalescing. The per-Worker queue now drains **one trigger per
activation**, in arrival (FIFO) order. Context per activation is bounded
regardless of how busy the Stream is; the backlog is worked off sequentially. The
existing "at most one in-flight activation per Worker" and per-(org, worker) lane
isolation invariants are unchanged.

Trade-off (intended): a busy Stream now produces one activation per event instead
of one coalesced activation — more sequential activations in exchange for bounded
context each. Per-worker serialization still prevents runaway concurrency.

## Changes

- `api/pkg/org/domain/activation/queue.go` — `Queue.run()` drains a single
  trigger per iteration (`pending[0]`, then `pending = pending[1:]`) and spawns
  with a one-element slice instead of the whole pending list. Doc comments
  updated to describe one-at-a-time draining.
- `api/pkg/org/application/dispatch/dispatcher.go` — package and `Dispatcher` doc
  comments updated: removed the "coalesced batch / collapses webhook cascades"
  wording, describe one-at-a-time FIFO delivery.
- `api/pkg/org/domain/activation/queue_test.go` — `TestQueueCoalescesBurstIntoOneBatch`
  rewritten as `TestQueueDrainsTriggersOneAtATime` (each Spawner call gets exactly
  one trigger, FIFO). Refreshed a stale comment in `TestQueueSerializesPerWorker`.
- `api/pkg/org/application/dispatch/dispatcher_test.go` — dispatch-level
  `TestDispatchCoalescesEvents` rewritten as `TestDispatchDeliversEventsOneAtATime`
  (4 events → 4 activations, one each, FIFO).

## Testing

`go test ./api/pkg/org/domain/activation/... ./api/pkg/org/application/dispatch/...`
— all pass, including serialization, parallel-workers, and cross-org isolation.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kv88j8j8jnh0vr6qj56ec5qf)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002117_im-having-a-problem-in/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002117_im-having-a-problem-in/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002117_im-having-a-problem-in/tasks.md)

🚀 Built with [Helix](https://helix.ml)