### PR TITLE
fix(provider): Anthropic providers send x-api-key not Bearer for /v1/models

### DIFF
--- a/api/pkg/openai/anthropic_models_regression_test.go
+++ b/api/pkg/openai/anthropic_models_regression_test.go
@@ -13,30 +13,39 @@ import (
 // Anthropic provider (no SetIsAnthropic) hits /v1/models with Authorization: Bearer
 // instead of x-api-key, causing Anthropic to return 401 "Invalid bearer token".
 func TestAnthropicModels_HeaderRegression(t *testing.T) {
-	var gotAuth, gotAPIKey string
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAuth = r.Header.Get("Authorization")
-		gotAPIKey = r.Header.Get("x-api-key")
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":[{"id":"claude-opus-4-1","display_name":"Claude","type":"model"}]}`))
-	}))
-	defer ts.Close()
+	// newServer returns a server plus a func that yields the captured headers
+	// from the last request — scoped per-subtest so parallelism/ordering can't
+	// leak captures between cases.
+	newServer := func() (*httptest.Server, func() (auth, apiKey string)) {
+		var gotAuth, gotAPIKey string
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			gotAPIKey = r.Header.Get("x-api-key")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":[{"id":"claude-opus-4-1","display_name":"Claude","type":"model"}]}`))
+		}))
+		return ts, func() (string, string) { return gotAuth, gotAPIKey }
+	}
 
 	t.Run("without SetIsAnthropic sends Bearer (the bug)", func(t *testing.T) {
+		ts, captured := newServer()
+		defer ts.Close()
 		client := NewWithOptions("sk-ant-test", ts.URL+"/v1", false, ClientOptions{})
 		_, _ = client.ListModels(context.Background())
-		require.Empty(t, gotAPIKey, "bug: x-api-key not sent")
-		require.NotEmpty(t, gotAuth, "bug: falls through to OpenAI Bearer path")
+		auth, apiKey := captured()
+		require.Empty(t, apiKey, "bug: x-api-key not sent")
+		require.NotEmpty(t, auth, "bug: falls through to OpenAI Bearer path")
 	})
 
-	gotAuth, gotAPIKey = "", ""
-
 	t.Run("with SetIsAnthropic sends x-api-key (the fix)", func(t *testing.T) {
+		ts, captured := newServer()
+		defer ts.Close()
 		client := NewWithOptions("sk-ant-test", ts.URL+"/v1", false, ClientOptions{})
 		client.SetIsAnthropic(true)
 		_, err := client.ListModels(context.Background())
 		require.NoError(t, err)
-		require.Equal(t, "sk-ant-test", gotAPIKey, "must send x-api-key")
-		require.Empty(t, gotAuth, "must not send Authorization Bearer")
+		auth, apiKey := captured()
+		require.Equal(t, "sk-ant-test", apiKey, "must send x-api-key")
+		require.Empty(t, auth, "must not send Authorization Bearer")
 	})
 }

