### PR TITLE
fix(api): durably GC orphaned session zvols and workspace checkouts

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -45,6 +45,25 @@ type ServerConfig struct {
 	// DesktopIdleCheckInterval controls how often the idle checker scans for desktops to shut down.
 	DesktopIdleCheckInterval time.Duration `envconfig:"HELIX_DESKTOP_IDLE_CHECK_INTERVAL" default:"5m"`
 
+	// OrphanReaperEnabled toggles the durable, DB-driven orphan-resource reaper
+	// that garbage-collects leaked session zvols and per-task/session workspace
+	// dirs after host reboots / API restarts / failed destroys.
+	OrphanReaperEnabled bool `envconfig:"HELIX_ORPHAN_REAPER_ENABLED" default:"true"`
+
+	// OrphanReaperInterval is how often the orphan-resource reaper computes the
+	// DB live-set and fans it out to connected sandboxes.
+	OrphanReaperInterval time.Duration `envconfig:"HELIX_ORPHAN_REAPER_INTERVAL" default:"30m"`
+
+	// OrphanReaperGracePeriod is the minimum age a resource must reach before
+	// the reaper will destroy it. Guards against racing newly-created resources
+	// the DB live-set hasn't caught up with yet.
+	OrphanReaperGracePeriod time.Duration `envconfig:"HELIX_ORPHAN_REAPER_GRACE_PERIOD" default:"6h"`
+
+	// OrphanReaperDryRun, when true, makes the reaper report what it WOULD reap
+	// without destroying anything. Defaults to true so the safety-critical zvol
+	// destroys are opt-in until an operator has reviewed the dry-run logs.
+	OrphanReaperDryRun bool `envconfig:"HELIX_ORPHAN_REAPER_DRY_RUN" default:"true"`
+
 	// SandboxReaperInterval is how often the sandbox-instance reaper scans
 	// the sandbox_instances table for stale rows and flips their status to
 	// offline. Used in conjunction with SandboxStaleThreshold and

--- a/api/pkg/external-agent/executor.go
+++ b/api/pkg/external-agent/executor.go
@@ -30,6 +30,10 @@ type Executor interface {
 
 	// Golden build result from sandbox
 	GetGoldenBuildResult(ctx context.Context, sandboxID, projectID string) (*hydra.GoldenBuildResult, error)
+
+	// ReconcileSandboxResources fans a DB-driven GC reconcile request out to a
+	// connected sandbox's hydra, which reaps orphaned zvols + workspace dirs.
+	ReconcileSandboxResources(ctx context.Context, sandboxID string, req *hydra.GCReconcileRequest) (*hydra.GCReconcileResponse, error)
 }
 
 // Shared types used by all executor implementations

--- a/api/pkg/external-agent/executor_mocks.go
+++ b/api/pkg/external-agent/executor_mocks.go
@@ -99,6 +99,21 @@ func (mr *MockExecutorMockRecorder) GetGoldenBuildResult(ctx, sandboxID, project
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGoldenBuildResult", reflect.TypeOf((*MockExecutor)(nil).GetGoldenBuildResult), ctx, sandboxID, projectID)
 }
 
+// ReconcileSandboxResources mocks base method.
+func (m *MockExecutor) ReconcileSandboxResources(ctx context.Context, sandboxID string, req *hydra.GCReconcileRequest) (*hydra.GCReconcileResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileSandboxResources", ctx, sandboxID, req)
+	ret0, _ := ret[0].(*hydra.GCReconcileResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReconcileSandboxResources indicates an expected call of ReconcileSandboxResources.
+func (mr *MockExecutorMockRecorder) ReconcileSandboxResources(ctx, sandboxID, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileSandboxResources", reflect.TypeOf((*MockExecutor)(nil).ReconcileSandboxResources), ctx, sandboxID, req)
+}
+
 // GetSession mocks base method.
 func (m *MockExecutor) GetSession(sessionID string) (*ZedSession, error) {
 	m.ctrl.T.Helper()

--- a/api/pkg/external-agent/gc_reaper.go
+++ b/api/pkg/external-agent/gc_reaper.go
@@ -1,0 +1,133 @@
+package external_agent
+
+import (
+	"context"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/hydra"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/rs/zerolog/log"
+)
+
+// specTaskTerminalStatuses are statuses where a spec-task is finished and its
+// ephemeral on-disk resources (workspace checkout) are no longer needed. Tasks
+// in these states are NOT in the live-set (so they become reap candidates once
+// they age past hydra's grace period), unless they were updated very recently.
+var specTaskTerminalStatuses = map[types.SpecTaskStatus]bool{
+	types.TaskStatusDone:                 true,
+	types.TaskStatusSpecFailed:           true,
+	types.TaskStatusImplementationFailed: true,
+}
+
+// RunOrphanResourceReaper is a durable, DB-driven garbage-collection ticker. On
+// each tick it computes the live-set from Postgres (sessions + spec-tasks) and
+// fans it out to every recently-seen sandbox's hydra, which lists on-disk
+// session zvols and per-task/session workspace dirs, subtracts the live-set,
+// applies the grace period, and reaps the rest.
+//
+// Unlike the legacy in-memory hydra GC (DevContainerManager.GCOrphanedSessions),
+// this survives host reboots / API restarts because the live-set comes from the
+// database, not from hydra's in-memory container map.
+//
+// It blocks until ctx is cancelled and is intended to run in a goroutine.
+// Errors are logged, never fatal.
+func RunOrphanResourceReaper(ctx context.Context, executor Executor, st store.Store, interval, gracePeriod time.Duration, dryRun bool) {
+	log.Info().
+		Dur("interval", interval).
+		Dur("grace_period", gracePeriod).
+		Bool("dry_run", dryRun).
+		Msg("starting orphan-resource reaper")
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			reapOrphanResources(ctx, executor, st, gracePeriod, dryRun)
+		}
+	}
+}
+
+func reapOrphanResources(ctx context.Context, executor Executor, st store.Store, gracePeriod time.Duration, dryRun bool) {
+	// Use a cutoff generous enough that anything created/updated within the
+	// grace window is still considered live, so we never race a fresh resource.
+	cutoff := time.Now().Add(-gracePeriod)
+
+	liveSessionIDs, err := st.ListExternalAgentSessionIDs(ctx, cutoff)
+	if err != nil {
+		log.Error().Err(err).Msg("orphan reaper: failed to list live session ids")
+		return
+	}
+
+	liveSpecTaskIDs, err := liveSpecTaskIDsForReaper(ctx, st, cutoff)
+	if err != nil {
+		log.Error().Err(err).Msg("orphan reaper: failed to list live spec-task ids")
+		return
+	}
+
+	sandboxes, err := st.ListSandboxInstances(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("orphan reaper: failed to list sandbox instances")
+		return
+	}
+
+	req := &hydra.GCReconcileRequest{
+		LiveSessionIDs:     liveSessionIDs,
+		LiveSpecTaskIDs:    liveSpecTaskIDs,
+		GracePeriodSeconds: int(gracePeriod.Seconds()),
+		DryRun:             dryRun,
+	}
+
+	for _, sandbox := range sandboxes {
+		// Only reconcile against sandboxes we've heard from recently — a stale
+		// row is likely a dead host that can't be reached over RevDial anyway.
+		if sandbox.LastSeen.Before(cutoff) {
+			continue
+		}
+
+		resp, err := executor.ReconcileSandboxResources(ctx, sandbox.ID, req)
+		if err != nil {
+			log.Warn().Err(err).
+				Str("sandbox_id", sandbox.ID).
+				Msg("orphan reaper: failed to reconcile sandbox resources")
+			continue
+		}
+
+		log.Info().
+			Str("sandbox_id", sandbox.ID).
+			Bool("dry_run", dryRun).
+			Strs("zvols_reaped", resp.ZvolsReaped).
+			Int("zvols_skipped", len(resp.ZvolsSkipped)).
+			Strs("workspaces_reaped", resp.WorkspacesReaped).
+			Int("workspaces_skipped", len(resp.WorkspacesSkipped)).
+			Int64("bytes_freed", resp.BytesFreed).
+			Msg("orphan reaper: sandbox reconciled")
+	}
+}
+
+// liveSpecTaskIDsForReaper returns the IDs of spec-tasks that should be treated
+// as live: those in a non-terminal status OR updated at/after cutoff. Archived
+// tasks are included in the scan but are live only if recently updated, so a
+// long-archived task's workspace eventually reaps.
+func liveSpecTaskIDsForReaper(ctx context.Context, st store.Store, cutoff time.Time) ([]string, error) {
+	tasks, err := st.ListSpecTasks(ctx, &types.SpecTaskFilters{IncludeArchived: true})
+	if err != nil {
+		return nil, err
+	}
+
+	var ids []string
+	for _, t := range tasks {
+		live := !specTaskTerminalStatuses[t.Status] && !t.Archived
+		if !live && !t.UpdatedAt.Before(cutoff) {
+			live = true // recently touched — keep its workspace a bit longer
+		}
+		if live {
+			ids = append(ids, t.ID)
+		}
+	}
+	return ids, nil
+}

--- a/api/pkg/external-agent/gc_reaper_test.go
+++ b/api/pkg/external-agent/gc_reaper_test.go
@@ -1,0 +1,105 @@
+package external_agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/hydra"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestReapOrphanResources_CallsRecentSandboxesWithCorrectRequest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockExec := NewMockExecutor(ctrl)
+
+	const grace = 6 * time.Hour
+	now := time.Now()
+
+	liveSessions := []string{"ses_live1", "ses_live2"}
+
+	mockStore.EXPECT().
+		ListExternalAgentSessionIDs(gomock.Any(), gomock.Any()).
+		Return(liveSessions, nil)
+
+	// Two spec tasks: one live (implementation), one terminal+old (done) → excluded.
+	mockStore.EXPECT().
+		ListSpecTasks(gomock.Any(), gomock.Any()).
+		Return([]*types.SpecTask{
+			{ID: "spt_live", Status: types.TaskStatusImplementation, UpdatedAt: now},
+			{ID: "spt_done", Status: types.TaskStatusDone, UpdatedAt: now.Add(-30 * 24 * time.Hour)},
+		}, nil)
+
+	// One recent sandbox (reconciled) + one stale sandbox (skipped).
+	mockStore.EXPECT().
+		ListSandboxInstances(gomock.Any()).
+		Return([]*types.SandboxInstance{
+			{ID: "sbox_recent", LastSeen: now},
+			{ID: "sbox_stale", LastSeen: now.Add(-24 * time.Hour)},
+		}, nil)
+
+	// Only the recent sandbox is reconciled, exactly once, with the correct request.
+	mockExec.EXPECT().
+		ReconcileSandboxResources(gomock.Any(), "sbox_recent", gomock.Any()).
+		DoAndReturn(func(_ context.Context, sandboxID string, req *hydra.GCReconcileRequest) (*hydra.GCReconcileResponse, error) {
+			assert.Equal(t, []string{"ses_live1", "ses_live2"}, req.LiveSessionIDs)
+			assert.Equal(t, []string{"spt_live"}, req.LiveSpecTaskIDs)
+			assert.Equal(t, int(grace.Seconds()), req.GracePeriodSeconds)
+			assert.True(t, req.DryRun)
+			return &hydra.GCReconcileResponse{ZvolsReaped: []string{"x"}, BytesFreed: 42}, nil
+		})
+
+	reapOrphanResources(context.Background(), mockExec, mockStore, grace, true /* dryRun */)
+}
+
+func TestReapOrphanResources_StoreErrorIsNotFatal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockExec := NewMockExecutor(ctrl)
+
+	// First store call fails → reaper bails early, no executor call, no panic.
+	mockStore.EXPECT().
+		ListExternalAgentSessionIDs(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("db down"))
+
+	// No ListSpecTasks / ListSandboxInstances / ReconcileSandboxResources expected.
+	assert.NotPanics(t, func() {
+		reapOrphanResources(context.Background(), mockExec, mockStore, 6*time.Hour, false)
+	})
+}
+
+func TestReapOrphanResources_SandboxReconcileErrorContinues(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockExec := NewMockExecutor(ctrl)
+
+	now := time.Now()
+
+	mockStore.EXPECT().ListExternalAgentSessionIDs(gomock.Any(), gomock.Any()).Return([]string{}, nil)
+	mockStore.EXPECT().ListSpecTasks(gomock.Any(), gomock.Any()).Return([]*types.SpecTask{}, nil)
+	mockStore.EXPECT().ListSandboxInstances(gomock.Any()).Return([]*types.SandboxInstance{
+		{ID: "sbox_a", LastSeen: now},
+		{ID: "sbox_b", LastSeen: now},
+	}, nil)
+
+	// First sandbox errors; reaper must continue to the second.
+	mockExec.EXPECT().ReconcileSandboxResources(gomock.Any(), "sbox_a", gomock.Any()).
+		Return(nil, errors.New("revdial down"))
+	mockExec.EXPECT().ReconcileSandboxResources(gomock.Any(), "sbox_b", gomock.Any()).
+		Return(&hydra.GCReconcileResponse{}, nil)
+
+	assert.NotPanics(t, func() {
+		reapOrphanResources(context.Background(), mockExec, mockStore, 6*time.Hour, false)
+	})
+}

