### PR TITLE
fix(hydra): gate statfs disk-pressure code to unix builds

### DIFF
--- a/api/pkg/hydra/disk_pressure.go
+++ b/api/pkg/hydra/disk_pressure.go
@@ -2,13 +2,11 @@ package hydra
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -215,125 +213,10 @@ func diskPressurePaths() []string {
 	return append([]string{}, defaultDiskPressurePaths...)
 }
 
-// statfsFn is the seam used to mock syscall.Statfs in tests. Production code
-// calls syscall.Statfs directly; tests can swap it to model ENOENT, zero-block
-// devices, and pinned free-percentage scenarios without touching the real
-// filesystem.
-var statfsFn = func(path string, stat *syscall.Statfs_t) error {
-	return syscall.Statfs(path, stat)
-}
-
-// statfsFreePercent returns the percentage of `path`'s underlying filesystem
-// that is free, computed from a POSIX statfs(2) call.
-//
-// Uses Bavail (blocks available to non-root) rather than Bfree, matching the
-// semantics most operators reason about ("df -h"). Bsize is cast to uint64
-// because it is int32 on Linux/Darwin (matches the existing pattern in
-// cmd/sandbox-heartbeat/main.go).
-//
-// Returns an error when statfs itself fails (e.g. ENOENT for a misconfigured
-// path) or when the filesystem reports zero total blocks (defensive, should
-// not happen on a real filesystem).
-func statfsFreePercent(path string) (float64, error) {
-	var stat syscall.Statfs_t
-	if err := statfsFn(path, &stat); err != nil {
-		return 0, fmt.Errorf("statfs %q failed: %w", path, err)
-	}
-	total := stat.Blocks * uint64(stat.Bsize)
-	avail := stat.Bavail * uint64(stat.Bsize)
-	if total == 0 {
-		return 0, fmt.Errorf("statfs %q reports zero total blocks", path)
-	}
-	return float64(avail) / float64(total) * 100, nil
-}
-
-// statfsFreeBytes returns the number of bytes available to non-root on the
-// filesystem backing `path`. Mirrors statfsFreePercent's error contract.
-func statfsFreeBytes(path string) (int64, error) {
-	var stat syscall.Statfs_t
-	if err := statfsFn(path, &stat); err != nil {
-		return 0, fmt.Errorf("statfs %q failed: %w", path, err)
-	}
-	avail := stat.Bavail * uint64(stat.Bsize)
-	return int64(avail), nil
-}
-
-// statfsFreePercentMulti runs statfsFreePercent against every path in `paths`
-// and returns the LOWEST free-percentage, the path that produced it, and a
-// pathENOENT flag set when any path returned ENOENT.
-//
-// Policy:
-//   - ENOENT on any path: pathENOENT=true. The start guard treats this as
-//     fail-closed because a missing path indicates operator misconfiguration
-//     (HELIX_DISK_PRESSURE_PATHS lists a directory that does not exist).
-//   - Non-ENOENT error on a path: log and skip that path. Other paths may
-//     still measure successfully; we want one bad mount to not blind the
-//     guard against the rest.
-//   - At least one successful measurement: return min(freePct) and the
-//     corresponding triggerPath. The caller threads triggerPath into refusal
-//     logs and user-facing errors so operators see which volume is full.
-//   - All paths errored without any ENOENT: return the last error so the
-//     caller falls open with the existing warn log.
-//
-// `paths` must be non-empty; callers should pass diskPressurePaths().
-func statfsFreePercentMulti(paths []string) (minPct float64, triggerPath string, pathENOENT bool, err error) {
-	if len(paths) == 0 {
-		return 0, "", false, fmt.Errorf("statfsFreePercentMulti: no paths configured")
-	}
-	have := false
-	var lastErr error
-	for _, p := range paths {
-		pct, perr := statfsFreePercent(p)
-		if perr != nil {
-			if errors.Is(perr, syscall.ENOENT) {
-				pathENOENT = true
-				lastErr = perr
-				log.Error().Err(perr).Str("path", p).
-					Msg("disk-pressure: configured path does not exist (set HELIX_DISK_PRESSURE_PATHS or create the directory)")
-				continue
-			}
-			lastErr = perr
-			log.Warn().Err(perr).Str("path", p).
-				Msg("disk-pressure: statfs failed for path, skipping (other paths may still measure)")
-			continue
-		}
-		if !have || pct < minPct {
-			minPct = pct
-			triggerPath = p
-			have = true
-		}
-	}
-	if !have {
-		if lastErr != nil {
-			return 0, "", pathENOENT, fmt.Errorf("statfs probe failed for all paths: %w", lastErr)
-		}
-		return 0, "", pathENOENT, fmt.Errorf("statfs probe failed for all paths")
-	}
-	return minPct, triggerPath, pathENOENT, nil
-}
-
-// statfsFreeBytesMulti returns the free-bytes reading from the SAME path
-// that statfsFreePercentMulti would identify as the constraining volume.
-// Picking the min-free-pct path (rather than e.g. the sum of free bytes
-// across all paths) keeps the GC reaper's before/after delta sensible: the
-// reaper reclaims space on the volume that is actually under pressure, so
-// the delta we surface should track that volume. ENOENT on the trigger path
-// is propagated to the caller so it can fail closed exactly like the start
-// guard.
-func statfsFreeBytesMulti(paths []string) (int64, string, bool, error) {
-	_, triggerPath, pathENOENT, err := statfsFreePercentMulti(paths)
-	if err != nil {
-		return 0, "", pathENOENT, err
-	}
-	free, ferr := statfsFreeBytes(triggerPath)
-	if ferr != nil {
-		if errors.Is(ferr, syscall.ENOENT) {
-			pathENOENT = true
-		}
-		return 0, triggerPath, pathENOENT, ferr
-	}
-	return free, triggerPath, pathENOENT, nil
-}
+// statfsFreePercentMulti and statfsFreeBytesMulti are implemented per-OS:
+//   - disk_pressure_statfs_unix.go: real syscall.Statfs-backed implementation
+//   - disk_pressure_statfs_windows.go: not-supported stubs (hydra is not
+//     deployed on windows; the CLI just needs to cross-compile)
 
 // measurement describes the result of a free-space probe. Backend identifies
 // which probe produced it (zfs / statfs / none) so callers can log and tests

