### PR TITLE
fix(compute): wire active_sandboxes counter end-to-end + configurable per-Runner ceiling

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -64,6 +64,33 @@ type ServerConfig struct {
 	// their DB row.
 	SandboxDispatchStaleThreshold time.Duration `envconfig:"HELIX_SANDBOX_DISPATCH_STALE_THRESHOLD" default:"90s"`
 
+	// SandboxMaxDevContainers is the per-Runner ceiling on isolated dev
+	// containers (current vocab "sandboxes") that hydra will spawn
+	// inside one helix-sandbox host. Written to SandboxInstance.MaxSandboxes
+	// when a Runner is registered (both legacy auto-register and
+	// Manager-provisioned paths). The ComputeManager's autoscaler treats
+	// `headroom = sum(max_sandboxes) - sum(active_sandboxes) < ScaleUpHeadroomMin`
+	// as demand pressure, so this value is what determines when scale-up
+	// fires under load.
+	//
+	// NOTE: this value only affects the autoscaler signal today; the
+	// dispatcher (FindAvailableSandboxInstance) does NOT enforce a hard
+	// rejection at the ceiling - new dev containers can still be placed
+	// on a "full" Runner (sorted ASC by active_sandboxes). Hard
+	// dispatcher rejection is tracked separately as a follow-up.
+	//
+	// Default 20. Raise for hosts with more headroom, lower to make
+	// the autoscaler trigger sooner on smaller hosts. Range is not
+	// enforced - sane values are typically 1-50, beyond which the host
+	// kernel will OOM before the limit binds.
+	//
+	// Changing this env var only affects newly-registered Runners and
+	// Manager-provisioned rows on the next boot; existing rows keep
+	// their persisted MaxSandboxes value. A boot-time backfill rewrites
+	// rows that disagree with the current config so the new value takes
+	// effect across the fleet on next API restart.
+	SandboxMaxDevContainers int `envconfig:"HELIX_SANDBOX_MAX_DEV_CONTAINERS" default:"20"`
+
 	DisableLLMCallLogging bool `envconfig:"DISABLE_LLM_CALL_LOGGING" default:"false"`
 	DisableUsageLogging   bool `envconfig:"DISABLE_USAGE_LOGGING" default:"false"`
 	DisableVersionPing    bool `envconfig:"DISABLE_VERSION_PING" default:"false"`

--- a/api/pkg/external-agent/executor.go
+++ b/api/pkg/external-agent/executor.go
@@ -102,4 +102,11 @@ type ZedSession struct {
 	ContainerID string `json:"container_id,omitempty"` // Docker container ID
 	ContainerIP string `json:"container_ip,omitempty"` // Container IP address on bridge network
 	SandboxID   string `json:"sandbox_id,omitempty"`   // Sandbox running this container (for RevDial routing)
+
+	// GoldenBuild marks this session as a golden-build run rather than a
+	// user-facing dev container. Golden builds are cleaned up internally
+	// by hydra's monitorGoldenBuild (which bypasses HydraExecutor.StopDesktop),
+	// so we don't bump active_sandboxes for them on either side - otherwise
+	// the counter would drift up monotonically as builds complete.
+	GoldenBuild bool `json:"golden_build,omitempty"`
 }

--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -861,8 +861,26 @@ func (h *HydraExecutor) HasRunningContainer(ctx context.Context, sessionID strin
 				Str("sandbox_id", sandboxID).
 				Msg("Container no longer running on sandbox, cleaning up stale session entry")
 			h.mutex.Lock()
+			// Re-check membership under the write lock in case a concurrent
+			// StopDesktop already removed the session (and decremented).
+			_, stillTracked := h.sessions[sessionID]
 			delete(h.sessions, sessionID)
 			h.mutex.Unlock()
+			// Mirror the decrement that StopDesktop would have fired:
+			// the container is gone from the Runner, so the matching
+			// counter slot is gone too. Without this, sessions evicted
+			// via this stale-detection path would leak the counter up
+			// (autoscaler would never see them released). Same guards
+			// as the StopDesktop decrement: was-tracked, not a golden
+			// build, real Runner row.
+			if stillTracked && !session.GoldenBuild && sandboxID != "" && sandboxID != "local" {
+				if decErr := h.store.DecrementSandboxContainerCount(ctx, sandboxID); decErr != nil {
+					log.Warn().Err(decErr).
+						Str("sandbox_id", sandboxID).
+						Str("session_id", sessionID).
+						Msg("Failed to decrement active_sandboxes on Runner after stale-session eviction")
+				}
+			}
 			return false
 		}
 	}
@@ -1415,22 +1433,14 @@ func (h *HydraExecutor) DiscoverContainersFromSandbox(ctx context.Context, sandb
 		return nil
 	}
 
