### PR TITLE
docs: clarify NEURON_COMPILE_CACHE_URL format (s3 key prefix, not a folder)

### DIFF
--- a/api/cmd/compose-manager/main.go
+++ b/api/cmd/compose-manager/main.go
@@ -35,7 +35,7 @@ func main() {
 		configDir       = flag.String("config-dir", envOr("HELIX_RUNNER_CONFIG_DIR", "/etc/helix"), "directory for active.yaml")
 		registryMirror  = flag.String("registry-mirror", os.Getenv("HELIX_RUNNER_REGISTRY"), "rewrite leading registry portion of image: refs to this mirror")
 		offline         = flag.Bool("offline", os.Getenv("HELIX_RUNNER_OFFLINE") == "true", "skip docker compose pull; fail fast if images absent")
-		neuronCacheURL  = flag.String("neuron-compile-cache-url", os.Getenv("HELIX_NEURON_COMPILE_CACHE_URL"), "exported as NEURON_COMPILE_CACHE_URL into compose; shared Neuron compile cache, e.g. s3://<bucket>/neuron-cache")
+		neuronCacheURL  = flag.String("neuron-compile-cache-url", os.Getenv("HELIX_NEURON_COMPILE_CACHE_URL"), "exported as NEURON_COMPILE_CACHE_URL into compose; shared Neuron compile cache. Format s3://<bucket>/<prefix> where <prefix> is an S3 key prefix (not a folder; only the bucket need exist) or a local path")
 		pollInterval    = flag.Duration("poll-interval", 15*time.Second, "how often to check for assignment changes")
 		trimEvery       = flag.Duration("trim-every", 24*time.Hour, "how often to prune unreferenced images")
 		trimOlderThan   = flag.Duration("trim-older-than", 72*time.Hour, "min age before pruning an unreferenced image")

--- a/api/pkg/composemgr/manager.go
+++ b/api/pkg/composemgr/manager.go
@@ -77,12 +77,17 @@ type Options struct {
 
 	// NeuronCompileCacheURL, if set, is exported as NEURON_COMPILE_CACHE_URL
 	// into the `docker compose` environment so Neuron (Inferentia/Trainium)
-	// profiles share a compiled-graph cache (e.g. "s3://<bucket>/neuron-cache").
-	// vLLM-Neuron compiles the model on first start; with this set, the NEFFs
-	// are uploaded once and every other runner loads them instead of
-	// recompiling. Empty means vLLM uses a local (ephemeral) cache.
-	// Implements HELIX_NEURON_COMPILE_CACHE_URL. The runner host must have
-	// credentials for the URL's backend (e.g. an instance role for s3://).
+	// profiles share a compiled-graph cache. vLLM-Neuron compiles the model on
+	// first start; with this set, the NEFFs are uploaded once and every other
+	// runner loads them instead of recompiling. Empty means vLLM uses a local
+	// (ephemeral) cache. Implements HELIX_NEURON_COMPILE_CACHE_URL.
+	//
+	// Format: "s3://<bucket>/<prefix>" (or a local path). The part after the
+	// bucket is an S3 key PREFIX, not a folder - there is nothing to pre-create
+	// beyond the bucket itself; the Neuron SDK writes the substructure
+	// (<prefix>/neuronxcc-<version>/MODULE_<hash>/...) under it on first compile.
+	// The runner host must have credentials for the backend (e.g. an instance
+	// role for s3://).
 	NeuronCompileCacheURL string
 
 	// ReadinessPollInterval is how often we poll service health after

--- a/frontend/src/components/dashboard/profileBlocks.ts
+++ b/frontend/src/components/dashboard/profileBlocks.ts
@@ -434,9 +434,11 @@ export const blockChatNeuronQwen15B: ProfileBlock = {
   // a subprocess, so command must invoke the api_server module itself (the
   // NVIDIA vllm-openai image bakes that into its entrypoint; this one does not).
   // NEURON_COMPILE_CACHE_URL is listed by name; compose-manager exports its
-  // value from the operator-set HELIX_NEURON_COMPILE_CACHE_URL config knob
-  // (e.g. s3://<bucket>/neuron-cache) so the compiled NEFFs are shared
-  // fleet-wide. Without it set, vLLM falls back to a local compile cache.
+  // value from the operator-set HELIX_NEURON_COMPILE_CACHE_URL config knob so
+  // the compiled NEFFs are shared fleet-wide. The value is s3://<bucket>/<prefix>
+  // where <prefix> is an S3 key prefix, not a folder - only the bucket need
+  // exist; the Neuron SDK creates everything under the prefix. Without it set,
+  // vLLM falls back to a local compile cache.
   composeService: `vllm-neuron-qwen:
     image: public.ecr.aws/neuron/pytorch-inference-vllm-neuronx:0.16.0-neuronx-py312-sdk2.30.0-ubuntu24.04
     container_name: vllm-neuron-qwen


### PR DESCRIPTION
Follow-up to #2663 (the clarification commit was pushed just after that PR merged, so it didn't land).

Makes explicit, in three places (composemgr `Options` doc, the `compose-manager` flag help, and the neuron profile comment), that `NEURON_COMPILE_CACHE_URL` is:

- `s3://<bucket>/<prefix>` where `<prefix>` is an **S3 key prefix, not a folder** - only the bucket needs to exist; nothing under it is pre-created
- the Neuron SDK writes the substructure (`<prefix>/neuronxcc-<version>/MODULE_<hash>/...`) on first compile
- a plain local path is also accepted (the default cache mode)

Docs only, no behaviour change. Verified empirically (deleting the prefix and recompiling recreates the keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)