### PR TITLE
feat(hydra): aggregate per-service logs into admin Runner Logs WS

### DIFF
--- a/api/cmd/hydra/main.go
+++ b/api/cmd/hydra/main.go
@@ -101,6 +101,19 @@ func run(cmd *cobra.Command, args []string) {
 		cancel()
 	}()
 
+	// Tail per-service log files written by the cont-init.d wrappers
+	// (compose-manager, inference-proxy, sandbox-heartbeat, dockerd)
+	// into the same LogBuffer hydra's zerolog uses. Each tailed line
+	// gets a "[<svc>] " prefix derived from the filename, so the admin
+	// Runner Logs view shows everything in the sandbox container with
+	// no new endpoint or operator config. Done via tee-to-file from
+	// the wrappers rather than a hydra-served Unix socket because
+	// (a) it's a zero-IPC change, (b) the existing wrappers already
+	// pipe through sed, so adding `tee -a` is one line each, and
+	// (c) file-based decoupling means a hydra restart doesn't lose
+	// in-flight log lines from the other services.
+	hydra.StartServiceLogTailers(ctx, logBuffer, "/var/log/helix-services")
+
 	// Start server
 	if err := server.Start(ctx); err != nil {
 		log.Fatal().Err(err).Msg("Failed to start Hydra server")

--- a/api/pkg/hydra/log_tailer.go
+++ b/api/pkg/hydra/log_tailer.go
@@ -1,0 +1,171 @@
+package hydra
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// serviceLogTailPollInterval is how often each per-file tailer polls for
+// new content. 500ms is a balance between log-line latency in the admin
+// UI (operators expect near-real-time) and the syscall cost of a stat
+// per file per tick. The number of files is small (one per long-running
+// service inside helix-sandbox, today: dockerd, sandbox-heartbeat, hydra,
+// compose-manager, inference-proxy = up to 5).
+const serviceLogTailPollInterval = 500 * time.Millisecond
+
+// serviceLogDirRescanInterval is how often we re-scan the service-log
+// directory for newly-appeared log files. Services that start AFTER
+// hydra (e.g. compose-manager) won't have created their log file yet
+// when hydra's main() runs, so we poll for them periodically rather
+// than only at startup.
+const serviceLogDirRescanInterval = 10 * time.Second
+
+// StartServiceLogTailers watches dir for *.log files and tails each one
+// into buf with a "[<svc>] " prefix derived from the filename. The
+// existing /logs WS endpoint streams from buf, so this surfaces ALL
+// long-running services (compose-manager, inference-proxy, dockerd,
+// sandbox-heartbeat) in the admin Runner Logs view alongside hydra's
+// own zerolog output - not just hydra.
+//
+// Files appearing after this returns ARE picked up by a rescan goroutine.
+// Files removed are abandoned (their tailer goroutine continues reading
+// the last open file descriptor, which is harmless; new content at the
+// same path after re-creation would be missed without rotation logic).
+//
+// Tailers start at end-of-file (not from the beginning) so the LogBuffer
+// reflects live state, not a startup history dump that could displace
+// recent legitimate lines from the ring.
+//
+// Errors are logged but do not abort - a single broken file path does
+// not take down the whole aggregator. Safe to call with a nil buf
+// (turns into a no-op).
+func StartServiceLogTailers(ctx context.Context, buf *LogBuffer, dir string) {
+	if buf == nil {
+		return
+	}
+
+	// Best-effort mkdir so the wrappers' `tee -a` calls don't fail on a
+	// fresh container. If this fails, we proceed anyway - a service that
+	// successfully creates its own log file will still be picked up.
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		log.Warn().Err(err).Str("dir", dir).
+			Msg("StartServiceLogTailers: mkdir failed; service logs may be unavailable")
+	}
+
+	tailed := &sync.Map{} // path -> struct{} sentinel; avoids double-tailing on rescan
+
+	// Initial scan + spawn one tailer per existing .log file.
+	if entries, err := os.ReadDir(dir); err == nil {
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".log") {
+				continue
+			}
+			path := filepath.Join(dir, e.Name())
+			tailed.Store(path, struct{}{})
+			go tailServiceLog(ctx, buf, path)
+		}
+	}
+
+	// Rescan loop: pick up files created after hydra started.
+	go func() {
+		t := time.NewTicker(serviceLogDirRescanInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				entries, err := os.ReadDir(dir)
+				if err != nil {
+					continue
+				}
+				for _, e := range entries {
+					if e.IsDir() || !strings.HasSuffix(e.Name(), ".log") {
+						continue
+					}
+					path := filepath.Join(dir, e.Name())
+					if _, loaded := tailed.LoadOrStore(path, struct{}{}); loaded {
+						continue
+					}
+					log.Info().Str("file", path).
+						Msg("StartServiceLogTailers: tailing newly-appeared service log")
+					go tailServiceLog(ctx, buf, path)
+				}
+			}
+		}
+	}()
+}
+
+// tailServiceLog follows a single log file, writing each appended line
+// into buf with a "[<basename-without-.log>] " prefix. Starts from
+// end-of-file. Survives transient read errors. Exits when ctx is done.
+//
+// Rotation is NOT handled: if a service rotates its log (rename + truncate
+// or remove + recreate), we'll keep reading the unlinked inode until
+// process exit. helix-sandbox today doesn't rotate, so this is fine.
+// If/when rotation gets added inside the sandbox, use inotify or
+// stat-based detection of size shrinkage to reopen.
+func tailServiceLog(ctx context.Context, buf *LogBuffer, path string) {
+	prefix := "[" + strings.TrimSuffix(filepath.Base(path), ".log") + "] "
+
+	// Open create-if-missing so a tailer started before the producing
+	// service can still attach. O_RDONLY would race the producer on
+	// systems where O_CREAT semantics differ; here we want the file to
+	// exist with the producer's eventual ownership / mode (the producer
+	// opens with O_APPEND|O_CREATE itself in `tee -a`).
+	f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0o644)
+	if err != nil {
+		log.Warn().Err(err).Str("path", path).
+			Msg("tailServiceLog: open failed; abandoning tailer for this file")
+		return
+	}
+	defer f.Close()
+
+	if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		log.Warn().Err(err).Str("path", path).
+			Msg("tailServiceLog: seek-end failed; abandoning tailer for this file")
+		return
+	}
+
+	reader := bufio.NewReader(f)
+	poll := time.NewTicker(serviceLogTailPollInterval)
+	defer poll.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-poll.C:
+			// Drain everything available before sleeping again.
+			for {
+				line, err := reader.ReadString('\n')
+				if line != "" {
+					// Trim trailing newline (added back by the
+					// LogBuffer consumers if they care about line
+					// framing). Keep partial lines without a
+					// trailing \n - bufio's ReadString returns them
+					// only on EOF, so they represent a producer that
+					// hasn't flushed yet; we ship them anyway to
+					// minimise latency on burst-tail.
+					buf.Write(prefix + strings.TrimRight(line, "\r\n"))
+				}
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					log.Debug().Err(err).Str("path", path).
+						Msg("tailServiceLog: read error; will retry next tick")
+					break
+				}
+			}
+		}
+	}
+}

