### PR TITLE
fix(api): query org_bot_runtime_state after bot table rename

### DIFF
--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -387,12 +387,12 @@ func (s *HelixAPIServer) markHelixOrgAgents(ctx context.Context, orgID string, a
 		return nil
 	}
 
-	// org_worker_runtime_state holds one row per (org, worker, backend, key).
+	// org_bot_runtime_state holds one row per (org, bot, backend, key).
 	// The "helix" backend's "agent_app_id" value is the App backing that
-	// Worker — see api/pkg/org/infrastructure/runtime/helix/state.go.
+	// Bot — see api/pkg/org/infrastructure/runtime/helix/state.go.
 	var agentAppIDs []string
 	if err := accessor.GormDB().WithContext(ctx).
-		Table("org_worker_runtime_state").
+		Table("org_bot_runtime_state").
 		Where("org_id = ? AND backend = ? AND key = ? AND value <> ?", orgID, "helix", "agent_app_id", "").
 		Distinct("value").
 		Pluck("value", &agentAppIDs).Error; err != nil {

--- a/api/pkg/server/app_handlers_test.go
+++ b/api/pkg/server/app_handlers_test.go
@@ -19,8 +19,8 @@ import (
 // no app is flagged and the database is never touched (the mock store does not
 // implement GormDB, so any query would panic). This guards the no-regression
 // guarantee for the default (feature-off) configuration. The positive path
-// (flagging an app that backs an org-chart Worker) requires a live Postgres
-// org_worker_runtime_state table and is verified end-to-end, not here.
+// (flagging an app that backs an org-chart Bot) requires a live Postgres
+// org_bot_runtime_state table and is verified end-to-end, not here.
 func Test_markHelixOrgAgents_FeatureDisabled_NoOp(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
## Summary

Listing apps for an org failed with
`failed to list helix-org agent apps: ERROR: relation "org_worker_runtime_state" does not exist (SQLSTATE 42P01)`.

This was a straggler from the bot refactor (spectask `002185`), which merged the
helix-org `Role` + `Worker` concepts into a single `Bot` and dropped the
`org_worker_runtime_state` table (migration `0005`). GORM AutoMigrate recreates
the runtime-state sidecar under the new name `org_bot_runtime_state`, but
`markHelixOrgAgents` in `app_handlers.go` still queried the old, now-dropped
table — so every org app listing (with helix-org enabled) returned a 500.

## Changes

- `api/pkg/server/app_handlers.go`: `markHelixOrgAgents` now queries
  `org_bot_runtime_state` instead of `org_worker_runtime_state`; the accompanying
  comment is updated to the new schema (org, bot, backend, key). The query's
  filter columns are unchanged across the rename, so the table name was the only
  functional change.
- `api/pkg/server/app_handlers_test.go`: fixed a stale doc-comment referencing the
  old table/"Worker" wording (no test logic changed).

## Testing

- `go build ./...` (in `api/`) passes.
- End-to-end in the local inner Helix with `HELIX_ORG_ENABLED=true`: registered an
  admin user, created an org and an app in it, then
  `GET /api/v1/apps?organization_id=<org>` returned **200** (exercising the
  `org_bot_runtime_state` query). API logs showed **0** occurrences of `42P01`,
  `org_worker_runtime_state`, or `failed to list helix-org agent apps`.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwcng248twhk7nshjpj0g5q3)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002191_please-fix-this-this-is/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002191_please-fix-this-this-is/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002191_please-fix-this-this-is/tasks.md)

🚀 Built with [Helix](https://helix.ml)