### PR TITLE
fix(compute): D3 counts in-flight provisioning toward committed capacity

### DIFF
--- a/api/pkg/sandbox/compute/manager.go
+++ b/api/pkg/sandbox/compute/manager.go
@@ -632,6 +632,19 @@ func (m *Manager) computeNeeded(rows []*types.SandboxInstance) int {
 	readyOnlineCount := 0
 	readyCapacity := 0
 	readyDemand := 0
+	// provisioningCapacity is the MaxSandboxes total across rows we've
+	// ALREADY submitted a Provision for but that haven't reached Ready
+	// yet. Counted toward "committed capacity" in the D3 headroom
+	// decision so we don't fire a second Provision in the next cycle
+	// for the same demand the first one is on its way to satisfy.
+	// Without this, a 2-session burst on a single-Runner fleet with
+	// HEADROOM_MIN=1 produces 2 new Runners instead of 1: cycle 1
+	// sees headroom=0 and fires Provision A; cycle 2 (15-30s later,
+	// A still booting since EC2+image pull takes 60-90s) STILL sees
+	// readyCapacity=2/readyDemand=2/headroom=0 and fires Provision B.
+	// The deficit gets double-counted because future-but-not-yet-Ready
+	// capacity is invisible to the math.
+	provisioningCapacity := 0
 	for _, r := range rows {
 		if isAvailable(r) {
 			available++
@@ -643,6 +656,9 @@ func (m *Manager) computeNeeded(rows []*types.SandboxInstance) int {
 			readyOnlineCount++
 			readyCapacity += int(r.MaxSandboxes)
 			readyDemand += int(r.ActiveSandboxes)
+		}
+		if State(r.ComputeState) == StateProvisioning {
+			provisioningCapacity += int(r.MaxSandboxes)
 		}
 	}
 
@@ -685,7 +701,14 @@ func (m *Manager) computeNeeded(rows []*types.SandboxInstance) int {
 	// provisioning 4x on smaller-capacity hosts.
 	demandNeed := 0
 	if m.cfg.Max > m.cfg.Floor && readyOnlineCount > 0 {
-		headroom := readyCapacity - readyDemand
+		// Committed capacity: Ready+online (real serving) PLUS in-flight
+		// provisioning (will serve soon). Both contribute slots toward
+		// the headroom we already have on order. The readyOnlineCount
+		// gate above still uses ONLY real-online so D3 doesn't fire
+		// with zero serving capacity - but for the deficit math, count
+		// committed slots so we don't double-fire across cycles while
+		// a Provision is still in flight.
+		headroom := readyCapacity + provisioningCapacity - readyDemand
 		if headroom < m.cfg.ScaleUpHeadroomMin {
 			slotsShort := m.cfg.ScaleUpHeadroomMin - headroom
 			demandNeed = slotsShort

--- a/api/pkg/sandbox/compute/manager_d3_burst_test.go
+++ b/api/pkg/sandbox/compute/manager_d3_burst_test.go
@@ -1,0 +1,198 @@
+package compute
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// TestD3DoesNotDoubleProvisionWhileFirstStillBooting is the regression
+// test for the demo-time observation on 2026-06-17: HEADROOM_MIN=1 with
+// a single Ready Runner at-cap and 2 sessions placed on it produced
+// 2 new Runners across two reconcile cycles instead of 1.
+//
+// Root cause: computeNeeded only counted Ready+online rows toward
+// readyCapacity. The first cycle saw headroom=0 < 1 and fired a
+// Provision. The second cycle (15-30s later, while the new Runner was
+// still in StateProvisioning - EC2 boot + image pull take 60-90s)
+// STILL saw readyCapacity=2 / readyDemand=2 / headroom=0 and fired a
+// second Provision. The deficit was double-counted because in-flight
+// capacity was invisible.
+//
+// Fix: count provisioning rows' MaxSandboxes toward `committed
+// capacity` for the headroom math. The Ready-vs-Provisioning distinction
+// is preserved for the readyOnlineCount gate (D3 still won't fire with
+// zero serving capacity to measure against) but the deficit calc uses
+// committed slots.
+func TestD3DoesNotDoubleProvisionWhileFirstStillBooting(t *testing.T) {
+	store := newFakeStore()
+	stub := NewStubProvider("stub")
+	m, err := NewManager(stub, store, ManagerConfig{
+		Floor:                   1,
+		Max:                     3,
+		ScaleUpHeadroomMin:      1,
+		MaxConcurrentProvisions: 1,
+		ReconcileInterval:       10 * time.Millisecond,
+		HealthCheckTimeout:      100 * time.Millisecond,
+		IdleTimeout:             time.Hour, // disable D4 noise
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// One Ready Runner at full cap (the live demo scenario).
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-live",
+		Provider:        "stub",
+		ProviderID:      "wr-live",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 2,
+	})
+
+	// Cycle 1: headroom = (2 ready + 0 provisioning) - 2 = 0, fire 1 Provision.
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile 1: %v", err)
+	}
+	rows, _ := store.ListSandboxInstances(context.Background())
+	provisioningAfter1 := 0
+	for _, r := range rows {
+		if r.Provider == "stub" && r.ComputeState == string(StateProvisioning) {
+			provisioningAfter1++
+		}
+	}
+	if provisioningAfter1 != 1 {
+		t.Fatalf("cycle 1: expected exactly 1 new Provision, got %d. all rows: %+v",
+			provisioningAfter1, rows)
+	}
+
+	// Cycle 2 (immediate; new Runner still in StateProvisioning,
+	// MaxSandboxes=2 from the stub). Bug-on-old-code: headroom would
+	// still be 0 because the provisioning row didn't count toward
+	// readyCapacity -> a SECOND Provision fires. Post-fix: committed
+	// capacity = 2 ready + 2 provisioning = 4; demand = 2; headroom =
+	// 2 >= MIN=1, so NO additional Provision.
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile 2: %v", err)
+	}
+	rows, _ = store.ListSandboxInstances(context.Background())
+	provisioningAfter2 := 0
+	for _, r := range rows {
+		if r.Provider == "stub" && r.ComputeState == string(StateProvisioning) {
+			provisioningAfter2++
+		}
+	}
+	if provisioningAfter2 != 1 {
+		t.Fatalf("cycle 2: expected SAME 1 provisioning row (no second fire), got %d. "+
+			"this is the over-provision bug. all rows: %+v",
+			provisioningAfter2, rows)
+	}
+}
+
+// TestD3StillFiresWhenCommittedCapacityIsBelowMin guards against
+// over-correction: the new committed-capacity math must STILL fire a
+// Provision when the deficit is real (no in-flight provision yet).
+func TestD3StillFiresWhenCommittedCapacityIsBelowMin(t *testing.T) {
+	store := newFakeStore()
+	stub := NewStubProvider("stub")
+	m, err := NewManager(stub, store, ManagerConfig{
+		Floor:                   1,
+		Max:                     3,
+		ScaleUpHeadroomMin:      1,
+		MaxConcurrentProvisions: 1,
+		ReconcileInterval:       10 * time.Millisecond,
+		HealthCheckTimeout:      100 * time.Millisecond,
+		IdleTimeout:             time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// One Ready Runner at full cap. No provisioning row yet.
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-live",
+		Provider:        "stub",
+		ProviderID:      "wr-live",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 2,
+	})
+
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	rows, _ := store.ListSandboxInstances(context.Background())
+	provisioning := 0
+	for _, r := range rows {
+		if r.Provider == "stub" && r.ComputeState == string(StateProvisioning) {
+			provisioning++
+		}
+	}
+	if provisioning != 1 {
+		t.Fatalf("real deficit must still trigger D3; expected 1 new Provision, got %d. "+
+			"all rows: %+v", provisioning, rows)
+	}
+}
+
+// TestD3FiresAgainWhenLargerBurstOutpacesInFlightCapacity verifies that
+// the fix doesn't go too far the other way: if committed capacity still
+// can't satisfy HEADROOM_MIN, D3 must fire another Provision (subject
+// to MaxConcurrentProvisions and Max ceiling).
+//
+// Scenario: Max=5, HEADROOM_MIN=3, one Ready Runner saturated (2/2),
+// one provisioning (will give +2). committed = 4, demand = 2, headroom
+// = 2, which is still < MIN=3 -> fire one more.
+func TestD3FiresAgainWhenLargerBurstOutpacesInFlightCapacity(t *testing.T) {
+	store := newFakeStore()
+	stub := NewStubProvider("stub")
+	m, err := NewManager(stub, store, ManagerConfig{
+		Floor:                   1,
+		Max:                     5,
+		ScaleUpHeadroomMin:      3,
+		MaxConcurrentProvisions: 1,
+		ReconcileInterval:       10 * time.Millisecond,
+		HealthCheckTimeout:      100 * time.Millisecond,
+		IdleTimeout:             time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-live",
+		Provider:        "stub",
+		ProviderID:      "wr-live",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 2,
+	})
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:           "sbx-inflight",
+		Provider:     "stub",
+		ProviderID:   "wr-inflight",
+		ComputeState: string(StateProvisioning),
+		Status:       "offline",
+		MaxSandboxes: 2,
+	})
+
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	rows, _ := store.ListSandboxInstances(context.Background())
+	provisioning := 0
+	for _, r := range rows {
+		if r.Provider == "stub" && r.ComputeState == string(StateProvisioning) {
+			provisioning++
+		}
+	}
+	// 1 pre-existing + 1 newly fired = 2 provisioning total.
+	if provisioning != 2 {
+		t.Fatalf("with MIN=3 and committed capacity still short, D3 must fire one more; "+
+			"expected 2 provisioning rows total, got %d. all: %+v", provisioning, rows)
+	}
+}


### PR DESCRIPTION
## Summary

Fix D3 over-provisioning. The headroom math previously only counted Ready+online rows' MaxSandboxes toward `readyCapacity`. Demand bursts that arrived faster than EC2 boot time (always, since boot is 60-90s and reconcile is 15-30s) double-counted the deficit and fired one new Runner per cycle until hitting Max.

## Concrete repro (yd.helix.ml demo, 2026-06-17)

- Floor=1, Max=3, HEADROOM_MIN=1, MaxConcurrent=1
- 1 Ready Runner at cap (2/2 active), 2 sessions running
- Cycle 1: readyCapacity=2, demand=2, headroom=0 < 1 -> fire R2
- Cycle 2 (R2 still booting): readyCapacity still 2 because R2 hasn't transitioned to StateReady, headroom still 0 < 1 -> fire R3
- End state: 3 Runners for what 1 Runner could serve. Then 2 of them sit idle, D4 sheds them, ... churn.

## Fix

Separate the predicate that gates the D3 decision (still `readyOnlineCount > 0`, prevents firing with zero serving capacity to measure against) from the math that calculates the deficit. The deficit now uses **committed** capacity:

```go
committed = readyCapacity (Ready+online) + provisioningCapacity (StateProvisioning)
headroom  = committed - readyDemand
```

Once we've submitted a Provision, its `MaxSandboxes` is in `provisioningCapacity` immediately; the next cycle sees the slots are already on order and doesn't double-fire.

If the burst is genuinely larger than one cycle's MaxConcurrent can satisfy, D3 still fires again next cycle because committed is still short - this is the correct behaviour and is covered by the third test below.

## Tests

- `TestD3DoesNotDoubleProvisionWhileFirstStillBooting` - the exact yd.helix.ml repro
- `TestD3StillFiresWhenCommittedCapacityIsBelowMin` - guard against over-correction
- `TestD3FiresAgainWhenLargerBurstOutpacesInFlightCapacity` - genuine deficits keep iterating

All pre-existing compute tests pass unchanged.

## Test plan

- [x] `go test ./pkg/sandbox/compute/...` green
- [x] `go build ./pkg/sandbox/compute/...` clean
- [ ] CI green
- [ ] After the next release lands on yd.helix.ml, validate by repeating today's scenario: 1 Runner at cap, 2 sessions, observe only ONE additional Runner provisioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)