### PR TITLE
fix(sandbox): default-expand HYDRA env vars to survive leaked set -u

### DIFF
--- a/sandbox/10-start-hydra.sh
+++ b/sandbox/10-start-hydra.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 set -e
 
+# Default-expand every env var below (${VAR:-...}). This script is SOURCED by
+# entrypoint.sh into the same shell as the other cont-init scripts, and a
+# sibling (05-start-dns-proxy.sh) runs `set -u` at top level - which leaks in
+# and makes any bare unset reference here a fatal "unbound variable". Only
+# install.sh-launched runners set HYDRA_PRIVILEGED_MODE_ENABLED; YD-launched
+# runners do not, so a bare reference aborted container init on them. Defaulting
+# keeps the script correct regardless of which caller set which var.
+
 # Skip if Hydra is not enabled
 # NOTE: Use "return" not "exit" - this script is sourced by entrypoint.sh!
-if [ "$HYDRA_ENABLED" != "true" ]; then
+if [ "${HYDRA_ENABLED:-false}" != "true" ]; then
     echo "ℹ️  Hydra not enabled (HYDRA_ENABLED != true), skipping multi-Docker isolation"
     return 0
 fi
@@ -51,7 +59,7 @@ done
 echo "✅ Hydra socket ready at /var/run/hydra/hydra.sock"
 
 # Log privileged mode status
-if [ "$HYDRA_PRIVILEGED_MODE_ENABLED" = "true" ]; then
+if [ "${HYDRA_PRIVILEGED_MODE_ENABLED:-false}" = "true" ]; then
     echo "⚠️  Hydra PRIVILEGED MODE ENABLED - host Docker access available for Helix development"
 else
     echo "ℹ️  Hydra running in normal mode (isolated Docker instances per scope)"


### PR DESCRIPTION
## The bug

Every YellowDog-provisioned sandbox fails at hydra init - the YD task exits 1, the runner never registers. The container log shows:

```
/etc/cont-init.d/70-start-hydra.sh: line 54: HYDRA_PRIVILEGED_MODE_ENABLED: unbound variable
```

## Root cause

Three things combine:

1. `10-start-hydra.sh` references `$HYDRA_PRIVILEGED_MODE_ENABLED` (and `$HYDRA_ENABLED`) **bare**.
2. It's **sourced** by `entrypoint.sh` into the same shell as the other cont-init scripts. `05-start-dns-proxy.sh` runs `set -u` at top level (added when it was reworked into a supervised script), which **leaks** into this later-sourced script.
3. Only `install.sh`-launched runners set `HYDRA_PRIVILEGED_MODE_ENABLED` (`install.sh:2823`). **YD-launched runners never do** - the compute manager's `yellowdog` provider `bash_script.sh` doesn't pass it.

So on YD runners the bare reference is unset, `set -u` makes it fatal, `set -e` aborts container init. This worked on `2.11.16` (the 2026-06-10 YD validation) and regressed once the dns-proxy `set -u` started leaking (~`2.11.31`). `install.sh` runners are unaffected because they always pass the var.

## The fix

Default-expand both HYDRA vars (`${VAR:-false}`) so the script is correct regardless of which caller set them. Verified: the new form runs clean under `set -u`; the old form reproduces the exact `unbound variable` abort.

## Scope / follow-up

This fixes the reported failure with minimal blast radius. The deeper issue - cont-init scripts leaking shell options (`set -u`) into siblings because `entrypoint.sh` sources them into one shell - is worth a separate hardening pass (source in a subshell, or scope `set -u` locally). Flagging, not fixing here.

Found while debugging YD runner registration on yd.helix.ml (2026-06-29). Separate from #2744 (compute-manager Max-ceiling wedge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)