### PR TITLE
fix(install): use sudo for .env writes in --upgrade

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -937,16 +937,23 @@ do_upgrade() {
         esac
     fi
 
+    # $INSTALL_DIR is typically root-owned (/opt/HelixML created by a sudo
+    # install), so .env writes need sudo even when docker runs without it.
+    local SUDO=""
+    if [ "$ENVIRONMENT" != "gitbash" ] && [ ! -w "$INSTALL_DIR/.env" ]; then
+        SUDO="sudo"
+    fi
+
     local backup="$INSTALL_DIR/.env.bak.$(date +%Y%m%d-%H%M%S)"
-    cp "$INSTALL_DIR/.env" "$backup"
+    $SUDO cp "$INSTALL_DIR/.env" "$backup"
     echo "Backed up .env to $backup"
 
     # Rewrite HELIX_VERSION in place. If the line is absent, append it.
     if grep -qE '^HELIX_VERSION=' "$INSTALL_DIR/.env"; then
-        sed -i.tmp "s|^HELIX_VERSION=.*|HELIX_VERSION=${target_version}|" "$INSTALL_DIR/.env"
-        rm -f "$INSTALL_DIR/.env.tmp"
+        $SUDO sed -i.tmp "s|^HELIX_VERSION=.*|HELIX_VERSION=${target_version}|" "$INSTALL_DIR/.env"
+        $SUDO rm -f "$INSTALL_DIR/.env.tmp"
     else
-        printf '\nHELIX_VERSION=%s\n' "$target_version" >> "$INSTALL_DIR/.env"
+        printf '\nHELIX_VERSION=%s\n' "$target_version" | $SUDO tee -a "$INSTALL_DIR/.env" >/dev/null
     fi
     echo "Set HELIX_VERSION=$target_version in $INSTALL_DIR/.env"
 


### PR DESCRIPTION
## Problem

`./install.sh --upgrade` fails on a standard controlplane install:

```
cp: cannot create regular file '/opt/HelixML/.env.bak.20260625-165718': Permission denied
```

`do_upgrade()` writes to `$INSTALL_DIR/.env` (typically `/opt/HelixML`, root-owned from the original sudo install) without `sudo`: the backup `cp`, the `sed -i` rewrite, and the append all run as the unprivileged operator. Docker commands succeed because the user is in the `docker` group, which masks that the file writes still need root.

## Fix

Compute a `SUDO` prefix in `do_upgrade()` only when `.env` is not writable (and not Git Bash), and apply it to the file mutations:

- `$SUDO cp` for the backup
- `$SUDO sed -i` / `$SUDO rm` for the in-place rewrite
- `printf ... | $SUDO tee -a` for the append (the old `>> file` redirect runs in the unprivileged shell, so `sudo` on `printf` wouldn't help)

User-owned installs are unaffected: `SUDO` stays empty. `bash -n` passes.

## Test

- Root-owned `/opt/HelixML`, operator in docker group: upgrade now backs up and rewrites `.env`, then pulls and recreates.
- User-owned install dir: `SUDO` empty, behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)