### PR TITLE
Please take the following notes and using your knowledge ...

### DIFF
--- a/design/2026-06-28-helix-org-roadmap.md
+++ b/design/2026-06-28-helix-org-roadmap.md
@@ -1,0 +1,225 @@
+# Helix-Org Roadmap
+
+_Date: 2026-06-28 · Status: draft for discussion_
+
+## Thesis
+
+Automate traditional, information-centric back-office jobs by employing AI to do
+the small, recurring tasks a business needs done. These jobs typically share a
+shape: **ingest information → take some action → pass an approval / acknowledgement
+gate**. Helix-Org aims to be generic across these workloads.
+
+**Anchor example — the documentation bot.** Simple, has an approval gate, requires
+teaching. We use it throughout this roadmap to keep ideas concrete.
+
+## Mental model (the domain today)
+
+Modelled deliberately as an **org chart** so it can be explained in ordinary
+business language.
+
+- **Role** — the job description. A markdown `role.md`: what the job is, who/what it
+  interacts with, how the work is done, the workflow to follow. Editable by anyone
+  with edit permission (usually a manager) in the UI.
+  _(`orgchart.Role`, `api/pkg/org/domain/orgchart/role.go`)_
+- **Worker** — hired into a role; implemented as an AI agent. Has an **identity**
+  (most importantly a name, used to refer to it; plus a markdown `identity.md`).
+  _(`orgchart.Worker` / `orgchart.Position`)_
+- **Topic** — the connection to the outside world; an event stream the worker
+  subscribes to (e.g. GitHub, Slack). **Streams** carry the messages; filters /
+  processors can be applied mid-stream to cut noise.
+  _(`api/pkg/org/domain/streaming/`, wake via `infrastructure/wakebus`)_
+- **Activation** — a topic message spins up a new ACP agent session with a special
+  briefing prompt that points the agent at its `role.md`, lists its tools, and
+  includes the trigger. The agent then decides what to do (e.g. `gh` for GitHub,
+  Slack REST for Slack).
+  _(`briefing.BuildPrompt`, `api/pkg/org/domain/briefing/prompt.go`)_
+- **Credential provider** — wraps a third-party service; Helix mints a short-lived
+  OAuth credential on demand so an agent can call a token-secured API (e.g. Slack).
+- **Learnings** — the agent improves via its own mechanism (e.g. Claude memories /
+  a markdown file). Managers improve behaviour by editing the role.
+
+**Design stance: no procedural pipelines.** The agents are good enough; improve the
+role prompt or the model rather than writing and maintaining procedural workflow
+code. Everything assumes ACP communication — a deliberate simplification.
+
+## Where we are today
+
+The mental model is highly flexible and the system "just about works" end to end.
+Day-to-day usage is flaky: rough edges in the UI and the Helix interface, not yet
+100% stable, personal-subscription token exhaustion, imperfect org configuration.
+**Priority: actually use the system and find the rough edges.**
+
+---
+
+## Roadmap
+
+Ordered top-down: highest-level domain flexibility first, then domain enhancements,
+then lower-level implementation, productionization, adoption, and UX.
+
+### Horizon at a glance
+
+| Horizon | Theme | Headline items |
+|---|---|---|
+| **Now** | Stabilise & exercise | Dogfood real bots; fix rough edges; finish humans + hierarchy demos |
+| **Next** | Observability & events | Audit/record activity; rich domain events + UI status pills; reliable stream queues |
+| **Next** | Productionize | Remove gating, ship to prod; Agent + Sandbox as the workspace |
+| **Later** | Performance & reach | Fast agent harness; many more topic types; UX overhaul |
+
+---
+
+### 1. Complete the domain (top-level flexibility)
+
+Two domain concepts exist as placeholders but are not yet exercised.
+
+#### 1.1 Humans in the org
+**Goal.** Humans act as placeholders for real people, holding their identifiers
+across systems and a description of what they are responsible for.
+
+- A human (e.g. "Luke") carries cross-system identifiers: Slack handle, email,
+  GitHub login, plus a responsibility description (e.g. "point of contact for Helix
+  code; commercial sales meetings").
+- AI workers can query the org for "who is responsible for X", resolve to a human,
+  and reach them across the right channels (ping on GitHub, email, etc.).
+
+**Demo.** Worker finds a bug → asks the org who owns Helix code → tags Luke on
+GitHub and emails him.
+
+#### 1.2 Hierarchy — approvals & escalation
+**Goal.** Make the existing manager/subordinate structure useful. Tools already
+expose who a worker's manager and subordinates are; the open question is _when a
+worker would use it_.
+
+- Lead use case: **approval gates / escalation.** Role prompt states the worker must
+  get line-manager approval before a given action.
+- Build a demo that genuinely requires hierarchy (approval → approved/denied loop).
+
+---
+
+### 2. Domain enhancements — observability & events ("two heads")
+
+The biggest enhancement is multifaceted, spanning both the **observational** end and
+the **event-emission** front end.
+
+#### 2.1 Observability / audit (record, then expose)
+**Problem.** Very hard to see what's happening inside the org and hard to debug. Fix
+by first **recording** activity, then **exposing** it.
+
+- Decide the right **granularity** — likely not every raw interaction/log, but enough
+  for visibility and debugging (some cases may warrant full capture).
+- Address both the **technical** challenge (high traffic volume) and the **UX**
+  challenge (presenting it usefully).
+- _Scaffolding exists:_ a `domainevent` package and project-level audit logging
+  (`org_domain_events`, `services/audit_log_service.go`) — build on these rather than
+  starting fresh.
+
+#### 2.2 Domain events (DDD sense)
+**Goal.** Rich, first-class domain events emitted throughout the org. Today there are
+many slots for them but effectively none in use.
+
+- Examples: `approval.required` → `approval.approved` / `approval.denied`; worker
+  lifecycle (sleeping → woken → handling message → finalising).
+- Drives real-time visibility in the org chart and unlocks observability broadly.
+
+#### 2.3 UI status pills
+**Goal.** Per-worker status pills in the UI showing what each worker is doing
+("sleeping", "woken", "awaiting approval", "finalising work").
+
+- Useful, accurate states — driven by domain events, not cosmetic noise.
+
+#### 2.4 Reliable streams — proper queues with ack
+**Problem.** Streams are currently lightweight/in-memory with no read-acknowledgement.
+Future use cases (e.g. several workers in one role pulling tickets off a queue) need
+**pull + ack** so a message is handled exactly once.
+
+- Add acknowledgement / "message read" semantics so multiple workers don't double-handle.
+- **Option:** back streams with **NATS** (already used elsewhere, incl. JetStream) for
+  durable, reliable delivery. Trade-off: heavier than the current simple ~few-hundred-line
+  in-memory model. Weigh durability vs. simplicity.
+
+#### 2.5 Outbound communication — settled principle (revisit only if it breaks down)
+**Decision (default for now).** Only **incoming** streams exist. All outbound
+communication is done by the **agent itself** via tools/actions it writes — no
+custom outbound adapters/APIs.
+
+- **Why.** Avoids writing a per-app outbound translation layer (e.g. a single JSON
+  packet + Helix-side parser fanned out into Slack's separate "react / post text /
+  attach file" REST calls). Let the agent make those calls directly.
+- Inbound stays flexible: a message is just a string in whatever format, parsed
+  Helix-side; one message = one complete result.
+- Revisit only when a concrete case makes agent-owned outbound impractical.
+
+---
+
+### 3. Connectivity — more incoming topic types
+
+**Definition of a good topic.** Any system that **emits events** usable as a trigger.
+Poor topics are external systems that are stores of data rather than event streams —
+for those, trigger the agent another way (a person asking, a cron) and let it pull the
+data via API/MCP with the right credentials.
+
+- **Harden existing:** email path exists but is untested/may need rewiring; Sentry.
+- **Good candidates:** Postmark (email), WhatsApp, Discord, Teams, Azure DevOps, other
+  comms/edit-in-motion event sources.
+- **Not topics (data stores):** Google Analytics and similar — access via tool/MCP on
+  demand, don't model as a stream.
+
+---
+
+### 4. Productionize
+
+#### 4.1 Release to prod (remove gating)
+Currently gated by two things:
+1. An environment variable disabling most org code paths — **`HELIX_ORG_ENABLED`**
+   (`api/pkg/config/config.go`).
+2. A **per-user feature flag** on the users table.
+
+**Plan.** Deploy Helix-Org to prod and run the more stable bots there. Create a
+top-level org and a personal space for bots.
+
+#### 4.2 Workspace: Agent + Sandbox (replace spec-task infra)
+Org currently rides on the spec-task infrastructure (well-hardened from heavy coding
+use, with useful helpers). **Target:** move to the first-class **sandbox** concept.
+A worker's workspace = a **Helix agent** + a **Helix sandbox** (the agent concept
+already exists and is good).
+
+#### 4.3 Fast agent harness
+**Problem.** Today everything runs through Zed + MCP — fine, but cold-starting the
+desktop, starting a session, and basic cloud interactions are slow.
+
+**Goal.** A much faster agent harness in Helix Agents (shape TBD).
+
+- **Targets:** quick-response use cases — chatbots, real-time replies, voice / phone,
+  and faster Slack interactions.
+
+---
+
+### 5. Adoption & dogfooding
+
+**High value:** real usage finds rough edges _and_ delivers value when the bot itself
+is worthwhile.
+
+- Build genuinely useful agents (e.g. Chris automating sales tasks) — double whammy of
+  new demos/use cases plus real value.
+- Migrate internally-run systems over to Helix-Org.
+
+---
+
+### 6. UX (owned by Karolis)
+
+**Audience.** Aim at the average **technical-ish business user** — someone comfortable
+with Excel and SaaS tools, not a non-technical consumer. Don't dumb it down to the
+point of losing flexibility (false economy).
+
+- Preserve **power-user flexibility**: ability to change agent type / model.
+- Fix the current pain of hopping between disjoint parts of the Helix UI — unify the
+  org experience.
+
+---
+
+## Open questions
+
+- Audit **granularity** — what to record vs. drop, and how to present it at scale.
+- Streams: adopt **NATS/JetStream** for durable queues, or keep the simple in-memory
+  model? Where's the line?
+- What is the **fast agent harness** actually — architecture and surface?
+- The right **hierarchy demo** that genuinely needs manager/subordinate awareness.


### PR DESCRIPTION
Please take the following notes and using your knowledge of Helix-Org convert them into a road map.
---
This is a long monologue on the potential future roadmap for Helix-Org. I think before we get started it's worth re-visiting my high-level thesis. The main use case that I want to fulfil is the idea that many traditional back-office jobs can be somewhat automated. I want to be able to employ an AI to do these little jobs for me. You can think of lots of examples in your life but there's also lots of examples in traditional businesses as well. They're usually quite information-centric, they require some form of action and then some form of approval gate or acknowledgement that the work has been done.

Given that premise, to be openly generic to workloads, it's worth thinking about one specific example to help pin down some of the ideas. Let's imagine an example that we are all familiar with and that is the documentation bot. It is quite a useful example because it is simple, it has an approval gate, and it requires teaching.

Let's recap the domain entities because these are really important. The whole thing is modelled like an org chart and that's deliberate because it makes it really easy to explain to people. I think it's easy to understand because you can treat your org chart like a traditional business and so you can use traditional business language.

The first thing that we need to do in our org chart is to define the roles that we need within our organisation. For our documentation bot we only need one role at the moment because it's best to keep it simple to start with and see where we split up later on if you need to. 

Our documentation bot first needs a job description and that is described in their role. We create a markdown file that describes their job, who they interact with, what systems they interact with, how they do their work, and the workflow that they should follow. This role can be edited by a manager, somebody with an edit role permission in the org. It's usually a manager but it doesn't technically have to be. You can edit it manually as a power user in the UI.

Once you have a role, then you need to hire a worker into that role. That worker has an identity and probably the most important identity is its name because you use that to refer to it in various places. There is also a markdown field to provide a bit more information about that particular identity but to be honest that's probably the least important part of this.

That worker is implemented as an AI agent. It's really important that we specify it that way because it makes the code simpler. If we just assume that we are constantly communicating over ACP then yeah it's just one of the simplifications to make. I honestly don't think it's worth adding any procedural workflows in here because the agents are just so damn good. If they're not good enough then you can improve the prompt, the role prompt, or you can just improve the model, use a better model, and that fixes the problem. Why write loads of code and have lots of code to manage procedural pipelines when we don't need it?

Ok so next we've got our documentation bot. They have a role. We have hired that thing. Now it needs access to the outside, it needs a connection to the outside world.

For this I've used event terminology, event-driven design terminology, and the outside world comes into Helix-Org as a topic and a worker subscribes to a topic. For the documentation bot we need a GitHub topic. We would create a new GitHub topic with filters set up so that that worker doesn't. We also want a Slack topic so we install those two things.

For the GitHub topic we might want to alter that stream of messages coming from the topic so that we don't get too much noise. We can apply processes in the middle of that stream to filter out messages that we are not interested in.

Now we've got that external trigger from the topics and the streams on that topic, and that gets presented to the worker, who then spins up a new ACP agent session with the underlying agent implementation. It has a special system prompt that is called... it's got a name in the code, I forget what it's called. That is the thing that tells the agent: "Please look at your role.md. That's your job and these are the tools that you have available in there in the org. This is the incoming topic, message. Please start, you know, stuff like that." Then the agent is free to do what it wants.

The agent can use a gh tool to communicate with github. It can use a slack REST API to communicate over slack but really it's entirely up to the agent to decide what to do at that point. If it's not doing a good job then you can tell the manager to update the rule or you can tell the agent itself to apply some learnings and it will use its internal implementation for learnings. For stuff like Claude, it uses memories for simple agents. It can just write to a markdown file.

There's a couple of other interesting smaller domain features that you'll probably come across. I think one that makes sense for later in this discussion to mention now is the ability to mint credentials that are stored in Helix. Helix Org has this interface called a credential provider and that wraps other things in Helix Org. Helix Org can then use OAuth to mint a short-lived credential and an agent can ask for that credential.

If you need your agent to get access to a secure third party that's secured by a token, no auth dance, then you need to implement the credential provider for that service. I think the one I added the other day was for Slack, for example. Whenever an agent is connected to Slack, it mints a new credential in order to write the message back each time.

So that's where we are today. It's incredibly flexible and I want to take some time to actually use the system because there's probably lots of rough edges. There are rough edges in the UI, there are rough edges in the Helix interface. It is still not 100% stable, running out of tokens on a subscription if using a personal subscription, things like this. All of these things can kind of cause it to break. The configuration of the org is not perfect so on and so on. Basically the whole experience, as it is, just about works. I believe that the mental model is incredibly flexible but the actual day-to-day usage is a bit more flaky. 

Moving forward there's lots of small implementations and improvements that we can think of but I think I would like to start at the top and go down.

At the highest level in terms of the flexibility of the domain there are two key pieces that are not fully implemented in the domain yet:
1. The idea of humans within the org. The reason why I wanted humans in the first place was to act as placeholders for real people and I kind of wanted those placeholders to hold the references to their personal identifiers in various systems. For example if we had a Luke in Helix-Org, he would be a human and he would have identifiers for Luke Marsden on Slack, Luke at helix.ml on email, and also some kind of description of what they are responsible for. For example he's maybe the point of contact for Helix code and he is the person to speak to about any commercial sales meetings or something like that. That allows if you have an AI worker in the org and they don't quite know what to do or they think they've found a bug, they can ask the org for the users and say who's responsible for Helix code. Then we'll see Luke and they will ping Luke on GitHub, Luke Marsden on GitHub, attach him to the messages, and send him an email to say I found a new bug and so on and so forth. That was the intention for the human in the org.
2. The second thing that's missing from the domain is that we have this idea of the ability to specify hierarchy within the organisation but I haven't really thought about it. I haven't taken the time to think about a good demo that requires hierarchy in the tools. There are some special tools that the workers get access to that tell them who is their manager and who are their subordinates, who they are managing themselves. The information is there but in what cases would a worker actually need to use that information?
I think maybe one of the possible use cases is for approvals or gates. I wonder if we could do escalation or something like that. If we can have some sort of demo where we say in the role prompts that you must get approval from your line manager to take some action, would that work? 

So these are the two outstanding domain concepts that have been implemented but not really exercised or at least the placeholders are there ready for implementation. Now let's turn our minds to future domain enhancements. I think probably the biggest future enhancement is multifaceted and is on both ends actually. On the observational end we need a better way to audit actions and audit everything that happens inside the Org. I don't quite know to what level of granularity to go to. I don't think we will store all of the actual interactions and logs but I don't know in some cases you do. I don't know to what level of granularity we need but basically we need a lot more visibility into what's happening inside the Org. It's very hard to see what's going on and it's very hard to debug. The only way to make that easier is to first record that activity and then expose it somehow.

Now the problem is that there's a huge amount of traffic and information going about so there are technical challenges but also user experience challenges as well. Next I would love to control the streams or observe the streams a little bit better as well. At the moment we can kind of see the things flowing on the streams but there isn't a very good acknowledgement system to say that something's being read. I can foresee a lot of future use cases where you've got multiple agents working as one role to do customer support and then just pulling tickets off a ticketing system or something, at a stream of tickets coming in. We need that queue to be a proper queue where we're pulling messages off and acknowledging that they've been read so nobody else needs to read it. We have what's called Nax in Helix so maybe we could just convert streams to Nax and then just leverage that for reliable durable delivery. That would work but it's a bit heavyweight. At the moment the whole sort of stream topic stream thing is all in memory. It's all really simple. It's only a few hundred lines of code so that's a trade-off.

I said there were two sides to this. There are two heads to it. That's on the observational side but actually there's kind of the front ends of that process as well. There we basically don't have any domain events yet. We have lots of slots where domain events could be plugged in but we don't actually have any yet. When I say domain events I mean domain events in the domain-driven design sense.

So those domain events could be quite rich and we could expose them throughout the org. For example when a worker needs to get an approval, they could emit an event saying "approval required" and then eventually the manager would send "approval approved" or something. Either way you can imagine seeing that pop up in the chart in real time. That's another cool thing that could be added to the domain that would really sort of unlock the observability of the domain.

I can imagine these little pills in the UI that show what the worker is doing, like a little status pill that's sleeping and then waking up, dealing with a message asking for approval, finalising work. They're kind of like the status messages you see in Claude but not the shitty random ones, actually something useful that could be really cool.

All right I've just thought of one more sort of semi-unfinished domain thing that is quite important and I sort of half made the decision but I'm still not sure it's the right one.

We talked about topics being the connection to the outside world. That's how information comes into the system. So far the way information goes out of the system is due to some kind of tool or action or code that is written directly by the agent itself so there are no outbound streams, there are only incoming streams. I quite like that and I've kind of sort of half decided to go in this direction for now at least. I quite like that only the agents themselves are in full control over what gets written. The reason I like that is that I do not want to have to write a custom outbound adaptor/API to intercept and translate app-specific functionality into a single JSON packet.

To give you an example of what I mean here imagine that you are working in Slack. The Slack message comes in as a JSON blob. The message has to be just some sort of string so it could be any format you want because you're writing the parser on the Helix side. I think we do mandate that one message is like one entire result. If you imagine an agent working with Slack, they want to:
- thumbs up the previous user's message
- write some text
- attach some files
- add et cetera, et cetera


Each one of those in Slack is a separate API. It's three separate API requests. You'd have to write a single JSON blob on the Helix side and a parser on the Helix side to say:
- thumbs up to this message
- write text of that message
- send this file


Pass all of that information through the API and then the API layer would then have to translate that into the three separate REST calls to call the Slack API. I can't be asked to do that. Let's just let the agent do it. Now let's just make the agent do all of this work and all outbound communication is done by the agent itself. Until I sort of hit a situation where it doesn't make sense to do that, I think that is the default and let's just sort of leave it at that.

Okay so there's a whole slew of smaller low-level implementation-type tasks. The first obvious one is way more incoming topic types, like we talked about Sentry. I've got the email code in there but I haven't really tested it in a while and it might need rewiring again:
- connection to Postmark
- connection to Google Analytics


That's a good discussion actually. Let's just talk about what was the definition of a good topic. Basically it's any system that emits events. Anything that acts like Sentry reporting new issues, incoming email, incoming GitHub activity, and incoming Slack message. Some other examples of good incoming topics might be:
- a WhatsApp incoming topic
- other communication tools
- Discord
- Teams
- Azure DevOps
- edits in motion
- things like that


Things that don't make good topics are external systems that are not event streams or at least the bits of external systems that are not events. For example Google Analytics is not a good event stream because that's more a store of information. In that case it's much better for the agent itself to be triggered by something else, like a person asking for a report or a cron or something like that, and it using the Google Analytics API or MCP tool to access that external data.

So basically a good topic is any event stream that could be treated as a trigger for something else. I mean technically the event stream could be just pure data and that's fine but I would suggest that they are lower value at this point in time because typically the agent themselves can actually access that data if you give them the right credentials. 
What else? I think demos. I think actual usage of the system and finding the rough edges is a very worthwhile use of time especially if that is a valuable agent in itself in its own right. For example Chris using Helix-Org to automate some of his sales stuff. You know that is inherently valuable and so if we get a double whammy of new demos, new use cases but also real-life value as well. I have a couple of things that I want to implement myself and I think I hope I will. I've got some systems that I run internally that I want to migrate over to Helix Org.
A really big feature would be a super-fast agent harness in Helix, in Helix Agents, basically because at the moment we're just using Zed and MCP for all of this and it's great, it's fine. Spinning up that desktop from Cold Start, starting a new session, even just simple interactions with the underlying kind of cloud, is just slow as fuck. It would be great if we had a much much much faster agent harness implementation in Helix. I don't know what that would be and I don't know what it would look like.
The use cases that you're targeting there are like quick response use cases, like chatbots, maybe anything that sort of needs to communicate, any use case where you need to reply in real time, so like any sort of voice-based use case, like phone use case. Maybe some of the Slack interactions could do with being faster.
Another big task is to release this onto prod. At the moment we are gated behind two things:
- We're gated behind an environmental variable that disables most of the org code paths.
- We're gated behind a feature flag on the users table in Helix.
There are two things that are gating it. I suggest that we get Helix sort deployed in prod and start running our more stable bots in there. Feel free to create a new org, a high-level org, and create a personal space just for bots for you.
One thing: Helix-Org is currently using all of the spec task infrastructure and it's got lots of interesting little helpers and things in there. It's been used quite heavily for the coding so it's quite hardened. Ultimately I think we do need to switch out to use this outside concept of a sandbox. We already have the concept of an agent and that's good. Ideally I think Org should take a Helix agent and a Helix sandbox and that is the workspace, the environment that the AI worker does their work. 
So one thing I haven't mentioned so far is the UX, mainly because Karolis said he was going to take this. I think the user experience of this needs to match the level of technical capability that we think our users are going to have with this. I think, given our background and our current users and our current sales approach and things, I still think that our users are going to be pretty technical. I don't think we need to try and make the UX work for plumbers or something. I think that would be a false economy because as soon as you try and make it that simple, you lose a lot of flexibility, I think.

I think we need to aim for an average business user who is capable of using software and things like that. It's not like your grandma or your mum or whoever. It's someone who has some innate technical capability because they've used Excel before. They've used some SaaS systems for a while now. I also want to maintain the flexibility, though, for me, for us, for the power users. We still need the ability to change the agent type or the model. But yeah, having to hop between different parts of the Helix UI is currently pretty horrible. 

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kw7a0697vzzczf363wz6q0d9)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002177_please-take-the/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002177_please-take-the/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002177_please-take-the/tasks.md)

🚀 Built with [Helix](https://helix.ml)