### PR TITLE
Filter org-chart and non-external agents from spec task agent switchers

### DIFF
--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/robfig/cron/v3"
 	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
 )
 
 // AlternativeModelOption represents a provider/model combination for fallback substitution
@@ -345,6 +346,13 @@ func (s *HelixAPIServer) listOrganizationApps(ctx context.Context, user *types.U
 		return nil, system.NewHTTPError500(err.Error())
 	}
 
+	// Flag apps that back a Helix org-chart Worker so the frontend can hide
+	// them from the spec-task agent switchers. Done before the owner/member
+	// split so both return paths carry the flag.
+	if httpErr := s.markHelixOrgAgents(ctx, orgID, apps); httpErr != nil {
+		return nil, httpErr
+	}
+
 	// Org owners see all apps
 	if orgMembership.Role == types.OrganizationRoleOwner {
 		return apps, nil
@@ -360,6 +368,51 @@ func (s *HelixAPIServer) listOrganizationApps(ctx context.Context, user *types.U
 	}
 
 	return authorizedApps, nil
+}
+
+// markHelixOrgAgents sets IsHelixOrgAgent on any app that backs a Helix
+// org-chart Worker for the given org. Org-chart Workers only exist when the
+// helix-org feature is enabled and are always org-scoped, so this is a no-op
+// otherwise.
+func (s *HelixAPIServer) markHelixOrgAgents(ctx context.Context, orgID string, apps []*types.App) *system.HTTPError {
+	if !s.Cfg.HelixOrgEnabled || orgID == "" || len(apps) == 0 {
+		return nil
+	}
+
+	// helix-org shares helix's Postgres connection; reach the *gorm.DB via the
+	// same anonymous-interface accessor used by openOrgStore (helix_org.go).
+	accessor, ok := s.Store.(interface{ GormDB() *gorm.DB })
+	if !ok {
+		// A non-Postgres store means helix-org cannot be running either.
+		return nil
+	}
+
+	// org_worker_runtime_state holds one row per (org, worker, backend, key).
+	// The "helix" backend's "agent_app_id" value is the App backing that
+	// Worker — see api/pkg/org/infrastructure/runtime/helix/state.go.
+	var agentAppIDs []string
+	if err := accessor.GormDB().WithContext(ctx).
+		Table("org_worker_runtime_state").
+		Where("org_id = ? AND backend = ? AND key = ? AND value <> ?", orgID, "helix", "agent_app_id", "").
+		Distinct("value").
+		Pluck("value", &agentAppIDs).Error; err != nil {
+		return system.NewHTTPError500(fmt.Sprintf("failed to list helix-org agent apps: %s", err))
+	}
+
+	if len(agentAppIDs) == 0 {
+		return nil
+	}
+
+	orgAgents := make(map[string]struct{}, len(agentAppIDs))
+	for _, id := range agentAppIDs {
+		orgAgents[id] = struct{}{}
+	}
+	for _, app := range apps {
+		if _, ok := orgAgents[app.ID]; ok {
+			app.IsHelixOrgAgent = true
+		}
+	}
+	return nil
 }
 
 // createApp godoc

--- a/api/pkg/server/app_handlers_test.go
+++ b/api/pkg/server/app_handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/openai/manager"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
@@ -13,6 +14,51 @@ import (
 
 	"go.uber.org/mock/gomock"
 )
