### PR TITLE
feat(server): generic configurable reverse-proxy endpoint

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -889,6 +889,17 @@ type WebServer struct {
 	// legacy global API key) with Zone:Zone:Read + Zone:DNS:Edit
 	// permissions on the zones Helix issues certs for.
 	VHostCloudflareAPIToken string `envconfig:"HELIX_VHOST_CLOUDFLARE_API_TOKEN" description:"Cloudflare API token (Zone:Zone:Read + Zone:DNS:Edit) used when HELIX_VHOST_ACME_DNS_PROVIDER=cloudflare."`
+
+	// ProxyPathPrefix + ProxyUpstream configure a single generic reverse
+	// proxy: requests whose path starts with ProxyPathPrefix are forwarded
+	// to ProxyUpstream (the original Host and X-Forwarded-* headers are
+	// preserved). Both must be set for the route to mount; empty = disabled.
+	// This is deliberately generic (not tied to any one service) — its first
+	// use is fronting an external OIDC IdP (e.g. Keycloak at /auth/) when
+	// Helix terminates TLS for the canonical host itself, so the IdP path
+	// keeps working without a separate reverse proxy.
+	ProxyPathPrefix string `envconfig:"HELIX_PROXY_PATH_PREFIX" description:"Path prefix to reverse-proxy to HELIX_PROXY_UPSTREAM (e.g. '/auth/'). Requires HELIX_PROXY_UPSTREAM. Empty disables."`
+	ProxyUpstream   string `envconfig:"HELIX_PROXY_UPSTREAM" description:"Upstream base URL for HELIX_PROXY_PATH_PREFIX (e.g. 'http://keycloak:8080'). Empty disables."`
 }
 
 // AdminAllUsers is the special value for ADMIN_USER_IDS that makes all users admins

--- a/api/pkg/server/path_proxy.go
+++ b/api/pkg/server/path_proxy.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/rs/zerolog/log"
+)
+
+// mountConfiguredProxy mounts a single generic reverse proxy when both
+// HELIX_PROXY_PATH_PREFIX and HELIX_PROXY_UPSTREAM are set: requests whose
+// path starts with the prefix are forwarded to the upstream, with the
+// original Host preserved and X-Forwarded-* set. It is deliberately not
+// tied to any specific service — the first use is fronting an external
+// OIDC IdP (e.g. Keycloak at /auth/) when Helix terminates TLS itself, so
+// that path keeps reaching the IdP without a separate reverse proxy.
+//
+// It must be registered before the SPA catch-all ("/") so the prefix wins.
+// A no-op when either var is empty.
+func (apiServer *HelixAPIServer) mountConfiguredProxy(router *mux.Router) error {
+	prefix := strings.TrimSpace(apiServer.Cfg.WebServer.ProxyPathPrefix)
+	upstream := strings.TrimSpace(apiServer.Cfg.WebServer.ProxyUpstream)
+	if prefix == "" && upstream == "" {
+		return nil
+	}
+	if prefix == "" || upstream == "" {
+		return fmt.Errorf("HELIX_PROXY_PATH_PREFIX and HELIX_PROXY_UPSTREAM must both be set (got prefix=%q upstream=%q)", prefix, upstream)
+	}
+	if !strings.HasPrefix(prefix, "/") {
+		return fmt.Errorf("HELIX_PROXY_PATH_PREFIX must start with '/' (got %q)", prefix)
+	}
+
+	target, err := url.Parse(upstream)
+	if err != nil {
+		return fmt.Errorf("invalid HELIX_PROXY_UPSTREAM %q: %w", upstream, err)
+	}
+	if target.Scheme == "" || target.Host == "" {
+		return fmt.Errorf("HELIX_PROXY_UPSTREAM %q must be an absolute URL (scheme://host)", upstream)
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			// Preserve the inbound Host so the upstream (e.g. an IdP that
+			// derives issuer/redirect URLs from it) sees the public name.
+			if req.Header.Get("X-Forwarded-Host") == "" {
+				req.Header.Set("X-Forwarded-Host", req.Host)
+			}
+			if req.Header.Get("X-Forwarded-Proto") == "" {
+				// Helix terminates TLS for the canonical host, so inbound is https.
+				proto := "https"
+				if req.TLS == nil {
+					proto = "http"
+				}
+				req.Header.Set("X-Forwarded-Proto", proto)
+			}
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+			// Keep req.Host as the inbound public host (do not overwrite with
+			// the upstream host) so the IdP keeps generating public URLs.
+		},
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
+			log.Error().Err(err).Str("upstream", upstream).Msg("configured path proxy: upstream error")
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+		},
+	}
+
+	router.PathPrefix(prefix).Handler(proxy)
+	log.Info().Str("prefix", prefix).Str("upstream", upstream).Msg("mounted configured reverse proxy")
+	return nil
+}

