### PR TITLE
feat(api): paginated JSON:API endpoint for stream messages

### DIFF
--- a/api/pkg/org/application/queries/queries.go
+++ b/api/pkg/org/application/queries/queries.go
@@ -112,6 +112,18 @@ func (q *Queries) AllEvents(ctx context.Context, orgID string, limit int) ([]str
 	return q.events.ListAll(ctx, orgID, limit)
 }
 
+// PageStreamEvents returns a page of events on a Stream, newest first,
+// for the paginated REST messages endpoint.
+func (q *Queries) PageStreamEvents(ctx context.Context, orgID string, streamID streaming.StreamID, limit, offset int) ([]streaming.Event, error) {
+	return q.events.PageForStream(ctx, orgID, streamID, limit, offset)
+}
+
+// CountStreamEvents returns the total number of events on a Stream —
+// the total-count meta the paginated messages endpoint surfaces.
+func (q *Queries) CountStreamEvents(ctx context.Context, orgID string, streamID streaming.StreamID) (int, error) {
+	return q.events.CountForStream(ctx, orgID, streamID)
+}
+
 func (q *Queries) WorkerEvents(ctx context.Context, orgID string, workerID orgchart.WorkerID, limit int) ([]streaming.Event, error) {
 	return q.events.ListForWorker(ctx, orgID, workerID, limit)
 }

--- a/api/pkg/org/domain/store/options.go
+++ b/api/pkg/org/domain/store/options.go
@@ -33,6 +33,7 @@ type Query struct {
 	table      string
 	selects    string
 	limit      int
+	offset     int
 	updates    map[string]any
 }
 
@@ -65,6 +66,9 @@ func (q Query) Selects() string { return q.selects }
 
 // Limit returns the row cap (0 means unbounded).
 func (q Query) Limit() int { return q.limit }
