### PR TITLE
feat(runner): AWS Neuron (Inferentia2/Trainium) inference support

### DIFF
--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -1408,6 +1408,36 @@ func (dm *DevContainerManager) configureGPU(hostConfig *container.HostConfig, ve
 			Int("explicit_dev_mounts", len(hostConfig.Devices)).
 			Msg("Configured NVIDIA GPU passthrough")
 
+	case "neuron":
+		// AWS Neuron (Inferentia2 / Trainium): mount the /dev/neuron*
+		// device nodes into the nested Docker. All neuronx silicon
+		// presents the same device-node family — one node per Neuron core
+		// (/dev/neuron0, /dev/neuron1, ...). The count varies by instance
+		// type (2 on inf2.xlarge, 16 on inf2.48xlarge, 16 on trn1.32xlarge,
+		// ...), so glob rather than hardcode and the same arm covers every
+		// inf2 SKU and Trainium. The Neuron driver lives on the host (AWS
+		// Neuron DLC AMI); we only pass the device nodes through. No
+		// container runtime, no /dev/kfd, no DRM render node — Neuron has
+		// no display path.
+		//
+		// ponytail: glob covers every inf2/trn SKU; per-core pinning
+		// (gpuIndex) is not wired — add when multi-tenant Neuron packing
+		// on one host is needed (one model per pool in v1, so unused).
+		neuronDevs, _ := filepath.Glob("/dev/neuron*")
+		if len(neuronDevs) == 0 {
+			log.Warn().Msg("neuron passthrough: no /dev/neuron* nodes found in outer container; inner serving stack will not see the accelerator")
+		}
+		for _, dev := range neuronDevs {
+			hostConfig.Devices = append(hostConfig.Devices,
+				container.DeviceMapping{
+					PathOnHost:        dev,
+					PathInContainer:   dev,
+					CgroupPermissions: "rwm",
+				},
+			)
+		}
+		log.Debug().Strs("neuron_devs", neuronDevs).Msg("Configured Neuron device passthrough")
+
 	case "amd":
 		// AMD: mount /dev/kfd (shared across all AMD GPUs — always
 		// mounted regardless of pinning) plus the matching render+card

--- a/api/pkg/runner/profile/store.go
+++ b/api/pkg/runner/profile/store.go
@@ -125,8 +125,10 @@ func (s *Service) buildProfile(in SaveInput) (*types.RunnerProfile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("compose parse: %w", err)
 	}
-	if in.Vendor != "" && in.Vendor != types.GPUVendorNVIDIA && in.Vendor != types.GPUVendorAMD {
-		return nil, fmt.Errorf("invalid vendor %q (must be empty, %q, or %q)", in.Vendor, types.GPUVendorNVIDIA, types.GPUVendorAMD)
+	switch in.Vendor {
+	case "", types.GPUVendorNVIDIA, types.GPUVendorAMD, types.GPUVendorNeuron:
+	default:
+		return nil, fmt.Errorf("invalid vendor %q (must be empty, %q, %q, or %q)", in.Vendor, types.GPUVendorNVIDIA, types.GPUVendorAMD, types.GPUVendorNeuron)
 	}
 	return &types.RunnerProfile{
 		Name:        in.Name,

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -28197,11 +28197,13 @@ const docTemplate = `{
             "type": "string",
             "enum": [
                 "nvidia",
-                "amd"
+                "amd",
+                "neuron"
             ],
             "x-enum-varnames": [
                 "GPUVendorNVIDIA",
-                "GPUVendorAMD"
+                "GPUVendorAMD",
+                "GPUVendorNeuron"
             ]
         },
         "types.GitHub": {

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -28193,11 +28193,13 @@
             "type": "string",
             "enum": [
                 "nvidia",
-                "amd"
+                "amd",
+                "neuron"
             ],
             "x-enum-varnames": [
                 "GPUVendorNVIDIA",
-                "GPUVendorAMD"
+                "GPUVendorAMD",
+                "GPUVendorNeuron"
             ]
         },
         "types.GitHub": {

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -5211,10 +5211,12 @@ definitions:
     enum:
     - nvidia
     - amd
+    - neuron
     type: string
     x-enum-varnames:
     - GPUVendorNVIDIA
     - GPUVendorAMD
+    - GPUVendorNeuron
   types.GitHub:
     properties:
       app_id:

--- a/api/pkg/types/runner_profile.go
+++ b/api/pkg/types/runner_profile.go
@@ -9,6 +9,11 @@ type GPUVendor string
 const (
 	GPUVendorNVIDIA GPUVendor = "nvidia"
 	GPUVendorAMD    GPUVendor = "amd"
+	// GPUVendorNeuron covers all AWS neuronx silicon (Inferentia2 inf2.*
+	// SKUs and Trainium trn1/trn2) — same device-node family and serving
+	// path, so one vendor value. inf1 (older neuron-cc runtime) is not
+	// supported.
+	GPUVendorNeuron GPUVendor = "neuron"
 )
 
 // ProfileModel describes one model exposed by a profile, derived by parsing

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -3269,6 +3269,7 @@ export interface TypesGPUStatus {
 export enum TypesGPUVendor {
   GPUVendorNVIDIA = "nvidia",
   GPUVendorAMD = "amd",
+  GPUVendorNeuron = "neuron",
 }
 
 export interface TypesGitHub {

--- a/frontend/src/components/dashboard/EditRunnerProfile.tsx
+++ b/frontend/src/components/dashboard/EditRunnerProfile.tsx
@@ -73,7 +73,7 @@ const EditRunnerProfile: FC<Props> = ({ profile, template, onClose }) => {
     name: profile?.name || template?.name || "",
     description: profile?.description || template?.description || "",
     composeYAML: profile?.compose_yaml || template?.composeYAML || SAMPLE_COMPOSE,
-    vendor: (profile?.gpu_requirement?.vendor as "" | "nvidia" | "amd") || template?.vendor || "",
+    vendor: (profile?.gpu_requirement?.vendor as "" | "nvidia" | "amd" | "neuron") || template?.vendor || "",
     architectures: (profile?.gpu_requirement?.architectures || template?.architectures || []).join(", "),
     modelMatch: profile?.gpu_requirement?.model_match || template?.modelMatch || "",
     minVRAMBytes: (profile?.gpu_requirement?.min_vram_bytes ?? template?.minVRAMBytes ?? 0).toString(),
@@ -81,8 +81,8 @@ const EditRunnerProfile: FC<Props> = ({ profile, template, onClose }) => {
   const [name, setName] = useState(init.name);
   const [description, setDescription] = useState(init.description);
   const [composeYAML, setComposeYAML] = useState(init.composeYAML);
-  const [vendor, setVendor] = useState<"" | "nvidia" | "amd">(
-    init.vendor as "" | "nvidia" | "amd",
+  const [vendor, setVendor] = useState<"" | "nvidia" | "amd" | "neuron">(
+    init.vendor as "" | "nvidia" | "amd" | "neuron",
   );
   const [architectures, setArchitectures] = useState<string>(init.architectures);
   const [modelMatch, setModelMatch] = useState(init.modelMatch);
@@ -163,11 +163,12 @@ const EditRunnerProfile: FC<Props> = ({ profile, template, onClose }) => {
             <Select
               label="Vendor"
               value={vendor}
-              onChange={(e) => setVendor(e.target.value as "" | "nvidia" | "amd")}
+              onChange={(e) => setVendor(e.target.value as "" | "nvidia" | "amd" | "neuron")}
             >
               <MenuItem value="">(any)</MenuItem>
               <MenuItem value="nvidia">nvidia</MenuItem>
               <MenuItem value="amd">amd</MenuItem>
+              <MenuItem value="neuron">neuron (AWS Inferentia2 / Trainium)</MenuItem>
             </Select>
           </FormControl>
 

--- a/frontend/src/components/dashboard/ProfileGallery.tsx
+++ b/frontend/src/components/dashboard/ProfileGallery.tsx
@@ -41,7 +41,7 @@ export interface PickedTemplate {
   name: string;
   description: string;
   composeYAML: string;
-  vendor: "" | "nvidia" | "amd";
+  vendor: "" | "nvidia" | "amd" | "neuron";
   architectures: string[];
   modelMatch: string;
   minVRAMBytes: number;
@@ -187,7 +187,7 @@ const CuratedCard: FC<{ profile: CuratedProfile; onPick: (t: PickedTemplate) => 
 
 const BlocksTab: FC<{ onPick: (t: PickedTemplate) => void }> = ({ onPick }) => {
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [vendor, setVendor] = useState<"" | "nvidia" | "amd">("nvidia");
+  const [vendor, setVendor] = useState<"" | "nvidia" | "amd" | "neuron">("nvidia");
 
   const toggle = (id: string) => {
     setSelected((prev) => {

--- a/frontend/src/components/dashboard/profileBlocks.ts
+++ b/frontend/src/components/dashboard/profileBlocks.ts
@@ -35,7 +35,7 @@ export interface ProfileBlock {
   composeService: string;
   // Optional architecture hints — empty = any vendor's any arch.
   requiresArchitectures?: string[];
-  requiresVendor?: "nvidia" | "amd" | "";
+  requiresVendor?: "nvidia" | "amd" | "neuron" | "";
 }
 
 const GIB = 1024 * 1024 * 1024;
@@ -378,6 +378,84 @@ export const blockDesktopReserve: ProfileBlock = {
   composeService: "", // informational only
 };
 
+// ----------------------------------------------------------------------
+// AWS Neuron (Inferentia2 / Trainium) — non-NVIDIA inference
+// ----------------------------------------------------------------------
+
+// vLLM-Neuron serving a pre-compiled artifact from AWS's public aws-neuron
+// HF org. No operator compile step, no S3: the container downloads the
+// artifact by HF model ID on first start. inf2.xlarge has 2 Neuron cores,
+// so the published artifact is tp=2; the two cores are exposed as
+// /dev/neuron0..1. The hydra "neuron" arm globs and mounts these into the
+// nested Docker; the compose service below claims them via `devices:`.
+//
+// ponytail: devices hardcoded to neuron0/neuron1 for the inf2.xlarge demo
+// (2 cores). Larger SKUs (inf2.8xlarge=12, trn1=16) need more entries —
+// expand the list when a bigger pool is provisioned.
+//
+// NOTE: pin `image` and the HF artifact revision to an SDK-compatible pair
+// at wire-up time against the host's Neuron DLC AMI (design risk #4 — graph
+// load fails on ABI mismatch). `latest` is a placeholder, not a contract.
+//
+// GATING NOTE — do NOT "fix" the derived GPURequirement.Count to 2. Neuron
+// runners report an empty GPU inventory (gpudetect has no neuron probe; the
+// design stubs neuron GPU stats on purpose). The assignment compatibility
+// check (profile/compatibility.go) therefore gates neuron purely on Vendor:
+//   - neuron profile -> neuron host (empty inventory): count 0>0 false, vendor
+//     loop over [] is vacuous -> ASSIGNS.
+//   - neuron profile -> nvidia host: vendor check rejects (nvidia != neuron).
+//   - nvidia profile -> neuron host: count 1>0 rejects.
+// If composeparse ever learns to count neuron `devices:` (Count=2), it MUST
+// land together with a gpudetect neuron probe, or assignment to the inf2
+// runner breaks (2 > 0 reject). Both are out of scope for this v1 demo.
+export const blockChatNeuronMistral7B: ProfileBlock = {
+  id: "chat-neuron-mistral-7b",
+  name: "inf2.xlarge - Mistral-7B (Neuron)",
+  category: "chat",
+  description:
+    "Mistral-7B-Instruct-v0.3 pre-compiled by AWS for Inferentia2 (HF: aws-neuron/Mistral-7B-Instruct-v0.3-neuronx). Demo profile for non-NVIDIA inference on a single inf2.xlarge (~$0.99/hr, us-east-1).",
+  pros: [
+    "Runs LLM inference on AWS Inferentia2 — no NVIDIA hardware",
+    "Pre-compiled artifact: no operator compile step, no S3",
+    "Same control plane and YD provisioning loop as NVIDIA runners",
+  ],
+  cons: [
+    "Artifact compiled with fixed (bs, sl, tp) — deviating needs a recompile",
+    "30-60s cold start while the Neuron graph loads",
+    "vLLM-Neuron is less mature than CUDA vLLM",
+  ],
+  // GPU-memory fields don't model Neuron device memory; left at 1 core's
+  // worth of "claim the whole accelerator" since one model owns the pool.
+  gpuMemoryFraction: 1,
+  gpuCount: 1,
+  minVRAMBytesPerGPU: 0,
+  requiresVendor: "neuron",
+  composeService: `vllm-neuron-mistral:
+    image: public.ecr.aws/neuron/vllm:latest
+    container_name: vllm-neuron-mistral
+    ports:
+      - "127.0.0.1:8000:8000"
+    volumes:
+      - /models:/root/.cache/huggingface
+    devices:
+      - "/dev/neuron0:/dev/neuron0"
+      - "/dev/neuron1:/dev/neuron1"
+    shm_size: 1g
+    command:
+      - --model
+      - aws-neuron/Mistral-7B-Instruct-v0.3-neuronx
+      - --served-model-name
+      - mistralai/Mistral-7B-Instruct-v0.3
+      - --device
+      - neuron
+      - --tensor-parallel-size
+      - "2"
+      - --max-num-seqs
+      - "4"
+      - --max-model-len
+      - "8192"`,
+};
+
 export const allBlocks: ProfileBlock[] = [
   blockChatTiny,
   blockChat7B,
@@ -386,6 +464,7 @@ export const allBlocks: ProfileBlock[] = [
   blockEmbedText,
   blockEmbedVL,
   blockDesktopReserve,
+  blockChatNeuronMistral7B,
 ];
 
 // ----------------------------------------------------------------------
@@ -399,7 +478,7 @@ export interface CuratedProfile {
   pros: string[];
   cons: string[];
   blockIDs: string[];
-  vendor: "nvidia" | "amd" | "";
+  vendor: "nvidia" | "amd" | "neuron" | "";
   architectures: string[];
   modelMatch?: string;
   minVRAMBytes?: number;
@@ -471,6 +550,25 @@ export const curatedProfiles: CuratedProfile[] = [
     architectures: ["hopper", "blackwell"],
     minVRAMBytes: 80 * GIB,
     composeYAML: composeFromBlocks([blockChat35B]),
+  },
+  {
+    id: "inf2-mistral-7b-neuron",
+    name: "AWS Inferentia2: Mistral-7B (Neuron)",
+    description:
+      "Single inf2.xlarge serving Mistral-7B-Instruct-v0.3 on AWS Neuron. Demonstrates hardware-agnostic inference — the same control plane that drives NVIDIA g5 runners drives Inferentia2 via the same YD provisioning loop.",
+    pros: [
+      "LLM inference on non-NVIDIA (Inferentia2) hardware",
+      "Pre-compiled AWS artifact — no operator compile or S3 management",
+      "~$0.99/hr, comparable to g5.xlarge",
+    ],
+    cons: [
+      "One model per pool (artifact is fixed bs/sl/tp)",
+      "Neuron SDK / AMI / artifact must be a compatible triple",
+    ],
+    blockIDs: ["chat-neuron-mistral-7b"],
+    vendor: "neuron",
+    architectures: [],
+    composeYAML: composeFromBlocks([blockChatNeuronMistral7B]),
   },
   {
     id: "8xh100-prod",

--- a/frontend/src/services/runnerProfilesService.ts
+++ b/frontend/src/services/runnerProfilesService.ts
@@ -30,7 +30,7 @@ export interface ProfileModel {
 
 export interface ProfileGPURequirement {
   count: number;
-  vendor?: "nvidia" | "amd" | "";
+  vendor?: "nvidia" | "amd" | "neuron" | "";
   architectures?: string[];
   model_match?: string;
   min_vram_bytes?: number;
@@ -41,7 +41,7 @@ export interface RunnerProfileSaveRequest {
   name: string;
   description?: string;
   compose_yaml: string;
-  vendor?: "nvidia" | "amd" | "";
+  vendor?: "nvidia" | "amd" | "neuron" | "";
   architectures?: string[];
   model_match?: string;
   min_vram_bytes?: number;

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -5211,10 +5211,12 @@ definitions:
     enum:
     - nvidia
     - amd
+    - neuron
     type: string
     x-enum-varnames:
     - GPUVendorNVIDIA
     - GPUVendorAMD
+    - GPUVendorNeuron
   types.GitHub:
     properties:
       app_id:

--- a/install.sh
+++ b/install.sh
@@ -1044,6 +1044,22 @@ check_intel_amd_gpu() {
     fi
 }
 
+# Function to check for AWS Neuron device (Inferentia2 / Trainium)
+# Detects neuronx hosts (inf2.*, trn1/trn2) by the /dev/neuron* device nodes
+# the Neuron driver creates, or the neuron-ls CLI from the Neuron DLC AMI.
+# Provider-agnostic: true on any inf2/trn host regardless of how it was
+# provisioned (YD, manual EC2, etc.). inf1 (older neuron-cc runtime) is
+# unsupported.
+check_neuron_device() {
+    if ls /dev/neuron0 &> /dev/null; then
+        return 0
+    fi
+    if command -v neuron-ls &> /dev/null; then
+        return 0
+    fi
+    return 1
+}
+
 # Function to check if NVIDIA Docker runtime needs installation
 check_nvidia_runtime_needed() {
     # Only relevant if we have an NVIDIA GPU
@@ -2615,6 +2631,10 @@ if [ "$SANDBOX" = true ]; then
         GPU_TYPE="amd"
         GPU_VENDOR="amd"
         echo "AMD GPU detected with ROCm support"
+    elif check_neuron_device; then
+        GPU_TYPE="neuron"
+        GPU_VENDOR="neuron"
+        echo "AWS Neuron device detected (Inferentia2 / Trainium)"
     elif check_intel_amd_gpu; then
         GPU_TYPE="intel"
         GPU_VENDOR="intel"
@@ -2725,6 +2745,16 @@ elif [ "$GPU_VENDOR" = "amd" ]; then
 elif [ "$GPU_VENDOR" = "intel" ]; then
     GPU_FLAGS="--device /dev/dri"
     GPU_ENV_FLAGS="-e GPU_VENDOR=intel"
+elif [ "$GPU_VENDOR" = "neuron" ]; then
+    # AWS Neuron (Inferentia2 / Trainium): pass every /dev/neuron* node into
+    # the outer helix-sandbox container so hydra can forward them to the
+    # nested Docker. No --gpus / --runtime / DRI (Neuron has no display path).
+    # Glob runs here on the host, so this covers any inf2/trn core count.
+    GPU_FLAGS=""
+    for neuron_dev in /dev/neuron*; do
+        [ -e "$neuron_dev" ] && GPU_FLAGS="$GPU_FLAGS --device $neuron_dev"
+    done
+    GPU_ENV_FLAGS="-e GPU_VENDOR=neuron"
 elif [ "$GPU_VENDOR" = "virtio" ]; then
     # macOS ARM with virtio-gpu (QEMU VideoToolbox H.264 via scanout)
     GPU_FLAGS="--device /dev/dri"

--- a/swagger.json
+++ b/swagger.json
@@ -28193,11 +28193,13 @@
             "type": "string",
             "enum": [
                 "nvidia",
-                "amd"
+                "amd",
+                "neuron"
             ],
             "x-enum-varnames": [
                 "GPUVendorNVIDIA",
-                "GPUVendorAMD"
+                "GPUVendorAMD",
+                "GPUVendorNeuron"
             ]
         },
         "types.GitHub": {


### PR DESCRIPTION
## What

Adds support for running Helix inference runners on AWS Neuron silicon (Inferentia2 + Trainium), via the existing YD-provisioned runner loop. Implements the design at `design/2026-06-15-neuron-inference-design.md` (v1, demo-grade).

One vendor value `neuron` covers **every inf2 SKU and trn1/trn2** - they share the `/dev/neuron*` device family and the vLLM-Neuron serving path, so the per-chip variation (device count, tensor-parallel degree, instance type, AMI, model artifact) lives in Runner Profiles and YD templates as data, not in code branches. inf1 (older `neuron-cc` runtime, no vLLM) is intentionally unsupported.

## Changes

- **`api/pkg/hydra/devcontainer.go`** - new `case "neuron":` in `configureGPU`: globs `/dev/neuron*` and mounts each device node into the nested Docker, mirroring the existing nvidia/amd/intel arms. No container runtime, `/dev/kfd`, or DRM render node (Neuron has no display path).
- **`api/pkg/types/runner_profile.go`** - `GPUVendorNeuron` const.
- **`api/pkg/runner/profile/store.go`** - vendor validation accepts `neuron`.
- **`frontend/.../profileBlocks.ts`** - neuron profile block + curated `AWS Inferentia2: Mistral-7B (Neuron)` profile (vLLM-Neuron consuming AWS's pre-compiled `aws-neuron/Mistral-7B-Instruct-v0.3-neuronx` artifact); widened both vendor unions.
- **`frontend/.../EditRunnerProfile.tsx`, `ProfileGallery.tsx`** - widened vendor type, added the `neuron` menu option.
- Regenerated swagger + TS client for the new enum value.

## Gating model (by design - read before changing)

Neuron runners report an **empty** GPU inventory (gpudetect has no neuron probe; the design stubs neuron GPU stats on purpose). The assignment compatibility check therefore gates neuron purely on **vendor**:

- neuron profile -> neuron host (empty inventory): passes -> assigns
- neuron profile -> nvidia host: vendor check rejects (`nvidia != neuron`)
- nvidia profile -> neuron host: count check rejects (`1 > 0`)

If `composeparse` ever learns to count neuron `devices:` (Count=2), it MUST land together with a gpudetect neuron probe, or assignment to the inf2 runner breaks. Both are out of scope here (the design lists neuron GPU stats as a non-goal). There's a `GATING NOTE` comment in `profileBlocks.ts` capturing this.

## Reviewed

Ran an agent review. Findings on the count/inventory interaction were assessed and are addressed by the gating-note comment; the demo path works as-is. Build green: Go packages compile, frontend tsc 0 errors.

## Not done (operator/ops, not code)

- YD compute-source template (jsonnet) - operator-side, not in this repo.
- Pin the real `public.ecr.aws/neuron/vllm` tag + Neuron DLC AMI ID as a compatible triple (compose uses `:latest` as a flagged placeholder).
- **NOT tested end-to-end** - needs a real inf2 host. Device passthrough mirrors the proven nvidia/amd arms; the vLLM-Neuron command flags need validation against the pinned image at wire-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)