--- a/api/pkg/openai/anthropic_models_regression_test.go
+++ b/api/pkg/openai/anthropic_models_regression_test.go
@@ -1,0 +1,42 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAnthropicModels_HeaderRegression reproduces the prod bug where a UI/DB-added
+// Anthropic provider (no SetIsAnthropic) hits /v1/models with Authorization: Bearer
+// instead of x-api-key, causing Anthropic to return 401 "Invalid bearer token".
+func TestAnthropicModels_HeaderRegression(t *testing.T) {
+	var gotAuth, gotAPIKey string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotAPIKey = r.Header.Get("x-api-key")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"claude-opus-4-1","display_name":"Claude","type":"model"}]}`))
+	}))
+	defer ts.Close()
+
+	t.Run("without SetIsAnthropic sends Bearer (the bug)", func(t *testing.T) {
+		client := NewWithOptions("sk-ant-test", ts.URL+"/v1", false, ClientOptions{})
+		_, _ = client.ListModels(context.Background())
+		require.Empty(t, gotAPIKey, "bug: x-api-key not sent")
+		require.NotEmpty(t, gotAuth, "bug: falls through to OpenAI Bearer path")
+	})
+
+	gotAuth, gotAPIKey = "", ""
+
+	t.Run("with SetIsAnthropic sends x-api-key (the fix)", func(t *testing.T) {
+		client := NewWithOptions("sk-ant-test", ts.URL+"/v1", false, ClientOptions{})
+		client.SetIsAnthropic(true)
+		_, err := client.ListModels(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "sk-ant-test", gotAPIKey, "must send x-api-key")
+		require.Empty(t, gotAuth, "must not send Authorization Bearer")
+	})
+}

--- a/api/pkg/openai/manager/anthropic_endpoint_test.go
+++ b/api/pkg/openai/manager/anthropic_endpoint_test.go
@@ -1,0 +1,76 @@
+package manager
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsAnthropicAPIEndpoint(t *testing.T) {
+	cases := []struct {
+		name string
+		ep   types.ProviderEndpoint
+		want bool
+	}{
+		{"canonical name", types.ProviderEndpoint{Name: "anthropic"}, true},
+		{"display name (EqualFold)", types.ProviderEndpoint{Name: "Anthropic"}, true},
+		{"base url match", types.ProviderEndpoint{Name: "custom", BaseURL: "https://api.anthropic.com/v1"}, true},
+		{"openai", types.ProviderEndpoint{Name: "openai", BaseURL: "https://api.openai.com/v1"}, false},
+		{"renamed proxy (known gap)", types.ProviderEndpoint{Name: "claude-prod", BaseURL: "https://gw.internal/anthropic"}, false},
+		{"vertex anthropic excluded", types.ProviderEndpoint{Name: "anthropic", VertexProjectID: "proj-1"}, false},
+		{"vertex googleapis not matched", types.ProviderEndpoint{Name: "x", BaseURL: "https://anthropic.googleapis.com"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isAnthropicAPIEndpoint(&tc.ep))
+		})
+	}
+}
+
+// Test_InitializeClient_AnthropicAuth covers the actual fix site: a DB/UI
+// ProviderEndpoint run through initializeClient must send x-api-key (not Bearer)
+// to /v1/models when it targets Anthropic, and Bearer otherwise.
+func (suite *MultiClientManagerTestSuite) Test_InitializeClient_AnthropicAuth() {
+	manager := NewProviderManager(suite.cfg, suite.store, nil, suite.modelInfoProvider)
+
+	cases := []struct {
+		name        string
+		ep          types.ProviderEndpoint
+		wantXAPIKey bool
+	}{
+		{"anthropic by name", types.ProviderEndpoint{Name: "anthropic", APIKey: "test-key"}, true},
+		{"Anthropic display name", types.ProviderEndpoint{Name: "Anthropic", APIKey: "test-key"}, true},
+		{"openai falls through to bearer", types.ProviderEndpoint{Name: "openai", APIKey: "test-key"}, false},
+		{"vertex excluded -> bearer", types.ProviderEndpoint{Name: "anthropic", VertexProjectID: "proj-1", APIKey: "test-key"}, false},
+	}
+
+	for _, tc := range cases {
+		suite.Run(tc.name, func() {
+			var gotXAPIKey, gotAuth string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotXAPIKey = r.Header.Get("x-api-key")
+				gotAuth = r.Header.Get("Authorization")
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"claude-x","display_name":"x","type":"model"}]}`))
+			}))
+			defer ts.Close()
+
+			tc.ep.BaseURL = ts.URL
+			client, err := manager.initializeClient(&tc.ep)
+			suite.Require().NoError(err)
+			_, _ = client.ListModels(context.Background())
+
+			if tc.wantXAPIKey {
+				suite.Equal("test-key", gotXAPIKey, "must send x-api-key")
+				suite.Empty(gotAuth, "must not send Authorization Bearer")
+			} else {
+				suite.Empty(gotXAPIKey, "must not send x-api-key")
+				suite.NotEmpty(gotAuth, "must send Authorization Bearer")
+			}
+		})
+	}
+}