+
+// Offset returns the row offset (0 means no skip).
+func (q Query) Offset() int { return q.offset }
 
 // Updates returns the column → value map for UPDATE statements.
 func (q Query) Updates() map[string]any {
@@ -156,6 +160,18 @@ func WithLimit(limit int) Option {
 	return func(q Query) Query {
 		if limit > 0 {
 			q.limit = limit
+		}
+		return q
+	}
+}
+
+// WithOffset skips the first n rows. offset <= 0 is a no-op so callers
+// can pass through a user-supplied offset unchanged. Pair with
+// WithLimit and a stable ORDER BY for page-number pagination.
+func WithOffset(offset int) Option {
+	return func(q Query) Query {
+		if offset > 0 {
+			q.offset = offset
 		}
 		return q
 	}

--- a/api/pkg/org/domain/store/store.go
+++ b/api/pkg/org/domain/store/store.go
@@ -141,6 +141,16 @@ type Subscriptions interface {
 type Events interface {
 	Append(ctx context.Context, e streaming.Event) error
 	ListForStream(ctx context.Context, orgID string, streamID streaming.StreamID, limit int) ([]streaming.Event, error)
+	// PageForStream returns a window of events on one Stream, newest
+	// first (same ordering as ListForStream), skipping offset rows and
+	// returning at most limit. Powers page-number pagination of the
+	// REST messages endpoint. offset/limit <= 0 are treated as "no
+	// skip" / "no cap" respectively.
+	PageForStream(ctx context.Context, orgID string, streamID streaming.StreamID, limit, offset int) ([]streaming.Event, error)
+	// CountForStream returns the total number of events on one Stream —
+	// the total-count meta the paginated messages endpoint surfaces,
+	// independent of any page window.
+	CountForStream(ctx context.Context, orgID string, streamID streaming.StreamID) (int, error)
 	ListForWorker(ctx context.Context, orgID string, workerID orgchart.WorkerID, limit int) ([]streaming.Event, error)
 	ListSince(ctx context.Context, orgID string, streamIDs []streaming.StreamID, since streaming.EventID, limit int) ([]streaming.Event, error)
 	// ListAll returns events across every Stream in the given org,

--- a/api/pkg/org/infrastructure/persistence/gorm/apply.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/apply.go
@@ -46,6 +46,9 @@ func ApplyOptions(db *gorm.DB, opts ...store.Option) *gorm.DB {
 	if l := q.Limit(); l > 0 {
 		db = db.Limit(l)
 	}
+	if o := q.Offset(); o > 0 {
+		db = db.Offset(o)
+	}
 	return db
 }
 

--- a/api/pkg/org/infrastructure/persistence/gorm/event.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/event.go
@@ -74,6 +74,24 @@ func (r *eventsRepo) ListForStream(ctx context.Context, orgID string, streamID s
 	)
 }
 
+func (r *eventsRepo) PageForStream(ctx context.Context, orgID string, streamID streaming.StreamID, limit, offset int) ([]streaming.Event, error) {
+	return r.Repository.Find(ctx,
+		store.WithOrg(orgID),
+		store.WithCondition("stream_id", string(streamID)),
+		store.WithOrderDesc("created_at"),
+		store.WithOrderDesc("id"),
+		store.WithLimit(limit),
+		store.WithOffset(offset),
+	)
+}
+
+func (r *eventsRepo) CountForStream(ctx context.Context, orgID string, streamID streaming.StreamID) (int, error) {
+	return r.Repository.Count(ctx,
+		store.WithOrg(orgID),
+		store.WithCondition("stream_id", string(streamID)),
+	)
+}
+
 func (r *eventsRepo) ListAll(ctx context.Context, orgID string, limit int) ([]streaming.Event, error) {
 	return r.Repository.Find(ctx,
 		store.WithOrg(orgID),

--- a/api/pkg/org/infrastructure/persistence/gorm/events_page_test.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/events_page_test.go
@@ -1,0 +1,97 @@
+package gorm_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+)
+
+// TestEventsPageAndCountForStream exercises the page-number pagination
+// primitives (PageForStream + CountForStream) the REST messages
+// endpoint composes over. Ordering is newest-first, matching
+// ListForStream.
+func TestEventsPageAndCountForStream(t *testing.T) {
+	t.Parallel()
+	s := newStore(t)
+	ctx := context.Background()
+	base := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+
+	// Five events on s-a, one on s-b (noise that must not be counted or
+	// paged into s-a results).
+	for _, e := range []struct {
+		id, st string
+		offset time.Duration
+	}{
+		{"e-1", "s-a", 1 * time.Second},
+		{"e-2", "s-a", 2 * time.Second},
+		{"e-3", "s-a", 3 * time.Second},
+		{"e-4", "s-a", 4 * time.Second},
+		{"e-5", "s-a", 5 * time.Second},
+		{"e-other", "s-b", 6 * time.Second},
+	} {
+		ev, _ := streaming.NewEvent(streaming.EventID(e.id), streaming.StreamID(e.st), "w-owner", "body", base.Add(e.offset), "org-test")
+		if err := s.Events.Append(ctx, ev); err != nil {
+			t.Fatalf("Append %s: %v", e.id, err)
+		}
+	}
+
+	// Count is per-stream and independent of any page window.
+	total, err := s.Events.CountForStream(ctx, "org-test", "s-a")
+	if err != nil {
+		t.Fatalf("CountForStream: %v", err)
+	}
+	if total != 5 {
+		t.Fatalf("count = %d, want 5", total)
+	}
+
+	// First page: newest two.
+	page1, err := s.Events.PageForStream(ctx, "org-test", "s-a", 2, 0)
+	if err != nil {
+		t.Fatalf("PageForStream page1: %v", err)
+	}
+	if len(page1) != 2 || page1[0].ID != "e-5" || page1[1].ID != "e-4" {
+		t.Fatalf("page1 = %v, want [e-5 e-4]", ids(page1))
+	}
+
+	// Second page: offset 2.
+	page2, err := s.Events.PageForStream(ctx, "org-test", "s-a", 2, 2)
+	if err != nil {
+		t.Fatalf("PageForStream page2: %v", err)
+	}
+	if len(page2) != 2 || page2[0].ID != "e-3" || page2[1].ID != "e-2" {
+		t.Fatalf("page2 = %v, want [e-3 e-2]", ids(page2))
+	}
+
+	// Last (partial) page.
+	page3, err := s.Events.PageForStream(ctx, "org-test", "s-a", 2, 4)
+	if err != nil {
+		t.Fatalf("PageForStream page3: %v", err)
+	}
+	if len(page3) != 1 || page3[0].ID != "e-1" {
+		t.Fatalf("page3 = %v, want [e-1]", ids(page3))
+	}
+
+	// Out-of-range offset yields an empty page, not an error.
+	empty, err := s.Events.PageForStream(ctx, "org-test", "s-a", 2, 10)
+	if err != nil {
+		t.Fatalf("PageForStream out-of-range: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("out-of-range page = %v, want []", ids(empty))
+	}
+
+	// Unknown stream: zero count, empty page.
+	if c, err := s.Events.CountForStream(ctx, "org-test", "s-missing"); err != nil || c != 0 {
+		t.Fatalf("CountForStream(missing) = %d, %v, want 0, nil", c, err)
+	}
+}
+
+func ids(evs []streaming.Event) []streaming.EventID {
+	out := make([]streaming.EventID, len(evs))
+	for i, e := range evs {
+		out[i] = e.ID
+	}
+	return out
+}

--- a/api/pkg/org/infrastructure/persistence/gorm/repository.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/repository.go
@@ -146,6 +146,18 @@ func (r *Repository[D, R]) Delete(ctx context.Context, opts ...store.Option) err
 	return nil
 }
 
+// Count returns the number of rows matching the given filters. Like
+// Exists it applies only the WHERE clauses — ORDER / LIMIT / OFFSET
+// are irrelevant to a count.
+func (r *Repository[D, R]) Count(ctx context.Context, opts ...store.Option) (int, error) {
+	var count int64
+	db := ApplyConditions(r.db.WithContext(ctx).Model(new(R)), opts...)
+	if err := db.Count(&count).Error; err != nil {
+		return 0, fmt.Errorf("count %s: %w", r.label, err)
+	}
+	return int(count), nil
+}
+
 // Exists reports whether any row matches the given filters.
 func (r *Repository[D, R]) Exists(ctx context.Context, opts ...store.Option) (bool, error) {
 	var count int64

--- a/api/pkg/org/infrastructure/persistence/memory/memorystore.go
+++ b/api/pkg/org/infrastructure/persistence/memory/memorystore.go
@@ -594,6 +594,41 @@ func (e *eventsRepo) ListForStream(_ context.Context, orgID string, streamID str
 	return out, nil
 }
 
+func (e *eventsRepo) PageForStream(_ context.Context, orgID string, streamID streaming.StreamID, limit, offset int) ([]streaming.Event, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	out := make([]streaming.Event, 0)
+	skipped := 0
+	// Newest first, same ordering as ListForStream.
+	for i := len(e.rows) - 1; i >= 0; i-- {
+		ev := e.rows[i]
+		if ev.OrganizationID != orgID || ev.StreamID != streamID {
+			continue
+		}
+		if offset > 0 && skipped < offset {
+			skipped++
+			continue
+		}
+		out = append(out, ev)
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (e *eventsRepo) CountForStream(_ context.Context, orgID string, streamID streaming.StreamID) (int, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	count := 0
+	for _, ev := range e.rows {
+		if ev.OrganizationID == orgID && ev.StreamID == streamID {
+			count++
+		}
+	}
+	return count, nil
+}
+
 func (e *eventsRepo) ListForWorker(ctx context.Context, orgID string, workerID orgchart.WorkerID, limit int) ([]streaming.Event, error) {
 	// Match gorm's join semantics: events on streams the worker is
 	// subscribed to. Subscriptions are worker-anchored.

--- a/api/pkg/org/interfaces/jsonapi/document.go
+++ b/api/pkg/org/interfaces/jsonapi/document.go
@@ -1,0 +1,106 @@
+// Package jsonapi is a small, composable toolkit for emitting
+// jsonapi.org-formatted responses from the helix-org HTTP interfaces.
+//
+// The codebase had no JSON:API helpers, so this package provides the
+// minimum the stream-messages endpoint needs while staying generic and
+// reusable for any future org/interfaces endpoint.
+//
+// The design is composition-first: a Document is assembled by applying
+// independent Components, each of which contributes its own slice
+// (meta keys, links, …). Meta and pagination are therefore separate,
+// reusable units rather than fields baked into one bespoke response
+// struct — compose whichever ones a given endpoint needs:
+//
+//	doc := jsonapi.NewDocument(resources,
+//	    jsonapi.TotalMeta{Total: total},          // meta via composition
+//	    jsonapi.Pagination{...},                  // pagination via composition
+//	)
+//	jsonapi.Write(w, http.StatusOK, doc)
+package jsonapi
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// ContentType is the media type the JSON:API spec mandates.
+const ContentType = "application/vnd.api+json"
+
+// Meta is the top-level (or resource-level) free-form metadata object.
+type Meta map[string]any
+
+// Links is a JSON:API links object (self/first/prev/next/last/…).
+type Links map[string]string
+
+// Document is a top-level JSON:API document. Data is the primary data
+// (a single Resource, a slice of Resource, or nil); Meta and Links are
+// contributed by Components and omitted from the wire when empty.
+type Document struct {
+	Data  any   `json:"data"`
+	Meta  Meta  `json:"meta,omitempty"`
+	Links Links `json:"links,omitempty"`
+}
+
+// Component contributes its part to a Document. Composition is "apply
+// many": NewDocument folds each Component onto the document in turn.
+type Component interface {
+	Apply(*Document)
+}
+
+// NewDocument builds a Document around data and applies each Component.
+// Components mutate the document's Meta/Links via the ensure* helpers,
+// so the maps only materialise when something actually populates them.
+func NewDocument(data any, components ...Component) *Document {
+	d := &Document{Data: data}
+	for _, c := range components {
+		if c != nil {
+			c.Apply(d)
+		}
+	}
+	return d
+}
+
+// ensureMeta lazily creates the Meta map so Components can write into
+// it without each one nil-checking.
+func (d *Document) ensureMeta() Meta {
+	if d.Meta == nil {
+		d.Meta = Meta{}
+	}
+	return d.Meta
+}
+
+// ensureLinks lazily creates the Links map.
+func (d *Document) ensureLinks() Links {
+	if d.Links == nil {
+		d.Links = Links{}
+	}
+	return d.Links
+}
+
+// Resource is a single JSON:API resource object.
+type Resource struct {
+	Type       string `json:"type"`
+	ID         string `json:"id"`
+	Attributes any    `json:"attributes,omitempty"`
+}
+
+// TotalMeta is a Component that contributes the total item count to
+// meta.total. Kept separate from Pagination so an endpoint can surface
+// a total without paging (and vice versa).
+type TotalMeta struct {
+	Total int
+}
+
+// Apply writes total into the document's meta.
+func (m TotalMeta) Apply(d *Document) {
+	d.ensureMeta()["total"] = m.Total
+}
+
+// Write encodes doc as JSON:API with the correct content type and
+// status. Encoding errors are swallowed after the header is written —
+// the same contract as the sibling api package's writeJSON.
+func Write(w http.ResponseWriter, status int, doc *Document) {
+	w.Header().Set("Content-Type", ContentType)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(doc)
+}

--- a/api/pkg/org/interfaces/jsonapi/jsonapi_test.go
+++ b/api/pkg/org/interfaces/jsonapi/jsonapi_test.go
@@ -1,0 +1,160 @@
+package jsonapi
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestNewDocumentComposesComponents(t *testing.T) {
+	data := []Resource{{Type: "messages", ID: "e-1"}}
+	doc := NewDocument(data,
+		TotalMeta{Total: 7},
+		Pagination{Number: 1, Size: 5, Total: 7},
+	)
+	if doc.Meta["total"] != 7 {
+		t.Fatalf("meta.total = %v, want 7", doc.Meta["total"])
+	}
+	if doc.Meta["total_pages"] != 2 {
+		t.Fatalf("meta.total_pages = %v, want 2", doc.Meta["total_pages"])
+	}
+	if doc.Links["self"] == "" || doc.Links["first"] == "" || doc.Links["last"] == "" {
+		t.Fatalf("expected self/first/last links, got %v", doc.Links)
+	}
+}
+
+func TestNewDocumentNoComponentsOmitsMetaAndLinks(t *testing.T) {
+	doc := NewDocument([]Resource{})
+	if doc.Meta != nil || doc.Links != nil {
+		t.Fatalf("expected nil meta/links, got meta=%v links=%v", doc.Meta, doc.Links)
+	}
+	b, _ := json.Marshal(doc)
+	// data must serialise as [] (not null) and meta/links omitted.
+	if got := string(b); got != `{"data":[]}` {
+		t.Fatalf("marshalled = %s, want {\"data\":[]}", got)
+	}
+}
+
+func TestTotalMetaStandalone(t *testing.T) {
+	doc := NewDocument(nil, TotalMeta{Total: 0})
+	if doc.Meta["total"] != 0 {
+		t.Fatalf("meta.total = %v, want 0", doc.Meta["total"])
+	}
+	if doc.Links != nil {
+		t.Fatalf("TotalMeta must not add links, got %v", doc.Links)
+	}
+}
+
+func TestPaginationLinksFirstPage(t *testing.T) {
+	doc := NewDocument(nil, Pagination{Number: 1, Size: 2, Total: 5})
+	if _, ok := doc.Links["prev"]; ok {
+		t.Fatalf("first page must not have prev: %v", doc.Links)
+	}
+	if doc.Links["next"] == "" {
+		t.Fatalf("first page of 3 must have next: %v", doc.Links)
+	}
+	if doc.Links["last"] != "?page%5Bnumber%5D=3&page%5Bsize%5D=2" {
+		t.Fatalf("last = %q", doc.Links["last"])
+	}
+}
+
+func TestPaginationLinksMiddlePage(t *testing.T) {
+	doc := NewDocument(nil, Pagination{Number: 2, Size: 2, Total: 5})
+	if doc.Links["prev"] == "" || doc.Links["next"] == "" {
+		t.Fatalf("middle page needs prev and next: %v", doc.Links)
+	}
+}
+
+func TestPaginationLinksLastPage(t *testing.T) {
+	doc := NewDocument(nil, Pagination{Number: 3, Size: 2, Total: 5})
+	if _, ok := doc.Links["next"]; ok {
+		t.Fatalf("last page must not have next: %v", doc.Links)
+	}
+	if doc.Links["prev"] == "" {
+		t.Fatalf("last page needs prev: %v", doc.Links)
+	}
+}
+
+func TestPaginationOutOfRangePageNoNext(t *testing.T) {
+	// Page beyond the last: no next, self still emitted, total_pages correct.
+	doc := NewDocument(nil, Pagination{Number: 99, Size: 2, Total: 5})
+	if _, ok := doc.Links["next"]; ok {
+		t.Fatalf("out-of-range page must not have next: %v", doc.Links)
+	}
+	if doc.Meta["total_pages"] != 3 {
+		t.Fatalf("total_pages = %v, want 3", doc.Meta["total_pages"])
+	}
+}
+
+func TestPaginationEmptySet(t *testing.T) {
+	doc := NewDocument([]Resource{}, Pagination{Number: 1, Size: 50, Total: 0})
+	if doc.Meta["total_pages"] != 0 {
+		t.Fatalf("total_pages = %v, want 0", doc.Meta["total_pages"])
+	}
+	// first/last still point at page 1 so clients have a stable anchor.
+	if doc.Links["first"] == "" || doc.Links["last"] == "" {
+		t.Fatalf("empty set still needs first/last: %v", doc.Links)
+	}
+	if _, ok := doc.Links["next"]; ok {
+		t.Fatalf("empty set must not have next: %v", doc.Links)
+	}
+}
+
+func TestPaginationPreservesExtraQuery(t *testing.T) {
+	q := url.Values{}
+	q.Set("filter", "x")
+	q.Set(PageNumberParam, "5") // should be overwritten
+	doc := NewDocument(nil, Pagination{Number: 1, Size: 2, Total: 4, Query: q})
+	self, err := url.Parse(doc.Links["self"])
+	if err != nil {
+		t.Fatalf("parse self link: %v", err)
+	}
+	got := self.Query()
+	if got.Get("filter") != "x" {
+		t.Fatalf("filter not preserved: %v", got)
+	}
+	if got.Get(PageNumberParam) != "1" {
+		t.Fatalf("page[number] = %q, want 1 (overwritten)", got.Get(PageNumberParam))
+	}
+}
+
+func TestPageParams(t *testing.T) {
+	mk := func(raw string) Page {
+		r := httptest.NewRequest("GET", "/x"+raw, nil)
+		p, err := PageParams(r, 50, 200)
+		if err != nil {
+			t.Fatalf("PageParams(%q): %v", raw, err)
+		}
+		return p
+	}
+	if p := mk(""); p.Number != 1 || p.Size != 50 {
+		t.Fatalf("defaults = %+v, want {1 50}", p)
+	}
+	if p := mk("?page[number]=3&page[size]=10"); p.Number != 3 || p.Size != 10 {
+		t.Fatalf("parsed = %+v, want {3 10}", p)
+	}
+	if p := mk("?page[size]=9999"); p.Size != 200 {
+		t.Fatalf("size cap = %d, want 200", p.Size)
+	}
+	if p := mk("?page[number]=2"); p.Offset() != 50 || p.Limit() != 50 {
+		t.Fatalf("offset/limit = %d/%d, want 50/50", p.Offset(), p.Limit())
+	}
+}
+
+func TestPageParamsInvalid(t *testing.T) {
+	for _, raw := range []string{"?page[number]=0", "?page[number]=-1", "?page[number]=abc", "?page[size]=0", "?page[size]=x"} {
+		r := httptest.NewRequest("GET", "/x"+raw, nil)
+		if _, err := PageParams(r, 50, 200); err == nil {
+			t.Fatalf("PageParams(%q) expected error", raw)
+		}
+	}
+}
+
+func TestWriteSetsContentType(t *testing.T) {
+	rec := httptest.NewRecorder()
+	Write(rec, 200, NewDocument([]Resource{}))
+	if ct := rec.Header().Get("Content-Type"); ct != ContentType {
+		t.Fatalf("Content-Type = %q, want %q", ct, ContentType)
+	}
+}

--- a/api/pkg/org/interfaces/jsonapi/pagination.go
+++ b/api/pkg/org/interfaces/jsonapi/pagination.go
@@ -1,0 +1,125 @@
+package jsonapi
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// Pagination query-parameter names, per the JSON:API recommended
+// page-based profile (https://jsonapi.org/format/#fetching-pagination).
+const (
+	PageNumberParam = "page[number]"
+	PageSizeParam   = "page[size]"
+)
+
+// Page is the parsed, validated pagination request: a 1-based page
+// number and a page size. It carries the offset/limit translation the
+// store layer consumes so handlers never recompute it.
+type Page struct {
+	Number int
+	Size   int
+}
+
+// Offset is the number of rows to skip for this page.
+func (p Page) Offset() int {
+	if p.Number < 1 {
+		return 0
+	}
+	return (p.Number - 1) * p.Size
+}
+
+// Limit is the row cap for this page.
+func (p Page) Limit() int { return p.Size }
+
+// PageParams parses page[number]/page[size] off the request. number
+// defaults to 1, size to defaultSize and is capped at maxSize (when
+// maxSize > 0). Non-numeric or out-of-range (< 1) values are a 400-class
+// error the handler surfaces — an out-of-range *page* (past the last
+// page) is NOT an error here; it simply yields an empty data array.
+func PageParams(r *http.Request, defaultSize, maxSize int) (Page, error) {
+	q := r.URL.Query()
+	number := 1
+	if v := q.Get(PageNumberParam); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			return Page{}, fmt.Errorf("invalid %s %q: must be a positive integer", PageNumberParam, v)
+		}
+		number = n
+	}
+	size := defaultSize
+	if v := q.Get(PageSizeParam); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			return Page{}, fmt.Errorf("invalid %s %q: must be a positive integer", PageSizeParam, v)
+		}
+		size = n
+	}
+	if maxSize > 0 && size > maxSize {
+		size = maxSize
+	}
+	return Page{Number: number, Size: size}, nil
+}
+
+// Pagination is a Component that contributes page-based JSON:API links
+// (self/first/prev/next/last) and pagination meta (page/size/total_pages)
+// to a Document. It is independent of TotalMeta — compose either or both.
+//
+// Links are emitted as query-only relative references (e.g.
+// "?page[number]=2&page[size]=50"). Per RFC 3986 §5 these resolve
+// against the request URL, so they are correct whether the org API is
+// served standalone or mounted behind the helix-embedded prefix-
+// stripping middleware — neither path needs to know its mount point.
+type Pagination struct {
+	Number int        // 1-based current page
+	Size   int        // page size
+	Total  int        // total items across all pages
+	Query  url.Values // request query to preserve in links (page[*] overwritten); may be nil
+}
+
+// Apply writes the pagination links and meta onto the document.
+func (p Pagination) Apply(d *Document) {
+	size := p.Size
+	if size < 1 {
+		size = 1
+	}
+	totalPages := (p.Total + size - 1) / size
+
+	links := d.ensureLinks()
+	links["self"] = p.link(p.Number)
+	links["first"] = p.link(1)
+	last := totalPages
+	if last < 1 {
+		last = 1
+	}
+	links["last"] = p.link(last)
+	if p.Number > 1 {
+		links["prev"] = p.link(p.Number - 1)
+	}
+	if p.Number < totalPages {
+		links["next"] = p.link(p.Number + 1)
+	}
+
+	meta := d.ensureMeta()
+	meta["page"] = p.Number
+	meta["size"] = p.Size
+	meta["total_pages"] = totalPages
+}
+
+// link builds the query-only relative reference for the given page,
+// preserving any non-pagination query params.
+func (p Pagination) link(number int) string {
+	q := url.Values{}
+	for k, vs := range p.Query {
+		if k == PageNumberParam || k == PageSizeParam {
+			continue
+		}
+		for _, v := range vs {
+			q.Add(k, v)
+		}
+	}
+	q.Set(PageNumberParam, strconv.Itoa(number))
+	q.Set(PageSizeParam, strconv.Itoa(p.Size))
+	return "?" + q.Encode()
+}

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -271,6 +271,7 @@ func Routes(deps Deps) []Route {
 		{Pattern: "PUT /streams/{id}", Handler: http.HandlerFunc(a.updateStream)},
 		{Pattern: "DELETE /streams/{id}", Handler: http.HandlerFunc(a.deleteStream)},
 		{Pattern: "GET /streams/{id}/events", Handler: http.HandlerFunc(a.streamEventsSSE)},
+		{Pattern: "GET /streams/{id}/messages", Handler: http.HandlerFunc(a.listStreamMessages)},
 		{Pattern: "POST /streams/{id}/publish", Handler: http.HandlerFunc(a.publishToStream)},
 		// Inbound webhook for the GitHub transport. The transport
 		// resolves orgID from the request context (set by the org

--- a/api/pkg/org/interfaces/server/api/dto.go
+++ b/api/pkg/org/interfaces/server/api/dto.go
@@ -221,6 +221,48 @@ type EventCard struct {
 	MessageBody string `json:"message_body,omitempty"`
 }
 
+// MessageAttributes is the JSON:API `attributes` object for a
+// `messages` resource: the decoded Message envelope plus the event
+// coordinates. Body is the visible text — the parsed Message.Body when
+// the event carries a Message, otherwise the raw stored body.
+type MessageAttributes struct {
+	StreamID   string   `json:"stream_id"`
+	Source     string   `json:"source,omitempty"`
+	CreatedAt  string   `json:"created_at"`
+	From       string   `json:"from,omitempty"`
+	To         []string `json:"to,omitempty"`
+	Subject    string   `json:"subject,omitempty"`
+	Body       string   `json:"body"`
+	HasMessage bool     `json:"has_message"`
+}
+
+// MessageResource is one JSON:API resource object in the messages list.
+type MessageResource struct {
+	Type       string            `json:"type"`
+	ID         string            `json:"id"`
+	Attributes MessageAttributes `json:"attributes"`
+}
+
+// MessagesMeta is the top-level `meta` of the messages document:
+// total item count plus the pagination state.
+type MessagesMeta struct {
+	Total      int `json:"total"`
+	Page       int `json:"page"`
+	Size       int `json:"size"`
+	TotalPages int `json:"total_pages"`
+}
+
+// MessagesDocument is the JSON:API document returned by
+// GET /streams/{id}/messages. It documents the concrete shape the
+// jsonapi composition helpers emit so the generated OpenAPI client has
+// a typed response. Links are page-relative references
+// (self/first/prev/next/last).
+type MessagesDocument struct {
+	Data  []MessageResource `json:"data"`
+	Meta  MessagesMeta      `json:"meta"`
+	Links map[string]string `json:"links,omitempty"`
+}
+
 // WorkerSubscriptionDTO is one row in a worker's subscription list.
 type WorkerSubscriptionDTO struct {
 	StreamID  string `json:"stream_id"`

--- a/api/pkg/org/interfaces/server/api/messages_test.go
+++ b/api/pkg/org/interfaces/server/api/messages_test.go
@@ -1,0 +1,207 @@
+package api_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+	"github.com/helixml/helix/api/pkg/org/domain/transport"
+	"github.com/helixml/helix/api/pkg/org/interfaces/jsonapi"
+	orgapi "github.com/helixml/helix/api/pkg/org/interfaces/server/api"
+)
+
+// seedStreamWithEvents creates a local-transport stream and appends n
+// message events (e-0 oldest … e-(n-1) newest), one minute apart.
+func seedStreamWithEvents(t *testing.T, st *store.Store, id string, n int) {
+	t.Helper()
+	ctx := context.Background()
+	stream, err := streaming.NewStream(
+		streaming.StreamID(id), id, "",
+		"w-owner", time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC),
+		transport.Transport{Kind: transport.KindLocal}, "org-test",
+	)
+	if err != nil {
+		t.Fatalf("new stream: %v", err)
+	}
+	if err := st.Streams.Create(ctx, stream); err != nil {
+		t.Fatalf("create stream: %v", err)
+	}
+	for i := 0; i < n; i++ {
+		body := fmt.Sprintf(`{"from":"w-owner","subject":"s%d","body":"body %d"}`, i, i)
+		ev, err := streaming.NewEvent(
+			streaming.EventID(fmt.Sprintf("e-%d", i)), streaming.StreamID(id),
+			"w-owner", body, time.Date(2026, 5, 22, 12, i, 0, 0, time.UTC), "org-test",
+		)
+		if err != nil {
+			t.Fatalf("new event %d: %v", i, err)
+		}
+		if err := st.Events.Append(ctx, ev); err != nil {
+			t.Fatalf("append event %d: %v", i, err)
+		}
+	}
+}
+
+// TestListStreamMessages_FirstPage pins the JSON:API shape: data is a
+// `messages` array newest-first, meta carries the full total + page
+// state, and the links object has self/first/next/last (no prev on
+// page 1).
+func TestListStreamMessages_FirstPage(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	h := orgapi.Handler(deps)
+	seedStreamWithEvents(t, st, "s-msgs", 5)
+
+	rec := do(t, h, "GET", "/streams/s-msgs/messages?page[size]=2&page[number]=1", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != jsonapi.ContentType {
+		t.Errorf("Content-Type = %q, want %q", ct, jsonapi.ContentType)
+	}
+	var doc orgapi.MessagesDocument
+	decode(t, rec, &doc)
+	if len(doc.Data) != 2 {
+		t.Fatalf("data len = %d, want 2: %+v", len(doc.Data), doc.Data)
+	}
+	if doc.Data[0].Type != "messages" {
+		t.Errorf("type = %q, want messages", doc.Data[0].Type)
+	}
+	// Newest first: e-4 then e-3.
+	if doc.Data[0].ID != "e-4" || doc.Data[1].ID != "e-3" {
+		t.Errorf("ids = [%s %s], want [e-4 e-3]", doc.Data[0].ID, doc.Data[1].ID)
+	}
+	if doc.Data[0].Attributes.Body != "body 4" || doc.Data[0].Attributes.Subject != "s4" {
+		t.Errorf("attrs = %+v, want decoded message", doc.Data[0].Attributes)
+	}
+	if !doc.Data[0].Attributes.HasMessage {
+		t.Error("has_message = false, want true")
+	}
+	if doc.Meta.Total != 5 {
+		t.Errorf("meta.total = %d, want 5", doc.Meta.Total)
+	}
+	if doc.Meta.TotalPages != 3 {
+		t.Errorf("meta.total_pages = %d, want 3", doc.Meta.TotalPages)
+	}
+	if doc.Links["next"] == "" || doc.Links["self"] == "" || doc.Links["last"] == "" {
+		t.Errorf("missing links: %v", doc.Links)
+	}
+	if _, ok := doc.Links["prev"]; ok {
+		t.Errorf("page 1 should have no prev: %v", doc.Links)
+	}
+}
+
+// TestListStreamMessages_LastPartialPage pins the tail: the final page
+// holds the remainder, has prev, and no next. meta.total is unchanged.
+func TestListStreamMessages_LastPartialPage(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	h := orgapi.Handler(deps)
+	seedStreamWithEvents(t, st, "s-msgs", 5)
+
+	rec := do(t, h, "GET", "/streams/s-msgs/messages?page[size]=2&page[number]=3", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body)
+	}
+	var doc orgapi.MessagesDocument
+	decode(t, rec, &doc)
+	if len(doc.Data) != 1 || doc.Data[0].ID != "e-0" {
+		t.Fatalf("data = %+v, want single e-0", doc.Data)
+	}
+	if doc.Meta.Total != 5 {
+		t.Errorf("meta.total = %d, want 5", doc.Meta.Total)
+	}
+	if doc.Links["prev"] == "" {
+		t.Errorf("last page should have prev: %v", doc.Links)
+	}
+	if _, ok := doc.Links["next"]; ok {
+		t.Errorf("last page should have no next: %v", doc.Links)
+	}
+}
+
+// TestListStreamMessages_BeyondLastPage pins that requesting a page past
+// the end returns an empty data array (not an error), with total intact.
+func TestListStreamMessages_BeyondLastPage(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	h := orgapi.Handler(deps)
+	seedStreamWithEvents(t, st, "s-msgs", 3)
+
+	rec := do(t, h, "GET", "/streams/s-msgs/messages?page[size]=2&page[number]=9", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body)
+	}
+	var doc orgapi.MessagesDocument
+	decode(t, rec, &doc)
+	if len(doc.Data) != 0 {
+		t.Fatalf("data = %+v, want empty", doc.Data)
+	}
+	if doc.Meta.Total != 3 {
+		t.Errorf("meta.total = %d, want 3", doc.Meta.Total)
+	}
+}
+
+// TestListStreamMessages_EmptyStream pins total:0 / data:[] for a stream
+// with no messages.
+func TestListStreamMessages_EmptyStream(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	h := orgapi.Handler(deps)
+	seedStreamWithEvents(t, st, "s-empty", 0)
+
+	rec := do(t, h, "GET", "/streams/s-empty/messages", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body)
+	}
+	var doc orgapi.MessagesDocument
+	decode(t, rec, &doc)
+	if len(doc.Data) != 0 {
+		t.Errorf("data = %+v, want empty", doc.Data)
+	}
+	if doc.Meta.Total != 0 {
+		t.Errorf("meta.total = %d, want 0", doc.Meta.Total)
+	}
+}
+
+// TestListStreamMessages_TotalConsistentAcrossPages pins that meta.total
+// is the full count regardless of which page is fetched.
+func TestListStreamMessages_TotalConsistentAcrossPages(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	h := orgapi.Handler(deps)
+	seedStreamWithEvents(t, st, "s-msgs", 5)
+
+	for _, page := range []string{"1", "2", "3"} {
+		rec := do(t, h, "GET", "/streams/s-msgs/messages?page[size]=2&page[number]="+page, nil)
+		var doc orgapi.MessagesDocument
+		decode(t, rec, &doc)
+		if doc.Meta.Total != 5 {
+			t.Errorf("page %s: meta.total = %d, want 5", page, doc.Meta.Total)
+		}
+	}
+}
+
+// TestListStreamMessages_UnknownStream pins 404 for a stream that
+// doesn't exist (rather than an empty 200).
+func TestListStreamMessages_UnknownStream(t *testing.T) {
+	deps, _, _ := newDeps(t)
+	h := orgapi.Handler(deps)
+
+	rec := do(t, h, "GET", "/streams/s-ghost/messages", nil)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", rec.Code, rec.Body)
+	}
+}
+
+// TestListStreamMessages_BadPagingParams pins 400 for non-numeric /
+// out-of-range paging params.
+func TestListStreamMessages_BadPagingParams(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	h := orgapi.Handler(deps)
+	seedStreamWithEvents(t, st, "s-msgs", 2)
+
+	for _, q := range []string{"page[number]=0", "page[number]=abc", "page[size]=-1"} {
+		rec := do(t, h, "GET", "/streams/s-msgs/messages?"+q, nil)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: status got %d, want 400; body=%s", q, rec.Code, rec.Body)
+		}
+	}
+}