--- a/api/pkg/hydra/log_tailer.go
+++ b/api/pkg/hydra/log_tailer.go
@@ -104,23 +104,37 @@ func StartServiceLogTailers(ctx context.Context, buf *LogBuffer, dir string) {
 	}()
 }
 
-// tailServiceLog follows a single log file, writing each appended line
-// into buf with a "[<basename-without-.log>] " prefix. Starts from
-// end-of-file. Survives transient read errors. Exits when ctx is done.
+// tailServiceLog follows a single log file, writing each newline-terminated
+// line into buf with a "[<basename-without-.log>] " prefix. Survives
+// transient read errors. Exits when ctx is done.
 //
-// Rotation is NOT handled: if a service rotates its log (rename + truncate
-// or remove + recreate), we'll keep reading the unlinked inode until
-// process exit. helix-sandbox today doesn't rotate, so this is fine.
-// If/when rotation gets added inside the sandbox, use inotify or
-// stat-based detection of size shrinkage to reopen.
+// Reads from the START of the file (NOT seek-to-end). The cont-init.d
+// wrappers truncate their respective files at boot, so on a fresh
+// helix-sandbox container the file is empty when this tailer opens it -
+// safe to read from the beginning. On hydra reconnect after its own
+// crash-and-supervisor-restart, the file may contain pre-restart
+// content; we replay that into the LogBuffer too (better to show stale
+// context on the admin UI than to silently swallow the diagnostic
+// content the operator most needs - if a service crashed before hydra
+// came back up, its last-words are exactly what we want surfaced).
+//
+// Partial-line buffering: if the producer writes "pulling layer abc... "
+// without a trailing newline, the previous version of this code shipped
+// the partial line, then shipped the rest on the next tick - resulting
+// in two LogBuffer entries with broken prefixes. We now accumulate
+// partials in `pending` and only Write when we have a complete line
+// terminator, with a safety cap (partialLineCap) so a producer that
+// writes a million bytes without a newline can't OOM us.
+//
+// Rotation is NOT handled: if a service rotates its log (rename +
+// recreate), we'll keep reading the unlinked inode until process exit.
+// helix-sandbox today doesn't rotate inside its lifetime. If/when that
+// changes, add stat-based detection of file-size shrinkage and reopen.
 func tailServiceLog(ctx context.Context, buf *LogBuffer, path string) {
 	prefix := "[" + strings.TrimSuffix(filepath.Base(path), ".log") + "] "
 
 	// Open create-if-missing so a tailer started before the producing
-	// service can still attach. O_RDONLY would race the producer on
-	// systems where O_CREAT semantics differ; here we want the file to
-	// exist with the producer's eventual ownership / mode (the producer
-	// opens with O_APPEND|O_CREATE itself in `tee -a`).
+	// service can still attach. O_RDONLY because we never write.
 	f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0o644)
 	if err != nil {
 		log.Warn().Err(err).Str("path", path).
@@ -129,43 +143,67 @@ func tailServiceLog(ctx context.Context, buf *LogBuffer, path string) {
 	}
 	defer f.Close()
 
-	if _, err := f.Seek(0, io.SeekEnd); err != nil {
-		log.Warn().Err(err).Str("path", path).
-			Msg("tailServiceLog: seek-end failed; abandoning tailer for this file")
-		return
-	}
-
 	reader := bufio.NewReader(f)
 	poll := time.NewTicker(serviceLogTailPollInterval)
 	defer poll.Stop()
+
+	// Buffer for the trailing partial line (no \n yet). Flushed when a
+	// later read sees the terminator, OR when it grows past partialLineCap
+	// (defensive against producers that never newline-terminate).
+	var pending strings.Builder
+
+	flushComplete := func() {
+		// Drain everything available before sleeping again. We loop
+		// because bufio's read buffer may return EOF in the middle of a
+		// larger physical chunk if the producer is mid-write.
+		for {
+			line, err := reader.ReadString('\n')
+			if line != "" {
+				if strings.HasSuffix(line, "\n") {
+					// Complete line - prepend any pending partial,
+					// trim, ship.
+					if pending.Len() > 0 {
+						line = pending.String() + line
+						pending.Reset()
+					}
+					buf.Write(prefix + strings.TrimRight(line, "\r\n"))
+				} else {
+					// Partial line (only happens at EOF). Append to
+					// pending and bail to the cap check below.
+					pending.WriteString(line)
+					if pending.Len() > partialLineCap {
+						// Producer is misbehaving (or it's a binary
+						// blob). Flush what we have rather than buffer
+						// forever, mark with a [partial] suffix so the
+						// operator knows the line was cut.
+						buf.Write(prefix + pending.String() + " [partial: line exceeded cap]")
+						pending.Reset()
+					}
+				}
+			}
+			if err == io.EOF {
+				return
+			}
+			if err != nil {
+				log.Debug().Err(err).Str("path", path).
+					Msg("tailServiceLog: read error; will retry next tick")
+				return
+			}
+		}
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-poll.C:
-			// Drain everything available before sleeping again.
-			for {
-				line, err := reader.ReadString('\n')
-				if line != "" {
-					// Trim trailing newline (added back by the
-					// LogBuffer consumers if they care about line
-					// framing). Keep partial lines without a
-					// trailing \n - bufio's ReadString returns them
-					// only on EOF, so they represent a producer that
-					// hasn't flushed yet; we ship them anyway to
-					// minimise latency on burst-tail.
-					buf.Write(prefix + strings.TrimRight(line, "\r\n"))
-				}
-				if err == io.EOF {
-					break
-				}
-				if err != nil {
-					log.Debug().Err(err).Str("path", path).
-						Msg("tailServiceLog: read error; will retry next tick")
-					break
-				}
-			}
+			flushComplete()
 		}
 	}
 }
