### PR TITLE
fix(hydra): narrow disk-pressure defaults to paths that exist everywhere

### DIFF
--- a/api/pkg/hydra/disk_pressure.go
+++ b/api/pkg/hydra/disk_pressure.go
@@ -36,13 +36,16 @@ import (
 //             configured. This is the original implementation.
 //   - statfs: `syscall.Statfs(2)` against EACH of the configured data paths.
 //             Used as a fallback on non-ZFS hosts (most K8s deployments,
-//             which run on ext4 / xfs / overlay). The K8s helix-sandbox
-//             chart provisions three separate PVCs per pod (docker-storage
-//             /var/lib/docker, hydra-data /hydra-data, workspace-data
-//             /data), and a fill on any one of them stops sandbox starts
-//             (the original incident was a fill of /var/lib/docker mid
-//             image-layer extract). The statfs backend measures every path
-//             and uses the LOWEST free percentage as the admission signal,
+//             which run on ext4 / xfs / overlay). Default measures
+//             /var/lib/docker (image layers, the original ENOSPC site) and
+//             /hydra-data (hydra state, zvol-equivalent storage); these
+//             two exist in every Helix sandbox runtime (K8s chart,
+//             docker-compose dev, Mac UTM VM). The K8s helix-sandbox
+//             chart additionally provisions a workspace-data PVC at
+//             /data; operators on that chart should set
+//             HELIX_DISK_PRESSURE_PATHS="/var/lib/docker,/hydra-data,/data"
+//             to cover it. The statfs backend measures every path and
+//             uses the LOWEST free percentage as the admission signal,
 //             so adding paths only ever makes the guard stricter.
 //
 // Fail policy:
@@ -156,17 +159,23 @@ func poolName() string {
 }
 
 // defaultDiskPressurePaths is the set of filesystem paths the statfs backend
-// measures by default. They correspond 1:1 to the three PVCs the
-// helix-sandbox K8s chart mounts into each pod: /var/lib/docker
-// (docker-storage, image layers), /hydra-data (hydra-data, hydra state and
-// zvol-equivalent storage), /data (workspace-data, per-session workspaces).
-// Statfs-ing only one of these would miss fills on the other two, which is
-// the specific failure mode the multi-path admission check guards against
-// (helix-ubuntu pulls fill /var/lib/docker, not /hydra-data).
+// measures by default. /var/lib/docker (image layers, the original
+// ENOSPC-during-pull site) and /hydra-data (hydra state, zvol-equivalent
+// storage) exist in every Helix sandbox runtime: the K8s helix-sandbox
+// chart, docker-compose dev, and the Mac UTM VM all mount or create them.
+// Statfs-ing only /var/lib/docker would miss fills on /hydra-data, which is
+// the specific failure mode the multi-path admission check guards against.
+//
+// /data (the workspace-data PVC) is deliberately NOT a default: it only
+// exists on the K8s helix-sandbox chart. The previous default included it
+// and that caused fail-closed admission in local dev environments where
+// /data does not exist (statfs ENOENT -> pathENOENT=true -> every start
+// refused). Chart deployments that want /data covered should set
+// HELIX_DISK_PRESSURE_PATHS="/var/lib/docker,/hydra-data,/data" in Helm
+// values; see charts/helix-sandbox/values.yaml sandbox.extraEnv.
 var defaultDiskPressurePaths = []string{
 	"/var/lib/docker",
 	"/hydra-data",
-	"/data",
 }
 
 // diskPressurePaths returns the list of filesystem paths the statfs backend
@@ -178,7 +187,10 @@ var defaultDiskPressurePaths = []string{
 //  2. HELIX_DISK_PRESSURE_PATH (singular, kept for backwards compatibility
 //     with deployments that adopted the original single-path fallback):
 //     used as a one-element list when the plural form is unset.
-//  3. Default: defaultDiskPressurePaths, the three K8s PVC mount points.
+//  3. Default: defaultDiskPressurePaths (/var/lib/docker, /hydra-data) -
+//     paths that exist in every Helix sandbox runtime. K8s chart
+//     deployments wanting /data covered must opt in via the env var; see
+//     defaultDiskPressurePaths for the rationale.
 //
 // The admission check uses the LOWEST free percentage across the returned
 // paths, so adding paths only ever makes the guard stricter.

--- a/api/pkg/hydra/disk_pressure_test.go
+++ b/api/pkg/hydra/disk_pressure_test.go
@@ -494,11 +494,26 @@ func (s *DiskPressureStatfsSuite) TestPoolFreeBytes_StatfsFallback() {
 // diskPressurePaths: env parsing + defaults
 // -----------------------------------------------------------------------
 
-func (s *DiskPressureStatfsSuite) TestDiskPressurePaths_DefaultIsK8sLayout() {
-	// Default must cover the three PVC mount points the helix-sandbox chart
-	// provisions. Without /var/lib/docker the original ENOSPC-during-pull
-	// failure mode would still slip past the guard.
-	assert.Equal(s.T(), []string{"/var/lib/docker", "/hydra-data", "/data"}, diskPressurePaths())
+func (s *DiskPressureStatfsSuite) TestDiskPressurePaths_DefaultIsRuntimeUbiquitous() {
+	// Default must cover paths that exist in every Helix sandbox runtime
+	// (K8s chart, docker-compose dev, Mac UTM VM). Without /var/lib/docker
+	// the original ENOSPC-during-pull failure mode would still slip past
+	// the guard. /data is deliberately excluded from the default because
+	// it only exists on the K8s chart; including it broke local dev by
+	// triggering fail-closed admission (ENOENT) on every start.
+	assert.Equal(s.T(), []string{"/var/lib/docker", "/hydra-data"}, diskPressurePaths())
+}
+
+func (s *DiskPressureStatfsSuite) TestDiskPressurePaths_DefaultExcludesWorkspaceData() {
+	// Regression guard: /data must NOT be in the default. It is a
+	// K8s-chart-specific PVC mount; including it caused fail-closed
+	// admission on every non-K8s deployment (docker-compose dev, UTM)
+	// because statfs returned ENOENT for /data and the multi-path probe
+	// marks pathENOENT=true, refusing every sandbox start. Operators on
+	// the K8s chart opt in via HELIX_DISK_PRESSURE_PATHS instead.
+	for _, p := range diskPressurePaths() {
+		assert.NotEqual(s.T(), "/data", p, "/data must not be in default disk-pressure paths")
+	}
 }
 
 func (s *DiskPressureStatfsSuite) TestDiskPressurePaths_SingularBackCompat() {

--- a/charts/helix-sandbox/values.yaml
+++ b/charts/helix-sandbox/values.yaml
@@ -94,6 +94,15 @@ sandbox:
   #   extraEnv:
   #     - name: HELIX_SANDBOX_APT_MIRROR
   #       value: "http://apt.internal/ubuntu"
+  #
+  # Disk-pressure admission paths: the chart provisions three PVCs
+  # (docker-storage /var/lib/docker, hydra-data /hydra-data, workspace-data
+  # /data). The hydra default only watches the first two because /data does
+  # not exist outside this chart. To extend coverage to /data on chart
+  # deployments, set:
+  #   extraEnv:
+  #     - name: HELIX_DISK_PRESSURE_PATHS
+  #       value: "/var/lib/docker,/hydra-data,/data"
   extraEnv: []
 
 # Hydra configuration (multi-tenant container isolation)


### PR DESCRIPTION
## Summary

Drop `/data` from the hydra disk-pressure statfs default path list. The multi-path admission control added in https://github.com/helixml/helix/pull/2712 defaulted to `[/var/lib/docker, /hydra-data, /data]`. `/data` is a K8s-chart-specific PVC mount; outside the chart it does not exist, so the probe returns ENOENT, admission fails closed, and every sandbox-start is refused.

## Why

The previous default broke every non-K8s deployment of the sandbox:

- Local dev environments where `/data` does not exist (docker-compose dev stack, Mac UTM VM, any DinD setup without the helm chart) hit `statfs ENOENT` on the first sandbox-start.
- `statfsFreePercentMulti` sets `pathENOENT=true` on any ENOENT.
- `checkDiskPressureForStart` treats `pathENOENT` as fail-closed (correct for operator-set paths, but the default was effectively unconditionally operator-set here).
- Result: every sandbox-start gets refused with a misleading `disk pressure: path /data missing` error, on hosts that have plenty of disk.

`/data` only makes sense as a default for the `charts/helix-sandbox` deployment, which provisions a `workspace-data` PVC at that path. The K8s case is the minority; defaulting for it broke the majority.

## Fix

Narrow `defaultDiskPressurePaths` to:

```go
[]string{"/var/lib/docker", "/hydra-data"}
```

Both exist in every Helix sandbox runtime:

- K8s helix-sandbox chart: provisioned as `docker-storage` and `hydra-data` PVCs.
- docker-compose dev: created by the sandbox container.
- Mac UTM VM: created by the sandbox container.

The original ENOSPC-during-pull failure mode (which motivated https://github.com/helixml/helix/pull/2712) was a fill of `/var/lib/docker`, so the narrowed default still covers it. `/hydra-data` covers hydra state and zvol-equivalent storage.

## Migration for K8s operators

If you want `/data` (the chart's `workspace-data` PVC) covered, set this in your Helm values:

```yaml
sandbox:
  extraEnv:
    - name: HELIX_DISK_PRESSURE_PATHS
      value: "/var/lib/docker,/hydra-data,/data"
```

`charts/helix-sandbox/values.yaml` has been updated with this documented example next to the existing `sandbox.extraEnv` block.

## Test plan

- [x] `cd api && go build ./pkg/hydra/...` passes
- [x] `cd api && GOOS=linux go build ./pkg/hydra/...` cross-compile passes
- [x] `cd api && go test -run TestDiskPressure -v ./pkg/hydra/... -count=1` passes (all 35+ subtests including the existing trigger-path regression test that uses explicit `HELIX_DISK_PRESSURE_PATHS="/var/lib/docker,/hydra-data,/data"`)
- [x] New regression test `TestDiskPressurePaths_DefaultExcludesWorkspaceData` asserts `/data` stays out of the default
- [x] Existing `TestDiskPressurePaths_DefaultIsK8sLayout` renamed to `TestDiskPressurePaths_DefaultIsRuntimeUbiquitous` and updated to the two-path expectation
- [ ] K8s chart deployment: operator sets `HELIX_DISK_PRESSURE_PATHS` via `sandbox.extraEnv`, verifies refusal log names `/data` when that volume is full
- [ ] Local dev: sandbox-start succeeds without the spurious `/data missing` refusal

## Out of scope

- Not changing the refuse / stop thresholds.
- Not changing the configured-vs-default ENOENT semantics (operator-set paths still fail closed on missing path; that is correct behaviour).
- Not adding a new chart values field for disk-pressure (operators already have `sandbox.extraEnv`). A dedicated structured field could be a separate PR if anyone wants it.
- Not touching the ZFS backend.