--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -1477,6 +1477,22 @@ func (h *HydraExecutor) DiscoverContainersFromSandbox(ctx context.Context, sandb
 	return nil
 }
 
+// ReconcileSandboxResources posts the DB-derived live-set to a connected
+// sandbox's hydra over RevDial and returns hydra's report of reaped / skipped
+// orphan resources. Mirrors the DiscoverContainersFromSandbox RevDial wiring.
+func (h *HydraExecutor) ReconcileSandboxResources(ctx context.Context, sandboxID string, req *hydra.GCReconcileRequest) (*hydra.GCReconcileResponse, error) {
+	if h.connman == nil {
+		return nil, fmt.Errorf("connection manager not available")
+	}
+
+	// Hydra runner ID follows the pattern: hydra-{SANDBOX_INSTANCE_ID}
+	hydraRunnerID := "hydra-" + sandboxID
+
+	hydraClient := hydra.NewRevDialClient(h.connman, hydraRunnerID)
+
+	return hydraClient.ReconcileGC(ctx, req)
+}
+
 // checkLimits checks desktop limits for the user/org
 func (h *HydraExecutor) checkLimits(ctx context.Context, agent *types.DesktopAgent) (*types.QuotaLimitReachedResponse, error) {
 	// Get system settings

--- a/api/pkg/hydra/client.go
+++ b/api/pkg/hydra/client.go
@@ -523,6 +523,27 @@ func (c *RevDialClient) DeleteGoldenCache(ctx context.Context, projectID string)
 	return err
 }
 
