### PR TITLE
fix(frontend): hide stale profile/health badges for offline runners

### DIFF
--- a/frontend/src/components/admin/Runners.tsx
+++ b/frontend/src/components/admin/Runners.tsx
@@ -238,8 +238,12 @@ const SandboxProfileCard: FC<{ sandbox: SandboxInstanceInfo }> = ({ sandbox }) =
         <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
           {sandbox.id}
         </Typography>
-        <Chip label={status || 'idle'} size="small" color={getProfileStatusColor(status)} />
-        {!isOnline && (
+        {/* Profile status reflects the last heartbeat; once the runner is
+            offline it's stale, so show only the offline state rather than a
+            misleading "running" badge. */}
+        {isOnline ? (
+          <Chip label={status || 'idle'} size="small" color={getProfileStatusColor(status)} />
+        ) : (
           <Chip label={sandbox.status} size="small" variant="outlined" color="default" />
         )}
       </Box>
@@ -269,7 +273,7 @@ const SandboxProfileCard: FC<{ sandbox: SandboxInstanceInfo }> = ({ sandbox }) =
           {assignError}
         </Alert>
       )}
-      {progressEntries.length > 0 && (
+      {isOnline && progressEntries.length > 0 && (
         <Box sx={{ mt: 1 }}>
           {progressEntries.map(([svc, p]) => (
             <Box key={svc} sx={{ mb: 1.5 }}>
@@ -291,7 +295,7 @@ const SandboxProfileCard: FC<{ sandbox: SandboxInstanceInfo }> = ({ sandbox }) =
           ))}
         </Box>
       )}
-      {services.length > 0 && (
+      {isOnline && services.length > 0 && (
         <Box sx={{ mt: 1, display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
           {services.map(([svc, health]) => (
             <Chip


### PR DESCRIPTION
## Problem

In the admin **Runners** tab, an **offline** runner still showed a green **"running"** profile badge and **"vllm-tiny: healthy"** service badge - right next to its own **"offline"** chip, with **0 Online Runners** above it. That's dishonest: once a runner is offline we can't verify its profile or model health.

## Cause

The reaper flips a sandbox's `Status` to `offline` when `last_seen` goes stale, but leaves `ProfileStatus` and `ServiceHealth` at their last-heartbeat values. The card rendered those fields unconditionally.

## Fix (UI only)

Gate the three stale runtime signals behind `isOnline` in `Runners.tsx`:
- profile-status chip (the green "running")
- per-service health chips ("svc: healthy")
- download-progress bars

Offline runners now show only the `offline` chip plus the assigned-profile id - no stale runtime state. Online runners are unchanged.

Not touched on purpose: the inference router already withholds offline runners from real routing (`RouteableModels` requires `Status == "running"`), so this is purely an admin-display honesty fix. The stored last-known values are kept in the DB; they're just never shown as current.

## Verify

`tsc --noEmit` clean. Behaviour: select an offline runner in the Runners tab - the green badges are gone, only "offline" + profile id remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)