+
+// markHelixOrgAgents must be a no-op when the helix-org feature is disabled:
+// no app is flagged and the database is never touched (the mock store does not
+// implement GormDB, so any query would panic). This guards the no-regression
+// guarantee for the default (feature-off) configuration. The positive path
+// (flagging an app that backs an org-chart Worker) requires a live Postgres
+// org_worker_runtime_state table and is verified end-to-end, not here.
+func Test_markHelixOrgAgents_FeatureDisabled_NoOp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	server := &HelixAPIServer{
+		Store: store.NewMockStore(ctrl),
+		Cfg:   &config.ServerConfig{}, // HelixOrgEnabled defaults to false
+	}
+
+	apps := []*types.App{
+		{ID: "app_1"},
+		{ID: "app_2"},
+	}
+
+	httpErr := server.markHelixOrgAgents(context.Background(), "org_1", apps)
+	require.Nil(t, httpErr)
+	for _, app := range apps {
+		assert.False(t, app.IsHelixOrgAgent, "app %s should not be flagged when feature is off", app.ID)
+	}
+}
+
+// With the feature enabled but an empty org id there are no org-chart Workers
+// to consider, so it stays a no-op and never queries the database.
+func Test_markHelixOrgAgents_NoOrg_NoOp(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	server := &HelixAPIServer{
+		Store: store.NewMockStore(ctrl),
+		Cfg:   &config.ServerConfig{HelixOrgEnabled: true},
+	}
+
+	apps := []*types.App{{ID: "app_1"}}
+
+	httpErr := server.markHelixOrgAgents(context.Background(), "", apps)
+	require.Nil(t, httpErr)
+	assert.False(t, apps[0].IsHelixOrgAgent)
+}
 
 func Test_populateAppOwner_PopulateUser(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -1878,6 +1878,11 @@ type App struct {
 	Config    AppConfig `json:"config" gorm:"jsonb"`
 
 	User User `json:"user" gorm:"-"` // Owner user struct, populated by the server for organization views
+
+	// IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
+	// (see api/pkg/org). Computed at list time, not persisted, so the frontend
+	// can hide org-chart agents from the spec-task agent switchers.
+	IsHelixOrgAgent bool `json:"is_helix_org_agent" gorm:"-"`
 }
 
 type KeyPair struct {

--- a/frontend/src/components/session/SwitchAgentControl.tsx
+++ b/frontend/src/components/session/SwitchAgentControl.tsx
@@ -12,7 +12,7 @@ import AgentDropdown from "../agent/AgentDropdown";
 import useApps from "../../hooks/useApps";
 import useSnackbar from "../../hooks/useSnackbar";
 import { useGetSession, useSwitchAgent } from "../../services/sessionService";
-import { AGENT_TYPE_ZED_EXTERNAL } from "../../types";
+import { isSpecTaskSwitchableAgent } from "../../utils/apps";
 
 interface SwitchAgentControlProps {
   /** Session being viewed in the chat panel. The dropdown's current value
@@ -59,21 +59,24 @@ const SwitchAgentControl: FC<SwitchAgentControlProps> = ({
   const session = sessionResponse?.data;
   const switchMutation = useSwitchAgent(sessionId);
 
-  // Filter to zed_external agents — switching only makes sense between
-  // external-agent frameworks that run inside Zed.
-  const eligibleAgents = useMemo(() => {
-    if (!apps.apps) return [];
-    return apps.apps.filter((app) =>
-      app.config?.helix?.assistants?.some(
-        (a) => a.agent_type === AGENT_TYPE_ZED_EXTERNAL,
-      ),
-    );
-  }, [apps.apps]);
-
   // The dropdown value reflects the session's parent_app (the helix app the
   // agent was launched from). For sessions without parent_app the dropdown
   // shows "Select Agent" and any selection becomes a switch.
   const currentAppId = session?.parent_app || "";
+
+  // Switching only makes sense between external-agent frameworks that run
+  // inside Zed, and never to a Helix org-chart Worker agent — those belong to
+  // the org chart, not to spec tasks. The session's current agent is kept
+  // visible even if it would be filtered out, so its name still renders.
+  const eligibleAgents = useMemo(() => {
+    if (!apps.apps) return [];
+    const list = apps.apps.filter(isSpecTaskSwitchableAgent);
+    if (currentAppId && !list.some((a) => a.id === currentAppId)) {
+      const current = apps.apps.find((a) => a.id === currentAppId);
+      if (current) list.unshift(current);
+    }
+    return list;
+  }, [apps.apps, currentAppId]);
 
   const handleSelect = (newAppId: string) => {
     if (!sessionId || pending || newAppId === currentAppId) return;

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -75,7 +75,8 @@ import {
   useGetSession,
   GET_SESSION_QUERY_KEY,
 } from "../../services/sessionService";
-import { SESSION_TYPE_TEXT, AGENT_TYPE_ZED_EXTERNAL } from "../../types";
+import { SESSION_TYPE_TEXT } from "../../types";
+import { isSpecTaskSwitchableAgent } from "../../utils/apps";
 import {
   useUpdateSpecTask,
   useSpecTask,
@@ -244,23 +245,18 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   // Chat panel collapse state - when true, uses mobile-style tab layout even on desktop
   const [chatCollapsed, setChatCollapsed] = useState(false);
 
-  // Sort apps: zed_external agents first, then others
-  const sortedApps = useMemo(() => {
+  // Agents the task can switch to: external agents that are not part of the
+  // Helix org chart. The currently-assigned agent is kept visible even if it
+  // would be filtered out, so the dropdown selection stays valid.
+  const eligibleApps = useMemo(() => {
     if (!apps.apps) return [];
-    const zedExternalApps = apps.apps.filter(
-      (app) =>
-        app.config?.helix?.assistants?.some(
-          (a) => a.agent_type === AGENT_TYPE_ZED_EXTERNAL,
-        ) || app.config?.helix?.default_agent_type === AGENT_TYPE_ZED_EXTERNAL,
-    );
-    const otherApps = apps.apps.filter(
-      (app) =>
-        !app.config?.helix?.assistants?.some(
-          (a) => a.agent_type === AGENT_TYPE_ZED_EXTERNAL,
-        ) && app.config?.helix?.default_agent_type !== AGENT_TYPE_ZED_EXTERNAL,
-    );
-    return [...zedExternalApps, ...otherApps];
-  }, [apps.apps]);
+    const list = apps.apps.filter(isSpecTaskSwitchableAgent);
+    if (selectedAgent && !list.some((a) => a.id === selectedAgent)) {
+      const current = apps.apps.find((a) => a.id === selectedAgent);
+      if (current) list.unshift(current);
+    }
+    return list;
+  }, [apps.apps, selectedAgent]);
 
   // Get display settings from the task's app configuration
   const displaySettings = useMemo(() => {
@@ -1453,7 +1449,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
         <AgentDropdown
           value={selectedAgent}
           onChange={handleAgentChange}
-          agents={sortedApps}
+          agents={eligibleApps}
           label="Agent"
           disabled={updatingAgent}
           size="small"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -770,6 +770,10 @@ export interface IApp {
   owner: string;
   owner_type: IOwnerType;
   user?: IUser;
+  // True when this app backs a Helix org-chart Worker. Computed server-side at
+  // list time (not persisted); used to hide org-chart agents from the spec-task
+  // agent switchers.
+  is_helix_org_agent?: boolean;
 }
 
 export interface IAppUpdate {

--- a/frontend/src/utils/apps.test.ts
+++ b/frontend/src/utils/apps.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { isExternalAgent, isHelixOrgChartAgent, isSpecTaskSwitchableAgent } from './apps'
+import { IApp, AGENT_TYPE_ZED_EXTERNAL, AGENT_TYPE_HELIX_AGENT } from '../types'
+
+// Minimal IApp builder — only the fields the predicates read.
+const makeApp = (opts: {
+  agentType?: string
+  defaultAgentType?: string
+  isHelixOrgAgent?: boolean
+}): IApp =>
+  ({
+    id: 'app_test',
+    config: {
+      helix: {
+        assistants: opts.agentType ? [{ agent_type: opts.agentType }] : [],
+        default_agent_type: opts.defaultAgentType,
+      },
+    },
+    is_helix_org_agent: opts.isHelixOrgAgent,
+  } as unknown as IApp)
+
+describe('isExternalAgent', () => {
+  it('is true when an assistant is zed_external', () => {
+    expect(isExternalAgent(makeApp({ agentType: AGENT_TYPE_ZED_EXTERNAL }))).toBe(true)
+  })
+
+  it('is true when default_agent_type is zed_external', () => {
+    expect(isExternalAgent(makeApp({ defaultAgentType: AGENT_TYPE_ZED_EXTERNAL }))).toBe(true)
+  })
+
+  it('is false for a non-external agent', () => {
+    expect(isExternalAgent(makeApp({ agentType: AGENT_TYPE_HELIX_AGENT }))).toBe(false)
+  })
+})
+
+describe('isSpecTaskSwitchableAgent', () => {
+  it('keeps an external agent that is not part of the org chart', () => {
+    expect(
+      isSpecTaskSwitchableAgent(makeApp({ agentType: AGENT_TYPE_ZED_EXTERNAL })),
+    ).toBe(true)
+  })
+
+  it('drops an external agent that backs an org-chart Worker', () => {
+    const app = makeApp({ agentType: AGENT_TYPE_ZED_EXTERNAL, isHelixOrgAgent: true })
+    expect(isHelixOrgChartAgent(app)).toBe(true)
+    expect(isSpecTaskSwitchableAgent(app)).toBe(false)
+  })
+
+  it('drops a non-external agent', () => {
+    expect(
+      isSpecTaskSwitchableAgent(makeApp({ agentType: AGENT_TYPE_HELIX_AGENT })),
+    ).toBe(false)
+  })
+})

--- a/frontend/src/utils/apps.ts
+++ b/frontend/src/utils/apps.ts
@@ -1,6 +1,7 @@
 import {
   IApp,
   IAssistantConfig,
+  AGENT_TYPE_ZED_EXTERNAL,
 } from '../types'
 
 export const getAppImage = (app: IApp): string => {
@@ -76,6 +77,28 @@ export const getAssistantDescription = (app: IApp, assistantID: string): string 
   return assistant?.description || app.config.helix?.description || ''
 }
 
+
+// An "external" agent runs an external framework inside Zed (zed_external),
+// either as one of its assistants or as the app's default agent type.
+export const isExternalAgent = (app: IApp): boolean => {
+  return (
+    app.config?.helix?.assistants?.some(
+      (a) => a.agent_type === AGENT_TYPE_ZED_EXTERNAL,
+    ) || app.config?.helix?.default_agent_type === AGENT_TYPE_ZED_EXTERNAL
+  ) || false
+}
+
+// True when this app backs a Helix org-chart Worker (flagged server-side).
+// These belong to the org chart, not to spec tasks.
+export const isHelixOrgChartAgent = (app: IApp): boolean => {
+  return app.is_helix_org_agent === true
+}
+
+// Agents you can switch a spec task to: external agents that are not part of
+// the Helix org chart.
+export const isSpecTaskSwitchableAgent = (app: IApp): boolean => {
+  return isExternalAgent(app) && !isHelixOrgChartAgent(app)
+}
 
 export const getAssistant = (app: IApp, assistantID: string): IAssistantConfig | undefined => {
   if(!app || !app.config) return


### PR DESCRIPTION
## Summary

The spec task details page has two agent pickers — the live-switch control at the top of
the chat panel (`SwitchAgentControl`) and the details-panel selector (`AgentDropdown`). Both
listed agents that don't make sense for a spec task: non-external agents, and agents that
belong to the **Helix org chart** (Phil's org-chart-of-agents feature, `HELIX_ORG_ENABLED`).

This change limits both dropdowns to standalone external (`zed_external`) agents and hides
org-chart Worker agents. Agents owned by a customer organization are unaffected — only
org-chart Worker agents are excluded.

## Changes

**Backend**
- Added computed, non-persisted `App.IsHelixOrgAgent` (`json:"is_helix_org_agent"`,
  `gorm:"-"`).
- `markHelixOrgAgents` in `app_handlers.go` flags apps that back a Helix org-chart Worker by
  looking up `org_worker_runtime_state` (`backend='helix'`, `key='agent_app_id'`) for the
  org. Wired into the org-scoped apps listing only (org-chart agents are always org-scoped).
  Gated on `HELIX_ORG_ENABLED` — a complete no-op (no DB access) when the feature is off.
- Reaches the shared `*gorm.DB` via the same anonymous-interface accessor used by
  `openOrgStore`, so it adds no hard dependency on the concrete store type.
- Unit tests for the feature-off / no-org no-op paths.

**Frontend**
- Added `is_helix_org_agent?` to `IApp`.
- New shared predicates in `utils/apps.ts`: `isExternalAgent`, `isHelixOrgChartAgent`,
  `isSpecTaskSwitchableAgent` (+ unit tests).
- `SwitchAgentControl` and the details-panel selector both filter with
  `isSpecTaskSwitchableAgent`, and keep the currently active/assigned agent visible even if
  it would be filtered out.

## Testing

- `go build` clean; backend unit tests pass (gate no-op cases).
- Frontend `tsc --noEmit` clean; `vitest` predicate tests 6/6 pass.
- NOT verified end-to-end: org-chart Worker agents disappearing from the dropdowns requires
  `HELIX_ORG_ENABLED=true` and a hired AI Worker — the inner Helix runs with the feature off
  and the `org_worker_runtime_state` table absent. Verify on a feature-enabled stack.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kvsrtzmae6mz5qh17c6mjce2)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002165_filter-out-non-external/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002165_filter-out-non-external/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002165_filter-out-non-external/tasks.md)

🚀 Built with [Helix](https://helix.ml)