--- a/api/pkg/hydra/disk_pressure_statfs_unix.go
+++ b/api/pkg/hydra/disk_pressure_statfs_unix.go
@@ -1,0 +1,131 @@
+//go:build unix
+
+package hydra
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+
+	"github.com/rs/zerolog/log"
+)
+
+// statfsFn is the seam used to mock syscall.Statfs in tests. Production code
+// calls syscall.Statfs directly; tests can swap it to model ENOENT, zero-block
+// devices, and pinned free-percentage scenarios without touching the real
+// filesystem.
+var statfsFn = func(path string, stat *syscall.Statfs_t) error {
+	return syscall.Statfs(path, stat)
+}
+
+// statfsFreePercent returns the percentage of `path`'s underlying filesystem
+// that is free, computed from a POSIX statfs(2) call.
+//
+// Uses Bavail (blocks available to non-root) rather than Bfree, matching the
+// semantics most operators reason about ("df -h"). Bsize is cast to uint64
+// because it is int32 on Linux/Darwin (matches the existing pattern in
+// cmd/sandbox-heartbeat/main.go).
+//
+// Returns an error when statfs itself fails (e.g. ENOENT for a misconfigured
+// path) or when the filesystem reports zero total blocks (defensive, should
+// not happen on a real filesystem).
+func statfsFreePercent(path string) (float64, error) {
+	var stat syscall.Statfs_t
+	if err := statfsFn(path, &stat); err != nil {
+		return 0, fmt.Errorf("statfs %q failed: %w", path, err)
+	}
+	total := stat.Blocks * uint64(stat.Bsize)
+	avail := stat.Bavail * uint64(stat.Bsize)
+	if total == 0 {
+		return 0, fmt.Errorf("statfs %q reports zero total blocks", path)
+	}
+	return float64(avail) / float64(total) * 100, nil
+}
+
+// statfsFreeBytes returns the number of bytes available to non-root on the
+// filesystem backing `path`. Mirrors statfsFreePercent's error contract.
+func statfsFreeBytes(path string) (int64, error) {
+	var stat syscall.Statfs_t
+	if err := statfsFn(path, &stat); err != nil {
+		return 0, fmt.Errorf("statfs %q failed: %w", path, err)
+	}
+	avail := stat.Bavail * uint64(stat.Bsize)
+	return int64(avail), nil
+}
+
+// statfsFreePercentMulti runs statfsFreePercent against every path in `paths`
+// and returns the LOWEST free-percentage, the path that produced it, and a
+// pathENOENT flag set when any path returned ENOENT.
+//
+// Policy:
+//   - ENOENT on any path: pathENOENT=true. The start guard treats this as
+//     fail-closed because a missing path indicates operator misconfiguration
+//     (HELIX_DISK_PRESSURE_PATHS lists a directory that does not exist).
+//   - Non-ENOENT error on a path: log and skip that path. Other paths may
+//     still measure successfully; we want one bad mount to not blind the
+//     guard against the rest.
+//   - At least one successful measurement: return min(freePct) and the
+//     corresponding triggerPath. The caller threads triggerPath into refusal
+//     logs and user-facing errors so operators see which volume is full.
+//   - All paths errored without any ENOENT: return the last error so the
+//     caller falls open with the existing warn log.
+//
+// `paths` must be non-empty; callers should pass diskPressurePaths().
+func statfsFreePercentMulti(paths []string) (minPct float64, triggerPath string, pathENOENT bool, err error) {
+	if len(paths) == 0 {
+		return 0, "", false, fmt.Errorf("statfsFreePercentMulti: no paths configured")
+	}
+	have := false
+	var lastErr error
+	for _, p := range paths {
+		pct, perr := statfsFreePercent(p)
+		if perr != nil {
+			if errors.Is(perr, syscall.ENOENT) {
+				pathENOENT = true
+				lastErr = perr
+				log.Error().Err(perr).Str("path", p).
+					Msg("disk-pressure: configured path does not exist (set HELIX_DISK_PRESSURE_PATHS or create the directory)")
+				continue
+			}
+			lastErr = perr
+			log.Warn().Err(perr).Str("path", p).
+				Msg("disk-pressure: statfs failed for path, skipping (other paths may still measure)")
+			continue
+		}
+		if !have || pct < minPct {
+			minPct = pct
+			triggerPath = p
+			have = true
+		}
+	}
+	if !have {
+		if lastErr != nil {
+			return 0, "", pathENOENT, fmt.Errorf("statfs probe failed for all paths: %w", lastErr)
+		}
+		return 0, "", pathENOENT, fmt.Errorf("statfs probe failed for all paths")
+	}
+	return minPct, triggerPath, pathENOENT, nil
+}
+
+// statfsFreeBytesMulti returns the free-bytes reading from the SAME path
+// that statfsFreePercentMulti would identify as the constraining volume.
+// Picking the min-free-pct path (rather than e.g. the sum of free bytes
+// across all paths) keeps the GC reaper's before/after delta sensible: the
+// reaper reclaims space on the volume that is actually under pressure, so
+// the delta we surface should track that volume. ENOENT on the trigger path
+// is propagated to the caller so it can fail closed exactly like the start
+// guard.
+func statfsFreeBytesMulti(paths []string) (int64, string, bool, error) {
+	_, triggerPath, pathENOENT, err := statfsFreePercentMulti(paths)
+	if err != nil {
+		return 0, "", pathENOENT, err
+	}
+	free, ferr := statfsFreeBytes(triggerPath)
+	if ferr != nil {
+		if errors.Is(ferr, syscall.ENOENT) {
+			pathENOENT = true
+		}
+		return 0, triggerPath, pathENOENT, ferr
+	}
+	return free, triggerPath, pathENOENT, nil
+}

