### PR TITLE
feat(slack): auto-router — route Slack messages by worker name + thread-follow

### DIFF
--- a/api/pkg/org/application/lifecycle/hire_test.go
+++ b/api/pkg/org/application/lifecycle/hire_test.go
@@ -21,10 +21,10 @@ func hireClock() time.Time { return time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC
 // (Helix / Mirror / Owner) stay nil — these tests never fire.
 func newHireService(st *store.Store) *lifecycle.Service {
 	return &lifecycle.Service{
-		Store:      st,
-		Reconciler: reconcile.New(reconcile.Deps{Workers: st.Workers, ReportingLines: st.ReportingLines, Topics: st.Topics, Subscriptions: st.Subscriptions, Now: hireClock}),
-		Now:        hireClock,
-		NewID:      func() string { return "id" },
+		Store:             st,
+		WorkerReconcilers: []lifecycle.WorkerReconciler{reconcile.New(reconcile.Deps{Workers: st.Workers, ReportingLines: st.ReportingLines, Topics: st.Topics, Subscriptions: st.Subscriptions, Now: hireClock})},
+		Now:               hireClock,
+		NewID:             func() string { return "id" },
 	}
 }
 

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -19,7 +19,6 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/helixml/helix/api/pkg/org/application/reconcile"
 	"github.com/helixml/helix/api/pkg/org/domain/activation"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/org/domain/store"
@@ -44,13 +43,27 @@ type HelixRuntime interface {
 	DeleteApp(ctx context.Context, id string) error
 }
 
-// OrgReconciler converges some derived state for a whole org after a
-// structural change. Contract: org-scoped (no per-Worker scoping),
-// idempotent, and best-effort (the lifecycle logs a failure and carries on —
-// the reconciler re-runs on the next mutation / at startup). *slackrouting.
-// Reconciler is the first implementer; new whole-org reconcilers just satisfy
-// this and get appended to Service.Reconcilers. Declared here (the consumer)
-// so lifecycle stays decoupled from each reconciler's package.
+// The lifecycle runs two kinds of reconciler after a structural change, and
+// they are deliberately separate types because their CONTRACTS differ — not
+// just a comment, the compiler enforces which list a reconciler can join.
+//
+// WorkerReconciler is scoped to the Worker(s) that changed: callers pass the
+// affected ids and it converges only their neighbourhood (cheap, and it
+// no-ops on an empty set). It is structural — Hire treats a failure as FATAL
+// (the new Worker's channels weren't set up), Fire as best-effort.
+// *reconcile.Reconciler (activation/team/DM Topics) is the implementer.
+type WorkerReconciler interface {
+	Reconcile(ctx context.Context, orgID string, affected ...orgchart.WorkerID) error
+}
+
+// OrgReconciler converges some derived state for the WHOLE org — it takes no
+// affected set. Contract: idempotent and always best-effort (a failure is
+// logged and the mutation proceeds; it re-runs on the next mutation / at
+// startup). *slackrouting.Reconciler (Slack auto-router routes) is the first
+// implementer; new whole-org reconcilers just satisfy this and append.
+//
+// Both are declared here (the consumer) so lifecycle stays decoupled from
+// each reconciler's package.
 type OrgReconciler interface {
 	Reconcile(ctx context.Context, orgID string) error
 }
@@ -63,23 +76,20 @@ type Service struct {
 	Helix  HelixRuntime
 	Logger *slog.Logger
 
-	// Reconciler reconciles the activation/team Topics after the Worker
-	// row is gone — it tears down the fired Worker's own Topics and
-	// collapses an ex-manager's team Topic when its last report just
-	// left. nil is a no-op (tests without topology wiring).
-	Reconciler *reconcile.Reconciler
+	// WorkerReconcilers are the Worker-scoped reconcilers (see the contract
+	// on WorkerReconciler) run on hire (FATAL) and fire (best-effort) with the
+	// affected Worker ids. Today just the activation/team/DM topology
+	// reconciler. Empty/nil is a no-op.
+	WorkerReconcilers []WorkerReconciler
 
 	// Mirror is the transcript mirror; Fire stops the fired Worker's
 	// subscription so it doesn't leak. nil is a no-op.
 	Mirror *helix.Mirror
 
-	// Reconcilers are whole-org, best-effort reconcilers run after every
-	// hire/fire — each converges some derived state (Slack auto-router routes
-	// today; future ones just append). They differ from Reconciler above,
-	// which is scoped to the affected Workers and is fatal on hire; these take
-	// only the org and their failures are logged, never aborting the
-	// mutation. Empty/nil is a no-op.
-	Reconcilers []OrgReconciler
+	// OrgReconcilers are the whole-org, best-effort reconcilers (see the
+	// contract on OrgReconciler) run after every hire/fire — Slack auto-router
+	// routes today; future ones just append. Empty/nil is a no-op.
+	OrgReconcilers []OrgReconciler
 
 	// --- Hire collaborators (the create half of the lifecycle) ---
 
@@ -200,18 +210,23 @@ func (s *Service) Hire(ctx context.Context, orgID string, p HireParams) (HireRes
 		}
 	}
 
-	// Reconcile the activation/team Topics implied by the new Worker and
-	// its reporting line (mints the hire's transcript + the
-	// manager's team Topic from one declarative pass). A nil Reconciler is
-	// a no-op (the Reconciler guards its own nil receiver).
-	if err := s.Reconciler.Reconcile(ctx, orgID, id); err != nil {
-		return HireResult{}, fmt.Errorf("reconcile topology for hire %q: %w", id, err)
+	// Reconcile the activation/team Topics implied by the new Worker and its
+	// reporting line (mints the hire's transcript + the manager's team Topic
+	// from one declarative pass). FATAL: a Worker without its channels is a
+	// broken hire. Worker-scoped to the new id.
+	for _, rec := range s.WorkerReconcilers {
+		if rec == nil {
+			continue
+		}
+		if err := rec.Reconcile(ctx, orgID, id); err != nil {
+			return HireResult{}, fmt.Errorf("reconcile topology for hire %q: %w", id, err)
+		}
 	}
 
 	// Run the whole-org reconcilers (Slack auto-router routes, …) for the new
 	// Worker. Best-effort: a failure must not abort the hire — each is
 	// idempotent and re-runs on the next hire/fire and at startup.
-	s.runReconcilers(ctx, orgID, "hire", id)
+	s.runOrgReconcilers(ctx, orgID, "hire", id)
 
 	// Persist the hiring user's identity (if the request carried one)
 	// BEFORE dispatch so the Spawner picks it up on its first call.
@@ -330,18 +345,18 @@ func (s *Service) Fire(ctx context.Context, orgID string, id orgchart.WorkerID) 
 		return fmt.Errorf("delete worker row %q: %w", id, err)
 	}
 
-	// Settle the activation/team Topics now that the row (and its
-	// reporting lines) are gone. topology is the single owner of their
-	// lifecycle: reconciling `id` tears down the fired Worker's own
-	// activation + team Topics (it has fallen out of the graph), and
-	// reconciling the ex-managers collapses a manager's team Topic when
-	// its last report just left. Best-effort: a failure here leaves a
-	// dangling Topic row, not a half-deleted worker, so we log and
-	// continue rather than failing the Fire.
-	if s.Reconciler != nil {
-		affected := append([]orgchart.WorkerID{id}, exManagers...)
-		affected = append(affected, exReports...)
-		if err := s.Reconciler.Reconcile(ctx, orgID, affected...); err != nil {
+	// Settle the activation/team Topics now that the row (and its reporting
+	// lines) are gone — the Worker-scoped reconcilers tear down the fired
+	// Worker's own Topics and collapse an ex-manager's team Topic when its
+	// last report just left. Best-effort here (unlike hire): a failure leaves
+	// a dangling Topic row, not a half-deleted worker, so we log and continue.
+	affected := append([]orgchart.WorkerID{id}, exManagers...)
+	affected = append(affected, exReports...)
+	for _, rec := range s.WorkerReconcilers {
+		if rec == nil {
+			continue
+		}
+		if err := rec.Reconcile(ctx, orgID, affected...); err != nil {
 			s.logger().Warn("fire: reconcile topology", "worker", id, "err", err)
 		}
 	}
@@ -349,15 +364,15 @@ func (s *Service) Fire(ctx context.Context, orgID string, id orgchart.WorkerID) 
 	// Run the whole-org reconcilers so the fired Worker's Slack auto-route is
 	// GC'd (its subscription already cascaded with the row; the reconciler
 	// drops the route + owned Topic). Best-effort, like topology above.
-	s.runReconcilers(ctx, orgID, "fire", id)
+	s.runOrgReconcilers(ctx, orgID, "fire", id)
 	return nil
 }
 
-// runReconcilers runs every whole-org reconciler best-effort, logging (not
+// runOrgReconcilers runs every whole-org reconciler best-effort, logging (not
 // propagating) failures so one reconciler can't abort the lifecycle mutation
 // or block the others. phase/worker are for the log line only.
-func (s *Service) runReconcilers(ctx context.Context, orgID, phase string, worker orgchart.WorkerID) {
-	for _, rec := range s.Reconcilers {
+func (s *Service) runOrgReconcilers(ctx context.Context, orgID, phase string, worker orgchart.WorkerID) {
+	for _, rec := range s.OrgReconcilers {
 		if rec == nil {
 			continue
 		}

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -44,6 +44,13 @@ type HelixRuntime interface {
 	DeleteApp(ctx context.Context, id string) error
 }
 
+// SlackRouterReconciler converges Slack auto-routers' managed routes for an
+// org. *slackrouting.Reconciler satisfies it; declared here (not imported)
+// so lifecycle stays decoupled from the Slack-routing package.
+type SlackRouterReconciler interface {
+	Reconcile(ctx context.Context, orgID string) error
+}
+
 // Service composes the worker-lifecycle operations the REST layer
 // drives. All fields are required; pass nil HelixRuntime only in
 // tests that don't need the Helix-side teardown.
@@ -61,6 +68,12 @@ type Service struct {
 	// Mirror is the transcript mirror; Fire stops the fired Worker's
 	// subscription so it doesn't leak. nil is a no-op.
 	Mirror *helix.Mirror
+
+	// SlackRouter converges the Slack auto-routers' per-Worker routes after
+	// a hire/fire (add a route for the new Worker; GC the departed Worker's
+	// route). Org-scoped and idempotent. nil is a no-op (runtimes without
+	// Slack routing). Best-effort on fire, like the topology Reconciler.
+	SlackRouter SlackRouterReconciler
 
 	// --- Hire collaborators (the create half of the lifecycle) ---
 
@@ -187,6 +200,15 @@ func (s *Service) Hire(ctx context.Context, orgID string, p HireParams) (HireRes
 	// a no-op (the Reconciler guards its own nil receiver).
 	if err := s.Reconciler.Reconcile(ctx, orgID, id); err != nil {
 		return HireResult{}, fmt.Errorf("reconcile topology for hire %q: %w", id, err)
+	}
+
+	// Add a Slack auto-route for the new Worker (no-op without Slack routing
+	// or an auto-router). Best-effort: a routing failure must not abort the
+	// hire — the reconciler is idempotent and re-runs on the next hire/fire.
+	if s.SlackRouter != nil {
+		if err := s.SlackRouter.Reconcile(ctx, orgID); err != nil {
+			s.logger().Warn("hire: reconcile slack routes", "worker", id, "err", err)
+		}
 	}
 
 	// Persist the hiring user's identity (if the request carried one)
@@ -319,6 +341,14 @@ func (s *Service) Fire(ctx context.Context, orgID string, id orgchart.WorkerID) 
 		affected = append(affected, exReports...)
 		if err := s.Reconciler.Reconcile(ctx, orgID, affected...); err != nil {
 			s.logger().Warn("fire: reconcile topology", "worker", id, "err", err)
+		}
+	}
+
+	// GC the fired Worker's Slack auto-route (its subscription already
+	// cascaded with the row; the reconciler drops the route + owned Topic).
+	if s.SlackRouter != nil {
+		if err := s.SlackRouter.Reconcile(ctx, orgID); err != nil {
+			s.logger().Warn("fire: reconcile slack routes", "worker", id, "err", err)
 		}
 	}
 	return nil

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -44,10 +44,14 @@ type HelixRuntime interface {
 	DeleteApp(ctx context.Context, id string) error
 }
 
-// SlackRouterReconciler converges Slack auto-routers' managed routes for an
-// org. *slackrouting.Reconciler satisfies it; declared here (not imported)
-// so lifecycle stays decoupled from the Slack-routing package.
-type SlackRouterReconciler interface {
+// OrgReconciler converges some derived state for a whole org after a
+// structural change. Contract: org-scoped (no per-Worker scoping),
+// idempotent, and best-effort (the lifecycle logs a failure and carries on —
+// the reconciler re-runs on the next mutation / at startup). *slackrouting.
+// Reconciler is the first implementer; new whole-org reconcilers just satisfy
+// this and get appended to Service.Reconcilers. Declared here (the consumer)
+// so lifecycle stays decoupled from each reconciler's package.
+type OrgReconciler interface {
 	Reconcile(ctx context.Context, orgID string) error
 }
 
@@ -69,11 +73,13 @@ type Service struct {
 	// subscription so it doesn't leak. nil is a no-op.
 	Mirror *helix.Mirror
 
-	// SlackRouter converges the Slack auto-routers' per-Worker routes after
-	// a hire/fire (add a route for the new Worker; GC the departed Worker's
-	// route). Org-scoped and idempotent. nil is a no-op (runtimes without
-	// Slack routing). Best-effort on fire, like the topology Reconciler.
-	SlackRouter SlackRouterReconciler
+	// Reconcilers are whole-org, best-effort reconcilers run after every
+	// hire/fire — each converges some derived state (Slack auto-router routes
+	// today; future ones just append). They differ from Reconciler above,
+	// which is scoped to the affected Workers and is fatal on hire; these take
+	// only the org and their failures are logged, never aborting the
+	// mutation. Empty/nil is a no-op.
+	Reconcilers []OrgReconciler
 
 	// --- Hire collaborators (the create half of the lifecycle) ---
 
@@ -202,14 +208,10 @@ func (s *Service) Hire(ctx context.Context, orgID string, p HireParams) (HireRes
 		return HireResult{}, fmt.Errorf("reconcile topology for hire %q: %w", id, err)
 	}
 
-	// Add a Slack auto-route for the new Worker (no-op without Slack routing
-	// or an auto-router). Best-effort: a routing failure must not abort the
-	// hire — the reconciler is idempotent and re-runs on the next hire/fire.
-	if s.SlackRouter != nil {
-		if err := s.SlackRouter.Reconcile(ctx, orgID); err != nil {
-			s.logger().Warn("hire: reconcile slack routes", "worker", id, "err", err)
-		}
-	}
+	// Run the whole-org reconcilers (Slack auto-router routes, …) for the new
+	// Worker. Best-effort: a failure must not abort the hire — each is
+	// idempotent and re-runs on the next hire/fire and at startup.
+	s.runReconcilers(ctx, orgID, "hire", id)
 
 	// Persist the hiring user's identity (if the request carried one)
 	// BEFORE dispatch so the Spawner picks it up on its first call.
@@ -344,14 +346,25 @@ func (s *Service) Fire(ctx context.Context, orgID string, id orgchart.WorkerID) 
 		}
 	}
 
-	// GC the fired Worker's Slack auto-route (its subscription already
-	// cascaded with the row; the reconciler drops the route + owned Topic).
-	if s.SlackRouter != nil {
-		if err := s.SlackRouter.Reconcile(ctx, orgID); err != nil {
-			s.logger().Warn("fire: reconcile slack routes", "worker", id, "err", err)
+	// Run the whole-org reconcilers so the fired Worker's Slack auto-route is
+	// GC'd (its subscription already cascaded with the row; the reconciler
+	// drops the route + owned Topic). Best-effort, like topology above.
+	s.runReconcilers(ctx, orgID, "fire", id)
+	return nil
+}
+
+// runReconcilers runs every whole-org reconciler best-effort, logging (not
+// propagating) failures so one reconciler can't abort the lifecycle mutation
+// or block the others. phase/worker are for the log line only.
+func (s *Service) runReconcilers(ctx context.Context, orgID, phase string, worker orgchart.WorkerID) {
+	for _, rec := range s.Reconcilers {
+		if rec == nil {
+			continue
+		}
+		if err := rec.Reconcile(ctx, orgID); err != nil {
+			s.logger().Warn(phase+": reconcile", "worker", worker, "err", err)
 		}
 	}
-	return nil
 }
 
 // DeleteRole tears down a Role end-to-end:

--- a/api/pkg/org/application/lifecycle/lifecycle_test.go
+++ b/api/pkg/org/application/lifecycle/lifecycle_test.go
@@ -68,7 +68,7 @@ func TestFire_RemovesWorkersTranscript(t *testing.T) {
 		t.Fatalf("precondition: transcript not seeded: %v", err)
 	}
 
-	svc := &lifecycle.Service{Store: st, Reconciler: reconcile.New(reconcile.Deps{Workers: st.Workers, ReportingLines: st.ReportingLines, Topics: st.Topics, Subscriptions: st.Subscriptions})}
+	svc := &lifecycle.Service{Store: st, WorkerReconcilers: []lifecycle.WorkerReconciler{reconcile.New(reconcile.Deps{Workers: st.Workers, ReportingLines: st.ReportingLines, Topics: st.Topics, Subscriptions: st.Subscriptions})}}
 	if err := svc.Fire(ctx, orgID, worker.ID()); err != nil {
 		t.Fatalf("Fire: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestFire_CascadesReportingLinesAndSubscriptions(t *testing.T) {
 		t.Fatalf("create subscription: %v", err)
 	}
 
-	svc := &lifecycle.Service{Store: st, Reconciler: reconcile.New(reconcile.Deps{Workers: st.Workers, ReportingLines: st.ReportingLines, Topics: st.Topics, Subscriptions: st.Subscriptions})}
+	svc := &lifecycle.Service{Store: st, WorkerReconcilers: []lifecycle.WorkerReconciler{reconcile.New(reconcile.Deps{Workers: st.Workers, ReportingLines: st.ReportingLines, Topics: st.Topics, Subscriptions: st.Subscriptions})}}
 	if err := svc.Fire(ctx, orgID, mgr.ID()); err != nil {
 		t.Fatalf("Fire: %v", err)
 	}
@@ -224,7 +224,7 @@ func TestFire_TearsDownDMChannelToReports(t *testing.T) {
 		t.Fatalf("precondition: DM channel %q should exist after wiring the edge: %v", dm, err)
 	}
 
-	svc := &lifecycle.Service{Store: st, Reconciler: rec}
+	svc := &lifecycle.Service{Store: st, WorkerReconcilers: []lifecycle.WorkerReconciler{rec}}
 	if err := svc.Fire(ctx, orgID, mgr.ID()); err != nil {
 		t.Fatalf("Fire: %v", err)
 	}
@@ -249,8 +249,8 @@ func TestFire_TearsDownDMChannelToReports(t *testing.T) {
 // Helix project/app, so the Fire cascade never calls into Helix).
 func newLifecycleSvc(st *store.Store) *lifecycle.Service {
 	return &lifecycle.Service{
-		Store:      st,
-		Reconciler: reconcile.New(reconcile.Deps{Workers: st.Workers, ReportingLines: st.ReportingLines, Topics: st.Topics, Subscriptions: st.Subscriptions}),
+		Store:             st,
+		WorkerReconcilers: []lifecycle.WorkerReconciler{reconcile.New(reconcile.Deps{Workers: st.Workers, ReportingLines: st.ReportingLines, Topics: st.Topics, Subscriptions: st.Subscriptions})},
 	}
 }
 
@@ -366,7 +366,7 @@ func TestDeleteRole_ReconcilesSurvivingCrossRoleReport(t *testing.T) {
 
 	svc := newLifecycleSvc(st)
 	// Provision the channels the edge implies (team topic + DM channel).
-	if err := svc.Reconciler.Reconcile(ctx, orgID, "w-mgr", "w-ic"); err != nil {
+	if err := svc.WorkerReconcilers[0].Reconcile(ctx, orgID, "w-mgr", "w-ic"); err != nil {
 		t.Fatalf("reconcile (wire edge): %v", err)
 	}
 	dm := channels.DMTopicID("w-mgr", "w-ic")

--- a/api/pkg/org/application/processing/runner.go
+++ b/api/pkg/org/application/processing/runner.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/helixml/helix/api/pkg/org/domain/processor"
 	"github.com/helixml/helix/api/pkg/org/domain/store"
 	"github.com/helixml/helix/api/pkg/org/domain/streaming"
 )
@@ -57,18 +58,36 @@ func withHop(ctx context.Context) context.Context {
 	return context.WithValue(ctx, hopCtxKey{}, hopCount(ctx)+1)
 }
 
+// PostRouter is a late-bound observer fired after an Automated processor
+// routes a Message — the seam thread-follow plugs into. It receives the
+// processor, the input Message, and the Results its pure Process produced
+// (the name-matched routes), so it can record/extend routing with state the
+// pure Process must not touch. Defined here (not imported) so processing
+// stays Slack-agnostic; slackrouting.ThreadFollower satisfies it and is
+// registered at the composition root, exactly like the ProcessorRunner /
+// Outbound arms. nil → no post-routing, the default.
+type PostRouter interface {
+	AfterRoute(ctx context.Context, p processor.Processor, msg streaming.Message, results []processor.Result)
+}
+
 // Runner executes the processors that read a topic and publishes their
 // results. Construct with New.
 type Runner struct {
-	procs     store.Processors
-	publisher Publisher
-	logger    *slog.Logger
+	procs      store.Processors
+	publisher  Publisher
+	logger     *slog.Logger
+	postRouter PostRouter
 }
 
 // New constructs a Runner. logger must be non-nil.
 func New(procs store.Processors, publisher Publisher, logger *slog.Logger) *Runner {
 	return &Runner{procs: procs, publisher: publisher, logger: logger}
 }
+
+// RegisterPostRouter wires the post-routing observer (thread-follow).
+// Late-bound for the same reason as the dispatcher's arms: the follower
+// depends on the publishing service built after the Runner.
+func (r *Runner) RegisterPostRouter(pr PostRouter) { r.postRouter = pr }
 
 // Run is the Dispatcher's late-bound fan-out hook. For each processor
 // reading e.TopicID it applies the processor to msg and publishes every
@@ -104,6 +123,13 @@ func (r *Runner) Run(ctx context.Context, e streaming.Event, msg streaming.Messa
 				r.logger.Warn("processing: publish result",
 					"processor", p.ID, "output_topic", res.TopicID, "err", err)
 			}
+		}
+		// Post-routing arm (thread-follow): only Automated processors carry
+		// stateful routing, so the cheap field check gates the hop into the
+		// Slack-aware follower. The follower extends delivery (to thread
+		// members) using state Process is forbidden to read.
+		if r.postRouter != nil && p.Automated() {
+			r.postRouter.AfterRoute(ctx, p, msg, results)
 		}
 	}
 }

--- a/api/pkg/org/application/processors/processors.go
+++ b/api/pkg/org/application/processors/processors.go
@@ -81,6 +81,10 @@ type OutputSpec struct {
 	TopicID streaming.TopicID
 	Label   string
 	Match   string
+	// ManagedFor tags an auto-managed route with the orgchart.WorkerID it
+	// serves (see processor.Output.ManagedFor). Empty for ordinary
+	// human-authored outputs.
+	ManagedFor string
 }
 
 // CreateParams describes a new Processor. ID is optional (minted
@@ -92,8 +96,11 @@ type CreateParams struct {
 	InputTopicID streaming.TopicID
 	Kind         processor.Kind
 	Config       json.RawMessage
-	CreatedBy    string
-	Outputs      []OutputSpec
+	// CreatedBy anchors the processor to a Worker on the chart, or carries
+	// processor.SystemActor ("helix") when automation owns it — which is how
+	// a processor is marked Automated (see processor.Processor.Automated).
+	CreatedBy string
+	Outputs   []OutputSpec
 }
 
 // Create validates the config, auto-provisions the output Topic(s),
@@ -126,20 +133,22 @@ func (s *Processors) Create(ctx context.Context, orgID string, p CreateParams) (
 		if spec.TopicID != "" {
 			// Explicit existing topic — not owned by the processor, so it
 			// is not provisioned here and not torn down on delete.
-			outputs = append(outputs, processor.Output{TopicID: spec.TopicID, Match: spec.Match, Label: spec.Label, Owned: false})
+			outputs = append(outputs, processor.Output{TopicID: spec.TopicID, Match: spec.Match, Label: spec.Label, Owned: false, ManagedFor: spec.ManagedFor})
 			continue
 		}
 		t, err := s.topics.Create(ctx, orgID, topics.CreateParams{
 			Name:        outputTopicName(id, spec.Label, i, len(specs)),
 			Description: fmt.Sprintf("Output of processor %s (%s)", id, p.Name),
-			CreatedBy:   p.CreatedBy,
+			// Inherit CreatedBy so an automated router's output Topics carry
+			// the same SystemActor marker for free.
+			CreatedBy: p.CreatedBy,
 		})
 		if err != nil {
 			rollback()
 			return processor.Processor{}, fmt.Errorf("provision output topic: %w", err)
 		}
 		provisioned = append(provisioned, t.ID)
-		outputs = append(outputs, processor.Output{TopicID: t.ID, Match: spec.Match, Label: spec.Label, Owned: true})
+		outputs = append(outputs, processor.Output{TopicID: t.ID, Match: spec.Match, Label: spec.Label, Owned: true, ManagedFor: spec.ManagedFor})
 	}
 
 	proc, err := processor.NewProcessor(id, p.Name, p.InputTopicID, p.Kind, p.Config, outputs, p.CreatedBy, s.now(), orgID)
@@ -199,6 +208,96 @@ func (s *Processors) Update(ctx context.Context, orgID string, id processor.Proc
 	return existing, nil
 }
 
+// AddOutput appends one output branch ("route") to an existing Processor,
+// provisioning and owning a new output Topic when spec.TopicID is empty
+// (the same auto-provision rule as Create), or wiring an explicit existing
+// Topic otherwise. It re-validates the Kind config against the new output
+// set and re-runs the cycle check before persisting. On any failure it
+// deletes a Topic it provisioned so a failed add leaves no orphan. Returns
+// the resulting Output (with its TopicID filled in) so callers can wire a
+// subscription to it.
+func (s *Processors) AddOutput(ctx context.Context, orgID string, id processor.ProcessorID, spec OutputSpec) (processor.Output, error) {
+	existing, err := s.procs.Get(ctx, orgID, id)
+	if err != nil {
+		return processor.Output{}, err
+	}
+
+	var out processor.Output
+	var provisioned streaming.TopicID
+	if spec.TopicID != "" {
+		out = processor.Output{TopicID: spec.TopicID, Match: spec.Match, Label: spec.Label, Owned: false, ManagedFor: spec.ManagedFor}
+	} else {
+		t, err := s.topics.Create(ctx, orgID, topics.CreateParams{
+			Name:        addedOutputTopicName(id, spec.Label, spec.ManagedFor),
+			Description: fmt.Sprintf("Output of processor %s (%s)", id, existing.Name),
+			// Inherit CreatedBy so a managed route's output Topic carries the
+			// router's SystemActor marker.
+			CreatedBy: existing.CreatedBy,
+		})
+		if err != nil {
+			return processor.Output{}, fmt.Errorf("provision output topic: %w", err)
+		}
+		provisioned = t.ID
+		out = processor.Output{TopicID: t.ID, Match: spec.Match, Label: spec.Label, Owned: true, ManagedFor: spec.ManagedFor}
+	}
+	rollback := func() {
+		if provisioned != "" {
+			_ = s.topics.Delete(ctx, orgID, provisioned)
+		}
+	}
+
+	existing.Outputs = append(existing.Outputs, out)
+	if err := existing.Validate(); err != nil {
+		rollback()
+		return processor.Output{}, err
+	}
+	if err := s.checkAcyclic(ctx, orgID, existing, id); err != nil {
+		rollback()
+		return processor.Output{}, err
+	}
+	if err := s.procs.Update(ctx, existing); err != nil {
+		rollback()
+		return processor.Output{}, err
+	}
+	return out, nil
+}
+
+// RemoveOutput drops the output branch whose destination is topicID and,
+// when that branch owned its Topic, deletes the Topic (cascading its
+// subscriptions). Idempotent: an unknown topicID is a no-op. Rejected when
+// it would leave the Processor with zero outputs (Validate forbids that) —
+// delete the whole Processor instead.
+func (s *Processors) RemoveOutput(ctx context.Context, orgID string, id processor.ProcessorID, topicID streaming.TopicID) error {
+	existing, err := s.procs.Get(ctx, orgID, id)
+	if err != nil {
+		return err
+	}
+	idx := -1
+	for i, o := range existing.Outputs {
+		if o.TopicID == topicID {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return nil // already gone
+	}
+	removed := existing.Outputs[idx]
+	existing.Outputs = append(existing.Outputs[:idx:idx], existing.Outputs[idx+1:]...)
+	if err := existing.Validate(); err != nil {
+		return fmt.Errorf("remove output %q: %w", topicID, err)
+	}
+	if err := s.procs.Update(ctx, existing); err != nil {
+		return err
+	}
+	if removed.Owned {
+		if err := s.topics.Delete(ctx, orgID, removed.TopicID); err != nil && !errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("output removed but owned topic %q cleanup failed: %w", removed.TopicID, err)
+		}
+	}
+	return nil
+}
+
 // Delete removes the Processor and the output Topics it owns (cascading
 // their subscriptions, as topic delete already does).
 func (s *Processors) Delete(ctx context.Context, orgID string, id processor.ProcessorID) error {
@@ -222,6 +321,28 @@ func (s *Processors) Delete(ctx context.Context, orgID string, id processor.Proc
 				continue
 			}
 			return fmt.Errorf("processor deleted but output topic %q cleanup failed: %w", o.TopicID, err)
+		}
+	}
+	return nil
+}
+
+// DeleteAutomatedByInput deletes every Automated Processor whose input is
+// inputTopicID, cascading each one's owned output Topics (via Delete). It is
+// how the Slack auto-router is torn down when its workspace Topic — or the
+// workspace integration itself — is deleted: the router's lifecycle is bound
+// to the Topic it reads. Human-authored processors reading the same Topic are
+// left untouched (they become inert, but the operator owns them). Idempotent.
+func (s *Processors) DeleteAutomatedByInput(ctx context.Context, orgID string, inputTopicID streaming.TopicID) error {
+	all, err := s.procs.List(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("list processors: %w", err)
+	}
+	for _, p := range all {
+		if p.InputTopicID != inputTopicID || !p.Automated() {
+			continue
+		}
+		if err := s.Delete(ctx, orgID, p.ID); err != nil && !errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("delete automated processor %q: %w", p.ID, err)
 		}
 	}
 	return nil
@@ -308,6 +429,23 @@ func (s *Processors) checkAcyclic(ctx context.Context, orgID string, candidate p
 		}
 	}
 	return nil
+}
+
+// addedOutputTopicName names an output Topic provisioned by AddOutput.
+// Unlike outputTopicName (which knows the full branch count up front), an
+// added branch names itself from its label, falling back to its ManagedFor
+// Worker id, then a generic suffix. Processor names are unique per org, so
+// `<procID> · <label>` cannot collide across processors; the topic id is
+// independently minted and unique even if two labels coincide.
+func addedOutputTopicName(id processor.ProcessorID, label, managedFor string) string {
+	suffix := label
+	if suffix == "" {
+		suffix = managedFor
+	}
+	if suffix == "" {
+		suffix = "out"
+	}
+	return fmt.Sprintf("%s · %s", id, suffix)
 }
 
 // outputTopicName builds a unique, human-readable name for an

--- a/api/pkg/org/application/processors/processors_test.go
+++ b/api/pkg/org/application/processors/processors_test.go
@@ -127,4 +127,115 @@ func TestUpdateRevalidatesConfig(t *testing.T) {
 	}
 }
 
+// filterCfg builds an empty filter config blob.
+func filterRouter(t *testing.T, ctx context.Context, svc *processors.Processors, top *topics.Topics) processor.Processor {
+	t.Helper()
+	_, _ = top.Create(ctx, org, topics.CreateParams{ID: "s-slack", Name: "Slack"})
+	p, err := svc.Create(ctx, org, processors.CreateParams{
+		Name: "Router", InputTopicID: "s-slack", Kind: processor.KindFilter,
+		Outputs: []processors.OutputSpec{{Label: "default"}}, // unconditional default
+	})
+	if err != nil {
+		t.Fatalf("create router: %v", err)
+	}
+	return p
+}
+
+func TestAddOutputProvisionsOwnedTopicAndPersists(t *testing.T) {
+	ctx := context.Background()
+	s, svc, top := setup(t)
+	p := filterRouter(t, ctx, svc, top)
+
+	out, err := svc.AddOutput(ctx, org, p.ID, processors.OutputSpec{
+		Label: "alice", Match: `{{ mentions "alice" .Message.body }}`, ManagedFor: "w-alice",
+	})
+	if err != nil {
+		t.Fatalf("add output: %v", err)
+	}
+	if out.TopicID == "" || !out.Owned || out.ManagedFor != "w-alice" {
+		t.Fatalf("unexpected output: %+v", out)
+	}
+	// The owned topic exists.
+	if _, err := s.Topics.Get(ctx, org, out.TopicID); err != nil {
+		t.Errorf("owned output topic not created: %v", err)
+	}
+	// Persisted: the processor now has 2 outputs.
+	got, _ := svc.Get(ctx, org, p.ID)
+	if len(got.Outputs) != 2 {
+		t.Fatalf("want 2 outputs after add, got %d", len(got.Outputs))
+	}
+}
+
+func TestRemoveOutputDropsRouteAndOwnedTopic(t *testing.T) {
+	ctx := context.Background()
+	s, svc, top := setup(t)
+	p := filterRouter(t, ctx, svc, top)
+	out, _ := svc.AddOutput(ctx, org, p.ID, processors.OutputSpec{Label: "alice", Match: "x", ManagedFor: "w-alice"})
+
+	if err := svc.RemoveOutput(ctx, org, p.ID, out.TopicID); err != nil {
+		t.Fatalf("remove output: %v", err)
+	}
+	got, _ := svc.Get(ctx, org, p.ID)
+	if len(got.Outputs) != 1 {
+		t.Fatalf("want 1 output after remove, got %d", len(got.Outputs))
+	}
+	if _, err := s.Topics.Get(ctx, org, out.TopicID); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("owned output topic %q should be deleted, err=%v", out.TopicID, err)
+	}
+}
+
+func TestRemoveLastOutputRejected(t *testing.T) {
+	ctx := context.Background()
+	_, svc, top := setup(t)
+	p := filterRouter(t, ctx, svc, top)
+	// The router starts with exactly one (default) output; removing it would
+	// leave the processor with zero outputs, which Validate forbids.
+	if err := svc.RemoveOutput(ctx, org, p.ID, p.Outputs[0].TopicID); err == nil {
+		t.Error("want error removing the last output, got nil")
+	}
+}
+
+func TestDeleteAutomatedByInputRemovesRouterButNotManual(t *testing.T) {
+	ctx := context.Background()
+	s, svc, top := setup(t)
+	_, _ = top.Create(ctx, org, topics.CreateParams{ID: "s-ws", Name: "Workspace"})
+
+	// Automated router on s-ws (CreatedBy = SystemActor) with an owned output.
+	auto, err := svc.Create(ctx, org, processors.CreateParams{
+		Name: "Auto", InputTopicID: "s-ws", Kind: processor.KindFilter,
+		Outputs: []processors.OutputSpec{{Label: "default"}}, CreatedBy: processor.SystemActor,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	autoOut := auto.Outputs[0].TopicID
+	// A human-authored filter on the SAME input topic — must be left alone.
+	manual, err := svc.Create(ctx, org, processors.CreateParams{
+		Name: "Manual", InputTopicID: "s-ws", Kind: processor.KindFilter,
+		Outputs: []processors.OutputSpec{{Label: "default"}}, CreatedBy: "w-alice",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.DeleteAutomatedByInput(ctx, org, "s-ws"); err != nil {
+		t.Fatalf("DeleteAutomatedByInput: %v", err)
+	}
+	// Automated router gone + its owned output topic cascaded.
+	if _, err := svc.Get(ctx, org, auto.ID); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("automated router should be deleted, err=%v", err)
+	}
+	if _, err := s.Topics.Get(ctx, org, autoOut); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("automated router's owned output topic should be cascaded, err=%v", err)
+	}
+	// Manual processor untouched.
+	if _, err := svc.Get(ctx, org, manual.ID); err != nil {
+		t.Errorf("manual processor should survive, err=%v", err)
+	}
+	// Idempotent: a second call is a no-op.
+	if err := svc.DeleteAutomatedByInput(ctx, org, "s-ws"); err != nil {
+		t.Errorf("second DeleteAutomatedByInput should be no-op, got %v", err)
+	}
+}
+
 var _ = streaming.TopicID("")

--- a/api/pkg/org/application/slackrouting/config.go
+++ b/api/pkg/org/application/slackrouting/config.go
@@ -1,0 +1,36 @@
+package slackrouting
+
+import "encoding/json"
+
+// RouterConfig is the Slack auto-router's Processor.Config. The filter Kind
+// ignores it entirely (its predicates live on the Outputs); only the
+// thread-follow arm reads it. Kept here so router creation and the follower
+// share one shape.
+type RouterConfig struct {
+	// ThreadFollow, when true, routes every later message in a thread to the
+	// Workers already participating in it — not just the Workers named in
+	// the message. On by default (see DefaultConfig): it matches what Slack
+	// users expect — once you're in a thread you keep getting replies.
+	ThreadFollow bool `json:"thread_follow"`
+}
+
+// DefaultConfig is the Config a freshly-created auto-router carries:
+// thread-follow ON, matching Slack's "everyone in the thread is notified"
+// expectation. Operators can turn it off per-router in the UI.
+func DefaultConfig() json.RawMessage {
+	b, _ := json.Marshal(RouterConfig{ThreadFollow: true})
+	return b
+}
+
+// ThreadFollowEnabled reports whether a router Config opts into thread
+// participation. A malformed or empty blob reads as off.
+func ThreadFollowEnabled(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var c RouterConfig
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return false
+	}
+	return c.ThreadFollow
+}

--- a/api/pkg/org/application/slackrouting/reconciler.go
+++ b/api/pkg/org/application/slackrouting/reconciler.go
@@ -29,7 +29,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/helixml/helix/api/pkg/org/application/processors"
@@ -159,10 +158,9 @@ func (r *Reconciler) reconcileRouter(ctx context.Context, orgID string, router p
 			}
 			continue
 		}
-		name := routeName(workerID)
 		out, err := r.procs.AddOutput(ctx, orgID, router.ID, processors.OutputSpec{
-			Label:      name,
-			Match:      matchPredicate(name),
+			Label:      string(workerID),
+			Match:      matchPredicate(workerID),
 			ManagedFor: string(workerID),
 		})
 		if err != nil {
@@ -199,14 +197,11 @@ func (r *Reconciler) ensureSubscribed(ctx context.Context, orgID string, workerI
 	return nil
 }
 
-// routeName is the human-facing name a Worker is mentioned by: the Worker id
-// with its `w-` prefix stripped (`w-alice` → `alice`).
-func routeName(id orgchart.WorkerID) string {
-	return strings.TrimPrefix(string(id), "w-")
-}
-
 // matchPredicate builds the filter predicate for a managed route — a
-// word-boundary, case-insensitive mention of the Worker's name in the body.
-func matchPredicate(name string) string {
-	return fmt.Sprintf(`{{ mentions %q .Message.body }}`, name)
+// word-boundary, case-insensitive mention of the Worker's FULL id in the body
+// (`w-jokebot`, not `jokebot`). The id is the Worker's canonical name and is
+// what the org refers to it by; matching the bare slug would over-trigger on
+// common words. `mentions`'s `\b…\b` handles the internal hyphen fine.
+func matchPredicate(workerID orgchart.WorkerID) string {
+	return fmt.Sprintf(`{{ mentions %q .Message.body }}`, string(workerID))
 }

--- a/api/pkg/org/application/slackrouting/reconciler.go
+++ b/api/pkg/org/application/slackrouting/reconciler.go
@@ -1,0 +1,212 @@
+// Package slackrouting keeps each Slack auto-router's per-Worker routes in
+// sync with the org's Workers. It is a second, independent reconciler that
+// *composes* the existing processor machinery (it drives the processors
+// application service to add/remove route Outputs) rather than extending
+// reconcile.Reconciler — exactly the composition the feature calls for.
+//
+// What it owns: for every Automated Slack router Processor in an org, one
+// "managed route" per AI Worker — a filter Output whose predicate is
+// `mentions "<name>" .Message.body` (word-boundary, case-insensitive) and
+// whose auto-provisioned output Topic the Worker is subscribed to. The
+// route carries the Worker id in Output.ManagedFor, which is the only thing
+// the reconciler keys on:
+//
+//   - AI Worker exists, no managed route → add the route + subscribe.
+//   - Managed route whose Worker no longer exists (or is no longer AI) →
+//     remove the route (cascading its owned Topic + subscription).
+//   - Manual routes (empty ManagedFor) and the default route → never touched.
+//   - Existing managed route for a live Worker → left as-is (so user edits
+//     to the predicate survive), but its subscription is self-healed.
+//
+// It never *creates* the router — that is bound to the workspace-connect
+// event — so a deleted router stays deleted (Reconcile is a no-op when no
+// Automated router exists). Worker names are immutable ids, so the
+// reconciler only ever reconciles route presence/absence, never content;
+// there is no fingerprint and no rename-sync.
+package slackrouting
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/application/processors"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/processor"
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+)
+
+// ProcessorService is the slice of the processors application service the
+// reconciler drives. *processors.Processors satisfies it.
+type ProcessorService interface {
+	List(ctx context.Context, orgID string) ([]processor.Processor, error)
+	AddOutput(ctx context.Context, orgID string, id processor.ProcessorID, spec processors.OutputSpec) (processor.Output, error)
+	RemoveOutput(ctx context.Context, orgID string, id processor.ProcessorID, topicID streaming.TopicID) error
+}
+
+// Reconciler converges Automated Slack routers' managed routes onto the
+// org's AI Workers. Construct with New.
+type Reconciler struct {
+	workers store.Workers
+	subs    store.Subscriptions
+	procs   ProcessorService
+	now     func() time.Time
+	logger  *slog.Logger
+}
+
+// Deps are the constructor-injected collaborators.
+type Deps struct {
+	Workers       store.Workers
+	Subscriptions store.Subscriptions
+	Processors    ProcessorService
+	Now           func() time.Time
+	Logger        *slog.Logger
+}
+
+// New builds a Reconciler. A nil Workers or Processors repo yields a
+// Reconciler whose Reconcile no-ops, so runtimes/tests that don't wire
+// Slack routing degrade gracefully.
+func New(deps Deps) *Reconciler {
+	now := deps.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	logger := deps.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Reconciler{
+		workers: deps.Workers,
+		subs:    deps.Subscriptions,
+		procs:   deps.Processors,
+		now:     now,
+		logger:  logger,
+	}
+}
+
+// Reconcile converges every Automated Slack router in the org. Safe to call
+// on every hire/fire and at startup; idempotent. A nil/unwired Reconciler,
+// or an org with no Automated router, is a no-op.
+func (r *Reconciler) Reconcile(ctx context.Context, orgID string) error {
+	if r == nil || r.workers == nil || r.procs == nil {
+		return nil
+	}
+
+	procs, err := r.procs.List(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("slackrouting: list processors: %w", err)
+	}
+	var routers []processor.Processor
+	for _, p := range procs {
+		if p.Automated() && p.Kind == processor.KindFilter {
+			routers = append(routers, p)
+		}
+	}
+	if len(routers) == 0 {
+		return nil // nothing to maintain — router never created or deleted
+	}
+
+	workers, err := r.workers.List(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("slackrouting: list workers: %w", err)
+	}
+	// The Workers the router should route to: AI Workers only (only they
+	// activate). Keyed by id for diffing against ManagedFor.
+	aiWorkers := map[orgchart.WorkerID]struct{}{}
+	for _, w := range workers {
+		if w.Kind() == orgchart.WorkerKindAI {
+			aiWorkers[w.ID()] = struct{}{}
+		}
+	}
+
+	for _, router := range routers {
+		if err := r.reconcileRouter(ctx, orgID, router, aiWorkers); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// reconcileRouter brings one router's managed routes to match aiWorkers.
+func (r *Reconciler) reconcileRouter(ctx context.Context, orgID string, router processor.Processor, aiWorkers map[orgchart.WorkerID]struct{}) error {
+	managed := map[orgchart.WorkerID]processor.Output{} // ManagedFor → route
+	for _, o := range router.Outputs {
+		if o.ManagedFor != "" {
+			managed[orgchart.WorkerID(o.ManagedFor)] = o
+		}
+	}
+
+	// Remove managed routes whose Worker is gone (or no longer AI).
+	for workerID, out := range managed {
+		if _, ok := aiWorkers[workerID]; ok {
+			continue
+		}
+		if err := r.procs.RemoveOutput(ctx, orgID, router.ID, out.TopicID); err != nil {
+			return fmt.Errorf("slackrouting: remove route for %q: %w", workerID, err)
+		}
+		r.logger.Info("slackrouting: removed route for departed worker", "router", router.ID, "worker", workerID)
+	}
+
+	// Add a managed route for every AI Worker that lacks one; self-heal the
+	// subscription for those that already have one.
+	for workerID := range aiWorkers {
+		if out, ok := managed[workerID]; ok {
+			if err := r.ensureSubscribed(ctx, orgID, workerID, out.TopicID); err != nil {
+				return err
+			}
+			continue
+		}
+		name := routeName(workerID)
+		out, err := r.procs.AddOutput(ctx, orgID, router.ID, processors.OutputSpec{
+			Label:      name,
+			Match:      matchPredicate(name),
+			ManagedFor: string(workerID),
+		})
+		if err != nil {
+			return fmt.Errorf("slackrouting: add route for %q: %w", workerID, err)
+		}
+		if err := r.ensureSubscribed(ctx, orgID, workerID, out.TopicID); err != nil {
+			return err
+		}
+		r.logger.Info("slackrouting: added route for worker", "router", router.ID, "worker", workerID, "topic", out.TopicID)
+	}
+	return nil
+}
+
+// ensureSubscribed idempotently subscribes the Worker to the route's output
+// Topic, so a managed route always delivers even if the subscription was
+// dropped out-of-band.
+func (r *Reconciler) ensureSubscribed(ctx context.Context, orgID string, workerID orgchart.WorkerID, topicID streaming.TopicID) error {
+	if r.subs == nil {
+		return nil
+	}
+	if _, err := r.subs.Find(ctx, orgID, workerID, topicID); err == nil {
+		return nil // already subscribed
+	}
+	sub, err := streaming.NewSubscription(string(workerID), topicID, r.now(), orgID)
+	if err != nil {
+		return fmt.Errorf("slackrouting: build subscription %q→%q: %w", workerID, topicID, err)
+	}
+	if err := r.subs.Create(ctx, sub); err != nil {
+		// Lost a create race? A now-present row means success.
+		if _, findErr := r.subs.Find(ctx, orgID, workerID, topicID); findErr != nil {
+			return fmt.Errorf("slackrouting: subscribe %q→%q: %w", workerID, topicID, err)
+		}
+	}
+	return nil
+}
+
+// routeName is the human-facing name a Worker is mentioned by: the Worker id
+// with its `w-` prefix stripped (`w-alice` → `alice`).
+func routeName(id orgchart.WorkerID) string {
+	return strings.TrimPrefix(string(id), "w-")
+}
+
+// matchPredicate builds the filter predicate for a managed route — a
+// word-boundary, case-insensitive mention of the Worker's name in the body.
+func matchPredicate(name string) string {
+	return fmt.Sprintf(`{{ mentions %q .Message.body }}`, name)
+}

--- a/api/pkg/org/application/slackrouting/reconciler_test.go
+++ b/api/pkg/org/application/slackrouting/reconciler_test.go
@@ -1,0 +1,191 @@
+package slackrouting_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/application/processors"
+	"github.com/helixml/helix/api/pkg/org/application/slackrouting"
+	"github.com/helixml/helix/api/pkg/org/application/topics"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/processor"
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+	"github.com/helixml/helix/api/pkg/org/domain/transport"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
+)
+
+const org = "org-1"
+
+func setup(t *testing.T) (*store.Store, *processors.Processors, *slackrouting.Reconciler) {
+	t.Helper()
+	var n int
+	id := func() string { n++; return time.Now().Format("150405.000000") + "-" + string(rune('a'+n%26)) + string(rune('a'+n/26%26)) }
+	s := memory.New()
+	top := topics.New(topics.Deps{Topics: s.Topics, NewID: id})
+	procs := processors.New(processors.Deps{Processors: s.Processors, Topics: top, NewID: id})
+	rec := slackrouting.New(slackrouting.Deps{Workers: s.Workers, Subscriptions: s.Subscriptions, Processors: procs})
+	return s, procs, rec
+}
+
+// makeRouter creates an Automated filter router on a Slack input topic.
+func makeRouter(t *testing.T, ctx context.Context, s *store.Store, procs *processors.Processors) processor.Processor {
+	t.Helper()
+	in, err := streaming.NewTopic("s-slack", "Slack", "", "", time.Now().UTC(), transport.Transport{}, org)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Topics.Create(ctx, in); err != nil {
+		t.Fatal(err)
+	}
+	p, err := procs.Create(ctx, org, processors.CreateParams{
+		ID: "p-slack-router", Name: "Slack Router", InputTopicID: "s-slack", Kind: processor.KindFilter,
+		Outputs: []processors.OutputSpec{{Label: "default"}}, CreatedBy: processor.SystemActor,
+	})
+	if err != nil {
+		t.Fatalf("create router: %v", err)
+	}
+	return p
+}
+
+func addAIWorker(t *testing.T, ctx context.Context, s *store.Store, id string) {
+	t.Helper()
+	w, err := orgchart.NewAIWorker(id, "r-x", "", org)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Workers.Create(ctx, w); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func routesByWorker(p processor.Processor) map[string]processor.Output {
+	m := map[string]processor.Output{}
+	for _, o := range p.Outputs {
+		if o.ManagedFor != "" {
+			m[o.ManagedFor] = o
+		}
+	}
+	return m
+}
+
+func TestReconcileAddsRoutePerAIWorkerAndSubscribes(t *testing.T) {
+	ctx := context.Background()
+	s, procs, rec := setup(t)
+	makeRouter(t, ctx, s, procs)
+	addAIWorker(t, ctx, s, "w-alice")
+	addAIWorker(t, ctx, s, "w-bob")
+
+	if err := rec.Reconcile(ctx, org); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	p, _ := procs.Get(ctx, org, "p-slack-router")
+	routes := routesByWorker(p)
+	if len(routes) != 2 {
+		t.Fatalf("want 2 managed routes, got %d (%+v)", len(routes), p.Outputs)
+	}
+	for _, wid := range []string{"w-alice", "w-bob"} {
+		o, ok := routes[wid]
+		if !ok {
+			t.Fatalf("no route for %s", wid)
+		}
+		// Worker subscribed to the route's output topic.
+		if _, err := s.Subscriptions.Find(ctx, org, orgchart.WorkerID(wid), o.TopicID); err != nil {
+			t.Errorf("%s not subscribed to %s: %v", wid, o.TopicID, err)
+		}
+	}
+	// The default (unconditional) route is untouched.
+	if len(p.Outputs) != 3 {
+		t.Errorf("want 3 outputs (default + 2 managed), got %d", len(p.Outputs))
+	}
+}
+
+func TestReconcileIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	s, procs, rec := setup(t)
+	makeRouter(t, ctx, s, procs)
+	addAIWorker(t, ctx, s, "w-alice")
+
+	_ = rec.Reconcile(ctx, org)
+	_ = rec.Reconcile(ctx, org)
+	p, _ := procs.Get(ctx, org, "p-slack-router")
+	if got := len(routesByWorker(p)); got != 1 {
+		t.Fatalf("want 1 managed route after double reconcile, got %d", got)
+	}
+}
+
+func TestReconcileRemovesRouteForDepartedWorker(t *testing.T) {
+	ctx := context.Background()
+	s, procs, rec := setup(t)
+	makeRouter(t, ctx, s, procs)
+	addAIWorker(t, ctx, s, "w-alice")
+	addAIWorker(t, ctx, s, "w-bob")
+	_ = rec.Reconcile(ctx, org)
+
+	// Bob leaves.
+	if err := s.Workers.Delete(ctx, org, "w-bob"); err != nil {
+		t.Fatal(err)
+	}
+	if err := rec.Reconcile(ctx, org); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	p, _ := procs.Get(ctx, org, "p-slack-router")
+	routes := routesByWorker(p)
+	if _, ok := routes["w-bob"]; ok {
+		t.Errorf("bob's route should be gone")
+	}
+	if _, ok := routes["w-alice"]; !ok {
+		t.Errorf("alice's route should remain")
+	}
+}
+
+func TestReconcilePreservesManualRoutesAndEdits(t *testing.T) {
+	ctx := context.Background()
+	s, procs, rec := setup(t)
+	makeRouter(t, ctx, s, procs)
+	addAIWorker(t, ctx, s, "w-alice")
+	_ = rec.Reconcile(ctx, org)
+
+	// User adds a manual route (empty ManagedFor) and edits alice's predicate.
+	if _, err := procs.AddOutput(ctx, org, "p-slack-router", processors.OutputSpec{Label: "manual", Match: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	p, _ := procs.Get(ctx, org, "p-slack-router")
+	for i := range p.Outputs {
+		if p.Outputs[i].ManagedFor == "w-alice" {
+			p.Outputs[i].Match = "EDITED"
+		}
+	}
+	if err := s.Processors.Update(ctx, p); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := rec.Reconcile(ctx, org); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	p, _ = procs.Get(ctx, org, "p-slack-router")
+	// Manual route still present.
+	manual := 0
+	for _, o := range p.Outputs {
+		if o.Label == "manual" && o.ManagedFor == "" {
+			manual++
+		}
+	}
+	if manual != 1 {
+		t.Errorf("manual route should be preserved, found %d", manual)
+	}
+	// Alice's edited predicate untouched.
+	if routesByWorker(p)["w-alice"].Match != "EDITED" {
+		t.Errorf("alice's edited predicate was overwritten: %q", routesByWorker(p)["w-alice"].Match)
+	}
+}
+
+func TestReconcileNoRouterIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	s, _, rec := setup(t)
+	addAIWorker(t, ctx, s, "w-alice")
+	if err := rec.Reconcile(ctx, org); err != nil {
+		t.Fatalf("reconcile with no router should be no-op, got %v", err)
+	}
+}

--- a/api/pkg/org/application/slackrouting/reconciler_test.go
+++ b/api/pkg/org/application/slackrouting/reconciler_test.go
@@ -90,6 +90,11 @@ func TestReconcileAddsRoutePerAIWorkerAndSubscribes(t *testing.T) {
 		if !ok {
 			t.Fatalf("no route for %s", wid)
 		}
+		// The predicate matches on the FULL worker id (w-alice), not the slug.
+		want := `{{ mentions "` + wid + `" .Message.body }}`
+		if o.Match != want {
+			t.Errorf("%s route predicate = %q, want %q", wid, o.Match, want)
+		}
 		// Worker subscribed to the route's output topic.
 		if _, err := s.Subscriptions.Find(ctx, org, orgchart.WorkerID(wid), o.TopicID); err != nil {
 			t.Errorf("%s not subscribed to %s: %v", wid, o.TopicID, err)

--- a/api/pkg/org/application/slackrouting/reconciler_test.go
+++ b/api/pkg/org/application/slackrouting/reconciler_test.go
@@ -181,6 +181,39 @@ func TestReconcilePreservesManualRoutesAndEdits(t *testing.T) {
 	}
 }
 
+// Two workspaces in one org → two automated routers. The reconciler must
+// maintain a managed route (and subscription) per AI Worker on BOTH, so a
+// Worker is reachable by name from either workspace.
+func TestReconcileMaintainsEveryRouterInOrg(t *testing.T) {
+	ctx := context.Background()
+	s, procs, rec := setup(t)
+	makeRouter(t, ctx, s, procs) // p-slack-router on s-slack
+	// A second workspace's router on its own input topic.
+	in2, _ := streaming.NewTopic("s-slack-2", "Slack 2", "", "", time.Now().UTC(), transport.Transport{}, org)
+	_ = s.Topics.Create(ctx, in2)
+	if _, err := procs.Create(ctx, org, processors.CreateParams{
+		ID: "p-slack-router-2", Name: "Slack Router 2", InputTopicID: "s-slack-2", Kind: processor.KindFilter,
+		Outputs: []processors.OutputSpec{{Label: "default"}}, CreatedBy: processor.SystemActor,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	addAIWorker(t, ctx, s, "w-alice")
+
+	if err := rec.Reconcile(ctx, org); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	for _, rid := range []string{"p-slack-router", "p-slack-router-2"} {
+		p, _ := procs.Get(ctx, org, rid)
+		route, ok := routesByWorker(p)["w-alice"]
+		if !ok {
+			t.Fatalf("router %s has no route for w-alice", rid)
+		}
+		if _, err := s.Subscriptions.Find(ctx, org, "w-alice", route.TopicID); err != nil {
+			t.Errorf("w-alice not subscribed to %s's route topic %s: %v", rid, route.TopicID, err)
+		}
+	}
+}
+
 func TestReconcileNoRouterIsNoOp(t *testing.T) {
 	ctx := context.Background()
 	s, _, rec := setup(t)

--- a/api/pkg/org/application/slackrouting/threadfollow.go
+++ b/api/pkg/org/application/slackrouting/threadfollow.go
@@ -82,6 +82,14 @@ func NewThreadFollower(deps ThreadFollowerDeps) *ThreadFollower {
 	}
 }
 
+// threadSubject scopes a thread root to the router that owns it, so thread
+// membership is keyed by (workspace-router, thread) rather than thread alone.
+// `/` is a safe separator: a processor id (p-slack-router-<connID>) and a
+// Slack ts ("1700000000.000100") contain none.
+func threadSubject(routerID processor.ProcessorID, root string) string {
+	return string(routerID) + "/" + root
+}
+
 // threadRoot derives the thread key a message belongs to: its explicit
 // thread id, falling back to its own message id (a top-level Slack message
 // is a potential thread root). Empty when neither is set (a non-Slack or
@@ -106,6 +114,12 @@ func (f *ThreadFollower) AfterRoute(ctx context.Context, p processor.Processor, 
 		return
 	}
 	orgID := p.OrganizationID
+	// Scope thread identity to this router. One router exists per Slack
+	// workspace connection, so this keys membership by (workspace, thread)
+	// rather than thread alone: two workspaces in the same org can never
+	// share membership even if Slack reuses a `ts` value across them. p.ID is
+	// stable per connection (p-slack-router-<connID>).
+	subject := threadSubject(p.ID, root)
 
 	// route output Topic ⇄ ManagedFor Worker.
 	workerByTopic := map[streaming.TopicID]string{}
@@ -130,9 +144,9 @@ func (f *ThreadFollower) AfterRoute(ctx context.Context, p processor.Processor, 
 	if f.window > 0 {
 		since = f.now().Add(-f.window)
 	}
-	prior, err := f.events.ListBySubject(ctx, orgID, domainevent.TypeSlackThreadParticipant, root, since)
+	prior, err := f.events.ListBySubject(ctx, orgID, domainevent.TypeSlackThreadParticipant, subject, since)
 	if err != nil {
-		f.logger.Warn("slackrouting.threadfollow: list members", "thread", root, "err", err)
+		f.logger.Warn("slackrouting.threadfollow: list members", "thread", subject, "err", err)
 	}
 	priorMembers := domainevent.Participants(prior)
 	priorSet := map[string]struct{}{}
@@ -145,7 +159,7 @@ func (f *ThreadFollower) AfterRoute(ctx context.Context, p processor.Processor, 
 		if _, ok := priorSet[w]; ok {
 			continue
 		}
-		ev, err := domainevent.New(f.mintID(), orgID, domainevent.TypeSlackThreadParticipant, root, w, string(p.ID), nil, f.now())
+		ev, err := domainevent.New(f.mintID(), orgID, domainevent.TypeSlackThreadParticipant, subject, w, string(p.ID), nil, f.now())
 		if err != nil {
 			f.logger.Warn("slackrouting.threadfollow: build event", "worker", w, "err", err)
 			continue

--- a/api/pkg/org/application/slackrouting/threadfollow.go
+++ b/api/pkg/org/application/slackrouting/threadfollow.go
@@ -1,0 +1,188 @@
+package slackrouting
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/domain/domainevent"
+	"github.com/helixml/helix/api/pkg/org/domain/processor"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+)
+
+// defaultWindow bounds the membership read: a Worker is a thread
+// participant only if they were routed into it within this window. It is a
+// read bound, not a retention policy — the log keeps everything; old
+// participation simply ages out of "currently following". A week covers
+// "reply the next morning" and "reply after the weekend".
+const defaultWindow = 7 * 24 * time.Hour
+
+// Publisher is the narrow publish port the follower uses to deliver a
+// message to a thread member's route Topic. publishing.Publishing satisfies
+// it (same shape as processing.Publisher).
+type Publisher interface {
+	Publish(ctx context.Context, orgID string, topicID streaming.TopicID, from string, msg streaming.Message) (streaming.Event, error)
+}
+
+// ThreadFollower implements processing.PostRouter for Slack auto-routers. It
+// turns name-match routing into thread-aware routing using the append-only
+// domain-event log as the only state:
+//
+//  1. Every Worker the message was name-matched to is recorded as a
+//     participant of the message's thread (idempotently). Naming a new
+//     Worker mid-thread pulls them in here.
+//  2. When the router opts into thread-follow, every Worker already
+//     participating in the thread — but not named in this message — is
+//     ALSO delivered the message, so an ongoing conversation reaches
+//     everyone in it, not just whoever was named last.
+//
+// All of this lives outside the pure processor.Process, which only ever
+// does the stateless name match.
+type ThreadFollower struct {
+	events    domainevent.Repository
+	publisher Publisher
+	window    time.Duration
+	now       func() time.Time
+	newID     func() string
+	logger    *slog.Logger
+}
+
+// ThreadFollowerDeps are the constructor-injected collaborators.
+type ThreadFollowerDeps struct {
+	Events    domainevent.Repository
+	Publisher Publisher
+	NewID     func() string
+	Now       func() time.Time
+	// Window overrides the participation read window (default 7 days).
+	Window time.Duration
+	Logger *slog.Logger
+}
+
+// NewThreadFollower constructs a ThreadFollower.
+func NewThreadFollower(deps ThreadFollowerDeps) *ThreadFollower {
+	now := deps.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	logger := deps.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	window := deps.Window
+	if window == 0 {
+		window = defaultWindow
+	}
+	return &ThreadFollower{
+		events:    deps.Events,
+		publisher: deps.Publisher,
+		window:    window,
+		now:       now,
+		newID:     deps.NewID,
+		logger:    logger,
+	}
+}
+
+// threadRoot derives the thread key a message belongs to: its explicit
+// thread id, falling back to its own message id (a top-level Slack message
+// is a potential thread root). Empty when neither is set (a non-Slack or
+// id-less message — nothing to track).
+func threadRoot(msg streaming.Message) string {
+	if msg.ThreadID != "" {
+		return msg.ThreadID
+	}
+	return msg.MessageID
+}
+
+// AfterRoute records participation for the named recipients and, when
+// thread-follow is on, fans the message out to the thread's existing
+// members. Best-effort: failures are logged, never propagated — a routing
+// extension must not break the publish that triggered it.
+func (f *ThreadFollower) AfterRoute(ctx context.Context, p processor.Processor, msg streaming.Message, results []processor.Result) {
+	if f == nil || f.events == nil {
+		return
+	}
+	root := threadRoot(msg)
+	if root == "" {
+		return
+	}
+	orgID := p.OrganizationID
+
+	// route output Topic ⇄ ManagedFor Worker.
+	workerByTopic := map[streaming.TopicID]string{}
+	topicByWorker := map[string]streaming.TopicID{}
+	for _, o := range p.Outputs {
+		if o.ManagedFor != "" {
+			workerByTopic[o.TopicID] = o.ManagedFor
+			topicByWorker[o.ManagedFor] = o.TopicID
+		}
+	}
+
+	// Workers this message was name-matched to.
+	matched := map[string]struct{}{}
+	for _, res := range results {
+		if w, ok := workerByTopic[res.TopicID]; ok {
+			matched[w] = struct{}{}
+		}
+	}
+
+	// Prior members (before this message), within the window.
+	var since time.Time
+	if f.window > 0 {
+		since = f.now().Add(-f.window)
+	}
+	prior, err := f.events.ListBySubject(ctx, orgID, domainevent.TypeSlackThreadParticipant, root, since)
+	if err != nil {
+		f.logger.Warn("slackrouting.threadfollow: list members", "thread", root, "err", err)
+	}
+	priorMembers := domainevent.Participants(prior)
+	priorSet := map[string]struct{}{}
+	for _, w := range priorMembers {
+		priorSet[w] = struct{}{}
+	}
+
+	// Record newly-named participants (skip those already members).
+	for w := range matched {
+		if _, ok := priorSet[w]; ok {
+			continue
+		}
+		ev, err := domainevent.New(f.mintID(), orgID, domainevent.TypeSlackThreadParticipant, root, w, string(p.ID), nil, f.now())
+		if err != nil {
+			f.logger.Warn("slackrouting.threadfollow: build event", "worker", w, "err", err)
+			continue
+		}
+		if err := f.events.Append(ctx, ev); err != nil {
+			f.logger.Warn("slackrouting.threadfollow: append member", "worker", w, "thread", root, "err", err)
+		}
+	}
+
+	// Thread-follow fan-out: deliver to prior members not named in this
+	// message (the named ones already got it via the normal route publish).
+	if !ThreadFollowEnabled(p.Config) || f.publisher == nil {
+		return
+	}
+	for _, w := range priorMembers {
+		if _, ok := matched[w]; ok {
+			continue
+		}
+		topic, ok := topicByWorker[w]
+		if !ok {
+			continue // member's managed route is gone (Worker departed) — skip
+		}
+		if _, err := f.publisher.Publish(ctx, orgID, topic, "", msg); err != nil {
+			f.logger.Warn("slackrouting.threadfollow: deliver to member", "worker", w, "topic", topic, "err", err)
+		}
+	}
+}
+
+func (f *ThreadFollower) mintID() string {
+	if f.newID != nil {
+		return f.newID()
+	}
+	// Fall back to a timestamp-derived id (Now is always seamed).
+	return "de-" + f.now().UTC().Format("20060102150405.000000000")
+}
+
+// compile-time assertion that AfterRoute matches processing.PostRouter.
+var _ interface {
+	AfterRoute(ctx context.Context, p processor.Processor, msg streaming.Message, results []processor.Result)
+} = (*ThreadFollower)(nil)

--- a/api/pkg/org/application/slackrouting/threadfollow_test.go
+++ b/api/pkg/org/application/slackrouting/threadfollow_test.go
@@ -61,7 +61,16 @@ func newFollower(t *testing.T) (*store.Store, *slackrouting.ThreadFollower, *rec
 // log.
 func participants(t *testing.T, s *store.Store, threadRoot string) []string {
 	t.Helper()
-	evs, err := s.DomainEvents.ListBySubject(context.Background(), org, domainevent.TypeSlackThreadParticipant, threadRoot, time.Time{})
+	// Membership is keyed by (router, thread) — mirror the production scoping
+	// (router id "p-slack-router" from threadRouter).
+	return participantsFor(t, s, "p-slack-router", threadRoot)
+}
+
+// participantsFor reads membership for a specific router's thread (the
+// production subject scoping is "<routerID>/<threadRoot>").
+func participantsFor(t *testing.T, s *store.Store, routerID, threadRoot string) []string {
+	t.Helper()
+	evs, err := s.DomainEvents.ListBySubject(context.Background(), org, domainevent.TypeSlackThreadParticipant, routerID+"/"+threadRoot, time.Time{})
 	if err != nil {
 		t.Fatalf("list members: %v", err)
 	}
@@ -134,6 +143,29 @@ func TestThreadFollowPullsInNewlyNamedWorkerMidThread(t *testing.T) {
 	f.AfterRoute(ctx, router, streaming.Message{ThreadID: "T1", MessageID: "T3", Body: "thanks"}, nil)
 	if len(pub.calls) != 2 {
 		t.Fatalf("want fan-out to both members, got %v", pub.calls)
+	}
+}
+
+// Two workspaces (two routers) sharing a colliding Slack thread_ts must not
+// share thread membership — subjects are router-scoped.
+func TestThreadFollowIsolatedPerRouter(t *testing.T) {
+	ctx := context.Background()
+	box, f, _ := newFollower(t)
+
+	r1 := threadRouter(true) // p-slack-router, routes alice/bob
+	r2 := r1
+	r2.ID = "p-slack-router-2"
+
+	// Same thread_ts "T1" arrives in both workspaces, each naming a different
+	// worker. Membership must stay separate.
+	f.AfterRoute(ctx, r1, streaming.Message{MessageID: "T1", Body: "hi alice"}, nameMatch("s-alice"))
+	f.AfterRoute(ctx, r2, streaming.Message{MessageID: "T1", Body: "hi bob"}, nameMatch("s-bob"))
+
+	if p := participantsFor(t, box, "p-slack-router", "T1"); len(p) != 1 || p[0] != "w-alice" {
+		t.Fatalf("router 1 thread T1 should have only alice, got %v", p)
+	}
+	if p := participantsFor(t, box, "p-slack-router-2", "T1"); len(p) != 1 || p[0] != "w-bob" {
+		t.Fatalf("router 2 thread T1 should have only bob, got %v", p)
 	}
 }
 

--- a/api/pkg/org/application/slackrouting/threadfollow_test.go
+++ b/api/pkg/org/application/slackrouting/threadfollow_test.go
@@ -1,0 +1,153 @@
+package slackrouting_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/application/slackrouting"
+	"github.com/helixml/helix/api/pkg/org/domain/domainevent"
+	"github.com/helixml/helix/api/pkg/org/domain/processor"
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
+)
+
+// recordingPublisher captures fan-out publishes.
+type recordingPublisher struct {
+	calls []streaming.TopicID
+}
+
+func (p *recordingPublisher) Publish(_ context.Context, _ string, topicID streaming.TopicID, _ string, _ streaming.Message) (streaming.Event, error) {
+	p.calls = append(p.calls, topicID)
+	return streaming.Event{}, nil
+}
+
+// router builds a processor with two managed routes (alice→s-alice,
+// bob→s-bob) and the given thread-follow setting.
+func threadRouter(threadFollow bool) processor.Processor {
+	cfg, _ := json.Marshal(slackrouting.RouterConfig{ThreadFollow: threadFollow})
+	return processor.Processor{
+		ID: "p-slack-router", OrganizationID: org, Kind: processor.KindFilter, CreatedBy: processor.SystemActor, Config: cfg,
+		Outputs: []processor.Output{
+			{TopicID: "s-default", Label: "default"},
+			{TopicID: "s-alice", ManagedFor: "w-alice", Owned: true},
+			{TopicID: "s-bob", ManagedFor: "w-bob", Owned: true},
+		},
+	}
+}
+
+func nameMatch(topic streaming.TopicID) []processor.Result {
+	return []processor.Result{{TopicID: topic, Message: streaming.Message{}}}
+}
+
+func newFollower(t *testing.T) (*store.Store, *slackrouting.ThreadFollower, *recordingPublisher) {
+	t.Helper()
+	s := memory.New()
+	pub := &recordingPublisher{}
+	var n int
+	clock := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	f := slackrouting.NewThreadFollower(slackrouting.ThreadFollowerDeps{
+		Events:    s.DomainEvents,
+		Publisher: pub,
+		NewID:     func() string { n++; return "de-" + string(rune('a'+n)) },
+		Now:       func() time.Time { return clock },
+	})
+	return s, f, pub
+}
+
+// participants reads the recorded members of a thread from the domain-event
+// log.
+func participants(t *testing.T, s *store.Store, threadRoot string) []string {
+	t.Helper()
+	evs, err := s.DomainEvents.ListBySubject(context.Background(), org, domainevent.TypeSlackThreadParticipant, threadRoot, time.Time{})
+	if err != nil {
+		t.Fatalf("list members: %v", err)
+	}
+	return domainevent.Participants(evs)
+}
+
+func TestDefaultConfigEnablesThreadFollow(t *testing.T) {
+	if !slackrouting.ThreadFollowEnabled(slackrouting.DefaultConfig()) {
+		t.Error("DefaultConfig should enable thread-follow (on by default)")
+	}
+}
+
+func TestThreadFollowRecordsNamedParticipant(t *testing.T) {
+	ctx := context.Background()
+	box, f, pub := newFollower(t)
+
+	// Root message (ts=T1) names alice. threadRoot = its own message id.
+	msg := streaming.Message{MessageID: "T1", Body: "hey alice"}
+	f.AfterRoute(ctx, threadRouter(false), msg, nameMatch("s-alice"))
+
+	// Alice recorded as participant of thread T1; no fan-out (follow off).
+	parts := participants(t, box, "T1")
+	if len(parts) != 1 || parts[0] != "w-alice" {
+		t.Fatalf("want [w-alice], got %v", parts)
+	}
+	if len(pub.calls) != 0 {
+		t.Errorf("thread-follow off: want no fan-out, got %v", pub.calls)
+	}
+}
+
+func TestThreadFollowDeliversToPriorMembers(t *testing.T) {
+	ctx := context.Background()
+	box, f, pub := newFollower(t)
+	router := threadRouter(true)
+
+	// Turn 1: root T1 names alice → alice joins.
+	f.AfterRoute(ctx, router, streaming.Message{MessageID: "T1", Body: "hey alice"}, nameMatch("s-alice"))
+	// Turn 2: a reply in thread T1 names nobody. Alice (prior member) should
+	// still receive it via thread-follow.
+	pub.calls = nil
+	f.AfterRoute(ctx, router, streaming.Message{ThreadID: "T1", MessageID: "T2", Body: "what do you think?"}, nil)
+
+	if len(pub.calls) != 1 || pub.calls[0] != "s-alice" {
+		t.Fatalf("want fan-out to s-alice, got %v", pub.calls)
+	}
+	_ = box
+}
+
+func TestThreadFollowPullsInNewlyNamedWorkerMidThread(t *testing.T) {
+	ctx := context.Background()
+	box, f, pub := newFollower(t)
+	router := threadRouter(true)
+
+	f.AfterRoute(ctx, router, streaming.Message{MessageID: "T1", Body: "hey alice"}, nameMatch("s-alice"))
+	// Turn 2 names bob mid-thread. Bob gets the normal route (not a fan-out),
+	// alice gets the fan-out, and bob is now a member.
+	pub.calls = nil
+	f.AfterRoute(ctx, router, streaming.Message{ThreadID: "T1", MessageID: "T2", Body: "ask bob too"}, nameMatch("s-bob"))
+
+	// Fan-out goes to alice only (bob was name-matched, delivered normally).
+	if len(pub.calls) != 1 || pub.calls[0] != "s-alice" {
+		t.Fatalf("want fan-out to s-alice only, got %v", pub.calls)
+	}
+	parts := participants(t, box, "T1")
+	if len(parts) != 2 {
+		t.Fatalf("want alice+bob as members, got %v", parts)
+	}
+	// Turn 3 names nobody: both alice and bob get the fan-out.
+	pub.calls = nil
+	f.AfterRoute(ctx, router, streaming.Message{ThreadID: "T1", MessageID: "T3", Body: "thanks"}, nil)
+	if len(pub.calls) != 2 {
+		t.Fatalf("want fan-out to both members, got %v", pub.calls)
+	}
+}
+
+func TestThreadFollowOffStillRecordsButNoFanout(t *testing.T) {
+	ctx := context.Background()
+	box, f, pub := newFollower(t)
+	router := threadRouter(false)
+
+	f.AfterRoute(ctx, router, streaming.Message{MessageID: "T1", Body: "hey alice"}, nameMatch("s-alice"))
+	f.AfterRoute(ctx, router, streaming.Message{ThreadID: "T1", MessageID: "T2", Body: "still there?"}, nil)
+	if len(pub.calls) != 0 {
+		t.Errorf("follow off: want no fan-out, got %v", pub.calls)
+	}
+	if len(participants(t, box, "T1")) != 1 {
+		t.Errorf("alice should still be recorded")
+	}
+}

--- a/api/pkg/org/application/topics/topics.go
+++ b/api/pkg/org/application/topics/topics.go
@@ -80,6 +80,13 @@ func (s *Topics) Create(ctx context.Context, orgID string, p CreateParams) (stre
 	if id == "" {
 		id = streaming.TopicID("s-" + s.newID())
 	}
+	// Validate (org, name) uniqueness up front so a clash fails as a clean
+	// conflict instead of a leaked unique-constraint error. The store's
+	// idx_topic_org_name index is the race backstop (it also returns
+	// store.ErrConflict), but this pre-check gives an early, friendly error.
+	if err := s.ensureNameAvailable(ctx, orgID, p.Name); err != nil {
+		return streaming.Topic{}, err
+	}
 	topic, err := streaming.NewTopic(id, p.Name, p.Description, p.CreatedBy, s.now(), p.Transport, orgID)
 	if err != nil {
 		return streaming.Topic{}, err
@@ -88,6 +95,21 @@ func (s *Topics) Create(ctx context.Context, orgID string, p CreateParams) (stre
 		return streaming.Topic{}, err
 	}
 	return topic, nil
+}
+
+// ensureNameAvailable returns store.ErrConflict when the org already has a
+// Topic with this name (the same exact-match the gorm unique index enforces).
+func (s *Topics) ensureNameAvailable(ctx context.Context, orgID, name string) error {
+	existing, err := s.topics.List(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("check topic name uniqueness: %w", err)
+	}
+	for _, t := range existing {
+		if t.Name == name {
+			return fmt.Errorf("a topic named %q already exists in this org: %w", name, store.ErrConflict)
+		}
+	}
+	return nil
 }
 
 // TransportPatch is the partial transport update applied by Update.

--- a/api/pkg/org/application/topics/topics_test.go
+++ b/api/pkg/org/application/topics/topics_test.go
@@ -70,6 +70,26 @@ func TestTopicsCreate_HappyPath(t *testing.T) {
 	}
 }
 
+func TestTopicsCreate_DuplicateNameRejected(t *testing.T) {
+	t.Parallel()
+	st := memory.New()
+	svc := newService(st)
+	ctx := context.Background()
+
+	if _, err := svc.Create(ctx, "org-test", CreateParams{ID: "s-a", Name: "general"}); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	// Same name, different id, same org → conflict (mapped to 409 by adapters).
+	_, err := svc.Create(ctx, "org-test", CreateParams{ID: "s-b", Name: "general"})
+	if !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("want store.ErrConflict for duplicate name, got %v", err)
+	}
+	// The same name in a DIFFERENT org is fine (uniqueness is per-org).
+	if _, err := svc.Create(ctx, "org-other", CreateParams{ID: "s-c", Name: "general"}); err != nil {
+		t.Fatalf("same name in another org should be allowed: %v", err)
+	}
+}
+
 func TestTopicsCreate_AutoID(t *testing.T) {
 	t.Parallel()
 	st := memory.New()

--- a/api/pkg/org/domain/domainevent/domainevent.go
+++ b/api/pkg/org/domain/domainevent/domainevent.go
@@ -1,0 +1,113 @@
+// Package domainevent owns a generic, append-only audit log of
+// *decisions* an org-graph component made — distinct from the runtime
+// streaming.Event data plane (which carries Messages between Topics).
+// The name is deliberately not "event" to avoid that collision: a
+// DomainEvent is a recorded fact ("processor P decided Worker W is a
+// participant of thread T"), not a payload in flight.
+//
+// v1 is intentionally minimal (see design/2026-06-26-slack-auto-router.md
+// §5 / non-goals): one aggregate, append + query, no subscribers,
+// projections engine, or replay. Derived state (e.g. Slack thread
+// membership) is computed by *querying* the log over a time window, so
+// nothing is reaped for correctness — the window is a read bound, not a
+// retention policy.
+package domainevent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// Type names a category of recorded decision. Free-form by design so new
+// kinds of fact can be logged without touching the core; consumers filter
+// on it. Defined as constants beside the component that emits them.
+type Type = string
+
+// TypeSlackThreadParticipant records that a Worker was routed into a Slack
+// thread by an auto-router and is therefore a participant of it. Subject is
+// the thread root, Worker the participant, Source the router's processor id.
+const TypeSlackThreadParticipant Type = "slack.thread_participant"
+
+// DomainEvent is one recorded decision.
+//
+//   - Subject is the entity the event is keyed and queried on (for a Slack
+//     thread-participant fact: the thread root id).
+//   - Worker is the orgchart.WorkerID the decision concerns (the
+//     participant). Stored as a plain string — the aggregate does not import
+//     orgchart, mirroring streaming.Topic.CreatedBy.
+//   - Source is what made the decision (the router's processor id).
+//   - Metadata is optional structured context, opaque to the store.
+type DomainEvent struct {
+	ID             string
+	OrganizationID string
+	Type           Type
+	Subject        string
+	Worker         string
+	Source         string
+	Metadata       json.RawMessage
+	CreatedAt      time.Time
+}
+
+// New validates and constructs a DomainEvent. id, orgID, typ and subject
+// are required; worker/source/metadata are optional.
+func New(id, orgID string, typ Type, subject, worker, source string, metadata json.RawMessage, createdAt time.Time) (DomainEvent, error) {
+	if id == "" {
+		return DomainEvent{}, errors.New("domain event id is empty")
+	}
+	if orgID == "" {
+		return DomainEvent{}, errors.New("domain event orgID is empty")
+	}
+	if typ == "" {
+		return DomainEvent{}, errors.New("domain event type is empty")
+	}
+	if subject == "" {
+		return DomainEvent{}, errors.New("domain event subject is empty")
+	}
+	if createdAt.IsZero() {
+		return DomainEvent{}, errors.New("domain event createdAt is zero")
+	}
+	return DomainEvent{
+		ID:             id,
+		OrganizationID: orgID,
+		Type:           typ,
+		Subject:        subject,
+		Worker:         worker,
+		Source:         source,
+		Metadata:       metadata,
+		CreatedAt:      createdAt.UTC(),
+	}, nil
+}
+
+// Repository persists DomainEvents. The interface lives beside the
+// aggregate (like activation.Repository) so the storage boundary is part of
+// the domain package, not a parallel declaration in store.go.
+type Repository interface {
+	// Append records one DomainEvent.
+	Append(ctx context.Context, e DomainEvent) error
+	// ListBySubject returns the org's DomainEvents of the given type for the
+	// given subject, newest first, created at or after `since`. A zero
+	// `since` applies no lower bound. Returns an empty slice (never
+	// ErrNotFound) when none match.
+	ListBySubject(ctx context.Context, orgID string, typ Type, subject string, since time.Time) ([]DomainEvent, error)
+}
+
+// Participants returns the distinct, order-stable set of Worker ids from a
+// slice of participant DomainEvents (newest-first input preserved). A small
+// read-side helper so callers don't re-implement the dedupe.
+func Participants(events []DomainEvent) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(events))
+	for _, e := range events {
+		if e.Worker == "" {
+			continue
+		}
+		if _, ok := seen[e.Worker]; ok {
+			continue
+		}
+		seen[e.Worker] = struct{}{}
+		out = append(out, e.Worker)
+	}
+	return out
+}

--- a/api/pkg/org/domain/processor/mentions_test.go
+++ b/api/pkg/org/domain/processor/mentions_test.go
@@ -15,6 +15,15 @@ func TestMentionsWord(t *testing.T) {
 		{"data-bot", "ping data-bot now", true},      // hyphenated name
 		{"w-jokebot", "hey w-jokebot tell a joke", true}, // full worker id (w- prefix)
 		{"w-jokebot", "jokebot tell a joke", false},      // bare slug must NOT match the full-id route
+		// A hyphen is part of the id token, not a boundary: a longer id that
+		// merely starts with this one must NOT match.
+		{"w-jokebot", "ask w-jokebot-2 about it", false},
+		{"w-jokebot", "w-jokebot-2", false},
+		{"w-joke", "w-jokebot says hi", false},
+		// …but real delimiters around the full id still match.
+		{"w-jokebot", "w-jokebot, please", true},
+		{"w-jokebot", "(w-jokebot)", true},
+		{"w-jokebot", "w-jokebot", true},
 		{"bob", "no mention here", false},
 		{"", "anything at all", false},           // empty name never matches
 		{"alice", "", false},

--- a/api/pkg/org/domain/processor/mentions_test.go
+++ b/api/pkg/org/domain/processor/mentions_test.go
@@ -1,0 +1,25 @@
+package processor
+
+import "testing"
+
+func TestMentionsWord(t *testing.T) {
+	cases := []struct {
+		name, text string
+		want       bool
+	}{
+		{"alice", "hey alice can you help", true},
+		{"alice", "Alice, please review", true},  // case-insensitive
+		{"alice", "ALICE!", true},
+		{"sam", "the salmon was sampled", false}, // word boundary
+		{"sam", "ask Sam about it", true},
+		{"data-bot", "ping data-bot now", true},  // hyphenated name
+		{"bob", "no mention here", false},
+		{"", "anything at all", false},           // empty name never matches
+		{"alice", "", false},
+	}
+	for _, c := range cases {
+		if got := mentionsWord(c.name, c.text); got != c.want {
+			t.Errorf("mentions(%q,%q)=%v want %v", c.name, c.text, got, c.want)
+		}
+	}
+}

--- a/api/pkg/org/domain/processor/mentions_test.go
+++ b/api/pkg/org/domain/processor/mentions_test.go
@@ -12,7 +12,9 @@ func TestMentionsWord(t *testing.T) {
 		{"alice", "ALICE!", true},
 		{"sam", "the salmon was sampled", false}, // word boundary
 		{"sam", "ask Sam about it", true},
-		{"data-bot", "ping data-bot now", true},  // hyphenated name
+		{"data-bot", "ping data-bot now", true},      // hyphenated name
+		{"w-jokebot", "hey w-jokebot tell a joke", true}, // full worker id (w- prefix)
+		{"w-jokebot", "jokebot tell a joke", false},      // bare slug must NOT match the full-id route
 		{"bob", "no mention here", false},
 		{"", "anything at all", false},           // empty name never matches
 		{"alice", "", false},

--- a/api/pkg/org/domain/processor/processor.go
+++ b/api/pkg/org/domain/processor/processor.go
@@ -62,6 +62,14 @@ type Output struct {
 	// down on delete. False when the branch points at a pre-existing,
 	// shared Topic (explicit output) that outlives the Processor.
 	Owned bool
+	// ManagedFor names the orgchart.WorkerID this route was
+	// auto-generated for by a reconciler (e.g. the Slack auto-router).
+	// Empty means a human-authored ("manual") route: reconcilers must
+	// never rewrite or garbage-collect it. Non-empty makes the route
+	// reconciler-owned, keyed by that Worker — present-while-the-Worker-
+	// exists, removed when the Worker is gone. Stored in the Outputs JSON
+	// blob, so it needs no schema migration.
+	ManagedFor string `json:",omitempty"`
 }
 
 // Result is one (output Topic, Message) pair produced by Process. A
@@ -126,9 +134,24 @@ type Processor struct {
 	Outputs        []Output
 	Kind           Kind
 	Config         json.RawMessage
-	CreatedBy      string // orgchart.WorkerID
+	CreatedBy      string // orgchart.WorkerID, or SystemActor for automation
 	CreatedAt      time.Time
 }
+
+// SystemActor is the CreatedBy value automation stamps on the records it
+// owns (the Slack auto-router and its output Topics) in place of a human
+// Worker id. It is a sentinel orgchart.WorkerID — not a real Worker — so the
+// chart leaves it unanchored. Reusing CreatedBy (rather than a separate
+// boolean column) means a provisioned output Topic inherits the marker for
+// free, since the processors service already copies the processor's
+// CreatedBy onto the Topics it owns.
+const SystemActor = "helix"
+
+// Automated reports whether this Processor was created by Helix automation
+// (the Slack auto-router) rather than by a human — i.e. CreatedBy is the
+// SystemActor sentinel. The route reconciler and the post-routing hook key
+// on it; the API surfaces it so the UI can show the thread-follow toggle.
+func (p Processor) Automated() bool { return p.CreatedBy == SystemActor }
 
 // NewProcessor validates and constructs a Processor. orgID, id, name,
 // inputTopicID and at least one Output are required; the Config is

--- a/api/pkg/org/domain/processor/template.go
+++ b/api/pkg/org/domain/processor/template.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
+	"sync"
 	txttemplate "text/template"
 
 	"github.com/helixml/helix/api/pkg/org/domain/streaming"
@@ -44,6 +46,38 @@ var templateFuncs = txttemplate.FuncMap{
 	"contains":  func(sub, s string) bool { return strings.Contains(s, sub) },
 	"hasPrefix": func(pre, s string) bool { return strings.HasPrefix(s, pre) },
 	"hasSuffix": func(suf, s string) bool { return strings.HasSuffix(s, suf) },
+	// mentions reports whether name appears in s as a whole word,
+	// case-insensitively — `\bname\b`. It is what the Slack auto-router's
+	// per-Worker routes match on, so "Sam" fires on "hey Sam" but not on
+	// "salmon"/"sample". Reads as a predicate: `mentions "alice" .Message.body`.
+	"mentions": mentionsWord,
+}
+
+// mentionsWord reports a case-insensitive, word-boundary match of name in
+// s. An empty name never matches (a route with no name is inert rather than
+// matching everything). The pattern is cached per distinct name so repeated
+// predicate evaluation on a hot Topic doesn't recompile the regexp.
+func mentionsWord(name, s string) bool {
+	if strings.TrimSpace(name) == "" {
+		return false
+	}
+	return wordRegexp(name).MatchString(s)
+}
+
+var (
+	wordRegexpMu    sync.Mutex
+	wordRegexpCache = map[string]*regexp.Regexp{}
+)
+
+func wordRegexp(name string) *regexp.Regexp {
+	wordRegexpMu.Lock()
+	defer wordRegexpMu.Unlock()
+	if re, ok := wordRegexpCache[name]; ok {
+		return re
+	}
+	re := regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(name) + `\b`)
+	wordRegexpCache[name] = re
+	return re
 }
 
 // Validate enforces: exactly one output, with an empty Match (a

--- a/api/pkg/org/domain/processor/template.go
+++ b/api/pkg/org/domain/processor/template.go
@@ -46,17 +46,18 @@ var templateFuncs = txttemplate.FuncMap{
 	"contains":  func(sub, s string) bool { return strings.Contains(s, sub) },
 	"hasPrefix": func(pre, s string) bool { return strings.HasPrefix(s, pre) },
 	"hasSuffix": func(suf, s string) bool { return strings.HasSuffix(s, suf) },
-	// mentions reports whether name appears in s as a whole word,
-	// case-insensitively — `\bname\b`. It is what the Slack auto-router's
-	// per-Worker routes match on, so "Sam" fires on "hey Sam" but not on
-	// "salmon"/"sample". Reads as a predicate: `mentions "alice" .Message.body`.
+	// mentions reports whether name appears in s as a whole token,
+	// case-insensitively. It is what the Slack auto-router's per-Worker routes
+	// match on, so "Sam" fires on "hey Sam" but not on "salmon", and the FULL
+	// worker id "w-jokebot" fires on "w-jokebot" but NOT on "w-jokebot-2".
+	// Reads as a predicate: `mentions "w-jokebot" .Message.body`.
 	"mentions": mentionsWord,
 }
 
-// mentionsWord reports a case-insensitive, word-boundary match of name in
-// s. An empty name never matches (a route with no name is inert rather than
-// matching everything). The pattern is cached per distinct name so repeated
-// predicate evaluation on a hot Topic doesn't recompile the regexp.
+// mentionsWord reports a case-insensitive, whole-token match of name in s. An
+// empty name never matches (a route with no name is inert rather than matching
+// everything). The pattern is cached per distinct name so repeated predicate
+// evaluation on a hot Topic doesn't recompile the regexp.
 func mentionsWord(name, s string) bool {
 	if strings.TrimSpace(name) == "" {
 		return false
@@ -69,13 +70,20 @@ var (
 	wordRegexpCache = map[string]*regexp.Regexp{}
 )
 
+// wordRegexp matches name as a whole token. We can't use \b: a hyphen is a
+// non-word char, so \bw-jokebot\b would treat the dash in "w-jokebot-2" as a
+// boundary and over-match. Worker ids ARE hyphenated, so the token alphabet
+// includes `-`; the match must therefore be flanked by start/end of string or
+// a char that is neither a word char nor a hyphen ([^\w-]). RE2 has no
+// lookarounds, so the flanks are matched (and consumed) explicitly — fine for
+// a boolean MatchString, which only needs one occurrence.
 func wordRegexp(name string) *regexp.Regexp {
 	wordRegexpMu.Lock()
 	defer wordRegexpMu.Unlock()
 	if re, ok := wordRegexpCache[name]; ok {
 		return re
 	}
-	re := regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(name) + `\b`)
+	re := regexp.MustCompile(`(?i)(^|[^\w-])` + regexp.QuoteMeta(name) + `([^\w-]|$)`)
 	wordRegexpCache[name] = re
 	return re
 }

--- a/api/pkg/org/domain/store/store.go
+++ b/api/pkg/org/domain/store/store.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/helixml/helix/api/pkg/org/domain/activation"
 	"github.com/helixml/helix/api/pkg/org/domain/config"
+	"github.com/helixml/helix/api/pkg/org/domain/domainevent"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/org/domain/processor"
 	"github.com/helixml/helix/api/pkg/org/domain/streaming"
@@ -222,4 +223,8 @@ type Store struct {
 	Configs            Configs
 	Activations        activation.Repository
 	Processors         Processors
+	// DomainEvents is the append-only decision/audit log (e.g. Slack
+	// thread participation). Typed port defined beside its aggregate,
+	// like Activations.
+	DomainEvents domainevent.Repository
 }

--- a/api/pkg/org/domain/streaming/topic.go
+++ b/api/pkg/org/domain/streaming/topic.go
@@ -24,7 +24,7 @@ type Topic struct {
 	OrganizationID string
 	Name           string
 	Description    string
-	CreatedBy      string // orgchart.WorkerID
+	CreatedBy      string // orgchart.WorkerID (or processor.SystemActor for automation)
 	CreatedAt      time.Time
 	Transport      transport.Transport
 }

--- a/api/pkg/org/infrastructure/persistence/gorm/domainevent.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/domainevent.go
@@ -1,0 +1,106 @@
+package gorm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/helixml/helix/api/pkg/org/domain/domainevent"
+)
+
+// domainEventRow is the GORM row for an append-only DomainEvent.
+//
+// One composite index serves the only read path — ListBySubject —
+// exactly: (org_id, type, subject, created_at DESC). The three equality
+// columns are the prefix (org_id first: every query is org-scoped and it is
+// the most selective leading filter), and created_at is the trailing column
+// so Postgres satisfies the `created_at >= ?` window AND the
+// `ORDER BY created_at DESC` from the index alone — no separate filter or
+// sort step. The leading prefix also covers cheaper future reads
+// (e.g. by (org_id, type)).
+//
+// Deliberately NO standalone created_at index: nothing queries created_at
+// without the full subject prefix, so it would only cost write throughput on
+// this append-heavy table. A retention/pruning job (a non-goal today) would
+// add its own index if/when it lands.
+type domainEventRow struct {
+	ID        string    `gorm:"primaryKey;type:text"`
+	OrgID     string    `gorm:"not null;type:text;index:idx_org_domain_events_lookup,priority:1"`
+	Type      string    `gorm:"not null;type:text;index:idx_org_domain_events_lookup,priority:2"`
+	Subject   string    `gorm:"not null;type:text;index:idx_org_domain_events_lookup,priority:3"`
+	Worker    string    `gorm:"type:text"`
+	Source    string    `gorm:"type:text"`
+	Metadata  string    `gorm:"type:text"`
+	CreatedAt time.Time `gorm:"not null;index:idx_org_domain_events_lookup,priority:4,sort:desc"`
+}
+
+func (domainEventRow) TableName() string { return "org_domain_events" }
+
+func toDomainEventRow(e domainevent.DomainEvent) domainEventRow {
+	meta := ""
+	if len(e.Metadata) > 0 {
+		meta = string(e.Metadata)
+	}
+	return domainEventRow{
+		ID:        e.ID,
+		OrgID:     e.OrganizationID,
+		Type:      e.Type,
+		Subject:   e.Subject,
+		Worker:    e.Worker,
+		Source:    e.Source,
+		Metadata:  meta,
+		CreatedAt: e.CreatedAt,
+	}
+}
+
+func fromDomainEventRow(row domainEventRow) domainevent.DomainEvent {
+	var meta json.RawMessage
+	if row.Metadata != "" {
+		meta = json.RawMessage(row.Metadata)
+	}
+	return domainevent.DomainEvent{
+		ID:             row.ID,
+		OrganizationID: row.OrgID,
+		Type:           row.Type,
+		Subject:        row.Subject,
+		Worker:         row.Worker,
+		Source:         row.Source,
+		Metadata:       meta,
+		CreatedAt:      row.CreatedAt,
+	}
+}
+
+type domainEventsRepo struct {
+	db *gorm.DB
+}
+
+func newDomainEventsRepo(db *gorm.DB) *domainEventsRepo {
+	return &domainEventsRepo{db: db}
+}
+
+func (r *domainEventsRepo) Append(ctx context.Context, e domainevent.DomainEvent) error {
+	if err := r.db.WithContext(ctx).Create(toDomainEventRow(e)).Error; err != nil {
+		return fmt.Errorf("append domain event %q: %w", e.ID, err)
+	}
+	return nil
+}
+
+func (r *domainEventsRepo) ListBySubject(ctx context.Context, orgID string, typ domainevent.Type, subject string, since time.Time) ([]domainevent.DomainEvent, error) {
+	q := r.db.WithContext(ctx).
+		Where("org_id = ? AND type = ? AND subject = ?", orgID, typ, subject)
+	if !since.IsZero() {
+		q = q.Where("created_at >= ?", since.UTC())
+	}
+	var rows []domainEventRow
+	if err := q.Order("created_at DESC").Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("list domain events for subject %q: %w", subject, err)
+	}
+	out := make([]domainevent.DomainEvent, len(rows))
+	for i, row := range rows {
+		out[i] = fromDomainEventRow(row)
+	}
+	return out, nil
+}

--- a/api/pkg/org/infrastructure/persistence/gorm/domainevent.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/domainevent.go
@@ -3,12 +3,12 @@ package gorm
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"gorm.io/gorm"
 
 	"github.com/helixml/helix/api/pkg/org/domain/domainevent"
+	"github.com/helixml/helix/api/pkg/org/domain/store"
 )
 
 // domainEventRow is the GORM row for an append-only DomainEvent.
@@ -39,7 +39,11 @@ type domainEventRow struct {
 
 func (domainEventRow) TableName() string { return "org_domain_events" }
 
-func toDomainEventRow(e domainevent.DomainEvent) domainEventRow {
+// domainEventMapper converts between the aggregate and its row, the only
+// per-entity glue the generic Repository needs.
+type domainEventMapper struct{}
+
+func (domainEventMapper) ToRow(e domainevent.DomainEvent) (domainEventRow, error) {
 	meta := ""
 	if len(e.Metadata) > 0 {
 		meta = string(e.Metadata)
@@ -53,10 +57,10 @@ func toDomainEventRow(e domainevent.DomainEvent) domainEventRow {
 		Source:    e.Source,
 		Metadata:  meta,
 		CreatedAt: e.CreatedAt,
-	}
+	}, nil
 }
 
-func fromDomainEventRow(row domainEventRow) domainevent.DomainEvent {
+func (domainEventMapper) ToDomain(row domainEventRow) (domainevent.DomainEvent, error) {
 	var meta json.RawMessage
 	if row.Metadata != "" {
 		meta = json.RawMessage(row.Metadata)
@@ -70,37 +74,39 @@ func fromDomainEventRow(row domainEventRow) domainevent.DomainEvent {
 		Source:         row.Source,
 		Metadata:       meta,
 		CreatedAt:      row.CreatedAt,
-	}
+	}, nil
 }
 
+// domainEventsRepo wraps the generic Repository, exactly like every other
+// per-entity store (topicsRepo, activationsRepo). Append/ListBySubject just
+// name the two operations the domainevent.Repository port exposes; all the
+// gorm boilerplate lives in the generic primitive.
 type domainEventsRepo struct {
-	db *gorm.DB
+	*Repository[domainevent.DomainEvent, domainEventRow]
 }
 
 func newDomainEventsRepo(db *gorm.DB) *domainEventsRepo {
-	return &domainEventsRepo{db: db}
+	return &domainEventsRepo{Repository: NewRepository[domainevent.DomainEvent, domainEventRow](db, domainEventMapper{}, "domain event")}
 }
 
+// Append records one event (a Create under the hood).
 func (r *domainEventsRepo) Append(ctx context.Context, e domainevent.DomainEvent) error {
-	if err := r.db.WithContext(ctx).Create(toDomainEventRow(e)).Error; err != nil {
-		return fmt.Errorf("append domain event %q: %w", e.ID, err)
-	}
-	return nil
+	return r.Repository.Create(ctx, e)
 }
 
+// ListBySubject is the membership-projection read: the (org, type, subject)
+// equalities plus the optional created_at window, newest first — served by
+// idx_org_domain_events_lookup. Expressed in store.Options so it rides the
+// same query layer as every other repo.
 func (r *domainEventsRepo) ListBySubject(ctx context.Context, orgID string, typ domainevent.Type, subject string, since time.Time) ([]domainevent.DomainEvent, error) {
-	q := r.db.WithContext(ctx).
-		Where("org_id = ? AND type = ? AND subject = ?", orgID, typ, subject)
+	opts := []store.Option{
+		store.WithOrg(orgID),
+		store.WithCondition("type", string(typ)),
+		store.WithCondition("subject", subject),
+		store.WithOrderDesc("created_at"),
+	}
 	if !since.IsZero() {
-		q = q.Where("created_at >= ?", since.UTC())
+		opts = append(opts, store.WithWhere("created_at >= ?", since.UTC()))
 	}
-	var rows []domainEventRow
-	if err := q.Order("created_at DESC").Find(&rows).Error; err != nil {
-		return nil, fmt.Errorf("list domain events for subject %q: %w", subject, err)
-	}
-	out := make([]domainevent.DomainEvent, len(rows))
-	for i, row := range rows {
-		out[i] = fromDomainEventRow(row)
-	}
-	return out, nil
+	return r.Repository.Find(ctx, opts...)
 }

--- a/api/pkg/org/infrastructure/persistence/gorm/domainevent_test.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/domainevent_test.go
@@ -1,0 +1,66 @@
+package gorm_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/domain/domainevent"
+)
+
+// TestDomainEventsAppendAndListBySubject exercises the gorm-backed
+// domain-event store end to end against a real DB — in particular the
+// store.Option composition ListBySubject relies on: the (org, type,
+// subject) equalities, the optional created_at window (WithWhere), and the
+// newest-first ordering. Mirrors the in-memory contract test.
+func TestDomainEventsAppendAndListBySubject(t *testing.T) {
+	t.Parallel()
+	s := newStore(t)
+	ctx := context.Background()
+	base := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+
+	mk := func(id, org, subject, worker string, at time.Time) domainevent.DomainEvent {
+		e, err := domainevent.New(id, org, domainevent.TypeSlackThreadParticipant, subject, worker, "p-router", nil, at)
+		if err != nil {
+			t.Fatalf("new %s: %v", id, err)
+		}
+		return e
+	}
+	for _, e := range []domainevent.DomainEvent{
+		mk("d-1", "org-1", "T", "w-alice", base),
+		mk("d-2", "org-1", "T", "w-bob", base.Add(time.Minute)),
+		mk("d-3", "org-1", "U", "w-carol", base), // other subject — noise
+		mk("d-4", "org-2", "T", "w-dave", base),  // other org — noise
+	} {
+		if err := s.DomainEvents.Append(ctx, e); err != nil {
+			t.Fatalf("append %s: %v", e.ID, err)
+		}
+	}
+
+	// All of thread T in org-1, newest first.
+	got, err := s.DomainEvents.ListBySubject(ctx, "org-1", domainevent.TypeSlackThreadParticipant, "T", time.Time{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if parts := domainevent.Participants(got); len(parts) != 2 || parts[0] != "w-bob" || parts[1] != "w-alice" {
+		t.Fatalf("want [w-bob w-alice] (newest first, org+subject scoped), got %v", parts)
+	}
+
+	// created_at window (WithWhere) excludes the older event.
+	recent, err := s.DomainEvents.ListBySubject(ctx, "org-1", domainevent.TypeSlackThreadParticipant, "T", base.Add(30*time.Second))
+	if err != nil {
+		t.Fatalf("list windowed: %v", err)
+	}
+	if parts := domainevent.Participants(recent); len(parts) != 1 || parts[0] != "w-bob" {
+		t.Fatalf("window: want [w-bob], got %v", parts)
+	}
+
+	// Empty result is not an error.
+	none, err := s.DomainEvents.ListBySubject(ctx, "org-1", domainevent.TypeSlackThreadParticipant, "does-not-exist", time.Time{})
+	if err != nil {
+		t.Fatalf("list empty: %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("want no rows for unknown subject, got %d", len(none))
+	}
+}

--- a/api/pkg/org/infrastructure/persistence/gorm/gorm.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/gorm.go
@@ -28,6 +28,7 @@ var orgRowTypes = []any{
 	&configRow{},
 	&activationRow{},
 	&processorRow{},
+	&domainEventRow{},
 }
 
 // orgTableNames returns the SQL table names for orgRowTypes. Used by
@@ -47,6 +48,7 @@ var orgTableNames = []string{
 	"org_configs",
 	"org_activations",
 	"org_processors",
+	"org_domain_events",
 }
 
 // Options controls OpenWithDB behaviour for callers that need to
@@ -120,6 +122,7 @@ func OpenWithDB(db *gorm.DB, opts Options) (*store.Store, error) {
 		Configs:            newConfigsRepo(db),
 		Activations:        newActivationsRepo(db),
 		Processors:         newProcessorsRepo(db),
+		DomainEvents:       newDomainEventsRepo(db),
 	}, nil
 }
 

--- a/api/pkg/org/infrastructure/persistence/gorm/stream.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/stream.go
@@ -70,6 +70,19 @@ func newTopicsRepo(db *gorm.DB) *topicsRepo {
 	return &topicsRepo{Repository: NewRepository[streaming.Topic, topicRow](db, topicMapper{}, "topic")}
 }
 
+// Create maps a unique-constraint violation (the idx_topic_org_name index)
+// to store.ErrConflict so adapters return 409 instead of a leaked driver
+// error — mirroring processorsRepo.Create.
+func (r *topicsRepo) Create(ctx context.Context, t streaming.Topic) error {
+	if err := r.Repository.Create(ctx, t); err != nil {
+		if isUniqueViolation(err) {
+			return fmt.Errorf("a topic named %q in this org %w", t.Name, store.ErrConflict)
+		}
+		return err
+	}
+	return nil
+}
+
 func (r *topicsRepo) Get(ctx context.Context, orgID string, id streaming.TopicID) (streaming.Topic, error) {
 	return r.FindOne(ctx, store.WithOrg(orgID), store.WithID(string(id)))
 }

--- a/api/pkg/org/infrastructure/persistence/gorm/topic_conflict_test.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/topic_conflict_test.go
@@ -1,0 +1,41 @@
+package gorm_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+	"github.com/helixml/helix/api/pkg/org/domain/transport"
+)
+
+// TestTopicsCreate_DuplicateNameMapsToConflict verifies the gorm store maps
+// the idx_topic_org_name unique violation to store.ErrConflict (the race
+// backstop behind the topics service pre-check), against a real DB.
+func TestTopicsCreate_DuplicateNameMapsToConflict(t *testing.T) {
+	t.Parallel()
+	s := newStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+
+	mk := func(id string) streaming.Topic {
+		tp, err := streaming.NewTopic(streaming.TopicID(id), "general", "", "", now, transport.Transport{}, "org-1")
+		if err != nil {
+			t.Fatalf("NewTopic: %v", err)
+		}
+		return tp
+	}
+	if err := s.Topics.Create(ctx, mk("s-a")); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	if err := s.Topics.Create(ctx, mk("s-b")); !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("duplicate name: want store.ErrConflict, got %v", err)
+	}
+	// Different org, same name is fine.
+	tp, _ := streaming.NewTopic("s-c", "general", "", "", now, transport.Transport{}, "org-2")
+	if err := s.Topics.Create(ctx, tp); err != nil {
+		t.Fatalf("same name, other org should be allowed: %v", err)
+	}
+}

--- a/api/pkg/org/infrastructure/persistence/memory/domainevent_test.go
+++ b/api/pkg/org/infrastructure/persistence/memory/domainevent_test.go
@@ -1,0 +1,49 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/domain/domainevent"
+)
+
+func TestDomainEventsAppendAndListBySubject(t *testing.T) {
+	ctx := context.Background()
+	s := New()
+	base := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+
+	mk := func(id, org, subject, worker string, at time.Time) domainevent.DomainEvent {
+		e, err := domainevent.New(id, org, domainevent.TypeSlackThreadParticipant, subject, worker, "p-router", nil, at)
+		if err != nil {
+			t.Fatalf("new: %v", err)
+		}
+		return e
+	}
+	// Two participants in thread T, one in thread U, one in another org.
+	for _, e := range []domainevent.DomainEvent{
+		mk("d1", "org-1", "T", "w-alice", base),
+		mk("d2", "org-1", "T", "w-bob", base.Add(time.Minute)),
+		mk("d3", "org-1", "U", "w-carol", base),
+		mk("d4", "org-2", "T", "w-dave", base),
+	} {
+		if err := s.DomainEvents.Append(ctx, e); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+
+	got, err := s.DomainEvents.ListBySubject(ctx, "org-1", domainevent.TypeSlackThreadParticipant, "T", time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := domainevent.Participants(got)
+	if len(parts) != 2 || parts[0] != "w-bob" || parts[1] != "w-alice" {
+		t.Fatalf("want [w-bob w-alice] (newest first), got %v", parts)
+	}
+
+	// Time window excludes the older event.
+	recent, _ := s.DomainEvents.ListBySubject(ctx, "org-1", domainevent.TypeSlackThreadParticipant, "T", base.Add(30*time.Second))
+	if p := domainevent.Participants(recent); len(p) != 1 || p[0] != "w-bob" {
+		t.Fatalf("window: want [w-bob], got %v", p)
+	}
+}

--- a/api/pkg/org/infrastructure/persistence/memory/memorystore.go
+++ b/api/pkg/org/infrastructure/persistence/memory/memorystore.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/helixml/helix/api/pkg/org/domain/activation"
 	"github.com/helixml/helix/api/pkg/org/domain/config"
+	"github.com/helixml/helix/api/pkg/org/domain/domainevent"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/org/domain/processor"
 	"github.com/helixml/helix/api/pkg/org/domain/store"
@@ -48,7 +49,42 @@ func New() *store.Store {
 		Configs:            &configsRepo{rows: map[orgKey]config.Config{}},
 		Activations:        &activationsRepo{rows: map[orgKey]*activation.Activation{}},
 		Processors:         &processorsRepo{rows: map[orgKey]processor.Processor{}},
+		DomainEvents:       &domainEventsRepo{},
 	}
+}
+
+// ---- DomainEvents -------------------------------------------------------
+
+// domainEventsRepo is the in-memory append-only log. A flat slice is fine:
+// the log is small and only ever appended to and range-scanned.
+type domainEventsRepo struct {
+	mu   sync.RWMutex
+	rows []domainevent.DomainEvent
+}
+
+func (r *domainEventsRepo) Append(_ context.Context, e domainevent.DomainEvent) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.rows = append(r.rows, e)
+	return nil
+}
+
+func (r *domainEventsRepo) ListBySubject(_ context.Context, orgID string, typ domainevent.Type, subject string, since time.Time) ([]domainevent.DomainEvent, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]domainevent.DomainEvent, 0)
+	for _, e := range r.rows {
+		if e.OrganizationID != orgID || e.Type != typ || e.Subject != subject {
+			continue
+		}
+		if !since.IsZero() && e.CreatedAt.Before(since) {
+			continue
+		}
+		out = append(out, e)
+	}
+	// Newest first.
+	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt.After(out[j].CreatedAt) })
+	return out, nil
 }
 
 // orgKey is the composite (orgID, id) the memory repos use as a

--- a/api/pkg/org/infrastructure/persistence/memory/memorystore.go
+++ b/api/pkg/org/infrastructure/persistence/memory/memorystore.go
@@ -400,10 +400,11 @@ func (s *topicsRepo) Create(_ context.Context, st streaming.Topic) error {
 		return fmt.Errorf("topic %q in org %q: already exists", st.ID, st.OrganizationID)
 	}
 	// Enforce composite (org_id, name) uniqueness to mirror the gorm
-	// idx_topic_org_name constraint.
+	// idx_topic_org_name constraint. Wrap store.ErrConflict so adapters map
+	// it to 409 (and the topics service's pre-check reads it).
 	for k2, ex := range s.rows {
 		if k2.OrgID == st.OrganizationID && ex.Name == st.Name {
-			return fmt.Errorf("topic name %q already in use in org %q", st.Name, st.OrganizationID)
+			return fmt.Errorf("a topic named %q in this org %w", st.Name, store.ErrConflict)
 		}
 	}
 	s.rows[k] = st

--- a/api/pkg/org/interfaces/mcptools/builtins.go
+++ b/api/pkg/org/interfaces/mcptools/builtins.go
@@ -170,11 +170,11 @@ func (c Config) workersService() *workers.Workers {
 // surface never fires Workers, so Helix/Mirror/Owner stay nil).
 func (c Config) lifecycleService() *lifecycle.Service {
 	svc := &lifecycle.Service{
-		Store:      c.Store,
-		Reconciler: c.Reconciler,
-		HireHook:   c.HireHook,
-		Now:        c.Now,
-		NewID:      c.NewID,
+		Store:             c.Store,
+		WorkerReconcilers: []lifecycle.WorkerReconciler{c.Reconciler},
+		HireHook:          c.HireHook,
+		Now:               c.Now,
+		NewID:             c.NewID,
 	}
 	// c.Dispatcher (EventDispatcher) satisfies lifecycle.HireDispatcher
 	// (DispatchHire); guard the typed-nil-in-interface case.

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -348,6 +348,8 @@ func errStatus(err error) int {
 	switch {
 	case errors.Is(err, store.ErrNotFound):
 		return http.StatusNotFound
+	case errors.Is(err, store.ErrConflict):
+		return http.StatusConflict
 	default:
 		return http.StatusInternalServerError
 	}

--- a/api/pkg/org/interfaces/server/api/api_test.go
+++ b/api/pkg/org/interfaces/server/api/api_test.go
@@ -76,7 +76,7 @@ func newDepsClock(t *testing.T, clock func() time.Time, newID func() string) (or
 		// power Hire; Owner guards Fire. Helix/Mirror stay nil — the REST
 		// tests don't exercise the Helix-side teardown.
 		Lifecycle: &lifecycle.Service{
-			Store: st, Reconciler: topo,
+			Store: st, WorkerReconcilers: []lifecycle.WorkerReconciler{topo},
 			Now: clock, NewID: newID,
 		},
 		Subscriptions: subscriptions.New(subscriptions.Deps{Subscriptions: st.Subscriptions, Topics: st.Topics, Workers: st.Workers, Now: clock}),

--- a/api/pkg/org/interfaces/server/api/processors.go
+++ b/api/pkg/org/interfaces/server/api/processors.go
@@ -19,6 +19,10 @@ type ProcessorOutputDTO struct {
 	Match   string `json:"match,omitempty"`
 	Label   string `json:"label,omitempty"`
 	Owned   bool   `json:"owned"`
+	// ManagedFor is set when this route is auto-managed by a reconciler for
+	// the named Worker (the Slack auto-router). Empty for human-authored
+	// routes. Read-only — the UI surfaces it; reconcilers own these routes.
+	ManagedFor string `json:"managed_for,omitempty"`
 }
 
 // ProcessorAttributes is the JSON:API attributes object for a
@@ -31,6 +35,9 @@ type ProcessorAttributes struct {
 	Outputs      []ProcessorOutputDTO `json:"outputs"`
 	CreatedBy    string               `json:"created_by,omitempty"`
 	CreatedAt    string               `json:"created_at,omitempty"`
+	// Automated marks an automation-created processor (the Slack auto-router)
+	// rather than a human-created one. Read-only provenance flag.
+	Automated bool `json:"automated"`
 }
 
 // --- Request DTOs (swagger only) ---------------------------------------
@@ -75,7 +82,7 @@ func processorResource(p processor.Processor) jsonapi.Resource {
 	outs := make([]ProcessorOutputDTO, 0, len(p.Outputs))
 	for _, o := range p.Outputs {
 		outs = append(outs, ProcessorOutputDTO{
-			TopicID: string(o.TopicID), Match: o.Match, Label: o.Label, Owned: o.Owned,
+			TopicID: string(o.TopicID), Match: o.Match, Label: o.Label, Owned: o.Owned, ManagedFor: o.ManagedFor,
 		})
 	}
 	return jsonapi.Resource{
@@ -89,6 +96,7 @@ func processorResource(p processor.Processor) jsonapi.Resource {
 			Outputs:      outs,
 			CreatedBy:    p.CreatedBy,
 			CreatedAt:    p.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			Automated:    p.Automated(),
 		},
 	}
 }

--- a/api/pkg/org/interfaces/server/api/streams.go
+++ b/api/pkg/org/interfaces/server/api/streams.go
@@ -363,6 +363,14 @@ func (a *apiHandler) deleteTopic(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusConflict, fmt.Errorf("topic %q is an output of processor %q; delete the processor instead", id, pid))
 			return
 		}
+		// Tear down any Automated processor bound to this topic as its input
+		// (the Slack auto-router), cascading its owned route topics, before the
+		// topic goes — automation's lifecycle follows the topic it reads.
+		// Human-authored processors reading the topic are left alone.
+		if err := a.deps.Processors.DeleteAutomatedByInput(ctx, orgID, id); err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Errorf("delete topic: tear down bound auto-router: %w", err))
+			return
+		}
 	}
 	if err := a.deps.Topics.Delete(ctx, orgID, id); err != nil {
 		writeError(w, errStatus(err), fmt.Errorf("delete topic: %w", err))

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -618,11 +618,10 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		Store:  st,
 		Helix:  inProcClient,
 		Logger: logger,
-		// Single topology reconciler shared with the tools registry and
-		// the REST handlers — one owner of activation/team Topic
-		// lifecycle across hire, reparent, and fire.
-		Reconciler: deps.Reconciler,
-		Mirror:     mirror, // Fire stops the fired worker's subscription
+		// Worker-scoped reconcilers: the single topology reconciler (one owner
+		// of activation/team Topic lifecycle across hire, reparent, and fire).
+		WorkerReconcilers: []lifecycle.WorkerReconciler{deps.Reconciler},
+		Mirror:            mirror, // Fire stops the fired worker's subscription
 		// Hire collaborators (the create half of the lifecycle). REST POST
 		// /workers and the MCP hire_worker tool both drive Hire through
 		// this service, so the hire semantics live in one place.
@@ -694,7 +693,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		Now:           deps.Now,
 		Logger:        logger,
 	})
-	lifecycleSvc.Reconcilers = append(lifecycleSvc.Reconcilers, slackRouteReconciler)
+	lifecycleSvc.OrgReconcilers = append(lifecycleSvc.OrgReconcilers, slackRouteReconciler)
 	// Thread-follow: the post-routing arm that records thread participation
 	// in the domain-event log and (when enabled) fans later thread messages
 	// out to existing participants. Registered late on the runner, like the

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -22,6 +22,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
 	"github.com/helixml/helix/api/pkg/org/application/processing"
 	"github.com/helixml/helix/api/pkg/org/application/processors"
+	"github.com/helixml/helix/api/pkg/org/application/slackrouting"
 	"github.com/helixml/helix/api/pkg/org/application/prompts"
 	"github.com/helixml/helix/api/pkg/org/application/publishing"
 	"github.com/helixml/helix/api/pkg/org/application/queries"
@@ -95,6 +96,10 @@ type helixOrgHandlers struct {
 	// a workspace is connected/disconnected. An org primitive owned by
 	// this subsystem, not the core server.
 	slackTopics *slackWorkspaceTopics
+	// slackAutoRouter creates the per-workspace auto-router on connect and
+	// keeps its per-Worker routes in sync (composition over the processors
+	// service + slackrouting reconciler). nil when org/Slack is disabled.
+	slackAutoRouter *slackAutoRouter
 	// slackSocket reconciles live Socket Mode connections against the
 	// configured socket-mode apps; Kicked by the admin service-connection
 	// handlers when a slack_app changes so it applies without a restart.
@@ -675,7 +680,33 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	// output through svc.Publishing, so it is wired after buildOrgServices
 	// (which builds Publishing) and registered late on the dispatcher,
 	// exactly like the outbound emitters above.
-	dispatcher.RegisterProcessorRunner(processing.New(st.Processors, svc.Publishing, logger))
+	processorRunner := processing.New(st.Processors, svc.Publishing, logger)
+	dispatcher.RegisterProcessorRunner(processorRunner)
+
+	// Slack auto-router: a second reconciler (composition over the processors
+	// service) maintains one route per AI Worker on each Automated Slack
+	// router. Wired into hire/fire via the lifecycle service, and invoked on
+	// workspace-connect via slackAutoRouter below.
+	slackRouteReconciler := slackrouting.New(slackrouting.Deps{
+		Workers:       st.Workers,
+		Subscriptions: st.Subscriptions,
+		Processors:    svc.Processors,
+		Now:           deps.Now,
+		Logger:        logger,
+	})
+	lifecycleSvc.SlackRouter = slackRouteReconciler
+	// Thread-follow: the post-routing arm that records thread participation
+	// in the domain-event log and (when enabled) fans later thread messages
+	// out to existing participants. Registered late on the runner, like the
+	// dispatcher's other arms.
+	processorRunner.RegisterPostRouter(slackrouting.NewThreadFollower(slackrouting.ThreadFollowerDeps{
+		Events:    st.DomainEvents,
+		Publisher: svc.Publishing,
+		NewID:     deps.NewID,
+		Now:       deps.Now,
+		Logger:    logger,
+	}))
+	slackAutoRouter := &slackAutoRouter{procs: svc.Processors, routes: slackRouteReconciler, logger: logger}
 	// The activations service owns the manual-activate command (REST
 	// activateWorker delegates to it). Built here because it needs the
 	// project ensurer, the dispatcher's DispatchManual, and a session
@@ -767,7 +798,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		Str("root", orgRoot).
 		Int("json_api_routes", len(extras)).
 		Msg("helix-org mounted at /api/v1/orgs/{org}/helix-org/")
-	scope := newHelixOrgScope(configReg, st, helixStore, mirror)
+	scope := newHelixOrgScope(configReg, st, helixStore, mirror, slackRouteReconciler)
 
 	// Public github webhook handler — mounted on the insecure router
 	// because GitHub deliveries authenticate via HMAC, not the helix
@@ -850,6 +881,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		publicSlackEvents:            publicSlackEvents,
 		slackSocketRun:               slackSocketRun,
 		slackTopics:                  slackTopics,
+		slackAutoRouter:              slackAutoRouter,
 		slackSocket:                  slackSocket,
 	}, nil
 }

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -694,7 +694,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		Now:           deps.Now,
 		Logger:        logger,
 	})
-	lifecycleSvc.SlackRouter = slackRouteReconciler
+	lifecycleSvc.Reconcilers = append(lifecycleSvc.Reconcilers, slackRouteReconciler)
 	// Thread-follow: the post-routing arm that records thread participation
 	// in the domain-event log and (when enabled) fans later thread messages
 	// out to existing participants. Registered late on the runner, like the

--- a/api/pkg/server/helix_org_middleware.go
+++ b/api/pkg/server/helix_org_middleware.go
@@ -13,6 +13,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
 	"github.com/helixml/helix/api/pkg/org/application/reconcile"
 	"github.com/helixml/helix/api/pkg/org/application/roles"
+	"github.com/helixml/helix/api/pkg/org/application/slackrouting"
 	helixorgstore "github.com/helixml/helix/api/pkg/org/domain/store"
 	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
 	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
@@ -32,6 +33,11 @@ type helixOrgScope struct {
 	// inline-chat-only workers are mirrored without an activation first.
 	mirror *runtimehelix.Mirror
 
+	// slackRoutes converges Slack auto-router routes on first request,
+	// catching Workers hired while the server was down. nil when Slack
+	// routing isn't wired.
+	slackRoutes *slackrouting.Reconciler
+
 	mu           sync.Mutex
 	bootstrapped map[string]bool
 	// bootstrapFlight dedupes concurrent first-load races on the same
@@ -44,12 +50,13 @@ type helixOrgScope struct {
 
 // newHelixOrgScope wires the data the middleware needs. configs and
 // orgStore are the same instances handed to the helix-org handler.
-func newHelixOrgScope(configs *configregistry.Registry, orgStore *helixorgstore.Store, hs helixstore.Store, mirror *runtimehelix.Mirror) *helixOrgScope {
+func newHelixOrgScope(configs *configregistry.Registry, orgStore *helixorgstore.Store, hs helixstore.Store, mirror *runtimehelix.Mirror, slackRoutes *slackrouting.Reconciler) *helixOrgScope {
 	return &helixOrgScope{
 		configs:      configs,
 		orgStore:     orgStore,
 		helixStore:   hs,
 		mirror:       mirror,
+		slackRoutes:  slackRoutes,
 		bootstrapped: map[string]bool{},
 	}
 }
@@ -109,6 +116,16 @@ func (s *helixOrgScope) ensureBootstrap(ctx context.Context, orgID string) error
 		})
 		if err := rec.ReconcileAll(ctx, orgID); err != nil {
 			log.Warn().Err(err).Str("org_id", orgID).Msg("helix-org topology reconcile-all failed")
+		}
+
+		// Converge Slack auto-router routes for this org too: catches Workers
+		// hired while the server was down (or before this feature shipped).
+		// No-op for orgs without an Automated router. Reuses the
+		// composition-root reconciler so it has the real id-generator.
+		if s.slackRoutes != nil {
+			if err := s.slackRoutes.Reconcile(ctx, orgID); err != nil {
+				log.Warn().Err(err).Str("org_id", orgID).Msg("helix-org slack route reconcile failed")
+			}
 		}
 
 		// Backfill the universal read baseline on every Role in this

--- a/api/pkg/server/helix_org_middleware_test.go
+++ b/api/pkg/server/helix_org_middleware_test.go
@@ -56,6 +56,7 @@ func TestEnsureBootstrapConcurrentCallsAllSucceed(t *testing.T) {
 		orgStore,
 		&noAdminHelixStore{},
 		nil, // mirror — nil is a safe no-op for this bootstrap-race test
+		nil, // slackRoutes — nil is a safe no-op
 	)
 
 	const N = 8

--- a/api/pkg/server/helix_org_slack.go
+++ b/api/pkg/server/helix_org_slack.go
@@ -16,6 +16,9 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/helixml/helix/api/pkg/crypto"
+	"github.com/helixml/helix/api/pkg/org/application/processors"
+	"github.com/helixml/helix/api/pkg/org/application/slackrouting"
+	"github.com/helixml/helix/api/pkg/org/domain/processor"
 	helixorgstore "github.com/helixml/helix/api/pkg/org/domain/store"
 	"github.com/helixml/helix/api/pkg/org/domain/streaming"
 	"github.com/helixml/helix/api/pkg/org/domain/transport"
@@ -49,7 +52,10 @@ func (r *slackWorkspaceTopics) ensure(ctx context.Context, orgID, connID, worksp
 	}
 	name := slacktransport.TopicName(appName, workspaceName)
 	cfg, _ := json.Marshal(transport.SlackConfig{ServiceConnectionID: connID})
-	topic, err := streaming.NewTopic(id, name, "Messages from the connected Slack workspace.", "", time.Now().UTC(),
+	// CreatedBy = SystemActor marks this as an automation-created stream
+	// (auto-connect, not a hand-made one) — the same marker the auto-router
+	// carries.
+	topic, err := streaming.NewTopic(id, name, "Messages from the connected Slack workspace.", processor.SystemActor, time.Now().UTC(),
 		transport.Transport{Kind: transport.KindSlack, Config: cfg}, orgID)
 	if err != nil {
 		r.logger.Error("slack.reconcile: build topic", "org", orgID, "conn", connID, "err", err)
@@ -66,6 +72,76 @@ func (r *slackWorkspaceTopics) remove(ctx context.Context, orgID, connID string)
 	}
 	if err := r.topics.Delete(ctx, orgID, slackWorkspaceTopicID(connID)); err != nil {
 		r.logger.Warn("slack.reconcile: delete topic", "org", orgID, "conn", connID, "err", err)
+	}
+}
+
+// slackAutoRouter creates the per-workspace auto-router Processor on connect
+// and keeps its per-Worker routes in sync. The router is a filter Processor
+// (Automated=true) on the workspace Topic: it routes Slack messages naming a
+// Worker to that Worker, with thread-follow as an opt-in. Creation is bound
+// to the workspace-connect event so a user-deleted router stays deleted —
+// the reconciler only ever maintains routes inside an existing router.
+type slackAutoRouter struct {
+	procs  *processors.Processors
+	routes *slackrouting.Reconciler
+	logger *slog.Logger
+}
+
+// slackAutoRouterID is the deterministic id of a workspace's auto-router.
+func slackAutoRouterID(connID string) processor.ProcessorID {
+	return processor.ProcessorID("p-slack-router-" + connID)
+}
+
+// createOnConnect creates the auto-router for a freshly-connected workspace
+// (create-once) and populates routes for the org's current Workers. Callers
+// invoke this ONLY from the workspace-create branch, never on re-install, so
+// it never resurrects a deleted router.
+func (r *slackAutoRouter) createOnConnect(ctx context.Context, orgID, connID, topicName string) {
+	if r == nil || r.procs == nil {
+		return
+	}
+	_, err := r.procs.Create(ctx, orgID, processors.CreateParams{
+		ID:           string(slackAutoRouterID(connID)),
+		Name:         "Auto-router · " + topicName,
+		InputTopicID: slackWorkspaceTopicID(connID),
+		Kind:         processor.KindFilter,
+		Config:       slackrouting.DefaultConfig(),
+		// A single unconditional "unmatched" branch: it exists so a user can
+		// wire a catch-all (e.g. subscribe a human), but it has no subscriber
+		// by default, so nothing triggers on un-named messages.
+		Outputs: []processors.OutputSpec{{Label: "unmatched"}},
+		// SystemActor CreatedBy IS the "automated" marker (processor.Automated)
+		// and propagates to the output Topics this router owns.
+		CreatedBy: processor.SystemActor,
+	})
+	if err != nil {
+		r.logger.Error("slack.autorouter: create", "org", orgID, "conn", connID, "err", err)
+		// Fall through: reconcile is still safe and may have a router to fill.
+	}
+	r.reconcile(ctx, orgID)
+}
+
+// removeForWorkspace tears down the workspace's auto-router (and its owned
+// output Topics) when the Slack integration/workspace is disconnected.
+// Keyed by the workspace Topic the router reads, so it also catches a
+// re-created router. Idempotent: no router → no-op.
+func (r *slackAutoRouter) removeForWorkspace(ctx context.Context, orgID, connID string) {
+	if r == nil || r.procs == nil {
+		return
+	}
+	if err := r.procs.DeleteAutomatedByInput(ctx, orgID, slackWorkspaceTopicID(connID)); err != nil {
+		r.logger.Warn("slack.autorouter: remove on disconnect", "org", orgID, "conn", connID, "err", err)
+	}
+}
+
+// reconcile converges the org's Slack auto-routers onto its current Workers.
+// No-op when no router exists (deleted or never created).
+func (r *slackAutoRouter) reconcile(ctx context.Context, orgID string) {
+	if r == nil || r.routes == nil {
+		return
+	}
+	if err := r.routes.Reconcile(ctx, orgID); err != nil {
+		r.logger.Warn("slack.autorouter: reconcile", "org", orgID, "err", err)
 	}
 }
 
@@ -588,6 +664,11 @@ func (s *HelixAPIServer) upsertSlackWorkspace(ctx context.Context, orgID string,
 				return err
 			}
 			s.helixOrg.slackTopics.ensure(ctx, orgID, conn.ID, conn.Name, appName)
+			// Re-install of an existing workspace: do NOT (re)create the
+			// router — a user-deleted router must stay deleted. Just reconcile
+			// routes (no-op if the router was deleted; picks up new Workers if
+			// it still exists).
+			s.helixOrg.slackAutoRouter.reconcile(ctx, orgID)
 			return nil
 		}
 	}
