### PR TITLE
feat(hydra): disk-pressure fallback to statfs on non-ZFS hosts

### DIFF
--- a/api/pkg/hydra/disk_pressure.go
+++ b/api/pkg/hydra/disk_pressure.go
@@ -2,11 +2,13 @@ package hydra
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -15,22 +17,40 @@ import (
 
 // Disk-pressure admission control.
 //
-// The ZFS pool that backs every session zvol must never hit 0% free: ENOSPC
-// inside a session's XFS zvol corrupts the filesystem, which cascades into
-// Postgres faults and git-repository corruption. This guard watches the pool's
-// FREE PERCENT and applies two protections, both keyed off thresholds that are
-// configurable via env:
+// The storage backing every session must never hit 0% free: ENOSPC inside a
+// session's filesystem corrupts state, which cascades into Postgres faults and
+// git-repository corruption. This guard watches the storage's FREE PERCENT and
+// applies two protections, both keyed off thresholds that are configurable via
+// env:
 //
-//   - Free ≤ refuse threshold (default 2%): refuse to START new dev containers,
-//     surfacing a clear user-facing error.
-//   - Free ≤ stop threshold (default 1%): an emergency brake STOPS (not deletes)
-//     existing running dev containers so they stop writing. Sessions remain
-//     resumable — the zvol/workspace is never touched.
+//   - Free <= refuse threshold (default 2%): refuse to START new dev
+//     containers, surfacing a clear user-facing error.
+//   - Free <= stop threshold (default 1%): an emergency brake STOPS (not
+//     deletes) existing running dev containers so they stop writing. Sessions
+//     remain resumable, the zvol/workspace is never touched.
 //
-// CRITICAL fail-open contract: a failed or unknowable measurement must NEVER
-// refuse a start and NEVER trigger an emergency stop. When we cannot read the
-// pool's free percent we do nothing — the alternative (acting on garbage) is
-// worse than not acting.
+// Two backends measure free space:
+//
+//   - zfs:    `zpool list -Hp -o size,free <pool>` against the ZFS pool that
+//             backs zvols. Used when ZFS is available and a parent dataset is
+//             configured. This is the original implementation.
+//   - statfs: `syscall.Statfs(2)` against the hydra data directory. Used as a
+//             fallback on non-ZFS hosts (most K8s deployments, which run on
+//             ext4 / xfs / overlay). Without this fallback the disk-pressure
+//             guard fails-open silently on non-ZFS hosts, which is how a
+//             K8s-on-ext4 deployment silently filled its volume mid-pull.
+//
+// Fail policy:
+//
+//   - Backend reports a measurement: act on it (refuse / stop / allow per
+//     thresholds).
+//   - statfs fails with ENOENT (configured path does not exist): the operator
+//     misconfigured `HELIX_DISK_PRESSURE_PATH`, FAIL CLOSED on start (refuse)
+//     so we do not silently allow unprotected starts. Monitor logs and skips
+//     the tick.
+//   - Both backends unavailable (ZFS absent AND statfs path errors for other
+//     reasons): FAIL OPEN with a prominent warn log, matching pre-fallback
+//     behaviour. This should be unreachable in practice on any sane host.
 
 const (
 	defaultDiskPressureRefuseFreePct = 2.0
@@ -117,8 +137,8 @@ func envDuration(key string, def time.Duration) time.Duration {
 	return d
 }
 
-// poolName returns the ZFS pool name — the first "/"-separated component of
-// zfsParentDataset (e.g. "prod/helix-zvols" → "prod"). Empty if the parent
+// poolName returns the ZFS pool name, the first "/"-separated component of
+// zfsParentDataset (e.g. "prod/helix-zvols" -> "prod"). Empty if the parent
 // dataset is unset.
 func poolName() string {
 	if zfsParentDataset == "" {
@@ -127,14 +147,148 @@ func poolName() string {
 	return strings.SplitN(zfsParentDataset, "/", 2)[0]
 }
 
-// poolFreePercent returns the percentage of the ZFS pool that is free, computed
-// from `zpool list -Hp -o size,free <pool>` (raw byte values).
+// diskPressurePath returns the filesystem path that the statfs fallback should
+// measure. Defaults to DefaultDataDir (/hydra-data) and is overridable via
+// HELIX_DISK_PRESSURE_PATH for operators who mount their volume elsewhere
+// (e.g. /var/lib/hydra on a K8s PVC).
+func diskPressurePath() string {
+	if v := strings.TrimSpace(os.Getenv("HELIX_DISK_PRESSURE_PATH")); v != "" {
+		return v
+	}
+	return DefaultDataDir
+}
+
+// statfsFn is the seam used to mock syscall.Statfs in tests. Production code
+// calls syscall.Statfs directly; tests can swap it to model ENOENT, zero-block
+// devices, and pinned free-percentage scenarios without touching the real
+// filesystem.
+var statfsFn = func(path string, stat *syscall.Statfs_t) error {
+	return syscall.Statfs(path, stat)
+}
+
+// statfsFreePercent returns the percentage of `path`'s underlying filesystem
+// that is free, computed from a POSIX statfs(2) call.
+//
+// Uses Bavail (blocks available to non-root) rather than Bfree, matching the
+// semantics most operators reason about ("df -h"). Bsize is cast to uint64
+// because it is int32 on Linux/Darwin (matches the existing pattern in
+// cmd/sandbox-heartbeat/main.go).
+//
+// Returns an error when statfs itself fails (e.g. ENOENT for a misconfigured
+// path) or when the filesystem reports zero total blocks (defensive, should
+// not happen on a real filesystem).
+func statfsFreePercent(path string) (float64, error) {
+	var stat syscall.Statfs_t
+	if err := statfsFn(path, &stat); err != nil {
+		return 0, fmt.Errorf("statfs %q failed: %w", path, err)
+	}
+	total := stat.Blocks * uint64(stat.Bsize)
+	avail := stat.Bavail * uint64(stat.Bsize)
+	if total == 0 {
+		return 0, fmt.Errorf("statfs %q reports zero total blocks", path)
+	}
+	return float64(avail) / float64(total) * 100, nil
+}
+
+// statfsFreeBytes returns the number of bytes available to non-root on the
+// filesystem backing `path`. Mirrors statfsFreePercent's error contract.
+func statfsFreeBytes(path string) (int64, error) {
+	var stat syscall.Statfs_t
+	if err := statfsFn(path, &stat); err != nil {
+		return 0, fmt.Errorf("statfs %q failed: %w", path, err)
+	}
+	avail := stat.Bavail * uint64(stat.Bsize)
+	return int64(avail), nil
+}
+
+// measurement describes the result of a free-space probe. Backend identifies
+// which probe produced it (zfs / statfs / none) so callers can log and tests
+// can assert. PathENOENT is true when the statfs backend was selected but the
+// configured path does not exist, which the start guard treats as fail-closed.
+type measurement struct {
+	freePct    float64
+	freeBytes  int64
+	backend    string
+	hasPct     bool
+	hasBytes   bool
+	pathENOENT bool
+}
+
+// zfsBackendAvailable reports whether the ZFS backend can be queried. Both ZFS
+// itself AND a configured parent dataset are required (an empty dataset means
+// hydra is running in non-ZFS mode even on a host with ZFS userspace
+// installed).
+func zfsBackendAvailable() bool {
+	return ZFSAvailable() && zfsParentDataset != ""
+}
+
+// measureDisk runs the active backend (ZFS or statfs) and returns a populated
+// measurement. The error is non-nil only when NEITHER backend produced a
+// usable reading.
+func measureDisk() (measurement, error) {
+	var m measurement
+	if zfsBackendAvailable() {
+		m.backend = "zfs"
+		pct, pctErr := poolFreePercentZFS()
+		free, freeErr := poolFreeBytesZFS()
+		if pctErr == nil {
+			m.freePct = pct
+			m.hasPct = true
+		}
+		if freeErr == nil {
+			m.freeBytes = free
+			m.hasBytes = true
+		}
+		if m.hasPct || m.hasBytes {
+			return m, nil
+		}
+		// ZFS configured but both probes failed (e.g. transient `zpool`
+		// failure). Don't fall over to statfs, the operator selected ZFS, log
+		// the error so they can see it.
+		return m, fmt.Errorf("zfs probe failed: pct_err=%v free_err=%v", pctErr, freeErr)
+	}
+
+	// Non-ZFS host: statfs the hydra data directory.
+	m.backend = "statfs"
+	path := diskPressurePath()
+	pct, pctErr := statfsFreePercent(path)
+	free, freeErr := statfsFreeBytes(path)
+	if pctErr == nil {
+		m.freePct = pct
+		m.hasPct = true
+	}
+	if freeErr == nil {
+		m.freeBytes = free
+		m.hasBytes = true
+	}
+	if m.hasPct || m.hasBytes {
+		return m, nil
+	}
+	// Both calls failed identically (same syscall). If the path doesn't exist
+	// the operator misconfigured HELIX_DISK_PRESSURE_PATH; mark the
+	// measurement so the start guard can fail closed.
+	if errors.Is(pctErr, syscall.ENOENT) || errors.Is(freeErr, syscall.ENOENT) {
+		m.pathENOENT = true
+	}
+	return m, fmt.Errorf("statfs probe failed at %q: %w", path, pctErr)
+}
+
+// poolFreePercent returns the percentage of the ZFS pool that is free.
+//
+// Thin wrapper around poolFreePercentZFS that exists for the test suite which
+// pokes at the ZFS path directly (forcing zfsAvailableFlag and mocking
+// execCmdOutput). The production admission/monitor paths go through
+// measureDisk() instead so they pick up the statfs fallback.
+func poolFreePercent() (float64, error) {
+	return poolFreePercentZFS()
+}
+
+// poolFreePercentZFS is the ZFS-only implementation, computed from
+// `zpool list -Hp -o size,free <pool>` (raw byte values).
 //
 // Returns an error if ZFS is unavailable, the pool name is empty, the command
-// fails, the output can't be parsed, or size is zero. Callers MUST treat any
-// error as "unknown — do nothing" (fail open): never refuse a start and never
-// trigger an emergency stop on a failed/unknowable measurement.
-func poolFreePercent() (float64, error) {
+// fails, the output can't be parsed, or size is zero.
+func poolFreePercentZFS() (float64, error) {
 	if !ZFSAvailable() {
 		return 0, fmt.Errorf("ZFS not available; cannot measure pool free space")
 	}
@@ -168,14 +322,26 @@ func poolFreePercent() (float64, error) {
 	return float64(free) / float64(size) * 100, nil
 }
 
-// poolFreeBytes returns the number of free bytes in the ZFS pool, read from
+// poolFreeBytes returns the number of free bytes for the GC reconcile path's
+// before/after delta. Tries ZFS first, then falls back to statfs against the
+// hydra data directory so the GC reaper produces a meaningful number on
+// non-ZFS hosts too.
+//
+// Used by the GC reconcile path to cheaply measure reclaimed space as a
+// before/after delta instead of running a per-directory `du` sweep.
+func poolFreeBytes() (int64, error) {
+	if zfsBackendAvailable() {
+		return poolFreeBytesZFS()
+	}
+	return statfsFreeBytes(diskPressurePath())
+}
+
+// poolFreeBytesZFS is the ZFS-only implementation, read from
 // `zpool list -Hp -o free <pool>` (raw byte value).
 //
-// Returns an error under the same conditions as poolFreePercent (ZFS
-// unavailable, empty pool name, command failure, or unparsable output). Used by
-// the GC reconcile path to cheaply measure reclaimed space as a before/after
-// delta instead of running a per-directory `du` sweep.
-func poolFreeBytes() (int64, error) {
+// Returns an error if ZFS is unavailable, the pool name is empty, the command
+// fails, or output can't be parsed.
+func poolFreeBytesZFS() (int64, error) {
 	if !ZFSAvailable() {
 		return 0, fmt.Errorf("ZFS not available; cannot measure pool free space")
 	}
@@ -203,40 +369,65 @@ func poolFreeBytes() (int64, error) {
 }
 
 // checkDiskPressureForStart is the admission-control guard for new dev
-// containers. It returns a non-nil error (to be surfaced to the user) ONLY when
-// the pool's free percent is at or below the refuse threshold.
+// containers. It returns a non-nil error (to be surfaced to the user) when the
+// active backend's free percent is at or below the refuse threshold.
 //
-// Fail-open: if disk pressure is disabled, or the measurement errors, it returns
-// nil (allow the start).
+// Fail policy:
+//   - Disabled: allow.
+//   - Successful measurement above threshold: allow.
+//   - Successful measurement at/below threshold: refuse.
+//   - statfs path missing (ENOENT, misconfiguration): refuse. Silently
+//     allowing on misconfig is exactly the bug this fallback fixes.
+//   - All other measurement failures: fail-open (allow) with a warn log,
+//     preserving prior behaviour for transient `zpool` failures.
 func checkDiskPressureForStart() error {
 	cfg := getDiskPressureConfig()
 	if !cfg.enabled {
 		return nil
 	}
 
-	freePct, err := poolFreePercent()
+	m, err := measureDisk()
 	if err != nil {
-		// Unknown measurement → fail open, allow the start.
-		log.Warn().Err(err).Msg("disk-pressure: could not measure pool free percent for start guard, allowing start (fail-open)")
+		if m.pathENOENT {
+			log.Error().Err(err).
+				Str("backend", m.backend).
+				Str("path", diskPressurePath()).
+				Msg("disk-pressure: refusing to start dev container, configured data path does not exist (set HELIX_DISK_PRESSURE_PATH or create the directory)")
+			return fmt.Errorf("refusing to start dev container: disk-pressure path %q does not exist; set HELIX_DISK_PRESSURE_PATH to the hydra data directory and retry", diskPressurePath())
+		}
+		// Unknown measurement, both backends unavailable. Fail open, allow
+		// the start, but log loudly so operators notice.
+		log.Warn().Err(err).Str("backend", m.backend).
+			Msg("disk-pressure: could not measure free space for start guard, allowing start (fail-open)")
 		return nil
 	}
 
-	if freePct <= cfg.refuseFreePct {
+	if !m.hasPct {
+		// Successful probe but no percentage (statfs Blocks=0 only).
+		log.Warn().Str("backend", m.backend).
+			Msg("disk-pressure: measurement returned no percentage, allowing start (fail-open)")
+		return nil
+	}
+
+	if m.freePct <= cfg.refuseFreePct {
 		log.Error().
+			Str("backend", m.backend).
 			Str("pool", poolName()).
-			Float64("free_pct", freePct).
+			Str("path", diskPressurePath()).
+			Float64("free_pct", m.freePct).
 			Float64("refuse_pct", cfg.refuseFreePct).
-			Msg("disk-pressure: refusing to start dev container — pool free space critically low")
-		return fmt.Errorf("refusing to start dev container: disk space critically low — pool %q is %.2f%% free (minimum %.0f%% required); free up space and retry", poolName(), freePct, cfg.refuseFreePct)
+			Msg("disk-pressure: refusing to start dev container, free space critically low")
+		return fmt.Errorf("refusing to start dev container: disk space critically low, %s reports %.2f%% free (minimum %.0f%% required); free up space and retry", m.backend, m.freePct, cfg.refuseFreePct)
 	}
 
 	return nil
 }
 
-// runDiskPressureMonitor is the emergency-brake monitor goroutine. It polls the
-// pool's free percent on a ticker and, when free percent drops to or below the
-// stop threshold, gracefully STOPS all running dev containers (resumable — never
-// deletes). Returns immediately if disk pressure is disabled.
+// runDiskPressureMonitor is the emergency-brake monitor goroutine. It polls
+// the active backend's free percent on a ticker and, when free percent drops
+// to or below the stop threshold, gracefully STOPS all running dev containers
+// (resumable, never deletes). Returns immediately if disk pressure is
+// disabled.
 func (dm *DevContainerManager) runDiskPressureMonitor() {
 	cfg := getDiskPressureConfig()
 	if !cfg.enabled {
@@ -244,7 +435,14 @@ func (dm *DevContainerManager) runDiskPressureMonitor() {
 		return
 	}
 
+	backend := "statfs"
+	if zfsBackendAvailable() {
+		backend = "zfs"
+	}
 	log.Info().
+		Str("backend", backend).
+		Str("pool", poolName()).
+		Str("path", diskPressurePath()).
 		Float64("refuse_free_pct", cfg.refuseFreePct).
 		Float64("stop_free_pct", cfg.stopFreePct).
 		Dur("check_interval", cfg.checkInterval).
@@ -253,20 +451,25 @@ func (dm *DevContainerManager) runDiskPressureMonitor() {
 	ticker := time.NewTicker(cfg.checkInterval)
 	defer ticker.Stop()
 	for range ticker.C {
-		freePct, err := poolFreePercent()
+		m, err := measureDisk()
 		if err != nil {
-			// Unknown measurement → do nothing this tick (fail-open).
-			log.Debug().Err(err).Msg("disk-pressure: could not measure pool free percent this tick, skipping")
+			// Unknown measurement, do nothing this tick (fail-open).
+			log.Debug().Err(err).Str("backend", m.backend).Msg("disk-pressure: could not measure free space this tick, skipping")
+			continue
+		}
+		if !m.hasPct {
 			continue
 		}
 
-		if freePct <= cfg.stopFreePct {
+		if m.freePct <= cfg.stopFreePct {
 			log.Error().
+				Str("backend", m.backend).
 				Str("pool", poolName()).
-				Float64("free_pct", freePct).
+				Str("path", diskPressurePath()).
+				Float64("free_pct", m.freePct).
 				Float64("stop_pct", cfg.stopFreePct).
-				Msg("disk-pressure: EMERGENCY BRAKE — pool free space below stop threshold, stopping all dev containers")
-			dm.emergencyStopAllDevContainers(freePct)
+				Msg("disk-pressure: EMERGENCY BRAKE, free space below stop threshold, stopping all dev containers")
+			dm.emergencyStopAllDevContainers(m.freePct)
 		}
 	}
 }

--- a/api/pkg/hydra/disk_pressure.go
+++ b/api/pkg/hydra/disk_pressure.go
@@ -34,23 +34,31 @@ import (
 //   - zfs:    `zpool list -Hp -o size,free <pool>` against the ZFS pool that
 //             backs zvols. Used when ZFS is available and a parent dataset is
 //             configured. This is the original implementation.
-//   - statfs: `syscall.Statfs(2)` against the hydra data directory. Used as a
-//             fallback on non-ZFS hosts (most K8s deployments, which run on
-//             ext4 / xfs / overlay). Without this fallback the disk-pressure
-//             guard fails-open silently on non-ZFS hosts, which is how a
-//             K8s-on-ext4 deployment silently filled its volume mid-pull.
+//   - statfs: `syscall.Statfs(2)` against EACH of the configured data paths.
+//             Used as a fallback on non-ZFS hosts (most K8s deployments,
+//             which run on ext4 / xfs / overlay). The K8s helix-sandbox
+//             chart provisions three separate PVCs per pod (docker-storage
+//             /var/lib/docker, hydra-data /hydra-data, workspace-data
+//             /data), and a fill on any one of them stops sandbox starts
+//             (the original incident was a fill of /var/lib/docker mid
+//             image-layer extract). The statfs backend measures every path
+//             and uses the LOWEST free percentage as the admission signal,
+//             so adding paths only ever makes the guard stricter.
 //
 // Fail policy:
 //
 //   - Backend reports a measurement: act on it (refuse / stop / allow per
 //     thresholds).
-//   - statfs fails with ENOENT (configured path does not exist): the operator
-//     misconfigured `HELIX_DISK_PRESSURE_PATH`, FAIL CLOSED on start (refuse)
-//     so we do not silently allow unprotected starts. Monitor logs and skips
-//     the tick.
-//   - Both backends unavailable (ZFS absent AND statfs path errors for other
-//     reasons): FAIL OPEN with a prominent warn log, matching pre-fallback
-//     behaviour. This should be unreachable in practice on any sane host.
+//   - statfs fails with ENOENT for ANY configured path: the operator
+//     misconfigured `HELIX_DISK_PRESSURE_PATHS`, FAIL CLOSED on start
+//     (refuse) so we do not silently allow unprotected starts. Monitor
+//     logs and skips the tick.
+//   - statfs fails with a non-ENOENT error on a path: log and skip that
+//     path; other paths may still produce a usable reading.
+//   - Both backends unavailable (ZFS absent AND statfs probe errors on
+//     every path for other reasons): FAIL OPEN with a prominent warn log,
+//     matching pre-fallback behaviour. This should be unreachable in
+//     practice on any sane host.
 
 const (
 	defaultDiskPressureRefuseFreePct = 2.0
@@ -147,15 +155,52 @@ func poolName() string {
 	return strings.SplitN(zfsParentDataset, "/", 2)[0]
 }
 
-// diskPressurePath returns the filesystem path that the statfs fallback should
-// measure. Defaults to DefaultDataDir (/hydra-data) and is overridable via
-// HELIX_DISK_PRESSURE_PATH for operators who mount their volume elsewhere
-// (e.g. /var/lib/hydra on a K8s PVC).
-func diskPressurePath() string {
-	if v := strings.TrimSpace(os.Getenv("HELIX_DISK_PRESSURE_PATH")); v != "" {
-		return v
+// defaultDiskPressurePaths is the set of filesystem paths the statfs backend
+// measures by default. They correspond 1:1 to the three PVCs the
+// helix-sandbox K8s chart mounts into each pod: /var/lib/docker
+// (docker-storage, image layers), /hydra-data (hydra-data, hydra state and
+// zvol-equivalent storage), /data (workspace-data, per-session workspaces).
+// Statfs-ing only one of these would miss fills on the other two, which is
+// the specific failure mode the multi-path admission check guards against
+// (helix-ubuntu pulls fill /var/lib/docker, not /hydra-data).
+var defaultDiskPressurePaths = []string{
+	"/var/lib/docker",
+	"/hydra-data",
+	"/data",
+}
+
+// diskPressurePaths returns the list of filesystem paths the statfs backend
+// should measure. Selection rules (in order):
+//
+//  1. HELIX_DISK_PRESSURE_PATHS (plural, comma-separated): each entry is
+//     whitespace-trimmed; empty entries are dropped. Use this on
+//     multi-volume deployments to monitor every mount that could fill.
+//  2. HELIX_DISK_PRESSURE_PATH (singular, kept for backwards compatibility
+//     with deployments that adopted the original single-path fallback):
+//     used as a one-element list when the plural form is unset.
+//  3. Default: defaultDiskPressurePaths, the three K8s PVC mount points.
+//
+// The admission check uses the LOWEST free percentage across the returned
+// paths, so adding paths only ever makes the guard stricter.
+func diskPressurePaths() []string {
+	if v := strings.TrimSpace(os.Getenv("HELIX_DISK_PRESSURE_PATHS")); v != "" {
+		raw := strings.Split(v, ",")
+		paths := make([]string, 0, len(raw))
+		for _, p := range raw {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			paths = append(paths, p)
+		}
+		if len(paths) > 0 {
+			return paths
+		}
 	}
-	return DefaultDataDir
+	if v := strings.TrimSpace(os.Getenv("HELIX_DISK_PRESSURE_PATH")); v != "" {
+		return []string{v}
+	}
+	return append([]string{}, defaultDiskPressurePaths...)
 }
 
 // statfsFn is the seam used to mock syscall.Statfs in tests. Production code
@@ -201,17 +246,100 @@ func statfsFreeBytes(path string) (int64, error) {
 	return int64(avail), nil
 }
 
+// statfsFreePercentMulti runs statfsFreePercent against every path in `paths`
+// and returns the LOWEST free-percentage, the path that produced it, and a
+// pathENOENT flag set when any path returned ENOENT.
+//
+// Policy:
+//   - ENOENT on any path: pathENOENT=true. The start guard treats this as
+//     fail-closed because a missing path indicates operator misconfiguration
+//     (HELIX_DISK_PRESSURE_PATHS lists a directory that does not exist).
+//   - Non-ENOENT error on a path: log and skip that path. Other paths may
+//     still measure successfully; we want one bad mount to not blind the
+//     guard against the rest.
+//   - At least one successful measurement: return min(freePct) and the
+//     corresponding triggerPath. The caller threads triggerPath into refusal
+//     logs and user-facing errors so operators see which volume is full.
+//   - All paths errored without any ENOENT: return the last error so the
+//     caller falls open with the existing warn log.
+//
+// `paths` must be non-empty; callers should pass diskPressurePaths().
+func statfsFreePercentMulti(paths []string) (minPct float64, triggerPath string, pathENOENT bool, err error) {
+	if len(paths) == 0 {
+		return 0, "", false, fmt.Errorf("statfsFreePercentMulti: no paths configured")
+	}
+	have := false
+	var lastErr error
+	for _, p := range paths {
+		pct, perr := statfsFreePercent(p)
+		if perr != nil {
+			if errors.Is(perr, syscall.ENOENT) {
+				pathENOENT = true
+				lastErr = perr
+				log.Error().Err(perr).Str("path", p).
+					Msg("disk-pressure: configured path does not exist (set HELIX_DISK_PRESSURE_PATHS or create the directory)")
+				continue
+			}
+			lastErr = perr
+			log.Warn().Err(perr).Str("path", p).
+				Msg("disk-pressure: statfs failed for path, skipping (other paths may still measure)")
+			continue
+		}
+		if !have || pct < minPct {
+			minPct = pct
+			triggerPath = p
+			have = true
+		}
+	}
+	if !have {
+		if lastErr != nil {
+			return 0, "", pathENOENT, fmt.Errorf("statfs probe failed for all paths: %w", lastErr)
+		}
+		return 0, "", pathENOENT, fmt.Errorf("statfs probe failed for all paths")
+	}
+	return minPct, triggerPath, pathENOENT, nil
+}
+
+// statfsFreeBytesMulti returns the free-bytes reading from the SAME path
+// that statfsFreePercentMulti would identify as the constraining volume.
+// Picking the min-free-pct path (rather than e.g. the sum of free bytes
+// across all paths) keeps the GC reaper's before/after delta sensible: the
+// reaper reclaims space on the volume that is actually under pressure, so
+// the delta we surface should track that volume. ENOENT on the trigger path
+// is propagated to the caller so it can fail closed exactly like the start
+// guard.
+func statfsFreeBytesMulti(paths []string) (int64, string, bool, error) {
+	_, triggerPath, pathENOENT, err := statfsFreePercentMulti(paths)
+	if err != nil {
+		return 0, "", pathENOENT, err
+	}
+	free, ferr := statfsFreeBytes(triggerPath)
+	if ferr != nil {
+		if errors.Is(ferr, syscall.ENOENT) {
+			pathENOENT = true
+		}
+		return 0, triggerPath, pathENOENT, ferr
+	}
+	return free, triggerPath, pathENOENT, nil
+}
+
 // measurement describes the result of a free-space probe. Backend identifies
 // which probe produced it (zfs / statfs / none) so callers can log and tests
-// can assert. PathENOENT is true when the statfs backend was selected but the
-// configured path does not exist, which the start guard treats as fail-closed.
+// can assert. PathENOENT is true when the statfs backend was selected but a
+// configured path does not exist, which the start guard treats as
+// fail-closed. TriggerPath is the path that produced the worst (lowest-free)
+// reading on the statfs backend; empty for the ZFS backend. Threading it
+// through to the refusal log lets operators see which volume is constraining
+// (e.g. "refused: /var/lib/docker at 1.3% free") rather than a generic
+// message.
 type measurement struct {
-	freePct    float64
-	freeBytes  int64
-	backend    string
-	hasPct     bool
-	hasBytes   bool
-	pathENOENT bool
+	freePct     float64
+	freeBytes   int64
+	backend     string
+	hasPct      bool
+	hasBytes    bool
+	pathENOENT  bool
+	triggerPath string
 }
 
 // zfsBackendAvailable reports whether the ZFS backend can be queried. Both ZFS
@@ -248,29 +376,32 @@ func measureDisk() (measurement, error) {
 		return m, fmt.Errorf("zfs probe failed: pct_err=%v free_err=%v", pctErr, freeErr)
 	}
 
-	// Non-ZFS host: statfs the hydra data directory.
+	// Non-ZFS host: statfs every configured path and take the worst
+	// (lowest free percent) reading as the admission signal.
 	m.backend = "statfs"
-	path := diskPressurePath()
-	pct, pctErr := statfsFreePercent(path)
-	free, freeErr := statfsFreeBytes(path)
+	paths := diskPressurePaths()
+	pct, triggerPath, pctENOENT, pctErr := statfsFreePercentMulti(paths)
 	if pctErr == nil {
 		m.freePct = pct
 		m.hasPct = true
+		m.triggerPath = triggerPath
+	} else if pctENOENT {
+		m.pathENOENT = true
 	}
+	free, byteTrigger, bytesENOENT, freeErr := statfsFreeBytesMulti(paths)
 	if freeErr == nil {
 		m.freeBytes = free
 		m.hasBytes = true
+		if m.triggerPath == "" {
+			m.triggerPath = byteTrigger
+		}
+	} else if bytesENOENT {
+		m.pathENOENT = true
 	}
 	if m.hasPct || m.hasBytes {
 		return m, nil
 	}
-	// Both calls failed identically (same syscall). If the path doesn't exist
-	// the operator misconfigured HELIX_DISK_PRESSURE_PATH; mark the
-	// measurement so the start guard can fail closed.
-	if errors.Is(pctErr, syscall.ENOENT) || errors.Is(freeErr, syscall.ENOENT) {
-		m.pathENOENT = true
-	}
-	return m, fmt.Errorf("statfs probe failed at %q: %w", path, pctErr)
+	return m, fmt.Errorf("statfs probe failed for paths %v: %w", paths, pctErr)
 }
 
 // poolFreePercent returns the percentage of the ZFS pool that is free.
@@ -323,17 +454,23 @@ func poolFreePercentZFS() (float64, error) {
 }
 
 // poolFreeBytes returns the number of free bytes for the GC reconcile path's
-// before/after delta. Tries ZFS first, then falls back to statfs against the
-// hydra data directory so the GC reaper produces a meaningful number on
-// non-ZFS hosts too.
+// before/after delta. Tries ZFS first, then falls back to statfs on the
+// configured disk-pressure paths.
 //
-// Used by the GC reconcile path to cheaply measure reclaimed space as a
-// before/after delta instead of running a per-directory `du` sweep.
+// On the statfs backend we report the free-bytes value from the SAME path
+// that statfsFreePercentMulti identifies as the constraining volume (the
+// lowest-free-percent path), not the sum across all paths. Summing would
+// hide whether the reaper actually clawed back space on the volume that is
+// under pressure: if /var/lib/docker is full and the reaper frees space on
+// /data, the sum would still grow but pressure remains. Reporting the
+// constraining-volume figure keeps the delta meaningful for the reaper's
+// before/after comparison.
 func poolFreeBytes() (int64, error) {
 	if zfsBackendAvailable() {
 		return poolFreeBytesZFS()
 	}
-	return statfsFreeBytes(diskPressurePath())
+	free, _, _, err := statfsFreeBytesMulti(diskPressurePaths())
+	return free, err
 }
 
 // poolFreeBytesZFS is the ZFS-only implementation, read from
@@ -391,9 +528,9 @@ func checkDiskPressureForStart() error {
 		if m.pathENOENT {
 			log.Error().Err(err).
 				Str("backend", m.backend).
-				Str("path", diskPressurePath()).
-				Msg("disk-pressure: refusing to start dev container, configured data path does not exist (set HELIX_DISK_PRESSURE_PATH or create the directory)")
-			return fmt.Errorf("refusing to start dev container: disk-pressure path %q does not exist; set HELIX_DISK_PRESSURE_PATH to the hydra data directory and retry", diskPressurePath())
+				Strs("paths", diskPressurePaths()).
+				Msg("disk-pressure: refusing to start dev container, a configured data path does not exist (set HELIX_DISK_PRESSURE_PATHS or create the directory)")
+			return fmt.Errorf("refusing to start dev container: one of the disk-pressure paths %v does not exist; set HELIX_DISK_PRESSURE_PATHS to the correct mounts and retry", diskPressurePaths())
 		}
 		// Unknown measurement, both backends unavailable. Fail open, allow
 		// the start, but log loudly so operators notice.
@@ -413,11 +550,15 @@ func checkDiskPressureForStart() error {
 		log.Error().
 			Str("backend", m.backend).
 			Str("pool", poolName()).
-			Str("path", diskPressurePath()).
+			Str("trigger_path", m.triggerPath).
 			Float64("free_pct", m.freePct).
 			Float64("refuse_pct", cfg.refuseFreePct).
 			Msg("disk-pressure: refusing to start dev container, free space critically low")
-		return fmt.Errorf("refusing to start dev container: disk space critically low, %s reports %.2f%% free (minimum %.0f%% required); free up space and retry", m.backend, m.freePct, cfg.refuseFreePct)
+		where := m.backend
+		if m.triggerPath != "" {
+			where = fmt.Sprintf("%s at %s", m.backend, m.triggerPath)
+		}
+		return fmt.Errorf("refusing to start dev container: disk space critically low, %s reports %.2f%% free (minimum %.0f%% required); free up space and retry", where, m.freePct, cfg.refuseFreePct)
 	}
 
 	return nil
@@ -442,7 +583,7 @@ func (dm *DevContainerManager) runDiskPressureMonitor() {
 	log.Info().
 		Str("backend", backend).
 		Str("pool", poolName()).
-		Str("path", diskPressurePath()).
+		Strs("paths", diskPressurePaths()).
 		Float64("refuse_free_pct", cfg.refuseFreePct).
 		Float64("stop_free_pct", cfg.stopFreePct).
 		Dur("check_interval", cfg.checkInterval).
@@ -465,7 +606,7 @@ func (dm *DevContainerManager) runDiskPressureMonitor() {
 			log.Error().
 				Str("backend", m.backend).
 				Str("pool", poolName()).
-				Str("path", diskPressurePath()).
+				Str("trigger_path", m.triggerPath).
 				Float64("free_pct", m.freePct).
 				Float64("stop_pct", cfg.stopFreePct).
 				Msg("disk-pressure: EMERGENCY BRAKE, free space below stop threshold, stopping all dev containers")

--- a/api/pkg/hydra/disk_pressure_bsize_darwin_test.go
+++ b/api/pkg/hydra/disk_pressure_bsize_darwin_test.go
@@ -1,0 +1,11 @@
+//go:build darwin
+
+package hydra
+
+import "syscall"
+
+// setStatfsBsize fills Statfs_t.Bsize without forcing a typed literal in the
+// shared test (linux: int64, darwin: uint32).
+func setStatfsBsize(stat *syscall.Statfs_t, v int64) {
+	stat.Bsize = uint32(v)
+}

--- a/api/pkg/hydra/disk_pressure_bsize_linux_test.go
+++ b/api/pkg/hydra/disk_pressure_bsize_linux_test.go
@@ -1,0 +1,11 @@
+//go:build linux
+
+package hydra
+
+import "syscall"
+
+// setStatfsBsize fills Statfs_t.Bsize without forcing a typed literal in the
+// shared test (linux: int64, darwin: uint32).
+func setStatfsBsize(stat *syscall.Statfs_t, v int64) {
+	stat.Bsize = v
+}

--- a/api/pkg/hydra/disk_pressure_test.go
+++ b/api/pkg/hydra/disk_pressure_test.go
@@ -3,6 +3,7 @@ package hydra
 import (
 	"fmt"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -293,4 +294,211 @@ func (s *DiskPressureSuite) TestConfigEnvOverrides() {
 	assert.InDelta(s.T(), 5.0, cfg.refuseFreePct, 0.0001)
 	assert.InDelta(s.T(), 3.0, cfg.stopFreePct, 0.0001)
 	assert.Equal(s.T(), "10s", cfg.checkInterval.String())
+}
+
+// =======================================================================
+// statfs fallback (non-ZFS hosts: K8s on ext4/xfs, the actual deployment
+// shape where the original implementation silently failed open).
+// =======================================================================
+
+// DiskPressureStatfsSuite exercises the non-ZFS code path: ZFS is forced
+// "unavailable" so measureDisk() picks the statfs backend, and statfsFn is
+// swapped for a table-driven mock so we can pin free percentages and inject
+// ENOENT without touching the real filesystem.
+type DiskPressureStatfsSuite struct {
+	suite.Suite
+
+	origStatfs func(path string, stat *syscall.Statfs_t) error
+	origOutput func(name string, args ...string) ([]byte, error)
+
+	// statfsBlocks/statfsBavail/statfsBsize define the synthetic filesystem
+	// returned by the mock. Free % = Bavail/Blocks.
+	statfsBlocks uint64
+	statfsBavail uint64
+	statfsBsize  int64
+	statfsErr    error
+}
+
+func TestDiskPressureStatfsSuite(t *testing.T) {
+	suite.Run(t, new(DiskPressureStatfsSuite))
+}
+
+func (s *DiskPressureStatfsSuite) SetupTest() {
+	resetZFSState()
+	resetDiskPressureConfig()
+
+	// Force ZFS UNAVAILABLE so zfsBackendAvailable() returns false and
+	// measureDisk() takes the statfs branch.
+	zfsAvailableFlag = false
+	zfsParentDataset = ""
+	zfsAvailableOnce.Do(func() {})
+
+	// Default: 1000 blocks total, 100 available, 1-byte blocks => 10% free.
+	s.statfsBlocks = 1000
+	s.statfsBavail = 100
+	s.statfsBsize = 1
+	s.statfsErr = nil
+
+	s.origStatfs = statfsFn
+	statfsFn = func(_ string, stat *syscall.Statfs_t) error {
+		if s.statfsErr != nil {
+			return s.statfsErr
+		}
+		stat.Blocks = s.statfsBlocks
+		stat.Bavail = s.statfsBavail
+		setStatfsBsize(stat, s.statfsBsize)
+		return nil
+	}
+
+	// Trip wires: ZFS should NEVER be queried when the backend is statfs. If
+	// these fire, the routing is wrong.
+	s.origOutput = execCmdOutput
+	execCmdOutput = func(name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("statfs suite should not invoke %s %s", name, strings.Join(args, " "))
+	}
+}
+
+func (s *DiskPressureStatfsSuite) TearDownTest() {
+	statfsFn = s.origStatfs
+	execCmdOutput = s.origOutput
+	resetZFSState()
+	resetDiskPressureConfig()
+}
+
+// -----------------------------------------------------------------------
+// statfsFreePercent / statfsFreeBytes
+// -----------------------------------------------------------------------
+
+func (s *DiskPressureStatfsSuite) TestStatfsFreePercent_TenPercent() {
+	pct, err := statfsFreePercent("/anywhere")
+	require.NoError(s.T(), err)
+	assert.InDelta(s.T(), 10.0, pct, 0.0001)
+}
+
+func (s *DiskPressureStatfsSuite) TestStatfsFreePercent_ZeroBlocksError() {
+	s.statfsBlocks = 0
+	_, err := statfsFreePercent("/anywhere")
+	require.Error(s.T(), err)
+}
+
+func (s *DiskPressureStatfsSuite) TestStatfsFreePercent_ENOENT() {
+	s.statfsErr = syscall.ENOENT
+	_, err := statfsFreePercent("/no/such/path")
+	require.Error(s.T(), err)
+}
+
+func (s *DiskPressureStatfsSuite) TestStatfsFreeBytes_Computes() {
+	// 100 available blocks * 4096 = 409,600 bytes
+	s.statfsBavail = 100
+	s.statfsBsize = 4096
+	free, err := statfsFreeBytes("/anywhere")
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), int64(100*4096), free)
+}
+
+// -----------------------------------------------------------------------
+// measureDisk: backend selection
+// -----------------------------------------------------------------------
+
+func (s *DiskPressureStatfsSuite) TestMeasureDisk_PicksStatfsWhenNoZFS() {
+	m, err := measureDisk()
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "statfs", m.backend)
+	assert.True(s.T(), m.hasPct)
+	assert.InDelta(s.T(), 10.0, m.freePct, 0.0001)
+}
+
+func (s *DiskPressureStatfsSuite) TestMeasureDisk_StatfsENOENTPropagates() {
+	s.statfsErr = syscall.ENOENT
+	m, err := measureDisk()
+	require.Error(s.T(), err)
+	assert.Equal(s.T(), "statfs", m.backend)
+	assert.True(s.T(), m.pathENOENT, "ENOENT must surface so the start guard can fail closed")
+}
+
+// -----------------------------------------------------------------------
+// checkDiskPressureForStart on the statfs backend
+// -----------------------------------------------------------------------
+
+func (s *DiskPressureStatfsSuite) TestCheckStart_StatfsRefusesAtThreshold() {
+	// Bavail/Blocks = 20/1000 = 2.0%, refuse threshold default 2% => refuse.
+	s.statfsBavail = 20
+	err := checkDiskPressureForStart()
+	require.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "disk space critically low")
+}
+
+func (s *DiskPressureStatfsSuite) TestCheckStart_StatfsRefusesBelowThreshold() {
+	// 5/1000 = 0.5%
+	s.statfsBavail = 5
+	err := checkDiskPressureForStart()
+	require.Error(s.T(), err)
+}
+
+func (s *DiskPressureStatfsSuite) TestCheckStart_StatfsAllowsAmple() {
+	// 100/1000 = 10%
+	s.statfsBavail = 100
+	err := checkDiskPressureForStart()
+	require.NoError(s.T(), err)
+}
+
+func (s *DiskPressureStatfsSuite) TestCheckStart_StatfsAllowsJustAbove() {
+	// 25/1000 = 2.5%, strictly above 2% refuse threshold
+	s.statfsBavail = 25
+	err := checkDiskPressureForStart()
+	require.NoError(s.T(), err)
+}
+
+func (s *DiskPressureStatfsSuite) TestCheckStart_StatfsFailsClosedOnENOENT() {
+	// Misconfigured path: refuse, do NOT silently allow. This is the bug the
+	// fallback exists to fix.
+	s.statfsErr = syscall.ENOENT
+	err := checkDiskPressureForStart()
+	require.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "does not exist")
+}
+
+func (s *DiskPressureStatfsSuite) TestCheckStart_StatfsFailsOpenOnOtherErr() {
+	// EIO and friends are transient hardware / FUSE errors. Fail open here so
+	// a flaky filesystem doesn't lock out all sandbox starts; the warn log
+	// surfaces the issue for operators.
+	s.statfsErr = syscall.EIO
+	err := checkDiskPressureForStart()
+	require.NoError(s.T(), err)
+}
+
+func (s *DiskPressureStatfsSuite) TestCheckStart_StatfsAllowsWhenDisabled() {
+	s.T().Setenv("HELIX_DISK_PRESSURE_ENABLED", "false")
+	resetDiskPressureConfig()
+
+	// Even with 0% free, disabled => allow.
+	s.statfsBavail = 0
+	err := checkDiskPressureForStart()
+	require.NoError(s.T(), err)
+}
+
+// -----------------------------------------------------------------------
+// poolFreeBytes fallback on non-ZFS hosts
+// -----------------------------------------------------------------------
+
+func (s *DiskPressureStatfsSuite) TestPoolFreeBytes_StatfsFallback() {
+	// 250 blocks * 4096 byte blocks = 1,024,000 bytes available.
+	s.statfsBavail = 250
+	s.statfsBsize = 4096
+	free, err := poolFreeBytes()
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), int64(250*4096), free)
+}
+
+// -----------------------------------------------------------------------
+// diskPressurePath: env override
+// -----------------------------------------------------------------------
+
+func (s *DiskPressureStatfsSuite) TestDiskPressurePath_Default() {
+	assert.Equal(s.T(), DefaultDataDir, diskPressurePath())
+}
+
+func (s *DiskPressureStatfsSuite) TestDiskPressurePath_EnvOverride() {
+	s.T().Setenv("HELIX_DISK_PRESSURE_PATH", "/var/lib/hydra")
+	assert.Equal(s.T(), "/var/lib/hydra", diskPressurePath())
 }

--- a/api/pkg/hydra/disk_pressure_test.go
+++ b/api/pkg/hydra/disk_pressure_test.go
@@ -491,14 +491,153 @@ func (s *DiskPressureStatfsSuite) TestPoolFreeBytes_StatfsFallback() {
 }
 
 // -----------------------------------------------------------------------
-// diskPressurePath: env override
+// diskPressurePaths: env parsing + defaults
 // -----------------------------------------------------------------------
 
-func (s *DiskPressureStatfsSuite) TestDiskPressurePath_Default() {
-	assert.Equal(s.T(), DefaultDataDir, diskPressurePath())
+func (s *DiskPressureStatfsSuite) TestDiskPressurePaths_DefaultIsK8sLayout() {
+	// Default must cover the three PVC mount points the helix-sandbox chart
+	// provisions. Without /var/lib/docker the original ENOSPC-during-pull
+	// failure mode would still slip past the guard.
+	assert.Equal(s.T(), []string{"/var/lib/docker", "/hydra-data", "/data"}, diskPressurePaths())
 }
 
-func (s *DiskPressureStatfsSuite) TestDiskPressurePath_EnvOverride() {
+func (s *DiskPressureStatfsSuite) TestDiskPressurePaths_SingularBackCompat() {
+	// Operators on the previous single-path env var keep working.
 	s.T().Setenv("HELIX_DISK_PRESSURE_PATH", "/var/lib/hydra")
-	assert.Equal(s.T(), "/var/lib/hydra", diskPressurePath())
+	assert.Equal(s.T(), []string{"/var/lib/hydra"}, diskPressurePaths())
+}
+
+func (s *DiskPressureStatfsSuite) TestDiskPressurePaths_PluralWins() {
+	// When both are set the plural form takes precedence.
+	s.T().Setenv("HELIX_DISK_PRESSURE_PATH", "/single")
+	s.T().Setenv("HELIX_DISK_PRESSURE_PATHS", "/a,/b,/c")
+	assert.Equal(s.T(), []string{"/a", "/b", "/c"}, diskPressurePaths())
+}
+
+func (s *DiskPressureStatfsSuite) TestDiskPressurePaths_TrimsAndDropsEmpties() {
+	s.T().Setenv("HELIX_DISK_PRESSURE_PATHS", "  /a , ,/b ,  ,/c  ")
+	assert.Equal(s.T(), []string{"/a", "/b", "/c"}, diskPressurePaths())
+}
+
+func (s *DiskPressureStatfsSuite) TestDiskPressurePaths_EmptyPluralFallsThroughToSingular() {
+	// Plural set to whitespace-only entries -> treated as unset; singular wins.
+	s.T().Setenv("HELIX_DISK_PRESSURE_PATHS", " , , ")
+	s.T().Setenv("HELIX_DISK_PRESSURE_PATH", "/var/lib/hydra")
+	assert.Equal(s.T(), []string{"/var/lib/hydra"}, diskPressurePaths())
+}
+
+// -----------------------------------------------------------------------
+// statfsFreePercentMulti
+// -----------------------------------------------------------------------
+
+// perPathResult describes the synthetic statfs reply for a single path.
+type perPathResult struct {
+	blocks uint64
+	bavail uint64
+	bsize  int64
+	err    error
+}
+
+// installPerPathStatfs swaps statfsFn for a map-driven mock keyed by path.
+// Returns a cleanup the suite should invoke in TearDown order; for these
+// tests we just rely on the suite's TearDownTest which restores origStatfs.
+func (s *DiskPressureStatfsSuite) installPerPathStatfs(results map[string]perPathResult) {
+	statfsFn = func(path string, stat *syscall.Statfs_t) error {
+		r, ok := results[path]
+		if !ok {
+			return fmt.Errorf("unexpected statfs path in test: %s", path)
+		}
+		if r.err != nil {
+			return r.err
+		}
+		stat.Blocks = r.blocks
+		stat.Bavail = r.bavail
+		setStatfsBsize(stat, r.bsize)
+		return nil
+	}
+}
+
+func (s *DiskPressureStatfsSuite) TestStatfsMulti_PicksMinFreePct() {
+	// /a 50%, /b 10%, /c 30%  -> min is /b at 10%.
+	s.installPerPathStatfs(map[string]perPathResult{
+		"/a": {blocks: 1000, bavail: 500, bsize: 1},
+		"/b": {blocks: 1000, bavail: 100, bsize: 1},
+		"/c": {blocks: 1000, bavail: 300, bsize: 1},
+	})
+	pct, trigger, enoent, err := statfsFreePercentMulti([]string{"/a", "/b", "/c"})
+	require.NoError(s.T(), err)
+	assert.False(s.T(), enoent)
+	assert.Equal(s.T(), "/b", trigger)
+	assert.InDelta(s.T(), 10.0, pct, 0.0001)
+}
+
+func (s *DiskPressureStatfsSuite) TestStatfsMulti_TriggerPathIsTheConstrainingOne() {
+	// Single path: trigger must be that path.
+	s.installPerPathStatfs(map[string]perPathResult{
+		"/only": {blocks: 1000, bavail: 17, bsize: 1},
+	})
+	_, trigger, _, err := statfsFreePercentMulti([]string{"/only"})
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "/only", trigger)
+}
+
+func (s *DiskPressureStatfsSuite) TestStatfsMulti_AnyENOENTIsFailClosed() {
+	// /a measures fine, /b is ENOENT. Overall must surface pathENOENT=true
+	// AND return an error so the start guard refuses.
+	s.installPerPathStatfs(map[string]perPathResult{
+		"/a": {blocks: 1000, bavail: 500, bsize: 1},
+		"/b": {err: syscall.ENOENT},
+	})
+	_, _, enoent, err := statfsFreePercentMulti([]string{"/a", "/b"})
+	// At least one measurement succeeded so freePct is returned (no error),
+	// but pathENOENT must be set so callers can fail closed on misconfig.
+	require.NoError(s.T(), err)
+	assert.True(s.T(), enoent, "any ENOENT path must surface pathENOENT=true")
+}
+
+func (s *DiskPressureStatfsSuite) TestStatfsMulti_TransientErrorSkipped() {
+	// /a is EIO (transient), /b is fine. Multi should use /b and NOT fail.
+	s.installPerPathStatfs(map[string]perPathResult{
+		"/a": {err: syscall.EIO},
+		"/b": {blocks: 1000, bavail: 250, bsize: 1},
+	})
+	pct, trigger, enoent, err := statfsFreePercentMulti([]string{"/a", "/b"})
+	require.NoError(s.T(), err)
+	assert.False(s.T(), enoent)
+	assert.Equal(s.T(), "/b", trigger)
+	assert.InDelta(s.T(), 25.0, pct, 0.0001)
+}
+
+func (s *DiskPressureStatfsSuite) TestStatfsMulti_AllErrorsReturnError() {
+	// All paths error (non-ENOENT): no measurement, caller falls open.
+	s.installPerPathStatfs(map[string]perPathResult{
+		"/a": {err: syscall.EIO},
+		"/b": {err: syscall.EACCES},
+	})
+	_, _, _, err := statfsFreePercentMulti([]string{"/a", "/b"})
+	require.Error(s.T(), err)
+}
+
+func (s *DiskPressureStatfsSuite) TestStatfsMulti_EmptyPathsErrors() {
+	_, _, _, err := statfsFreePercentMulti(nil)
+	require.Error(s.T(), err)
+}
+
+// -----------------------------------------------------------------------
+// admission refusal surfaces the triggering path
+// -----------------------------------------------------------------------
+
+func (s *DiskPressureStatfsSuite) TestCheckStart_RefusalIncludesTriggerPath() {
+	// /var/lib/docker is the full one. The refusal log + error must name it
+	// so operators can fix the right volume.
+	s.T().Setenv("HELIX_DISK_PRESSURE_PATHS", "/var/lib/docker,/hydra-data,/data")
+	s.installPerPathStatfs(map[string]perPathResult{
+		"/var/lib/docker": {blocks: 1000, bavail: 13, bsize: 1}, // 1.3% free
+		"/hydra-data":     {blocks: 1000, bavail: 800, bsize: 1},
+		"/data":           {blocks: 1000, bavail: 700, bsize: 1},
+	})
+	err := checkDiskPressureForStart()
+	require.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "/var/lib/docker", "operator must see which volume is constraining")
+	assert.Contains(s.T(), err.Error(), "disk space critically low")
 }


### PR DESCRIPTION
## Summary

Hydra's disk-pressure admission control only worked with ZFS. On non-ZFS hosts (most K8s deployments, which use ext4/xfs on a PVC or ephemeral storage) the guard logged `ZFS not available; cannot measure pool free space` and silently failed open, so sandboxes had no protection against disk-fill mid-pull. An enterprise K8s deployment on a non-ZFS host just hit exactly that failure mode.

This PR adds a `syscall.Statfs(2)` fallback so the same refuse / stop thresholds apply on any POSIX filesystem, and (critically) measures every volume the helix-sandbox pod mounts rather than a single path.

## Root cause

`poolFreePercent` / `poolFreeBytes` shelled out to `zpool list` unconditionally. When `ZFSAvailable()` returned false they returned an error, and `checkDiskPressureForStart` treated that error as fail-open ("unknown -> allow start"). The unconditional fail-open is correct for transient ZFS errors but wrong for the steady-state non-ZFS case, where every measurement fails forever.

### Volume layout

The helix-sandbox K8s chart (`charts/helix-sandbox/templates/statefulset.yaml`) provisions three separate PVCs per pod:

| PVC | Mount path | Default size |
|---|---|---|
| `docker-storage` | `/var/lib/docker` | 50Gi |
| `hydra-data` | `/hydra-data` | 20Gi |
| `workspace-data` | `/data` | 100Gi |

A fill of any one of them stops sandbox starts. The original incident was a fill of `/var/lib/docker` during a `helix-ubuntu` image-layer extract. Statfs of only `/hydra-data` does not see that.

## Fix

- New `measureDisk()` selects a backend at call time: `zfs` when `ZFSAvailable() && zfsParentDataset != ""`, otherwise `statfs`.
- New `statfsFreePercent(path)` / `statfsFreeBytes(path)` use `syscall.Statfs_t` (mirrors the existing pattern in `cmd/sandbox-heartbeat/main.go`). Free % is `Bavail*Bsize / Blocks*Bsize`.
- New `statfsFreePercentMulti(paths)` measures every configured path, returns the LOWEST free percentage and the path that produced it as `triggerPath`. Adding paths only ever makes the guard stricter.
- Paths come from `HELIX_DISK_PRESSURE_PATHS` (plural, comma-separated; whitespace trimmed, empty entries dropped). Singular `HELIX_DISK_PRESSURE_PATH` is kept as a one-element back-compat for deployments that adopted the earlier draft. Plural wins when both are set. Default when neither is set: `[/var/lib/docker, /hydra-data, /data]` (the three K8s PVC mount points).
- Per-path error policy: ENOENT on any path indicates operator misconfiguration and surfaces `pathENOENT=true` so the start guard fails closed. Non-ENOENT errors (EIO, EACCES, FUSE flakes) are logged and that path is skipped, so a single bad mount does not blind the guard against the rest. All paths erroring with non-ENOENT preserves the existing warn-and-fail-open behaviour.
- Refusal error and admission log thread `triggerPath` through so operators see e.g. "refused: /var/lib/docker at 1.3% free" rather than a generic message.
- `runDiskPressureMonitor` logs `backend`, `pool`, `paths` at startup so operators can confirm which probe is active and which volumes it covers.
- `poolFreeBytes` (used by the GC reconcile path's before/after delta) falls through to a multi-path version that picks the SAME constraining path as the percentage measurement, so the reaper's delta tracks the volume that is actually under pressure rather than summing across all volumes.

Thresholds, `check_interval` cadence, the ZFS code path, and the call site in `devcontainer.go` are unchanged.

## Test plan

Unit tests:
- `TestDiskPressureStatfsSuite` covers the statfs path: percentage computation, `ENOENT` propagation, threshold logic (refuse at, below, allow above, just above), fail-closed on ENOENT, fail-open on transient errors (`EIO`), disabled override, `poolFreeBytes` fallback, env-var parsing (default K8s layout, singular back-compat, plural-wins, whitespace/empty handling, fallback to singular when plural is whitespace-only).
- New multi-path coverage: `TestStatfsMulti_PicksMinFreePct`, `TestStatfsMulti_TriggerPathIsTheConstrainingOne`, `TestStatfsMulti_AnyENOENTIsFailClosed`, `TestStatfsMulti_TransientErrorSkipped`, `TestStatfsMulti_AllErrorsReturnError`, `TestStatfsMulti_EmptyPathsErrors`, `TestCheckStart_RefusalIncludesTriggerPath`.
- Pre-existing `TestDiskPressureSuite` still passes, ZFS path behaviour unchanged.

Local commands run:
```
cd api && CGO_ENABLED=0 go build ./pkg/hydra/...
cd api && CGO_ENABLED=0 GOOS=linux go build ./pkg/hydra/...
cd api && go test -run TestDiskPressure -v ./pkg/hydra/... -count=1
```
Result: build clean on both platforms, 54 sub-tests pass.

Manual K8s test plan (to run on the affected deployment):

1. Deploy hydra to a non-ZFS sandbox pod (ext4 PVC). Confirm startup log shows `disk-pressure: monitor started backend=statfs paths=[/var/lib/docker /hydra-data /data] ...`.
2. Fill `/var/lib/docker` above the refuse threshold (e.g. `dd if=/dev/zero of=/var/lib/docker/fill bs=1M count=...` until `df` shows < 2% free).
3. Attempt to create a sandbox; confirm the API returns `refusing to start dev container: disk space critically low, statfs at /var/lib/docker reports ...% free` and the hydra log entry names the same trigger_path.
4. Remove the fill file, confirm new starts succeed.
5. Repeat for `/hydra-data` and `/data` to confirm every volume is covered.

Misconfiguration check (fail-closed):

1. Set `HELIX_DISK_PRESSURE_PATHS=/no/such/path`, restart hydra.
2. Attempt to create a sandbox; confirm refusal with `does not exist` in the message and the error log entry.

## Out of scope

- Hydra image-recovery (separate PR).
- Sandbox startup script changes (separate PR).
- Threshold defaults are unchanged. The 2% / 1% values were chosen for ZFS pool guarding; K8s docker-layer extraction may need higher defaults. Tracked separately.