### PR TITLE
feat(org): implement Slack transport with REST/Socket ingest and OAuth install

### DIFF
--- a/api/pkg/org/application/dispatch/dispatcher.go
+++ b/api/pkg/org/application/dispatch/dispatcher.go
@@ -129,6 +129,34 @@ func (d *Dispatcher) DispatchManual(_ context.Context, orgID string, workerID or
 // a time in arrival order; outbound POSTs have no such ordering
 // guarantee.
 func (d *Dispatcher) Dispatch(ctx context.Context, e streaming.Event) {
+	subs, err := d.store.Subscriptions.ListForStream(ctx, e.OrganizationID, e.StreamID)
+	if err != nil {
+		// Still attempt outbound emission (DispatchTo does it) even when
+		// the subscription list fails — keep the two side effects
+		// independent. Pass no targets so fan-out is a no-op.
+		d.logger.Error("dispatch: list subscriptions", "stream", e.StreamID, "err", err)
+		d.DispatchTo(ctx, e, nil)
+		return
+	}
+	targets := make([]orgchart.WorkerID, 0, len(subs))
+	for _, sub := range subs {
+		targets = append(targets, orgchart.WorkerID(sub.WorkerID))
+	}
+	d.DispatchTo(ctx, e, targets)
+}
+
+// DispatchTo is the fan-out seam: it emits the Stream's outbound
+// traffic (always) and activates exactly the named target Workers
+// (subject to the same publisher-skip, AI-only, and source-kind rules
+// as the broadcast path). Dispatch computes `targets` as every
+// subscriber; the Slack ingest narrows them through a Router first
+// (§9.4). A target not subscribed/known is skipped with a warning, so a
+// Router can only ever restrict the subscriber set, never invent a
+// recipient outside it.
+//
+// Returns immediately. Each fan-out target runs on the per-Worker queue;
+// outbound POSTs have no ordering guarantee.
+func (d *Dispatcher) DispatchTo(ctx context.Context, e streaming.Event, targets []orgchart.WorkerID) {
 	orgID := e.OrganizationID
 	d.emitOutbound(ctx, e)
 	// Parse the canonical Message envelope. Every production write
@@ -143,11 +171,6 @@ func (d *Dispatcher) Dispatch(ctx context.Context, e streaming.Event) {
 		d.logger.Error("dispatch: parse message — skipping fan-out", "event", e.ID, "err", err)
 		return
 	}
-	subs, err := d.store.Subscriptions.ListForStream(ctx, orgID, e.StreamID)
-	if err != nil {
-		d.logger.Error("dispatch: list subscriptions", "stream", e.StreamID, "err", err)
-		return
-	}
 	// Resolve the publishing Worker's kind once so every fan-out target
 	// gets the same source_kind on its Trigger. Empty Source (system or
 	// transport inbound) leaves SourceKind empty — agent.md treats that
@@ -158,12 +181,10 @@ func (d *Dispatcher) Dispatch(ctx context.Context, e streaming.Event) {
 			sourceKind = sourceWorker.Kind()
 		}
 	}
-	// Subscriptions are worker-anchored: each subscription names the
-	// AI worker to activate directly. A subscription pointing at a
-	// fired worker silently dispatches to nobody (the row is dropped
-	// on fire — see lifecycle.Fire).
-	for _, sub := range subs {
-		workerID := orgchart.WorkerID(sub.WorkerID)
+	// Targets are worker-anchored: each names the AI worker to activate
+	// directly. A target pointing at a fired worker silently dispatches
+	// to nobody (the row is dropped on fire — see lifecycle.Fire).
+	for _, workerID := range targets {
 		if string(workerID) == string(e.Source) {
 			continue // do not deliver the event back to its publisher
 		}

--- a/api/pkg/org/application/dispatch/dispatcher_test.go
+++ b/api/pkg/org/application/dispatch/dispatcher_test.go
@@ -534,6 +534,52 @@ func TestDispatchSkipsPublisher(t *testing.T) {
 	}
 }
 
+// TestDispatchToRestrictsFanOut proves DispatchTo activates only the
+// named targets — not every subscriber — while still emitting outbound.
+// This is the seam the Slack ingest uses to route to a Router-selected
+// subset (§9.4).
+func TestDispatchToRestrictsFanOut(t *testing.T) {
+	t.Parallel()
+	d, s, rec := newDispatcherWithSpawner(t)
+	seedWebhookStream(t, s, "s-team", transport.Transport{Kind: transport.KindLocal})
+	seedAIWorker(t, s, "w-a")
+	seedAIWorker(t, s, "w-b")
+	seedAIWorker(t, s, "w-c")
+	seedSubscription(t, s, "w-a", "s-team")
+	seedSubscription(t, s, "w-b", "s-team")
+	seedSubscription(t, s, "w-c", "s-team")
+
+	e := makeEvent(t, "s-team", `{"body":"hi"}`)
+	// Route to only w-b even though all three are subscribed.
+	d.DispatchTo(context.Background(), e, []orgchart.WorkerID{"w-b"})
+
+	got := drainActivations(t, rec, 0)
+	if len(got) != 1 || got[0].WorkerID != "w-b" {
+		t.Fatalf("DispatchTo activated %+v, want only w-b", got)
+	}
+}
+
+// TestDispatchBroadcastsToAllSubscribers proves the unchanged Dispatch
+// path still fans out to every subscriber (the broadcast default the
+// non-Slack transports rely on).
+func TestDispatchBroadcastsToAllSubscribers(t *testing.T) {
+	t.Parallel()
+	d, s, rec := newDispatcherWithSpawner(t)
+	seedWebhookStream(t, s, "s-team", transport.Transport{Kind: transport.KindLocal})
+	seedAIWorker(t, s, "w-a")
+	seedAIWorker(t, s, "w-b")
+	seedSubscription(t, s, "w-a", "s-team")
+	seedSubscription(t, s, "w-b", "s-team")
+
+	e := makeEvent(t, "s-team", `{"body":"hi"}`)
+	d.Dispatch(context.Background(), e)
+
+	got := drainActivations(t, rec, 0)
+	if len(got) != 2 {
+		t.Fatalf("Dispatch activated %d workers, want 2 (broadcast)", len(got))
+	}
+}
+
 // TestDispatchAttachesSourceKind pins that the dispatcher resolves the
 // Source Worker's WorkerKind and threads it onto the Trigger so the
 // activation prompt (rendered by spawner.renderTrigger) can surface

--- a/api/pkg/org/domain/transport/slack.go
+++ b/api/pkg/org/domain/transport/slack.go
@@ -1,0 +1,81 @@
+package transport
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// KindSlack binds a Stream to a single Slack channel within its org's
+// installed Slack workspace. The three tenancy layers live apart:
+//
+//   - The global Slack *app* (client id/secret, signing secret, app
+//     token, ingress-mode toggle) is an admin-configured OAuthProvider
+//     row, instance-wide.
+//   - The per-org *installation* (bot token + team id) lives in the
+//     operational config registry under `transport.slack`.
+//   - This per-stream config carries only the channel binding.
+//
+// Inbound: Slack delivers channel messages over one shared ingest path
+// (REST Events API or Socket Mode — operator's choice). The ingest
+// routes team_id → org, drops the bot's own events, then fans the
+// message out to every Stream in that org whose SlackConfig.Channel
+// matches.
+//
+// Outbound: a Worker's publish to a slack Stream becomes a
+// chat.postMessage under the Worker's persona (name + avatar) through
+// the org's shared bot.
+//
+// See design/2026-06-16-helix-org-slack-stream.md.
+const KindSlack Kind = "slack"
+
+// SlackConfig is the parsed shape of Transport.Config when
+// Kind == KindSlack. Workspace credentials are not here — they live at
+// the per-org install layer (configregistry `transport.slack`); this is
+// purely the channel binding.
+type SlackConfig struct {
+	// Channel is the Slack channel id (e.g. "C0123ABCD") this Stream is
+	// bound to. Required. Inbound messages in this channel fan out to
+	// the Stream's subscribers; outbound publishes post here.
+	Channel string `json:"channel,omitempty"`
+}
+
+// Validate enforces that a channel is set. The channel id format is not
+// pinned — Slack mints opaque ids and we route on exact match, so a
+// non-empty value is the only invariant.
+func (c SlackConfig) Validate() error {
+	if c.Channel == "" {
+		return errors.New("slack transport: channel is required")
+	}
+	return nil
+}
+
+// SlackConfig parses t.Config as a SlackConfig. Same shape and
+// semantics as the other per-Kind accessors.
+func (t Transport) SlackConfig() (SlackConfig, error) {
+	if t.Kind != KindSlack {
+		return SlackConfig{}, fmt.Errorf("transport kind is %q, not slack", t.Kind)
+	}
+	return parseSlackConfig(t.Config)
+}
+
+// slack is the Strategy for KindSlack.
+type slack struct{}
+
+// ParseConfig satisfies Strategy.
+func (slack) ParseConfig(raw json.RawMessage) (Config, error) {
+	c, err := parseSlackConfig(raw)
+	return c, err
+}
+
+// parseSlackConfig is the typed parser.
+func parseSlackConfig(raw json.RawMessage) (SlackConfig, error) {
+	var c SlackConfig
+	if len(raw) == 0 {
+		return c, nil
+	}
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return SlackConfig{}, fmt.Errorf("parse slack config: %w", err)
+	}
+	return c, nil
+}

--- a/api/pkg/org/domain/transport/slack_test.go
+++ b/api/pkg/org/domain/transport/slack_test.go
@@ -1,0 +1,106 @@
+// Slack transport domain tests. The Slack Kind binds a Stream to a
+// single Slack channel; per-stream config carries just the channel id
+// (workspace credentials live at the per-org install layer, the global
+// app at the OAuthProvider layer — see
+// design/2026-06-16-helix-org-slack-stream.md §9.2). These tests pin
+// the same surface the other Kinds pin: Validate rules, the typed
+// accessor round-trip, and KindSlack's place in the canonical order.
+package transport_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/org/domain/transport"
+)
+
+func TestTransportValidate_Slack(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		cfg     string
+		wantErr string
+	}{
+		{"valid channel id", `{"channel":"C0123ABCD"}`, ""},
+		{"valid channel id lowercase", `{"channel":"c0123abcd"}`, ""},
+
+		{"missing channel (no config)", "", "channel is required"},
+		{"empty channel", `{"channel":""}`, "channel is required"},
+		{"malformed json", `{not json`, "parse slack config"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tr := transport.Transport{Kind: transport.KindSlack}
+			if tc.cfg != "" {
+				tr.Config = json.RawMessage(tc.cfg)
+			}
+			err := tr.Validate()
+			assertError(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestSlackConfigParse_RejectsWrongKind(t *testing.T) {
+	t.Parallel()
+	_, err := transport.Transport{Kind: transport.KindLocal}.SlackConfig()
+	if err == nil {
+		t.Fatalf("expected error parsing local transport as slack")
+	}
+}
+
+func TestSlackConfigParse_EmptyConfigReturnsZeroValue(t *testing.T) {
+	t.Parallel()
+	c, err := transport.Transport{Kind: transport.KindSlack}.SlackConfig()
+	if err != nil {
+		t.Fatalf("SlackConfig() = %v, want nil", err)
+	}
+	if c.Channel != "" {
+		t.Fatalf("Channel = %q, want empty", c.Channel)
+	}
+}
+
+func TestSlackConfigParse_PopulatedConfigRoundTrips(t *testing.T) {
+	t.Parallel()
+	raw := json.RawMessage(`{"channel":"C0123ABCD"}`)
+	c, err := transport.Transport{Kind: transport.KindSlack, Config: raw}.SlackConfig()
+	if err != nil {
+		t.Fatalf("SlackConfig() = %v", err)
+	}
+	if c.Channel != "C0123ABCD" {
+		t.Fatalf("Channel = %q", c.Channel)
+	}
+}
+
+func TestSlackConfigParse_UnknownFieldsIgnored(t *testing.T) {
+	t.Parallel()
+	raw := json.RawMessage(`{"channel":"C1","future":"ignored"}`)
+	c, err := transport.Transport{Kind: transport.KindSlack, Config: raw}.SlackConfig()
+	if err != nil {
+		t.Fatalf("SlackConfig() = %v", err)
+	}
+	if c.Channel != "C1" {
+		t.Fatalf("Channel = %q", c.Channel)
+	}
+}
+
+func TestSlackConfigParse_MalformedJSONFails(t *testing.T) {
+	t.Parallel()
+	raw := json.RawMessage(`{not json`)
+	_, err := transport.Transport{Kind: transport.KindSlack, Config: raw}.SlackConfig()
+	assertError(t, err, "parse slack config")
+}
+
+// TestTransportKindValues_IncludesSlack pins KindSlack's membership and
+// canonical position (last — added after cron). The bare
+// TestTransportKindValues_ListsEveryKnownKind in transport_test.go
+// keeps the full ordered list; this one isolates the slack addition.
+func TestTransportKindValues_IncludesSlack(t *testing.T) {
+	t.Parallel()
+	got := transport.KindValues()
+	if len(got) == 0 || got[len(got)-1] != transport.KindSlack {
+		t.Fatalf("KindValues() = %v, want KindSlack last", got)
+	}
+}

--- a/api/pkg/org/domain/transport/transport.go
+++ b/api/pkg/org/domain/transport/transport.go
@@ -62,7 +62,7 @@ type Config interface {
 // the system. The order is part of the public surface — it shows up
 // in JSON Schema enum lists, in "(valid: …)" error messages, and in
 // the MCP create_stream tool description. Tests pin it explicitly.
-var kindOrder = []Kind{KindLocal, KindWebhook, KindEmail, KindGitHub, KindCron}
+var kindOrder = []Kind{KindLocal, KindWebhook, KindEmail, KindGitHub, KindCron, KindSlack}
 
 // strategies registers every known Kind's Strategy. Adding a new Kind
 // means adding a new file in this package that defines its Kind
@@ -75,6 +75,7 @@ var strategies = map[Kind]Strategy{
 	KindEmail:   email{},
 	KindGitHub:  github{},
 	KindCron:    cron{},
+	KindSlack:   slack{},
 }
 
 // KindValues lists every registered Kind in canonical display order

--- a/api/pkg/org/domain/transport/transport_test.go
+++ b/api/pkg/org/domain/transport/transport_test.go
@@ -188,7 +188,8 @@ func TestTransportValidate_UnknownKindFails(t *testing.T) {
 		!strings.Contains(err.Error(), `"webhook"`) ||
 		!strings.Contains(err.Error(), `"email"`) ||
 		!strings.Contains(err.Error(), `"github"`) ||
-		!strings.Contains(err.Error(), `"cron"`) {
+		!strings.Contains(err.Error(), `"cron"`) ||
+		!strings.Contains(err.Error(), `"slack"`) {
 		t.Fatalf("unknown-kind error should list every valid kind; got %q", err)
 	}
 }
@@ -439,6 +440,7 @@ func TestTransportKindValues_ListsEveryKnownKind(t *testing.T) {
 		transport.KindEmail,
 		transport.KindGitHub,
 		transport.KindCron,
+		transport.KindSlack,
 	}
 	if len(got) != len(want) {
 		t.Fatalf("TransportKindValues() length = %d, want %d (%v)", len(got), len(want), got)

--- a/api/pkg/org/infrastructure/transports/slack/client.go
+++ b/api/pkg/org/infrastructure/transports/slack/client.go
@@ -1,0 +1,16 @@
+package slack
+
+import "github.com/slack-go/slack"
+
+// newSlackClient builds a slack-go client for a given bot token. apiURL
+// overrides the Slack API base (must end in "/"); empty uses the real
+// slack.com endpoint. Tests point apiURL at an httptest.Server standing
+// in for slack.com. This is the one place the underlying SDK is
+// constructed, so the API base override is threaded uniformly through
+// every caller (outbound, provisioner, oauth).
+func newSlackClient(token, apiURL string) *slack.Client {
+	if apiURL != "" {
+		return slack.New(token, slack.OptionAPIURL(apiURL))
+	}
+	return slack.New(token)
+}

--- a/api/pkg/org/infrastructure/transports/slack/config.go
+++ b/api/pkg/org/infrastructure/transports/slack/config.go
@@ -1,0 +1,80 @@
+// Package slack implements helix-org's Slack transport. It binds
+// helix-org Streams to Slack channels and gives Workers a way to post
+// to and receive from those channels as personas of a single shared
+// per-org bot.
+//
+// Three tenancy layers, three storage homes
+// (design/2026-06-16-helix-org-slack-stream.md §9.2):
+//
+//   - Global app (instance-wide, admin): client id/secret, signing
+//     secret, app-level token, ingress-mode toggle — an
+//     OAuthProvider(type=slack) row, read through the GlobalApp port.
+//   - Per-org install: bot token (xoxb-…) + team id — the operational
+//     config registry key `transport.slack` (this file's Config).
+//   - Channel binding: one Slack channel id — per-stream
+//     transport.SlackConfig.
+//
+// Inbound flows through one shared path (ingest.Receive) fed by either
+// the REST Events API source or the Socket Mode source. Outbound is
+// ingress-agnostic: the dispatcher emits a chat.postMessage per
+// appended Event on a KindSlack stream.
+package slack
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+)
+
+// nowUTC returns the current wall-clock time in UTC. Matches the helper
+// convention the other transports use; trivial to override in a test if
+// a deterministic timestamp is ever needed.
+func nowUTC() time.Time { return time.Now().UTC() }
+
+// configKey is the operational-config registry key under which each
+// org's Slack installation (bot token + team id) is stored.
+const configKey = "transport.slack"
+
+// Config is the parsed shape of the per-org operational-config row
+// `transport.slack`. Read on every operation so an install (or a
+// re-install via OAuth) takes effect without a restart.
+type Config struct {
+	// BotToken is the org's bot user OAuth token (xoxb-…), minted when
+	// the org installed the global app into its workspace. Used as the
+	// auth token for every outbound chat.postMessage and for membership
+	// checks. Secret — redacted/encrypted at the registry layer.
+	BotToken string `json:"bot_token"`
+
+	// TeamID is the Slack workspace/team id (T0123…). It is the routing
+	// key the inbound ingest uses to map a delivery back to this org
+	// (FR-17). Exactly one org owns a given team id (one workspace per
+	// org — §6 Out of Scope).
+	TeamID string `json:"team_id"`
+}
+
+// Validate enforces both fields are present. A row missing either is
+// an incomplete install and the transport treats the org as not
+// connected.
+func (c Config) Validate() error {
+	if c.BotToken == "" {
+		return errors.New("bot_token is empty")
+	}
+	if c.TeamID == "" {
+		return errors.New("team_id is empty")
+	}
+	return nil
+}
+
+// readConfig loads and validates the per-org install config.
+func readConfig(ctx context.Context, reg *configregistry.Registry, orgID string) (Config, error) {
+	var c Config
+	if err := reg.GetObject(ctx, orgID, configKey, &c); err != nil {
+		return Config{}, err
+	}
+	if err := c.Validate(); err != nil {
+		return Config{}, err
+	}
+	return c, nil
+}

--- a/api/pkg/org/infrastructure/transports/slack/events_api.go
+++ b/api/pkg/org/infrastructure/transports/slack/events_api.go
@@ -1,0 +1,155 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+)
+
+// SigningSecretFunc resolves the global Slack app's signing secret (the
+// REST-mode request-authenticity key, NFR-4). Backed by the GlobalApp
+// port at the composition root. Returning empty string + nil error
+// means "no app configured" — the handler treats that as inert and
+// rejects deliveries (FR-3).
+type SigningSecretFunc func(ctx context.Context) (string, error)
+
+// EventsAPI is the REST ingress source (Slack Events API). It verifies
+// the request signature against the global app's signing secret,
+// answers the url_verification handshake, and forwards real events to
+// the shared ingest path. One handler serves every per-org install;
+// routing to the right org happens downstream in the ingest, keyed on
+// team_id (FR-17).
+type EventsAPI struct {
+	receiver      Receiver
+	signingSecret SigningSecretFunc
+	logger        *slog.Logger
+}
+
+// NewEventsAPI builds the REST source.
+func NewEventsAPI(r Receiver, signingSecret SigningSecretFunc, logger *slog.Logger) *EventsAPI {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &EventsAPI{receiver: r, signingSecret: signingSecret, logger: logger}
+}
+
+// maxBody caps the inbound body size. Slack event payloads are small;
+// 1 MiB is generous.
+const maxBody = 1 << 20
+
+// Handler returns the http.Handler Slack POSTs events to.
+//
+// Status codes:
+//   - 405 on non-POST
+//   - 503 when no global app / signing secret is configured (inert; FR-3)
+//   - 401 on missing, malformed, stale, or mismatched signature (NFR-4)
+//   - 400 on an unparseable body
+//   - 200 on the url_verification challenge (body = challenge) and on
+//     every accepted event (Slack needs a prompt 2xx or it retries)
+func (e *EventsAPI) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		secret, err := e.signingSecret(r.Context())
+		if err != nil || secret == "" {
+			// No global app configured: the subsystem is inert. Reject so
+			// a misconfigured Slack app subscription doesn't look healthy.
+			e.logger.Info("slack.events: no signing secret — inert", "err", err)
+			http.Error(w, "slack not configured", http.StatusServiceUnavailable)
+			return
+		}
+
+		body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxBody))
+		if err != nil {
+			http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		// Signature first — fail closed before parsing an adversarial body.
+		// NewSecretsVerifier also enforces the 5-minute timestamp window,
+		// so a replayed (stale) delivery is rejected here too.
+		verifier, err := slack.NewSecretsVerifier(r.Header, secret)
+		if err != nil {
+			e.logger.Warn("slack.events: build verifier", "err", err)
+			http.Error(w, "invalid signature", http.StatusUnauthorized)
+			return
+		}
+		if _, err := verifier.Write(body); err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		if err := verifier.Ensure(); err != nil {
+			e.logger.Warn("slack.events: bad signature", "err", err)
+			http.Error(w, "invalid signature", http.StatusUnauthorized)
+			return
+		}
+
+		// url_verification handshake — Slack signs it too, so we only
+		// reach here after the signature check. Echo the challenge.
+		var probe struct {
+			Type      string `json:"type"`
+			Challenge string `json:"challenge"`
+		}
+		if err := json.Unmarshal(body, &probe); err != nil {
+			http.Error(w, "parse body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if probe.Type == slackevents.URLVerification {
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte(probe.Challenge))
+			return
+		}
+
+		parsed, err := slackevents.ParseEvent(body, slackevents.OptionNoVerifyToken())
+		if err != nil {
+			e.logger.Warn("slack.events: parse event", "err", err)
+			http.Error(w, "parse event: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if parsed.Type == slackevents.CallbackEvent {
+			if ev, ok := toIngestEvent(parsed.InnerEvent.Data); ok {
+				if err := e.receiver.Receive(r.Context(), parsed.TeamID, ev); err != nil {
+					e.logger.Error("slack.events: ingest", "team", parsed.TeamID, "err", err)
+					// Still answer 2xx so Slack doesn't retry — the failure
+					// is on our side and retrying won't fix it.
+				}
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+// toIngestEvent normalises a parsed inner event into the transport-
+// neutral Event the ingest consumes. Only message-bearing events
+// (message, app_mention) map; everything else is ignored (ok=false).
+func toIngestEvent(inner any) (Event, bool) {
+	switch m := inner.(type) {
+	case *slackevents.MessageEvent:
+		return Event{
+			Channel:  m.Channel,
+			User:     m.User,
+			Text:     m.Text,
+			TS:       m.TimeStamp,
+			ThreadTS: m.ThreadTimeStamp,
+			BotID:    m.BotID,
+		}, true
+	case *slackevents.AppMentionEvent:
+		return Event{
+			Channel:  m.Channel,
+			User:     m.User,
+			Text:     m.Text,
+			TS:       m.TimeStamp,
+			ThreadTS: m.ThreadTimeStamp,
+			BotID:    m.BotID,
+		}, true
+	default:
+		return Event{}, false
+	}
+}

--- a/api/pkg/org/infrastructure/transports/slack/events_api_test.go
+++ b/api/pkg/org/infrastructure/transports/slack/events_api_test.go
@@ -25,7 +25,9 @@ import (
 	slacktransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/slack"
 )
 
-const testSigningSecret = "8f742231b10e8888abcd99yyyzzz85a5"
+// Not a real secret — just an HMAC key for the signature round-trip below.
+// Kept low-entropy and obviously-fake so the secret scanner doesn't flag it.
+const testSigningSecret = "test-slack-signing-secret-fake"
 
 // recordingReceiver captures Receive calls for the REST/Socket tests.
 type recordingReceiver struct {

--- a/api/pkg/org/infrastructure/transports/slack/events_api_test.go
+++ b/api/pkg/org/infrastructure/transports/slack/events_api_test.go
@@ -1,0 +1,237 @@
+// REST source tests (Slack Events API), §9.1 / FR-14 / NFR-4. The
+// handler verifies the request signature against the global app's
+// signing secret, answers the url_verification challenge, and forwards
+// real events to the shared ingest path. These tests drive it through
+// an httptest.Server against a fake Receiver so the REST seam is
+// exercised independently of the DB-backed ingest.
+package slack_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	slacktransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/slack"
+)
+
+const testSigningSecret = "8f742231b10e8888abcd99yyyzzz85a5"
+
+// recordingReceiver captures Receive calls for the REST/Socket tests.
+type recordingReceiver struct {
+	mu    sync.Mutex
+	teams []string
+	evs   []slacktransport.Event
+}
+
+func (r *recordingReceiver) Receive(_ context.Context, teamID string, ev slacktransport.Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.teams = append(r.teams, teamID)
+	r.evs = append(r.evs, ev)
+	return nil
+}
+
+func (r *recordingReceiver) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.evs)
+}
+
+func (r *recordingReceiver) last() (string, slacktransport.Event) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.evs) == 0 {
+		return "", slacktransport.Event{}
+	}
+	return r.teams[len(r.teams)-1], r.evs[len(r.evs)-1]
+}
+
+// signSlack computes the X-Slack-Signature header for a body+timestamp.
+func signSlack(secret string, ts int64, body []byte) string {
+	base := fmt.Sprintf("v0:%d:%s", ts, body)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(base))
+	return "v0=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func newEventsAPI(r slacktransport.Receiver) http.Handler {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	api := slacktransport.NewEventsAPI(r, func(context.Context) (string, error) {
+		return testSigningSecret, nil
+	}, logger)
+	return api.Handler()
+}
+
+// slackPost posts a body with Slack signature headers. ts=0 uses now;
+// sig="" computes a correct signature; sig="-" sends none.
+func slackPost(t *testing.T, h http.Handler, body []byte, ts int64, sig string) *http.Response {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	if ts == 0 {
+		ts = time.Now().Unix()
+	}
+	if sig == "" {
+		sig = signSlack(testSigningSecret, ts, body)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Slack-Request-Timestamp", strconv.FormatInt(ts, 10))
+	if sig != "-" {
+		req.Header.Set("X-Slack-Signature", sig)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	return resp
+}
+
+func TestEventsAPI_URLVerification(t *testing.T) {
+	rec := &recordingReceiver{}
+	h := newEventsAPI(rec)
+	body := []byte(`{"type":"url_verification","challenge":"abc123challenge"}`)
+	resp := slackPost(t, h, body, 0, "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != "abc123challenge" {
+		t.Fatalf("challenge echo = %q, want abc123challenge", string(got))
+	}
+	if rec.count() != 0 {
+		t.Fatalf("receiver called %d times for url_verification, want 0", rec.count())
+	}
+}
+
+func TestEventsAPI_ValidMessageForwarded(t *testing.T) {
+	rec := &recordingReceiver{}
+	h := newEventsAPI(rec)
+	body := []byte(`{
+		"type":"event_callback",
+		"team_id":"TAAA",
+		"api_app_id":"A001",
+		"event":{"type":"message","user":"U999","text":"hello there","channel":"C123","ts":"1700000000.000100","thread_ts":"1699999999.000001"}
+	}`)
+	resp := slackPost(t, h, body, 0, "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if rec.count() != 1 {
+		t.Fatalf("receiver count = %d, want 1", rec.count())
+	}
+	team, ev := rec.last()
+	if team != "TAAA" {
+		t.Errorf("team = %q, want TAAA", team)
+	}
+	if ev.Channel != "C123" || ev.User != "U999" || ev.Text != "hello there" {
+		t.Errorf("event mismapped: %+v", ev)
+	}
+	if ev.TS != "1700000000.000100" || ev.ThreadTS != "1699999999.000001" {
+		t.Errorf("ts/thread mismapped: %+v", ev)
+	}
+}
+
+func TestEventsAPI_BadSignatureRejected(t *testing.T) {
+	rec := &recordingReceiver{}
+	h := newEventsAPI(rec)
+	body := []byte(`{"type":"event_callback","team_id":"TAAA","event":{"type":"message","user":"U1","text":"x","channel":"C1","ts":"1.1"}}`)
+	resp := slackPost(t, h, body, 0, "v0=deadbeef")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+	if rec.count() != 0 {
+		t.Fatalf("receiver called %d times on bad signature, want 0", rec.count())
+	}
+}
+
+func TestEventsAPI_MissingSignatureRejected(t *testing.T) {
+	rec := &recordingReceiver{}
+	h := newEventsAPI(rec)
+	body := []byte(`{"type":"event_callback","team_id":"TAAA","event":{"type":"message","user":"U1","text":"x","channel":"C1","ts":"1.1"}}`)
+	resp := slackPost(t, h, body, 0, "-")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+	if rec.count() != 0 {
+		t.Fatalf("receiver called %d times on missing signature, want 0", rec.count())
+	}
+}
+
+func TestEventsAPI_StaleTimestampRejected(t *testing.T) {
+	rec := &recordingReceiver{}
+	h := newEventsAPI(rec)
+	body := []byte(`{"type":"event_callback","team_id":"TAAA","event":{"type":"message","user":"U1","text":"x","channel":"C1","ts":"1.1"}}`)
+	stale := time.Now().Add(-10 * time.Minute).Unix()
+	resp := slackPost(t, h, body, stale, "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 for stale timestamp", resp.StatusCode)
+	}
+	if rec.count() != 0 {
+		t.Fatalf("receiver called on stale timestamp, want 0")
+	}
+}
+
+func TestEventsAPI_AppMentionForwarded(t *testing.T) {
+	rec := &recordingReceiver{}
+	h := newEventsAPI(rec)
+	body := []byte(`{
+		"type":"event_callback",
+		"team_id":"TBBB",
+		"event":{"type":"app_mention","user":"U777","text":"<@U0BOT> hi","channel":"C9","ts":"1700000001.000200"}
+	}`)
+	resp := slackPost(t, h, body, 0, "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if rec.count() != 1 {
+		t.Fatalf("receiver count = %d, want 1", rec.count())
+	}
+	team, ev := rec.last()
+	if team != "TBBB" || ev.Channel != "C9" || ev.User != "U777" {
+		t.Errorf("app_mention mismapped: team=%q ev=%+v", team, ev)
+	}
+}
+
+func TestEventsAPI_BotMessageStillForwardedToIngest(t *testing.T) {
+	// The events_api source forwards bot-authored messages verbatim; the
+	// self-echo guard lives in the ingest (so both ingress modes share
+	// it). Here we just confirm BotID is threaded through, not dropped at
+	// the REST seam.
+	rec := &recordingReceiver{}
+	h := newEventsAPI(rec)
+	body := []byte(`{
+		"type":"event_callback",
+		"team_id":"TAAA",
+		"event":{"type":"message","user":"U1","text":"x","channel":"C1","ts":"1.1","bot_id":"B0001"}
+	}`)
+	resp := slackPost(t, h, body, 0, "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	_, ev := rec.last()
+	if ev.BotID != "B0001" {
+		t.Errorf("BotID = %q, want B0001 threaded through", ev.BotID)
+	}
+}

--- a/api/pkg/org/infrastructure/transports/slack/globalapp.go
+++ b/api/pkg/org/infrastructure/transports/slack/globalapp.go
@@ -1,0 +1,44 @@
+package slack
+
+import (
+	"context"
+	"errors"
+)
+
+// Ingress modes (FR-16). Selected by an explicit admin toggle on the
+// global app, never inferred from which credentials are present.
+const (
+	IngressREST   = "rest"
+	IngressSocket = "socket"
+)
+
+// App is the global, instance-wide Slack application an administrator
+// configures once (§9.2). It carries everything the ingress sources and
+// the OAuth install flow need; the per-org bot token + team id live
+// separately in the configregistry.
+type App struct {
+	// ClientID / ClientSecret authorise the OAuth install exchange.
+	ClientID     string
+	ClientSecret string
+	// SigningSecret verifies REST Events API request authenticity (NFR-4).
+	SigningSecret string
+	// AppToken is the app-level token (xapp-…) Socket Mode authenticates
+	// the WebSocket with.
+	AppToken string
+	// IngressMode is the explicit REST/Socket toggle (FR-16). Empty means
+	// no ingress is active.
+	IngressMode string
+	// Enabled mirrors the OAuthProvider row's Enabled flag. A disabled (or
+	// absent) app makes the whole subsystem inert (FR-3).
+	Enabled bool
+}
+
+// ErrNoApp signals that no global Slack app is configured (or it is
+// disabled). Callers treat it as "feature dormant", not a hard error
+// (FR-3).
+var ErrNoApp = errors.New("no slack app configured")
+
+// GlobalApp resolves the admin-configured global Slack app. Backed at
+// the composition root by store.ListOAuthProviders(type=slack,
+// enabled=true). Returns ErrNoApp when none is configured/enabled.
+type GlobalApp func(ctx context.Context) (App, error)

--- a/api/pkg/org/infrastructure/transports/slack/globalapp.go
+++ b/api/pkg/org/infrastructure/transports/slack/globalapp.go
@@ -25,6 +25,12 @@ type App struct {
 	// AppToken is the app-level token (xapp-…) Socket Mode authenticates
 	// the WebSocket with.
 	AppToken string
+	// BotToken is the bot token (xoxb-…) Socket Mode posts with. Only set
+	// for the single-workspace Socket Mode deployment, where there is no
+	// per-org OAuth install to mint one. REST installs leave it empty —
+	// each org's bot token is minted by the OAuth flow into the
+	// configregistry instead.
+	BotToken string
 	// IngressMode is the explicit REST/Socket toggle (FR-16). Empty means
 	// no ingress is active.
 	IngressMode string

--- a/api/pkg/org/infrastructure/transports/slack/ingest.go
+++ b/api/pkg/org/infrastructure/transports/slack/ingest.go
@@ -1,0 +1,287 @@
+package slack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+	"github.com/helixml/helix/api/pkg/org/domain/transport"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/wakebus"
+)
+
+// routerConfigKey is the per-org operational-config key naming the
+// Router implementation for inbound Slack disambiguation (§9.4).
+const routerConfigKey = "slack.router"
+
+// Event is the transport-neutral inbound Slack event the ingest
+// consumes. Both ingress sources (REST Events API, Socket Mode)
+// normalise their provider-specific payloads into this shape before
+// calling Receive, so the processing path is identical across modes
+// (FR-19 / NFR-1).
+type Event struct {
+	// Channel is the Slack channel id the message landed in. Routed
+	// against each org-scoped KindSlack stream's SlackConfig.Channel.
+	Channel string
+	// User is the Slack user id of the poster. Carried verbatim as
+	// Message.From.
+	User string
+	// Text is the message body.
+	Text string
+	// TS is the Slack message timestamp ("1700000000.000100"). Unique
+	// per message; carried as Message.MessageID.
+	TS string
+	// ThreadTS is the parent message ts when the message is in a thread;
+	// empty for top-level messages. Carried as Message.ThreadID so
+	// outbound replies can preserve threading (FR-13).
+	ThreadTS string
+	// BotID is non-empty when the message was posted by a bot (including
+	// our own shared bot). Used as the self-echo guard (FR-20): any
+	// bot-authored event is dropped so Workers' own posts — and other
+	// bots — never re-enter as inbound events.
+	BotID string
+	// AppID is the Slack app id that authored the message, when present.
+	AppID string
+}
+
+// Dispatcher is the subset of the application dispatcher the ingest
+// needs. Defining it here keeps the import edge one-directional. The
+// ingest resolves the channel's subscribers, narrows them through the
+// per-org Router, and activates exactly the chosen targets — so it uses
+// the router-aware DispatchTo rather than the broadcast Dispatch.
+type Dispatcher interface {
+	DispatchTo(ctx context.Context, event streaming.Event, targets []orgchart.WorkerID)
+}
+
+// Receiver is the inbound seam the ingress sources (REST Events API,
+// Socket Mode) depend on. Both normalise their provider payloads into a
+// transport-neutral Event and call Receive — the single shared
+// processing path (FR-19). *Ingest is the production implementation.
+type Receiver interface {
+	Receive(ctx context.Context, teamID string, ev Event) error
+}
+
+// compile-time assertion that Ingest is a Receiver.
+var _ Receiver = (*Ingest)(nil)
+
+// Ingest is the one shared inbound path (§9.1). A single instance
+// serves every org and both ingress sources; Receive resolves the
+// owning org from the event's team id on each call.
+type Ingest struct {
+	registry    *configregistry.Registry
+	store       *store.Store
+	broadcaster *wakebus.Bus
+	dispatcher  Dispatcher
+	logger      *slog.Logger
+}
+
+// NewIngest builds the ingest. broadcaster and dispatcher may be nil in
+// tests that don't exercise those paths.
+func NewIngest(reg *configregistry.Registry, st *store.Store, bc *wakebus.Bus, d Dispatcher, logger *slog.Logger) *Ingest {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Ingest{
+		registry:    reg,
+		store:       st,
+		broadcaster: bc,
+		dispatcher:  d,
+		logger:      logger,
+	}
+}
+
+// errUnknownTeam signals that no installed org owns the delivery's team
+// id. Treated as a drop, not an error, by Receive's callers.
+var errUnknownTeam = errors.New("no org installed for team id")
+
+// Receive is the single entry point for inbound Slack events. It:
+//
+//  1. resolves the owning org from teamID (per-org install; FR-17),
+//  2. drops the bot's own events (self-echo guard; FR-20),
+//  3. finds every KindSlack stream in that org bound to the channel,
+//  4. builds a canonical Message envelope,
+//  5. appends an Event, wakes long-poll observers, and dispatches to
+//     subscribed Workers (existing fan-out; FR-18).
+//
+// An unknown team id or a channel with no bound stream is a no-op (nil
+// error) — there is nothing to deliver to, and the caller should answer
+// the provider 2xx so it stops retrying.
+func (i *Ingest) Receive(ctx context.Context, teamID string, ev Event) error {
+	if teamID == "" {
+		return errors.New("slack ingest: empty team id")
+	}
+	// Self-echo guard: any bot-authored message (our shared bot, or any
+	// other bot in the channel) is dropped so Workers' own posts never
+	// loop back in (FR-20).
+	if ev.BotID != "" {
+		i.logger.Debug("slack.ingest: dropping bot event", "team", teamID, "channel", ev.Channel, "bot_id", ev.BotID)
+		return nil
+	}
+
+	orgID, err := i.resolveOrg(ctx, teamID)
+	if err != nil {
+		if errors.Is(err, errUnknownTeam) {
+			i.logger.Info("slack.ingest: no org for team — dropping", "team", teamID)
+			return nil
+		}
+		return err
+	}
+
+	streams, err := i.matchingStreams(ctx, orgID, ev.Channel)
+	if err != nil {
+		return err
+	}
+	if len(streams) == 0 {
+		i.logger.Info("slack.ingest: no bound stream for channel", "org", orgID, "channel", ev.Channel)
+		return nil
+	}
+
+	msg := streaming.Message{
+		From:      ev.User,
+		Body:      ev.Text,
+		ThreadID:  ev.ThreadTS,
+		MessageID: ev.TS,
+	}
+
+	for _, s := range streams {
+		event, err := streaming.NewMessageEvent(
+			streaming.EventID("e-"+uuid.NewString()),
+			s.ID,
+			"", // system-emitted: external sender, no helix Worker source
+			msg,
+			nowUTC(),
+			orgID,
+		)
+		if err != nil {
+			i.logger.Error("slack.ingest: build event", "stream", s.ID, "err", err)
+			continue
+		}
+		if err := i.store.Events.Append(ctx, event); err != nil {
+			i.logger.Error("slack.ingest: append", "stream", s.ID, "err", err)
+			continue
+		}
+		if i.broadcaster != nil {
+			i.broadcaster.Notify(orgID, s.ID)
+		}
+		if i.dispatcher != nil {
+			targets, err := i.route(ctx, orgID, s, msg)
+			if err != nil {
+				i.logger.Error("slack.ingest: route", "stream", s.ID, "err", err)
+				continue
+			}
+			i.dispatcher.DispatchTo(ctx, event, targets)
+		}
+		i.logger.Info("slack.ingest", "org", orgID, "stream", s.ID, "channel", ev.Channel, "from", ev.User)
+	}
+	return nil
+}
+
+// route resolves the channel's subscribers into routing Candidates,
+// picks the per-org Router (slack.router config; default broadcast),
+// and returns the WorkerIDs to activate. The Router only ever narrows
+// the subscriber set — DispatchTo enforces that a returned id outside
+// the subscriber/known-worker set is skipped, so routing can't invent a
+// recipient.
+func (i *Ingest) route(ctx context.Context, orgID string, stream streaming.Stream, msg streaming.Message) ([]orgchart.WorkerID, error) {
+	subs, err := i.store.Subscriptions.ListForStream(ctx, orgID, stream.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list subscriptions: %w", err)
+	}
+	candidates := make([]Candidate, 0, len(subs))
+	for _, sub := range subs {
+		workerID := orgchart.WorkerID(sub.WorkerID)
+		identity := i.candidateText(ctx, orgID, workerID)
+		candidates = append(candidates, Candidate{WorkerID: workerID, Identity: identity})
+	}
+
+	routerName, err := i.registry.GetString(ctx, orgID, routerConfigKey)
+	if err != nil {
+		// Unset / not-configured → broadcast default.
+		routerName = ""
+	}
+	router := RouterFor(routerName)
+	return router.Route(ctx, Inbound{
+		OrgID:       orgID,
+		Stream:      stream,
+		Message:     msg,
+		Subscribers: candidates,
+	})
+}
+
+// candidateText gathers the Worker's identity + role text for fuzzy
+// matching. A lookup failure degrades to empty text (the candidate
+// simply scores zero), never an error — routing must not fail because
+// one worker row is missing.
+func (i *Ingest) candidateText(ctx context.Context, orgID string, workerID orgchart.WorkerID) string {
+	var sb strings.Builder
+	w, err := i.store.Workers.Get(ctx, orgID, workerID)
+	if err != nil {
+		return ""
+	}
+	sb.WriteString(w.IdentityContent())
+	if role, err := i.store.Roles.Get(ctx, orgID, w.RoleID()); err == nil {
+		sb.WriteByte(' ')
+		sb.WriteString(role.Content)
+	}
+	return sb.String()
+}
+
+// resolveOrg maps a Slack team id to the org that installed the app
+// into that workspace. It scans the orgs that own KindSlack streams and
+// reads each one's per-org install config; the org whose configured
+// team id matches wins. One workspace per org (§6) guarantees at most
+// one match. Orgs with an install but no streams need no resolution —
+// there is nothing to deliver to.
+func (i *Ingest) resolveOrg(ctx context.Context, teamID string) (string, error) {
+	streams, err := i.store.Streams.ListByTransportKind(ctx, transport.KindSlack)
+	if err != nil {
+		return "", fmt.Errorf("list slack streams: %w", err)
+	}
+	seen := map[string]bool{}
+	for _, s := range streams {
+		if seen[s.OrganizationID] {
+			continue
+		}
+		seen[s.OrganizationID] = true
+		cfg, err := readConfig(ctx, i.registry, s.OrganizationID)
+		if err != nil {
+			continue
+		}
+		if cfg.TeamID == teamID {
+			return s.OrganizationID, nil
+		}
+	}
+	return "", errUnknownTeam
+}
+
+// matchingStreams returns every KindSlack stream in the org bound to
+// the given channel. Org-scoped list enforces isolation (FR-5): a
+// delivery for org A's workspace can only ever match org A's streams.
+func (i *Ingest) matchingStreams(ctx context.Context, orgID, channel string) ([]streaming.Stream, error) {
+	all, err := i.store.Streams.List(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("list streams: %w", err)
+	}
+	var matched []streaming.Stream
+	for _, s := range all {
+		if s.Transport.Kind != transport.KindSlack {
+			continue
+		}
+		cfg, err := s.Transport.SlackConfig()
+		if err != nil {
+			i.logger.Warn("slack.ingest: stream config parse", "stream", s.ID, "err", err)
+			continue
+		}
+		if cfg.Channel == channel {
+			matched = append(matched, s)
+		}
+	}
+	return matched, nil
+}

--- a/api/pkg/org/infrastructure/transports/slack/ingest_test.go
+++ b/api/pkg/org/infrastructure/transports/slack/ingest_test.go
@@ -1,0 +1,312 @@
+// These tests pin the slack ingest — the one shared inbound path
+// (design/2026-06-16-helix-org-slack-stream.md §9.1). They drive
+// Ingest.Receive with synthetic events against a seeded GORM test DB:
+//
+//   - team id → correct org; unknown team id → dropped, no dispatch (FR-17)
+//   - message in a bound channel → one Event appended + dispatched (FR-18)
+//   - two orgs, same channel name → strict org isolation (FR-5/FR-17)
+//   - event with a bot_id → dropped (self-echo guard, FR-20)
+//   - envelope mapping: From=user, Body=text, ThreadID=thread_ts, MessageID=ts
+package slack_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+	"github.com/helixml/helix/api/pkg/org/domain/transport"
+	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
+	slacktransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/slack"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/wakebus"
+	"github.com/helixml/helix/api/pkg/pubsub"
+)
+
+// recordingDispatcher captures Dispatch / DispatchTo calls so tests can
+// assert the dispatcher was woken and with which targets.
+type recordingDispatcher struct {
+	mu        sync.Mutex
+	events    []streaming.Event
+	targets   [][]orgchart.WorkerID
+	dispatchN int
+}
+
+func (d *recordingDispatcher) Dispatch(_ context.Context, e streaming.Event) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.events = append(d.events, e)
+	d.targets = append(d.targets, nil)
+	d.dispatchN++
+}
+
+func (d *recordingDispatcher) DispatchTo(_ context.Context, e streaming.Event, targets []orgchart.WorkerID) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.events = append(d.events, e)
+	d.targets = append(d.targets, targets)
+	d.dispatchN++
+}
+
+func (d *recordingDispatcher) snapshot() ([]streaming.Event, [][]orgchart.WorkerID) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	ev := make([]streaming.Event, len(d.events))
+	copy(ev, d.events)
+	tg := make([][]orgchart.WorkerID, len(d.targets))
+	copy(tg, d.targets)
+	return ev, tg
+}
+
+func newTestIngest(t *testing.T) (*slacktransport.Ingest, *store.Store, *recordingDispatcher, *configregistry.Registry) {
+	t.Helper()
+	st := orggorm.GetOrgTestDB(t)
+	ps, err := pubsub.NewInMemoryNats()
+	if err != nil {
+		t.Fatalf("NewInMemoryNats: %v", err)
+	}
+	bc := wakebus.New(ps)
+	rd := &recordingDispatcher{}
+	reg := configregistry.New(st.Configs)
+	reg.Register(configregistry.Spec{
+		Key:     "transport.slack",
+		Type:    configregistry.TypeObject,
+		Secrets: []string{"bot_token"},
+	})
+	reg.Register(configregistry.Spec{
+		Key:     "slack.router",
+		Type:    configregistry.TypeString,
+		Default: `"broadcast"`,
+	})
+	in := slacktransport.NewIngest(reg, st, bc, rd, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	return in, st, rd, reg
+}
+
+func setSlackInstall(t *testing.T, reg *configregistry.Registry, orgID, botToken, teamID string) {
+	t.Helper()
+	val, _ := json.Marshal(map[string]string{"bot_token": botToken, "team_id": teamID})
+	if err := reg.Set(context.Background(), orgID, "transport.slack", string(val)); err != nil {
+		t.Fatalf("set slack config for %s: %v", orgID, err)
+	}
+}
+
+func seedSlackStream(t *testing.T, st *store.Store, orgID string, id streaming.StreamID, channel string) streaming.Stream {
+	t.Helper()
+	cfg, _ := json.Marshal(map[string]any{"channel": channel})
+	stream, err := streaming.NewStream(id, string(id), "", "w-owner", time.Now().UTC(),
+		transport.Transport{Kind: transport.KindSlack, Config: cfg}, orgID)
+	if err != nil {
+		t.Fatalf("new stream: %v", err)
+	}
+	if err := st.Streams.Create(context.Background(), stream); err != nil {
+		t.Fatalf("create stream: %v", err)
+	}
+	return stream
+}
+
+func TestIngest_RoutesToOrgByTeamID(t *testing.T) {
+	in, st, rd, reg := newTestIngest(t)
+	setSlackInstall(t, reg, "org-a", "xoxb-a", "TAAA")
+	stream := seedSlackStream(t, st, "org-a", "str-a", "C123")
+
+	ev := slacktransport.Event{Channel: "C123", User: "U999", Text: "hello", TS: "1700000000.000100"}
+	if err := in.Receive(context.Background(), "TAAA", ev); err != nil {
+		t.Fatalf("Receive: %v", err)
+	}
+
+	events, _ := rd.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("dispatch count = %d, want 1", len(events))
+	}
+	if events[0].StreamID != stream.ID {
+		t.Fatalf("dispatched to stream %q, want %q", events[0].StreamID, stream.ID)
+	}
+	if events[0].OrganizationID != "org-a" {
+		t.Fatalf("event org = %q, want org-a", events[0].OrganizationID)
+	}
+	// Event was appended.
+	stored, err := st.Events.ListForStream(context.Background(), "org-a", stream.ID, 10)
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(stored) != 1 {
+		t.Fatalf("stored events = %d, want 1", len(stored))
+	}
+}
+
+func TestIngest_UnknownTeamDropped(t *testing.T) {
+	in, st, rd, reg := newTestIngest(t)
+	setSlackInstall(t, reg, "org-a", "xoxb-a", "TAAA")
+	seedSlackStream(t, st, "org-a", "str-a", "C123")
+
+	ev := slacktransport.Event{Channel: "C123", User: "U999", Text: "hello", TS: "1.1"}
+	if err := in.Receive(context.Background(), "TZZZ", ev); err != nil {
+		t.Fatalf("Receive: %v", err)
+	}
+	events, _ := rd.snapshot()
+	if len(events) != 0 {
+		t.Fatalf("dispatch count = %d, want 0 for unknown team", len(events))
+	}
+}
+
+func TestIngest_OrgIsolationSameChannelName(t *testing.T) {
+	in, st, rd, reg := newTestIngest(t)
+	setSlackInstall(t, reg, "org-a", "xoxb-a", "TAAA")
+	setSlackInstall(t, reg, "org-b", "xoxb-b", "TBBB")
+	streamA := seedSlackStream(t, st, "org-a", "str-a", "Cshared")
+	seedSlackStream(t, st, "org-b", "str-b", "Cshared")
+
+	ev := slacktransport.Event{Channel: "Cshared", User: "U1", Text: "hi", TS: "1.2"}
+	if err := in.Receive(context.Background(), "TAAA", ev); err != nil {
+		t.Fatalf("Receive: %v", err)
+	}
+	events, _ := rd.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("dispatch count = %d, want 1 (org-a only)", len(events))
+	}
+	if events[0].StreamID != streamA.ID || events[0].OrganizationID != "org-a" {
+		t.Fatalf("leaked to wrong stream/org: %+v", events[0])
+	}
+	// org-b stream must have no events.
+	bEvents, _ := st.Events.ListForStream(context.Background(), "org-b", "str-b", 10)
+	if len(bEvents) != 0 {
+		t.Fatalf("org-b stream got %d events, want 0 (isolation breach)", len(bEvents))
+	}
+}
+
+func TestIngest_BotEventDropped(t *testing.T) {
+	in, st, rd, reg := newTestIngest(t)
+	setSlackInstall(t, reg, "org-a", "xoxb-a", "TAAA")
+	seedSlackStream(t, st, "org-a", "str-a", "C123")
+
+	ev := slacktransport.Event{Channel: "C123", User: "U999", Text: "echo", TS: "1.3", BotID: "B0001"}
+	if err := in.Receive(context.Background(), "TAAA", ev); err != nil {
+		t.Fatalf("Receive: %v", err)
+	}
+	events, _ := rd.snapshot()
+	if len(events) != 0 {
+		t.Fatalf("dispatch count = %d, want 0 for bot event (self-echo)", len(events))
+	}
+}
+
+// seedAISubscriber creates an AI worker (with a role carrying matchable
+// text) subscribed to the stream, so routing has candidates to choose
+// among.
+func seedAISubscriber(t *testing.T, st *store.Store, orgID string, workerID orgchart.WorkerID, roleID orgchart.RoleID, roleText string, streamID streaming.StreamID) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := st.Roles.Get(ctx, orgID, roleID); err != nil {
+		role, err := orgchart.NewRole(roleID, roleText, nil, nil, time.Now().UTC(), orgID)
+		if err != nil {
+			t.Fatalf("new role: %v", err)
+		}
+		if err := st.Roles.Create(ctx, role); err != nil {
+			t.Fatalf("create role: %v", err)
+		}
+	}
+	w, err := orgchart.NewAIWorker(workerID, roleID, "# "+string(workerID), orgID)
+	if err != nil {
+		t.Fatalf("new worker: %v", err)
+	}
+	if err := st.Workers.Create(ctx, w); err != nil {
+		t.Fatalf("create worker: %v", err)
+	}
+	sub, err := streaming.NewSubscription(string(workerID), streamID, time.Now().UTC(), orgID)
+	if err != nil {
+		t.Fatalf("new subscription: %v", err)
+	}
+	if err := st.Subscriptions.Create(ctx, sub); err != nil {
+		t.Fatalf("create subscription: %v", err)
+	}
+}
+
+func TestIngest_DefaultBroadcastsToAllSubscribers(t *testing.T) {
+	in, st, rd, reg := newTestIngest(t)
+	setSlackInstall(t, reg, "org-a", "xoxb-a", "TAAA")
+	stream := seedSlackStream(t, st, "org-a", "str-a", "C123")
+	seedAISubscriber(t, st, "org-a", "w-billing", "r-billing", "# Billing\nHandles invoices and refunds.", stream.ID)
+	seedAISubscriber(t, st, "org-a", "w-eng", "r-eng", "# Engineering\nFixes bugs in code.", stream.ID)
+
+	ev := slacktransport.Event{Channel: "C123", User: "U1", Text: "I need a refund on my invoice", TS: "1.9"}
+	if err := in.Receive(context.Background(), "TAAA", ev); err != nil {
+		t.Fatalf("Receive: %v", err)
+	}
+	_, targets := rd.snapshot()
+	if len(targets) != 1 {
+		t.Fatalf("dispatch calls = %d, want 1", len(targets))
+	}
+	if len(targets[0]) != 2 {
+		t.Fatalf("default routed to %v, want both subscribers (broadcast)", targets[0])
+	}
+}
+
+func TestIngest_FuzzyRouterActivatesChosenWorker(t *testing.T) {
+	in, st, rd, reg := newTestIngest(t)
+	setSlackInstall(t, reg, "org-a", "xoxb-a", "TAAA")
+	if err := reg.Set(context.Background(), "org-a", "slack.router", `"fuzzy"`); err != nil {
+		t.Fatalf("set slack.router: %v", err)
+	}
+	stream := seedSlackStream(t, st, "org-a", "str-a", "C123")
+	seedAISubscriber(t, st, "org-a", "w-billing", "r-billing", "# Billing\nHandles invoices refunds payments.", stream.ID)
+	seedAISubscriber(t, st, "org-a", "w-eng", "r-eng", "# Engineering\nFixes bugs writes code reviews.", stream.ID)
+
+	ev := slacktransport.Event{Channel: "C123", User: "U1", Text: "I need a refund on my invoice, the payment failed", TS: "2.0"}
+	if err := in.Receive(context.Background(), "TAAA", ev); err != nil {
+		t.Fatalf("Receive: %v", err)
+	}
+	_, targets := rd.snapshot()
+	if len(targets) != 1 {
+		t.Fatalf("dispatch calls = %d, want 1", len(targets))
+	}
+	if len(targets[0]) != 1 || targets[0][0] != "w-billing" {
+		t.Fatalf("fuzzy routed to %v, want [w-billing]", targets[0])
+	}
+}
+
+func TestIngest_EnvelopeMapping(t *testing.T) {
+	in, st, _, reg := newTestIngest(t)
+	setSlackInstall(t, reg, "org-a", "xoxb-a", "TAAA")
+	stream := seedSlackStream(t, st, "org-a", "str-a", "C123")
+
+	ev := slacktransport.Event{
+		Channel:  "C123",
+		User:     "U999",
+		Text:     "the body",
+		TS:       "1700000000.000100",
+		ThreadTS: "1699999999.000001",
+	}
+	if err := in.Receive(context.Background(), "TAAA", ev); err != nil {
+		t.Fatalf("Receive: %v", err)
+	}
+
+	stored, _ := st.Events.ListForStream(context.Background(), "org-a", stream.ID, 10)
+	if len(stored) != 1 {
+		t.Fatalf("stored events = %d, want 1", len(stored))
+	}
+	msg, err := stored[0].Message()
+	if err != nil {
+		t.Fatalf("decode message: %v", err)
+	}
+	if msg.From != "U999" {
+		t.Errorf("From = %q, want U999", msg.From)
+	}
+	if msg.Body != "the body" {
+		t.Errorf("Body = %q, want 'the body'", msg.Body)
+	}
+	if msg.ThreadID != "1699999999.000001" {
+		t.Errorf("ThreadID = %q, want thread_ts", msg.ThreadID)
+	}
+	if msg.MessageID != "1700000000.000100" {
+		t.Errorf("MessageID = %q, want ts", msg.MessageID)
+	}
+	// Inbound events are system-sourced (external sender, no helix Worker).
+	if stored[0].Source != "" {
+		t.Errorf("Source = %q, want empty", stored[0].Source)
+	}
+}

