### PR TITLE
Add drag-and-drop file upload to the New SpecTask form

### DIFF
--- a/frontend/src/components/tasks/NewSpecTaskForm.tsx
+++ b/frontend/src/components/tasks/NewSpecTaskForm.tsx
@@ -24,8 +24,10 @@ import {
   Autocomplete,
   Tooltip,
   IconButton,
+  Fade,
 } from "@mui/material";
-import { Add as AddIcon, AttachFile as AttachFileIcon, Close as CloseIcon } from "@mui/icons-material";
+import { Add as AddIcon, AttachFile as AttachFileIcon, Close as CloseIcon, CloudUpload as CloudUploadIcon } from "@mui/icons-material";
+import { useDropzone } from "react-dropzone";
 import { ChevronDown, UserCircle2, X } from "lucide-react";
 import AssigneeSelector from "./AssigneeSelector";
 import GooseRecipeSelector from "./GooseRecipeSelector";
@@ -160,6 +162,45 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
   const [pendingAttachments, setPendingAttachments] = useState<File[]>([]);
   const attachmentInput = useRef<HTMLInputElement | null>(null);
   const uploadAttachments = useUploadSpecTaskAttachments();
+
+  // Shared by both the file picker and the drag-and-drop zone so they apply
+  // identical validation (remaining-slot count + per-file size limit).
+  const handleAddFiles = useCallback(
+    (files: File[]) => {
+      if (!files.length) return;
+      setPendingAttachments((prev) => {
+        const remaining = SPEC_TASK_ATTACHMENT_MAX_PER_TASK - prev.length;
+        if (files.length > remaining) {
+          snackbar.error(
+            `Can only attach ${remaining} more file(s) — limit is ${SPEC_TASK_ATTACHMENT_MAX_PER_TASK}.`,
+          );
+          return prev;
+        }
+        const accepted: File[] = [];
+        for (const f of files) {
+          if (f.size > SPEC_TASK_ATTACHMENT_MAX_BYTES) {
+            snackbar.error(`${f.name} is too large (max ${humanAttachmentSize(SPEC_TASK_ATTACHMENT_MAX_BYTES)}).`);
+            continue;
+          }
+          accepted.push(f);
+        }
+        return accepted.length ? [...prev, ...accepted] : prev;
+      });
+    },
+    [snackbar],
+  );
+
+  const attachmentsFull = pendingAttachments.length >= SPEC_TASK_ATTACHMENT_MAX_PER_TASK;
+  const {
+    getRootProps: getAttachmentRootProps,
+    isDragActive: isAttachmentDragActive,
+  } = useDropzone({
+    onDrop: handleAddFiles,
+    accept: SPEC_TASK_ATTACHMENT_ACCEPTED_MIME,
+    noClick: true,
+    noKeyboard: true,
+    disabled: attachmentsFull,
+  });
 
   // Empty string = "Unassigned". Pre-filled with the current user below.
   const [assigneeId, setAssigneeId] = useState<string>("");
@@ -778,7 +819,7 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
               the dialog reliably with no JS involvement.
 
               Uploads happen after task creation in handleCreateTask. */}
-          <Box>
+          <Box {...getAttachmentRootProps()} sx={{ position: "relative" }}>
             <input
               ref={attachmentInput}
               id="new-spectask-attach-input"
@@ -789,28 +830,33 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
               onChange={(e) => {
                 const files = Array.from(e.target.files || []);
                 e.target.value = "";
-                if (!files.length) return;
-
-                const remaining = SPEC_TASK_ATTACHMENT_MAX_PER_TASK - pendingAttachments.length;
-                if (files.length > remaining) {
-                  snackbar.error(
-                    `Can only attach ${remaining} more file(s) — limit is ${SPEC_TASK_ATTACHMENT_MAX_PER_TASK}.`,
-                  );
-                  return;
-                }
-                const accepted: File[] = [];
-                for (const f of files) {
-                  if (f.size > SPEC_TASK_ATTACHMENT_MAX_BYTES) {
-                    snackbar.error(`${f.name} is too large (max ${humanAttachmentSize(SPEC_TASK_ATTACHMENT_MAX_BYTES)}).`);
-                    continue;
-                  }
-                  accepted.push(f);
-                }
-                if (accepted.length) {
-                  setPendingAttachments((prev) => [...prev, ...accepted]);
-                }
+                handleAddFiles(files);
               }}
             />