--- a/api/pkg/server/path_proxy_test.go
+++ b/api/pkg/server/path_proxy_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/config"
+)
+
+func newProxyTestServer(prefix, upstream string) *HelixAPIServer {
+	return &HelixAPIServer{
+		Cfg: &config.ServerConfig{
+			WebServer: config.WebServer{
+				ProxyPathPrefix: prefix,
+				ProxyUpstream:   upstream,
+			},
+		},
+	}
+}
+
+func TestMountConfiguredProxy_DisabledWhenUnset(t *testing.T) {
+	s := newProxyTestServer("", "")
+	r := mux.NewRouter()
+	if err := s.mountConfiguredProxy(r); err != nil {
+		t.Fatalf("expected nil error when unset, got %v", err)
+	}
+	// No route should be registered → catch-all 404.
+	r.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot) // sentinel: fell through to catch-all
+	})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "http://app.helix.ml/auth/realms/helix", nil))
+	if rec.Code != http.StatusTeapot {
+		t.Fatalf("expected fall-through to catch-all (418), got %d", rec.Code)
+	}
+}
+
+func TestMountConfiguredProxy_ErrorWhenHalfSet(t *testing.T) {
+	for _, tc := range []struct{ prefix, upstream string }{
+		{"/auth/", ""},
+		{"", "http://keycloak:8080"},
+		{"auth/", "http://keycloak:8080"}, // missing leading slash
+		{"/auth/", "://bad"},
+	} {
+		s := newProxyTestServer(tc.prefix, tc.upstream)
+		if err := s.mountConfiguredProxy(mux.NewRouter()); err == nil {
+			t.Fatalf("expected error for prefix=%q upstream=%q, got nil", tc.prefix, tc.upstream)
+		}
+	}
+}
+
+func TestMountConfiguredProxy_ForwardsPreservingHost(t *testing.T) {
+	var gotPath, gotHost, gotXFH, gotXFP string
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		gotPath = req.URL.Path
+		gotHost = req.Host
+		gotXFH = req.Header.Get("X-Forwarded-Host")
+		gotXFP = req.Header.Get("X-Forwarded-Proto")
+	}))
+	defer upstream.Close()
+
+	s := newProxyTestServer("/auth/", upstream.URL)
+	r := mux.NewRouter()
+	if err := s.mountConfiguredProxy(r); err != nil {
+		t.Fatalf("mountConfiguredProxy: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "http://app.helix.ml/auth/realms/helix/protocol", nil))
+
+	if gotPath != "/auth/realms/helix/protocol" {
+		t.Errorf("upstream path = %q, want /auth/realms/helix/protocol", gotPath)
+	}
+	if gotHost != "app.helix.ml" {
+		t.Errorf("upstream Host = %q, want app.helix.ml (inbound host preserved)", gotHost)
+	}
+	if gotXFH != "app.helix.ml" {
+		t.Errorf("X-Forwarded-Host = %q, want app.helix.ml", gotXFH)
+	}
+	if gotXFP != "http" { // httptest.NewRequest has no TLS → http
+		t.Errorf("X-Forwarded-Proto = %q, want http", gotXFP)
+	}
+}
+
+func TestMountConfiguredProxy_NonPrefixPathUntouched(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway) // should never be hit for /api
+	}))
+	defer upstream.Close()
+
+	s := newProxyTestServer("/auth/", upstream.URL)
+	r := mux.NewRouter()
+	if err := s.mountConfiguredProxy(r); err != nil {
+		t.Fatalf("mountConfiguredProxy: %v", err)
+	}
+	r.PathPrefix("/api/").HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "http://app.helix.ml/api/v1/whatever", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("non-prefix path should not be proxied, got %d", rec.Code)
+	}
+}

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -847,6 +847,13 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	// if there is a token we will assign the user if not then oh well no user it's all gravy
 	router.Use(ErrorLoggingMiddleware)
 
