### PR TITLE
chore(deps): upgrade kodit to v1.3.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/go-retryablehttp v0.7.8
-	github.com/helixml/kodit v1.3.7
+	github.com/helixml/kodit v1.3.8
 	github.com/infracloudio/msbotbuilder-go v0.2.5
 	github.com/jfrog/froggit-go v1.20.1
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -546,8 +546,8 @@ github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/helixml/kodit v1.3.7 h1:5s1n1UOsEIlh4ZjNPHpS+uHs14CArzpYh/qj8fJt2ic=
-github.com/helixml/kodit v1.3.7/go.mod h1:NhT1+0j9LZk6u0mZzuMbyc/P/Rfheh8OYLUxANN9JTg=
+github.com/helixml/kodit v1.3.8 h1:bdAzZgdeFvoTdT+tht4G6drlkSsEdqAzFnReLC4RTW8=
+github.com/helixml/kodit v1.3.8/go.mod h1:NhT1+0j9LZk6u0mZzuMbyc/P/Rfheh8OYLUxANN9JTg=
 github.com/helixml/langchaingo v0.1.15 h1:6cEwRQgEri4aDrvDnSESmsMY9H35UUoWuOEukSP3lJw=
 github.com/helixml/langchaingo v0.1.15/go.mod h1:EeervIv/DNYhSfQSMaql20wMFvhgF7lDaVaatp8lVPw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=


### PR DESCRIPTION
## Summary

Upgrades the `github.com/helixml/kodit` dependency from v1.3.7 to v1.3.8.

- `go.mod` / `go.sum` updated and `go mod tidy` is clean
- Packages importing kodit (`api/pkg/rag`, `api/pkg/services`, `api/pkg/server`) build successfully
- No version pin in the Dockerfile/.drone.yml needs bumping — they invoke kodit via `go run github.com/helixml/kodit/...`, which resolves from `go.mod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)