### PR TITLE
fix(compute): D4 must not shed Runners that have a Runner Profile assigned

### DIFF
--- a/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
@@ -76,6 +76,9 @@ func (nullStore) UpdateSandboxInstanceProviderID(context.Context, string, string
 func (nullStore) DeregisterSandboxInstance(context.Context, string) error {
 	return nil
 }
+func (nullStore) ListRunnerAssignments(context.Context) ([]*types.RunnerAssignment, error) {
+	return nil, nil
+}
 
 func TestBootstrapDisabledWhenProviderUnset(t *testing.T) {
 	// THE core disabled-by-default contract: HELIX_COMPUTE_PROVIDER

--- a/api/pkg/sandbox/compute/manager.go
+++ b/api/pkg/sandbox/compute/manager.go
@@ -26,6 +26,14 @@ type SandboxStore interface {
 	UpdateSandboxInstanceComputeState(ctx context.Context, id, computeState string) error
 	UpdateSandboxInstanceProviderID(ctx context.Context, id, providerID string) error
 	DeregisterSandboxInstance(ctx context.Context, id string) error
+	// ListRunnerAssignments lets D4 (tryDeprovisionIdle) protect any
+	// Runner that has a Runner Profile assigned. A profile-assigned
+	// Runner may be serving inference (e.g. vllm-tiny via compose-
+	// manager) even when active_sandboxes is 0; shedding it would tear
+	// down a live inference service. Only the runner IDs are used;
+	// the full assignment payload is loaded but cheap (one row per
+	// Runner, and the fleet is small).
+	ListRunnerAssignments(ctx context.Context) ([]*types.RunnerAssignment, error)
 }
 
 // ManagerConfig configures a single ComputeManager instance.
@@ -490,6 +498,31 @@ func (m *Manager) tryDeprovisionIdle(ctx context.Context, rows []*types.SandboxI
 		return nil
 	}
 
+	// Load the set of Runner IDs that currently have a Runner Profile
+	// assigned. Those Runners may be serving inference (vllm-tiny etc.)
+	// even when active_sandboxes is 0; the dispatcher's idleness
+	// signal only tracks dev-container sandboxes and is blind to
+	// inference traffic served by the compose-managed profile. D4
+	// MUST NOT shed them: tearing down a profile-assigned Runner kills
+	// its inference engine and breaks routed traffic. The operator
+	// un-assigns the profile when they actually want the Runner gone.
+	//
+	// On store error we log and conservatively skip the whole shed
+	// cycle - better to leave an idle Runner alive for one cycle than
+	// risk killing inference because the assignments query timed out.
+	assignedIDs := make(map[string]struct{})
+	assignments, err := m.store.ListRunnerAssignments(ctx)
+	if err != nil {
+		log.Warn().Err(err).
+			Msg("D4: ListRunnerAssignments failed; skipping shed this cycle to avoid killing a profile-assigned Runner")
+		return nil
+	}
+	for _, a := range assignments {
+		if a != nil {
+			assignedIDs[a.RunnerID] = struct{}{}
+		}
+	}
+
 	// Pick the longest-idle candidate that has crossed the IdleTimeout
 	// window. Single deprovision per cycle.
 	//
@@ -510,6 +543,11 @@ func (m *Manager) tryDeprovisionIdle(ctx context.Context, rows []*types.SandboxI
 	for _, id := range ids {
 		idleAt := m.idleSince[id]
 		if now.Sub(idleAt) < m.cfg.IdleTimeout {
+			continue
+		}
+		if _, assigned := assignedIDs[id]; assigned {
+			// Profile-assigned Runner: protected from shed even when
+			// dev-container sandboxes are zero (may be serving inference).
 			continue
 		}
 		r := readyByID[id]

--- a/api/pkg/sandbox/compute/manager_d4_profile_test.go
+++ b/api/pkg/sandbox/compute/manager_d4_profile_test.go
@@ -1,0 +1,204 @@
+package compute
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// TestD4SkipsProfileAssignedRunner is the priority correctness fix:
+// a Runner with a Runner Profile assigned may be serving inference
+// (e.g. vllm-tiny via compose-manager) even with active_sandboxes = 0.
+// D4 must not shed it - tearing it down kills the inference engine.
+func TestD4SkipsProfileAssignedRunner(t *testing.T) {
+	store := newFakeStore()
+	stub := NewStubProvider("stub")
+	m, err := NewManager(stub, store, ManagerConfig{
+		Floor:                   1,
+		Max:                     3,
+		ScaleUpHeadroomMin:      0,
+		MaxConcurrentProvisions: 1,
+		ReconcileInterval:       10 * time.Millisecond,
+		HealthCheckTimeout:      100 * time.Millisecond,
+		IdleTimeout:             1 * time.Millisecond,
+
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// R1: keeps the floor met so D4 is allowed to consider others.
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-r1-keepalive",
+		Provider:        "stub",
+		ProviderID:      "wr-r1",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 0,
+	})
+	// R2: profile-assigned. 0 sandboxes but presumed serving inference
+	// via the assigned profile. MUST be protected from D4.
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-r2-inference",
+		Provider:        "stub",
+		ProviderID:      "wr-r2",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 0,
+	})
+	store.setAssignment("sbx-r2-inference", "rprof_vllm_tiny")
+
+	// Arm idle tracker, then trigger a shed cycle.
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile arm: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile shed: %v", err)
+	}
+
+	// Per-cycle MaxConcurrent=1: at most one shed. The protected R2
+	// must NOT be the one. R1 was the keepalive; D4 should have shed R1
+	// instead (it's the only unprotected candidate).
+	if _, err := store.GetSandboxInstance(context.Background(), "sbx-r2-inference"); err != nil {
+		t.Fatalf("R2 (profile-assigned) was shed despite the protection; "+
+			"this is the bug fixed here. error: %v", err)
+	}
+	// R1 deregistered. (Floor=1: this leaves 1 ready row, the profile-
+	// assigned R2.)
+	if _, err := store.GetSandboxInstance(context.Background(), "sbx-r1-keepalive"); err == nil {
+		t.Fatalf("R1 (unprotected, idle) should have been shed; still present")
+	}
+}
+
+// TestD4ShedsUnassignedRunnerNormally guards against false positives:
+// when a Runner has NO profile assignment, the new code path must NOT
+// inhibit shedding. Same shape as TestD4SkipsProfileAssignedRunner but
+// with no assignment set.
+func TestD4ShedsUnassignedRunnerNormally(t *testing.T) {
+	store := newFakeStore()
+	stub := NewStubProvider("stub")
+	m, err := NewManager(stub, store, ManagerConfig{
+		Floor:                   1,
+		Max:                     3,
+		ScaleUpHeadroomMin:      0,
+		MaxConcurrentProvisions: 1,
+		ReconcileInterval:       10 * time.Millisecond,
+		HealthCheckTimeout:      100 * time.Millisecond,
+		IdleTimeout:             1 * time.Millisecond,
+
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-r1",
+		Provider:        "stub",
+		ProviderID:      "wr-r1",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 0,
+	})
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-r2-noprofile",
+		Provider:        "stub",
+		ProviderID:      "wr-r2",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 0,
+	})
+	// no assignment set on either row
+
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile arm: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile shed: %v", err)
+	}
+
+	// Exactly one shed (MaxConcurrent=1). Which one doesn't matter.
+	left := 0
+	for _, id := range []string{"sbx-r1", "sbx-r2-noprofile"} {
+		if _, err := store.GetSandboxInstance(context.Background(), id); err == nil {
+			left++
+		}
+	}
+	if left != 1 {
+		t.Fatalf("expected exactly 1 of 2 idle unassigned Runners shed; %d still present", left)
+	}
+}
+
+// TestD4SkipsShedOnAssignmentLookupError verifies the conservative
+// failure mode: if ListRunnerAssignments fails (DB hiccup, timeout),
+// D4 must NOT shed - we'd rather hold an idle Runner alive for one
+// cycle than risk killing inference because we didn't know the
+// assignments.
+func TestD4SkipsShedOnAssignmentLookupError(t *testing.T) {
+	store := &assignmentErrorStore{fakeStore: newFakeStore()}
+	stub := NewStubProvider("stub")
+	m, err := NewManager(stub, store, ManagerConfig{
+		Floor:                   1,
+		Max:                     3,
+		ScaleUpHeadroomMin:      0,
+		MaxConcurrentProvisions: 1,
+		ReconcileInterval:       10 * time.Millisecond,
+		HealthCheckTimeout:      100 * time.Millisecond,
+		IdleTimeout:             1 * time.Millisecond,
+
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-r1",
+		Provider:        "stub",
+		ProviderID:      "wr-r1",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 0,
+	})
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx-r2",
+		Provider:        "stub",
+		ProviderID:      "wr-r2",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		MaxSandboxes:    2,
+		ActiveSandboxes: 0,
+	})
+
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile arm: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile shed: %v", err)
+	}
+
+	// Both rows should still be present - the shed was skipped.
+	for _, id := range []string{"sbx-r1", "sbx-r2"} {
+		if _, err := store.GetSandboxInstance(context.Background(), id); err != nil {
+			t.Fatalf("row %s shed despite the assignments-lookup error; "+
+				"D4 should have bailed conservatively. error: %v", id, err)
+		}
+	}
+}
+
+// assignmentErrorStore wraps fakeStore and always errors on
+// ListRunnerAssignments. Used to verify the conservative-skip path.
+type assignmentErrorStore struct{ *fakeStore }
+
+func (s *assignmentErrorStore) ListRunnerAssignments(_ context.Context) ([]*types.RunnerAssignment, error) {
+	return nil, errors.New("simulated DB timeout")
+}

