### PR TITLE
fix(sync): open_thread must reopen the session's own Zed thread

### DIFF
--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -428,13 +428,23 @@ func (apiServer *HelixAPIServer) handleExternalAgentSync(res http.ResponseWriter
 			// opens the thread it replays history as message_added events that corrupt
 			// the current interaction.
 			if helixSession.Metadata.ZedThreadID != "" {
+				// Reopen THIS session's own thread — the exact thread every
+				// chat_message send path targets (session.Metadata.ZedThreadID).
+				// Do NOT substitute a spec-task-global "latest" thread here: the
+				// connection — and the waiting interaction queued moments earlier
+				// by pickupWaitingInteraction — both belong to helixSession, and
+				// that send uses helixSession.Metadata.ZedThreadID. If open_thread
+				// addresses a different thread, Zed foregrounds/streams one thread
+				// while Helix sends messages into another (opened ≠ sent-to), which
+				// the user sees as their messages vanishing into a thread that
+				// isn't on screen — without ever switching session in the UI.
+				// The global "latest" override never made the send land correctly
+				// (the send was always on the session's own thread); it could only
+				// ever cause the mismatch. Compaction-created threads are their own
+				// Helix sessions (handleUserCreatedThread) and must be driven by
+				// reconnecting under that session, not by retargeting this one.
+				// See design/2026-06-22-zed-open-thread-send-mismatch.md.
 				targetThreadID := helixSession.Metadata.ZedThreadID
-				if helixSession.Metadata.SpecTaskID != "" {
-					latestThreadID := apiServer.findLatestZedThreadForSpecTask(ctx, helixSession.Metadata.SpecTaskID)
-					if latestThreadID != "" {
-						targetThreadID = latestThreadID
-					}
-				}
 
 				agentNameForOpen := apiServer.getAgentNameForSession(ctx, helixSession)
 				log.Info().
@@ -3750,31 +3760,6 @@ func (apiServer *HelixAPIServer) handleAgentReady(sessionID string, syncMsg *typ
 	go apiServer.processAnyPendingPrompt(context.Background(), sessionID)
 
 	return nil
-}
-
-// findLatestZedThreadForSpecTask returns the most recently active Zed thread ID
-// for a spectask. Used on reconnect to open the user's current thread rather than
-// the original one.
-func (apiServer *HelixAPIServer) findLatestZedThreadForSpecTask(ctx context.Context, specTaskID string) string {
-	workSessions, err := apiServer.Controller.Options.Store.ListSpecTaskWorkSessions(ctx, specTaskID)
-	if err != nil || len(workSessions) == 0 {
-		return ""
-	}
-
-	// Find the work session with the most recent activity
-	var latestThread string
-	var latestTime time.Time
-	for _, ws := range workSessions {
-		session, err := apiServer.Controller.Options.Store.GetSession(ctx, ws.HelixSessionID)
-		if err != nil || session == nil {
-			continue
-		}
-		if session.Metadata.ZedThreadID != "" && session.Updated.After(latestTime) {
-			latestTime = session.Updated
-			latestThread = session.Metadata.ZedThreadID
-		}
-	}
-	return latestThread
 }
 
 // findSessionByZedThreadID finds a session by its ZedThreadID metadata

--- a/design/2026-06-22-zed-open-thread-send-mismatch.md
+++ b/design/2026-06-22-zed-open-thread-send-mismatch.md
@@ -1,0 +1,84 @@
+# Zed `open_thread` ↔ `chat_message` thread mismatch on reconnect
+
+**Date:** 2026-06-22
+**Area:** `api/pkg/server/websocket_external_agent_sync.go`
+**Symptom:** Within a single Helix session — without the user switching session in
+the UI — the Zed thread that Zed *opened* (foregrounded/streamed) differed from
+the thread Helix was *sending messages to*. User messages appeared to vanish into
+a thread that wasn't on screen.
+
+## How it was found
+
+A spec task (`spt_01kvfq6m8a07gywpj6jmadyrb8`, "Configurable Model Selection for
+Claude Subscription Mode") had **5 distinct Zed threads** across 5 `Spec Generation`
+Helix sessions. The session-proliferation itself was expected (repeated
+backlog → re-plan cycles each clear `planning_session_id` and mint a fresh
+session + thread — see `spec_driven_task_handlers.go:1015-1040`). The real defect
+was the *intra-session* mismatch described below.
+
+## Root cause
+
+`open_thread` and every `chat_message` send path disagreed about which Zed thread
+a given Helix session maps to.
+
+- **`chat_message`** (all paths: the reconnect-queued send in `pickupWaitingInteraction`,
+  `sendChatMessageToExternalAgent`, and the first-message sends) used the session's
+  own thread: `session.Metadata.ZedThreadID`.
+- **`open_thread`** (sent on WS reconnect in `handleExternalAgentConnection`) used a
+  *spec-task-global* override, `findLatestZedThreadForSpecTask(specTaskID)`, which
+  scans **all** work sessions of the spec task and returns whichever thread has the
+  largest `session.Updated` — independent of which session the connection belongs to.
+
+`findLatestZedThreadForSpecTask` was the **only** caller of that helper; every other
+thread reference in the file used `session.Metadata.ZedThreadID`.
+
+### Why it produces "opened ≠ sent-to" with no UI action
+
+On an ordinary WS reconnect of the desktop bound to session **S** (thread `T_S`):
+
+1. `open_thread` runs the global query → returns `T_latest`, the thread of whichever
+   *other* session was most recently touched → **Zed foregrounds `T_latest`**.
+2. `pickupWaitingInteraction`, called moments later on the same connection, sends
+   `S`'s waiting interaction to `T_S`.
+
+Zed shows/streams `T_latest`; Helix streams the user's messages into `T_S`. The
+mismatch is produced entirely server-side by the reconnect handler — no session
+switch in the UI is required. Reconnects happen on API restart, network blips, and
+the agent_ready cycle.
+
+It is also self-perturbing: each send calls `TouchSession(S)`, bumping `S.Updated`,
+so the session that wins the global "latest" query flips around as different
+sessions get touched — the thread `open_thread` picks can change connect-to-connect
+independently of which session is actually being driven.
+
+### The override never worked anyway
+
+The override (commit `92293ca98`, "use latest thread on reconnect") was intended to
+follow zed-agent **manual compaction**, where the agent spins up a fresh thread
+mid-run and reconnect should land on it. But the immediately-following send always
+used the session's *own* `ZedThreadID`, so the override could never make the send
+land on the compacted thread — it could only foreground a thread nobody was sending
+to. It strictly caused the mismatch and never delivered the compaction-follow it was
+written for.
+
+## Fix
+
+Remove the spec-task-global override in the `open_thread` reconnect path; reopen the
+connection's own `helixSession.Metadata.ZedThreadID` — identical to every send path.
+`open_thread` and `chat_message` are then guaranteed to address the same thread, so
+multiple sessions per task become harmless (each session ↔ exactly one thread, both
+opened and sent-to). The now-dead `findLatestZedThreadForSpecTask` is deleted.
+
+Compaction-created threads are already their own Helix sessions
+(`handleUserCreatedThread`). The correct way to "follow" them is to reconnect the
+desktop *under that session*, not to retarget a different session's `open_thread` —
+that belongs to the broader ACP-v2 / WS-sync rewrite
+(`design/2026-06-19-acp-v2-and-websocket-sync-rewrite-strategy.md`) and is out of
+scope here.
+
+## Testing
+
+- `CGO_ENABLED=0 go build ./pkg/server/` — clean.
+- `go test -run TestWebSocketSyncSuite ./pkg/server/` — see PR notes.
+- Live reconnect test against a connected Zed (spec task) is the meaningful check
+  for this path; see PR description for status.


### PR DESCRIPTION
## The bug

Within a **single** Helix session — with no UI session switch — the Zed thread Zed *opened* (foregrounded/streamed) differed from the thread Helix was *sending messages to*. The user's messages disappeared into a thread that wasn't on screen.

## Root cause

`open_thread` and every `chat_message` send path disagreed about which Zed thread a Helix session maps to:

- **`chat_message`** (reconnect-queued send in `pickupWaitingInteraction`, `sendChatMessageToExternalAgent`, first-message sends) → `session.Metadata.ZedThreadID` (the session's **own** thread).
- **`open_thread`** (sent on WS reconnect) → `findLatestZedThreadForSpecTask(specTaskID)`, a spec-task-**global** query returning whichever thread had the largest `session.Updated`, *independent of which session the connection belongs to*. This was the **only** caller of that helper.

On an ordinary reconnect (API restart, network blip, agent_ready cycle) of the desktop bound to session **S** (thread `T_S`):

1. `open_thread` → `T_latest` (some other session's thread) → **Zed foregrounds `T_latest`**.
2. `pickupWaitingInteraction` sends `S`'s waiting interaction → `T_S`.

Opened ≠ sent-to, produced entirely server-side. It's also self-perturbing: every send `TouchSession`s its session, so the "latest" winner flips around connect-to-connect.

**The override never worked anyway.** It was added (commit `92293ca98`) to follow zed-agent manual compaction, but the send always used the session's own thread — so it could only ever foreground a thread nobody was sending to. It strictly caused the mismatch.

## Fix

`open_thread` reopens `helixSession.Metadata.ZedThreadID` — identical to every send path. open and send now always agree, so multiple sessions per task become harmless (each session ↔ exactly one thread, both opened and sent-to). Deleted the now-dead `findLatestZedThreadForSpecTask`.

Compaction-created threads are already their own Helix sessions (`handleUserCreatedThread`); following them belongs to reconnecting *under that session*, part of the ACP-v2 / WS-sync rewrite, not this path.

## Testing

- `CGO_ENABLED=0 go build ./pkg/server/` — clean.
- `CGO_ENABLED=1 go test -run TestWebSocketSyncSuite ./pkg/server/` — **passes**.
- ⚠️ **NOT yet tested live** against a connected Zed. Per repo guidance, lifecycle/reconnect changes should be exercised against a live spec-task Zed (kill+reconnect the WS, confirm the opened thread == the thread receiving messages). Will do this before merge.

Design doc: `design/2026-06-22-zed-open-thread-send-mismatch.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)