### PR TITLE
feat(webservice): mirror spec-task workspace layout in web-service deploys

### DIFF
--- a/api/pkg/webservice/controller.go
+++ b/api/pkg/webservice/controller.go
@@ -412,7 +412,7 @@ func (c *Controller) deployInPlace(ctx context.Context, sb *types.Sandbox, repo 
 		return err
 	}
 
-	script := deployScript(repo.CloneURL, sha, containerPort)
+	script := deployScript(repo.CloneURL, sha, repoDirName(repo), containerPort)
 
 	// Inject prod-scoped project secrets via the exec environment (NOT inlined
 	// into the shell script) so the values don't leak into command logs. The
@@ -527,23 +527,58 @@ func (c *Controller) lastLiveSHA(ctx context.Context, projectID string) string {
 	return ""
 }
 
-// deployScript builds the in-place deploy shell script. It stops any
-// previously-launched app (tracked via a pidfile under /data) BEFORE starting
-// the new one, guaranteeing a single writer of the durable /data dir. The app
-// is launched in its own session (setsid) so we can stop its whole process
-// group on the next deploy. It receives HELIX_WEB_SERVICE_PORT and
-// HELIX_WEB_SERVICE_DATA_DIR=/data — apps put their database/uploads under the
-// latter so state survives redeploys and reboots.
-func deployScript(cloneURL, sha string, containerPort int) string {
+// repoDirName returns a filesystem-safe single path component for the app
+// code checkout, mirroring the spec-task convention of cloning the primary
+// repo into a dir named after it (helix-run-startup-script.sh uses
+// $HOME/work/$HELIX_PRIMARY_REPO_NAME). Falls back to "app" when the name is
+// empty or unusable.
+func repoDirName(repo *types.GitRepository) string {
+	safe := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			return r
+		default:
+			return '-'
+		}
+	}, strings.TrimSpace(repo.Name))
+	safe = strings.Trim(safe, "-.")
+	if safe == "" {
+		return "app"
+	}
+	return safe
+}
+
+// deployScript builds the in-place deploy shell script. It reproduces the
+// spec-task agent workspace layout EXACTLY so a project's .helix/startup.sh
+// behaves identically in both contexts — no script can work in one and fail in
+// the other:
+//   - the app code is cloned into its own dir ($CODE = /workspace/<repo>),
+//   - the helix-specs branch is checked out as a SIBLING git worktree
+//     ($SPECS = /workspace/helix-specs) — never a subdir of the code, so
+//     `dirname "$0"/..` is the helix-specs worktree in both contexts (matching
+//     helix-run-startup-script.sh), not the code dir,
+//   - startup.sh is invoked with CWD = the code dir and
+//     $0 = $SPECS/.helix/startup.sh.
+//
+// It stops any previously-launched app (tracked via a pidfile under /data)
+// BEFORE starting the new one, guaranteeing a single writer of the durable
+// /data dir. The app is launched in its own session (setsid) so we can stop its
+// whole process group on the next deploy. It receives HELIX_WEB_SERVICE_PORT
+// and HELIX_WEB_SERVICE_DATA_DIR=/data — apps put their database/uploads under
+// the latter so state survives redeploys and reboots.
+func deployScript(cloneURL, sha, codeDir string, containerPort int) string {
+	code := "/workspace/" + codeDir
 	checkout := ""
 	if sha != "" {
-		checkout = "git checkout " + shellEscape(sha)
+		checkout = "git -C " + shellEscape(code) + " checkout " + shellEscape(sha)
 	}
 	return strings.Join([]string{
 		"set -e",
 		"mkdir -p /data /workspace",
 		"PIDFILE=/data/.helix-webservice.pid",
 		"LOGFILE=/data/.helix-webservice.log",
+		"CODE=" + shellEscape(code),
+		"SPECS=/workspace/helix-specs",
 		// Stop the previous app instance (single-writer guarantee). setsid made
 		// it a group leader, so PID == PGID and `kill -- -PID` stops the group.
 		`if [ -f "$PIDFILE" ]; then`,
@@ -555,33 +590,39 @@ func deployScript(cloneURL, sha string, containerPort int) string {
 		`  fi`,
 		`  rm -f "$PIDFILE"`,
 		"fi",
-		"cd /workspace",
 		// Embed the deploy token (passed via env, not the script string) into
 		// the clone URL so git can authenticate to Helix's private git server.
 		"CLONE_URL=" + shellEscape(cloneURL),
 		`if [ -n "${HELIX_GIT_TOKEN:-}" ]; then CLONE_URL=$(printf '%s' "$CLONE_URL" | sed -E "s#^(https?://)#\1api:${HELIX_GIT_TOKEN}@#"); fi`,
-		"if [ ! -d .git ]; then",
-		`  git clone --depth 50 "$CLONE_URL" .`,
-		"else",
-		// Refresh origin with the current token (the previous deploy's token
-		// has been revoked) so fetch authenticates.
-		`  git remote set-url origin "$CLONE_URL"`,
-		"fi",
-		"git fetch --all",
+		// Clone the app code into its own dir on first run; refresh origin (the
+		// previous deploy's token was revoked) otherwise.
+		`if [ ! -d "$CODE/.git" ]; then`,
+		`  git clone --depth 50 "$CLONE_URL" "$CODE"`,
+		`else`,
+		`  git -C "$CODE" remote set-url origin "$CLONE_URL"`,
+		`fi`,
+		`git -C "$CODE" fetch --all`,
 		checkout,
 		// The startup script is sourced exclusively from the project's
-		// helix-specs branch (its canonical Helix-metadata branch) — never
-		// from the deployed app branch — so there is a single definition of
-		// how the project boots. The app code still comes from the branch
-		// checked out above; only .helix/ is overlaid from helix-specs.
-		// Shallow clone implies --single-branch, so origin/helix-specs has no
-		// tracking ref; fetch it explicitly and overlay .helix from FETCH_HEAD.
-		"git fetch --depth 1 origin helix-specs && git checkout FETCH_HEAD -- .helix",
-		"chmod +x .helix/startup.sh 2>/dev/null || true",
-		"if [ ! -f .helix/startup.sh ]; then",
-		"  echo 'No .helix/startup.sh found on the helix-specs branch' >&2; exit 2",
-		"fi",
-		fmt.Sprintf(`setsid env HELIX_WEB_SERVICE_PORT=%d HELIX_WEB_SERVICE_DATA_DIR=/data bash .helix/startup.sh >"$LOGFILE" 2>&1 &`, containerPort),
+		// helix-specs branch (its canonical Helix-metadata branch) — never from
+		// the deployed app branch — so there is a single definition of how the
+		// project boots. Check it out as a SIBLING worktree of the code,
+		// detached at the fetched tip so redeploys never hit a branch-checkout
+		// conflict; remove any stale worktree first. Shallow clone implies
+		// --single-branch, so helix-specs must be fetched explicitly.
+		`git -C "$CODE" worktree remove --force "$SPECS" 2>/dev/null || true`,
+		`rm -rf "$SPECS"`,
+		`git -C "$CODE" fetch --depth 1 origin helix-specs`,
+		`git -C "$CODE" worktree add --force --detach "$SPECS" FETCH_HEAD`,
+		`if [ ! -f "$SPECS/.helix/startup.sh" ]; then`,
+		`  echo 'No .helix/startup.sh found on the helix-specs branch' >&2; exit 2`,
+		`fi`,
+		`chmod +x "$SPECS/.helix/startup.sh" 2>/dev/null || true`,
+		// Invoke exactly like the spec-task runner (helix-run-startup-script.sh):
+		// CWD = code root, $0 = the sibling helix-specs worktree. setsid → own
+		// process group for a clean stop on the next deploy.
+		`cd "$CODE"`,
+		fmt.Sprintf(`setsid env HELIX_WEB_SERVICE_PORT=%d HELIX_WEB_SERVICE_DATA_DIR=/data bash "$SPECS/.helix/startup.sh" >"$LOGFILE" 2>&1 &`, containerPort),
 		`echo $! > "$PIDFILE"`,
 	}, "\n")
 }

--- a/api/pkg/webservice/controller_test.go
+++ b/api/pkg/webservice/controller_test.go
@@ -74,7 +74,7 @@ func TestProjectSecretEnv(t *testing.T) {
 // script must kill the previous app instance BEFORE launching the new one, so
 // the durable /data dir is never opened by two processes at once.
 func TestDeployScriptStopsBeforeStart(t *testing.T) {
-	script := deployScript("https://github.com/o/r.git", "abc123", 3000)
+	script := deployScript("https://github.com/o/r.git", "abc123", "myrepo", 3000)
 
 	killIdx := strings.Index(script, "kill -TERM")
 	launchIdx := strings.Index(script, "startup.sh")
@@ -92,7 +92,7 @@ func TestDeployScriptStopsBeforeStart(t *testing.T) {
 // TestDeployScriptExportsDataDirAndPort — the app receives the durable data
 // dir and its port via env so it knows where to persist state.
 func TestDeployScriptExportsDataDirAndPort(t *testing.T) {
-	script := deployScript("https://github.com/o/r.git", "", 8080)
+	script := deployScript("https://github.com/o/r.git", "", "myrepo", 8080)
 	for _, want := range []string{
 		"HELIX_WEB_SERVICE_DATA_DIR=/data",
 		"HELIX_WEB_SERVICE_PORT=8080",
@@ -102,21 +102,49 @@ func TestDeployScriptExportsDataDirAndPort(t *testing.T) {
 			t.Errorf("deploy script missing %q:\n%s", want, script)
 		}
 	}
-	// No SHA → no SHA checkout (the quoted-SHA form). The .helix dir is always
-	// overlaid from the helix-specs branch, so a FETCH_HEAD checkout is expected.
-	if strings.Contains(script, "git checkout '") {
+	// No SHA → no SHA checkout (the quoted-SHA form).
+	if strings.Contains(script, "checkout '") {
 		t.Errorf("empty SHA should not produce a SHA checkout:\n%s", script)
 	}
-	if !strings.Contains(script, "git checkout FETCH_HEAD -- .helix") {
-		t.Errorf("startup script must be overlaid from the helix-specs branch:\n%s", script)
+	// The startup script is sourced from the helix-specs branch, checked out as
+	// a SIBLING worktree of the code (not overlaid into it).
+	if !strings.Contains(script, `worktree add --force --detach "$SPECS" FETCH_HEAD`) {
+		t.Errorf("helix-specs must be checked out as a sibling worktree:\n%s", script)
 	}
 }
 
-// TestDeployScriptChecksOutSHA — when a SHA is given it is checked out.
+// TestDeployScriptChecksOutSHA — when a SHA is given it is checked out (in the
+// code worktree).
 func TestDeployScriptChecksOutSHA(t *testing.T) {
-	script := deployScript("https://github.com/o/r.git", "deadbeef", 8080)
-	if !strings.Contains(script, "git checkout 'deadbeef'") {
+	script := deployScript("https://github.com/o/r.git", "deadbeef", "myrepo", 8080)
+	if !strings.Contains(script, "checkout 'deadbeef'") {
 		t.Errorf("expected checkout of the requested SHA:\n%s", script)
+	}
+}
+
+// TestDeployScriptMirrorsSpecTaskLayout encodes the core guarantee: the deploy
+// reproduces the spec-task workspace layout so a startup script behaves
+// identically in both contexts. The app code is cloned into its own dir and
+// helix-specs is a SIBLING worktree (never a subdir of the code); startup.sh is
+// invoked with CWD = the code dir and $0 = the helix-specs worktree.
+func TestDeployScriptMirrorsSpecTaskLayout(t *testing.T) {
+	script := deployScript("https://github.com/o/r.git", "", "myrepo", 8080)
+	for _, want := range []string{
+		`CODE='/workspace/myrepo'`,
+		`SPECS=/workspace/helix-specs`,
+		`git -C "$CODE" worktree add --force --detach "$SPECS" FETCH_HEAD`,
+		`cd "$CODE"`,
+		`bash "$SPECS/.helix/startup.sh"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("deploy script missing %q (spec-task layout parity):\n%s", want, script)
+		}
+	}
+	// helix-specs must be a SIBLING, not nested under the code dir — otherwise
+	// `dirname "$0"/..` resolves to the code dir in web-service but the
+	// helix-specs worktree in spec-task, re-introducing the asymmetry.
+	if strings.Contains(script, "/workspace/myrepo/helix-specs") {
+		t.Errorf("helix-specs must not be nested under the code dir:\n%s", script)
 	}
 }
 


### PR DESCRIPTION
Web-service deploys overlaid `.helix/` into the code checkout at `/workspace`, while spec-task agent sessions check out `helix-specs` as its own **sibling** worktree next to the code. That divergence let a startup script work in one context and fail in the other — a script computing its dir from `dirname "$0"/..` resolves to the code dir under the overlay but to the `helix-specs` worktree under spec-task (this bit find-ai: works as a web service, fails in a spec task).

This makes the web-service deploy reproduce the spec-task layout exactly:
- app code cloned into its own dir (`$CODE=/workspace/<repo>`),
- `helix-specs` checked out as a **sibling** worktree (`$SPECS=/workspace/helix-specs`) — never a subdir of the code,
- `startup.sh` invoked with `CWD=$CODE` and `$0=$SPECS/.helix/startup.sh`, mirroring `helix-run-startup-script.sh`.

Now no startup script can pass in one context and fail in the other. The only intentional difference stays: web-service sets `HELIX_WEB_SERVICE_PORT` (the explicit mode signal the script branches on).

## Testing
- Unit: `deployScript` tests updated + new `TestDeployScriptMirrorsSpecTaskLayout` encoding the guarantee. `go test ./pkg/webservice/...` green.
- Ran the new git-worktree mechanics against the **real find-ai bare repo**: clone-into-subdir, sibling worktree (detached FETCH_HEAD), invocation contract (`dirname $0/..` = helix-specs worktree, not code), redeploy idempotency — all verified.
- Air-rebuilt clean on meta (api serving 200).
- NOT yet live app-boot e2e on meta — gated on GitHub→Helix sync of the matching find-ai startup-script fix; will be validated in the next release.

Companion: helixml/find-ai `helix-specs` startup.sh updated to trust CWD instead of `$0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)