### PR TITLE
feat(session): auto-restart crashed agents on autonomous surfaces

### DIFF
--- a/api/pkg/server/auto_restart_crashed_agent_test.go
+++ b/api/pkg/server/auto_restart_crashed_agent_test.go
@@ -1,0 +1,179 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/controller"
+	external_agent "github.com/helixml/helix/api/pkg/external-agent"
+	"github.com/helixml/helix/api/pkg/pubsub"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// AutoRestartCrashedAgentSuite pins the guard-rail contract for automatic
+// agent-crash recovery on AUTONOMOUS surfaces (spec tasks, org workers) where
+// no human is present to click the in-chat Restart button. The crash handlers
+// call maybeAutoRestartCrashedAgent; this suite verifies it:
+//   - actually recovers (StopDesktop → StartDesktop) and spends one unit of
+//     restart budget when the session opted in and has budget left;
+//   - is a NO-OP for human desktop sessions (AutoRestartOnCrash == false), which
+//     keep the explicit button;
+//   - STOPS once the budget is exhausted, so a boot-crash loop can't churn
+//     containers forever;
+//   - DEDUPES concurrent triggers (a single crash can surface as both
+//     thread_load_error and chat_response_error).
+type AutoRestartCrashedAgentSuite struct {
+	suite.Suite
+	ctrl     *gomock.Controller
+	store    *store.MockStore
+	executor *external_agent.MockExecutor
+	server   *HelixAPIServer
+
+	prevBackoff time.Duration
+}
+
+func TestAutoRestartCrashedAgentSuite(t *testing.T) {
+	suite.Run(t, new(AutoRestartCrashedAgentSuite))
+}
+
+func (s *AutoRestartCrashedAgentSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.store = store.NewMockStore(s.ctrl)
+	s.executor = external_agent.NewMockExecutor(s.ctrl)
+
+	s.server = &HelixAPIServer{
+		Store:                 s.store,
+		externalAgentExecutor: s.executor,
+		Cfg:                   &config.ServerConfig{},
+		Controller: &controller.Controller{
+			Options: controller.Options{Store: s.store, PubSub: pubsub.NewNoop()},
+		},
+	}
+
+	// Don't actually wait the backoff in unit tests.
+	s.prevBackoff = autoRestartMinBackoff
+	autoRestartMinBackoff = 0
+}
+
+func (s *AutoRestartCrashedAgentSuite) TearDownTest() {
+	autoRestartMinBackoff = s.prevBackoff
+	s.ctrl.Finish()
+}
+
+// autonomousSession is a restartable external-agent session that opted into
+// auto-restart with `count` units of budget already spent. ZedThreadID is left
+// empty so resumeSessionInternal does not spawn the async open_thread goroutine
+// (which would call into mocks after the test finishes).
+func autonomousSession(id, userID, projectID string, count int) *types.Session {
+	return &types.Session{
+		ID:        id,
+		Owner:     userID,
+		OwnerType: types.OwnerTypeUser,
+		ProjectID: projectID,
+		Metadata: types.SessionMetadata{
+			AgentType:          "zed_external",
+			ProjectID:          projectID,
+			AutoRestartOnCrash: true,
+			AutoRestartCount:   count,
+		},
+	}
+}
+
+// TestAutonomousRestartsAndIncrements is the core gate: an opted-in session with
+// budget left is recovered by recreating the container (StopDesktop →
+// StartDesktop) and one unit of restart budget is persisted (AutoRestartCount
+// 0 → 1) BEFORE the restart, so a restart that itself boot-crashes still counts.
+func (s *AutoRestartCrashedAgentSuite) TestAutonomousRestartsAndIncrements() {
+	const (
+		userID    = "user_svc"
+		projectID = "prj_auto"
+		sessionID = "ses_auto"
+	)
+	session := autonomousSession(sessionID, userID, projectID, 0)
+
+	s.store.EXPECT().GetSession(gomock.Any(), sessionID).Return(session, nil).AnyTimes()
+	s.store.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(&types.User{ID: userID}, nil).AnyTimes()
+	s.store.EXPECT().GetProject(gomock.Any(), projectID).Return(&types.Project{ID: projectID, UserID: userID}, nil).AnyTimes()
+	s.store.EXPECT().ListGitRepositories(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	// Capture every persisted session so we can assert the budget was spent.
+	var persistedCounts []int
+	s.store.EXPECT().UpdateSession(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, sess types.Session) (*types.Session, error) {
+			persistedCounts = append(persistedCounts, sess.Metadata.AutoRestartCount)
+			return &sess, nil
+		}).AnyTimes()
+
+	// The recovery itself: recreate the container.
+	gomock.InOrder(
+		s.executor.EXPECT().StopDesktop(gomock.Any(), sessionID).Return(nil).Times(1),
+		s.executor.EXPECT().StartDesktop(gomock.Any(), gomock.Any()).Return(&types.DesktopAgentResponse{DevContainerID: "dev_new"}, nil).Times(1),
+	)
+	s.store.EXPECT().ResetCrashedPromptsForSession(gomock.Any(), sessionID).Return(0, nil).Times(1)
+
+	// restartSessionContainer kicks the queue in a goroutine; signal so we can
+	// wait for it before TearDownTest runs ctrl.Finish().
+	pumped := make(chan struct{})
+	s.store.EXPECT().GetAnyPendingPrompt(gomock.Any(), sessionID).DoAndReturn(
+		func(_ context.Context, _ string) (*types.PromptHistoryEntry, error) {
+			close(pumped)
+			return nil, nil
+		}).Times(1)
+
+	s.server.maybeAutoRestartCrashedAgent(sessionID)
+
+	select {
+	case <-pumped:
+	case <-time.After(2 * time.Second):
+		s.Fail("auto-restart did not recreate the container / kick the queue")
+	}
+
+	s.Contains(persistedCounts, 1, "auto-restart must persist AutoRestartCount 0 → 1 before restarting")
+}
+
+// TestHumanSurfaceNoOp: a human desktop session (AutoRestartOnCrash == false)
+// keeps the explicit Restart button — auto-restart must not touch the container.
+func (s *AutoRestartCrashedAgentSuite) TestHumanSurfaceNoOp() {
+	const sessionID = "ses_human"
+	session := &types.Session{
+		ID:    sessionID,
+		Owner: "user_h",
+		Metadata: types.SessionMetadata{
+			AgentType:          "zed_external",
+			AutoRestartOnCrash: false,
+		},
+	}
+	s.store.EXPECT().GetSession(gomock.Any(), sessionID).Return(session, nil).Times(1)
+	// No StopDesktop/StartDesktop/UpdateSession expectations — gomock fails if hit.
+
+	s.server.maybeAutoRestartCrashedAgent(sessionID)
+}
+
+// TestBudgetExhaustedNoOp: once AutoRestartCount has reached the cap, stop — a
+// boot-crash loop must not rebuild containers forever. The crash stays terminal.
+func (s *AutoRestartCrashedAgentSuite) TestBudgetExhaustedNoOp() {
+	const sessionID = "ses_exhausted"
+	session := autonomousSession(sessionID, "user_x", "prj_x", autoRestartMaxAttempts)
+	s.store.EXPECT().GetSession(gomock.Any(), sessionID).Return(session, nil).Times(1)
+	// No GetUser/StopDesktop/StartDesktop — gomock fails if the restart runs.
+
+	s.server.maybeAutoRestartCrashedAgent(sessionID)
+}
+
+// TestInflightDedup: a crash can surface as BOTH thread_load_error and
+// chat_response_error. The second concurrent trigger must no-op without even
+// reading the session, so a single crash recreates the container once.
+func (s *AutoRestartCrashedAgentSuite) TestInflightDedup() {
+	const sessionID = "ses_dedup"
+	// Simulate an in-flight restart already holding the session.
+	s.server.autoRestartInflight.Store(sessionID, struct{}{})
+	// No store expectations at all — a deduped trigger must not even GetSession.
+
+	s.server.maybeAutoRestartCrashedAgent(sessionID)
+}

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -483,6 +483,9 @@ func (c *inProcHelixClient) StartSession(ctx context.Context, params runtimeheli
 		Provider:       types.Provider(params.Provider),
 		Model:          params.Model,
 		SessionRole:    "exploratory",
+		// Org workers are fully autonomous — nobody is watching to click the
+		// in-chat Restart button — so recover the agent automatically on crash.
+		AutoRestartOnCrash: true,
 		Messages: []*types.Message{{
 			Role:    "user",
 			Content: types.MessageContent{Parts: []any{params.Prompt}},

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -126,6 +126,7 @@ type HelixAPIServer struct {
 	externalAgentSessionMapping map[string]string      // External agent session_id -> Helix session_id mapping
 	externalAgentUserMapping    map[string]string      // External agent session_id -> user_id mapping
 	pendingCancelChannels       map[string]chan string // request_id -> channel that receives turn_cancelled status
+	autoRestartInflight         sync.Map               // session_id -> struct{}: dedupes concurrent auto-restart triggers (zero value ready)
 	// Comment processing timeouts - uses database for queue state (QueuedAt/RequestID fields)
 	sessionCommentTimeout     map[string]*time.Timer // planning_session_id -> timeout timer for current comment
 	sessionCommentMutex       sync.RWMutex           // Mutex for timeout operations

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -2429,6 +2429,127 @@ func (s *HelixAPIServer) restartSessionContainer(ctx context.Context, user *type
 	return resetCount, nil
 }
 
+// autoRestartMaxAttempts bounds how many times Helix will automatically
+// recreate a crashed autonomous-surface (spec-task / org-worker) container
+// without an intervening successful turn. Past this we stop and leave the
+// prompt crash-marked (terminal) for a human to investigate, so a
+// boot-crash-looping agent can't trigger an endless container-rebuild storm.
+const autoRestartMaxAttempts = 3
+
+// autoRestartMinBackoff is the base gap before an automatic restart. The actual
+// wait grows exponentially per consecutive attempt (autoRestartMinBackoff <<
+// count → 15s, 30s, 60s), so a fast crash loop is throttled. It is a var (not a
+// const) only so tests can drop it to zero; production never reassigns it.
+var autoRestartMinBackoff = 15 * time.Second
+
+// maybeAutoRestartCrashedAgent automatically recovers a crashed external agent
+// for AUTONOMOUS surfaces — spec tasks and org workers — where no human is
+// present to click the in-chat Restart button. It is called from the websocket
+// crash handlers right after a prompt is crash-marked.
+//
+// Human desktop sessions (Metadata.AutoRestartOnCrash == false) are left
+// untouched: they keep the explicit button. The recovery itself reuses the
+// canonical restartSessionContainer primitive (StopDesktop → recreate → reset
+// crashed prompts → kick queue), so "restart" cannot diverge across surfaces.
+//
+// Guard rails against a boot-crash loop: a sync.Map dedupes concurrent triggers
+// (a single crash can surface as both thread_load_error and chat_response_error);
+// Metadata.AutoRestartCount bounds consecutive restarts without an intervening
+// success (reset to 0 on the next successful completion); and an exponential
+// backoff throttles the cadence.
+func (s *HelixAPIServer) maybeAutoRestartCrashedAgent(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+
+	// Dedupe concurrent triggers for the same session — a crash can arrive via
+	// both thread_load_error and chat_response_error. First caller wins; the
+	// rest no-op until this one finishes.
+	if _, inflight := s.autoRestartInflight.LoadOrStore(sessionID, struct{}{}); inflight {
+		return
+	}
+	defer s.autoRestartInflight.Delete(sessionID)
+
+	ctx := context.Background()
+	session, err := s.Store.GetSession(ctx, sessionID)
+	if err != nil || session == nil {
+		log.Warn().Err(err).Str("session_id", sessionID).Msg("Auto-restart: session lookup failed — skipping")
+		return
+	}
+
+	// Only autonomous surfaces opt in; human desktop sessions keep the button.
+	if !session.Metadata.AutoRestartOnCrash {
+		return
+	}
+	if session.Metadata.AgentType != "zed_external" {
+		return
+	}
+
+	// Anti-storm: stop after the budget is spent. The crash stays terminal
+	// (prompt crash-marked) so the failure is visible rather than silently
+	// churning containers forever.
+	if session.Metadata.AutoRestartCount >= autoRestartMaxAttempts {
+		log.Error().
+			Str("session_id", sessionID).
+			Int("attempts", session.Metadata.AutoRestartCount).
+			Msg("🛑 [HELIX] Auto-restart budget exhausted — leaving crashed agent terminal (avoids container-rebuild storm)")
+		return
+	}
+
+	attempt := session.Metadata.AutoRestartCount
+	backoff := autoRestartMinBackoff * time.Duration(int64(1)<<uint(attempt))
+
+	// The autonomous surface's session owner (spec-task creator / worker
+	// service user) is already authorized for this session — drive the restart
+	// as them.
+	user, err := s.Store.GetUser(ctx, &store.GetUserQuery{ID: session.Owner})
+	if err != nil || user == nil {
+		log.Error().Err(err).Str("session_id", sessionID).Str("owner", session.Owner).
+			Msg("Auto-restart: owner lookup failed — skipping")
+		return
+	}
+
+	log.Warn().
+		Str("session_id", sessionID).
+		Int("attempt", attempt+1).
+		Int("max", autoRestartMaxAttempts).
+		Dur("backoff", backoff).
+		Msg("♻️ [HELIX] Auto-restarting crashed autonomous agent (no human present to click Restart)")
+
+	time.Sleep(backoff)
+
+	// Persist the incremented budget BEFORE restarting, on a fresh read, so a
+	// restart that itself boot-crashes still counts toward the cap and a
+	// concurrent metadata write isn't clobbered. The counter lives on the
+	// session, so ResetCrashedPromptsForSession (inside restartSessionContainer)
+	// won't zero it — only a successful completion resets it.
+	fresh, err := s.Store.GetSession(ctx, sessionID)
+	if err != nil || fresh == nil {
+		log.Warn().Err(err).Str("session_id", sessionID).Msg("Auto-restart: re-read failed — skipping")
+		return
+	}
+	fresh.Metadata.AutoRestartCount = attempt + 1
+	fresh.Metadata.LastAutoRestartAt = time.Now()
+	if _, err := s.Store.UpdateSession(ctx, *fresh); err != nil {
+		log.Error().Err(err).Str("session_id", sessionID).Msg("Auto-restart: failed to persist restart budget — skipping")
+		return
+	}
+
+	if _, herr := s.restartSessionContainer(ctx, user, fresh); herr != nil {
+		log.Error().
+			Str("session_id", sessionID).
+			Str("error", herr.Error()).
+			Int("attempt", attempt+1).
+			Msg("Auto-restart of crashed agent failed")
+		return
+	}
+
+	log.Info().
+		Str("session_id", sessionID).
+		Int("attempt", attempt+1).
+		Msg("✅ [HELIX] Auto-restarted crashed autonomous agent — container recreated, prompts re-queued")
+}
+
 // attachProjectContext sets agent.ProjectID and loads the project's
 // repositories, populating agent.RepositoryIDs and agent.PrimaryRepositoryID
 // via DesktopAgent.SetRepoContext. No-op when projectID is empty.
@@ -2533,6 +2654,13 @@ func (s *HelixAPIServer) StartExternalAgentSession(ctx context.Context, req *typ
 				CallbackURL:  req.CallbackURL,
 			},
 		}
+	}
+
+	// Autonomous surfaces (org workers) ask for crash auto-recovery. Set it on
+	// the metadata after the build/reuse branch so it sticks on the reused
+	// exploratory singleton too, not only on a freshly minted row.
+	if req.AutoRestartOnCrash {
+		session.Metadata.AutoRestartOnCrash = true
 	}
 
 	session, err = appendOrOverwrite(session, req)

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -2776,6 +2776,22 @@ func (apiServer *HelixAPIServer) handleMessageCompleted(sessionID string, syncMs
 		return fmt.Errorf("failed to update interaction %s: %w", targetInteraction.ID, err)
 	}
 
+	// Reaching message_completed means the agent is alive and produced a turn,
+	// so any consumed auto-restart budget is refunded: a recovered autonomous
+	// session that runs a successful turn gets a fresh restart budget. The
+	// counter lives on the session (not the prompt) precisely so it survives
+	// ResetCrashedPromptsForSession and only clears here, on proven success.
+	if helixSession.Metadata.AutoRestartOnCrash && helixSession.Metadata.AutoRestartCount > 0 {
+		helixSession.Metadata.AutoRestartCount = 0
+		if _, err := apiServer.Controller.Options.Store.UpdateSession(context.Background(), *helixSession); err != nil {
+			log.Warn().Err(err).Str("helix_session_id", helixSessionID).
+				Msg("Failed to reset auto-restart budget after successful turn")
+		} else {
+			log.Info().Str("helix_session_id", helixSessionID).
+				Msg("♻️ [HELIX] Reset auto-restart budget after successful turn")
+		}
+	}
+
 	// Continuous reconciliation: if the queued prompt was never marked sent
 	// via handleMessageAdded (e.g. the agent went straight to message_completed
 	// without intermediate streaming, or the streaming path missed it), this
@@ -3291,7 +3307,7 @@ func (apiServer *HelixAPIServer) sendQueuedPromptToSession(ctx context.Context, 
 			"message":       outgoingMessage,
 			"request_id":    requestID,
 			"agent_name":    agentName,
-			"from_queue":    true,         // Indicate this came from the queue
+			"from_queue":    true,             // Indicate this came from the queue
 			"interrupt":     prompt.Interrupt, // Tell Zed to cancel the current turn before sending
 		},
 	}
@@ -3482,6 +3498,17 @@ func (apiServer *HelixAPIServer) handleThreadLoadError(sessionID string, syncMsg
 	if helixSessionID != "" {
 		helixSession, err := apiServer.Controller.Options.Store.GetSession(context.Background(), helixSessionID)
 		if err == nil && helixSession != nil {
+			// A hard agent crash ("Claude Agent process exited", "Session not
+			// found") on an autonomous session must auto-recover regardless of how
+			// the crashing turn was sent — a queued planning prompt (PromptID set)
+			// OR a blocking follow-up via handleBlockingSession (no PromptID). The
+			// prompt crash-marking below is rightly PromptID-gated, but the RESTART
+			// decision is not: it keys only on "crash + autonomous". maybeAutoRestart
+			// self-gates on the flag and dedupes, so this is safe even when the
+			// in-loop crash-mark path also fires.
+			if isAgentCrashError(errorMsg) && helixSession.Metadata.AutoRestartOnCrash {
+				go apiServer.maybeAutoRestartCrashedAgent(helixSessionID)
+			}
 			// Find the waiting interaction and mark it with error
 			interactions, _, err := apiServer.Controller.Options.Store.ListInteractions(context.Background(), &types.ListInteractionsQuery{
 				SessionID:    helixSessionID,
@@ -3542,6 +3569,14 @@ func (apiServer *HelixAPIServer) handleThreadLoadError(sessionID string, syncMsg
 									Bool("recurring_thread_load_failure", recurringThreadLoadFailure).
 									Msg("💥 [HELIX] Agent thread terminal (hard crash or recurring thread_load_error) — marking prompt crashed (suppress auto-retry, awaits user Restart)")
 								markErr = apiServer.Controller.Options.Store.MarkPromptAsCrashed(context.Background(), interactions[i].PromptID, failureMsg)
+								// The hard-crash case already triggered auto-restart above
+								// (outside this loop, PromptID-independent). Here we also
+								// cover the RECURRING thread_load_error case — a wedged queue
+								// prompt that isn't a hard-crash marker — which only reaches
+								// terminal after retries and so always has a PromptID.
+								if recurringThreadLoadFailure && helixSession.Metadata.AutoRestartOnCrash {
+									go apiServer.maybeAutoRestartCrashedAgent(helixSessionID)
+								}
 							} else {
 								markErr = apiServer.Controller.Options.Store.MarkPromptAsFailed(context.Background(), interactions[i].PromptID, failureMsg)
 							}
@@ -3599,6 +3634,34 @@ func (apiServer *HelixAPIServer) handleChatResponseError(sessionID string, syncM
 			if _, err := apiServer.Controller.Options.Store.UpdateInteraction(context.Background(), interaction); err != nil {
 				log.Warn().Err(err).Str("interaction_id", interactionID).
 					Msg("chat_response_error: persist failed")
+			}
+
+			// The Zed crash fix surfaces a mid-turn agent crash here as a
+			// chat_response_error (rather than wedging the turn). When the error
+			// is a known terminal Claude Agent crash, pin the prompt as crashed
+			// so the queue stops re-dispatching into the dead process, then
+			// auto-recover on autonomous surfaces (guarded no-op for human
+			// desktop, which keeps the explicit Restart button).
+			if isAgentCrashError(errorMsg) {
+				// Crash-marking is for QUEUE prompts only (so the queue stops
+				// re-dispatching); a blocking send has no PromptID and needs none.
+				if interaction.PromptID != "" {
+					failureMsg := fmt.Sprintf("Agent crashed: %s", errorMsg)
+					if markErr := apiServer.Controller.Options.Store.MarkPromptAsCrashed(context.Background(), interaction.PromptID, failureMsg); markErr != nil {
+						log.Error().Err(markErr).Str("prompt_id", interaction.PromptID).
+							Str("interaction_id", interaction.ID).
+							Msg("chat_response_error: failed to crash-mark prompt")
+					}
+				}
+				log.Warn().
+					Str("session_id", interaction.SessionID).
+					Str("interaction_id", interaction.ID).
+					Msg("💥 [HELIX] Agent crash surfaced via chat_response_error — evaluating auto-restart")
+				// The auto-restart decision is PromptID-independent — it keys on
+				// "crash + autonomous". Use the interaction's own SessionID (the
+				// helix session id); the handler param is the agent session id and
+				// the two can differ. maybeAutoRestart self-gates on the flag.
+				go apiServer.maybeAutoRestartCrashedAgent(interaction.SessionID)
 			}
 		}
 	}

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -392,6 +392,9 @@ func (s *SpecDrivenTaskService) StartSpecGeneration(ctx context.Context, task *t
 		Stream:           false,
 		SpecTaskID:       task.ID,          // CRITICAL: Set SpecTaskID so session restore uses correct workspace path
 		CodeAgentRuntime: codeAgentRuntime, // For open_thread on resume
+		// Autonomous surface: no human watches a planning run, so recover the
+		// agent automatically on crash rather than stalling errored+idle.
+		AutoRestartOnCrash: true,
 	}
 
 	session := &types.Session{
@@ -624,7 +627,7 @@ func (s *SpecDrivenTaskService) StartSpecGeneration(ctx context.Context, task *t
 		Resolution:         resolution,
 		ZoomLevel:          zoomLevel,
 		DesktopType:        desktopType,
-		Env: envVars,
+		Env:                envVars,
 		OnBeforeCreate: func(hookCtx context.Context, a *types.DesktopAgent) error {
 			apiKey, err := s.GetOrCreateSessionAPIKey(hookCtx, &SessionAPIKeyRequest{
 				OrganizationID: launchOrgID,
@@ -800,6 +803,9 @@ func (s *SpecDrivenTaskService) StartJustDoItMode(ctx context.Context, task *typ
 		Stream:           false,
 		SpecTaskID:       task.ID,             // CRITICAL: Set SpecTaskID so session restore uses correct workspace path
 		CodeAgentRuntime: codeAgentRuntimeJDI, // For open_thread on resume
+		// Autonomous surface: no human watches a just-do-it run, so recover the
+		// agent automatically on crash rather than stalling errored+idle.
+		AutoRestartOnCrash: true,
 	}
 
 	session := &types.Session{
@@ -2129,7 +2135,7 @@ func (s *SpecDrivenTaskService) ResumeSession(ctx context.Context, task *types.S
 		DisplayRefreshRate:  displayRefreshRate,
 		Resolution:          fmt.Sprintf("%dx%d", displayWidth, displayHeight),
 		ZoomLevel:           1.0,
-		DesktopType: desktopType,
+		DesktopType:         desktopType,
 		OnBeforeCreate: func(hookCtx context.Context, a *types.DesktopAgent) error {
 			apiKey, err := s.GetOrCreateSessionAPIKey(hookCtx, &SessionAPIKeyRequest{
 				OrganizationID: task.OrganizationID,

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -420,6 +420,19 @@ type SessionMetadata struct {
 	AgentType               string              `json:"agent_type,omitempty"`     // Agent type: "helix" or "zed_external"
 	SystemSession           bool                `json:"system_session,omitempty"` // True for internal system sessions (e.g., summary generation) - skip summary generation to avoid loops
 
+	// Autonomous crash recovery. Set true at session creation for surfaces with
+	// no human present to click the in-chat Restart button (spec tasks, org
+	// workers). When the external agent crashes mid-turn, the websocket crash
+	// handler auto-invokes the canonical restart primitive instead of leaving
+	// the session errored+idle. Human desktop sessions leave this false and keep
+	// the explicit button. AutoRestartCount bounds consecutive auto-restarts
+	// without an intervening successful turn (anti-storm guard); it is reset to 0
+	// on the next successful completion and lives on the SESSION (not the prompt)
+	// so ResetCrashedPromptsForSession can't zero the restart budget.
+	AutoRestartOnCrash bool      `json:"auto_restart_on_crash,omitempty"`
+	AutoRestartCount   int       `json:"auto_restart_count,omitempty"`
+	LastAutoRestartAt  time.Time `json:"last_auto_restart_at,omitempty"`
+
 	// Title history - tracks evolution of session topics (newest first)
 	// Shown on hover in the SpecTask tab view to see what topics were covered
 	TitleHistory []*TitleHistoryEntry `json:"title_history,omitempty"`
@@ -521,16 +534,17 @@ type PaginatedSessionsList struct {
 // the user wants to do inference against a model
 // we turn this into a InternalSessionRequest
 type SessionChatRequest struct {
-	AppID               string               `json:"app_id"`                 // Assign the session settings from the specified app
-	ProjectID           string               `json:"project_id"`             // The project this session belongs to, if any
-	OrganizationID      string               `json:"organization_id"`        // The organization this session belongs to, if any
-	AssistantID         string               `json:"assistant_id"`           // Which assistant are we speaking to?
-	SessionID           string               `json:"session_id"`             // If empty, we will start a new session
-	InteractionID       string               `json:"interaction_id"`         // If empty, we will start a new interaction
-	Stream              bool                 `json:"stream"`                 // If true, we will stream the response
-	SessionRole         string               `json:"session_role,omitempty"` // e.g. "job" — categorizes sessions for filtering
-	CallbackURL         string               `json:"callback_url,omitempty"` // Webhook URL to POST on session completion
-	Type                SessionType          `json:"type"`                   // e.g. text, image
+	AppID               string               `json:"app_id"`                          // Assign the session settings from the specified app
+	ProjectID           string               `json:"project_id"`                      // The project this session belongs to, if any
+	OrganizationID      string               `json:"organization_id"`                 // The organization this session belongs to, if any
+	AssistantID         string               `json:"assistant_id"`                    // Which assistant are we speaking to?
+	SessionID           string               `json:"session_id"`                      // If empty, we will start a new session
+	InteractionID       string               `json:"interaction_id"`                  // If empty, we will start a new interaction
+	Stream              bool                 `json:"stream"`                          // If true, we will stream the response
+	SessionRole         string               `json:"session_role,omitempty"`          // e.g. "job" — categorizes sessions for filtering
+	CallbackURL         string               `json:"callback_url,omitempty"`          // Webhook URL to POST on session completion
+	AutoRestartOnCrash  bool                 `json:"auto_restart_on_crash,omitempty"` // Autonomous surfaces: auto-recover the agent on crash (no human to click Restart)
+	Type                SessionType          `json:"type"`                            // e.g. text, image
 	LoraDir             string               `json:"lora_dir"`
 	SystemPrompt        string               `json:"system"`                          // System message, only applicable when starting a new session
 	Messages            []*Message           `json:"messages"`                        // Initial messages
@@ -1090,31 +1104,31 @@ type ServerConfigForFrontend struct {
 	// it's a low level filestore path
 	// if we are using an object storage thing - then this URL
 	// can be the prefix to the bucket
-	RegistrationEnabled                    bool                 `json:"registration_enabled"`
-	AuthProvider                           AuthProvider         `json:"auth_provider"`
-	FilestorePrefix                        string               `json:"filestore_prefix"`
-	StripeEnabled                          bool                 `json:"stripe_enabled"`              // Stripe top-ups enabled
-	BillingEnabled                         bool                 `json:"billing_enabled"`             // Charging for usage
-	RequireActiveSubscription              bool                 `json:"require_active_subscription"` // Require an active subscription before allowing to use the product
-	SentryDSNFrontend                      string               `json:"sentry_dsn_frontend"`
-	GoogleAnalyticsFrontend                string               `json:"google_analytics_frontend"`
-	ToolsEnabled                           bool                 `json:"tools_enabled"`
-	AppsEnabled                            bool                 `json:"apps_enabled"`
-	RudderStackWriteKey                    string               `json:"rudderstack_write_key"`
-	RudderStackDataPlaneURL                string               `json:"rudderstack_data_plane_url"`
-	DisableLLMCallLogging                  bool                 `json:"disable_llm_call_logging"`
-	Version                                string               `json:"version"`
-	LatestVersion                          string               `json:"latest_version"`
-	DeploymentID                           string               `json:"deployment_id"`
-	OrganizationsCreateEnabledForNonAdmins bool                 `json:"organizations_create_enabled_for_non_admins"`
-	ProvidersManagementEnabled             bool                 `json:"providers_management_enabled"` // Controls if users can add their own AI provider API keys
-	HasProviders                           bool                 `json:"has_providers"`                // Whether any global AI provider with enabled chat models exists
+	RegistrationEnabled                    bool         `json:"registration_enabled"`
+	AuthProvider                           AuthProvider `json:"auth_provider"`
+	FilestorePrefix                        string       `json:"filestore_prefix"`
+	StripeEnabled                          bool         `json:"stripe_enabled"`              // Stripe top-ups enabled
+	BillingEnabled                         bool         `json:"billing_enabled"`             // Charging for usage
+	RequireActiveSubscription              bool         `json:"require_active_subscription"` // Require an active subscription before allowing to use the product
+	SentryDSNFrontend                      string       `json:"sentry_dsn_frontend"`
+	GoogleAnalyticsFrontend                string       `json:"google_analytics_frontend"`
+	ToolsEnabled                           bool         `json:"tools_enabled"`
+	AppsEnabled                            bool         `json:"apps_enabled"`
+	RudderStackWriteKey                    string       `json:"rudderstack_write_key"`
+	RudderStackDataPlaneURL                string       `json:"rudderstack_data_plane_url"`
+	DisableLLMCallLogging                  bool         `json:"disable_llm_call_logging"`
+	Version                                string       `json:"version"`
+	LatestVersion                          string       `json:"latest_version"`
+	DeploymentID                           string       `json:"deployment_id"`
+	OrganizationsCreateEnabledForNonAdmins bool         `json:"organizations_create_enabled_for_non_admins"`
+	ProvidersManagementEnabled             bool         `json:"providers_management_enabled"` // Controls if users can add their own AI provider API keys
+	HasProviders                           bool         `json:"has_providers"`                // Whether any global AI provider with enabled chat models exists
 	// MaxConcurrentDesktops: cap on concurrent desktop sessions. Enforced per
 	// organisation when the session has an org, per user otherwise.
 	// -1 = unlimited. Note: /config is unauthenticated, so this is the
 	// Free-tier floor; real enforcement uses the resolved per-user/per-org cap.
-	MaxConcurrentDesktops int                  `json:"max_concurrent_desktops"`
-	Edition                                string               `json:"edition,omitempty"` // "mac-desktop", "server", "cloud", etc.
+	MaxConcurrentDesktops int    `json:"max_concurrent_desktops"`
+	Edition               string `json:"edition,omitempty"` // "mac-desktop", "server", "cloud", etc.
 	// DefaultChatSystemPrompt is the system prompt the platform applies to
 	// direct model chats when the user has not customised one. Surfaced to
 	// the frontend so the chat-settings page can prefill the textbox.


### PR DESCRIPTION
## Summary

Implement automatic recovery for crashed external agents (Zed) on autonomous surfaces (spec tasks, org workers) where no human is present to click the in-chat Restart button.

### The Problem
A Zed fix makes mid-turn agent crashes terminate cleanly (chat_response_error) instead of wedging. But recovery still requires the manual `restartSessionContainer` primitive, which only has manual triggers (in-chat Restart button). Spec tasks and org workers stall when the agent crashes — nobody clicks the button.

### The Solution
- **Auto-detection**: Websocket crash handlers detect hard agent crashes ("Claude Agent process exited", "Session not found") via `isAgentCrashError()`
- **Auto-recovery**: Spawn `maybeAutoRestartCrashedAgent()` goroutine immediately (PromptID-independent)
- **Guard rails** (anti-storm):
  - `AutoRestartCount ≤ 3` consecutive restarts without an intervening success
  - Exponential backoff: 15s, 30s, 60s between attempts
  - In-flight dedup via `sync.Map` (single crash triggers one restart)
  - Budget resets to 0 on next successful completion
- **Human desktop unchanged**: Flag `AutoRestartOnCrash=false` keeps the explicit Restart button

### Implementation Details

**SessionMetadata fields** (api/pkg/types/types.go):
- `AutoRestartOnCrash bool` — set at creation for autonomous surfaces
- `AutoRestartCount int` — bounded counter for guard rails
- `LastAutoRestartAt time.Time` — audit trail

**Set at creation** (autonomous surfaces only):
- `spec_driven_task_service.go`: `StartSpecGeneration`, `StartJustDoItMode`
- `helix_org_inproc.go`: `StartSession` → `SessionChatRequest.AutoRestartOnCrash`

**Crash detection** (api/pkg/server/websocket_external_agent_sync.go):
- `handleThreadLoadError`: PromptID-independent hard-crash spawn at session block top
- `handleChatResponseError`: Crash-mark prompt (PromptID-gated), then auto-restart spawn (PromptID-independent)

**Recovery** (api/pkg/server/session_handlers.go):
- `maybeAutoRestartCrashedAgent()`: Dedupe → check flag/budget → backoff → persist count → `restartSessionContainer()` → success log
- `handleMessageCompleted()`: Reset `AutoRestartCount=0` on successful turn (budget refresh)

### Testing

**Full TDD** (api/pkg/server/auto_restart_crashed_agent_test.go):
- `TestAutonomousRestartsAndIncrement`: happy path — autonomous flag + budget left → restart + increment
- `TestHumanSurfaceNoOp`: human desktop (flag=false) → no-op
- `TestBudgetExhaustedNoOp`: count ≥ 3 → no-op
- `TestInflightDedup`: concurrent crashes → one restart via sync.Map gate
- Guards proven load-bearing by neutering flag/budget checks and verifying no-op tests fail

**Live e2e** (spec-task surface):
- Create spec task in subscription-backed org (claude-acp registration works)
- Kill claude SDK child mid-turn
- Verify logs: crash detected → auto-restart spawned → backoff → container recreated (ZedThreadID preserved) → recovered agent → next turn reaches `state=complete` → budget reset to 0

**Bug caught & fixed**: Blocking sends (`handleBlockingSession`) create interactions with no PromptID. Original gate `interaction.PromptID != ""` never fired auto-restart. Decoupled restart decision from PromptID (prompt crash-marking stays PromptID-gated).

### Files Changed
- `api/pkg/types/types.go`: Added `SessionMetadata` fields + `SessionChatRequest.AutoRestartOnCrash`
- `api/pkg/server/server.go`: Added `autoRestartInflight sync.Map` to `HelixAPIServer`
- `api/pkg/server/session_handlers.go`: `maybeAutoRestartCrashedAgent()` helper + flag plumbing in `StartExternalAgentSession()`
- `api/pkg/server/websocket_external_agent_sync.go`: Crash handlers + budget reset on completion
- `api/pkg/services/spec_driven_task_service.go`: Set `AutoRestartOnCrash=true` at spec creation
- `api/pkg/server/helix_org_inproc.go`: Set `AutoRestartOnCrash=true` for org workers
- `api/pkg/server/auto_restart_crashed_agent_test.go`: Comprehensive unit test suite (NEW)

Diff: 428 insertions, 34 deletions (incl. formatting alignment in types.go)

🤖 Generated with Claude Code