+	// Optional generic reverse proxy (HELIX_PROXY_PATH_PREFIX → HELIX_PROXY_UPSTREAM).
+	// Registered on the bare router (no auth/CSRF) and before the SPA catch-all so
+	// the prefix wins — e.g. /auth/ → external IdP when Helix terminates TLS itself.
+	if err := apiServer.mountConfiguredProxy(router); err != nil {
+		return nil, err
+	}
+
 	// insecure router is under /api/v1 but not protected by auth
 	insecureRouter := router.PathPrefix(APIPrefix).Subrouter()
 

--- a/design/2026-06-25-prod-tls-sni-split.md
+++ b/design/2026-06-25-prod-tls-sni-split.md
@@ -1,0 +1,74 @@
+# Prod TLS: Helix certmagic terminates all Helix domains; nginx keeps legacy; Cloudflare stays on
+
+Date: 2026-06-25 (revised 2026-06-29). Decision (Luke): **Helix terminates TLS (certmagic) for all
+its own domains — `app.helix.ml`, `*.apps.helix.ml`, and customer custom domains — while nginx keeps
+terminating the legacy/infra domains (registry, get, demos, kodit, marketing, docs, posthog, k8s…)
+on their existing certbot certs.** This makes custom-domain TLS self-serve and consolidates Helix TLS
+under certmagic, matching how `meta.helix.ml` already runs.
+
+## Key constraints (verified against live prod + code, 2026-06-29)
+- **Cloudflare proxy stays ON (orange) for all Helix domains, incl. custom ones.** `app.helix.ml` is
+  already orange; `*.apps.helix.ml` is currently grey and moves to orange.
+- **Behind CF orange, LE network challenges can't reach the origin** → certmagic must use **DNS-01
+  via Cloudflare** for `*.helix.ml`.
+- **`app.helix.ml` is path-coupled to Keycloak.** The OIDC issuer is
+  `https://app.helix.ml/auth/realms/helix`; nginx currently routes `/auth/*` → the Keycloak
+  container. An SNI router can't path-split, and Helix doesn't proxy `/auth`. So Helix must proxy
+  `/auth/*` → Keycloak itself when it terminates `app.helix.ml`.
+- **certmagic binds `:443`/`:80` inside the container** (`vhost_tls.go`, hardcoded). Keep it; use a
+  docker host **loopback** port so nginx can own `:443` as an SNI router. Overlay port is
+  env-configurable (`${VHOST_HTTPS_PORT:-443}:443`).
+- **certmagic shares the same router** as the plain HTTP listener, so the `/auth` proxy + vhost
+  routing work identically under TLS. The cert gate (`vhostShouldIssueCert`) already allows canonical
+  hostnames + any `vhost_routes` row.
+
+## Architecture
+```
+nginx :443 → stream { ssl_preread on; map $ssl_preread_server_name → backend }
+  legacy SNIs → 127.0.0.1:8443   (existing nginx http server blocks, certbot, unchanged)
+  app.helix.ml, *.apps.helix.ml, default → 127.0.0.1:8444   (Helix api container :443, certmagic)
+nginx :80 → keep for legacy certbot renew + http→https redirects
+Helix api: HELIX_VHOST_TLS_MODE=auto, certs in filestore, generic proxy /auth/ → keycloak:8080
+custom domains → CF for SaaS edge (optional) → origin → Helix (LE cert it issued) → route by Host
+```
+
+## Generic reverse proxy (NOT Keycloak-specific) — shipped
+A single configurable reverse proxy mounts when both `HELIX_PROXY_PATH_PREFIX` and
+`HELIX_PROXY_UPSTREAM` are set: requests under the prefix are forwarded to the upstream, **Host
+preserved** + `X-Forwarded-*` set. Mounted on the bare router (no auth/CSRF) before the SPA
+catch-all. Empty = disabled (meta uses Google OIDC and leaves it empty). On prod:
+`HELIX_PROXY_PATH_PREFIX=/auth/`, `HELIX_PROXY_UPSTREAM=http://keycloak-config-keycloak-1:8080`,
+which keeps the issuer URL intact. Code: `api/pkg/server/path_proxy.go`, mounted in
+`registerRoutes` (`server.go`); config in `api/pkg/config/config.go`.
+
+## Custom-domain certs: Helix issues its own (no Cloudflare required)
+Custom domains must work **with or without** Cloudflare. To get a valid cert on the CF→origin hop
+(or directly), Helix issues the cert itself. Challenge selection is **per-name** (a Stage-2 code
+item — the deployed single global DNS-01 solver disables HTTP-01/ALPN for all names):
+- `*.helix.ml` (behind CF orange) → **DNS-01 via Cloudflare** (our zone, our token).
+- custom domain pointed **directly** at us (grey/no CF) → **HTTP-01 / TLS-ALPN-01** — the customer
+  just points DNS at us; that A/CNAME is the proof of control. **No extra record, no UI needed.**
+- custom domain behind **their** Cloudflare (orange) → **DNS-01 CNAME delegation**: a one-time
+  `_acme-challenge.<host>` CNAME into `helix.ml` (certmagic v0.25.3 follows cross-zone CNAMEs; add
+  explicit public `Resolvers` for reliability). A small "add this record" UI helps here only.
+
+The cert gate already allows any `vhost_routes` hostname; custom-domain verification exists
+(`/.well-known/helix-domain-verify`). Cloudflare-for-SaaS is only the *edge* option, not required.
+
+## Stages
+- **Stage 0 (code, this PR):** generic configurable reverse proxy + tests. (Per-name challenge
+  selection + `Resolvers` come in Stage 2.) Remove dead `PORT_NOXY` (prod `.env`).
+- **Stage 1 (prod):** enable certmagic DNS-01 on loopback `127.0.0.1:8444`; convert nginx `:443` to
+  `stream`+`ssl_preread` (legacy→`8443` certbot, app+apps+default→`8444`); flip `*.apps.helix.ml` to
+  CF orange. Pre-warm certs; cut over with an `nginx reload`; instant rollback via config backup.
+  Set prod `.env`: `HELIX_VHOST_TLS_MODE=auto`, `HELIX_VHOST_ACME_DNS_PROVIDER=cloudflare`,
+  `HELIX_VHOST_CLOUDFLARE_API_TOKEN`, `HELIX_VHOST_LETSENCRYPT_EMAIL`, `HELIX_PROXY_PATH_PREFIX=/auth/`,
+  `HELIX_PROXY_UPSTREAM=http://keycloak-config-keycloak-1:8080`.
+- **Stage 2 (custom domains):** per-name challenge selection (DNS-01 for `helix.ml`, HTTP-01/ALPN for
+  custom) in `buildACMEChallengeSolver` (`vhost_tls_dns.go`) + re-enable `:80` for HTTP-01; optional
+  CF-for-SaaS edge; optional "add this DNS record" UI for the orange-custom-domain case.
+
+## Risk
+High blast radius — `:443` carries registry image pulls, the `app.helix.ml` console+auth, and demos.
+Pre-warm certs + loopback-first + nginx config backup keep the cutover to a reload with instant
+rollback. Ship Stage 0, then Stage 1, then Stage 2 as separate verified steps.


