### PR TITLE
feat(runners): show runner hardware (instance type + accelerator) in admin

### DIFF
--- a/api/cmd/sandbox-heartbeat/main.go
+++ b/api/cmd/sandbox-heartbeat/main.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -64,6 +65,7 @@ type HeartbeatRequest struct {
 	ContainerUsage        []ContainerDiskUsage `json:"container_usage,omitempty"`
 	PrivilegedModeEnabled bool                 `json:"privileged_mode_enabled,omitempty"`
 	GPUVendor             string               `json:"gpu_vendor,omitempty"`    // nvidia, amd, intel, none
+	InstanceType          string               `json:"instance_type,omitempty"` // cloud instance type via IMDS; empty on bare metal
 	HelixVersion          string               `json:"helix_version,omitempty"` // git commit hash or release version
 
 	// Sandbox-absorbs-runner pivot: rich GPU inventory used by the inference
@@ -162,6 +164,47 @@ func main() {
 	}
 }
 
+// detectInstanceType queries the AWS IMDS for the EC2 instance type (e.g.
+// "inf2.8xlarge"). Uses IMDSv2 (token-authenticated). Returns "" on any
+// failure — bare-metal hosts (e.g. prime), non-AWS clouds, and IMDS being
+// unreachable all just yield an empty string with no hang. The 1.5s client
+// timeout caps the wait so a non-existent metadata endpoint can't block the
+// heartbeat loop.
+func detectInstanceType(ctx context.Context) string {
+	const imds = "http://169.254.169.254"
+	client := &http.Client{Timeout: 1500 * time.Millisecond}
+
+	tokReq, err := http.NewRequestWithContext(ctx, http.MethodPut, imds+"/latest/api/token", nil)
+	if err != nil {
+		return ""
+	}
+	tokReq.Header.Set("X-aws-ec2-metadata-token-ttl-seconds", "60")
+	tokResp, err := client.Do(tokReq)
+	if err != nil {
+		return ""
+	}
+	token, _ := io.ReadAll(tokResp.Body)
+	tokResp.Body.Close()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imds+"/latest/meta-data/instance-type", nil)
+	if err != nil {
+		return ""
+	}
+	if len(token) > 0 {
+		req.Header.Set("X-aws-ec2-metadata-token", string(token))
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	body, _ := io.ReadAll(resp.Body)
+	return strings.TrimSpace(string(body))
+}
+
 func sendHeartbeat(apiURL, runnerToken, sandboxInstanceID string, privilegedModeEnabled bool) {
 	// Discover all desktop versions dynamically
 	// Scans /opt/images/helix-*.version files
@@ -180,6 +223,8 @@ func sendHeartbeat(apiURL, runnerToken, sandboxInstanceID string, privilegedMode
 	// rather than block the loop.
 	probeCtx, probeCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	gpus := gpudetect.Detect(probeCtx)
+	// Cloud instance type (e.g. inf2.8xlarge). Empty on bare-metal / non-AWS.
+	instanceType := detectInstanceType(probeCtx)
 	probeCancel()
 
 	// Read compose-manager status from the file it writes after each Apply.
@@ -195,6 +240,7 @@ func sendHeartbeat(apiURL, runnerToken, sandboxInstanceID string, privilegedMode
 		ContainerUsage:        containerUsage,
 		PrivilegedModeEnabled: privilegedModeEnabled,
 		GPUVendor:             gpuVendor,
+		InstanceType:          instanceType,
 		HelixVersion:          data.GetHelixVersion(),
 		GPUs:                  gpus,
 		ProfileStatus:         profileStatus,

--- a/api/cmd/sandbox-heartbeat/main.go
+++ b/api/cmd/sandbox-heartbeat/main.go
@@ -12,7 +12,9 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -164,12 +166,36 @@ func main() {
 	}
 }
 
+// instanceTypeRe matches a plausible EC2 instance type (e.g. "inf2.8xlarge",
+// "g5.xlarge", "trn1n.32xlarge"). Used to reject garbage from a non-AWS host
+// that happens to answer at the IMDS link-local IP (captive portals, on-prem
+// metadata services) — without it, an HTML error page could be stored verbatim
+// and overflow the varchar(100) column, failing the whole heartbeat UPDATE.
+var instanceTypeRe = regexp.MustCompile(`^[a-z][a-z0-9-]{0,30}\.[a-z0-9]+$`)
+
+// cachedInstanceType memoises the (immutable) instance type after the first
+// successful lookup so we stop hitting IMDS on every 30s heartbeat. Empty
+// results are not cached, so a transient boot-time IMDS failure self-heals.
+var cachedInstanceType atomic.Value // string
+
+// instanceType returns the cached instance type or probes IMDS once to find it.
+func instanceType(ctx context.Context) string {
+	if v, _ := cachedInstanceType.Load().(string); v != "" {
+		return v
+	}
+	t := detectInstanceType(ctx)
+	if t != "" {
+		cachedInstanceType.Store(t)
+	}
+	return t
+}
+
 // detectInstanceType queries the AWS IMDS for the EC2 instance type (e.g.
 // "inf2.8xlarge"). Uses IMDSv2 (token-authenticated). Returns "" on any
-// failure — bare-metal hosts (e.g. prime), non-AWS clouds, and IMDS being
-// unreachable all just yield an empty string with no hang. The 1.5s client
-// timeout caps the wait so a non-existent metadata endpoint can't block the
-// heartbeat loop.
+// failure or an implausible response — bare-metal hosts (e.g. prime), non-AWS
+// clouds, and IMDS being unreachable all yield an empty string with no hang.
+// The 1.5s client timeout caps the wait (URL is a literal IP, so there is no
+// DNS) so a non-existent metadata endpoint can't block the heartbeat loop.
 func detectInstanceType(ctx context.Context) string {
 	const imds = "http://169.254.169.254"
 	client := &http.Client{Timeout: 1500 * time.Millisecond}
@@ -183,7 +209,10 @@ func detectInstanceType(ctx context.Context) string {
 	if err != nil {
 		return ""
 	}
-	token, _ := io.ReadAll(tokResp.Body)
+	var token []byte
+	if tokResp.StatusCode == http.StatusOK {
+		token, _ = io.ReadAll(io.LimitReader(tokResp.Body, 1024))
+	}
 	tokResp.Body.Close()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imds+"/latest/meta-data/instance-type", nil)
@@ -201,8 +230,14 @@ func detectInstanceType(ctx context.Context) string {
 	if resp.StatusCode != http.StatusOK {
 		return ""
 	}
-	body, _ := io.ReadAll(resp.Body)
-	return strings.TrimSpace(string(body))
+	// Cap the read so a rogue responder can't hand us a huge body, then
+	// validate the shape so junk never reaches the varchar(100) column.
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 128))
+	it := strings.TrimSpace(string(body))
+	if !instanceTypeRe.MatchString(it) {
+		return ""
+	}
+	return it
 }
 
 func sendHeartbeat(apiURL, runnerToken, sandboxInstanceID string, privilegedModeEnabled bool) {
@@ -224,7 +259,8 @@ func sendHeartbeat(apiURL, runnerToken, sandboxInstanceID string, privilegedMode
 	probeCtx, probeCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	gpus := gpudetect.Detect(probeCtx)
 	// Cloud instance type (e.g. inf2.8xlarge). Empty on bare-metal / non-AWS.
-	instanceType := detectInstanceType(probeCtx)
+	// Cached after first success, so this is a no-op on subsequent heartbeats.
+	instType := instanceType(probeCtx)
 	probeCancel()
 
 	// Read compose-manager status from the file it writes after each Apply.
@@ -240,7 +276,7 @@ func sendHeartbeat(apiURL, runnerToken, sandboxInstanceID string, privilegedMode
 		ContainerUsage:        containerUsage,
 		PrivilegedModeEnabled: privilegedModeEnabled,
 		GPUVendor:             gpuVendor,
-		InstanceType:          instanceType,
+		InstanceType:          instType,
 		HelixVersion:          data.GetHelixVersion(),
 		GPUs:                  gpus,
 		ProfileStatus:         profileStatus,

--- a/api/pkg/gpudetect/gpudetect.go
+++ b/api/pkg/gpudetect/gpudetect.go
@@ -12,6 +12,8 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -32,8 +34,39 @@ func Detect(ctx context.Context) []types.GPUStatus {
 	var out []types.GPUStatus
 	out = append(out, detectNVIDIA(ctx)...)
 	out = append(out, detectAMD(ctx)...)
+	out = append(out, detectNeuron()...)
 	if out == nil {
 		out = []types.GPUStatus{}
+	}
+	return out
+}
+
+// neuronDeviceRe matches the per-chip Neuron device nodes (/dev/neuron0,
+// /dev/neuron1, ...) while excluding control nodes like /dev/neuron-rtd.
+var neuronDeviceRe = regexp.MustCompile(`^neuron[0-9]+$`)
+
+// detectNeuron enumerates AWS Neuron accelerator devices (Inferentia /
+// Trainium) by globbing /dev/neuron*. One GPUStatus entry per chip, so the
+// inference router and admin UI see the device count. The chip family and
+// NeuronCore count are derived from the instance type elsewhere — the device
+// node alone doesn't reveal inf2 vs trn1 vs trn2. Returns nil on any host
+// without Neuron devices (the common case), so NVIDIA/AMD/bare-metal hosts
+// are unaffected.
+func detectNeuron() []types.GPUStatus {
+	devs, err := filepath.Glob("/dev/neuron*")
+	if err != nil {
+		return nil
+	}
+	var out []types.GPUStatus
+	for _, d := range devs {
+		if !neuronDeviceRe.MatchString(filepath.Base(d)) {
+			continue
+		}
+		out = append(out, types.GPUStatus{
+			Index:     len(out),
+			Vendor:    types.GPUVendorNeuron,
+			ModelName: "AWS Neuron Device",
+		})
 	}
 	return out
 }

--- a/api/pkg/gpudetect/gpudetect_test.go
+++ b/api/pkg/gpudetect/gpudetect_test.go
@@ -85,3 +85,20 @@ func TestSplitCSVTrim(t *testing.T) {
 		}
 	}
 }
+
+// TestNeuronDeviceRe ensures the Neuron device glob matches per-chip device
+// nodes (/dev/neuron0, neuron1, ...) and excludes control nodes.
+func TestNeuronDeviceRe(t *testing.T) {
+	match := []string{"neuron0", "neuron1", "neuron15"}
+	noMatch := []string{"neuron", "neuron-rtd", "neuronx", "neuron0a", "nvidia0"}
+	for _, m := range match {
+		if !neuronDeviceRe.MatchString(m) {
+			t.Errorf("expected %q to match neuronDeviceRe", m)
+		}
+	}
+	for _, n := range noMatch {
+		if neuronDeviceRe.MatchString(n) {
+			t.Errorf("expected %q NOT to match neuronDeviceRe", n)
+		}
+	}
+}

--- a/api/pkg/server/agent_sandboxes_handlers.go
+++ b/api/pkg/server/agent_sandboxes_handlers.go
@@ -44,6 +44,13 @@ type SandboxInstanceInfo struct {
 	ProfileError    string                                       `json:"profile_error,omitempty"`
 	ServiceHealth   map[string]string                            `json:"service_health,omitempty"`
 	ProfileProgress map[string]types.ServiceDownloadProgress     `json:"profile_progress,omitempty"`
+
+	// Hardware reported by the sandbox heartbeat — drives the admin UI's
+	// per-runner architecture display so an operator can pick a compatible
+	// profile. InstanceType is empty on bare-metal hosts (e.g. prime).
+	InstanceType string            `json:"instance_type,omitempty"` // e.g. "inf2.8xlarge"
+	GPUVendor    string            `json:"gpu_vendor,omitempty"`    // nvidia | amd | neuron
+	GPUs         []types.GPUStatus `json:"gpus,omitempty"`          // per-accelerator inventory
 }
 
 // DevContainerWithClients extends DevContainerResponse with connected clients and video stats
@@ -130,6 +137,8 @@ func (apiServer *HelixAPIServer) getAgentSandboxesDebug(rw http.ResponseWriter, 
 			ActiveProfileID: sb.ActiveProfileID,
 			ProfileStatus:   sb.ProfileStatus,
 			ProfileError:    sb.ProfileError,
+			InstanceType:    sb.InstanceType,
+			GPUVendor:       sb.GPUVendor,
 		}
 		// jsonb columns deserialise as []byte; unmarshal best-effort.
 		if len(sb.ServiceHealth) > 0 {
@@ -137,6 +146,9 @@ func (apiServer *HelixAPIServer) getAgentSandboxesDebug(rw http.ResponseWriter, 
 		}
 		if len(sb.ProfileProgress) > 0 {
 			_ = json.Unmarshal(sb.ProfileProgress, &info.ProfileProgress)
+		}
+		if len(sb.GPUs) > 0 {
+			_ = json.Unmarshal(sb.GPUs, &info.GPUs)
 		}
 		sandboxInfos[i] = info
 	}

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -23168,6 +23168,10 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "is_helix_org_agent": {
+                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
+                    "type": "boolean"
+                },
                 "model_substitutions": {
                     "type": "array",
                     "items": {
@@ -24778,7 +24782,22 @@ const docTemplate = `{
                 "container_id": {
                     "type": "string"
                 },
+                "gpu_vendor": {
+                    "description": "nvidia | amd | neuron",
+                    "type": "string"
+                },
+                "gpus": {
+                    "description": "per-accelerator inventory",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.GPUStatus"
+                    }
+                },
                 "id": {
+                    "type": "string"
+                },
+                "instance_type": {
+                    "description": "Hardware reported by the sandbox heartbeat — drives the admin UI's\nper-runner architecture display so an operator can pick a compatible\nprofile. InstanceType is empty on bare-metal hosts (e.g. prime).",
                     "type": "string"
                 },
                 "profile_error": {
@@ -25696,6 +25715,10 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "is_helix_org_agent": {
+                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
+                    "type": "boolean"
+                },
                 "organization_id": {
                     "type": "string"
                 },
@@ -25935,7 +25958,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/types.AssistantCalculator"
                 },
                 "claude_subscription_model": {
-                    "description": "ClaudeSubscriptionModel is the Anthropic model to use when CodeAgentRuntime is\n\"claude_code\" and CodeAgentCredentialType is \"subscription\". It flows through\nCodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,\nwhich the claude-agent-acp package reads (resolveModelPreference) to pick the\nmodel — otherwise Claude Code defaults to Sonnet. Empty means \"claude-opus-4-6\".",
+                    "description": "ClaudeSubscriptionModel is the Anthropic model to use when CodeAgentRuntime is\n\"claude_code\" and CodeAgentCredentialType is \"subscription\". It flows through\nCodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,\nwhich the claude-agent-acp package reads (resolveModelPreference) to pick the\nmodel — otherwise Claude Code defaults to Sonnet. Empty means \"opus\"\n(resolveModelPreference resolves this to the latest Opus version).",
                     "type": "string"
                 },
                 "code_agent_credential_type": {
@@ -27646,7 +27669,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "scope": {
-                    "description": "optional, one of \"dev\", \"prod\", \"both\"; defaults to \"both\"",
+                    "description": "optional, one of \"dev\", \"prod\", \"both\"; defaults to \"dev\"",
                     "type": "string"
                 },
                 "value": {
@@ -32878,6 +32901,10 @@ const docTemplate = `{
                     "description": "Helix version running on this sandbox (git commit hash or release version)",
                     "type": "string"
                 },
+                "instance_type": {
+                    "description": "InstanceType is the cloud instance type (e.g. \"inf2.8xlarge\", \"g5.xlarge\")\ndetected via the AWS IMDS. Empty on bare-metal hosts (e.g. prime) and any\nnon-AWS environment — the admin UI then just shows the GPU model instead.",
+                    "type": "string"
+                },
                 "privileged_mode_enabled": {
                     "description": "Privileged mode (host Docker access for development)",
                     "type": "boolean"
@@ -32955,6 +32982,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "instance_type": {
+                    "description": "InstanceType is the cloud instance type reported by the sandbox heartbeat\n(e.g. \"inf2.8xlarge\"). Empty on bare-metal / non-AWS hosts.",
                     "type": "string"
                 },
                 "ip_address": {
@@ -33095,7 +33126,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "scope": {
-                    "description": "Scope controls which environment a project secret is injected into.\nDefaults to \"both\" so pre-existing secrets keep their original behaviour.",
+                    "description": "Scope controls which environment a project secret is injected into.\nDefaults to \"dev\" so pre-existing secrets keep their original (dev-only)\nbehaviour and dev stays the primary path.",
                     "allOf": [
                         {
                             "$ref": "#/definitions/types.SecretScope"

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -23164,6 +23164,10 @@
                 "id": {
                     "type": "string"
                 },
+                "is_helix_org_agent": {
+                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
+                    "type": "boolean"
+                },
                 "model_substitutions": {
                     "type": "array",
                     "items": {
@@ -24774,7 +24778,22 @@
                 "container_id": {
                     "type": "string"
                 },
+                "gpu_vendor": {
+                    "description": "nvidia | amd | neuron",
+                    "type": "string"
+                },
+                "gpus": {
+                    "description": "per-accelerator inventory",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.GPUStatus"
+                    }
+                },
                 "id": {
+                    "type": "string"
+                },
+                "instance_type": {
+                    "description": "Hardware reported by the sandbox heartbeat — drives the admin UI's\nper-runner architecture display so an operator can pick a compatible\nprofile. InstanceType is empty on bare-metal hosts (e.g. prime).",
                     "type": "string"
                 },
                 "profile_error": {
@@ -25692,6 +25711,10 @@
                 "id": {
                     "type": "string"
                 },
+                "is_helix_org_agent": {
+                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
+                    "type": "boolean"
+                },
                 "organization_id": {
                     "type": "string"
                 },
@@ -25931,7 +25954,7 @@
                     "$ref": "#/definitions/types.AssistantCalculator"
                 },
                 "claude_subscription_model": {
-                    "description": "ClaudeSubscriptionModel is the Anthropic model to use when CodeAgentRuntime is\n\"claude_code\" and CodeAgentCredentialType is \"subscription\". It flows through\nCodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,\nwhich the claude-agent-acp package reads (resolveModelPreference) to pick the\nmodel — otherwise Claude Code defaults to Sonnet. Empty means \"claude-opus-4-6\".",
+                    "description": "ClaudeSubscriptionModel is the Anthropic model to use when CodeAgentRuntime is\n\"claude_code\" and CodeAgentCredentialType is \"subscription\". It flows through\nCodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,\nwhich the claude-agent-acp package reads (resolveModelPreference) to pick the\nmodel — otherwise Claude Code defaults to Sonnet. Empty means \"opus\"\n(resolveModelPreference resolves this to the latest Opus version).",
                     "type": "string"
                 },
                 "code_agent_credential_type": {
@@ -27642,7 +27665,7 @@
                     "type": "string"
                 },
                 "scope": {
-                    "description": "optional, one of \"dev\", \"prod\", \"both\"; defaults to \"both\"",
+                    "description": "optional, one of \"dev\", \"prod\", \"both\"; defaults to \"dev\"",
                     "type": "string"
                 },
                 "value": {
@@ -32874,6 +32897,10 @@
                     "description": "Helix version running on this sandbox (git commit hash or release version)",
                     "type": "string"
                 },
+                "instance_type": {
+                    "description": "InstanceType is the cloud instance type (e.g. \"inf2.8xlarge\", \"g5.xlarge\")\ndetected via the AWS IMDS. Empty on bare-metal hosts (e.g. prime) and any\nnon-AWS environment — the admin UI then just shows the GPU model instead.",
+                    "type": "string"
+                },
                 "privileged_mode_enabled": {
                     "description": "Privileged mode (host Docker access for development)",
                     "type": "boolean"
@@ -32951,6 +32978,10 @@
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "instance_type": {
+                    "description": "InstanceType is the cloud instance type reported by the sandbox heartbeat\n(e.g. \"inf2.8xlarge\"). Empty on bare-metal / non-AWS hosts.",
                     "type": "string"
                 },
                 "ip_address": {
@@ -33091,7 +33122,7 @@
                     "type": "string"
                 },
                 "scope": {
-                    "description": "Scope controls which environment a project secret is injected into.\nDefaults to \"both\" so pre-existing secrets keep their original behaviour.",
+                    "description": "Scope controls which environment a project secret is injected into.\nDefaults to \"dev\" so pre-existing secrets keep their original (dev-only)\nbehaviour and dev stays the primary path.",
                     "allOf": [
                         {
                             "$ref": "#/definitions/types.SecretScope"

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -1464,6 +1464,12 @@ definitions:
         type: boolean
       id:
         type: string
+      is_helix_org_agent:
+        description: |-
+          IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
+          (see api/pkg/org). Computed at list time, not persisted, so the frontend
+          can hide org-chart agents from the spec-task agent switchers.
+        type: boolean
       model_substitutions:
         items:
           $ref: '#/definitions/server.ModelSubstitution'
@@ -2534,7 +2540,21 @@ definitions:
         type: string
       container_id:
         type: string
+      gpu_vendor:
+        description: nvidia | amd | neuron
+        type: string
+      gpus:
+        description: per-accelerator inventory
+        items:
+          $ref: '#/definitions/types.GPUStatus'
+        type: array
       id:
+        type: string
+      instance_type:
+        description: |-
+          Hardware reported by the sandbox heartbeat — drives the admin UI's
+          per-runner architecture display so an operator can pick a compatible
+          profile. InstanceType is empty on bare-metal hosts (e.g. prime).
         type: string
       profile_error:
         type: string
@@ -3199,6 +3219,12 @@ definitions:
         type: boolean
       id:
         type: string
+      is_helix_org_agent:
+        description: |-
+          IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
+          (see api/pkg/org). Computed at list time, not persisted, so the frontend
+          can hide org-chart agents from the spec-task agent switchers.
+        type: boolean
       organization_id:
         type: string
       owner:
@@ -3366,7 +3392,8 @@ definitions:
           "claude_code" and CodeAgentCredentialType is "subscription". It flows through
           CodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,
           which the claude-agent-acp package reads (resolveModelPreference) to pick the
-          model — otherwise Claude Code defaults to Sonnet. Empty means "claude-opus-4-6".
+          model — otherwise Claude Code defaults to Sonnet. Empty means "opus"
+          (resolveModelPreference resolves this to the latest Opus version).
         type: string
       code_agent_credential_type:
         allOf:
@@ -4627,7 +4654,7 @@ definitions:
           project
         type: string
       scope:
-        description: optional, one of "dev", "prod", "both"; defaults to "both"
+        description: optional, one of "dev", "prod", "both"; defaults to "dev"
         type: string
       value:
         type: string
@@ -8375,6 +8402,12 @@ definitions:
         description: Helix version running on this sandbox (git commit hash or release
           version)
         type: string
+      instance_type:
+        description: |-
+          InstanceType is the cloud instance type (e.g. "inf2.8xlarge", "g5.xlarge")
+          detected via the AWS IMDS. Empty on bare-metal hosts (e.g. prime) and any
+          non-AWS environment — the admin UI then just shows the GPU model instead.
+        type: string
       privileged_mode_enabled:
         description: Privileged mode (host Docker access for development)
         type: boolean
@@ -8460,6 +8493,11 @@ definitions:
         description: Hostname for DNS resolution
         type: string
       id:
+        type: string
+      instance_type:
+        description: |-
+          InstanceType is the cloud instance type reported by the sandbox heartbeat
+          (e.g. "inf2.8xlarge"). Empty on bare-metal / non-AWS hosts.
         type: string
       ip_address:
         description: IP address of the sandbox
@@ -8588,7 +8626,8 @@ definitions:
         - $ref: '#/definitions/types.SecretScope'
         description: |-
           Scope controls which environment a project secret is injected into.
-          Defaults to "both" so pre-existing secrets keep their original behaviour.
+          Defaults to "dev" so pre-existing secrets keep their original (dev-only)
+          behaviour and dev stays the primary path.
       updated:
         type: string
       value:

--- a/api/pkg/store/store_sandbox.go
+++ b/api/pkg/store/store_sandbox.go
@@ -31,6 +31,12 @@ func (s *PostgresStore) UpdateSandboxHeartbeat(ctx context.Context, id string, r
 		updates["helix_version"] = req.HelixVersion
 	}
 
+	// Store cloud instance type if detected. Empty on bare-metal / non-AWS
+	// hosts, so we only write when present to avoid blanking a known value.
+	if req.InstanceType != "" {
+		updates["instance_type"] = req.InstanceType
+	}
+
 	// Store desktop versions as JSON if provided
 	if len(req.DesktopVersions) > 0 {
 		updates["desktop_versions"] = req.DesktopVersions

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -3254,6 +3254,10 @@ type SandboxInstance struct {
 	GPUVendor  string `json:"gpu_vendor,omitempty" gorm:"type:varchar(50)"`  // "nvidia", "amd", "intel", "none"
 	RenderNode string `json:"render_node,omitempty" gorm:"type:varchar(50)"` // /dev/dri/renderD128 or SOFTWARE
 
+	// InstanceType is the cloud instance type reported by the sandbox heartbeat
+	// (e.g. "inf2.8xlarge"). Empty on bare-metal / non-AWS hosts.
+	InstanceType string `json:"instance_type,omitempty" gorm:"type:varchar(100)"`
+
 	// Sandbox capacity. MaxSandboxes is set explicitly at auto-register
 	// and Manager-provisioned paths from HELIX_SANDBOX_MAX_DEV_CONTAINERS
 	// (default 20); the gorm default below only applies to rows inserted
@@ -3356,6 +3360,11 @@ type SandboxHeartbeatRequest struct {
 	// GPU configuration
 	GPUVendor  string `json:"gpu_vendor,omitempty"`  // nvidia, amd, intel, none
 	RenderNode string `json:"render_node,omitempty"` // /dev/dri/renderD128 or SOFTWARE
+
+	// InstanceType is the cloud instance type (e.g. "inf2.8xlarge", "g5.xlarge")
+	// detected via the AWS IMDS. Empty on bare-metal hosts (e.g. prime) and any
+	// non-AWS environment — the admin UI then just shows the GPU model instead.
+	InstanceType string `json:"instance_type,omitempty"`
 
 	// Privileged mode (host Docker access for development)
 	PrivilegedModeEnabled bool `json:"privileged_mode_enabled,omitempty"`

--- a/frontend/src/components/admin/Runners.tsx
+++ b/frontend/src/components/admin/Runners.tsx
@@ -206,8 +206,11 @@ const neuronChip = (instanceType?: string): { family: string; coresPerChip: numb
 // Handles Neuron, NVIDIA/AMD, and bare-metal hosts (no instance type).
 const RunnerHardwareCard: FC<{ sandbox: SandboxInstanceInfo }> = ({ sandbox }) => {
   const gpus = sandbox.gpus || []
-  const vendor = sandbox.gpu_vendor || gpus[0]?.vendor || ''
-  const isNeuron = vendor === 'neuron' || gpus.some((g) => g.vendor === 'neuron')
+  const isNeuron = sandbox.gpu_vendor === 'neuron' || gpus.some((g) => g.vendor === 'neuron')
+  // Prefer the per-accelerator vendor for Neuron: install.sh leaves the coarse
+  // GPU_VENDOR env empty/none on Neuron hosts, so the device inventory is the
+  // reliable signal.
+  const vendor = isNeuron ? 'neuron' : (sandbox.gpu_vendor || gpus[0]?.vendor || '')
 
   let accelerator: React.ReactNode = (
     <Typography variant="body2" color="text.secondary">No accelerator reported</Typography>
@@ -215,7 +218,7 @@ const RunnerHardwareCard: FC<{ sandbox: SandboxInstanceInfo }> = ({ sandbox }) =
   if (isNeuron) {
     const chip = neuronChip(sandbox.instance_type)
     const chips = gpus.length || 1
-    const family = chip?.family || 'AWS Neuron'
+    const family = chip?.family || 'Neuron' // template prepends "AWS "
     const totalCores = chip ? chips * chip.coresPerChip : 0
     accelerator = (
       <Typography variant="body2">

--- a/frontend/src/components/admin/Runners.tsx
+++ b/frontend/src/components/admin/Runners.tsx
@@ -115,6 +115,17 @@ interface ServiceDownloadProgress {
   stage?: string
 }
 
+// RunnerGPU is one entry of the per-runner accelerator inventory reported by
+// the heartbeat (a subset of the Go types.GPUStatus). For Neuron there is one
+// entry per chip with vendor "neuron"; memory/arch may be empty.
+interface RunnerGPU {
+  index: number
+  model_name?: string
+  vendor?: string
+  architecture?: string
+  total_memory?: number
+}
+
 interface SandboxInstanceInfo {
   id: string
   session_id: string
@@ -125,6 +136,10 @@ interface SandboxInstanceInfo {
   profile_error?: string
   service_health?: Record<string, string>
   profile_progress?: Record<string, ServiceDownloadProgress>
+  // Hardware reported by the heartbeat — drives the architecture display.
+  instance_type?: string
+  gpu_vendor?: string
+  gpus?: RunnerGPU[]
 }
 
 interface AgentSandboxesDebugResponse {
@@ -172,6 +187,74 @@ const getProfileStatusColor = (status: string): 'success' | 'warning' | 'error' 
     default:
       return 'default'
   }
+}
+
+// neuronChip maps an AWS instance type to its Neuron accelerator family and
+// NeuronCores-per-chip, so the UI can show "1 x Inferentia2 (2 NeuronCores)".
+// Returns null for non-Neuron / unknown instance types.
+const neuronChip = (instanceType?: string): { family: string; coresPerChip: number } | null => {
+  const t = (instanceType || '').toLowerCase()
+  if (t.startsWith('inf1.')) return { family: 'Inferentia1', coresPerChip: 4 }
+  if (t.startsWith('inf2.')) return { family: 'Inferentia2', coresPerChip: 2 }
+  if (t.startsWith('trn1.') || t.startsWith('trn1n.')) return { family: 'Trainium1', coresPerChip: 2 }
+  if (t.startsWith('trn2.')) return { family: 'Trainium2', coresPerChip: 8 }
+  return null
+}
+
+// RunnerHardwareCard shows the runner's architecture — cloud instance type and
+// accelerator inventory — so an operator can choose a compatible profile.
+// Handles Neuron, NVIDIA/AMD, and bare-metal hosts (no instance type).
+const RunnerHardwareCard: FC<{ sandbox: SandboxInstanceInfo }> = ({ sandbox }) => {
+  const gpus = sandbox.gpus || []
+  const vendor = sandbox.gpu_vendor || gpus[0]?.vendor || ''
+  const isNeuron = vendor === 'neuron' || gpus.some((g) => g.vendor === 'neuron')
+
+  let accelerator: React.ReactNode = (
+    <Typography variant="body2" color="text.secondary">No accelerator reported</Typography>
+  )
+  if (isNeuron) {
+    const chip = neuronChip(sandbox.instance_type)
+    const chips = gpus.length || 1
+    const family = chip?.family || 'AWS Neuron'
+    const totalCores = chip ? chips * chip.coresPerChip : 0
+    accelerator = (
+      <Typography variant="body2">
+        {chips} × AWS {family}
+        {totalCores > 0 ? ` — ${totalCores} NeuronCore${totalCores > 1 ? 's' : ''}` : ''}
+      </Typography>
+    )
+  } else if (gpus.length > 0) {
+    const names = Array.from(new Set(gpus.map((g) => g.model_name).filter(Boolean)))
+    accelerator = (
+      <Typography variant="body2">
+        {gpus.length} × {names.join(', ') || (vendor ? vendor.toUpperCase() : 'GPU')}
+      </Typography>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader title="Hardware" subheader="Architecture reported by the runner heartbeat" />
+      <CardContent>
+        <Grid container spacing={2}>
+          <Grid item xs={6}>
+            <Typography variant="caption" color="text.secondary" display="block">Instance type</Typography>
+            <Typography variant="body2">{sandbox.instance_type || 'Bare metal / unknown'}</Typography>
+          </Grid>
+          <Grid item xs={6}>
+            <Typography variant="caption" color="text.secondary" display="block">Accelerator</Typography>
+            {accelerator}
+          </Grid>
+          {vendor && (
+            <Grid item xs={6}>
+              <Typography variant="caption" color="text.secondary" display="block">Vendor</Typography>
+              <Typography variant="body2">{vendor.toUpperCase()}</Typography>
+            </Grid>
+          )}
+        </Grid>
+      </CardContent>
+    </Card>
+  )
 }
 
 // SandboxProfileCard renders the inference-profile state for one sandbox:
@@ -901,6 +984,7 @@ const Runners: FC = () => {
             )
             return (
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <RunnerHardwareCard sandbox={selectedRunner} />
                 <SandboxProfileCard sandbox={selectedRunner} />
                 <Card>
                   <CardHeader

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -1464,6 +1464,12 @@ definitions:
         type: boolean
       id:
         type: string
+      is_helix_org_agent:
+        description: |-
+          IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
+          (see api/pkg/org). Computed at list time, not persisted, so the frontend
+          can hide org-chart agents from the spec-task agent switchers.
+        type: boolean
       model_substitutions:
         items:
           $ref: '#/definitions/server.ModelSubstitution'
@@ -2534,7 +2540,21 @@ definitions:
         type: string
       container_id:
         type: string
+      gpu_vendor:
+        description: nvidia | amd | neuron
+        type: string
+      gpus:
+        description: per-accelerator inventory
+        items:
+          $ref: '#/definitions/types.GPUStatus'
+        type: array
       id:
+        type: string
+      instance_type:
+        description: |-
+          Hardware reported by the sandbox heartbeat — drives the admin UI's
+          per-runner architecture display so an operator can pick a compatible
+          profile. InstanceType is empty on bare-metal hosts (e.g. prime).
         type: string
       profile_error:
         type: string
@@ -3199,6 +3219,12 @@ definitions:
         type: boolean
       id:
         type: string
+      is_helix_org_agent:
+        description: |-
+          IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
+          (see api/pkg/org). Computed at list time, not persisted, so the frontend
+          can hide org-chart agents from the spec-task agent switchers.
+        type: boolean
       organization_id:
         type: string
       owner:
@@ -3366,7 +3392,8 @@ definitions:
           "claude_code" and CodeAgentCredentialType is "subscription". It flows through
           CodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,
           which the claude-agent-acp package reads (resolveModelPreference) to pick the
-          model — otherwise Claude Code defaults to Sonnet. Empty means "claude-opus-4-6".
+          model — otherwise Claude Code defaults to Sonnet. Empty means "opus"
+          (resolveModelPreference resolves this to the latest Opus version).
         type: string
       code_agent_credential_type:
         allOf:
@@ -4627,7 +4654,7 @@ definitions:
           project
         type: string
       scope:
-        description: optional, one of "dev", "prod", "both"; defaults to "both"
+        description: optional, one of "dev", "prod", "both"; defaults to "dev"
         type: string
       value:
         type: string
@@ -8375,6 +8402,12 @@ definitions:
         description: Helix version running on this sandbox (git commit hash or release
           version)
         type: string
+      instance_type:
+        description: |-
+          InstanceType is the cloud instance type (e.g. "inf2.8xlarge", "g5.xlarge")
+          detected via the AWS IMDS. Empty on bare-metal hosts (e.g. prime) and any
+          non-AWS environment — the admin UI then just shows the GPU model instead.
+        type: string
       privileged_mode_enabled:
         description: Privileged mode (host Docker access for development)
         type: boolean
@@ -8460,6 +8493,11 @@ definitions:
         description: Hostname for DNS resolution
         type: string
       id:
+        type: string
+      instance_type:
+        description: |-
+          InstanceType is the cloud instance type reported by the sandbox heartbeat
+          (e.g. "inf2.8xlarge"). Empty on bare-metal / non-AWS hosts.
         type: string
       ip_address:
         description: IP address of the sandbox
@@ -8588,7 +8626,8 @@ definitions:
         - $ref: '#/definitions/types.SecretScope'
         description: |-
           Scope controls which environment a project secret is injected into.
-          Defaults to "both" so pre-existing secrets keep their original behaviour.
+          Defaults to "dev" so pre-existing secrets keep their original (dev-only)
+          behaviour and dev stays the primary path.
       updated:
         type: string
       value:

--- a/swagger.json
+++ b/swagger.json
@@ -23164,6 +23164,10 @@
                 "id": {
                     "type": "string"
                 },
+                "is_helix_org_agent": {
+                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
+                    "type": "boolean"
+                },
                 "model_substitutions": {
                     "type": "array",
                     "items": {
@@ -24774,7 +24778,22 @@
                 "container_id": {
                     "type": "string"
                 },
+                "gpu_vendor": {
+                    "description": "nvidia | amd | neuron",
+                    "type": "string"
+                },
+                "gpus": {
+                    "description": "per-accelerator inventory",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.GPUStatus"
+                    }
+                },
                 "id": {
+                    "type": "string"
+                },
+                "instance_type": {
+                    "description": "Hardware reported by the sandbox heartbeat — drives the admin UI's\nper-runner architecture display so an operator can pick a compatible\nprofile. InstanceType is empty on bare-metal hosts (e.g. prime).",
                     "type": "string"
                 },
                 "profile_error": {
@@ -25692,6 +25711,10 @@
                 "id": {
                     "type": "string"
                 },
+                "is_helix_org_agent": {
+                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
+                    "type": "boolean"
+                },
                 "organization_id": {
                     "type": "string"
                 },
@@ -25931,7 +25954,7 @@
                     "$ref": "#/definitions/types.AssistantCalculator"
                 },
                 "claude_subscription_model": {
-                    "description": "ClaudeSubscriptionModel is the Anthropic model to use when CodeAgentRuntime is\n\"claude_code\" and CodeAgentCredentialType is \"subscription\". It flows through\nCodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,\nwhich the claude-agent-acp package reads (resolveModelPreference) to pick the\nmodel — otherwise Claude Code defaults to Sonnet. Empty means \"claude-opus-4-6\".",
+                    "description": "ClaudeSubscriptionModel is the Anthropic model to use when CodeAgentRuntime is\n\"claude_code\" and CodeAgentCredentialType is \"subscription\". It flows through\nCodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,\nwhich the claude-agent-acp package reads (resolveModelPreference) to pick the\nmodel — otherwise Claude Code defaults to Sonnet. Empty means \"opus\"\n(resolveModelPreference resolves this to the latest Opus version).",
                     "type": "string"
                 },
                 "code_agent_credential_type": {
@@ -27642,7 +27665,7 @@
                     "type": "string"
                 },
                 "scope": {
-                    "description": "optional, one of \"dev\", \"prod\", \"both\"; defaults to \"both\"",
+                    "description": "optional, one of \"dev\", \"prod\", \"both\"; defaults to \"dev\"",
                     "type": "string"
                 },
                 "value": {
@@ -32874,6 +32897,10 @@
                     "description": "Helix version running on this sandbox (git commit hash or release version)",
                     "type": "string"
                 },
+                "instance_type": {
+                    "description": "InstanceType is the cloud instance type (e.g. \"inf2.8xlarge\", \"g5.xlarge\")\ndetected via the AWS IMDS. Empty on bare-metal hosts (e.g. prime) and any\nnon-AWS environment — the admin UI then just shows the GPU model instead.",
+                    "type": "string"
+                },
                 "privileged_mode_enabled": {
                     "description": "Privileged mode (host Docker access for development)",
                     "type": "boolean"
@@ -32951,6 +32978,10 @@
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "instance_type": {
+                    "description": "InstanceType is the cloud instance type reported by the sandbox heartbeat\n(e.g. \"inf2.8xlarge\"). Empty on bare-metal / non-AWS hosts.",
                     "type": "string"
                 },
                 "ip_address": {
@@ -33091,7 +33122,7 @@
                     "type": "string"
                 },
                 "scope": {
-                    "description": "Scope controls which environment a project secret is injected into.\nDefaults to \"both\" so pre-existing secrets keep their original behaviour.",
+                    "description": "Scope controls which environment a project secret is injected into.\nDefaults to \"dev\" so pre-existing secrets keep their original (dev-only)\nbehaviour and dev stays the primary path.",
                     "allOf": [
                         {
                             "$ref": "#/definitions/types.SecretScope"


### PR DESCRIPTION
**Improvement 1 of 2** (runner hardware visibility). On the admin Runners page, selecting a runner now shows its architecture so you can pick a compatible profile.

## What it adds
- **Neuron detection** in `gpudetect` (glob `/dev/neuron*` → one `GPUStatus` per chip, vendor=neuron). Today neuron runners report an empty GPU list.
- **Instance type** via IMDSv2 in `sandbox-heartbeat` (1.5s timeout, fail-silent).
- `instance_type` on the heartbeat payload + `sandbox_instances` row (GORM AutoMigrate adds the column); debug DTO surfaces per-runner `instance_type`/`gpu_vendor`/`gpus`.
- **Hardware card** in `Runners.tsx`: instance type + accelerator inventory (derives Neuron family + NeuronCore count from the instance type, e.g. "1 × AWS Inferentia2 — 2 NeuronCores"; GPU model for NVIDIA/AMD).

## Bare-metal safe (e.g. prime)
The NVIDIA `nvidia-smi` path is untouched. Neuron glob returns nothing on non-neuron hosts; IMDS fails silently off-AWS (no hang) → instance type just shows "Bare metal / unknown" and the GPU model still renders as today.

## Validated
Live on inf2.8xlarge: IMDSv2 → `inf2.8xlarge`, glob → `/dev/neuron0`. Unit test for the neuron device regex. All changed Go packages build; Runners.tsx type-checks.

Next: Improvement 2 (explicit per-substrate runner placement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)