--- a/api/pkg/openai/manager/anthropic_endpoint_test.go
+++ b/api/pkg/openai/manager/anthropic_endpoint_test.go
@@ -19,6 +19,7 @@ func TestIsAnthropicAPIEndpoint(t *testing.T) {
 		{"canonical name", types.ProviderEndpoint{Name: "anthropic"}, true},
 		{"display name (EqualFold)", types.ProviderEndpoint{Name: "Anthropic"}, true},
 		{"base url match", types.ProviderEndpoint{Name: "custom", BaseURL: "https://api.anthropic.com/v1"}, true},
+		{"lookalike host not matched", types.ProviderEndpoint{Name: "custom", BaseURL: "https://api.anthropic.com.proxy.evil.com/v1"}, false},
 		{"openai", types.ProviderEndpoint{Name: "openai", BaseURL: "https://api.openai.com/v1"}, false},
 		{"renamed proxy (known gap)", types.ProviderEndpoint{Name: "claude-prod", BaseURL: "https://gw.internal/anthropic"}, false},
 		{"vertex anthropic excluded", types.ProviderEndpoint{Name: "anthropic", VertexProjectID: "proj-1"}, false},

--- a/api/pkg/openai/manager/provider_manager.go
+++ b/api/pkg/openai/manager/provider_manager.go
@@ -286,6 +286,11 @@ func (m *MultiClientManager) updateClientAPIKeyFromFile(provider types.Provider,
 		TLSSkipVerify: m.cfg.Tools.TLSSkipVerify,
 	})
 
+	// Preserve x-api-key auth across key rotation for the Anthropic global provider.
+	if provider == types.ProviderAnthropic {
+		openaiClient.SetIsAnthropic(true)
+	}
+
 	loggedClient := logger.Wrap(m.cfg, provider, openaiClient, m.modelInfoProvider, m.billingLogger, m.logStores...)
 
 	m.globalClientsMu.Lock()

--- a/api/pkg/openai/manager/provider_manager.go
+++ b/api/pkg/openai/manager/provider_manager.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -438,8 +439,15 @@ func isAnthropicAPIEndpoint(endpoint *types.ProviderEndpoint) bool {
 	if endpoint.VertexProjectID != "" {
 		return false
 	}
-	return strings.EqualFold(endpoint.Name, string(types.ProviderAnthropic)) ||
-		strings.Contains(strings.ToLower(endpoint.BaseURL), "api.anthropic.com")
+	if strings.EqualFold(endpoint.Name, string(types.ProviderAnthropic)) {
+		return true
+	}
+	// Host-exact match so a lookalike like api.anthropic.com.proxy.evil.com
+	// does not match.
+	if u, err := url.Parse(endpoint.BaseURL); err == nil {
+		return strings.EqualFold(u.Hostname(), "api.anthropic.com")
+	}
+	return false
 }
 
 func (m *MultiClientManager) initializeClient(endpoint *types.ProviderEndpoint) (openai.Client, error) {

--- a/api/pkg/openai/manager/provider_manager.go
+++ b/api/pkg/openai/manager/provider_manager.go
@@ -425,6 +425,23 @@ func (m *MultiClientManager) GetClient(_ context.Context, req *GetClientRequest)
 	return nil, fmt.Errorf("no client found for provider: %s, available providers: [%s]", req.Provider, strings.Join(availableProviders, ", "))
 }
 
+// isAnthropicAPIEndpoint reports whether a DB/UI-configured provider endpoint
+// targets the direct Anthropic API and therefore needs x-api-key auth (not
+// Bearer) for /v1/models. Detection keys off the canonical provider name
+// (matching the frontend's `name === 'anthropic'` convention) or an
+// api.anthropic.com base URL. Vertex endpoints are excluded — they authenticate
+// via OAuth, not x-api-key.
+// ponytail: name/URL heuristic; the proper fix is an explicit provider-kind /
+// api-format field on ProviderEndpoint, which would also catch Anthropic
+// endpoints renamed and pointed at a proxy (not matched here today).
+func isAnthropicAPIEndpoint(endpoint *types.ProviderEndpoint) bool {
+	if endpoint.VertexProjectID != "" {
+		return false
+	}
+	return strings.EqualFold(endpoint.Name, string(types.ProviderAnthropic)) ||
+		strings.Contains(strings.ToLower(endpoint.BaseURL), "api.anthropic.com")
+}
+
 func (m *MultiClientManager) initializeClient(endpoint *types.ProviderEndpoint) (openai.Client, error) {
 	apiKey := endpoint.APIKey
 	if endpoint.APIKeyFromFile != "" {
@@ -450,10 +467,8 @@ func (m *MultiClientManager) initializeClient(endpoint *types.ProviderEndpoint) 
 	}, endpoint.Models...)
 
 	// DB/UI-configured Anthropic providers must use x-api-key auth (not Bearer) for
