### PR TITLE
feat(org): clear worker session before each re-activation

### DIFF
--- a/api/pkg/org/infrastructure/runtime/helix/sessions.go
+++ b/api/pkg/org/infrastructure/runtime/helix/sessions.go
@@ -56,6 +56,13 @@ type SpawnerClient interface {
 	GetOutput(ctx context.Context, sessionID string) (types.SessionOutputResponse, error)
 	StopExternalAgent(ctx context.Context, sessionID string) error
 	SessionOwner(ctx context.Context, sessionID string) (string, error)
+	// ClearSession wipes the session's prior conversation (the DB
+	// interactions, and for a Zed/ACP session the Zed thread too) while
+	// keeping the session row. The Spawner calls this before every
+	// re-activation so each worker turn starts on a fresh context window
+	// instead of growing one long-lived session until it hits the model
+	// limit and compacts. See SpawnerConfig.ensureSession.
+	ClearSession(ctx context.Context, sessionID string) error
 }
 
 // checkDesktopQuota pre-flights the desktop quota gate before

--- a/api/pkg/org/infrastructure/runtime/helix/spawner.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner.go
@@ -453,6 +453,28 @@ func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID
 		return "", fmt.Errorf("worker %s has no helix project — ensureProject must run first", workerID)
 	}
 
+	// Re-activation of an existing session: clear the prior conversation
+	// before sending the new prompt so each activation starts on a fresh
+	// context window. Re-using one long-lived session across many
+	// activations grows the transcript until it hits the model's context
+	// limit and triggers expensive, lossy compaction. A Worker persists
+	// its durable learnings to markdown in the git workspace — not to the
+	// chat history — so wiping the conversation discards no real state.
+	// For Zed/ACP worker sessions (AgentType == "zed_external") the clear
+	// also resets the Zed thread, so the EnsureAndSend follow-up below
+	// lands on a brand-new thread. First activation (no persisted session
+	// yet) has nothing to clear and falls straight through to a fresh
+	// StartSession.
+	if state.SessionID != "" {
+		if err := c.Client.ClearSession(ctx, state.SessionID); err != nil {
+			return "", fmt.Errorf("clear session %s before re-activation: %w", state.SessionID, err)
+		}
+		if c.Logger != nil {
+			c.Logger.Info("spawner: cleared session before re-activation",
+				"worker", workerID, "session", state.SessionID)
+		}
+	}
+
 	// Follow-up: the persisted session ID is the durable target. We
 	// continue the session via /sessions/chat with SessionID set
 	// rather than the /sessions/{id}/messages queue endpoint —

