### PR TITLE
fix helix-agent provider preflight

### DIFF
--- a/api/pkg/controller/inference.go
+++ b/api/pkg/controller/inference.go
@@ -83,6 +83,32 @@ func (c *Controller) ChatCompletion(ctx context.Context, user *types.User, req o
 		return nil, nil, err
 	}
 
+	if opts.AppID != "" && assistant.AgentType == types.AgentTypeHelixAgent {
+		if err := c.preflightHelixAgentModels(ctx, user, opts, assistant); err != nil {
+			return nil, nil, err
+		}
+
+		if err := c.evalAndAddOAuthTokens(ctx, nil, opts, user); err != nil {
+			return nil, nil, fmt.Errorf("failed to add OAuth tokens: %w", err)
+		}
+
+		log.Info().
+			Str("app_id", opts.AppID).
+			Msg("running in agent mode")
+
+		resp, err := c.runAgentBlocking(ctx, &runAgentRequest{
+			OrganizationID: opts.OrganizationID,
+			Assistant:      assistant,
+			User:           user,
+			Request:        req,
+			Options:        opts,
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to run agent: %w", err)
+		}
+		return resp, &req, nil
+	}
+
 	if assistant.Provider != "" {
 		opts.Provider = assistant.Provider
 	}
@@ -110,24 +136,6 @@ func (c *Controller) ChatCompletion(ctx context.Context, user *types.User, req o
 	err = c.evalAndAddOAuthTokens(ctx, client, opts, user)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to add OAuth tokens: %w", err)
-	}
-
-	if opts.AppID != "" && assistant.AgentType == types.AgentTypeHelixAgent {
-		log.Info().
-			Str("app_id", opts.AppID).
-			Msg("running in agent mode")
-
-		resp, err := c.runAgentBlocking(ctx, &runAgentRequest{
-			OrganizationID: opts.OrganizationID,
-			Assistant:      assistant,
-			User:           user,
-			Request:        req,
-			Options:        opts,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to run agent: %w", err)
-		}
-		return resp, &req, nil
 	}
 
 	if len(assistant.Tools) > 0 {
@@ -270,6 +278,32 @@ func (c *Controller) ChatCompletionStream(ctx context.Context, user *types.User,
 		return nil, nil, err
 	}
 
+	if opts.AppID != "" && assistant.AgentType == types.AgentTypeHelixAgent {
+		if err := c.preflightHelixAgentModels(ctx, user, opts, assistant); err != nil {
+			return nil, nil, err
+		}
+
+		if err := c.evalAndAddOAuthTokens(ctx, nil, opts, user); err != nil {
+			return nil, nil, fmt.Errorf("failed to add OAuth tokens: %w", err)
+		}
+
+		log.Info().
+			Str("app_id", opts.AppID).
+			Msg("running in agent mode")
+
+		resp, err := c.runAgentStream(ctx, &runAgentRequest{
+			OrganizationID: opts.OrganizationID,
+			Assistant:      assistant,
+			User:           user,
+			Request:        req,
+			Options:        opts,
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to run agent: %w", err)
+		}
+		return resp, &req, nil
+	}
+
 	if assistant.Provider != "" {
 		opts.Provider = assistant.Provider
 	}
@@ -297,24 +331,6 @@ func (c *Controller) ChatCompletionStream(ctx context.Context, user *types.User,
 	err = c.evalAndAddOAuthTokens(ctx, client, opts, user)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to add OAuth tokens: %w", err)
-	}
-
-	if opts.AppID != "" && assistant.AgentType == types.AgentTypeHelixAgent {
-		log.Info().
-			Str("app_id", opts.AppID).
-			Msg("running in agent mode")
-
-		resp, err := c.runAgentStream(ctx, &runAgentRequest{
-			OrganizationID: opts.OrganizationID,
-			Assistant:      assistant,
-			User:           user,
-			Request:        req,
-			Options:        opts,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to run agent: %w", err)
-		}
-		return resp, &req, nil
 	}
 
 	if len(assistant.Tools) > 0 {
@@ -402,6 +418,69 @@ func (c *Controller) ChatCompletionStream(ctx context.Context, user *types.User,
 	}
 
 	return stream, &req, nil
+}
+
+type helixAgentModelRef struct {
+	field    string
+	provider string
+	model    string
+}
+
+func helixAgentModelRefs(assistant *types.AssistantConfig) []helixAgentModelRef {
+	if assistant == nil {
+		return nil
+	}
+	return []helixAgentModelRef{
+		{field: "reasoning_model", provider: assistant.ReasoningModelProvider, model: assistant.ReasoningModel},
+		{field: "generation_model", provider: assistant.GenerationModelProvider, model: assistant.GenerationModel},
+		{field: "small_reasoning_model", provider: assistant.SmallReasoningModelProvider, model: assistant.SmallReasoningModel},
+		{field: "small_generation_model", provider: assistant.SmallGenerationModelProvider, model: assistant.SmallGenerationModel},
+	}
+}
+
+func (c *Controller) preflightHelixAgentModels(ctx context.Context, user *types.User, opts *ChatCompletionOptions, assistant *types.AssistantConfig) error {
+	billingEnabled := false
+	checkedProviders := make(map[string]bool)
+
+	for _, ref := range helixAgentModelRefs(assistant) {
+		if ref.model == "" {
+			return fmt.Errorf("helix_agent assistant %q must configure %s", assistant.Name, ref.field)
+		}
+
+		provider := withFallbackProvider(ref.provider, assistant)
+		if provider == "" {
+			return fmt.Errorf("helix_agent assistant %q must configure %s_provider", assistant.Name, ref.field)
+		}
+
+		if checkedProviders[provider] {
+			continue
+		}
+		checkedProviders[provider] = true
+
+		if err := c.checkInferenceTokenQuota(ctx, user.ID, provider); err != nil {
+			return err
+		}
+
+		client, err := c.getClient(ctx, opts.OrganizationID, user.ID, provider, "")
+		if err != nil {
+			return fmt.Errorf("failed to get client for helix_agent provider %q: %w", provider, err)
+		}
+
+		if client.BillingEnabled() {
+			billingEnabled = true
+		}
+	}
+
+	hasEnoughBalance, err := c.HasEnoughBalance(ctx, user, opts.OrganizationID, billingEnabled)
+	if err != nil {
+		return fmt.Errorf("failed to check balance: %w", err)
+	}
+
+	if !hasEnoughBalance {
+		return fmt.Errorf("insufficient balance")
+	}
+
+	return nil
 }
 
 // getClient returns the OpenAI-compatible client for an inference request.

--- a/api/pkg/controller/inference_agent_preflight_test.go
+++ b/api/pkg/controller/inference_agent_preflight_test.go
@@ -1,0 +1,56 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/config"
+	oai "github.com/helixml/helix/api/pkg/openai"
+	"github.com/helixml/helix/api/pkg/openai/manager"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestPreflightHelixAgentModelsIgnoresTopLevelProvider(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	openAIClient := oai.NewMockClient(ctrl)
+	openAIClient.EXPECT().BillingEnabled().Return(false).Times(1)
+
+	providerManager := manager.NewMockProviderManager(ctrl)
+	providerManager.EXPECT().
+		GetClient(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *manager.GetClientRequest) (oai.Client, error) {
+			require.Equal(t, "openai", req.Provider)
+			return openAIClient, nil
+		}).
+		Times(1)
+
+	c := &Controller{
+		Options: Options{
+			Config: &config.ServerConfig{},
+		},
+		providerManager: providerManager,
+	}
+
+	assistant := &types.AssistantConfig{
+		Name:      "agent",
+		AgentType: types.AgentTypeHelixAgent,
+		Provider:  "user/google",
+		Model:     "models/gemini-2.0-flash",
+
+		ReasoningModelProvider:       "openai",
+		ReasoningModel:               "gpt-5-nano",
+		GenerationModelProvider:      "openai",
+		GenerationModel:              "gpt-5-nano",
+		SmallReasoningModelProvider:  "openai",
+		SmallReasoningModel:          "gpt-5-nano",
+		SmallGenerationModelProvider: "openai",
+		SmallGenerationModel:         "gpt-5-nano",
+	}
+
+	err := c.preflightHelixAgentModels(context.Background(), &types.User{ID: "user1"}, &ChatCompletionOptions{}, assistant)
+	require.NoError(t, err)
+}

--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -173,15 +173,7 @@ func (s *HelixAPIServer) applyModelSubstitutions(ctx context.Context, user *type
 			}
 		}
 
-		// Apply substitutions for all model fields
-
-		// Main provider/model
-		applySubstitution("provider/model", assistant.Provider, assistant.Model,
-			func(p string) { assistant.Provider = p },
-			func(m string) { assistant.Model = m })
-
-		// Agent mode model fields
-		if assistant.IsAgentMode() {
+		if assistant.AgentType == types.AgentTypeHelixAgent {
 			// Reasoning model
 			applySubstitution("reasoning_model", assistant.ReasoningModelProvider, assistant.ReasoningModel,
 				func(p string) { assistant.ReasoningModelProvider = p },
@@ -201,10 +193,29 @@ func (s *HelixAPIServer) applyModelSubstitutions(ctx context.Context, user *type
 			applySubstitution("small_generation_model", assistant.SmallGenerationModelProvider, assistant.SmallGenerationModel,
 				func(p string) { assistant.SmallGenerationModelProvider = p },
 				func(m string) { assistant.SmallGenerationModel = m })
+		} else {
+			// Main provider/model for non-agent assistants.
+			applySubstitution("provider/model", assistant.Provider, assistant.Model,
+				func(p string) { assistant.Provider = p },
+				func(m string) { assistant.Model = m })
 		}
 	}
 
 	return substitutions, nil
+}
+
+func normalizeHelixAgentAssistantSpecs(app *types.App) {
+	if app == nil {
+		return
+	}
+	for idx := range app.Config.Helix.Assistants {
+		assistant := &app.Config.Helix.Assistants[idx]
+		if assistant.AgentType != types.AgentTypeHelixAgent {
+			continue
+		}
+		assistant.Provider = ""
+		assistant.Model = ""
+	}
 }
 
 // findModelSubstitution finds the first available model from the alternatives list.
@@ -467,6 +478,8 @@ func (s *HelixAPIServer) createApp(_ http.ResponseWriter, r *http.Request) (*App
 			Msg("No model classes provided, skipping substitution")
 	}
 
+	normalizeHelixAgentAssistantSpecs(app)
+
 	err = s.validateProvidersAndModels(ctx, user, app)
 	if err != nil {
 		return nil, system.NewHTTPError400(err.Error())
@@ -615,22 +628,31 @@ func (s *HelixAPIServer) validateProvidersAndModels(ctx context.Context, user *t
 		Msg("Available providers during validation")
 
 	// Helper function to validate a provider/model pair
-	validateProviderModel := func(fieldName, provider, model string, assistantName string, isAgentMode bool) error {
+	validateProviderModel := func(fieldName, provider, model string, assistantName string, allowEmptyProvider bool) error {
 		if provider == "" && model == "" {
 			return nil // Both empty is ok
 		}
 
-		if model == "" && !isAgentMode {
+		if provider == "" && !allowEmptyProvider {
 			log.Error().
 				Str("user_id", user.ID).
 				Str("assistant_name", assistantName).
 				Str("field_name", fieldName).
-				Msg("Validation failed: assistant has no model and is not in agent mode")
+				Msg("Validation failed: assistant has no provider")
+			return fmt.Errorf("assistant '%s' must have a provider for %s", assistantName, fieldName)
+		}
+
+		if model == "" {
+			log.Error().
+				Str("user_id", user.ID).
+				Str("assistant_name", assistantName).
+				Str("field_name", fieldName).
+				Msg("Validation failed: assistant has no model")
 			return fmt.Errorf("assistant '%s' must have a model for %s", assistantName, fieldName)
 		}
 
-		// If provider set, check if we have it
-		if provider != "" && !isAgentMode {
+		// If provider set, check if we have it.
+		if provider != "" {
 			if !providerKnown(provider) {
 				log.Error().
 					Str("user_id", user.ID).
@@ -658,6 +680,10 @@ func (s *HelixAPIServer) validateProvidersAndModels(ctx context.Context, user *t
 			Str("agent_type", string(assistant.GetAgentType())).
 			Msg("Validating individual assistant")
 
+		if assistant.AgentType == types.AgentTypeHelixAgent && (assistant.Provider != "" || assistant.Model != "") {
+			return fmt.Errorf("helix_agent assistant '%s' must not set top-level provider/model; use reasoning_model_provider, generation_model_provider, small_reasoning_model_provider, and small_generation_model_provider", assistant.Name)
+		}
+
 		if assistant.CodeAgentRuntime != "" && assistant.CodeAgentCredentialType == types.CodeAgentCredentialTypeAPIKey {
 			// Provider and model are only required in explicit API key mode,
 			// where the agent routes through the Helix proxy.
@@ -672,13 +698,13 @@ func (s *HelixAPIServer) validateProvidersAndModels(ctx context.Context, user *t
 		}
 
 		// Validate main provider/model
-		err := validateProviderModel("provider/model", assistant.Provider, assistant.Model, assistant.Name, assistant.IsAgentMode())
+		err := validateProviderModel("provider/model", assistant.Provider, assistant.Model, assistant.Name, true)
 		if err != nil {
 			return err
 		}
 
 		// If in agent mode, validate all agent mode model fields
-		if assistant.IsAgentMode() {
+		if assistant.AgentType == types.AgentTypeHelixAgent {
 			// Validate reasoning model
 			err := validateProviderModel("reasoning_model", assistant.ReasoningModelProvider, assistant.ReasoningModel, assistant.Name, false)
 			if err != nil {
@@ -1032,6 +1058,8 @@ func (s *HelixAPIServer) updateApp(_ http.ResponseWriter, r *http.Request) (*typ
 	if err != nil {
 		return nil, system.NewHTTPError403(err.Error())
 	}
+
+	normalizeHelixAgentAssistantSpecs(&update)
 
 	err = s.validateProvidersAndModels(r.Context(), user, &update)
 	if err != nil {
@@ -2013,6 +2041,7 @@ func (s *HelixAPIServer) duplicateApp(_ http.ResponseWriter, r *http.Request) (*
 	app.Updated = time.Now()
 
 	app.Config.Helix.Name = r.URL.Query().Get("name")
+	normalizeHelixAgentAssistantSpecs(app)
 
 	app, err = s.Store.CreateApp(r.Context(), app)
 	if err != nil {

--- a/api/pkg/server/app_handlers_test.go
+++ b/api/pkg/server/app_handlers_test.go
@@ -644,14 +644,11 @@ func TestApplyModelSubstitutions_AgentMode(t *testing.T) {
 	substitutions, err := server.applyModelSubstitutions(ctx, user, app, modelClasses)
 	require.NoError(t, err)
 
-	// Should have 3 substitutions (main provider/model, reasoning_model, and generation_model)
-	// Note: reasoning_model gets substituted even though anthropic is available because
-	// the substitution logic always uses the first available alternative from the same class
-	require.Len(t, substitutions, 5) // All 5 model fields should be substituted
+	require.Len(t, substitutions, 4) // Agent-mode model fields should be substituted; top-level provider/model is ignored.
 
-	// Verify the main provider/model substitution
-	assert.Equal(t, "helix", app.Config.Helix.Assistants[0].Provider)
-	assert.Equal(t, "llama3.1:8b-instruct-q8_0", app.Config.Helix.Assistants[0].Model)
+	// Main provider/model is not used by helix_agent and is normalized before persistence.
+	assert.Equal(t, "together", app.Config.Helix.Assistants[0].Provider)
+	assert.Equal(t, "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", app.Config.Helix.Assistants[0].Model)
 
 	// Verify agent mode model substitutions
 	assistant := app.Config.Helix.Assistants[0]
@@ -675,7 +672,6 @@ func TestApplyModelSubstitutions_AgentMode(t *testing.T) {
 	}
 
 	// Check that all expected field substitutions were recorded
-	assert.True(t, substitutionFields["Original provider 'together' not available for provider/model"])
 	assert.True(t, substitutionFields["Original provider 'together' not available for reasoning_model"])
 	assert.True(t, substitutionFields["Original provider 'anthropic' not available for generation_model"])
 	assert.True(t, substitutionFields["Original provider 'together' not available for small_reasoning_model"])
@@ -739,12 +735,12 @@ func TestApplyModelSubstitutions_AgentModePartialSubstitution(t *testing.T) {
 	substitutions, err := server.applyModelSubstitutions(ctx, user, app, modelClasses)
 	require.NoError(t, err)
 
-	// Should only have 2 substitutions (main provider/model and generation_model)
-	require.Len(t, substitutions, 2)
+	// Should only have 1 substitution (generation_model); top-level provider/model is ignored in agent mode.
+	require.Len(t, substitutions, 1)
 
-	// Verify the main provider/model substitution
-	assert.Equal(t, "helix", app.Config.Helix.Assistants[0].Provider)
-	assert.Equal(t, "llama3.1:8b-instruct-q8_0", app.Config.Helix.Assistants[0].Model)
+	// Main provider/model is not used by helix_agent and is normalized before persistence.
+	assert.Equal(t, "together", app.Config.Helix.Assistants[0].Provider)
+	assert.Equal(t, "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", app.Config.Helix.Assistants[0].Model)
 
 	// Verify agent mode model states
 	assistant := app.Config.Helix.Assistants[0]
@@ -894,6 +890,128 @@ func TestO3MiniSubstitution(t *testing.T) {
 		assert.Equal(t, "anthropic", sub.NewProvider)
 		assert.Equal(t, "claude-3-5-sonnet-20241022", sub.NewModel)
 	}
+}
+
+func TestNormalizeHelixAgentAssistantSpecs(t *testing.T) {
+	app := &types.App{
+		Config: types.AppConfig{
+			Helix: types.AppHelixConfig{
+				Assistants: []types.AssistantConfig{
+					{
+						Name:                         "agent",
+						AgentType:                    types.AgentTypeHelixAgent,
+						Provider:                     "user/google",
+						Model:                        "models/gemini-2.0-flash",
+						ReasoningModelProvider:       "openai",
+						ReasoningModel:               "gpt-5-nano",
+						GenerationModelProvider:      "openai",
+						GenerationModel:              "gpt-5-nano",
+						SmallReasoningModelProvider:  "openai",
+						SmallReasoningModel:          "gpt-5-nano",
+						SmallGenerationModelProvider: "openai",
+						SmallGenerationModel:         "gpt-5-nano",
+					},
+					{
+						Name:      "simple",
+						Provider:  "openai",
+						Model:     "gpt-5-nano",
+						AgentType: types.AgentTypeHelixBasic,
+					},
+				},
+			},
+		},
+	}
+
+	normalizeHelixAgentAssistantSpecs(app)
+
+	agent := app.Config.Helix.Assistants[0]
+	assert.Empty(t, agent.Provider)
+	assert.Empty(t, agent.Model)
+	assert.Equal(t, "openai", agent.GenerationModelProvider)
+	assert.Equal(t, "gpt-5-nano", agent.GenerationModel)
+
+	simple := app.Config.Helix.Assistants[1]
+	assert.Equal(t, "openai", simple.Provider)
+	assert.Equal(t, "gpt-5-nano", simple.Model)
+}
+
+func TestValidateProvidersAndModels_HelixAgentRejectsTopLevelProviderModel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProviderManager := manager.NewMockProviderManager(ctrl)
+	server := &HelixAPIServer{providerManager: mockProviderManager}
+	ctx := context.Background()
+	user := &types.User{ID: "user1"}
+
+	mockProviderManager.EXPECT().
+		ListProviderEndpoints(ctx, user.ID).
+		Return([]*types.ProviderEndpoint{{Name: "openai"}}, nil)
+
+	app := &types.App{
+		Config: types.AppConfig{
+			Helix: types.AppHelixConfig{
+				Assistants: []types.AssistantConfig{
+					{
+						Name:                         "agent",
+						AgentType:                    types.AgentTypeHelixAgent,
+						Provider:                     "user/google",
+						Model:                        "models/gemini-2.0-flash",
+						ReasoningModelProvider:       "openai",
+						ReasoningModel:               "gpt-5-nano",
+						GenerationModelProvider:      "openai",
+						GenerationModel:              "gpt-5-nano",
+						SmallReasoningModelProvider:  "openai",
+						SmallReasoningModel:          "gpt-5-nano",
+						SmallGenerationModelProvider: "openai",
+						SmallGenerationModel:         "gpt-5-nano",
+					},
+				},
+			},
+		},
+	}
+
+	err := server.validateProvidersAndModels(ctx, user, app)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not set top-level provider/model")
+}
+
+func TestValidateProvidersAndModels_HelixAgentRequiresModelProviders(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockProviderManager := manager.NewMockProviderManager(ctrl)
+	server := &HelixAPIServer{providerManager: mockProviderManager}
+	ctx := context.Background()
+	user := &types.User{ID: "user1"}
+
+	mockProviderManager.EXPECT().
+		ListProviderEndpoints(ctx, user.ID).
+		Return([]*types.ProviderEndpoint{{Name: "openai"}}, nil)
+
+	app := &types.App{
+		Config: types.AppConfig{
+			Helix: types.AppHelixConfig{
+				Assistants: []types.AssistantConfig{
+					{
+						Name:                         "agent",
+						AgentType:                    types.AgentTypeHelixAgent,
+						ReasoningModel:               "gpt-5-nano",
+						GenerationModelProvider:      "openai",
+						GenerationModel:              "gpt-5-nano",
+						SmallReasoningModelProvider:  "openai",
+						SmallReasoningModel:          "gpt-5-nano",
+						SmallGenerationModelProvider: "openai",
+						SmallGenerationModel:         "gpt-5-nano",
+					},
+				},
+			},
+		},
+	}
+
+	err := server.validateProvidersAndModels(ctx, user, app)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must have a provider for reasoning_model")
 }
 
 // TestListEndpointsForApp covers the org-aware behaviour added in the


### PR DESCRIPTION
## Summary

- Route `helix_agent` chat completions into the agent path before copying the top-level assistant `provider` into inference options.
- Preflight quota/balance/client availability against the actual helix-agent model providers instead of the legacy top-level provider/model pair.
- Normalize helix-agent app specs on create/update/duplicate by clearing top-level `provider`/`model`, and validate the four agent model provider/model fields.
- Add regression coverage for the `user/google` top-level provider case and app-spec validation.

## Root Cause

`/v1/chat/completions` loaded the app assistant, copied `assistant.Provider` into `opts.Provider`, and requested that client before checking `agent_type`. For helix-agent apps, that meant a legacy/spec top-level `provider: user/google` could fail with `no client found for provider: user/google` even though the actual agent model providers were all `openai`.

## Validation

- `go test -v -run 'TestPreflightHelixAgentModelsIgnoresTopLevelProvider|TestControllerSuite/Test_getClient|TestControllerSuite/Test_checkInferenceTokenQuota' ./api/pkg/controller -count=1`\n- `go test -v -run 'TestApplyModelSubstitutions_AgentMode|TestApplyModelSubstitutions_AgentModePartialSubstitution|TestO3MiniSubstitution|TestNormalizeHelixAgentAssistantSpecs|TestValidateProvidersAndModels_HelixAgent' ./api/pkg/server -count=1`\n- `go test ./api/pkg/controller -count=1`\n- `go test ./api/pkg/server -count=1`\n- `go build ./api/pkg/server/ ./api/pkg/store/ ./api/pkg/types/`\n\nNote: `Dockerfile.ubuntu-helix` has an unrelated unstaged local edit and is intentionally not included in this PR.