### PR TITLE
Fix qwen-code desktop-image build for v0.14.4 workspaces

### DIFF
--- a/Dockerfile.qwen-build
+++ b/Dockerfile.qwen-build
@@ -16,8 +16,18 @@ RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 COPY . /app
 WORKDIR /app
 
+# Build matches upstream qwen-code's own Dockerfile: a full `npm ci` (NOT
+# --ignore-scripts) so the workspace packages under packages/channels/* and
+# packages/web-templates get built during install, then `npm run build`
+# (scripts/build.js) and `npm run bundle`. Since v0.14.4 the cli bundle imports
+# @qwen-code/channel-* and web-templates' generated templates; with
+# --ignore-scripts those workspace dist/ outputs are never produced and esbuild
+# fails with "Could not resolve @qwen-code/channel-base". HUSKY=0 disables the
+# git-hook install in the `prepare` script (the build context excludes .git).
+ENV HUSKY=0
 RUN --mount=type=cache,target=/root/.npm \
-    npm ci --ignore-scripts && \
+    npm ci && \
+    npm run build && \
     npm run bundle
 
 # Collect runtime files into /output


### PR DESCRIPTION
## Problem

`main` is red on `build-qwen-code` (e.g. https://drone.lukemarsden.net/helixml/helix/2326/6/3) after `QWEN_COMMIT` was bumped to the qwen-code v0.14.4 upgrade (`36fae6014`).

`Dockerfile.qwen-build` built qwen with `npm ci --ignore-scripts && npm run bundle`. That worked for the old v0.4.1-era pin, but since v0.14.4 the CLI bundle imports the `@qwen-code/channel-*` workspace packages (`packages/channels/{base,telegram,weixin,dingtalk}`) and `web-templates`' generated templates. `--ignore-scripts` skips building those workspace `dist/` outputs, so esbuild fails:

```
✘ [ERROR] Could not resolve "@qwen-code/channel-base"
✘ [ERROR] Could not resolve "./generated/insightTemplate.js"
esbuild build failed: Build failed with 9 errors
ERROR: process "/bin/sh -c npm ci --ignore-scripts && npm run bundle" did not complete successfully: exit code: 1
```

## Fix

Match upstream qwen-code's own `Dockerfile`: full `npm ci && npm run build && npm run bundle` (no `--ignore-scripts`), so the workspace packages get built before bundling. `HUSKY=0` disables the `prepare` git-hook install since the build context excludes `.git`.

## Verification

Clean `docker build -f Dockerfile.qwen-build` against the v0.14.4 source (`ca5f3a28c`, the commit `QWEN_COMMIT` resolves to on main):
- build succeeds, `✅ All bundle assets copied to dist/`
- output `dist/cli.js` reports `0.14.4`
- `packages/channels/base/dist/` and `web-templates` generated files present in the output

This is the build-fix companion to the already-merged task-002098 work (qwen `--yolo` / `default_mode`, model-routing cold-cache fix, and the `QWEN_COMMIT` bump that exposed this build path).
