### PR TITLE
fix(compute): forward neuron cache + readiness knobs to YD runners

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -370,6 +370,17 @@ type Compute struct {
 	// The operator is responsible for the pinned image actually existing
 	// in a registry the workers can pull from.
 	SandboxImage string `envconfig:"HELIX_COMPUTE_SANDBOX_IMAGE" default:""`
+
+	// NeuronCompileCacheURL and RunnerReadinessTimeout are runner-side knobs
+	// (read by compose-manager inside the sandbox) that the Manager forwards
+	// onto provisioned hosts. They share the operator-facing names
+	// HELIX_NEURON_COMPILE_CACHE_URL / HELIX_RUNNER_READINESS_TIMEOUT with the
+	// vars compose-manager reads directly on bare (install.sh) runners — set
+	// the same var once and it works on both runner topologies. On YD runners
+	// the value travels control-plane -> task env -> bash_script -e -> sandbox.
+	// Empty = not forwarded (compose-manager keeps its own default).
+	NeuronCompileCacheURL  string `envconfig:"HELIX_NEURON_COMPILE_CACHE_URL" default:""`
+	RunnerReadinessTimeout string `envconfig:"HELIX_RUNNER_READINESS_TIMEOUT" default:""`
 }
 
 // Yellowdog is the YellowDog-provider-specific configuration block.

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap.go
@@ -194,9 +194,11 @@ func buildProvider(cfg config.Compute, serverURL, runnerToken string) (compute.P
 			WorkerTag:     workerTag,
 			TaskTimeout:   cfg.Yellowdog.TaskTimeout,
 			MaxRetries:    cfg.Yellowdog.MaxRetries,
-			HelixURL:      serverURL,
-			RunnerToken:   runnerToken,
-			HelixImage:    sandboxImage,
+			HelixURL:               serverURL,
+			RunnerToken:            runnerToken,
+			HelixImage:             sandboxImage,
+			NeuronCompileCacheURL:  cfg.NeuronCompileCacheURL,
+			RunnerReadinessTimeout: cfg.RunnerReadinessTimeout,
 		})
 	default:
 		return nil, fmt.Errorf("unknown HELIX_COMPUTE_PROVIDER %q (supported: \"yellowdog\")", cfg.Provider)

--- a/api/pkg/sandbox/compute/yellowdog/bash_script.sh
+++ b/api/pkg/sandbox/compute/yellowdog/bash_script.sh
@@ -113,6 +113,18 @@ sudo docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
 # status flip without OS-signal delivery. When YD does signal, this
 # fix lets us shut down cleanly; when it doesn't, the only recourse
 # is `yd-terminate` on the Compute Requirement (which kills the VM).
+# DELIVERY CONTRACT: this `-e` list is the ONLY way a control-plane / operator
+# env var reaches compose-manager (and everything else) inside the sandbox on a
+# YD-provisioned runner. If you add a var that compose-manager or the sandbox
+# reads, it MUST be forwarded here (or set by install.sh for bare runners) or it
+# is silently dead on YD hosts. Values for the optional knobs below arrive via
+# the YD task environment (provider.taskEnvironment); `-e NAME` passes them
+# through from this script's env. Only forward when set so an unconfigured knob
+# leaves compose-manager on its own default.
+EXTRA_ENV=""
+[ -n "${HELIX_NEURON_COMPILE_CACHE_URL:-}" ] && EXTRA_ENV="$EXTRA_ENV -e HELIX_NEURON_COMPILE_CACHE_URL"
+[ -n "${HELIX_RUNNER_READINESS_TIMEOUT:-}" ] && EXTRA_ENV="$EXTRA_ENV -e HELIX_RUNNER_READINESS_TIMEOUT"
+
 sudo docker run --rm --name "$CONTAINER_NAME" \
   --privileged $GPU_FLAGS $DEVICE_FLAGS \
   -v /var/lib/docker \
@@ -121,6 +133,7 @@ sudo docker run --rm --name "$CONTAINER_NAME" \
   -e SANDBOX_INSTANCE_ID="$SANDBOX_ID" \
   -e GPU_VENDOR="$GPU_VENDOR" \
   -e MAX_SANDBOXES="$MAX_SANDBOXES" \
+  $EXTRA_ENV \
   "$IMG" &
 DOCKER_PID=$!
 wait "$DOCKER_PID"