--- a/api/pkg/hydra/disk_pressure_statfs_windows.go
+++ b/api/pkg/hydra/disk_pressure_statfs_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package hydra
+
+import "fmt"
+
+// Windows stubs for the statfs disk-pressure backend. Hydra is not deployed
+// on Windows; these exist solely so the CLI (and any other transitive
+// importer) can cross-compile to windows/amd64. At runtime they always
+// report "not supported", which causes measureDisk() to surface the
+// existing "all backends unavailable, fail-open" path in
+// checkDiskPressureForStart with a prominent warn log.
+
+func statfsFreePercentMulti(_ []string) (float64, string, bool, error) {
+	return 0, "", false, fmt.Errorf("statfs disk-pressure not supported on windows")
+}
+
+func statfsFreeBytesMulti(_ []string) (int64, string, bool, error) {
+	return 0, "", false, fmt.Errorf("statfs disk-pressure not supported on windows")
+}


### PR DESCRIPTION
## Summary

Fix-forward for the failing release-backend step that broke the 2.11.25 tag build at https://drone.lukemarsden.net/helixml/helix/2467. Splits the statfs disk-pressure functions into platform-conditional files so the package compiles on Windows.

## Why this broke

https://github.com/helixml/helix/pull/2712 added a statfs fallback for non-ZFS disk-pressure admission. The statfs functions call `syscall.Statfs` and `syscall.Statfs_t`, both unix-only in the Go stdlib.

