### PR TITLE
feat(compute): D4 inhibition while fleet at-or-over cap (option E)

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -257,6 +257,18 @@ type Compute struct {
 	// grace before convergence resumes.
 	IdleTimeout time.Duration `envconfig:"HELIX_COMPUTE_IDLE_TIMEOUT" default:"10m"`
 
+	// HardIdleTimeout is the safety override for D4's fleet-pressure
+	// inhibition (see manager.go tryDeprovisionIdle). When ANY Ready
+	// Runner is at-or-over its MaxSandboxes cap, D4 normally won't shed
+	// idle peers - because shedding them would just re-fire D3 next
+	// cycle (the oscillation bug fixed by the inhibition). But if a
+	// stuck session pins a Runner at-cap forever, the inhibition would
+	// hold idle peers alive indefinitely. HardIdleTimeout is the
+	// upper-bound: once an idle Runner crosses this threshold, D4
+	// sheds it regardless of the inhibition. Default 4h covers normal
+	// long-running sessions; set 0 to disable the override entirely.
+	HardIdleTimeout time.Duration `envconfig:"HELIX_COMPUTE_HARD_IDLE_TIMEOUT" default:"4h"`
+
 	// Yellowdog is the provider-specific config block. Only consulted
 	// when Provider="yellowdog".
 	Yellowdog Yellowdog

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap.go
@@ -100,6 +100,7 @@ func Bootstrap(cfg config.Compute, maxSandboxesPerHost int, serverURL, runnerTok
 		Max:                     cfg.Max,
 		ScaleUpHeadroomMin:      cfg.ScaleUpHeadroomMin,
 		IdleTimeout:             cfg.IdleTimeout,
+		HardIdleTimeout:         cfg.HardIdleTimeout,
 		SpecTemplate: compute.Spec{
 			MaxSandboxes: maxSandboxesPerHost,
 		},
@@ -114,6 +115,7 @@ func Bootstrap(cfg config.Compute, maxSandboxesPerHost int, serverURL, runnerTok
 		Int("max", cfg.Max).
 		Int("scaleup_headroom_min", cfg.ScaleUpHeadroomMin).
 		Dur("idle_timeout", cfg.IdleTimeout).
+		Dur("hard_idle_timeout", cfg.HardIdleTimeout).
 		Dur("reconcile_interval", cfg.ReconcileInterval).
 		Dur("max_provisioning_age", cfg.MaxProvisioningAge).
 		Int("max_concurrent_provisions", cfg.MaxConcurrentProvisions).

--- a/api/pkg/sandbox/compute/manager.go
+++ b/api/pkg/sandbox/compute/manager.go
@@ -130,6 +130,16 @@ type ManagerConfig struct {
 	// (pure on-demand, no warm baseline) gets full scale-down to
 	// zero hosts once all sandboxes drain.
 	IdleTimeout time.Duration
+
+	// HardIdleTimeout is the absolute upper bound on how long a Ready
+	// host can stay idle, even when the fleet-pressure inhibition
+	// (see tryDeprovisionIdle) would otherwise keep it alive. Without
+	// this safety net a stuck-at-cap Runner (e.g. a session whose
+	// container hangs and never reports ActiveSandboxes=0) would pin
+	// idle Runners next to it indefinitely. Default at the envconfig
+	// boundary is 4h. Set to 0 to disable the override and trust the
+	// inhibition unconditionally.
+	HardIdleTimeout time.Duration
 }
 
 // validate returns an error if cfg is missing required fields or has
@@ -167,6 +177,10 @@ func (cfg ManagerConfig) validate() error {
 	if cfg.IdleTimeout < 0 {
 		return fmt.Errorf("compute.ManagerConfig.IdleTimeout must be >= 0, got %s",
 			cfg.IdleTimeout)
+	}
+	if cfg.HardIdleTimeout < 0 {
+		return fmt.Errorf("compute.ManagerConfig.HardIdleTimeout must be >= 0, got %s",
+			cfg.HardIdleTimeout)
 	}
 	return nil
 }
@@ -442,12 +456,27 @@ func (m *Manager) tryDeprovisionIdle(ctx context.Context, rows []*types.SandboxI
 	now := m.now()
 	readyByID := make(map[string]*types.SandboxInstance)
 	readyCount := 0
+	// fleetAtCap tracks whether ANY Ready+online host is currently at or
+	// over its MaxSandboxes. Used below to inhibit shedding so we don't
+	// reclaim an idle pre-warm Runner while another Runner is still
+	// pressed up against its cap - that would just re-fire D3 next
+	// cycle, causing oscillation. See design/2026-06-17-d3-dispatcher-
+	// coupling.md option E for the analysis.
+	//
+	// "At cap" rather than "over cap" because the dispatcher's lowest-
+	// active sort places a new session on the at-cap Runner the moment
+	// the over-cap Runner returns to the at-cap side - so anything
+	// already at MaxSandboxes is plausible imminent overflow.
+	fleetAtCap := false
 	for _, r := range rows {
 		if !isReadyState(r) {
 			continue
 		}
 		readyByID[r.ID] = r
 		readyCount++
+		if isReadyAndOnline(r) && r.MaxSandboxes > 0 && r.ActiveSandboxes >= r.MaxSandboxes {
+			fleetAtCap = true
+		}
 	}
 
 	// Update tracker: mark currently-idle Ready rows; clear busy ones;
@@ -529,6 +558,29 @@ func (m *Manager) tryDeprovisionIdle(ctx context.Context, rows []*types.SandboxI
 	}
 
 	idleFor := now.Sub(candidateIdleSince)
+
+	// Inhibit shedding if any OTHER Runner in the fleet is at-or-over
+	// its MaxSandboxes cap. Reasoning: the candidate is idle precisely
+	// because the dispatcher placed every session on the at-cap Runner
+	// (lowest-active sort, no migration). Shedding the candidate while
+	// load is still pressed against cap just re-fires D3 next cycle
+	// (over-cap trigger or HEADROOM_MIN trigger) and the system
+	// oscillates. The inhibition holds the pre-warm in place until the
+	// real demand drops below cap.
+	//
+	// HardIdleTimeout is the safety net for the pathological case
+	// (e.g. a stuck container that never reports ActiveSandboxes=0):
+	// even if the fleet looks at-cap forever, an idle Runner past the
+	// hard cutoff is shed anyway. Default 4h at the envconfig boundary;
+	// 0 disables the override.
+	if fleetAtCap && (m.cfg.HardIdleTimeout == 0 || idleFor < m.cfg.HardIdleTimeout) {
+		log.Debug().
+			Str("sandbox_id", candidate.ID).
+			Dur("idle_for", idleFor).
+			Dur("hard_idle_timeout", m.cfg.HardIdleTimeout).
+			Msg("compute manager: D4 inhibited; another Runner in fleet is at-cap")
+		return nil
+	}
 	log.Info().
 		Str("sandbox_id", candidate.ID).
 		Str("provider_id", candidate.ProviderID).

--- a/api/pkg/sandbox/compute/manager_d4_inhibition_test.go
+++ b/api/pkg/sandbox/compute/manager_d4_inhibition_test.go
@@ -1,0 +1,268 @@
+package compute
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// TestD4InhibitedWhileFleetAtCap is the regression test for the
+// oscillation observed on yd.helix.ml on 2026-06-17:
+//
+//   1. R1 at cap (2/2)
+//   2. D3 fires R2 (pre-warm)
+//   3. R2 boots, 0 active
+//   4. D4 sheds R2 (old behavior) -> R1 still at cap -> D3 re-fires -> loop
+//
+// Option E fix: D4 must inhibit shedding while ANY other Ready Runner
+// in the fleet is at-or-over its MaxSandboxes cap. The pre-warm R2 is
+// real demand-pressure relief; pulling it triggers immediate re-fire.
+func TestD4InhibitedWhileFleetAtCap(t *testing.T) {
+	store := newFakeStore()
+	stub := NewStubProvider("stub")
+	m, err := NewManager(stub, store, ManagerConfig{
+		Floor:                   1,
+		Max:                     3,
+		ScaleUpHeadroomMin:      1,
+		MaxConcurrentProvisions: 1,
+		ReconcileInterval:       10 * time.Millisecond,
+		HealthCheckTimeout:      100 * time.Millisecond,
+		IdleTimeout:             1 * time.Millisecond, // fire D4 immediately
+		HardIdleTimeout:         4 * time.Hour,        // safety net far away
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// R1: at cap. R2: pre-warmed by an earlier D3, now idle.
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-r1",
+		Provider:        "stub",
+		ProviderID:      "wr-r1",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 2, // at cap
+	})
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-r2",
+		Provider:        "stub",
+		ProviderID:      "wr-r2",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 0,
+	})
+
+	// Arm: tracker registers R2 as idle.
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile arm: %v", err)
+	}
+	// Past IdleTimeout for R2, but R1 still at cap -> D4 inhibited.
+	time.Sleep(10 * time.Millisecond)
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile shed-attempt: %v", err)
+	}
+
+	rows, _ := store.ListSandboxInstances(context.Background())
+	ids := make(map[string]bool)
+	for _, r := range rows {
+		ids[r.ID] = true
+	}
+	if !ids["sbx-r2"] {
+		t.Fatalf("R2 was shed despite R1 being at cap; inhibition not working. rows: %+v", rows)
+	}
+}
+
+// TestD4ShedAfterFleetDropsBelowCap verifies the convergence half:
+// once R1 returns to under-cap (sessions end), the inhibition lifts
+// and D4 sheds the idle R2 as it would in a steady-state shrink.
+func TestD4ShedAfterFleetDropsBelowCap(t *testing.T) {
+	store := newFakeStore()
+	stub := NewStubProvider("stub")
+	m, err := NewManager(stub, store, ManagerConfig{
+		Floor:                   1,
+		Max:                     3,
+		ScaleUpHeadroomMin:      1,
+		MaxConcurrentProvisions: 1,
+		ReconcileInterval:       10 * time.Millisecond,
+		HealthCheckTimeout:      100 * time.Millisecond,
+		IdleTimeout:             1 * time.Millisecond,
+		HardIdleTimeout:         4 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// R1 starts at cap; R2 idle.
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-r1",
+		Provider:        "stub",
+		ProviderID:      "wr-r1",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 2,
+	})
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-r2",
+		Provider:        "stub",
+		ProviderID:      "wr-r2",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 0,
+	})
+
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile arm: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	// R1's sessions end - simulate by mutating ActiveSandboxes on the row.
+	_ = store.UpdateSandboxInstanceStatus(context.Background(), "sbx-r1", "online")
+	r1, _ := store.GetSandboxInstance(context.Background(), "sbx-r1")
+	r1.ActiveSandboxes = 0
+	_ = store.RegisterSandboxInstance(context.Background(), r1) // re-store with new value
+
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile shed: %v", err)
+	}
+
+	rows, _ := store.ListSandboxInstances(context.Background())
+	// Exactly one of R1 or R2 should remain (Floor=1, MaxConcurrent=1).
+	stubReady := 0
+	for _, r := range rows {
+		if r.Provider == "stub" && r.ComputeState == string(StateReady) {
+			stubReady++
+		}
+	}
+	if stubReady != 1 {
+		t.Fatalf("after fleet drops below cap, D4 should converge to Floor=1; "+
+			"got %d Ready rows. all: %+v", stubReady, rows)
+	}
+}
+
+// TestD4HardIdleTimeoutOverride guards the stuck-session edge case:
+// if a Runner is permanently at cap (e.g. a hung session never reports
+// ActiveSandboxes=0), the idle peer can't be pinned forever. After
+// HardIdleTimeout the override fires and D4 sheds anyway.
+func TestD4HardIdleTimeoutOverride(t *testing.T) {
+	store := newFakeStore()
+	stub := NewStubProvider("stub")
+	clk := &fakeClock{now: time.Unix(1_700_000_000, 0)}
+	m, err := NewManager(stub, store, ManagerConfig{
+		Floor:                   1,
+		Max:                     3,
+		ScaleUpHeadroomMin:      1,
+		MaxConcurrentProvisions: 1,
+		ReconcileInterval:       time.Second,
+		HealthCheckTimeout:      100 * time.Millisecond,
+		IdleTimeout:             1 * time.Minute,
+		HardIdleTimeout:         10 * time.Minute, // tight for the test
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	m.now = clk.Now
+
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-r1-stuck",
+		Provider:        "stub",
+		ProviderID:      "wr-r1",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 2, // PERMANENTLY at cap (stuck session)
+	})
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-r2-idle",
+		Provider:        "stub",
+		ProviderID:      "wr-r2",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 0,
+	})
+
+	// Arm idle tracker.
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile arm: %v", err)
+	}
+
+	// Advance to past IdleTimeout but well within HardIdleTimeout:
+	// inhibition should hold.
+	clk.Advance(5 * time.Minute)
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile pre-hard: %v", err)
+	}
+	if _, err := store.GetSandboxInstance(context.Background(), "sbx-r2-idle"); err != nil {
+		t.Fatalf("R2 shed too early (before HardIdleTimeout); inhibition not working")
+	}
+
+	// Advance past HardIdleTimeout: override fires.
+	clk.Advance(6 * time.Minute) // total 11m, > 10m HardIdleTimeout
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile post-hard: %v", err)
+	}
+	if _, err := store.GetSandboxInstance(context.Background(), "sbx-r2-idle"); err == nil {
+		t.Fatalf("R2 should have been shed by HardIdleTimeout override; still present")
+	}
+}
+
+// TestD4ShedsNormallyWhenFleetUnderCap guards against false inhibition:
+// if the only at-cap signal is gone (under-cap or zero load), D4 sheds
+// the usual way.
+func TestD4ShedsNormallyWhenFleetUnderCap(t *testing.T) {
+	store := newFakeStore()
+	stub := NewStubProvider("stub")
+	m, err := NewManager(stub, store, ManagerConfig{
+		Floor:                   1,
+		Max:                     3,
+		ScaleUpHeadroomMin:      1,
+		MaxConcurrentProvisions: 1,
+		ReconcileInterval:       10 * time.Millisecond,
+		HealthCheckTimeout:      100 * time.Millisecond,
+		IdleTimeout:             1 * time.Millisecond,
+		HardIdleTimeout:         4 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// R1 under cap, R2 idle. Both Ready.
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-r1",
+		Provider:        "stub",
+		ProviderID:      "wr-r1",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 1, // under cap
+	})
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-r2",
+		Provider:        "stub",
+		ProviderID:      "wr-r2",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 0,
+	})
+
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile arm: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile shed: %v", err)
+	}
+
+	if _, err := store.GetSandboxInstance(context.Background(), "sbx-r2"); err == nil {
+		t.Fatalf("R2 should have been shed (fleet under-cap, no inhibition); still present")
+	}
+}
+
+// fakeClock helper already declared in manager_test.go.