--- a/api/pkg/sandbox/compute/yellowdog/provider.go
+++ b/api/pkg/sandbox/compute/yellowdog/provider.go
@@ -112,6 +112,17 @@ type Config struct {
 	// will docker-run. Last positional in the docker run args.
 	HelixImage string
 
+	// NeuronCompileCacheURL and RunnerReadinessTimeout are operator
+	// config (HELIX_NEURON_COMPILE_CACHE_URL / HELIX_RUNNER_READINESS_TIMEOUT)
+	// that compose-manager consumes INSIDE the sandbox container. They have
+	// to be forwarded explicitly: compose-manager's env on a YD runner is
+	// only what bash_script's `docker run -e` list injects, so a knob set on
+	// the control plane is otherwise dead on YD hosts (it only reaches
+	// install.sh runners). taskEnvironment puts them in the task env and
+	// bash_script forwards them with `-e`. Empty = not forwarded.
+	NeuronCompileCacheURL  string
+	RunnerReadinessTimeout string
+
 	// HTTPClient overrides the default *http.Client. Tests inject
 	// an httptest-backed client. Nil falls back to http.DefaultClient.
 	HTTPClient *http.Client
@@ -482,6 +493,17 @@ func (p *Provider) taskEnvironment(spec compute.Spec) map[string]string {
 	// node count.
 	if spec.GPUVendor != "" {
 		env["GPU_VENDOR"] = spec.GPUVendor
+	}
+	// Forward operator knobs that compose-manager reads inside the sandbox.
+	// Without this they never reach a YD runner (see Config fields). The
+	// names are kept identical so compose-manager's existing env lookups
+	// (HELIX_NEURON_COMPILE_CACHE_URL / HELIX_RUNNER_READINESS_TIMEOUT) work
+	// unchanged; bash_script forwards them with `-e`.
+	if p.cfg.NeuronCompileCacheURL != "" {
+		env["HELIX_NEURON_COMPILE_CACHE_URL"] = p.cfg.NeuronCompileCacheURL
+	}
+	if p.cfg.RunnerReadinessTimeout != "" {
+		env["HELIX_RUNNER_READINESS_TIMEOUT"] = p.cfg.RunnerReadinessTimeout
 	}
 	if len(env) == 0 {
 		return nil

--- a/api/pkg/sandbox/compute/yellowdog/provider_test.go
+++ b/api/pkg/sandbox/compute/yellowdog/provider_test.go
@@ -280,6 +280,36 @@ func TestTaskEnvironmentSetsGPUVendor(t *testing.T) {
 	}
 }
 
+func TestTaskEnvironmentForwardsRunnerKnobs(t *testing.T) {
+	// The cache URL + readiness timeout are read by compose-manager INSIDE the
+	// sandbox; on a YD runner they only arrive if taskEnvironment emits them
+	// (and bash_script forwards them). Without this they're silently dead on YD.
+	p, err := NewProvider(Config{
+		APIKeyID: "k", APISecret: "s", Namespace: "n", DeploymentTag: "d", WorkerTag: "w",
+		NeuronCompileCacheURL:  "s3://bucket/neuron-cache",
+		RunnerReadinessTimeout: "45m",
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	env := p.taskEnvironment(compute.Spec{Labels: map[string]string{"helix.sandbox_id": "x"}})
+	if env["HELIX_NEURON_COMPILE_CACHE_URL"] != "s3://bucket/neuron-cache" {
+		t.Errorf("HELIX_NEURON_COMPILE_CACHE_URL: got %q", env["HELIX_NEURON_COMPILE_CACHE_URL"])
+	}
+	if env["HELIX_RUNNER_READINESS_TIMEOUT"] != "45m" {
+		t.Errorf("HELIX_RUNNER_READINESS_TIMEOUT: got %q", env["HELIX_RUNNER_READINESS_TIMEOUT"])
+	}
+	// Unset knobs must not inject keys (compose-manager keeps its own default).
+	p2, _ := NewProvider(Config{APIKeyID: "k", APISecret: "s", Namespace: "n", DeploymentTag: "d", WorkerTag: "w"})
+	env2 := p2.taskEnvironment(compute.Spec{Labels: map[string]string{"helix.sandbox_id": "x"}})
+	if _, ok := env2["HELIX_NEURON_COMPILE_CACHE_URL"]; ok {
+		t.Error("cache URL should be absent when unset")
+	}
+	if _, ok := env2["HELIX_RUNNER_READINESS_TIMEOUT"]; ok {
+		t.Error("readiness timeout should be absent when unset")
+	}
+}
+
 func TestProviderNameDifferentDeploymentTags(t *testing.T) {
 	// Cross-tenancy regression guard: two Providers with the same
 	// kind but different deployment tags MUST report different


### PR DESCRIPTION
## The gap

`HELIX_NEURON_COMPILE_CACHE_URL` (#2663) and `HELIX_RUNNER_READINESS_TIMEOUT` (#2690) are read by **compose-manager inside the sandbox container**. On a YD-provisioned runner, compose-manager's env is **only** what `bash_script`'s fixed `docker run -e` list injects (`HELIX_API_URL`, `RUNNER_TOKEN`, `SANDBOX_INSTANCE_ID`, `GPU_VENDOR`, `MAX_SANDBOXES`). Neither knob was in that list, so setting them on the control plane was a **silent no-op on YD hosts** - they only ever worked on `install.sh` runners.

Consequence: the catalog neuron profile uses passthrough `- NEURON_COMPILE_CACHE_URL` (expects compose-manager to supply it), which resolved to **empty** on YD runners → no compile cache → the Neuron compile (>5 min) hit the 5-min readiness timeout → recreation loop. The only reason it cached on prime was a per-profile DB hack.

## Fix (same pattern as the GPU_VENDOR wiring)

- `config.Compute` reads both vars (shared operator-facing names → one var works on **both** runner topologies).
- `bootstrap` passes them into `yellowdog.Config`.
- `taskEnvironment` emits them into the YD task env when set.
- `bash_script` forwards them with `-e` (only when set), and gains a **DELIVERY CONTRACT** comment: any var the sandbox reads must be forwarded here or it's dead on YD runners.

Now the catalog profile's passthrough resolves on YD runners straight from the control-plane knob - no per-profile hardcoding, no DB edit.

## Tests
`TestTaskEnvironmentForwardsRunnerKnobs`: both vars forwarded when set, omitted when unset. Existing taskEnvironment/bootstrap suites green (verified locally + CGO).

## Why it was missed (retro)
The cache var was verified at its **consumer** (compose-manager reads+exports correctly) but its **delivery** across the YD topology was never traced - only `GPU_VENDOR` forced that trace because it failed loudly. PR reviews were diff-scoped, so a missing seam between components was invisible. Guard added: the `bash_script -e` list is the single delivery chokepoint and now carries a contract comment; the fix is to trace every new sandbox-read var producer→consumer across both runner topologies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)