--- a/api/pkg/org/interfaces/server/api/streams.go
+++ b/api/pkg/org/interfaces/server/api/streams.go
@@ -14,6 +14,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/streams"
 	"github.com/helixml/helix/api/pkg/org/domain/streaming"
 	"github.com/helixml/helix/api/pkg/org/domain/transport"
+	"github.com/helixml/helix/api/pkg/org/interfaces/jsonapi"
 )
 
 // ---- Streams ------------------------------------------------------------
@@ -392,6 +393,92 @@ func eventCard(ev streaming.Event) EventCard {
 		}
 	}
 	return card
+}
+
+// messageResource maps an Event to a JSON:API `messages` resource.
+// Mirrors eventCard's decode: the parsed Message envelope when the
+// body holds Message JSON, the raw body otherwise.
+func messageResource(ev streaming.Event) jsonapi.Resource {
+	attrs := MessageAttributes{
+		StreamID:  string(ev.StreamID),
+		Source:    string(ev.Source),
+		CreatedAt: ev.CreatedAt.Format(time.RFC3339),
+		Body:      ev.Body,
+	}
+	if msg, err := ev.Message(); err == nil {
+		attrs.HasMessage = true
+		attrs.From = msg.From
+		attrs.To = msg.To
+		attrs.Subject = msg.Subject
+		attrs.Body = msg.Body
+	}
+	return jsonapi.Resource{Type: "messages", ID: string(ev.ID), Attributes: attrs}
+}
+
+const (
+	streamMessagesDefaultPageSize = 50
+	streamMessagesMaxPageSize     = 200
+)
+
+// listStreamMessages returns the messages on one Stream as a paginated
+// JSON:API document, newest first. meta.total carries the full count;
+// links/meta carry the page-based pagination state. The JSON:API
+// document is assembled by composing independent components (TotalMeta,
+// Pagination) — see api/pkg/org/interfaces/jsonapi.
+//
+// @Summary Helix-org: list a stream's messages (JSON:API, paginated)
+// @Tags HelixOrg
+// @Produce application/vnd.api+json
+// @Param id path string true "Stream ID"
+// @Param page[number] query int false "1-based page number (default 1)"
+// @Param page[size] query int false "page size (default 50, max 200)"
+// @Success 200 {object} api.MessagesDocument
+// @Failure 400 {object} api.ErrorResponse
+// @Failure 404 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/streams/{id}/messages [get]
+func (a *apiHandler) listStreamMessages(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	orgID, err := resolveOrgID(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	id := streaming.StreamID(r.PathValue("id"))
+	if id == "" {
+		writeError(w, http.StatusBadRequest, errors.New("stream id is required"))
+		return
+	}
+	page, err := jsonapi.PageParams(r, streamMessagesDefaultPageSize, streamMessagesMaxPageSize)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	// Unknown stream → 404 (don't silently return an empty page).
+	if _, err := a.deps.Queries.GetStream(ctx, orgID, id); err != nil {
+		writeError(w, errStatus(err), fmt.Errorf("get stream %s: %w", id, err))
+		return
+	}
+	total, err := a.deps.Queries.CountStreamEvents(ctx, orgID, id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Errorf("count messages for %s: %w", id, err))
+		return
+	}
+	events, err := a.deps.Queries.PageStreamEvents(ctx, orgID, id, page.Limit(), page.Offset())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, fmt.Errorf("list messages for %s: %w", id, err))
+		return
+	}
+	resources := make([]jsonapi.Resource, 0, len(events))
+	for _, ev := range events {
+		resources = append(resources, messageResource(ev))
+	}
+	doc := jsonapi.NewDocument(
+		resources,
+		jsonapi.TotalMeta{Total: total},
+		jsonapi.Pagination{Number: page.Number, Size: page.Size, Total: total, Query: r.URL.Query()},
+	)
+	jsonapi.Write(w, http.StatusOK, doc)
 }
 
 // streamEventsSSE pushes EventCard JSON arrays on every Hub.Notify.

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -10049,6 +10049,63 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/orgs/{org}/streams/{id}/messages": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: list a stream's messages (JSON:API, paginated)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Stream ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "1-based page number (default 1)",
+                        "name": "page[number]",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "page size (default 50, max 200)",
+                        "name": "page[size]",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.MessagesDocument"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/streams/{id}/publish": {
             "post": {
                 "security": [
@@ -20875,6 +20932,89 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "webhook_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "api.MessageAttributes": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "from": {
+                    "type": "string"
+                },
+                "has_message": {
+                    "type": "boolean"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "stream_id": {
+                    "type": "string"
+                },
+                "subject": {
+                    "type": "string"
+                },
+                "to": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "api.MessageResource": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/api.MessageAttributes"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.MessagesDocument": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.MessageResource"
+                    }
+                },
+                "links": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "meta": {
+                    "$ref": "#/definitions/api.MessagesMeta"
+                }
+            }
+        },
+        "api.MessagesMeta": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "total_pages": {
                     "type": "integer"
                 }
             }

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -10045,6 +10045,63 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/streams/{id}/messages": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: list a stream's messages (JSON:API, paginated)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Stream ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "1-based page number (default 1)",
+                        "name": "page[number]",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "page size (default 50, max 200)",
+                        "name": "page[size]",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.MessagesDocument"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/streams/{id}/publish": {
             "post": {
                 "security": [
@@ -20871,6 +20928,89 @@
                     "type": "string"
                 },
                 "webhook_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "api.MessageAttributes": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "from": {
+                    "type": "string"
+                },
+                "has_message": {
+                    "type": "boolean"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "stream_id": {
+                    "type": "string"
+                },
+                "subject": {
+                    "type": "string"
+                },
+                "to": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "api.MessageResource": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/api.MessageAttributes"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.MessagesDocument": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.MessageResource"
+                    }
+                },
+                "links": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "meta": {
+                    "$ref": "#/definitions/api.MessagesMeta"
+                }
+            }
+        },
+        "api.MessagesMeta": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "total_pages": {
                     "type": "integer"
                 }
             }

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -178,6 +178,60 @@ definitions:
       webhook_id:
         type: integer
     type: object
