### PR TITLE
feat(webservice): continuous delivery for GitHub-hosted apps

### DIFF
--- a/api/pkg/server/ensure_pull_request_test.go
+++ b/api/pkg/server/ensure_pull_request_test.go
@@ -122,6 +122,12 @@ func (f *fakeGitRepoService) PullFromRemote(_ context.Context, _, _ string, _ bo
 func (f *fakeGitRepoService) SyncAllBranches(_ context.Context, _ string, _ bool) error {
 	panic("SyncAllBranches unexpected")
 }
+func (f *fakeGitRepoService) SyncBaseBranch(_ context.Context, _, _ string) error {
+	panic("SyncBaseBranch unexpected")
+}
+func (f *fakeGitRepoService) GetLocalBranchSHA(_ context.Context, _, _ string) (string, error) {
+	panic("GetLocalBranchSHA unexpected")
+}
 func (f *fakeGitRepoService) GetExternalRepoStatus(_ context.Context, _, _ string) (*types.ExternalStatus, error) {
 	panic("GetExternalRepoStatus unexpected")
 }

--- a/api/pkg/server/git_repository_servicer.go
+++ b/api/pkg/server/git_repository_servicer.go
@@ -35,6 +35,8 @@ type gitRepositoryServicer interface {
 	PullFromRemote(ctx context.Context, repoID, branchName string, force bool) error
 	PushBranchToRemote(ctx context.Context, repoID, branchName string, force bool, userID ...string) error
 	SyncAllBranches(ctx context.Context, repoID string, force bool) error
+	SyncBaseBranch(ctx context.Context, repoID, branchName string) error
+	GetLocalBranchSHA(ctx context.Context, repoID, branch string) (string, error)
 	GetExternalRepoStatus(ctx context.Context, repoID, branchName string) (*types.ExternalStatus, error)
 	GetRepoLock(repoID string) *sync.Mutex
 	WithRepoLock(repoID string, fn func() error) error

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -729,6 +729,11 @@ func (apiServer *HelixAPIServer) ListenAndServe(ctx context.Context, _ *system.C
 	// (crashed/hung stack heals without a human).
 	go webservice.NewHealthMonitor(apiServer.Store, apiServer.webServiceController, apiServer.sandboxController).Start(ctx)
 
+	// Continuous delivery for agent-created apps: when a GitHub-hosted project's
+	// default branch advances (e.g. a PR is merged), redeploy its web service.
+	// (Helix-hosted repos already auto-deploy via the git post-receive hook.)
+	go webservice.NewGitHubDeployWatcher(apiServer.Store, apiServer.webServiceController, apiServer.gitRepositoryService).Start(ctx)
+
 	// Reap stale runner registrations: sandbox_instances rows whose
 	// last_seen is older than the stale-threshold get their status
 	// flipped to "offline" so the admin UI + the FindAvailable selector

--- a/api/pkg/services/git_repository_service.go
+++ b/api/pkg/services/git_repository_service.go
@@ -153,6 +153,21 @@ func (s *GitRepositoryService) GetGitHomePath() string {
 	return filepath.Join(s.filestoreBase, "git-home")
 }
 
+// GetLocalBranchSHA returns the commit SHA that the local mirror's <branch>
+// currently points at (refs/heads/<branch>). The web-service CD watcher uses
+// this — after a SyncBaseBranch — to detect when a GitHub default branch has
+// advanced and a redeploy is due.
+func (s *GitRepositoryService) GetLocalBranchSHA(ctx context.Context, repoID, branch string) (string, error) {
+	repoPath := filepath.Join(s.gitRepoBase, repoID)
+	stdout, _, err := gitcmd.NewCommand("rev-parse").
+		AddDynamicArguments("refs/heads/" + branch).
+		RunStdString(ctx, &gitcmd.RunOpts{Dir: repoPath})
+	if err != nil {
+		return "", fmt.Errorf("rev-parse refs/heads/%s in %s: %w", branch, repoID, err)
+	}
+	return strings.TrimSpace(stdout), nil
+}
+
 // Initialize creates the git repository base directory and sets up git server
 func (s *GitRepositoryService) Initialize(ctx context.Context) error {
 	// Create git repositories base directory

--- a/api/pkg/webservice/github_cd.go
+++ b/api/pkg/webservice/github_cd.go
@@ -1,0 +1,177 @@
+package webservice
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/rs/zerolog/log"
+)
+
+// GitSyncer is the slice of the git-repository service the CD watcher needs:
+// pull an external repo's branch into the local mirror, then read its HEAD.
+type GitSyncer interface {
+	SyncBaseBranch(ctx context.Context, repoID, branch string) error
+	GetLocalBranchSHA(ctx context.Context, repoID, branch string) (string, error)
+}
+
+// Redeployer is the slice of *Controller the watcher needs (mockable in tests).
+type Redeployer interface {
+	Redeploy(ctx context.Context, req DeployRequest) (*types.WebServiceDeploy, error)
+}
+
+// GitHubDeployWatcher gives agent-created apps continuous delivery: when a
+// project's GitHub default branch advances (e.g. a PR is merged), it redeploys
+// that project's web service.
+//
+// Helix's own git server fires onDefaultBranchPush for direct pushes, but
+// GitHub-hosted repos only reach Helix via a pull/sync — so a PR merged on
+// GitHub never triggers the push hook. This watcher closes that gap by polling
+// the external default branch and redeploying when it moves. It acts ONLY on
+// external repos; Helix-hosted repos already auto-deploy via the post-receive
+// hook and are skipped to avoid double-deploys.
+type GitHubDeployWatcher struct {
+	store      store.Store
+	controller Redeployer
+	git        GitSyncer
+
+	interval time.Duration
+
+	mu       sync.Mutex
+	lastSeen map[string]string // projectID -> last default-branch SHA deployed/baselined
+}
+
+// NewGitHubDeployWatcher polls every 60s — fast enough that "merge a PR → site
+// updates" feels immediate next to a build/deploy, without hammering GitHub.
+func NewGitHubDeployWatcher(s store.Store, c Redeployer, g GitSyncer) *GitHubDeployWatcher {
+	return &GitHubDeployWatcher{
+		store:      s,
+		controller: c,
+		git:        g,
+		interval:   60 * time.Second,
+		lastSeen:   map[string]string{},
+	}
+}
+
+// Start runs the watcher on a ticker until ctx is cancelled.
+func (w *GitHubDeployWatcher) Start(ctx context.Context) {
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+	log.Info().Dur("interval", w.interval).Msg("web-service GitHub CD watcher started")
+	for {
+		w.runOnce(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (w *GitHubDeployWatcher) runOnce(ctx context.Context) {
+	states, err := w.store.ListActiveWebServices(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("github-cd: list active web services failed")
+		return
+	}
+	for _, st := range states {
+		w.checkOne(ctx, st.ProjectID)
+	}
+}
+
+func (w *GitHubDeployWatcher) checkOne(ctx context.Context, projectID string) {
+	project, err := w.store.GetProject(ctx, projectID)
+	if err != nil || project.DefaultRepoID == "" {
+		return
+	}
+	repo, err := w.store.GetGitRepository(ctx, project.DefaultRepoID)
+	if err != nil {
+		return
+	}
+	// Helix-hosted repos auto-deploy via the git post-receive hook; only
+	// external (GitHub/GitLab/…) repos need polling.
+	if !repo.IsExternal || repo.DefaultBranch == "" {
+		return
+	}
+	branch := repo.DefaultBranch
+
+	// Pull the latest default branch from the external remote into the mirror.
+	if err := w.git.SyncBaseBranch(ctx, repo.ID, branch); err != nil {
+		log.Debug().Err(err).Str("repo_id", repo.ID).Msg("github-cd: sync failed, will retry next tick")
+		return
+	}
+	head, err := w.git.GetLocalBranchSHA(ctx, repo.ID, branch)
+	if err != nil || head == "" {
+		return
+	}
+
+	baseline := w.baseline(ctx, projectID, head)
+	if head == baseline {
+		return
+	}
+
+	log.Info().Str("project_id", projectID).
+		Str("from", shortSHA(baseline)).Str("to", shortSHA(head)).
+		Msg("github-cd: default branch advanced — redeploying web service")
+	if _, err := w.controller.Redeploy(ctx, DeployRequest{
+		ProjectID: projectID,
+		Owner:     project.UserID,
+		CommitSHA: head,
+	}); err != nil {
+		log.Error().Err(err).Str("project_id", projectID).Msg("github-cd: redeploy failed")
+		return
+	}
+	w.setSeen(projectID, head)
+}
+
+// baseline returns the SHA to compare HEAD against. On first sight it seeds from
+// the last deployed commit (so a merge that landed while the API was down is
+// still caught), falling back to the current HEAD when nothing was recorded —
+// so we never redeploy an app that's already on HEAD (e.g. right after a manual
+// deploy, which records no SHA).
+func (w *GitHubDeployWatcher) baseline(ctx context.Context, projectID, head string) string {
+	w.mu.Lock()
+	if s, ok := w.lastSeen[projectID]; ok {
+		w.mu.Unlock()
+		return s
+	}
+	w.mu.Unlock()
+
+	seed := w.lastDeployedSHA(ctx, projectID)
+	if seed == "" {
+		seed = head
+	}
+	w.setSeen(projectID, seed)
+	return seed
+}
+
+func (w *GitHubDeployWatcher) setSeen(projectID, sha string) {
+	w.mu.Lock()
+	w.lastSeen[projectID] = sha
+	w.mu.Unlock()
+}
+
+// lastDeployedSHA returns the commit SHA of the most recent live/superseded
+// deploy that recorded one (watcher-driven deploys always do), or "".
+func (w *GitHubDeployWatcher) lastDeployedSHA(ctx context.Context, projectID string) string {
+	deploys, err := w.store.ListWebServiceDeploys(ctx, projectID, 20)
+	if err != nil {
+		return ""
+	}
+	for _, d := range deploys {
+		if d.CommitSHA != "" &&
+			(d.Status == types.WebServiceDeployStatusLive || d.Status == types.WebServiceDeployStatusSuperseded) {
+			return d.CommitSHA
+		}
+	}
+	return ""
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}

--- a/api/pkg/webservice/github_cd_test.go
+++ b/api/pkg/webservice/github_cd_test.go
@@ -1,0 +1,113 @@
+package webservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"go.uber.org/mock/gomock"
+)
+
+type fakeGitSyncer struct {
+	head    string
+	syncErr error
+	synced  int
+}
+
+func (f *fakeGitSyncer) SyncBaseBranch(_ context.Context, _, _ string) error {
+	f.synced++
+	return f.syncErr
+}
+func (f *fakeGitSyncer) GetLocalBranchSHA(_ context.Context, _, _ string) (string, error) {
+	return f.head, nil
+}
+
+type fakeRedeployer struct{ calls []DeployRequest }
+
+func (f *fakeRedeployer) Redeploy(_ context.Context, req DeployRequest) (*types.WebServiceDeploy, error) {
+	f.calls = append(f.calls, req)
+	return &types.WebServiceDeploy{}, nil
+}
+
+func newWatcher(st store.Store, rd Redeployer, g GitSyncer) *GitHubDeployWatcher {
+	return &GitHubDeployWatcher{store: st, controller: rd, git: g, lastSeen: map[string]string{}}
+}
+
+func mockStoreFor(ctrl *gomock.Controller, repo *types.GitRepository, deploys []*types.WebServiceDeploy) *store.MockStore {
+	st := store.NewMockStore(ctrl)
+	st.EXPECT().ListActiveWebServices(gomock.Any()).
+		Return([]*types.ProjectWebServiceState{{ProjectID: "prj_1"}}, nil).AnyTimes()
+	st.EXPECT().GetProject(gomock.Any(), "prj_1").
+		Return(&types.Project{ID: "prj_1", DefaultRepoID: repo.ID, UserID: "u1"}, nil).AnyTimes()
+	st.EXPECT().GetGitRepository(gomock.Any(), repo.ID).Return(repo, nil).AnyTimes()
+	st.EXPECT().ListWebServiceDeploys(gomock.Any(), "prj_1", gomock.Any()).
+		Return(deploys, nil).AnyTimes()
+	return st
+}
+
+// Default branch advanced past the last deployed commit → redeploy once, with
+// the new SHA and the project owner. A second tick with no further movement
+// must NOT redeploy again.
+func TestGitHubCD_DeploysOnAdvance(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	repo := &types.GitRepository{ID: "repo1", IsExternal: true, DefaultBranch: "main"}
+	st := mockStoreFor(ctrl, repo, []*types.WebServiceDeploy{
+		{Status: types.WebServiceDeployStatusLive, CommitSHA: "oldsha"},
+	})
+	git := &fakeGitSyncer{head: "newsha"}
+	rd := &fakeRedeployer{}
+	w := newWatcher(st, rd, git)
+
+	w.runOnce(context.Background())
+	w.runOnce(context.Background())
+
+	if len(rd.calls) != 1 {
+		t.Fatalf("expected exactly 1 redeploy, got %d", len(rd.calls))
+	}
+	if rd.calls[0].CommitSHA != "newsha" || rd.calls[0].Owner != "u1" || rd.calls[0].ProjectID != "prj_1" {
+		t.Errorf("unexpected deploy request: %+v", rd.calls[0])
+	}
+}
+
+// Helix-hosted (non-external) repos auto-deploy via the git post-receive hook —
+// the watcher must skip them entirely (no sync, no deploy) to avoid double-deploys.
+func TestGitHubCD_SkipsHelixHosted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	repo := &types.GitRepository{ID: "repo1", IsExternal: false, DefaultBranch: "main"}
+	st := mockStoreFor(ctrl, repo, nil)
+	git := &fakeGitSyncer{head: "newsha"}
+	rd := &fakeRedeployer{}
+	w := newWatcher(st, rd, git)
+
+	w.runOnce(context.Background())
+
+	if git.synced != 0 {
+		t.Errorf("non-external repo should not be synced, synced=%d", git.synced)
+	}
+	if len(rd.calls) != 0 {
+		t.Errorf("non-external repo should not deploy, calls=%d", len(rd.calls))
+	}
+}
+
+// HEAD already equals the last deployed commit → nothing to do (don't redeploy
+// an app that's already on HEAD, e.g. right after a manual deploy).
+func TestGitHubCD_NoDeployWhenUnchanged(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	repo := &types.GitRepository{ID: "repo1", IsExternal: true, DefaultBranch: "main"}
+	st := mockStoreFor(ctrl, repo, []*types.WebServiceDeploy{
+		{Status: types.WebServiceDeployStatusLive, CommitSHA: "samesha"},
+	})
+	git := &fakeGitSyncer{head: "samesha"}
+	rd := &fakeRedeployer{}
+	w := newWatcher(st, rd, git)
+
+	w.runOnce(context.Background())
+
+	if len(rd.calls) != 0 {
+		t.Errorf("unchanged HEAD should not deploy, calls=%d", len(rd.calls))
+	}
+}


### PR DESCRIPTION
Closes the gap where **merging a PR on GitHub did not deploy** an agent-created app's web service.

Helix's git server fires `onDefaultBranchPush` for *direct* pushes, so Helix-hosted repos auto-deploy. But GitHub-hosted repos only reach Helix via a pull/sync — a PR merged on GitHub never triggers that hook, so the live site silently went stale.

**`GitHubDeployWatcher`** — a 60s poller (same ticker shape as `HealthMonitor`): for each active web service on an **external** repo, sync the default branch from the remote and **redeploy when HEAD advances** past the last deployed commit. Helix-hosted repos are skipped (already covered by the post-receive hook). Baseline seeds from the last deployed `commit_sha`, so a merge that landed while the API was down is still caught, and an app already on HEAD is never needlessly redeployed.

- new `GetLocalBranchSHA` on `GitRepositoryService` (`rev-parse refs/heads/<branch>`)
- small `GitSyncer`/`Redeployer` interfaces keep it testable + import-cycle-free
- wired next to the health-monitor in `ListenAndServe`

This is the agent-app half of the CD story — together with the stack CD (#2727), a merged PR now flows all the way to the live site.

## Testing
- Unit tests: deploys on advance (correct SHA + owner, idempotent on a second tick), skips Helix-hosted repos, no-op when HEAD unchanged. `go test ./pkg/webservice/` green.
- `go build ./pkg/server/ ./pkg/services/ ./pkg/webservice/` clean; server test pkg compiles.
- Not yet exercised against a live GitHub merge — ships via release, validate on meta/prod after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)