### PR TITLE
fix(gc): reap orphaned zvols/workspaces by default (dry-run off)

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -60,9 +60,14 @@ type ServerConfig struct {
 	OrphanReaperGracePeriod time.Duration `envconfig:"HELIX_ORPHAN_REAPER_GRACE_PERIOD" default:"6h"`
 
 	// OrphanReaperDryRun, when true, makes the reaper report what it WOULD reap
-	// without destroying anything. Defaults to true so the safety-critical zvol
-	// destroys are opt-in until an operator has reviewed the dry-run logs.
-	OrphanReaperDryRun bool `envconfig:"HELIX_ORPHAN_REAPER_DRY_RUN" default:"true"`
+	// without destroying anything. Defaults to FALSE so garbage collection
+	// actually runs out of the box — the previous true default meant any
+	// deployment that didn't explicitly opt in never reclaimed leaked zvols, so
+	// pools filled up (the recurring prod ~95%-full / fragmentation incidents).
+	// Safety is provided by the DB-driven live-set + the grace period
+	// (OrphanReaperGracePeriod), not by withholding the destroy. Set to true to
+	// audit what would be reaped without deleting.
+	OrphanReaperDryRun bool `envconfig:"HELIX_ORPHAN_REAPER_DRY_RUN" default:"false"`
 
 	// SandboxReaperInterval is how often the sandbox-instance reaper scans
 	// the sandbox_instances table for stale rows and flips their status to


### PR DESCRIPTION
## Root cause
The DB-driven orphan-resource reaper (`RunOrphanResourceReaper`) was shipping with `HELIX_ORPHAN_REAPER_DRY_RUN` **default `true`** — i.e. report-only. Any deployment that didn't explicitly set it `false` (including **prod**) ran the reaper, logged what it *would* reap, and **deleted nothing**. Result: leaked session zvols + workspace dirs accumulate forever → ZFS pool fills toward ~95% and fragments → the box goes **I/O-bound** (load spikes from `txg_sync`/`zvol_tq` contention, high `f_await`), which presents as "slow box" even though CPU/memory/thermals are fine.

Confirmed live on meta: with the var set `false`, a single reaper tick reclaimed **7 zvols + 5 workspaces (~20 GB)** correctly, only touching ended/old sessions (running/recent/keep_alive sessions are in the live-set and skipped).

## Fix
Flip the default to `false` so GC runs out of the box. Safety is **not** lost — it's provided by:
- the DB live-set (sessions with `external_agent_status=running`, recently `updated`, or backing a `keep_alive` spec-task are never reaped), and
- `OrphanReaperGracePeriod` (default 6h) so freshly-created resources are never raced.

Set `HELIX_ORPHAN_REAPER_DRY_RUN=true` to audit-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)