### PR TITLE
fix(hydra): reap orphaned file-copy session docker-data dirs

### DIFF
--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -1992,6 +1992,14 @@ func (dm *DevContainerManager) ReconcileGC(req GCReconcileRequest) GCReconcileRe
 	resp.WorkspacesReaped = wReaped
 	resp.WorkspacesSkipped = wSkipped
 
+	// Reap file-copy per-session docker-data dirs for dead sessions. The zvol
+	// reaper above only covers ZFS hosts; on file-copy hosts (ZFS unavailable)
+	// the inner docker storage lives in these dirs, and nothing durable reaped
+	// them before — they leaked indefinitely.
+	fReaped, fSkipped := ReconcileOrphanFileCopyDirs(liveSessions, grace, req.DryRun)
+	resp.FileCopyDirsReaped = fReaped
+	resp.FileCopyDirsSkipped = fSkipped
+
 	if !req.DryRun {
 		// Prune golden snapshots the flatten just absorbed plus any other stale
 		// no-clone snapshots (>7d). Frees the old generations the dead session
@@ -2016,6 +2024,8 @@ func (dm *DevContainerManager) ReconcileGC(req GCReconcileRequest) GCReconcileRe
 		Int("zvols_skipped", len(resp.ZvolsSkipped)).
 		Int("workspaces_reaped", len(resp.WorkspacesReaped)).
 		Int("workspaces_skipped", len(resp.WorkspacesSkipped)).
+		Int("filecopy_dirs_reaped", len(resp.FileCopyDirsReaped)).
+		Int("filecopy_dirs_skipped", len(resp.FileCopyDirsSkipped)).
 		Int("goldens_flattened", len(resp.GoldensFlattened)).
 		Int64("bytes_freed", resp.BytesFreed).
 		Msg("GC_RECONCILE completed")

--- a/api/pkg/hydra/golden.go
+++ b/api/pkg/hydra/golden.go
@@ -854,11 +854,13 @@ func GCOrphanedSessionDirs(activeSessions map[string]bool) (int, int64, error) {
 			continue
 		}
 
-		// Only clean up dirs that haven't been active in over a week.
-		// If there's no .last-active marker (pre-existing dir), don't
-		// GC it — it'll get a marker next time the container runs or stops.
-		age := sessionLastActiveAge(dir)
-		if age == 0 || age < maxAge {
+		// Only clean up dirs that haven't been active in over a week. Use the
+		// newer of the dir mtime and the .last-active marker (fileCopyDirAge):
+		// a marker-less dir (pre-marker, or a crashed/unclean stop) falls back
+		// to the dir mtime rather than being skipped forever — the bug that
+		// leaked old file-copy docker-data dirs indefinitely.
+		age := fileCopyDirAge(dir)
+		if age < maxAge {
 			continue
 		}
 

--- a/api/pkg/hydra/golden_zvol.go
+++ b/api/pkg/hydra/golden_zvol.go
@@ -916,6 +916,86 @@ func ReconcileOrphanZvols(liveSet map[string]bool, grace time.Duration, dryRun b
 	return reaped, skipped
 }
 
+// ReconcileOrphanFileCopyDirs reaps per-session file-copy docker-data dirs
+// (sessionsBaseDir/docker-data-<id>) whose session is NOT in the DB-derived
+// liveSet and whose on-disk age has passed the grace period.
+//
+// These dirs hold the inner docker storage on hosts where ZFS is unavailable
+// (the file-copy fallback in resolveDockerDataDir), and stale marker dirs on
+// ZFS hosts. The durable reaper previously ignored them entirely — only the
+// legacy in-memory GCOrphanedSessionDirs touched them, and that path skips any
+// dir without a .last-active marker forever (age == 0). Ended-session docker
+// data therefore leaked indefinitely (this is what accumulated ~1T of dead
+// docker-data dirs on a file-copy host). This closes the gap using the same
+// durable, DB-derived live-set the zvol reaper uses.
+func ReconcileOrphanFileCopyDirs(liveSet map[string]bool, grace time.Duration, dryRun bool) (reaped []string, skipped []GCSkip) {
+	entries, err := os.ReadDir(sessionsBaseDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Warn().Err(err).Msg("ReconcileOrphanFileCopyDirs: failed to read sessions dir")
+		}
+		return nil, nil
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "docker-data-") {
+			continue
+		}
+		sessionID := strings.TrimPrefix(entry.Name(), "docker-data-")
+		dir := filepath.Join(sessionsBaseDir, entry.Name())
+
+		if liveSet[sessionID] {
+			// Live per the DB — keep, and refresh the marker so the legacy
+			// 7-day GC also keeps treating it as fresh.
+			TouchSessionLastActive(dir)
+			skipped = append(skipped, GCSkip{Name: dir, Reason: "live"})
+			continue
+		}
+
+		// Not live. Apply the grace period using fileCopyDirAge (dir mtime or
+		// marker, whichever is newer) — never the marker alone, so a dir
+		// lacking a .last-active marker is still reapable.
+		if fileCopyDirAge(dir) < grace {
+			skipped = append(skipped, GCSkip{Name: dir, Reason: "grace"})
+			continue
+		}
+
+		if dryRun {
+			reaped = append(reaped, dir)
+			continue
+		}
+
+		if err := os.RemoveAll(dir); err != nil {
+			log.Warn().Err(err).Str("dir", dir).Msg("ReconcileOrphanFileCopyDirs: failed to remove orphan docker-data dir")
+			skipped = append(skipped, GCSkip{Name: dir, Reason: "error: " + err.Error()})
+			continue
+		}
+		reaped = append(reaped, dir)
+	}
+
+	return reaped, skipped
+}
+
+// fileCopyDirAge returns how long since a session docker-data dir was last
+// active, using the newer of the dir's own mtime and its .last-active marker.
+// Unlike sessionLastActiveAge it never returns 0 for a marker-less dir: a
+// missing marker falls back to the dir mtime, so pre-marker / crashed dirs are
+// still reapable. Returns 0 only when the dir can't be stat'd at all (treated
+// as fresh — conservative, won't reap).
+func fileCopyDirAge(dir string) time.Duration {
+	var newest time.Time
+	if fi, err := os.Stat(dir); err == nil {
+		newest = fi.ModTime()
+	}
+	if fi, err := os.Stat(filepath.Join(dir, ".last-active")); err == nil && fi.ModTime().After(newest) {
+		newest = fi.ModTime()
+	}
+	if newest.IsZero() {
+		return 0
+	}
+	return time.Since(newest)
+}
+
 // GCStaleSnapshots destroys golden snapshots older than 7 days that have no
 // remaining clones. Keeps recent snapshots so the user can see cache progression.
 // Snapshots with active session clones can't be destroyed (ZFS refuses) — that's