+            <Fade in={isAttachmentDragActive}>
+              <Box
+                sx={{
+                  position: "absolute",
+                  inset: 0,
+                  m: -1,
+                  borderRadius: 1,
+                  border: "2px dashed",
+                  borderColor: "primary.main",
+                  backgroundColor: "rgba(25, 118, 210, 0.12)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: 1,
+                  zIndex: 2,
+                  pointerEvents: "none",
+                }}
+              >
+                <CloudUploadIcon sx={{ color: "primary.main" }} />
+                <Typography variant="body2" color="primary">
+                  Drop files to attach
+                </Typography>
+              </Box>
+            </Fade>
             <Stack direction="row" spacing={1} alignItems="center" sx={{ flexWrap: "wrap", gap: 1 }}>
               <Box
                 component="label"
@@ -851,8 +897,9 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
               ))}
               {pendingAttachments.length === 0 && (
                 <Typography variant="caption" color="text.secondary">
-                  Optional — screenshots / PDFs / text the agent should look at.
-                  Max {SPEC_TASK_ATTACHMENT_MAX_PER_TASK} files,{" "}
+                  Optional — drag &amp; drop or click to add screenshots / PDFs /
+                  text the agent should look at. Max{" "}
+                  {SPEC_TASK_ATTACHMENT_MAX_PER_TASK} files,{" "}
                   {humanAttachmentSize(SPEC_TASK_ATTACHMENT_MAX_BYTES)} each.
                 </Typography>
               )}


### PR DESCRIPTION
## Summary
You can now drag files/screenshots straight onto the New SpecTask form's
attachment area instead of only clicking the "Attach files" button. This reuses
`react-dropzone` (already a dependency, used elsewhere in the app) and routes
dropped files through the exact same validation as the file picker.

## Changes
- `frontend/src/components/tasks/NewSpecTaskForm.tsx`:
  - Extracted the file-picker validation into a shared `handleAddFiles()` so the
    picker and the dropzone behave identically (remaining-slot count + per-file
    size limit; the count is read from the state updater to avoid stale closures).
  - Added a `react-dropzone` dropzone around the attachment row
    (`accept` = the spec-task MIME set, `noClick`/`noKeyboard` so the existing
    button stays the only click path — no double file dialog, `disabled` at the
    10-file cap).
  - Added a drag-active overlay (dashed border + cloud icon + "Drop files to
    attach") shown only while dragging.
  - Updated the helper hint to mention drag & drop.
- No backend, API, accepted-types, or size-limit changes. No new dependencies.

## Testing
Verified end-to-end in the inner Helix (Vite HMR):
- Drag-over shows the overlay; dropping a valid PNG adds a deletable chip;
  overlay clears after drop.
- Wrong type (`.exe`) rejected by `accept`; oversize (11 MB) rejected with the
  existing "too large" snackbar.
- Single `<input type=file>` in the dropzone + label `htmlFor` intact → the
  "Attach files" button still opens the native picker.
- `tsc --noEmit` clean; `vite build` to a writable out dir exits 0 (repo
  `dist/` is root-owned in this env).

## Screenshots
![Form with drag & drop hint](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002188_it-should-be-possible-to/screenshots/01-form-with-dropzone-hint.png)
![Drag overlay active](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002188_it-should-be-possible-to/screenshots/02-drag-overlay-active.png)
![File attached after drop](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002188_it-should-be-possible-to/screenshots/03-file-attached-after-drop.png)
![Oversize file rejected](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002188_it-should-be-possible-to/screenshots/04-oversize-rejected-snackbar.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwc1ffsqefrhxafqhx2e5e6j)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002188_it-should-be-possible-to/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002188_it-should-be-possible-to/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002188_it-should-be-possible-to/tasks.md)

🚀 Built with [Helix](https://helix.ml)