### PR TITLE
fix(frontend): correct neuron runner profile to validated inf2 config

### DIFF
--- a/api/cmd/compose-manager/main.go
+++ b/api/cmd/compose-manager/main.go
@@ -35,6 +35,7 @@ func main() {
 		configDir       = flag.String("config-dir", envOr("HELIX_RUNNER_CONFIG_DIR", "/etc/helix"), "directory for active.yaml")
 		registryMirror  = flag.String("registry-mirror", os.Getenv("HELIX_RUNNER_REGISTRY"), "rewrite leading registry portion of image: refs to this mirror")
 		offline         = flag.Bool("offline", os.Getenv("HELIX_RUNNER_OFFLINE") == "true", "skip docker compose pull; fail fast if images absent")
+		neuronCacheURL  = flag.String("neuron-compile-cache-url", os.Getenv("HELIX_NEURON_COMPILE_CACHE_URL"), "exported as NEURON_COMPILE_CACHE_URL into compose; shared Neuron compile cache, e.g. s3://<bucket>/neuron-cache")
 		pollInterval    = flag.Duration("poll-interval", 15*time.Second, "how often to check for assignment changes")
 		trimEvery       = flag.Duration("trim-every", 24*time.Hour, "how often to prune unreferenced images")
 		trimOlderThan   = flag.Duration("trim-older-than", 72*time.Hour, "min age before pruning an unreferenced image")
@@ -49,11 +50,15 @@ func main() {
 	}
 
 	mgr := composemgr.New(composemgr.Options{
-		ConfigDir:           *configDir,
-		DockerComposeBinary: "docker",
-		RegistryMirror:      *registryMirror,
-		Offline:             *offline,
+		ConfigDir:             *configDir,
+		DockerComposeBinary:   "docker",
+		RegistryMirror:        *registryMirror,
+		Offline:               *offline,
+		NeuronCompileCacheURL: *neuronCacheURL,
 	})
+	if *neuronCacheURL != "" {
+		log.Info().Str("neuron_compile_cache_url", *neuronCacheURL).Msg("Neuron compile cache enabled for compose stacks")
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/api/pkg/composemgr/manager.go
+++ b/api/pkg/composemgr/manager.go
@@ -75,6 +75,16 @@ type Options struct {
 	// HELIX_RUNNER_OFFLINE.
 	Offline bool
 
+	// NeuronCompileCacheURL, if set, is exported as NEURON_COMPILE_CACHE_URL
+	// into the `docker compose` environment so Neuron (Inferentia/Trainium)
+	// profiles share a compiled-graph cache (e.g. "s3://<bucket>/neuron-cache").
+	// vLLM-Neuron compiles the model on first start; with this set, the NEFFs
+	// are uploaded once and every other runner loads them instead of
+	// recompiling. Empty means vLLM uses a local (ephemeral) cache.
+	// Implements HELIX_NEURON_COMPILE_CACHE_URL. The runner host must have
+	// credentials for the URL's backend (e.g. an instance role for s3://).
+	NeuronCompileCacheURL string
+
 	// ReadinessPollInterval is how often we poll service health after
 	// `up -d`. Default 2s.
 	ReadinessPollInterval time.Duration
@@ -245,6 +255,13 @@ func (m *Manager) Trim(ctx context.Context, olderThan time.Duration) error {
 func (m *Manager) runCompose(ctx context.Context, args ...string) error {
 	full := append([]string{"compose"}, args...)
 	cmd := exec.CommandContext(ctx, m.opts.DockerComposeBinary, full...)
+	// Export the Neuron compile-cache URL into the compose environment so
+	// profiles that pass `- NEURON_COMPILE_CACHE_URL` through resolve it.
+	// Leaving cmd.Env nil would inherit os.Environ(); we only override when
+	// the knob is set so we still inherit everything else.
+	if m.opts.NeuronCompileCacheURL != "" {
+		cmd.Env = append(os.Environ(), "NEURON_COMPILE_CACHE_URL="+m.opts.NeuronCompileCacheURL)
+	}
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {

--- a/frontend/src/components/dashboard/profileBlocks.ts
+++ b/frontend/src/components/dashboard/profileBlocks.ts
@@ -408,20 +408,35 @@ export const blockDesktopReserve: ProfileBlock = {
 // If composeparse ever learns to count neuron `devices:` (Count=2), it MUST
 // land together with a gpudetect neuron probe, or assignment to the inf2
 // runner breaks (2 > 0 reject). Both are out of scope for this v1 demo.
-export const blockChatNeuronMistral7B: ProfileBlock = {
-  id: "chat-neuron-mistral-7b",
-  name: "inf2.xlarge - Mistral-7B (Neuron)",
+// Validated live on a real inf2.xlarge (2026-06-19). Every value below was
+// proven on the box - see design/2026-06-15-neuron-inference-design.md and the
+// findings writeup. Notable corrections vs the original design guesses:
+//   - image is pytorch-inference-vllm-neuronx (the AWS vLLM DLC), NOT neuron/vllm
+//   - inf2.xlarge exposes a SINGLE /dev/neuron0 (1 device, 2 cores -> tp=2)
+//   - needs cap_add SYS_ADMIN + IPC_LOCK
+//   - neuron backend is selected by VLLM_NEURON_FRAMEWORK env; vLLM 0.16 dropped
+//     the --device / --override-neuron-config flags
+//   - needs --block-size 8 (vLLM asserts block_size when prefix caching is on)
+//   - --swap-space 0: vLLM reserves ~8GB host RAM for CPU swap by default, which
+//     OOMs the 16GB inf2.xlarge; disabling it is required
+//   - vLLM compiles the model on first start (~minutes for ~1B); NEURON_COMPILE_
+//     CACHE_URL=s3://... makes that a compile-once-per-fleet cost (validated)
+//   - inf2.xlarge's ~16GB HOST RAM caps the model at ~1B-2B (weights load into
+//     host memory before the device). 3B/7B OOM here and need inf2.8xlarge.
+export const blockChatNeuronQwen15B: ProfileBlock = {
+  id: "chat-neuron-qwen-1.5b",
+  name: "inf2.xlarge - Qwen2.5-1.5B (Neuron)",
   category: "chat",
   description:
-    "Mistral-7B-Instruct-v0.3 pre-compiled by AWS for Inferentia2 (HF: aws-neuron/Mistral-7B-Instruct-v0.3-neuronx). Demo profile for non-NVIDIA inference on a single inf2.xlarge (~$0.99/hr, us-east-1).",
+    "Qwen2.5-1.5B-Instruct served by vLLM on AWS Inferentia2 (inf2.xlarge, ~$0.99/hr). Demonstrates Helix inference on non-NVIDIA hardware over the standard OpenAI API. inf2.xlarge host RAM caps the model around 1-2B; use inf2.8xlarge for 7B.",
   pros: [
-    "Runs LLM inference on AWS Inferentia2 — no NVIDIA hardware",
-    "Pre-compiled artifact: no operator compile step, no S3",
-    "Same control plane and YD provisioning loop as NVIDIA runners",
+    "LLM inference on AWS Inferentia2 - no NVIDIA hardware",
+    "Standard OpenAI API (vLLM) - Helix's router routes to it unchanged",
+    "First-compile result cached to S3 for fleet-wide reuse",
   ],
   cons: [
-    "Artifact compiled with fixed (bs, sl, tp) — deviating needs a recompile",
-    "30-60s cold start while the Neuron graph loads",
+    "vLLM compiles the model on first start (cached afterwards via S3)",
+    "inf2.xlarge host RAM caps model size at ~1-2B; 7B needs inf2.8xlarge",
     "vLLM-Neuron is less mature than CUDA vLLM",
   ],
   // GPU-memory fields don't model Neuron device memory; left at 1 core's
@@ -430,30 +445,48 @@ export const blockChatNeuronMistral7B: ProfileBlock = {
   gpuCount: 1,
   minVRAMBytesPerGPU: 0,
   requiresVendor: "neuron",
-  composeService: `vllm-neuron-mistral:
-    image: public.ecr.aws/neuron/vllm:latest
-    container_name: vllm-neuron-mistral
+  // The pytorch-inference-vllm-neuronx entrypoint runs the container command as
+  // a subprocess, so command must invoke the api_server module itself (the
+  // NVIDIA vllm-openai image bakes that into its entrypoint; this one does not).
+  // NEURON_COMPILE_CACHE_URL is listed by name so the operator supplies the
+  // bucket via host env (s3://<bucket>/neuron-cache); without it vLLM falls back
+  // to a local compile cache.
+  composeService: `vllm-neuron-qwen:
+    image: public.ecr.aws/neuron/pytorch-inference-vllm-neuronx:0.16.0-neuronx-py312-sdk2.30.0-ubuntu24.04
+    container_name: vllm-neuron-qwen
     ports:
       - "127.0.0.1:8000:8000"
     volumes:
       - /models:/root/.cache/huggingface
     devices:
       - "/dev/neuron0:/dev/neuron0"
-      - "/dev/neuron1:/dev/neuron1"
+    cap_add:
+      - SYS_ADMIN
+      - IPC_LOCK
+    environment:
+      - VLLM_NEURON_FRAMEWORK=neuronx-distributed-inference
+      - NEURON_COMPILE_CACHE_URL
     shm_size: 1g
     command:
+      - python
+      - -m
+      - vllm.entrypoints.openai.api_server
       - --model
-      - aws-neuron/Mistral-7B-Instruct-v0.3-neuronx
+      - Qwen/Qwen2.5-1.5B-Instruct
       - --served-model-name
-      - mistralai/Mistral-7B-Instruct-v0.3
-      - --device
-      - neuron
+      - qwen2.5-1.5b-instruct
       - --tensor-parallel-size
       - "2"
       - --max-num-seqs
       - "4"
       - --max-model-len
-      - "8192"`,
+      - "8192"
+      - --block-size
+      - "8"
+      - --swap-space
+      - "0"
+      - --port
+      - "8000"`,
 };
 
 export const allBlocks: ProfileBlock[] = [
@@ -464,7 +497,7 @@ export const allBlocks: ProfileBlock[] = [
   blockEmbedText,
   blockEmbedVL,
   blockDesktopReserve,
-  blockChatNeuronMistral7B,
+  blockChatNeuronQwen15B,
 ];
 
 // ----------------------------------------------------------------------
@@ -552,23 +585,24 @@ export const curatedProfiles: CuratedProfile[] = [
     composeYAML: composeFromBlocks([blockChat35B]),
   },
   {
-    id: "inf2-mistral-7b-neuron",
-    name: "AWS Inferentia2: Mistral-7B (Neuron)",
+    id: "inf2-qwen-1.5b-neuron",
+    name: "AWS Inferentia2: Qwen2.5-1.5B (Neuron)",
     description:
-      "Single inf2.xlarge serving Mistral-7B-Instruct-v0.3 on AWS Neuron. Demonstrates hardware-agnostic inference — the same control plane that drives NVIDIA g5 runners drives Inferentia2 via the same YD provisioning loop.",
+      "Single inf2.xlarge serving Qwen2.5-1.5B-Instruct on AWS Neuron via vLLM. Demonstrates hardware-agnostic inference - the same control plane that drives NVIDIA g5 runners drives Inferentia2 via the same YD provisioning loop. Validated live on inf2.xlarge.",
     pros: [
       "LLM inference on non-NVIDIA (Inferentia2) hardware",
-      "Pre-compiled AWS artifact — no operator compile or S3 management",
-      "~$0.99/hr, comparable to g5.xlarge",
+      "Standard OpenAI API - inference router routes to it unchanged",
+      "Compile cached to S3 for fleet-wide reuse",
     ],
     cons: [
-      "One model per pool (artifact is fixed bs/sl/tp)",
-      "Neuron SDK / AMI / artifact must be a compatible triple",
+      "vLLM compiles on first start (cached afterwards via S3)",
+      "inf2.xlarge host RAM caps model at ~1-2B; 7B needs inf2.8xlarge",
+      "Neuron SDK / AMI / image-tag must be a compatible triple",
     ],
-    blockIDs: ["chat-neuron-mistral-7b"],
+    blockIDs: ["chat-neuron-qwen-1.5b"],
     vendor: "neuron",
     architectures: [],
-    composeYAML: composeFromBlocks([blockChatNeuronMistral7B]),
+    composeYAML: composeFromBlocks([blockChatNeuronQwen15B]),
   },
   {
     id: "8xh100-prod",

--- a/frontend/src/components/dashboard/profileBlocks.ts
+++ b/frontend/src/components/dashboard/profileBlocks.ts
@@ -382,21 +382,6 @@ export const blockDesktopReserve: ProfileBlock = {
 // AWS Neuron (Inferentia2 / Trainium) — non-NVIDIA inference
 // ----------------------------------------------------------------------
 
-// vLLM-Neuron serving a pre-compiled artifact from AWS's public aws-neuron
-// HF org. No operator compile step, no S3: the container downloads the
-// artifact by HF model ID on first start. inf2.xlarge has 2 Neuron cores,
-// so the published artifact is tp=2; the two cores are exposed as
-// /dev/neuron0..1. The hydra "neuron" arm globs and mounts these into the
-// nested Docker; the compose service below claims them via `devices:`.
-//
-// ponytail: devices hardcoded to neuron0/neuron1 for the inf2.xlarge demo
-// (2 cores). Larger SKUs (inf2.8xlarge=12, trn1=16) need more entries —
-// expand the list when a bigger pool is provisioned.
-//
-// NOTE: pin `image` and the HF artifact revision to an SDK-compatible pair
-// at wire-up time against the host's Neuron DLC AMI (design risk #4 — graph
-// load fails on ABI mismatch). `latest` is a placeholder, not a contract.
-//
 // GATING NOTE — do NOT "fix" the derived GPURequirement.Count to 2. Neuron
 // runners report an empty GPU inventory (gpudetect has no neuron probe; the
 // design stubs neuron GPU stats on purpose). The assignment compatibility
@@ -407,7 +392,7 @@ export const blockDesktopReserve: ProfileBlock = {
 //   - nvidia profile -> neuron host: count 1>0 rejects.
 // If composeparse ever learns to count neuron `devices:` (Count=2), it MUST
 // land together with a gpudetect neuron probe, or assignment to the inf2
-// runner breaks (2 > 0 reject). Both are out of scope for this v1 demo.
+// runner breaks (2 > 0 reject). Both are out of scope for v1.
 // Validated live on a real inf2.xlarge (2026-06-19). Every value below was
 // proven on the box - see design/2026-06-15-neuron-inference-design.md and the
 // findings writeup. Notable corrections vs the original design guesses:
@@ -428,7 +413,7 @@ export const blockChatNeuronQwen15B: ProfileBlock = {
   name: "inf2.xlarge - Qwen2.5-1.5B (Neuron)",
   category: "chat",
   description:
-    "Qwen2.5-1.5B-Instruct served by vLLM on AWS Inferentia2 (inf2.xlarge, ~$0.99/hr). Demonstrates Helix inference on non-NVIDIA hardware over the standard OpenAI API. inf2.xlarge host RAM caps the model around 1-2B; use inf2.8xlarge for 7B.",
+    "Qwen2.5-1.5B-Instruct served by vLLM on AWS Inferentia2 (inf2.xlarge, ~$0.99/hr). Helix inference on non-NVIDIA hardware over the standard OpenAI API. inf2.xlarge host RAM caps the model around 1-2B; use inf2.8xlarge for 7B.",
   pros: [
     "LLM inference on AWS Inferentia2 - no NVIDIA hardware",
     "Standard OpenAI API (vLLM) - Helix's router routes to it unchanged",
@@ -588,7 +573,7 @@ export const curatedProfiles: CuratedProfile[] = [
     id: "inf2-qwen-1.5b-neuron",
     name: "AWS Inferentia2: Qwen2.5-1.5B (Neuron)",
     description:
-      "Single inf2.xlarge serving Qwen2.5-1.5B-Instruct on AWS Neuron via vLLM. Demonstrates hardware-agnostic inference - the same control plane that drives NVIDIA g5 runners drives Inferentia2 via the same YD provisioning loop. Validated live on inf2.xlarge.",
+      "Single inf2.xlarge serving Qwen2.5-1.5B-Instruct on AWS Neuron via vLLM. Hardware-agnostic inference - the same control plane that drives NVIDIA g5 runners drives Inferentia2 via the same YD provisioning loop. Validated live on inf2.xlarge.",
     pros: [
       "LLM inference on non-NVIDIA (Inferentia2) hardware",
       "Standard OpenAI API - inference router routes to it unchanged",

--- a/frontend/src/components/dashboard/profileBlocks.ts
+++ b/frontend/src/components/dashboard/profileBlocks.ts
@@ -433,9 +433,10 @@ export const blockChatNeuronQwen15B: ProfileBlock = {
   // The pytorch-inference-vllm-neuronx entrypoint runs the container command as
   // a subprocess, so command must invoke the api_server module itself (the
   // NVIDIA vllm-openai image bakes that into its entrypoint; this one does not).
-  // NEURON_COMPILE_CACHE_URL is listed by name so the operator supplies the
-  // bucket via host env (s3://<bucket>/neuron-cache); without it vLLM falls back
-  // to a local compile cache.
+  // NEURON_COMPILE_CACHE_URL is listed by name; compose-manager exports its
+  // value from the operator-set HELIX_NEURON_COMPILE_CACHE_URL config knob
+  // (e.g. s3://<bucket>/neuron-cache) so the compiled NEFFs are shared
+  // fleet-wide. Without it set, vLLM falls back to a local compile cache.
   composeService: `vllm-neuron-qwen:
     image: public.ecr.aws/neuron/pytorch-inference-vllm-neuronx:0.16.0-neuronx-py312-sdk2.30.0-ubuntu24.04
     container_name: vllm-neuron-qwen


### PR DESCRIPTION
## What

The neuron Runner Profile compose block added in https://github.com/helixml/helix/pull/2657 was built from the design doc's assumptions. **All of them were wrong** - verified live on a real inf2.xlarge (provisioned via the YD POC) on 2026-06-19. This corrects the block to the configuration that actually serves.

## Corrections (each verified on the box)

| Field | Was (PR #2657) | Now (proven) |
|---|---|---|
| image | `public.ecr.aws/neuron/vllm:latest` (404, doesn't exist) | `public.ecr.aws/neuron/pytorch-inference-vllm-neuronx:0.16.0-neuronx-py312-sdk2.30.0-ubuntu24.04` (AWS Neuron verified DLC) |
| devices | `neuron0` + `neuron1` | single `/dev/neuron0` (inf2.xlarge = 1 device, 2 cores) |
| caps | none | `cap_add: [SYS_ADMIN, IPC_LOCK]` |
| backend select | `--device neuron` | `VLLM_NEURON_FRAMEWORK` env (flag removed in vLLM 0.16) |
| command | bare `--model ...` | `python -m vllm.entrypoints.openai.api_server ...` (image entrypoint runs the command as a subprocess) |
| neuron config | `--override-neuron-config` | removed (rejected by vLLM 0.16); `--block-size 8` required instead |
| host memory | (none) | `--swap-space 0` (default ~8GB CPU swap OOMs the 16GB host) |
| model artifact | `aws-neuron/Mistral-7B-Instruct-v0.3-neuronx` (404; "pre-compiled, no compile") | standard HF model, vLLM compiles on first start; cached fleet-wide via `NEURON_COMPILE_CACHE_URL=s3://` |
| model size | Mistral-7B | Qwen2.5-1.5B (inf2.xlarge ~16GB host RAM caps at ~1-2B; 3B/7B OOM at load and need inf2.8xlarge) |

## Validation

- vLLM served real tokens over the OpenAI `/v1/chat/completions` API on Inferentia2 (TinyLlama smoke + the corrected invocation).
- S3 compile cache validated: cold compile+load+serve 485s -> fresh container from cache 178s with **0 compile events**.
- Full findings + repro: design writeup (Obsidian), summarized in the commit.

## Notes / follow-ups (not in this PR)

- **`NEURON_COMPILE_CACHE_URL`** is listed by env-name only; the operator supplies the bucket. Without it vLLM uses a local compile cache.
- Helix end-to-end (hydra `configureGPU` passthrough -> `composemgr` -> inference router) not yet run; the serving half is proven.
- The YD Manager `taskEnvironment` doesn't yet set `GPU_VENDOR=neuron`/device flags, so Floor-based provisioning still launches nvidia defaults - separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)