### PR TITLE
fix(api): unblock design-review comment queue when a comment is never finalized

### DIFF
--- a/api/pkg/server/spec_task_design_review_handlers.go
+++ b/api/pkg/server/spec_task_design_review_handlers.go
@@ -25,6 +25,12 @@ import (
 // real response.
 const CommentTimerNoResponseMessage = "[Agent did not respond - try sending your comment again]"
 
+// commentResponseTimeout is how long we wait for the agent to respond to a
+// queued review comment before the backstop timer fires. The timer is a
+// best-effort safety net behind finalizeCommentResponse (which fires on the
+// message_completed event); see handleCommentTimeout for the decision tree.
+const commentResponseTimeout = 2 * time.Minute
+
 // Design Review Handlers - Simple versions
 
 // ResumeCommentQueueProcessing resumes processing of any queued comments after server restart.
@@ -35,19 +41,30 @@ const CommentTimerNoResponseMessage = "[Agent did not respond - try sending your
 func (s *HelixAPIServer) ResumeCommentQueueProcessing(ctx context.Context) {
 	log.Info().Msg("🔄 Resuming comment queue processing after startup...")
 
-	// Step 1: Reset any comments that were mid-processing when server crashed
+	// Find all sessions with pending comments up front — used both for terminal
+	// reconciliation and for triggering processing.
+	sessionIDs, err := s.Store.GetSessionsWithPendingComments(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get sessions with pending comments")
+		return
+	}
+
+	// Step 1a: Reconcile comments whose agent interaction already COMPLETED but
+	// were never finalized (their message_completed never mapped back). These must
+	// be finalized — not blindly reset — otherwise the bulk reset below would clear
+	// their request_id and the queue would re-send an already-answered comment.
+	for _, sessionID := range sessionIDs {
+		s.reconcileStuckInFlightComment(ctx, sessionID)
+	}
+
+	// Step 1b: Reset any comments still stuck mid-processing (request_id set, no
+	// response, interaction NOT terminal — a genuine crash mid-flight). Clearing
+	// request_id lets them be re-sent on the next processing pass.
 	resetCount, err := s.Store.ResetStuckComments(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to reset stuck comments")
 	} else if resetCount > 0 {
 		log.Info().Int64("count", resetCount).Msg("✅ Reset stuck comments (were mid-processing during crash)")
-	}
-
-	// Step 2: Find all sessions with pending comments and trigger processing
-	sessionIDs, err := s.Store.GetSessionsWithPendingComments(ctx)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to get sessions with pending comments")
-		return
 	}
 
 	if len(sessionIDs) == 0 {
@@ -745,6 +762,20 @@ func (s *HelixAPIServer) processNextCommentInQueue(ctx context.Context, sessionI
 		return
 	}
 	if isProcessing {
+		// A comment is marked in-flight (request_id set). Normally we skip to avoid
+		// interleaving agent responses. But a comment can get stuck in-flight forever
+		// if its message_completed event never maps back to it — e.g. the agent
+		// coalesced several re-sends under a different request_id, the completion was
+		// missed/duplicated, or a restart lost the in-memory mapping. In that case the
+		// linked interaction is already terminal but finalizeCommentResponse never ran,
+		// so request_id stays set and blocks the whole session's comment queue.
+		//
+		// Reconcile before skipping: if the in-flight comment's interaction is terminal,
+		// finalize it now (copies the response, clears the marker, advances the queue).
+		if s.reconcileStuckInFlightComment(ctx, sessionID) {
+			// finalizeCommentResponse already triggered the next queue item.
+			return
+		}
 		log.Debug().
 			Str("session_id", sessionID).
 			Msg("Comment already being processed (database check), skipping")
@@ -814,26 +845,78 @@ func (s *HelixAPIServer) processNextCommentInQueue(ctx context.Context, sessionI
 	}
 
 	// Comment sent successfully - start timeout to handle agent not responding
-	// 2 minute timeout for agent to respond to the comment
-	const commentResponseTimeout = 2 * time.Minute
-	s.sessionCommentMutex.Lock()
-	// Cancel any existing timeout for this session
-	if existingTimer := s.sessionCommentTimeout[sessionID]; existingTimer != nil {
-		existingTimer.Stop()
-	}
-	commentID := comment.ID
-	// Use a fresh context for the timer body. The ctx passed into
-	// processNextCommentInQueue may be an HTTP request context that is
-	// already cancelled by the time the timer fires 2 minutes later.
-	s.sessionCommentTimeout[sessionID] = time.AfterFunc(commentResponseTimeout, func() {
-		s.handleCommentTimeout(context.Background(), sessionID, commentID)
-	})
-	s.sessionCommentMutex.Unlock()
+	s.armCommentTimer(sessionID, comment.ID)
 
 	log.Info().
 		Str("session_id", sessionID).
 		Str("comment_id", comment.ID).
 		Msg("Comment sent to agent, started 2-minute response timeout")
+}
+
+// armCommentTimer (re)arms the per-session backstop timer for a comment. It
+// cancels any existing timer for the session and schedules handleCommentTimeout
+// to run after commentResponseTimeout. A fresh context.Background() is used for
+// the timer body because the originating HTTP request context may already be
+// cancelled by the time the timer fires.
+func (s *HelixAPIServer) armCommentTimer(sessionID, commentID string) {
+	s.sessionCommentMutex.Lock()
+	defer s.sessionCommentMutex.Unlock()
+	if existingTimer := s.sessionCommentTimeout[sessionID]; existingTimer != nil {
+		existingTimer.Stop()
+	}
+	s.sessionCommentTimeout[sessionID] = time.AfterFunc(commentResponseTimeout, func() {
+		s.handleCommentTimeout(context.Background(), sessionID, commentID)
+	})
+}
+
+// reconcileStuckInFlightComment detects a comment that is marked in-flight
+// (request_id set) for a session but whose linked agent interaction has already
+// reached a terminal state without finalizeCommentResponse ever running. This
+// happens when the message_completed event for the turn never maps back to the
+// comment's request_id (the agent coalesced several re-sends under a different
+// request_id, the completion was missed/duplicated, or a restart lost the
+// in-memory mapping). Left alone, such a zombie blocks the session's comment
+// queue forever.
+//
+// If a stuck comment is found and reconciled it is finalized (response copied
+// from the interaction, request_id/queued_at cleared, next queued comment
+// processed) and true is returned. A genuinely in-flight comment whose
+// interaction is still waiting/streaming is left untouched and false is returned.
+func (s *HelixAPIServer) reconcileStuckInFlightComment(ctx context.Context, sessionID string) bool {
+	inFlight, err := s.Store.GetPendingCommentByPlanningSessionID(ctx, sessionID)
+	if err != nil || inFlight == nil {
+		return false
+	}
+	if inFlight.InteractionID == "" {
+		// No linked interaction — we can't prove the agent finished, so treat it as
+		// genuinely in flight and leave it for the backstop timer / re-send path.
+		return false
+	}
+	interaction, ierr := s.Store.GetInteraction(ctx, inFlight.InteractionID)
+	if ierr != nil || interaction == nil {
+		return false
+	}
+	terminal := interaction.State == types.InteractionStateComplete ||
+		interaction.State == types.InteractionStateInterrupted ||
+		interaction.State == types.InteractionStateError
+	if !terminal {
+		// Agent is still working on this comment — correct to wait.
+		return false
+	}
+	log.Warn().
+		Str("session_id", sessionID).
+		Str("comment_id", inFlight.ID).
+		Str("interaction_id", inFlight.InteractionID).
+		Str("interaction_state", string(interaction.State)).
+		Str("request_id", inFlight.RequestID).
+		Msg("🩹 [HELIX] Reconciling stuck in-flight comment: interaction is terminal but was never finalized — finalizing now to unblock the queue")
+	if err := s.finalizeCommentResponse(ctx, inFlight.RequestID); err != nil {
+		log.Error().Err(err).
+			Str("comment_id", inFlight.ID).
+			Msg("Failed to finalize stuck in-flight comment during reconciliation")
+		return false
+	}
+	return true
 }
 
 // handleCommentTimeout is the body of the per-comment 2-minute response timer.
@@ -883,14 +966,57 @@ func (s *HelixAPIServer) handleCommentTimeout(ctx context.Context, sessionID, co
 			terminal := interaction.State == types.InteractionStateComplete ||
 				interaction.State == types.InteractionStateInterrupted ||
 				interaction.State == types.InteractionStateError
-			if agentText != "" || terminal {
-				log.Info().
+			if terminal {
+				// The agent is DONE but finalizeCommentResponse never ran — its
+				// message_completed didn't map back to this comment (coalesced
+				// re-sends, missed/duplicate completion, restart). Don't just defer:
+				// finalize here so the comment gets its response and the queue is
+				// unblocked. Without this the comment stays in-flight forever and
+				// every later comment for this session is silently never delivered.
+				log.Warn().
 					Str("session_id", sessionID).
 					Str("comment_id", commentID).
 					Str("interaction_id", interaction.ID).
 					Str("interaction_state", string(interaction.State)).
 					Int("interaction_response_len", len(agentText)).
-					Msg("⏭️  Comment timer: skipping error stamp — agent is streaming / interaction is terminal; finalizeCommentResponse will copy content")
+					Msg("🩹 Comment timer: interaction is terminal but was never finalized — finalizing now to unblock the queue")
+				if err := s.finalizeCommentResponse(ctx, currentComment.RequestID); err != nil {
+					log.Error().Err(err).
+						Str("comment_id", commentID).
+						Str("request_id", currentComment.RequestID).
+						Msg("Comment timer: failed to finalize terminal interaction")
+				}
+				return
+			}
+			if agentText != "" {
+				// Non-terminal but has content. Distinguish a long answer that is
+				// still actively streaming (defer + re-check) from one that has
+				// stalled mid-stream because the agent died (finalize with what we
+				// have, otherwise the queue is blocked forever). The interaction's
+				// Updated timestamp tells them apart: a live stream keeps bumping it.
+				if time.Since(interaction.Updated) > commentResponseTimeout {
+					log.Warn().
+						Str("session_id", sessionID).
+						Str("comment_id", commentID).
+						Str("interaction_id", interaction.ID).
+						Time("interaction_updated", interaction.Updated).
+						Msg("🩹 Comment timer: interaction stalled mid-stream (no updates for a full window) — finalizing partial response to unblock the queue")
+					if err := s.finalizeCommentResponse(ctx, currentComment.RequestID); err != nil {
+						log.Error().Err(err).
+							Str("comment_id", commentID).
+							Msg("Comment timer: failed to finalize stalled interaction")
+					}
+					return
+				}
+				// Still streaming — re-arm the timer and re-check rather than
+				// deferring indefinitely to a finalize that may never arrive.
+				log.Info().
+					Str("session_id", sessionID).
+					Str("comment_id", commentID).
+					Str("interaction_id", interaction.ID).
+					Int("interaction_response_len", len(agentText)).
+					Msg("⏭️  Comment timer: agent still streaming — re-arming timer to re-check")
+				s.armCommentTimer(sessionID, commentID)
 				return
 			}
 		} else if ierr != nil {

--- a/api/pkg/server/spec_task_design_review_handlers_test.go
+++ b/api/pkg/server/spec_task_design_review_handlers_test.go
@@ -73,41 +73,107 @@ func (s *CommentTimerSuite) TestHandleCommentTimeout_SkipsErrorWhenInteractionHa
 		SessionID:       "ses-streaming",
 		State:           types.InteractionStateWaiting,
 		ResponseMessage: "Sure — here is the plan. Step 1: ...",
+		// Updated recently => the agent is actively streaming a long answer.
+		// The timer must re-arm and re-check, not stamp an error or finalize.
+		Updated: time.Now(),
 	}
 
 	s.store.EXPECT().GetSpecTaskDesignReviewComment(gomock.Any(), "comment-streaming").
 		Return(comment, nil)
 	s.store.EXPECT().GetInteraction(gomock.Any(), "int-streaming").
 		Return(streamingInteraction, nil)
-	// Critical: NO UpdateSpecTaskDesignReviewComment call is expected.
-	// gomock's strict mode fails the test if any unexpected call is made.
+	// Critical: NO UpdateSpecTaskDesignReviewComment call is expected — the timer
+	// re-arms (in-memory only) and defers. gomock's strict mode fails the test if
+	// any unexpected store call is made.
 
 	s.server.handleCommentTimeout(context.Background(), "ses-streaming", "comment-streaming")
+
+	// Re-arm scheduled a real 2-minute timer; stop it so it can't fire after the
+	// mock controller is torn down.
+	if t := s.server.sessionCommentTimeout["ses-streaming"]; t != nil {
+		t.Stop()
+	}
 }
 
-// TestHandleCommentTimeout_SkipsErrorWhenInteractionIsTerminal covers the
-// race where message_completed has already finalized the interaction
-// (state=complete) but the comment row hasn't been written yet — between
-// the interaction Save and the comment Save. The timer must not stamp the
-// error in that micro-window either.
-func (s *CommentTimerSuite) TestHandleCommentTimeout_SkipsErrorWhenInteractionIsTerminal() {
+// TestHandleCommentTimeout_FinalizesStalledStream covers an agent that started
+// streaming a response but then died mid-stream: the interaction has partial
+// content but is non-terminal AND has not been updated for a full timeout
+// window. Deferring forever would block the queue, so the timer finalizes the
+// partial response to unblock it.
+func (s *CommentTimerSuite) TestHandleCommentTimeout_FinalizesStalledStream() {
+	comment := &types.SpecTaskDesignReviewComment{
+		ID:            "comment-stalled",
+		ReviewID:      "review-stalled",
+		RequestID:     "req-stalled",
+		InteractionID: "int-stalled",
+	}
+	stalledInteraction := &types.Interaction{
+		ID:              "int-stalled",
+		SessionID:       "ses-stalled",
+		State:           types.InteractionStateWaiting,
+		ResponseMessage: "Partial answer that never finished...",
+		Updated:         time.Now().Add(-3 * commentResponseTimeout), // stale
+	}
+
+	s.store.EXPECT().GetSpecTaskDesignReviewComment(gomock.Any(), "comment-stalled").
+		Return(comment, nil)
+	s.store.EXPECT().GetInteraction(gomock.Any(), "int-stalled").
+		Return(stalledInteraction, nil).AnyTimes()
+	s.store.EXPECT().GetCommentByRequestID(gomock.Any(), "req-stalled").
+		Return(comment, nil)
+	s.store.EXPECT().UpdateSpecTaskDesignReviewComment(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, c *types.SpecTaskDesignReviewComment) error {
+			s.Equal("Partial answer that never finished...", c.AgentResponse,
+				"stalled stream must be finalized with its partial content")
+			s.Empty(c.RequestID, "RequestID must be cleared so the queue is unblocked")
+			return nil
+		},
+	)
+	// Short-circuit the queue-continuation lookup.
+	s.store.EXPECT().GetSpecTaskDesignReview(gomock.Any(), "review-stalled").
+		Return(nil, errNotFound{}).AnyTimes()
+
+	s.server.handleCommentTimeout(context.Background(), "ses-stalled", "comment-stalled")
+}
+
+// TestHandleCommentTimeout_FinalizesWhenInteractionIsTerminal covers the core
+// deadlock fix: the agent finished (interaction state=complete with content) but
+// finalizeCommentResponse never ran because the message_completed event never
+// mapped back to this comment (coalesced re-sends, missed/duplicate completion,
+// restart). The backstop timer MUST finalize the comment itself — copy the
+// response and clear request_id — otherwise the comment stays in-flight forever
+// and blocks every later comment for the session.
+func (s *CommentTimerSuite) TestHandleCommentTimeout_FinalizesWhenInteractionIsTerminal() {
 	comment := &types.SpecTaskDesignReviewComment{
 		ID:            "comment-terminal",
+		ReviewID:      "review-terminal",
 		RequestID:     "req-terminal",
 		InteractionID: "int-terminal",
 	}
 	terminalInteraction := &types.Interaction{
-		ID:        "int-terminal",
-		SessionID: "ses-terminal",
-		State:     types.InteractionStateComplete,
-		// Even with empty body: state=complete means the run is over,
-		// finalizeCommentResponse owns the comment from here.
+		ID:              "int-terminal",
+		SessionID:       "ses-terminal",
+		State:           types.InteractionStateComplete,
+		ResponseMessage: "The agent's completed response.",
 	}
 
 	s.store.EXPECT().GetSpecTaskDesignReviewComment(gomock.Any(), "comment-terminal").
 		Return(comment, nil)
 	s.store.EXPECT().GetInteraction(gomock.Any(), "int-terminal").
-		Return(terminalInteraction, nil)
+		Return(terminalInteraction, nil).AnyTimes()
+	s.store.EXPECT().GetCommentByRequestID(gomock.Any(), "req-terminal").
+		Return(comment, nil)
+	s.store.EXPECT().UpdateSpecTaskDesignReviewComment(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, c *types.SpecTaskDesignReviewComment) error {
+			s.Equal("The agent's completed response.", c.AgentResponse,
+				"terminal interaction must be finalized onto the comment")
+			s.Empty(c.RequestID, "RequestID must be cleared so the queue is unblocked")
+			s.Nil(c.QueuedAt)
+			return nil
+		},
+	)
+	s.store.EXPECT().GetSpecTaskDesignReview(gomock.Any(), "review-terminal").
+		Return(nil, errNotFound{}).AnyTimes()
 
 	s.server.handleCommentTimeout(context.Background(), "ses-terminal", "comment-terminal")
 }
@@ -254,6 +320,66 @@ func (s *CommentTimerSuite) TestFinalizeCommentResponse_PopulatesEmptyComment() 
 
 	err := s.server.finalizeCommentResponse(context.Background(), "req-happy")
 	s.NoError(err)
+}
+
+// TestReconcileStuckInFlightComment_FinalizesTerminal verifies that a comment
+// stuck in-flight (request_id set, no response) whose interaction has already
+// completed is finalized — clearing the marker so the session's queue can drain.
+func (s *CommentTimerSuite) TestReconcileStuckInFlightComment_FinalizesTerminal() {
+	stuck := &types.SpecTaskDesignReviewComment{
+		ID:            "comment-zombie",
+		ReviewID:      "review-zombie",
+		RequestID:     "req-zombie",
+		InteractionID: "int-zombie",
+	}
+	terminalInteraction := &types.Interaction{
+		ID:              "int-zombie",
+		State:           types.InteractionStateComplete,
+		ResponseMessage: "Already answered long ago.",
+	}
+
+	s.store.EXPECT().GetPendingCommentByPlanningSessionID(gomock.Any(), "ses-zombie").
+		Return(stuck, nil)
+	s.store.EXPECT().GetInteraction(gomock.Any(), "int-zombie").
+		Return(terminalInteraction, nil).AnyTimes()
+	s.store.EXPECT().GetCommentByRequestID(gomock.Any(), "req-zombie").
+		Return(stuck, nil)
+	s.store.EXPECT().UpdateSpecTaskDesignReviewComment(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, c *types.SpecTaskDesignReviewComment) error {
+			s.Equal("Already answered long ago.", c.AgentResponse)
+			s.Empty(c.RequestID)
+			return nil
+		},
+	)
+	s.store.EXPECT().GetSpecTaskDesignReview(gomock.Any(), "review-zombie").
+		Return(nil, errNotFound{}).AnyTimes()
+
+	reconciled := s.server.reconcileStuckInFlightComment(context.Background(), "ses-zombie")
+	s.True(reconciled, "a terminal stuck comment must be reconciled")
+}
+
+// TestReconcileStuckInFlightComment_SkipsActive verifies that a comment whose
+// interaction is still waiting/streaming is left untouched — the agent is
+// genuinely working and we must not steal the in-flight slot.
+func (s *CommentTimerSuite) TestReconcileStuckInFlightComment_SkipsActive() {
+	active := &types.SpecTaskDesignReviewComment{
+		ID:            "comment-active",
+		RequestID:     "req-active",
+		InteractionID: "int-active",
+	}
+	activeInteraction := &types.Interaction{
+		ID:    "int-active",
+		State: types.InteractionStateWaiting,
+	}
+
+	s.store.EXPECT().GetPendingCommentByPlanningSessionID(gomock.Any(), "ses-active").
+		Return(active, nil)
+	s.store.EXPECT().GetInteraction(gomock.Any(), "int-active").
+		Return(activeInteraction, nil)
+	// NO finalize calls expected.
+
+	reconciled := s.server.reconcileStuckInFlightComment(context.Background(), "ses-active")
+	s.False(reconciled, "an actively-processing comment must not be reconciled")
 }
 
 // errNotFound is a trivial sentinel returned to short-circuit the


