### PR TITLE
fix(api): serialize prompt-queue drain per session to stop out-of-order dispatch

### DIFF
--- a/api/pkg/server/prompt_history_handlers.go
+++ b/api/pkg/server/prompt_history_handlers.go
@@ -290,6 +290,11 @@ func (apiServer *HelixAPIServer) processPendingPromptsForIdleSessions(ctx contex
 // processInterruptPrompt processes ONLY interrupt prompts (interrupt=true)
 // Used when the session is busy but user sent an interrupt message
 func (apiServer *HelixAPIServer) processInterruptPrompt(ctx context.Context, sessionID string) {
+	// Serialise drains for this session — see lockPromptDrain. Held across
+	// cancel → send so two rapid interrupts can't cancel + dispatch concurrently
+	// and reorder; the second interrupt cancels the first's freshly-started turn.
+	defer apiServer.lockPromptDrain(sessionID)()
+
 	// Get the next interrupt prompt for this session
 	nextPrompt, err := apiServer.Store.GetNextInterruptPrompt(ctx, sessionID)
 	if err != nil {

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -127,6 +127,7 @@ type HelixAPIServer struct {
 	externalAgentUserMapping    map[string]string      // External agent session_id -> user_id mapping
 	pendingCancelChannels       map[string]chan string // request_id -> channel that receives turn_cancelled status
 	autoRestartInflight         sync.Map               // session_id -> struct{}: dedupes concurrent auto-restart triggers (zero value ready)
+	promptDrainMutexes          sync.Map               // session_id -> *sync.Mutex: serialises queue-drain dispatch per session (zero value ready). See lockPromptDrain.
 	// Comment processing timeouts - uses database for queue state (QueuedAt/RequestID fields)
 	sessionCommentTimeout     map[string]*time.Timer // planning_session_id -> timeout timer for current comment
 	sessionCommentMutex       sync.RWMutex           // Mutex for timeout operations

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -3043,9 +3043,32 @@ func (apiServer *HelixAPIServer) handleMessageCompleted(sessionID string, syncMs
 	return nil
 }
 
+// lockPromptDrain serialises queue-drain dispatch for a single session and
+// returns the unlock func (call via defer). Without it, two drain goroutines —
+// e.g. message_completed → processPromptQueue and agent_ready →
+// processAnyPendingPrompt — can each atomically claim a DIFFERENT pending prompt
+// and dispatch both to Zed at the same instant. Zed then serialises them in
+// arrival order, which is non-deterministic w.r.t. submission order, producing
+// out-of-order interactions (the streaming one ends up above an already-complete
+// one in the transcript). Holding this lock across claim → [cancel] → send →
+// CreateInteraction guarantees the next drain's busy re-check (in
+// sendQueuedPromptToSession) observes the committed Waiting interaction and
+// defers (queue mode) or cancels the freshly-started turn in order (interrupt
+// mode). See design/2026-06-23-queue-drain-out-of-order-dispatch.md.
+func (apiServer *HelixAPIServer) lockPromptDrain(sessionID string) func() {
+	muIface, _ := apiServer.promptDrainMutexes.LoadOrStore(sessionID, &sync.Mutex{})
+	mu := muIface.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
 // processPromptQueue checks for pending non-interrupt prompts and sends the next one
 // This is called after a message is completed to process queued non-interrupt messages
 func (apiServer *HelixAPIServer) processPromptQueue(ctx context.Context, sessionID string) {
+	// Serialise drains for this session — see lockPromptDrain. Acquired before
+	// the busy-check so the check + claim + dispatch are atomic w.r.t. other drains.
+	defer apiServer.lockPromptDrain(sessionID)()
+
 	// Check if the session is busy (last interaction is waiting for a response).
 	// This prevents sending a queue-mode prompt while Zed is already processing
 	// a locally-submitted message. The check uses DB state which is race-free:
@@ -3132,6 +3155,11 @@ func (apiServer *HelixAPIServer) processPromptQueue(ctx context.Context, session
 // processAnyPendingPrompt checks for any pending prompt (interrupt or non-interrupt) and sends it
 // This is used when the session is idle to process ALL pending prompts, not just non-interrupt ones
 func (apiServer *HelixAPIServer) processAnyPendingPrompt(ctx context.Context, sessionID string) {
+	// Serialise drains for this session — see lockPromptDrain. Without this, this
+	// readiness-path drain can claim one pending prompt while processPromptQueue
+	// concurrently claims another and both dispatch to Zed at once, reordering them.
+	defer apiServer.lockPromptDrain(sessionID)()
+
 	// Get the next pending prompt (any type)
 	nextPrompt, err := apiServer.Store.GetAnyPendingPrompt(ctx, sessionID)
 	if err != nil {

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -3468,3 +3468,49 @@ func (s *WebSocketSyncSuite) TestSendChatMessage_ExistingThread_NoSessionMapping
 	s.server.contextMappingsMutex.RUnlock()
 	s.False(ok, "same-thread continuation must NOT register a mapping (would leak — no thread_created consumes it)")
 }
+
+// TestLockPromptDrainSerializesPerSession verifies the per-session drain lock
+// (a) serialises concurrent drains for the SAME session — the core fix for the
+// out-of-order dispatch race — and (b) does NOT block drains for DIFFERENT
+// sessions. See design/2026-06-23-queue-drain-out-of-order-dispatch.md.
+func TestLockPromptDrainSerializesPerSession(t *testing.T) {
+	apiServer := &HelixAPIServer{}
+
+	// (a) Same session: a held lock must block a second acquisition until released.
+	unlock := apiServer.lockPromptDrain("ses_same")
+	acquired := make(chan struct{})
+	go func() {
+		release := apiServer.lockPromptDrain("ses_same")
+		close(acquired)
+		release()
+	}()
+	select {
+	case <-acquired:
+		t.Fatal("second lockPromptDrain for the same session acquired while first was held — not serialised")
+	case <-time.After(100 * time.Millisecond):
+		// expected: still blocked
+	}
+	unlock()
+	select {
+	case <-acquired:
+		// expected: unblocked after release
+	case <-time.After(time.Second):
+		t.Fatal("second lockPromptDrain did not acquire after the first was released")
+	}
+
+	// (b) Different session: must not block even while ses_same's lock is held.
+	hold := apiServer.lockPromptDrain("ses_same")
+	defer hold()
+	other := make(chan struct{})
+	go func() {
+		release := apiServer.lockPromptDrain("ses_other")
+		close(other)
+		release()
+	}()
+	select {
+	case <-other:
+		// expected: different session is independent
+	case <-time.After(time.Second):
+		t.Fatal("lockPromptDrain for a different session blocked — lock is not per-session")
+	}
+}

--- a/design/2026-06-23-queue-drain-out-of-order-dispatch.md
+++ b/design/2026-06-23-queue-drain-out-of-order-dispatch.md
@@ -1,0 +1,138 @@
+# Out-of-order interaction: concurrent queue-drain race (2026-06-23)
+
+Task: `spt_01kvsf30y4xxkz976hfhe4a3dc` ("Subscription Mode Should Default to Latest Opus")
+Session: `ses_01kvsf30yr0x8f4s070n0engmp`  Zed thread: `2f358321-b4c0-434d-ab46-45b4c966930d`
+
+## Symptom
+
+User typed two messages while a turn was streaming. They were processed in the
+wrong order; the older one is still streaming *above* the newer one which has
+already completed, so live updates appear inserted in the middle of the
+transcript ("not at the end"), confusing the reader.
+
+## The two messages (three orderings, all disagree)
+
+| Prompt | Submitted (prompt_id ts) | Interaction created | Zed msg id | State |
+|---|---|---|---|---|
+| A "switching from external agent…" | **07:04:43.930** (first) | 07:05:31.899601 | 512→534 (later) | **waiting / still streaming** |
+| B "but then refreshing the page…" | **07:04:54.753** (second) | 07:05:31.899716 | 510 (earlier) | complete @ 07:06:01 |
+
+- **Submission order:** A then B (≈11s apart).
+- **Display order:** A then B (created_at / ULID tiebreak — A first).
+- **Zed processing order:** B then A (B = msg 510, A = msg 512+). **Reversed.**
+
+Both were typed while "oh it works now!" (`…39ghpv`, submitted 07:04:00, completed
+07:05:31.784) was running, so both were **queued** (`prompt_history_entries`,
+status pending, `queue_position=NULL`, `interrupt=f`). Note both interactions were
+created within **115µs** of each other — they were drained simultaneously, not
+one-after-another.
+
+## Root cause: two drain goroutines, no per-session serialization
+
+When the running turn completed, two different drain paths fired as goroutines
+with nothing serializing them per session:
+
+- `processAnyPendingPrompt` (readiness/idle path, sync.go:3780) — **no busy check** —
+  called `GetAnyPendingPrompt`, which atomically claimed the FIFO-oldest pending
+  prompt = **A** (`gevjx6bqi`).
+- `processPromptQueue` (turn-complete path, sync.go:3041) — its busy check passed
+  (A's interaction not yet committed) — called `GetNextPendingPrompt`, which
+  skipped A (already `status=sending`) and claimed the only one left = **B**
+  (`coofq4cfo`).
+
+Proven by the API log — interleaved, same second:
+
+```
+07:05:31Z 3102 [QUEUE] Processing next non-interrupt prompt … "but then refreshing…" coofq4cfo   (processPromptQueue → B)
+07:05:31Z 3154 [QUEUE] Processing pending prompt          … "switching from external…" gevjx6bqi (processAnyPendingPrompt → A)
+07:05:31Z 3129 [QUEUE] Successfully dispatched …          coofq4cfo
+07:05:31Z 3182 [QUEUE] Successfully processed pending …   gevjx6bqi
+```
+
+Both prompts were dispatched to Zed concurrently. Zed serialized them in arrival
+order (non-deterministic w.r.t. submission) and happened to run B (510) before
+A (512+). A is the long turn and is still streaming; B already finished.
+
+The `processPromptQueue` busy-check (sync.go:3075 — "defer if last interaction is
+`waiting`") cannot prevent this: (1) `processAnyPendingPrompt` has no busy check
+at all, and (2) it's a TOCTOU — the first claim's interaction isn't committed
+before the second goroutine reads state.
+
+## Why the UI looks wrong
+
+Display sorts by `created_at` (assigned at drain). A sorts first (submitted first)
+so it sits on top — but Zed answered B first, so the **top** interaction (A) is the
+one still streaming while the one **below** (B) is already complete. Hence "updates
+inserted not at the end." This is a *consequence* of the dispatch reversal, not a
+separate frontend bug — if A had been processed first (correct FIFO), it would have
+completed first and B would stream at the bottom.
+
+## Fix direction
+
+Serialize queue draining per session so only one queued prompt is in flight at a
+time, in strict FIFO order:
+
+1. A per-session keyed mutex (e.g. keyed by `sessionID`) held across
+   claim + `sendQueuedPromptToSession` (interaction create) in **both**
+   `processPromptQueue` and `processAnyPendingPrompt`, so the second goroutine's
+   busy-check runs only after the first interaction is committed `waiting` — and
+   then defers.
+2. Apply the same busy-check to `processAnyPendingPrompt` (currently missing).
+
+Either alone is insufficient: (1) without the busy-check in the "any" path, the
+two paths still claim different prompts; (2) the busy-check without a lock is the
+TOCTOU that already failed here. Want both: one drain at a time, busy-defer if a
+turn is live.
+
+No mass-targeting; single-session correctness fix.
+
+## Frontend dimension: the interrupt toggle never reached the backend
+
+User recollection: pressed empty-Enter and/or clicked the queue lightning toggle
+to make these interrupts. Evidence says the backend never saw it:
+
+- `updateInterrupt` (usePromptHistory.ts:696) mutates **localStorage only**
+  (`syncedToBackend:false`) and relies on a background sync to PATCH the backend.
+- The backend recorded both prompts `interrupt=f` for their whole lifetime and
+  dispatched both via the non-interrupt paths (logs: `interrupt=false`). No
+  interrupt PATCH for `gevjx6bqi`/`coofq4cfo` appears in the logs at all.
+
+So whatever was toggled in the UI lost the race to the queue drain (turn completed
+07:05:31 and the backend drained the stale `interrupt=f` before the local→backend
+sync pushed `interrupt=true`) — or never fired. Either way the escalation silently
+didn't apply. This is a second consistency gap: interrupt state is localStorage-
+first and syncs lazily, so an escalation made shortly before a turn ends can be
+ignored.
+
+Separately, empty-Enter promotion is itself an ordering hazard:
+`handleKeyDown` (RobustPromptInput.tsx:944-969) promotes the **most-recent**
+queued non-interrupt (`reduce` by max timestamp) to interrupt. With [A(older),
+B(newer)] queued, one empty-Enter escalates **B**, dispatching it ahead of A —
+directly producing B-before-A. Pressing twice then escalates A too, and now two
+interrupts race through `processInterruptPrompt` (same concurrency hole).
+
+Even had the toggle synced, interrupts hit `processInterruptPrompt`, which shares
+the unserialized-drain race — so the backend per-session drain lock is required
+regardless of interrupt vs queue.
+
+## Implemented
+
+Branch `fix/queue-drain-out-of-order-dispatch`.
+
+- **Backend per-session drain lock** (`HelixAPIServer.lockPromptDrain`, a
+  `sync.Map` of per-session `*sync.Mutex`). Acquired at the top of
+  `processPromptQueue`, `processAnyPendingPrompt` and `processInterruptPrompt` and
+  held across claim → [cancel] → send → `CreateInteraction`. The second drain's
+  busy re-check in `sendQueuedPromptToSession` now observes the committed Waiting
+  interaction and defers (queue) or cancels in order (interrupt). The busy-defer
+  for the readiness path falls out of this — no separate blanket busy-check was
+  added (that would wrongly defer interrupts meant to land mid-turn). Unit test:
+  `TestLockPromptDrainSerializesPerSession`.
+- **Frontend immediate interrupt persistence** (`usePromptHistory.updateInterrupt`):
+  toggling interrupt now pushes that single entry to the backend immediately
+  instead of waiting for the 100ms debounced batch sync, closing the window where
+  a queue drain reads a stale `interrupt=f`.
+- **Frontend empty-Enter FIFO escalation** (`RobustPromptInput.handleKeyDown`):
+  empty-Enter now promotes the OLDEST queued non-interrupt message, not the
+  newest, so repeated presses escalate in submission order instead of dispatching
+  a newer message ahead of older ones. Test updated.

--- a/frontend/src/components/common/RobustPromptInput.test.tsx
+++ b/frontend/src/components/common/RobustPromptInput.test.tsx
@@ -46,7 +46,7 @@ const mkEntry = (id: string, ts: number, overrides: Partial<PromptHistoryEntry> 
   ...overrides,
 })
 
-describe('RobustPromptInput empty-Enter promotes most-recent queued to interrupt', () => {
+describe('RobustPromptInput empty-Enter promotes oldest queued to interrupt', () => {
   beforeEach(() => {
     updateInterrupt.mockClear()
     saveToHistory.mockClear()
@@ -68,7 +68,7 @@ describe('RobustPromptInput empty-Enter promotes most-recent queued to interrupt
     fireEvent.keyDown(textarea!, { key: 'Enter', shiftKey: false })
   }
 
-  it('flips the highest-timestamp pending non-interrupt entry to interrupt', () => {
+  it('flips the lowest-timestamp (oldest) pending non-interrupt entry to interrupt', () => {
     pendingPrompts = [
       mkEntry('a', 1000),
       mkEntry('b', 3000),
@@ -77,7 +77,7 @@ describe('RobustPromptInput empty-Enter promotes most-recent queued to interrupt
     const { container } = renderInput()
     pressEnter(container)
     expect(updateInterrupt).toHaveBeenCalledTimes(1)
-    expect(updateInterrupt).toHaveBeenCalledWith('b', true)
+    expect(updateInterrupt).toHaveBeenCalledWith('a', true)
     expect(saveToHistory).not.toHaveBeenCalled()
   })
 

--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -941,9 +941,13 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
 
   // Handle key events
   // Enter = queue mode (non-interrupt), Ctrl+Enter = interrupt mode
-  // Empty Enter (no draft, no attachments) = promote the most recent queued
-  // entry to interrupt mode, which dispatches it immediately via the existing
-  // sync loop. Equivalent to clicking the lightning icon on that queue item.
+  // Empty Enter (no draft, no attachments) = promote the OLDEST queued entry to
+  // interrupt mode, which dispatches it immediately via the existing sync loop.
+  // Equivalent to clicking the lightning icon on that queue item.
+  // Oldest-first (not most-recent) so repeated empty-Enter escalates the queue in
+  // FIFO order — promoting the newest would dispatch it ahead of older queued
+  // messages, reordering the conversation.
+  // See design/2026-06-23-queue-drain-out-of-order-dispatch.md.
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
@@ -954,7 +958,7 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
       // Empty field: promote most-recent queued entry to interrupt instead of sending nothing.
       if (!content && attachments.length === 0) {
         if (disabled) return
-        // Promote the most-recent NON-interrupt queued message to interrupt.
+        // Promote the OLDEST NON-interrupt queued message to interrupt.
         // Scans queuedPrompts (failed + pending) so a deferred message — the one
         // the user is actually trying to escalate — is still a candidate.
         const candidates = queuedPrompts.filter(p =>
@@ -964,7 +968,7 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
           p.id !== editingId
         )
         if (candidates.length === 0) return
-        const target = candidates.reduce((a, b) => (b.timestamp > a.timestamp ? b : a))
+        const target = candidates.reduce((a, b) => (b.timestamp < a.timestamp ? b : a))
         updateInterrupt(target.id, true)
         return
       }

--- a/frontend/src/hooks/usePromptHistory.ts
+++ b/frontend/src/hooks/usePromptHistory.ts
@@ -214,6 +214,10 @@ export function usePromptHistory({
 }: UsePromptHistoryOptions): UsePromptHistoryReturn {
   // Load initial state from localStorage
   const [history, setHistory] = useState<PromptHistoryEntry[]>(() => loadHistory(specTaskId))
+  // Mirror of the latest history for synchronous reads in event handlers (e.g.
+  // updateInterrupt's immediate push) without depending on a stale closure.
+  const historyRef = useRef<PromptHistoryEntry[]>(history)
+  historyRef.current = history
   const [draft, setDraftState] = useState<string>(() => loadDraft(sessionId))
   const [historyIndex, setHistoryIndex] = useState(-1)  // -1 = current draft, 0+ = history
 
@@ -701,7 +705,28 @@ export function usePromptHistory({
       saveHistory(updated, specTaskId)
       return updated
     })
-  }, [specTaskId])
+
+    // Persist the interrupt flag IMMEDIATELY rather than waiting for the
+    // SYNC_DEBOUNCE_MS batched sync. Interrupt is an intent-bearing escalation:
+    // if the backend drains the queue (current turn completes) before the
+    // debounced sync lands, the escalation is silently lost and the prompt is
+    // dispatched as a plain queue message — which can also reorder it relative
+    // to a sibling. A targeted single-entry push closes that window.
+    // See design/2026-06-23-queue-drain-out-of-order-dispatch.md.
+    const existing = historyRef.current.find(h => h.id === id)
+    if (existing && apiClient && specTaskId && projectId && navigator.onLine) {
+      syncPromptHistory(apiClient, projectId, specTaskId, [{ ...existing, interrupt }])
+        .then(() => {
+          setHistory(prev =>
+            prev.map(h => (h.id === id ? { ...h, syncedToBackend: true } : h))
+          )
+        })
+        .catch(e => {
+          // Leave syncedToBackend=false so the debounced sync retries.
+          console.warn('[PromptHistory] Failed to flush interrupt toggle immediately:', e)
+        })
+    }
+  }, [specTaskId, apiClient, projectId])
 
   // Remove a message from queue by marking it as deleted (tombstone).
   // The entry stays in localStorage to prevent re-import from backend on sync.


### PR DESCRIPTION
## Problem

On spec task `spt_01kvsf30y4xxkz976hfhe4a3dc`, two messages typed in quick succession ended up **out of order**: the older one is still streaming *above* the newer one which already completed, so live updates appear inserted in the middle of the transcript rather than at the end.

Investigation (full write-up in `design/2026-06-23-queue-drain-out-of-order-dispatch.md`):

| Prompt | Submitted | Zed processed | State |
|---|---|---|---|
| A "switching from external agent…" | 07:04:43 (first) | msg 512→534 (second) | still streaming |
| B "but then refreshing the page…" | 07:04:54 (second) | msg 510 (first) | completed |

Submission order, display order and Zed's processing order all disagree. The API log shows both prompts dispatched in the same second by two different goroutines.

## Root cause

A TOCTOU race. Two drain goroutines — `message_completed → processPromptQueue` and `agent_ready → processAnyPendingPrompt` — each atomically claimed a *different* pending prompt and dispatched both to Zed concurrently. The busy re-check in `sendQueuedPromptToSession` defers a queue prompt only if the latest interaction is already `Waiting`, but both drains pass it before either commits its interaction. Zed then serialised the two arrivals in non-deterministic order.

## Fix

**Backend**
- `HelixAPIServer.lockPromptDrain` — a per-session keyed mutex (`sync.Map` of `*sync.Mutex`), held across claim → [cancel] → send → `CreateInteraction` in `processPromptQueue`, `processAnyPendingPrompt`, and `processInterruptPrompt`. The next drain's busy re-check now observes the committed `Waiting` interaction and defers (queue mode) or cancels the freshly-started turn in order (interrupt mode).
- Unit test `TestLockPromptDrainSerializesPerSession` (same-session serialises, different-session independent).

**Frontend**
- `usePromptHistory.updateInterrupt` persists the interrupt flag **immediately** (single-entry push) instead of waiting for the 100ms debounced batch sync — closing the window where a drain reads a stale `interrupt=f` and the escalation is silently lost.
- `RobustPromptInput` empty-Enter now escalates the **oldest** queued non-interrupt message, not the newest, so repeated presses escalate in FIFO order instead of dispatching a newer message ahead of older ones. Test updated.

## Testing
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/` ✅
- `go test ./pkg/server/` queue/sync suites + new lock test ✅
- `vitest run RobustPromptInput.test.tsx` (7) ✅
- `yarn build` ✅
- Not yet exercised against a live Zed double-send end-to-end — the lock is a serialization primitive verified by unit test + existing dispatch suite; a live double-interrupt repro would further confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)