--- a/api/pkg/sandbox/compute/manager_test.go
+++ b/api/pkg/sandbox/compute/manager_test.go
@@ -14,12 +14,39 @@ import (
 // fakeStore is a goroutine-safe in-memory SandboxStore for unit tests.
 // Mirrors the subset of the real store the Manager touches.
 type fakeStore struct {
-	mu   sync.Mutex
-	rows map[string]*types.SandboxInstance
+	mu          sync.Mutex
+	rows        map[string]*types.SandboxInstance
+	assignments map[string]*types.RunnerAssignment // runner_id -> assignment
 }
 
 func newFakeStore() *fakeStore {
-	return &fakeStore{rows: make(map[string]*types.SandboxInstance)}
+	return &fakeStore{
+		rows:        make(map[string]*types.SandboxInstance),
+		assignments: make(map[string]*types.RunnerAssignment),
+	}
+}
+
+// setAssignment is a test helper that records a profile assignment for
+// the given runner_id. Used by tests covering the D4 profile-assigned
+// protection path.
+func (f *fakeStore) setAssignment(runnerID, profileID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.assignments[runnerID] = &types.RunnerAssignment{
+		RunnerID:  runnerID,
+		ProfileID: profileID,
+	}
+}
+
+func (f *fakeStore) ListRunnerAssignments(ctx context.Context) ([]*types.RunnerAssignment, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]*types.RunnerAssignment, 0, len(f.assignments))
+	for _, a := range f.assignments {
+		cp := *a
+		out = append(out, &cp)
+	}
+	return out, nil
 }
 
 func (f *fakeStore) ListSandboxInstances(ctx context.Context) ([]*types.SandboxInstance, error) {


### PR DESCRIPTION
## Summary

Critical correctness bug. D4 (idle scale-down) currently picks shed candidates based only on \`active_sandboxes == 0\`. But that counter tracks dev containers (user-facing sandboxes) - it's blind to inference traffic served by the assigned Runner Profile (e.g. vllm-tiny). A profile-assigned Runner with 0 sandboxes IS doing work; tearing it down kills the inference engine.

## Production scenario

1. Operator assigns Runner Profile "Dev box: tiny LLM + desktops" to sbx_X.
2. compose-manager polls /assignment, picks it up, runs \`docker compose up\` against the inner dockerd. vllm-tiny starts on the GPU. inference-proxy reverse-routes.
3. Helix's inference router learns sbx_X serves \`qwen2.5-0.5b\` (heartbeat-versioned profile model list).
4. End users send chat completions for qwen2.5-0.5b; requests get routed via RevDial to sbx_X's inference-proxy to vllm-tiny.
5. No dev containers run on this Runner. \`active_sandboxes\` stays at 0.
6. \`HELIX_COMPUTE_IDLE_TIMEOUT\` elapses (default 10m). D4 picks sbx_X as longest-idle candidate.
7. Provider.Deprovision is called. YD cancels the Work Requirement. The helix-sandbox container dies, taking vllm-tiny with it.
8. Live inference traffic to that model starts returning 503.

## Fix

In \`tryDeprovisionIdle\`, before picking the shed candidate, load the set of currently-assigned Runner IDs from \`runner_assignments\`. Skip candidates whose ID is in that set. Operator un-assigns the profile (via admin UI) when they actually want the Runner shed.

## Why this layer, not a smarter signal

Step 2 of the design (Obsidian note \`design/2026-06-17-d3-dispatcher-coupling.md\` referenced earlier) would track per-Runner inference activity timestamps and shed profile-assigned Runners that haven't served traffic in some larger window. That's more nuanced but adds DB churn on the inference hot path and a tunable parameter. The simpler Step 1 (this PR) takes operator intent as the source of truth: presence of a Runner Profile assignment IS the "this Runner is in service" declaration. No magic.

## Failure mode

If \`ListRunnerAssignments\` errors (DB hiccup, timeout), D4 logs a warning and skips the entire shed cycle. Better to hold an idle Runner alive for 15-30s longer than risk killing inference because the DB query failed.

## Tests

- \`TestD4SkipsProfileAssignedRunner\` - the bug repro: R1 (no profile) + R2 (with profile), both idle. R2 must survive; R1 must be shed.
- \`TestD4ShedsUnassignedRunnerNormally\` - guard against false positive: no assignments, normal D4 behaviour.
- \`TestD4SkipsShedOnAssignmentLookupError\` - conservative-bail safety: ListRunnerAssignments errors -> no shed.

## Test plan

- [x] \`go test ./pkg/sandbox/compute/...\` green
- [x] All existing compute tests pass (interface extension added a method to nullStore in bootstrap_test.go + to fakeStore)
- [ ] CI green
- [ ] Validate post-merge on yd.helix.ml: assign a profile to a Runner, wait past IdleTimeout, confirm D4 does NOT shed

## Related

- Step 2 (per-Runner inference activity timestamps) intentionally NOT done; user feedback was Step 1 alone is sufficient
- PR https://github.com/helixml/helix/pull/2648 - Option E fleet-pressure inhibition - composes cleanly with this fix (both refine D4 candidate selection independently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)