### PR TITLE
chore: meta nits — web-service tab copy + prod runbooks

### DIFF
--- a/design/2026-06-25-london-web-service-rollout.md
+++ b/design/2026-06-25-london-web-service-rollout.md
@@ -1,0 +1,126 @@
+# London (prod) web-service hosting rollout — runbook
+
+Date: 2026-06-25. Goal: switch prod (helix.ml) on to **web-service hosting** — host web services
+(find-ai first) on `*.apps.helix.ml`, mirroring what now works on meta.helix.ml, with nginx
+terminating TLS via a certbot DNS-01 wildcard cert.
+
+This is a **one-time feature switch**. The version-bump portion (Phase 3) is delegated to the
+generic **`design/2026-06-25-prod-version-bump-runbook.md`** — read that for the controlplane +
+runner upgrade mechanics, topology, and rollback. This doc covers only the web-service-specific
+work.
+
+## STATUS (2026-06-25)
+- **Phase 1 ✅** — `*.apps.helix.ml` DNS (grey-cloud, pre-existing) + certbot DNS-01 wildcard issued.
+- **Phase 2 ✅** — nginx `*.apps.helix.ml` block live, TLS verified, no regression on existing domains.
+- **Phase 3 ✅** — controlplane + runner both on **2.11.28** (clean, 0 errors). Rollback snapshot:
+  `data/helix-postgres@pre-2.11.28-20260625-071423`.
+- **Phase 4 ✅** — `DEV_SUBDOMAIN=apps.helix.ml` set; log confirms `vhost middleware enabled
+  base_domain=apps.helix.ml`. certmagic off (nginx terminates).
+- **Phase 5 ⏳ BLOCKED** — no FindAI project exists on prod (it's only on meta); zero web-service
+  states on prod. Needs the project created on prod (owner org + repo) before deploy. **Decision
+  pending.**
+- **Phase 6** — vestigial flag cleanup, not started.
+
+## Why this shape
+- Prod's TLS edge is HOST nginx (`/etc/nginx/nginx.conf`, monolithic) which owns `:443`/`:80`
+  for ~13 live domains incl. registry.helix.ml + app.helix.ml. You can't cleanly mix
+  SNI-passthrough on that shared `:443`, so **nginx terminates the wildcard** (certbot DNS-01)
+  and Helix serves the vhost over **HTTP behind nginx** — certmagic stays OFF in prod (unlike
+  meta, which has no nginx and lets certmagic terminate per-host on-demand).
+- The web-service feature lives in the 2.11.28 images (PRs #2718 certmagic-persistence,
+  #2720 self-healing, #2721 dns-proxy + lean boot, #2722 supervisor fix).
+
+## Prerequisites
+- Release **2.11.28** built & pushed (Step 1 of the generic runbook) — includes the four PRs above.
+
+## Phase 1 — Cloudflare DNS + wildcard cert (no prod impact until nginx reload)
+1. Cloudflare: add `*.apps.helix.ml` A record → london public IP (same as app.helix.ml),
+   **grey-cloud (DNS-only)** so nginx terminates TLS, not CF. (TXT for the DNS-01 challenge is
+   created/removed automatically by the plugin; cloud colour is irrelevant for TXT.)
+2. On london, add the cloudflare DNS plugin to the snap certbot (5.6.0 already installed):
+   ```bash
+   snap install certbot-dns-cloudflare
+   snap set certbot trust-plugin-with-root=ok
+   snap connect certbot:plugin certbot-dns-cloudflare
+   mkdir -p /root/.secrets
+   printf 'dns_cloudflare_api_token = <ZONE_TOKEN>\n' > /root/.secrets/cloudflare.ini
+   chmod 600 /root/.secrets/cloudflare.ini
+   ```
+   (Same Cloudflare zone token used for meta.)
+3. Issue the wildcard via DNS-01 + register an nginx-reload deploy hook (renews automatically on
+   the existing `snap.certbot.renew.timer`):
+   ```bash
+   certbot certonly --dns-cloudflare \
+     --dns-cloudflare-credentials /root/.secrets/cloudflare.ini \
+     -d '*.apps.helix.ml' \
+     --deploy-hook 'systemctl reload nginx'
+   ```
+   → `/etc/letsencrypt/live/apps.helix.ml/{fullchain,privkey}.pem`.
+
+## Phase 2 — nginx wildcard server block (shared blast radius — gate on `nginx -t`) — DONE 2026-06-25
+nginx.conf is **monolithic** (no conf.d/sites-enabled include); the `$connection_upgrade` map
+already exists. The controlplane is `http://localhost:8001` (helix-api-1 → :8080); `localhost:8180`
+is keycloak. The vhost router lives in the controlplane, so proxy to **8001**.
+4. Back up `/etc/nginx/nginx.conf` (timestamped). Insert the block below at the **end of the
+   `http{}` block** (before its final closing brace), so it sees the maps/upstreams/cert includes:
+   ```nginx
+   server {                                   # http→https redirect
+       listen 80; listen [::]:80;
+       server_name *.apps.helix.ml;
+       return 301 https://$host$request_uri;
+   }
+   server {
+       listen 443 ssl; listen [::]:443 ssl;
+       server_name *.apps.helix.ml;
+       ssl_certificate     /etc/letsencrypt/live/apps.helix.ml/fullchain.pem;
+       ssl_certificate_key /etc/letsencrypt/live/apps.helix.ml/privkey.pem;
+       include /etc/letsencrypt/options-ssl-nginx.conf;
+       ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+       location / {
+           proxy_pass         http://localhost:8001;   # controlplane (vhost router by Host)
+           proxy_redirect off; proxy_http_version 1.1;
+           client_max_body_size 0; proxy_buffering off; proxy_cache off;
+           proxy_set_header   Host $host;               # vhost router keys on Host — MUST be $host (not $server_name)
+           proxy_set_header   X-Real-IP $remote_addr;
+           proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+           proxy_set_header   X-Forwarded-Proto https;
+           proxy_set_header   X-Forwarded-Host $host;
+           proxy_set_header   Upgrade $http_upgrade;    # ws (terminal/logs streams)
+           proxy_set_header   Connection $connection_upgrade;
+       }
+   }
+   ```
+5. `nginx -t` → `systemctl reload nginx` (graceful; registry.helix.ml/app.helix.ml stay up).
+   **Risk gate**: a bad config fails `-t`; never reload without it passing — this nginx also
+   fronts the registry and the cloud app.
+6. Install a renewal-reload hook so future cert renewals reload nginx:
+   `printf '#!/bin/sh\nsystemctl reload nginx\n' > /etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh && chmod +x`.
+7. **Copy the working config to `/data/helix-app/nginx.conf`** (it's on ZFS, snapshotted +
+   backed up to rsync.net): `cp -a /etc/nginx/nginx.conf /data/helix-app/nginx.conf`.
+8. Verify (from london, via `--resolve …:127.0.0.1` to avoid hairpin-NAT): SNI
+   `find-ai.apps.helix.ml` serves `CN=*.apps.helix.ml`; `curl` → 200; app.helix.ml /
+   registry.helix.ml still serve their own cert + 200 (no regression). **Verified.**
+
+## Phase 3 — upgrade controlplane + runner to 2.11.28
+6. Follow **`design/2026-06-25-prod-version-bump-runbook.md`** with `NEW_VERSION=2.11.28`,
+   `OLD_VERSION=2.11.14` (DB backup → controlplane → runner → verify both online on 2.11.28).
+   This is the highest-risk step (it upgrades the live cloud app), covered there.
+
+## Phase 4 — enable web-service hosting config on prod
+7. In `/data/helix-app/.env`, mirror meta's web-service env, swapping base domain + disabling
+   certmagic (nginx terminates TLS here): set the web-service base domain to `apps.helix.ml`
+   and `HELIX_VHOST_TLS_MODE` to OFF. `docker compose up -d api`.
+   (Verify exact var names against meta's `.env` at execution — mirror, don't guess.)
+
+## Phase 5 — deploy find-ai + verify
+8. Enable web-service on the FindAI project, deploy, verify
+   `curl https://find-ai.apps.helix.ml` → 200, DB persisted to per-project `/data`.
+9. Confirm health-monitor running: `docker logs helix-api-1 | grep -i "health-monitor"`.
+
+## Phase 6 — cleanup (separate, non-blocking)
+10. Remove vestigial `privileged_mode_enabled` flag (write-only; nothing branches on it) in its
+    own small PR.
+
+## Open items to confirm at execution
+- Exact meta web-service env var names (base domain + TLS mode) to mirror.
+- Whether app.helix.ml's cert is a SAN on helix.ml or standalone (informational only).

--- a/design/2026-06-25-prod-version-bump-runbook.md
+++ b/design/2026-06-25-prod-version-bump-runbook.md
@@ -1,0 +1,73 @@
+# Prod version-bump runbook (generic)
+
+Reusable procedure for upgrading the **helix.ml production deployment** to a new release.
+Version-agnostic — substitute `<NEW_VERSION>` (e.g. `2.11.25`) and `<OLD_VERSION>` throughout.
+For the web-service hosting feature switch, see
+`design/2026-06-25-london-web-service-rollout.md`, which references this runbook for the
+upgrade step.
+
+## Prod topology (verified 2026-06-25)
+- **Controlplane**: GCP `helix-cloud-london` (europe-west2-a). Container `helix-api-1` =
+  `ghcr.io/helixml/controlplane:<VERSION>`. This **is** app.helix.ml / app.tryhelix.ai — live
+  customers. Stack at `/data/helix-app`. Shares the box with Harbor (registry.helix.ml),
+  Keycloak, demos. DB = `helix-postgres-1`.
+  Access: `gcloud compute ssh --zone europe-west2-a helix-cloud-london --project helixml`.
+- **Runner / sandbox host**: `root@code.helix.ml` (SSH key-based, Hetzner). One sandbox host
+  `helix-sandbox-app` = `ghcr.io/helixml/helix-sandbox:<VERSION>`,
+  `SANDBOX_INSTANCE_ID=code-for-app`, points at https://app.helix.ml. Upgraded by editing
+  `/opt/HelixML/upgrade-sandbox-app.helix.ml.sh` (a `docker run` wrapper, **not** compose).
+- The two move **together**: the runner pulls desktop images by heartbeat version, so a version
+  mismatch between controlplane and runner means stale desktop/sandbox images. Always bump both.
+
+## Step 1 — build & publish images (no prod impact)
+1. Land all PRs for the release on `main`.
+2. Cut release tag **`<NEW_VERSION>`** → Drone builds and pushes `controlplane:<NEW_VERSION>`,
+   `helix-sandbox:<NEW_VERSION>`, and desktop images to ghcr.
+3. Confirm the build is green and images exist on ghcr before touching prod.
+
+## Step 2 — back up the controlplane DB (do this every time)
+```bash
+gcloud compute ssh --zone europe-west2-a helix-cloud-london --project helixml --command \
+  'docker exec helix-postgres-1 pg_dumpall -U postgres | gzip > /data/helix-app/backup-<OLD_VERSION>-$(date +%F).sql.gz && ls -la /data/helix-app/backup-*.sql.gz'
+```
+
+## Step 3 — upgrade the controlplane (london) — HIGHEST RISK (customer-facing)
+1. SSH to london. Confirm the version-pin location (compose vs. install script) — typically the
+   `image: ghcr.io/helixml/controlplane:<OLD_VERSION>` line in `/data/helix-app/docker-compose.yaml`.
+2. Bump the tag → `<NEW_VERSION>`, then:
+   ```bash
+   cd /data/helix-app
+   docker compose pull api
+   docker compose up -d api
+   ```
+3. **Watch GORM AutoMigrate** on start: `docker logs -f helix-api-1` (look for migrate
+   completion, no panics).
+4. Verify app.helix.ml is healthy: login + one chat round-trip. Check
+   `docker ps` shows `controlplane:<NEW_VERSION>` Up.
+5. **Rollback**: set the tag back to `<OLD_VERSION>`, `docker compose up -d api`. If a migration
+   ran and the new schema is incompatible, restore the Step-2 dump first.
+
+## Step 4 — upgrade the runner (code.helix.ml)
+1. SSH `root@code.helix.ml`. Edit the version in the upgrade script and re-run it:
+   ```bash
+   sed -i 's/^SANDBOX_TAG=.*/SANDBOX_TAG="<NEW_VERSION>"/' /opt/HelixML/upgrade-sandbox-app.helix.ml.sh
+   /opt/HelixML/upgrade-sandbox-app.helix.ml.sh
+   ```
+   The script stop/rm/runs `helix-sandbox-app` on the new tag (auto-pulls), then prunes old
+   sandbox images. Named volumes `sandbox-storage-app:/var/lib/docker`, `sandbox-data-app:/data`,
+   `hydra-storage-app:/hydra-data` persist across the swap. **~seconds offline** during the swap
+   (and a brief blip for any live sandbox/web-service while its container restarts; `/data`
+   survives).
+2. Verify re-registration on london:
+   ```bash
+   docker exec helix-postgres-1 psql -U postgres -d postgres -x -c \
+     "SELECT id,status,desktop_versions,last_seen FROM sandbox_instances WHERE id='code-for-app';"
+   ```
+   Expect `status=online`, `desktop_versions` showing `<NEW_VERSION>`, recent `last_seen`.
+3. **Rollback**: set `SANDBOX_TAG` back to `<OLD_VERSION>`, re-run the script.
+
+## Order & notes
+- Order: Step 1 → 2 → 3 (controlplane) → 4 (runner). Controlplane is the schema owner; bring it
+  up first, verify, then the runner.
+- Do customer-facing steps (3, 4) in a low-traffic window.
+- Both controlplane and runner must end on the **same** `<NEW_VERSION>`.

--- a/frontend/src/components/project/WebServiceTab.tsx
+++ b/frontend/src/components/project/WebServiceTab.tsx
@@ -123,8 +123,8 @@ const WebServiceTab: FC<WebServiceTabProps> = ({ projectId }) => {
           Host this project as a live website. Turn it on and you'll get
           a default URL straight away. You can also point your own domain
           at it. Every push to your default branch deploys automatically —
-          Helix runs the <code>.helix/startup.sh</code> script in your repo
-          to start your app.
+          Helix runs the <code>.helix/startup.sh</code> script from your
+          repo's <code>helix-specs</code> branch to start your app.
         </Typography>
       </Box>
 


### PR DESCRIPTION
Small tidy-ups collected during the web-service hosting work:
- `WebServiceTab.tsx`: clarify the startup script comes from the **helix-specs** branch (it was ambiguous "in your repo").
- Add the prod runbooks: `design/2026-06-25-prod-version-bump-runbook.md` (generic upgrade) + `design/2026-06-25-london-web-service-rollout.md` (web-service switch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)