--- a/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
@@ -39,6 +39,13 @@ type fakeHelixClient struct {
 	lastStartParams    StartSessionParams
 	lastSendSID        string
 	lastSendBody       string
+	clearCalls         int32
+	lastClearSID       string
+	// clearedBeforeSend records whether ClearSession ran before the
+	// first SendMessage, so tests can assert the activation clears the
+	// prior conversation ahead of dispatching the new prompt.
+	clearedBeforeSend bool
+	clearErr          error
 	// startBlock, when non-nil, blocks StartSession until the channel
 	// closes or the caller's context is done — lets tests verify that
 	// the spawner's SessionStartupTimeout actually bounds session
@@ -72,6 +79,20 @@ func (f *fakeHelixClient) SendMessage(_ context.Context, sessionID, prompt strin
 	f.lastSendBody = prompt
 	f.mu.Unlock()
 	return f.sendErr
+}
+
+func (f *fakeHelixClient) ClearSession(_ context.Context, sessionID string) error {
+	atomic.AddInt32(&f.clearCalls, 1)
+	f.mu.Lock()
+	f.lastClearSID = sessionID
+	// The clear must precede the prompt dispatch — if no SendMessage has
+	// run yet, this clear happened first.
+	if atomic.LoadInt32(&f.sendCalls) == 0 {
+		f.clearedBeforeSend = true
+	}
+	clearErr := f.clearErr
+	f.mu.Unlock()
+	return clearErr
 }
 
 func (f *fakeHelixClient) GetOutput(_ context.Context, _ string) (types.SessionOutputResponse, error) {
@@ -159,6 +180,10 @@ func TestSpawnerStartsFreshAndPersistsSession(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&fc.startCalls); got != 1 {
 		t.Errorf("StartChat calls: %d", got)
+	}
+	// First activation has no prior session, so there is nothing to clear.
+	if got := atomic.LoadInt32(&fc.clearCalls); got != 0 {
+		t.Errorf("ClearSession called %d times on a first activation; a fresh StartSession has no prior context to wipe", got)
 	}
 	state, err := LoadState(context.Background(), s, "org-test", wid)
 	if err != nil {
@@ -292,9 +317,100 @@ func TestSpawnerFollowUpResumesPersistedSession(t *testing.T) {
 	if got := atomic.LoadInt32(&fc.startCalls); got != 0 {
 		t.Errorf("StartSession called %d times; a follow-up must reuse the session, not create a fresh one", got)
 	}
+	// The persisted session must be cleared exactly once, and before the
+	// prompt is dispatched, so the worker turn starts on a fresh context
+	// window rather than re-using the prior (potentially huge) transcript.
+	if got := atomic.LoadInt32(&fc.clearCalls); got != 1 {
+		t.Errorf("ClearSession called %d times; a follow-up must clear the session exactly once before re-activation", got)
+	}
+	if fc.lastClearSID != "ses_existing" {
+		t.Errorf("ClearSession sessionID = %q (want ses_existing) — must clear the persisted session", fc.lastClearSID)
+	}
+	if !fc.clearedBeforeSend {
+		t.Error("ClearSession must run BEFORE SendMessage — otherwise the new prompt lands on the old context window")
+	}
 	state, _ := LoadState(context.Background(), s, "org-test", wid)
 	if state.SessionID != "ses_existing" {
 		t.Errorf("session pointer changed to %q; follow-up must NOT open a fresh session", state.SessionID)
+	}
+}
+
+// TestSpawnerClearsSessionOnReactivationOnly drives two activations of
+// the same Worker through the real Spawner closure and pins the
+// context-hygiene contract end to end: the first activation opens a
+// fresh session and clears nothing; the second re-uses that persisted
+// session but clears it first, so each worker turn starts on a fresh
+// context window instead of accumulating one ever-growing transcript.
+func TestSpawnerClearsSessionOnReactivationOnly(t *testing.T) {
+	t.Parallel()
+	s, wid := newHelixTestStore(t)
+	fc := &fakeHelixClient{
+		startSessionID: "ses_new",
+		outputs:        []types.SessionOutputResponse{{Status: "complete", Output: "ok"}},
+	}
+	sp := Spawner(newHelixCfg(t, fc, s))
+
+	// First activation: no persisted session → fresh StartSession, no clear.
+	if err := sp(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerHire}}); err != nil {
+		t.Fatalf("spawn 1: %v", err)
+	}
+	if got := atomic.LoadInt32(&fc.clearCalls); got != 0 {
+		t.Fatalf("first activation cleared %d times; a fresh session has no prior context to wipe", got)
+	}
+	if got := atomic.LoadInt32(&fc.startCalls); got != 1 {
+		t.Fatalf("first activation StartSession calls = %d, want 1", got)
+	}
+
+	// Second activation: the persisted session is cleared before the new
+	// prompt is sent, and the same warm session is re-used (no churn).
+	if err := sp(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerEvent, EventID: "e-2"}}); err != nil {
+		t.Fatalf("spawn 2: %v", err)
+	}
+	if got := atomic.LoadInt32(&fc.clearCalls); got != 1 {
+		t.Errorf("second activation cleared %d times, want 1", got)
+	}
+	fc.mu.Lock()
+	clearSID, sendSID := fc.lastClearSID, fc.lastSendSID
+	fc.mu.Unlock()
+	if clearSID != "ses_new" {
+		t.Errorf("ClearSession sessionID = %q, want ses_new (the persisted session)", clearSID)
+	}
+	if sendSID != "ses_new" {
+		t.Errorf("SendMessage sessionID = %q, want ses_new — re-activation must re-use the warm session", sendSID)
+	}
+	if got := atomic.LoadInt32(&fc.startCalls); got != 1 {
+		t.Errorf("StartSession calls = %d after two activations; the second must re-use the session, not open a fresh one", got)
+	}
+}
+
+// TestSpawnerClearFailureAbortsActivation pins fail-fast behaviour: if
+// the pre-activation clear errors we must NOT silently fall through and
+// dispatch the prompt onto the stale, oversized context — the whole
+// point of the clear. The activation returns the error instead.
+func TestSpawnerClearFailureAbortsActivation(t *testing.T) {
+	t.Parallel()
+	s, wid := newHelixTestStore(t)
+	if err := SaveProject(context.Background(), s, "org-test", wid, "prj_test", "app_test", "repo_test"); err != nil {
+		t.Fatalf("save project: %v", err)
+	}
+	if err := SaveSession(context.Background(), s, "org-test", wid, "ses_existing"); err != nil {
+		t.Fatalf("save session: %v", err)
+	}
+	fc := &fakeHelixClient{
+		startSessionID: "ses_existing",
+		clearErr:       errors.New("boom"),
+		outputs:        []types.SessionOutputResponse{{Status: "complete", Output: "ok"}},
+	}
+	sp := Spawner(newHelixCfg(t, fc, s))
+	err := sp(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerEvent, EventID: "e-1"}})
+	if err == nil {
+		t.Fatal("expected activation to fail when the pre-activation clear errors")
+	}
+	if !strings.Contains(err.Error(), "clear session") {
+		t.Errorf("error %q does not mention the clear failure", err)
+	}
+	if got := atomic.LoadInt32(&fc.sendCalls); got != 0 {
+		t.Errorf("SendMessage called %d times after a failed clear; the prompt must NOT land on the stale context", got)
 	}
 }
 
