### PR TITLE
docs(claude): require concise output, comments only for external docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@
 - **Current year: 2026** — include "2026" in web searches for current info
 - If you find yourself adding hacks or workarounds, **stop** — take a step back, root cause the issue, understand the wider context, and fix it properly. Don't always take the path of least resistance — we need maintainable code.
 - **Always give full URLs for PRs and issues** — never use the `owner/repo#123` shorthand format. Use `https://github.com/helixml/helix/pull/123` etc.
+- **Be concise. Only write comments when necessary for external documentation.**
 - See also: `.cursor/rules/*.mdc`
 
 ## FORBIDDEN ACTIONS


### PR DESCRIPTION
## Summary

Adds one line to the Communication Style section of `CLAUDE.md`:

> Be concise. Only write comments when necessary for external documentation.

## Why

Today's incident triage produced a lot of verbose intermediate output and inline-comment noise that nobody needed. The existing rules already nudge in this direction ("No docstrings or type annotations on code not being changed") but never stated the principle directly. Stating it up front in Communication Style makes it explicit.

The intent: comments are for callers / external readers (public API docs, runbook snippets), not for narrating what the code already says.

## Out of scope

Existing em-dash usage in the file is unchanged. Not rewriting the existing rules; this is a single-line addition.