### PR TITLE
fix(compute): -e NAME=value forwarding under sudo (knobs were dropped)

### DIFF
--- a/api/pkg/sandbox/compute/yellowdog/bash_script.sh
+++ b/api/pkg/sandbox/compute/yellowdog/bash_script.sh
@@ -118,12 +118,16 @@ sudo docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
 # YD-provisioned runner. If you add a var that compose-manager or the sandbox
 # reads, it MUST be forwarded here (or set by install.sh for bare runners) or it
 # is silently dead on YD hosts. Values for the optional knobs below arrive via
-# the YD task environment (provider.taskEnvironment); `-e NAME` passes them
-# through from this script's env. Only forward when set so an unconfigured knob
-# leaves compose-manager on its own default.
+# the YD task environment (provider.taskEnvironment) and so are in THIS script's
+# env. MUST use the `-e NAME="$NAME"` value form (expanded by the shell before
+# `sudo`): the docker run below is `sudo docker run`, and sudo's env_reset
+# strips the var, so the bare `-e NAME` passthrough form silently delivers
+# NOTHING. (GPU_VENDOR uses the value form for exactly this reason; the bare
+# form was an earlier bug that dropped these knobs on every YD runner.) Only
+# forward when set so an unconfigured knob leaves compose-manager on its default.
 EXTRA_ENV=""
-[ -n "${HELIX_NEURON_COMPILE_CACHE_URL:-}" ] && EXTRA_ENV="$EXTRA_ENV -e HELIX_NEURON_COMPILE_CACHE_URL"
-[ -n "${HELIX_RUNNER_READINESS_TIMEOUT:-}" ] && EXTRA_ENV="$EXTRA_ENV -e HELIX_RUNNER_READINESS_TIMEOUT"
+[ -n "${HELIX_NEURON_COMPILE_CACHE_URL:-}" ] && EXTRA_ENV="$EXTRA_ENV -e HELIX_NEURON_COMPILE_CACHE_URL=$HELIX_NEURON_COMPILE_CACHE_URL"
+[ -n "${HELIX_RUNNER_READINESS_TIMEOUT:-}" ] && EXTRA_ENV="$EXTRA_ENV -e HELIX_RUNNER_READINESS_TIMEOUT=$HELIX_RUNNER_READINESS_TIMEOUT"
 
 sudo docker run --rm --name "$CONTAINER_NAME" \
   --privileged $GPU_FLAGS $DEVICE_FLAGS \


### PR DESCRIPTION
## Bug

#2697 forwards `HELIX_NEURON_COMPILE_CACHE_URL` / `HELIX_RUNNER_READINESS_TIMEOUT` into the YD task env, but `bash_script` used the **bare `-e NAME` passthrough** form on `sudo docker run`. `sudo`'s `env_reset` strips the var before docker reads it → the passthrough delivers **nothing**.

**Confirmed live on a 2.11.24 YD inf2 runner:**
```
bash_script task env:  HELIX_NEURON_COMPILE_CACHE_URL=<set>  HELIX_RUNNER_READINESS_TIMEOUT=<set>  GPU_VENDOR=<set>
reached sandbox:       GPU_VENDOR=<set>     ← only this one
```
`GPU_VENDOR` arrived because it already uses `-e GPU_VENDOR="$GPU_VENDOR"` (value form, shell-expanded before sudo). The two new knobs used `-e NAME` and were dropped → the runner kept looping on the 5-min readiness default, cache never engaged.

## Fix
Use the value form `-e NAME=$NAME` (expanded before the sudo boundary), matching the GPU_VENDOR precedent. Updated the DELIVERY CONTRACT comment to name the sudo/env_reset trap.

## Why it slipped #2697's review
The delivery-chain review traced the chain and checked `-e NAME` docker semantics - but assumed `docker run`, not `sudo docker run`. The sudo interaction is the missing factor. Verified this time by reading the live task process env vs the container env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)