### PR TITLE
Add per-bot toggle to preserve conversation context across triggers

### DIFF
--- a/api/pkg/org/application/bots/bots.go
+++ b/api/pkg/org/application/bots/bots.go
@@ -88,10 +88,11 @@ func New(deps Deps) *Bots {
 // `b-<id>` is minted. Tools is unioned with the injected base read
 // tools; Topics is the typed manifest stored verbatim.
 type CreateParams struct {
-	ID      string
-	Content string
-	Tools   []tool.Name
-	Topics  []streaming.TopicID
+	ID              string
+	Content         string
+	Tools           []tool.Name
+	Topics          []streaming.TopicID
+	PreserveContext bool
 }
 
 // Create builds and persists a new Bot, returning the created
@@ -106,6 +107,9 @@ func (s *Bots) Create(ctx context.Context, orgID string, p CreateParams) (orgcha
 	if err != nil {
 		return orgchart.Bot{}, err
 	}
+	if p.PreserveContext {
+		bot = bot.WithPreserveContext(true)
+	}
 	if err := s.bots.Create(ctx, bot); err != nil {
 		return orgchart.Bot{}, err
 	}
@@ -116,9 +120,10 @@ func (s *Bots) Create(ctx context.Context, orgID string, p CreateParams) (orgcha
 // leaves the corresponding field unchanged — this is what preserves
 // Tools/Topics on a content-only update.
 type UpdateParams struct {
-	Content *string
-	Tools   *[]tool.Name
-	Topics  *[]streaming.TopicID
+	Content         *string
+	Tools           *[]tool.Name
+	Topics          *[]streaming.TopicID
+	PreserveContext *bool
 }
 
 // Update reads the existing Bot, applies the patch via the domain's
@@ -138,6 +143,9 @@ func (s *Bots) Update(ctx context.Context, orgID string, id orgchart.BotID, p Up
 	}
 	if p.Topics != nil {
 		updated = updated.WithTopics(*p.Topics)
+	}
+	if p.PreserveContext != nil {
+		updated = updated.WithPreserveContext(*p.PreserveContext)
 	}
 	updated = updated.WithUpdatedAt(s.now())
 	if err := s.bots.Update(ctx, updated); err != nil {

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -120,11 +120,12 @@ type Service struct {
 // (empty only for the org root). Content is the bot's prompt; Tools and
 // Topics are its capability/manifest.
 type CreateParams struct {
-	ID       string
-	Content  string
-	Tools    []tool.Name
-	Topics   []streaming.TopicID
-	ParentID orgchart.BotID
+	ID              string
+	Content         string
+	Tools           []tool.Name
+	Topics          []streaming.TopicID
+	ParentID        orgchart.BotID
+	PreserveContext bool
 }
 
 // CreateResult carries the new Bot and the pre-allocated
@@ -165,10 +166,11 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 	}
 
 	bot, err := s.Bots.Create(ctx, orgID, bots.CreateParams{
-		ID:      p.ID,
-		Content: p.Content,
-		Tools:   p.Tools,
-		Topics:  p.Topics,
+		ID:              p.ID,
+		Content:         p.Content,
+		Tools:           p.Tools,
+		Topics:          p.Topics,
+		PreserveContext: p.PreserveContext,
 	})
 	if err != nil {
 		return CreateResult{}, err

--- a/api/pkg/org/domain/orgchart/bot.go
+++ b/api/pkg/org/domain/orgchart/bot.go
@@ -34,8 +34,16 @@ type Bot struct {
 	Content        string
 	Tools          []tool.Name
 	Topics         []streaming.TopicID
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	// PreserveContext, when true, tells the runtime spawner NOT to wipe
+	// the Bot's chat session before each re-activation. The default
+	// (false) keeps the existing behaviour: every trigger starts on a
+	// fresh context window. Enabling it lets the Bot accumulate context
+	// across triggers (faster, more context-aware follow-ups — e.g. for
+	// Slack), at the cost of the session growing toward the model's
+	// context limit. See infrastructure/runtime/helix/spawner.go.
+	PreserveContext bool
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
 }
 
 // NewBot validates and constructs a Bot. Treat the returned value as
@@ -90,5 +98,12 @@ func (b Bot) WithTopics(topics []streaming.TopicID) Bot {
 // WithUpdatedAt returns a copy of the Bot with UpdatedAt replaced.
 func (b Bot) WithUpdatedAt(t time.Time) Bot {
 	b.UpdatedAt = t
+	return b
+}
+
+// WithPreserveContext returns a copy of the Bot with PreserveContext
+// replaced.
+func (b Bot) WithPreserveContext(preserve bool) Bot {
+	b.PreserveContext = preserve
 	return b
 }

--- a/api/pkg/org/domain/orgchart/bot_test.go
+++ b/api/pkg/org/domain/orgchart/bot_test.go
@@ -1,0 +1,40 @@
+package orgchart
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNewBotDefaultsPreserveContextFalse pins that a freshly constructed
+// Bot does not preserve context — the spawner wipes its session on every
+// re-activation unless the operator opts in.
+func TestNewBotDefaultsPreserveContextFalse(t *testing.T) {
+	t.Parallel()
+	b, err := NewBot("b-test", "content", nil, nil, time.Now(), "org-test")
+	if err != nil {
+		t.Fatalf("NewBot: %v", err)
+	}
+	if b.PreserveContext {
+		t.Error("NewBot PreserveContext = true, want false (wipe-on-trigger is the default)")
+	}
+}
+
+// TestWithPreserveContext checks the immutable builder flips the flag on a
+// copy without mutating the receiver.
+func TestWithPreserveContext(t *testing.T) {
+	t.Parallel()
+	b, err := NewBot("b-test", "content", nil, nil, time.Now(), "org-test")
+	if err != nil {
+		t.Fatalf("NewBot: %v", err)
+	}
+	on := b.WithPreserveContext(true)
+	if !on.PreserveContext {
+		t.Error("WithPreserveContext(true).PreserveContext = false, want true")
+	}
+	if b.PreserveContext {
+		t.Error("WithPreserveContext mutated the receiver; builders must return a copy")
+	}
+	if on.WithPreserveContext(false).PreserveContext {
+		t.Error("WithPreserveContext(false).PreserveContext = true, want false")
+	}
+}

--- a/api/pkg/org/infrastructure/persistence/gorm/bot.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/bot.go
@@ -26,13 +26,14 @@ import (
 // separate many-to-many relation — see reportingLineRow — so a Bot
 // carries no parent column.
 type botRow struct {
-	ID        string   `gorm:"primaryKey;type:text"`
-	OrgID     string   `gorm:"primaryKey;type:text;index"`
-	Content   string   `gorm:"not null"`
-	Tools     []string `gorm:"serializer:json"`
-	Topics    []string `gorm:"serializer:json"`
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID              string   `gorm:"primaryKey;type:text"`
+	OrgID           string   `gorm:"primaryKey;type:text;index"`
+	Content         string   `gorm:"not null"`
+	Tools           []string `gorm:"serializer:json"`
+	Topics          []string `gorm:"serializer:json"`
+	PreserveContext bool     `gorm:"not null;default:false"`
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
 }
 
 func (botRow) TableName() string { return "org_bots" }
@@ -55,13 +56,14 @@ func (botMapper) ToRow(b orgchart.Bot) (botRow, error) {
 		topics = nil
 	}
 	return botRow{
-		ID:        string(b.ID),
-		OrgID:     b.OrganizationID,
-		Content:   b.Content,
-		Tools:     tools,
-		Topics:    topics,
-		CreatedAt: b.CreatedAt,
-		UpdatedAt: b.UpdatedAt,
+		ID:              string(b.ID),
+		OrgID:           b.OrganizationID,
+		Content:         b.Content,
+		Tools:           tools,
+		Topics:          topics,
+		PreserveContext: b.PreserveContext,
+		CreatedAt:       b.CreatedAt,
+		UpdatedAt:       b.UpdatedAt,
 	}, nil
 }
 
@@ -81,13 +83,14 @@ func (botMapper) ToDomain(row botRow) (orgchart.Bot, error) {
 		}
 	}
 	return orgchart.Bot{
-		ID:             orgchart.BotID(row.ID),
-		OrganizationID: row.OrgID,
-		Content:        row.Content,
-		Tools:          tools,
-		Topics:         topics,
-		CreatedAt:      row.CreatedAt,
-		UpdatedAt:      row.UpdatedAt,
+		ID:              orgchart.BotID(row.ID),
+		OrganizationID:  row.OrgID,
+		Content:         row.Content,
+		Tools:           tools,
+		Topics:          topics,
+		PreserveContext: row.PreserveContext,
+		CreatedAt:       row.CreatedAt,
+		UpdatedAt:       row.UpdatedAt,
 	}, nil
 }
 
@@ -132,10 +135,11 @@ func (r *botsRepo) Update(ctx context.Context, b orgchart.Bot) error {
 		store.WithOrg(row.OrgID),
 		store.WithID(row.ID),
 		store.WithUpdates(map[string]any{
-			"content":    row.Content,
-			"tools":      string(toolsJSON),
-			"topics":     string(topicsJSON),
-			"updated_at": row.UpdatedAt,
+			"content":          row.Content,
+			"tools":            string(toolsJSON),
+			"topics":           string(topicsJSON),
+			"preserve_context": row.PreserveContext,
+			"updated_at":       row.UpdatedAt,
 		}),
 	)
 }

--- a/api/pkg/org/infrastructure/runtime/helix/spawner.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner.go
@@ -466,12 +466,34 @@ func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID
 	// lands on a brand-new thread. First activation (no persisted session
 	// yet) has nothing to clear and falls straight through to a fresh
 	// StartSession.
+	//
+	// Opt-out: a Bot with PreserveContext=true keeps its conversation
+	// across triggers — we skip ClearSession so the follow-up lands on the
+	// existing session (and, for Zed/ACP, the same thread). This trades
+	// the fresh-window guarantee for faster, context-aware follow-ups
+	// (the Slack-support experiment); the session then relies on Helix's
+	// own context-limit/compaction handling. Failing to read the Bot must
+	// not silently fall back to wiping a preserve-context Bot, so the
+	// error propagates.
+	preserve := false
 	if state.SessionID != "" {
+		bot, err := c.Store.Bots.Get(ctx, orgID, workerID)
+		if err != nil {
+			return "", fmt.Errorf("load bot %s for context policy: %w", workerID, err)
+		}
+		preserve = bot.PreserveContext
+	}
+	if state.SessionID != "" && !preserve {
 		if err := c.Client.ClearSession(ctx, state.SessionID); err != nil {
 			return "", fmt.Errorf("clear session %s before re-activation: %w", state.SessionID, err)
 		}
 		if c.Logger != nil {
 			c.Logger.Info("spawner: cleared session before re-activation",
+				"worker", workerID, "session", state.SessionID)
+		}
+	} else if state.SessionID != "" && preserve {
+		if c.Logger != nil {
+			c.Logger.Info("spawner: preserving session context across re-activation",
 				"worker", workerID, "session", state.SessionID)
 		}
 	}

--- a/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
@@ -331,6 +331,48 @@ func TestSpawnerFollowUpResumesPersistedSession(t *testing.T) {
 	}
 }
 
+// TestSpawnerPreservesContextWhenBotOptsIn pins the opt-out: a Bot with
+// PreserveContext=true must NOT have its session wiped on re-activation,
+// so its conversation accumulates across triggers. The follow-up still
+// targets the persisted session (no churn), it just isn't cleared first.
+func TestSpawnerPreservesContextWhenBotOptsIn(t *testing.T) {
+	t.Parallel()
+	s, wid := newHelixTestStore(t)
+	// Flip the bot to preserve context across triggers.
+	bot, err := s.Bots.Get(context.Background(), "org-test", wid)
+	if err != nil {
+		t.Fatalf("get bot: %v", err)
+	}
+	if err := s.Bots.Update(context.Background(), bot.WithPreserveContext(true)); err != nil {
+		t.Fatalf("update bot: %v", err)
+	}
+	if err := SaveProject(context.Background(), s, "org-test", wid, "prj_test", "app_test", "repo_test"); err != nil {
+		t.Fatalf("save project: %v", err)
+	}
+	if err := SaveSession(context.Background(), s, "org-test", wid, "ses_existing"); err != nil {
+		t.Fatalf("save session: %v", err)
+	}
+	fc := &fakeHelixClient{
+		startSessionID: "ses_existing",
+		outputs:        []types.SessionOutputResponse{{Status: "complete", Output: "ok"}},
+	}
+	sp := Spawner(newHelixCfg(t, fc, s))
+	if err := sp(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerEvent, EventID: "e-1"}}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	if got := atomic.LoadInt32(&fc.clearCalls); got != 0 {
+		t.Errorf("ClearSession called %d times; a PreserveContext bot must keep its context across triggers", got)
+	}
+	if fc.lastSendSID != "ses_existing" {
+		t.Errorf("SendMessage sessionID = %q (want ses_existing) — follow-up must still target the persisted session", fc.lastSendSID)
+	}
+	if got := atomic.LoadInt32(&fc.startCalls); got != 0 {
+		t.Errorf("StartSession called %d times; a preserve-context follow-up must reuse the warm session", got)
+	}
+}
+
 // TestSpawnerClearsSessionOnReactivationOnly drives two activations of
 // the same Worker through the real Spawner closure and pins the
 // context-hygiene contract end to end: the first activation opens a

--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -101,11 +101,12 @@ func (a *apiHandler) createBot(w http.ResponseWriter, r *http.Request) {
 	// service so a "New Bot" dialog with no tools picker still gets a
 	// usable MCP surface.
 	res, err := a.deps.Lifecycle.Create(ctx, orgID, lifecycle.CreateParams{
-		ID:       strings.TrimSpace(req.ID),
-		Content:  req.Content,
-		Tools:    toToolNames(req.Tools),
-		Topics:   toTopicIDs(req.Topics),
-		ParentID: orgchart.BotID(strings.TrimSpace(req.ParentID)),
+		ID:              strings.TrimSpace(req.ID),
+		Content:         req.Content,
+		Tools:           toToolNames(req.Tools),
+		Topics:          toTopicIDs(req.Topics),
+		ParentID:        orgchart.BotID(strings.TrimSpace(req.ParentID)),
+		PreserveContext: req.PreserveContext,
 	})
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)
@@ -198,9 +199,10 @@ func (a *apiHandler) updateBot(w http.ResponseWriter, r *http.Request) {
 		topicsPatch = &s
 	}
 	updated, err := a.deps.Bots.Update(ctx, orgID, id, bots.UpdateParams{
-		Content: req.Content,
-		Tools:   toolsPatch,
-		Topics:  topicsPatch,
+		Content:         req.Content,
+		Tools:           toolsPatch,
+		Topics:          topicsPatch,
+		PreserveContext: req.PreserveContext,
 	})
 	if err != nil {
 		writeError(w, errStatus(err), fmt.Errorf("update bot: %w", err))
@@ -547,10 +549,11 @@ func (a *apiHandler) managerIDs(ctx context.Context, orgID string, id orgchart.B
 // top-level Bot.
 func botDTO(b orgchart.Bot, parentIDs []string) BotDTO {
 	dto := BotDTO{
-		ID:             string(b.ID),
-		Content:        b.Content,
-		ParentIDs:      parentIDs,
-		OrganizationID: b.OrganizationID,
+		ID:              string(b.ID),
+		Content:         b.Content,
+		ParentIDs:       parentIDs,
+		OrganizationID:  b.OrganizationID,
+		PreserveContext: b.PreserveContext,
 	}
 	if !b.CreatedAt.IsZero() {
 		dto.CreatedAt = b.CreatedAt.Format(time.RFC3339)

--- a/api/pkg/org/interfaces/server/api/dto.go
+++ b/api/pkg/org/interfaces/server/api/dto.go
@@ -40,8 +40,12 @@ type BotDTO struct {
 	Topics         []string `json:"topics,omitempty"`
 	ParentIDs      []string `json:"parent_ids,omitempty"`
 	OrganizationID string   `json:"organization_id,omitempty"`
-	CreatedAt      string   `json:"created_at,omitempty"`
-	UpdatedAt      string   `json:"updated_at,omitempty"`
+	// PreserveContext, when true, stops the runtime from wiping this
+	// Bot's chat session before each re-activation, so it accumulates
+	// context across triggers (e.g. Slack). Defaults to false.
+	PreserveContext bool   `json:"preserve_context"`
+	CreatedAt       string `json:"created_at,omitempty"`
+	UpdatedAt       string `json:"updated_at,omitempty"`
 }
 
 // BotChatDTO is the POST /bots/{id}/chat response. AgentAppID is the
@@ -76,11 +80,12 @@ type BotDetailDTO struct {
 // create_bot tool's args. ID is optional (a fresh handle is minted when
 // empty). ParentID is the manager the new Bot reports to.
 type CreateBotRequest struct {
-	ID       string   `json:"id,omitempty"`
-	Content  string   `json:"content"`
-	Tools    []string `json:"tools,omitempty"`
-	Topics   []string `json:"topics,omitempty"`
-	ParentID string   `json:"parent_id,omitempty"`
+	ID              string   `json:"id,omitempty"`
+	Content         string   `json:"content"`
+	Tools           []string `json:"tools,omitempty"`
+	Topics          []string `json:"topics,omitempty"`
+	ParentID        string   `json:"parent_id,omitempty"`
+	PreserveContext bool     `json:"preserve_context,omitempty"`
 }
 
 // CreateBotResponse is the body of POST /bots on success.
@@ -90,11 +95,13 @@ type CreateBotResponse struct {
 }
 
 // UpdateBotRequest is the body of PATCH /bots/{id}. A nil field is left
-// unchanged (content-only edit preserves Tools/Topics).
+// unchanged (content-only edit preserves Tools/Topics). PreserveContext
+// is a pointer for the same reason: nil leaves the current setting alone.
 type UpdateBotRequest struct {
-	Content *string  `json:"content,omitempty"`
-	Tools   []string `json:"tools,omitempty"`
-	Topics  []string `json:"topics,omitempty"`
+	Content         *string  `json:"content,omitempty"`
+	Tools           []string `json:"tools,omitempty"`
+	Topics          []string `json:"topics,omitempty"`
+	PreserveContext *bool    `json:"preserve_context,omitempty"`
 }
 
 // AddBotParentRequest is the body of POST /bots/{id}/parents. ParentID

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -21177,6 +21177,10 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "preserve_context": {
+                    "description": "PreserveContext, when true, stops the runtime from wiping this\nBot's chat session before each re-activation, so it accumulates\ncontext across triggers (e.g. Slack). Defaults to false.",
+                    "type": "boolean"
+                },
                 "tools": {
                     "type": "array",
                     "items": {
@@ -21245,6 +21249,9 @@ const docTemplate = `{
                 },
                 "parent_id": {
                     "type": "string"
+                },
+                "preserve_context": {
+                    "type": "boolean"
                 },
                 "tools": {
                     "type": "array",
@@ -21776,6 +21783,9 @@ const docTemplate = `{
             "properties": {
                 "content": {
                     "type": "string"
+                },
+                "preserve_context": {
+                    "type": "boolean"
                 },
                 "tools": {
                     "type": "array",

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -21173,6 +21173,10 @@
                         "type": "string"
                     }
                 },
+                "preserve_context": {
+                    "description": "PreserveContext, when true, stops the runtime from wiping this\nBot's chat session before each re-activation, so it accumulates\ncontext across triggers (e.g. Slack). Defaults to false.",
+                    "type": "boolean"
+                },
                 "tools": {
                     "type": "array",
                     "items": {
@@ -21241,6 +21245,9 @@
                 },
                 "parent_id": {
                     "type": "string"
+                },
+                "preserve_context": {
+                    "type": "boolean"
                 },
                 "tools": {
                     "type": "array",
@@ -21772,6 +21779,9 @@
             "properties": {
                 "content": {
                     "type": "string"
+                },
+                "preserve_context": {
+                    "type": "boolean"
                 },
                 "tools": {
                     "type": "array",

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -41,6 +41,12 @@ definitions:
         items:
           type: string
         type: array
+      preserve_context:
+        description: |-
+          PreserveContext, when true, stops the runtime from wiping this
+          Bot's chat session before each re-activation, so it accumulates
+          context across triggers (e.g. Slack). Defaults to false.
+        type: boolean
       tools:
         items:
           type: string
@@ -86,6 +92,8 @@ definitions:
         type: string
       parent_id:
         type: string
+      preserve_context:
+        type: boolean
       tools:
         items:
           type: string
@@ -472,6 +480,8 @@ definitions:
     properties:
       content:
         type: string
+      preserve_context:
+        type: boolean
       tools:
         items:
           type: string

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -35,6 +35,12 @@ export interface ApiBotDTO {
   id?: string;
   organization_id?: string;
   parent_ids?: string[];
+  /**
+   * PreserveContext, when true, stops the runtime from wiping this
+   * Bot's chat session before each re-activation, so it accumulates
+   * context across triggers (e.g. Slack). Defaults to false.
+   */
+  preserve_context?: boolean;
   tools?: string[];
   topics?: string[];
   updated_at?: string;
@@ -61,6 +67,7 @@ export interface ApiCreateBotRequest {
   content?: string;
   id?: string;
   parent_id?: string;
+  preserve_context?: boolean;
   tools?: string[];
   topics?: string[];
 }
@@ -317,6 +324,7 @@ export interface ApiTransportRequestField {
 
 export interface ApiUpdateBotRequest {
   content?: string;
+  preserve_context?: boolean;
   tools?: string[];
   topics?: string[];
 }

--- a/frontend/src/pages/HelixOrgBotDetail.tsx
+++ b/frontend/src/pages/HelixOrgBotDetail.tsx
@@ -25,10 +25,12 @@ import Chip from '@mui/material/Chip'
 import CircularProgress from '@mui/material/CircularProgress'
 import Container from '@mui/material/Container'
 import Divider from '@mui/material/Divider'
+import FormControlLabel from '@mui/material/FormControlLabel'
 import Grid from '@mui/material/Grid'
 import Link from '@mui/material/Link'
 import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
+import Switch from '@mui/material/Switch'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import CheckBoxIcon from '@mui/icons-material/CheckBox'
@@ -104,10 +106,12 @@ const HelixOrgBotDetail: FC = () => {
   // loads/refreshes so a cancelled edit re-syncs to server state.
   const [content, setContent] = useState('')
   const [tools, setTools] = useState<string[]>([])
+  const [preserveContext, setPreserveContext] = useState(false)
   useEffect(() => {
     setContent(bot?.content ?? '')
     setTools(bot?.tools ?? [])
-  }, [bot?.content, bot?.tools])
+    setPreserveContext(bot?.preserve_context ?? false)
+  }, [bot?.content, bot?.tools, bot?.preserve_context])
 
   // The Autocomplete needs Option objects, but the bot's tool list is
   // just a string[] of names. Render every catalogue entry plus any
@@ -127,13 +131,14 @@ const HelixOrgBotDetail: FC = () => {
     if (!bot) return false
     if ((bot.content ?? '') !== content) return true
     if ((bot.tools ?? []).join(',') !== tools.join(',')) return true
+    if ((bot.preserve_context ?? false) !== preserveContext) return true
     return false
-  }, [bot, content, tools])
+  }, [bot, content, tools, preserveContext])
 
   const handleSave = async () => {
     if (!botId) return
     try {
-      await updateBot.mutateAsync({ id: botId, content, tools })
+      await updateBot.mutateAsync({ id: botId, content, tools, preserve_context: preserveContext })
       snackbar.success(`bot ${botId} saved`)
     } catch (err: any) {
       snackbar.error(err?.response?.data?.error ?? err?.message ?? 'save failed')
@@ -397,6 +402,27 @@ const HelixOrgBotDetail: FC = () => {
                       />
                     )}
                   />
+                </Box>
+
+                <Box>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={preserveContext}
+                        onChange={(_e, checked) => setPreserveContext(checked)}
+                      />
+                    }
+                    label="Preserve context across triggers"
+                  />
+                  <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                    By default each trigger wipes the bot's session so every turn
+                    starts on a fresh context window. Enable this to keep the
+                    conversation across triggers — faster, more context-aware
+                    follow-ups (e.g. for Slack), at the cost of the session
+                    growing toward the model's context limit (where compaction
+                    kicks in). Durable state still belongs in the bot's git
+                    workspace, not the chat history.
+                  </Typography>
                 </Box>
 
                 <SubscriptionsPanel botID={bot?.id} />

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -41,6 +41,12 @@ definitions:
         items:
           type: string
         type: array
+      preserve_context:
+        description: |-
+          PreserveContext, when true, stops the runtime from wiping this
+          Bot's chat session before each re-activation, so it accumulates
+          context across triggers (e.g. Slack). Defaults to false.
+        type: boolean
       tools:
         items:
           type: string
@@ -86,6 +92,8 @@ definitions:
         type: string
       parent_id:
         type: string
+      preserve_context:
+        type: boolean
       tools:
         items:
           type: string
@@ -472,6 +480,8 @@ definitions:
     properties:
       content:
         type: string
+      preserve_context:
+        type: boolean
       tools:
         items:
           type: string

--- a/openapi.json
+++ b/openapi.json
@@ -25476,6 +25476,10 @@
                             "type": "string"
                         }
                     },
+                    "preserve_context": {
+                        "description": "PreserveContext, when true, stops the runtime from wiping this\nBot's chat session before each re-activation, so it accumulates\ncontext across triggers (e.g. Slack). Defaults to false.",
+                        "type": "boolean"
+                    },
                     "tools": {
                         "type": "array",
                         "items": {
@@ -25544,6 +25548,9 @@
                     },
                     "parent_id": {
                         "type": "string"
+                    },
+                    "preserve_context": {
+                        "type": "boolean"
                     },
                     "tools": {
                         "type": "array",
@@ -26075,6 +26082,9 @@
                 "properties": {
                     "content": {
                         "type": "string"
+                    },
+                    "preserve_context": {
+                        "type": "boolean"
                     },
                     "tools": {
                         "type": "array",

--- a/swagger.json
+++ b/swagger.json
@@ -21173,6 +21173,10 @@
                         "type": "string"
                     }
                 },
+                "preserve_context": {
+                    "description": "PreserveContext, when true, stops the runtime from wiping this\nBot's chat session before each re-activation, so it accumulates\ncontext across triggers (e.g. Slack). Defaults to false.",
+                    "type": "boolean"
+                },
                 "tools": {
                     "type": "array",
                     "items": {
@@ -21241,6 +21245,9 @@
                 },
                 "parent_id": {
                     "type": "string"
+                },
+                "preserve_context": {
+                    "type": "boolean"
                 },
                 "tools": {
                     "type": "array",
@@ -21772,6 +21779,9 @@
             "properties": {
                 "content": {
                     "type": "string"
+                },
+                "preserve_context": {
+                    "type": "boolean"
                 },
                 "tools": {
                     "type": "array",


### PR DESCRIPTION
## Summary

Slack-support experiment for helix-org. Adds an opt-in per-bot setting,
`PreserveContext` (default **off**), that stops the runtime spawner from
wiping a bot's chat session before each re-activation. With it on, a bot
keeps its conversation (and, for Zed/ACP, the same thread) across triggers,
so Slack replies are faster and more context-aware instead of starting cold
every time. Default-off preserves today's wipe-on-every-trigger behaviour
for every existing bot.

## Changes

- **Domain** (`orgchart.Bot`): new `PreserveContext bool` field +
  `WithPreserveContext` builder; defaults false. Unit tests added.
- **Persistence** (gorm): new `preserve_context` column
  (`not null;default:false`), mapped both ways and in the partial-update
  map. AutoMigrate adds the column; existing rows backfill to false. Memory
  store stores the aggregate by value, so no mapper change.
- **Application** (`bots`, `lifecycle`): threaded `PreserveContext` through
  `CreateParams`/`UpdateParams` (update uses a `*bool` patch — nil = leave
  unchanged).
- **REST** (`BotDTO`, `CreateBotRequest`, `UpdateBotRequest`): exposed
  `preserve_context`; mapped in the create/update handlers and `botDTO`.
- **Runtime** (`spawner.go::ensureSession`): on re-activation, loads the bot
  and skips `ClearSession` when `PreserveContext` is true; logs the
  cleared-vs-preserved branch. Failing to read the bot propagates the error
  rather than silently wiping a preserve-context bot. New test
  `TestSpawnerPreservesContextWhenBotOptsIn`; existing clear-on-reactivation
  tests still pin the default-off behaviour.
- **Frontend** (`HelixOrgBotDetail.tsx`): a "Preserve context across
  triggers" switch wired through `useUpdateBot`, with help text covering the
  speed-vs-compaction trade-off. Regenerated OpenAPI/TS client.

## Screenshots

Bot detail page — the new toggle (default off, left; enabled, right):

![Toggle off](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002189_once-the-bot-refactor/screenshots/01-toggle-off.png)
![Toggle on](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002189_once-the-bot-refactor/screenshots/02-toggle-on.png)

## Notes

- MCP `create_bot`/`update_bot` intentionally do NOT expose this — keeping
  the MCP surface to org-graph primitives (helix-org philosophy); a bot
  shouldn't toggle its own context policy.
- Verified live in the inner Helix (helix-org enabled): the
  `preserve_context` field round-trips through `POST`/`GET`/`PATCH /bots`
  (create true→true, patch false→false with content untouched, patch
  true→true) and persists in the `org_bots.preserve_context` column. The
  spawner's skip-clear branch itself is proven by
  `TestSpawnerPreservesContextWhenBotOptsIn` (real Spawner + real store);
  capturing it in a live re-activation is timing-gated by per-worker
  activation serialization, so it was not observed in the live log.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwc2hmbrj8aw0xyk3tqjd1em)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002189_once-the-bot-refactor/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002189_once-the-bot-refactor/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002189_once-the-bot-refactor/tasks.md)

🚀 Built with [Helix](https://helix.ml)