### PR TITLE
fix(compute): exclude Ready+offline rows from Floor count

### DIFF
--- a/api/pkg/sandbox/compute/manager.go
+++ b/api/pkg/sandbox/compute/manager.go
@@ -1027,14 +1027,10 @@ func isAvailable(r *types.SandboxInstance) bool {
 // every heartbeat in that window. A real flap (one missed beat) is
 // well inside the window and never triggers this.
 func isAliveForFloor(r *types.SandboxInstance) bool {
-	switch State(r.ComputeState) {
-	case StateProvisioning:
-		return true
-	case StateReady:
-		return r.Status == "online"
-	default:
-		return false
-	}
+	// Compose from isReadyAndOnline rather than re-inlining the
+	// (ready AND online) check so future tightening of one predicate
+	// propagates automatically instead of silently drifting.
+	return State(r.ComputeState) == StateProvisioning || isReadyAndOnline(r)
 }
 
 // isReadyState reports whether the row's ComputeState is Ready, ignoring

--- a/api/pkg/sandbox/compute/manager.go
+++ b/api/pkg/sandbox/compute/manager.go
@@ -628,12 +628,16 @@ func (m *Manager) tryDeprovisionIdle(ctx context.Context, rows []*types.SandboxI
 // and a row that timed out is no longer counted.
 func (m *Manager) computeNeeded(rows []*types.SandboxInstance) int {
 	available := 0
+	aliveForFloor := 0
 	readyOnlineCount := 0
 	readyCapacity := 0
 	readyDemand := 0
 	for _, r := range rows {
 		if isAvailable(r) {
 			available++
+		}
+		if isAliveForFloor(r) {
+			aliveForFloor++
 		}
 		if isReadyAndOnline(r) {
 			readyOnlineCount++
@@ -642,8 +646,13 @@ func (m *Manager) computeNeeded(rows []*types.SandboxInstance) int {
 		}
 	}
 
-	// Floor pressure: how many short of Floor are we?
-	floorNeed := m.cfg.Floor - available
+	// Floor pressure: how many short of Floor are we? Floor is the
+	// operator's guarantee of HEALTHY capacity, so Ready+offline rows
+	// (whose YD WR is dying and waiting for D4 to shed) do not count -
+	// see isAliveForFloor for the rationale. The Max ceiling further
+	// down still uses `available` so we don't double-provision during
+	// D4's shed cycle.
+	floorNeed := m.cfg.Floor - aliveForFloor
 	if floorNeed < 0 {
 		floorNeed = 0
 	}
@@ -961,17 +970,68 @@ func (m *Manager) provisionOne(ctx context.Context) error {
 	return nil
 }
 
-// isAvailable reports whether a row counts toward the Floor.
+// isAvailable reports whether a row counts as "owned by us, do not
+// double-provision while D4 sheds." Used for the Max ceiling, NOT for
+// the Floor calculation - see isAliveForFloor for that.
 //
 // Ready rows count (host is up and registered). Provisioning rows
 // also count (host is on its way) so we don't double-provision while
 // the first one is still booting. Failed and Terminated rows do not
 // count - they are dead and should be cleaned up by a follow-up
 // idle-deprovision pass.
+//
+// Note: Ready+offline rows count here even though they aren't
+// session-routable, because they're still consuming a YD WR (and the
+// AWS EC2 instance underneath it) until D4 sheds them. Provisioning
+// a replacement on top would temporarily push us past Max.
 func isAvailable(r *types.SandboxInstance) bool {
 	switch State(r.ComputeState) {
 	case StateReady, StateProvisioning:
 		return true
+	default:
+		return false
+	}
+}
+
+// isAliveForFloor reports whether a row should count toward the Floor.
+//
+// Unlike isAvailable (which is owner-scoped), this is health-scoped:
+// the Floor is the operator's guarantee of available capacity for
+// sandbox sessions, so an offline row - even one we own - does NOT
+// satisfy it. The sandbox-instance reaper (server/sandbox_instance_reaper.go)
+// flips status to "offline" once last_seen drifts past
+// HELIX_SANDBOX_STALE_THRESHOLD (default 5m). At that point the
+// underlying compute (YD WR + EC2) is either dead or unreachable, so
+// counting it toward Floor leaves the operator below their requested
+// healthy-capacity guarantee for an unbounded amount of time (until
+// D4 happens to shed it).
+//
+// Provisioning rows still count - the host is on its way and the
+// next cycle will see it Ready, so firing another Provision now would
+// be the same double-provision-during-boot bug isAvailable was
+// originally written to prevent.
+//
+// Why a separate predicate, not a tighter isAvailable:
+//
+//	A previous tightening of isAvailable to require Status=="online"
+//	broke the Max ceiling: D4's shed cycle takes one or two reconciles
+//	to run, and during that window the offline-Ready row stops counting
+//	against Max - so Reconcile fires a fresh Provision, then D4 fires
+//	a Deprovision, and we churn. Keeping isAvailable broad for the
+//	ceiling and using this narrower predicate for the Floor gets both
+//	behaviours: prompt replacement of dead hosts, no churn while D4
+//	is in flight.
+//
+// The reaper's 5-minute stale threshold IS the heartbeat-flap defence:
+// by the time status flips to "offline" the row has already missed
+// every heartbeat in that window. A real flap (one missed beat) is
+// well inside the window and never triggers this.
+func isAliveForFloor(r *types.SandboxInstance) bool {
+	switch State(r.ComputeState) {
+	case StateProvisioning:
+		return true
+	case StateReady:
+		return r.Status == "online"
 	default:
 		return false
 	}

--- a/api/pkg/sandbox/compute/manager_floor_offline_test.go
+++ b/api/pkg/sandbox/compute/manager_floor_offline_test.go
@@ -194,11 +194,20 @@ func TestReconcileFloor2MixedRows(t *testing.T) {
 // is unchanged. So a Ready+offline row that's also idle past
 // IdleTimeout still gets shed - this test pins that interaction so
 // any future tightening of isReadyState catches the regression.
+//
+// Floor=1 with one healthy companion (online) plus one dead row
+// (offline). aliveForFloor=1 so Floor is met (no D3 fire). D4's
+// internal Floor guard uses the broad readyCount (=2), so it sees
+// readyCount > Floor and is free to shed the offline row.
+//
+// Earlier version of this test used Floor=0, which vacuously skipped
+// D4's guard and so didn't actually exercise the interaction. See
+// reviewer finding 2026-06-17.
 func TestD4StillShedsReadyOfflineRow(t *testing.T) {
 	store := newFakeStore()
 	stub := NewStubProvider("stub")
 	m, err := NewManager(stub, store, ManagerConfig{
-		Floor:                   0,
+		Floor:                   1,
 		Max:                     0,
 		ReconcileInterval:       10 * time.Millisecond,
 		HealthCheckTimeout:      100 * time.Millisecond,
@@ -209,6 +218,14 @@ func TestD4StillShedsReadyOfflineRow(t *testing.T) {
 		t.Fatalf("NewManager: %v", err)
 	}
 
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-healthy",
+		Provider:        "stub",
+		ProviderID:      "wr-healthy",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		ActiveSandboxes: 0,
+	})
 	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
 		ID:              "sbx-dead",
 		Provider:        "stub",
@@ -231,7 +248,8 @@ func TestD4StillShedsReadyOfflineRow(t *testing.T) {
 	rows, _ := store.ListSandboxInstances(context.Background())
 	for _, r := range rows {
 		if r.ID == "sbx-dead" && r.ComputeState == string(StateReady) {
-			t.Fatalf("Ready+offline row should have been shed by D4; still Ready. all: %+v", rows)
+			t.Fatalf("Ready+offline row should have been shed by D4 (readyCount=2 > Floor=1); "+
+				"still Ready. all: %+v", rows)
 		}
 	}
 }
@@ -262,8 +280,13 @@ func TestComputeNeededFloorIgnoresOfflineRows(t *testing.T) {
 			wantNeed: 1,
 		},
 		{
-			name:     "provisioning row satisfies floor (in-flight)",
+			name:     "provisioning+offline satisfies floor (in-flight, not yet registered)",
 			row:      &types.SandboxInstance{Provider: "stub", ComputeState: string(StateProvisioning), Status: "offline"},
+			wantNeed: 0,
+		},
+		{
+			name:     "provisioning+online satisfies floor (regardless of status)",
+			row:      &types.SandboxInstance{Provider: "stub", ComputeState: string(StateProvisioning), Status: "online"},
 			wantNeed: 0,
 		},
 		{

--- a/api/pkg/sandbox/compute/manager_floor_offline_test.go
+++ b/api/pkg/sandbox/compute/manager_floor_offline_test.go
@@ -1,0 +1,285 @@
+package compute
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// TestReconcileReplacesReadyOfflineRow is the regression test for the
+// yd.helix.ml outage on 2026-06-17. Before the fix, isAvailable counted
+// a Ready+offline row toward the Floor, so when the sandbox-instance
+// reaper flipped a dead runner from "online" to "offline" the
+// ComputeManager kept thinking the Floor was satisfied and never
+// provisioned a replacement. Result: Floor=1 but 0 healthy runners,
+// indefinitely - until D4 happened to shed the dead row.
+//
+// Post-fix, isAliveForFloor excludes Ready+offline rows, so the very
+// next Reconcile cycle sees the gap and submits a new Provision.
+func TestReconcileReplacesReadyOfflineRow(t *testing.T) {
+	m, _, store := newTestManager(t, 1)
+
+	// Seed a row that the reaper has already flipped to offline. It's
+	// still owned by our Provider (compute_state=ready) but its YD WR
+	// is dead. This is exactly the state sbx_99c93f07 was in on yd.helix.ml.
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:           "sbx-dead",
+		Provider:     "stub",
+		ProviderID:   "wr-dead",
+		ComputeState: string(StateReady),
+		Status:       "offline",
+	})
+
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	rows, _ := store.ListSandboxInstances(context.Background())
+	stubProvisioning := 0
+	for _, r := range rows {
+		if r.Provider == "stub" && r.ComputeState == string(StateProvisioning) {
+			stubProvisioning++
+		}
+	}
+	if stubProvisioning != 1 {
+		t.Fatalf("Floor=1 with 1 Ready+offline row should provision a replacement; "+
+			"expected 1 provisioning stub row, got %d. all rows: %+v",
+			stubProvisioning, rows)
+	}
+}
+
+// TestReconcileDoesNotDoubleProvisionDuringD4Shed ensures the fix
+// doesn't over-correct. If a Ready+offline row exists AND we've
+// already provisioned a replacement (so Floor is met by the new
+// provisioning row), Reconcile must NOT provision a SECOND replacement
+// just because the offline row still sits there.
+//
+// This is the case the comments on isAvailable describe: keeping
+// Ready+offline rows in the Max ceiling prevents churn while D4 sheds
+// the dead row asynchronously.
+func TestReconcileDoesNotDoubleProvisionDuringD4Shed(t *testing.T) {
+	m, _, store := newTestManager(t, 1)
+
+	// Dead row that's about to be shed.
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:           "sbx-dead",
+		Provider:     "stub",
+		ProviderID:   "wr-dead",
+		ComputeState: string(StateReady),
+		Status:       "offline",
+	})
+	// Replacement already in flight (previous Reconcile fired this).
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:           "sbx-replacement",
+		Provider:     "stub",
+		ProviderID:   "wr-new",
+		ComputeState: string(StateProvisioning),
+		Status:       "offline", // not online until it registers
+	})
+
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	rows, _ := store.ListSandboxInstances(context.Background())
+	provisioningCount := 0
+	for _, r := range rows {
+		if r.Provider == "stub" && r.ComputeState == string(StateProvisioning) {
+			provisioningCount++
+		}
+	}
+	if provisioningCount != 1 {
+		t.Fatalf("with one dead row + one in-flight replacement, Reconcile must NOT "+
+			"fire a third Provision; expected 1 provisioning row, got %d. all rows: %+v",
+			provisioningCount, rows)
+	}
+}
+
+// TestReconcileMaxCeilingHonoursOwnedOfflineRows confirms the
+// counterpart of the Floor-predicate split: the Max ceiling still
+// counts Ready+offline rows as "owned." Without this, an operator who
+// set Floor=0 / Max=1 would see endless churn (Ready+offline row
+// stops counting against Max -> Reconcile fires Provision -> D4
+// fires Deprovision -> repeat).
+//
+// Distinct from TestReconcileDoesNotDoubleProvisionDuringD4Shed
+// (which conflates the Floor-met-by-provisioning-row case): here Floor=0
+// so no Floor pressure exists at all, isolating the Max-ceiling
+// behaviour.
+func TestReconcileMaxCeilingHonoursOwnedOfflineRows(t *testing.T) {
+	store := newFakeStore()
+	stub := NewStubProvider("stub")
+	m, err := NewManager(stub, store, ManagerConfig{
+		Floor:                   0,
+		Max:                     1,
+		ScaleUpHeadroomMin:      1,
+		MaxConcurrentProvisions: 1,
+		ReconcileInterval:       10 * time.Millisecond,
+		HealthCheckTimeout:      100 * time.Millisecond,
+		IdleTimeout:             time.Hour, // disable D4 for this test
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:           "sbx-dead",
+		Provider:     "stub",
+		ProviderID:   "wr-dead",
+		ComputeState: string(StateReady),
+		Status:       "offline",
+	})
+
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	rows, _ := store.ListSandboxInstances(context.Background())
+	provisioningCount := 0
+	for _, r := range rows {
+		if r.Provider == "stub" && r.ComputeState == string(StateProvisioning) {
+			provisioningCount++
+		}
+	}
+	if provisioningCount != 0 {
+		t.Fatalf("Floor=0 Max=1 with 1 Ready+offline row owned by us must NOT provision "+
+			"a replacement (would breach Max during D4 shed); got %d provisioning rows. all: %+v",
+			provisioningCount, rows)
+	}
+}
+
+// TestReconcileFloor2MixedRows locks in the count math when the input
+// is a mix of Ready+online and Ready+offline rows. Floor=2, one online
+// row, one offline row -> aliveForFloor=1, floorNeed=1, exactly one
+// Provision (not two, not zero).
+func TestReconcileFloor2MixedRows(t *testing.T) {
+	m, _, store := newTestManager(t, 2)
+
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:           "sbx-healthy",
+		Provider:     "stub",
+		ProviderID:   "wr-healthy",
+		ComputeState: string(StateReady),
+		Status:       "online",
+	})
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:           "sbx-dead",
+		Provider:     "stub",
+		ProviderID:   "wr-dead",
+		ComputeState: string(StateReady),
+		Status:       "offline",
+	})
+
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	rows, _ := store.ListSandboxInstances(context.Background())
+	provisioningCount := 0
+	for _, r := range rows {
+		if r.Provider == "stub" && r.ComputeState == string(StateProvisioning) {
+			provisioningCount++
+		}
+	}
+	if provisioningCount != 1 {
+		t.Fatalf("Floor=2 with 1 online + 1 offline should fire exactly 1 Provision; "+
+			"got %d. all rows: %+v", provisioningCount, rows)
+	}
+}
+
+// TestD4StillShedsReadyOfflineRow confirms the Floor-predicate split
+// doesn't strand dead rows. D4 keys off isReadyState (broad), which
+// is unchanged. So a Ready+offline row that's also idle past
+// IdleTimeout still gets shed - this test pins that interaction so
+// any future tightening of isReadyState catches the regression.
+func TestD4StillShedsReadyOfflineRow(t *testing.T) {
+	store := newFakeStore()
+	stub := NewStubProvider("stub")
+	m, err := NewManager(stub, store, ManagerConfig{
+		Floor:                   0,
+		Max:                     0,
+		ReconcileInterval:       10 * time.Millisecond,
+		HealthCheckTimeout:      100 * time.Millisecond,
+		IdleTimeout:             1 * time.Millisecond,
+		MaxConcurrentProvisions: 1,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-dead",
+		Provider:        "stub",
+		ProviderID:      "wr-dead",
+		ComputeState:    string(StateReady),
+		Status:          "offline",
+		ActiveSandboxes: 0,
+	})
+
+	// First Reconcile arms the idle tracker. Second (after IdleTimeout
+	// expires) sheds.
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile arm: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile shed: %v", err)
+	}
+
+	rows, _ := store.ListSandboxInstances(context.Background())
+	for _, r := range rows {
+		if r.ID == "sbx-dead" && r.ComputeState == string(StateReady) {
+			t.Fatalf("Ready+offline row should have been shed by D4; still Ready. all: %+v", rows)
+		}
+	}
+}
+
+// TestComputeNeededFloorIgnoresOfflineRows is a direct unit test on
+// computeNeeded covering the predicate boundary. Tested:
+//
+//   - Ready+online row    -> counts toward Floor          (the healthy case)
+//   - Ready+offline row   -> does NOT count toward Floor  (the bug fix)
+//   - Provisioning row    -> counts toward Floor          (in-flight, don't double-provision)
+//   - Failed row          -> does not count               (dead, D4 will clean it up)
+func TestComputeNeededFloorIgnoresOfflineRows(t *testing.T) {
+	cases := []struct {
+		name string
+		row  *types.SandboxInstance
+		// wantNeed is the result of computeNeeded with Floor=1 and just this row.
+		// 0 = row covers the floor; 1 = floor still needs filling.
+		wantNeed int
+	}{
+		{
+			name:     "ready+online satisfies floor",
+			row:      &types.SandboxInstance{Provider: "stub", ComputeState: string(StateReady), Status: "online"},
+			wantNeed: 0,
+		},
+		{
+			name:     "ready+offline does NOT satisfy floor (regression)",
+			row:      &types.SandboxInstance{Provider: "stub", ComputeState: string(StateReady), Status: "offline"},
+			wantNeed: 1,
+		},
+		{
+			name:     "provisioning row satisfies floor (in-flight)",
+			row:      &types.SandboxInstance{Provider: "stub", ComputeState: string(StateProvisioning), Status: "offline"},
+			wantNeed: 0,
+		},
+		{
+			name:     "failed row does NOT satisfy floor",
+			row:      &types.SandboxInstance{Provider: "stub", ComputeState: string(StateFailed), Status: "offline"},
+			wantNeed: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _, _ := newTestManager(t, 1)
+			got := m.computeNeeded([]*types.SandboxInstance{tc.row})
+			if got != tc.wantNeed {
+				t.Fatalf("computeNeeded(%s) = %d, want %d", tc.name, got, tc.wantNeed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Split `isAvailable` (ready OR provisioning) into two predicates: `isAvailable` (unchanged, for Max ceiling) and `isAliveForFloor` (new, for Floor calc). Ready+offline rows no longer satisfy Floor.
- Five regression tests pin the new behaviour and the unchanged interactions (Max ceiling, D4 shed, mixed-row counting).

## Why

`api/pkg/sandbox/compute/manager.go:971` counted any row with `compute_state ∈ {ready, provisioning}` as alive for Floor — `Status` was ignored entirely. The sandbox-instance reaper at `api/pkg/server/sandbox_instance_reaper.go` flips `status` to `offline` once `last_seen` drifts past `HELIX_SANDBOX_STALE_THRESHOLD` (default 5m), but leaves `compute_state=ready` alone. So a dead runner kept counting toward Floor indefinitely — until D4's idle deprovisioner happened to shed it.

Hit on yd.helix.ml on 2026-06-17: Floor=1, the one runner went offline, the reaper flipped it correctly, but ComputeManager kept thinking the cluster was full and never submitted a replacement Work Requirement. The user had to terminate the entire Compute Requirement to recover.

## The split

| Predicate | What it answers | Used by |
|---|---|---|
| `isAvailable` (unchanged) | "Is this row owned by us and not-yet-cleaned?" | Max ceiling. Keeps Ready+offline rows counted so we don't push past Max while D4's shed cycle is in flight. |
| `isAliveForFloor` (new) | "Is this row healthy?" | Floor calculation. Excludes Ready+offline so the reaper's status flip immediately triggers a replacement. |
| `isReadyAndOnline` (unchanged) | "Can this row serve traffic right now?" | D3 demand math. |
| `isReadyState` (unchanged) | "Is this a shed candidate?" | D4 idle deprovisioner. |

## Heartbeat-flap safety

The earlier ultrareview-fixup-of-the-fixup (visible in the existing `isReadyAndOnline` comment) was a separate tightening that broke D4's idle-tracker prune. This change does NOT touch any D4 predicate and adds a parallel predicate rather than tightening an existing one.

For Floor itself, the reaper's 5-minute stale threshold is the heartbeat-flap defence: `status` only flips after every beat in a 5-minute window has been missed. A real flap stays well inside that window and never triggers replacement.

## Test plan

- [x] `go test ./pkg/sandbox/compute/...` passes (all 5 new tests + existing suite)
- [x] `go vet ./pkg/sandbox/compute/` clean
- [ ] CI green
- [ ] Deploy to yd.helix.ml, terminate the runner pool, watch ComputeManager re-provision within the reconcile interval after reaper flips the row offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)