### PR DESCRIPTION
Adds a single, **service-agnostic** reverse proxy to the Helix API, gated on two env vars:

- `HELIX_PROXY_PATH_PREFIX` (e.g. `/auth/`)
- `HELIX_PROXY_UPSTREAM` (e.g. `http://keycloak:8080`)

Requests whose path starts with the prefix are forwarded to the upstream with the **inbound Host preserved** and `X-Forwarded-Host`/`X-Forwarded-Proto` set. Mounted on the bare router (no auth/CSRF) before the SPA catch-all so the prefix wins. No-op when either var is unset.

### Why
Part of the prod TLS plan (`design/2026-06-25-prod-tls-sni-split.md`): we want Helix to terminate TLS (certmagic) for `app.helix.ml` itself. But prod's OIDC issuer is `https://app.helix.ml/auth/realms/helix`, and today nginx path-routes `/auth/*` to the Keycloak container. An SNI router can't path-split, so Helix must forward `/auth/*` to Keycloak itself. This is deliberately **generic**, not Keycloak-specific — on prod it's configured `/auth/` → Keycloak; meta (Google OIDC) leaves it empty and is unaffected.

### Tests
`TestMountConfiguredProxy_*` cover: disabled-when-unset, error-on-half-set/bad-input, forwarding with Host + X-Forwarded-* preserved, and non-prefix paths untouched. `go build ./pkg/server/` + `go test ./pkg/server/ -run TestMountConfiguredProxy` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)