### PR DESCRIPTION
## Problem

A design-review comment submitted on a spec task was **never shipped to the agent**. Reported case:
`/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kvfpxgb5jtez4m3vv1ke9xfv/review/77ad643c-…`

### Root cause

Review comments are delivered to the agent **one at a time per planning session**. A comment is marked in-flight by setting `request_id`; that marker is cleared (and the agent's response copied onto the comment) only by `finalizeCommentResponse`, which runs when a `message_completed` event maps back to the comment via `GetCommentByRequestID(request_id)`.

When that mapping fails the comment is **never finalized** — `request_id` stays set and `agent_response` stays empty *even though the linked interaction is already `complete` with the full answer*. `IsCommentBeingProcessedForSession` then returns `true` forever, so every later comment for that session is queued but silently never sent.

In the reported task, comment `stdrc_01030ad6…` had `request_id` set, empty `agent_response`, and a linked interaction (`int_01kvq9q4…`) that was `complete` with a 7666-char response. It blocked two follow-up comments indefinitely. The mapping likely failed because the agent coalesced three near-identical re-sends into one turn under a different `request_id` (its reply literally begins *"Three identical re-sends of a comment…"*).

The 2-minute backstop timer did **not** rescue this: `handleCommentTimeout` explicitly deferred to `finalizeCommentResponse` whenever the interaction was terminal or had content — so when finalize never fired, the deferral was permanent. A deadlock.

## Fix

Make the timer a true backstop and add queue self-healing — three complementary changes, all in `spec_task_design_review_handlers.go`:

1. **`handleCommentTimeout`** — if the linked interaction is **terminal**, finalize the comment itself instead of deferring. If it's non-terminal but **stalled** (no updates for a full timeout window → agent died mid-stream), finalize the partial response. Only an **actively-streaming** interaction is deferred, and it now **re-arms** the timer rather than waiting forever.
2. **`processNextCommentInQueue`** — before skipping on "already processing", `reconcileStuckInFlightComment` checks whether the in-flight comment's interaction is terminal-but-unfinalized and finalizes it, so the queue self-heals on the next submission.
3. **`ResumeCommentQueueProcessing`** (startup) — reconcile terminal stuck comments *before* the bulk `ResetStuckComments`, so completed-but-unfinalized comments get their response instead of being blindly re-sent.

## Testing

- New/updated unit tests in `spec_task_design_review_handlers_test.go` cover: terminal-interaction finalize, stalled-stream finalize, still-streaming re-arm, and `reconcileStuckInFlightComment` (terminal vs. active). `go test -run TestCommentTimerSuite ./pkg/server/` passes.
- **Verified live** on the local stack: on deploy, startup recovery logged `🩹 Reconciling stuck in-flight comment … interaction_state=complete` for the exact stuck comment, the queue drained, and the agent began streaming a response to the previously-stuck comment. All three comments on the affected review now have responses; none remain in-flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)