### PR TITLE
fix(agent): always set type:object on MCP tool parameters

### DIFF
--- a/api/pkg/agent/skill/mcp/mcp_skill.go
+++ b/api/pkg/agent/skill/mcp/mcp_skill.go
@@ -171,15 +171,16 @@ func buildParameters(inputSchema mcp.ToolInputSchema) jsonschema.Definition {
 	}
 
 	// Always ensure we return an object type schema with properties
-	// This is required by the OpenAI function calling API
-	// Even if the MCP tool doesn't specify a type, we must return "object"
+	// This is required by the OpenAI/Anthropic function calling API: the
+	// parameters object MUST declare "type": "object" even when the tool
+	// takes no arguments. Setting it only when properties exist makes
+	// zero-argument MCP tools serialize without a type, which the model API
+	// rejects with `tools.N.function.parameters.type: Field required`,
+	// poisoning the entire tools array for the request.
 	result := jsonschema.Definition{
+		Type:       jsonschema.Object,
 		Properties: properties,
 		Required:   required,
-	}
-
-	if len(result.Properties) > 0 {
-		result.Type = jsonschema.Object
 	}
 
 	log.Debug().


### PR DESCRIPTION
## Problem

When an agent uses an external MCP server that exposes a **zero-argument tool**, the agent can't call **any** tool — the model API rejects the whole request with:

```
tools.N.function.parameters.type: Field required
```

### Root cause

`buildParameters` (`api/pkg/agent/skill/mcp/mcp_skill.go`) only set the parameter schema's `type` when the tool had ≥1 property:

```go
result := jsonschema.Definition{
    Properties: properties,
    Required:   required,
}
if len(result.Properties) > 0 {   // <- only sets type when there are properties
    result.Type = jsonschema.Object
}
```

So a no-argument tool serializes its parameters as `{}` with **no `type`**. The OpenAI/Anthropic function-calling API requires `parameters.type` to be present, and it rejects the **entire** `tools` array if any single tool is malformed — so the agent ends up unable to call anything. The function's own comment already says the type must always be `"object"`; the code just didn't do it.

## Fix

Set `type: "object"` unconditionally (one line), matching the existing comment:

```go
result := jsonschema.Definition{
    Type:       jsonschema.Object,
    Properties: properties,
    Required:   required,
}
```

## Reproduce

1. Configure an agent (`helix_agent`) with an external MCP server that exposes a tool with an empty input schema (no properties).
2. Chat with the agent and ask it to use any tool.
3. Before: the turn fails with `tools.N.function.parameters.type: Field required` and no tool is called. After: tools are accepted and called normally.

## Scope

One file, one effective line (plus an expanded comment). No behaviour change for tools that already declare properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)