### PR TITLE
Remove workspace-setup terminal auto-close timeout

### DIFF
--- a/desktop/shared/helix-workspace-setup.sh
+++ b/desktop/shared/helix-workspace-setup.sh
@@ -39,18 +39,6 @@ SETUP_LOG="$HOME/.helix-setup.log"
 : > "$SETUP_LOG" || true
 exec > >(tee -a "$SETUP_LOG") 2>&1
 
-# How long the cleanup_and_prompt menu waits for a human at the terminal before
-# giving up and exiting with the original failure code. Without this timeout an
-# unattended spec-task agent's setup failure parks the script on `read` forever:
-# Zed never sees ~/.helix-setup-complete, no WebSocket ever connects, and the
-# API eventually times out with the generic
-#   "Agent never connected after auto-wake cold-start retries"
-# banner — burying the real error in the framebuffer scrollback.
-#
-# 60s gives a watching human plenty of time to react while still freeing the
-# session for the API to report the real failure when no one is there.
-HELIX_SETUP_PROMPT_TIMEOUT="${HELIX_SETUP_PROMPT_TIMEOUT:-60}"
-
 # Trap any exit (success or failure) to show interactive menu
 # This ensures users can see errors and debug
 cleanup_and_prompt() {
@@ -91,20 +79,17 @@ JSON
     echo "  1) Close this window"
     echo "  2) Start an interactive shell for debugging"
     echo ""
-    # Time out the prompt so unattended containers don't block forever on
-    # read. Default to "1) Close" so the container exits with the real
-    # exit code, which lets the API observe and report the failure.
-    local choice=""
-    if read -t "$HELIX_SETUP_PROMPT_TIMEOUT" -p "Enter choice [1-2] (auto-close in ${HELIX_SETUP_PROMPT_TIMEOUT}s): " choice; then
-        : # got input
-    else
-        echo ""
-        echo "(no input within ${HELIX_SETUP_PROMPT_TIMEOUT}s — closing)"
-        choice=1
-    fi
+    # Block indefinitely so the window stays open until the user decides —
+    # they often want to inspect whether the stack actually started up.
+    read -p "Enter choice [1-2]: " choice
 
     case "$choice" in
-        2)
+        1)
+            # Disable trap before exiting to avoid infinite loop
+            trap - EXIT
+            exit $exit_code
+            ;;
+        2|*)
             echo ""
             echo "Starting interactive shell..."
             echo "Type 'exit' to close this window."
@@ -115,12 +100,6 @@ JSON
                 cd "$HOME/work"
             fi
             exec bash
-            ;;
-        *)
-            # Default (1 or timeout): disable trap to avoid recursion and
-            # exit with the original code so the parent observes the failure.
-            trap - EXIT
-            exit $exit_code
             ;;
     esac
 }


### PR DESCRIPTION
## Summary

Commit `389435bb1` changed the post-setup prompt in `helix-workspace-setup.sh`
from a blocking `read` (waited indefinitely, default → open a shell) to a
`read -t 60` that auto-closes the terminal after 60 seconds. The countdown
closes the window out from under a user who is trying to check whether the
stack actually started up correctly.

This restores the original blocking-prompt behavior: the terminal stays open
until the user chooses. The error-surfacing parts of `389435bb1` (the
`~/.helix-setup-failed` sentinel and `~/.helix-setup.log` tee, plus the
matching reader in `auto_wake_stuck_interactions.go`) are intentionally kept —
this is a surgical revert of only the timeout, not the whole commit.

## Changes

- `desktop/shared/helix-workspace-setup.sh`:
  - Remove the `HELIX_SETUP_PROMPT_TIMEOUT` variable and its comment block.
  - Replace the timed `read -t "$HELIX_SETUP_PROMPT_TIMEOUT" ...` with a
    blocking `read -p "Enter choice [1-2]: "`.
  - Restore the original `case`: `1` closes the window; `2` or any other
    input (including a bare Enter) opens an interactive shell.
- Kept: log tee, `~/.helix-setup-failed` sentinel write, and start-of-script
  sentinel cleanup. `api/pkg/server/auto_wake_stuck_interactions.go` is
  unchanged.

## Trade-off

Restoring the blocking prompt means an unattended session whose setup *fails*
parks on the prompt again instead of self-closing. UI error surfacing is
unaffected — the API still reads the `~/.helix-setup-failed` sentinel
out-of-band.

## Testing

- `bash -n` syntax check passes.
- Menu-routing harness confirms: `1` → close + exit with original code;
  `2`, bare Enter, and any other input → interactive shell (terminal stays open).
- NOT run: `./stack build-ubuntu` + live session test. `build-ubuntu` invokes
  `build-qwen-code`, which currently fails on pre-existing TypeScript errors
  (`error TS5083: Cannot read file '/build/tsconfig.json'`) unrelated to this
  change. Verify end-to-end once the qwen-code build is fixed.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kvqx0xwpzvk3rfgvjq8bevsx)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002160_someone-made-the/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002160_someone-made-the/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002160_someone-made-the/tasks.md)

🚀 Built with [Helix](https://helix.ml)