### PR TITLE
fix(sandbox): dns-proxy supervisor must log to a file, not a pipe (SIGPIPE)

### DIFF
--- a/sandbox/05-start-dns-proxy.sh
+++ b/sandbox/05-start-dns-proxy.sh
@@ -39,13 +39,20 @@ for _ in $(seq 1 30); do
 done
 
 # Supervisor: keep dns-proxy alive for the lifetime of the container.
+#
+# Redirect to a log FILE rather than piping to `sed`/stdout. cont-init's stdout
+# is closed once init finishes, so a `... | sed` supervisor dies of SIGPIPE the
+# first time it writes after boot (silently leaving dns-proxy unsupervised).
+# Writing to a persistent file fd avoids that — this is exactly why the dockerd
+# supervisor in 04-start-dockerd.sh tees to /var/log/helix-services. The
+# log-tailer surfaces /var/log/helix-services/*.log in the Runner Logs stream.
+mkdir -p /var/log/helix-services 2>/dev/null || true
 (
     while true; do
         dns-proxy -listen "${GATEWAY}:53" -upstream "${UPSTREAM_DNS}"
-        code=$?
-        echo "[dns-proxy] exited (code ${code}); restarting in 2s..."
+        echo "[$(date -Iseconds)] dns-proxy exited (code $?); restarting in 2s..."
         sleep 2
     done
-) | sed -u 's/^/[DNS-PROXY] /' &
+) >> /var/log/helix-services/dns-proxy.log 2>&1 &
 
 echo "✅ DNS proxy supervisor started (${GATEWAY}:53 → ${UPSTREAM_DNS})"


### PR DESCRIPTION
Follow-up to #2721. The dns-proxy supervisor loop piped to `| sed` → stdout. cont-init closes stdout once init finishes, so the first post-boot write killed `sed` with SIGPIPE and tore down the supervisor — dns-proxy kept running but was no longer restarted if it died (the exact failure mode #2721 was meant to fix). Caught by a kill-test on the rebuilt image: killing dns-proxy did not bring it back.

Fix: redirect the supervisor loop to `/var/log/helix-services/dns-proxy.log` (a persistent fd) instead of piping to sed — the same reason `04-start-dockerd.sh` tees dockerd to a file. Verified on meta: `pkill dns-proxy` → supervisor auto-restarts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)