### PR TITLE
fix(webservice): health-monitor skips projects with an in-flight deploy

### DIFF
--- a/api/pkg/webservice/health_monitor.go
+++ b/api/pkg/webservice/health_monitor.go
@@ -71,6 +71,14 @@ func (m *HealthMonitor) runOnce(ctx context.Context) {
 	active := make(map[string]struct{}, len(states))
 	for _, st := range states {
 		active[st.ProjectID] = struct{}{}
+		// A deploy in flight (initial `docker compose up --build` or a redeploy)
+		// legitimately won't answer for minutes — don't treat that as unhealthy.
+		// Recovering mid-build needlessly restarts the stack, and for a slow build
+		// could repeatedly interrupt it. Skip and clear any accrued failures.
+		if m.deployInProgress(ctx, st.ProjectID) {
+			m.reset(st.ProjectID)
+			continue
+		}
 		if m.probe(ctx, st) {
 			m.reset(st.ProjectID)
 			continue
@@ -78,6 +86,21 @@ func (m *HealthMonitor) runOnce(ctx context.Context) {
 		m.onFailure(st.ProjectID)
 	}
 	m.gc(active)
+}
+
+// deployInProgress reports whether the project's most recent web-service deploy
+// is still pending or building. ListWebServiceDeploys returns newest-first.
+func (m *HealthMonitor) deployInProgress(ctx context.Context, projectID string) bool {
+	deploys, err := m.store.ListWebServiceDeploys(ctx, projectID, 1)
+	if err != nil || len(deploys) == 0 {
+		return false
+	}
+	switch deploys[0].Status {
+	case types.WebServiceDeployStatusPending, types.WebServiceDeployStatusBuilding:
+		return true
+	default:
+		return false
+	}
 }
 
 // probe returns true if the project's web service answers on its container

--- a/api/pkg/webservice/health_monitor_test.go
+++ b/api/pkg/webservice/health_monitor_test.go
@@ -1,0 +1,46 @@
+package webservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"go.uber.org/mock/gomock"
+)
+
+// TestHealthMonitorDeployInProgress: the monitor must NOT treat a project as
+// unhealthy while its latest deploy is still pending/building — otherwise it
+// races (and can interrupt) an in-flight initial deploy.
+func TestHealthMonitorDeployInProgress(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	st := store.NewMockStore(ctrl)
+	m := &HealthMonitor{store: st}
+	ctx := context.Background()
+
+	cases := []struct {
+		name   string
+		status types.WebServiceDeployStatus
+		want   bool
+	}{
+		{"pending", types.WebServiceDeployStatusPending, true},
+		{"building", types.WebServiceDeployStatusBuilding, true},
+		{"live", types.WebServiceDeployStatusLive, false},
+		{"failed", types.WebServiceDeployStatusFailed, false},
+		{"superseded", types.WebServiceDeployStatusSuperseded, false},
+	}
+	for _, c := range cases {
+		st.EXPECT().ListWebServiceDeploys(gomock.Any(), c.name, 1).
+			Return([]*types.WebServiceDeploy{{Status: c.status}}, nil)
+		if got := m.deployInProgress(ctx, c.name); got != c.want {
+			t.Errorf("%s: deployInProgress = %v, want %v", c.name, got, c.want)
+		}
+	}
+
+	// No deploys yet → not in progress (don't block probing a never-deployed row).
+	st.EXPECT().ListWebServiceDeploys(gomock.Any(), "none", 1).Return(nil, nil)
+	if m.deployInProgress(ctx, "none") {
+		t.Error("no deploys should not count as in-progress")
+	}
+}


### PR DESCRIPTION
The web-service health-monitor probed active services and recovered after 3 consecutive failures — but a fresh deploy's `docker compose up --build` legitimately 502s for minutes. So the monitor **raced the initial deploy** and fired a redundant restart-in-place (the benign `superseded` we saw on find-ai's first prod deploy); for a slow build it could repeatedly interrupt it.

Fix: skip recovery for any project whose latest `web_service_deploy` is `pending`/`building`, and clear accrued failures so a genuine post-deploy failure still recovers.

Unit test covers the status gate (pending/building → skip; live/failed/superseded/none → probe normally). `go test ./pkg/webservice/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)