### PR TITLE
fix(api): filter chat model picker to only routeable models

### DIFF
--- a/api/pkg/openai/helix_openai_server.go
+++ b/api/pkg/openai/helix_openai_server.go
@@ -91,8 +91,13 @@ func (c *InternalHelixServer) ListModels(ctx context.Context) ([]types.OpenAIMod
 	var models []types.OpenAIModel
 	served := make(map[string]bool) // model IDs already in the response
 	for _, model := range helixModels {
-		// Skip embedding models as they should not appear in chat model pickers
+		// Skip embedding models as they should not appear in chat model pickers.
+		// Mark served BEFORE the continue: otherwise the router-only union loop
+		// below re-synthesizes the same id as a chat model, defeating the
+		// embed filter (e.g. an embedding model surfaced by a profile that's
+		// also registered in the DB would reappear in the chat picker).
 		if model.Type == types.ModelTypeEmbed {
+			served[model.ID] = true
 			continue
 		}
 

--- a/api/pkg/openai/helix_openai_server.go
+++ b/api/pkg/openai/helix_openai_server.go
@@ -79,7 +79,13 @@ func (c *InternalHelixServer) ListModels(ctx context.Context) ([]types.OpenAIMod
 		return nil, fmt.Errorf("error listing models: %w", err)
 	}
 
-	// Get available models from runners to filter dead models
+	// Filter to only models a connected runner can actually serve right now.
+	// Pre-pivot we kept VLLM rows in the picker even when no runner had them
+	// loaded, on the assumption the scheduler would pull-and-start on demand.
+	// Post-sandbox-absorbs-runner that's no longer true: a VLLM model only
+	// runs if it's in an active Runner Profile on a connected runner. Showing
+	// it in the picker otherwise just leads to "model X is not available"
+	// errors when the user picks it (NoRunnerError in inferencerouter).
 	availableModels := c.getAvailableModelsFromRunners()
 
 	var models []types.OpenAIModel
@@ -90,23 +96,12 @@ func (c *InternalHelixServer) ListModels(ctx context.Context) ([]types.OpenAIMod
 			continue
 		}
 
-		// Only include models that are actually available on connected runners
-		// For VLLM models, we are more permissive since they're started dynamically
-		isAvailable := availableModels[model.ID]
-		if !isAvailable && model.Runtime != types.RuntimeVLLM {
+		if !availableModels[model.ID] {
 			log.Debug().
 				Str("model_id", model.ID).
 				Str("runtime", string(model.Runtime)).
 				Msg("Filtering out model not available on any runner")
 			continue
-		}
-
-		// For VLLM models, log if they're not available (for debugging) but still include them
-		if !isAvailable && model.Runtime == types.RuntimeVLLM {
-			log.Debug().
-				Str("model_id", model.ID).
-				Str("runtime", string(model.Runtime)).
-				Msg("VLLM model not currently reported as available, but including anyway (will be started dynamically)")
 		}
 
 		openAIModel := types.OpenAIModel{

--- a/api/pkg/openai/helix_openai_server_list_models_test.go
+++ b/api/pkg/openai/helix_openai_server_list_models_test.go
@@ -39,7 +39,6 @@ func TestListModels_FiltersOutModelsNoRunnerCanServe(t *testing.T) {
 	rtr := inferencerouter.NewRouter()
 	rtr.SetRunnerState(&inferencerouter.RunnerState{
 		ID:     "runner-1",
-		URL:    "http://10.0.0.5",
 		Status: "running",
 		ActiveProfile: &types.RunnerProfile{
 			ID:   "rprof_qwen_0_5b",
@@ -82,7 +81,6 @@ func TestListModels_FiltersOutModelsWhenRunnerNotRunning(t *testing.T) {
 	rtr := inferencerouter.NewRouter()
 	rtr.SetRunnerState(&inferencerouter.RunnerState{
 		ID:     "runner-1",
-		URL:    "http://10.0.0.5",
 		Status: "pulling",
 		ActiveProfile: &types.RunnerProfile{
 			Models: []types.ProfileModel{

--- a/api/pkg/openai/helix_openai_server_list_models_test.go
+++ b/api/pkg/openai/helix_openai_server_list_models_test.go
@@ -98,6 +98,108 @@ func TestListModels_FiltersOutModelsWhenRunnerNotRunning(t *testing.T) {
 		"a runner that isn't running can't route; its profile must not populate the picker")
 }
 
+// TestListModels_FiltersOllamaSameAsVLLM ensures the filter applies
+// uniformly to ALL runtimes, not just VLLM. Pre-fix, only VLLM rows
+// had the special-case exemption that let them slip through when no
+// runner served them. The fix removed the runtime branch, so an Ollama
+// row that no runner serves must also be filtered.
+func TestListModels_FiltersOllamaSameAsVLLM(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockStore.EXPECT().ListModels(gomock.Any(), gomock.Any()).Return([]*types.Model{
+		{ID: "llama3.2:1b", Type: types.ModelTypeChat, Runtime: types.RuntimeOllama, Enabled: true},
+		{ID: "qwen2.5-0.5b", Type: types.ModelTypeChat, Runtime: types.RuntimeVLLM, Enabled: true},
+	}, nil)
+
+	rtr := inferencerouter.NewRouter()
+	rtr.SetRunnerState(&inferencerouter.RunnerState{
+		ID:     "runner-1",
+		Status: "running",
+		ActiveProfile: &types.RunnerProfile{
+			Models: []types.ProfileModel{
+				{Name: "qwen2.5-0.5b"},
+			},
+		},
+	})
+
+	srv := NewInternalHelixServer(&config.ServerConfig{}, mockStore, nil)
+	srv.SetInferenceRouter(rtr)
+
+	models, err := srv.ListModels(context.Background())
+	require.NoError(t, err)
+	ids := make([]string, 0, len(models))
+	for _, m := range models {
+		ids = append(ids, m.ID)
+	}
+	require.ElementsMatch(t, []string{"qwen2.5-0.5b"}, ids,
+		"Ollama rows with no runner serving them must be filtered the same as VLLM rows")
+}
+
+// TestListModels_PreservesDBFieldsWhenAlsoInRouter is the regression
+// guard for the embed-leak fix: when a model appears in BOTH the DB and
+// the router, the DB row's metadata (Name, Description, ContextLength,
+// Type) must be used, NOT the router's synthesized chat default. Also
+// pins the embed-leak fix: an embedding model that's both DB-registered
+// AND surfaced by a profile must be excluded from the chat picker.
+func TestListModels_PreservesDBFieldsWhenAlsoInRouter(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockStore.EXPECT().ListModels(gomock.Any(), gomock.Any()).Return([]*types.Model{
+		{
+			ID:            "qwen2.5-0.5b",
+			Name:          "Qwen 2.5 0.5B",
+			Description:   "Small VLLM chat model",
+			ContextLength: 32768,
+			Type:          types.ModelTypeChat,
+			Runtime:       types.RuntimeVLLM,
+			Enabled:       true,
+		},
+		{
+			ID:      "bge-embed",
+			Type:    types.ModelTypeEmbed, // explicit embed type
+			Runtime: types.RuntimeVLLM,
+			Enabled: true,
+		},
+	}, nil)
+
+	rtr := inferencerouter.NewRouter()
+	rtr.SetRunnerState(&inferencerouter.RunnerState{
+		ID:     "runner-1",
+		Status: "running",
+		ActiveProfile: &types.RunnerProfile{
+			Models: []types.ProfileModel{
+				{Name: "qwen2.5-0.5b"},
+				{Name: "bge-embed"}, // ALSO surfaced by the profile
+			},
+		},
+	})
+
+	srv := NewInternalHelixServer(&config.ServerConfig{}, mockStore, nil)
+	srv.SetInferenceRouter(rtr)
+
+	models, err := srv.ListModels(context.Background())
+	require.NoError(t, err)
+
+	var chat *types.OpenAIModel
+	for i := range models {
+		if models[i].ID == "qwen2.5-0.5b" {
+			chat = &models[i]
+		}
+		if models[i].ID == "bge-embed" {
+			t.Fatalf("embed model bge-embed must be excluded from the chat picker "+
+				"even though it's surfaced by the active profile; got %+v", models[i])
+		}
+	}
+	require.NotNil(t, chat, "expected qwen2.5-0.5b in the picker")
+	require.Equal(t, "Qwen 2.5 0.5B", chat.Name, "DB Name field must be preserved")
+	require.Equal(t, "Small VLLM chat model", chat.Description, "DB Description must be preserved")
+	require.Equal(t, 32768, chat.ContextLength, "DB ContextLength must be preserved (the union-only path synthesizes 0)")
+}
+
 // TestListModels_NilRouterReturnsEmpty guards the partially-constructed
 // server case (SetInferenceRouter not called yet). Returning ALL DB models
 // here would re-introduce the original bug at cold start.

--- a/api/pkg/openai/helix_openai_server_list_models_test.go
+++ b/api/pkg/openai/helix_openai_server_list_models_test.go
@@ -1,0 +1,121 @@
+package openai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/inferencerouter"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// TestListModels_FiltersOutModelsNoRunnerCanServe is the regression test for
+// the picker-vs-router mismatch we hit on yd.helix.ml on 2026-06-17. A user
+// could pick Qwen2.5-VL-3B-Instruct from the dropdown even though the only
+// connected runner had qwen2.5-0.5b in its active Runner Profile. The chat
+// then errored with "model X is not available (currently configured: Y)"
+// from the inferencerouter.
+//
+// Pre-fix: ListModels included VLLM rows even when no runner had them in
+// an active profile, on the theory the scheduler would pull-and-start them
+// on demand. Post-sandbox-absorbs-runner pivot that's false: a VLLM model
+// only runs if it's in an active Runner Profile. The picker has to mirror
+// what the router can actually route.
+func TestListModels_FiltersOutModelsNoRunnerCanServe(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockStore.EXPECT().ListModels(gomock.Any(), gomock.Any()).Return([]*types.Model{
+		{ID: "qwen2.5-0.5b", Type: types.ModelTypeChat, Runtime: types.RuntimeVLLM, Enabled: true},
+		{ID: "Qwen/Qwen2.5-VL-3B-Instruct", Type: types.ModelTypeChat, Runtime: types.RuntimeVLLM, Enabled: true},
+		{ID: "Qwen/Qwen2.5-VL-7B-Instruct", Type: types.ModelTypeChat, Runtime: types.RuntimeVLLM, Enabled: true},
+		{ID: "BAAI/bge-small-en", Type: types.ModelTypeEmbed, Runtime: types.RuntimeVLLM, Enabled: true},
+	}, nil)
+
+	rtr := inferencerouter.NewRouter()
+	rtr.SetRunnerState(&inferencerouter.RunnerState{
+		ID:     "runner-1",
+		URL:    "http://10.0.0.5",
+		Status: "running",
+		ActiveProfile: &types.RunnerProfile{
+			ID:   "rprof_qwen_0_5b",
+			Name: "qwen-0.5b",
+			Models: []types.ProfileModel{
+				{Name: "qwen2.5-0.5b", ContainerName: "vllm-tiny", InternalPort: 8000},
+			},
+		},
+	})
+
+	srv := NewInternalHelixServer(&config.ServerConfig{}, mockStore, nil)
+	srv.SetInferenceRouter(rtr)
+
+	models, err := srv.ListModels(context.Background())
+	require.NoError(t, err)
+
+	ids := make([]string, 0, len(models))
+	for _, m := range models {
+		ids = append(ids, m.ID)
+	}
+	require.ElementsMatch(t, []string{"qwen2.5-0.5b"}, ids,
+		"picker must only include models a connected runner can serve right now; "+
+			"VLLM rows that aren't in any active profile MUST be filtered (the bug fixed here)")
+}
+
+// TestListModels_FiltersOutModelsWhenRunnerNotRunning verifies that a runner
+// in pulling/starting/assigning state contributes nothing to the picker.
+// Otherwise we'd advertise a model that PickRunner can't actually pick yet
+// (RouteableModels gates on Status=="running"), and the user would still hit
+// "model X is not available".
+func TestListModels_FiltersOutModelsWhenRunnerNotRunning(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockStore.EXPECT().ListModels(gomock.Any(), gomock.Any()).Return([]*types.Model{
+		{ID: "qwen2.5-0.5b", Type: types.ModelTypeChat, Runtime: types.RuntimeVLLM, Enabled: true},
+	}, nil)
+
+	rtr := inferencerouter.NewRouter()
+	rtr.SetRunnerState(&inferencerouter.RunnerState{
+		ID:     "runner-1",
+		URL:    "http://10.0.0.5",
+		Status: "pulling",
+		ActiveProfile: &types.RunnerProfile{
+			Models: []types.ProfileModel{
+				{Name: "qwen2.5-0.5b"},
+			},
+		},
+	})
+
+	srv := NewInternalHelixServer(&config.ServerConfig{}, mockStore, nil)
+	srv.SetInferenceRouter(rtr)
+
+	models, err := srv.ListModels(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, models,
+		"a runner that isn't running can't route; its profile must not populate the picker")
+}
+
+// TestListModels_NilRouterReturnsEmpty guards the partially-constructed
+// server case (SetInferenceRouter not called yet). Returning ALL DB models
+// here would re-introduce the original bug at cold start.
+func TestListModels_NilRouterReturnsEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	mockStore.EXPECT().ListModels(gomock.Any(), gomock.Any()).Return([]*types.Model{
+		{ID: "qwen2.5-0.5b", Type: types.ModelTypeChat, Runtime: types.RuntimeVLLM, Enabled: true},
+	}, nil)
+
+	srv := NewInternalHelixServer(&config.ServerConfig{}, mockStore, nil)
+	// deliberately no SetInferenceRouter
+
+	models, err := srv.ListModels(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, models, "with no router, nothing is routeable, so the picker must be empty")
+}

--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -276,6 +276,17 @@ func (s *HelixAPIServer) listProviderEndpoints(rw http.ResponseWriter, r *http.R
 // doesn't empty the model picker for every UI page — see getProviderModels.
 const modelCacheTTL = 1 * time.Hour
 
+// emptyModelCacheTTL is a much shorter TTL applied when an upstream
+// returned ZERO models. The long modelCacheTTL is safe for "here is the
+// list" answers, but pinning an empty list for 1h causes a cold-start
+// blackout: the Helix self-provider returns an empty list during the
+// brief window between API boot and the first sandbox heartbeat landing,
+// and an unlucky cache miss in that window would leave the model picker
+// empty for up to an hour after sandboxes came online. 30s lets the
+// picker recover within a single user retry without forcing every page
+// load to re-fetch.
+const emptyModelCacheTTL = 30 * time.Second
+
 // errUpstreamUnreachable marks refresh failures that came from the upstream
 // /v1/models call itself (not from provider client construction). Callers use
 // errors.Is to decide whether falling back to a cached payload is safe: an
@@ -443,7 +454,11 @@ func (s *HelixAPIServer) refreshProviderModels(ctx context.Context, providerEndp
 		if err != nil {
 			return nil, err
 		}
-		s.cache.SetWithTTL(key, string(payload), 1, modelCacheTTL)
+		ttl := modelCacheTTL
+		if len(models) == 0 {
+			ttl = emptyModelCacheTTL
+		}
+		s.cache.SetWithTTL(key, string(payload), 1, ttl)
 
 		return models, nil
 	})


### PR DESCRIPTION
## Summary

- Drop the VLLM exception in `InternalHelixServer.ListModels` that kept VLLM rows in the chat model picker even when no connected runner had them in an active Runner Profile.
- Filter all runtimes uniformly against `inferenceRouter.AvailableModels()`.
- Add regression tests covering the yd.helix.ml scenario, the runner-not-running case, and the nil-router cold-start guard.

## Why

Pre-sandbox-absorbs-runner pivot, the scheduler could pull-and-start a VLLM model on demand, so it was useful to show models the scheduler might satisfy later. Post-pivot, a VLLM model only runs if some Runner Profile is currently assigned that contains it. The exception just means the picker offers options that `NoRunnerError` rejects at routing time.

Hit on yd.helix.ml on 2026-06-17: a runner with the `qwen2.5-0.5b` profile loaded, picker still listed `Qwen/Qwen2.5-VL-3B-Instruct` (auto-seeded by `GetDefaultVLLMModels` in `api/pkg/model/models.go:392`). Picking it produced:

```
error enqueuing request: model "Qwen/Qwen2.5-VL-3B-Instruct" is not available (currently configured: qwen2.5-0.5b)
```

## Test plan

- [x] `go test -run TestListModels_ ./pkg/openai/` passes (three new tests)
- [x] `go build ./pkg/openai/ ./pkg/server/ ./pkg/inferencerouter/` clean
- [ ] Deploy to yd.helix.ml, confirm `Qwen2.5-VL-3B-Instruct` no longer appears in the picker when only `qwen2.5-0.5b` is loaded, and DOES appear if an operator assigns a profile containing it
- [ ] CI green

## Behaviour change to be aware of

The default VLLM models auto-seeded by `models.go:392/407` (`Qwen2.5-VL-3B`, `Qwen2.5-VL-7B`) will vanish from the chat picker on deployments whose active Runner Profile doesn't include them. That's the point — but users who relied on them being silently listed will see fewer options. No DB migration, env var, or API schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)