### PR TITLE
Add configurable OIDC email-domain restriction

### DIFF
--- a/api/pkg/auth/domain_test.go
+++ b/api/pkg/auth/domain_test.go
@@ -1,0 +1,63 @@
+package auth
+
+import "testing"
+
+func TestEmailDomainAllowed(t *testing.T) {
+	helix := []string{"helix.ml"}
+	multi := []string{"helix.ml", "example.com"}
+
+	cases := []struct {
+		name     string
+		email    string
+		verified bool
+		allowed  []string
+		want     bool
+	}{
+		{"empty list allows anything", "anyone@gmail.com", true, nil, true},
+		{"empty list allows unverified", "anyone@gmail.com", false, nil, true},
+		{"verified match", "luke@helix.ml", true, helix, true},
+		{"verified match case-insensitive", "Luke@Helix.ML", true, helix, true},
+		{"unverified match rejected", "luke@helix.ml", false, helix, false},
+		{"wrong domain rejected", "someone@gmail.com", true, helix, false},
+		{"spoofed subdomain rejected", "evil@helix.ml.evil.com", true, helix, false},
+		{"subdomain of allowed rejected", "evil@sub.helix.ml", true, helix, false},
+		{"no at-sign rejected", "notanemail", true, helix, false},
+		{"trailing at rejected", "user@", true, helix, false},
+		{"second domain in list matches", "person@example.com", true, multi, true},
+		{"empty email with restriction rejected", "", true, helix, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := emailDomainAllowed(tc.email, tc.verified, tc.allowed); got != tc.want {
+				t.Errorf("emailDomainAllowed(%q, %v, %v) = %v, want %v",
+					tc.email, tc.verified, tc.allowed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseEmailDomains(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"   ", nil},
+		{"helix.ml", []string{"helix.ml"}},
+		{"helix.ml, example.com", []string{"helix.ml", "example.com"}},
+		{" Helix.ML , , EXAMPLE.com ", []string{"helix.ml", "example.com"}},
+	}
+
+	for _, tc := range cases {
+		got := ParseEmailDomains(tc.in)
+		if len(got) != len(tc.want) {
+			t.Fatalf("ParseEmailDomains(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Fatalf("ParseEmailDomains(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		}
+	}
+}

--- a/api/pkg/auth/oidc.go
+++ b/api/pkg/auth/oidc.go
@@ -61,6 +61,9 @@ type OIDCConfig struct {
 	Waitlist bool
 	// EventHandler receives lifecycle events (e.g., new user created). Optional.
 	EventHandler OIDCEventHandler
+	// AllowedEmailDomains restricts login/registration to these email domains
+	// (lowercased, e.g. "helix.ml"). Empty means no restriction.
+	AllowedEmailDomains []string
 }
 
 func NewOIDCClient(ctx context.Context, cfg OIDCConfig) (*OIDCClient, error) {
@@ -321,6 +324,15 @@ func (c *OIDCClient) ValidateUserToken(ctx context.Context, accessToken string) 
 		return nil, fmt.Errorf("invalid access token (could not get user info): %w", err)
 	}
 
+	// Enforce the allowed email-domain restriction (if configured) BEFORE creating
+	// any user or granting access. Without this gate, any verified OIDC account is
+	// accepted even on deployments that intend to restrict sign-in to a specific
+	// domain. Empty AllowedEmailDomains means no restriction (default).
+	if !emailDomainAllowed(userInfo.Email, userInfo.EmailVerified, c.cfg.AllowedEmailDomains) {
+		log.Warn().Str("email", userInfo.Email).Msg("OIDC login rejected: email domain not allowed")
+		return nil, fmt.Errorf("access restricted: email domain not permitted")
+	}
+
 	// Try to get the user from the database by their OIDC subject ID
 	user, err := c.store.GetUser(ctx, &store.GetUserQuery{
 		ID: userInfo.Subject,
@@ -452,6 +464,44 @@ func (c *OIDCClient) tryAutoJoinOrganization(ctx context.Context, userID, email 
 		Str("email", email).
 		Str("domain", domain).
 		Msg("user auto-joined organization via email domain")
+}
+
+// ParseEmailDomains parses a comma-separated list of email domains into a
+// normalised (trimmed, lowercased, non-empty) slice. Empty input yields nil,
+// meaning "no restriction".
+func ParseEmailDomains(s string) []string {
+	var domains []string
+	for _, d := range strings.Split(s, ",") {
+		if trimmed := strings.ToLower(strings.TrimSpace(d)); trimmed != "" {
+			domains = append(domains, trimmed)
+		}
+	}
+	return domains
+}
+
+// emailDomainAllowed reports whether an OIDC login should be permitted based on
+// the user's email domain. If allowed is empty there is no restriction. Otherwise
+// the email must be verified and its domain (the part after the last "@") must
+// match one of the allowed domains exactly (case-insensitive). Exact matching —
+// not suffix matching — prevents spoofing like "helix.ml.evil.com".
+func emailDomainAllowed(email string, verified bool, allowed []string) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	if !verified {
+		return false
+	}
+	at := strings.LastIndex(email, "@")
+	if at < 0 || at == len(email)-1 {
+		return false
+	}
+	domain := strings.ToLower(email[at+1:])
+	for _, d := range allowed {
+		if domain == d {
+			return true
+		}
+	}
+	return false
 }
 
 type TokenResponse struct {

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -516,6 +516,12 @@ type OIDC struct {
 	// This is especially useful with Google OIDC + OIDC_OFFLINE_ACCESS=true, as the refresh token
 	// will be preserved and can obtain new access tokens even after the browser is closed.
 	CookieMaxAge int `envconfig:"OIDC_COOKIE_MAX_AGE" default:"0"`
+	// AllowedEmailDomains restricts OIDC login/registration to these email domains
+	// (comma-separated, e.g. "helix.ml"). When empty (the default) there is no
+	// restriction — any verified account may sign in, preserving multi-tenant and
+	// customer deployments. Set it (e.g. on meta.helix.ml) to lock sign-in to a
+	// specific organisation's domain(s).
+	AllowedEmailDomains string `envconfig:"OIDC_ALLOWED_EMAIL_DOMAINS" default:""`
 }
 
 // Notifications is used for sending notifications to users when certain events happen

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -240,18 +240,19 @@ func NewServer(
 		}
 
 		oidcCfg := auth.OIDCConfig{
-			ProviderURL:    cfg.Auth.OIDC.URL,
-			ClientID:       cfg.Auth.OIDC.ClientID,
-			ClientSecret:   cfg.Auth.OIDC.ClientSecret,
-			RedirectURL:    helixRedirectURL,
-			AdminUserIDs:   cfg.WebServer.AdminUserIDs,
-			Audience:       cfg.Auth.OIDC.Audience,
-			Scopes:         strings.Split(cfg.Auth.OIDC.Scopes, ","),
-			Store:          store,
-			ExpectedIssuer: cfg.Auth.OIDC.ExpectedIssuer,
-			TokenURL:       cfg.Auth.OIDC.TokenURL,
-			OfflineAccess:  cfg.Auth.OIDC.OfflineAccess,
-			Waitlist:       cfg.Auth.Waitlist,
+			ProviderURL:         cfg.Auth.OIDC.URL,
+			ClientID:            cfg.Auth.OIDC.ClientID,
+			ClientSecret:        cfg.Auth.OIDC.ClientSecret,
+			RedirectURL:         helixRedirectURL,
+			AdminUserIDs:        cfg.WebServer.AdminUserIDs,
+			Audience:            cfg.Auth.OIDC.Audience,
+			Scopes:              strings.Split(cfg.Auth.OIDC.Scopes, ","),
+			Store:               store,
+			ExpectedIssuer:      cfg.Auth.OIDC.ExpectedIssuer,
+			TokenURL:            cfg.Auth.OIDC.TokenURL,
+			OfflineAccess:       cfg.Auth.OIDC.OfflineAccess,
+			Waitlist:            cfg.Auth.Waitlist,
+			AllowedEmailDomains: auth.ParseEmailDomains(cfg.Auth.OIDC.AllowedEmailDomains),
 		}
 		if adminAlerter != nil {
 			oidcCfg.EventHandler = &oidcSignupNotifier{alerter: adminAlerter}


### PR DESCRIPTION
## Summary
Helix accepts any verified Google/OIDC account and creates a user (and grants
tokens) for it. On deployments that intend to restrict sign-in to a specific
organisation (e.g. `meta.helix.ml` → `@helix.ml`) there was no enforcement. This
adds an opt-in, configurable allowed-email-domain gate to the OIDC login path.

## Changes
- `api/pkg/config/config.go`: add `OIDC.AllowedEmailDomains`
  (`OIDC_ALLOWED_EMAIL_DOMAINS`, comma-separated). **Default empty = no
  restriction**, so existing customer/dev deployments are unaffected.
- `api/pkg/auth/oidc.go`: add `emailDomainAllowed(...)` and exported
  `ParseEmailDomains(...)`; gate `ValidateUserToken()` immediately after the
  userinfo lookup and **before** any `CreateUser` / invitation / token grant —
  returning an error so rejected accounts never create a user row. Requires
  `email_verified`; exact domain match after the last `@` (case-insensitive), so
  `helix.ml.evil.com` and `sub.helix.ml` are rejected.
- `api/pkg/server/server.go`: wire `AllowedEmailDomains` into `auth.OIDCConfig`.
- `api/pkg/auth/domain_test.go`: table tests for `emailDomainAllowed` and
  `ParseEmailDomains` (empty list, verified match, unverified, case, wrong
  domain, spoofed subdomain, malformed email).

## Notes
- Because the check is in `ValidateUserToken` (the funnel for every OIDC request),
  it also blocks existing users if their domain is later removed from the list.
- Operator action: set `OIDC_ALLOWED_EMAIL_DOMAINS=helix.ml` on `meta.helix.ml`
  to actually lock it down — the default is intentionally unrestricted.
- Builds pass (`go build ./pkg/auth/ ./pkg/config/ ./pkg/server/`); tests pass
  with `CGO_ENABLED=1`.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kk95f1seff98mbxhfa31qj81/tasks/spt_01kv88c88szcxntm6a0kq1sga1)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002116_both-helixos-and-helix/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002116_both-helixos-and-helix/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002116_both-helixos-and-helix/tasks.md)

🚀 Built with [Helix](https://helix.ml)