+
+// partialLineCap bounds how much we'll buffer waiting for a newline.
+// Long enough for any realistic log line including JSON-encoded
+// heartbeat payloads or dockerd image-pull progress lines, short
+// enough to bound memory if a producer streams a binary blob.
+const partialLineCap = 256 * 1024 // 256 KiB

--- a/api/pkg/hydra/log_tailer_test.go
+++ b/api/pkg/hydra/log_tailer_test.go
@@ -1,0 +1,135 @@
+package hydra
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStartServiceLogTailers_AppendsToBufferWithPrefix verifies the happy
+// path: a wrapper writes lines to /var/log/helix-services/<svc>.log,
+// hydra's tailer picks them up, and they appear in the LogBuffer with the
+// "[<svc>] " prefix the admin UI consumes.
+func TestStartServiceLogTailers_AppendsToBufferWithPrefix(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "compose-manager.log")
+
+	// Create the file BEFORE starting the tailer to exercise the initial-
+	// scan code path. Append-mode so the tailer's seek-to-end positions
+	// just before any future writes.
+	f, err := os.OpenFile(logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatalf("create log file: %v", err)
+	}
+	defer f.Close()
+
+	buf := NewLogBuffer(64)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	StartServiceLogTailers(ctx, buf, dir)
+
+	// Give the tailer a moment to open the file + seek to end.
+	time.Sleep(250 * time.Millisecond)
+
+	wantLines := []string{
+		"hello compose-manager",
+		"second line",
+		"third line with a UTF-8 char é",
+	}
+	for _, line := range wantLines {
+		if _, err := fmt.Fprintln(f, line); err != nil {
+			t.Fatalf("write line: %v", err)
+		}
+	}
+	if err := f.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	// Wait up to 3s for all lines to land in the buffer (poll interval
+	// is 500ms; 3s = 6 ticks of slack for CI jitter).
+	deadline := time.Now().Add(3 * time.Second)
+	var snap []LogLine
+	for time.Now().Before(deadline) {
+		snap = buf.Snapshot(1024)
+		if len(snap) >= len(wantLines) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if len(snap) < len(wantLines) {
+		t.Fatalf("expected at least %d lines in buffer, got %d: %+v", len(wantLines), len(snap), snap)
+	}
+
+	prefix := "[compose-manager] "
+	for i, want := range wantLines {
+		got := snap[i].Line
+		if !strings.HasPrefix(got, prefix) {
+			t.Errorf("line %d: expected prefix %q, got %q", i, prefix, got)
+		}
+		if !strings.Contains(got, want) {
+			t.Errorf("line %d: expected to contain %q, got %q", i, want, got)
+		}
+	}
+}
+
+// TestStartServiceLogTailers_PicksUpFileAppearingAfterStart verifies the
+// rescan path: a wrapper that starts AFTER hydra (e.g. compose-manager
+// in 12-start-... when hydra was in 10-start-...) creates its log file
+// later in the boot, and the tailer must notice it within the rescan
+// interval.
+func TestStartServiceLogTailers_PicksUpFileAppearingAfterStart(t *testing.T) {
+	dir := t.TempDir()
+
+	buf := NewLogBuffer(64)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	StartServiceLogTailers(ctx, buf, dir)
+
+	// No log file exists yet. Wait briefly so the initial scan completes
+	// without finding anything.
+	time.Sleep(250 * time.Millisecond)
+
+	// Now create the file. Rescan interval is 10s; the test waits up to
+	// 15s for the new file to be noticed. CI-friendly but slow if the
+	// rescan path is broken.
+	logPath := filepath.Join(dir, "inference-proxy.log")
+	f, err := os.Create(logPath)
+	if err != nil {
+		t.Fatalf("create late log file: %v", err)
+	}
+	defer f.Close()
+
+	want := "late-arriving service line"
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := fmt.Fprintln(f, want); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		_ = f.Sync()
+		snap := buf.Snapshot(1024)
+		for _, l := range snap {
+			if strings.Contains(l.Line, want) && strings.HasPrefix(l.Line, "[inference-proxy] ") {
+				return // pass
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("expected line with prefix [inference-proxy] not found in buffer; snapshot: %+v", buf.Snapshot(1024))
+}
+
+// TestStartServiceLogTailers_NilBufferIsNoOp guards against a panic if a
+// caller forgets to construct the buffer before calling the tailer.
+// hydra/main.go always provides one but defensive.
+func TestStartServiceLogTailers_NilBufferIsNoOp(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Must not panic.
+	StartServiceLogTailers(ctx, nil, t.TempDir())
+}

--- a/api/pkg/hydra/log_tailer_test.go
+++ b/api/pkg/hydra/log_tailer_test.go
@@ -13,19 +13,24 @@ import (
 // TestStartServiceLogTailers_AppendsToBufferWithPrefix verifies the happy
 // path: a wrapper writes lines to /var/log/helix-services/<svc>.log,
 // hydra's tailer picks them up, and they appear in the LogBuffer with the
-// "[<svc>] " prefix the admin UI consumes.
+// "[<svc>] " prefix the admin UI consumes. ALSO verifies that lines
+// written BEFORE the tailer starts are still captured (review #4: the
+// cont-init.d wrappers run dockerd/heartbeat before hydra, so their
+// startup output is already on disk when the tailer opens the file).
 func TestStartServiceLogTailers_AppendsToBufferWithPrefix(t *testing.T) {
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "compose-manager.log")
 
-	// Create the file BEFORE starting the tailer to exercise the initial-
-	// scan code path. Append-mode so the tailer's seek-to-end positions
-	// just before any future writes.
-	f, err := os.OpenFile(logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
-	if err != nil {
-		t.Fatalf("create log file: %v", err)
+	// Pre-existing content written BEFORE the tailer starts. The tailer
+	// must replay this from the start of the file - it represents the
+	// boot-time output the operator most cares about for T-10-style debug.
+	preLines := []string{
+		"pre-tailer line 1: dockerd starting at t=0",
+		"pre-tailer line 2: NVIDIA runtime selected",
 	}
-	defer f.Close()
+	if err := os.WriteFile(logPath, []byte(strings.Join(preLines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("seed log file: %v", err)
+	}
 
 	buf := NewLogBuffer(64)
 
@@ -33,15 +38,22 @@ func TestStartServiceLogTailers_AppendsToBufferWithPrefix(t *testing.T) {
 	defer cancel()
 	StartServiceLogTailers(ctx, buf, dir)
 
-	// Give the tailer a moment to open the file + seek to end.
+	// Give the tailer a moment to open + read existing content.
 	time.Sleep(250 * time.Millisecond)
 
-	wantLines := []string{
-		"hello compose-manager",
-		"second line",
-		"third line with a UTF-8 char é",
+	// Now append more lines like a live producer would.
+	f, err := os.OpenFile(logPath, os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatalf("open for append: %v", err)
 	}
-	for _, line := range wantLines {
+	defer f.Close()
+
+	liveLines := []string{
+		"live line 1: compose-manager polling",
+		"live line 2: assignment fetched",
+		"live line 3 with UTF-8 char é",
+	}
+	for _, line := range liveLines {
 		if _, err := fmt.Fprintln(f, line); err != nil {
 			t.Fatalf("write line: %v", err)
 		}
@@ -50,24 +62,25 @@ func TestStartServiceLogTailers_AppendsToBufferWithPrefix(t *testing.T) {
 		t.Fatalf("sync: %v", err)
 	}
 
-	// Wait up to 3s for all lines to land in the buffer (poll interval
-	// is 500ms; 3s = 6 ticks of slack for CI jitter).
+	wantTotal := len(preLines) + len(liveLines)
 	deadline := time.Now().Add(3 * time.Second)
 	var snap []LogLine
 	for time.Now().Before(deadline) {
 		snap = buf.Snapshot(1024)
-		if len(snap) >= len(wantLines) {
+		if len(snap) >= wantTotal {
 			break
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	if len(snap) < len(wantLines) {
-		t.Fatalf("expected at least %d lines in buffer, got %d: %+v", len(wantLines), len(snap), snap)
+	if len(snap) < wantTotal {
+		t.Fatalf("expected at least %d lines in buffer (pre %d + live %d), got %d: %+v",
+			wantTotal, len(preLines), len(liveLines), len(snap), snap)
 	}
 
+	allWant := append(append([]string{}, preLines...), liveLines...)
 	prefix := "[compose-manager] "
-	for i, want := range wantLines {
+	for i, want := range allWant {
 		got := snap[i].Line
 		if !strings.HasPrefix(got, prefix) {
 			t.Errorf("line %d: expected prefix %q, got %q", i, prefix, got)
@@ -75,6 +88,69 @@ func TestStartServiceLogTailers_AppendsToBufferWithPrefix(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("line %d: expected to contain %q, got %q", i, want, got)
 		}
+	}
+}
+
+// TestTailServiceLog_PartialLinesAreBufferedAcrossPolls verifies the
+// review finding fix: a producer writing "foo " (no newline) followed
+// by "bar\n" later should produce ONE LogBuffer entry "foo bar", not
+// two fragments. The previous version of the tailer shipped the
+// partial on the first tick (bufio.ReadString returns content+EOF for
+// a partial), then shipped the rest on the next tick.
+func TestTailServiceLog_PartialLinesAreBufferedAcrossPolls(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "compose-manager.log")
+
+	if err := os.WriteFile(logPath, nil, 0o644); err != nil {
+		t.Fatalf("seed empty file: %v", err)
+	}
+
+	buf := NewLogBuffer(32)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	StartServiceLogTailers(ctx, buf, dir)
+	time.Sleep(250 * time.Millisecond)
+
+	f, err := os.OpenFile(logPath, os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatalf("open for append: %v", err)
+	}
+	defer f.Close()
+
+	// First half of the line - NO trailing newline. Producer hasn't
+	// flushed yet (think a docker pull progress bar mid-write).
+	if _, err := fmt.Fprint(f, "pulling layer abc... "); err != nil {
+		t.Fatalf("write partial: %v", err)
+	}
+	f.Sync()
+
+	// Let the tailer poll once (it will see the partial and buffer it).
+	time.Sleep(1 * time.Second)
+
+	// Second half + newline.
+	if _, err := fmt.Fprintln(f, "done in 42ms"); err != nil {
+		t.Fatalf("write completion: %v", err)
+	}
+	f.Sync()
+
+	// Wait for the combined line to land in the buffer.
+	deadline := time.Now().Add(3 * time.Second)
+	var snap []LogLine
+	for time.Now().Before(deadline) {
+		snap = buf.Snapshot(1024)
+		if len(snap) >= 1 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if len(snap) != 1 {
+		t.Fatalf("expected exactly 1 buffered line, got %d: %+v", len(snap), snap)
+	}
+	wantLine := "[compose-manager] pulling layer abc... done in 42ms"
+	if snap[0].Line != wantLine {
+		t.Fatalf("expected %q, got %q", wantLine, snap[0].Line)
 	}
 }
 

--- a/sandbox/04-start-dockerd.sh
+++ b/sandbox/04-start-dockerd.sh
@@ -128,9 +128,13 @@ fi
 # dockerd output in the admin Runner Logs WS stream. dockerd's output
 # is noisy but invaluable when image pulls fail or the inner daemon
 # misbehaves on a YD-allocated host (see T-10 family of issues).
-mkdir -p /var/log/helix-services
+# `|| true` + truncate-on-boot + SIGPIPE trap below: see
+# 12-start-compose-manager.sh for the rationale.
+mkdir -p /var/log/helix-services 2>/dev/null || true
+: > /var/log/helix-services/dockerd.log 2>/dev/null || true
 
 (
+    trap '' PIPE
     while true; do
         # Clean up stale PID files before each restart attempt
         rm -f /var/run/docker.pid /run/docker/containerd/containerd.pid 2>/dev/null || true

--- a/sandbox/04-start-dockerd.sh
+++ b/sandbox/04-start-dockerd.sh
@@ -123,6 +123,13 @@ fi
 
 # Start dockerd with auto-restart supervisor loop in background
 # This ensures dockerd restarts if it crashes (which would break all sandboxes)
+#
+# tee to /var/log/helix-services/dockerd.log so hydra's tailer surfaces
+# dockerd output in the admin Runner Logs WS stream. dockerd's output
+# is noisy but invaluable when image pulls fail or the inner daemon
+# misbehaves on a YD-allocated host (see T-10 family of issues).
+mkdir -p /var/log/helix-services
+
 (
     while true; do
         # Clean up stale PID files before each restart attempt
@@ -135,7 +142,7 @@ fi
         echo "[$(date -Iseconds)] ⚠️  dockerd exited with code $EXIT_CODE, restarting in 2s..."
         sleep 2
     done
-) 2>&1 | sed -u 's/^/[DOCKERD] /' &
+) 2>&1 | tee -a /var/log/helix-services/dockerd.log | sed -u 's/^/[DOCKERD] /' &
 
 DOCKERD_WRAPPER_PID=$!
 echo "Started dockerd with auto-restart (wrapper PID: $DOCKERD_WRAPPER_PID)"

--- a/sandbox/08-start-sandbox-heartbeat.sh
+++ b/sandbox/08-start-sandbox-heartbeat.sh
@@ -30,10 +30,13 @@ done
 # The daemon can be safely killed and will automatically restart within 2 seconds
 # tee to /var/log/helix-services/heartbeat.log so hydra's tailer surfaces
 # heartbeat output in the admin Runner Logs WS stream (see
-# 12-start-compose-manager.sh for the same pattern + rationale).
-mkdir -p /var/log/helix-services
+# 12-start-compose-manager.sh for the same pattern + rationale, plus
+# the `|| true` mkdir guard, truncate-on-boot, and SIGPIPE trap).
+mkdir -p /var/log/helix-services 2>/dev/null || true
+: > /var/log/helix-services/heartbeat.log 2>/dev/null || true
 
 (
+    trap '' PIPE
     while true; do
         echo "[$(date -Iseconds)] Starting heartbeat daemon..."
         /usr/local/bin/sandbox-heartbeat

--- a/sandbox/08-start-sandbox-heartbeat.sh
+++ b/sandbox/08-start-sandbox-heartbeat.sh
@@ -28,6 +28,11 @@ done
 # - Reports container disk usage
 # - Sends heartbeat every 30 seconds
 # The daemon can be safely killed and will automatically restart within 2 seconds
+# tee to /var/log/helix-services/heartbeat.log so hydra's tailer surfaces
+# heartbeat output in the admin Runner Logs WS stream (see
+# 12-start-compose-manager.sh for the same pattern + rationale).
+mkdir -p /var/log/helix-services
+
 (
     while true; do
         echo "[$(date -Iseconds)] Starting heartbeat daemon..."
@@ -36,7 +41,7 @@ done
         echo "[$(date -Iseconds)] ⚠️  Heartbeat daemon exited with code $EXIT_CODE, restarting in 2s..."
         sleep 2
     done
-) 2>&1 | sed -u 's/^/[HEARTBEAT] /' &
+) 2>&1 | tee -a /var/log/helix-services/heartbeat.log | sed -u 's/^/[HEARTBEAT] /' &
 
 HEARTBEAT_PID=$!
 echo "✅ Sandbox heartbeat daemon started with auto-restart (wrapper PID: $HEARTBEAT_PID)"

--- a/sandbox/12-start-compose-manager.sh
+++ b/sandbox/12-start-compose-manager.sh
@@ -15,6 +15,13 @@ fi
 SANDBOX_INSTANCE_ID=${SANDBOX_INSTANCE_ID:-local}
 echo "🧱 Starting compose-manager for sandbox: $SANDBOX_INSTANCE_ID"
 
+# Ensure the per-service log dir exists. Hydra's tailServiceLog reads
+# /var/log/helix-services/*.log and pushes each line into the LogBuffer
+# the admin Runner Logs WS streams from, so we tee into the file here
+# AND keep the existing sed-prefixed stdout for `docker logs` viewers
+# on docker-compose-style deployments.
+mkdir -p /var/log/helix-services
+
 # The compose-manager polls /api/v1/runners/{id}/assignment and applies
 # the assigned profile by running `docker compose` against the inner
 # dockerd. Auto-restart on crash.
@@ -31,7 +38,7 @@ echo "🧱 Starting compose-manager for sandbox: $SANDBOX_INSTANCE_ID"
         echo "[$(date -Iseconds)] ⚠️  compose-manager exited with $EXIT_CODE, restarting in 2s..."
         sleep 2
     done
-) 2>&1 | sed -u 's/^/[COMPOSE-MGR] /' &
+) 2>&1 | tee -a /var/log/helix-services/compose-manager.log | sed -u 's/^/[COMPOSE-MGR] /' &
 
 CM_PID=$!
 echo "✅ compose-manager started with auto-restart (wrapper PID: $CM_PID)"

--- a/sandbox/12-start-compose-manager.sh
+++ b/sandbox/12-start-compose-manager.sh
@@ -20,12 +20,33 @@ echo "🧱 Starting compose-manager for sandbox: $SANDBOX_INSTANCE_ID"
 # the admin Runner Logs WS streams from, so we tee into the file here
 # AND keep the existing sed-prefixed stdout for `docker logs` viewers
 # on docker-compose-style deployments.
-mkdir -p /var/log/helix-services
+#
+# `|| true` guards: this script is `source`d by entrypoint.sh under
+# `set -e`, so a hostile filesystem (readonly /var, mount race) would
+# otherwise abort container init. The tee inside the pipeline below
+# will surface the same error if it can't write, but failures there
+# don't kill the supervisor (see SIGPIPE trap rationale below).
+mkdir -p /var/log/helix-services 2>/dev/null || true
+# Truncate-on-boot so the file always starts empty for this container's
+# lifetime. Hydra's tailer reads from the START of the file, so this
+# both (a) avoids replaying a previous container's logs (the file lives
+# on the container layer; not persisted across recreates anyway, but
+# defensive) and (b) ensures dockerd/heartbeat startup output - which
+# is written BEFORE hydra boots in 10-start-hydra.sh - is captured
+# from t=0 once hydra's tailer attaches a moment later.
+: > /var/log/helix-services/compose-manager.log 2>/dev/null || true
 
 # The compose-manager polls /api/v1/runners/{id}/assignment and applies
 # the assigned profile by running `docker compose` against the inner
 # dockerd. Auto-restart on crash.
 (
+    # Ignore SIGPIPE inside the supervisor: if `tee` or `sed` downstream
+    # dies (file unwritable, FD exhausted, mount drops mid-run), the
+    # next write inside this loop would otherwise SIGPIPE and kill the
+    # supervisor, leaving compose-manager permanently dead. Trapping
+    # PIPE means individual writes silently fail but the loop keeps
+    # restarting compose-manager forever.
+    trap '' PIPE
     while true; do
         echo "[$(date -Iseconds)] Starting compose-manager..."
         HELIX_RUNNER_ID="$SANDBOX_INSTANCE_ID" \

--- a/sandbox/14-start-inference-proxy.sh
+++ b/sandbox/14-start-inference-proxy.sh
@@ -14,10 +14,13 @@ echo "🚦 Starting inference-proxy on $LISTEN (active.yaml: $ACTIVE_YAML)"
 
 # tee to /var/log/helix-services/inference-proxy.log so hydra's tailer
 # can pick these lines up into the admin Runner Logs WS stream (see
-# 12-start-compose-manager.sh for the same pattern + rationale).
-mkdir -p /var/log/helix-services
+# 12-start-compose-manager.sh for the same pattern + rationale, plus
+# the `|| true` mkdir guard, truncate-on-boot, and SIGPIPE trap).
+mkdir -p /var/log/helix-services 2>/dev/null || true
+: > /var/log/helix-services/inference-proxy.log 2>/dev/null || true
 
 (
+    trap '' PIPE
     while true; do
         echo "[$(date -Iseconds)] Starting inference-proxy..."
         /usr/local/bin/inference-proxy --listen "$LISTEN" --compose "$ACTIVE_YAML"

--- a/sandbox/14-start-inference-proxy.sh
+++ b/sandbox/14-start-inference-proxy.sh
@@ -12,6 +12,11 @@ ACTIVE_YAML=${HELIX_RUNNER_ACTIVE_YAML:-/etc/helix/active.yaml}
 
 echo "🚦 Starting inference-proxy on $LISTEN (active.yaml: $ACTIVE_YAML)"
 
+# tee to /var/log/helix-services/inference-proxy.log so hydra's tailer
+# can pick these lines up into the admin Runner Logs WS stream (see
+# 12-start-compose-manager.sh for the same pattern + rationale).
+mkdir -p /var/log/helix-services
+
 (
     while true; do
         echo "[$(date -Iseconds)] Starting inference-proxy..."
@@ -20,7 +25,7 @@ echo "🚦 Starting inference-proxy on $LISTEN (active.yaml: $ACTIVE_YAML)"
         echo "[$(date -Iseconds)] ⚠️  inference-proxy exited with $EXIT_CODE, restarting in 2s..."
         sleep 2
     done
-) 2>&1 | sed -u 's/^/[INF-PROXY] /' &
+) 2>&1 | tee -a /var/log/helix-services/inference-proxy.log | sed -u 's/^/[INF-PROXY] /' &
 
 PROXY_PID=$!
 echo "✅ inference-proxy started with auto-restart (wrapper PID: $PROXY_PID)"


### PR DESCRIPTION
## Summary

- Tail each long-running service's stdout (compose-manager, inference-proxy, sandbox-heartbeat, dockerd) into hydra's existing `LogBuffer` so the admin Runner Logs WS view surfaces all of them, not just hydra's own zerolog.
- Implementation: each cont-init.d wrapper now also `tee -a`'s into a per-service file at `/var/log/helix-services/<svc>.log`; hydra on startup launches one goroutine per file that tails it and writes lines into the LogBuffer with a `[<svc>] ` prefix.
- Zero operator config, no new endpoints, no S3 round-trip.

## Why

Today the admin Runner Logs view only shows hydra's own log. Everything else inside helix-sandbox is invisible. On docker-compose deployments this is recoverable (operator can `docker logs helix-sandbox-nvidia-1`); on YD-allocated EC2 it's not (no public IP, no SSM access on the YD subaccount). When something dies inside helix-sandbox (compose-manager going silent after ~75s on YD-backed compute, see T-10) we have no observability without this fix.

S3 stdout capture on task completion was the alternative; this is strictly better for live debugging and avoids the operator-supplied S3-URL env var that fix would require (YD's API doesn't expose the `dataClient.remote` config so we'd have to plumb it from outside).

## Test plan

- [x] `go build ./...` clean
- [x] Three new unit tests in `api/pkg/hydra/log_tailer_test.go` covering happy path, late-arriving file (rescan), and nil-buffer defensive guard - all pass locally
- [x] Hydra package tests pass apart from a pre-existing ZFS test that doesn't run on macOS
- [ ] Drone CI green
- [ ] Smoke test on prime: rebuild helix-sandbox, watch admin Runner Logs while assigning a profile - should see `[compose-manager]`, `[dockerd]` prefixed lines live
- [ ] Smoke test on yd: roll a new helix-sandbox WR with the new image - watch admin Runner Logs as compose-manager spins up to capture its last words live (the T-10 diagnostic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)