-	if len(containerList.Containers) == 0 {
-		return nil
-	}
-
-	log.Info().
-		Str("sandbox_id", sandboxID).
-		Int("container_count", len(containerList.Containers)).
-		Msg("Discovered running containers from sandbox")
-
-	// Resync active_sandboxes from ground truth: hydra reported N
-	// running containers on this Runner. SET (not Increment) the DB
-	// counter to that exact value. This is the only authoritative path
-	// when there's been counter drift from missed Increment/Decrement
-	// (API restart, hydra-side internal deletes, etc.). Runs even if
-	// no NEW containers are added below - we still want the counter to
-	// match reality for the already-tracked ones.
+	// Resync active_sandboxes from ground truth FIRST, before any
+	// early-return on the empty-list case. hydra is the source of truth:
+	// if it reports 0 containers, the DB MUST become 0 too (otherwise a
+	// Runner that previously drifted up stays drifted forever after
+	// becoming empty - the exact failure mode this resync was added to
+	// prevent). SET (not Increment) writes the exact count, recovering
+	// from any drift accumulated by missed Increment/Decrement calls
+	// (API restart, hydra-side internal deletes, failed StopDesktop).
 	if sandboxID != "" && sandboxID != "local" {
 		if setErr := h.store.SetSandboxContainerCount(ctx, sandboxID, len(containerList.Containers)); setErr != nil {
 			log.Warn().
@@ -1440,6 +1450,15 @@ func (h *HydraExecutor) DiscoverContainersFromSandbox(ctx context.Context, sandb
 				Msg("Failed to set active_sandboxes from discovery; counter may be stale")
 		}
 	}
+
+	if len(containerList.Containers) == 0 {
+		return nil
+	}
+
+	log.Info().
+		Str("sandbox_id", sandboxID).
+		Int("container_count", len(containerList.Containers)).
+		Msg("Discovered running containers from sandbox")
 
 	// Collect containers that need to be added to our map
 	// We do this in two phases to avoid holding the lock during DB operations

--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -457,6 +457,11 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 		Str("ip_address", resp.IPAddress).
 		Msg("Dev container created successfully via Hydra")
 
+	// Increment moved below to the point where the session enters
+	// h.sessions, so increment/decrement stay paired on the same
+	// gate (membership in h.sessions). See the increment block right
+	// after the h.sessions insert.
+
 	// No bridging needed - desktop runs its own dockerd, so all containers
 	// are on the same Docker network inside the desktop container.
 
@@ -492,11 +497,35 @@ func (h *HydraExecutor) StartDesktop(ctx context.Context, agent *types.DesktopAg
 		ContainerID:    resp.ContainerID,
 		ContainerIP:    resp.IPAddress,
 		SandboxID:      sandboxID,
+		GoldenBuild:    agent.GoldenBuild,
 		// DevContainerID is not used in Hydra mode, but we store container info here
 	}
 	h.mutex.Lock()
+	_, alreadyTracked := h.sessions[agent.SessionID]
 	h.sessions[agent.SessionID] = session
 	h.mutex.Unlock()
+
+	// Increment active_sandboxes on the Runner row, paired with the
+	// h.sessions insertion above. Gating on (!alreadyTracked) keeps
+	// the increment idempotent if StartDesktop is somehow called twice
+	// for the same session (counter would otherwise double-count).
+	// Skipping golden builds: they aren't user-facing workload and the
+	// hydra-side monitorGoldenBuild path doesn't go through StopDesktop,
+	// so counting them would create a one-way drift up. Skipping the
+	// "local" sentinel: no Runner row exists when SandboxID is unset.
+	//
+	// The matching decrement lives in StopDesktop, gated on the session
+	// actually being present in h.sessions at stop time (so double-stop
+	// can't over-decrement).
+	if !alreadyTracked && !agent.GoldenBuild && sandboxID != "" && sandboxID != "local" {
+		if incErr := h.store.IncrementSandboxContainerCount(ctx, sandboxID); incErr != nil {
+			log.Warn().
+				Err(incErr).
+				Str("sandbox_id", sandboxID).
+				Str("session_id", agent.SessionID).
+				Msg("Failed to increment active_sandboxes on Runner; autoscaler may underestimate demand")
+		}
+	}
 
 	// Update database session with container info and debug info
 	if dbSession, err := h.store.GetSession(ctx, agent.SessionID); err == nil {
@@ -557,13 +586,23 @@ func (h *HydraExecutor) StopDesktop(ctx context.Context, sessionID string) error
 	log.Info().Str("session_id", sessionID).Msg("Stopping dev container via Hydra")
 
 	h.mutex.Lock()
-	session, exists := h.sessions[sessionID]
+	session, sessionWasTracked := h.sessions[sessionID]
 	var sandboxID string
-	if exists {
+	var sessionGoldenBuild bool
+	if sessionWasTracked {
 		sandboxID = session.SandboxID
+		sessionGoldenBuild = session.GoldenBuild
 		delete(h.sessions, sessionID)
 	}
 	h.mutex.Unlock()
+
+	// Capture once for the decrement decision below. If the session
+	// was never in h.sessions when this Stop fired (e.g. double-stop,
+	// or a stop on a session that was never tracked), the matching
+	// increment never happened either, so no decrement should fire.
+	// Likewise for golden builds: StartDesktop deliberately skipped the
+	// increment, so we must skip the decrement to keep the counter balanced.
+	exists := sessionWasTracked && !sessionGoldenBuild
 
 	// Get sandbox ID from database if not in memory
 	// Use SandboxID as sandbox identifier for now (they're often the same or related)
@@ -589,14 +628,40 @@ func (h *HydraExecutor) StopDesktop(ctx context.Context, sessionID string) error
 
 	// Delete dev container via Hydra
 	resp, err := hydraClient.DeleteDevContainer(ctx, sessionID)
+	deleteSucceeded := err == nil
 	if err != nil {
 		log.Warn().Err(err).Str("session_id", sessionID).Msg("Failed to delete dev container (may already be stopped)")
-		// Don't return error - container might already be gone
+		// Don't return error - container might already be gone. We
+		// also do NOT decrement here: if the delete failed but the
+		// container is actually still alive on the host, decrementing
+		// would create a phantom "free slot" that the dispatcher
+		// would place new work onto. Operator visibility (a counter
+		// stuck high) is the lesser harm. The periodic reconcile via
+		// DiscoverContainersFromSandbox is the corrective path - it
+		// SETs the counter to the actual container count.
 	} else {
 		log.Info().
 			Str("session_id", sessionID).
 			Str("container_id", resp.ContainerID).
 			Msg("Dev container stopped successfully via Hydra")
+	}
+
+	// Decrement gated on TWO conditions:
+	//   1. The session was actually in h.sessions when stop started
+	//      (so the matching increment fired earlier; double-stop and
+	//      stop-of-untracked-session both have exists=false here).
+	//   2. The delete actually succeeded (so the container is really
+	//      gone; on failure we keep the counter high to avoid phantom
+	//      free slots, see comment above).
+	// Skip the "local" sentinel (no Runner row to decrement).
+	if exists && deleteSucceeded && sandboxID != "" && sandboxID != "local" {
+		if decErr := h.store.DecrementSandboxContainerCount(ctx, sandboxID); decErr != nil {
+			log.Warn().
+				Err(decErr).
+				Str("sandbox_id", sandboxID).
+				Str("session_id", sessionID).
+				Msg("Failed to decrement active_sandboxes on Runner; counter may drift high")
+		}
 	}
 
 	// Revoke session-scoped ephemeral API keys
@@ -1359,6 +1424,23 @@ func (h *HydraExecutor) DiscoverContainersFromSandbox(ctx context.Context, sandb
 		Int("container_count", len(containerList.Containers)).
 		Msg("Discovered running containers from sandbox")
 
+	// Resync active_sandboxes from ground truth: hydra reported N
+	// running containers on this Runner. SET (not Increment) the DB
+	// counter to that exact value. This is the only authoritative path
+	// when there's been counter drift from missed Increment/Decrement
+	// (API restart, hydra-side internal deletes, etc.). Runs even if
+	// no NEW containers are added below - we still want the counter to
+	// match reality for the already-tracked ones.
+	if sandboxID != "" && sandboxID != "local" {
+		if setErr := h.store.SetSandboxContainerCount(ctx, sandboxID, len(containerList.Containers)); setErr != nil {
+			log.Warn().
+				Err(setErr).
+				Str("sandbox_id", sandboxID).
+				Int("container_count", len(containerList.Containers)).
+				Msg("Failed to set active_sandboxes from discovery; counter may be stale")
+		}
+	}
+
 	// Collect containers that need to be added to our map
 	// We do this in two phases to avoid holding the lock during DB operations
 	type containerToAdd struct {
@@ -1449,7 +1531,10 @@ func (h *HydraExecutor) DiscoverContainersFromSandbox(ctx context.Context, sandb
 			}
 		}
 
-		// Add to in-memory sessions map
+		// Add to in-memory sessions map. SandboxID populated so a
+		// later StopDesktop for this session can resolve the right
+		// Runner for the decrement (previously left blank, which
+		// meant the decrement fell back to "local" and skipped).
 		h.mutex.Lock()
 		h.sessions[sessionID] = &ZedSession{
 			OrganizationID: dbSession.OrganizationID,
@@ -1459,6 +1544,7 @@ func (h *HydraExecutor) DiscoverContainersFromSandbox(ctx context.Context, sandb
 			ContainerName:  container.containerName,
 			Status:         "running",
 			ContainerIP:    container.containerIP,
+			SandboxID:      sandboxID,
 			LastAccess:     time.Now(),
 		}
 		h.mutex.Unlock()

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap.go
@@ -41,7 +41,13 @@ import (
 // introduce parallel env vars. The Provider injects them into the
 // upstream task environment so helix-sandbox knows how to phone
 // home and how to authenticate.
-func Bootstrap(cfg config.Compute, serverURL, runnerToken string, store compute.SandboxStore) (*compute.Manager, error) {
+// Bootstrap signature note: maxSandboxesPerHost is the per-Runner ceiling
+// on inner dev containers, read from ServerConfig.SandboxMaxDevContainers
+// at the call site. Threaded in explicitly rather than via config.Compute
+// because the value originates from ServerConfig (used by both
+// Manager-provisioned and legacy auto-register paths) - putting it in
+// config.Compute would suggest it only affects ComputeManager.
+func Bootstrap(cfg config.Compute, maxSandboxesPerHost int, serverURL, runnerToken string, store compute.SandboxStore) (*compute.Manager, error) {
 	if cfg.Provider == "" {
 		log.Info().Msg("HELIX_COMPUTE_PROVIDER unset; compute subsystem disabled (no Provider, no Manager, no reconcile)")
 		return nil, nil
@@ -79,6 +85,12 @@ func Bootstrap(cfg config.Compute, serverURL, runnerToken string, store compute.
 		return nil, fmt.Errorf("build %q provider: %w", cfg.Provider, err)
 	}
 
+	// SpecTemplate.MaxSandboxes is what Manager-provisioned Runner rows
+	// get written with (manager.go:892 reads m.cfg.SpecTemplate via
+	// defaultMaxSandboxes). Threading maxSandboxesPerHost in here ensures
+	// YD-provisioned and legacy auto-registered Runners share the same
+	// ceiling — without this, YD Runners would silently fall back to the
+	// hardcoded 20 in defaultMaxSandboxes regardless of operator config.
 	mgr, err := compute.NewManager(provider, store, compute.ManagerConfig{
 		Floor:                   cfg.Floor,
 		ReconcileInterval:       cfg.ReconcileInterval,
@@ -88,6 +100,9 @@ func Bootstrap(cfg config.Compute, serverURL, runnerToken string, store compute.
 		Max:                     cfg.Max,
 		ScaleUpHeadroomMin:      cfg.ScaleUpHeadroomMin,
 		IdleTimeout:             cfg.IdleTimeout,
+		SpecTemplate: compute.Spec{
+			MaxSandboxes: maxSandboxesPerHost,
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("construct compute manager: %w", err)

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
@@ -83,7 +83,7 @@ func TestBootstrapDisabledWhenProviderUnset(t *testing.T) {
 	// behavioural change for existing deployments. Returning (nil,
 	// nil) is how the boot path detects "disabled" without a
 	// sentinel.
-	mgr, err := Bootstrap(config.Compute{}, "", "", nullStore{})
+	mgr, err := Bootstrap(config.Compute{}, 20, "", "", nullStore{})
 	if err != nil {
 		t.Fatalf("expected nil error for disabled config, got %v", err)
 	}
@@ -105,7 +105,7 @@ func TestBootstrapDisabledIgnoresAllOtherFields(t *testing.T) {
 		MaxConcurrentProvisions: 3,
 		MaxProvisioningAge:      30 * time.Minute,
 	}
-	mgr, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
+	mgr, err := Bootstrap(cfg, 20, "https://helix.example.com", "test-token", nullStore{})
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}
@@ -121,7 +121,7 @@ func TestBootstrapErrorsWhenNoTagAndNoNamespace(t *testing.T) {
 	cfg := config.Compute{
 		Provider: "yellowdog",
 	}
-	_, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
+	_, err := Bootstrap(cfg, 20, "https://helix.example.com", "test-token", nullStore{})
 	if err == nil {
 		t.Fatal("expected error for missing DeploymentTag + no namespace, got nil")
 	}
@@ -181,7 +181,7 @@ func TestBootstrapDerivesTagFromYellowdogNamespace(t *testing.T) {
 			TaskTimeout: time.Hour,
 		},
 	}
-	mgr, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
+	mgr, err := Bootstrap(cfg, 20, "https://helix.example.com", "test-token", nullStore{})
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestBootstrapUnknownProviderErrors(t *testing.T) {
 		Provider:      "nonesuch",
 		DeploymentTag: "prod",
 	}
-	_, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
+	_, err := Bootstrap(cfg, 20, "https://helix.example.com", "test-token", nullStore{})
 	if err == nil {
 		t.Fatal("expected error for unknown provider, got nil")
 	}
@@ -231,7 +231,7 @@ func TestBootstrapDerivesWorkerTagFromNamespace(t *testing.T) {
 			TaskTimeout: time.Hour,
 		},
 	}
-	mgr, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
+	mgr, err := Bootstrap(cfg, 20, "https://helix.example.com", "test-token", nullStore{})
 	if err != nil {
 		t.Fatalf("Bootstrap with empty WorkerTag should auto-derive, got error: %v", err)
 	}
@@ -386,7 +386,7 @@ func TestBootstrapErrorsWhenWorkerTagAndNamespaceBothEmpty(t *testing.T) {
 	// yellowdog.NewProvider, since Namespace is required for the
 	// provider itself; WorkerTag derivation never gets a chance to
 	// run with no namespace input.
-	_, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
+	_, err := Bootstrap(cfg, 20, "https://helix.example.com", "test-token", nullStore{})
 	if err == nil {
 		t.Fatal("expected error when Namespace is empty (which blocks both Namespace validation and WorkerTag derivation)")
 	}
@@ -404,7 +404,7 @@ func TestBootstrapYellowdogRequiresCredentials(t *testing.T) {
 		MaxProvisioningAge:      time.Minute,
 		// Yellowdog block empty - missing APIKeyID/APISecret etc.
 	}
-	_, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
+	_, err := Bootstrap(cfg, 20, "https://helix.example.com", "test-token", nullStore{})
 	if err == nil {
 		t.Fatal("expected error for missing yellowdog credentials, got nil")
 	}
@@ -415,7 +415,7 @@ func TestBootstrapNilStoreErrors(t *testing.T) {
 		Provider:      "yellowdog",
 		DeploymentTag: "prod",
 	}
-	_, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nil)
+	_, err := Bootstrap(cfg, 20, "https://helix.example.com", "test-token", nil)
 	if err == nil {
 		t.Fatal("expected error for nil store, got nil")
 	}
@@ -442,7 +442,7 @@ func TestBootstrapValidYellowdogConfigBuildsManager(t *testing.T) {
 			TaskTimeout: 4 * time.Hour,
 		},
 	}
-	mgr, err := Bootstrap(cfg, "https://helix.example.com", "test-token", nullStore{})
+	mgr, err := Bootstrap(cfg, 20, "https://helix.example.com", "test-token", nullStore{})
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}

--- a/api/pkg/sandbox/controller.go
+++ b/api/pkg/sandbox/controller.go
@@ -215,8 +215,22 @@ func (c *Controller) Delete(ctx context.Context, id string) error {
 	if sandbox.HostDeviceID != "" {
 		hydraClient := c.newHydraClient(sandbox.HostDeviceID)
 		// Delete container — best effort, log but don't block the row deletion.
+		deleteSucceeded := true
 		if _, err := hydraClient.DeleteDevContainer(ctx, sandbox.ID); err != nil {
 			log.Warn().Err(err).Str("sandbox_id", id).Msg("hydra DeleteDevContainer failed; continuing with row deletion")
+			deleteSucceeded = false
+		}
+		// Decrement active_sandboxes on the Runner row to match the
+		// increment that fired in Provision. Mirrors HydraExecutor.StopDesktop:
+		// only decrement when the upstream delete actually succeeded, so a
+		// failed delete leaves the counter high (operator visibility +
+		// avoids creating a phantom free-slot the dispatcher would re-fill).
+		// DiscoverContainersFromSandbox is the recovery path for any drift.
+		if deleteSucceeded {
+			if decErr := c.store.DecrementSandboxContainerCount(ctx, sandbox.HostDeviceID); decErr != nil {
+				log.Warn().Err(decErr).Str("sandbox_id", id).Str("host_device_id", sandbox.HostDeviceID).
+					Msg("Failed to decrement active_sandboxes on Runner after sandbox delete")
+			}
 		}
 		// Forget cached command records on hydra.
 		if err := hydraClient.ForgetSandboxOps(ctx, sandbox.ID); err != nil {

--- a/api/pkg/sandbox/controller.go
+++ b/api/pkg/sandbox/controller.go
@@ -214,9 +214,17 @@ func (c *Controller) Delete(ctx context.Context, id string) error {
 
 	if sandbox.HostDeviceID != "" {
 		hydraClient := c.newHydraClient(sandbox.HostDeviceID)
+		// Detach from the caller's ctx for the hydra teardown. If the
+		// HTTP caller goes away (LB closed connection, user navigated
+		// off, ctx cancelled), the container may still be in mid-tear
+		// on the Runner; we want the delete to finish AND the matching
+		// decrement to fire. Mirrors HydraExecutor.StopDesktop's
+		// context-detachment pattern.
+		teardownCtx, teardownCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer teardownCancel()
 		// Delete container — best effort, log but don't block the row deletion.
 		deleteSucceeded := true
-		if _, err := hydraClient.DeleteDevContainer(ctx, sandbox.ID); err != nil {
+		if _, err := hydraClient.DeleteDevContainer(teardownCtx, sandbox.ID); err != nil {
 			log.Warn().Err(err).Str("sandbox_id", id).Msg("hydra DeleteDevContainer failed; continuing with row deletion")
 			deleteSucceeded = false
 		}
@@ -227,13 +235,13 @@ func (c *Controller) Delete(ctx context.Context, id string) error {
 		// avoids creating a phantom free-slot the dispatcher would re-fill).
 		// DiscoverContainersFromSandbox is the recovery path for any drift.
 		if deleteSucceeded {
-			if decErr := c.store.DecrementSandboxContainerCount(ctx, sandbox.HostDeviceID); decErr != nil {
+			if decErr := c.store.DecrementSandboxContainerCount(teardownCtx, sandbox.HostDeviceID); decErr != nil {
 				log.Warn().Err(decErr).Str("sandbox_id", id).Str("host_device_id", sandbox.HostDeviceID).
 					Msg("Failed to decrement active_sandboxes on Runner after sandbox delete")
 			}
 		}
 		// Forget cached command records on hydra.
-		if err := hydraClient.ForgetSandboxOps(ctx, sandbox.ID); err != nil {
+		if err := hydraClient.ForgetSandboxOps(teardownCtx, sandbox.ID); err != nil {
 			log.Debug().Err(err).Str("sandbox_id", id).Msg("hydra ForgetSandboxOps failed")
 		}
 	}

--- a/api/pkg/sandbox/controller_provision.go
+++ b/api/pkg/sandbox/controller_provision.go
@@ -205,11 +205,41 @@ func (c *Controller) provision(ctx context.Context, sandboxID string) {
 		return
 	}
 
+	// Increment active_sandboxes on the Runner row so the autoscaler
+	// sees this user-facing sandbox as load (mirrors what HydraExecutor
+	// does for spec-task / agent dev containers). The matching decrement
+	// fires in Controller.Delete. If a downstream persist step below
+	// fails and we tear down the container, we also decrement there to
+	// keep the count balanced.
+	devContainerIncremented := false
+	if incErr := c.store.IncrementSandboxContainerCount(provisionCtx, host.ID); incErr != nil {
+		log.Warn().Err(incErr).Str("sandbox_id", sandboxID).Str("host_device_id", host.ID).
+			Msg("Failed to increment active_sandboxes on Runner; autoscaler may underestimate load")
+	} else {
+		devContainerIncremented = true
+	}
+
+	// rollbackOnFailure tears down the container we just provisioned
+	// and rolls back the counter increment, used by the two failure
+	// branches below (persist host/container ids, persist status).
+	rollbackOnFailure := func(stage string) {
+		if _, deleteErr := hydraClient.DeleteDevContainer(context.Background(), sandbox.ID); deleteErr != nil {
+			log.Warn().Err(deleteErr).Str("sandbox_id", sandboxID).Str("container_id", resp.ContainerID).
+				Msgf("failed to clean up provisioned container after %s failure", stage)
+			// Don't decrement on a failed cleanup: container may still be running.
+			return
+		}
+		if devContainerIncremented {
+			if decErr := c.store.DecrementSandboxContainerCount(context.Background(), host.ID); decErr != nil {
+				log.Warn().Err(decErr).Str("sandbox_id", sandboxID).Str("host_device_id", host.ID).
+					Msgf("Failed to decrement active_sandboxes after %s rollback", stage)
+			}
+		}
+	}
+
 	if err := c.store.SetSandboxContainer(provisionCtx, sandboxID, host.ID, resp.ContainerID); err != nil {
 		log.Warn().Err(err).Str("sandbox_id", sandboxID).Str("container_id", resp.ContainerID).Msg("failed to persist host/container ids; deleting provisioned container")
-		if _, deleteErr := hydraClient.DeleteDevContainer(context.Background(), sandbox.ID); deleteErr != nil {
-			log.Warn().Err(deleteErr).Str("sandbox_id", sandboxID).Str("container_id", resp.ContainerID).Msg("failed to clean up provisioned container after persist failure")
-		}
+		rollbackOnFailure("persist")
 		return
 	}
 
@@ -219,9 +249,7 @@ func (c *Controller) provision(ctx context.Context, sandboxID string) {
 	}
 	if err := c.store.SetSandboxStatus(provisionCtx, sandboxID, status, ""); err != nil {
 		log.Warn().Err(err).Str("sandbox_id", sandboxID).Str("container_id", resp.ContainerID).Msg("failed to persist sandbox status; deleting provisioned container")
-		if _, deleteErr := hydraClient.DeleteDevContainer(context.Background(), sandbox.ID); deleteErr != nil {
-			log.Warn().Err(deleteErr).Str("sandbox_id", sandboxID).Str("container_id", resp.ContainerID).Msg("failed to clean up provisioned container after status failure")
-		}
+		rollbackOnFailure("status")
 	}
 }
 

--- a/api/pkg/sandbox/controller_provision_test.go
+++ b/api/pkg/sandbox/controller_provision_test.go
@@ -172,6 +172,9 @@ func (s *ProvisionSuite) expectProvisionStoreCalls(sb *types.Sandbox, host *type
 		// Heartbeat-versioned (desktop) path.
 		s.store.EXPECT().FindAvailableSandboxInstance(gomock.Any(), gomock.Any()).Return(host, nil)
 	}
+	// IncrementSandboxContainerCount is called after CreateDevContainer
+	// succeeds so the autoscaler sees user-facing sandbox API load.
+	s.store.EXPECT().IncrementSandboxContainerCount(gomock.Any(), host.ID).Return(nil)
 	s.store.EXPECT().SetSandboxContainer(gomock.Any(), sb.ID, host.ID, gomock.Any()).Return(nil)
 	s.store.EXPECT().SetSandboxStatus(gomock.Any(), sb.ID, types.SandboxStatusRunning, "").Return(nil)
 }
@@ -270,7 +273,11 @@ func (s *ProvisionSuite) TestProvisionDeletesContainerWhenRowWasDeletedBeforeCon
 
 	s.store.EXPECT().GetSandbox(gomock.Any(), sbID).Return(sb, nil)
 	s.store.EXPECT().ListSandboxInstances(gomock.Any()).Return([]*types.SandboxInstance{host}, nil)
+	// Increment fires after the container is created; the SetSandboxContainer
+	// failure below triggers the rollback path which also decrements.
+	s.store.EXPECT().IncrementSandboxContainerCount(gomock.Any(), host.ID).Return(nil)
 	s.store.EXPECT().SetSandboxContainer(gomock.Any(), sbID, host.ID, gomock.Any()).Return(store.ErrNotFound)
+	s.store.EXPECT().DecrementSandboxContainerCount(gomock.Any(), host.ID).Return(nil)
 
 	s.controller.provision(s.ctx, sbID)
 
@@ -297,8 +304,12 @@ func (s *ProvisionSuite) TestProvisionDeletesContainerWhenRowWasDeletedBeforeSta
 
 	s.store.EXPECT().GetSandbox(gomock.Any(), sbID).Return(sb, nil)
 	s.store.EXPECT().ListSandboxInstances(gomock.Any()).Return([]*types.SandboxInstance{host}, nil)
+	s.store.EXPECT().IncrementSandboxContainerCount(gomock.Any(), host.ID).Return(nil)
 	s.store.EXPECT().SetSandboxContainer(gomock.Any(), sbID, host.ID, gomock.Any()).Return(nil)
 	s.store.EXPECT().SetSandboxStatus(gomock.Any(), sbID, types.SandboxStatusRunning, "").Return(store.ErrNotFound)
+	// SetSandboxStatus failure triggers the rollback path; delete succeeds
+	// and the counter increment is rolled back.
+	s.store.EXPECT().DecrementSandboxContainerCount(gomock.Any(), host.ID).Return(nil)
 
 	s.controller.provision(s.ctx, sbID)
 
@@ -526,6 +537,9 @@ func (s *ProvisionSuite) TestDeleteCallsHydraDeleteAndForgetOps() {
 	}
 	s.store.EXPECT().GetSandbox(s.ctx, sb.ID).Return(sb, nil)
 	s.store.EXPECT().SetSandboxStatus(s.ctx, sb.ID, types.SandboxStatusStopping, "").Return(nil)
+	// Decrement fires after the successful hydra delete to mirror the
+	// Increment that happened on Provision.
+	s.store.EXPECT().DecrementSandboxContainerCount(gomock.Any(), "host-z").Return(nil)
 	s.store.EXPECT().GetAPIKey(s.ctx, gomock.Any()).Return(nil, store.ErrNotFound)
 	s.store.EXPECT().DeleteSandbox(s.ctx, sb.ID).Return(nil)
 
@@ -642,6 +656,7 @@ func (s *ProvisionSuite) TestProvisionRecordsContainerIDFromHydraResponse() {
 	s.expectCreateOK("org_1", sb)
 	s.store.EXPECT().GetSandbox(gomock.Any(), sbID).Return(sb, nil)
 	s.store.EXPECT().ListSandboxInstances(gomock.Any()).Return([]*types.SandboxInstance{host}, nil)
+	s.store.EXPECT().IncrementSandboxContainerCount(gomock.Any(), "host-recorded").Return(nil)
 	gotContainer := make(chan string, 1)
 	s.store.EXPECT().SetSandboxContainer(gomock.Any(), sbID, "host-recorded", gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ string, _ string, containerID string) error {
@@ -689,6 +704,7 @@ func (s *ProvisionSuite) TestProvisionUsesPendingStatusWhenHydraNotYetRunning() 
 	s.expectCreateOK("org_1", sb)
 	s.store.EXPECT().GetSandbox(gomock.Any(), sbID).Return(sb, nil)
 	s.store.EXPECT().ListSandboxInstances(gomock.Any()).Return([]*types.SandboxInstance{host}, nil)
+	s.store.EXPECT().IncrementSandboxContainerCount(gomock.Any(), "host-a").Return(nil)
 	s.store.EXPECT().SetSandboxContainer(gomock.Any(), sbID, "host-a", gomock.Any()).Return(nil)
 	s.store.EXPECT().SetSandboxStatus(gomock.Any(), sbID, types.SandboxStatusPending, "").Return(nil)
 

--- a/api/pkg/server/sandbox_auto_register_test.go
+++ b/api/pkg/server/sandbox_auto_register_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/sandbox/compute"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
@@ -26,7 +27,7 @@ import (
 func TestEnsureSandboxRegistered_BridgesProvisioningRow_TargetedUpdates(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := store.NewMockStore(ctrl)
-	server := &HelixAPIServer{Store: mockStore}
+	server := &HelixAPIServer{Store: mockStore, Cfg: &config.ServerConfig{SandboxMaxDevContainers: 20}}
 
 	existing := &types.SandboxInstance{
 		ID:           "sbx_provisioning",
@@ -68,7 +69,7 @@ func TestEnsureSandboxRegistered_BridgesFailedRow_RecoveryPath(t *testing.T) {
 	// pre-warms a replacement, and the host serves but doesn't count.
 	ctrl := gomock.NewController(t)
 	mockStore := store.NewMockStore(ctrl)
-	server := &HelixAPIServer{Store: mockStore}
+	server := &HelixAPIServer{Store: mockStore, Cfg: &config.ServerConfig{SandboxMaxDevContainers: 20}}
 
 	existing := &types.SandboxInstance{
 		ID:           "sbx_recovered",
@@ -101,7 +102,7 @@ func TestEnsureSandboxRegistered_LegacyReconnectPathUnchanged(t *testing.T) {
 	// log spam and overwrite heartbeat fields.
 	ctrl := gomock.NewController(t)
 	mockStore := store.NewMockStore(ctrl)
-	server := &HelixAPIServer{Store: mockStore}
+	server := &HelixAPIServer{Store: mockStore, Cfg: &config.ServerConfig{SandboxMaxDevContainers: 20}}
 
 	existing := &types.SandboxInstance{
 		ID:           "sbx_existing",
@@ -127,7 +128,7 @@ func TestEnsureSandboxRegistered_LegacyReconnectForEmptyComputeState(t *testing.
 	// empty value must NOT match the provisioning branch.
 	ctrl := gomock.NewController(t)
 	mockStore := store.NewMockStore(ctrl)
-	server := &HelixAPIServer{Store: mockStore}
+	server := &HelixAPIServer{Store: mockStore, Cfg: &config.ServerConfig{SandboxMaxDevContainers: 20}}
 
 	existing := &types.SandboxInstance{
 		ID:           "sbx_legacy",
@@ -150,7 +151,7 @@ func TestEnsureSandboxRegistered_NoRowInsertsFreshLegacyRow(t *testing.T) {
 	// exists, so we INSERT a fresh one with Provider="" (legacy).
 	ctrl := gomock.NewController(t)
 	mockStore := store.NewMockStore(ctrl)
-	server := &HelixAPIServer{Store: mockStore}
+	server := &HelixAPIServer{Store: mockStore, Cfg: &config.ServerConfig{SandboxMaxDevContainers: 20}}
 
 	mockStore.EXPECT().
 		ListSandboxInstances(gomock.Any()).
@@ -182,7 +183,7 @@ func TestEnsureSandboxRegistered_BridgeEarlyStoreErrorAborts(t *testing.T) {
 	// to the legacy paths. Next reconcile cycle will retry.
 	ctrl := gomock.NewController(t)
 	mockStore := store.NewMockStore(ctrl)
-	server := &HelixAPIServer{Store: mockStore}
+	server := &HelixAPIServer{Store: mockStore, Cfg: &config.ServerConfig{SandboxMaxDevContainers: 20}}
 
 	existing := &types.SandboxInstance{
 		ID:           "sbx_provisioning_err",

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -420,11 +420,24 @@ func NewServer(
 	// Helix on the legacy self-registered-host path. A non-nil error
 	// is fatal: better to fail boot than start with a misconfigured
 	// Manager that silently drops Provision calls.
-	computeManager, err := bootstrap.Bootstrap(cfg.Compute, cfg.WebServer.URL, cfg.WebServer.RunnerToken, store)
+	computeManager, err := bootstrap.Bootstrap(cfg.Compute, cfg.SandboxMaxDevContainers, cfg.WebServer.URL, cfg.WebServer.RunnerToken, store)
 	if err != nil {
 		return nil, fmt.Errorf("bootstrap compute subsystem: %w", err)
 	}
 	apiServer.computeManager = computeManager
+
+	// Backfill existing Runner rows with the current ceiling so a change
+	// to HELIX_SANDBOX_MAX_DEV_CONTAINERS takes effect across the fleet
+	// on next API restart, not just for Runners that re-register after
+	// the change. Idempotent (only updates rows that disagree), and
+	// non-fatal: a backfill failure logs but doesn't block boot.
+	if rows, backfillErr := store.BackfillSandboxMaxSandboxes(context.Background(), cfg.SandboxMaxDevContainers); backfillErr != nil {
+		log.Warn().Err(backfillErr).Int("max_dev_containers", cfg.SandboxMaxDevContainers).
+			Msg("Boot-time backfill of sandbox_instances.max_sandboxes failed; existing Runners keep their persisted value")
+	} else if rows > 0 {
+		log.Info().Int("rows_updated", int(rows)).Int("new_value", cfg.SandboxMaxDevContainers).
+			Msg("Backfilled max_sandboxes on existing Runner rows to current HELIX_SANDBOX_MAX_DEV_CONTAINERS")
+	}
 
 	// Sandbox-absorbs-runner: wire the inference router into the
 	// internal helix server so it picks sandboxes by model name. Safe
@@ -2495,12 +2508,18 @@ func (apiServer *HelixAPIServer) ensureSandboxRegistered(ctx context.Context, sa
 		return
 	}
 
-	// Not registered - auto-register it
+	// Not registered - auto-register it.
+	//
+	// MaxSandboxes comes from HELIX_SANDBOX_MAX_DEV_CONTAINERS (default 20).
+	// This is the per-Runner ceiling on isolated dev containers that hydra
+	// will spawn inside this helix-sandbox host. Operators tuning for
+	// smaller hosts or wanting the autoscaler to trigger sooner can drop
+	// this without redeploying the runner image.
 	instance := &types.SandboxInstance{
 		ID:           sandboxID,
 		Hostname:     fmt.Sprintf("sandbox-%s", sandboxID),
 		IPAddress:    remoteAddr,
-		MaxSandboxes: 20, // Default capacity
+		MaxSandboxes: apiServer.Cfg.SandboxMaxDevContainers,
 		Status:       "online",
 	}
 

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -2503,7 +2503,7 @@ func (apiServer *HelixAPIServer) ensureSandboxRegistered(ctx context.Context, sa
 			log.Info().
 				Str("sandbox_id", sandboxID).
 				Int("previous_container_count", instance.ActiveSandboxes).
-				Msg("Reset sandbox on reconnect (cleared stale container count)")
+				Msg("Reset sandbox on reconnect (flipped status to online; container count is preserved and will be resynced from hydra by DiscoverContainersFromSandbox)")
 		}
 		return
 	}

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -799,6 +799,8 @@ type Store interface {
 	MarkSandboxInstanceOfflineIfStale(ctx context.Context, id string, staleBefore time.Time) (int64, error)
 	IncrementSandboxContainerCount(ctx context.Context, id string) error
 	DecrementSandboxContainerCount(ctx context.Context, id string) error
+	SetSandboxContainerCount(ctx context.Context, id string, count int) error
+	BackfillSandboxMaxSandboxes(ctx context.Context, value int) (int64, error)
 	ResetSandboxOnReconnect(ctx context.Context, id string) error
 	GetSandboxInstancesOlderThanHeartbeat(ctx context.Context, olderThan time.Time) ([]*types.SandboxInstance, error)
 	FindAvailableSandboxInstance(ctx context.Context, desktopType string) (*types.SandboxInstance, error)

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -25,6 +25,7 @@ import (
 type MockStore struct {
 	ctrl     *gomock.Controller
 	recorder *MockStoreMockRecorder
+	isgomock struct{}
 }
 
 // MockStoreMockRecorder is the mock recorder for MockStore.
@@ -70,6 +71,21 @@ func (m *MockStore) AttachRepositoryToProject(ctx context.Context, projectID, re
 func (mr *MockStoreMockRecorder) AttachRepositoryToProject(ctx, projectID, repoID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachRepositoryToProject", reflect.TypeOf((*MockStore)(nil).AttachRepositoryToProject), ctx, projectID, repoID)
+}
+
+// BackfillSandboxMaxSandboxes mocks base method.
+func (m *MockStore) BackfillSandboxMaxSandboxes(ctx context.Context, value int) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BackfillSandboxMaxSandboxes", ctx, value)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BackfillSandboxMaxSandboxes indicates an expected call of BackfillSandboxMaxSandboxes.
+func (mr *MockStoreMockRecorder) BackfillSandboxMaxSandboxes(ctx, value any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackfillSandboxMaxSandboxes", reflect.TypeOf((*MockStore)(nil).BackfillSandboxMaxSandboxes), ctx, value)
 }
 
 // BulkDismissAttentionEvents mocks base method.
@@ -160,21 +176,6 @@ func (m *MockStore) ClearStaleStartingSessions(ctx context.Context) (int64, erro
 func (mr *MockStoreMockRecorder) ClearStaleStartingSessions(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearStaleStartingSessions", reflect.TypeOf((*MockStore)(nil).ClearStaleStartingSessions), ctx)
-}
-
-// MarkSessionStartingIfIdle mocks base method.
-func (m *MockStore) MarkSessionStartingIfIdle(ctx context.Context, sessionID string) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkSessionStartingIfIdle", ctx, sessionID)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// MarkSessionStartingIfIdle indicates an expected call of MarkSessionStartingIfIdle.
-func (mr *MockStoreMockRecorder) MarkSessionStartingIfIdle(ctx, sessionID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkSessionStartingIfIdle", reflect.TypeOf((*MockStore)(nil).MarkSessionStartingIfIdle), ctx, sessionID)
 }
 
 // ConsumePendingInvitations mocks base method.
@@ -5512,6 +5513,21 @@ func (mr *MockStoreMockRecorder) MarkSandboxInstanceOfflineIfStale(ctx, id, stal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkSandboxInstanceOfflineIfStale", reflect.TypeOf((*MockStore)(nil).MarkSandboxInstanceOfflineIfStale), ctx, id, staleBefore)
 }
 
+// MarkSessionStartingIfIdle mocks base method.
+func (m *MockStore) MarkSessionStartingIfIdle(ctx context.Context, sessionID string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkSessionStartingIfIdle", ctx, sessionID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MarkSessionStartingIfIdle indicates an expected call of MarkSessionStartingIfIdle.
+func (mr *MockStoreMockRecorder) MarkSessionStartingIfIdle(ctx, sessionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkSessionStartingIfIdle", reflect.TypeOf((*MockStore)(nil).MarkSessionStartingIfIdle), ctx, sessionID)
+}
+
 // MarkVHostRouteVerified mocks base method.
 func (m *MockStore) MarkVHostRouteVerified(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()
@@ -5842,6 +5858,20 @@ func (m *MockStore) SetSandboxContainer(ctx context.Context, id, hostDeviceID, c
 func (mr *MockStoreMockRecorder) SetSandboxContainer(ctx, id, hostDeviceID, containerID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSandboxContainer", reflect.TypeOf((*MockStore)(nil).SetSandboxContainer), ctx, id, hostDeviceID, containerID)
+}
+
+// SetSandboxContainerCount mocks base method.
+func (m *MockStore) SetSandboxContainerCount(ctx context.Context, id string, count int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetSandboxContainerCount", ctx, id, count)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetSandboxContainerCount indicates an expected call of SetSandboxContainerCount.
+func (mr *MockStoreMockRecorder) SetSandboxContainerCount(ctx, id, count any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSandboxContainerCount", reflect.TypeOf((*MockStore)(nil).SetSandboxContainerCount), ctx, id, count)
 }
 
 // SetSandboxStatus mocks base method.

--- a/api/pkg/store/store_sandbox.go
+++ b/api/pkg/store/store_sandbox.go
@@ -240,7 +240,17 @@ func (s *PostgresStore) SetSandboxContainerCount(ctx context.Context, id string,
 //
 // Idempotent: only writes rows where max_sandboxes already differs, so
 // repeat boots with the same config are no-ops.
+//
+// Zero-guard: refuses to backfill with value <= 0. The env var binding
+// defaults to 20, so receiving 0 here means the operator either set
+// HELIX_SANDBOX_MAX_DEV_CONTAINERS=0 explicitly (almost certainly a
+// mistake - it would render every Runner permanently "full") or the
+// config was loaded into an uninitialised struct. Either way, safer
+// to skip than to zero the entire fleet's ceiling.
 func (s *PostgresStore) BackfillSandboxMaxSandboxes(ctx context.Context, value int) (int64, error) {
+	if value <= 0 {
+		return 0, fmt.Errorf("BackfillSandboxMaxSandboxes refusing to write non-positive value %d (would render every Runner permanently full)", value)
+	}
 	res := s.gdb.WithContext(ctx).
 		Model(&types.SandboxInstance{}).
 		Where("max_sandboxes != ?", value).

--- a/api/pkg/store/store_sandbox.go
+++ b/api/pkg/store/store_sandbox.go
@@ -198,16 +198,57 @@ func (s *PostgresStore) DecrementSandboxContainerCount(ctx context.Context, id s
 		UpdateColumn("active_sandboxes", s.gdb.Raw("GREATEST(active_sandboxes - 1, 0)")).Error
 }
 
-// ResetSandboxOnReconnect resets sandbox state when it reconnects
+// ResetSandboxOnReconnect resets sandbox state when it reconnects.
+//
+// Flips status back to online and refreshes last_seen so the heartbeat
+// reaper doesn't immediately mark the row offline again. We deliberately
+// do NOT zero active_sandboxes here: a brief RevDial blip on a healthy
+// Runner with N running containers must not silently produce a phantom
+// "free capacity" signal for the autoscaler. The corrective path is
+// DiscoverContainersFromSandbox, which queries hydra for the real
+// container list on every reconnect and calls SetSandboxContainerCount
+// to write the authoritative value.
 func (s *PostgresStore) ResetSandboxOnReconnect(ctx context.Context, id string) error {
 	return s.gdb.WithContext(ctx).
 		Model(&types.SandboxInstance{}).
 		Where("id = ?", id).
 		Updates(map[string]interface{}{
-			"status":           "online",
-			"last_seen":        time.Now(),
-			"active_sandboxes": 0,
+			"status":    "online",
+			"last_seen": time.Now(),
 		}).Error
+}
+
+// SetSandboxContainerCount sets active_sandboxes to an explicit value.
+// Used by DiscoverContainersFromSandbox to write the authoritative
+// container count after querying hydra. Distinct from Increment /
+// Decrement which assume a known delta from the prior value; this
+// resyncs from ground truth, recovering from any drift caused by
+// API restarts, missed Increment/Decrement calls (e.g. hydra-side
+// internal deletes that bypass StopDesktop), or other inconsistencies.
+func (s *PostgresStore) SetSandboxContainerCount(ctx context.Context, id string, count int) error {
+	return s.gdb.WithContext(ctx).
+		Model(&types.SandboxInstance{}).
+		Where("id = ?", id).
+		UpdateColumn("active_sandboxes", count).Error
+}
+
+// BackfillSandboxMaxSandboxes rewrites max_sandboxes on every existing
+// Runner row to the supplied value. Called once at API boot so a change
+// to HELIX_SANDBOX_MAX_DEV_CONTAINERS takes effect across the entire
+// fleet on next restart, not just for Runners that re-register after
+// the change. Returns the number of rows updated for logging.
+//
+// Idempotent: only writes rows where max_sandboxes already differs, so
+// repeat boots with the same config are no-ops.
+func (s *PostgresStore) BackfillSandboxMaxSandboxes(ctx context.Context, value int) (int64, error) {
+	res := s.gdb.WithContext(ctx).
+		Model(&types.SandboxInstance{}).
+		Where("max_sandboxes != ?", value).
+		UpdateColumn("max_sandboxes", value)
+	if res.Error != nil {
+		return 0, res.Error
+	}
+	return res.RowsAffected, nil
 }
 
 // GetSandboxInstancesOlderThanHeartbeat returns sandbox hosts that haven't sent a heartbeat recently.

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -3182,9 +3182,13 @@ type SandboxInstance struct {
 	GPUVendor  string `json:"gpu_vendor,omitempty" gorm:"type:varchar(50)"`  // "nvidia", "amd", "intel", "none"
 	RenderNode string `json:"render_node,omitempty" gorm:"type:varchar(50)"` // /dev/dri/renderD128 or SOFTWARE
 
-	// Sandbox capacity
+	// Sandbox capacity. MaxSandboxes is set explicitly at auto-register
+	// and Manager-provisioned paths from HELIX_SANDBOX_MAX_DEV_CONTAINERS
+	// (default 20); the gorm default below only applies to rows inserted
+	// via paths that don't set the field. Kept aligned with the env-var
+	// default to avoid surprises.
 	ActiveSandboxes int  `json:"active_sandboxes" gorm:"default:0"` // Number of active desktop containers
-	MaxSandboxes    int  `json:"max_sandboxes" gorm:"default:10"`   // Maximum allowed containers
+	MaxSandboxes    int  `json:"max_sandboxes" gorm:"default:20"`   // Maximum allowed containers
 	PrivilegedMode  bool `json:"privileged_mode" gorm:"default:false"`
 
 	// Helix version running on this sandbox (git commit hash or release version)


### PR DESCRIPTION
## Summary

- Wire `IncrementSandboxContainerCount` / `DecrementSandboxContainerCount` across all four paths that create or destroy dev containers on a Runner (HydraExecutor StartDesktop/StopDesktop, Controller Provision/Delete, HasRunningContainer eviction, DiscoverContainersFromSandbox).
- Add `HELIX_SANDBOX_MAX_DEV_CONTAINERS` (default 20) to replace the hardcoded ceiling at the auto-register site, and thread through to Manager-provisioned Runners. Backfill existing rows on boot so a config change takes effect across the fleet.
- Drop the unconditional zero in `ResetSandboxOnReconnect`; the corrective path is `DiscoverContainersFromSandbox` SETting the counter to ground truth from hydra.

## Why this matters

Before this PR, nothing in production code wrote to `sandbox_instances.active_sandboxes` (the only writers were test mocks). So the autoscaler's demand-driven scale-up path (`computeNeeded` / `demandPressureExists`) computed `headroom = max_sandboxes - 0 = max_sandboxes` regardless of real load. D3 was effectively half-functional: Floor pressure worked but demand pressure couldn't fire on actual session demand.

This PR makes the counter real, and threads the ceiling through to operators via a single env var.

## Two rounds of multi-agent review

This PR went through two rounds of the bundled `code-review` skill (high-effort multi-agent review, 3+4 angles x 6 candidates each, 1-vote verify, recall-biased). Round 1 caught 10 CONFIRMED issues with the naive wiring; round 2 caught 10 more drift-related issues with the round-1 fixes. The current commits address both rounds' critical-correctness findings.

Out-of-scope follow-ups (real but narrow):

- Provision crash-in-window: api OOMs between Increment and SetSandboxContainer -> sandbox row has empty HostDeviceID -> Delete skips the decrement -> permanent drift on that Runner. Needs either a periodic reconciler or a state machine on the sandbox row.
- Periodic from-truth reconcile: current model relies on `DiscoverContainersFromSandbox` triggering on every reconnect; if a Runner reconnects without triggering Discover, drift persists until the next event. A background reconciler that calls Discover for every online Runner closes this.
- Hard dispatcher rejection at MaxSandboxes: the autoscaler's headroom math honours the ceiling, but `FindAvailableSandboxInstance` only sorts by `active_sandboxes ASC` and doesn't refuse placement on a full Runner. Tracked separately.

## Test plan

- [x] `go build ./...` clean
- [x] Unit tests pass for the changed packages (`sandbox`, `sandbox/compute`, `sandbox/compute/bootstrap`, `sandbox/compute/yellowdog`, `server`, `external-agent`, `config`)
- [ ] Store package tests run in CI (require Postgres)
- [ ] Drone CI green
- [ ] Smoke test on yd.helix.ml post-merge: start a spec task, verify `active_sandboxes` increments; stop it, verify decrement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)