+  api.MessageAttributes:
+    properties:
+      body:
+        type: string
+      created_at:
+        type: string
+      from:
+        type: string
+      has_message:
+        type: boolean
+      source:
+        type: string
+      stream_id:
+        type: string
+      subject:
+        type: string
+      to:
+        items:
+          type: string
+        type: array
+    type: object
+  api.MessageResource:
+    properties:
+      attributes:
+        $ref: '#/definitions/api.MessageAttributes'
+      id:
+        type: string
+      type:
+        type: string
+    type: object
+  api.MessagesDocument:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.MessageResource'
+        type: array
+      links:
+        additionalProperties:
+          type: string
+        type: object
+      meta:
+        $ref: '#/definitions/api.MessagesMeta'
+    type: object
+  api.MessagesMeta:
+    properties:
+      page:
+        type: integer
+      size:
+        type: integer
+      total:
+        type: integer
+      total_pages:
+        type: integer
+    type: object
   api.OrgOverview:
     properties:
       groups:
@@ -18020,6 +18074,42 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: 'Helix-org: live webhook status for a github stream'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/streams/{id}/messages:
+    get:
+      parameters:
+      - description: Stream ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: 1-based page number (default 1)
+        in: query
+        name: page[number]
+        type: integer
+      - description: page size (default 50, max 200)
+        in: query
+        name: page[size]
+        type: integer
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.MessagesDocument'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: list a stream''s messages (JSON:API, paginated)'
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/streams/{id}/publish:

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -141,6 +141,36 @@ export interface ApiInstallGitHubWebhookResponse {
   webhook_id?: number;
 }
 