@@ -608,6 +689,9 @@ func (s *HelixAPIServer) upsertSlackWorkspace(ctx context.Context, orgID string,
 		return err
 	}
 	s.helixOrg.slackTopics.ensure(ctx, orgID, conn.ID, conn.Name, appName)
+	// First install of this workspace: create the auto-router (create-once)
+	// and populate routes for the org's current Workers.
+	s.helixOrg.slackAutoRouter.createOnConnect(ctx, orgID, conn.ID, slacktransport.TopicName(appName, conn.Name))
 	return nil
 }
 
@@ -709,6 +793,10 @@ func (s *HelixAPIServer) deleteSlackWorkspaceAndTopic(ctx context.Context, orgID
 	if err := s.Store.DeleteServiceConnection(ctx, connID); err != nil {
 		return err
 	}
+	// Tear down the auto-router (cascading its owned route Topics) before the
+	// workspace Topic it reads — the router's lifecycle is bound to the
+	// integration.
+	s.helixOrg.slackAutoRouter.removeForWorkspace(ctx, orgID, connID)
 	s.helixOrg.slackTopics.remove(ctx, orgID, connID)
 	return nil
 }

--- a/design/2026-06-26-slack-auto-router.md
+++ b/design/2026-06-26-slack-auto-router.md
@@ -107,10 +107,11 @@ A new, independent reconciler (composition — it *uses* the processors service
 and the worker/subscription stores; it is not bolted onto reconcile.Reconciler).
 For each automated Slack router in the org:
 
