### PR TITLE
feat(server): per-name ACME challenge selection for custom domains

### DIFF
--- a/api/pkg/server/vhost_tls.go
+++ b/api/pkg/server/vhost_tls.go
@@ -84,33 +84,52 @@ func (apiServer *HelixAPIServer) startCertMagicListener(ctx context.Context, vho
 		Email:  email,
 		Agreed: true,
 	}
+
 	if dnsSolver != nil {
-		// Setting DNS01Solver on the issuer disables HTTP-01 and
-		// TLS-ALPN-01 for it (per certmagic docs) — DNS-01 is used
-		// exclusively. That's the right behaviour behind Cloudflare,
-		// where the network challenges can't reach the origin.
-		issuerTmpl.DNS01Solver = dnsSolver
-	}
-	magicACME := certmagic.NewACMEIssuer(cfg, issuerTmpl)
-	cfg.Issuers = []certmagic.Issuer{magicACME}
+		// Per-name challenge selection via issuer fallback. certmagic tries
+		// issuers in order and falls through on failure:
+		//   1. DNS-01 (Cloudflare): issues for names in our zone
+		//      (app.helix.ml, *.apps.helix.ml) AND custom domains that
+		//      CNAME _acme-challenge into our zone (delegation). Works behind
+		//      Cloudflare orange-cloud, where network challenges can't reach us.
+		//   2. TLS-ALPN-01 fallback: for custom domains pointed DIRECTLY at us
+		//      (not in our DNS, no CNAME delegation). ALPN-01 runs over the
+		//      :443 listener (through the SNI passthrough), so it needs no :80.
+		//      HTTP is disabled here since we don't bind :80 in DNS-01 mode.
+		// So a custom domain works whether or not it uses Cloudflare, with no
+		// required DNS interface for the direct case.
+		dnsIssuer := issuerTmpl
+		dnsIssuer.DNS01Solver = dnsSolver
 
-	log.Info().
-		Str("email", email).
-		Str("challenge", challengeDesc).
-		Msg("vhost TLS auto mode enabled (certmagic + Let's Encrypt)")
+		alpnIssuer := issuerTmpl
+		alpnIssuer.DisableHTTPChallenge = true // no :80; TLS-ALPN-01 only
 
-	if dnsSolver == nil {
-		// HTTP-01 challenges + plaintext redirects on :80. Only useful
-		// when LE can reach the origin directly on :80 — i.e. when
-		// using the HTTP-01 challenge. Skipped in DNS-01 mode where
-		// :80 isn't part of the challenge flow.
+		cfg.Issuers = []certmagic.Issuer{
+			certmagic.NewACMEIssuer(cfg, dnsIssuer),
+			certmagic.NewACMEIssuer(cfg, alpnIssuer),
+		}
+
+		log.Info().
+			Str("email", email).
+			Str("challenge", challengeDesc+" + tls-alpn-01 fallback").
+			Msg("vhost TLS auto mode enabled (certmagic + Let's Encrypt)")
+		log.Info().Msg("vhost TLS: skipping :80 listener (DNS-01 primary, TLS-ALPN-01 fallback on :443)")
+	} else {
+		// No DNS provider: HTTP-01 + TLS-ALPN-01 for all names, with a :80
+		// challenge listener. Only works when LE can reach the origin directly.
+		magicACME := certmagic.NewACMEIssuer(cfg, issuerTmpl)
+		cfg.Issuers = []certmagic.Issuer{magicACME}
+
+		log.Info().
+			Str("email", email).
+			Str("challenge", challengeDesc).
+			Msg("vhost TLS auto mode enabled (certmagic + Let's Encrypt)")
+
 		go func() {
 			if err := http.ListenAndServe(":80", magicACME.HTTPChallengeHandler(httpToHTTPSRedirect())); err != nil {
 				log.Warn().Err(err).Msg("vhost TLS: :80 challenge listener exited")
 			}
 		}()
-	} else {
-		log.Info().Msg("vhost TLS: skipping :80 listener (DNS-01 mode does not use it)")
 	}
 
 	// HTTPS listener on :443 — same handler as the plain HTTP listener,

--- a/api/pkg/server/vhost_tls_dns.go
+++ b/api/pkg/server/vhost_tls_dns.go
@@ -38,9 +38,16 @@ func buildACMEChallengeSolver(ws config.WebServer) (*certmagic.DNS01Solver, stri
 		solver := &certmagic.DNS01Solver{
 			DNSManager: certmagic.DNSManager{
 				DNSProvider: &cloudflare.Provider{APIToken: token},
+				// Public resolvers so _acme-challenge CNAME delegation
+				// resolves reliably: a custom domain not in our zone can
+				// CNAME _acme-challenge.<host> into our Cloudflare zone, and
+				// certmagic follows that CNAME to place the TXT where our
+				// token has access. The container's default resolver may be
+				// internal and not see those external records.
+				Resolvers: []string{"1.1.1.1:53", "8.8.8.8:53"},
 			},
 		}
-		return solver, "dns-01 via cloudflare", nil
+		return solver, "dns-01 via cloudflare (with CNAME delegation)", nil
 	default:
 		return nil, "", fmt.Errorf("HELIX_VHOST_ACME_DNS_PROVIDER=%q is not supported (supported: cloudflare)", provider)
 	}