+// ReconcileGC posts the DB-derived live-set to hydra and returns its report of
+// reaped / skipped orphan resources, via RevDial.
+func (c *RevDialClient) ReconcileGC(ctx context.Context, req *GCReconcileRequest) (*GCReconcileResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	respBody, err := c.doRequest(ctx, "POST", "/api/v1/gc/reconcile", body)
+	if err != nil {
+		return nil, err
+	}
+
+	var result GCReconcileResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return &result, nil
+}
+
 // doRequest performs an HTTP request over RevDial
 func (c *RevDialClient) doRequest(ctx context.Context, method, path string, body []byte) ([]byte, error) {
 	conn, err := c.connman.Dial(ctx, c.deviceID)

--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -1736,6 +1736,59 @@ func (dm *DevContainerManager) GCOrphanedSessions() {
 	}
 }
 
+// ReconcileGC reconciles on-disk ephemeral resources (session zvols and
+// per-task/session workspace dirs) against the DB-derived live-set supplied by
+// the API, reaping anything orphaned and past the grace period.
+//
+// The DB live-set is the durable source of truth (it survives reboots). As
+// extra protection we UNION in the session IDs of currently-running containers
+// from hydra's in-memory map, so an in-flight session whose row hasn't been
+// observed by the API yet is never reaped.
+func (dm *DevContainerManager) ReconcileGC(req GCReconcileRequest) GCReconcileResponse {
+	liveSessions := make(map[string]bool, len(req.LiveSessionIDs))
+	for _, id := range req.LiveSessionIDs {
+		liveSessions[id] = true
+	}
+	liveSpecTasks := make(map[string]bool, len(req.LiveSpecTaskIDs))
+	for _, id := range req.LiveSpecTaskIDs {
+		liveSpecTasks[id] = true
+	}
+
+	// Union in currently-running container session IDs (belt-and-braces).
+	dm.mu.RLock()
+	for sessionID := range dm.containers {
+		liveSessions[sessionID] = true
+	}
+	dm.mu.RUnlock()
+
+	grace := time.Duration(req.GracePeriodSeconds) * time.Second
+
+	var resp GCReconcileResponse
+
+	zReaped, zSkipped := ReconcileOrphanZvols(liveSessions, grace, req.DryRun)
+	resp.ZvolsReaped = zReaped
+	resp.ZvolsSkipped = zSkipped
+
+	wReaped, wSkipped, freed := ReconcileOrphanWorkspaces(liveSessions, liveSpecTasks, grace, req.DryRun)
+	resp.WorkspacesReaped = wReaped
+	resp.WorkspacesSkipped = wSkipped
+	resp.BytesFreed = freed
+
+	log.Info().
+		Bool("dry_run", req.DryRun).
+		Dur("grace", grace).
+		Int("live_sessions", len(liveSessions)).
+		Int("live_spec_tasks", len(liveSpecTasks)).
+		Int("zvols_reaped", len(resp.ZvolsReaped)).
+		Int("zvols_skipped", len(resp.ZvolsSkipped)).
+		Int("workspaces_reaped", len(resp.WorkspacesReaped)).
+		Int("workspaces_skipped", len(resp.WorkspacesSkipped)).
+		Int64("bytes_freed", resp.BytesFreed).
+		Msg("GC_RECONCILE completed")
+
+	return resp
+}
+
 // GetDevContainer returns the status of a dev container
 func (dm *DevContainerManager) GetDevContainer(ctx context.Context, sessionID string) (*DevContainerResponse, error) {
 	dm.mu.RLock()

--- a/api/pkg/hydra/golden_zvol.go
+++ b/api/pkg/hydra/golden_zvol.go
@@ -816,6 +816,96 @@ func GCOrphanedZvols(activeSessions map[string]bool) (int, error) {
 	return cleaned, nil
 }
 
+// zvolCreationAge returns how long ago a zvol was created, using the ZFS
+// `creation` property (unix seconds, via -p). Returns 0 if the property can't
+// be read or parsed — callers treat 0 as "unknown age" and apply their own
+// safe default.
+func zvolCreationAge(zvolName string) time.Duration {
+	out, err := execCmdOutput("zfs", "get", "-Hp", "-o", "value", "creation", zvolName)
+	if err != nil {
+		return 0
+	}
+	var created int64
+	if _, err := fmt.Sscanf(strings.TrimSpace(string(out)), "%d", &created); err != nil || created <= 0 {
+		return 0
+	}
+	return time.Since(time.Unix(created, 0))
+}
+
+// ReconcileOrphanZvols reaps session zvols (prefix "<parent>/ses-") that are NOT
+// in the DB-derived liveSet, have aged past the grace period, and can be safely
+// destroyed.
+//
+// Safety contract (do not weaken):
+//   - Only ses- zvols are ever enumerated; golden-* zvols are never touched
+//     (the prefix guard filters them out, mirroring GCOrphanedZvols).
+//   - Destroys go through CleanupSessionZvol, which uses `zfs destroy -r`
+//     (lowercase). A clone-root or busy zvol fails with "has dependent clones"
+//     / "dataset is busy"; we record it as skipped and move on. We NEVER force
+//     (no `-R`, no `-f`) — refusing to destroy a busy/parent dataset is the
+//     desired behaviour.
+//   - Live sessions get their external marker refreshed so the legacy on-disk
+//     GC keeps treating them as fresh.
+func ReconcileOrphanZvols(liveSet map[string]bool, grace time.Duration, dryRun bool) (reaped []string, skipped []GCSkip) {
+	if !ZFSAvailable() {
+		return nil, nil
+	}
+
+	prefix := zfsParentDataset + "/ses-"
+	out, err := execCmdOutput("zfs", "list", "-H", "-o", "name", "-t", "volume", "-r", zfsParentDataset)
+	if err != nil {
+		log.Warn().Err(err).Msg("ReconcileOrphanZvols: failed to list zvols")
+		return nil, nil
+	}
+
+	for _, name := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if !strings.HasPrefix(name, prefix) {
+			continue // never touch golden- or anything else
+		}
+		sessionID := strings.TrimPrefix(name, prefix)
+
+		if liveSet[sessionID] {
+			// Live per the DB — keep, and refresh the on-disk marker so the
+			// legacy 7-day GC also keeps treating it as fresh.
+			externalDir := filepath.Join(sessionsBaseDir, "docker-data-"+sessionID)
+			_ = os.MkdirAll(externalDir, 0755)
+			TouchSessionLastActive(externalDir)
+			skipped = append(skipped, GCSkip{Name: name, Reason: "live"})
+			continue
+		}
+
+		// Not live. Apply the grace period using zvol creation time. age == 0
+		// means we couldn't read the creation property — be conservative and
+		// skip (treat as within grace).
+		age := zvolCreationAge(name)
+		if age < grace {
+			skipped = append(skipped, GCSkip{Name: name, Reason: "grace"})
+			continue
+		}
+
+		if dryRun {
+			reaped = append(reaped, name)
+			continue
+		}
+
+		if err := CleanupSessionZvol(sessionID); err != nil {
+			msg := err.Error()
+			// "has dependent clones" / "dataset is busy" → a golden clone-root
+			// or a manually-cloned descendant depends on this zvol. NEVER force.
+			if strings.Contains(msg, "dependent clones") || strings.Contains(msg, "busy") {
+				skipped = append(skipped, GCSkip{Name: name, Reason: "dependent: " + msg})
+				continue
+			}
+			log.Warn().Err(err).Str("zvol", name).Msg("ReconcileOrphanZvols: failed to destroy zvol")
+			skipped = append(skipped, GCSkip{Name: name, Reason: "error: " + msg})
+			continue
+		}
+		reaped = append(reaped, name)
+	}
+
+	return reaped, skipped
+}
+
 // GCStaleSnapshots destroys golden snapshots older than 7 days that have no
 // remaining clones. Keeps recent snapshots so the user can see cache progression.
 // Snapshots with active session clones can't be destroyed (ZFS refuses) — that's

