### PR TITLE
fix(hydra): flatten golden zvols to root so dead session roots are reapable

### DIFF
--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -795,7 +795,6 @@ func (dm *DevContainerManager) buildEnv(req *CreateDevContainerRequest) []string
 	// Our containers run as root, so without this Claude Code prompts for every tool use.
 	env = append(env, "IS_SANDBOX=1")
 
-
 	// Add GPU-specific environment variables
 	switch req.GPUVendor {
 	case "nvidia":
@@ -1314,13 +1313,13 @@ func enumerateDRMDevices(targetDriver string) []drmDevice {
 // tests can stand up a synthetic /sys/class/drm tree.
 //
 // This is the function with the actual PCI walk:
-//   1. Glob `<devRoot>/dri/renderD*` to find render nodes (compute path).
-//   2. For each render node, look up `<sysfsRoot>/class/drm/<base>/device`
-//      to get the PCI BDF and driver name.
-//   3. Filter to targetDriver if set.
-//   4. For each matching render node, find the sibling card device by
-//      walking `<sysfsRoot>/class/drm/card*/device` and matching BDF.
-//   5. Sort the resulting list by PCI BDF.
+//  1. Glob `<devRoot>/dri/renderD*` to find render nodes (compute path).
+//  2. For each render node, look up `<sysfsRoot>/class/drm/<base>/device`
+//     to get the PCI BDF and driver name.
+//  3. Filter to targetDriver if set.
+//  4. For each matching render node, find the sibling card device by
+//     walking `<sysfsRoot>/class/drm/card*/device` and matching BDF.
+//  5. Sort the resulting list by PCI BDF.
 //
 // A render node with no sibling card device is still returned (cards
 // are display-only nodes; some headless compute GPUs have no card device).
@@ -1978,6 +1977,13 @@ func (dm *DevContainerManager) ReconcileGC(req GCReconcileRequest) GCReconcileRe
 		before, _ = poolFreeBytes()
 	}
 
+	// Heal the legacy inverted topology where a golden zvol is itself a clone of
+	// an ended session's zvol (making that session zvol an unreapable
+	// clone-origin that leaks old snapshots forever). Promote such goldens to
+	// true roots FIRST, so the now-detached session roots fall to the orphan
+	// reaper below in the same pass. Metadata-only; in dry-run we only report.
+	resp.GoldensFlattened = FlattenInvertedGoldens(req.DryRun)
+
 	zReaped, zSkipped := ReconcileOrphanZvols(liveSessions, grace, req.DryRun)
 	resp.ZvolsReaped = zReaped
 	resp.ZvolsSkipped = zSkipped
@@ -1987,6 +1993,11 @@ func (dm *DevContainerManager) ReconcileGC(req GCReconcileRequest) GCReconcileRe
 	resp.WorkspacesSkipped = wSkipped
 
 	if !req.DryRun {
+		// Prune golden snapshots the flatten just absorbed plus any other stale
+		// no-clone snapshots (>7d). Frees the old generations the dead session
+		// roots used to pin. Safe: never touches snapshots with live clones.
+		GCStaleSnapshots()
+
 		// Ignore measurement errors → 0. Pool free can also move for unrelated
 		// reasons; clamp to a non-negative delta.
 		if after, err := poolFreeBytes(); err == nil {
@@ -2005,6 +2016,7 @@ func (dm *DevContainerManager) ReconcileGC(req GCReconcileRequest) GCReconcileRe
 		Int("zvols_skipped", len(resp.ZvolsSkipped)).
 		Int("workspaces_reaped", len(resp.WorkspacesReaped)).
 		Int("workspaces_skipped", len(resp.WorkspacesSkipped)).
+		Int("goldens_flattened", len(resp.GoldensFlattened)).
 		Int64("bytes_freed", resp.BytesFreed).
 		Msg("GC_RECONCILE completed")
 

--- a/api/pkg/hydra/golden_zvol.go
+++ b/api/pkg/hydra/golden_zvol.go
@@ -653,6 +653,16 @@ func PromoteSessionToGoldenZvol(projectID, sessionID string) error {
 	_ = runCmd("umount", goldenMount)
 	_ = os.Remove(goldenMount)
 
+	// Ensure golden ends up a true root dataset. `zfs promote` above only
+	// detaches one level, so without this golden stays a clone of the original
+	// session's zvol, which then becomes an unreapable clone-origin and leaks
+	// old snapshots forever. Metadata-only; the project lock is already held.
+	if n, err := flattenGoldenToRootLocked(goldenName); err != nil {
+		log.Warn().Err(err).Str("golden", goldenName).Msg("Failed to flatten golden to root after promote")
+	} else if n > 0 {
+		log.Info().Str("golden", goldenName).Int("promotes", n).Msg("Flattened golden to root after promote")
+	}
+
 	log.Info().
 		Str("project_id", projectID).
 		Str("golden", goldenName).
@@ -981,6 +991,99 @@ func GCStaleSnapshots() int {
 	}
 
 	return cleaned
+}
+
+// zfsOrigin returns the origin snapshot of a dataset, or "" when it has none
+// (a root dataset; ZFS reports "-"). "" is also returned on error.
+func zfsOrigin(dataset string) string {
+	out, err := execCmdOutput("zfs", "get", "-H", "-o", "value", "origin", dataset)
+	if err != nil {
+		return ""
+	}
+	v := strings.TrimSpace(string(out))
+	if v == "-" {
+		return ""
+	}
+	return v
+}
+
+// flattenGoldenToRootLocked promotes a golden zvol until it is a true root
+// dataset (origin == "-"). golden is built by promoting/cloning a running
+// session, and `zfs promote` only detaches ONE level — so without this, golden
+// stays a clone of the *first* session's zvol, which then becomes an
+// unreapable clone-origin holding old snapshots forever (the GC leak).
+//
+// `zfs promote` is metadata-only: it re-parents the shared snapshots onto
+// golden without copying or deleting any data, and live session clones keep
+// working throughout. Once golden is a root, the former origin session zvols
+// become ordinary leaf clones the orphan reaper can destroy, and their
+// now-absorbed old snapshots are pruned by GCStaleSnapshots. Safe + reversible.
+//
+// The caller MUST hold the project's golden lock.
+func flattenGoldenToRootLocked(goldenName string) (promotes int, err error) {
+	if !zfsDatasetExists(goldenName) {
+		return 0, nil
+	}
+	// Chains are short (golden ← session ← golden …); guard against an
+	// unexpected cycle so we can never spin forever.
+	const maxPromotes = 50
+	for promotes < maxPromotes {
+		if zfsOrigin(goldenName) == "" {
+			return promotes, nil // already a root
+		}
+		if err := runCmd("zfs", "promote", goldenName); err != nil {
+			return promotes, fmt.Errorf("zfs promote %s failed: %w", goldenName, err)
+		}
+		promotes++
+	}
+	return promotes, fmt.Errorf("golden %s still has an origin after %d promotes (possible clone cycle)", goldenName, maxPromotes)
+}
+
+// FlattenGoldenToRoot is the locked, public per-project entry point.
+func FlattenGoldenToRoot(projectID string) (int, error) {
+	lock := getGoldenLock(projectID)
+	lock.Lock()
+	defer lock.Unlock()
+	return flattenGoldenToRootLocked(goldenZvolName(projectID))
+}
+
+// FlattenInvertedGoldens finds golden zvols that are still clones of another
+// dataset (origin != "-") — the legacy topology where golden hangs off an
+// ended session's zvol — and promotes each to a true root, detaching the dead
+// session origin so the orphan reaper can reclaim it. Metadata-only and safe;
+// returns the goldens it flattened (or, in dryRun, would flatten).
+func FlattenInvertedGoldens(dryRun bool) (flattened []string) {
+	if !ZFSAvailable() {
+		return nil
+	}
+	out, err := execCmdOutput("zfs", "list", "-H", "-o", "name", "-t", "volume", "-r", zfsParentDataset)
+	if err != nil {
+		log.Warn().Err(err).Msg("FlattenInvertedGoldens: failed to list zvols")
+		return nil
+	}
+	goldenPrefix := zfsParentDataset + "/golden-"
+	for _, name := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if !strings.HasPrefix(name, goldenPrefix) {
+			continue
+		}
+		if zfsOrigin(name) == "" {
+			continue // already a root — nothing to do
+		}
+		if dryRun {
+			flattened = append(flattened, name)
+			continue
+		}
+		projectID := strings.TrimPrefix(name, goldenPrefix)
+		promotes, err := FlattenGoldenToRoot(projectID)
+		if err != nil {
+			log.Warn().Err(err).Str("golden", name).Msg("FlattenInvertedGoldens: failed to flatten golden to root")
+			continue
+		}
+		log.Info().Str("golden", name).Int("promotes", promotes).
+			Msg("Flattened inverted golden to root (detached dead session origin)")
+		flattened = append(flattened, name)
+	}
+	return flattened
 }
 
 // effectiveGoldenBaseDir returns the golden base directory, respecting test overrides.

--- a/api/pkg/hydra/types.go
+++ b/api/pkg/hydra/types.go
@@ -229,5 +229,6 @@ type GCReconcileResponse struct {
 	ZvolsSkipped      []GCSkip `json:"zvols_skipped"`
 	WorkspacesReaped  []string `json:"workspaces_reaped"`
 	WorkspacesSkipped []GCSkip `json:"workspaces_skipped"`
+	GoldensFlattened  []string `json:"goldens_flattened"`
 	BytesFreed        int64    `json:"bytes_freed"`
 }


### PR DESCRIPTION
## Root cause
Golden zvols are built by promoting a running session's clone. `zfs promote` only detaches **one level**, so a golden stayed a clone of the **first** session's zvol — e.g. `golden-prj_01kg02` was a clone of `ses_01kratzbdv@gen34`, and every live session cloned from the golden. That original session zvol was therefore an **unreapable clone-origin** (`zfs destroy -r` → "volume has dependent clones") pinning **198 GB** of old snapshots forever. These were the big `zvols_skipped` the reaper could never clear — the actual GC leak behind ZFS pools filling/fragmenting and the resulting I/O-bound slowdowns. (Pairs with #2755, which made the reaper actually run.)

## Fix
`flattenGoldenToRootLocked` / `FlattenGoldenToRoot` / `FlattenInvertedGoldens`: `zfs promote` a golden until `origin == "-"`. Promote is **metadata-only** — it re-parents shared snapshots onto golden without copying/deleting data, and live clones keep working — so it's safe and reversible. Wired in two places:
- **(a) prevent new ones:** at the end of `PromoteSessionToGoldenZvol`, flatten golden to root after the build.
- **(b) auto-heal existing:** in `ReconcileGC`, flatten inverted goldens **before** the zvol reaper — the now-detached session roots become ordinary leaves and reap normally; `GCStaleSnapshots` then prunes the absorbed old generations.

No new manual steps; no `zfs send/recv`; no `-R`/`-f` force-destroys.

## Validated on meta
All 4 goldens re-rooted (`origin=-`); the 285 GB `ses_01kratzbdv` root reaped; **~83 GB reclaimed** across two ticks (frag 65%→63%, cap 70%→67%); `app.helix.ml` stayed 200 throughout — zero impact on live sessions.

## Deploy note
This is **hydra** code (runs in the sandbox image), so it reaches prod via a sandbox rebuild (`./stack build-sandbox` + `SANDBOX_TAG` bump), not the controlplane release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)