--- a/api/pkg/server/vhost_tls_dns_test.go
+++ b/api/pkg/server/vhost_tls_dns_test.go
@@ -11,12 +11,12 @@ import (
 
 func TestBuildACMEChallengeSolver(t *testing.T) {
 	cases := []struct {
-		name        string
-		provider    string
-		token       string
-		wantSolver  bool
-		wantDesc    string
-		wantErrSub  string // substring of error message; "" means no error
+		name       string
+		provider   string
+		token      string
+		wantSolver bool
+		wantDesc   string
+		wantErrSub string // substring of error message; "" means no error
 	}{
 		{
 			name:       "empty provider falls back to HTTP-01",

--- a/api/pkg/server/vhost_tls_dns_test.go
+++ b/api/pkg/server/vhost_tls_dns_test.go
@@ -34,14 +34,14 @@ func TestBuildACMEChallengeSolver(t *testing.T) {
 			provider:   "cloudflare",
 			token:      "topsecret",
 			wantSolver: true,
-			wantDesc:   "dns-01 via cloudflare",
+			wantDesc:   "dns-01 via cloudflare (with CNAME delegation)",
 		},
 		{
 			name:       "cloudflare provider name is case-insensitive",
 			provider:   "Cloudflare",
 			token:      "topsecret",
 			wantSolver: true,
-			wantDesc:   "dns-01 via cloudflare",
+			wantDesc:   "dns-01 via cloudflare (with CNAME delegation)",
 		},
 		{
 			name:       "cloudflare without token errors",
@@ -95,6 +95,9 @@ func TestBuildACMEChallengeSolver(t *testing.T) {
 				}
 				if prov.APIToken != strings.TrimSpace(tc.token) {
 					t.Errorf("APIToken = %q want %q", prov.APIToken, strings.TrimSpace(tc.token))
+				}
+				if len(solver.DNSManager.Resolvers) == 0 {
+					t.Errorf("expected DNSManager.Resolvers to be set (for reliable _acme-challenge CNAME delegation)")
 				}
 			} else if solver != nil {
 				t.Errorf("expected nil solver, got %+v", solver)

--- a/design/2026-06-25-prod-tls-sni-split.md
+++ b/design/2026-06-25-prod-tls-sni-split.md
@@ -64,9 +64,14 @@ The cert gate already allows any `vhost_routes` hostname; custom-domain verifica
   Set prod `.env`: `HELIX_VHOST_TLS_MODE=auto`, `HELIX_VHOST_ACME_DNS_PROVIDER=cloudflare`,
   `HELIX_VHOST_CLOUDFLARE_API_TOKEN`, `HELIX_VHOST_LETSENCRYPT_EMAIL`, `HELIX_PROXY_PATH_PREFIX=/auth/`,
   `HELIX_PROXY_UPSTREAM=http://keycloak-config-keycloak-1:8080`.
-- **Stage 2 (custom domains):** per-name challenge selection (DNS-01 for `helix.ml`, HTTP-01/ALPN for
-  custom) in `buildACMEChallengeSolver` (`vhost_tls_dns.go`) + re-enable `:80` for HTTP-01; optional
-  CF-for-SaaS edge; optional "add this DNS record" UI for the orange-custom-domain case.
+- **Stage 2 (custom domains) — code SHIPPED:** per-name challenge selection via certmagic issuer
+  fallback in `startCertMagicListener` (`vhost_tls.go`): issuer 1 = DNS-01 (Cloudflare) for
+  `helix.ml` names + custom domains that CNAME `_acme-challenge` into our zone; issuer 2 =
+  TLS-ALPN-01 (over `:443`, no `:80` needed) for custom domains pointed directly at us. The DNS
+  solver gets public `Resolvers` (`vhost_tls_dns.go`) so CNAME delegation resolves from inside the
+  container. Net effect: a custom domain works **with or without** Cloudflare, and the direct case
+  needs **no DNS-record UI** (the A/CNAME to us is the proof). Remaining optional: CF-for-SaaS edge
+  for orange custom domains; a small "add this `_acme-challenge` CNAME" hint UI for that case.
 
 ## Risk
 High blast radius — `:443` carries registry image pulls, the `app.helix.ml` console+auth, and demos.


### PR DESCRIPTION
Stage 2 of the prod TLS plan (`design/2026-06-25-prod-tls-sni-split.md`). Makes Helix issue valid certs for **customer custom domains**, with or without Cloudflare.

### Problem
Behind Cloudflare, only **DNS-01** reaches a proxied origin. But certmagic's single global DNS-01 solver **disables HTTP-01/TLS-ALPN-01 for all names** — and our Cloudflare token only controls `helix.ml`, so a custom domain in someone else's DNS zone could never get a cert.

### Fix — certmagic issuer fallback (per-name)
- **Issuer 1 — DNS-01 (Cloudflare):** `helix.ml` names (`app.helix.ml`, `*.apps.helix.ml`) **and** custom domains that CNAME `_acme-challenge.<host>` into our zone (delegation; certmagic follows the cross-zone CNAME).
- **Issuer 2 — TLS-ALPN-01:** custom domains pointed **directly** at us (not in our DNS, no CNAME). Runs over the existing `:443` listener through the SNI passthrough — **no `:80` needed**; HTTP-01 disabled.

certmagic tries issuers in order and falls through on failure, so a name DNS-01 can't satisfy gets ALPN-01. Net result: **custom domains work with or without Cloudflare, and the direct case needs no DNS-record UI** (the A/CNAME to us is the proof of control).

Also adds public `Resolvers` to the DNS-01 solver so `_acme-challenge` CNAME delegation resolves reliably from inside the container.

### Tests
`TestBuildACMEChallengeSolver` updated (new description + asserts `Resolvers` set). `go build ./pkg/server/` + `go test -run TestBuildACMEChallengeSolver` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)