-	// /v1/models. Exclude Vertex (VertexProjectID set) — it routes via OAuth, not x-api-key.
-	if endpoint.VertexProjectID == "" &&
-		(endpoint.Name == string(types.ProviderAnthropic) ||
-			strings.Contains(strings.ToLower(endpoint.BaseURL), "api.anthropic.com")) {
+	// /v1/models. See isAnthropicAPIEndpoint.
+	if isAnthropicAPIEndpoint(endpoint) {
 		openaiClient.SetIsAnthropic(true)
 	}
 

--- a/api/pkg/openai/manager/provider_manager.go
+++ b/api/pkg/openai/manager/provider_manager.go
@@ -444,6 +444,14 @@ func (m *MultiClientManager) initializeClient(endpoint *types.ProviderEndpoint) 
 		TLSSkipVerify: m.cfg.Tools.TLSSkipVerify,
 	}, endpoint.Models...)
 
+	// DB/UI-configured Anthropic providers must use x-api-key auth (not Bearer) for
+	// /v1/models. Exclude Vertex (VertexProjectID set) — it routes via OAuth, not x-api-key.
+	if endpoint.VertexProjectID == "" &&
+		(endpoint.Name == string(types.ProviderAnthropic) ||
+			strings.Contains(strings.ToLower(endpoint.BaseURL), "api.anthropic.com")) {
+		openaiClient.SetIsAnthropic(true)
+	}
+
 	// If it's a personal endpoint, replace the billing logger with a NoopBillingLogger
 	billingLogger := m.billingLogger
 	if !endpoint.BillingEnabled && (endpoint.EndpointType == types.ProviderEndpointTypeUser || endpoint.EndpointType == types.ProviderEndpointTypeOrg) {


### PR DESCRIPTION
## Problem

Adding Anthropic as a provider via the UI fails with:

```
upstream models endpoint unreachable: failed to get models from
'https://api.anthropic.com/v1/models' provider: 401 Unauthorized -
{"type":"error","error":{"type":"authentication_error","message":"Invalid bearer token"}}
```

Zed agents using that provider also fail to authenticate. "Invalid bearer token" is the tell: Anthropic only emits that when an `Authorization: Bearer` header reaches it. API keys must go in `x-api-key`.

## Root cause

`RetryableClient.ListModels` dispatches to `listAnthropicModels` (which sends `x-api-key`) only when `c.isAnthropic` is true; otherwise it falls through to `listOpenAIModels` (which sends `Authorization: Bearer`).

The env/config provider path sets the flag (`SetIsAnthropic(true)`), but `initializeClient` — the DB/UI-configured provider path — never did. This regressed in commit `c6f57128f` which removed the `isAnthropicProvider(c.baseURL)` base-URL fallback from the dispatch, leaving the DB path with no way to be detected as Anthropic.

## Fix

Set `isAnthropic` in `initializeClient` for endpoints that target Anthropic (name `anthropic`, matching the UI's canonical name, or an `api.anthropic.com` base URL). Vertex endpoints are excluded since they authenticate via OAuth, not `x-api-key`.

## Test

`anthropic_models_regression_test.go` captures the auth header via httptest: without the flag the client sends `Authorization: Bearer` (the bug); with it, `x-api-key` (the fix).

NOT yet tested end-to-end against a live stack — needs `./stack rebuild api` then re-adding the provider in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)