### PR TITLE
fix(hydra): surface pull-stream errors and verify image in tryRecoverImage

### DIFF
--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -208,76 +208,182 @@ func resolveRegistryImageWithBase(image string, baseDir string) string {
 	return ref
 }
 
-// tryRecoverImage attempts to pull a missing desktop image from available registries.
-// It tries the production registry (.ref file), then the local shared registry.
-// Returns true if the image was recovered and is available for container creation.
-func (dm *DevContainerManager) tryRecoverImage(ctx context.Context, dockerClient *client.Client, resolvedImage, originalImage string) bool {
-	log.Warn().
-		Str("resolved_image", resolvedImage).
-		Str("original_image", originalImage).
-		Msg("Image missing from Docker — attempting recovery")
+// imageRecoveryClient is the minimum Docker client surface tryRecoverImage
+// needs. The real *client.Client satisfies it; tests substitute a fake.
+type imageRecoveryClient interface {
+	ImagePull(ctx context.Context, refStr string, options dockertypes.ImagePullOptions) (io.ReadCloser, error)
+	ImageTag(ctx context.Context, source, target string) error
+	ImageInspectWithRaw(ctx context.Context, imageID string) (dockertypes.ImageInspect, []byte, error)
+}
 
-	// Extract image name without tag for looking up registry sources
+// pullStatus matches the JSON status messages emitted by Docker's image-pull
+// stream. ImagePull only returns a Go error for setup failures (bad ref,
+// transport). The interesting failures, "no space left on device",
+// "manifest unknown", "denied", 5xx from the registry, are reported as
+// JSON messages with a non-empty Error / ErrorDetail.Message. Code that
+// drains the stream without decoding it silently treats those as success.
+type pullStatus struct {
+	Status      string `json:"status"`
+	Error       string `json:"error"`
+	ErrorDetail struct {
+		Message string `json:"message"`
+	} `json:"errorDetail"`
+}
+
+// drainPullStream decodes the JSON message stream from ImagePull. Returns
+// an error if any message reports a pull failure (Error or
+// ErrorDetail.Message populated). Returns nil on a clean EOF.
+func drainPullStream(r io.Reader) error {
+	dec := json.NewDecoder(r)
+	for {
+		var msg pullStatus
+		if err := dec.Decode(&msg); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("decode pull status: %w", err)
+		}
+		if msg.Error != "" {
+			return fmt.Errorf("pull failed: %s", msg.Error)
+		}
+		if msg.ErrorDetail.Message != "" {
+			return fmt.Errorf("pull failed: %s", msg.ErrorDetail.Message)
+		}
+	}
+}
+
+// buildRecoveryPullSources returns the ordered list of registry refs to try
+// when recovering a missing image. Priority:
+//  1. Production registry ref (<refDir>/<image>.ref, e.g.
+//     ghcr.io/helixml/helix-ubuntu:VERSION)
+//  2. Local shared registry via host (registryHost)
+//  3. Local shared registry via DNS name (registry:5000)
+func buildRecoveryPullSources(originalImage, refDir, registryHost string) []string {
 	imageName := originalImage
 	if idx := strings.LastIndex(originalImage, ":"); idx != -1 {
 		imageName = originalImage[:idx]
 	}
 
-	// Build list of registry sources to try, in priority order:
-	// 1. Production registry ref (.ref file, e.g., ghcr.io/helixml/helix-ubuntu:VERSION)
-	// 2. Local shared registry (registry:5000/IMAGE:TAG)
-	var pullSources []string
+	var sources []string
 
-	// Check for production registry ref
-	refFile := filepath.Join("/opt/images", imageName+".ref")
+	refFile := filepath.Join(refDir, imageName+".ref")
 	if refData, err := os.ReadFile(refFile); err == nil {
 		ref := strings.TrimSpace(string(refData))
 		if ref != "" {
-			// Replace the tag with the requested version
 			tag := imageTag(originalImage)
 			if baseRef := strings.LastIndex(ref, ":"); baseRef != -1 && tag != "" {
 				ref = ref[:baseRef] + ":" + tag
 			}
-			pullSources = append(pullSources, ref)
+			sources = append(sources, ref)
 		}
 	}
 
-	// Try the local shared registry
-	registryHost := GetRegistryHost()
 	if registryHost != "" {
-		pullSources = append(pullSources, registryHost+"/"+originalImage)
+		sources = append(sources, registryHost+"/"+originalImage)
 	}
-	// Also try the DNS name (works when registry is on the same Docker network)
-	pullSources = append(pullSources, "registry:5000/"+originalImage)
+	sources = append(sources, "registry:5000/"+originalImage)
 
-	for _, source := range pullSources {
+	return sources
+}
+
+// tryRecoverImage attempts to pull a missing desktop image from available registries.
+// It tries the production registry (.ref file), then the local shared registry.
+// Returns true if the image was recovered and is verified present locally under
+// the expected name.
+func (dm *DevContainerManager) tryRecoverImage(ctx context.Context, dockerClient *client.Client, resolvedImage, originalImage string) bool {
+	sources := buildRecoveryPullSources(originalImage, "/opt/images", GetRegistryHost())
+	return recoverImageFromSources(ctx, dockerClient, sources, resolvedImage, originalImage)
+}
+
+// recoverImageFromSources is the testable core of tryRecoverImage. It walks
+// the supplied sources in order, attempting a pull + tag + verify for each.
+// The first source that ends with originalImage present locally wins.
+//
+// This is where the three previously-silent failure modes are surfaced:
+//  1. ImagePull JSON stream errors (e.g. "no space left on device") are
+//     decoded and returned as errors, not discarded.
+//  2. ImageTag errors are captured and logged with source/target refs,
+//     and treated as "this source did not work, try the next one".
+//  3. ImageInspectWithRaw confirms the image is actually present locally
+//     before we report success. Without this, a partially-extracted pull
+//     would let the caller log "recovered" then fail again on
+//     ContainerCreate with the same "No such image" message.
+func recoverImageFromSources(ctx context.Context, dockerClient imageRecoveryClient, sources []string, resolvedImage, originalImage string) bool {
+	log.Warn().
+		Str("resolved_image", resolvedImage).
+		Str("original_image", originalImage).
+		Strs("sources", sources).
+		Msg("Image missing from Docker, attempting recovery")
+
+	for _, source := range sources {
 		log.Info().Str("source", source).Msg("Trying recovery pull")
+
 		pullOut, pullErr := dockerClient.ImagePull(ctx, source, dockertypes.ImagePullOptions{})
 		if pullErr != nil {
-			log.Debug().Err(pullErr).Str("source", source).Msg("Recovery pull failed, trying next source")
+			log.Warn().Err(pullErr).Str("source", source).Msg("Recovery pull setup failed, trying next source")
 			continue
 		}
-		// Drain the pull output to completion
-		_, _ = io.Copy(io.Discard, pullOut)
+		streamErr := drainPullStream(pullOut)
 		pullOut.Close()
+		if streamErr != nil {
+			log.Error().Err(streamErr).Str("source", source).Msg("Recovery pull reported error in stream, trying next source")
+			continue
+		}
 
-		// Tag as the expected local name so the container creation succeeds
+		// Tag the pulled image under the expected local names so
+		// ContainerCreate finds it. Capture errors instead of swallowing
+		// them: a failed tag means this source did not actually land
+		// the image we need.
+		tagFailed := false
 		if source != resolvedImage {
-			_ = dockerClient.ImageTag(ctx, source, resolvedImage)
+			if err := dockerClient.ImageTag(ctx, source, resolvedImage); err != nil {
+				log.Warn().Err(err).
+					Str("source", source).
+					Str("target", resolvedImage).
+					Msg("ImageTag failed during recovery, trying next source")
+				tagFailed = true
+			}
 		}
-		if source != originalImage {
-			_ = dockerClient.ImageTag(ctx, source, originalImage)
+		if !tagFailed && source != originalImage {
+			if err := dockerClient.ImageTag(ctx, source, originalImage); err != nil {
+				log.Warn().Err(err).
+					Str("source", source).
+					Str("target", originalImage).
+					Msg("ImageTag failed during recovery, trying next source")
+				tagFailed = true
+			}
 		}
+		if tagFailed {
+			continue
+		}
+
+		// Verify the image is actually present under the name
+		// ContainerCreate will look up. Without this, a pull that
+		// "succeeded" with cached "Already exists" layers but never
+		// finished extracting (e.g. disk full) would still report
+		// recovery success, and the very next ContainerCreate would
+		// fail with the same misleading "No such image".
+		inspect, _, inspectErr := dockerClient.ImageInspectWithRaw(ctx, originalImage)
+		if inspectErr != nil {
+			log.Error().Err(inspectErr).
+				Str("source", source).
+				Str("image", originalImage).
+				Msg("Image not present locally after pull+tag, trying next source")
+			continue
+		}
+
 		log.Info().
-			Str("image", resolvedImage).
+			Str("image", originalImage).
+			Str("resolved_image", resolvedImage).
 			Str("source", source).
+			Strs("local_tags", inspect.RepoTags).
 			Msg("Image recovered successfully")
 		return true
 	}
 
 	log.Error().
 		Str("image", resolvedImage).
-		Strs("sources_tried", pullSources).
+		Strs("sources_tried", sources).
 		Msg("Failed to recover image from any registry source")
 	return false
 }

--- a/api/pkg/hydra/devcontainer_test.go
+++ b/api/pkg/hydra/devcontainer_test.go
@@ -1,9 +1,15 @@
 package hydra
 
 import (
+	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	dockertypes "github.com/docker/docker/api/types"
 )
 
 func TestImageTag(t *testing.T) {
@@ -258,6 +264,268 @@ func TestGPUDevicePaths(t *testing.T) {
 	if filepath.Base(got.cardDevice) != "card2" {
 		t.Errorf("want card2, got %s", got.cardDevice)
 	}
+}
+
+// fakeRecoveryClient is a hand-rolled imageRecoveryClient for testing
+// recoverImageFromSources. It records call args and lets each method's
+// behaviour be overridden per source ref.
+type fakeRecoveryClient struct {
+	pullBody  func(source string) (io.ReadCloser, error)
+	tagErr    func(source, target string) error
+	inspect   func(image string) (dockertypes.ImageInspect, []byte, error)
+	pullCalls []string
+	tagCalls  []struct{ source, target string }
+	inspects  []string
+}
+
+func (f *fakeRecoveryClient) ImagePull(_ context.Context, source string, _ dockertypes.ImagePullOptions) (io.ReadCloser, error) {
+	f.pullCalls = append(f.pullCalls, source)
+	if f.pullBody == nil {
+		return io.NopCloser(strings.NewReader(`{"status":"Pull complete"}`)), nil
+	}
+	return f.pullBody(source)
+}
+
+func (f *fakeRecoveryClient) ImageTag(_ context.Context, source, target string) error {
+	f.tagCalls = append(f.tagCalls, struct{ source, target string }{source, target})
+	if f.tagErr == nil {
+		return nil
+	}
+	return f.tagErr(source, target)
+}
+
+func (f *fakeRecoveryClient) ImageInspectWithRaw(_ context.Context, image string) (dockertypes.ImageInspect, []byte, error) {
+	f.inspects = append(f.inspects, image)
+	if f.inspect == nil {
+		return dockertypes.ImageInspect{RepoTags: []string{image}}, nil, nil
+	}
+	return f.inspect(image)
+}
+
+func TestDrainPullStream(t *testing.T) {
+	t.Run("clean stream returns nil", func(t *testing.T) {
+		body := `{"status":"Pulling from helixml/helix-ubuntu"}
+{"status":"Pull complete"}
+`
+		if err := drainPullStream(strings.NewReader(body)); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+	})
+
+	t.Run("error field surfaces", func(t *testing.T) {
+		body := `{"status":"Pulling fs layer"}
+{"error":"no space left on device"}
+`
+		err := drainPullStream(strings.NewReader(body))
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "no space left on device") {
+			t.Errorf("expected error mentioning disk-full, got %v", err)
+		}
+	})
+
+	t.Run("errorDetail.message surfaces", func(t *testing.T) {
+		body := `{"status":"Pulling"}
+{"errorDetail":{"message":"manifest unknown: manifest unknown"},"error":""}
+`
+		err := drainPullStream(strings.NewReader(body))
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "manifest unknown") {
+			t.Errorf("expected error mentioning manifest, got %v", err)
+		}
+	})
+
+	t.Run("empty stream is fine", func(t *testing.T) {
+		if err := drainPullStream(strings.NewReader("")); err != nil {
+			t.Fatalf("expected nil for empty stream, got %v", err)
+		}
+	})
+}
+
+func TestRecoverImageFromSources_HappyPath(t *testing.T) {
+	fc := &fakeRecoveryClient{}
+	ok := recoverImageFromSources(
+		context.Background(),
+		fc,
+		[]string{"registry:5000/helix-ubuntu:abc123"},
+		"helix-ubuntu:abc123",
+		"helix-ubuntu:abc123",
+	)
+	if !ok {
+		t.Fatalf("expected recovery success")
+	}
+	if len(fc.pullCalls) != 1 || fc.pullCalls[0] != "registry:5000/helix-ubuntu:abc123" {
+		t.Errorf("unexpected pull calls: %v", fc.pullCalls)
+	}
+	// source differs from both targets, so both tag calls fire
+	if len(fc.tagCalls) != 2 {
+		t.Errorf("expected 2 tag calls, got %v", fc.tagCalls)
+	}
+	if len(fc.inspects) != 1 || fc.inspects[0] != "helix-ubuntu:abc123" {
+		t.Errorf("expected one inspect call on originalImage, got %v", fc.inspects)
+	}
+}
+
+func TestRecoverImageFromSources_TagsBothRefs(t *testing.T) {
+	fc := &fakeRecoveryClient{}
+	ok := recoverImageFromSources(
+		context.Background(),
+		fc,
+		[]string{"ghcr.io/helixml/helix-ubuntu:abc123"},
+		"helix-ubuntu:abc123",
+		"helix-ubuntu:abc123",
+	)
+	if !ok {
+		t.Fatalf("expected recovery success")
+	}
+	// source differs from both resolvedImage and originalImage, so both
+	// tag operations fire (even though the two targets happen to be the
+	// same string here).
+	if len(fc.tagCalls) != 2 {
+		t.Fatalf("expected 2 tag calls, got %v", fc.tagCalls)
+	}
+	for _, c := range fc.tagCalls {
+		if c.source != "ghcr.io/helixml/helix-ubuntu:abc123" ||
+			c.target != "helix-ubuntu:abc123" {
+			t.Errorf("unexpected tag call: %+v", c)
+		}
+	}
+}
+
+func TestRecoverImageFromSources_PullStreamErrorIsSurfaced(t *testing.T) {
+	// Simulate the production fault: pull stream contains errorDetail.message
+	// with "no space left on device". recoverImageFromSources should treat
+	// this source as failed, not log "recovered successfully".
+	fc := &fakeRecoveryClient{
+		pullBody: func(source string) (io.ReadCloser, error) {
+			return io.NopCloser(strings.NewReader(
+				`{"status":"Extracting"}
+{"errorDetail":{"message":"failed to register layer: write /var/lib/docker/...: no space left on device"},"error":"failed to register layer"}
+`)), nil
+		},
+	}
+	ok := recoverImageFromSources(
+		context.Background(),
+		fc,
+		[]string{"registry:5000/helix-ubuntu:2.11.23-linux-amd64"},
+		"helix-ubuntu:2.11.23-linux-amd64",
+		"helix-ubuntu:2.11.23-linux-amd64",
+	)
+	if ok {
+		t.Fatalf("expected recovery to fail when pull stream reports disk-full")
+	}
+	if len(fc.tagCalls) != 0 {
+		t.Errorf("expected no tag attempts after pull-stream error, got %v", fc.tagCalls)
+	}
+	if len(fc.inspects) != 0 {
+		t.Errorf("expected no inspect attempts after pull-stream error, got %v", fc.inspects)
+	}
+}
+
+func TestRecoverImageFromSources_TagFailureFailsSource(t *testing.T) {
+	fc := &fakeRecoveryClient{
+		tagErr: func(source, target string) error {
+			return errors.New("Error response from daemon: invalid reference format")
+		},
+	}
+	ok := recoverImageFromSources(
+		context.Background(),
+		fc,
+		[]string{"ghcr.io/helixml/helix-ubuntu:abc123"},
+		"helix-ubuntu:abc123",
+		"helix-ubuntu:abc123",
+	)
+	if ok {
+		t.Fatalf("expected recovery to fail when ImageTag errors")
+	}
+	if len(fc.inspects) != 0 {
+		t.Errorf("inspect should not run after tag failure, got %v", fc.inspects)
+	}
+}
+
+func TestRecoverImageFromSources_InspectNotFoundFailsSource(t *testing.T) {
+	fc := &fakeRecoveryClient{
+		inspect: func(image string) (dockertypes.ImageInspect, []byte, error) {
+			return dockertypes.ImageInspect{}, nil, errors.New("Error: No such image: " + image)
+		},
+	}
+	ok := recoverImageFromSources(
+		context.Background(),
+		fc,
+		[]string{"registry:5000/helix-ubuntu:abc123"},
+		"helix-ubuntu:abc123",
+		"helix-ubuntu:abc123",
+	)
+	if ok {
+		t.Fatalf("expected recovery to fail when post-pull inspect returns NotFound")
+	}
+}
+
+func TestRecoverImageFromSources_FallsThroughToNextSource(t *testing.T) {
+	// First source fails in pull stream, second succeeds. Recovery returns
+	// true and reports the second source as the one that worked.
+	fc := &fakeRecoveryClient{
+		pullBody: func(source string) (io.ReadCloser, error) {
+			if strings.HasPrefix(source, "ghcr.io/") {
+				return io.NopCloser(strings.NewReader(
+					`{"errorDetail":{"message":"denied: not authorized"},"error":"denied"}` + "\n",
+				)), nil
+			}
+			return io.NopCloser(strings.NewReader(`{"status":"Pull complete"}`)), nil
+		},
+	}
+	ok := recoverImageFromSources(
+		context.Background(),
+		fc,
+		[]string{
+			"ghcr.io/helixml/helix-ubuntu:abc123",
+			"registry:5000/helix-ubuntu:abc123",
+		},
+		"helix-ubuntu:abc123",
+		"helix-ubuntu:abc123",
+	)
+	if !ok {
+		t.Fatalf("expected recovery to succeed via fallback source")
+	}
+	if len(fc.pullCalls) != 2 {
+		t.Errorf("expected both sources tried, got %v", fc.pullCalls)
+	}
+}
+
+func TestBuildRecoveryPullSources(t *testing.T) {
+	tmp := t.TempDir()
+
+	t.Run("no ref file, no registry host", func(t *testing.T) {
+		got := buildRecoveryPullSources("helix-ubuntu:abc123", tmp, "")
+		want := []string{"registry:5000/helix-ubuntu:abc123"}
+		if len(got) != len(want) || got[0] != want[0] {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("ref file rewrites tag and is first", func(t *testing.T) {
+		ref := filepath.Join(tmp, "helix-ubuntu.ref")
+		if err := os.WriteFile(ref, []byte("ghcr.io/helixml/helix-ubuntu:oldtag\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		got := buildRecoveryPullSources("helix-ubuntu:abc123", tmp, "10.0.0.5:5000")
+		want := []string{
+			"ghcr.io/helixml/helix-ubuntu:abc123",
+			"10.0.0.5:5000/helix-ubuntu:abc123",
+			"registry:5000/helix-ubuntu:abc123",
+		}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("[%d] got %q, want %q", i, got[i], want[i])
+			}
+		}
+	})
 }
 
 func TestEnumerateDRMDevices_HeadlessCompute(t *testing.T) {


### PR DESCRIPTION
## Summary

When an enterprise K8s customer hit disk-full on a runner's `/var/lib/docker`, every desktop container create kept failing with the misleading message:

```
Error response from daemon: No such image: helix-ubuntu:<version>
```

The real cause was `no space left on device` while extracting a layer. `tryRecoverImage` masked it because the pull stream's JSON error messages were discarded, `ImageTag` errors were ignored, and nothing verified the image was actually present locally before logging `Image recovered successfully`. The retry loop reported false success and triage spent hours chasing the wrong cause.

## Root cause

Three silent error sites inside `tryRecoverImage` (in `api/pkg/hydra/devcontainer.go`):

1. `_, _ = io.Copy(io.Discard, pullOut)` discarded the `ImagePull` JSON message stream. Docker reports pull-time failures (`no space left on device`, `denied`, `manifest unknown`, registry 5xx) as JSON messages in this stream with a non-empty `error` or `errorDetail.message` field, **not** as a Go error from `ImagePull` itself.
2. `_ = dockerClient.ImageTag(...)` swallowed tag errors. A failed retag means the source did not land the image under the name `ContainerCreate` looks up, but the loop fell through to logging success anyway.
3. No `ImageInspectWithRaw` after the tag step. A pull that "succeeded" because cached layers reported `Already exists` but never finished extracting still let the function log `Image recovered successfully`, and the next `ContainerCreate` failed with the same `No such image`.

## Fix

1. Decode the `ImagePull` stream with `json.NewDecoder` in a loop until `io.EOF`. Return an error if any message carries a non-empty `Error` or `ErrorDetail.Message`. The decode lives in a small new helper `drainPullStream`.
2. Capture the return value of every `ImageTag` call. Log at warn level with `source` and `target` refs. A tag failure flips a local flag and skips to the next source.
3. After the tag step, call `dockerClient.ImageInspectWithRaw(ctx, originalImage)`. Only log `Image recovered successfully` and return `true` if that call succeeds. The success log includes the source ref used and the confirmed local `RepoTags` list.
4. Extract the loop into `recoverImageFromSources` taking a small `imageRecoveryClient` interface (`ImagePull`, `ImageTag`, `ImageInspectWithRaw`) so the three failure modes are unit-testable with a fake Docker client. `tryRecoverImage` is now a thin wrapper that builds the source list via the new helper `buildRecoveryPullSources` and delegates.

## Test plan

- `cd api && CGO_ENABLED=0 go build ./pkg/hydra/...`: clean.
- `cd api && go test -run 'TestDrainPullStream|TestRecoverImageFromSources|TestBuildRecoveryPullSources|TestImageTag|TestResolveRegistry|TestEnumerateDRM|TestGPUDevicePaths' ./pkg/hydra/ -count=1`: passes.
- New tests added in `api/pkg/hydra/devcontainer_test.go`:
  - `TestDrainPullStream`: clean stream, `error` field surfaces, `errorDetail.message` surfaces, empty stream is fine.
  - `TestRecoverImageFromSources_HappyPath`: pull + tag + inspect all succeed, returns true.
  - `TestRecoverImageFromSources_TagsBothRefs`: both `resolvedImage` and `originalImage` retag attempts run when source differs.
  - `TestRecoverImageFromSources_PullStreamErrorIsSurfaced`: replays a real-world `errorDetail.message: "...: no space left on device"` payload, asserts no tag attempt and no inspect attempt after the error.
  - `TestRecoverImageFromSources_TagFailureFailsSource`: `ImageTag` returns an error, recovery fails, inspect never runs.
  - `TestRecoverImageFromSources_InspectNotFoundFailsSource`: inspect after pull+tag returns NotFound, recovery fails.
  - `TestRecoverImageFromSources_FallsThroughToNextSource`: first source returns `denied` in JSON stream, second source succeeds, recovery returns true.
  - `TestBuildRecoveryPullSources`: ref-file tag rewrite + ordering.
- A small number of pre-existing tests in this package (`TestParallelCopyDir_*`, `TestGoldenZvolSuite`) fail locally on macOS because they shell out to GNU `cp --reflink=auto`, which BSD `cp` rejects. Verified to fail identically on `main` before this change. CI runs Linux and is the source of truth.

## Out of scope

- `validateImageVersion`, `resolveRegistryImage`, `resolveRegistryImageWithBase`: untouched.
- `CreateDevContainer` outer flow: untouched.
- Sandbox startup-time disk pressure handling.
- Anything outside `api/pkg/hydra/devcontainer.go` and its test file.

These three follow-ups deserve their own PRs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
