### PR TITLE
feat(quota): admin-granted paid plans via wallet PlanOverride (no Stripe)

### DIFF
--- a/api/pkg/quota/quota.go
+++ b/api/pkg/quota/quota.go
@@ -60,6 +60,12 @@ func (m *DefaultQuotaManager) getOrgQuotas(ctx context.Context, orgID string) (*
 			MaxSpecTasks:          -1,
 		}
 	// Active subscription
+	// Admin plan override (paid out-of-band; independent of Stripe, so it's
+	// never reverted by a webhook). Takes precedence over the subscription.
+	case wallet.PlanOverride == types.PlanOverridePro:
+		quotas = m.getProQuotas()
+	case wallet.PlanOverride == types.PlanOverrideFree:
+		quotas = m.getFreeQuotas()
 	case wallet.StripeSubscriptionID != "" && wallet.IsSubscriptionActive():
 		// Paid plan limits
 		quotas = m.getProQuotas()
@@ -130,6 +136,12 @@ func (m *DefaultQuotaManager) getUserQuotas(ctx context.Context, userID string) 
 			MaxRepositories:       -1,
 			MaxSpecTasks:          -1,
 		}
+	// Admin plan override (paid out-of-band; independent of Stripe, so it's
+	// never reverted by a webhook). Takes precedence over the subscription.
+	case wallet.PlanOverride == types.PlanOverridePro:
+		quotas = m.getProQuotas()
+	case wallet.PlanOverride == types.PlanOverrideFree:
+		quotas = m.getFreeQuotas()
 	case wallet.StripeSubscriptionID != "" && wallet.IsSubscriptionActive():
 		// Paid plan limits
 		quotas = m.getProQuotas()

--- a/api/pkg/quota/quota_test.go
+++ b/api/pkg/quota/quota_test.go
@@ -161,6 +161,29 @@ func (s *QuotaManagerSuite) TestGetQuotas_UserTrialingGetsProQuotas() {
 	s.Equal(20, resp.MaxProjects)
 }
 
+// An admin PlanOverride="pro" grants Pro with NO Stripe subscription at all —
+// the out-of-band-paid-customer case.
+func (s *QuotaManagerSuite) TestGetQuotas_PlanOverrideProGrantsProWithoutSub() {
+	w := &types.Wallet{UserID: "user1", PlanOverride: types.PlanOverridePro}
+	s.expectUserQuotaDefaults("user1", w, enforceQuotasSettings())
+
+	resp, err := s.manager.GetQuotas(context.Background(), &types.QuotaRequest{UserID: "user1"})
+	s.NoError(err)
+	s.Equal(5, resp.MaxConcurrentDesktops, "PlanOverride=pro grants Pro without any subscription")
+}
+
+// PlanOverride="free" forces Free even when an active subscription exists
+// (override takes precedence over the Stripe-derived tier).
+func (s *QuotaManagerSuite) TestGetQuotas_PlanOverrideFreeBeatsActiveSub() {
+	w := proWallet("user1")
+	w.PlanOverride = types.PlanOverrideFree
+	s.expectUserQuotaDefaults("user1", w, enforceQuotasSettings())
+
+	resp, err := s.manager.GetQuotas(context.Background(), &types.QuotaRequest{UserID: "user1"})
+	s.NoError(err)
+	s.Equal(2, resp.MaxConcurrentDesktops, "PlanOverride=free forces Free even with an active sub")
+}
+
 func (s *QuotaManagerSuite) TestGetQuotas_UserQuotasDisabled() {
 	s.expectUserQuotaDefaults("user1", freeWallet("user1"), disabledQuotasSettings())
 

--- a/api/pkg/server/admin_org_handlers.go
+++ b/api/pkg/server/admin_org_handlers.go
@@ -1,12 +1,68 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 
+	"github.com/gorilla/mux"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/rs/zerolog/log"
 )
