### PR TITLE
fix(sandbox): never place sandboxes on non-render-capable (inf2/neuron) hosts

### DIFF
--- a/api/pkg/sandbox/compute/manager.go
+++ b/api/pkg/sandbox/compute/manager.go
@@ -414,8 +414,11 @@ func (m *Manager) demandPressureExists(rows []*types.SandboxInstance) bool {
 	for _, r := range rows {
 		// Capacity math uses only REACHABLE hosts. A Ready+offline
 		// row contributes no live sandbox slots, so counting it would
-		// hide real demand pressure.
-		if !isReadyAndOnline(r) {
+		// hide real demand pressure. Non-render-capable hosts (neuron)
+		// can't run sandboxes at all, so they never contribute sandbox
+		// capacity or absorb demand - exclude them so a neuron fleet
+		// never masks real desktop demand nor scales up to "meet" it.
+		if !isReadyAndOnline(r) || !r.CanHostSandbox() {
 			continue
 		}
 		readyAny = true
@@ -482,7 +485,7 @@ func (m *Manager) tryDeprovisionIdle(ctx context.Context, rows []*types.SandboxI
 		}
 		readyByID[r.ID] = r
 		readyCount++
-		if isReadyAndOnline(r) && r.MaxSandboxes > 0 && r.ActiveSandboxes >= r.MaxSandboxes {
+		if isReadyAndOnline(r) && r.CanHostSandbox() && r.MaxSandboxes > 0 && r.ActiveSandboxes >= r.MaxSandboxes {
 			fleetAtCap = true
 		}
 	}
@@ -751,7 +754,12 @@ func (m *Manager) computeNeeded(rows []*types.SandboxInstance) int {
 		if isAliveForFloor(r) {
 			aliveForFloor++
 		}
-		if isReadyAndOnline(r) {
+		// Sandbox demand (D3) is satisfied only by render-capable hosts;
+		// a neuron host has no sandbox slots, so it must not count toward
+		// capacity/demand or it would suppress real scale-up. Floor
+		// counting above (isAliveForFloor) stays vendor-blind so a neuron
+		// floor runner is still kept alive.
+		if isReadyAndOnline(r) && r.CanHostSandbox() {
 			readyOnlineCount++
 			readyCapacity += int(r.MaxSandboxes)
 			readyDemand += int(r.ActiveSandboxes)

--- a/api/pkg/sandbox/compute/manager_test.go
+++ b/api/pkg/sandbox/compute/manager_test.go
@@ -707,6 +707,31 @@ func TestD3DisabledWhenMaxZero(t *testing.T) {
 	}
 }
 
+func TestD3IgnoresNonRenderCapableCapacity(t *testing.T) {
+	// A neuron host at near-full sandbox capacity must NOT trigger D3
+	// scale-up: sandboxes can't run on it, so its slots are not real
+	// demand pressure. The host still satisfies Floor (floor counting is
+	// vendor-blind), so the Manager provisions nothing this cycle.
+	// Contrast with TestD3ScalesUpWhenHeadroomBelowMin (same shape, nvidia).
+	m, _, store := newD3Manager(t, 1, 3, 2)
+	_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+		ID:              "sbx_neuron",
+		Provider:        "stub",
+		ComputeState:    string(StateReady),
+		Status:          "online",
+		ActiveSandboxes: 9,
+		MaxSandboxes:    10,
+		GPUVendor:       "neuron", // inf2: cannot host sandboxes
+	})
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	rows, _ := store.ListSandboxInstances(context.Background())
+	if len(rows) != 1 {
+		t.Fatalf("neuron capacity must not drive D3 scale-up; expected 1 row, got %d", len(rows))
+	}
+}
+
 func TestD3ScalesUpWhenHeadroomBelowMin(t *testing.T) {
 	// Floor=1, Max=3, HeadroomMin=2: a single Ready host using 9/10
 	// slots leaves 1 free, which is below 2. Manager must provision

--- a/api/pkg/sandbox/controller_provision.go
+++ b/api/pkg/sandbox/controller_provision.go
@@ -434,7 +434,10 @@ func (c *Controller) pickHostForSandbox(ctx context.Context, sandbox *types.Sand
 		return nil, fmt.Errorf("list hosts: %w", err)
 	}
 	for _, h := range hosts {
-		if h.Status == "online" {
+		// Headless sandboxes are still sandboxes - keep them off
+		// non-render-capable (e.g. neuron/inf2) hosts, which are
+		// inference-only.
+		if h.Status == "online" && h.CanHostSandbox() {
 			return h, nil
 		}
 	}

--- a/api/pkg/store/store_sandbox.go
+++ b/api/pkg/store/store_sandbox.go
@@ -301,6 +301,12 @@ func (s *PostgresStore) FindAvailableSandboxInstance(ctx context.Context, deskto
 
 	// Find one with the required desktop version
 	for _, instance := range instances {
+		// Sandboxes only run on render-capable hosts. A neuron/inf2 host
+		// (no /dev/dri render node) would otherwise be picked on load
+		// alone, then the desktop container FATALs at startup.
+		if !instance.CanHostSandbox() {
+			continue
+		}
 		if len(instance.DesktopVersions) > 0 {
 			var versions map[string]string
 			if err := json.Unmarshal(instance.DesktopVersions, &versions); err != nil {

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -3344,6 +3344,21 @@ func (SandboxInstance) TableName() string {
 	return "sandbox_instances"
 }
 
+// CanHostSandbox reports whether this host can run a sandbox (desktop or
+// headless dev container). Sandboxes need display/encode hardware, so we
+// exclude the accelerators that lack it: AWS Inferentia/Trainium
+// (GPUVendor "neuron") has no /dev/dri render node - its desktop startup
+// FATALs - and "none" is a CPU-only host. A SOFTWARE render node has no
+// hardware encoder for streaming. Everything else (nvidia / amd / intel,
+// and not-yet-reported hosts) is treated as capable.
+func (s *SandboxInstance) CanHostSandbox() bool {
+	switch s.GPUVendor {
+	case "neuron", "none":
+		return false
+	}
+	return s.RenderNode != "SOFTWARE"
+}
+
 // SandboxHeartbeatRequest is sent by sandbox-heartbeat daemon every 30 seconds
 type SandboxHeartbeatRequest struct {
 	// Desktop image versions (content-addressable Docker image hashes)

--- a/api/pkg/types/types_test.go
+++ b/api/pkg/types/types_test.go
@@ -7,6 +7,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSandboxInstanceCanHostSandbox(t *testing.T) {
+	cases := []struct {
+		name   string
+		vendor string
+		render string
+		want   bool
+	}{
+		{"nvidia gpu", "nvidia", "/dev/dri/renderD128", true},
+		{"amd gpu", "amd", "/dev/dri/renderD128", true},
+		{"intel gpu", "intel", "/dev/dri/renderD128", true},
+		{"neuron excluded", "neuron", "", false},
+		{"none excluded", "none", "", false},
+		{"software render excluded", "nvidia", "SOFTWARE", false},
+		{"unreported treated as capable", "", "", true},
+	}
+	for _, tc := range cases {
+		s := &SandboxInstance{GPUVendor: tc.vendor, RenderNode: tc.render}
+		if got := s.CanHostSandbox(); got != tc.want {
+			t.Errorf("%s: CanHostSandbox()=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
 func Test_SessionChatRequest_PlainString(t *testing.T) {
 	request := &SessionChatRequest{
 		Messages: []*Message{


### PR DESCRIPTION
## Problem

Mixed-accelerator fleets exposed a placement bug: sandbox host selection was **vendor-blind**, so a neuron/inf2 host (no `/dev/dri` render node) could be picked for a sandbox on load alone, then the desktop container FATALs at startup (`detect-render-node.sh` has no neuron case). Inference routes by model (vendor-aware via profiles) and is unaffected — this is purely sandbox-host placement + scaling.

## Change

- `types.SandboxInstance.CanHostSandbox()`: excludes `GPUVendor` in {neuron, none} and `RenderNode == SOFTWARE`; nvidia/amd/intel qualify (we run sandboxes on amd too — the rule is "not inf2", not "nvidia-only").
- **Placement**: `FindAvailableSandboxInstance` (desktop) and the headless path in `pickHostForSandbox` skip non-capable hosts.
- **Scaling**: `demandPressureExists`, `computeNeeded`, and the D4 fleet-at-cap check only count sandbox capacity on render-capable hosts — a neuron fleet never masks real desktop demand nor scales up to "meet" it. Floor counting stays vendor-blind so a neuron floor runner is kept alive to serve inference.

## Tests

`TestSandboxInstanceCanHostSandbox`, `TestD3IgnoresNonRenderCapableCapacity`. Full `pkg/sandbox/compute` + `pkg/types` suites green; vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)