--- a/api/pkg/hydra/golden_zvol_test.go
+++ b/api/pkg/hydra/golden_zvol_test.go
@@ -36,6 +36,10 @@ type mockZFS struct {
 	commands []cmdRecord
 	// failCommands maps command prefixes to errors (e.g. "zfs clone" → error)
 	failCommands map[string]error
+	// creationByDataset maps a dataset name to its ZFS `creation` time (unix
+	// seconds), returned by `zfs get -Hp -o value creation <ds>`. Datasets not
+	// present here report "now" (age ~0).
+	creationByDataset map[string]int64
 }
 
 func newMockZFS() *mockZFS {
@@ -44,7 +48,14 @@ func newMockZFS() *mockZFS {
 		mountedPaths:       make(map[string]bool),
 		snapshotsByDataset: make(map[string][]string),
 		failCommands:       make(map[string]error),
+		creationByDataset:  make(map[string]int64),
 	}
+}
+
+// setCreationAge records that a dataset was created `age` ago, so
+// `zfs get -Hp -o value creation` (and thus zvolCreationAge) reports it.
+func (m *mockZFS) setCreationAge(dataset string, age time.Duration) {
+	m.creationByDataset[dataset] = time.Now().Add(-age).Unix()
 }
 
 func (m *mockZFS) addDataset(name string) {
@@ -182,6 +193,16 @@ func (m *mockZFS) handleZFS(args ...string) ([]byte, error) {
 	}
 
 	switch args[0] {
+	case "get":
+		// zfs get -Hp -o value creation <dataset>
+		// Return the recorded creation unix-secs, or "now" if not set.
+		dataset := args[len(args)-1]
+		created, ok := m.creationByDataset[dataset]
+		if !ok {
+			created = time.Now().Unix()
+		}
+		return []byte(fmt.Sprintf("%d\n", created)), nil
+
 	case "list":
 		// Handle various list commands
 		if contains(args, "-t") && contains(args, "snapshot") && contains(args, "-r") {
@@ -1457,4 +1478,152 @@ func (s *GoldenZvolSuite) TestCreateGoldenZvol_DedupOff() {
 	assert.Contains(s.T(), cmdStr, "dedup=off", "golden zvols must have dedup=off")
 	assert.Contains(s.T(), cmdStr, "compression=lz4")
 	assert.Contains(s.T(), cmdStr, "-s", "must be thin-provisioned")
+}
+
+// -----------------------------------------------------------------------
+// ReconcileOrphanZvols (DB-driven reaper)
+// -----------------------------------------------------------------------
+
+const reconcileGrace = time.Hour
+
+// assertNeverForcedDestroy fails if any `zfs destroy -R` or any destroy with the
+// `-f` flag was ever issued. This is the safety-critical invariant: the reaper
+// must NEVER force-destroy a busy or clone-parent zvol.
+func (s *GoldenZvolSuite) assertNeverForcedDestroy() {
+	for _, c := range s.mock.commands {
+		if c.Name != "zfs" || len(c.Args) == 0 || c.Args[0] != "destroy" {
+			continue
+		}
+		for _, a := range c.Args {
+			assert.NotEqual(s.T(), "-R", a, "reaper must never use `zfs destroy -R` (recursive clone cascade)")
+			assert.NotEqual(s.T(), "-f", a, "reaper must never use `zfs destroy -f` (force)")
+		}
+	}
+}
+
+func (s *GoldenZvolSuite) TestReconcileOrphanZvols_ReapsNonLivePastGrace() {
+	zfsParentDataset = "prod/helix-zvols"
+	zfsAvailableFlag = true
+
+	s.mock.addDataset("prod/helix-zvols/ses-ses_orphan")
+	s.mock.setCreationAge("prod/helix-zvols/ses-ses_orphan", 8*time.Hour) // past grace
+
+	reaped, skipped := ReconcileOrphanZvols(map[string]bool{}, reconcileGrace, false)
+
+	assert.Equal(s.T(), []string{"prod/helix-zvols/ses-ses_orphan"}, reaped)
+	assert.Empty(s.T(), skipped)
+	assert.True(s.T(), s.mock.hasCommand("zfs destroy -r prod/helix-zvols/ses-ses_orphan"))
+	assert.False(s.T(), s.mock.datasets["prod/helix-zvols/ses-ses_orphan"])
+	s.assertNeverForcedDestroy()
+}
+
+func (s *GoldenZvolSuite) TestReconcileOrphanZvols_SkipsLive() {
+	zfsParentDataset = "prod/helix-zvols"
+	zfsAvailableFlag = true
+
+	s.mock.addDataset("prod/helix-zvols/ses-ses_live")
+	s.mock.setCreationAge("prod/helix-zvols/ses-ses_live", 8*time.Hour) // old but LIVE
+
+	// Use a temp sessionsBaseDir so the live-marker refresh doesn't touch /container-docker.
+	oldSessionsBaseDir := sessionsBaseDir
+	sessionsBaseDir = filepath.Join(s.tmpDir, "sessions")
+	defer func() { sessionsBaseDir = oldSessionsBaseDir }()
+
+	reaped, skipped := ReconcileOrphanZvols(map[string]bool{"ses_live": true}, reconcileGrace, false)
+
+	assert.Empty(s.T(), reaped)
+	require.Len(s.T(), skipped, 1)
+	assert.Equal(s.T(), "live", skipped[0].Reason)
+	assert.False(s.T(), s.mock.hasCommand("zfs destroy"))
+	assert.True(s.T(), s.mock.datasets["prod/helix-zvols/ses-ses_live"])
+}
+
+func (s *GoldenZvolSuite) TestReconcileOrphanZvols_SkipsWithinGrace() {
+	zfsParentDataset = "prod/helix-zvols"
+	zfsAvailableFlag = true
+
+	s.mock.addDataset("prod/helix-zvols/ses-ses_fresh")
+	s.mock.setCreationAge("prod/helix-zvols/ses-ses_fresh", 10*time.Minute) // within grace
+
+	reaped, skipped := ReconcileOrphanZvols(map[string]bool{}, reconcileGrace, false)
+
+	assert.Empty(s.T(), reaped)
+	require.Len(s.T(), skipped, 1)
+	assert.Equal(s.T(), "grace", skipped[0].Reason)
+	assert.False(s.T(), s.mock.hasCommand("zfs destroy"))
+	assert.True(s.T(), s.mock.datasets["prod/helix-zvols/ses-ses_fresh"])
+}
+
+// TestReconcileOrphanZvols_SkipsCloneRoot covers the safety-critical case: a
+// session zvol that is the origin/ancestor of a golden (CleanupSessionZvol's
+// `zfs destroy -r` returns "has dependent clones"). The reaper must record it
+// as skipped and NEVER force.
+func (s *GoldenZvolSuite) TestReconcileOrphanZvols_SkipsCloneRoot() {
+	zfsParentDataset = "prod/helix-zvols"
+	zfsAvailableFlag = true
+
+	s.mock.addDataset("prod/helix-zvols/ses-ses_parent")
+	s.mock.setCreationAge("prod/helix-zvols/ses-ses_parent", 8*time.Hour)
+	// destroy -r fails because the golden was promoted from a clone of this zvol.
+	s.mock.failOn("zfs destroy -r prod/helix-zvols/ses-ses_parent",
+		fmt.Errorf("cannot destroy 'prod/helix-zvols/ses-ses_parent': filesystem has dependent clones"))
+
+	reaped, skipped := ReconcileOrphanZvols(map[string]bool{}, reconcileGrace, false)
+
+	assert.Empty(s.T(), reaped)
+	require.Len(s.T(), skipped, 1)
+	assert.Equal(s.T(), "prod/helix-zvols/ses-ses_parent", skipped[0].Name)
+	assert.Contains(s.T(), skipped[0].Reason, "dependent")
+	// The destroy was ATTEMPTED with -r (lowercase) and failed safely — no force retry.
+	assert.True(s.T(), s.mock.hasCommand("zfs destroy -r prod/helix-zvols/ses-ses_parent"))
+	s.assertNeverForcedDestroy()
+}
+
+func (s *GoldenZvolSuite) TestReconcileOrphanZvols_SkipsBusy() {
+	zfsParentDataset = "prod/helix-zvols"
+	zfsAvailableFlag = true
+
+	s.mock.addDataset("prod/helix-zvols/ses-ses_busy")
+	s.mock.setCreationAge("prod/helix-zvols/ses-ses_busy", 8*time.Hour)
+	s.mock.failOn("zfs destroy -r prod/helix-zvols/ses-ses_busy",
+		fmt.Errorf("cannot destroy 'prod/helix-zvols/ses-ses_busy': dataset is busy"))
+
+	reaped, skipped := ReconcileOrphanZvols(map[string]bool{}, reconcileGrace, false)
+
+	assert.Empty(s.T(), reaped)
+	require.Len(s.T(), skipped, 1)
+	assert.Contains(s.T(), skipped[0].Reason, "busy")
+	s.assertNeverForcedDestroy()
+}
+
+func (s *GoldenZvolSuite) TestReconcileOrphanZvols_NeverEnumeratesGolden() {
+	zfsParentDataset = "prod/helix-zvols"
+	zfsAvailableFlag = true
+
+	// Only a golden zvol exists — must never be considered for reaping.
+	s.mock.addDataset("prod/helix-zvols/golden-prj_abc")
+	s.mock.setCreationAge("prod/helix-zvols/golden-prj_abc", 30*24*time.Hour) // very old
+
+	reaped, skipped := ReconcileOrphanZvols(map[string]bool{}, reconcileGrace, false)
+
+	assert.Empty(s.T(), reaped)
+	assert.Empty(s.T(), skipped)
+	assert.False(s.T(), s.mock.hasCommand("zfs destroy"))
+	assert.True(s.T(), s.mock.datasets["prod/helix-zvols/golden-prj_abc"], "golden must be untouched")
+}
+
+func (s *GoldenZvolSuite) TestReconcileOrphanZvols_DryRunIssuesNoDestroy() {
+	zfsParentDataset = "prod/helix-zvols"
+	zfsAvailableFlag = true
+
+	s.mock.addDataset("prod/helix-zvols/ses-ses_orphan")
+	s.mock.setCreationAge("prod/helix-zvols/ses-ses_orphan", 8*time.Hour)
+
+	reaped, skipped := ReconcileOrphanZvols(map[string]bool{}, reconcileGrace, true /* dryRun */)
+
+	assert.Equal(s.T(), []string{"prod/helix-zvols/ses-ses_orphan"}, reaped)
+	assert.Empty(s.T(), skipped)
+	// Dry run: NO destroy issued, dataset still present.
+	assert.False(s.T(), s.mock.hasCommand("zfs destroy"))
+	assert.True(s.T(), s.mock.datasets["prod/helix-zvols/ses-ses_orphan"])
 }

--- a/api/pkg/hydra/server.go
+++ b/api/pkg/hydra/server.go
@@ -215,6 +215,10 @@ func (s *Server) registerRoutes(router *mux.Router) {
 	api.HandleFunc("/dev-containers/{session_id}/terminal", s.handleSandboxTerminal).Methods("GET")
 	api.HandleFunc("/dev-containers/{session_id}/forget", s.handleSandboxForget).Methods("POST")
 
+	// Durable DB-driven garbage collection: the API computes the live-set from
+	// Postgres and posts it here; hydra reconciles on-disk zvols + workspace dirs.
+	api.HandleFunc("/gc/reconcile", s.handleGCReconcile).Methods("POST")
+
 	// System stats (GPU info, active sessions)
 	api.HandleFunc("/system/stats", s.handleSystemStats).Methods("GET")
 
@@ -719,6 +723,22 @@ func (s *Server) handleDevContainerWebSocketProxy(w http.ResponseWriter, r *http
 	}()
 
 	wg.Wait()
+}
+
+// handleGCReconcile reconciles on-disk ephemeral resources against the
+// DB-derived live-set supplied by the API and reports what was (or would be)
+// reaped.
+func (s *Server) handleGCReconcile(w http.ResponseWriter, r *http.Request) {
+	var req GCReconcileRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid request: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	resp := s.devContainerManager.ReconcileGC(req)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
 }
 
 // handleSystemStats returns GPU stats and session counts

--- a/api/pkg/hydra/types.go
+++ b/api/pkg/hydra/types.go
@@ -185,3 +185,43 @@ type VersionResponse struct {
 	Version string   `json:"version"`
 	Routes  []string `json:"routes"`
 }
+
+// GCReconcileRequest is the durable, DB-driven garbage-collection request the
+// API sends to hydra. The API computes the live-set from Postgres (the source
+// of truth that survives reboots) and hydra reconciles on-disk resources
+// (session zvols, per-task/session workspace dirs) against it.
+type GCReconcileRequest struct {
+	// LiveSessionIDs is the set of session IDs (full ses_… strings) that the
+	// API considers alive. zvols and session workspace dirs for IDs NOT in this
+	// set are candidates for reaping (subject to the grace period).
+	LiveSessionIDs []string `json:"live_session_ids"`
+
+	// LiveSpecTaskIDs is the set of spec-task IDs (full spt_… strings) the API
+	// considers alive. Spec-task workspace dirs for IDs NOT in this set are
+	// candidates for reaping (subject to the grace period).
+	LiveSpecTaskIDs []string `json:"live_spec_task_ids"`
+
+	// GracePeriodSeconds is the minimum age (since creation / mtime) a resource
+	// must reach before it can be reaped. Guards against racing newly-created
+	// resources the DB live-set hasn't caught up with yet.
+	GracePeriodSeconds int `json:"grace_period_seconds"`
+
+	// DryRun reports what WOULD be reaped without destroying anything.
+	DryRun bool `json:"dry_run"`
+}
+
+// GCSkip records a resource the reconciler chose NOT to reap, with the reason.
+type GCSkip struct {
+	Name   string `json:"name"`
+	Reason string `json:"reason"`
+}
+
+// GCReconcileResponse is hydra's report of what it reaped (or would reap, in
+// dry-run mode) and what it deliberately skipped.
+type GCReconcileResponse struct {
+	ZvolsReaped       []string `json:"zvols_reaped"`
+	ZvolsSkipped      []GCSkip `json:"zvols_skipped"`
+	WorkspacesReaped  []string `json:"workspaces_reaped"`
+	WorkspacesSkipped []GCSkip `json:"workspaces_skipped"`
+	BytesFreed        int64    `json:"bytes_freed"`
+}

--- a/api/pkg/hydra/workspace_gc.go
+++ b/api/pkg/hydra/workspace_gc.go
@@ -1,0 +1,138 @@
+package hydra
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// workspacesBaseDir is the base directory for per-task / per-session workspace
+// checkouts on the helix-workspaces filesystem dataset (mounted at /data inside
+// the sandbox). These are PLAIN DIRECTORIES, not zvols — reap with os.RemoveAll,
+// never any zfs command. Var (not const) so tests can override it.
+var workspacesBaseDir = "/data/workspaces"
+
+// dirSizeBytes returns the on-disk size of a directory in bytes (du -sb style).
+// Returns 0 on error.
+func dirSizeBytes(path string) int64 {
+	out, err := exec.Command("du", "-sb", path).Output()
+	if err != nil {
+		return 0
+	}
+	var size int64
+	fmt.Sscanf(string(out), "%d", &size)
+	return size
+}
+
+// reconcileWorkspaceSubdir reaps orphaned directories under
+// workspacesBaseDir/<subdir>. A dir is reaped iff its name has the required
+// prefix, its name is NOT in liveSet, and its mtime is older than the grace
+// period. dryRun records candidates without removing them.
+//
+// Safety: only ever os.RemoveAll a path of the exact form
+// workspacesBaseDir/<subdir>/<validated-name>. The name must be a single path
+// element (no separators, no "..") and carry the expected prefix, so we can
+// never escape the subtree.
+func reconcileWorkspaceSubdir(subdir, requiredPrefix string, liveSet map[string]bool, grace time.Duration, dryRun bool) (reaped []string, skipped []GCSkip, freed int64) {
+	base := filepath.Join(workspacesBaseDir, subdir)
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Warn().Err(err).Str("dir", base).Msg("ReconcileOrphanWorkspaces: failed to read subdir")
+		}
+		return nil, nil, 0
+	}
+
+	cutoff := time.Now().Add(-grace)
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+
+		// Guard against path traversal — name must be a single, well-formed
+		// element carrying the expected prefix.
+		if !strings.HasPrefix(name, requiredPrefix) ||
+			strings.ContainsAny(name, "/\\") ||
+			name == "." || name == ".." {
+			skipped = append(skipped, GCSkip{Name: filepath.Join(subdir, name), Reason: "name not eligible"})
+			continue
+		}
+
+		// id == directory name (full ses_… / spt_… string).
+		if liveSet[name] {
+			skipped = append(skipped, GCSkip{Name: filepath.Join(subdir, name), Reason: "live"})
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			skipped = append(skipped, GCSkip{Name: filepath.Join(subdir, name), Reason: "stat error: " + err.Error()})
+			continue
+		}
+		if info.ModTime().After(cutoff) {
+			skipped = append(skipped, GCSkip{Name: filepath.Join(subdir, name), Reason: "grace"})
+			continue
+		}
+
+		dir := filepath.Join(base, name)
+		size := dirSizeBytes(dir)
+
+		if dryRun {
+			reaped = append(reaped, dir)
+			freed += size
+			continue
+		}
+
+		if err := os.RemoveAll(dir); err != nil {
+			log.Warn().Err(err).Str("dir", dir).Msg("ReconcileOrphanWorkspaces: failed to remove workspace dir")
+			skipped = append(skipped, GCSkip{Name: filepath.Join(subdir, name), Reason: "error: " + err.Error()})
+			continue
+		}
+		reaped = append(reaped, dir)
+		freed += size
+		log.Info().
+			Str("dir", dir).
+			Int64("size_bytes", size).
+			Dur("age", time.Since(info.ModTime())).
+			Msg("Reaped orphaned workspace dir")
+	}
+
+	return reaped, skipped, freed
+}
+
+// ReconcileOrphanWorkspaces reaps per-task and per-session workspace checkout
+// directories that are no longer referenced by any live spec-task / session and
+// have aged past the grace period.
+//
+// Layout under workspacesBaseDir (/data/workspaces):
+//
+//	spec-tasks/<spt_id>   ← per-task checkouts (reaped against liveSpecTaskIDs)
+//	sessions/<ses_id>     ← per-session checkouts (reaped against liveSessionIDs)
+//	sandboxes/            ← NEVER descended into or removed (separate lifecycle)
+//
+// All entries are plain directories on the helix-workspaces filesystem dataset,
+// so reaping is os.RemoveAll — never a zfs command.
+func ReconcileOrphanWorkspaces(liveSessionIDs, liveSpecTaskIDs map[string]bool, grace time.Duration, dryRun bool) (reaped []string, skipped []GCSkip, freed int64) {
+	// spec-tasks/<spt_…>
+	r, s, f := reconcileWorkspaceSubdir("spec-tasks", "spt_", liveSpecTaskIDs, grace, dryRun)
+	reaped = append(reaped, r...)
+	skipped = append(skipped, s...)
+	freed += f
+
+	// sessions/<ses_…>
+	r, s, f = reconcileWorkspaceSubdir("sessions", "ses_", liveSessionIDs, grace, dryRun)
+	reaped = append(reaped, r...)
+	skipped = append(skipped, s...)
+	freed += f
+
+	// NOTE: the "sandboxes/" subtree is intentionally never touched here.
+
+	return reaped, skipped, freed
+}

