### PR TITLE
feat(webservice): configurable custom-domain CNAME target (grey ingress)

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -900,6 +900,14 @@ type WebServer struct {
 	// keeps working without a separate reverse proxy.
 	ProxyPathPrefix string `envconfig:"HELIX_PROXY_PATH_PREFIX" description:"Path prefix to reverse-proxy to HELIX_PROXY_UPSTREAM (e.g. '/auth/'). Requires HELIX_PROXY_UPSTREAM. Empty disables."`
 	ProxyUpstream   string `envconfig:"HELIX_PROXY_UPSTREAM" description:"Upstream base URL for HELIX_PROXY_PATH_PREFIX (e.g. 'http://keycloak:8080'). Empty disables."`
+
+	// VHostCNAMETarget overrides the hostname customers are told to point
+	// their custom-domain CNAME at. It should be a GREY / DNS-only host that
+	// resolves DIRECTLY to this origin, so a directly-pointed custom domain
+	// gets its cert via TLS-ALPN-01 with no DNS-01 fiddling. Empty falls back
+	// to the canonical hostname parsed from SERVER_URL — which is wrong when
+	// SERVER_URL is Cloudflare-proxied (orange), so set this in that case.
+	VHostCNAMETarget string `envconfig:"HELIX_VHOST_CNAME_TARGET" description:"Grey/DNS-only hostname customers CNAME custom domains to (resolves directly to this origin). Empty = use SERVER_URL host."`
 }
 
 // AdminAllUsers is the special value for ADMIN_USER_IDS that makes all users admins

--- a/api/pkg/server/project_web_service_handlers.go
+++ b/api/pkg/server/project_web_service_handlers.go
@@ -95,11 +95,20 @@ func (s *HelixAPIServer) getProjectWebService(_ http.ResponseWriter, r *http.Req
 		return nil, system.NewHTTPError500(err.Error())
 	}
 
+	// Customers CNAME their custom domain at this host. Prefer the explicit
+	// grey/DNS-only ingress (HELIX_VHOST_CNAME_TARGET) so the domain resolves
+	// directly to this origin and certmagic can issue via TLS-ALPN-01 without
+	// any DNS-01 fiddling. Fall back to the SERVER_URL host otherwise.
+	cnameTarget := strings.TrimSpace(s.Cfg.WebServer.VHostCNAMETarget)
+	if cnameTarget == "" {
+		cnameTarget = hostnameOf(s.Cfg.WebServer.URL)
+	}
+
 	return &ProjectWebServiceResponse{
 		State:       state,
 		Domains:     domains,
 		Deploys:     deploys,
-		CNAMETarget: hostnameOf(s.Cfg.WebServer.URL),
+		CNAMETarget: cnameTarget,
 	}, nil
 }
 

--- a/frontend/src/components/project/WebServiceTab.tsx
+++ b/frontend/src/components/project/WebServiceTab.tsx
@@ -297,7 +297,19 @@ const WebServiceTab: FC<WebServiceTabProps> = ({ projectId }) => {
                 <Typography variant="body2">
                   3. That's it. Helix checks every minute and your domain
                   will go live automatically — usually within a couple
-                  of minutes once DNS has propagated.
+                  of minutes once DNS has propagated. The HTTPS certificate
+                  is issued and renewed for you, no extra steps.
+                </Typography>
+                <Typography
+                  variant="body2"
+                  sx={{ mt: 1.5, pt: 1.5, borderTop: '1px solid rgba(0,0,0,0.12)' }}
+                >
+                  <strong>Behind Cloudflare or another proxy/CDN?</strong> Point the proxy
+                  straight at <code>{cnameTarget}</code> and it still works. Because a proxy
+                  hides your server from Let's Encrypt, the certificate for the Helix ↔ proxy
+                  connection needs a one-time <strong>ACME challenge delegation</strong> — get
+                  in touch and we'll give you the exact <code>_acme-challenge</code> record to add.
+                  Domains pointed directly at <code>{cnameTarget}</code> (no proxy) need none of this.
                 </Typography>
               </Alert>
             )}


### PR DESCRIPTION
Makes self-serve **custom domains** actually resolve, and keeps the direct case **zero-DNS-fiddling**.

### Problem
`cname_target` (the host customers CNAME their domain to) was hardcoded to the `SERVER_URL` host = `app.helix.ml`, which on prod is **Cloudflare-orange**. A bare CNAME to an orange host doesn't resolve to our origin (CF returns 1014/1016), and the origin isn't reachable for TLS-ALPN-01.

### Fix
- New `HELIX_VHOST_CNAME_TARGET` config: point customers at a **grey/DNS-only ingress** host (e.g. `ingress.helix.ml` → origin IP). A directly-pointed custom domain then resolves straight to the origin and certmagic issues its cert via **TLS-ALPN-01** — no `_acme-challenge`, no TXT, nothing for the user to do beyond the one CNAME. Falls back to the `SERVER_URL` host when unset (existing behaviour).
- `WebServiceTab` note for the **behind-Cloudflare/proxy** case: point the proxy at the ingress host; because a proxy hides the origin from Let's Encrypt, that case needs a one-time ACME challenge delegation (guidance copy; exact record provided on request).

### Deploy
On prod: create grey `ingress.helix.ml` A → origin (done), set `HELIX_VHOST_CNAME_TARGET=ingress.helix.ml`. Pairs with the per-name challenge selection from #2746.

🤖 Generated with [Claude Code](https://claude.com/claude-code)