--- a/api/pkg/org/infrastructure/transports/slack/oauth.go
+++ b/api/pkg/org/infrastructure/transports/slack/oauth.go
@@ -1,0 +1,162 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+)
+
+// authorizeURL is the Slack OAuth v2 authorize endpoint the "Add to
+// Slack" button sends the admin to.
+const authorizeURL = "https://slack.com/oauth/v2/authorize"
+
+// defaultTokenURL is Slack's OAuth v2 token-exchange endpoint. The
+// exchange is done with a plain HTTP call (not slack-go, whose endpoint
+// is hardcoded) so tests can redirect it to a fake server.
+const defaultTokenURL = "https://slack.com/api/oauth.v2.access"
+
+// StateEncoder / StateDecoder carry the org id through the OAuth round
+// trip in the (encrypted) state param. Production wires
+// crypto.EncryptAES256GCM / Decrypt; the org id is the only payload.
+type (
+	StateEncoder func(orgID string) (string, error)
+	StateDecoder func(state string) (orgID string, err error)
+)
+
+// OAuth drives the per-org install of the global app into an org's
+// workspace (FR-4, REST mode). StartURL builds the "Add to Slack"
+// authorize link; HandleCallback exchanges the returned code for a bot
+// token + team id and persists them as the org's transport.slack
+// install.
+type OAuth struct {
+	app         GlobalApp
+	registry    *configregistry.Registry
+	encode      StateEncoder
+	decode      StateDecoder
+	redirectURI string
+	tokenURL    string
+	client      *http.Client
+	logger      *slog.Logger
+}
+
+// NewOAuth builds the install flow.
+func NewOAuth(app GlobalApp, reg *configregistry.Registry, encode StateEncoder, decode StateDecoder, redirectURI string, logger *slog.Logger) *OAuth {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &OAuth{
+		app:         app,
+		registry:    reg,
+		encode:      encode,
+		decode:      decode,
+		redirectURI: redirectURI,
+		tokenURL:    defaultTokenURL,
+		client:      &http.Client{Timeout: 10 * time.Second},
+		logger:      logger,
+	}
+}
+
+// SetTokenURL overrides the token-exchange endpoint (tests).
+func (o *OAuth) SetTokenURL(u string) { o.tokenURL = u }
+
+// SetHTTPClient overrides the HTTP client (tests).
+func (o *OAuth) SetHTTPClient(c *http.Client) { o.client = c }
+
+// StartURL builds the Slack OAuth v2 authorize URL the admin is sent to
+// when installing the app into their org's workspace. The org id is
+// carried in the state param so the callback knows which org installed.
+func (o *OAuth) StartURL(ctx context.Context, orgID string, scopes []string) (string, error) {
+	app, err := o.app(ctx)
+	if err != nil {
+		return "", err
+	}
+	state, err := o.encode(orgID)
+	if err != nil {
+		return "", fmt.Errorf("encode state: %w", err)
+	}
+	q := url.Values{}
+	q.Set("client_id", app.ClientID)
+	q.Set("scope", strings.Join(scopes, ","))
+	q.Set("redirect_uri", o.redirectURI)
+	q.Set("state", state)
+	return authorizeURL + "?" + q.Encode(), nil
+}
+
+// oauthV2Response is the subset of Slack's oauth.v2.access response we
+// persist: the bot access token and the installed workspace's team id.
+type oauthV2Response struct {
+	OK          bool   `json:"ok"`
+	Error       string `json:"error"`
+	AccessToken string `json:"access_token"`
+	Team        struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"team"`
+}
+
+// HandleCallback completes the install: decode the org from state,
+// exchange the code for a bot token + team id against the global app's
+// client credentials, and persist them as transport.slack for that org.
+// A state that won't decode is rejected before any exchange or write.
+func (o *OAuth) HandleCallback(ctx context.Context, code, state string) error {
+	orgID, err := o.decode(state)
+	if err != nil {
+		return fmt.Errorf("slack oauth: bad state: %w", err)
+	}
+	if orgID == "" {
+		return fmt.Errorf("slack oauth: empty org in state")
+	}
+	app, err := o.app(ctx)
+	if err != nil {
+		return err
+	}
+
+	form := url.Values{}
+	form.Set("client_id", app.ClientID)
+	form.Set("client_secret", app.ClientSecret)
+	form.Set("code", code)
+	form.Set("redirect_uri", o.redirectURI)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("slack oauth: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("slack oauth: exchange: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+
+	var parsed oauthV2Response
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return fmt.Errorf("slack oauth: decode response: %w", err)
+	}
+	if !parsed.OK {
+		return fmt.Errorf("slack oauth: exchange failed: %s", parsed.Error)
+	}
+	if parsed.AccessToken == "" || parsed.Team.ID == "" {
+		return fmt.Errorf("slack oauth: response missing access_token or team id")
+	}
+
+	cfg := Config{BotToken: parsed.AccessToken, TeamID: parsed.Team.ID}
+	val, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("slack oauth: marshal config: %w", err)
+	}
+	if err := o.registry.Set(ctx, orgID, configKey, string(val)); err != nil {
+		return fmt.Errorf("slack oauth: persist install: %w", err)
+	}
+	o.logger.Info("slack.oauth: installed", "org", orgID, "team", parsed.Team.ID)
+	return nil
+}

--- a/api/pkg/org/infrastructure/transports/slack/oauth_test.go
+++ b/api/pkg/org/infrastructure/transports/slack/oauth_test.go
@@ -1,0 +1,140 @@
+// OAuth install tests (FR-4, US-1). The callback exchanges the code
+// Slack hands back for a bot token + team id and persists them as the
+// org's transport.slack install. The org is carried in the encrypted
+// state param; a state that won't decode is rejected without touching
+// the store. Driven against a fake oauth.v2.access endpoint.
+package slack_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
+	slacktransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/slack"
+)
+
+// fakeOAuth serves oauth.v2.access.
+type fakeOAuth struct {
+	server   *httptest.Server
+	failNext bool
+}
+
+func newFakeOAuth(t *testing.T) *fakeOAuth {
+	t.Helper()
+	f := &fakeOAuth{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth.v2.access", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "application/json")
+		if f.failNext || r.PostForm.Get("code") == "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "invalid_code"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ok":           true,
+			"access_token": "xoxb-installed-token",
+			"team":         map[string]any{"id": "T0WORKSPACE", "name": "Acme"},
+		})
+	})
+	f.server = httptest.NewServer(mux)
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+// trivialCodec is a reversible non-secret state codec for tests
+// (production uses crypto.EncryptAES256GCM).
+func encodeState(orgID string) (string, error) { return "state:" + orgID, nil }
+func decodeState(state string) (string, error) {
+	const p = "state:"
+	if len(state) < len(p) || state[:len(p)] != p {
+		return "", errBadState
+	}
+	return state[len(p):], nil
+}
+
+var errBadState = errorString("bad state")
+
+type errorString string
+
+func (e errorString) Error() string { return string(e) }
+
+func newTestOAuth(t *testing.T, fake *fakeOAuth, app slacktransport.App) (*slacktransport.OAuth, *store.Store, *configregistry.Registry) {
+	t.Helper()
+	st := orggorm.GetOrgTestDB(t)
+	reg := configregistry.New(st.Configs)
+	reg.Register(configregistry.Spec{Key: "transport.slack", Type: configregistry.TypeObject, Secrets: []string{"bot_token"}})
+	globalApp := func(context.Context) (slacktransport.App, error) { return app, nil }
+	o := slacktransport.NewOAuth(globalApp, reg, encodeState, decodeState, "https://helix.example.com/api/v1/slack/oauth/callback", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	o.SetTokenURL(fake.server.URL + "/oauth.v2.access")
+	return o, st, reg
+}
+
+func TestOAuth_CallbackPersistsInstall(t *testing.T) {
+	fake := newFakeOAuth(t)
+	o, st, reg := newTestOAuth(t, fake, slacktransport.App{ClientID: "cid", ClientSecret: "secret", Enabled: true})
+
+	state, _ := encodeState("org-a")
+	if err := o.HandleCallback(context.Background(), "the-code", state); err != nil {
+		t.Fatalf("HandleCallback: %v", err)
+	}
+
+	var cfg slacktransport.Config
+	if err := reg.GetObject(context.Background(), "org-a", "transport.slack", &cfg); err != nil {
+		t.Fatalf("read persisted config: %v", err)
+	}
+	if cfg.BotToken != "xoxb-installed-token" {
+		t.Errorf("bot_token = %q, want xoxb-installed-token", cfg.BotToken)
+	}
+	if cfg.TeamID != "T0WORKSPACE" {
+		t.Errorf("team_id = %q, want T0WORKSPACE", cfg.TeamID)
+	}
+	_ = st
+}
+
+func TestOAuth_BadStateRejected(t *testing.T) {
+	fake := newFakeOAuth(t)
+	o, _, reg := newTestOAuth(t, fake, slacktransport.App{ClientID: "cid", ClientSecret: "secret", Enabled: true})
+
+	err := o.HandleCallback(context.Background(), "the-code", "garbage-state")
+	if err == nil {
+		t.Fatalf("HandleCallback with bad state = nil, want error")
+	}
+	// Nothing persisted.
+	var cfg slacktransport.Config
+	if err := reg.GetObject(context.Background(), "org-a", "transport.slack", &cfg); err == nil {
+		t.Fatalf("config persisted despite bad state")
+	}
+}
+
+func TestOAuth_StartURLContainsClientAndState(t *testing.T) {
+	fake := newFakeOAuth(t)
+	o, _, _ := newTestOAuth(t, fake, slacktransport.App{ClientID: "my-client-id", Enabled: true})
+
+	u, err := o.StartURL(context.Background(), "org-a", []string{"chat:write", "channels:read"})
+	if err != nil {
+		t.Fatalf("StartURL: %v", err)
+	}
+	for _, want := range []string{"client_id=my-client-id", "state=state%3Aorg-a", "chat%3Awrite", "redirect_uri="} {
+		if !containsSub(u, want) {
+			t.Errorf("authorize URL %q missing %q", u, want)
+		}
+	}
+}
+
+func containsSub(s, sub string) bool {
+	return len(s) >= len(sub) && (func() bool {
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				return true
+			}
+		}
+		return false
+	})()
+}

--- a/api/pkg/org/infrastructure/transports/slack/outbound.go
+++ b/api/pkg/org/infrastructure/transports/slack/outbound.go
@@ -1,0 +1,96 @@
+package slack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/slack-go/slack"
+
+	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+)
+
+// Outbound delivers an appended Event on a KindSlack stream to its bound
+// channel via chat.postMessage, applying the posting Worker's persona
+// (FR-10/11). It satisfies streaming.Outbound, so the dispatcher emits
+// it for every worker-published Event the same way it does for webhook
+// and email — ingress-agnostic by construction (FR-12).
+type Outbound struct {
+	registry *configregistry.Registry
+	store    *store.Store
+	persona  PersonaResolver
+	apiURL   string
+	logger   *slog.Logger
+}
+
+// NewOutbound builds the emitter. A nil persona resolver falls back to
+// DefaultPersonaResolver (bare worker id as username, bot avatar).
+func NewOutbound(reg *configregistry.Registry, st *store.Store, persona PersonaResolver, logger *slog.Logger) *Outbound {
+	if persona == nil {
+		persona = DefaultPersonaResolver
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Outbound{registry: reg, store: st, persona: persona, logger: logger}
+}
+
+// SetAPIURL overrides the Slack API base (trailing slash). Tests point
+// it at an httptest.Server; production leaves it empty (real slack.com).
+func (o *Outbound) SetAPIURL(u string) { o.apiURL = u }
+
+// Emit posts the Event's Message body to the stream's bound channel
+// under the Worker's persona, preserving thread context where present
+// (FR-13). A missing per-org bot token is a typed error (not a panic):
+// the dispatcher logs and drops it, the underlying append already
+// succeeded.
+func (o *Outbound) Emit(ctx context.Context, stream streaming.Stream, event streaming.Event) error {
+	msg, err := event.Message()
+	if err != nil {
+		return fmt.Errorf("slack emit: parse message: %w", err)
+	}
+	sc, err := stream.Transport.SlackConfig()
+	if err != nil {
+		return fmt.Errorf("slack emit: stream config: %w", err)
+	}
+	if sc.Channel == "" {
+		return errors.New("slack emit: stream has no channel")
+	}
+	cfg, err := readConfig(ctx, o.registry, event.OrganizationID)
+	if err != nil {
+		return fmt.Errorf("slack emit: org %s not installed: %w", event.OrganizationID, err)
+	}
+
+	persona, err := o.persona(ctx, event.OrganizationID, event.Source)
+	if err != nil {
+		// Persona resolution failure must not block the post — fall back
+		// to the bot's default identity.
+		o.logger.Warn("slack.emit: persona resolve", "org", event.OrganizationID, "worker", event.Source, "err", err)
+		persona = Persona{}
+	}
+
+	opts := []slack.MsgOption{slack.MsgOptionText(msg.Body, false)}
+	if persona.Username != "" {
+		opts = append(opts, slack.MsgOptionUsername(persona.Username))
+	}
+	if persona.IconURL != "" {
+		opts = append(opts, slack.MsgOptionIconURL(persona.IconURL))
+	}
+	if msg.ThreadID != "" {
+		opts = append(opts, slack.MsgOptionTS(msg.ThreadID))
+	}
+
+	client := newSlackClient(cfg.BotToken, o.apiURL)
+	_, ts, err := client.PostMessageContext(ctx, sc.Channel, opts...)
+	if err != nil {
+		return fmt.Errorf("slack emit: postMessage to %s: %w", sc.Channel, err)
+	}
+	o.logger.Info("slack.emit", "org", event.OrganizationID, "stream", event.StreamID, "channel", sc.Channel, "ts", ts, "persona", persona.Username)
+	return nil
+}
+
+// compile-time assertion that Outbound satisfies the port.
+var _ streaming.Outbound = (*Outbound)(nil)

--- a/api/pkg/org/infrastructure/transports/slack/outbound_test.go
+++ b/api/pkg/org/infrastructure/transports/slack/outbound_test.go
@@ -1,0 +1,159 @@
+// Outbound tests (FR-10/11/12/13). Emit renders an appended Event on a
+// KindSlack stream into a chat.postMessage carrying the bound channel,
+// the Worker's persona (username + icon_url), and thread_ts for
+// threaded replies. Driven against a fake Slack API (httptest.Server)
+// so no network is touched.
+package slack_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
+	slacktransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/slack"
+)
+
+// fakeSlack records the last chat.postMessage form and replies ok.
+type fakeSlack struct {
+	mu     sync.Mutex
+	form   url.Values
+	calls  int
+	server *httptest.Server
+}
+
+func newFakeSlack(t *testing.T) *fakeSlack {
+	t.Helper()
+	f := &fakeSlack{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		f.mu.Lock()
+		f.form = r.PostForm
+		f.calls++
+		f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "channel": r.PostForm.Get("channel"), "ts": "1700000002.000300"})
+	})
+	f.server = httptest.NewServer(mux)
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+// apiURL returns the base URL slack-go expects (trailing slash).
+func (f *fakeSlack) apiURL() string { return f.server.URL + "/" }
+
+func (f *fakeSlack) get(key string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.form == nil {
+		return ""
+	}
+	return f.form.Get(key)
+}
+
+func (f *fakeSlack) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func newTestOutbound(t *testing.T, persona slacktransport.PersonaResolver) (*slacktransport.Outbound, *store.Store, *configregistry.Registry, *fakeSlack) {
+	t.Helper()
+	st := orggorm.GetOrgTestDB(t)
+	reg := configregistry.New(st.Configs)
+	reg.Register(configregistry.Spec{Key: "transport.slack", Type: configregistry.TypeObject, Secrets: []string{"bot_token"}})
+	fake := newFakeSlack(t)
+	out := slacktransport.NewOutbound(reg, st, persona, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	out.SetAPIURL(fake.apiURL())
+	return out, st, reg, fake
+}
+
+// emitEvent builds and emits a worker-published event on a slack stream.
+func emitEvent(t *testing.T, out *slacktransport.Outbound, stream streaming.Stream, source string, msg streaming.Message) error {
+	t.Helper()
+	ev, err := streaming.NewMessageEvent(streaming.EventID("e-1"), stream.ID, source, msg, time.Now().UTC(), stream.OrganizationID)
+	if err != nil {
+		t.Fatalf("new event: %v", err)
+	}
+	return out.Emit(context.Background(), stream, ev)
+}
+
+func TestOutbound_PostsWithPersonaAndThread(t *testing.T) {
+	persona := func(_ context.Context, _, workerID string) (slacktransport.Persona, error) {
+		return slacktransport.Persona{Username: "Sam the Support Bot", IconURL: "https://example.com/sam.png"}, nil
+	}
+	out, st, reg, fake := newTestOutbound(t, persona)
+	setSlackInstall(t, reg, "org-a", "xoxb-token-a", "TAAA")
+	stream := seedSlackStream(t, st, "org-a", "str-a", "C123")
+
+	err := emitEvent(t, out, stream, "w-sam", streaming.Message{Body: "hello channel", ThreadID: "1699999999.000001"})
+	if err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if fake.callCount() != 1 {
+		t.Fatalf("postMessage calls = %d, want 1", fake.callCount())
+	}
+	if got := fake.get("channel"); got != "C123" {
+		t.Errorf("channel = %q, want C123", got)
+	}
+	if got := fake.get("text"); got != "hello channel" {
+		t.Errorf("text = %q, want 'hello channel'", got)
+	}
+	if got := fake.get("username"); got != "Sam the Support Bot" {
+		t.Errorf("username = %q, want persona username", got)
+	}
+	if got := fake.get("icon_url"); got != "https://example.com/sam.png" {
+		t.Errorf("icon_url = %q, want persona icon", got)
+	}
+	if got := fake.get("thread_ts"); got != "1699999999.000001" {
+		t.Errorf("thread_ts = %q, want Message.ThreadID", got)
+	}
+}
+
+func TestOutbound_NoThreadOmitsThreadTS(t *testing.T) {
+	out, st, reg, fake := newTestOutbound(t, slacktransport.DefaultPersonaResolver)
+	setSlackInstall(t, reg, "org-a", "xoxb-token-a", "TAAA")
+	stream := seedSlackStream(t, st, "org-a", "str-a", "C123")
+
+	if err := emitEvent(t, out, stream, "w-sam", streaming.Message{Body: "top level"}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if got := fake.get("thread_ts"); got != "" {
+		t.Errorf("thread_ts = %q, want empty for non-threaded message", got)
+	}
+	// Default persona uses the bare worker id as username.
+	if got := fake.get("username"); got != "w-sam" {
+		t.Errorf("username = %q, want w-sam (default persona)", got)
+	}
+}
+
+func TestOutbound_MissingTokenTypedError(t *testing.T) {
+	out, st, _, fake := newTestOutbound(t, slacktransport.DefaultPersonaResolver)
+	// No install config set for org-a → no bot token.
+	stream := seedSlackStream(t, st, "org-a", "str-a", "C123")
+
+	err := emitEvent(t, out, stream, "w-sam", streaming.Message{Body: "hi"})
+	if err == nil {
+		t.Fatalf("Emit() = nil, want error for missing token")
+	}
+	if fake.callCount() != 0 {
+		t.Fatalf("postMessage called %d times without a token, want 0", fake.callCount())
+	}
+}
+
+// TestOutbound_SatisfiesPort is a compile-time-ish guard that Outbound
+// is a streaming.Outbound (the dispatcher registers it by that port).
+func TestOutbound_SatisfiesPort(t *testing.T) {
+	var _ streaming.Outbound = (*slacktransport.Outbound)(nil)
+}

--- a/api/pkg/org/infrastructure/transports/slack/persona.go
+++ b/api/pkg/org/infrastructure/transports/slack/persona.go
@@ -1,0 +1,31 @@
+package slack
+
+import "context"
+
+// Persona is the name + avatar a Worker's message is posted under
+// through the shared bot (FR-11). A channel has exactly one real Slack
+// member (the bot); personas let Slack participants tell Workers apart.
+type Persona struct {
+	// Username is the display name applied to the message
+	// (chat.postMessage `username`).
+	Username string
+	// IconURL is the avatar applied to the message
+	// (chat.postMessage `icon_url`). Empty ⇒ Slack falls back to the
+	// bot's default avatar. The plumbing ships now; its source (a
+	// Worker-avatar attribute) is deferred — §13.
+	IconURL string
+}
+
+// PersonaResolver maps a posting Worker to its Persona. Modelled as an
+// injected port (like the GitHub TokenResolver) rather than a field on
+// streaming.Message, so the shared envelope stays transport-neutral.
+type PersonaResolver func(ctx context.Context, orgID, workerID string) (Persona, error)
+
+// DefaultPersonaResolver derives the persona from the Worker's identity
+// as it exists today: the bare Worker id as the username, no avatar (so
+// Slack shows the bot's default). A richer resolver — pulling a
+// friendly name and avatar from the Worker's identity/role — can be
+// injected at the composition root without touching the outbound path.
+func DefaultPersonaResolver(_ context.Context, _ string, workerID string) (Persona, error) {
+	return Persona{Username: workerID}, nil
+}

--- a/api/pkg/org/infrastructure/transports/slack/provisioner.go
+++ b/api/pkg/org/infrastructure/transports/slack/provisioner.go
@@ -1,0 +1,88 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/slack-go/slack"
+
+	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+)
+
+// Provisioner is the slack side of the streaming.Inbound port. "Install"
+// for Slack means ensuring the org's shared bot is a member of the bound
+// channel (conversations.join) — there is no per-stream webhook to
+// register, since inbound flows through the one shared ingest. "Status"
+// reports whether the bot is in the channel, degrading to "unknown"
+// rather than erroring when the workspace can't be reached.
+type Provisioner struct {
+	registry *configregistry.Registry
+	apiURL   string
+	logger   *slog.Logger
+}
+
+// NewProvisioner builds the provisioner.
+func NewProvisioner(reg *configregistry.Registry, logger *slog.Logger) *Provisioner {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Provisioner{registry: reg, logger: logger}
+}
+
+// SetAPIURL overrides the Slack API base (trailing slash). Tests point
+// it at an httptest.Server; production leaves it empty.
+func (p *Provisioner) SetAPIURL(u string) { p.apiURL = u }
+
+// Install ensures the bot has joined the stream's bound channel. It is
+// idempotent on Slack's side — joining a channel the bot is already in
+// is a success. Returns a nil Config (nothing extra to persist on the
+// stream; the channel binding is already in SlackConfig).
+func (p *Provisioner) Install(ctx context.Context, orgID string, stream streaming.Stream) (streaming.InstallResult, error) {
+	sc, err := stream.Transport.SlackConfig()
+	if err != nil {
+		return streaming.InstallResult{}, &streaming.Failure{Kind: streaming.FailBadRequest, Err: fmt.Errorf("slack install: %w", err)}
+	}
+	if sc.Channel == "" {
+		return streaming.InstallResult{}, &streaming.Failure{Kind: streaming.FailBadRequest, Err: fmt.Errorf("slack install: stream has no channel")}
+	}
+	cfg, err := readConfig(ctx, p.registry, orgID)
+	if err != nil {
+		return streaming.InstallResult{}, &streaming.Failure{Kind: streaming.FailPrecondition, Err: fmt.Errorf("slack install: org %s not connected: %w", orgID, err)}
+	}
+	client := newSlackClient(cfg.BotToken, p.apiURL)
+	if _, _, _, err := client.JoinConversationContext(ctx, sc.Channel); err != nil {
+		return streaming.InstallResult{}, &streaming.Failure{Kind: streaming.FailUpstream, Err: fmt.Errorf("slack install: join %s: %w", sc.Channel, err)}
+	}
+	p.logger.Info("slack.install", "org", orgID, "channel", sc.Channel, "stream", stream.ID)
+	return streaming.InstallResult{}, nil
+}
+
+// Status reports whether the bot is a member of the bound channel:
+// "installed" when it is, "missing" when it isn't, "unknown" when the
+// org isn't connected or the workspace can't be reached. Never errors —
+// "can't tell" degrades to unknown per the Inbound contract.
+func (p *Provisioner) Status(ctx context.Context, orgID string, stream streaming.Stream) (streaming.InboundState, error) {
+	sc, err := stream.Transport.SlackConfig()
+	if err != nil {
+		return streaming.InboundState{State: "unknown", Detail: err.Error()}, nil
+	}
+	cfg, err := readConfig(ctx, p.registry, orgID)
+	if err != nil {
+		return streaming.InboundState{State: "unknown", Detail: "org not connected to Slack"}, nil
+	}
+	client := newSlackClient(cfg.BotToken, p.apiURL)
+	ch, err := client.GetConversationInfoContext(ctx, &slack.GetConversationInfoInput{ChannelID: sc.Channel})
+	if err != nil {
+		p.logger.Warn("slack.status: conversations.info", "org", orgID, "channel", sc.Channel, "err", err)
+		return streaming.InboundState{State: "unknown", Detail: err.Error()}, nil
+	}
+	if ch.IsMember {
+		return streaming.InboundState{State: "installed", Active: true}, nil
+	}
+	return streaming.InboundState{State: "missing"}, nil
+}
+
+// compile-time assertion that Provisioner satisfies the port.
+var _ streaming.Inbound = (*Provisioner)(nil)

--- a/api/pkg/org/infrastructure/transports/slack/provisioner_test.go
+++ b/api/pkg/org/infrastructure/transports/slack/provisioner_test.go
@@ -1,0 +1,154 @@
+// Provisioner tests (FR-6). Install ensures the bot is a member of the
+// bound channel (conversations.join); Status reports membership,
+// degrading to "unknown" on an API failure rather than erroring (the
+// streaming.Inbound contract). Driven against a fake Slack API.
+package slack_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
+	slacktransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/slack"
+)
+
+// fakeConversations serves conversations.join / conversations.info.
+type fakeConversations struct {
+	server   *httptest.Server
+	isMember atomic.Bool
+	joinErr  atomic.Bool
+	infoErr  atomic.Bool
+	joined   atomic.Int32
+}
+
+func newFakeConversations(t *testing.T) *fakeConversations {
+	t.Helper()
+	f := &fakeConversations{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/conversations.join", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		f.joined.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if f.joinErr.Load() {
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "channel_not_found"})
+			return
+		}
+		f.isMember.Store(true)
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "channel": map[string]any{"id": r.PostForm.Get("channel"), "is_member": true}})
+	})
+	mux.HandleFunc("/conversations.info", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "application/json")
+		if f.infoErr.Load() {
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "channel_not_found"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "channel": map[string]any{"id": r.PostForm.Get("channel"), "is_member": f.isMember.Load()}})
+	})
+	f.server = httptest.NewServer(mux)
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+func (f *fakeConversations) apiURL() string { return f.server.URL + "/" }
+
+func newTestProvisioner(t *testing.T, fake *fakeConversations) (*slacktransport.Provisioner, *store.Store, *configregistry.Registry) {
+	t.Helper()
+	st := orggorm.GetOrgTestDB(t)
+	reg := configregistry.New(st.Configs)
+	reg.Register(configregistry.Spec{Key: "transport.slack", Type: configregistry.TypeObject, Secrets: []string{"bot_token"}})
+	p := slacktransport.NewProvisioner(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	p.SetAPIURL(fake.apiURL())
+	return p, st, reg
+}
+
+func TestProvisioner_InstallJoinsChannel(t *testing.T) {
+	fake := newFakeConversations(t)
+	p, st, reg := newTestProvisioner(t, fake)
+	setSlackInstall(t, reg, "org-a", "xoxb-a", "TAAA")
+	stream := seedSlackStream(t, st, "org-a", "str-a", "C123")
+
+	_, err := p.Install(context.Background(), "org-a", stream)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if fake.joined.Load() != 1 {
+		t.Fatalf("conversations.join calls = %d, want 1", fake.joined.Load())
+	}
+
+	state, err := p.Status(context.Background(), "org-a", stream)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if state.State != "installed" {
+		t.Fatalf("post-install status = %q, want installed", state.State)
+	}
+}
+
+func TestProvisioner_StatusMissingWhenNotMember(t *testing.T) {
+	fake := newFakeConversations(t)
+	p, st, reg := newTestProvisioner(t, fake)
+	setSlackInstall(t, reg, "org-a", "xoxb-a", "TAAA")
+	stream := seedSlackStream(t, st, "org-a", "str-a", "C123")
+	// isMember defaults false → not joined.
+
+	state, err := p.Status(context.Background(), "org-a", stream)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if state.State != "missing" {
+		t.Fatalf("status = %q, want missing", state.State)
+	}
+}
+
+func TestProvisioner_StatusUnknownOnAPIError(t *testing.T) {
+	fake := newFakeConversations(t)
+	fake.infoErr.Store(true)
+	p, st, reg := newTestProvisioner(t, fake)
+	setSlackInstall(t, reg, "org-a", "xoxb-a", "TAAA")
+	stream := seedSlackStream(t, st, "org-a", "str-a", "C123")
+
+	state, err := p.Status(context.Background(), "org-a", stream)
+	if err != nil {
+		t.Fatalf("Status should degrade, not error: %v", err)
+	}
+	if state.State != "unknown" {
+		t.Fatalf("status = %q, want unknown on API failure", state.State)
+	}
+}
+
+func TestProvisioner_StatusUnknownWhenNotInstalled(t *testing.T) {
+	fake := newFakeConversations(t)
+	p, st, _ := newTestProvisioner(t, fake)
+	// No transport.slack config for org-a → org not connected.
+	stream := seedSlackStream(t, st, "org-a", "str-a", "C123")
+
+	state, err := p.Status(context.Background(), "org-a", stream)
+	if err != nil {
+		t.Fatalf("Status should degrade, not error: %v", err)
+	}
+	if state.State != "unknown" {
+		t.Fatalf("status = %q, want unknown when org has no install", state.State)
+	}
+}
+
+func TestProvisioner_InstallUpstreamError(t *testing.T) {
+	fake := newFakeConversations(t)
+	fake.joinErr.Store(true)
+	p, st, reg := newTestProvisioner(t, fake)
+	setSlackInstall(t, reg, "org-a", "xoxb-a", "TAAA")
+	stream := seedSlackStream(t, st, "org-a", "str-a", "C123")
+
+	_, err := p.Install(context.Background(), "org-a", stream)
+	if err == nil {
+		t.Fatalf("Install() = nil, want error when join fails")
+	}
+}

--- a/api/pkg/org/infrastructure/transports/slack/router.go
+++ b/api/pkg/org/infrastructure/transports/slack/router.go
@@ -1,0 +1,167 @@
+package slack
+
+import (
+	"context"
+	"strings"
+
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+)
+
+// Candidate is one subscribed Worker the Router may activate, paired
+// with the text the Router scores against (its identity + role text).
+type Candidate struct {
+	WorkerID orgchart.WorkerID
+	Identity string
+}
+
+// Inbound is the routing context: the new message, prior thread
+// messages (oldest-first), and the channel's subscriber set. A Router
+// chooses a subset of Subscribers — it never invents a target outside
+// it.
+type Inbound struct {
+	OrgID       string
+	Stream      streaming.Stream
+	Message     streaming.Message
+	Thread      []streaming.Message
+	Subscribers []Candidate
+}
+
+// Router narrows the subscriber set to the Worker(s) an inbound message
+// should activate (§9.4 / OQ-1). Personas can't be @mentioned, so when
+// several Workers share a channel something has to pick — but that
+// choice is an org-graph concern, pluggable per org. The default is to
+// not choose at all (broadcast).
+type Router interface {
+	Route(ctx context.Context, in Inbound) ([]orgchart.WorkerID, error)
+}
+
+// BroadcastRouter returns every subscriber (FR-25). Helix decides
+// nothing; disambiguation is left to the org graph (e.g. a routing
+// Worker reading the channel). This is the default.
+type BroadcastRouter struct{}
+
+// Route returns all subscriber WorkerIDs.
+func (BroadcastRouter) Route(_ context.Context, in Inbound) ([]orgchart.WorkerID, error) {
+	out := make([]orgchart.WorkerID, 0, len(in.Subscribers))
+	for _, c := range in.Subscribers {
+		out = append(out, c.WorkerID)
+	}
+	return out, nil
+}
+
+// FuzzyRouter scores each candidate by keyword overlap of the
+// message + thread text against the Worker's identity/role text and
+// returns the best match. Code-only — no LLM, no network. It never
+// drops to zero: on a tie among the top scorers, or when no candidate
+// scores above zero (low confidence), it returns all tied / all
+// subscribers, so a message is never silently delivered to nobody.
+type FuzzyRouter struct{}
+
+// Route picks the highest-overlap candidate(s).
+func (FuzzyRouter) Route(_ context.Context, in Inbound) ([]orgchart.WorkerID, error) {
+	if len(in.Subscribers) == 0 {
+		return nil, nil
+	}
+	// Build the haystack of message words (new message + thread).
+	var sb strings.Builder
+	sb.WriteString(in.Message.Subject)
+	sb.WriteByte(' ')
+	sb.WriteString(in.Message.Body)
+	for _, m := range in.Thread {
+		sb.WriteByte(' ')
+		sb.WriteString(m.Subject)
+		sb.WriteByte(' ')
+		sb.WriteString(m.Body)
+	}
+	msgTokens := tokenSet(sb.String())
+
+	best := 0
+	scores := make([]int, len(in.Subscribers))
+	for i, c := range in.Subscribers {
+		score := overlap(msgTokens, tokenSet(c.Identity))
+		scores[i] = score
+		if score > best {
+			best = score
+		}
+	}
+	// Low confidence: nobody matched → broadcast (never drop).
+	if best == 0 {
+		return BroadcastRouter{}.Route(context.Background(), in)
+	}
+	var out []orgchart.WorkerID
+	for i, c := range in.Subscribers {
+		if scores[i] == best {
+			out = append(out, c.WorkerID)
+		}
+	}
+	return out, nil
+}
+
+// overlap counts how many message tokens appear in the identity tokens.
+func overlap(msg, identity map[string]struct{}) int {
+	n := 0
+	for tok := range msg {
+		if _, ok := identity[tok]; ok {
+			n++
+		}
+	}
+	return n
+}
+
+// stopWords are common words excluded from fuzzy matching so they don't
+// dominate the overlap score.
+var stopWords = map[string]struct{}{
+	"the": {}, "a": {}, "an": {}, "and": {}, "or": {}, "to": {}, "of": {},
+	"in": {}, "on": {}, "for": {}, "is": {}, "are": {}, "i": {}, "you": {},
+	"my": {}, "me": {}, "we": {}, "it": {}, "this": {}, "that": {}, "can": {},
+	"please": {}, "was": {}, "with": {}, "at": {}, "be": {}, "have": {},
+}
+
+// tokenSet lowercases, splits on non-alphanumeric runs, drops stop
+// words and 1-char tokens, naively singularises (so "invoices" matches
+// "invoice"), and returns the distinct set.
+func tokenSet(s string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, f := range strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9')
+	}) {
+		if len(f) < 2 {
+			continue
+		}
+		if _, skip := stopWords[f]; skip {
+			continue
+		}
+		out[stem(f)] = struct{}{}
+	}
+	return out
+}
+
+// stem applies a deliberately crude singularisation: trim a trailing
+// "s" from tokens longer than three characters ("refunds" → "refund",
+// "payments" → "payment"). Good enough to align plural/singular forms
+// for keyword overlap without pulling in a real stemmer.
+func stem(tok string) string {
+	if len(tok) > 3 && strings.HasSuffix(tok, "s") {
+		return tok[:len(tok)-1]
+	}
+	return tok
+}
+
+// routerRegistry maps the per-org `slack.router` config value to a
+// Router. Adding an implementation (e.g. an LLMRouter) is a new entry
+// here plus the type — no edits to the ingest. Unknown/unset names
+// resolve to broadcast.
+var routerRegistry = map[string]Router{
+	"broadcast": BroadcastRouter{},
+	"fuzzy":     FuzzyRouter{},
+}
+
+// RouterFor resolves a `slack.router` config value to a Router,
+// defaulting to BroadcastRouter for unknown or empty names (§9.4).
+func RouterFor(name string) Router {
+	if r, ok := routerRegistry[name]; ok {
+		return r
+	}
+	return BroadcastRouter{}
+}

--- a/api/pkg/org/infrastructure/transports/slack/router_test.go
+++ b/api/pkg/org/infrastructure/transports/slack/router_test.go
@@ -1,0 +1,160 @@
+// Router tests (§9.4). The Router narrows a channel's subscriber set to
+// the Worker(s) an inbound message should activate. BroadcastRouter
+// (the default) returns everyone; FuzzyRouter scores candidates by
+// keyword overlap with their identity/role text and returns the best
+// match — but never drops to zero, falling back to all on a tie or low
+// confidence. The registry maps the per-org `slack.router` value to an
+// implementation, defaulting to broadcast.
+package slack_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+	slacktransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/slack"
+)
+
+func candidates() []slacktransport.Candidate {
+	return []slacktransport.Candidate{
+		{WorkerID: "w-billing", Identity: "Handles billing, invoices, payments and refunds."},
+		{WorkerID: "w-eng", Identity: "Software engineer. Fixes bugs, writes code, reviews pull requests."},
+		{WorkerID: "w-sales", Identity: "Sales rep. Talks to prospects about pricing and demos."},
+	}
+}
+
+func ids(cs []slacktransport.Candidate) []orgchart.WorkerID {
+	out := make([]orgchart.WorkerID, len(cs))
+	for i, c := range cs {
+		out[i] = c.WorkerID
+	}
+	return out
+}
+
+func contains(set []orgchart.WorkerID, id orgchart.WorkerID) bool {
+	for _, s := range set {
+		if s == id {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBroadcastRouter_ReturnsAll(t *testing.T) {
+	r := slacktransport.BroadcastRouter{}
+	in := slacktransport.Inbound{
+		Subscribers: candidates(),
+		Message:     streaming.Message{Body: "anything"},
+	}
+	got, err := r.Route(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("BroadcastRouter returned %d, want all 3", len(got))
+	}
+	for _, want := range ids(candidates()) {
+		if !contains(got, want) {
+			t.Errorf("missing %q from broadcast result", want)
+		}
+	}
+}
+
+func TestFuzzyRouter_PicksBestMatch(t *testing.T) {
+	r := slacktransport.FuzzyRouter{}
+	in := slacktransport.Inbound{
+		Subscribers: candidates(),
+		Message:     streaming.Message{Body: "I need a refund on my invoice, the payment was wrong"},
+	}
+	got, err := r.Route(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if len(got) != 1 || got[0] != "w-billing" {
+		t.Fatalf("FuzzyRouter = %v, want [w-billing]", got)
+	}
+}
+
+func TestFuzzyRouter_UsesThreadContext(t *testing.T) {
+	r := slacktransport.FuzzyRouter{}
+	in := slacktransport.Inbound{
+		Subscribers: candidates(),
+		Message:     streaming.Message{Body: "can you take a look?"},
+		Thread: []streaming.Message{
+			{Body: "There is a bug in the code, the pull requests are failing"},
+		},
+	}
+	got, err := r.Route(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if len(got) != 1 || got[0] != "w-eng" {
+		t.Fatalf("FuzzyRouter with thread = %v, want [w-eng]", got)
+	}
+}
+
+func TestFuzzyRouter_LowConfidenceReturnsAll(t *testing.T) {
+	r := slacktransport.FuzzyRouter{}
+	in := slacktransport.Inbound{
+		Subscribers: candidates(),
+		Message:     streaming.Message{Body: "hello everyone good morning"},
+	}
+	got, err := r.Route(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("FuzzyRouter low-confidence = %v, want all 3 (never drops)", got)
+	}
+}
+
+func TestFuzzyRouter_TieReturnsAllTied(t *testing.T) {
+	r := slacktransport.FuzzyRouter{}
+	cs := []slacktransport.Candidate{
+		{WorkerID: "w-a", Identity: "refund refund"},
+		{WorkerID: "w-b", Identity: "refund refund"},
+		{WorkerID: "w-c", Identity: "totally unrelated topic"},
+	}
+	in := slacktransport.Inbound{
+		Subscribers: cs,
+		Message:     streaming.Message{Body: "refund please"},
+	}
+	got, err := r.Route(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Route: %v", err)
+	}
+	if len(got) != 2 || !contains(got, "w-a") || !contains(got, "w-b") {
+		t.Fatalf("FuzzyRouter tie = %v, want [w-a w-b]", got)
+	}
+}
+
+func TestRouterRegistry_Resolves(t *testing.T) {
+	cases := []struct {
+		name string
+		want string // type name fragment for the assertion
+	}{
+		{"broadcast", "broadcast"},
+		{"fuzzy", "fuzzy"},
+		{"", "broadcast"},
+		{"nonsense", "broadcast"},
+	}
+	for _, tc := range cases {
+		r := slacktransport.RouterFor(tc.name)
+		if r == nil {
+			t.Fatalf("RouterFor(%q) = nil", tc.name)
+		}
+		// Behavioural check: broadcast returns all; fuzzy narrows.
+		in := slacktransport.Inbound{
+			Subscribers: candidates(),
+			Message:     streaming.Message{Body: "refund invoice payment billing"},
+		}
+		got, _ := r.Route(context.Background(), in)
+		if tc.want == "broadcast" && len(got) != 3 {
+			t.Errorf("RouterFor(%q) routed %d, want broadcast(3)", tc.name, len(got))
+		}
+		if tc.want == "fuzzy" && len(got) != 1 {
+			t.Errorf("RouterFor(%q) routed %d, want fuzzy(1)", tc.name, len(got))
+		}
+	}
+}

--- a/api/pkg/org/infrastructure/transports/slack/singleowner.go
+++ b/api/pkg/org/infrastructure/transports/slack/singleowner.go
@@ -1,0 +1,114 @@
+package slack
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+)
+
+// Locker is an exclusive, cross-replica lock. TryLock returns
+// acquired=true only for the single caller that currently holds it;
+// Unlock releases it. The production implementation is a Postgres
+// advisory lock (one connection holds the session lock); tests use a
+// fake shared lockbox.
+type Locker interface {
+	TryLock(ctx context.Context) (acquired bool, err error)
+	Unlock(ctx context.Context) error
+}
+
+// SingleOwner gates the Socket Mode connection so that, across a
+// multi-replica deployment, exactly one replica opens the single
+// outbound WebSocket and runs ingest (NFR-2). The winner holds the
+// lock; losers poll to take over on failover (NFR-5).
+type SingleOwner struct {
+	locker Locker
+	logger *slog.Logger
+}
+
+// NewSingleOwner wraps a Locker.
+func NewSingleOwner(locker Locker, logger *slog.Logger) *SingleOwner {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &SingleOwner{locker: locker, logger: logger}
+}
+
+// TryAcquire reports whether this replica won (or already holds) the
+// lock. A lock error is treated as "not acquired" and logged — a replica
+// that can't reach the lock must not assume ownership.
+func (o *SingleOwner) TryAcquire(ctx context.Context) bool {
+	ok, err := o.locker.TryLock(ctx)
+	if err != nil {
+		o.logger.Warn("slack.singleowner: try-lock", "err", err)
+		return false
+	}
+	return ok
+}
+
+// Release frees the lock so another replica can take over.
+func (o *SingleOwner) Release(ctx context.Context) {
+	if err := o.locker.Unlock(ctx); err != nil {
+		o.logger.Warn("slack.singleowner: unlock", "err", err)
+	}
+}
+
+// SocketModeLockKey is the constant advisory-lock key the Socket Mode
+// owner contends on. Arbitrary but fixed across replicas so they all
+// fight over the same lock.
+const SocketModeLockKey int64 = 0x5_1ACC_50C7 // "slack soc(ket)"
+
+// PgAdvisoryLock is the production Locker: a Postgres session-level
+// advisory lock held on one dedicated connection. pg_try_advisory_lock
+// is non-blocking — it returns immediately with whether the lock was
+// taken — which is exactly the poll-and-take-over semantics SingleOwner
+// wants.
+type PgAdvisoryLock struct {
+	db   *sql.DB
+	key  int64
+	conn *sql.Conn
+}
+
+// NewPgAdvisoryLock builds a Postgres advisory lock on the given key.
+func NewPgAdvisoryLock(db *sql.DB, key int64) *PgAdvisoryLock {
+	return &PgAdvisoryLock{db: db, key: key}
+}
+
+// TryLock attempts pg_try_advisory_lock on a fresh dedicated connection.
+// On success the connection is retained (the session lock lives on it);
+// on failure the connection is returned to the pool. Re-calling while
+// already holding is a no-op success.
+func (p *PgAdvisoryLock) TryLock(ctx context.Context) (bool, error) {
+	if p.conn != nil {
+		return true, nil
+	}
+	conn, err := p.db.Conn(ctx)
+	if err != nil {
+		return false, err
+	}
+	var acquired bool
+	if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", p.key).Scan(&acquired); err != nil {
+		_ = conn.Close()
+		return false, err
+	}
+	if !acquired {
+		_ = conn.Close()
+		return false, nil
+	}
+	p.conn = conn
+	return true, nil
+}
+
+// Unlock releases the advisory lock and returns the dedicated
+// connection to the pool. No-op when not held.
+func (p *PgAdvisoryLock) Unlock(ctx context.Context) error {
+	if p.conn == nil {
+		return nil
+	}
+	_, err := p.conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", p.key)
+	_ = p.conn.Close()
+	p.conn = nil
+	return err
+}
+
+// compile-time assertion.
+var _ Locker = (*PgAdvisoryLock)(nil)

--- a/api/pkg/org/infrastructure/transports/slack/singleowner_test.go
+++ b/api/pkg/org/infrastructure/transports/slack/singleowner_test.go
@@ -1,0 +1,83 @@
+// Single-owner tests (NFR-2): the advisory-lock gate ensures exactly
+// one replica owns the Socket Mode connection. The Postgres
+// implementation is exercised in production; here a fake shared lockbox
+// stands in so the contention logic is tested without a database.
+package slack_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	slacktransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/slack"
+)
+
+// lockbox is a shared lock two fakeLockers contend over.
+type lockbox struct {
+	mu   sync.Mutex
+	held bool
+}
+
+type fakeLocker struct {
+	box     *lockbox
+	holding bool
+}
+
+func (l *fakeLocker) TryLock(context.Context) (bool, error) {
+	l.box.mu.Lock()
+	defer l.box.mu.Unlock()
+	if l.holding {
+		return true, nil
+	}
+	if l.box.held {
+		return false, nil
+	}
+	l.box.held = true
+	l.holding = true
+	return true, nil
+}
+
+func (l *fakeLocker) Unlock(context.Context) error {
+	l.box.mu.Lock()
+	defer l.box.mu.Unlock()
+	if l.holding {
+		l.box.held = false
+		l.holding = false
+	}
+	return nil
+}
+
+func newOwner(box *lockbox) *slacktransport.SingleOwner {
+	return slacktransport.NewSingleOwner(&fakeLocker{box: box}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func TestSingleOwner_OnlyOneAcquires(t *testing.T) {
+	box := &lockbox{}
+	a := newOwner(box)
+	b := newOwner(box)
+	ctx := context.Background()
+
+	if !a.TryAcquire(ctx) {
+		t.Fatalf("first contender failed to acquire")
+	}
+	if b.TryAcquire(ctx) {
+		t.Fatalf("second contender acquired while first holds the lock")
+	}
+}
+
+func TestSingleOwner_TakesOverAfterRelease(t *testing.T) {
+	box := &lockbox{}
+	a := newOwner(box)
+	b := newOwner(box)
+	ctx := context.Background()
+
+	if !a.TryAcquire(ctx) {
+		t.Fatalf("first contender failed to acquire")
+	}
+	a.Release(ctx)
+	if !b.TryAcquire(ctx) {
+		t.Fatalf("second contender failed to take over after release")
+	}
+}

--- a/api/pkg/org/infrastructure/transports/slack/socketmode.go
+++ b/api/pkg/org/infrastructure/transports/slack/socketmode.go
@@ -133,6 +133,29 @@ func NewSlackConnector(appToken, botToken, apiURL string, logger *slog.Logger) C
 
 		go func() {
 			for evt := range client.Events {
+				// NOTE: logging the connection LIFECYCLE (not message
+				// content) is vital to operating Socket Mode. A Socket Mode
+				// app fails silently in a way REST never does: the socket
+				// connects fine, but if Event Subscriptions isn't enabled on
+				// the Slack app — or the right bot events aren't subscribed —
+				// no message events ever arrive, and there is nothing in any
+				// log to say so. Emitting connecting/connected/disconnect/
+				// error transitions is what lets an operator tell "the socket
+				// is up and Slack just isn't sending us anything" apart from
+				// "the socket never came up". We deliberately log only
+				// connection-state transitions and per-event metadata
+				// (channel/team, in the ingest) — never message bodies:
+				// that keeps the signal high and avoids logging user content.
+				switch evt.Type {
+				case socketmode.EventTypeConnecting:
+					logger.Info("slack.socketmode: connecting")
+				case socketmode.EventTypeConnected:
+					logger.Info("slack.socketmode: connected — waiting for events (requires Event Subscriptions enabled on the app)")
+				case socketmode.EventTypeDisconnect:
+					logger.Warn("slack.socketmode: disconnected")
+				case socketmode.EventTypeConnectionError, socketmode.EventTypeInvalidAuth:
+					logger.Warn("slack.socketmode: connection problem", "type", string(evt.Type))
+				}
 				if evt.Type != socketmode.EventTypeEventsAPI {
 					// Hello / connecting / disconnect / ping are connection
 					// lifecycle, not application events. Ack interactive
@@ -149,8 +172,13 @@ func NewSlackConnector(appToken, botToken, apiURL string, logger *slog.Logger) C
 				if eventsAPI.Type != slackevents.CallbackEvent {
 					continue
 				}
+				// Metadata only (the event type, never the body): confirms
+				// events are flowing and surfaces ones we don't yet map.
+				logger.Info("slack.socketmode: event received", "team", eventsAPI.TeamID, "inner_type", eventsAPI.InnerEvent.Type)
 				if ev, ok := toIngestEvent(eventsAPI.InnerEvent.Data); ok {
 					handle(eventsAPI.TeamID, ev)
+				} else {
+					logger.Debug("slack.socketmode: event not mapped to ingest", "inner_type", eventsAPI.InnerEvent.Type)
 				}
 			}
 		}()

--- a/api/pkg/org/infrastructure/transports/slack/socketmode.go
+++ b/api/pkg/org/infrastructure/transports/slack/socketmode.go
@@ -1,0 +1,166 @@
+package slack
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
+)
+
+// Connector opens one Socket Mode session and pumps inbound events to
+// handle until the context is cancelled or the connection drops
+// (returning the error). It is the seam the SocketMode runner depends
+// on; production wraps slack-go's socketmode client, tests supply a
+// fake. handle receives the already-normalised (teamID, Event).
+type Connector func(ctx context.Context, handle func(teamID string, ev Event)) error
+
+// SocketMode is the WebSocket ingress source (Socket Mode) — Slack-
+// managed auth, no inbound HTTP endpoint required (FR-15, US-6). One
+// replica owns the single connection (NFR-2) via SingleOwner; on
+// disconnect it reconnects with backoff (NFR-5). Inbound events feed the
+// same shared ingest path as the REST source (FR-19).
+type SocketMode struct {
+	receiver  Receiver
+	owner     *SingleOwner
+	connector Connector
+	logger    *slog.Logger
+	poll      time.Duration
+	backoff   time.Duration
+}
+
+// NewSocketMode builds the runner. poll is how often a non-owning
+// replica re-checks the lock (failover latency); backoff is the wait
+// after a dropped connection before reconnecting.
+func NewSocketMode(receiver Receiver, owner *SingleOwner, connector Connector, logger *slog.Logger) *SocketMode {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &SocketMode{
+		receiver:  receiver,
+		owner:     owner,
+		connector: connector,
+		logger:    logger,
+		poll:      10 * time.Second,
+		backoff:   2 * time.Second,
+	}
+}
+
+// SetIntervals overrides the poll/backoff durations (tests use short
+// values to keep them fast).
+func (s *SocketMode) SetIntervals(poll, backoff time.Duration) {
+	s.poll = poll
+	s.backoff = backoff
+}
+
+// Run blocks until ctx is cancelled. It polls for the single-owner lock;
+// the replica that wins opens the connection and consumes events,
+// reconnecting on drop. Losers keep polling so they take over on
+// failover. Releasing the lock on exit lets another replica step in.
+func (s *SocketMode) Run(ctx context.Context) error {
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if s.owner != nil && !s.owner.TryAcquire(ctx) {
+			if !sleepCtx(ctx, s.poll) {
+				return ctx.Err()
+			}
+			continue
+		}
+		// We own the connection now. Consume until it drops or ctx ends.
+		err := s.connector(ctx, s.handle)
+		if ctx.Err() != nil {
+			if s.owner != nil {
+				s.owner.Release(ctx)
+			}
+			return ctx.Err()
+		}
+		if err != nil {
+			s.logger.Warn("slack.socketmode: connection dropped, reconnecting", "err", err)
+		}
+		// Reconnect after backoff; keep the lock so we remain the owner.
+		if !sleepCtx(ctx, s.backoff) {
+			if s.owner != nil {
+				s.owner.Release(ctx)
+			}
+			return ctx.Err()
+		}
+	}
+}
+
+// handle forwards a normalised event to the shared ingest path. Errors
+// are logged, not propagated — a single bad event must not tear down the
+// connection.
+func (s *SocketMode) handle(teamID string, ev Event) {
+	if err := s.receiver.Receive(context.Background(), teamID, ev); err != nil {
+		s.logger.Error("slack.socketmode: ingest", "team", teamID, "err", err)
+	}
+}
+
+// sleepCtx sleeps for d unless ctx is cancelled first. Returns false if
+// the context was cancelled.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+// NewSlackConnector is the production Connector: it opens a slack-go
+// Socket Mode client (app-level token authenticates the socket; bot
+// token authorises API calls) and translates each Events-API event into
+// the transport-neutral Event before calling handle. apiURL overrides
+// the Slack API base for tests; empty uses slack.com.
+func NewSlackConnector(appToken, botToken, apiURL string, logger *slog.Logger) Connector {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return func(ctx context.Context, handle func(teamID string, ev Event)) error {
+		opts := []slack.Option{slack.OptionAppLevelToken(appToken)}
+		if apiURL != "" {
+			opts = append(opts, slack.OptionAPIURL(apiURL))
+		}
+		api := slack.New(botToken, opts...)
+		client := socketmode.New(api)
+
+		go func() {
+			for evt := range client.Events {
+				if evt.Type != socketmode.EventTypeEventsAPI {
+					// Hello / connecting / disconnect / ping are connection
+					// lifecycle, not application events. Ack interactive
+					// requests we do handle below; ignore the rest.
+					continue
+				}
+				eventsAPI, ok := evt.Data.(slackevents.EventsAPIEvent)
+				if !ok {
+					continue
+				}
+				if evt.Request != nil {
+					client.Ack(*evt.Request)
+				}
+				if eventsAPI.Type != slackevents.CallbackEvent {
+					continue
+				}
+				if ev, ok := toIngestEvent(eventsAPI.InnerEvent.Data); ok {
+					handle(eventsAPI.TeamID, ev)
+				}
+			}
+		}()
+
+		err := client.RunContext(ctx)
+		if err == nil {
+			// RunContext returned without error but the stream is over —
+			// surface a sentinel so Run treats it as a reconnect.
+			return errors.New("socketmode: connection closed")
+		}
+		return err
+	}
+}

--- a/api/pkg/org/infrastructure/transports/slack/socketmode_test.go
+++ b/api/pkg/org/infrastructure/transports/slack/socketmode_test.go
@@ -1,0 +1,110 @@
+// Socket Mode runner tests (FR-15, NFR-2/NFR-5). A fake Connector
+// stands in for the slack-go WebSocket so the Run loop — acquire lock,
+// consume events into the shared ingest, reconnect on drop — is tested
+// without a real Slack connection.
+package slack_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	slacktransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/slack"
+)
+
+func runSocket(t *testing.T, rec slacktransport.Receiver, connector slacktransport.Connector) (context.CancelFunc, func()) {
+	t.Helper()
+	box := &lockbox{}
+	owner := newOwner(box)
+	sm := slacktransport.NewSocketMode(rec, owner, connector, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	sm.SetIntervals(5*time.Millisecond, 5*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_ = sm.Run(ctx)
+		close(done)
+	}()
+	wait := func() {
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("socket Run did not exit after cancel")
+		}
+	}
+	return cancel, wait
+}
+
+func TestSocketMode_ForwardsEventToIngest(t *testing.T) {
+	rec := &recordingReceiver{}
+	var calls int32
+	connector := func(ctx context.Context, handle func(teamID string, ev slacktransport.Event)) error {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			handle("TAAA", slacktransport.Event{Channel: "C1", User: "U1", Text: "hi", TS: "1.1"})
+			return nil // clean disconnect → runner will reconnect
+		}
+		<-ctx.Done() // subsequent connects idle until shutdown
+		return ctx.Err()
+	}
+	cancel, wait := runSocket(t, rec, connector)
+
+	// Wait for the event to be ingested.
+	deadline := time.After(2 * time.Second)
+	for rec.count() < 1 {
+		select {
+		case <-deadline:
+			t.Fatalf("event not ingested")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	cancel()
+	wait()
+
+	if rec.count() != 1 {
+		t.Fatalf("ingest count = %d, want exactly 1", rec.count())
+	}
+	team, ev := rec.last()
+	if team != "TAAA" || ev.Channel != "C1" {
+		t.Fatalf("forwarded event mismapped: team=%q ev=%+v", team, ev)
+	}
+}
+
+func TestSocketMode_ReconnectsAfterError(t *testing.T) {
+	rec := &recordingReceiver{}
+	var calls int32
+	connector := func(ctx context.Context, handle func(teamID string, ev slacktransport.Event)) error {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			return errors.New("boom: first connect fails") // drop before any event
+		}
+		if n == 2 {
+			handle("TBBB", slacktransport.Event{Channel: "C2", User: "U2", Text: "second", TS: "2.2"})
+			return nil
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	cancel, wait := runSocket(t, rec, connector)
+
+	deadline := time.After(2 * time.Second)
+	for rec.count() < 1 {
+		select {
+		case <-deadline:
+			t.Fatalf("event not ingested after reconnect")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	cancel()
+	wait()
+
+	if atomic.LoadInt32(&calls) < 2 {
+		t.Fatalf("connector called %d times, want >= 2 (reconnect)", calls)
+	}
+	team, _ := rec.last()
+	if team != "TBBB" {
+		t.Fatalf("ingested team = %q, want TBBB (from second connect)", team)
+	}
+}

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -36,6 +37,7 @@ import (
 	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/streamcron"
 	githubtransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/github"
+	slacktransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/slack"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/transports/webhook"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/wakebus"
 	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
@@ -85,6 +87,18 @@ type helixOrgHandlers struct {
 	// then redirects to the install page. The installation id is reconciled
 	// later via GET /app/installations (no Setup-URL redirect needed).
 	publicGitHubManifestCallback http.Handler
+	// Slack transport handlers. publicSlackEvents is the REST Events API
+	// ingress (POST /api/v1/slack/events) — one global endpoint, routed to
+	// the right org by team id. publicSlackOAuthCallback completes the
+	// per-org "Add to Slack" install (GET /api/v1/slack/oauth/callback,
+	// insecure, authenticated by encrypted state). slackOAuthStart begins
+	// the install for an org (GET /api/v1/orgs/{org}/slack/oauth/start,
+	// auth-routed). runSlackSocket runs the Socket Mode ingress under a
+	// single-owner lock (no-op unless the admin selects socket ingress).
+	publicSlackEvents        http.Handler
+	publicSlackOAuthCallback http.Handler
+	slackOAuthStart          http.Handler
+	runSlackSocket           func(ctx context.Context)
 }
 
 // initHelixOrgHandler builds the in-process helix-org HTTP handler;
@@ -475,6 +489,9 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 			githubtransport.TokenResolver(gitHubTokenResolver),
 			cfg.APIServer.Cfg.WebServer.URL,
 		),
+		// Slack "install" = ensure the org's shared bot has joined the
+		// bound channel (conversations.join); no per-stream webhook.
+		transport.KindSlack: slacktransport.NewProvisioner(configReg, logger),
 	}
 
 	// Application services shared by the REST adapter. Built once here
@@ -644,6 +661,28 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		cfg.APIServer.Cfg.GitHub.WebURL(), cfg.APIServer.Cfg.GitHub.APIBaseURL(),
 	)
 
+	// Slack transport wiring — registers the outbound emitter on the
+	// dispatcher and builds the REST/Socket ingress + OAuth install
+	// handlers. The Socket Mode single-owner lock uses helix's Postgres
+	// connection when available; otherwise a single-replica no-op lock.
+	var slackSQLDB *sql.DB
+	if accessor, ok := helixStore.(interface{ GormDB() *gorm.DB }); ok {
+		if raw, err := accessor.GormDB().DB(); err == nil {
+			slackSQLDB = raw
+		}
+	}
+	slack := buildSlackWiring(slackWiringDeps{
+		configReg:     configReg,
+		orgStore:      st,
+		broadcaster:   bc,
+		dispatcher:    dispatcher,
+		helixStore:    helixStore,
+		sqlDB:         slackSQLDB,
+		encryptionKey: cfg.APIServer.getEncryptionKey,
+		publicURL:     cfg.APIServer.Cfg.WebServer.URL,
+		logger:        logger,
+	})
+
 	return &helixOrgHandlers{
 		api:                          orgServer.Handler(extras...),
 		scope:                        scope,
@@ -651,6 +690,10 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		publicGitHubWebhook:          publicGitHubWebhook,
 		publicGitHubWebhookForStream: publicGitHubWebhookForStream,
 		publicGitHubManifestCallback: publicGitHubManifestCallback,
+		publicSlackEvents:            slack.events,
+		publicSlackOAuthCallback:     slack.oauthCallback,
+		slackOAuthStart:              slack.oauthStart,
+		runSlackSocket:               slack.runSocket,
 	}, nil
 }
 

--- a/api/pkg/server/helix_org_slack.go
+++ b/api/pkg/server/helix_org_slack.go
@@ -146,6 +146,7 @@ func buildSlackWiring(deps slackWiringDeps) slackWiring {
 			ClientSecret:  p.ClientSecret,
 			SigningSecret: p.SlackSigningSecret,
 			AppToken:      p.SlackAppToken,
+			BotToken:      p.SlackBotToken,
 			IngressMode:   p.SlackIngressMode,
 			Enabled:       p.Enabled,
 		}, nil
@@ -249,7 +250,14 @@ func buildSlackWiring(deps slackWiringDeps) slackWiring {
 				}
 				return nil
 			}
-			botToken := resolveAnyBotToken(ctx, deps.configReg, deps.orgStore)
+			// Socket Mode posts with the single-workspace bot token
+			// configured on the global app. Fall back to scanning per-org
+			// installs for the rare case the workspace was onboarded via
+			// the OAuth flow rather than a pasted token.
+			botToken := app.BotToken
+			if botToken == "" {
+				botToken = resolveAnyBotToken(ctx, deps.configReg, deps.orgStore)
+			}
 			return slacktransport.NewSlackConnector(app.AppToken, botToken, "", logger)(ctx, handle)
 		}
 		runner := slacktransport.NewSocketMode(ingest, owner, connector, logger)

--- a/api/pkg/server/helix_org_slack.go
+++ b/api/pkg/server/helix_org_slack.go
@@ -1,0 +1,267 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/crypto"
+	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+	"github.com/helixml/helix/api/pkg/org/application/dispatch"
+	helixorgstore "github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/domain/transport"
+	slacktransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/slack"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/wakebus"
+	helixorgserver "github.com/helixml/helix/api/pkg/org/interfaces/server"
+	helixstore "github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// transportSlackKind aliases the Slack transport Kind for the wiring.
+const transportSlackKind = transport.KindSlack
+
+// slackSocketIdle is how long the Socket Mode connector waits before
+// re-checking config when Socket Mode isn't currently active.
+const slackSocketIdle = 30 * time.Second
+
+// noopLocker is the single-owner Locker used when no Postgres handle is
+// available (e.g. tests / non-Postgres dev): it always grants the lock,
+// which is correct for a single-replica deployment.
+type noopLocker struct{}
+
+func (noopLocker) TryLock(context.Context) (bool, error) { return true, nil }
+func (noopLocker) Unlock(context.Context) error          { return nil }
+
+// sleepCtxServer sleeps for d unless ctx is cancelled. Returns false on
+// cancellation.
+func sleepCtxServer(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+// resolveAnyBotToken returns the bot token of the single Slack install
+// (the Socket Mode on-premise case is one workspace). It scans the orgs
+// that own Slack streams and returns the first configured bot token.
+func resolveAnyBotToken(ctx context.Context, reg *configregistry.Registry, st *helixorgstore.Store) string {
+	streams, err := st.Streams.ListByTransportKind(ctx, transport.KindSlack)
+	if err != nil {
+		return ""
+	}
+	seen := map[string]bool{}
+	for _, s := range streams {
+		if seen[s.OrganizationID] {
+			continue
+		}
+		seen[s.OrganizationID] = true
+		var cfg slacktransport.Config
+		if err := reg.GetObject(ctx, s.OrganizationID, "transport.slack", &cfg); err == nil && cfg.BotToken != "" {
+			return cfg.BotToken
+		}
+	}
+	return ""
+}
+
+// slackOAuthScopes are the bot scopes the per-org "Add to Slack" install
+// requests. chat:write posts as personas; channels:* + groups:read let
+// the bot join and read bound channels; app_mentions:read surfaces
+// @mentions of the bot.
+var slackOAuthScopes = []string{
+	"chat:write",
+	"channels:read",
+	"channels:history",
+	"channels:join",
+	"groups:read",
+	"app_mentions:read",
+}
+
+// slackWiring bundles the HTTP handlers and the Socket Mode runner the
+// composition root mounts/starts for the Slack transport.
+type slackWiring struct {
+	// events is the REST Events API handler (POST /slack/events). One
+	// global endpoint; the ingest routes to the right org by team id.
+	events http.Handler
+	// oauthStart begins the per-org "Add to Slack" install
+	// (GET /orgs/{org}/slack/oauth/start). Auth-routed (an admin clicks
+	// it from settings); it redirects to Slack's authorize page.
+	oauthStart http.Handler
+	// oauthCallback completes the install (GET /slack/oauth/callback).
+	// Insecure — it's a top-level redirect from slack.com authenticated
+	// by the encrypted state param.
+	oauthCallback http.Handler
+	// runSocket runs the Socket Mode ingress under a single-owner lock.
+	// No-op unless the global app is enabled with ingress mode "socket".
+	runSocket func(ctx context.Context)
+}
+
+// slackWiringDeps are the collaborators buildSlackWiring needs from the
+// composition root.
+type slackWiringDeps struct {
+	configReg     *configregistry.Registry
+	orgStore      *helixorgstore.Store
+	broadcaster   *wakebus.Bus
+	dispatcher    *dispatch.Dispatcher
+	helixStore    helixstore.Store
+	sqlDB         *sql.DB // for the Socket Mode single-owner advisory lock; nil ⇒ no-op lock
+	encryptionKey func() ([]byte, error)
+	publicURL     string // externally-reachable base URL for the OAuth redirect
+	logger        *slog.Logger
+}
+
+// buildSlackWiring assembles the Slack transport's ingest, outbound,
+// provisioner, OAuth install, and ingress sources from the global app
+// (an OAuthProvider(type=slack) row) and the per-org install config.
+// It registers the outbound emitter on the dispatcher and returns the
+// handlers + socket runner for the server to mount/start.
+func buildSlackWiring(deps slackWiringDeps) slackWiring {
+	logger := deps.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	// GlobalApp port: the single admin-configured Slack app. Read live so
+	// enabling/disabling or switching ingress mode in the admin panel
+	// takes effect without a restart.
+	globalApp := func(ctx context.Context) (slacktransport.App, error) {
+		providers, err := deps.helixStore.ListOAuthProviders(ctx, &helixstore.ListOAuthProvidersQuery{
+			Type:    string(types.OAuthProviderTypeSlack),
+			Enabled: true,
+		})
+		if err != nil {
+			return slacktransport.App{}, err
+		}
+		if len(providers) == 0 {
+			return slacktransport.App{}, slacktransport.ErrNoApp
+		}
+		p := providers[0]
+		return slacktransport.App{
+			ClientID:      p.ClientID,
+			ClientSecret:  p.ClientSecret,
+			SigningSecret: p.SlackSigningSecret,
+			AppToken:      p.SlackAppToken,
+			IngressMode:   p.SlackIngressMode,
+			Enabled:       p.Enabled,
+		}, nil
+	}
+
+	// The one shared inbound path. Single instance for every org; Receive
+	// resolves the owning org from the event's team id.
+	ingest := slacktransport.NewIngest(deps.configReg, deps.orgStore, deps.broadcaster, deps.dispatcher, logger)
+
+	// Outbound: register the persona-posting emitter so worker publishes
+	// on KindSlack streams reach Slack (ingress-agnostic, FR-12).
+	outbound := slacktransport.NewOutbound(deps.configReg, deps.orgStore, slacktransport.DefaultPersonaResolver, logger)
+	deps.dispatcher.RegisterOutbound(transportSlackKind, outbound)
+
+	// REST Events API handler — verifies the global app's signing secret.
+	// Returning "" makes the handler inert when no app is configured (FR-3).
+	signingSecret := func(ctx context.Context) (string, error) {
+		app, err := globalApp(ctx)
+		if err != nil || !app.Enabled {
+			return "", nil
+		}
+		return app.SigningSecret, nil
+	}
+	events := slacktransport.NewEventsAPI(ingest, signingSecret, logger).Handler()
+
+	// OAuth install flow. The org id rides through the round trip in the
+	// encrypted state param.
+	encode := func(orgID string) (string, error) {
+		key, err := deps.encryptionKey()
+		if err != nil {
+			return "", err
+		}
+		return crypto.EncryptAES256GCM([]byte(orgID), key)
+	}
+	decode := func(state string) (string, error) {
+		key, err := deps.encryptionKey()
+		if err != nil {
+			return "", err
+		}
+		plain, err := crypto.DecryptAES256GCM(state, key)
+		if err != nil {
+			return "", err
+		}
+		return string(plain), nil
+	}
+	redirectURI := deps.publicURL + APIPrefix + "/slack/oauth/callback"
+	oauth := slacktransport.NewOAuth(globalApp, deps.configReg, encode, decode, redirectURI, logger)
+
+	oauthStart := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The orgID is resolved + membership-authorised by the
+		// withHelixOrgScope wrapper this handler is mounted behind, then
+		// stashed on the context. Reading it from there (rather than
+		// re-deriving from the path) is what prevents a non-member from
+		// starting an install bound to another org's workspace.
+		orgID := helixorgserver.OrgIDFromContext(r.Context())
+		if orgID == "" {
+			http.Error(w, "missing org", http.StatusBadRequest)
+			return
+		}
+		url, err := oauth.StartURL(r.Context(), orgID, slackOAuthScopes)
+		if err != nil {
+			http.Error(w, "slack not configured: "+err.Error(), http.StatusServiceUnavailable)
+			return
+		}
+		http.Redirect(w, r, url, http.StatusFound)
+	})
+
+	oauthCallback := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		code := r.URL.Query().Get("code")
+		state := r.URL.Query().Get("state")
+		if code == "" || state == "" {
+			http.Error(w, "missing code or state", http.StatusBadRequest)
+			return
+		}
+		if err := oauth.HandleCallback(r.Context(), code, state); err != nil {
+			logger.Error("slack.oauth.callback", "err", err)
+			http.Error(w, "slack install failed: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		// Land the admin back on the app's settings page.
+		http.Redirect(w, r, "/?slack_installed=1", http.StatusFound)
+	})
+
+	// Socket Mode runner. The connector reads the global app + a resolved
+	// bot token fresh on each connect, so it stays inert until the admin
+	// switches ingress mode to "socket" and an org has installed.
+	runSocket := func(ctx context.Context) {
+		var locker slacktransport.Locker
+		if deps.sqlDB != nil {
+			locker = slacktransport.NewPgAdvisoryLock(deps.sqlDB, slacktransport.SocketModeLockKey)
+		} else {
+			locker = noopLocker{}
+		}
+		owner := slacktransport.NewSingleOwner(locker, logger)
+		connector := func(ctx context.Context, handle func(teamID string, ev slacktransport.Event)) error {
+			app, err := globalApp(ctx)
+			if err != nil || !app.Enabled || app.IngressMode != slacktransport.IngressSocket || app.AppToken == "" {
+				// Not configured for Socket Mode — idle until it might be.
+				if !sleepCtxServer(ctx, slackSocketIdle) {
+					return ctx.Err()
+				}
+				return nil
+			}
+			botToken := resolveAnyBotToken(ctx, deps.configReg, deps.orgStore)
+			return slacktransport.NewSlackConnector(app.AppToken, botToken, "", logger)(ctx, handle)
+		}
+		runner := slacktransport.NewSocketMode(ingest, owner, connector, logger)
+		if err := runner.Run(ctx); err != nil && ctx.Err() == nil {
+			logger.Error("slack.socketmode: runner exited", "err", err)
+		}
+	}
+
+	return slackWiring{
+		events:        events,
+		oauthStart:    oauthStart,
+		oauthCallback: oauthCallback,
+		runSocket:     runSocket,
+	}
+}

--- a/api/pkg/server/helixorg/config_specs.go
+++ b/api/pkg/server/helixorg/config_specs.go
@@ -78,4 +78,24 @@ func RegisterConfigSpecs(r *configregistry.Registry) {
 		Secrets:     []string{"token", "webhook_secret"},
 		Description: `GitHub webhooks config: {"token","webhook_secret"}. Required only if any Stream uses transport=github. token is the gh PAT used by Workers; webhook_secret is the HMAC secret GitHub signs deliveries with.`,
 	})
+	// Per-org Slack installation: bot token + workspace/team id, written
+	// by the OAuth install callback (or by hand for Socket Mode). The
+	// global Slack app (client id/secret, signing secret, app token,
+	// ingress mode) lives separately on an OAuthProvider(type=slack) row.
+	// See design/2026-06-16-helix-org-slack-stream.md §9.2.
+	r.Register(configregistry.Spec{
+		Key:         "transport.slack",
+		Type:        configregistry.TypeObject,
+		Secrets:     []string{"bot_token"},
+		Description: `Slack install config: {"bot_token","team_id"}. Written per-org by the Slack OAuth install. bot_token (xoxb-…) authorises posts; team_id (T…) is the inbound routing key.`,
+	})
+	// Per-org inbound routing strategy for Slack channels with several
+	// subscribed Workers: "broadcast" (default — deliver to all) or
+	// "fuzzy" (keyword-match the best Worker). See §9.4.
+	r.Register(configregistry.Spec{
+		Key:         "slack.router",
+		Type:        configregistry.TypeString,
+		Default:     `"broadcast"`,
+		Description: "Inbound Slack disambiguation when several Workers share a channel. `broadcast` (default) activates every subscriber; `fuzzy` activates the best keyword match. Other strategies (e.g. an LLM router) plug in here later.",
+	})
 }

--- a/api/pkg/server/oauth.go
+++ b/api/pkg/server/oauth.go
@@ -108,6 +108,7 @@ func redactProviderSecrets(provider *types.OAuthProvider) {
 	provider.ClientSecret = ""
 	provider.SlackSigningSecret = ""
 	provider.SlackAppToken = ""
+	provider.SlackBotToken = ""
 }
 
 // handleCreateOAuthProvider creates a new OAuth provider

--- a/api/pkg/server/oauth.go
+++ b/api/pkg/server/oauth.go
@@ -93,11 +93,21 @@ func (s *HelixAPIServer) handleListOAuthProviders(_ http.ResponseWriter, r *http
 	// Remove sensitive information for non-admin users
 	if !user.Admin {
 		for _, provider := range providers {
-			provider.ClientSecret = ""
+			redactProviderSecrets(provider)
 		}
 	}
 
 	return providers, nil
+}
+
+// redactProviderSecrets blanks every secret field on a provider before
+// it is returned to a non-admin caller. Keeps the Slack secret fields in
+// lockstep with ClientSecret so a new secret can't leak by being missed
+// at one redaction site.
+func redactProviderSecrets(provider *types.OAuthProvider) {
+	provider.ClientSecret = ""
+	provider.SlackSigningSecret = ""
+	provider.SlackAppToken = ""
 }
 
 // handleCreateOAuthProvider creates a new OAuth provider
@@ -256,7 +266,7 @@ func (s *HelixAPIServer) handleGetOAuthProvider(_ http.ResponseWriter, r *http.R
 			return nil, fmt.Errorf("provider not found")
 		}
 
-		provider.ClientSecret = ""
+		redactProviderSecrets(provider)
 	}
 
 	return provider, nil

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -882,6 +882,45 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 					Methods(http.MethodGet)
 			}
 
+			// Slack Events API ingress — one global endpoint, routed to
+			// the right org by team id inside the ingest. Insecure mount:
+			// Slack signs deliveries with the app's signing secret (checked
+			// in the handler), not a helix session/api-key.
+			if orgHandlers.publicSlackEvents != nil {
+				insecureRouter.
+					Handle("/slack/events", orgHandlers.publicSlackEvents).
+					Methods(http.MethodPost)
+			}
+			// Slack OAuth install callback — top-level browser redirect from
+			// slack.com (GET), authenticated by the encrypted ?state=.
+			if orgHandlers.publicSlackOAuthCallback != nil {
+				insecureRouter.
+					Handle("/slack/oauth/callback", orgHandlers.publicSlackOAuthCallback).
+					Methods(http.MethodGet)
+			}
+			// Slack OAuth install start — an org admin clicks "Add to Slack"
+			// from settings. Wrapped in the same feature gate +
+			// org-membership scope as the rest of the org surface, so the
+			// org the install binds to is the caller's own (membership is
+			// authorised before StartURL reads the orgID off the context).
+			// Registered before the authRouter /orgs/{org}/ catch-all prefix
+			// so this exact path wins the match.
+			if orgHandlers.slackOAuthStart != nil {
+				authRouter.
+					Handle("/orgs/{org}/slack/oauth/start",
+						requireFeature(helixorg.AlphaFeature)(
+							apiServer.withHelixOrgScope(orgHandlers.scope, orgHandlers.slackOAuthStart),
+						),
+					).
+					Methods(http.MethodGet)
+			}
+			// Socket Mode ingress runner — runs for the lifetime of ctx,
+			// inert unless the admin selects socket ingress. The
+			// single-owner lock keeps exactly one replica connected.
+			if orgHandlers.runSlackSocket != nil {
+				go orgHandlers.runSlackSocket(ctx)
+			}
+
 			// /api/v1/orgs/{org}/* — per-tenant surface for the
 			// org-graph resources (chart, workers, roles, positions,
 			// streams, settings). withHelixOrgScope resolves {org}

--- a/api/pkg/types/oauth.go
+++ b/api/pkg/types/oauth.go
@@ -53,12 +53,14 @@ type OAuthProvider struct {
 
 	// Slack-specific configuration. Only meaningful when Type == "slack",
 	// where this OAuthProvider row models the single instance-wide Slack
-	// app (client id/secret carried in the common fields above). See
-	// design/2026-06-16-helix-org-slack-stream.md §9.2. The two secret
-	// fields are redacted for non-admins (like ClientSecret) and
-	// encrypted at rest.
+	// app. See design/2026-06-16-helix-org-slack-stream.md §9.2. Which
+	// fields apply depends on SlackIngressMode: REST uses the common
+	// client id/secret (OAuth install) + SlackSigningSecret; Socket Mode
+	// uses SlackAppToken + SlackBotToken instead. The secret fields are
+	// redacted for non-admins (like ClientSecret) and encrypted at rest.
 	SlackSigningSecret string `json:"slack_signing_secret" gorm:"type:text"` // REST Events API authenticity (NFR-4)
 	SlackAppToken      string `json:"slack_app_token" gorm:"type:text"`      // xapp-… app-level token for Socket Mode
+	SlackBotToken      string `json:"slack_bot_token" gorm:"type:text"`      // xoxb-… bot token for single-workspace Socket Mode
 	SlackIngressMode   string `json:"slack_ingress_mode"`                    // "rest" | "socket" | "" — explicit toggle (FR-16)
 }
 

--- a/api/pkg/types/oauth.go
+++ b/api/pkg/types/oauth.go
@@ -50,6 +50,16 @@ type OAuthProvider struct {
 
 	// Misc configuration
 	Enabled bool `json:"enabled" gorm:"not null;default:true"`
+
+	// Slack-specific configuration. Only meaningful when Type == "slack",
+	// where this OAuthProvider row models the single instance-wide Slack
+	// app (client id/secret carried in the common fields above). See
+	// design/2026-06-16-helix-org-slack-stream.md §9.2. The two secret
+	// fields are redacted for non-admins (like ClientSecret) and
+	// encrypted at rest.
+	SlackSigningSecret string `json:"slack_signing_secret" gorm:"type:text"` // REST Events API authenticity (NFR-4)
+	SlackAppToken      string `json:"slack_app_token" gorm:"type:text"`      // xapp-… app-level token for Socket Mode
+	SlackIngressMode   string `json:"slack_ingress_mode"`                    // "rest" | "socket" | "" — explicit toggle (FR-16)
 }
 
 // OAuthConnection represents a user's connection to an OAuth provider

--- a/design/2026-06-16-helix-org-slack-stream.md
+++ b/design/2026-06-16-helix-org-slack-stream.md
@@ -1,0 +1,587 @@
+# Helix-org Slack Stream — User Story & Requirements
+
+- **Date:** 2026-06-16
+- **Status:** Implemented (TDD) — pending live Slack credentials for full e2e. See "Implementation status" below.
+- **Area:** `api/pkg/org/` (Streams / Transports), Slack integration
+
+> **Implementation status (2026-06-16).** All phases of §11 are built test-first
+> and green (36 tests in `api/pkg/org/infrastructure/transports/slack/`, plus the
+> domain Kind tests and the `Dispatcher.DispatchTo` dispatcher tests). The
+> transport is wired into the composition root (`helix_org_slack.go`) and mounted
+> in `server.go`: `POST /api/v1/slack/events` (REST ingress), `GET
+> /api/v1/slack/oauth/callback` (install callback), `GET
+> /api/v1/orgs/{org}/slack/oauth/start` (membership-authorised install start), and
+> the Socket Mode runner goroutine. The admin OAuth Providers panel gained the
+> three Slack fields (signing secret / app token / ingress mode). Verified
+> end-to-end at the API+DB level on localhost:8080: creating an enabled
+> `type=slack` provider flips `/slack/events` from 503 (inert, FR-3) to 401
+> (signature check active, NFR-4), and the three columns persist + round-trip.
+> **Not yet exercised:** a real Slack workspace round-trip (OAuth install, inbound
+> message → Worker activation, outbound persona post) — blocked on live Slack app
+> credentials. Deferred per §13: human linking (FR-21/22/24), Worker-avatar
+> source, and the `LLMRouter`.
+
+> This document captures *what* we want and *why*. It deliberately does **not**
+> describe how to build it. Implementation design follows in a separate doc once
+> these requirements are agreed.
+
+---
+
+## 1. Context
+
+Helix-org is the org-graph runtime: **Workers** fill **Positions** bound to
+**Roles**, and communicate over **Streams** (named event channels, each backed by
+a **Transport**). Transports already exist for `local`, `webhook`, `email`,
+`github`, and `cron`.
+
+We want a new **Slack** capability so that Helix-org Workers can participate in a
+Slack workspace — posting into channels under their own identities and receiving
+messages from those channels — without provisioning a real Slack account per
+Worker.
+
+### Key decisions already made (constraints on these requirements)
+
+There are **three layers**, and the tenancy differs per layer:
+
+1. **One global Slack *app* per Helix instance**, configured once by an
+   administrator: client id, client secret, signing secret. One app definition
+   for the whole installation.
+2. **Per-org installation.** Each org OAuth-installs that one app into **its
+   own** Slack workspace, producing a per-org **bot token + workspace/team id**.
+   The app is global; the installation (and its token) is org-scoped.
+3. **Org isolation.** Workers in an org act only against that org's installed
+   workspace — its bot token, its channels. A Worker in org A cannot reach org
+   B's Slack.
+4. **Workers are personas of their org's bot**, not real Slack user accounts. A
+   Worker's name and avatar are applied per message; a channel has exactly one
+   real Slack member (the bot).
+5. **Multiple Workers may operate in the same channel** — this is expected and
+   acceptable.
+6. **Two inbound ingress modes must both be supported** from a single
+   implementation: an HTTP **REST** path (Slack Events API) and a **WebSocket**
+   path (Slack Socket Mode). The operator/deployment chooses which is active.
+   Their tenancy reach differs: **REST serves many per-org installs** (one
+   endpoint, route by team id); **Socket Mode suits the single-workspace
+   on-premise case**.
+
+---
+
+## 2. Actors
+
+| Actor | Description |
+|---|---|
+| **Administrator** | Operates the Helix instance. Registers the one global Slack app (instance-wide). Decides whether to use the REST API or WebSocket path. |
+| **Hiring manager / Worker** | A Helix-org Worker that creates Slack streams and subscribes other Workers (per existing org-graph conventions). |
+| **AI Worker** | A software Worker that posts to and receives from Slack channels as a persona. |
+| **Human Worker** | A person represented in the org graph who may also exist as a real user in the connected Slack workspace. |
+| **Slack participant** | Any human in the connected Slack workspace interacting in a channel the bot is in. |
+
+---
+
+## 3. User Stories
+
+**US-1 — Connect Slack (admin + org).**
+As an **administrator**, I want to register one Slack app for the whole Helix
+instance, and have each org install that app into its own Slack workspace, so
+that Workers can use Slack — scoped to their own org — without per-Worker setup.
+
+**US-2 — Bind a channel to a stream.**
+As a **hiring manager**, I want to create a Slack stream tied to a specific
+channel, so that I can route a conversation between that channel and the org
+graph.
+
+**US-3 — Connect Workers to a channel.**
+As a **hiring manager**, I want to subscribe Workers to a channel-bound Slack
+stream, so that those Workers send and receive messages in that channel.
+Subscribing several Workers to the same channel is allowed.
+
+**US-4 — Post as a persona.**
+As an **AI Worker**, I want my messages in a channel to appear under my own name
+and avatar, so that Slack participants can tell Workers apart even though we
+share one bot.
+
+**US-5 — Receive channel messages.**
+As an **AI Worker** subscribed to a channel-bound stream, I want to receive
+messages posted in that channel, so that I can act on them.
+
+**US-6 — Deploy behind a firewall.**
+As an **administrator** of an on-premise install that cannot expose inbound HTTP
+endpoints, I want Slack to work over an outbound WebSocket connection, so that I
+can use the integration without opening inbound network access.
+
+**US-7 — Link an existing human (secondary).**
+As an **administrator**, I want a Human Worker to be associated with their
+existing Slack user account, so that the org graph knows which Slack person maps
+to which Human Worker.
+
+---
+
+## 4. Functional Requirements
+
+Priority: **MUST** / **SHOULD** / **MAY**.
+
+### 4.1 Global app and per-org installations
+
+**Global app (instance-wide, admin):**
+
+- **FR-1 (MUST).** An administrator can configure exactly one global Slack app
+  for the Helix instance (client id, client secret, signing secret).
+- **FR-2 (MUST).** Configuring or changing the global Slack app is restricted to
+  administrators.
+- **FR-3 (MUST).** The integration is inert when no global app is configured —
+  no errors surfaced to Workers, no partial behaviour.
+
+**Per-org installation:**
+
+- **FR-4 (MUST).** Each org can install the global app into its own Slack
+  workspace, producing an org-scoped installation that stores the credentials
+  required by the active ingress mode (at minimum a bot token + workspace/team
+  id; plus what each mode needs — the app's signing secret for REST, an
+  app-level token for WebSocket).
+- **FR-5 (MUST).** An org has at most one Slack installation. Workers act only
+  against their own org's installation; there is no cross-org access to Slack.
+- **FR-6 (SHOULD).** An administrator (or org owner/admin, per existing org
+  authorization) can see the health/status of an org's installation (e.g.
+  installed / misconfigured / auth failed).
+
+### 4.2 Channels and streams
+
+- **FR-7 (MUST).** A Slack stream is bound to a single Slack channel within its
+  org's installed workspace.
+- **FR-8 (MUST).** A Worker is "connected to a channel" by subscribing to the
+  corresponding channel-bound Slack stream, using existing org-graph
+  subscription semantics.
+- **FR-9 (MUST).** Multiple Workers may be subscribed to the same channel-bound
+  stream simultaneously.
+
+### 4.3 Outbound (Worker → Slack)
+
+- **FR-10 (MUST).** A Worker can post a message to its channel through its org's
+  bot.
+- **FR-11 (MUST).** Outbound messages display the posting Worker's identity
+  (name and avatar) derived from the Worker's identity, not the bot's default
+  identity.
+- **FR-12 (MUST).** Outbound behaviour is identical regardless of which inbound
+  ingress mode is active.
+- **FR-13 (SHOULD).** Replies preserve Slack threading where a thread context
+  exists.
+
+### 4.4 Inbound (Slack → Worker)
+
+- **FR-14 (MUST).** The system supports an HTTP REST ingress (Slack Events API)
+  with request authenticity verification.
+- **FR-15 (MUST).** The system supports a WebSocket ingress (Slack Socket Mode)
+  requiring no inbound HTTP endpoint.
+- **FR-16 (MUST).** Exactly one ingress mode is active per deployment, chosen by
+  an explicit administrator toggle — not inferred from which credentials are
+  present.
+- **FR-17 (MUST).** Inbound events are routed to the correct org by
+  workspace/team id, and delivered only to that org's Workers (enforcing org
+  isolation, FR-5).
+- **FR-18 (MUST).** Messages posted in a bound channel are delivered to all
+  Workers subscribed to that channel-bound stream.
+- **FR-19 (MUST).** Both ingress modes deliver inbound events to a single shared
+  processing path, so message handling is identical across modes.
+- **FR-20 (SHOULD).** The bot's own messages do not re-enter the system as
+  inbound events (no self-echo loops).
+
+### 4.5 Human linking (secondary capability)
+
+- **FR-21 (SHOULD).** Human Workers are automatically associated with existing
+  Slack users in their org's workspace by matching email addresses. (Depends on
+  a Human Worker email attribute that does not yet exist — deferred to a future
+  task; see §7 Dependency.)
+- **FR-22 (MAY).** The mapping (Slack user ↔ Human Worker) is queryable for use
+  by other org-graph features.
+
+### 4.6 Messaging scope & routing
+
+- **FR-23 (MUST).** Worker-to-Worker communication uses internal org streams,
+  not Slack. Slack is used only for communication involving Slack participants.
+- **FR-24 (SHOULD).** A Worker uses a Slack DM to communicate with a human only
+  when that human is a linked org member with known Slack details (depends on
+  FR-21).
+- **FR-25 (MUST).** Helix delivers inbound channel messages to all subscribed
+  Workers (FR-18) and does not itself decide which Worker should respond.
+  Disambiguation among multiple Workers is an org-graph concern (e.g. a routing
+  Worker), not a Helix code responsibility.
+- **FR-26 (SHOULD).** The setup UI presents the configuration appropriate to the
+  selected ingress mode (OAuth "Add to Slack" for REST; app manifest + token
+  entry for Socket Mode).
+
+---
+
+## 5. Non-Functional Requirements
+
+- **NFR-1 (MUST).** A single implementation serves both ingress modes; the
+  modes differ only at the ingress seam, not in message handling or outbound
+  logic. We do not maintain two parallel Slack integrations.
+- **NFR-2 (MUST).** The WebSocket ingress tolerates a multi-replica deployment
+  without duplicate event processing (a single connection owner).
+- **NFR-3 (MUST).** Slack credentials are stored as secrets and never exposed to
+  Workers or non-admin users.
+- **NFR-4 (SHOULD).** Inbound request authenticity is verified (signing secret
+  for REST; Slack-managed authentication for Socket Mode).
+- **NFR-5 (SHOULD).** The integration degrades gracefully on Slack API
+  rate-limiting and transient connection loss (reconnect for WebSocket; retry
+  semantics for REST), without losing the deployment's single-connection
+  invariant.
+- **NFR-6 (SHOULD).** Channel and persona configuration follow the existing
+  helix-org philosophy: behaviour expressed as data/text (stream config, Role
+  text) rather than new code paths per channel or Worker.
+
+---
+
+## 6. Out of Scope
+
+Explicitly excluded from this body of work:
+
+- **More than one workspace per org, or more than one Slack app per instance.**
+  One global app; each org installs it into exactly one Slack workspace. Sharing
+  a single workspace across multiple orgs, an org spanning multiple workspaces,
+  or registering multiple apps, are excluded. (Per-org installs of the one app
+  *are* in scope — see FR-4/FR-5.)
+- **Real per-Worker Slack accounts** (SCIM provisioning, paid seats, Business+ /
+  Enterprise Grid requirements). Workers are personas, not members.
+- **Per-Worker OAuth or per-Worker tokens.** Workers share the one global bot.
+- **Addressing a specific Worker via Slack `@mention`** — personas are not real
+  Slack users and cannot be mentioned as members (see Open Questions).
+- **Slack Marketplace distribution.**
+
+---
+
+## 7. Resolved Questions & Accepted Limitations
+
+Resolved during review (2026-06-16):
+
+- **OQ-1 — Addressing a specific Worker. (Accepted limitation.)** There is no
+  native way to address one of several Workers in a channel — personas cannot be
+  `@mentioned`. Helix does not solve this in code: inbound messages go to all
+  subscribed Workers (FR-18, FR-25), and disambiguation is left to the org graph
+  — e.g. an org-defined **routing Worker** that reads the channel and decides who
+  responds. Accepted as a known limitation, not a blocker.
+- **OQ-2 — Direct messages. Resolved.** Worker-to-Worker messaging uses internal
+  org streams, never Slack. Slack DMs are used only for Worker↔human
+  communication, and only when the human is a linked org member with known Slack
+  details (FR-23, FR-24).
+- **OQ-3 — Ingress mode selection. Resolved.** An explicit administrator toggle
+  selects REST vs WebSocket; it is not inferred from credentials (FR-16).
+- **OQ-4 — Human-linking trigger. Resolved.** Automatic email matching against
+  the workspace member list, where possible (FR-21).
+- **OQ-5 — Credential acquisition per mode. Resolved.** The setup experience may
+  differ per mode; the frontend shows the configuration appropriate to the
+  selected ingress mode (FR-26).
+
+**Dependency / future work.** FR-21 (automatic human linking) requires a **Human
+Worker email attribute**, which does not exist in the org graph today. Adding
+that attribute is a prerequisite future task; until it lands, human linking
+cannot be implemented.
+
+---
+
+## 8. Glossary
+
+- **Persona** — a Worker's name + avatar applied to a message sent through the
+  shared bot; not a real Slack account.
+- **Global app** — the single, instance-wide, admin-configured Slack app
+  (client id, secret, signing secret).
+- **Installation** — an org's OAuth install of the global app into its own
+  workspace, yielding that org's bot token + workspace/team id.
+- **Channel-bound stream** — a helix-org Stream whose Transport targets one
+  specific Slack channel.
+- **Ingress mode** — how inbound Slack events reach Helix: REST (Events API) or
+  WebSocket (Socket Mode).
+
+---
+
+## Part II — Implementation Plan
+
+The Slack transport is a new `transport.Kind` plus one infrastructure package,
+reusing the existing append→notify→dispatch fan-out and subscription model.
+
+## 9. Architecture
+
+### 9.1 One processing path, two ingress sources
+
+Two ingress sources feed one shared path (**NFR-1 / FR-19**).
+
+```text
+        REST (Events API)            Socket Mode (WebSocket)
+   POST /api/v1/slack/events      outbound WS, single owner
+   verify signing-secret sig      Slack-managed auth
+   answer url_verification         reconnect/backoff
+            │                              │
+            └──────────────┬───────────────┘
+                           ▼
+              Ingest.Receive(teamID, slackEvent)     ← the ONE path
+                           │
+       1. team_id → orgID            (per-org install lookup; FR-17)
+       2. drop bot's own events      (self-echo guard; FR-20)
+       3. channel → matching streams (org-scoped, KindSlack; FR-7/FR-18)
+       4. build streaming.Message envelope
+       5. Events.Append → Hub.Notify → Dispatcher.Dispatch   (existing fan-out)
+                           │
+                           ▼
+          every subscribed Worker activates (existing dispatch; FR-18/FR-25)
+```
+
+Outbound is **ingress-agnostic** (FR-12): the dispatcher calls
+`streaming.Outbound.Emit` for every appended Event on a `KindSlack` stream, as it
+does for `webhook`/`email`.
+
+```text
+  Worker → publish MCP tool → Append → Dispatcher → Outbound.Emit (KindSlack)
+                                                          │ chat.postMessage
+                                                          ▼  username+icon (persona)
+                                                       Slack channel
+```
+
+### 9.2 Three config layers → two storage homes
+
+Three tenancy layers (§1) map onto config mechanisms that already exist. The
+global app is admin-editable in the UI.
+
+| Layer | What | Storage | Precedent | Reqs |
+|---|---|---|---|---|
+| **Global app** | client id/secret, signing secret, app token (`xapp-`), **ingress-mode toggle** | **`OAuthProvider` row** (`type="slack"`), edited in the admin panel | the existing admin **OAuth Providers** section | FR-1/2/3, FR-16, NFR-3 |
+| **Per-org install** | bot token (`xoxb-`), team/workspace id | **configregistry** key `transport.slack`, `Secrets:["bot_token"]`, per-org row | `transport.github`, `transport.postmark` | FR-4/5/6, NFR-3 |
+| **Channel binding** | one Slack channel id | per-**stream** `SlackConfig.Channel` (transport config JSON) | `EmailConfig.Alias`, `GitHubConfig.Repo` | FR-7 |
+
+Global app = `OAuthProvider` row, edited in the admin **OAuth Providers** panel
+(`frontend/src/components/dashboard/OAuthProvidersTable.tsx` →
+`/api/v1/oauth/providers`, handlers in `api/pkg/server/oauth.go`). The
+`types.OAuthProvider` model is instance-wide (no `OrganizationID`), admin-gated
+(`user.Admin` on create/update/delete — FR-2), already carries
+`ClientID`/`ClientSecret`/`Enabled`, and `type="slack"` is already defined.
+`Enabled=false` (or no row) ⇒ subsystem inert (FR-3). Ingress mode is a stored
+field, not inferred (FR-16).
+
+Add three nullable fields to `OAuthProvider`:
+
+```go
+// api/pkg/types/oauth.go
+SlackSigningSecret string `json:"slack_signing_secret" gorm:"type:text"` // REST authenticity (NFR-4)
+SlackAppToken      string `json:"slack_app_token"      gorm:"type:text"` // xapp-… for Socket Mode
+SlackIngressMode   string `json:"slack_ingress_mode"`                     // "rest" | "socket" | ""
+```
+
+- Redact the two secrets for non-admins (as `ClientSecret` already is) and
+  encrypt at rest via `crypto.EncryptAES256GCM` + `getEncryptionKey` (as
+  `ServiceConnection`/`GitProviderConnection` do). Retrofitting `ClientSecret`
+  encryption is a follow-on.
+- The New/Edit Provider dialog shows these inputs only when `type === "slack"`
+  (FR-26).
+
+Per-org `transport.slack` config (slack infra package, `postmark.Config` shape):
+
+```go
+type Config struct {
+    BotToken string `json:"bot_token"`        // xoxb-…
+    TeamID   string `json:"team_id"`          // T0123… — routing key (FR-17)
+}
+func (c Config) Validate() error { /* both non-empty */ }
+```
+
+The slack package reads the global app via an injected `GlobalApp(ctx) (App, error)`
+port, backed by `store.ListOAuthProviders(type=slack, enabled=true)` at the
+composition root.
+
+### 9.3 Persona model (FR-4 / FR-11)
+
+A Worker posts under its own name+avatar through the shared bot. The persona is a
+lookup keyed on the Worker, modelled as an injected port (like
+`gitHubTokenResolver`/`TokenResolver`), not a field on the shared
+`streaming.Message`:
+
+```go
+type PersonaResolver func(ctx context.Context, orgID, workerID string) (Persona, error)
+type Persona struct { Username, IconURL string }
+```
+
+`Outbound.Emit` reads `event.Source` + `event.OrganizationID`, calls the
+resolver, and sets `chat.postMessage`'s `username` + `icon_url`. The default
+returns `Username` from the Worker's identity (bare id today) and `IconURL == ""`
+⇒ Slack falls back to the bot avatar. `IconURL` plumbing ships now; its source
+(a Worker-avatar attribute) is deferred like FR-21's human-email attribute.
+
+### 9.4 Inbound routing to a Worker (FR-25 / OQ-1) — pluggable
+
+A bound channel may have several subscribed Workers (FR-9); personas cannot be
+`@mentioned` (OQ-1). A `Router` port selects which subscriber(s) an inbound
+message activates, behind one port:
+
+```go
+// Router narrows the subscriber set; it never invents a target outside it.
+type Router interface {
+    Route(ctx context.Context, in Inbound) ([]orgchart.WorkerID, error)
+}
+
+type Inbound struct {
+    OrgID       string
+    Stream      streaming.Stream
+    Message     streaming.Message    // the new message
+    Thread      []streaming.Message  // prior thread messages, oldest-first
+    Subscribers []Candidate          // WorkerID + identity/role text
+}
+```
+
+Implementations, selected **per org** (default broadcast):
+
+- **`BroadcastRouter` (default).** Returns every subscriber (FR-25).
+- **`FuzzyRouter` (this task).** Code-only. Scores each candidate by keyword
+  overlap of message+thread text against the Worker's identity/role text; returns
+  the best match, or all on a tie/low-confidence. No LLM, no network.
+- **`LLMRouter` (future work).** Same port; an LLM picks from the thread + roster.
+
+**Per-org selection.** A configregistry key `slack.router` (`TypeString`,
+`Default: "broadcast"`) names the implementation (`"broadcast"` | `"fuzzy"`). The
+ingest is built per-org (`New(orgID, …)`), reads `slack.router`, and resolves the
+`Router` from a `map[string]Router` registry; unknown/unset ⇒ `BroadcastRouter`.
+
+**Pipeline seam.** Add `Dispatcher.DispatchTo(ctx, event, targets []orgchart.WorkerID)`;
+the existing `Dispatch` becomes `DispatchTo(ctx, e, allSubscribers)` (same
+fan-out, outbound emit, self-source skip). Slack ingest resolves subscribers,
+`targets := router.Route(...)`, then `dispatcher.DispatchTo(ctx, event, targets)`.
+Only the Slack ingest consults the `Router`; other transports keep `Dispatch`.
+
+### 9.5 Single connection owner for Socket Mode (NFR-2)
+
+The Socket Mode runner gates its connection behind a **Postgres advisory lock**
+(`pg_try_advisory_lock(<const key>)`):
+
+- The replica that wins the lock opens the single WS connection and runs ingest.
+- Losers poll (~10s) to take over on failover (NFR-5).
+- Single-replica: always wins.
+
+Encapsulated as a `singleOwner` collaborator. Postgres is already the store; no
+new dependency.
+
+## 10. Component inventory
+
+New package `api/pkg/org/infrastructure/transports/slack/` — one job per file:
+
+| File | Responsibility | Implements |
+|---|---|---|
+| `config.go` | per-org `Config{BotToken,TeamID}` + `Validate`; typed read from configregistry | — |
+| `client.go` | thin wrapper over `slack-go/slack` (already a dep, v0.19.0): `PostMessage`, `OAuthV2`, `ConversationsJoin/Info`, `AuthTest` | — |
+| `ingest.go` | **the one path**: `Receive(ctx, teamID, ev)` — team→org, self-echo drop, channel→streams, envelope, `router.Route`, `DispatchTo` | — |
+| `router.go` | `Router` port + `BroadcastRouter` (default) + `FuzzyRouter` + `map[string]Router` registry, selected per-org by `slack.router` config — §9.4 | — |
+| `globalapp.go` | `GlobalApp` port: read the admin-configured `OAuthProvider(type=slack)` (client id/secret, signing secret, app token, ingress mode) | — |
+| `events_api.go` | REST source: `http.Handler`, HMAC signature verify, `url_verification` challenge → `ingest.Receive` | — |
+| `socketmode.go` | WS source: `Run(ctx)` under `singleOwner`, reconnect/backoff → `ingest.Receive` | — |
+| `singleowner.go` | `pg_try_advisory_lock` gate (NFR-2) | — |
+| `outbound.go` | `Emit` → `chat.postMessage` w/ persona + `thread_ts` threading (FR-13) | `streaming.Outbound` |
+| `provisioner.go` | `Install` = ensure bot is in channel (`conversations.join`); `Status` = membership check | `streaming.Inbound` |
+| `oauth.go` | per-org "Add to Slack" start + callback: exchange code → persist `transport.slack` (FR-4, REST mode) | — |
+| `persona.go` | `PersonaResolver` type + default | — |
+| `credential_provider.go` | optional `mint_credential` "slack" provider (bot token to Worker shells) | `credential.Provider` |
+
+Domain (one file, the established "new Kind = new file + one map entry" rule):
+
+| File | Responsibility |
+|---|---|
+| `api/pkg/org/domain/transport/slack.go` | `const KindSlack`, `SlackConfig{Channel}`, `Validate`, `slack{}` strategy, `Transport.SlackConfig()` accessor; add `KindSlack` to `kindOrder` + `strategies` in `transport.go` |
+
+Edited (global-app model, composition root, dispatch seam, admin UI):
+
+| File | Edit |
+|---|---|
+| `api/pkg/types/oauth.go` | extend `OAuthProvider` with `SlackSigningSecret`, `SlackAppToken`, `SlackIngressMode` (nullable; §9.2) |
+| `api/pkg/server/oauth.go` | redact + encrypt the two new secret fields on create/update/get (reuse `crypto.EncryptAES256GCM` + the existing `ClientSecret` redaction) |
+| `frontend/.../OAuthProvidersTable.tsx` | show the three Slack fields when `type==="slack"` (mode-appropriate — FR-26); regenerate API client |
+| `api/pkg/org/application/dispatch/dispatcher.go` | add `DispatchTo(ctx, event, targets)`; `Dispatch` delegates to it with all subscribers (§9.4) |
+| `api/pkg/server/helix_org.go` | register `transport.slack` + `slack.router` specs; `RegisterOutbound(KindSlack,…)`; add to `inboundProvisioners`; build `ingest` with `GlobalApp` + `PersonaResolver` + per-org `Router` registry (default broadcast); start the ingress source the global-app row selects |
+| `api/pkg/server/server.go` | mount REST `/slack/events` + `/slack/oauth/*` on the **insecure** router (auth is Slack-signature / encrypted-state, not the helix session layer — same as the github webhook); start the socket runner goroutine beside `streamCron.Start` |
+
+## 11. TDD build sequence
+
+Strict test-first, each phase green before the next. Fakes over mocks; gomock
+only for the store where a suite already uses it (project convention). Domain
+tests are pure table-driven (`transport_test.go` style); infra tests use the
+real GORM test DB (`orggorm.GetOrgTestDB`) + a `recordingDispatcher` fake +
+`wakebus` over in-memory NATS (`github_test.go` style); a fake Slack API
+(`httptest.Server`) stands in for slack.com.
+
+**Phase 1 — Domain: the Kind.** `slack_test.go` first: `Channel` required,
+unknown-kind rejection, accessor round-trip, `KindSlack` in `KindValues()` order.
+Then `slack.go` to green. *(FR-7)*
+
+**Phase 2 — Ingest core.** `ingest_test.go` first, driving `Receive` with
+synthetic events against a seeded DB:
+- team id → correct org; unknown team id → dropped, no dispatch *(FR-17)*
+- message in a bound channel → one Event appended, dispatched to **all** subscribed Workers *(FR-18)*
+- two streams, two orgs, same channel name → strict org isolation, no leakage *(FR-5/FR-17)*
+- event whose `bot_id`/`app_id` is our bot → dropped *(FR-20)*
+- envelope mapping: `From`=slack user id, `Body`=text, `ThreadID`=`thread_ts`, `MessageID`=`ts`
+Then `ingest.go`.
+
+**Phase 3 — REST source.** `events_api_test.go` first: valid signature → 200 +
+ingest called once; bad/stale signature → 401, ingest **not** called *(NFR-4)*;
+`url_verification` → echoes `challenge`; payload `team_id` threaded to ingest.
+Then `events_api.go` (uses `slack.SecretsVerifier`). *(FR-14)*
+
+**Phase 4 — Outbound.** `outbound_test.go` first against fake Slack API:
+`chat.postMessage` carries channel from `SlackConfig`, `username`+`icon_url` from
+`PersonaResolver`, `thread_ts` from `Message.ThreadID` *(FR-10/11/13)*; missing
+per-org token → typed error, no panic; emit identical with either ingress mode
+configured *(FR-12)*. Then `outbound.go` + register in dispatcher.
+
+**Phase 4b — Router port.** `router_test.go` first: `BroadcastRouter` returns all
+subscribers (FR-25 baseline); `FuzzyRouter` picks the best-matching Worker by
+message+thread overlap, returns all on a tie/low-confidence (never drops);
+registry resolves `slack.router` value → impl, unknown/unset → broadcast. Then
+`router.go` + `Dispatcher.DispatchTo` (with a dispatcher test that `DispatchTo`
+restricts fan-out to the named targets and still emits outbound). Ingest test
+extended: org with `slack.router=fuzzy` activates only the chosen Worker; an org
+left at the default still broadcasts *(§9.4)*.
+
+**Phase 5 — Socket Mode source + single owner.** `singleowner_test.go` first
+(two contenders, one acquires); `socketmode_test.go` drives a fake socketmode
+event through `Run` → ingest called once; reconnect path covered *(FR-15, NFR-2,
+NFR-5)*. Then `socketmode.go` + `singleowner.go`.
+
+**Phase 6 — Provisioner.** `provisioner_test.go` first: `Install` joins the
+channel and reports `installed`; `Status` reflects membership / `unknown` on API
+failure (degrade, don't error — matches the `Inbound` contract). Then
+`provisioner.go`.
+
+**Phase 7 — OAuth install.** `oauth_test.go` first: callback exchanges code
+(fake Slack), persists `transport.slack` with bot token + team id for the org in
+the encrypted `state`; bad state → rejected *(FR-4, US-1)*. Then `oauth.go`.
+
+**Phase 8 — Wiring + e2e.** Extend `OAuthProvider` + admin handlers/UI; edit
+composition root + `server.go`. Verify inert when no enabled `slack` provider
+row exists *(FR-3)*. Browser/CLI e2e in the inner Helix: admin configures the
+Slack app in the OAuth Providers panel, install an org, bind a channel-stream,
+subscribe two Workers, post in Slack → both activate (broadcast default); a
+Worker `publish` → appears in Slack under its persona.
+
+## 12. Requirements traceability
+
+| Req | Satisfied by |
+|---|---|
+| FR-1/2/3, FR-16, FR-26 | admin-editable `OAuthProvider(type=slack)` row; `Enabled`/`SlackIngressMode` fields (§9.2) |
+| FR-4/5, US-1 | `oauth.go` per-org install → `transport.slack` row; team-id routing (§10) |
+| FR-6 | `provisioner.Status` + per-org config presence on settings page |
+| FR-7/8/9 | `KindSlack` + `SlackConfig.Channel`; existing subscription model unchanged |
+| FR-10/11/13 | `outbound.go` + `PersonaResolver` + `thread_ts` |
+| FR-12 | `Outbound` is ingress-agnostic by construction (§9.1) |
+| FR-14, NFR-4 | `events_api.go` + `SecretsVerifier` |
+| FR-15, NFR-2, NFR-5 | `socketmode.go` + `singleowner.go` advisory lock |
+| FR-17/18/19, NFR-1 | `ingest.Receive` — the single shared path (§9.1) |
+| FR-25 | default `BroadcastRouter` (delivers to all; Helix decides nothing); per-org `slack.router` opts into the `Router` seam for code/LLM routing (§9.4) |
+| FR-20 | self-echo drop in `ingest` (bot_id/app_id guard) |
+| FR-23 | unchanged: Worker↔Worker stays on internal streams; Slack only touches channels |
+| NFR-3 | encrypted+redacted secret fields on the provider row; `Secrets:["bot_token"]` redaction in registry |
+| NFR-6 | behaviour is stream config + Role text; no per-channel/per-Worker code |
+| FR-21/22, FR-24 | **deferred** — depends on Worker-email attribute (§7 dependency); `IconURL` plumbing ships, source deferred |
+
+## 13. Deferred / out of scope for v1
+
+- **FR-21/22/24 human linking** — blocked on the Worker-email attribute (§7).
+- **Worker avatar source** — `IconURL` carried but unpopulated until a
+  Worker-avatar attribute exists; bot default avatar meanwhile.
+- **`LLMRouter` (OQ-1)** — future work; the `Router` port + `BroadcastRouter` +
+  `FuzzyRouter` ship now (§9.4).
+- **`mint_credential` slack provider** — include only if Workers need to call
+  Slack from their shell; the persona-post path does not require it.

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -3975,6 +3975,12 @@ export interface TypesOAuthProvider {
   enabled?: boolean;
   id?: string;
   name?: string;
+  /** xapp-… app-level token for Socket Mode */
+  slack_app_token?: string;
+  /** "rest" | "socket" | "" — explicit toggle (FR-16) */
+  slack_ingress_mode?: string;
+  /** REST Events API authenticity (NFR-4) */
+  slack_signing_secret?: string;
   token_url?: string;
   type?: TypesOAuthProviderType;
   updated_at?: string;

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -3977,6 +3977,8 @@ export interface TypesOAuthProvider {
   name?: string;
   /** xapp-… app-level token for Socket Mode */
   slack_app_token?: string;
+  /** xoxb-… bot token for single-workspace Socket Mode */
+  slack_bot_token?: string;
   /** "rest" | "socket" | "" — explicit toggle (FR-16) */
   slack_ingress_mode?: string;
   /** REST Events API authenticity (NFR-4) */

--- a/frontend/src/components/dashboard/OAuthProvidersTable.tsx
+++ b/frontend/src/components/dashboard/OAuthProvidersTable.tsx
@@ -21,7 +21,11 @@ import {
   Divider,
   Alert,
   Link,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
 } from '@mui/material'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import AddIcon from '@mui/icons-material/Add'
 import EditIcon from '@mui/icons-material/Edit'
 import DeleteIcon from '@mui/icons-material/Delete'
@@ -950,6 +954,62 @@ const OAuthProvidersTable: React.FC = () => {
                       client id/secret, callback, or signing secret. */}
                   {currentProvider.slack_ingress_mode === 'socket' && (
                     <>
+                      <Grid item xs={12}>
+                        <Accordion
+                          disableGutters
+                          elevation={0}
+                          sx={{
+                            border: '1px solid rgba(255,255,255,0.12)',
+                            borderRadius: 1,
+                            backgroundColor: 'rgba(33, 150, 243, 0.04)',
+                            '&:before': { display: 'none' },
+                          }}
+                        >
+                          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                              📖 Socket Mode setup guide — create the Slack app step by step
+                            </Typography>
+                          </AccordionSummary>
+                          <AccordionDetails>
+                            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+                              Socket Mode connects one Slack workspace over an outbound WebSocket — no public URL needed, so it works behind a firewall. Follow these steps in the{' '}
+                              <Link href="https://api.slack.com/apps" target="_blank" rel="noopener">Slack app dashboard ↗</Link>, then paste the two tokens below.
+                            </Typography>
+                            <Box component="ol" sx={{ m: 0, pl: 2.5, '& li': { mb: 1 } }}>
+                              <li>
+                                <Typography variant="caption" color="text.secondary">
+                                  <strong>Create the app.</strong> <Link href="https://api.slack.com/apps" target="_blank" rel="noopener">api.slack.com/apps</Link> → <em>Create New App</em> → <em>From scratch</em>. Name it (e.g. "Helix") and pick your workspace.
+                                </Typography>
+                              </li>
+                              <li>
+                                <Typography variant="caption" color="text.secondary">
+                                  <strong>Enable Socket Mode.</strong> <em>Settings → Socket Mode</em> → toggle <em>Enable Socket Mode</em> on. When prompted, generate an <em>App-Level Token</em> with the <code>connections:write</code> scope and copy the <code>xapp-…</code> value into <strong>App-Level Token</strong> below.
+                                </Typography>
+                              </li>
+                              <li>
+                                <Typography variant="caption" color="text.secondary">
+                                  <strong>Add bot scopes.</strong> <em>OAuth &amp; Permissions → Scopes → Bot Token Scopes</em>, add: <code>chat:write</code>, <code>chat:write.customize</code>, <code>channels:history</code>, <code>channels:read</code>, <code>channels:join</code>, <code>groups:history</code>, <code>groups:read</code>, <code>app_mentions:read</code>.
+                                </Typography>
+                              </li>
+                              <li>
+                                <Typography variant="caption" color="text.secondary">
+                                  <strong>Enable Event Subscriptions</strong> (easy to miss — without it the socket connects but no messages arrive). <em>Event Subscriptions</em> → toggle <em>Enable Events</em> on (no Request URL needed in Socket Mode). Under <em>Subscribe to bot events</em> add: <code>message.channels</code> (public channels), <code>message.groups</code> (<strong>private</strong> channels), <code>app_mention</code>. Save Changes. Note: these are <em>events</em>, configured on a different page than scopes.
+                                </Typography>
+                              </li>
+                              <li>
+                                <Typography variant="caption" color="text.secondary">
+                                  <strong>Install to the workspace.</strong> <em>Install App → Install to Workspace</em> → Allow. Copy the <em>Bot User OAuth Token</em> (<code>xoxb-…</code>) into <strong>Bot Token</strong> below.
+                                </Typography>
+                              </li>
+                              <li>
+                                <Typography variant="caption" color="text.secondary">
+                                  <strong>Invite the bot to a channel.</strong> In Slack, open the channel and run <code>/invite @YourApp</code>. Private channels <strong>must</strong> be invited manually — Slack doesn't allow apps to self-join private channels.
+                                </Typography>
+                              </li>
+                            </Box>
+                          </AccordionDetails>
+                        </Accordion>
+                      </Grid>
                       <Grid item xs={12}>
                         <TextField
                           fullWidth

--- a/frontend/src/components/dashboard/OAuthProvidersTable.tsx
+++ b/frontend/src/components/dashboard/OAuthProvidersTable.tsx
@@ -863,6 +863,53 @@ const OAuthProvidersTable: React.FC = () => {
                 />
               </Grid>
               
+              {currentProvider.type === 'slack' && (
+                <>
+                  <Grid item xs={12}>
+                    <TextField
+                      select
+                      fullWidth
+                      label="Ingress Mode"
+                      name="slack_ingress_mode"
+                      value={currentProvider.slack_ingress_mode || ''}
+                      onChange={handleInputChange}
+                      SelectProps={{ native: true }}
+                      helperText="How inbound Slack events reach Helix. REST (Events API) serves many per-org installs; Socket Mode suits a single on-premise workspace with no inbound HTTP."
+                    >
+                      <option value="">(disabled — no inbound)</option>
+                      <option value="rest">REST (Events API)</option>
+                      <option value="socket">Socket Mode (WebSocket)</option>
+                    </TextField>
+                  </Grid>
+                  {currentProvider.slack_ingress_mode === 'rest' && (
+                    <Grid item xs={12}>
+                      <TextField
+                        fullWidth
+                        label="Signing Secret"
+                        name="slack_signing_secret"
+                        value={currentProvider.slack_signing_secret || ''}
+                        onChange={handleInputChange}
+                        type="password"
+                        helperText="Slack app Signing Secret — verifies Events API request authenticity. Set the Request URL to https://<your-helix>/api/v1/slack/events"
+                      />
+                    </Grid>
+                  )}
+                  {currentProvider.slack_ingress_mode === 'socket' && (
+                    <Grid item xs={12}>
+                      <TextField
+                        fullWidth
+                        label="App-Level Token (xapp-…)"
+                        name="slack_app_token"
+                        value={currentProvider.slack_app_token || ''}
+                        onChange={handleInputChange}
+                        type="password"
+                        helperText="App-level token with connections:write — used to open the Socket Mode WebSocket. Generate it under Basic Information → App-Level Tokens."
+                      />
+                    </Grid>
+                  )}
+                </>
+              )}
+
               {currentProvider.type === 'custom' && (
                 <>
                   <Grid item xs={12}>

--- a/frontend/src/components/dashboard/OAuthProvidersTable.tsx
+++ b/frontend/src/components/dashboard/OAuthProvidersTable.tsx
@@ -805,8 +805,10 @@ const OAuthProvidersTable: React.FC = () => {
                 />
               </Grid>
 
-              {/* Setup guide for known provider types - shown after enable toggle */}
-              {currentProvider.type && currentProvider.type !== 'custom' && PROVIDER_SETUP_GUIDE[currentProvider.type] && (
+              {/* Setup guide for known provider types - shown after enable toggle.
+                  Slack is excluded: its mode-specific accordion guide below
+                  supersedes this generic one. */}
+              {currentProvider.type && currentProvider.type !== 'custom' && currentProvider.type !== 'slack' && PROVIDER_SETUP_GUIDE[currentProvider.type] && (
                 <Grid item xs={12}>
                   <Alert
                     severity="info"
@@ -971,6 +973,11 @@ const OAuthProvidersTable: React.FC = () => {
                             </Typography>
                           </AccordionSummary>
                           <AccordionDetails>
+                            <Alert severity="warning" icon={false} sx={{ mb: 1.5, py: 0.5, '& .MuiAlert-message': { width: '100%' } }}>
+                              <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                                <strong>⚠️ Single-workspace only — not for multi-tenant installs.</strong> Slack caps each app at <strong>~10 concurrent Socket Mode connections</strong>, and one app-level token authenticates one app, so Socket Mode can't scale to many customer workspaces. Use it for a single on-premise workspace; for multi-tenant / SaaS, use REST (Events API) instead.
+                              </Typography>
+                            </Alert>
                             <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
                               Socket Mode connects one Slack workspace over an outbound WebSocket — no public URL needed, so it works behind a firewall. Follow these steps in the{' '}
                               <Link href="https://api.slack.com/apps" target="_blank" rel="noopener">Slack app dashboard ↗</Link>, then paste the two tokens below.

--- a/frontend/src/components/dashboard/OAuthProvidersTable.tsx
+++ b/frontend/src/components/dashboard/OAuthProvidersTable.tsx
@@ -910,6 +910,72 @@ const OAuthProvidersTable: React.FC = () => {
                       verifies inbound Events API deliveries. */}
                   {(currentProvider.slack_ingress_mode || 'rest') === 'rest' && (
                     <>
+                      <Grid item xs={12}>
+                        <Accordion
+                          disableGutters
+                          elevation={0}
+                          sx={{
+                            border: '1px solid rgba(255,255,255,0.12)',
+                            borderRadius: 1,
+                            backgroundColor: 'rgba(33, 150, 243, 0.04)',
+                            '&:before': { display: 'none' },
+                          }}
+                        >
+                          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                              📖 REST (Events API) setup guide — create the Slack app step by step
+                            </Typography>
+                          </AccordionSummary>
+                          <AccordionDetails>
+                            <Alert severity="info" icon={false} sx={{ mb: 1.5, py: 0.5, '& .MuiAlert-message': { width: '100%' } }}>
+                              <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                                <strong>REST needs a public HTTPS URL</strong> Slack can POST events to — so Helix must be reachable from the internet (a real domain, or a tunnel like <code>cloudflared</code> for local testing). Unlike Socket Mode it scales to many workspaces, so this is the mode for multi-tenant / SaaS.
+                              </Typography>
+                            </Alert>
+                            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+                              Configure these in the{' '}
+                              <Link href="https://api.slack.com/apps" target="_blank" rel="noopener">Slack app dashboard ↗</Link>. Save the credentials below in Helix <em>before</em> setting the Request URL, so Slack's verification can succeed.
+                            </Typography>
+                            <Box component="ol" sx={{ m: 0, pl: 2.5, '& li': { mb: 1 } }}>
+                              <li>
+                                <Typography variant="caption" color="text.secondary">
+                                  <strong>Create the app.</strong> <Link href="https://api.slack.com/apps" target="_blank" rel="noopener">api.slack.com/apps</Link> → <em>Create New App</em> → <em>From scratch</em>. Name it and pick a workspace.
+                                </Typography>
+                              </li>
+                              <li>
+                                <Typography variant="caption" color="text.secondary">
+                                  <strong>Add bot scopes.</strong> <em>OAuth &amp; Permissions → Scopes → Bot Token Scopes</em>: <code>chat:write</code>, <code>chat:write.customize</code>, <code>channels:history</code>, <code>channels:read</code>, <code>channels:join</code>, <code>groups:history</code>, <code>groups:read</code>, <code>app_mentions:read</code>.
+                                </Typography>
+                              </li>
+                              <li>
+                                <Typography variant="caption" color="text.secondary">
+                                  <strong>Copy the app credentials.</strong> <em>Settings → Basic Information → App Credentials</em>: paste <strong>Client ID</strong>, <strong>Client Secret</strong>, and <strong>Signing Secret</strong> into the fields below, then save this provider. (Client id/secret drive the "Add to Slack" install; the signing secret verifies inbound events.)
+                                </Typography>
+                              </li>
+                              <li>
+                                <Typography variant="caption" color="text.secondary">
+                                  <strong>Turn Socket Mode OFF.</strong> <em>Settings → Socket Mode</em> → off. A Request URL is only available when Socket Mode is disabled.
+                                </Typography>
+                              </li>
+                              <li>
+                                <Typography variant="caption" color="text.secondary">
+                                  <strong>Set the Events Request URL.</strong> <em>Event Subscriptions</em> → <em>Enable Events</em> → Request URL = <code>https://&lt;your-helix-domain&gt;/api/v1/slack/events</code>. Slack signs a challenge that Helix verifies with the Signing Secret — you should see <em>Verified ✓</em>. Under <em>Subscribe to bot events</em> add <code>message.channels</code>, <code>message.groups</code> (private), <code>app_mention</code>. Save Changes.
+                                </Typography>
+                              </li>
+                              <li>
+                                <Typography variant="caption" color="text.secondary">
+                                  <strong>Add the OAuth redirect URL.</strong> <em>OAuth &amp; Permissions → Redirect URLs</em> → add <code>https://&lt;your-helix-domain&gt;/api/v1/slack/oauth/callback</code> → Save. This is where workspaces land after "Add to Slack".
+                                </Typography>
+                              </li>
+                              <li>
+                                <Typography variant="caption" color="text.secondary">
+                                  <strong>Connect each workspace.</strong> A workspace installs via OAuth ("Add to Slack"), which mints that workspace's bot token and records its team id — so REST serves many workspaces from this one app. The bot must still be <code>/invite</code>d to the channels you want it in (private channels require a manual invite).
+                                </Typography>
+                              </li>
+                            </Box>
+                          </AccordionDetails>
+                        </Accordion>
+                      </Grid>
                       <Grid item xs={6}>
                         <TextField
                           fullWidth

--- a/frontend/src/components/dashboard/OAuthProvidersTable.tsx
+++ b/frontend/src/components/dashboard/OAuthProvidersTable.tsx
@@ -227,6 +227,7 @@ const OAuthProvidersTable: React.FC = () => {
         callback_url: window.location.origin + '/api/v1/oauth/flow/callback',
         enabled: true,
         created_at: new Date().toISOString(),
+        ...(templateType === 'slack' ? { slack_ingress_mode: 'rest' } : {}),
       });
       setIsEditing(false);
     }
@@ -871,13 +872,12 @@ const OAuthProvidersTable: React.FC = () => {
                       fullWidth
                       label="Ingress Mode"
                       name="slack_ingress_mode"
-                      value={currentProvider.slack_ingress_mode || ''}
+                      value={currentProvider.slack_ingress_mode || 'rest'}
                       onChange={handleInputChange}
                       SelectProps={{ native: true }}
                       InputLabelProps={{ shrink: true }}
-                      helperText="How inbound Slack events reach Helix. REST (Events API) serves many per-org installs; Socket Mode suits a single on-premise workspace with no inbound HTTP."
+                      helperText="How inbound Slack events reach Helix when this provider is enabled. REST (Events API) serves many per-org installs; Socket Mode suits a single on-premise workspace with no inbound HTTP. Use the Enabled toggle above to turn Slack off entirely."
                     >
-                      <option value="">(disabled — no inbound)</option>
                       <option value="rest">REST (Events API)</option>
                       <option value="socket">Socket Mode (WebSocket)</option>
                     </TextField>

--- a/frontend/src/components/dashboard/OAuthProvidersTable.tsx
+++ b/frontend/src/components/dashboard/OAuthProvidersTable.tsx
@@ -874,6 +874,7 @@ const OAuthProvidersTable: React.FC = () => {
                       value={currentProvider.slack_ingress_mode || ''}
                       onChange={handleInputChange}
                       SelectProps={{ native: true }}
+                      InputLabelProps={{ shrink: true }}
                       helperText="How inbound Slack events reach Helix. REST (Events API) serves many per-org installs; Socket Mode suits a single on-premise workspace with no inbound HTTP."
                     >
                       <option value="">(disabled — no inbound)</option>

--- a/frontend/src/components/dashboard/OAuthProvidersTable.tsx
+++ b/frontend/src/components/dashboard/OAuthProvidersTable.tsx
@@ -286,15 +286,24 @@ const OAuthProvidersTable: React.FC = () => {
       if (!currentProvider.name || currentProvider.name.trim() === '') {
         errors.name = true;
       }
-      
-      if (!currentProvider.client_id || currentProvider.client_id.trim() === '') {
-        errors.client_id = true;
+
+      const isSlack = currentProvider.type === 'slack';
+      const slackMode = currentProvider.slack_ingress_mode || 'rest';
+      const blank = (v?: string) => !v || v.trim() === '';
+
+      if (isSlack && slackMode === 'socket') {
+        // Socket Mode skips OAuth entirely — only the two tokens apply.
+        if (blank(currentProvider.slack_app_token)) errors.slack_app_token = true;
+        if (blank(currentProvider.slack_bot_token)) errors.slack_bot_token = true;
+      } else {
+        // REST Slack and every other OAuth provider need client id/secret.
+        if (blank(currentProvider.client_id)) errors.client_id = true;
+        if (blank(currentProvider.client_secret)) errors.client_secret = true;
+        if (isSlack && blank(currentProvider.slack_signing_secret)) {
+          errors.slack_signing_secret = true;
+        }
       }
-      
-      if (!currentProvider.client_secret || currentProvider.client_secret.trim() === '') {
-        errors.client_secret = true;
-      }
-      
+
       // If there are any errors, show them and stop
       if (Object.keys(errors).length > 0) {
         setFieldErrors(errors);
@@ -826,44 +835,51 @@ const OAuthProvidersTable: React.FC = () => {
                 </Grid>
               )}
               
-              <Grid item xs={6}>
-                <TextField
-                  fullWidth
-                  label="Client ID"
-                  name="client_id"
-                  value={currentProvider.client_id}
-                  onChange={handleInputChange}
-                  required
-                  error={fieldErrors['client_id']}
-                  helperText={fieldErrors['client_id'] ? 'Client ID is required' : ''}
-                />
-              </Grid>
-              
-              <Grid item xs={6}>
-                <TextField
-                  fullWidth
-                  label="Client Secret"
-                  name="client_secret"
-                  value={currentProvider.client_secret}
-                  onChange={handleInputChange}
-                  type="password"
-                  required
-                  error={fieldErrors['client_secret']}
-                  helperText={fieldErrors['client_secret'] ? 'Client Secret is required' : ''}
-                />
-              </Grid>
-              
-              <Grid item xs={12}>
-                <TextField
-                  fullWidth
-                  label="Callback URL"
-                  name="callback_url"
-                  value={currentProvider.callback_url}
-                  onChange={handleInputChange}
-                  helperText="This URL should be configured in your OAuth provider's settings"
-                />
-              </Grid>
-              
+              {/* Slack credentials are mode-driven (see the dedicated
+                  block below); every other provider type uses the shared
+                  OAuth client id / secret / callback. */}
+              {currentProvider.type !== 'slack' && (
+                <>
+                  <Grid item xs={6}>
+                    <TextField
+                      fullWidth
+                      label="Client ID"
+                      name="client_id"
+                      value={currentProvider.client_id}
+                      onChange={handleInputChange}
+                      required
+                      error={fieldErrors['client_id']}
+                      helperText={fieldErrors['client_id'] ? 'Client ID is required' : ''}
+                    />
+                  </Grid>
+
+                  <Grid item xs={6}>
+                    <TextField
+                      fullWidth
+                      label="Client Secret"
+                      name="client_secret"
+                      value={currentProvider.client_secret}
+                      onChange={handleInputChange}
+                      type="password"
+                      required
+                      error={fieldErrors['client_secret']}
+                      helperText={fieldErrors['client_secret'] ? 'Client Secret is required' : ''}
+                    />
+                  </Grid>
+
+                  <Grid item xs={12}>
+                    <TextField
+                      fullWidth
+                      label="Callback URL"
+                      name="callback_url"
+                      value={currentProvider.callback_url}
+                      onChange={handleInputChange}
+                      helperText="This URL should be configured in your OAuth provider's settings"
+                    />
+                  </Grid>
+                </>
+              )}
+
               {currentProvider.type === 'slack' && (
                 <>
                   <Grid item xs={12}>
@@ -876,37 +892,91 @@ const OAuthProvidersTable: React.FC = () => {
                       onChange={handleInputChange}
                       SelectProps={{ native: true }}
                       InputLabelProps={{ shrink: true }}
-                      helperText="How inbound Slack events reach Helix when this provider is enabled. REST (Events API) serves many per-org installs; Socket Mode suits a single on-premise workspace with no inbound HTTP. Use the Enabled toggle above to turn Slack off entirely."
+                      helperText="How inbound Slack events reach Helix when this provider is enabled. REST (Events API) serves many per-org installs via OAuth; Socket Mode connects a single on-premise workspace with no inbound HTTP. Use the Enabled toggle above to turn Slack off entirely."
                     >
-                      <option value="rest">REST (Events API)</option>
-                      <option value="socket">Socket Mode (WebSocket)</option>
+                      <option value="rest">REST (Events API) — multi-workspace via OAuth</option>
+                      <option value="socket">Socket Mode (WebSocket) — single workspace</option>
                     </TextField>
                   </Grid>
-                  {currentProvider.slack_ingress_mode === 'rest' && (
-                    <Grid item xs={12}>
-                      <TextField
-                        fullWidth
-                        label="Signing Secret"
-                        name="slack_signing_secret"
-                        value={currentProvider.slack_signing_secret || ''}
-                        onChange={handleInputChange}
-                        type="password"
-                        helperText="Slack app Signing Secret — verifies Events API request authenticity. Set the Request URL to https://<your-helix>/api/v1/slack/events"
-                      />
-                    </Grid>
+
+                  {/* REST: OAuth "Add to Slack" install (client id/secret)
+                      mints each workspace's bot token; signing secret
+                      verifies inbound Events API deliveries. */}
+                  {(currentProvider.slack_ingress_mode || 'rest') === 'rest' && (
+                    <>
+                      <Grid item xs={6}>
+                        <TextField
+                          fullWidth
+                          label="Client ID"
+                          name="client_id"
+                          value={currentProvider.client_id}
+                          onChange={handleInputChange}
+                          required
+                          error={fieldErrors['client_id']}
+                          helperText={fieldErrors['client_id'] ? 'Client ID is required' : 'OAuth client id from Basic Information'}
+                        />
+                      </Grid>
+                      <Grid item xs={6}>
+                        <TextField
+                          fullWidth
+                          label="Client Secret"
+                          name="client_secret"
+                          value={currentProvider.client_secret}
+                          onChange={handleInputChange}
+                          type="password"
+                          required
+                          error={fieldErrors['client_secret']}
+                          helperText={fieldErrors['client_secret'] ? 'Client Secret is required' : 'OAuth client secret from Basic Information'}
+                        />
+                      </Grid>
+                      <Grid item xs={12}>
+                        <TextField
+                          fullWidth
+                          label="Signing Secret"
+                          name="slack_signing_secret"
+                          value={currentProvider.slack_signing_secret || ''}
+                          onChange={handleInputChange}
+                          type="password"
+                          required
+                          error={fieldErrors['slack_signing_secret']}
+                          helperText={fieldErrors['slack_signing_secret'] ? 'Signing Secret is required for REST' : 'Verifies Events API authenticity. Set the Request URL to https://<your-helix>/api/v1/slack/events'}
+                        />
+                      </Grid>
+                    </>
                   )}
+
+                  {/* Socket Mode: no OAuth. The app-level token opens the
+                      WebSocket; the bot token posts. No inbound HTTP, so no
+                      client id/secret, callback, or signing secret. */}
                   {currentProvider.slack_ingress_mode === 'socket' && (
-                    <Grid item xs={12}>
-                      <TextField
-                        fullWidth
-                        label="App-Level Token (xapp-…)"
-                        name="slack_app_token"
-                        value={currentProvider.slack_app_token || ''}
-                        onChange={handleInputChange}
-                        type="password"
-                        helperText="App-level token with connections:write — used to open the Socket Mode WebSocket. Generate it under Basic Information → App-Level Tokens."
-                      />
-                    </Grid>
+                    <>
+                      <Grid item xs={12}>
+                        <TextField
+                          fullWidth
+                          label="App-Level Token (xapp-…)"
+                          name="slack_app_token"
+                          value={currentProvider.slack_app_token || ''}
+                          onChange={handleInputChange}
+                          type="password"
+                          required
+                          error={fieldErrors['slack_app_token']}
+                          helperText={fieldErrors['slack_app_token'] ? 'App-Level Token is required for Socket Mode' : 'Token with connections:write that opens the WebSocket. Basic Information → App-Level Tokens.'}
+                        />
+                      </Grid>
+                      <Grid item xs={12}>
+                        <TextField
+                          fullWidth
+                          label="Bot Token (xoxb-…)"
+                          name="slack_bot_token"
+                          value={currentProvider.slack_bot_token || ''}
+                          onChange={handleInputChange}
+                          type="password"
+                          required
+                          error={fieldErrors['slack_bot_token']}
+                          helperText={fieldErrors['slack_bot_token'] ? 'Bot Token is required for Socket Mode' : 'Bot user OAuth token used to post messages. OAuth & Permissions → Bot User OAuth Token.'}
+                        />
+                      </Grid>
+                    </>
                   )}
                 </>
               )}


### PR DESCRIPTION
## Summary

Implements complete Slack transport integration for helix-org Streams, enabling:
- **Inbound:** REST Events API + Socket Mode WebSocket ingress with team-based routing
- **Outbound:** Worker publications as Slack messages with persona/threading
- **OAuth:** Per-org "Add to Slack" install flow
- **Routing:** Pluggable disambiguation (broadcast default, fuzzy keyword-match)
- **Security:** HMAC signature verify (REST), single-owner advisory lock (Socket), membership-based OAuth

## Implementation

**Transport domain** (`api/pkg/org/domain/transport/slack.go`):
- `KindSlack` constant + `SlackConfig{Channel}` with validation
- Registered in transport Kind registry and strategy map

**Ingest package** (`api/pkg/org/infrastructure/transports/slack/`):
- `Receive()`: team_id → org resolution, self-echo drop, channel matching, envelope building
- `Router` interface: broadcast (default) or fuzzy (keyword-overlap)
- `EventsAPI`: REST source with SecretsVerifier HMAC check
- `SocketMode`: WebSocket source with `SingleOwner` Postgres advisory lock
- `Provisioner`: conversations.join + membership Status

**Outbound** (`outbound.go`):
- `streaming.Outbound` impl emitting `chat.postMessage` with persona resolver
- Thread support via `thread_ts` parameter

**OAuth** (`oauth.go`):
- State-encrypted round trip for org routing
- Persists per-org `transport.slack` config

**Dispatcher seam** (`api/pkg/org/application/dispatch/dispatcher.go`):
- New `DispatchTo(ctx, event, targets)` for Router-selected fan-out
- `Dispatch` delegates to `DispatchTo` with all subscribers

**Wiring** (`api/pkg/server/helix_org_slack.go`):
- Composition root builds all components
- GlobalApp port for live config read (enabling/disabling without restart)
- Socket Mode runner with reconnect/backoff

**Admin config**:
- `OAuthProvider` gains `SlackSigningSecret`, `SlackAppToken`, `SlackIngressMode`
- Non-admin secret redaction via `redactProviderSecrets()`
- Config specs: `transport.slack` (per-org install) + `slack.router` (strategy)

**Frontend** (`OAuthProvidersTable.tsx`):
- Slack-specific fields (ingress mode toggle, signing secret, app token)
- Mode-dependent form visibility (REST vs Socket fields)

## Verification

- **36 tests** in slack package (config, ingest, events_api, outbound, router, socket, oauth, provisioner)
- **Localhost e2e**: Creating `type=slack` provider flips `/api/v1/slack/events` from 503 (inert, FR-3) → 401 (signature check, NFR-4)
- **DB persistence**: Three Slack columns round-trip via GORM
- **Security**: Membership-authorised OAuth start handler prevents cross-org hijack
- **All tests green**: domain Kind, Dispatcher.DispatchTo, config specs

## Blocked on

Live Slack workspace credentials for full e2e testing (OAuth install → inbound message → Worker activation → outbound persona post).

Deferred per design §13: human email-linking (FR-21/22/24), Worker-avatar source, LLM Router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)