--- a/api/pkg/hydra/workspace_gc_test.go
+++ b/api/pkg/hydra/workspace_gc_test.go
@@ -1,0 +1,133 @@
+package hydra
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type WorkspaceGCSuite struct {
+	suite.Suite
+	tmpDir  string
+	oldBase string
+}
+
+func TestWorkspaceGCSuite(t *testing.T) {
+	suite.Run(t, new(WorkspaceGCSuite))
+}
+
+func (s *WorkspaceGCSuite) SetupTest() {
+	var err error
+	s.tmpDir, err = os.MkdirTemp("", "workspace-gc-test-*")
+	require.NoError(s.T(), err)
+
+	s.oldBase = workspacesBaseDir
+	workspacesBaseDir = s.tmpDir
+}
+
+func (s *WorkspaceGCSuite) TearDownTest() {
+	workspacesBaseDir = s.oldBase
+	os.RemoveAll(s.tmpDir)
+}
+
+// mkdirOld creates a directory and backdates its mtime by `age`.
+func (s *WorkspaceGCSuite) mkdirOld(rel string, age time.Duration) string {
+	dir := filepath.Join(s.tmpDir, rel)
+	require.NoError(s.T(), os.MkdirAll(dir, 0755))
+	old := time.Now().Add(-age)
+	require.NoError(s.T(), os.Chtimes(dir, old, old))
+	return dir
+}
+
+func (s *WorkspaceGCSuite) TestReconcileOrphanWorkspaces_ReapsOnlyOrphans() {
+	const grace = time.Hour
+
+	// spec-tasks
+	sptLive := s.mkdirOld("spec-tasks/spt_live", 8*time.Hour) // old but live
+	sptOld := s.mkdirOld("spec-tasks/spt_old", 8*time.Hour)   // old + not live → reap
+	// sessions
+	sesOld := s.mkdirOld("sessions/ses_old", 8*time.Hour) // old + not live → reap
+	// protected / junk
+	sandboxDir := s.mkdirOld("sandboxes", 8*time.Hour)        // NEVER touched
+	junkDir := s.mkdirOld("spec-tasks/junkname", 8*time.Hour) // wrong prefix → skipped
+
+	liveSessions := map[string]bool{}                 // ses_old not live
+	liveSpecTasks := map[string]bool{"spt_live": true} // spt_live is live
+
+	reaped, _, freed := ReconcileOrphanWorkspaces(liveSessions, liveSpecTasks, grace, false)
+
+	// Only spt_old and ses_old removed.
+	_, err := os.Stat(sptOld)
+	assert.True(s.T(), os.IsNotExist(err), "spt_old should be reaped")
+	_, err = os.Stat(sesOld)
+	assert.True(s.T(), os.IsNotExist(err), "ses_old should be reaped")
+
+	// Everything else untouched.
+	_, err = os.Stat(sptLive)
+	assert.NoError(s.T(), err, "spt_live (live) must be kept")
+	_, err = os.Stat(sandboxDir)
+	assert.NoError(s.T(), err, "sandboxes/ must never be removed")
+	_, err = os.Stat(junkDir)
+	assert.NoError(s.T(), err, "wrong-prefix dir must be kept")
+
+	assert.ElementsMatch(s.T(), []string{sptOld, sesOld}, reaped)
+	assert.GreaterOrEqual(s.T(), freed, int64(0))
+}
+
+func (s *WorkspaceGCSuite) TestReconcileOrphanWorkspaces_SkipsWithinGrace() {
+	const grace = time.Hour
+
+	sptFresh := s.mkdirOld("spec-tasks/spt_fresh", 10*time.Minute) // within grace
+
+	reaped, _, _ := ReconcileOrphanWorkspaces(map[string]bool{}, map[string]bool{}, grace, false)
+
+	_, err := os.Stat(sptFresh)
+	assert.NoError(s.T(), err, "within-grace dir must be kept")
+	assert.Empty(s.T(), reaped)
+}
+
+func (s *WorkspaceGCSuite) TestReconcileOrphanWorkspaces_DryRunRemovesNothing() {
+	const grace = time.Hour
+
+	sptOld := s.mkdirOld("spec-tasks/spt_old", 8*time.Hour)
+	sesOld := s.mkdirOld("sessions/ses_old", 8*time.Hour)
+
+	reaped, _, _ := ReconcileOrphanWorkspaces(map[string]bool{}, map[string]bool{}, grace, true /* dryRun */)
+
+	// Reported as candidates...
+	assert.ElementsMatch(s.T(), []string{sptOld, sesOld}, reaped)
+	// ...but still present on disk.
+	_, err := os.Stat(sptOld)
+	assert.NoError(s.T(), err, "dry run must not remove spt_old")
+	_, err = os.Stat(sesOld)
+	assert.NoError(s.T(), err, "dry run must not remove ses_old")
+}
+
+func (s *WorkspaceGCSuite) TestReconcileOrphanWorkspaces_NeverTouchesSandboxesSubtree() {
+	const grace = time.Hour
+
+	// A sandbox checkout whose name happens to look like a session id — must
+	// still be ignored because it lives under sandboxes/, which we never scan.
+	inner := s.mkdirOld("sandboxes/ses_inside_sandboxes", 30*24*time.Hour)
+
+	reaped, _, _ := ReconcileOrphanWorkspaces(map[string]bool{}, map[string]bool{}, grace, false)
+
+	_, err := os.Stat(inner)
+	assert.NoError(s.T(), err, "nothing under sandboxes/ may be reaped")
+	assert.Empty(s.T(), reaped)
+}
+
+func (s *WorkspaceGCSuite) TestReconcileOrphanWorkspaces_NoBaseDir() {
+	workspacesBaseDir = filepath.Join(s.tmpDir, "does-not-exist")
+
+	reaped, skipped, freed := ReconcileOrphanWorkspaces(map[string]bool{}, map[string]bool{}, time.Hour, false)
+
+	assert.Empty(s.T(), reaped)
+	assert.Empty(s.T(), skipped)
+	assert.Equal(s.T(), int64(0), freed)
+}

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -693,6 +693,12 @@ func (apiServer *HelixAPIServer) ListenAndServe(ctx context.Context, _ *system.C
 	// Automatically shut down desktops that have been idle for too long
 	go external_agent.RunDesktopIdleChecker(ctx, apiServer.externalAgentExecutor, apiServer.Store, apiServer.Cfg.DesktopIdleTimeout, apiServer.Cfg.DesktopIdleCheckInterval)
 
+	// Durable, DB-driven garbage collection of leaked session zvols and
+	// per-task/session workspace dirs (survives host reboots / API restarts).
+	if apiServer.Cfg.OrphanReaperEnabled {
+		go external_agent.RunOrphanResourceReaper(ctx, apiServer.externalAgentExecutor, apiServer.Store, apiServer.Cfg.OrphanReaperInterval, apiServer.Cfg.OrphanReaperGracePeriod, apiServer.Cfg.OrphanReaperDryRun)
+	}
+
 	// Reap expired sandboxes (Sandboxes API).
 	go apiServer.sandboxController.StartReaper(ctx, time.Minute)
 

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -293,6 +293,7 @@ type Store interface {
 	ListSessionsBySandbox(ctx context.Context, sandboxID string) ([]*types.Session, error) // For cleanup on sandbox disconnect
 	ListSessionsByOwner(ctx context.Context, ownerID string) ([]*types.Session, error)     // All non-deleted sessions for a user (any org, any model_name) — used to fan out user-scoped events
 	ListIdleDesktops(ctx context.Context, idleSince time.Time) ([]*types.Session, error)   // Returns one session per desktop that has had no interaction since idleSince
+	ListExternalAgentSessionIDs(ctx context.Context, cutoff time.Time) ([]string, error)   // IDs of live external-agent sessions (running, recently-updated, or keep_alive) — for the orphan-resource reaper
 
 	// interactions
 	GetInteractionsSummary(ctx context.Context, sessionID string, generationID int) (count int64, maxUpdated time.Time, err error)

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -4447,6 +4447,21 @@ func (mr *MockStoreMockRecorder) ListIdleDesktops(ctx, idleSince any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIdleDesktops", reflect.TypeOf((*MockStore)(nil).ListIdleDesktops), ctx, idleSince)
 }
 
+// ListExternalAgentSessionIDs mocks base method.
+func (m *MockStore) ListExternalAgentSessionIDs(ctx context.Context, cutoff time.Time) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListExternalAgentSessionIDs", ctx, cutoff)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListExternalAgentSessionIDs indicates an expected call of ListExternalAgentSessionIDs.
+func (mr *MockStoreMockRecorder) ListExternalAgentSessionIDs(ctx, cutoff any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExternalAgentSessionIDs", reflect.TypeOf((*MockStore)(nil).ListExternalAgentSessionIDs), ctx, cutoff)
+}
+
 // ListInteractions mocks base method.
 func (m *MockStore) ListInteractions(ctx context.Context, query *types.ListInteractionsQuery) ([]*types.Interaction, int64, error) {
 	m.ctrl.T.Helper()

--- a/api/pkg/store/store_sessions.go
+++ b/api/pkg/store/store_sessions.go
@@ -471,6 +471,40 @@ ORDER BY s.config->>'dev_container_id', s.created ASC`
 	return sessions, nil
 }
 
+// ListExternalAgentSessionIDs returns the IDs of external-agent (hydra) sessions
+// that should be considered LIVE for the purposes of the orphan-resource reaper.
+//
+// A session is live if ANY of:
+//   - its external_agent_status is "running" (a desktop container is up), OR
+//   - it was updated at or after cutoff (recent activity — covers sessions
+//     mid-startup or recently stopped whose container row hasn't settled), OR
+//   - it backs a spec-task marked keep_alive = true (never auto-reap).
+//
+// Only the live set is returned. The reaper subtracts this from what's on disk,
+// so anything omitted here becomes a reap candidate (still subject to hydra's
+// grace period). Note: the sessions table uses the column `updated` (NOT
+// updated_at).
+func (s *PostgresStore) ListExternalAgentSessionIDs(ctx context.Context, cutoff time.Time) ([]string, error) {
+	var ids []string
+	err := s.gdb.WithContext(ctx).
+		Model(&types.Session{}).
+		Where("deleted_at IS NULL").
+		Where("model_name = ?", "external_agent").
+		Where(s.gdb.
+			Where("config->>'external_agent_status' = ?", "running").
+			Or("updated >= ?", cutoff).
+			Or(`EXISTS (
+				SELECT 1 FROM spec_tasks st
+				WHERE st.planning_session_id = sessions.id
+				  AND st.keep_alive = true
+			)`)).
+		Pluck("id", &ids).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list external agent session ids: %w", err)
+	}
+	return ids, nil
+}
+
 func (s *PostgresStore) notifySessionUpdates(ctx context.Context, operation StoreEventOperation, session *types.Session) error {
 	return s.publishStoreEvent(ctx, operation, session)
 }


### PR DESCRIPTION
## Problem
Ephemeral per-session zvols (`prod/helix-zvols/ses-*`) and per-task/session workspace checkouts (`/data/workspaces/{spec-tasks,sessions}/<id>`) leak and are never garbage-collected after **host reboots, API restarts, or failed destroys**. On a production box this accumulated **~676G of orphaned session zvols** and **~1T of workspace checkouts**, eventually filling the pool (ENOSPC → XFS errors, Postgres GP-fault, git corruption).

Root cause: the existing in-hydra GC (`DevContainerManager.GCOrphanedSessions`) keys its "active set" off hydra's **in-memory** container map (empty after restart) plus a 7-day on-disk marker, **never consults Postgres**, and **never touches the `/data/workspaces` tree at all**.

## Fix
A durable, **DB-driven** reconciliation reaper:
- **API side** (`RunOrphanResourceReaper`, mirrors `RunDesktopIdleChecker`): each tick computes the **live-set** from Postgres — running/recent/`keep_alive` external-agent sessions (`ListExternalAgentSessionIDs`) + non-terminal/recent spec-tasks — and fans it out per recently-seen sandbox over RevDial.
- **Hydra side** (`ReconcileGC` → `ReconcileOrphanZvols` + `ReconcileOrphanWorkspaces`): lists on-disk session zvols and workspace dirs, subtracts the live-set, applies a grace period, reaps the rest. Unions in hydra's in-memory running set as extra protection.

Survives reboots/restarts because the live-set is durable (DB), not in-memory.

## Safety
- **Zvol destroys reuse `CleanupSessionZvol` (`zfs destroy -r` only — never `-R`/`-f`).** A clone-root (e.g. a session a golden was cloned from) or a busy zvol fails with "has dependent clones"/"dataset is busy" and is **skipped + logged, never forced**. `golden-*` zvols are never enumerated (prefix-guarded to `…/ses-`).
- **Workspace reaper is `os.RemoveAll` only** (these are plain dirs, not zvols — no `zfs` ever), on **prefix-validated** `spec-tasks/<spt_*>` / `sessions/<ses_*>` paths with a path-traversal guard; the `sandboxes/` subtree is never touched.
- **Dry-run-first:** `HELIX_ORPHAN_REAPER_DRY_RUN=true` by default — the reaper only *logs* what it would reap until an operator verifies the live-set, then flip to `false`. Knobs: `HELIX_ORPHAN_REAPER_{ENABLED,INTERVAL=30m,GRACE_PERIOD=6h,DRY_RUN}`.

## Rollout
1. Deploy (note: **hydra code requires redeploying the binary into the sandbox container** — Air does not rebuild it).
2. Leave dry-run on for one cycle; confirm `orphan reaper: sandbox reconciled` logs list only genuinely-dead resources.
3. Set `HELIX_ORPHAN_REAPER_DRY_RUN=false` to enable reaping.

## Tests
- `golden_zvol_test.go`: reaps non-live/past-grace zvols; **skips a clone-ancestor** and asserts **no `-R`/`-f` is ever issued**; skips live/within-grace/busy; never enumerates `golden-*`; dry-run issues no destroy.
- `workspace_gc_test.go`: reaps only old non-live `spt_*`/`ses_*`; leaves `sandboxes/` and junk-named dirs; dry-run removes nothing.
- `gc_reaper_test.go`: correct per-sandbox fan-out; store errors non-fatal.
- `go build ./...` clean; `go test ./pkg/hydra/... ./pkg/external-agent/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)