The helix CLI's `release-backend` step cross-compiles for five targets (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64). `api/pkg/hydra` is pulled in transitively by the CLI, so it has to compile on every target. The Windows build fails:

```
Building helix-windows-amd64.exe
# github.com/helixml/helix/api/pkg/hydra
api/pkg/hydra/disk_pressure.go:222:48: undefined: syscall.Statfs_t
api/pkg/hydra/disk_pressure.go:223:17: undefined: syscall.Statfs
api/pkg/hydra/disk_pressure.go:238:19: undefined: syscall.Statfs_t
api/pkg/hydra/disk_pressure.go:253:19: undefined: syscall.Statfs_t
```

Per-PR CI for https://github.com/helixml/helix/pull/2712 and https://github.com/helixml/helix/pull/2713 only ran `GOOS=linux` cross-compile sanity, not `GOOS=windows`. The tag build caught it.

## Fix

Three files in `api/pkg/hydra/`:

- `disk_pressure.go`: drops the statfs implementations and the `syscall` / `errors` imports. Keeps the ZFS code, the `measureDisk` dispatcher, the monitor goroutine, the admission guard, env-var parsing.
- `disk_pressure_statfs_unix.go` (new, `//go:build unix`): owns `statfsFn`, `statfsFreePercent`, `statfsFreeBytes`, `statfsFreePercentMulti`, `statfsFreeBytesMulti`. The real syscall code lives here.
- `disk_pressure_statfs_windows.go` (new, `//go:build windows`): provides stubs for `statfsFreePercentMulti` / `statfsFreeBytesMulti` that return a "not supported on windows" error. The dispatcher falls open with a warn log. Hydra does not actually deploy on Windows; the CLI just has to compile.

## Test plan

All five release-backend cross-compile targets clean:

```
linux/amd64               ... OK
linux/arm64               ... OK
darwin/amd64              ... OK
darwin/arm64              ... OK
windows/amd64             ... OK
```

`go test -run TestDiskPressure -v ./pkg/hydra/... -count=1` -> PASS (same coverage as before, only on unix where the tests can compile).

## Out of scope

- Disk-pressure semantics, thresholds, and path defaults are unchanged.
- Not breaking the CLI -> hydra import chain. That is a larger structural change and not what is needed to unblock the tag build.

## Follow-up

The release-backend step should be added to per-PR CI as a build sanity check, so a windows-incompatible change does not block tag releases again. Out of scope for this PR; tracking separately.