### PR TITLE
fix(api): authorize knowledge list by app, not owner

### DIFF
--- a/api/pkg/server/knowledge_handlers.go
+++ b/api/pkg/server/knowledge_handlers.go
@@ -37,7 +37,29 @@ func (s *HelixAPIServer) listKnowledge(_ http.ResponseWriter, r *http.Request) (
 		AppID: appID,
 	}
 
-	if orgID != "" {
+	switch {
+	case appID != "":
+		// Knowledge is an app-scoped resource. Authorize against the app
+		// itself (the same way getApp does) instead of owner-equality, so
+		// everyone who can see the agent can see its knowledge — including
+		// org members editing a shared project agent they don't personally
+		// own. ensureKnowledge stamps each row with the app owner's id, so an
+		// owner-scoped list hides knowledge from any other authorized viewer
+		// (and a non-owner re-adding a source would silently delete the
+		// owner's existing sources). Listing by app_id alone is safe because
+		// app IDs are globally unique and access is gated by the check below.
+		app, err := s.Store.GetApp(ctx, appID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return nil, system.NewHTTPError404(store.ErrNotFound.Error())
+			}
+			return nil, system.NewHTTPError500(err.Error())
+		}
+		if err := s.authorizeUserToApp(ctx, user, app, types.ActionGet); err != nil {
+			return nil, system.NewHTTPError403(err.Error())
+		}
+		// No owner filter — app authorization is the gate.
+	case orgID != "":
 		org, err := s.lookupOrg(ctx, orgID)
 		if err != nil {
 			if errors.Is(err, store.ErrNotFound) {
@@ -50,7 +72,7 @@ func (s *HelixAPIServer) listKnowledge(_ http.ResponseWriter, r *http.Request) (
 		}
 		query.OwnerType = types.OwnerTypeOrg
 		query.Owner = org.ID
-	} else {
+	default:
 		query.OwnerType = user.Type
 		query.Owner = user.ID
 	}

--- a/api/pkg/server/knowledge_handlers_test.go
+++ b/api/pkg/server/knowledge_handlers_test.go
@@ -1,0 +1,153 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/suite"
+
+	"go.uber.org/mock/gomock"
+)
+
+// fakeKnowledgeManager is a no-op implementation of knowledge.Manager so the
+// listKnowledge handler can populate ephemeral progress without a real
+// reconciler.
+type fakeKnowledgeManager struct{}
+
+func (fakeKnowledgeManager) NextRun(_ context.Context, _ string) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (fakeKnowledgeManager) GetStatus(_ string) types.KnowledgeProgress {
+	return types.KnowledgeProgress{}
+}
+
+type ListKnowledgeSuite struct {
+	suite.Suite
+
+	ctrl  *gomock.Controller
+	store *store.MockStore
+
+	authCtx context.Context
+	userID  string
+
+	server *HelixAPIServer
+}
+
+func TestListKnowledgeSuite(t *testing.T) {
+	suite.Run(t, new(ListKnowledgeSuite))
+}
+
+func (suite *ListKnowledgeSuite) SetupTest() {
+	ctrl := gomock.NewController(suite.T())
+	suite.ctrl = ctrl
+	suite.store = store.NewMockStore(ctrl)
+
+	suite.userID = "user_id_test"
+	suite.authCtx = setRequestUser(context.Background(), types.User{
+		ID:   suite.userID,
+		Type: types.OwnerTypeUser,
+	})
+
+	suite.server = &HelixAPIServer{
+		Cfg:              &config.ServerConfig{},
+		Store:            suite.store,
+		knowledgeManager: fakeKnowledgeManager{},
+	}
+}
+
+func (suite *ListKnowledgeSuite) newRequest(query string) *http.Request {
+	req := httptest.NewRequest("GET", "/api/v1/knowledge"+query, http.NoBody)
+	return req.WithContext(suite.authCtx)
+}
+
+// When app_id is set, knowledge must be authorized against the app and listed
+// by app_id alone — NOT by owner-equality. Regression test for the bug where an
+// authorized non-owner (e.g. an org owner viewing a member's project agent) saw
+// an empty knowledge list because rows are stamped with the app owner's id.
+func (suite *ListKnowledgeSuite) TestAppScoped_AuthorizedNonOwner_NoOwnerFilter() {
+	// Global app owned by a different user — the requesting user is authorized
+	// via Global, not ownership.
+	app := &types.App{
+		ID:     "app_id_test",
+		Owner:  "some_other_owner",
+		Global: true,
+	}
+	suite.store.EXPECT().GetApp(gomock.Any(), app.ID).Return(app, nil)
+
+	var captured *store.ListKnowledgeQuery
+	suite.store.EXPECT().
+		ListKnowledge(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, q *store.ListKnowledgeQuery) ([]*types.Knowledge, error) {
+			captured = q
+			return []*types.Knowledge{
+				{ID: "kno_test", Name: "doc", AppID: app.ID, Owner: app.Owner},
+			}, nil
+		})
+
+	knowledge, httpErr := suite.server.listKnowledge(httptest.NewRecorder(), suite.newRequest("?app_id=app_id_test"))
+
+	suite.Nil(httpErr)
+	suite.Require().Len(knowledge, 1)
+	suite.Equal("kno_test", knowledge[0].ID)
+
+	// The crucial assertion: scoped by app, with no owner filter.
+	suite.Require().NotNil(captured)
+	suite.Equal(app.ID, captured.AppID)
+	suite.Empty(captured.Owner, "owner filter must not be applied when app_id is set")
+	suite.Empty(captured.OwnerType, "owner_type filter must not be applied when app_id is set")
+}
+
+// A user with no access to the app must be denied, and the store must never be
+// queried for its knowledge.
+func (suite *ListKnowledgeSuite) TestAppScoped_Unauthorized() {
+	app := &types.App{
+		ID:     "app_id_test",
+		Owner:  "some_other_owner",
+		Global: false,
+	}
+	suite.store.EXPECT().GetApp(gomock.Any(), app.ID).Return(app, nil)
+	// No ListKnowledge expectation — it must not be called.
+
+	knowledge, httpErr := suite.server.listKnowledge(httptest.NewRecorder(), suite.newRequest("?app_id=app_id_test"))
+
+	suite.Nil(knowledge)
+	suite.Require().NotNil(httpErr)
+	suite.Equal(http.StatusForbidden, httpErr.StatusCode)
+}
+
+func (suite *ListKnowledgeSuite) TestAppScoped_AppNotFound() {
+	suite.store.EXPECT().GetApp(gomock.Any(), "app_id_test").Return(nil, store.ErrNotFound)
+
+	knowledge, httpErr := suite.server.listKnowledge(httptest.NewRecorder(), suite.newRequest("?app_id=app_id_test"))
+
+	suite.Nil(knowledge)
+	suite.Require().NotNil(httpErr)
+	suite.Equal(http.StatusNotFound, httpErr.StatusCode)
+}
+
+// Without app_id (or org), listing stays scoped to the requesting user's own
+// knowledge — the personal-list behaviour is unchanged.
+func (suite *ListKnowledgeSuite) TestPersonalScoped_NoAppID() {
+	var captured *store.ListKnowledgeQuery
+	suite.store.EXPECT().
+		ListKnowledge(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, q *store.ListKnowledgeQuery) ([]*types.Knowledge, error) {
+			captured = q
+			return []*types.Knowledge{}, nil
+		})
+
+	_, httpErr := suite.server.listKnowledge(httptest.NewRecorder(), suite.newRequest(""))
+
+	suite.Nil(httpErr)
+	suite.Require().NotNil(captured)
+	suite.Equal(suite.userID, captured.Owner)
+	suite.Equal(types.OwnerTypeUser, captured.OwnerType)
+	suite.Empty(captured.AppID)
+}