-- Desired managed routes = one per **AI** Worker: `Match = {{ mentions "<name>"
-  .Message.body }}` (word-boundary, case-insensitive; `<name>` = worker id with
-  the `w-` prefix stripped), output = an auto-provisioned, Worker-subscribed
-  Topic, `ManagedFor=<workerID>`.
+- Desired managed routes = one per **AI** Worker: `Match = {{ mentions
+  "<workerID>" .Message.body }}` (word-boundary, case-insensitive; matches the
+  Worker's **full id**, e.g. `w-jokebot` — the org's canonical name for it, not
+  the bare `jokebot` slug, which would over-trigger on common words), output =
+  an auto-provisioned, Worker-subscribed Topic, `ManagedFor=<workerID>`.
 - Diff vs the router's current `ManagedFor` routes:
   - Worker exists, no managed route → **add** route (provision output Topic via
     the processors service, subscribe the Worker).

--- a/design/2026-06-26-slack-auto-router.md
+++ b/design/2026-06-26-slack-auto-router.md
@@ -186,6 +186,28 @@ follower:
 Purity preserved: `Process` only does name-match; all state lives in the
 follower + the domain-event log.
 
+## Multi-tenancy (multiple apps / workspaces)
+
+- **Multiple global Slack apps:** the auto-router is bound to the *workspace
+  connection*, not the app — it never references the global app. More apps just
+  means more workspace installs, each independent.
+- **Multiple workspaces per org:** each install has its own `connID` →
+  `s-slack-ws-<connID>` Topic → `p-slack-router-<connID>` router → per-router
+  owned route Topics (named by router id) → per-(worker,topic) subscriptions.
+  The reconciler iterates *every* automated router in the org, so a Worker gets
+  a route on each, reachable by name from any connected workspace. Inbound is
+  scoped by `ServiceConnectionID`, so a message only ever hits its own
+  workspace's router (no cross-workspace leakage).
+- **Thread membership is router-scoped:** the domain-event `subject` is
+  `<routerID>/<thread_root>`, so two workspaces can never share thread
+  membership even if Slack reuses a `ts` value across them.
+- **Known shared constraint (pre-existing, not introduced here):** the
+  workspace Topic and the router both carry an org-unique *name*. The existing
+  Slack integration already requires distinct workspace display names per org
+  (the Topic's `(org,name)` index); the router inherits the same. Two installs
+  with an identical display name in one org would collide — unusual, and a
+  property of the existing Topic naming, not this feature.
+
 ## Non-goals (v1)
 
 - No event-sourcing framework: no subscribers, projections engine, or replay

--- a/design/2026-06-26-slack-auto-router.md
+++ b/design/2026-06-26-slack-auto-router.md
@@ -1,0 +1,212 @@
+# Slack auto-router + thread participation
+
+Date: 2026-06-26
+Status: implemented + smoke-tested (live dev stack)
+Branch: feat/org-slack-auto-router
+
+## Smoke-test results (live API on localhost:8080, org `test`)
+
+Seeded a "Slack-connected" precondition (workspace topic + Automated filter
+router + two AI Workers) via SQL, then exercised the **running binary**:
+
+- Fire-triggered reconcile added one managed route per AI Worker
+  (`mentions "<name>" .Message.body`), provisioned + `automated`-marked output
+  Topics, and subscribed each Worker. A fired Worker got no route.
+- Live name-match routing: a message naming `smokealice` reached her route
+  Topic + the (subscriber-less) default; `ai-1` (unnamed) got nothing.
+- Word-boundary: `smokealicery` did NOT match `smokealice`; `ai-1` matched.
+- The auto-router renders in the helix-org **Chart UI** with its
+  `unmatched`/per-Worker outputs wired to the Workers.
+- Delete cascaded the 3 owned output Topics; a subsequent fire-reconcile did
+  NOT recreate the router (sticky-delete).
+
+Not exercised live (covered by unit tests only): **thread-follow** — the
+publish API doesn't carry Slack `ts`/`thread_ts`, so `thread_root` is empty
+and membership recording/fan-out require a real Slack event.
+
+## Problem
+
+Connecting a Slack workspace to an org currently delivers every message onto a
+single workspace-scoped Topic (`s-slack-ws-<connID>`). To get those messages to
+a *specific* Worker, an operator must hand-build a filter Processor (the
+"router") and wire one Output ("route") per Worker — a predicate that matches
+the Worker's name → a Topic that Worker subscribes to. That manual wiring is a
+faff and drifts out of sync as Workers come and go.
+
+We want this to happen automatically, with near-zero intervention, while still
+being fully customisable and overridable.
+
+## What already exists (and we reuse)
+
+- **filter Processor** (`domain/processor/filter.go`): reads one input Topic,
+  has N `Output`s. Each Output = `{Match predicate, destination TopicID}` — i.e.
+  *a route*. Match is a Go `text/template` returning truthy. Zero matches drops
+  the message; N matches fans out. **This is the router.** We instantiate one,
+  we do not reinvent it.
+- **reconcile.Reconciler** (`application/reconcile`): event-driven, idempotent
+  diff of the channel topology against the reporting graph; invoked by
+  hire/fire and at startup (`ReconcileAll`). **This is the pattern our new
+  route reconciler mirrors** (composition: a second, independent reconciler).
+- **slackWorkspaceTopics.ensure** (`server/helix_org_slack.go`): creates the
+  workspace Topic on connect. The auto-router is created right beside it.
+- **processing.Runner / dispatch.Dispatcher**: late-bound execution arms
+  (`RegisterProcessorRunner`, `RegisterOutbound`). Thread-follow registers the
+  same way.
+
+## Design
+
+### 1. Markers (the provenance the feature needs)
+
+Two cheap markers, no schema migration, reusing existing fields:
+
+- `processor.Output.ManagedFor string` (JSON field on the existing Outputs blob
+  — **no migration**). Non-empty = "this route is auto-managed for that Worker
+  ID". Empty = a manual route the user added. **The route reconciler only ever
+  touches `ManagedFor` routes**; manual routes are invisible to it (never
+  GC'd, never rewritten). This is the whole answer to "don't touch user edits"
+  and "GC routes for dead workers" — one field, keyed by worker.
+- **"Automated" = `CreatedBy == processor.SystemActor` ("helix")** — no new
+  column. `CreatedBy` already exists (the chart anchor) and is `""` / a Worker
+  id for human-made records; automation stamps the `SystemActor` sentinel
+  instead. `processor.Processor.Automated()` derives the flag from it; the route
+  reconciler and post-routing hook key on it; the API surfaces a computed
+  `automated` boolean (the chart leaves the sentinel unanchored, since no Worker
+  is named "helix"). Crucially the marker **propagates for free**: the
+  processors service already copies a processor's `CreatedBy` onto the output
+  Topics it owns, so an automated router's Topics are automatically `helix`-owned
+  too — no `Topic.Automated` plumbing needed.
+
+Worker *names are immutable IDs* (`w-alice`), so there is **no fingerprint and
+no rename-sync**: the reconciler only reconciles route *presence/absence* keyed
+by worker, never route *content*. A user editing a managed route's predicate is
+preserved because presence (a route tagged for that worker exists) is all the
+reconciler checks.
+
+### 2. Router creation — create-once, sticky-deleted
+
+The auto-router is created **only when the workspace ServiceConnection is first
+created** (the create branch of `upsertSlackWorkspace`), never on token-refresh
+re-install, and **never by the reconciler**. Deterministic id
+`p-slack-router-<connID>`, `CreatedBy=SystemActor` (the automated marker),
+`Kind=filter`, input = `s-slack-ws-<connID>`, one default (unconditional,
+**disconnected**) route, and `Config={"thread_follow":true}` (on by default —
+matches Slack's "everyone in the thread is notified" expectation; toggle per
+router in the UI).
+
+It is torn down with the workspace: disconnecting the Slack workspace (which
+removes the `s-slack-ws-<connID>` Topic) also deletes `p-slack-router-<connID>`,
+cascading its owned output Topics. A later reconnect creates a fresh one.
+
+Because creation is bound to the connect event and the reconciler only maintains
+routes *inside an existing* router, deleting the router makes it stay deleted —
+no tombstone required.
+
+### 3. Route reconciler (`application/slackrouting`)
+
+A new, independent reconciler (composition — it *uses* the processors service
+and the worker/subscription stores; it is not bolted onto reconcile.Reconciler).
+For each automated Slack router in the org:
+
+- Desired managed routes = one per **AI** Worker: `Match = {{ mentions "<name>"
+  .Message.body }}` (word-boundary, case-insensitive; `<name>` = worker id with
+  the `w-` prefix stripped), output = an auto-provisioned, Worker-subscribed
+  Topic, `ManagedFor=<workerID>`.
+- Diff vs the router's current `ManagedFor` routes:
+  - Worker exists, no managed route → **add** route (provision output Topic via
+    the processors service, subscribe the Worker).
+  - Managed route whose Worker no longer exists → **remove** route (cascades the
+    owned output Topic + its subscription). This is the GC backstop; the normal
+    worker-delete cascade already drops the *subscription*, the reconciler drops
+    the *route + topic*.
+  - Manual routes / the default route → untouched.
+
+Invoked by the same triggers as the channel reconciler: hire, fire, and startup
+(`ReconcileAll`), plus once at router-creation time.
+
+### 4. Editable processor outputs (refactor)
+
+`processors.Processors.Update` currently freezes Outputs (v1 "delete & recreate"
+note). The reconciler needs per-route add/remove. We add output-level operations
+to the service so the auto-provision/cascade/cycle-check invariants stay in one
+place:
+
+- `AddOutput(orgID, procID, OutputSpec) (Output, error)` — provisions the owned
+  output Topic (or wires an explicit one), appends, re-cycle-checks, persists.
+- `RemoveOutput(orgID, procID, topicID)` — drops the Output, deletes the owned
+  Topic.
+
+Done TDD. Existing `Update`/`Create` semantics unchanged.
+
+### 5. Domain-event log (`domain/domainevent` + store)
+
+A generic, append-only audit log of **decisions** — distinct from the runtime
+`streaming.Event` data plane (named `domainevent` precisely to avoid that
+collision). v1 is deliberately minimal: one table, append + query, one emitted
+type, no subscribers / projections / replay.
+
+```
+DomainEvent{ ID, OrgID, Type, Subject, Worker, Source, Metadata json, CreatedAt }
+```
+
+- `Subject` = the entity the event is keyed on (here: the Slack `thread_root`).
+- `Worker` = the Worker the decision concerns (the participant).
+- `Source` = what decided (the router's processor id).
+- Indexed on `(org_id, type, subject)` for the membership read.
+
+Thread membership becomes a **projection**: "distinct `Worker` for
+`(org, type='slack.thread_participant', subject=thread_root)` within the last N
+days (7)". Nothing is reaped for correctness — the time window is a query bound,
+not a delete policy. Optional pruning of old rows is a later, size-only concern.
+
+### 6. Thread-follow
+
+Slack users expect everyone already in a thread to keep receiving replies even
+when their name isn't repeated. Two routing modes on the automated router:
+
+1. **Name-match** (stateless) — the filter Outputs (§3). First contact.
+2. **Thread-follow** (stateful, new, gated by `Config.thread_follow`) — once a
+   Worker is in a thread, every later message in that thread reaches them.
+
+`thread_root` = `Message.ThreadID` if set else `Message.MessageID` (a top-level
+Slack message *is* a potential thread root).
+
+Execution stays out of the pure `Process`: the `processing.Runner`, after
+running a processor whose `Automated` is true, calls a late-bound
+`ThreadFollower` hook (registered like the other arms; defined in `processing`,
+implemented in `slackrouting`, so `processing` stays Slack-agnostic). The
+follower:
+
+1. Maps the name-matched results back to their `ManagedFor` Workers and
+   **records** `(thread_root → Worker)` for each (idempotent: skip if already a
+   member). Naming a new Worker mid-thread pulls them in here.
+2. If `thread_follow` is on: queries existing members of `thread_root`, and
+   **publishes** the message to the managed-route output Topic of every member
+   *not* already name-matched (those are delivered by the normal result publish).
+
+Purity preserved: `Process` only does name-match; all state lives in the
+follower + the domain-event log.
+
+## Non-goals (v1)
+
+- No event-sourcing framework: no subscribers, projections engine, or replay
+  over the domain-event log.
+- No mutable per-processor KV store (this is an append-only *fact* log).
+- No human-Worker routing (AI Workers only — only they activate).
+- No @mention routing (Slack mentions resolve to the app, not the Worker's
+  name; we match the Worker's name in text).
+- No backfill of routers for pre-existing workspaces; no router auto-recreate.
+- No domain-event-log retention/pruning job (window-bounded reads make it
+  unnecessary for correctness).
+
+## Build order (TDD each)
+
+1. Editable processor outputs (`AddOutput`/`RemoveOutput`).
+2. Markers (`Output.ManagedFor`, `Processor.Automated`, `Topic.Automated` +
+   gorm migration).
+3. `mentions` word-boundary template func.
+4. Domain-event log package + store.
+5. `slackrouting` route reconciler.
+6. Router creation on connect.
+7. Thread-follow arm + Runner hook + toggle.
+8. Wire reconciler into hire/fire/startup.
+9. Build, go test, UI smoke test on localhost:8080.

--- a/frontend/src/components/helix-org/ProcessorConfigDrawer.tsx
+++ b/frontend/src/components/helix-org/ProcessorConfigDrawer.tsx
@@ -14,7 +14,9 @@ import Button from '@mui/material/Button'
 import Collapse from '@mui/material/Collapse'
 import Divider from '@mui/material/Divider'
 import Drawer from '@mui/material/Drawer'
+import FormControlLabel from '@mui/material/FormControlLabel'
 import IconButton from '@mui/material/IconButton'
+import Switch from '@mui/material/Switch'
 import Link from '@mui/material/Link'
 import MenuItem from '@mui/material/MenuItem'
 import Stack from '@mui/material/Stack'
@@ -148,6 +150,7 @@ const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, 
   const [template, setTemplate] = useState(DEFAULT_TEMPLATE)
   const [maxBytes, setMaxBytes] = useState('500')
   const [filterRows, setFilterRows] = useState<FilterRow[]>(DEFAULT_FILTER_ROWS)
+  const [threadFollow, setThreadFollow] = useState(false)
   const [showHelp, setShowHelp] = useState(false)
 
   // Most recent real message on the input topic (null = topic has none).
@@ -164,6 +167,7 @@ const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, 
       setMaxBytes(String((processor.config?.max_bytes as number) ?? 500))
       const rows = (processor.outputs ?? []).map((o) => ({ label: o.label ?? '', match: o.match ?? '' }))
       setFilterRows(rows.length > 0 ? rows : DEFAULT_FILTER_ROWS)
+      setThreadFollow(Boolean(processor.config?.thread_follow))
     } else {
       setName('')
       setKind('template')
@@ -171,6 +175,7 @@ const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, 
       setTemplate(DEFAULT_TEMPLATE)
       setMaxBytes('500')
       setFilterRows(DEFAULT_FILTER_ROWS)
+      setThreadFollow(false)
     }
   }, [open, processor, presetInputTopicId])
 
@@ -178,9 +183,15 @@ const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, 
 
   const config = useMemo<Record<string, unknown>>(() => {
     if (kind === 'truncate') return { max_bytes: parseInt(maxBytes, 10) || 0 }
-    if (kind === 'filter') return {}
+    if (kind === 'filter') return { thread_follow: threadFollow }
     return { template }
-  }, [kind, template, maxBytes])
+  }, [kind, template, maxBytes, threadFollow])
+
+  // Thread-follow is only meaningful for the Slack auto-router (an
+  // automated filter): it routes later messages in a thread to everyone
+  // already participating, not just whoever is named. Hidden for ordinary
+  // hand-built filters, where it has no effect.
+  const showThreadFollow = kind === 'filter' && Boolean(processor?.automated)
 
   // Filter outputs carry the per-branch predicates; transforms have a
   // single auto-provisioned output (undefined → server defaults to one).
