### PR TITLE
feat(compute): discover YD pools + per-pool floor supervisor (the only mode)

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -400,25 +400,9 @@ type Yellowdog struct {
 	// Helix install.
 	Namespace string `envconfig:"HELIX_YD_NAMESPACE" default:""`
 
-	// WorkerTag is the tag the operator-provisioned YD worker pool
-	// advertises. Tasks include this in their RunSpecification so
-	// the YD scheduler only assigns them to matching workers.
-	//
-	// Auto-derived from Namespace when unset:
-	//   WorkerTag = "worker-" + Namespace
-	//
-	// Matches the yd-provision POC convention (`worker_tag =
-	// "worker-{{tag}}"`), so an operator who set up their pool
-	// per the POC docs gets working defaults. Override via
-	// HELIX_YD_WORKER_TAG when the pool was created with a
-	// different naming scheme.
-	//
-	// Mismatch between this value and the pool's advertised tag
-	// produces silent "tasks starved" failures rather than a
-	// clear error - the YD scheduler simply finds no eligible
-	// workers and leaves the task pending. Boot logs the resolved
-	// tag so the operator can spot a mismatch quickly.
-	WorkerTag string `envconfig:"HELIX_YD_WORKER_TAG" default:""`
+	// Worker tags are no longer configured: the pool supervisor discovers
+	// the worker tag of every online pool from the YD nodes and runs one
+	// Manager per pool. HELIX_YD_WORKER_TAG was removed.
 
 	// TaskTimeout bounds individual task runtime upstream-side. The
 	// platform aborts the task and records TaskError type=TIMED_OUT

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -178,13 +178,11 @@ type Compute struct {
 	// value is "yellowdog".
 	Provider string `envconfig:"HELIX_COMPUTE_PROVIDER" default:""`
 
-	// GPUVendor is the accelerator family of the hosts this Manager
-	// provisions ("nvidia", "amd", "neuron", or "" for the provider's
-	// default). It flows onto every provisioned host's task environment as
-	// GPU_VENDOR, which the runner launch script uses to pick the right
-	// docker device flags (e.g. neuron -> mount /dev/neuron* instead of
-	// --gpus all). A pool is single-vendor; set this to match the compute
-	// requirement's instance type (e.g. "neuron" for an inf2 pool).
+	// GPUVendor is vestigial. The pool supervisor now derives each pool's
+	// GPU vendor from its instance type, and the runner launch script also
+	// auto-detects the accelerator on the host - so this install-wide value
+	// is no longer consumed. Kept to avoid breaking an existing
+	// HELIX_COMPUTE_GPU_VENDOR setting; remove in a follow-up.
 	GPUVendor string `envconfig:"HELIX_COMPUTE_GPU_VENDOR" default:""`
 
 	// DeploymentTag distinguishes work requirements created by this

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap.go
@@ -1,21 +1,18 @@
-// Package bootstrap wires operator-supplied env-var config into a
-// concrete compute.Manager + Provider. Separated from package compute
-// because compute itself cannot import a concrete Provider (cyclic),
-// and from package server because the API server should not need to
-// know the catalogue of supported providers.
+// Package bootstrap wires operator-supplied env-var config into a running
+// compute.Service - a PoolSupervisor that runs one Manager per discovered
+// YD pool. Separated from package compute because compute cannot import a
+// concrete Provider (cyclic), and from package server because the API
+// server should not need to know the catalogue of supported providers.
 package bootstrap
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/data"
 	"github.com/helixml/helix/api/pkg/sandbox/compute"
-	"github.com/helixml/helix/api/pkg/sandbox/compute/yellowdog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -47,7 +44,7 @@ import (
 // because the value originates from ServerConfig (used by both
 // Manager-provisioned and legacy auto-register paths) - putting it in
 // config.Compute would suggest it only affects ComputeManager.
-func Bootstrap(cfg config.Compute, maxSandboxesPerHost int, serverURL, runnerToken string, store compute.SandboxStore) (*compute.Manager, error) {
+func Bootstrap(cfg config.Compute, maxSandboxesPerHost int, serverURL, runnerToken string, store compute.SandboxStore) (compute.Service, error) {
 	if cfg.Provider == "" {
 		log.Info().Msg("HELIX_COMPUTE_PROVIDER unset; compute subsystem disabled (no Provider, no Manager, no reconcile)")
 		return nil, nil
@@ -80,18 +77,23 @@ func Bootstrap(cfg config.Compute, maxSandboxesPerHost int, serverURL, runnerTok
 			Msg("compute: HELIX_COMPUTE_DEPLOYMENT_TAG auto-derived from provider namespace; set explicitly if multiple Helix installs share this YD namespace")
 	}
 
-	provider, err := buildProvider(cfg, serverURL, runnerToken)
-	if err != nil {
-		return nil, fmt.Errorf("build %q provider: %w", cfg.Provider, err)
+	// Discovery is the only mode: a PoolSupervisor enumerates the live YD
+	// pools (grouped by worker tag + instance type) and runs one Manager per
+	// pool under the same global Floor/Max/idle policy, with each pool's GPU
+	// vendor derived from its instance type. (The older single-Manager /
+	// single-worker-tag path has been removed.)
+	if cfg.Provider != "yellowdog" {
+		return nil, fmt.Errorf("unknown HELIX_COMPUTE_PROVIDER %q (supported: \"yellowdog\")", cfg.Provider)
 	}
+	return buildSupervisor(cfg, maxSandboxesPerHost, serverURL, runnerToken, store)
+}
 
-	// SpecTemplate.MaxSandboxes is what Manager-provisioned Runner rows
-	// get written with (manager.go:892 reads m.cfg.SpecTemplate via
-	// defaultMaxSandboxes). Threading maxSandboxesPerHost in here ensures
-	// YD-provisioned and legacy auto-registered Runners share the same
-	// ceiling — without this, YD Runners would silently fall back to the
-	// hardcoded 20 in defaultMaxSandboxes regardless of operator config.
-	mgr, err := compute.NewManager(provider, store, compute.ManagerConfig{
+// managerConfig builds the shared ManagerConfig from operator config,
+// plugging in the given per-host Spec. Used by the per-pool factory
+// (pool_discovery.go) so every pool's Manager gets identical Floor/Max/idle
+// policy - only the Spec (GPU vendor) differs per pool.
+func managerConfig(cfg config.Compute, spec compute.Spec) compute.ManagerConfig {
+	return compute.ManagerConfig{
 		Floor:                   cfg.Floor,
 		ReconcileInterval:       cfg.ReconcileInterval,
 		HealthCheckTimeout:      cfg.HealthCheckTimeout,
@@ -101,37 +103,17 @@ func Bootstrap(cfg config.Compute, maxSandboxesPerHost int, serverURL, runnerTok
 		ScaleUpHeadroomMin:      cfg.ScaleUpHeadroomMin,
 		IdleTimeout:             cfg.IdleTimeout,
 		HardIdleTimeout:         cfg.HardIdleTimeout,
-		SpecTemplate: compute.Spec{
-			MaxSandboxes: maxSandboxesPerHost,
-			GPUVendor:    cfg.GPUVendor,
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("construct compute manager: %w", err)
+		SpecTemplate:            spec,
 	}
-
-	log.Info().
-		Str("provider", provider.Name()).
-		Int("floor", cfg.Floor).
-		Int("max", cfg.Max).
-		Int("scaleup_headroom_min", cfg.ScaleUpHeadroomMin).
-		Dur("idle_timeout", cfg.IdleTimeout).
-		Dur("hard_idle_timeout", cfg.HardIdleTimeout).
-		Dur("reconcile_interval", cfg.ReconcileInterval).
-		Dur("max_provisioning_age", cfg.MaxProvisioningAge).
-		Int("max_concurrent_provisions", cfg.MaxConcurrentProvisions).
-		Msg("compute subsystem enabled; Manager will start at boot")
-	return mgr, nil
 }
 
 // deriveDeploymentTag computes the default DeploymentTag from the
 // provider-specific config when no operator override is set. Returns
 // empty string if no derivation is possible.
 //
-// One arm per supported provider, mirroring buildProvider. Each
-// provider exposes a namespace concept; we prefix with "helix-" so
-// the tag is recognisable in admin UIs and operator tooling that
-// inspects the upstream system directly.
+// One arm per supported provider. Each provider exposes a namespace
+// concept; we prefix with "helix-" so the tag is recognisable in admin
+// UIs and operator tooling that inspects the upstream system directly.
 func deriveDeploymentTag(cfg config.Compute) string {
 	switch cfg.Provider {
 	case "yellowdog":
@@ -140,69 +122,6 @@ func deriveDeploymentTag(cfg config.Compute) string {
 		}
 	}
 	return ""
-}
-
-// buildProvider dispatches on cfg.Provider to construct the
-// appropriate concrete Provider. Add new providers here as
-// implementations land.
-func buildProvider(cfg config.Compute, serverURL, runnerToken string) (compute.Provider, error) {
-	switch cfg.Provider {
-	case "yellowdog":
-		// WorkerTag resolution order:
-		//   1. HELIX_YD_WORKER_TAG explicit  -> use verbatim
-		//   2. Discover from YD nodes        -> query GET /workerPools/nodes,
-		//                                       use the unique tag if there
-		//                                       is exactly one across all
-		//                                       online nodes
-		//   3. Namespace-derived fallback    -> "worker-<namespace>"
-		//
-		// (2) replaces blind (3) as the primary path. The 2026-06-10 E2E
-		// run showed that the POC's `worker_tag = "worker-{{username}}"`
-		// convention is incompatible with naive namespace derivation: a
-		// pool registered as `worker-psamuel` would silently never accept
-		// WRs Helix submitted with `worker-development`. Discovery reads
-		// the truth from the running pool.
-		workerTag, err := resolveWorkerTag(cfg.Yellowdog)
-		if err != nil {
-			return nil, err
-		}
-		// HELIX_COMPUTE_SANDBOX_IMAGE pins the full image verbatim and
-		// bypasses version derivation — the escape hatch for dev/source
-		// builds (placeholder data.Version) and for pinning an in-flight
-		// sandbox SHA. Falls back to the version-derived tag when unset.
-		sandboxImage := cfg.SandboxImage
-		if sandboxImage == "" {
-			var err error
-			sandboxImage, err = helixSandboxImage(cfg.SandboxRegistry)
-			if err != nil {
-				return nil, err
-			}
-		}
-		// Log the resolved image at boot so operators can diagnose
-		// pull failures (typo'd hostname, mistyped account ID) by
-		// reading the api startup logs - matches the visibility of
-		// WorkerTag (resolveWorkerTag) and DeploymentTag (Bootstrap).
-		log.Info().
-			Str("sandbox_image", sandboxImage).
-			Msg("compute: resolved helix-sandbox image for YD task dispatch")
-		return yellowdog.NewProvider(yellowdog.Config{
-			APIKeyID:      cfg.Yellowdog.APIKeyID,
-			APISecret:     cfg.Yellowdog.APISecret,
-			BaseURL:       cfg.Yellowdog.BaseURL,
-			Namespace:     cfg.Yellowdog.Namespace,
-			DeploymentTag: cfg.DeploymentTag,
-			WorkerTag:     workerTag,
-			TaskTimeout:   cfg.Yellowdog.TaskTimeout,
-			MaxRetries:    cfg.Yellowdog.MaxRetries,
-			HelixURL:               serverURL,
-			RunnerToken:            runnerToken,
-			HelixImage:             sandboxImage,
-			NeuronCompileCacheURL:  cfg.NeuronCompileCacheURL,
-			RunnerReadinessTimeout: cfg.RunnerReadinessTimeout,
-		})
-	default:
-		return nil, fmt.Errorf("unknown HELIX_COMPUTE_PROVIDER %q (supported: \"yellowdog\")", cfg.Provider)
-	}
 }
 
 // helixSandboxImage returns the helix-sandbox image tag the YD task
@@ -225,81 +144,15 @@ func buildProvider(cfg config.Compute, serverURL, runnerToken string) (compute.P
 // fixes the build rather than discovering the mismatch later when
 // YD tasks ERROR on docker pull.
 var sentinelVersions = map[string]bool{
-	"":          true,
-	"<unknown>": true,
-	"v0.0.0":    true,
-	"0.0.0":     true,
+	"":           true,
+	"<unknown>":  true,
+	"v0.0.0":     true,
+	"0.0.0":      true,
 	"v0.0.0+dev": true,
 }
 
 func helixSandboxImage(registry string) (string, error) {
 	return helixSandboxImageFor(data.GetHelixVersion(), registry)
-}
-
-// resolveWorkerTag picks the YD WorkerTag for the Provider, preferring
-// an explicit operator override, then discovery from online nodes, then
-// a namespace-derived fallback.
-//
-// Returns (tag, err). err is non-nil only when the operator MUST act:
-// either Namespace is missing (no possible default) or discovery saw
-// multiple distinct tags in scope (ambiguous - pick one).
-//
-// Discovery transport errors fall through to the namespace-derived
-// fallback rather than failing boot: a transient YD outage shouldn't
-// prevent Helix from starting, and if the fallback turns out wrong the
-// operator will see WRs sit PENDING and can fix it.
-//
-// The discoverFn parameter is injectable for tests.
-var discoverFn = yellowdog.DiscoverOnlineWorkerTags
-
-func resolveWorkerTag(yd config.Yellowdog) (string, error) {
-	if yd.WorkerTag != "" {
-		log.Info().
-			Str("worker_tag", yd.WorkerTag).
-			Msg("compute: HELIX_YD_WORKER_TAG provided by operator")
-		return yd.WorkerTag, nil
-	}
-	if yd.Namespace == "" {
-		return "", errors.New(
-			"compute: HELIX_YD_NAMESPACE is required (cannot derive WorkerTag without it; alternatively set HELIX_YD_WORKER_TAG explicitly)",
-		)
-	}
-
-	// Discovery: query YD for the unique workerTag(s) currently visible
-	// to this API key. Bounded timeout so a hung YD doesn't pin boot.
-	discoverCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	tags, err := discoverFn(discoverCtx, yellowdog.Config{
-		APIKeyID:  yd.APIKeyID,
-		APISecret: yd.APISecret,
-		BaseURL:   yd.BaseURL,
-	})
-
-	fallback := "worker-" + yd.Namespace
-
-	switch {
-	case err != nil:
-		log.Warn().
-			Err(err).
-			Str("worker_tag", fallback).
-			Msg("compute: WorkerTag discovery failed; falling back to namespace-derived default. Set HELIX_YD_WORKER_TAG explicitly to override if WRs sit PENDING.")
-		return fallback, nil
-	case len(tags) == 1:
-		log.Info().
-			Str("worker_tag", tags[0]).
-			Msg("compute: WorkerTag auto-discovered from online YD nodes")
-		return tags[0], nil
-	case len(tags) == 0:
-		log.Warn().
-			Str("worker_tag", fallback).
-			Msg("compute: no online YD nodes visible for discovery; falling back to namespace-derived default. If your pool advertises a different tag and is currently offline, set HELIX_YD_WORKER_TAG explicitly.")
-		return fallback, nil
-	default:
-		return "", fmt.Errorf(
-			"compute: discovery found multiple distinct YD workerTags %v - cannot pick one automatically. Set HELIX_YD_WORKER_TAG explicitly to disambiguate.",
-			tags,
-		)
-	}
 }
 
 // defaultRegistryHost is the registry hostname helix-sandbox is published
@@ -332,26 +185,26 @@ const (
 // through to fail opaquely at docker pull on a worker):
 //
 //   - Internal whitespace:        "mirror.corp\nbaz", "foo bar"
-//                                 - TrimSpace only strips edges, the
-//                                   shell consumer would receive the
-//                                   embedded whitespace too.
+//   - TrimSpace only strips edges, the
+//     shell consumer would receive the
+//     embedded whitespace too.
 //   - URL form ("://"):           "https://mirror.corp"
-//                                 - shell consumer would produce
-//                                   "https://mirror.corp/..." which
-//                                   docker pull rejects.
+//   - shell consumer would produce
+//     "https://mirror.corp/..." which
+//     docker pull rejects.
 //   - Leading slash:              "/mirror.corp", "/ghcr.io"
-//                                 - Go side could strip it but the
-//                                   shell consumer (sed) would not,
-//                                   producing "/mirror.corp/...".
-//                                   Reject so the two consumers stay
-//                                   consistent.
+//   - Go side could strip it but the
+//     shell consumer (sed) would not,
+//     producing "/mirror.corp/...".
+//     Reject so the two consumers stay
+//     consistent.
 //   - Embedded path ("/" in middle): "mirror.corp/helixml"
-//                                    - would produce double-org path
-//                                      on YD side (helixml/helixml/...)
-//                                      and different garbage on shell.
+//   - would produce double-org path
+//     on YD side (helixml/helixml/...)
+//     and different garbage on shell.
 //   - Empty after trim:           "/", "  /  ", "   "
-//                                 - silent fallback to GHCR is wrong
-//                                   for an air-gapped deployment.
+//   - silent fallback to GHCR is wrong
+//     for an air-gapped deployment.
 //
 // Order of checks below: whitespace first (most-fundamental
 // corruption), then URL form, then leading-slash, then embedded path.

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap.go
@@ -1,8 +1,8 @@
 // Package bootstrap wires operator-supplied env-var config into a running
-// compute.Service - a PoolSupervisor that runs one Manager per discovered
-// YD pool. Separated from package compute because compute cannot import a
-// concrete Provider (cyclic), and from package server because the API
-// server should not need to know the catalogue of supported providers.
+// *compute.PoolSupervisor that runs one Manager per discovered YD pool.
+// Separated from package compute because compute cannot import a concrete
+// Provider (cyclic), and from package server because the API server should
+// not need to know the catalogue of supported providers.
 package bootstrap
 
 import (
@@ -44,7 +44,7 @@ import (
 // because the value originates from ServerConfig (used by both
 // Manager-provisioned and legacy auto-register paths) - putting it in
 // config.Compute would suggest it only affects ComputeManager.
-func Bootstrap(cfg config.Compute, maxSandboxesPerHost int, serverURL, runnerToken string, store compute.SandboxStore) (compute.Service, error) {
+func Bootstrap(cfg config.Compute, maxSandboxesPerHost int, serverURL, runnerToken string, store compute.SandboxStore) (*compute.PoolSupervisor, error) {
 	if cfg.Provider == "" {
 		log.Info().Msg("HELIX_COMPUTE_PROVIDER unset; compute subsystem disabled (no Provider, no Manager, no reconcile)")
 		return nil, nil

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
@@ -2,7 +2,6 @@ package bootstrap
 
 import (
 	"context"
-	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -11,41 +10,20 @@ import (
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/data"
 	"github.com/helixml/helix/api/pkg/sandbox/compute"
-	"github.com/helixml/helix/api/pkg/sandbox/compute/yellowdog"
 	"github.com/helixml/helix/api/pkg/types"
 )
 
 // TestMain sets a plausible release version on the data package
-// global so tests that construct a Manager via Bootstrap don't trip
+// global so tests that construct a supervisor via Bootstrap don't trip
 // the helixSandboxImage sentinel-rejection. Tests of the rejection
 // itself call helixSandboxImageFor directly with their own values.
-//
-// Also stubs discoverFn so unit tests never reach out to the real YD
-// portal during boot. The default stub returns no tags (zero-online-nodes
-// branch), which causes resolveWorkerTag to fall back to the namespace
-// derivation - the same shape the original tests assumed.
-// Tests that want to exercise the discovery branches override
-// discoverFn locally via withDiscoverFn.
 func TestMain(m *testing.M) {
 	origVersion := data.Version
 	data.Version = "0.0.0-test"
-	origDiscover := discoverFn
-	discoverFn = func(context.Context, yellowdog.Config) ([]string, error) {
-		return nil, nil
-	}
 	defer func() {
 		data.Version = origVersion
-		discoverFn = origDiscover
 	}()
 	os.Exit(m.Run())
-}
-
-// withDiscoverFn temporarily replaces the package's discoverFn for the
-// scope of a single test. Returns a cleanup func tests should defer.
-func withDiscoverFn(stub func(context.Context, yellowdog.Config) ([]string, error)) func() {
-	prev := discoverFn
-	discoverFn = stub
-	return func() { discoverFn = prev }
 }
 
 // nullStore is a no-op SandboxStore so we can construct Bootstrap
@@ -214,187 +192,6 @@ func TestBootstrapUnknownProviderErrors(t *testing.T) {
 	}
 }
 
-func TestBootstrapDerivesWorkerTagFromNamespace(t *testing.T) {
-	// 0-tags branch: discovery returns no online nodes (the TestMain
-	// default stub), so resolveWorkerTag falls back to the
-	// namespace-derived default `worker-<namespace>`. Bootstrap
-	// completes without error.
-	cfg := config.Compute{
-		Provider:                "yellowdog",
-		ReconcileInterval:       time.Second,
-		HealthCheckTimeout:      time.Second,
-		MaxConcurrentProvisions: 1,
-		MaxProvisioningAge:      time.Minute,
-		Yellowdog: config.Yellowdog{
-			APIKeyID:    "k",
-			APISecret:   "s",
-			BaseURL:     "https://portal.yellowdog.co/api",
-			Namespace:   "development",
-			WorkerTag:   "", // intentionally empty
-			TaskTimeout: time.Hour,
-		},
-	}
-	mgr, err := Bootstrap(cfg, 20, "https://helix.example.com", "test-token", nullStore{})
-	if err != nil {
-		t.Fatalf("Bootstrap with empty WorkerTag should auto-derive, got error: %v", err)
-	}
-	if mgr == nil {
-		t.Fatal("expected non-nil Manager")
-	}
-}
-
-func TestResolveWorkerTagExplicitWins(t *testing.T) {
-	// Explicit-tag branch: HELIX_YD_WORKER_TAG set -> discoverFn is
-	// never called and the operator's value passes through verbatim.
-	called := false
-	defer withDiscoverFn(func(context.Context, yellowdog.Config) ([]string, error) {
-		called = true
-		return []string{"unrelated-tag"}, nil
-	})()
-
-	got, err := resolveWorkerTag(config.Yellowdog{
-		APIKeyID:  "k",
-		APISecret: "s",
-		Namespace: "development",
-		WorkerTag: "operator-override",
-	})
-	if err != nil {
-		t.Fatalf("resolveWorkerTag returned error: %v", err)
-	}
-	if got != "operator-override" {
-		t.Fatalf("explicit tag should win; got %q", got)
-	}
-	if called {
-		t.Fatal("discoverFn should NOT be called when WorkerTag is explicit")
-	}
-}
-
-func TestResolveWorkerTagOneTagDiscoveredUsedAsIs(t *testing.T) {
-	// 1-tag branch: discovery returns exactly one tag -> use it
-	// verbatim. This is the happy path that fixes the POC
-	// `worker-<username>` vs `worker-<namespace>` mismatch.
-	defer withDiscoverFn(func(context.Context, yellowdog.Config) ([]string, error) {
-		return []string{"worker-psamuel"}, nil
-	})()
-
-	got, err := resolveWorkerTag(config.Yellowdog{
-		APIKeyID:  "k",
-		APISecret: "s",
-		Namespace: "development",
-	})
-	if err != nil {
-		t.Fatalf("resolveWorkerTag returned error: %v", err)
-	}
-	if got != "worker-psamuel" {
-		t.Fatalf("discovered tag should pass through; got %q", got)
-	}
-}
-
-func TestResolveWorkerTagMultipleTagsRefusesToStart(t *testing.T) {
-	// N-tags branch: discovery finds >1 distinct tag in scope ->
-	// fail fast with an actionable error. Silent picking of one
-	// would route WRs to an arbitrary pool.
-	defer withDiscoverFn(func(context.Context, yellowdog.Config) ([]string, error) {
-		return []string{"worker-prod", "worker-staging"}, nil
-	})()
-
-	_, err := resolveWorkerTag(config.Yellowdog{
-		APIKeyID:  "k",
-		APISecret: "s",
-		Namespace: "development",
-	})
-	if err == nil {
-		t.Fatal("expected error when discovery returns multiple distinct tags")
-	}
-	if !strings.Contains(err.Error(), "multiple distinct") {
-		t.Fatalf("error should mention ambiguity, got %q", err.Error())
-	}
-	if !strings.Contains(err.Error(), "HELIX_YD_WORKER_TAG") {
-		t.Fatalf("error should name the env var to set, got %q", err.Error())
-	}
-	for _, tag := range []string{"worker-prod", "worker-staging"} {
-		if !strings.Contains(err.Error(), tag) {
-			t.Fatalf("error should list each candidate tag (missing %q): %q", tag, err.Error())
-		}
-	}
-}
-
-func TestResolveWorkerTagDiscoveryErrorFallsBack(t *testing.T) {
-	// Transport-error branch: a network or auth blip during discovery
-	// should NOT block Helix boot. Fall back to the namespace-derived
-	// default and warn; the WR-PENDING diagnostic will surface a real
-	// mismatch later if the default was wrong.
-	defer withDiscoverFn(func(context.Context, yellowdog.Config) ([]string, error) {
-		return nil, errors.New("yellowdog: HTTP 503")
-	})()
-
-	got, err := resolveWorkerTag(config.Yellowdog{
-		APIKeyID:  "k",
-		APISecret: "s",
-		Namespace: "development",
-	})
-	if err != nil {
-		t.Fatalf("transport error in discovery should not fail boot, got: %v", err)
-	}
-	if got != "worker-development" {
-		t.Fatalf("expected fallback worker-development, got %q", got)
-	}
-}
-
-func TestResolveWorkerTagNamespaceRequiredWhenNoExplicitTag(t *testing.T) {
-	// Without explicit WorkerTag AND without Namespace, there's no
-	// way to compute even the fallback. resolveWorkerTag returns an
-	// actionable error rather than calling discovery with no
-	// fall-back basis.
-	defer withDiscoverFn(func(context.Context, yellowdog.Config) ([]string, error) {
-		t.Fatal("discoverFn should not be reached when Namespace is empty")
-		return nil, nil
-	})()
-
-	_, err := resolveWorkerTag(config.Yellowdog{
-		APIKeyID:  "k",
-		APISecret: "s",
-		Namespace: "",
-		WorkerTag: "",
-	})
-	if err == nil {
-		t.Fatal("expected error when both Namespace and WorkerTag are empty")
-	}
-	if !strings.Contains(err.Error(), "HELIX_YD_NAMESPACE") {
-		t.Fatalf("error should name HELIX_YD_NAMESPACE, got %q", err.Error())
-	}
-}
-
-func TestBootstrapErrorsWhenWorkerTagAndNamespaceBothEmpty(t *testing.T) {
-	// With BOTH WorkerTag AND Namespace empty, derivation can't
-	// produce a default and yellowdog.NewProvider rejects the
-	// empty WorkerTag (existing validation in provider.go).
-	cfg := config.Compute{
-		Provider:                "yellowdog",
-		DeploymentTag:           "explicit-tag", // skip the namespace-derived DeploymentTag path
-		ReconcileInterval:       time.Second,
-		HealthCheckTimeout:      time.Second,
-		MaxConcurrentProvisions: 1,
-		MaxProvisioningAge:      time.Minute,
-		Yellowdog: config.Yellowdog{
-			APIKeyID:    "k",
-			APISecret:   "s",
-			BaseURL:     "https://portal.yellowdog.co/api",
-			Namespace:   "", // intentionally empty - blocks the derivation
-			WorkerTag:   "",
-			TaskTimeout: time.Hour,
-		},
-	}
-	// Bootstrap should fail at the Namespace validation in
-	// yellowdog.NewProvider, since Namespace is required for the
-	// provider itself; WorkerTag derivation never gets a chance to
-	// run with no namespace input.
-	_, err := Bootstrap(cfg, 20, "https://helix.example.com", "test-token", nullStore{})
-	if err == nil {
-		t.Fatal("expected error when Namespace is empty (which blocks both Namespace validation and WorkerTag derivation)")
-	}
-}
-
 func TestBootstrapYellowdogRequiresCredentials(t *testing.T) {
 	// Bootstrap delegates field validation to yellowdog.NewProvider,
 	// so this test mostly proves the wiring is plumbed correctly.
@@ -465,7 +262,7 @@ func TestBootstrapSandboxImageOverrideBypassesVersionGuard(t *testing.T) {
 	}
 }
 
-func TestBootstrapValidYellowdogConfigBuildsManager(t *testing.T) {
+func TestBootstrapValidYellowdogConfigBuildsSupervisor(t *testing.T) {
 	cfg := config.Compute{
 		Provider:                "yellowdog",
 		DeploymentTag:           "prod",
@@ -483,20 +280,18 @@ func TestBootstrapValidYellowdogConfigBuildsManager(t *testing.T) {
 			TaskTimeout: 4 * time.Hour,
 		},
 	}
-	mgr, err := Bootstrap(cfg, 20, "https://helix.example.com", "test-token", nullStore{})
+	svc, err := Bootstrap(cfg, 20, "https://helix.example.com", "test-token", nullStore{})
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
-	if mgr == nil {
-		t.Fatal("expected non-nil Manager for valid config")
+	if svc == nil {
+		t.Fatal("expected non-nil Service for valid config")
 	}
-	// Compile-time check: returned value satisfies the public Manager
-	// surface (Run + Reconcile). If the bootstrap accidentally
-	// returns something else, this won't compile.
-	var _ interface {
-		Run(context.Context) error
-		Reconcile(context.Context) error
-	} = mgr
+	// Discovery is the only mode, so Bootstrap returns a PoolSupervisor
+	// (declared type is the narrower compute.Service).
+	if _, ok := svc.(*compute.PoolSupervisor); !ok {
+		t.Fatalf("expected *compute.PoolSupervisor, got %T", svc)
+	}
 }
 
 func TestHelixSandboxImageFor(t *testing.T) {

--- a/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
+++ b/api/pkg/sandbox/compute/bootstrap/bootstrap_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/data"
-	"github.com/helixml/helix/api/pkg/sandbox/compute"
 	"github.com/helixml/helix/api/pkg/types"
 )
 
@@ -158,7 +157,6 @@ func TestBootstrapDerivesTagFromYellowdogNamespace(t *testing.T) {
 			APISecret:   "s",
 			BaseURL:     "https://portal.yellowdog.co/api",
 			Namespace:   "development",
-			WorkerTag:   "w",
 			TaskTimeout: time.Hour,
 		},
 	}
@@ -241,7 +239,7 @@ func TestBootstrapSandboxImageOverrideBypassesVersionGuard(t *testing.T) {
 		MaxProvisioningAge:      30 * time.Minute,
 		Yellowdog: config.Yellowdog{
 			APIKeyID: "k", APISecret: "s", BaseURL: "https://portal.yellowdog.co/api",
-			Namespace: "development", WorkerTag: "helix-prod", TaskTimeout: 4 * time.Hour,
+			Namespace: "development", TaskTimeout: 4 * time.Hour,
 		},
 	}
 
@@ -276,7 +274,6 @@ func TestBootstrapValidYellowdogConfigBuildsSupervisor(t *testing.T) {
 			APISecret:   "test-secret",
 			BaseURL:     "https://portal.yellowdog.co/api",
 			Namespace:   "development",
-			WorkerTag:   "helix-prod",
 			TaskTimeout: 4 * time.Hour,
 		},
 	}
@@ -284,13 +281,9 @@ func TestBootstrapValidYellowdogConfigBuildsSupervisor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Bootstrap: %v", err)
 	}
+	// Discovery is the only mode, so Bootstrap returns a *PoolSupervisor.
 	if svc == nil {
-		t.Fatal("expected non-nil Service for valid config")
-	}
-	// Discovery is the only mode, so Bootstrap returns a PoolSupervisor
-	// (declared type is the narrower compute.Service).
-	if _, ok := svc.(*compute.PoolSupervisor); !ok {
-		t.Fatalf("expected *compute.PoolSupervisor, got %T", svc)
+		t.Fatal("expected non-nil PoolSupervisor for valid config")
 	}
 }
 
@@ -493,5 +486,4 @@ func TestHelixSandboxImageFor(t *testing.T) {
 			t.Fatalf("error should not mention a hardcoded registry; got %q", err.Error())
 		}
 	})
-	_ = compute.Manager{} // keep the compute import used even if signature simplifies later
 }

--- a/api/pkg/sandbox/compute/bootstrap/pool_discovery.go
+++ b/api/pkg/sandbox/compute/bootstrap/pool_discovery.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"strings"
 
 	"github.com/helixml/helix/api/pkg/config"
@@ -27,18 +28,24 @@ func (d *ydPoolDiscoverer) DiscoverPools(ctx context.Context) ([]compute.Discove
 	if err != nil {
 		return nil, err
 	}
+	return toDiscoveredPools(pools), nil
+}
+
+// toDiscoveredPools maps YD node-pool groups to provider-agnostic
+// DiscoveredPools. Pure (no I/O) so the keying is unit-testable. Key is the
+// raw (workerTag, instanceType) join - the supervisor dedups on it, and
+// poolDeploymentTag derives a collision-free deployment tag from it.
+func toDiscoveredPools(pools []yellowdog.NodePool) []compute.DiscoveredPool {
 	out := make([]compute.DiscoveredPool, 0, len(pools))
 	for _, p := range pools {
 		out = append(out, compute.DiscoveredPool{
-			// Key is unique per (workerTag, instanceType) so the reconcile
-			// diff never collides two pools that share a tag.
 			Key:          p.WorkerTag + "|" + p.InstanceType,
 			WorkerTag:    p.WorkerTag,
 			InstanceType: p.InstanceType,
 			NodeCount:    p.NodeCount,
 		})
 	}
-	return out, nil
+	return out
 }
 
 // ydManagerFactory builds one compute.Manager per discovered pool: a YD
@@ -67,7 +74,7 @@ func (f *ydManagerFactory) NewPoolManager(p compute.DiscoveredPool) (compute.Poo
 		Namespace: f.cfg.Yellowdog.Namespace,
 		// Per-pool deployment tag isolates row ownership: Manager.ownedRows
 		// filters by provider.Name() = "yellowdog-"+DeploymentTag.
-		DeploymentTag:          f.deploymentTagBase + "-" + sanitizeTagSegment(p.Key),
+		DeploymentTag:          poolDeploymentTag(f.deploymentTagBase, p.Key),
 		WorkerTag:              p.WorkerTag,
 		TaskTimeout:            f.cfg.Yellowdog.TaskTimeout,
 		MaxRetries:             f.cfg.Yellowdog.MaxRetries,
@@ -86,9 +93,24 @@ func (f *ydManagerFactory) NewPoolManager(p compute.DiscoveredPool) (compute.Poo
 	}))
 }
 
-// sanitizeTagSegment makes a pool Key safe to embed in a YD deployment tag:
+// poolDeploymentTag derives a per-pool YD deployment tag from the base tag
+// and the pool Key. The Key is hashed (fnv-32a, 8 hex chars) so the result
+// is collision-free even when two distinct Keys would sanitise to the same
+// readable suffix. This matters because the deployment tag IS the
+// row-ownership boundary (provider.Name() = "yellowdog-"+DeploymentTag): a
+// collision would make two pools' Managers share rows and double-count each
+// other's floor. The sanitised Key is kept as a readable prefix for admin
+// tooling.
+func poolDeploymentTag(base, key string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(key))
+	return fmt.Sprintf("%s-%s-%08x", base, sanitizeTagSegment(key), h.Sum32())
+}
+
+// sanitizeTagSegment makes a pool Key readable inside a YD deployment tag:
 // keep [a-zA-Z0-9-], replace everything else (the "|" separator and the "."
-// in e.g. "inf2.8xlarge") with "-".
+// in e.g. "inf2.8xlarge") with "-". Lossy by design - poolDeploymentTag adds
+// a hash for uniqueness; this is just the human-readable part.
 func sanitizeTagSegment(s string) string {
 	return strings.Map(func(r rune) rune {
 		switch {
@@ -102,13 +124,18 @@ func sanitizeTagSegment(s string) string {
 
 // buildSupervisor constructs the discovery-mode PoolSupervisor: a YD pool
 // discoverer + a per-pool Manager factory sharing the global ManagerConfig.
-// Returned to the API server as a compute.Service (same Run contract as a
-// single Manager). Assumes cfg.DeploymentTag has been resolved by Bootstrap.
-func buildSupervisor(cfg config.Compute, maxSandboxesPerHost int, serverURL, runnerToken string, store compute.SandboxStore) (compute.Service, error) {
-	// Fail fast at boot on missing credentials rather than only when the
-	// supervisor's first reconcile tries to discover/provision.
+// Validates the required YD config eagerly so a misconfigured install fails
+// fast at boot rather than silently doing nothing at reconcile time.
+// Assumes cfg.DeploymentTag has been resolved by Bootstrap.
+func buildSupervisor(cfg config.Compute, maxSandboxesPerHost int, serverURL, runnerToken string, store compute.SandboxStore) (*compute.PoolSupervisor, error) {
 	if cfg.Yellowdog.APIKeyID == "" || cfg.Yellowdog.APISecret == "" {
 		return nil, errors.New("compute: yellowdog APIKeyID and APISecret are required")
+	}
+	// Namespace is required by every per-pool yellowdog.NewProvider call, but
+	// those happen lazily at reconcile - validate here so an empty namespace
+	// fails boot instead of silently skipping every pool.
+	if cfg.Yellowdog.Namespace == "" {
+		return nil, errors.New("compute: yellowdog Namespace is required")
 	}
 	sandboxImage := cfg.SandboxImage
 	if sandboxImage == "" {

--- a/api/pkg/sandbox/compute/bootstrap/pool_discovery.go
+++ b/api/pkg/sandbox/compute/bootstrap/pool_discovery.go
@@ -1,0 +1,145 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/sandbox/compute"
+	"github.com/helixml/helix/api/pkg/sandbox/compute/yellowdog"
+	"github.com/rs/zerolog/log"
+)
+
+// ydPoolDiscoverer adapts yellowdog.DiscoverNodePools to the
+// compute.PoolDiscoverer interface the supervisor consumes.
+type ydPoolDiscoverer struct {
+	yd config.Yellowdog
+}
+
+func (d *ydPoolDiscoverer) DiscoverPools(ctx context.Context) ([]compute.DiscoveredPool, error) {
+	pools, err := yellowdog.DiscoverNodePools(ctx, yellowdog.Config{
+		APIKeyID:  d.yd.APIKeyID,
+		APISecret: d.yd.APISecret,
+		BaseURL:   d.yd.BaseURL,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]compute.DiscoveredPool, 0, len(pools))
+	for _, p := range pools {
+		out = append(out, compute.DiscoveredPool{
+			// Key is unique per (workerTag, instanceType) so the reconcile
+			// diff never collides two pools that share a tag.
+			Key:          p.WorkerTag + "|" + p.InstanceType,
+			WorkerTag:    p.WorkerTag,
+			InstanceType: p.InstanceType,
+			NodeCount:    p.NodeCount,
+		})
+	}
+	return out, nil
+}
+
+// ydManagerFactory builds one compute.Manager per discovered pool: a YD
+// provider scoped to the pool's worker tag with an isolated deployment tag
+// (so each Manager's Floor/D3/D4 sees only its own SandboxInstance rows),
+// the accelerator-derived GPU vendor, and the one global ManagerConfig.
+type ydManagerFactory struct {
+	cfg               config.Compute
+	deploymentTagBase string
+	serverURL         string
+	runnerToken       string
+	sandboxImage      string
+	maxSandboxes      int
+	store             compute.SandboxStore
+}
+
+func (f *ydManagerFactory) NewPoolManager(p compute.DiscoveredPool) (compute.PoolManager, error) {
+	vendor := compute.AcceleratorForInstanceType(p.InstanceType)
+	if vendor == "" {
+		return nil, fmt.Errorf("unclassifiable instance type %q (no accelerator mapping)", p.InstanceType)
+	}
+	provider, err := yellowdog.NewProvider(yellowdog.Config{
+		APIKeyID:  f.cfg.Yellowdog.APIKeyID,
+		APISecret: f.cfg.Yellowdog.APISecret,
+		BaseURL:   f.cfg.Yellowdog.BaseURL,
+		Namespace: f.cfg.Yellowdog.Namespace,
+		// Per-pool deployment tag isolates row ownership: Manager.ownedRows
+		// filters by provider.Name() = "yellowdog-"+DeploymentTag.
+		DeploymentTag:          f.deploymentTagBase + "-" + sanitizeTagSegment(p.Key),
+		WorkerTag:              p.WorkerTag,
+		TaskTimeout:            f.cfg.Yellowdog.TaskTimeout,
+		MaxRetries:             f.cfg.Yellowdog.MaxRetries,
+		HelixURL:               f.serverURL,
+		RunnerToken:            f.runnerToken,
+		HelixImage:             f.sandboxImage,
+		NeuronCompileCacheURL:  f.cfg.NeuronCompileCacheURL,
+		RunnerReadinessTimeout: f.cfg.RunnerReadinessTimeout,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return compute.NewManager(provider, f.store, managerConfig(f.cfg, compute.Spec{
+		MaxSandboxes: f.maxSandboxes,
+		GPUVendor:    vendor,
+	}))
+}
+
+// sanitizeTagSegment makes a pool Key safe to embed in a YD deployment tag:
+// keep [a-zA-Z0-9-], replace everything else (the "|" separator and the "."
+// in e.g. "inf2.8xlarge") with "-".
+func sanitizeTagSegment(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-':
+			return r
+		default:
+			return '-'
+		}
+	}, s)
+}
+
+// buildSupervisor constructs the discovery-mode PoolSupervisor: a YD pool
+// discoverer + a per-pool Manager factory sharing the global ManagerConfig.
+// Returned to the API server as a compute.Service (same Run contract as a
+// single Manager). Assumes cfg.DeploymentTag has been resolved by Bootstrap.
+func buildSupervisor(cfg config.Compute, maxSandboxesPerHost int, serverURL, runnerToken string, store compute.SandboxStore) (compute.Service, error) {
+	// Fail fast at boot on missing credentials rather than only when the
+	// supervisor's first reconcile tries to discover/provision.
+	if cfg.Yellowdog.APIKeyID == "" || cfg.Yellowdog.APISecret == "" {
+		return nil, errors.New("compute: yellowdog APIKeyID and APISecret are required")
+	}
+	sandboxImage := cfg.SandboxImage
+	if sandboxImage == "" {
+		img, err := helixSandboxImage(cfg.SandboxRegistry)
+		if err != nil {
+			return nil, err
+		}
+		sandboxImage = img
+	}
+	sup, err := compute.NewPoolSupervisor(
+		&ydPoolDiscoverer{yd: cfg.Yellowdog},
+		&ydManagerFactory{
+			cfg:               cfg,
+			deploymentTagBase: cfg.DeploymentTag,
+			serverURL:         serverURL,
+			runnerToken:       runnerToken,
+			sandboxImage:      sandboxImage,
+			maxSandboxes:      maxSandboxesPerHost,
+			store:             store,
+		},
+		cfg.ReconcileInterval,
+	)
+	if err != nil {
+		return nil, err
+	}
+	log.Info().
+		Str("deployment_tag_base", cfg.DeploymentTag).
+		Str("sandbox_image", sandboxImage).
+		Int("floor", cfg.Floor).
+		Int("max", cfg.Max).
+		Dur("reconcile_interval", cfg.ReconcileInterval).
+		Msg("compute subsystem enabled in DISCOVERY mode; PoolSupervisor (one Manager per discovered pool) will start at boot")
+	return sup, nil
+}

--- a/api/pkg/sandbox/compute/bootstrap/pool_discovery_test.go
+++ b/api/pkg/sandbox/compute/bootstrap/pool_discovery_test.go
@@ -6,7 +6,48 @@ import (
 
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/sandbox/compute"
+	"github.com/helixml/helix/api/pkg/sandbox/compute/yellowdog"
 )
+
+func TestToDiscoveredPools(t *testing.T) {
+	in := []yellowdog.NodePool{
+		{WorkerTag: "worker-gpu", InstanceType: "g5.xlarge", NodeCount: 2},
+		{WorkerTag: "worker-inf2", InstanceType: "inf2.8xlarge", NodeCount: 1},
+	}
+	got := toDiscoveredPools(in)
+	want := []compute.DiscoveredPool{
+		{Key: "worker-gpu|g5.xlarge", WorkerTag: "worker-gpu", InstanceType: "g5.xlarge", NodeCount: 2},
+		{Key: "worker-inf2|inf2.8xlarge", WorkerTag: "worker-inf2", InstanceType: "inf2.8xlarge", NodeCount: 1},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len=%d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("pool[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPoolDeploymentTagInjective(t *testing.T) {
+	// Two pool Keys that sanitise to the SAME readable string ("." and "_"
+	// both -> "-") must still produce DISTINCT deployment tags - otherwise
+	// the two Managers would share row ownership (provider.Name() collision)
+	// and double-count each other's floor.
+	a := poolDeploymentTag("helix-ns", "team.a|inf2.8xlarge")
+	b := poolDeploymentTag("helix-ns", "team_a|inf2.8xlarge")
+	if a == b {
+		t.Fatalf("distinct pool keys collided on deployment tag: %q", a)
+	}
+	// Same key is stable (deterministic).
+	if poolDeploymentTag("helix-ns", "team.a|inf2.8xlarge") != a {
+		t.Fatal("poolDeploymentTag is not deterministic for the same key")
+	}
+	// Tag carries the base prefix.
+	if got := poolDeploymentTag("base", "worker-gpu|g5.xlarge"); got[:5] != "base-" {
+		t.Fatalf("tag %q does not start with the base prefix", got)
+	}
+}
 
 func testFactory() *ydManagerFactory {
 	return &ydManagerFactory{

--- a/api/pkg/sandbox/compute/bootstrap/pool_discovery_test.go
+++ b/api/pkg/sandbox/compute/bootstrap/pool_discovery_test.go
@@ -1,0 +1,62 @@
+package bootstrap
+
+import (
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/sandbox/compute"
+)
+
+func testFactory() *ydManagerFactory {
+	return &ydManagerFactory{
+		cfg: config.Compute{
+			Provider:           "yellowdog",
+			Floor:              1,
+			ReconcileInterval:  30 * time.Second,
+			HealthCheckTimeout: 10 * time.Second,
+			Yellowdog: config.Yellowdog{
+				APIKeyID: "k", APISecret: "s", Namespace: "ns",
+			},
+		},
+		deploymentTagBase: "helix-ns",
+		serverURL:         "https://helix.example.com",
+		runnerToken:       "tok",
+		sandboxImage:      "ghcr.io/helixml/helix-sandbox:test",
+		maxSandboxes:      5,
+		store:             nullStore{},
+	}
+}
+
+func TestYDManagerFactoryClassifies(t *testing.T) {
+	f := testFactory()
+	// An nvidia pool builds a Manager.
+	m, err := f.NewPoolManager(compute.DiscoveredPool{Key: "worker-gpu|g5.xlarge", WorkerTag: "worker-gpu", InstanceType: "g5.xlarge"})
+	if err != nil {
+		t.Fatalf("NewPoolManager(g5): %v", err)
+	}
+	if m == nil {
+		t.Fatal("expected non-nil manager for g5")
+	}
+	// A neuron pool builds a Manager too.
+	if _, err := f.NewPoolManager(compute.DiscoveredPool{Key: "worker-inf2|inf2.8xlarge", WorkerTag: "worker-inf2", InstanceType: "inf2.8xlarge"}); err != nil {
+		t.Fatalf("NewPoolManager(inf2): %v", err)
+	}
+	// An unclassifiable instance type errors (the supervisor then skips it).
+	if _, err := f.NewPoolManager(compute.DiscoveredPool{Key: "worker-x|t3.small", WorkerTag: "worker-x", InstanceType: "t3.small"}); err == nil {
+		t.Fatal("expected error for unclassifiable instance type")
+	}
+}
+
+func TestSanitizeTagSegment(t *testing.T) {
+	cases := map[string]string{
+		"worker-psamuel|inf2.8xlarge": "worker-psamuel-inf2-8xlarge",
+		"worker-gpu|g5.xlarge":        "worker-gpu-g5-xlarge",
+		"a_b c":                       "a-b-c",
+	}
+	for in, want := range cases {
+		if got := sanitizeTagSegment(in); got != want {
+			t.Errorf("sanitizeTagSegment(%q)=%q want %q", in, got, want)
+		}
+	}
+}

--- a/api/pkg/sandbox/compute/pool_supervisor.go
+++ b/api/pkg/sandbox/compute/pool_supervisor.go
@@ -1,0 +1,225 @@
+package compute
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// DiscoveredPool is one provisioned worker pool as observed from live
+// nodes, in provider-agnostic terms.
+//
+// Key is the supervisor's identity for the pool - one Manager per distinct
+// Key. It MUST be unique per (WorkerTag, InstanceType): a worker tag that
+// spans accelerator types is two pools, and keying on the tag alone would
+// collide them in the reconcile diff and silently drop one. WorkerTag is
+// what a work requirement targets; InstanceType classifies the accelerator.
+// NOTE: because YD work-requirement placement is by worker tag ONLY, a
+// single tag that genuinely spans accelerators cannot be split safely (a
+// neuron task could land on an nvidia node) - the factory should reject
+// such a tag rather than build two Managers for it. See the design doc.
+type DiscoveredPool struct {
+	Key          string
+	WorkerTag    string
+	InstanceType string
+	NodeCount    int
+}
+
+// PoolDiscoverer enumerates the worker pools currently visible from live
+// nodes. Implemented in the provider layer (e.g. the YellowDog
+// DiscoverNodePools call) and injected so this package stays
+// provider-agnostic and import-cycle free.
+type PoolDiscoverer interface {
+	DiscoverPools(ctx context.Context) ([]DiscoveredPool, error)
+}
+
+// poolManager is the slice of *Manager the supervisor drives. An
+// interface (not the concrete *Manager) so the supervisor is testable
+// without constructing a real Provider + store.
+type poolManager interface {
+	Run(ctx context.Context) error
+}
+
+// ManagerFactory builds a Manager scoped to a single discovered pool.
+// The factory owns provider construction (per-pool worker tag, an
+// isolated deployment tag so each Manager's Floor/D3/D4 only sees its
+// own SandboxInstance rows, and the accelerator-specific sandbox image)
+// and applies the ONE global ManagerConfig. The supervisor never sees
+// per-pool policy because there is none - Floor/Max/Idle are global.
+type ManagerFactory interface {
+	NewPoolManager(p DiscoveredPool) (poolManager, error)
+}
+
+// PoolSupervisor keeps one running Manager per discovered pool. Each
+// reconcile cycle it diffs the live pools (from PoolDiscoverer) against
+// the running Managers: start a Manager when a pool appears, stop it
+// when the pool's nodes are gone. Each Manager runs the existing
+// Floor/D3/D4 loop unchanged, scoped to its pool.
+//
+// This is the discovery-driven alternative to declaring pools in config:
+// whatever the operator brought up with `yd-provision` shows up here and
+// gets a Manager; whatever they tear down loses its Manager next cycle.
+type PoolSupervisor struct {
+	discoverer PoolDiscoverer
+	factory    ManagerFactory
+	interval   time.Duration
+
+	mu sync.Mutex
+	// running maps a pool key to its in-flight Manager. The *poolRun
+	// pointer identity lets a Manager goroutine remove ONLY its own
+	// entry on exit without racing a newer start for the same key.
+	running map[string]*poolRun
+}
+
+// poolRun is one started Manager's cancel handle, tracked by pointer
+// identity in PoolSupervisor.running.
+type poolRun struct {
+	cancel context.CancelFunc
+}
+
+// NewPoolSupervisor validates inputs and returns a supervisor that has
+// not started reconciling. interval is how often the pool set is
+// re-discovered.
+func NewPoolSupervisor(d PoolDiscoverer, f ManagerFactory, interval time.Duration) (*PoolSupervisor, error) {
+	if d == nil {
+		return nil, errors.New("compute.NewPoolSupervisor: discoverer is required")
+	}
+	if f == nil {
+		return nil, errors.New("compute.NewPoolSupervisor: factory is required")
+	}
+	if interval <= 0 {
+		return nil, fmt.Errorf("compute.NewPoolSupervisor: interval must be > 0, got %s", interval)
+	}
+	return &PoolSupervisor{
+		discoverer: d,
+		factory:    f,
+		interval:   interval,
+		running:    map[string]*poolRun{},
+	}, nil
+}
+
+// Run blocks until ctx is cancelled, reconciling the pool set each
+// interval (first pass immediately so pre-warming starts at boot). On
+// exit every per-pool Manager is signalled to stop (their goroutines
+// then drain independently - Run does not wait for them).
+func (s *PoolSupervisor) Run(ctx context.Context) error {
+	t := time.NewTicker(s.interval)
+	defer t.Stop()
+
+	s.reconcile(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			s.stopAll()
+			return ctx.Err()
+		case <-t.C:
+			s.reconcile(ctx)
+		}
+	}
+}
+
+// reconcile diffs discovered pools against running Managers. A discovery
+// error is logged and the current Manager set is left intact - a
+// transient YD blip must not tear down healthy pre-warming.
+func (s *PoolSupervisor) reconcile(ctx context.Context) {
+	pools, err := s.discoverer.DiscoverPools(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("compute pool supervisor: discovery failed; keeping current managers")
+		return
+	}
+
+	desired := make(map[string]DiscoveredPool, len(pools))
+	for _, p := range pools {
+		if p.Key == "" {
+			continue
+		}
+		desired[p.Key] = p
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Stop Managers whose pool is no longer present (operator tore the
+	// pool down). Cancelling the Manager's context stops its loop; the
+	// pool's sandbox WRs die with the nodes that are already gone.
+	for key, run := range s.running {
+		if _, ok := desired[key]; !ok {
+			log.Info().Str("pool", key).Msg("compute pool supervisor: pool gone, stopping its manager")
+			run.cancel()
+			delete(s.running, key)
+		}
+	}
+
+	// Start a Manager for each newly-seen pool.
+	for key, p := range desired {
+		if _, ok := s.running[key]; ok {
+			continue
+		}
+		mgr, err := s.factory.NewPoolManager(p)
+		if err != nil {
+			// Most likely an unclassifiable instance type (no image
+			// mapped). Skip this pool; retry next cycle in case the
+			// mapping or the pool changes.
+			log.Error().Err(err).Str("pool", key).Str("instance_type", p.InstanceType).
+				Msg("compute pool supervisor: cannot build manager for pool; skipping")
+			continue
+		}
+		mctx, cancel := context.WithCancel(ctx)
+		run := &poolRun{cancel: cancel}
+		s.running[key] = run
+		log.Info().Str("pool", key).Str("worker_tag", p.WorkerTag).
+			Str("instance_type", p.InstanceType).Int("nodes", p.NodeCount).
+			Msg("compute pool supervisor: starting manager for pool")
+		go func(p DiscoveredPool, run *poolRun, mctx context.Context) {
+			err := mgr.Run(mctx)
+			if err != nil && !errors.Is(err, context.Canceled) {
+				log.Warn().Err(err).Str("pool", p.Key).Msg("compute pool supervisor: manager exited with error")
+			}
+			// Self-remove so a Manager that exited on its own (crash, or
+			// a non-cancel error) is rebuilt next cycle instead of being
+			// stuck "running" forever. Pointer check: only delete if this
+			// run is still the current one (a pool that was torn down and
+			// rebuilt for the same key has a different *poolRun).
+			s.mu.Lock()
+			if s.running[p.Key] == run {
+				delete(s.running, p.Key)
+			}
+			s.mu.Unlock()
+		}(p, run, mctx)
+	}
+}
+
+func (s *PoolSupervisor) stopAll() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for key, run := range s.running {
+		run.cancel()
+		delete(s.running, key)
+	}
+}
+
+// AcceleratorForInstanceType classifies an AWS instance type into the
+// accelerator family Helix must target, which selects the sandbox image
+// and GPU_VENDOR for that pool's Manager. Returns "" for types it can't
+// classify (the factory then skips the pool rather than guess).
+//
+// ponytail: prefix heuristic, not an exhaustive table. inf*/trn* = AWS
+// Neuron, g*/p* = NVIDIA GPU - which covers every pool this POC runs.
+// If an AMD GPU family (g4ad) or a new accelerator needs a distinct
+// path, add an explicit case before the g*/p* fallthrough.
+func AcceleratorForInstanceType(instanceType string) string {
+	fam, _, _ := strings.Cut(strings.ToLower(strings.TrimSpace(instanceType)), ".")
+	switch {
+	case strings.HasPrefix(fam, "inf"), strings.HasPrefix(fam, "trn"):
+		return "neuron"
+	case strings.HasPrefix(fam, "g"), strings.HasPrefix(fam, "p"):
+		return "nvidia"
+	default:
+		return ""
+	}
+}

--- a/api/pkg/sandbox/compute/pool_supervisor.go
+++ b/api/pkg/sandbox/compute/pool_supervisor.go
@@ -38,10 +38,19 @@ type PoolDiscoverer interface {
 	DiscoverPools(ctx context.Context) ([]DiscoveredPool, error)
 }
 
-// poolManager is the slice of *Manager the supervisor drives. An
+// PoolManager is the slice of *Manager the supervisor drives. An
 // interface (not the concrete *Manager) so the supervisor is testable
-// without constructing a real Provider + store.
-type poolManager interface {
+// without a real Provider + store, and so the ManagerFactory - implemented
+// outside this package (bootstrap, which builds the per-pool provider) -
+// can name the return type. *Manager satisfies it.
+type PoolManager interface {
+	Run(ctx context.Context) error
+}
+
+// Service is the reconcile loop bootstrap hands to the API server: either a
+// single Manager or a PoolSupervisor (discovery mode). The server only
+// nil-checks it and calls Run, so one interface covers both.
+type Service interface {
 	Run(ctx context.Context) error
 }
 
@@ -52,7 +61,7 @@ type poolManager interface {
 // and applies the ONE global ManagerConfig. The supervisor never sees
 // per-pool policy because there is none - Floor/Max/Idle are global.
 type ManagerFactory interface {
-	NewPoolManager(p DiscoveredPool) (poolManager, error)
+	NewPoolManager(p DiscoveredPool) (PoolManager, error)
 }
 
 // PoolSupervisor keeps one running Manager per discovered pool. Each

--- a/api/pkg/sandbox/compute/pool_supervisor.go
+++ b/api/pkg/sandbox/compute/pool_supervisor.go
@@ -47,13 +47,6 @@ type PoolManager interface {
 	Run(ctx context.Context) error
 }
 
-// Service is the reconcile loop bootstrap hands to the API server: either a
-// single Manager or a PoolSupervisor (discovery mode). The server only
-// nil-checks it and calls Run, so one interface covers both.
-type Service interface {
-	Run(ctx context.Context) error
-}
-
 // ManagerFactory builds a Manager scoped to a single discovered pool.
 // The factory owns provider construction (per-pool worker tag, an
 // isolated deployment tag so each Manager's Floor/D3/D4 only sees its
@@ -189,6 +182,11 @@ func (s *PoolSupervisor) reconcile(ctx context.Context) {
 			if err != nil && !errors.Is(err, context.Canceled) {
 				log.Warn().Err(err).Str("pool", p.Key).Msg("compute pool supervisor: manager exited with error")
 			}
+			// Cancel our own context so a Manager that returned for a
+			// non-cancel reason doesn't leave its child context attached to
+			// the parent for the server's lifetime. Idempotent if stopAll
+			// already cancelled it.
+			run.cancel()
 			// Self-remove so a Manager that exited on its own (crash, or
 			// a non-cancel error) is rebuilt next cycle instead of being
 			// stuck "running" forever. Pointer check: only delete if this

--- a/api/pkg/sandbox/compute/pool_supervisor_test.go
+++ b/api/pkg/sandbox/compute/pool_supervisor_test.go
@@ -1,0 +1,234 @@
+package compute
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeManager records its lifecycle and blocks until cancelled, standing
+// in for a real *Manager.Run.
+type fakeManager struct {
+	started chan struct{}
+	exitErr error // if set, Run returns it immediately instead of blocking
+	mu      sync.Mutex
+	stopped bool
+}
+
+func newFakeManager() *fakeManager { return &fakeManager{started: make(chan struct{})} }
+
+func (m *fakeManager) Run(ctx context.Context) error {
+	close(m.started)
+	if m.exitErr != nil {
+		return m.exitErr
+	}
+	<-ctx.Done()
+	m.mu.Lock()
+	m.stopped = true
+	m.mu.Unlock()
+	return ctx.Err()
+}
+
+func (m *fakeManager) isStopped() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.stopped
+}
+
+type fakeFactory struct {
+	mu       sync.Mutex
+	calls    int
+	managers map[string]*fakeManager // keyed by pool key
+	err      error
+	exitErr  error // managers built return this immediately from Run
+}
+
+func newFakeFactory() *fakeFactory { return &fakeFactory{managers: map[string]*fakeManager{}} }
+
+func (f *fakeFactory) NewPoolManager(p DiscoveredPool) (poolManager, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	m := newFakeManager()
+	m.exitErr = f.exitErr
+	f.managers[p.Key] = m
+	return m, nil
+}
+
+func (f *fakeFactory) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+type fakeDiscoverer struct {
+	mu    sync.Mutex
+	pools []DiscoveredPool
+	err   error
+}
+
+func (d *fakeDiscoverer) set(pools []DiscoveredPool, err error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.pools = pools
+	d.err = err
+}
+
+func (d *fakeDiscoverer) DiscoverPools(_ context.Context) ([]DiscoveredPool, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.pools, d.err
+}
+
+func waitFor(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for: %s", msg)
+}
+
+func TestPoolSupervisorStartsAndStopsManagers(t *testing.T) {
+	disc := &fakeDiscoverer{}
+	fac := newFakeFactory()
+	s, err := NewPoolSupervisor(disc, fac, time.Hour) // ticker irrelevant; we drive reconcile directly
+	if err != nil {
+		t.Fatalf("NewPoolSupervisor: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	poolA := DiscoveredPool{Key: "worker-nvidia", WorkerTag: "worker-nvidia", InstanceType: "g5.xlarge", NodeCount: 1}
+	poolB := DiscoveredPool{Key: "worker-inf2", WorkerTag: "worker-inf2", InstanceType: "inf2.8xlarge", NodeCount: 1}
+
+	// Pool A appears -> one manager started.
+	disc.set([]DiscoveredPool{poolA}, nil)
+	s.reconcile(ctx)
+	waitFor(t, func() bool { return fac.callCount() == 1 }, "manager A built")
+	mgrA := fac.managers["worker-nvidia"]
+	<-mgrA.started
+
+	// Reconcile again with the same pool -> no new manager.
+	s.reconcile(ctx)
+	if got := fac.callCount(); got != 1 {
+		t.Fatalf("stable pool rebuilt a manager: callCount=%d, want 1", got)
+	}
+
+	// Pool B also appears -> a second manager started, A untouched.
+	disc.set([]DiscoveredPool{poolA, poolB}, nil)
+	s.reconcile(ctx)
+	waitFor(t, func() bool { return fac.callCount() == 2 }, "manager B built")
+	mgrB := fac.managers["worker-inf2"]
+	<-mgrB.started
+	if mgrA.isStopped() {
+		t.Fatal("manager A stopped when B appeared")
+	}
+
+	// Pool A disappears -> its manager stops, B keeps running.
+	disc.set([]DiscoveredPool{poolB}, nil)
+	s.reconcile(ctx)
+	waitFor(t, func() bool { return mgrA.isStopped() }, "manager A stopped")
+	if mgrB.isStopped() {
+		t.Fatal("manager B stopped when only A was removed")
+	}
+
+	// Shut everything down.
+	cancel()
+	s.stopAll()
+	waitFor(t, func() bool { return mgrB.isStopped() }, "manager B stopped on shutdown")
+}
+
+func TestPoolSupervisorDiscoveryErrorKeepsManagers(t *testing.T) {
+	disc := &fakeDiscoverer{}
+	fac := newFakeFactory()
+	s, _ := NewPoolSupervisor(disc, fac, time.Hour)
+	ctx := context.Background()
+
+	disc.set([]DiscoveredPool{{Key: "p", WorkerTag: "p", InstanceType: "g5.xlarge", NodeCount: 1}}, nil)
+	s.reconcile(ctx)
+	waitFor(t, func() bool { return fac.callCount() == 1 }, "manager built")
+
+	// Discovery now errors: the running manager must NOT be torn down.
+	disc.set(nil, errors.New("yd down"))
+	s.reconcile(ctx)
+	if fac.managers["p"].isStopped() {
+		t.Fatal("manager stopped on a transient discovery error")
+	}
+}
+
+func TestPoolSupervisorRebuildsExitedManager(t *testing.T) {
+	disc := &fakeDiscoverer{}
+	fac := newFakeFactory()
+	fac.exitErr = errors.New("manager crashed") // every built manager returns immediately
+	s, _ := NewPoolSupervisor(disc, fac, time.Hour)
+	ctx := context.Background()
+
+	disc.set([]DiscoveredPool{{Key: "p", WorkerTag: "p", InstanceType: "g5.xlarge", NodeCount: 1}}, nil)
+
+	s.reconcile(ctx)
+	waitFor(t, func() bool { return fac.callCount() == 1 }, "first build")
+
+	// A Manager that returns on its own must self-remove from the running
+	// set, otherwise it is never rebuilt and the pool silently loses its floor.
+	waitFor(t, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return len(s.running) == 0
+	}, "exited manager removed from running set")
+
+	// Next cycle, the still-present pool gets a fresh Manager.
+	s.reconcile(ctx)
+	waitFor(t, func() bool { return fac.callCount() == 2 }, "rebuilt after exit")
+}
+
+func TestPoolSupervisorSkipsUnbuildablePool(t *testing.T) {
+	disc := &fakeDiscoverer{}
+	fac := newFakeFactory()
+	fac.err = errors.New("unclassifiable instance type")
+	s, _ := NewPoolSupervisor(disc, fac, time.Hour)
+	ctx := context.Background()
+
+	disc.set([]DiscoveredPool{{Key: "weird", WorkerTag: "weird", InstanceType: "t3.small"}}, nil)
+	s.reconcile(ctx)
+	// Factory was called and errored; nothing should be tracked as running.
+	if got := fac.callCount(); got != 1 {
+		t.Fatalf("callCount=%d, want 1", got)
+	}
+	s.mu.Lock()
+	n := len(s.running)
+	s.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("running managers=%d, want 0 (pool was unbuildable)", n)
+	}
+}
+
+func TestAcceleratorForInstanceType(t *testing.T) {
+	cases := map[string]string{
+		"g5.xlarge":      "nvidia",
+		"g4ad.xlarge":    "nvidia", // known-imperfect: g4ad is AMD; documents the heuristic ceiling
+		"g6.12xlarge":    "nvidia",
+		"p4d.24xlarge":   "nvidia",
+		"inf2.8xlarge":   "neuron",
+		"inf2.xlarge":    "neuron",
+		"trn2.3xlarge":   "neuron",
+		"trn1.32xlarge":  "neuron",
+		"t3.small":       "",
+		"m6g.large":      "",
+		"":               "",
+		" INF2.XLARGE  ": "neuron",
+	}
+	for in, want := range cases {
+		if got := AcceleratorForInstanceType(in); got != want {
+			t.Errorf("AcceleratorForInstanceType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/api/pkg/sandbox/compute/pool_supervisor_test.go
+++ b/api/pkg/sandbox/compute/pool_supervisor_test.go
@@ -47,7 +47,7 @@ type fakeFactory struct {
 
 func newFakeFactory() *fakeFactory { return &fakeFactory{managers: map[string]*fakeManager{}} }
 
-func (f *fakeFactory) NewPoolManager(p DiscoveredPool) (poolManager, error) {
+func (f *fakeFactory) NewPoolManager(p DiscoveredPool) (PoolManager, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.calls++

--- a/api/pkg/sandbox/compute/yellowdog/node_discovery.go
+++ b/api/pkg/sandbox/compute/yellowdog/node_discovery.go
@@ -20,38 +20,31 @@ type node struct {
 }
 
 type nodeDetails struct {
-	WorkerTag string `json:"workerTag"`
+	WorkerTag    string `json:"workerTag"`
+	InstanceType string `json:"instanceType"`
 }
 
 // sliceNode is the paginated envelope YD returns. We only read the
-// first page: WorkerTag discovery doesn't need full pagination since
-// healthy deployments routinely have <10 online nodes, well under the
-// 200 page size we request.
+// first page: discovery doesn't need full pagination since healthy
+// deployments routinely have <10 online nodes, well under the 200 page
+// size we request.
 type sliceNode struct {
 	Items []node `json:"items"`
 }
 
-// DiscoverOnlineWorkerTags queries the YD scheduler API for the set of
-// distinct workerTags advertised by currently-online (RUNNING) nodes
-// visible to the configured API key.
-//
-// Bootstrap callers use this to populate HELIX_YD_WORKER_TAG from the
-// operator's pre-existing pool, instead of guessing `worker-<namespace>`
-// (which silently mismatches whenever the pool was set up with a
-// different convention - the YD POC `config.toml`, for example, derives
-// its tag from `{{username}}` not `{{namespace}}`).
-//
-// Returns a sorted list of distinct non-empty tags. Empty list means
-// "no online nodes visible to this key" (likely no pool provisioned
-// yet); caller decides whether that's an error or whether to fall back
-// to a default.
-//
-// Assumption: this API key's visibility scope is one Helix install's
-// pool(s). YD scopes by key, not by namespace path; an operator who
-// uses one key across multiple Helix deployments' namespaces will get
-// the union of all tags and must set HELIX_YD_WORKER_TAG explicitly to
-// disambiguate (see bootstrap's >1-tag handling).
-func DiscoverOnlineWorkerTags(ctx context.Context, cfg Config) ([]string, error) {
+// NodePool is a distinct group of online nodes sharing a worker tag and
+// instance type - i.e. one provisioned YD pool as Helix observes it from
+// live nodes. NodeCount is how many RUNNING nodes back it right now.
+type NodePool struct {
+	WorkerTag    string
+	InstanceType string
+	NodeCount    int
+}
+
+// fetchOnlineNodes queries the YD scheduler API for the currently-online
+// (RUNNING) nodes visible to the configured API key. Shared by the tag
+// and pool discovery helpers.
+func fetchOnlineNodes(ctx context.Context, cfg Config) ([]node, error) {
 	creds := credentials{keyID: cfg.APIKeyID, secret: cfg.APISecret}
 	if !creds.valid() {
 		return nil, errors.New("yellowdog: discovery requires APIKeyID and APISecret")
@@ -86,9 +79,36 @@ func DiscoverOnlineWorkerTags(ctx context.Context, cfg Config) ([]string, error)
 	if err := doJSON(ctx, httpc, creds, base, http.MethodGet, "/workerPools/nodes", q, nil, &out, retryConfig{maxAttempts: 3}); err != nil {
 		return nil, fmt.Errorf("yellowdog: query nodes: %w", err)
 	}
+	return out.Items, nil
+}
 
+// DiscoverOnlineWorkerTags queries the YD scheduler API for the set of
+// distinct workerTags advertised by currently-online (RUNNING) nodes
+// visible to the configured API key.
+//
+// Bootstrap callers use this to populate HELIX_YD_WORKER_TAG from the
+// operator's pre-existing pool, instead of guessing `worker-<namespace>`
+// (which silently mismatches whenever the pool was set up with a
+// different convention - the YD POC `config.toml`, for example, derives
+// its tag from `{{username}}` not `{{namespace}}`).
+//
+// Returns a sorted list of distinct non-empty tags. Empty list means
+// "no online nodes visible to this key" (likely no pool provisioned
+// yet); caller decides whether that's an error or whether to fall back
+// to a default.
+//
+// Assumption: this API key's visibility scope is one Helix install's
+// pool(s). YD scopes by key, not by namespace path; an operator who
+// uses one key across multiple Helix deployments' namespaces will get
+// the union of all tags and must set HELIX_YD_WORKER_TAG explicitly to
+// disambiguate (see bootstrap's >1-tag handling).
+func DiscoverOnlineWorkerTags(ctx context.Context, cfg Config) ([]string, error) {
+	nodes, err := fetchOnlineNodes(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
 	seen := map[string]struct{}{}
-	for _, n := range out.Items {
+	for _, n := range nodes {
 		tag := strings.TrimSpace(n.Details.WorkerTag)
 		if tag == "" {
 			continue
@@ -101,4 +121,42 @@ func DiscoverOnlineWorkerTags(ctx context.Context, cfg Config) ([]string, error)
 	}
 	sort.Strings(tags)
 	return tags, nil
+}
+
+// DiscoverNodePools groups currently-online (RUNNING) nodes by
+// (workerTag, instanceType): the set of provisioned pools Helix can see
+// from live nodes, with the count of nodes backing each. This is the
+// discovery input for maintaining a floor per pool WITHOUT the operator
+// declaring pools in config - whatever they brought up with yd-provision
+// shows up here, keyed by the tag a work requirement must target and the
+// instance type a caller maps to an accelerator.
+//
+// Nodes missing a workerTag are skipped: a WR cannot target them. Same
+// visibility caveat as DiscoverOnlineWorkerTags - the key scopes what is
+// seen. Sorted by workerTag then instanceType for stable output.
+func DiscoverNodePools(ctx context.Context, cfg Config) ([]NodePool, error) {
+	nodes, err := fetchOnlineNodes(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	type key struct{ tag, itype string }
+	counts := map[key]int{}
+	for _, n := range nodes {
+		tag := strings.TrimSpace(n.Details.WorkerTag)
+		if tag == "" {
+			continue
+		}
+		counts[key{tag, strings.TrimSpace(n.Details.InstanceType)}]++
+	}
+	pools := make([]NodePool, 0, len(counts))
+	for k, c := range counts {
+		pools = append(pools, NodePool{WorkerTag: k.tag, InstanceType: k.itype, NodeCount: c})
+	}
+	sort.Slice(pools, func(i, j int) bool {
+		if pools[i].WorkerTag != pools[j].WorkerTag {
+			return pools[i].WorkerTag < pools[j].WorkerTag
+		}
+		return pools[i].InstanceType < pools[j].InstanceType
+	})
+	return pools, nil
 }

--- a/api/pkg/sandbox/compute/yellowdog/node_discovery.go
+++ b/api/pkg/sandbox/compute/yellowdog/node_discovery.go
@@ -82,47 +82,6 @@ func fetchOnlineNodes(ctx context.Context, cfg Config) ([]node, error) {
 	return out.Items, nil
 }
 
-// DiscoverOnlineWorkerTags queries the YD scheduler API for the set of
-// distinct workerTags advertised by currently-online (RUNNING) nodes
-// visible to the configured API key.
-//
-// Bootstrap callers use this to populate HELIX_YD_WORKER_TAG from the
-// operator's pre-existing pool, instead of guessing `worker-<namespace>`
-// (which silently mismatches whenever the pool was set up with a
-// different convention - the YD POC `config.toml`, for example, derives
-// its tag from `{{username}}` not `{{namespace}}`).
-//
-// Returns a sorted list of distinct non-empty tags. Empty list means
-// "no online nodes visible to this key" (likely no pool provisioned
-// yet); caller decides whether that's an error or whether to fall back
-// to a default.
-//
-// Assumption: this API key's visibility scope is one Helix install's
-// pool(s). YD scopes by key, not by namespace path; an operator who
-// uses one key across multiple Helix deployments' namespaces will get
-// the union of all tags and must set HELIX_YD_WORKER_TAG explicitly to
-// disambiguate (see bootstrap's >1-tag handling).
-func DiscoverOnlineWorkerTags(ctx context.Context, cfg Config) ([]string, error) {
-	nodes, err := fetchOnlineNodes(ctx, cfg)
-	if err != nil {
-		return nil, err
-	}
-	seen := map[string]struct{}{}
-	for _, n := range nodes {
-		tag := strings.TrimSpace(n.Details.WorkerTag)
-		if tag == "" {
-			continue
-		}
-		seen[tag] = struct{}{}
-	}
-	tags := make([]string, 0, len(seen))
-	for t := range seen {
-		tags = append(tags, t)
-	}
-	sort.Strings(tags)
-	return tags, nil
-}
-
 // DiscoverNodePools groups currently-online (RUNNING) nodes by
 // (workerTag, instanceType): the set of provisioned pools Helix can see
 // from live nodes, with the count of nodes backing each. This is the
@@ -131,9 +90,9 @@ func DiscoverOnlineWorkerTags(ctx context.Context, cfg Config) ([]string, error)
 // shows up here, keyed by the tag a work requirement must target and the
 // instance type a caller maps to an accelerator.
 //
-// Nodes missing a workerTag are skipped: a WR cannot target them. Same
-// visibility caveat as DiscoverOnlineWorkerTags - the key scopes what is
-// seen. Sorted by workerTag then instanceType for stable output.
+// Nodes missing a workerTag are skipped: a WR cannot target them. The API
+// key's visibility scopes what is seen (one key may span multiple Helix
+// installs' pools). Sorted by workerTag then instanceType for stable output.
 func DiscoverNodePools(ctx context.Context, cfg Config) ([]NodePool, error) {
 	nodes, err := fetchOnlineNodes(ctx, cfg)
 	if err != nil {

--- a/api/pkg/sandbox/compute/yellowdog/node_discovery_test.go
+++ b/api/pkg/sandbox/compute/yellowdog/node_discovery_test.go
@@ -4,97 +4,9 @@ import (
 	"context"
 	"net/http"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 )
-
-func TestDiscoverOnlineWorkerTags(t *testing.T) {
-	cases := []struct {
-		name     string
-		response string
-		want     []string
-	}{
-		{
-			name:     "no nodes",
-			response: `{"items":[]}`,
-			want:     []string{},
-		},
-		{
-			name: "single tag across multiple nodes is deduplicated",
-			response: `{"items":[
-				{"id":"n1","status":"RUNNING","details":{"workerTag":"worker-psamuel"}},
-				{"id":"n2","status":"RUNNING","details":{"workerTag":"worker-psamuel"}}
-			]}`,
-			want: []string{"worker-psamuel"},
-		},
-		{
-			name: "multiple distinct tags returned sorted",
-			response: `{"items":[
-				{"id":"n1","status":"RUNNING","details":{"workerTag":"worker-staging"}},
-				{"id":"n2","status":"RUNNING","details":{"workerTag":"worker-prod"}}
-			]}`,
-			want: []string{"worker-prod", "worker-staging"},
-		},
-		{
-			name: "empty workerTag fields are dropped",
-			response: `{"items":[
-				{"id":"n1","status":"RUNNING","details":{"workerTag":""}},
-				{"id":"n2","status":"RUNNING","details":{"workerTag":"worker-real"}}
-			]}`,
-			want: []string{"worker-real"},
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			f := newFakeServer(t)
-			f.handler = func(w http.ResponseWriter, r *http.Request) {
-				// Must hit the right endpoint with the right query
-				// shape. If this assertion ever fails it means we
-				// regressed away from the public OpenAPI contract.
-				if r.URL.Path != "/workerPools/nodes" {
-					t.Errorf("path = %q, want /workerPools/nodes", r.URL.Path)
-				}
-				if r.Method != http.MethodGet {
-					t.Errorf("method = %q, want GET", r.Method)
-				}
-				q := r.URL.Query()
-				if q.Get("nodeSearch") == "" {
-					t.Error("nodeSearch query param missing - YD will 400")
-				}
-				if q.Get("sliceReference") == "" {
-					t.Error("sliceReference query param missing - YD will 400")
-				}
-				// Only RUNNING nodes should be requested.
-				if !strings.Contains(q.Get("nodeSearch"), "RUNNING") {
-					t.Errorf("nodeSearch should filter to RUNNING, got %q", q.Get("nodeSearch"))
-				}
-				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(tc.response))
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			got, err := DiscoverOnlineWorkerTags(ctx, Config{
-				APIKeyID:             "k",
-				APISecret:            "s",
-				BaseURL:              f.srv.URL,
-				HTTPClient:           f.srv.Client(),
-				AllowInsecureBaseURL: true,
-			})
-			if err != nil {
-				t.Fatalf("DiscoverOnlineWorkerTags: %v", err)
-			}
-			// Treat nil and empty slice as equivalent for this comparison.
-			if got == nil {
-				got = []string{}
-			}
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Fatalf("got %v, want %v", got, tc.want)
-			}
-		})
-	}
-}
 
 func TestDiscoverNodePools(t *testing.T) {
 	cases := []struct {
@@ -174,8 +86,8 @@ func TestDiscoverNodePools(t *testing.T) {
 	}
 }
 
-func TestDiscoverOnlineWorkerTagsRequiresCreds(t *testing.T) {
-	_, err := DiscoverOnlineWorkerTags(context.Background(), Config{
+func TestDiscoverNodePoolsRequiresCreds(t *testing.T) {
+	_, err := DiscoverNodePools(context.Background(), Config{
 		BaseURL: "https://portal.yellowdog.co/api",
 	})
 	if err == nil {
@@ -183,8 +95,8 @@ func TestDiscoverOnlineWorkerTagsRequiresCreds(t *testing.T) {
 	}
 }
 
-func TestDiscoverOnlineWorkerTagsRefusesPlaintextURL(t *testing.T) {
-	_, err := DiscoverOnlineWorkerTags(context.Background(), Config{
+func TestDiscoverNodePoolsRefusesPlaintextURL(t *testing.T) {
+	_, err := DiscoverNodePools(context.Background(), Config{
 		APIKeyID:  "k",
 		APISecret: "s",
 		BaseURL:   "http://example.com/api",
@@ -194,14 +106,14 @@ func TestDiscoverOnlineWorkerTagsRefusesPlaintextURL(t *testing.T) {
 	}
 }
 
-func TestDiscoverOnlineWorkerTagsPropagatesServerError(t *testing.T) {
+func TestDiscoverNodePoolsPropagatesServerError(t *testing.T) {
 	f := newFakeServer(t)
 	f.handler = func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "boom", http.StatusInternalServerError)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	_, err := DiscoverOnlineWorkerTags(ctx, Config{
+	_, err := DiscoverNodePools(ctx, Config{
 		APIKeyID:             "k",
 		APISecret:            "s",
 		BaseURL:              f.srv.URL,

--- a/api/pkg/sandbox/compute/yellowdog/node_discovery_test.go
+++ b/api/pkg/sandbox/compute/yellowdog/node_discovery_test.go
@@ -96,6 +96,84 @@ func TestDiscoverOnlineWorkerTags(t *testing.T) {
 	}
 }
 
+func TestDiscoverNodePools(t *testing.T) {
+	cases := []struct {
+		name     string
+		response string
+		want     []NodePool
+	}{
+		{
+			name:     "no nodes",
+			response: `{"items":[]}`,
+			want:     []NodePool{},
+		},
+		{
+			name: "two pools of different instance types grouped and counted",
+			response: `{"items":[
+				{"id":"n1","status":"RUNNING","details":{"workerTag":"worker-nvidia","instanceType":"g5.xlarge"}},
+				{"id":"n2","status":"RUNNING","details":{"workerTag":"worker-nvidia","instanceType":"g5.xlarge"}},
+				{"id":"n3","status":"RUNNING","details":{"workerTag":"worker-inf2","instanceType":"inf2.8xlarge"}}
+			]}`,
+			want: []NodePool{
+				{WorkerTag: "worker-inf2", InstanceType: "inf2.8xlarge", NodeCount: 1},
+				{WorkerTag: "worker-nvidia", InstanceType: "g5.xlarge", NodeCount: 2},
+			},
+		},
+		{
+			name: "same tag different instance types are distinct pools",
+			response: `{"items":[
+				{"id":"n1","status":"RUNNING","details":{"workerTag":"worker-mix","instanceType":"g5.xlarge"}},
+				{"id":"n2","status":"RUNNING","details":{"workerTag":"worker-mix","instanceType":"inf2.8xlarge"}}
+			]}`,
+			want: []NodePool{
+				{WorkerTag: "worker-mix", InstanceType: "g5.xlarge", NodeCount: 1},
+				{WorkerTag: "worker-mix", InstanceType: "inf2.8xlarge", NodeCount: 1},
+			},
+		},
+		{
+			name: "nodes without a worker tag are dropped",
+			response: `{"items":[
+				{"id":"n1","status":"RUNNING","details":{"workerTag":"","instanceType":"g5.xlarge"}},
+				{"id":"n2","status":"RUNNING","details":{"workerTag":"worker-real","instanceType":"g5.xlarge"}}
+			]}`,
+			want: []NodePool{
+				{WorkerTag: "worker-real", InstanceType: "g5.xlarge", NodeCount: 1},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeServer(t)
+			f.handler = func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/workerPools/nodes" {
+					t.Errorf("path = %q, want /workerPools/nodes", r.URL.Path)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.response))
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			got, err := DiscoverNodePools(ctx, Config{
+				APIKeyID:             "k",
+				APISecret:            "s",
+				BaseURL:              f.srv.URL,
+				HTTPClient:           f.srv.Client(),
+				AllowInsecureBaseURL: true,
+			})
+			if err != nil {
+				t.Fatalf("DiscoverNodePools: %v", err)
+			}
+			if len(got) == 0 {
+				got = []NodePool{}
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestDiscoverOnlineWorkerTagsRequiresCreds(t *testing.T) {
 	_, err := DiscoverOnlineWorkerTags(context.Background(), Config{
 		BaseURL: "https://portal.yellowdog.co/api",
@@ -134,4 +212,3 @@ func TestDiscoverOnlineWorkerTagsPropagatesServerError(t *testing.T) {
 		t.Fatal("expected error when YD returns 500")
 	}
 }
-

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -192,13 +192,13 @@ type HelixAPIServer struct {
 	webServiceController *webservice.Controller
 
 	// computeManager pre-provisions sandbox HOSTS via a cloud
-	// compute.Provider (currently only yellowdog). Nil when
+	// compute.Provider (currently only yellowdog): a PoolSupervisor that
+	// runs one Manager per discovered YD pool. Nil when
 	// HELIX_COMPUTE_PROVIDER is unset - in that case the legacy
-	// self-registered host path is the only way SandboxInstance rows
-	// get created. Concretely a *compute.Manager, or a
-	// *compute.PoolSupervisor in discovery mode - the server only calls
-	// Run. See api/pkg/sandbox/compute and api/pkg/sandbox/compute/bootstrap.
-	computeManager compute.Service
+	// self-registered host path is the only way SandboxInstance rows get
+	// created. The server only nil-checks it and calls Run. See
+	// api/pkg/sandbox/compute and api/pkg/sandbox/compute/bootstrap.
+	computeManager *compute.PoolSupervisor
 }
 
 func NewServer(

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -195,8 +195,10 @@ type HelixAPIServer struct {
 	// compute.Provider (currently only yellowdog). Nil when
 	// HELIX_COMPUTE_PROVIDER is unset - in that case the legacy
 	// self-registered host path is the only way SandboxInstance rows
-	// get created. See api/pkg/sandbox/compute and api/pkg/sandbox/compute/bootstrap.
-	computeManager *compute.Manager
+	// get created. Concretely a *compute.Manager, or a
+	// *compute.PoolSupervisor in discovery mode - the server only calls
+	// Run. See api/pkg/sandbox/compute and api/pkg/sandbox/compute/bootstrap.
+	computeManager compute.Service
 }
 
 func NewServer(

--- a/design/2026-06-29-compute-floor-per-node-pool.md
+++ b/design/2026-06-29-compute-floor-per-node-pool.md
@@ -1,0 +1,149 @@
+# Compute Floor per Node Pool (discovery-driven)
+
+Date: 2026-06-29
+Status: Partial implementation (discovery + supervisor landed; wiring pending)
+Scope: control-plane compute provisioning (`api/pkg/sandbox/compute`)
+
+## Summary
+
+- Goal: with one NVIDIA pool and one Neuron pool brought up by the operator,
+  Helix keeps a floor of runners in EACH, without the operator declaring the
+  pools in config and without per-pool scaling policy.
+- Approach: the ComputeManager DISCOVERS pools at runtime from the YD API
+  (the operator's `yd-provision` is the only declaration), and one unchanged
+  Manager runs per discovered pool under ONE global scaling policy.
+- Status: the discovery primitive and the per-pool supervisor are implemented
+  and unit-tested. End-to-end wiring is gated on one prerequisite: the YD
+  provider is NVIDIA-only today (no GPU-vendor / device flags), so the inf2
+  half cannot run until that lands.
+
+## Why discovery, not a config pool list
+
+A first cut declared each pool in config (`pools: [...]`). Rejected by the
+operator on two grounds, both fair:
+
+1. Per-pool scaling policy is unwanted - Floor/Max/idle should be ONE global
+   policy, not tuned per pool.
+2. Declaring every pool ahead of time is heavy and duplicates what the
+   operator already expressed by running `yd-provision`.
+
+So the running pools are the source of truth. Helix asks the YD API "what
+pools exist right now?" each cycle and maintains the global floor in each.
+
+## What is a "node pool" here
+
+A distinct group of currently-online YD nodes sharing a `(workerTag,
+instanceType)`. The worker tag is what a work requirement must target; the
+instance type classifies the accelerator (which selects the sandbox image /
+GPU vendor). No new identity, no schema - both fields already ride on the YD
+`Node.details` object Helix was already fetching.
+
+## Implemented (this change)
+
+### 1. Discovery primitive - `yellowdog/node_discovery.go`
+
+Helix already called `GET /workerPools/nodes` (for worker-tag auto-discovery)
+but decoded only `workerTag`. Extended:
+
+- `nodeDetails` now also decodes `instanceType` (a real YD `NodeDetails`
+  field).
+- `fetchOnlineNodes()` extracted; both helpers share the one API call.
+- `DiscoverNodePools(ctx, cfg) []NodePool` groups online nodes by
+  `(workerTag, instanceType)` with a node count. Tag-less nodes dropped
+  (a WR can't target them). Sorted for stable output.
+- `DiscoverOnlineWorkerTags` refactored onto the shared fetch; behaviour and
+  existing tests unchanged.
+
+Tested: `TestDiscoverNodePools` (grouping, same-tag-different-type as distinct
+pools, tag-less drop).
+
+### 2. Per-pool supervisor - `compute/pool_supervisor.go`
+
+`PoolSupervisor` keeps one running Manager per discovered pool:
+
+- `PoolDiscoverer` interface (injected; keeps `compute` free of a YD import -
+  `yellowdog` imports `compute`, so the dependency cannot go the other way).
+- `ManagerFactory` interface - builds a Manager scoped to one pool, owning the
+  per-pool provider and applying the ONE global `ManagerConfig`.
+- Each reconcile diffs live pools against running Managers: start a Manager
+  when a pool appears, cancel its context when the pool's nodes are gone.
+- A discovery error leaves the current Manager set intact (transient YD blip
+  must not tear down healthy pre-warming).
+- `AcceleratorForInstanceType()` - prefix heuristic: `inf*/trn*` -> neuron,
+  `g*/p*` -> nvidia, else "". The small static map the operator agreed to.
+
+The existing `Manager` (Floor/D3/D4, all its guarded invariants) is NOT
+modified. The supervisor instantiates it N times.
+
+Tested: `TestPoolSupervisorStartsAndStopsManagers`,
+`...DiscoveryErrorKeepsManagers`, `...SkipsUnbuildablePool`,
+`TestAcceleratorForInstanceType`.
+
+## The isolation invariant (unchanged from the config-list design)
+
+Each pool's Manager must only see its own SandboxInstance rows.
+`Manager.ownedRows` filters by `provider.Name()` which is
+`"yellowdog-" + DeploymentTag`. So the factory MUST give each pool a distinct
+DeploymentTag (derived from the base tag + the worker tag). Otherwise pool A's
+Manager counts pool B's rows toward A's floor and they fight. This is the same
+worker-tag/deployment-tag separation the YD-side POC already relies on.
+
+## Dependency already in main: YD provider neuron plumbing
+
+The neuron path the supervisor relies on is ALREADY in main, so it is NOT part
+of this change:
+- `bash_script.sh` has a `GPU_VENDOR=neuron` branch (drops `--gpus`, enumerates
+  `/dev/neuron*`), and auto-detects the vendor on the host when unset.
+- `provider.taskEnvironment()` emits `GPU_VENDOR` from `Spec.GPUVendor`.
+- `config.Compute.GPUVendor` (`HELIX_COMPUTE_GPU_VENDOR`) is an optional
+  override, not the switch.
+
+This PR carries only the discovery primitive + the per-pool supervisor. When
+the factory (below) is wired, it sets `Spec.GPUVendor` per pool from the
+instance type, reusing that existing plumbing.
+
+## Not implemented - remaining wiring
+
+1. **The factory + supervisor wiring in `bootstrap` / `serve`.**
+   `bootstrap.Bootstrap` builds one Manager today. A discovery-mode branch
+   would instead build a `PoolDiscoverer` (adapting `DiscoverNodePools`) and a
+   `ManagerFactory` (per-pool provider: worker tag from the pool, isolated
+   DeploymentTag, accelerator-derived image/vendor; global `ManagerConfig`),
+   then return a `PoolSupervisor` for `serve.go` to `go Run`. Gated behind a
+   new `HELIX_COMPUTE_DISCOVER_POOLS` (or similar) so the single-Manager path
+   stays the default.
+
+2. **Global config knobs.** Floor/Max/idle already exist on `config.Compute`
+   and stay global - they are copied verbatim into every pool's Manager. No
+   per-pool config is added. (This is the whole point of the supervisor: one
+   policy, N pools.)
+
+## Edge cases / caveats
+
+- Pool removed from discovery -> its Manager is cancelled, but the Manager's
+  owned rows (now offline, since the nodes are gone) are not actively reaped
+  by anyone. The sandbox reaper flips them offline; a follow-up may want the
+  supervisor to drain a stopped pool's rows. Logged, not solved.
+- Mixed instance types under one worker tag show up as two pools, but YD
+  work-requirement placement is by worker tag ONLY - there is no instance-type
+  constraint on a WR. So if one tag genuinely spans accelerators (g5 + inf2),
+  the supervisor would build an nvidia Manager and a neuron Manager that both
+  submit WRs tagged the same, and YD could schedule the neuron task onto the
+  nvidia node (wrong `--gpus`/device flags). This is unsafe, not just untidy:
+  the factory MUST refuse to build per-accelerator Managers for a tag that
+  spans accelerators (or WRs must gain an instance-type constraint). Operators
+  should run one worker tag per accelerator (the natural setup). The
+  `DiscoveredPool.Key` contract reflects this - it is keyed on
+  (workerTag, instanceType) so the reconcile diff never collides two pools.
+- `AcceleratorForInstanceType` is a heuristic: `g4ad` (AMD) would mis-map to
+  nvidia. Out of scope for this POC (only g5 + inf2); add an explicit case if
+  an AMD pool ever appears.
+
+## Recommendation
+
+The discovery primitive and supervisor are the reusable core and are landed +
+tested. Do NOT wire the bootstrap discovery branch until the provider learns
+the neuron device-flag path - otherwise the feature can only floor NVIDIA
+pools, which the single-Manager path already does. Sequence: (1) provider
+GPU-vendor support, (2) bootstrap factory + supervisor wiring behind a flag,
+(3) flip the demo to it.

--- a/design/2026-06-29-compute-floor-per-node-pool.md
+++ b/design/2026-06-29-compute-floor-per-node-pool.md
@@ -142,16 +142,41 @@ point: one policy, N pools.)
   `DiscoveredPool.Key` contract reflects this - it is keyed on
   (workerTag, instanceType) so the reconcile diff never collides two pools.
 - `AcceleratorForInstanceType` is a heuristic: `g4ad` (AMD) would mis-map to
-  nvidia. Out of scope for this POC (only g5 + inf2); add an explicit case if
-  an AMD pool ever appears.
+  nvidia, and an unrecognised family returns "" so the factory errors and the
+  supervisor **skips that pool** (logged). There is no manual vendor override
+  anymore (`HELIX_COMPUTE_GPU_VENDOR` is vestigial). Acceptable for this POC
+  (g5 + inf2); add an explicit case when a new family appears.
+- **Zero online nodes => no pools => nothing provisions.** Discovery only sees
+  RUNNING nodes, so the floor is maintained only on pools that already have a
+  node. This is intended for the model "the operator brings up the YD pool;
+  Helix maintains a sandbox floor on whatever nodes exist" - Helix does not
+  bring the first node up from zero. (Behaviour change from the old
+  single-Manager path, which submitted floor WRs against a derived tag even at
+  zero - those just sat starved.)
+- **Shared API key sees foreign pools.** The old single-Manager path hard-erred
+  on multiple distinct worker tags; the supervisor instead manages *every*
+  discovered pool. If one YD API key's visibility spans another Helix install's
+  pools, this install will manage them too. Scope the API key per install.
+  (`HELIX_YD_WORKER_TAG` was removed, so there is no per-install tag filter.)
+
+## Review fixes applied
+
+- **Injective deployment tag.** `poolDeploymentTag` hashes the raw pool Key
+  (fnv-32a) into the tag, so two Keys that sanitise to the same readable string
+  (`team.a|...` vs `team_a|...`) no longer collide on `provider.Name()` and
+  share row ownership. Unit-tested (`TestPoolDeploymentTagInjective`).
+- **Eager Namespace validation** in `buildSupervisor` - empty namespace fails
+  boot instead of silently skipping every pool at reconcile.
+- **Context cleanup**: the self-remove goroutine calls `run.cancel()` so a
+  Manager that returns for a non-cancel reason doesn't leak its child context.
+- **Dropped the redundant `Service` interface** (identical to `PoolManager`
+  once the single-Manager path was gone); Bootstrap returns `*PoolSupervisor`.
+- Removed the now-dead `DiscoverOnlineWorkerTags`; `config.Yellowdog.WorkerTag`
+  (`HELIX_YD_WORKER_TAG`) deleted; pure `toDiscoveredPools` extracted + tested.
 
 ## Follow-ups (not in this change)
 
-- **Reject a worker tag that spans accelerators** in the factory (the caveat
-  above) - currently relies on the operator using one tag per accelerator.
-- **Drain a stopped pool's rows** when a pool disappears from discovery
-  (currently the Manager is cancelled but its offline rows are left to the
-  reaper).
-- `config.Compute.GPUVendor` (`HELIX_COMPUTE_GPU_VENDOR`) is now vestigial -
-  vendor is derived per pool from the instance type, and the runner also
-  auto-detects. Left in place for now; remove in a follow-up.
+- **Reject a worker tag that spans accelerators** in the factory - currently
+  relies on the operator using one tag per accelerator.
+- **Drain a stopped pool's rows** when a pool disappears from discovery.
+- Remove `config.Compute.GPUVendor` (`HELIX_COMPUTE_GPU_VENDOR`), now vestigial.

--- a/design/2026-06-29-compute-floor-per-node-pool.md
+++ b/design/2026-06-29-compute-floor-per-node-pool.md
@@ -1,7 +1,7 @@
 # Compute Floor per Node Pool (discovery-driven)
 
 Date: 2026-06-29
-Status: Partial implementation (discovery + supervisor landed; wiring pending)
+Status: Implemented. Discovery is the only mode - the single-Manager / single-worker-tag path has been removed.
 Scope: control-plane compute provisioning (`api/pkg/sandbox/compute`)
 
 ## Summary
@@ -12,10 +12,10 @@ Scope: control-plane compute provisioning (`api/pkg/sandbox/compute`)
 - Approach: the ComputeManager DISCOVERS pools at runtime from the YD API
   (the operator's `yd-provision` is the only declaration), and one unchanged
   Manager runs per discovered pool under ONE global scaling policy.
-- Status: the discovery primitive and the per-pool supervisor are implemented
-  and unit-tested. End-to-end wiring is gated on one prerequisite: the YD
-  provider is NVIDIA-only today (no GPU-vendor / device flags), so the inf2
-  half cannot run until that lands.
+- Status: discovery primitive, per-pool supervisor, AND the bootstrap/serve
+  wiring are implemented and unit-tested. Discovery is the ONLY mode - there is
+  no flag and no single-Manager fallback (that path, incl. worker-tag
+  resolution, was deleted). The neuron device plumbing it depends on is in main.
 
 ## Why discovery, not a config pool list
 
@@ -98,25 +98,31 @@ of this change:
 - `config.Compute.GPUVendor` (`HELIX_COMPUTE_GPU_VENDOR`) is an optional
   override, not the switch.
 
-This PR carries only the discovery primitive + the per-pool supervisor. When
-the factory (below) is wired, it sets `Spec.GPUVendor` per pool from the
-instance type, reusing that existing plumbing.
+The factory (below) sets `Spec.GPUVendor` per pool from the instance type,
+reusing that existing plumbing.
 
-## Not implemented - remaining wiring
+## Wiring (implemented)
 
-1. **The factory + supervisor wiring in `bootstrap` / `serve`.**
-   `bootstrap.Bootstrap` builds one Manager today. A discovery-mode branch
-   would instead build a `PoolDiscoverer` (adapting `DiscoverNodePools`) and a
-   `ManagerFactory` (per-pool provider: worker tag from the pool, isolated
-   DeploymentTag, accelerator-derived image/vendor; global `ManagerConfig`),
-   then return a `PoolSupervisor` for `serve.go` to `go Run`. Gated behind a
-   new `HELIX_COMPUTE_DISCOVER_POOLS` (or similar) so the single-Manager path
-   stays the default.
+The supervisor is the production path whenever the compute subsystem is enabled
+(`HELIX_COMPUTE_PROVIDER=yellowdog`). No flag, no single-Manager fallback:
 
-2. **Global config knobs.** Floor/Max/idle already exist on `config.Compute`
-   and stay global - they are copied verbatim into every pool's Manager. No
-   per-pool config is added. (This is the whole point of the supervisor: one
-   policy, N pools.)
+- `bootstrap.Bootstrap` returns a `compute.Service` (the shared `Run` contract;
+  here always a `*PoolSupervisor`). The old single-Manager construction and the
+  `buildProvider`/`resolveWorkerTag`/`discoverFn` worker-tag machinery were
+  deleted. `server.go`'s `computeManager` field is now `compute.Service`; the
+  boot site is unchanged (`go computeManager.Run(ctx)`).
+- `bootstrap/pool_discovery.go`: `ydPoolDiscoverer` adapts `DiscoverNodePools`
+  to `[]compute.DiscoveredPool` (Key = `workerTag|instanceType`);
+  `ydManagerFactory` builds one Manager per pool with the pool's worker tag, an
+  isolated `DeploymentTag` (`<base>-<sanitised key>`) for row-ownership, and
+  `Spec.GPUVendor` from `AcceleratorForInstanceType`. An unclassifiable
+  instance type errors and the supervisor skips that pool.
+- `managerConfig(cfg, spec)` is shared by the single and per-pool paths, so
+  Floor/Max/idle are identical everywhere - only the Spec (GPU vendor) differs.
+
+**Global config knobs.** Floor/Max/idle stay on `config.Compute` and are
+copied verbatim into every pool's Manager. No per-pool config. (The whole
+point: one policy, N pools.)
 
 ## Edge cases / caveats
 
@@ -139,11 +145,13 @@ instance type, reusing that existing plumbing.
   nvidia. Out of scope for this POC (only g5 + inf2); add an explicit case if
   an AMD pool ever appears.
 
-## Recommendation
+## Follow-ups (not in this change)
 
-The discovery primitive and supervisor are the reusable core and are landed +
-tested. Do NOT wire the bootstrap discovery branch until the provider learns
-the neuron device-flag path - otherwise the feature can only floor NVIDIA
-pools, which the single-Manager path already does. Sequence: (1) provider
-GPU-vendor support, (2) bootstrap factory + supervisor wiring behind a flag,
-(3) flip the demo to it.
+- **Reject a worker tag that spans accelerators** in the factory (the caveat
+  above) - currently relies on the operator using one tag per accelerator.
+- **Drain a stopped pool's rows** when a pool disappears from discovery
+  (currently the Manager is cancelled but its offline rows are left to the
+  reaper).
+- `config.Compute.GPUVendor` (`HELIX_COMPUTE_GPU_VENDOR`) is now vestigial -
+  vendor is derived per pool from the instance type, and the runner also
+  auto-detects. Left in place for now; remove in a follow-up.


### PR DESCRIPTION
## What

Replaces the single-Manager / single-worker-tag compute path with **runtime pool discovery**: whenever the compute subsystem is enabled (`HELIX_COMPUTE_PROVIDER=yellowdog`), a `PoolSupervisor` enumerates the live YD pools and runs **one Manager per pool** under one global Floor/Max/idle policy, with each pool's GPU vendor derived from its instance type. No flag, no fallback — discovery is how it works.

Rebased on current main; the neuron device plumbing it relies on is already there.

## Changes

- **Discovery** (`yellowdog/node_discovery.go`): `DiscoverNodePools` groups online nodes by `(workerTag, instanceType)` from `GET /workerPools/nodes` (instanceType now decoded; shares `fetchOnlineNodes`).
- **Supervisor** (`compute/pool_supervisor.go`): one unchanged `Manager` per discovered pool, started/stopped as pools appear/disappear; self-removes + rebuilds a Manager that exits on its own. `AcceleratorForInstanceType` classifies instance types (`g*`/`p*`→nvidia, `inf*`/`trn*`→neuron).
- **Wiring** (`bootstrap/pool_discovery.go`, `bootstrap.go`, `server.go`): `Bootstrap` returns a `compute.Service` (always the supervisor). `ydPoolDiscoverer` adapts discovery; `ydManagerFactory` builds a per-pool provider (pool worker tag, isolated `DeploymentTag` for row-ownership, per-pool `Spec.GPUVendor`), all sharing the global `ManagerConfig`. `server.go`'s `computeManager` is now `compute.Service`.
- **Removed**: the single-Manager construction plus `buildProvider` / `resolveWorkerTag` / `discoverFn` (worker tags come from discovery now), and their tests. `config.Compute.GPUVendor` is now vestigial (kept with a note).

## Tests

`pkg/sandbox/compute/...`, `pkg/config`, `pkg/server` green; supervisor tests `-race` clean. Covers grouping, supervisor start/stop/rebuild/skip, accelerator classification, factory classification + tag sanitization, and Bootstrap returning a supervisor.

Design: `design/2026-06-29-compute-floor-per-node-pool.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)