### PR DESCRIPTION
## Problem

Adding knowledge sources to an agent worked, but they **didn't show up** for anyone other than the agent's original creator — and worse, re-adding silently **deleted** the existing sources.

### Root cause

`listKnowledge` (`api/pkg/server/knowledge_handlers.go`) filtered knowledge by **owner-equality** (`owner = requesting user`), but `ensureKnowledge` stamps every knowledge row with the **app owner's** id (`app.Owner`). The frontend (`useKnowledge`/`useApp`) lists knowledge with only `?app_id=…`, never `organization_id`, so it always hit the user-scoped branch.

Consequences for any authorized **non-owner** of an agent (org owner/admin, or a collaborator on a shared **project agent**):

1. `GET /api/v1/knowledge?app_id=…` returns `[]` even though rows exist → "added knowledge doesn't get displayed".
2. Their local list being empty, the next save PUTs an app config missing the real sources, and `ensureKnowledge`'s "delete what's no longer declared" step **silently deletes the owner's knowledge**.

This became a regression as Helix moved agents under shared orgs/projects.

## Fix

Knowledge is an **app-scoped** resource. When `app_id` is provided, authorize against the **app itself** (exactly like `getApp`) and list by `app_id` alone, dropping the owner filter. The org-list (`?organization_id=`) and personal-list paths are unchanged.

This also closes the data-loss path: non-owners now load existing sources before editing, so their save no longer drops them.

## Verification

End-to-end against a running stack:

- Org owner viewing a member's project agent → **now returns** the agent's `ready` knowledge row (was `[]`).
- Unrelated user with no app access → **403** on both the app and the knowledge list (no leak).
- Personal list (no `app_id`) → **200**, unchanged.
- `go build ./pkg/server/` clean.

Unit tests added in `knowledge_handlers_test.go`:

- `TestAppScoped_AuthorizedNonOwner_NoOwnerFilter` — authorized non-owner gets the app's knowledge, and the store query carries **no owner filter** (the core assertion).
- `TestAppScoped_Unauthorized` — unauthorized user gets 403 and the store is never queried.
- `TestAppScoped_AppNotFound` — missing app → 404.
- `TestPersonalScoped_NoAppID` — personal listing still scopes by the requesting user.

No frontend change needed — it already sends `app_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)