+
+// SetOrgPlanRequest is the body for POST /admin/orgs/{id}/plan.
+type SetOrgPlanRequest struct {
+	// Plan: "pro" | "free" forces the org's quota tier independent of Stripe
+	// (for customers who paid out-of-band). "" clears the override and reverts
+	// to the Stripe-derived tier.
+	Plan string `json:"plan"`
+}
+
+// adminSetOrgPlan godoc
+// @Summary Set an organization's plan override (admin only)
+// @Description Force an org's quota tier independent of Stripe — for customers who paid out-of-band. plan: "pro" | "free" | "" (clear). Never reverted by a Stripe webhook.
+// @Tags    organizations
+// @Param id path string true "Organization ID"
+// @Param request body SetOrgPlanRequest true "Plan override"
+// @Success 200 {object} types.Wallet
+// @Router /api/v1/admin/orgs/{id}/plan [post]
+// @Security BearerAuth
+func (apiServer *HelixAPIServer) adminSetOrgPlan(rw http.ResponseWriter, r *http.Request) {
+	orgID := mux.Vars(r)["id"]
+	if orgID == "" {
+		http.Error(rw, "organization id is required", http.StatusBadRequest)
+		return
+	}
+	var body SetOrgPlanRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(rw, "invalid request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	switch body.Plan {
+	case "", types.PlanOverridePro, types.PlanOverrideFree:
+	default:
+		http.Error(rw, "plan must be one of: pro, free, or empty", http.StatusBadRequest)
+		return
+	}
+
+	adminUser := getRequestUser(r)
+	wallet, err := apiServer.getOrCreateWallet(r.Context(), adminUser, orgID)
+	if err != nil {
+		log.Err(err).Str("org_id", orgID).Msg("failed to get/create org wallet")
+		http.Error(rw, "failed to get org wallet: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	wallet.PlanOverride = body.Plan
+	updated, err := apiServer.Store.UpdateWallet(r.Context(), wallet)
+	if err != nil {
+		log.Err(err).Str("org_id", orgID).Msg("failed to update org wallet plan override")
+		http.Error(rw, "Internal server error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	log.Info().Str("admin_id", adminUser.ID).Str("org_id", orgID).Str("plan", body.Plan).
+		Msg("admin set org plan override")
+	writeResponse(rw, updated, http.StatusOK)
+}
 
 // adminListOrganizations godoc
 // @Summary List organizations with wallets (admin only)

--- a/api/pkg/server/admin_trial_handlers.go
+++ b/api/pkg/server/admin_trial_handlers.go
@@ -27,6 +27,10 @@ const (
 type ActivateTrialRequest struct {
 	Days    int     `json:"days"`
 	Credits float64 `json:"credits"`
+	// Plan selects what to grant. "pro" grants a PAID plan via a PlanOverride
+	// (no Stripe subscription) — for customers who paid out-of-band (bank
+	// transfer). Empty or "trial" uses the Stripe trial path (Days applies).
+	Plan string `json:"plan,omitempty"`
 }
 
 // ActivateTrialResponse describes the outcome of a trial activation.
@@ -129,6 +133,41 @@ func (s *HelixAPIServer) consumeUserTrialIntent(ctx context.Context, user *types
 		Msg(fmt.Sprintf("admin-granted trial subscription created for %d days", days))
 }
 
+// consumeUserPlanOnFirstOrg applies any admin-stashed paid-plan intent
+// (PlanOnFirstOrg) to the given org's wallet as a PlanOverride. Called after an
+// org is created. Best-effort: errors are logged, never block org creation.
+// Independent of the Stripe trial path — a paid out-of-band grant needs no
+// subscription.
+func (s *HelixAPIServer) consumeUserPlanOnFirstOrg(ctx context.Context, user *types.User, orgID string) {
+	if user == nil || user.PlanOnFirstOrg == nil || *user.PlanOnFirstOrg == "" {
+		return
+	}
+	plan := *user.PlanOnFirstOrg
+
+	wallet, err := s.getOrCreateWallet(ctx, user, orgID)
+	if err != nil {
+		log.Warn().Err(err).Str("user_id", user.ID).Str("org_id", orgID).
+			Msg("failed to get/create wallet for plan-override consumption")
+		return
+	}
+	wallet.PlanOverride = plan
+	if _, err := s.Store.UpdateWallet(ctx, wallet); err != nil {
+		log.Warn().Err(err).Str("wallet_id", wallet.ID).
+			Msg("failed to persist plan override to wallet")
+		return
+	}
+
+	user.PlanOnFirstOrg = nil
+	if _, err := s.Store.UpdateUser(ctx, user); err != nil {
+		log.Warn().Err(err).Str("user_id", user.ID).
+			Msg("failed to clear PlanOnFirstOrg after consumption")
+		return
+	}
+
+	log.Info().Str("user_id", user.ID).Str("org_id", orgID).Str("plan", plan).
+		Msg("admin-stashed paid plan applied to first org wallet")
+}
+
 // adminActivateTrial godoc
 // @Summary Activate a trial for a user (Admin, cloud only)
 // @Description Stash a trial intent on the user, or immediately create a Stripe trial subscription on the user's oldest-owned org. Days defaults to 90; credits are taken verbatim from the request (0 means no admin top-up beyond what Stripe's subscription invoice contributes).
@@ -184,6 +223,46 @@ func (apiServer *HelixAPIServer) adminActivateTrial(_ http.ResponseWriter, req *
 	oldestOrg, err := oldestOwnedOrg(ctx, apiServer.Store, targetUserID)
 	if err != nil {
 		return nil, system.NewHTTPError500("failed to list user organizations: " + err.Error())
+	}
+
+	// Paid plan granted out-of-band (e.g. bank transfer): set a PlanOverride,
+	// no Stripe subscription. Independent of Stripe so it is never reverted by
+	// a webhook. Applied to the oldest owned org now, or stashed for the user's
+	// first org.
+	if body.Plan == types.PlanOverridePro {
+		if oldestOrg == nil {
+			plan := types.PlanOverridePro
+			targetUser.PlanOnFirstOrg = &plan
+			if body.Credits > 0 {
+				c := body.Credits
+				targetUser.PendingAdminCreditsOnFirstOrg = &c
+			}
+			updated, uErr := apiServer.Store.UpdateUser(ctx, targetUser)
+			if uErr != nil {
+				return nil, system.NewHTTPError500("failed to stash paid-plan intent: " + uErr.Error())
+			}
+			log.Info().Str("admin_id", adminUser.ID).Str("target_user_id", targetUserID).
+				Msg("admin stashed paid-plan intent on user (no org yet)")
+			return &ActivateTrialResponse{User: updated, Status: "stashed"}, nil
+		}
+		wallet, wErr := apiServer.getOrCreateWallet(ctx, targetUser, oldestOrg.ID)
+		if wErr != nil {
+			return nil, system.NewHTTPError500("failed to get wallet for oldest owned org: " + wErr.Error())
+		}
+		wallet.PlanOverride = types.PlanOverridePro
+		if _, wErr := apiServer.Store.UpdateWallet(ctx, wallet); wErr != nil {
+			return nil, system.NewHTTPError500("failed to set plan override: " + wErr.Error())
+		}
+		if body.Credits > 0 {
+			if _, bErr := apiServer.Store.UpdateWalletBalance(ctx, wallet.ID, body.Credits, types.TransactionMetadata{
+				TransactionType: types.TransactionTypeSubscription,
+			}); bErr != nil {
+				log.Warn().Err(bErr).Str("wallet_id", wallet.ID).Msg("failed to top up wallet with credits")
+			}
+		}
+		log.Info().Str("admin_id", adminUser.ID).Str("target_user_id", targetUserID).Str("org_id", oldestOrg.ID).
+			Msg("admin granted paid plan (PlanOverride=pro) on oldest owned org")
+		return &ActivateTrialResponse{User: targetUser, OrgID: oldestOrg.ID, Status: "applied"}, nil
 	}
 
 	// Path A: no owned org yet. Stash intent on the user; consumeUserTrialIntent

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -743,6 +743,46 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/admin/orgs/{id}/plan": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Force an org's quota tier independent of Stripe — for customers who paid out-of-band. plan: \"pro\" | \"free\" | \"\" (clear). Never reverted by a Stripe webhook.",
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "Set an organization's plan override (admin only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Plan override",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.SetOrgPlanRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Wallet"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/users/{id}": {
             "delete": {
                 "security": [
@@ -23094,6 +23134,10 @@ const docTemplate = `{
                 },
                 "days": {
                     "type": "integer"
+                },
+                "plan": {
+                    "description": "Plan selects what to grant. \"pro\" grants a PAID plan via a PlanOverride\n(no Stripe subscription) — for customers who paid out-of-band (bank\ntransfer). Empty or \"trial\" uses the Stripe trial path (Days applies).",
+                    "type": "string"
                 }
             }
         },
@@ -24966,6 +25010,15 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "sandbox_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "server.SetOrgPlanRequest": {
+            "type": "object",
+            "properties": {
+                "plan": {
+                    "description": "Plan: \"pro\" | \"free\" forces the org's quota tier independent of Stripe\n(for customers who paid out-of-band). \"\" clears the override and reverts\nto the Stripe-derived tier.",
                     "type": "string"
                 }
             }
@@ -36870,6 +36923,10 @@ const docTemplate = `{
                     "description": "PendingAdminCreditsOnFirstOrg holds credits stashed by admin via the\n/admin/users/{id}/credits endpoint when the user has no owned org yet.\nConsumed by consumeUserAdminCredits on first owned org, then cleared.\nKept separate from TrialCreditsOnFirstOrg so admins can comp credits\nwithout entangling the grant with trial-state UI or revocation flows.",
                     "type": "number"
                 },
+                "plan_on_first_org": {
+                    "description": "PlanOnFirstOrg, when set (\"pro\"), grants a paid plan override to the\nuser's first owned org's wallet on creation — admin \"Activate\" with a\npaid (non-Stripe) plan for a user who has no org yet. Consumed alongside\nthe trial intent, then cleared.",
+                    "type": "string"
+                },
                 "project_id": {
                     "description": "When running in Helix Code sandbox",
                     "type": "string"
@@ -37262,6 +37319,10 @@ const docTemplate = `{
                 },
                 "org_id": {
                     "description": "If belongs to an organization",
+                    "type": "string"
+                },
+                "plan_override": {
+                    "description": "PlanOverride, when set (\"free\"|\"pro\"), forces the quota tier for this\nwallet regardless of the Stripe subscription — used to grant a paid plan\nto a customer who paid out-of-band (bank transfer, no card / no Stripe).\n\"\" means derive the tier from the Stripe subscription as usual. Stripe\nsync only ever writes the Subscription* fields, never this one, so an\nadmin grant can't be reverted by a webhook.",
                     "type": "string"
                 },
                 "stripe_customer_id": {

--- a/api/pkg/server/organization_handlers.go
+++ b/api/pkg/server/organization_handlers.go
@@ -338,6 +338,10 @@ func (apiServer *HelixAPIServer) createOrganization(rw http.ResponseWriter, r *h
 	// without entangling them with trial-state UI or revocation flows.
 	apiServer.consumeUserAdminCredits(ctx, user, createdOrg.ID)
 
+	// Apply any admin-stashed paid-plan grant (PlanOnFirstOrg) as a
+	// PlanOverride on this first org's wallet (out-of-band paid customers).
+	apiServer.consumeUserPlanOnFirstOrg(ctx, user, createdOrg.ID)
+
 	writeResponse(rw, createdOrg, http.StatusCreated)
 }
 

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1344,6 +1344,7 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	adminRouter.HandleFunc("/admin/users/{id}/owned-orgs", system.DefaultWrapper(apiServer.listUserOwnedOrgs)).Methods(http.MethodGet)
 
 	adminRouter.HandleFunc("/admin/orgs", apiServer.adminListOrganizations).Methods(http.MethodGet)
+	adminRouter.HandleFunc("/admin/orgs/{id}/plan", apiServer.adminSetOrgPlan).Methods(http.MethodPost)
 
 	// Sandbox-absorbs-runner pivot: /scheduler/heartbeats and /slots
 	// endpoints removed — no scheduler, no slots.

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -739,6 +739,46 @@
                 }
             }
         },
+        "/api/v1/admin/orgs/{id}/plan": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Force an org's quota tier independent of Stripe — for customers who paid out-of-band. plan: \"pro\" | \"free\" | \"\" (clear). Never reverted by a Stripe webhook.",
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "Set an organization's plan override (admin only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Plan override",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.SetOrgPlanRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Wallet"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/users/{id}": {
             "delete": {
                 "security": [
@@ -23090,6 +23130,10 @@
                 },
                 "days": {
                     "type": "integer"
+                },
+                "plan": {
+                    "description": "Plan selects what to grant. \"pro\" grants a PAID plan via a PlanOverride\n(no Stripe subscription) — for customers who paid out-of-band (bank\ntransfer). Empty or \"trial\" uses the Stripe trial path (Days applies).",
+                    "type": "string"
                 }
             }
         },
@@ -24962,6 +25006,15 @@
             "type": "object",
             "properties": {
                 "sandbox_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "server.SetOrgPlanRequest": {
+            "type": "object",
+            "properties": {
+                "plan": {
+                    "description": "Plan: \"pro\" | \"free\" forces the org's quota tier independent of Stripe\n(for customers who paid out-of-band). \"\" clears the override and reverts\nto the Stripe-derived tier.",
                     "type": "string"
                 }
             }
@@ -36866,6 +36919,10 @@
                     "description": "PendingAdminCreditsOnFirstOrg holds credits stashed by admin via the\n/admin/users/{id}/credits endpoint when the user has no owned org yet.\nConsumed by consumeUserAdminCredits on first owned org, then cleared.\nKept separate from TrialCreditsOnFirstOrg so admins can comp credits\nwithout entangling the grant with trial-state UI or revocation flows.",
                     "type": "number"
                 },
+                "plan_on_first_org": {
+                    "description": "PlanOnFirstOrg, when set (\"pro\"), grants a paid plan override to the\nuser's first owned org's wallet on creation — admin \"Activate\" with a\npaid (non-Stripe) plan for a user who has no org yet. Consumed alongside\nthe trial intent, then cleared.",
+                    "type": "string"
+                },
                 "project_id": {
                     "description": "When running in Helix Code sandbox",
                     "type": "string"
@@ -37258,6 +37315,10 @@
                 },
                 "org_id": {
                     "description": "If belongs to an organization",
+                    "type": "string"
+                },
+                "plan_override": {
+                    "description": "PlanOverride, when set (\"free\"|\"pro\"), forces the quota tier for this\nwallet regardless of the Stripe subscription — used to grant a paid plan\nto a customer who paid out-of-band (bank transfer, no card / no Stripe).\n\"\" means derive the tier from the Stripe subscription as usual. Stripe\nsync only ever writes the Subscription* fields, never this one, so an\nadmin grant can't be reverted by a webhook.",
                     "type": "string"
                 },
                 "stripe_customer_id": {

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -1417,6 +1417,12 @@ definitions:
         type: number
       days:
         type: integer
+      plan:
+        description: |-
+          Plan selects what to grant. "pro" grants a PAID plan via a PlanOverride
+          (no Stripe subscription) — for customers who paid out-of-band (bank
+          transfer). Empty or "trial" uses the Stripe trial path (Days applies).
+        type: string
     type: object
   server.ActivateTrialResponse:
     properties:
@@ -2667,6 +2673,15 @@ definitions:
   server.SetActiveSandboxRequest:
     properties:
       sandbox_id:
+        type: string
+    type: object
+  server.SetOrgPlanRequest:
+    properties:
+      plan:
+        description: |-
+          Plan: "pro" | "free" forces the org's quota tier independent of Stripe
+          (for customers who paid out-of-band). "" clears the override and reverts
+          to the Stripe-derived tier.
         type: string
     type: object
   server.SharePointSiteResolveRequest:
@@ -11367,6 +11382,13 @@ definitions:
           Kept separate from TrialCreditsOnFirstOrg so admins can comp credits
           without entangling the grant with trial-state UI or revocation flows.
         type: number
+      plan_on_first_org:
+        description: |-
+          PlanOnFirstOrg, when set ("pro"), grants a paid plan override to the
+          user's first owned org's wallet on creation — admin "Activate" with a
+          paid (non-Stripe) plan for a user who has no org yet. Consumed alongside
+          the trial intent, then cleared.
+        type: string
       project_id:
         description: When running in Helix Code sandbox
         type: string
@@ -11650,6 +11672,15 @@ definitions:
         type: string
       org_id:
         description: If belongs to an organization
+        type: string
+      plan_override:
+        description: |-
+          PlanOverride, when set ("free"|"pro"), forces the quota tier for this
+          wallet regardless of the Stripe subscription — used to grant a paid plan
+          to a customer who paid out-of-band (bank transfer, no card / no Stripe).
+          "" means derive the tier from the Stripe subscription as usual. Stripe
+          sync only ever writes the Subscription* fields, never this one, so an
+          admin grant can't be reverted by a webhook.
         type: string
       stripe_customer_id:
         type: string
@@ -12294,6 +12325,33 @@ paths:
       security:
       - BearerAuth: []
       summary: List organizations with wallets (admin only)
+      tags:
+      - organizations
+  /api/v1/admin/orgs/{id}/plan:
+    post:
+      description: 'Force an org''s quota tier independent of Stripe — for customers
+        who paid out-of-band. plan: "pro" | "free" | "" (clear). Never reverted by
+        a Stripe webhook.'
+      parameters:
+      - description: Organization ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Plan override
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/server.SetOrgPlanRequest'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Wallet'
+      security:
+      - BearerAuth: []
+      summary: Set an organization's plan override (admin only)
       tags:
       - organizations
   /api/v1/admin/users/{id}:

--- a/api/pkg/types/authz.go
+++ b/api/pkg/types/authz.go
@@ -253,6 +253,12 @@ type User struct {
 	TrialDaysOnFirstOrg    *int     `json:"trial_days_on_first_org,omitempty"`
 	TrialCreditsOnFirstOrg *float64 `json:"trial_credits_on_first_org,omitempty"`
 
+	// PlanOnFirstOrg, when set ("pro"), grants a paid plan override to the
+	// user's first owned org's wallet on creation — admin "Activate" with a
+	// paid (non-Stripe) plan for a user who has no org yet. Consumed alongside
+	// the trial intent, then cleared.
+	PlanOnFirstOrg *string `json:"plan_on_first_org,omitempty"`
+
 	// PendingAdminCreditsOnFirstOrg holds credits stashed by admin via the
 	// /admin/users/{id}/credits endpoint when the user has no owned org yet.
 	// Consumed by consumeUserAdminCredits on first owned org, then cleared.

--- a/api/pkg/types/wallet.go
+++ b/api/pkg/types/wallet.go
@@ -21,10 +21,24 @@ type Wallet struct {
 	SubscriptionCreated            int64                     `json:"subscription_created"`
 	SubscriptionCancelAtPeriodEnd  bool                      `json:"subscription_cancel_at_period_end"`
 
+	// PlanOverride, when set ("free"|"pro"), forces the quota tier for this
+	// wallet regardless of the Stripe subscription — used to grant a paid plan
+	// to a customer who paid out-of-band (bank transfer, no card / no Stripe).
+	// "" means derive the tier from the Stripe subscription as usual. Stripe
+	// sync only ever writes the Subscription* fields, never this one, so an
+	// admin grant can't be reverted by a webhook.
+	PlanOverride string `json:"plan_override,omitempty" gorm:"index"`
+
 	UserID  string  `json:"user_id" gorm:"index"`
 	OrgID   string  `json:"org_id" gorm:"index"` // If belongs to an organization
 	Balance float64 `json:"balance"`
 }
+
+// Plan override values for Wallet.PlanOverride.
+const (
+	PlanOverridePro  = "pro"
+	PlanOverrideFree = "free"
+)
 
 func (w *Wallet) IsSubscriptionActive() bool {
 	switch w.SubscriptionStatus {

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -924,6 +924,12 @@ export interface OpenaiViolence {
 export interface ServerActivateTrialRequest {
   credits?: number;
   days?: number;
+  /**
+   * Plan selects what to grant. "pro" grants a PAID plan via a PlanOverride
+   * (no Stripe subscription) — for customers who paid out-of-band (bank
+   * transfer). Empty or "trial" uses the Stripe trial path (Days applies).
+   */
+  plan?: string;
 }
 
 export interface ServerActivateTrialResponse {
@@ -952,6 +958,12 @@ export interface ServerAppCreateResponse {
   created?: string;
   global?: boolean;
   id?: string;
+  /**
+   * IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
+   * (see api/pkg/org). Computed at list time, not persisted, so the frontend
+   * can hide org-chart agents from the spec-task agent switchers.
+   */
+  is_helix_org_agent?: boolean;
   model_substitutions?: ServerModelSubstitution[];
   organization_id?: string;
   /** uuid of user ID */
@@ -1601,7 +1613,17 @@ export interface ServerSandboxInstanceInfo {
    */
   active_profile_id?: string;
   container_id?: string;
+  /** nvidia | amd | neuron */
+  gpu_vendor?: string;
+  /** per-accelerator inventory */
+  gpus?: TypesGPUStatus[];
   id?: string;
+  /**
+   * Hardware reported by the sandbox heartbeat — drives the admin UI's
+   * per-runner architecture display so an operator can pick a compatible
+   * profile. InstanceType is empty on bare-metal hosts (e.g. prime).
+   */
+  instance_type?: string;
   profile_error?: string;
   profile_progress?: Record<string, TypesServiceDownloadProgress>;
   profile_status?: string;
@@ -1672,6 +1694,15 @@ export interface ServerSessionTOCResponse {
 
 export interface ServerSetActiveSandboxRequest {
   sandbox_id?: string;
+}
+
+export interface ServerSetOrgPlanRequest {
+  /**
+   * Plan: "pro" | "free" forces the org's quota tier independent of Stripe
+   * (for customers who paid out-of-band). "" clears the override and reverts
+   * to the Stripe-derived tier.
+   */
+  plan?: string;
 }
 
 export interface ServerSharePointSiteResolveRequest {
@@ -2028,6 +2059,12 @@ export interface TypesApp {
   created?: string;
   global?: boolean;
   id?: string;
+  /**
+   * IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
+   * (see api/pkg/org). Computed at list time, not persisted, so the frontend
+   * can hide org-chart agents from the spec-task agent switchers.
+   */
+  is_helix_org_agent?: boolean;
   organization_id?: string;
   /** uuid of user ID */
   owner?: string;
@@ -2122,7 +2159,8 @@ export interface TypesAssistantConfig {
    * "claude_code" and CodeAgentCredentialType is "subscription". It flows through
    * CodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,
    * which the claude-agent-acp package reads (resolveModelPreference) to pick the
-   * model — otherwise Claude Code defaults to Sonnet. Empty means "claude-opus-4-6".
+   * model — otherwise Claude Code defaults to Sonnet. Empty means "opus"
+   * (resolveModelPreference resolves this to the latest Opus version).
    */
   claude_subscription_model?: string;
   /**
@@ -2913,7 +2951,7 @@ export interface TypesCreateSecretRequest {
   name?: string;
   /** optional, if set, the secret will be available to the specified project */
   project_id?: string;
-  /** optional, one of "dev", "prod", "both"; defaults to "both" */
+  /** optional, one of "dev", "prod", "both"; defaults to "dev" */
   scope?: string;
   value?: string;
 }
@@ -5189,6 +5227,12 @@ export interface TypesSandboxHeartbeatRequest {
   gpus?: TypesGPUStatus[];
   /** Helix version running on this sandbox (git commit hash or release version) */
   helix_version?: string;
+  /**
+   * InstanceType is the cloud instance type (e.g. "inf2.8xlarge", "g5.xlarge")
+   * detected via the AWS IMDS. Empty on bare-metal hosts (e.g. prime) and any
+   * non-AWS environment — the admin UI then just shows the GPU model instead.
+   */
+  instance_type?: string;
   /** Privileged mode (host Docker access for development) */
   privileged_mode_enabled?: boolean;
   /** ProfileError carries the failure detail when ProfileStatus="failed". */
@@ -5258,6 +5302,11 @@ export interface TypesSandboxInstance {
   /** Hostname for DNS resolution */
   hostname?: string;
   id?: string;
+  /**
+   * InstanceType is the cloud instance type reported by the sandbox heartbeat
+   * (e.g. "inf2.8xlarge"). Empty on bare-metal / non-AWS hosts.
+   */
+  instance_type?: string;
   /** IP address of the sandbox */
   ip_address?: string;
   /** Last heartbeat time */
@@ -5346,7 +5395,8 @@ export interface TypesSecret {
   project_id?: string;
   /**
    * Scope controls which environment a project secret is injected into.
-   * Defaults to "both" so pre-existing secrets keep their original behaviour.
+   * Defaults to "dev" so pre-existing secrets keep their original (dev-only)
+   * behaviour and dev stays the primary path.
    */
   scope?: TypesSecretScope;
   updated?: string;
@@ -7016,6 +7066,13 @@ export interface TypesUser {
    * without entangling the grant with trial-state UI or revocation flows.
    */
   pending_admin_credits_on_first_org?: number;
+  /**
+   * PlanOnFirstOrg, when set ("pro"), grants a paid plan override to the
+   * user's first owned org's wallet on creation — admin "Activate" with a
+   * paid (non-Stripe) plan for a user who has no org yet. Consumed alongside
+   * the trial intent, then cleared.
+   */
+  plan_on_first_org?: string;
   /** When running in Helix Code sandbox */
   project_id?: string;
   sb?: boolean;
@@ -7202,6 +7259,15 @@ export interface TypesWallet {
   id?: string;
   /** If belongs to an organization */
   org_id?: string;
+  /**
+   * PlanOverride, when set ("free"|"pro"), forces the quota tier for this
+   * wallet regardless of the Stripe subscription — used to grant a paid plan
+   * to a customer who paid out-of-band (bank transfer, no card / no Stripe).
+   * "" means derive the tier from the Stripe subscription as usual. Stripe
+   * sync only ever writes the Subscription* fields, never this one, so an
+   * admin grant can't be reverted by a webhook.
+   */
+  plan_override?: string;
   stripe_customer_id?: string;
   stripe_subscription_id?: string;
   subscription_cancel_at_period_end?: boolean;
@@ -7760,6 +7826,25 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         path: `/api/v1/admin/orgs`,
         method: "GET",
         secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description Force an org's quota tier independent of Stripe — for customers who paid out-of-band. plan: "pro" | "free" | "" (clear). Never reverted by a Stripe webhook.
+     *
+     * @tags organizations
+     * @name V1AdminOrgsPlanCreate
+     * @summary Set an organization's plan override (admin only)
+     * @request POST:/api/v1/admin/orgs/{id}/plan
+     * @secure
+     */
+    v1AdminOrgsPlanCreate: (id: string, request: ServerSetOrgPlanRequest, params: RequestParams = {}) =>
+      this.request<TypesWallet, any>({
+        path: `/api/v1/admin/orgs/${id}/plan`,
+        method: "POST",
+        body: request,
+        secure: true,
+        type: ContentType.Json,
         ...params,
       }),
 

--- a/frontend/src/components/dashboard/ActivateTrialDialog.tsx
+++ b/frontend/src/components/dashboard/ActivateTrialDialog.tsx
@@ -11,6 +11,7 @@ import {
     CircularProgress,
     IconButton,
     Typography,
+    MenuItem,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { TypesUser } from '../../api/api';
@@ -33,6 +34,8 @@ const DEFAULT_CREDITS = 0;
 const ActivateTrialDialog: FC<ActivateTrialDialogProps> = ({ open, onClose, user }) => {
     const [days, setDays] = useState(String(DEFAULT_DAYS));
     const [credits, setCredits] = useState(String(DEFAULT_CREDITS));
+    // '' = Stripe trial (uses days); 'pro' = paid plan via PlanOverride (no Stripe).
+    const [plan, setPlan] = useState('');
     const [error, setError] = useState('');
     const activateTrial = useAdminActivateTrial();
     const snackbar = useSnackbar();
@@ -41,15 +44,17 @@ const ActivateTrialDialog: FC<ActivateTrialDialogProps> = ({ open, onClose, user
         if (open) {
             setDays(String(DEFAULT_DAYS));
             setCredits(String(DEFAULT_CREDITS));
+            setPlan('');
             setError('');
         }
     }, [open]);
 
     const handleSubmit = async () => {
         if (!user?.id) return;
+        const isPaid = plan === 'pro';
         const daysNum = parseInt(days, 10);
         const creditsNum = parseFloat(credits);
-        if (!Number.isFinite(daysNum) || daysNum <= 0) {
+        if (!isPaid && (!Number.isFinite(daysNum) || daysNum <= 0)) {
             setError('Days must be a positive number');
             return;
         }
@@ -60,18 +65,19 @@ const ActivateTrialDialog: FC<ActivateTrialDialogProps> = ({ open, onClose, user
         try {
             const result = await activateTrial.mutateAsync({
                 userId: user.id,
-                days: daysNum,
+                days: isPaid ? 0 : daysNum,
                 credits: creditsNum,
+                plan,
             });
             const status = (result as any)?.status as string | undefined;
             if (status === 'stashed') {
-                snackbar.success(`Trial intent stashed — applied when ${user.email} creates their first org`);
+                snackbar.success(`${isPaid ? 'Paid plan' : 'Trial'} intent stashed — applied when ${user.email} creates their first org`);
             } else {
-                snackbar.success(`${daysNum}-day trial activated for ${user.email}`);
+                snackbar.success(isPaid ? `Paid (Pro) plan activated for ${user.email}` : `${daysNum}-day trial activated for ${user.email}`);
             }
             onClose();
         } catch (err: any) {
-            const msg = err?.response?.data?.error || err?.message || 'Failed to activate trial';
+            const msg = err?.response?.data?.error || err?.message || 'Failed to activate';
             setError(msg);
         }
     };
@@ -115,13 +121,31 @@ const ActivateTrialDialog: FC<ActivateTrialDialogProps> = ({ open, onClose, user
                     )}
 
                     <TextField
+                        select
+                        fullWidth
+                        label="Plan"
+                        value={plan}
+                        onChange={(e) => setPlan(e.target.value)}
+                        margin="normal"
+                        disabled={activateTrial.isPending}
+                        helperText={
+                            plan === 'pro'
+                                ? 'Paid Pro — no Stripe, no card, indefinite (for customers who paid out-of-band)'
+                                : 'Stripe trial for the chosen number of days'
+                        }
+                    >
+                        <MenuItem value="">Trial (Stripe)</MenuItem>
+                        <MenuItem value="pro">Paid — Pro (no Stripe)</MenuItem>
+                    </TextField>
+
+                    <TextField
                         fullWidth
                         label="Days"
                         value={days}
                         onChange={(e) => setDays(e.target.value)}
                         margin="normal"
-                        disabled={activateTrial.isPending}
-                        helperText="Length of the free trial in days"
+                        disabled={activateTrial.isPending || plan === 'pro'}
+                        helperText={plan === 'pro' ? 'Not used for a paid plan' : 'Length of the free trial in days'}
                     />
 
                     <TextField

--- a/frontend/src/components/dashboard/AdminOrgsTable.tsx
+++ b/frontend/src/components/dashboard/AdminOrgsTable.tsx
@@ -15,15 +15,34 @@ import {
     Chip,
     InputAdornment,
     IconButton,
+    Menu,
+    MenuItem,
 } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import ClearIcon from "@mui/icons-material/Clear";
+import EditIcon from "@mui/icons-material/Edit";
 import { TypesOrgDetails } from "../../api/api";
-import { useListAdminOrgs } from "../../services/dashboardService";
+import { useListAdminOrgs, useAdminSetOrgPlan } from "../../services/dashboardService";
 
 const AdminOrgsTable: FC = () => {
     const [searchQuery, setSearchQuery] = useState("");
     const { data: orgs, isLoading, error } = useListAdminOrgs();
+    const setOrgPlan = useAdminSetOrgPlan();
+    const [planAnchor, setPlanAnchor] = useState<null | HTMLElement>(null);
+    const [planOrgId, setPlanOrgId] = useState<string | null>(null);
+
+    const openPlanMenu = (e: React.MouseEvent<HTMLElement>, orgId: string) => {
+        setPlanAnchor(e.currentTarget);
+        setPlanOrgId(orgId);
+    };
+    const closePlanMenu = () => {
+        setPlanAnchor(null);
+        setPlanOrgId(null);
+    };
+    const applyPlan = (plan: string) => {
+        if (planOrgId) setOrgPlan.mutate({ orgId: planOrgId, plan });
+        closePlanMenu();
+    };
 
     const filtered = useMemo(() => {
         if (!orgs) return [];
@@ -112,13 +131,14 @@ const AdminOrgsTable: FC = () => {
                             <TableCell>Members</TableCell>
                             <TableCell>Stripe Customer ID</TableCell>
                             <TableCell>Subscription</TableCell>
+                            <TableCell>Plan</TableCell>
                             <TableCell align="right">Wallet Credits</TableCell>
                         </TableRow>
                     </TableHead>
                     <TableBody>
                         {filtered.length === 0 ? (
                             <TableRow>
-                                <TableCell colSpan={6} align="center">
+                                <TableCell colSpan={7} align="center">
                                     <Typography variant="body2" color="text.secondary">
                                         {searchQuery ? "No organizations matching your search" : "No organizations found"}
                                     </Typography>
@@ -196,6 +216,27 @@ const AdminOrgsTable: FC = () => {
                                                 <Typography variant="body2" color="text.secondary">None</Typography>
                                             )}
                                         </TableCell>
+                                        <TableCell>
+                                            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                                                {org.wallet?.plan_override ? (
+                                                    <Chip
+                                                        label={org.wallet.plan_override}
+                                                        size="small"
+                                                        color={org.wallet.plan_override === "pro" ? "success" : "default"}
+                                                    />
+                                                ) : (
+                                                    <Typography variant="body2" color="text.secondary">—</Typography>
+                                                )}
+                                                <IconButton
+                                                    size="small"
+                                                    aria-label="set plan"
+                                                    disabled={setOrgPlan.isPending}
+                                                    onClick={(e) => openPlanMenu(e, org.organization?.id || "")}
+                                                >
+                                                    <EditIcon fontSize="small" />
+                                                </IconButton>
+                                            </Box>
+                                        </TableCell>
                                         <TableCell align="right">
                                             <Typography variant="body2">
                                                 {balance !== undefined ? `$${balance.toFixed(2)}` : "N/A"}
@@ -208,6 +249,12 @@ const AdminOrgsTable: FC = () => {
                     </TableBody>
                 </Table>
             </TableContainer>
+
+            <Menu anchorEl={planAnchor} open={Boolean(planAnchor)} onClose={closePlanMenu}>
+                <MenuItem onClick={() => applyPlan("pro")}>Set Pro (paid, no Stripe)</MenuItem>
+                <MenuItem onClick={() => applyPlan("free")}>Set Free</MenuItem>
+                <MenuItem onClick={() => applyPlan("")}>Clear override (use Stripe)</MenuItem>
+            </Menu>
         </Paper>
     );
 };

--- a/frontend/src/services/dashboardService.ts
+++ b/frontend/src/services/dashboardService.ts
@@ -241,6 +241,14 @@ export interface ActivateTrialInput {
     userId: string;
     days?: number;
     credits?: number;
+    // plan "pro" grants a PAID plan via a PlanOverride (no Stripe subscription)
+    // — for customers who paid out-of-band. "" (default) uses the Stripe trial.
+    plan?: string;
+}
+
+export interface SetOrgPlanInput {
+    orgId: string;
+    plan: string; // "pro" | "free" | "" (clear → derive from Stripe)
 }
 
 export interface GrantCreditsInput {
@@ -292,11 +300,34 @@ export function useAdminActivateTrial() {
             const response = await apiClient.v1AdminUsersTrialActivateCreate(input.userId, {
                 days: input.days ?? 0,
                 credits: input.credits ?? 0,
+                plan: input.plan ?? "",
             });
             return response.data;
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["users"] });
+        },
+    });
+}
+
+/**
+ * Hook to set an organization's plan override (cloud edition, admin only).
+ * plan "pro"/"free" forces the quota tier independent of Stripe (for customers
+ * who paid out-of-band); "" clears the override. Never reverted by a Stripe
+ * webhook.
+ */
+export function useAdminSetOrgPlan() {
+    const api = useApi();
+    const apiClient = api.getApiClient();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (input: SetOrgPlanInput) => {
+            const response = await apiClient.v1AdminOrgsPlanCreate(input.orgId, { plan: input.plan });
+            return response.data;
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: adminOrgsQueryKey() });
         },
     });
 }

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -1417,6 +1417,12 @@ definitions:
         type: number
       days:
         type: integer
+      plan:
+        description: |-
+          Plan selects what to grant. "pro" grants a PAID plan via a PlanOverride
+          (no Stripe subscription) — for customers who paid out-of-band (bank
+          transfer). Empty or "trial" uses the Stripe trial path (Days applies).
+        type: string
     type: object
   server.ActivateTrialResponse:
     properties:
@@ -2667,6 +2673,15 @@ definitions:
   server.SetActiveSandboxRequest:
     properties:
       sandbox_id:
+        type: string
+    type: object
+  server.SetOrgPlanRequest:
+    properties:
+      plan:
+        description: |-
+          Plan: "pro" | "free" forces the org's quota tier independent of Stripe
+          (for customers who paid out-of-band). "" clears the override and reverts
+          to the Stripe-derived tier.
         type: string
     type: object
   server.SharePointSiteResolveRequest:
@@ -11367,6 +11382,13 @@ definitions:
           Kept separate from TrialCreditsOnFirstOrg so admins can comp credits
           without entangling the grant with trial-state UI or revocation flows.
         type: number
+      plan_on_first_org:
+        description: |-
+          PlanOnFirstOrg, when set ("pro"), grants a paid plan override to the
+          user's first owned org's wallet on creation — admin "Activate" with a
+          paid (non-Stripe) plan for a user who has no org yet. Consumed alongside
+          the trial intent, then cleared.
+        type: string
       project_id:
         description: When running in Helix Code sandbox
         type: string
@@ -11650,6 +11672,15 @@ definitions:
         type: string
       org_id:
         description: If belongs to an organization
+        type: string
+      plan_override:
+        description: |-
+          PlanOverride, when set ("free"|"pro"), forces the quota tier for this
+          wallet regardless of the Stripe subscription — used to grant a paid plan
+          to a customer who paid out-of-band (bank transfer, no card / no Stripe).
+          "" means derive the tier from the Stripe subscription as usual. Stripe
+          sync only ever writes the Subscription* fields, never this one, so an
+          admin grant can't be reverted by a webhook.
         type: string
       stripe_customer_id:
         type: string
@@ -12294,6 +12325,33 @@ paths:
       security:
       - BearerAuth: []
       summary: List organizations with wallets (admin only)
+      tags:
+      - organizations
+  /api/v1/admin/orgs/{id}/plan:
+    post:
+      description: 'Force an org''s quota tier independent of Stripe — for customers
+        who paid out-of-band. plan: "pro" | "free" | "" (clear). Never reverted by
+        a Stripe webhook.'
+      parameters:
+      - description: Organization ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Plan override
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/server.SetOrgPlanRequest'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Wallet'
+      security:
+      - BearerAuth: []
+      summary: Set an organization's plan override (admin only)
       tags:
       - organizations
   /api/v1/admin/users/{id}:

--- a/openapi.json
+++ b/openapi.json
@@ -876,6 +876,54 @@
                 }
             }
         },
+        "/api/v1/admin/orgs/{id}/plan": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Force an org's quota tier independent of Stripe — for customers who paid out-of-band. plan: \"pro\" | \"free\" | \"\" (clear). Never reverted by a Stripe webhook.",
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "Set an organization's plan override (admin only)",
+                "parameters": [
+                    {
+                        "description": "Organization ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/server.SetOrgPlanRequest"
+                            }
+                        }
+                    },
+                    "description": "Plan override",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.Wallet"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/users/{id}": {
             "delete": {
                 "security": [
@@ -27406,6 +27454,10 @@
                     },
                     "days": {
                         "type": "integer"
+                    },
+                    "plan": {
+                        "description": "Plan selects what to grant. \"pro\" grants a PAID plan via a PlanOverride\n(no Stripe subscription) — for customers who paid out-of-band (bank\ntransfer). Empty or \"trial\" uses the Stripe trial path (Days applies).",
+                        "type": "string"
                     }
                 }
             },
@@ -27479,6 +27531,10 @@
                     },
                     "id": {
                         "type": "string"
+                    },
+                    "is_helix_org_agent": {
+                        "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
+                        "type": "boolean"
                     },
                     "model_substitutions": {
                         "type": "array",
@@ -29090,7 +29146,22 @@
                     "container_id": {
                         "type": "string"
                     },
+                    "gpu_vendor": {
+                        "description": "nvidia | amd | neuron",
+                        "type": "string"
+                    },
+                    "gpus": {
+                        "description": "per-accelerator inventory",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/types.GPUStatus"
+                        }
+                    },
                     "id": {
+                        "type": "string"
+                    },
+                    "instance_type": {
+                        "description": "Hardware reported by the sandbox heartbeat — drives the admin UI's\nper-runner architecture display so an operator can pick a compatible\nprofile. InstanceType is empty on bare-metal hosts (e.g. prime).",
                         "type": "string"
                     },
                     "profile_error": {
@@ -29259,6 +29330,15 @@
                 "type": "object",
                 "properties": {
                     "sandbox_id": {
+                        "type": "string"
+                    }
+                }
+            },
+            "server.SetOrgPlanRequest": {
+                "type": "object",
+                "properties": {
+                    "plan": {
+                        "description": "Plan: \"pro\" | \"free\" forces the org's quota tier independent of Stripe\n(for customers who paid out-of-band). \"\" clears the override and reverts\nto the Stripe-derived tier.",
                         "type": "string"
                     }
                 }
@@ -30008,6 +30088,10 @@
                     "id": {
                         "type": "string"
                     },
+                    "is_helix_org_agent": {
+                        "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
+                        "type": "boolean"
+                    },
                     "organization_id": {
                         "type": "string"
                     },
@@ -30247,7 +30331,7 @@
                         "$ref": "#/components/schemas/types.AssistantCalculator"
                     },
                     "claude_subscription_model": {
-                        "description": "ClaudeSubscriptionModel is the Anthropic model to use when CodeAgentRuntime is\n\"claude_code\" and CodeAgentCredentialType is \"subscription\". It flows through\nCodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,\nwhich the claude-agent-acp package reads (resolveModelPreference) to pick the\nmodel — otherwise Claude Code defaults to Sonnet. Empty means \"claude-opus-4-6\".",
+                        "description": "ClaudeSubscriptionModel is the Anthropic model to use when CodeAgentRuntime is\n\"claude_code\" and CodeAgentCredentialType is \"subscription\". It flows through\nCodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,\nwhich the claude-agent-acp package reads (resolveModelPreference) to pick the\nmodel — otherwise Claude Code defaults to Sonnet. Empty means \"opus\"\n(resolveModelPreference resolves this to the latest Opus version).",
                         "type": "string"
                     },
                     "code_agent_credential_type": {
@@ -31958,7 +32042,7 @@
                         "type": "string"
                     },
                     "scope": {
-                        "description": "optional, one of \"dev\", \"prod\", \"both\"; defaults to \"both\"",
+                        "description": "optional, one of \"dev\", \"prod\", \"both\"; defaults to \"dev\"",
                         "type": "string"
                     },
                     "value": {
@@ -37190,6 +37274,10 @@
                         "description": "Helix version running on this sandbox (git commit hash or release version)",
                         "type": "string"
                     },
+                    "instance_type": {
+                        "description": "InstanceType is the cloud instance type (e.g. \"inf2.8xlarge\", \"g5.xlarge\")\ndetected via the AWS IMDS. Empty on bare-metal hosts (e.g. prime) and any\nnon-AWS environment — the admin UI then just shows the GPU model instead.",
+                        "type": "string"
+                    },
                     "privileged_mode_enabled": {
                         "description": "Privileged mode (host Docker access for development)",
                         "type": "boolean"
@@ -37267,6 +37355,10 @@
                         "type": "string"
                     },
                     "id": {
+                        "type": "string"
+                    },
+                    "instance_type": {
+                        "description": "InstanceType is the cloud instance type reported by the sandbox heartbeat\n(e.g. \"inf2.8xlarge\"). Empty on bare-metal / non-AWS hosts.",
                         "type": "string"
                     },
                     "ip_address": {
@@ -37407,7 +37499,7 @@
                         "type": "string"
                     },
                     "scope": {
-                        "description": "Scope controls which environment a project secret is injected into.\nDefaults to \"both\" so pre-existing secrets keep their original behaviour.",
+                        "description": "Scope controls which environment a project secret is injected into.\nDefaults to \"dev\" so pre-existing secrets keep their original (dev-only)\nbehaviour and dev stays the primary path.",
                         "allOf": [
                             {
                                 "$ref": "#/components/schemas/types.SecretScope"
@@ -41151,6 +41243,10 @@
                         "description": "PendingAdminCreditsOnFirstOrg holds credits stashed by admin via the\n/admin/users/{id}/credits endpoint when the user has no owned org yet.\nConsumed by consumeUserAdminCredits on first owned org, then cleared.\nKept separate from TrialCreditsOnFirstOrg so admins can comp credits\nwithout entangling the grant with trial-state UI or revocation flows.",
                         "type": "number"
                     },
+                    "plan_on_first_org": {
+                        "description": "PlanOnFirstOrg, when set (\"pro\"), grants a paid plan override to the\nuser's first owned org's wallet on creation — admin \"Activate\" with a\npaid (non-Stripe) plan for a user who has no org yet. Consumed alongside\nthe trial intent, then cleared.",
+                        "type": "string"
+                    },
                     "project_id": {
                         "description": "When running in Helix Code sandbox",
                         "type": "string"
@@ -41543,6 +41639,10 @@
                     },
                     "org_id": {
                         "description": "If belongs to an organization",
+                        "type": "string"
+                    },
+                    "plan_override": {
+                        "description": "PlanOverride, when set (\"free\"|\"pro\"), forces the quota tier for this\nwallet regardless of the Stripe subscription — used to grant a paid plan\nto a customer who paid out-of-band (bank transfer, no card / no Stripe).\n\"\" means derive the tier from the Stripe subscription as usual. Stripe\nsync only ever writes the Subscription* fields, never this one, so an\nadmin grant can't be reverted by a webhook.",
                         "type": "string"
                     },
                     "stripe_customer_id": {

--- a/swagger.json
+++ b/swagger.json
@@ -739,6 +739,46 @@
                 }
             }
         },
+        "/api/v1/admin/orgs/{id}/plan": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Force an org's quota tier independent of Stripe — for customers who paid out-of-band. plan: \"pro\" | \"free\" | \"\" (clear). Never reverted by a Stripe webhook.",
+                "tags": [
+                    "organizations"
+                ],
+                "summary": "Set an organization's plan override (admin only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Plan override",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.SetOrgPlanRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Wallet"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/users/{id}": {
             "delete": {
                 "security": [
@@ -23090,6 +23130,10 @@
                 },
                 "days": {
                     "type": "integer"
+                },
+                "plan": {
+                    "description": "Plan selects what to grant. \"pro\" grants a PAID plan via a PlanOverride\n(no Stripe subscription) — for customers who paid out-of-band (bank\ntransfer). Empty or \"trial\" uses the Stripe trial path (Days applies).",
+                    "type": "string"
                 }
             }
         },
@@ -24962,6 +25006,15 @@
             "type": "object",
             "properties": {
                 "sandbox_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "server.SetOrgPlanRequest": {
+            "type": "object",
+            "properties": {
+                "plan": {
+                    "description": "Plan: \"pro\" | \"free\" forces the org's quota tier independent of Stripe\n(for customers who paid out-of-band). \"\" clears the override and reverts\nto the Stripe-derived tier.",
                     "type": "string"
                 }
             }
@@ -36866,6 +36919,10 @@
                     "description": "PendingAdminCreditsOnFirstOrg holds credits stashed by admin via the\n/admin/users/{id}/credits endpoint when the user has no owned org yet.\nConsumed by consumeUserAdminCredits on first owned org, then cleared.\nKept separate from TrialCreditsOnFirstOrg so admins can comp credits\nwithout entangling the grant with trial-state UI or revocation flows.",
                     "type": "number"
                 },
+                "plan_on_first_org": {
+                    "description": "PlanOnFirstOrg, when set (\"pro\"), grants a paid plan override to the\nuser's first owned org's wallet on creation — admin \"Activate\" with a\npaid (non-Stripe) plan for a user who has no org yet. Consumed alongside\nthe trial intent, then cleared.",
+                    "type": "string"
+                },
                 "project_id": {
                     "description": "When running in Helix Code sandbox",
                     "type": "string"
@@ -37258,6 +37315,10 @@
                 },
                 "org_id": {
                     "description": "If belongs to an organization",
+                    "type": "string"
+                },
+                "plan_override": {
+                    "description": "PlanOverride, when set (\"free\"|\"pro\"), forces the quota tier for this\nwallet regardless of the Stripe subscription — used to grant a paid plan\nto a customer who paid out-of-band (bank transfer, no card / no Stripe).\n\"\" means derive the tier from the Stripe subscription as usual. Stripe\nsync only ever writes the Subscription* fields, never this one, so an\nadmin grant can't be reverted by a webhook.",
                     "type": "string"
                 },
                 "stripe_customer_id": {


### PR DESCRIPTION
Admins could only **Activate Trial** (a Stripe trial sub), which is wrong for a customer who paid **out-of-band** (bank transfer, no card): it's time-limited, Stripe-managed (so a manual fix gets reverted by Stripe sync — exactly what happened when I bumped find-ai to `active` and a webhook put it back to `trialing`), and ties the account to a trial lifecycle. find-ai/Leah hit all of this.

Adds a **Stripe-independent plan grant**:

- **`Wallet.PlanOverride`** (`"pro"`|`"free"`|`""`) — quota honors it over the Stripe-derived tier in both the org and user paths. Stripe sync only ever writes `subscription_*`, never `PlanOverride`, so an admin grant **can't be reverted by a webhook**.
- **`POST /admin/orgs/{id}/plan`** — set an existing org's plan.
- **Activate-with-plan** — grant a paid Pro plan (override, no Stripe) as an alternative to the trial; if the user has no org yet it stashes `PlanOnFirstOrg`, consumed onto their first org's wallet (`consumeUserPlanOnFirstOrg`, next to the existing trial/credit consumers in org creation).
- **Frontend**: AdminOrgsTable gains a **Plan** column + set-plan menu (Pro / Free / clear); the Activate dialog gains a **plan selector** (Trial vs Paid Pro). Regenerated API client + swagger.

## Testing
- Unit (`quota_test.go`): `PlanOverride=pro` → Pro with **no** subscription; `=free` forces Free even over an active sub. `go test ./pkg/quota/` green.
- `go build ./pkg/server/` clean; `yarn build` clean.
- Not yet live-exercised end-to-end (ships via release); meta E2E after merge: set a test org to Pro in the admin Orgs UI → GetQuotas returns Pro; confirm a Stripe sync does not change the override.

Once this ships, find-ai gets a proper **paid** plan (`PlanOverride=pro`) instead of the spurious trial, and the same admin control covers every out-of-band-paid customer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)