### PR DESCRIPTION
## Summary

Stop the autoscaler from oscillating under static at-cap load.

D4 now skips shedding when any other Ready Runner in the fleet has `active_sandboxes >= MaxSandboxes`. The pre-warm Runner that D3 created stays alive as long as the demand signal that justified it is still present. When the at-cap Runner's sessions end, the inhibition lifts and D4 sheds normally, converging to Floor.

Includes a new `HELIX_COMPUTE_HARD_IDLE_TIMEOUT` safety knob (default 4h) for the stuck-session edge case where a Runner pins itself at-cap forever.

## Why

Demoed live on yd.helix.ml on 2026-06-17:

1. R1 at cap (2/2 active)
2. D3 fires R2 as pre-warm (HEADROOM_MIN-driven)
3. R2 boots Ready, 0 active. Dispatcher does NOT migrate sessions, so R2 stays idle.
4. After IdleTimeout, D4 sheds R2.
5. R1 still at cap → D3 re-fires R2. Loop.

The system continuously spins EC2s up and down for a load that never changed. Wastes EC2 dollars on boot/terminate cycles AND produces stuck CANCELLING WRs (cancel path is also unreliable - separate fixes in PRs #2644 and #2646).

## Why not Option B (hard-cap dispatcher + queue)

Option B was the "correct architecture" answer but rejected for this specific autoscaler bug: a queued session waits 10-20 min for YD to boot a new EC2, install the NVIDIA driver, pull the helix-sandbox image, and start the supervisor. The autoscaler exists precisely to hide that latency from the user; queueing exposes it. Captured in the design doc as "considered, rejected on latency grounds."

## What changed

| Component | Change |
|---|---|
| `api/pkg/sandbox/compute/manager.go` | `tryDeprovisionIdle` tracks `fleetAtCap` across the Ready set; inhibits the shed if any peer is at/over cap and the candidate hasn't crossed HardIdleTimeout. |
| `api/pkg/sandbox/compute/manager.go` | New `ManagerConfig.HardIdleTimeout` field with validation. |
| `api/pkg/config/config.go` | New `HELIX_COMPUTE_HARD_IDLE_TIMEOUT` env var, default 4h. |
| `api/pkg/sandbox/compute/bootstrap/bootstrap.go` | Plumbs the new field from config to Manager. Logs it at boot alongside the other compute knobs. |
| `api/pkg/sandbox/compute/manager_d4_inhibition_test.go` | Four regression tests. |

## Test plan

- [x] `go test ./pkg/sandbox/compute/...` green
- [x] All existing compute tests pass unchanged
- [ ] CI green
- [ ] Once shipped, validate on yd.helix.ml: re-create today's scenario (1 Runner at cap with 2 sandboxes, observe D3 fires R2, R2 stays Ready/idle while R1 stays at cap, R2 sheds when R1 returns to under-cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)