### PR TITLE
ci(macos): make create-dmg non-blocking

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2282,6 +2282,11 @@ steps:
 
   # Step 3: Create DMG, sign, notarize, upload to R2
   - name: create-dmg
+    # Non-blocking: a Mac-client signing/notarization problem (e.g. an expired
+    # Apple Developer agreement) must not fail the tag build and block the
+    # server images + helm chart release. The DMG still builds; if notarize
+    # fails the step is marked failed-but-ignored and the release proceeds.
+    failure: ignore
     environment:
       PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/luke/go/bin
       KEYCHAIN_PASSWORD:


### PR DESCRIPTION
macOS create-dmg (build+sign+notarize+upload the Mac client) was failing the whole tag build on an Apple-side issue (expired Developer Program agreement, notarytool 403), gating the server images + helm chart release - 2.11.25/2.11.26 charts never published despite controlplane+sandbox images building fine. Add failure: ignore to create-dmg so a Mac-client signing/notarization problem no longer fails the build; DMG still builds, server images + charts publish regardless. Fix the Apple agreement separately to restore DMG upload.