@@ -261,6 +272,18 @@ const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, 
               onChange={(e) => setMaxBytes(e.target.value.replace(/[^0-9]/g, ''))}
               helperText="Cap the body to this many bytes (rune-safe)."
             />
+          )}
+          {showThreadFollow && (
+            <Box sx={{ border: '1px solid rgba(0,0,0,0.08)', borderRadius: 1, p: 1, backgroundColor: 'rgba(0,0,0,0.015)' }}>
+              <FormControlLabel
+                control={<Switch size="small" checked={threadFollow} onChange={(e) => setThreadFollow(e.target.checked)} />}
+                label={<Typography variant="body2" sx={{ fontWeight: 600 }}>Follow threads</Typography>}
+              />
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                When on, once a Worker is pulled into a Slack thread (by being named), every later message
+                in that thread also reaches them — even when their name isn't repeated. On by default.
+              </Typography>
+            </Box>
           )}
           {kind === 'filter' && (
             <Stack spacing={1}>

--- a/frontend/src/services/helixOrgService.ts
+++ b/frontend/src/services/helixOrgService.ts
@@ -101,6 +101,9 @@ export interface ProcessorOutput {
   match?: string
   label?: string
   owned?: boolean
+  // Set when this route is auto-managed by a reconciler for the named
+  // Worker (the Slack auto-router); empty for human-authored routes.
+  managed_for?: string
 }
 
 export interface ProcessorDTO {
@@ -112,6 +115,8 @@ export interface ProcessorDTO {
   outputs: ProcessorOutput[]
   created_by?: string
   created_at?: string
+  // True for automation-created processors (the Slack auto-router).
+  automated?: boolean
 }
 
 interface JsonApiResource<T> { id: string; type: string; attributes: T }


### PR DESCRIPTION
## What

Connecting a Slack workspace now **auto-creates a per-workspace "auto-router"** that routes messages naming a Worker to that Worker — no manual filter-wiring. A reconciler keeps one route per AI Worker in sync as Workers are hired/fired, and **thread-follow** (on by default) keeps delivering a thread's later messages to everyone already participating in it, even when their name isn't repeated.

Design doc: `design/2026-06-26-slack-auto-router.md`.

## Design (composition, small surface)

- **Reuses the existing filter Processor** ("the router") + a **new reconciler** that mirrors `reconcile.Reconciler`. No new Processor Kind.
- **"automated" = `CreatedBy == processor.SystemActor` ("helix")** — derived, not a new column; it propagates to the router's owned output Topics for free.
- **Managed routes keyed by `Output.ManagedFor`** (a JSON field — no migration). The reconciler only ever touches those, so manual/edited routes are never rewritten or GC'd.
- **Create-once, sticky-deleted**: router creation is bound to workspace-connect; deleting the router (or the workspace/topic) tears it down via `DeleteAutomatedByInput`, and it isn't resurrected.
- **Word-boundary name match** (`mentions` template func): "Sam" fires on "hey Sam", not "salmon".
- **Thread membership is a projection** over a generic **append-only domain-event log** (`domainevent`), not a bespoke table. One composite index `(org_id, type, subject, created_at DESC)` serves the only read path (filter + ORDER BY from the index, no sort). The pure `processor.Process` stays pure — thread-follow runs in a **late-bound post-routing hook**.

## UI

"Follow threads" toggle on the auto-router (shown only for automated routers); API exposes computed `automated` + per-route `managed_for`.

## Tests / verification

- New TDD unit tests: editable processor outputs, `mentions`, domain-event store, the route reconciler, thread-follow, delete-cascade.
- Full org suite + server Slack/lifecycle tests green; binary + frontend typecheck clean.
- Smoke-tested live on the dev stack (real UI): route creation/GC on hire/fire, name-match routing, word-boundary, the toggle persisting, delete-cascade, and the audit-log query plan (`Index Scan`, no Sort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)