### PR TITLE
fix(sandbox): line-buffer tee so service logs reach admin Runner Logs

### DIFF
--- a/sandbox/04-start-dockerd.sh
+++ b/sandbox/04-start-dockerd.sh
@@ -146,7 +146,7 @@ mkdir -p /var/log/helix-services 2>/dev/null || true
         echo "[$(date -Iseconds)] ⚠️  dockerd exited with code $EXIT_CODE, restarting in 2s..."
         sleep 2
     done
-) 2>&1 | tee -a /var/log/helix-services/dockerd.log | sed -u 's/^/[DOCKERD] /' &
+) 2>&1 | stdbuf -oL tee -a /var/log/helix-services/dockerd.log | sed -u 's/^/[DOCKERD] /' &
 
 DOCKERD_WRAPPER_PID=$!
 echo "Started dockerd with auto-restart (wrapper PID: $DOCKERD_WRAPPER_PID)"

--- a/sandbox/08-start-sandbox-heartbeat.sh
+++ b/sandbox/08-start-sandbox-heartbeat.sh
@@ -44,7 +44,7 @@ mkdir -p /var/log/helix-services 2>/dev/null || true
         echo "[$(date -Iseconds)] ⚠️  Heartbeat daemon exited with code $EXIT_CODE, restarting in 2s..."
         sleep 2
     done
-) 2>&1 | tee -a /var/log/helix-services/heartbeat.log | sed -u 's/^/[HEARTBEAT] /' &
+) 2>&1 | stdbuf -oL tee -a /var/log/helix-services/heartbeat.log | sed -u 's/^/[HEARTBEAT] /' &
 
 HEARTBEAT_PID=$!
 echo "✅ Sandbox heartbeat daemon started with auto-restart (wrapper PID: $HEARTBEAT_PID)"

--- a/sandbox/12-start-compose-manager.sh
+++ b/sandbox/12-start-compose-manager.sh
@@ -47,6 +47,14 @@ mkdir -p /var/log/helix-services 2>/dev/null || true
     # PIPE means individual writes silently fail but the loop keeps
     # restarting compose-manager forever.
     trap '' PIPE
+    # `stdbuf -oL tee` below: tee block-buffers its write to the file
+    # when its stdout is a pipe (not a TTY). For low-volume producers
+    # like compose-manager (a few hundred bytes/min when idle), the
+    # buffer holds output for minutes before flushing - making hydra's
+    # admin Runner Logs WS appear silent even though [COMPOSE-MGR]
+    # lines are visible on `docker logs`. `-oL` forces line buffering
+    # on tee's stdout writes so each line hits the file (and so the
+    # tailer) immediately. Same fix in 04/08/14 scripts.
     while true; do
         echo "[$(date -Iseconds)] Starting compose-manager..."
         HELIX_RUNNER_ID="$SANDBOX_INSTANCE_ID" \
@@ -59,7 +67,7 @@ mkdir -p /var/log/helix-services 2>/dev/null || true
         echo "[$(date -Iseconds)] ⚠️  compose-manager exited with $EXIT_CODE, restarting in 2s..."
         sleep 2
     done
-) 2>&1 | tee -a /var/log/helix-services/compose-manager.log | sed -u 's/^/[COMPOSE-MGR] /' &
+) 2>&1 | stdbuf -oL tee -a /var/log/helix-services/compose-manager.log | sed -u 's/^/[COMPOSE-MGR] /' &
 
 CM_PID=$!
 echo "✅ compose-manager started with auto-restart (wrapper PID: $CM_PID)"

--- a/sandbox/14-start-inference-proxy.sh
+++ b/sandbox/14-start-inference-proxy.sh
@@ -28,7 +28,7 @@ mkdir -p /var/log/helix-services 2>/dev/null || true
         echo "[$(date -Iseconds)] ⚠️  inference-proxy exited with $EXIT_CODE, restarting in 2s..."
         sleep 2
     done
-) 2>&1 | tee -a /var/log/helix-services/inference-proxy.log | sed -u 's/^/[INF-PROXY] /' &
+) 2>&1 | stdbuf -oL tee -a /var/log/helix-services/inference-proxy.log | sed -u 's/^/[INF-PROXY] /' &
 
 PROXY_PID=$!
 echo "✅ inference-proxy started with auto-restart (wrapper PID: $PROXY_PID)"


### PR DESCRIPTION
## Summary

Prepend `stdbuf -oL` to the four sandbox service-supervisor `tee` invocations so service logs reach `/var/log/helix-services/*.log` immediately, instead of waiting minutes for tee's pipe-mode buffer to fill.

Affected scripts:
- `sandbox/04-start-dockerd.sh`
- `sandbox/08-start-sandbox-heartbeat.sh`
- `sandbox/12-start-compose-manager.sh`
- `sandbox/14-start-inference-proxy.sh`

## Why

`tee` block-buffers its file write when its stdout is a pipe (not a TTY). The four supervisors pipe tee's output into `sed -u` for the `[PREFIX]` decoration, so tee's stdout IS a pipe and the file flush only happens when tee's ~4-8KB buffer fills. `sed -u` already line-buffers the docker-logs visible stdout, which is why these scripts looked fine in `docker logs helix-sandbox` but were silent in the admin UI's Runner Logs.

For low-volume producers (compose-manager polls every 15s with a few hundred bytes per cycle), the file barely grows for many minutes. Hydra's tailer at `/var/log/helix-services/*.log` has nothing to surface → admin Runner Logs WS appears silent for `[COMPOSE-MGR]`, `[HEARTBEAT]`, `[INF-PROXY]`, `[DOCKERD]`.

Confirmed missing on yd.helix.ml (2.11.20) today: admin Runner Logs streams `[DESKTOP ubuntu-external-...]` lines (via hydra's docker-logs capture path) and hydra's own zerolog output, but nothing from the service-supervisor file tailer.

This was specifically flagged in the round-2 code review of the original log aggregation feature (PR https://github.com/helixml/helix/pull/2634, shipped in 2.11.19) but never landed as its own follow-up.

## Test plan

- [x] `bash -n` syntax check passes on all 4 scripts
- [x] `stdbuf` is in `coreutils` (already present in the `ubuntu:25.04` base of `helix-sandbox`)
- [ ] CI green
- [ ] After the next release picks this up, deploy to yd.helix.ml and confirm `[COMPOSE-MGR]`, `[HEARTBEAT]`, `[INF-PROXY]`, `[DOCKERD]` lines appear in admin Runner Logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)