--- a/api/pkg/hydra/types.go
+++ b/api/pkg/hydra/types.go
@@ -225,10 +225,12 @@ type GCSkip struct {
 // GCReconcileResponse is hydra's report of what it reaped (or would reap, in
 // dry-run mode) and what it deliberately skipped.
 type GCReconcileResponse struct {
-	ZvolsReaped       []string `json:"zvols_reaped"`
-	ZvolsSkipped      []GCSkip `json:"zvols_skipped"`
-	WorkspacesReaped  []string `json:"workspaces_reaped"`
-	WorkspacesSkipped []GCSkip `json:"workspaces_skipped"`
-	GoldensFlattened  []string `json:"goldens_flattened"`
-	BytesFreed        int64    `json:"bytes_freed"`
+	ZvolsReaped         []string `json:"zvols_reaped"`
+	ZvolsSkipped        []GCSkip `json:"zvols_skipped"`
+	WorkspacesReaped    []string `json:"workspaces_reaped"`
+	WorkspacesSkipped   []GCSkip `json:"workspaces_skipped"`
+	FileCopyDirsReaped  []string `json:"file_copy_dirs_reaped"`
+	FileCopyDirsSkipped []GCSkip `json:"file_copy_dirs_skipped"`
+	GoldensFlattened    []string `json:"goldens_flattened"`
+	BytesFreed          int64    `json:"bytes_freed"`
 }


### PR DESCRIPTION
## Problem

The durable, DB-driven orphan reaper (`ReconcileGC`) reaps ZFS session zvols and `/data/workspaces` dirs — but **never** the file-copy per-session docker-data dirs at `/container-docker/sessions/docker-data-<id>`. On hosts where ZFS is unavailable, that path holds the inner docker storage, and it leaked **indefinitely**:

- The only thing that touched it was the legacy 10-minute in-memory `GCOrphanedSessionDirs`, which (a) keys off **in-memory** container state (blind after a restart, not the DB) and (b) **skips any dir without a `.last-active` marker forever** (`golden.go`: `age == 0` → `continue`).
- On one production host this accumulated **~1 T of dead docker-data** from sessions that ended months ago (Feb–May).

## Fix

- **`ReconcileOrphanFileCopyDirs`** (mirrors `ReconcileOrphanZvols`): reap `docker-data-<id>` dirs whose session is **not in the DB live-set** and whose age has passed the grace period. Wired into `ReconcileGC` + `GCReconcileResponse`.
- **`fileCopyDirAge`** — newer of the dir mtime and the `.last-active` marker — so a marker-less dir is reapable by its mtime instead of leaking forever.
- Fix the **legacy** `GCOrphanedSessionDirs` to use `fileCopyDirAge` too, closing the same no-marker leak there.

Safety mirrors the zvol reaper exactly: DB-derived live-set + grace period; only `docker-data-*` dirs are enumerated.

## Validation

Live dry-run `ReconcileGC` on the affected host flagged **105 stale docker-data dirs** to reap (sessions ended Feb–May), **0 running or updated within 7 days**, 20 correctly skipped as live/grace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)