@@ -486,6 +602,10 @@ func (c *concurrencyClient) StartSession(ctx context.Context, params StartSessio
 func (c *concurrencyClient) SendMessage(ctx context.Context, sessionID, prompt string) error {
 	defer c.track()()
 	return c.inner.SendMessage(ctx, sessionID, prompt)
+}
+
+func (c *concurrencyClient) ClearSession(ctx context.Context, sessionID string) error {
+	return c.inner.ClearSession(ctx, sessionID)
 }
 
 func (c *concurrencyClient) ServerStatus(ctx context.Context) (ServerStatus, error) {

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -513,6 +513,28 @@ func (c *inProcHelixClient) SendMessage(ctx context.Context, sessionID, prompt s
 	return nil
 }
 
+// ClearSession wipes a session's conversation history — and, for a
+// Zed/ACP external-agent session, resets the Zed thread — via the same
+// handler the public POST /sessions/{id}/clear endpoint uses. The
+// spawner calls this before every worker re-activation so each turn
+// starts on a fresh context window instead of growing one long-lived
+// session until it hits the model limit and compacts. Authorization is
+// identical to SendMessage's path (authorizeUserToSession ActionUpdate),
+// so the service/hiring user the activation already runs as is allowed.
+func (c *inProcHelixClient) ClearSession(ctx context.Context, sessionID string) error {
+	if sessionID == "" {
+		return errors.New("ClearSession: sessionID is required")
+	}
+	r, err := c.newRequest(ctx, http.MethodPost, "/api/v1/sessions/"+sessionID+"/clear", nil, map[string]string{"id": sessionID})
+	if err != nil {
+		return err
+	}
+	if _, herr := c.server.clearSessionHandler(nil, r); herr != nil {
+		return fmt.Errorf("clear session %s: %s", sessionID, herr.Error())
+	}
+	return nil
+}
+
 // RestartSession recreates a session's desktop container via the same
 // canonical backend primitive the in-chat restart button uses
 // (POST /sessions/{id}/restart-agent → restartSessionContainer). The

--- a/api/pkg/server/helix_org_inproc_test.go
+++ b/api/pkg/server/helix_org_inproc_test.go
@@ -137,6 +137,53 @@ func TestInProcSpawnerClient_StopExternalAgent_NoSession_ReturnsError(t *testing
 	require.Error(t, err)
 }
 
+// TestInProcSpawnerClient_ClearSession_RemovesInteractionsKeepsSession
+// pins the wiring the spawner relies on before every re-activation:
+// ClearSession routes through clearSessionHandler (so authz matches the
+// SendMessage path), wipes the session's interactions, and preserves the
+// session row itself. An internal (non-Zed) session has a no-op runtime
+// backend, so this exercises the shared DB clear in isolation.
+func TestInProcSpawnerClient_ClearSession_RemovesInteractionsKeepsSession(t *testing.T) {
+	_, store, client, user := newInProcTestSetup(t)
+
+	session, err := store.CreateSession(context.Background(), types.Session{
+		ID:    "ses_clear_1",
+		Owner: user.ID, // owner == service user so authz passes (no orgID)
+	})
+	require.NoError(t, err)
+	_, err = store.CreateInteraction(context.Background(), &types.Interaction{
+		ID:              "int_clear_1",
+		SessionID:       session.ID,
+		State:           types.InteractionStateComplete,
+		ResponseMessage: "prior context",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, client.ClearSession(context.Background(), "ses_clear_1"))
+
+	// Session row preserved.
+	got, err := store.GetSession(context.Background(), "ses_clear_1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	// Interactions gone — the next turn starts on an empty context.
+	ints, _, err := store.ListInteractions(context.Background(), &types.ListInteractionsQuery{
+		SessionID:    "ses_clear_1",
+		GenerationID: -1,
+	})
+	require.NoError(t, err)
+	require.Empty(t, ints, "ClearSession must remove the session's interactions")
+}
+
+// TestInProcSpawnerClient_ClearSession_NoSession_ReturnsError confirms a
+// missing session surfaces as an error rather than silently succeeding,
+// so a stale persisted session pointer fails the activation loudly.
+func TestInProcSpawnerClient_ClearSession_NoSession_ReturnsError(t *testing.T) {
+	_, _, client, _ := newInProcTestSetup(t)
+
+	err := client.ClearSession(context.Background(), "ses_does_not_exist")
+	require.Error(t, err)
+}
+
 // TODO: tests for StartSession / SendMessage. StartSession routes to
 // StartExternalAgentSession (starts a real dev container) and
 // SendMessage to sendSessionMessage (needs a connected external-agent

--- a/api/pkg/store/memorystore/memorystore.go
+++ b/api/pkg/store/memorystore/memorystore.go
@@ -321,6 +321,21 @@ func (m *MemoryStore) ListInteractions(_ context.Context, query *types.ListInter
 	return result, int64(len(result)), nil
 }
 
+// ClearSessionInteractions deletes every interaction for a session,
+// mirroring the gorm store's atomic delete-by-session_id. Idempotent: a
+// session with no interactions is a no-op. Backs the clear-session
+// coordinator (and the org spawner's pre-reactivation clear).
+func (m *MemoryStore) ClearSessionInteractions(_ context.Context, sessionID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for id, i := range m.interactions {
+		if i.SessionID == sessionID {
+			delete(m.interactions, id)
+		}
+	}
+	return nil
+}
+
 // --- Stubs for methods called in goroutines (prevent panics) ---
 
 // Design review comments — always return "not found" (no comments in test)


### PR DESCRIPTION
## Summary

Org Workers re-use one long-lived Helix session across every activation. That session's transcript grows without bound until it hits the model's context limit and triggers expensive, lossy compaction. A Worker persists its durable learnings to markdown in its git workspace (not to the chat history), so the conversation itself carries no state worth keeping between activations.

This change clears the Worker's session before every **re-activation**, so each turn starts on a fresh context window.

## How

- **`ensureSession` (spawner)** — when a persisted session exists, call `ClearSession` before the follow-up prompt. First activation has nothing to clear and falls straight through to a fresh `StartSession`.
- **`SpawnerClient.ClearSession`** — added to the activation-only `SpawnerClient` interface, *not* the shared `SessionClient` primitive, so owner-chat sends never accidentally clear.
- **`inProcHelixClient.ClearSession`** — routes through the same `clearSessionHandler` the public `POST /sessions/{id}/clear` endpoint uses (added in #2650). Authorization is identical to the existing `SendMessage` path (`authorizeUserToSession` `ActionUpdate`). For Zed/ACP worker sessions the clear also resets the Zed thread, so the next message opens a brand-new thread.
- **Fail fast** — a clear error aborts the activation rather than dispatching the prompt onto the stale, oversized context (the whole point of the clear).
- **`memorystore.ClearSessionInteractions`** — the #2650 store method was added to the gorm store and mocks but missed the in-memory store the Zed WebSocket-sync E2E test server uses; implemented here to match the gorm delete-by-session_id semantics.

## Testing

All green (`CGO_ENABLED=1` for tree-sitter):

- `TestSpawnerClearsSessionOnReactivationOnly` — two activations end-to-end: first clears nothing + opens fresh; second clears the persisted session before sending and re-uses the warm session (no churn).
- `TestSpawnerClearFailureAbortsActivation` — clear error aborts; no `SendMessage` onto stale context.
- `TestSpawnerFollowUpResumesPersistedSession` / `TestSpawnerStartsFreshAndPersistsSession` — extended with clear assertions.
- `TestInProcSpawnerClient_ClearSession_*` — wiring through `clearSessionHandler`, interactions removed + session row preserved, missing-session errors.
- Full `./pkg/org/...` suite + server clear/inproc suites pass; `go vet` clean.

> [!NOTE]
> Not yet verified against a live, connected Zed Worker doing activation-after-activation (per the repo's lifecycle-testing rule). The unit tests cover the wiring and the spawner contract; a live re-activation check is the remaining meaningful verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)