### PR TITLE
fix(compute): don't let Max ceiling starve Floor with offline orphans

### DIFF
--- a/api/pkg/sandbox/compute/manager.go
+++ b/api/pkg/sandbox/compute/manager.go
@@ -833,6 +833,25 @@ func (m *Manager) computeNeeded(rows []*types.SandboxInstance) int {
 		if totalNeed > room {
 			totalNeed = room
 		}
+
+		// Floor is a hard guarantee and NewManager enforces Max >= Floor,
+		// so the ceiling must never starve floor provisioning. `available`
+		// counts Ready+offline rows (deliberately - see isAvailable, it
+		// stops D4-shed churn), but those orphans are NOT healthy capacity
+		// (isAliveForFloor excludes them). When enough of them accumulate
+		// to fill Max while zero Ready+online hosts remain, room hits 0 and
+		// floorNeed>0 is clamped away - the fleet wedges at 0 healthy hosts
+		// indefinitely (D4 can only reap one orphan per cycle and its
+		// in-memory idle timer resets on every API restart, so long-lived
+		// orphans may never be shed). Re-floor here so the operator's
+		// healthy-capacity guarantee is honoured; the dead orphans still
+		// count against Max for the *demand* path above, and D4 reaps them.
+		// This can transiently exceed Max by up to floorNeed, self-correcting
+		// once D4 sheds the orphans (Max >= Floor keeps the steady state in
+		// bounds).
+		if totalNeed < floorNeed {
+			totalNeed = floorNeed
+		}
 	}
 
 	// Per-cycle provisioning fan-out cap (D1/D2 behaviour preserved).

--- a/api/pkg/sandbox/compute/manager_floor_offline_test.go
+++ b/api/pkg/sandbox/compute/manager_floor_offline_test.go
@@ -150,6 +150,62 @@ func TestReconcileMaxCeilingHonoursOwnedOfflineRows(t *testing.T) {
 	}
 }
 
+// TestReconcileFloorNotStarvedByOfflineOrphansAtMax is the regression
+// test for the yd.helix.ml wedge on 2026-06-29. Ready+offline orphan
+// rows count toward the Max ceiling (isAvailable, anti-churn) but NOT
+// toward the Floor (isAliveForFloor). When enough orphans accumulate to
+// fill Max while zero Ready+online hosts remain, the ceiling clamped
+// floorNeed to 0 and the fleet sat at 0 healthy hosts indefinitely -
+// Reconcile did nothing and logged nothing (computeNeeded=0).
+//
+// Observed in production: Floor=1, Max=3, 8 Ready+offline orphans (days
+// old). Post-fix, the Floor guarantee overrides the ceiling so a
+// replacement is provisioned; the orphans still bound the demand path
+// and D4 reaps them.
+func TestReconcileFloorNotStarvedByOfflineOrphansAtMax(t *testing.T) {
+	store := newFakeStore()
+	stub := NewStubProvider("stub")
+	m, err := NewManager(stub, store, ManagerConfig{
+		Floor:                   1,
+		Max:                     3,
+		MaxConcurrentProvisions: 1,
+		ReconcileInterval:       10 * time.Millisecond,
+		HealthCheckTimeout:      100 * time.Millisecond,
+		IdleTimeout:             time.Hour, // keep D4 out of this cycle
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// Three Ready+offline orphans == Max. Zero Ready+online hosts.
+	for _, id := range []string{"sbx-orphan-1", "sbx-orphan-2", "sbx-orphan-3"} {
+		_ = store.RegisterSandboxInstance(context.Background(), &types.SandboxInstance{
+			ID:           id,
+			Provider:     "stub",
+			ProviderID:   "wr-" + id,
+			ComputeState: string(StateReady),
+			Status:       "offline",
+		})
+	}
+
+	if err := m.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	rows, _ := store.ListSandboxInstances(context.Background())
+	provisioning := 0
+	for _, r := range rows {
+		if r.Provider == "stub" && r.ComputeState == string(StateProvisioning) {
+			provisioning++
+		}
+	}
+	if provisioning != 1 {
+		t.Fatalf("Floor=1 with %d Ready+offline orphans filling Max=3 must still provision "+
+			"1 healthy replacement (Floor is a hard guarantee, Max>=Floor); got %d. all: %+v",
+			3, provisioning, rows)
+	}
+}
+
 // TestReconcileFloor2MixedRows locks in the count math when the input
 // is a mix of Ready+online and Ready+offline rows. Floor=2, one online
 // row, one offline row -> aliveForFloor=1, floorNeed=1, exactly one


### PR DESCRIPTION
## The bug

On y*.helix.ml the ComputeManager wedged at **0 healthy hosts** and provisioned nothing - silently (no logs). Root caue: `Ready`+`offline` orphan rows count toward the **Max** ceiling (`isAvailable`, deliberately, to prevent D4-shed churn) but **not** toward the **Floor** (`isAliveForFloor`). When orphans accumulate to fill `Max` while zero `Ready`+`online` hosts remain:

- `floorNeed = 1` (orphans don't satisfy floor)
- `available = Max` → `room = Max - available = 0`
- `totalNeed = min(floorNeed, room) = 0` → never provisions

D4 can't recover fast enough: it reaps one orphan per cycle and its in-memory `idleSince` timer resets on every API restart, so long-lived orphans may never cross `IdleTimeout`. Production state: `Floor=1`, `Max=3`, 8 `Ready`+`offline` orphans days old.

## The fix

Re-floor after the ceiling clamp. `Floor` is a hard guarantee and `NewManager` already enforces `Max >= Floor`, so the ceiling must never starve floor provisioning:

```go
if totalNeed < floorNeed {
    totalNeed = floorNeed
}
```

Orphans still bound the **demand (D3)** path and D4 still reaps them. The transient overshoot is at most `floorNeed` and self-corrects once D4 sheds the orphans. `isAvailable`'s deliberate anti-churn breadth is untouched.

## Tests

- New `TestReconcileFloorNotStarvedByOfflineOrphansAtMax` reproduces the exact wedge (Floor=1, Max=3, orphans == Max → expects 1 provision).
- Existing `TestReconcileMaxCeilingHonoursOwnedOfflineRows` (Floor=0/Max=1 → 0 provisions) still passes - the re-floor is a no-op when `floorNeed=0`.
- Full `pkg/sandbox/compute` suite green.

## Operational note

The orphan rows on y*.helix.ml were manually deleted to unblock a demo; this fix prevents recurrence. A separate follow-up worth considering: a reaper for `Ready`+`offline` rows so they don't rely solely on D4's in-memory timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)