### PR TITLE
feat(web-service): self-healing — health monitor, hydra re-adoption, restart policies

### DIFF
--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -447,6 +447,13 @@ func (dm *DevContainerManager) CreateDevContainer(ctx context.Context, req *Crea
 		Image:    resolvedImage,
 		Hostname: req.Hostname,
 		Env:      dm.buildEnv(req),
+		// Stamp the session id as a label so hydra can re-adopt the container
+		// (with the exact session id, no name-prefix guessing) after a hydra
+		// restart. Covers both spec-task (ses_*) and sandbox-API (sbx_*)
+		// containers — the latter were previously orphaned on restart.
+		Labels: map[string]string{
+			containerSessionIDLabel: req.SessionID,
+		},
 	}
 	if len(req.Entrypoint) > 0 {
 		containerConfig.Entrypoint = req.Entrypoint
@@ -2014,17 +2021,35 @@ func (dm *DevContainerManager) GetDevContainer(ctx context.Context, sessionID st
 		return nil, fmt.Errorf("dev container not found for session: %s", sessionID)
 	}
 
-	// Optionally refresh status from Docker
+	// Refresh status AND IP from Docker. The container's IP can change across
+	// a container restart; a stale cached IP causes "no route to host" 502s on
+	// the proxy path. Since the proxy calls GetDevContainer on every request,
+	// refreshing the IP here keeps routing correct without any retry logic.
 	dockerClient, err := dm.getDockerClient(dc.DockerSocket)
 	if err == nil {
 		defer dockerClient.Close()
 		inspect, err := dockerClient.ContainerInspect(ctx, dc.ContainerID)
 		if err == nil {
+			status := DevContainerStatusStopped
 			if inspect.State.Running {
-				dc.Status = DevContainerStatusRunning
-			} else {
-				dc.Status = DevContainerStatusStopped
+				status = DevContainerStatusRunning
 			}
+			ip := ""
+			for _, network := range inspect.NetworkSettings.Networks {
+				if network.IPAddress != "" {
+					ip = network.IPAddress
+					break
+				}
+			}
+			if ip == "" {
+				ip = inspect.NetworkSettings.IPAddress
+			}
+			dm.mu.Lock()
+			dc.Status = status
+			if ip != "" {
+				dc.IPAddress = ip
+			}
+			dm.mu.Unlock()
 		}
 	}
 
@@ -2086,58 +2111,63 @@ func (dm *DevContainerManager) RecoverDevContainersFromDocker(ctx context.Contex
 
 	recoveredCount := 0
 	for _, c := range containers {
-		// Check if this looks like a Helix dev container
-		// Container names are like "/sway-external-ses_xxx" or "/ubuntu-external-ses_xxx"
-		for _, name := range c.Names {
-			name = strings.TrimPrefix(name, "/")
-			if strings.Contains(name, "-external-") {
-				// Extract session ID from container name
-				// Format: {type}-external-{session_id_suffix}
-				parts := strings.Split(name, "-external-")
-				if len(parts) == 2 {
-					sessionIDSuffix := parts[1]
-					sessionID := "ses_" + sessionIDSuffix
+		name := ""
+		if len(c.Names) > 0 {
+			name = strings.TrimPrefix(c.Names[0], "/")
+		}
 
-					// Determine container type from prefix
-					containerType := DevContainerTypeSway
-					if strings.HasPrefix(name, "ubuntu") {
-						containerType = DevContainerTypeUbuntu
-					}
-
-					// Get container IP
-					ipAddress := ""
-					for _, net := range c.NetworkSettings.Networks {
-						ipAddress = net.IPAddress
-						break
-					}
-
-					dc := &DevContainer{
-						SessionID:     sessionID,
-						ContainerID:   c.ID,
-						ContainerName: name,
-						Status:        DevContainerStatusRunning,
-						IPAddress:     ipAddress,
-						ContainerType: containerType,
-						CreatedAt:     time.Unix(c.Created, 0),
-						DockerSocket:  dockerSocket,
-					}
-
-					dm.mu.Lock()
-					dm.containers[sessionID] = dc
-					dm.mu.Unlock()
-
-					// Start streaming logs for recovered container
-					go dm.streamContainerLogs(context.Background(), c.ID, name, dockerSocket)
-
-					recoveredCount++
-					log.Info().
-						Str("session_id", sessionID).
-						Str("container_id", c.ID[:12]).
-						Str("container_name", name).
-						Msg("Recovered dev container from Docker")
+		// Prefer the helix.session_id label — it carries the exact session id
+		// and covers BOTH spec-task (ses_*) and sandbox-API (sbx_*) containers.
+		// The latter (web-service hosting) were previously orphaned on restart
+		// because the name-based fallback below only matches "*-external-*".
+		sessionID := c.Labels[containerSessionIDLabel]
+		if sessionID == "" {
+			// Legacy fallback for containers created before the label existed:
+			// names like "ubuntu-external-<suffix>" → "ses_<suffix>".
+			for _, n := range c.Names {
+				n = strings.TrimPrefix(n, "/")
+				if parts := strings.Split(n, "-external-"); len(parts) == 2 {
+					sessionID = "ses_" + parts[1]
+					name = n
+					break
 				}
 			}
 		}
+		if sessionID == "" {
+			continue // not a Helix dev container
+		}
+
+		// Get container IP (fresh from this list — survives container restarts).
+		ipAddress := ""
+		for _, net := range c.NetworkSettings.Networks {
+			ipAddress = net.IPAddress
+			break
+		}
+
+		dc := &DevContainer{
+			SessionID:     sessionID,
+			ContainerID:   c.ID,
+			ContainerName: name,
+			Status:        DevContainerStatusRunning,
+			IPAddress:     ipAddress,
+			ContainerType: containerTypeForName(name),
+			CreatedAt:     time.Unix(c.Created, 0),
+			DockerSocket:  dockerSocket,
+		}
+
+		dm.mu.Lock()
+		dm.containers[sessionID] = dc
+		dm.mu.Unlock()
+
+		// Start streaming logs for recovered container
+		go dm.streamContainerLogs(context.Background(), c.ID, name, dockerSocket)
+
+		recoveredCount++
+		log.Info().
+			Str("session_id", sessionID).
+			Str("container_id", c.ID[:12]).
+			Str("container_name", name).
+			Msg("Recovered dev container from Docker")
 	}
 
 	if recoveredCount > 0 {
@@ -2145,6 +2175,20 @@ func (dm *DevContainerManager) RecoverDevContainersFromDocker(ctx context.Contex
 	}
 
 	return nil
+}
+
+// containerTypeForName infers a DevContainerType from a container name for
+// recovery. Sandbox-API containers (sbx-*) are treated as headless; only the
+// container id/IP matter for proxy/exec, so this is best-effort.
+func containerTypeForName(name string) DevContainerType {
+	switch {
+	case strings.HasPrefix(name, "ubuntu"):
+		return DevContainerTypeUbuntu
+	case strings.HasPrefix(name, "sway"):
+		return DevContainerTypeSway
+	default:
+		return DevContainerTypeHeadless
+	}
 }
 
 // getDesktopVersion reads the version file for the given container type.

--- a/api/pkg/hydra/types.go
+++ b/api/pkg/hydra/types.go
@@ -18,6 +18,12 @@ type HealthResponse struct {
 	Version         string `json:"version"`
 }
 
+// containerSessionIDLabel is the Docker label hydra stamps on every dev
+// container with its session id, so hydra can re-adopt running containers
+// (with the exact session id) after a restart — see
+// DevContainerManager.RecoverDevContainersFromDocker.
+const containerSessionIDLabel = "helix.session_id"
+
 // DevContainerType represents the type of dev container
 type DevContainerType string
 

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -725,6 +725,10 @@ func (apiServer *HelixAPIServer) ListenAndServe(ctx context.Context, _ *system.C
 	// Reap expired sandboxes (Sandboxes API).
 	go apiServer.sandboxController.StartReaper(ctx, time.Minute)
 
+	// Probe live web services and auto-recover any that stop responding
+	// (crashed/hung stack heals without a human).
+	go webservice.NewHealthMonitor(apiServer.Store, apiServer.webServiceController, apiServer.sandboxController).Start(ctx)
+
 	// Reap stale runner registrations: sandbox_instances rows whose
 	// last_seen is older than the stale-threshold get their status
 	// flipped to "offline" so the admin UI + the FindAvailable selector

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -913,5 +913,6 @@ type Store interface {
 	UpdateWebServiceDeploy(ctx context.Context, id string, updates map[string]interface{}) error
 	ListWebServiceDeploys(ctx context.Context, projectID string, limit int) ([]*types.WebServiceDeploy, error)
 	ListEnabledWebServiceProjectsByRepo(ctx context.Context, repoID string) ([]*types.Project, error)
+	ListActiveWebServices(ctx context.Context) ([]*types.ProjectWebServiceState, error)
 	ListPendingVHostRoutes(ctx context.Context, limit int) ([]*types.VHostRoute, error)
 }

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -4206,6 +4206,21 @@ func (mr *MockStoreMockRecorder) ListAccessGrants(ctx, q any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccessGrants", reflect.TypeOf((*MockStore)(nil).ListAccessGrants), ctx, q)
 }
 
+// ListActiveWebServices mocks base method.
+func (m *MockStore) ListActiveWebServices(ctx context.Context) ([]*types.ProjectWebServiceState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListActiveWebServices", ctx)
+	ret0, _ := ret[0].([]*types.ProjectWebServiceState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListActiveWebServices indicates an expected call of ListActiveWebServices.
+func (mr *MockStoreMockRecorder) ListActiveWebServices(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListActiveWebServices", reflect.TypeOf((*MockStore)(nil).ListActiveWebServices), ctx)
+}
+
 // ListAgentRunners mocks base method.
 func (m *MockStore) ListAgentRunners(ctx context.Context, query types.ListAgentRunnersQuery) ([]*types.AgentRunner, int64, error) {
 	m.ctrl.T.Helper()
@@ -4402,6 +4417,21 @@ func (mr *MockStoreMockRecorder) ListExpiredSandboxes(ctx, now any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExpiredSandboxes", reflect.TypeOf((*MockStore)(nil).ListExpiredSandboxes), ctx, now)
 }
 
+// ListExternalAgentSessionIDs mocks base method.
+func (m *MockStore) ListExternalAgentSessionIDs(ctx context.Context, cutoff time.Time) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListExternalAgentSessionIDs", ctx, cutoff)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListExternalAgentSessionIDs indicates an expected call of ListExternalAgentSessionIDs.
+func (mr *MockStoreMockRecorder) ListExternalAgentSessionIDs(ctx, cutoff any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExternalAgentSessionIDs", reflect.TypeOf((*MockStore)(nil).ListExternalAgentSessionIDs), ctx, cutoff)
+}
+
 // ListGitProviderConnections mocks base method.
 func (m *MockStore) ListGitProviderConnections(ctx context.Context, userID string) ([]*types.GitProviderConnection, error) {
 	m.ctrl.T.Helper()
@@ -4460,21 +4490,6 @@ func (m *MockStore) ListIdleDesktops(ctx context.Context, idleSince time.Time) (
 func (mr *MockStoreMockRecorder) ListIdleDesktops(ctx, idleSince any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIdleDesktops", reflect.TypeOf((*MockStore)(nil).ListIdleDesktops), ctx, idleSince)
-}
-
-// ListExternalAgentSessionIDs mocks base method.
-func (m *MockStore) ListExternalAgentSessionIDs(ctx context.Context, cutoff time.Time) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListExternalAgentSessionIDs", ctx, cutoff)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListExternalAgentSessionIDs indicates an expected call of ListExternalAgentSessionIDs.
-func (mr *MockStoreMockRecorder) ListExternalAgentSessionIDs(ctx, cutoff any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExternalAgentSessionIDs", reflect.TypeOf((*MockStore)(nil).ListExternalAgentSessionIDs), ctx, cutoff)
 }
 
 // ListInteractions mocks base method.
@@ -5789,20 +5804,6 @@ func (mr *MockStoreMockRecorder) SetActiveWebServiceSandbox(ctx, projectID, sand
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetActiveWebServiceSandbox", reflect.TypeOf((*MockStore)(nil).SetActiveWebServiceSandbox), ctx, projectID, sandboxID)
 }
 
-// SetWebServiceHostDeviceID mocks base method.
-func (m *MockStore) SetWebServiceHostDeviceID(ctx context.Context, projectID, hostDeviceID string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetWebServiceHostDeviceID", ctx, projectID, hostDeviceID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetWebServiceHostDeviceID indicates an expected call of SetWebServiceHostDeviceID.
-func (mr *MockStoreMockRecorder) SetWebServiceHostDeviceID(ctx, projectID, hostDeviceID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWebServiceHostDeviceID", reflect.TypeOf((*MockStore)(nil).SetWebServiceHostDeviceID), ctx, projectID, hostDeviceID)
-}
-
 // SetLicenseKey mocks base method.
 func (m *MockStore) SetLicenseKey(ctx context.Context, licenseKey string) error {
 	m.ctrl.T.Helper()
@@ -5929,6 +5930,20 @@ func (m *MockStore) SetSandboxStatus(ctx context.Context, id string, status type
 func (mr *MockStoreMockRecorder) SetSandboxStatus(ctx, id, status, message any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSandboxStatus", reflect.TypeOf((*MockStore)(nil).SetSandboxStatus), ctx, id, status, message)
+}
+
+// SetWebServiceHostDeviceID mocks base method.
+func (m *MockStore) SetWebServiceHostDeviceID(ctx context.Context, projectID, hostDeviceID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetWebServiceHostDeviceID", ctx, projectID, hostDeviceID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetWebServiceHostDeviceID indicates an expected call of SetWebServiceHostDeviceID.
+func (mr *MockStoreMockRecorder) SetWebServiceHostDeviceID(ctx, projectID, hostDeviceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWebServiceHostDeviceID", reflect.TypeOf((*MockStore)(nil).SetWebServiceHostDeviceID), ctx, projectID, hostDeviceID)
 }
 
 // SpawnWorkSession mocks base method.

--- a/api/pkg/store/vhost.go
+++ b/api/pkg/store/vhost.go
@@ -260,6 +260,20 @@ func (s *PostgresStore) ListEnabledWebServiceProjectsByRepo(ctx context.Context,
 	return rows, nil
 }
 
+// ListActiveWebServices returns every project web-service state that is
+// enabled and has a live deployment (an active sandbox). Used by the
+// health-monitor to probe and auto-recover running web services.
+func (s *PostgresStore) ListActiveWebServices(ctx context.Context) ([]*types.ProjectWebServiceState, error) {
+	var rows []*types.ProjectWebServiceState
+	err := s.gdb.WithContext(ctx).
+		Where("enabled = ? AND active_sandbox_id <> ''", true).
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
 // ListWebServiceDeploys returns the most recent N deploys for a project,
 // newest first.
 func (s *PostgresStore) ListWebServiceDeploys(ctx context.Context, projectID string, limit int) ([]*types.WebServiceDeploy, error) {

--- a/api/pkg/webservice/controller.go
+++ b/api/pkg/webservice/controller.go
@@ -203,6 +203,11 @@ func (c *Controller) runDeploy(
 		return
 	}
 
+	// Make the hosted containers self-heal on crash. The compose file is
+	// user-controlled, so we enforce the restart policy from our side once the
+	// app is up. Best-effort — never fails the deploy.
+	c.applyRestartPolicy(ctx, sb)
+
 	// Same sandbox across deploys, but keep active_sandbox_id authoritative.
 	if err := c.store.SetActiveWebServiceSandbox(ctx, req.ProjectID, sb.ID); err != nil {
 		c.markFailed(ctx, deployID, sb.ID, fmt.Sprintf("set active sandbox: %s", err))
@@ -212,6 +217,111 @@ func (c *Controller) runDeploy(
 	// Mark this deploy live; supersede the previous live row if any.
 	c.markLive(ctx, deployID, sb.ID)
 	c.markSupersededPrevious(ctx, deployID, req.ProjectID)
+}
+
+// applyRestartPolicy sets restart=unless-stopped on every container in the
+// web-service sandbox so a crashed app container is brought back automatically
+// by the inner dockerd. The compose file is user-controlled, so we enforce
+// this from our side. Best-effort: logs and swallows errors.
+func (c *Controller) applyRestartPolicy(ctx context.Context, sb *types.Sandbox) {
+	hydraClient, err := c.sandboxes.HydraClient(sb)
+	if err != nil {
+		log.Warn().Err(err).Str("sandbox_id", sb.ID).Msg("web service: restart-policy: no hydra client")
+		return
+	}
+	cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	_, err = hydraClient.RunSandboxCommand(cctx, sb.ID, &hydra.ExecRequest{
+		SandboxID:      sb.ID,
+		Cmd:            "/bin/sh",
+		Args:           []string{"-c", `ids=$(docker ps -q); [ -n "$ids" ] && docker update --restart unless-stopped $ids >/dev/null || true`},
+		Cwd:            "/",
+		TimeoutSeconds: 25,
+	})
+	if err != nil {
+		log.Warn().Err(err).Str("sandbox_id", sb.ID).Msg("web service: failed to apply restart policy")
+	}
+}
+
+// sandboxDockerAlive returns true if the sandbox's inner dockerd answers a
+// quick `docker info`. Used by recovery to decide restart-in-place vs recreate.
+func (c *Controller) sandboxDockerAlive(ctx context.Context, sb *types.Sandbox) bool {
+	hydraClient, err := c.sandboxes.HydraClient(sb)
+	if err != nil {
+		return false
+	}
+	cctx, cancel := context.WithTimeout(ctx, 25*time.Second)
+	defer cancel()
+	resp, err := hydraClient.RunSandboxCommand(cctx, sb.ID, &hydra.ExecRequest{
+		SandboxID:      sb.ID,
+		Cmd:            "/bin/sh",
+		Args:           []string{"-c", "docker info >/dev/null 2>&1"},
+		Cwd:            "/",
+		TimeoutSeconds: 20,
+	})
+	if err != nil {
+		return false
+	}
+	if resp != nil && resp.ExitCode != nil && *resp.ExitCode != 0 {
+		return false
+	}
+	return true
+}
+
+// RecoverWebService brings a project's web service back to a serving state
+// after the health-monitor detects it down. It escalates:
+//  1. active sandbox row gone → Redeploy (provisions a fresh sandbox).
+//  2. sandbox not running, or its inner dockerd is unresponsive (the hung-
+//     dockerd failure that caused our outage) → delete the sandbox, then
+//     Redeploy. The broken container is removed via the OUTER docker, so a hung
+//     inner dockerd doesn't block it; the project-keyed /data (incl. Postgres)
+//     reattaches to the fresh sandbox.
+//  3. sandbox running + dockerd alive → Redeploy in place (re-runs
+//     .helix/startup.sh → docker compose up against the same sandbox).
+//
+// Redeploy is async; this returns once recovery has been kicked off.
+func (c *Controller) RecoverWebService(ctx context.Context, projectID string) error {
+	state, err := c.store.GetProjectWebServiceState(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("get web service state: %w", err)
+	}
+	if !state.Enabled || state.ActiveSandboxID == "" {
+		return nil // nothing to recover
+	}
+	project, err := c.store.GetProject(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("get project: %w", err)
+	}
+
+	recreate := false
+	reason := "restart in place"
+	sb, err := c.sandboxes.Get(ctx, state.ActiveSandboxID)
+	switch {
+	case err != nil || sb == nil:
+		reason = "active sandbox row is gone"
+		// Redeploy provisions a fresh sandbox; /data reattaches by project id.
+	case sb.Status != types.SandboxStatusRunning:
+		recreate, reason = true, fmt.Sprintf("sandbox status=%s", sb.Status)
+	case !c.sandboxDockerAlive(ctx, sb):
+		recreate, reason = true, "sandbox dockerd unresponsive"
+	}
+
+	if recreate {
+		log.Warn().Str("project_id", projectID).Str("sandbox_id", state.ActiveSandboxID).
+			Str("reason", reason).Msg("health-monitor: recreating web-service sandbox")
+		if delErr := c.sandboxes.Delete(context.Background(), state.ActiveSandboxID); delErr != nil {
+			log.Warn().Err(delErr).Str("sandbox_id", state.ActiveSandboxID).
+				Msg("health-monitor: failed to delete broken sandbox (continuing to redeploy)")
+		}
+	} else {
+		log.Info().Str("project_id", projectID).Str("reason", reason).
+			Msg("health-monitor: recovering web service")
+	}
+
+	if _, err := c.Redeploy(ctx, DeployRequest{ProjectID: projectID, Owner: project.UserID}); err != nil {
+		return fmt.Errorf("redeploy: %w", err)
+	}
+	return nil
 }
 
 // ensureSandbox returns the project's single web-service sandbox, creating it

--- a/api/pkg/webservice/health_monitor.go
+++ b/api/pkg/webservice/health_monitor.go
@@ -1,0 +1,143 @@
+package webservice
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/sandbox"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/rs/zerolog/log"
+)
+
+// HealthMonitor periodically probes every live project web service and
+// auto-recovers any that stop responding, so a crashed or hung stack heals
+// without a human. It follows the same ticker pattern as DomainVerifier and the
+// sandbox reaper.
+type HealthMonitor struct {
+	store      store.Store
+	controller *Controller
+	sandboxes  *sandbox.Controller
+
+	interval      time.Duration
+	probeTimeout  time.Duration
+	failThreshold int           // consecutive failed probes before recovery fires
+	cooldown      time.Duration // minimum gap between recoveries for one project
+
+	mu        sync.Mutex
+	fails     map[string]int       // projectID -> consecutive probe failures
+	lastRecov map[string]time.Time // projectID -> last recovery trigger time
+}
+
+// NewHealthMonitor builds a monitor with production-sane defaults: probe every
+// 30s, recover after ~90s of continuous failure, and don't re-recover the same
+// project more than once per 5 minutes (a cold redeploy can take minutes).
+func NewHealthMonitor(s store.Store, c *Controller, sb *sandbox.Controller) *HealthMonitor {
+	return &HealthMonitor{
+		store:         s,
+		controller:    c,
+		sandboxes:     sb,
+		interval:      30 * time.Second,
+		probeTimeout:  8 * time.Second,
+		failThreshold: 3,
+		cooldown:      5 * time.Minute,
+		fails:         map[string]int{},
+		lastRecov:     map[string]time.Time{},
+	}
+}
+
+// Start runs the monitor on a ticker until ctx is cancelled.
+func (m *HealthMonitor) Start(ctx context.Context) {
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+	log.Info().Dur("interval", m.interval).Msg("web-service health-monitor started")
+	for {
+		m.runOnce(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (m *HealthMonitor) runOnce(ctx context.Context) {
+	states, err := m.store.ListActiveWebServices(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("health-monitor: list active web services failed")
+		return
+	}
+	active := make(map[string]struct{}, len(states))
+	for _, st := range states {
+		active[st.ProjectID] = struct{}{}
+		if m.probe(ctx, st) {
+			m.reset(st.ProjectID)
+			continue
+		}
+		m.onFailure(st.ProjectID)
+	}
+	m.gc(active)
+}
+
+// probe returns true if the project's web service answers on its container
+// port through the hydra proxy. ProbeDevContainerPort errors on transport
+// failure / 4xx / 5xx (see hydra doRequest), so any of those count as down.
+func (m *HealthMonitor) probe(ctx context.Context, st *types.ProjectWebServiceState) bool {
+	sb, err := m.sandboxes.Get(ctx, st.ActiveSandboxID)
+	if err != nil || sb == nil || sb.Status != types.SandboxStatusRunning {
+		return false
+	}
+	hc, err := m.sandboxes.HydraClient(sb)
+	if err != nil {
+		return false
+	}
+	pctx, cancel := context.WithTimeout(ctx, m.probeTimeout)
+	defer cancel()
+	return hc.ProbeDevContainerPort(pctx, sb.ID, st.ContainerPort) == nil
+}
+
+func (m *HealthMonitor) reset(projectID string) {
+	m.mu.Lock()
+	delete(m.fails, projectID)
+	m.mu.Unlock()
+}
+
+// onFailure records a failed probe and, once the consecutive-failure threshold
+// is crossed (and we're not in cooldown), fires recovery in the background.
+func (m *HealthMonitor) onFailure(projectID string) {
+	m.mu.Lock()
+	m.fails[projectID]++
+	n := m.fails[projectID]
+	inCooldown := time.Since(m.lastRecov[projectID]) < m.cooldown
+	if n < m.failThreshold || inCooldown {
+		m.mu.Unlock()
+		return
+	}
+	m.lastRecov[projectID] = time.Now()
+	m.fails[projectID] = 0
+	m.mu.Unlock()
+
+	log.Warn().Str("project_id", projectID).Int("consecutive_failures", n).
+		Msg("health-monitor: web service unhealthy — triggering auto-recovery")
+	go func() {
+		// Detached from the tick ctx: recovery (a redeploy) can take minutes.
+		rctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+		defer cancel()
+		if err := m.controller.RecoverWebService(rctx, projectID); err != nil {
+			log.Error().Err(err).Str("project_id", projectID).Msg("health-monitor: auto-recovery failed")
+		}
+	}()
+}
+
+// gc drops failure counters for projects that are no longer active so the maps
+// don't grow unbounded.
+func (m *HealthMonitor) gc(active map[string]struct{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for pid := range m.fails {
+		if _, ok := active[pid]; !ok {
+			delete(m.fails, pid)
+		}
+	}
+}


### PR DESCRIPTION
Production-hardens project web-service hosting after a real incident on meta: a web-service sandbox's inner dockerd hung, the app went down, **nothing detected or recovered it**, and manual recovery cascaded — restarting the sandbox changed its IP (hydra cached the stale one → 502) and restarting hydra **orphaned the sandbox entirely** (404, hydra only re-adopted spec-task `*-external-` containers, not sandbox-API `sbx-*` ones). A transient hang became a ~30-min manual outage.

This is the **self-healing layer**. (The lean runtime to replace the GNOME desktop image is the agreed fast-follow.)

## Hydra (`api/pkg/hydra`)
- Stamp every dev container with a `helix.session_id` label at creation and **re-adopt by label** on hydra startup, so `sbx-*` web-service containers survive a hydra restart (name-parse kept as a legacy fallback).
- **Refresh the container IP** from Docker on every `GetDevContainer` (proxy path) — kills the stale-IP `no route to host` 502 class after a container restart.

## Web-service self-healing (`api/pkg/webservice`)
- **`HealthMonitor`** background loop: probes every live web service (30s); after ~90s of continuous failure auto-recovers, with a per-project cooldown + in-flight guard. Wired in server startup beside the other reapers.
- **`Controller.RecoverWebService`** escalates: restart in place → if the sandbox/dockerd is unresponsive (the hung-dockerd case), recreate the sandbox (delete + redeploy; the project-keyed `/data` incl. Postgres reattaches).
- **Restart policy** (`unless-stopped`) enforced on hosted containers after each deploy.
- `store.ListActiveWebServices` lists enabled services with an active sandbox.

## Verified end-to-end on meta
- App crash (`compose stop`) → monitor detected (`consecutive_failures=3`) → restart-in-place → **back to 200 in ~2 min, no human**.
- Hydra restart → escalation chose **recreate** (`reason="sandbox dockerd unresponsive"`); fresh sandbox came up labeled, DB reattached.
- `pkill hydra` with a labeled sandbox → web service **stayed 200** (re-adopted: `Recovered dev container ... session_id=sbx_...`); was a permanent 404 before.
- DB rows preserved across recreate (`/data` reattach).

## Notes / follow-ups
- The sandbox **dns-proxy** (serves `10.213.0.1:53` for sandbox DNS) is unsupervised and can die, breaking clones; worth supervising separately.
- Lean Docker runtime (drop the GNOME/streaming boot for web-service sandboxes) — fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)