+export interface ApiMessageAttributes {
+  body?: string;
+  created_at?: string;
+  from?: string;
+  has_message?: boolean;
+  source?: string;
+  stream_id?: string;
+  subject?: string;
+  to?: string[];
+}
+
+export interface ApiMessageResource {
+  attributes?: ApiMessageAttributes;
+  id?: string;
+  type?: string;
+}
+
+export interface ApiMessagesDocument {
+  data?: ApiMessageResource[];
+  links?: Record<string, string>;
+  meta?: ApiMessagesMeta;
+}
+
+export interface ApiMessagesMeta {
+  page?: number;
+  size?: number;
+  total?: number;
+  total_pages?: number;
+}
+
 export interface ApiOrgOverview {
   groups?: ApiRoleGroup[];
   roles?: ApiRoleBadge[];
@@ -12164,6 +12194,35 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       this.request<ApiGitHubWebhookStatusResponse, ApiErrorResponse>({
         path: `/api/v1/orgs/${org}/streams/${id}/github/webhook-status`,
         method: "GET",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsStreamsMessagesDetail
+     * @summary Helix-org: list a stream's messages (JSON:API, paginated)
+     * @request GET:/api/v1/orgs/{org}/streams/{id}/messages
+     * @secure
+     */
+    v1OrgsStreamsMessagesDetail: (
+      id: string,
+      org: string,
+      query?: {
+        /** 1-based page number (default 1) */
+        "page[number]"?: number;
+        /** page size (default 50, max 200) */
+        "page[size]"?: number;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<ApiMessagesDocument, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/streams/${id}/messages`,
+        method: "GET",
+        query: query,
         secure: true,
         format: "json",
         ...params,

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -178,6 +178,60 @@ definitions:
       webhook_id:
         type: integer
     type: object
+  api.MessageAttributes:
+    properties:
+      body:
+        type: string
+      created_at:
+        type: string
+      from:
+        type: string
+      has_message:
+        type: boolean
+      source:
+        type: string
+      stream_id:
+        type: string
+      subject:
+        type: string
+      to:
+        items:
+          type: string
+        type: array
+    type: object
+  api.MessageResource:
+    properties:
+      attributes:
+        $ref: '#/definitions/api.MessageAttributes'
+      id:
+        type: string
+      type:
+        type: string
+    type: object
+  api.MessagesDocument:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/api.MessageResource'
+        type: array
+      links:
+        additionalProperties:
+          type: string
+        type: object
+      meta:
+        $ref: '#/definitions/api.MessagesMeta'
+    type: object
+  api.MessagesMeta:
+    properties:
+      page:
+        type: integer
+      size:
+        type: integer
+      total:
+        type: integer
+      total_pages:
+        type: integer
+    type: object
   api.OrgOverview:
     properties:
       groups:
@@ -18020,6 +18074,42 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: 'Helix-org: live webhook status for a github stream'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/streams/{id}/messages:
+    get:
+      parameters:
+      - description: Stream ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: 1-based page number (default 1)
+        in: query
+        name: page[number]
+        type: integer
+      - description: page size (default 50, max 200)
+        in: query
+        name: page[size]
+        type: integer
+      produces:
+      - application/vnd.api+json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.MessagesDocument'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: list a stream''s messages (JSON:API, paginated)'
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/streams/{id}/publish:

--- a/swagger.json
+++ b/swagger.json
@@ -10045,6 +10045,63 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/streams/{id}/messages": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/vnd.api+json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: list a stream's messages (JSON:API, paginated)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Stream ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "1-based page number (default 1)",
+                        "name": "page[number]",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "page size (default 50, max 200)",
+                        "name": "page[size]",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.MessagesDocument"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/streams/{id}/publish": {
             "post": {
                 "security": [
@@ -20871,6 +20928,89 @@
                     "type": "string"
                 },
                 "webhook_id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "api.MessageAttributes": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "from": {
+                    "type": "string"
+                },
+                "has_message": {
+                    "type": "boolean"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "stream_id": {
+                    "type": "string"
+                },
+                "subject": {
+                    "type": "string"
+                },
+                "to": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "api.MessageResource": {
+            "type": "object",
+            "properties": {
+                "attributes": {
+                    "$ref": "#/definitions/api.MessageAttributes"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.MessagesDocument": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.MessageResource"
+                    }
+                },
+                "links": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "meta": {
+                    "$ref": "#/definitions/api.MessagesMeta"
+                }
+            }
+        },
+        "api.MessagesMeta": {
+            "type": "object",
+            "properties": {
+                "page": {
+                    "type": "integer"
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                },
+                "total_pages": {
                     "type": "integer"
                 }
             }


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/orgs/{org}/streams/{id}/messages` to the helix-org REST surface:
a [jsonapi.org](https://jsonapi.org)-formatted, paginated list of the messages in
a stream, newest first. The top-level `meta` carries the total item count and the
page state; `links` carry page-based navigation (self/first/prev/next/last).

The JSON:API plumbing is built as a small, **composition-first** toolkit in a new
`api/pkg/org/interfaces/jsonapi` package (the codebase had no JSON:API helpers).
A document is assembled by applying independent components, so meta and pagination
are separate, reusable units rather than fields baked into one bespoke response:

```go
doc := jsonapi.NewDocument(resources,
    jsonapi.TotalMeta{Total: total},                                   // meta via composition
    jsonapi.Pagination{Number: page.Number, Size: page.Size, Total: total, Query: r.URL.Query()}, // pagination via composition
)
jsonapi.Write(w, http.StatusOK, doc)
```

## Changes

- **New `jsonapi` package** (`api/pkg/org/interfaces/jsonapi`): `Document`/`Meta`/
  `Links`, a `Component` interface + `NewDocument(data, components...)`, the
  `TotalMeta` and `Pagination` components, a `Page`/`PageParams` query parser
  (`page[number]`/`page[size]`), and `Write` (sets `application/vnd.api+json`).
- **Endpoint**: `listStreamMessages` handler + `GET /streams/{id}/messages` route,
  with `MessageResource`/`MessageAttributes`/`MessagesDocument` DTOs and a
  `messageResource` mapper that decodes the canonical `streaming.Message`.
- **Store**: added `WithOffset` query option (+ apply), a generic
  `Repository.Count`, and `Events.PageForStream`/`Events.CountForStream` on both
  the gorm and memory backends. Facade gains `PageStreamEvents`/`CountStreamEvents`.
- **Generated**: regenerated `swagger.json`/`swagger.yaml` and the TS API client.
- **Tests**: jsonapi unit tests (composition, total, pagination links at
  first/middle/last/out-of-range, empty set, query preservation); store
  pagination/count tests; handler tests (first page, partial last page,
  beyond-last, empty stream, unknown stream 404, bad paging 400, total across pages).

## Design notes

- **Page-number pagination** (not cursor): supports `meta.total`/`total_pages`
  and maps cleanly to offset/limit.
- **Query-only relative links** (e.g. `?page[number]=2&page[size]=50`): per
  RFC 3986 these resolve against the request URL, so links are correct whether
  the org API runs standalone or embedded behind the prefix-stripping middleware,
  without the org package depending on the server package.

## Verification

`go build ./...` clean; full `pkg/org/...` suite green. Verified live in the inner
Helix: published 5 messages and paged through `/messages` — newest-first data,
`meta.total=5`/`total_pages=3`, correct boundary links, 404 on unknown stream,
400 on `page[number]=0`.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kv88n8adm098s6byr23w38dc)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002118_expose-a-new-rest-api/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002118_expose-a-new-rest-api/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002118_expose-a-new-rest-api/tasks.md)

🚀 Built with [Helix](https://helix.ml)