### PR TITLE
Add Desktop view to the Bot detail page

### DIFF
--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -69,6 +69,7 @@ import { useListOAuthProviders } from "../../services/oauthProvidersService";
 import { findOAuthProviderForType } from "../../utils/oauthProviders";
 import { getBrowserLocale } from "../../hooks/useBrowserLocale";
 import useApps from "../../hooks/useApps";
+import { deriveDisplaySettings } from "../../services/externalAgentDisplay";
 import { useStreaming } from "../../contexts/streaming";
 import { useQueryClient, useMutation } from "@tanstack/react-query";
 import {
@@ -260,33 +261,8 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
 
   // Get display settings from the task's app configuration
   const displaySettings = useMemo(() => {
-    if (!task?.helix_app_id || !apps.apps) {
-      return { width: 1920, height: 1080, fps: 60 };
-    }
-    const taskApp = apps.apps.find((a) => a.id === task.helix_app_id);
-    const config = taskApp?.config?.helix?.external_agent_config;
-    if (!config) {
-      return { width: 1920, height: 1080, fps: 60 };
-    }
-
-    let width = config.display_width || 1920;
-    let height = config.display_height || 1080;
-    if (config.resolution === "5k") {
-      width = 5120;
-      height = 2880;
-    } else if (config.resolution === "4k") {
-      width = 3840;
-      height = 2160;
-    } else if (config.resolution === "1080p") {
-      width = 1920;
-      height = 1080;
-    }
-
-    return {
-      width,
-      height,
-      fps: config.display_refresh_rate || 60,
-    };
+    const taskApp = apps.apps?.find((a) => a.id === task?.helix_app_id);
+    return deriveDisplaySettings(taskApp);
   }, [task?.helix_app_id, apps.apps]);
 
   // Check if the task's app uses Claude Code with subscription credentials

--- a/frontend/src/pages/HelixOrgBotDetail.tsx
+++ b/frontend/src/pages/HelixOrgBotDetail.tsx
@@ -30,6 +30,8 @@ import Link from '@mui/material/Link'
 import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
+import ToggleButton from '@mui/material/ToggleButton'
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import Typography from '@mui/material/Typography'
 import CheckBoxIcon from '@mui/icons-material/CheckBox'
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
@@ -47,14 +49,17 @@ import DeleteConfirmWindow from '../components/widgets/DeleteConfirmWindow'
 import EmbeddedSessionView, {
   EmbeddedSessionViewHandle,
 } from '../components/session/EmbeddedSessionView'
+import ExternalAgentDesktopViewer from '../components/external-agent/ExternalAgentDesktopViewer'
 import RobustPromptInput from '../components/common/RobustPromptInput'
 import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
 
 import router5 from '../router'
 import useAccount from '../hooks/useAccount'
 import useApi from '../hooks/useApi'
+import useApps from '../hooks/useApps'
 import useRouter from '../hooks/useRouter'
 import useSnackbar from '../hooks/useSnackbar'
+import { deriveDisplaySettings } from '../services/externalAgentDisplay'
 import { useStreaming } from '../contexts/streaming'
 import { SESSION_TYPE_TEXT } from '../types'
 import {
@@ -161,6 +166,19 @@ const HelixOrgBotDetail: FC = () => {
   const [chatSessionId, setChatSessionId] = useState<string | null>(null)
   const sessionViewRef = useRef<EmbeddedSessionViewHandle>(null)
 
+  // The session panel toggles between the inline Chat transcript and the
+  // live Desktop stream — both bound to the same exploratory session.
+  const [sessionTab, setSessionTab] = useState<'chat' | 'desktop'>('chat')
+
+  // Desktop resolution / fps for the stream, derived from the bot's agent
+  // app config (same helper the spec-task desktop uses). Falls back to
+  // 1920x1080x60 when the app or config is missing.
+  const apps = useApps()
+  const displaySettings = useMemo(
+    () => deriveDisplaySettings(apps.apps?.find((a) => a.id === agentAppID)),
+    [agentAppID, apps.apps],
+  )
+
   // chatApi adapts the generated client to the read-only shape the
   // workerChatSession helper expects (we only GET the existing session
   // here — provisioning is owned by the bot's activation flow). The
@@ -259,17 +277,35 @@ const HelixOrgBotDetail: FC = () => {
                   </Stack>
                 </Box>
 
-                {/* Chat panel — inline transcript (same view the spec-task
-                    page uses). The transcript auto-loads when the bot
-                    already has a session; otherwise it shows an empty
-                    state. */}
+                {/* Session panel — Chat | Desktop toggle, both bound to the
+                    bot's Project Desktop exploratory session (the same views
+                    the spec-task page uses). Auto-loads when the bot already
+                    has a session; otherwise shows an empty state. */}
                 <Paper variant="outlined" sx={{ p: 3 }}>
                   <Stack spacing={2} alignItems="flex-start">
-                    <Typography variant="subtitle1">Chat with this bot</Typography>
+                    <Stack
+                      direction="row"
+                      justifyContent="space-between"
+                      alignItems="center"
+                      sx={{ width: '100%' }}
+                    >
+                      <Typography variant="subtitle1">
+                        {sessionTab === 'chat' ? 'Chat with this bot' : 'Bot desktop'}
+                      </Typography>
+                      <ToggleButtonGroup
+                        size="small"
+                        exclusive
+                        value={sessionTab}
+                        onChange={(_e, value) => { if (value) setSessionTab(value) }}
+                      >
+                        <ToggleButton value="chat">Chat</ToggleButton>
+                        <ToggleButton value="desktop">Desktop</ToggleButton>
+                      </ToggleButtonGroup>
+                    </Stack>
                     <Typography variant="body2" color="text.secondary">
-                      The conversation below is the bot's Project Desktop session —
-                      the same transcript you'd see in the desktop tab, including its
-                      MCP tool calls. Send a message to drive it from here.
+                      {sessionTab === 'chat'
+                        ? "The conversation below is the bot's Project Desktop session — the same transcript you'd see in the desktop view, including its MCP tool calls. Send a message to drive it from here."
+                        : "The live desktop of the bot's Project Desktop session — watch and drive what its agent is doing in real time."}
                     </Typography>
 
                     {/* Inline transcript. EmbeddedSessionView self-fetches
@@ -277,46 +313,80 @@ const HelixOrgBotDetail: FC = () => {
                         turns; it needs a bounded, flex-column container to
                         scroll within. RobustPromptInput drives the same
                         session via streaming.NewInference. */}
-                    {chatSessionId ? (
-                      <Box
-                        sx={{
-                          width: '100%',
-                          height: 520,
-                          display: 'flex',
-                          flexDirection: 'column',
-                          border: (theme) =>
-                            `1px solid ${theme.palette.mode === 'light' ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.08)'}`,
-                          borderRadius: 1,
-                          overflow: 'hidden',
-                        }}
-                      >
-                        <EmbeddedSessionView
-                          ref={sessionViewRef}
-                          sessionId={chatSessionId}
-                          autoScrollOnMount
-                        />
-                        <Box sx={{ p: 1.5, flexShrink: 0 }}>
-                          <RobustPromptInput
+                    {sessionTab === 'chat' ? (
+                      chatSessionId ? (
+                        <Box
+                          sx={{
+                            width: '100%',
+                            height: 520,
+                            display: 'flex',
+                            flexDirection: 'column',
+                            border: (theme) =>
+                              `1px solid ${theme.palette.mode === 'light' ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.08)'}`,
+                            borderRadius: 1,
+                            overflow: 'hidden',
+                          }}
+                        >
+                          <EmbeddedSessionView
+                            ref={sessionViewRef}
                             sessionId={chatSessionId}
-                            projectId={projectID}
-                            apiClient={api.getApiClient()}
-                            onSend={async (message: string, interrupt?: boolean) => {
-                              await streaming.NewInference({
-                                type: SESSION_TYPE_TEXT,
-                                message,
-                                sessionId: chatSessionId,
-                                interrupt: interrupt ?? true,
-                              })
-                            }}
-                            onHeightChange={() => sessionViewRef.current?.scrollToBottom()}
-                            placeholder="Send message to agent..."
+                            autoScrollOnMount
+                          />
+                          <Box sx={{ p: 1.5, flexShrink: 0 }}>
+                            <RobustPromptInput
+                              sessionId={chatSessionId}
+                              projectId={projectID}
+                              apiClient={api.getApiClient()}
+                              onSend={async (message: string, interrupt?: boolean) => {
+                                await streaming.NewInference({
+                                  type: SESSION_TYPE_TEXT,
+                                  message,
+                                  sessionId: chatSessionId,
+                                  interrupt: interrupt ?? true,
+                                })
+                              }}
+                              onHeightChange={() => sessionViewRef.current?.scrollToBottom()}
+                              placeholder="Send message to agent..."
+                            />
+                          </Box>
+                        </Box>
+                      ) : (
+                        <Typography variant="body2" color="text.secondary">
+                          No conversation yet for this bot.
+                        </Typography>
+                      )
+                    ) : (
+                      // Desktop stream — same widget as the spec-task page.
+                      // ExternalAgentDesktopViewer handles the sandbox
+                      // lifecycle (starting/running/paused) internally; it
+                      // needs a bounded, flex-column container to fill.
+                      chatSessionId ? (
+                        <Box
+                          sx={{
+                            width: '100%',
+                            height: 520,
+                            display: 'flex',
+                            flexDirection: 'column',
+                            border: (theme) =>
+                              `1px solid ${theme.palette.mode === 'light' ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.08)'}`,
+                            borderRadius: 1,
+                            overflow: 'hidden',
+                          }}
+                        >
+                          <ExternalAgentDesktopViewer
+                            sessionId={chatSessionId}
+                            sandboxId={chatSessionId}
+                            mode="stream"
+                            displayWidth={displaySettings.width}
+                            displayHeight={displaySettings.height}
+                            displayFps={displaySettings.fps}
                           />
                         </Box>
-                      </Box>
-                    ) : (
-                      <Typography variant="body2" color="text.secondary">
-                        No conversation yet for this bot.
-                      </Typography>
+                      ) : (
+                        <Typography variant="body2" color="text.secondary">
+                          No desktop yet for this bot.
+                        </Typography>
+                      )
                     )}
                   </Stack>
                 </Paper>

--- a/frontend/src/services/externalAgentDisplay.test.ts
+++ b/frontend/src/services/externalAgentDisplay.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest'
 
 import { deriveDisplaySettings } from './externalAgentDisplay'
-import { TypesApp } from '../api/api'
+import { IApp } from '../types'
 
-const appWith = (cfg: Record<string, unknown>): TypesApp =>
-  ({ config: { helix: { external_agent_config: cfg } } } as unknown as TypesApp)
+const appWith = (cfg: Record<string, unknown>): IApp =>
+  ({ config: { helix: { external_agent_config: cfg } } } as unknown as IApp)
 
 describe('deriveDisplaySettings', () => {
   it('falls back to 1920x1080x60 when app is undefined', () => {
@@ -12,7 +12,7 @@ describe('deriveDisplaySettings', () => {
   })
 
   it('falls back when there is no external_agent_config', () => {
-    expect(deriveDisplaySettings({ config: { helix: {} } } as unknown as TypesApp)).toEqual({
+    expect(deriveDisplaySettings({ config: { helix: {} } } as unknown as IApp)).toEqual({
       width: 1920,
       height: 1080,
       fps: 60,

--- a/frontend/src/services/externalAgentDisplay.test.ts
+++ b/frontend/src/services/externalAgentDisplay.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+
+import { deriveDisplaySettings } from './externalAgentDisplay'
+import { TypesApp } from '../api/api'
+
+const appWith = (cfg: Record<string, unknown>): TypesApp =>
+  ({ config: { helix: { external_agent_config: cfg } } } as unknown as TypesApp)
+
+describe('deriveDisplaySettings', () => {
+  it('falls back to 1920x1080x60 when app is undefined', () => {
+    expect(deriveDisplaySettings(undefined)).toEqual({ width: 1920, height: 1080, fps: 60 })
+  })
+
+  it('falls back when there is no external_agent_config', () => {
+    expect(deriveDisplaySettings({ config: { helix: {} } } as unknown as TypesApp)).toEqual({
+      width: 1920,
+      height: 1080,
+      fps: 60,
+    })
+  })
+
+  it('uses explicit dimensions and refresh rate', () => {
+    expect(deriveDisplaySettings(appWith({ display_width: 1280, display_height: 720, display_refresh_rate: 30 }))).toEqual({
+      width: 1280,
+      height: 720,
+      fps: 30,
+    })
+  })
+
+  it('honours the 4k preset over explicit dimensions', () => {
+    expect(deriveDisplaySettings(appWith({ resolution: '4k', display_width: 800, display_height: 600 }))).toEqual({
+      width: 3840,
+      height: 2160,
+      fps: 60,
+    })
+  })
+
+  it('honours the 5k preset', () => {
+    expect(deriveDisplaySettings(appWith({ resolution: '5k' }))).toEqual({
+      width: 5120,
+      height: 2880,
+      fps: 60,
+    })
+  })
+
+  it('honours the 1080p preset', () => {
+    expect(deriveDisplaySettings(appWith({ resolution: '1080p' }))).toEqual({
+      width: 1920,
+      height: 1080,
+      fps: 60,
+    })
+  })
+})

--- a/frontend/src/services/externalAgentDisplay.ts
+++ b/frontend/src/services/externalAgentDisplay.ts
@@ -1,4 +1,4 @@
-import { TypesApp } from '../api/api'
+import { IApp } from '../types'
 
 export interface DisplaySettings {
   width: number
@@ -13,7 +13,7 @@ const DEFAULT_DISPLAY: DisplaySettings = { width: 1920, height: 1080, fps: 60 }
 // resolution presets and falling back to 1920x1080x60 when the app or config
 // is missing. Shared by the spec-task detail page and the bot detail page so
 // both feed ExternalAgentDesktopViewer identical settings.
-export function deriveDisplaySettings(app?: TypesApp): DisplaySettings {
+export function deriveDisplaySettings(app?: IApp): DisplaySettings {
   const config = app?.config?.helix?.external_agent_config
   if (!config) {
     return { ...DEFAULT_DISPLAY }

--- a/frontend/src/services/externalAgentDisplay.ts
+++ b/frontend/src/services/externalAgentDisplay.ts
@@ -1,0 +1,40 @@
+import { TypesApp } from '../api/api'
+
+export interface DisplaySettings {
+  width: number
+  height: number
+  fps: number
+}
+
+const DEFAULT_DISPLAY: DisplaySettings = { width: 1920, height: 1080, fps: 60 }
+
+// deriveDisplaySettings resolves the desktop resolution / refresh rate for an
+// external-agent app from its `external_agent_config`, honouring the
+// resolution presets and falling back to 1920x1080x60 when the app or config
+// is missing. Shared by the spec-task detail page and the bot detail page so
+// both feed ExternalAgentDesktopViewer identical settings.
+export function deriveDisplaySettings(app?: TypesApp): DisplaySettings {
+  const config = app?.config?.helix?.external_agent_config
+  if (!config) {
+    return { ...DEFAULT_DISPLAY }
+  }
+
+  let width = config.display_width || 1920
+  let height = config.display_height || 1080
+  if (config.resolution === '5k') {
+    width = 5120
+    height = 2880
+  } else if (config.resolution === '4k') {
+    width = 3840
+    height = 2160
+  } else if (config.resolution === '1080p') {
+    width = 1920
+    height = 1080
+  }
+
+  return {
+    width,
+    height,
+    fps: config.display_refresh_rate || 60,
+  }
+}


### PR DESCRIPTION
## Summary

The bot detail page (`HelixOrgBotDetail.tsx`) already showed the bot's
"Project Desktop" session as an inline **chat** transcript, but not its actual
desktop. This adds a **Chat | Desktop** toggle to that session panel so an
operator can watch and drive the bot's live desktop without leaving the page —
reusing the exact `ExternalAgentDesktopViewer` widget the spec-task detail
page uses (also used by `TeamDesktopPage`, `SandboxDesktopTab`, etc.).

Frontend-only — no backend changes. The Desktop view binds to the same
exploratory session the chat already resolves, and reuses the existing
external-agent WebSocket stream/input endpoints.

## Changes

- **New** `frontend/src/services/externalAgentDisplay.ts`: shared
  `deriveDisplaySettings(app?)` helper (resolution presets 1080p/4k/5k +
  explicit `display_width`/`display_height`/`display_refresh_rate`, fallback
  1920×1080×60) — extracted from `SpecTaskDetailContent.tsx` so both pages feed
  the viewer identical settings. Unit-tested (6 cases).
- `frontend/src/components/tasks/SpecTaskDetailContent.tsx`: refactored to use
  the shared helper (behaviour unchanged).
- `frontend/src/pages/HelixOrgBotDetail.tsx`: added a `Chat | Desktop`
  `ToggleButtonGroup` to the session panel; the Desktop branch renders
  `ExternalAgentDesktopViewer` (`mode="stream"`) bound to the bot's resolved
  session, with display settings derived from the bot's `agent_app_id`. Empty
  state ("No desktop yet") when no session is resolved; the Chat panel is
  unchanged.

## Testing

- `tsc --noEmit` clean; `deriveDisplaySettings` unit test green.
- End-to-end in the inner Helix: created a bot, opened its detail page,
  confirmed the toggle — Chat shows the transcript and **Desktop streams the
  bot's live GNOME desktop**.

## Screenshots

![Chat view](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002186_we-need-to-add-desktop/screenshots/01-bot-detail-chat.png)
![Desktop view — live stream](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002186_we-need-to-add-desktop/screenshots/03-bot-detail-desktop.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwbzys4p029mfbjzdj1d90fv)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002186_we-need-to-add-desktop/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002186_we-need-to-add-desktop/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002186_we-need-to-add-desktop/tasks.md)

🚀 Built with [Helix](https://helix.ml)