### PR TITLE
Make comment Resolve button discoverable on narrow screens

### DIFF
--- a/frontend/src/components/spec-tasks/CommentLogSidebar.tsx
+++ b/frontend/src/components/spec-tasks/CommentLogSidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Box, Typography, Paper, Chip, IconButton } from '@mui/material'
+import { Box, Typography, Paper, Chip, Button, Tooltip } from '@mui/material'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import { MessageWithToolCalls, ResponseEntry } from '../session/InteractionInference'
 import { DesignReviewComment } from '../../services/designReviewService'
@@ -73,9 +73,17 @@ export default function CommentLogSidebar({
                     color={comment.quoted_text ? "primary" : "default"}
                   />
                   {!comment.resolved && (
-                    <IconButton size="small" onClick={() => onResolveComment(comment.id!)} sx={{ color: 'success.main' }}>
-                      <CheckCircleIcon fontSize="small" />
-                    </IconButton>
+                    <Tooltip title="Resolve comment">
+                      <Button
+                        size="small"
+                        color="success"
+                        onClick={() => onResolveComment(comment.id!)}
+                        startIcon={<CheckCircleIcon fontSize="small" />}
+                        sx={{ flexShrink: 0, textTransform: 'none' }}
+                      >
+                        Resolve
+                      </Button>
+                    </Tooltip>
                   )}
                 </Box>
 

--- a/frontend/src/components/spec-tasks/DesignReviewContent.tsx
+++ b/frontend/src/components/spec-tasks/DesignReviewContent.tsx
@@ -27,12 +27,10 @@ import {
   Paper,
   Tooltip,
   Badge,
-  useMediaQuery,
   ToggleButtonGroup,
   ToggleButton,
   GlobalStyles,
 } from "@mui/material";
-import { useTheme } from "@mui/material/styles";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import EditIcon from "@mui/icons-material/Edit";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
@@ -105,15 +103,30 @@ export default function DesignReviewContent({
 }: DesignReviewContentProps) {
   const snackbar = useSnackbar();
   const api = useApi();
-  const theme = useTheme();
-  // Narrow viewport: comment panels should not overlay the document.
-  // The side-positioned bubble is absolutely placed at left:820px with
-  // width:300px (right edge ~1120px) relative to the centred 800px document
-  // column, so once centring margins are added it needs well over 1120px of
-  // viewport to fit. Below this threshold we switch to the stacked in-flow
-  // layout so the bubble (and its Resolve button) never overflows off-screen,
-  // which previously forced a horizontal scroll to reach it.
-  const isNarrowViewport = useMediaQuery(theme.breakpoints.down(1280));
+
+  // Narrow layout: comment bubbles stack in-flow below the document instead of
+  // floating in the document column's right gutter.
+  //
+  // The side-positioned bubble is absolutely placed at left:820px (width 300px)
+  // relative to the 800px document column, which is centred (mx:auto) inside the
+  // document area. Its right edge therefore lands at
+  // (contentWidth - 800) / 2 + 1120, which only stays within bounds when the
+  // document content area is at least ~1440px wide. Below that the bubble — and
+  // the Resolve button in its header — is pushed off the right edge, forcing a
+  // horizontal scroll to reach it.
+  //
+  // We measure the *actual* document-area width (documentRef.clientWidth), not
+  // the window, because this component renders both standalone
+  // (SpecTaskReviewPage) and embedded (workspace TabsView), where the
+  // surrounding chrome differs at the same window size. Empirically the side
+  // bubble stops overflowing once the document area is ~1440px wide; we add a
+  // small gutter margin on top of that.
+  const SIDE_PANEL_MIN_DOC_AREA_WIDTH = 1460;
+  const [docAreaWidth, setDocAreaWidth] = useState<number | null>(null);
+  // Default to the stacked layout until measured, so the bubble never flashes
+  // off-screen on first paint.
+  const isNarrowViewport =
+    docAreaWidth === null || docAreaWidth < SIDE_PANEL_MIN_DOC_AREA_WIDTH;
 
   // Review state
   const [activeTab, setActiveTab] = useState<DocumentType>(initialTab);
@@ -155,6 +168,20 @@ export default function DesignReviewContent({
   // Bump to force re-stacking after the form mounts/unmounts and we have its
   // measured height (offsetHeight isn't reactive on its own).
   const [commentFormMeasureTick, setCommentFormMeasureTick] = useState(0);
+
+  // Track the rendered width of the scrollable document area so we can decide
+  // between the side-gutter (wide) and stacked (narrow) comment layouts based
+  // on real available space rather than the window size. Re-attached whenever
+  // the main content (re)mounts.
+  useEffect(() => {
+    const el = documentRef.current;
+    if (!el) return;
+    const measure = () => setDocAreaWidth(el.clientWidth);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  });
 
   // Refs and state for highlight preservation and hover button
   const savedRangeRef = useRef<Range | null>(null);

--- a/frontend/src/components/spec-tasks/DesignReviewContent.tsx
+++ b/frontend/src/components/spec-tasks/DesignReviewContent.tsx
@@ -106,9 +106,14 @@ export default function DesignReviewContent({
   const snackbar = useSnackbar();
   const api = useApi();
   const theme = useTheme();
-  // Narrow viewport: comment panels should not overlay the document
-  // 1000px = document (800px) + panel (300px) + minimal padding
-  const isNarrowViewport = useMediaQuery(theme.breakpoints.down(1000));
+  // Narrow viewport: comment panels should not overlay the document.
+  // The side-positioned bubble is absolutely placed at left:820px with
+  // width:300px (right edge ~1120px) relative to the centred 800px document
+  // column, so once centring margins are added it needs well over 1120px of
+  // viewport to fit. Below this threshold we switch to the stacked in-flow
+  // layout so the bubble (and its Resolve button) never overflows off-screen,
+  // which previously forced a horizontal scroll to reach it.
+  const isNarrowViewport = useMediaQuery(theme.breakpoints.down(1280));
 
   // Review state
   const [activeTab, setActiveTab] = useState<DocumentType>(initialTab);

--- a/frontend/src/components/spec-tasks/InlineCommentBubble.tsx
+++ b/frontend/src/components/spec-tasks/InlineCommentBubble.tsx
@@ -3,10 +3,10 @@ import {
   Paper,
   Box,
   Chip,
-  IconButton,
   Typography,
   CircularProgress,
   Button,
+  Tooltip,
 } from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -126,9 +126,17 @@ export default function InlineCommentBubble({
         mb={1}
       >
         <Chip label="Comment" size="small" color="primary" />
-        <IconButton size="small" onClick={() => onResolve(comment.id!)} sx={{ color: "success.main" }}>
-          <CheckCircleIcon fontSize="small" />
-        </IconButton>
+        <Tooltip title="Resolve comment">
+          <Button
+            size="small"
+            color="success"
+            onClick={() => onResolve(comment.id!)}
+            startIcon={<CheckCircleIcon fontSize="small" />}
+            sx={{ flexShrink: 0, textTransform: "none" }}
+          >
+            Resolve
+          </Button>
+        </Tooltip>
       </Box>
 
       {comment.quoted_text && (


### PR DESCRIPTION
## Summary

On less-wide screens the spec-review comment's Resolve action was hard to find,
and often required a horizontal scroll to reach it. The action was a bare,
unlabeled green check-circle icon button, and the side-positioned comment bubble
overflowed off the right edge of the document area in a wide band of viewport
widths.

This makes the Resolve action obvious and always reachable without horizontal
scrolling.

## Changes

- **`InlineCommentBubble.tsx` / `CommentLogSidebar.tsx`** — replaced the bare
  `IconButton` (check-circle) with a `Tooltip`-wrapped, labeled MUI `Button`
  ("Resolve", green, check-circle icon). Resolve behaviour is unchanged. Removed
  the now-unused `IconButton` import.
- **`DesignReviewContent.tsx`** — fixed the layout decision that caused the
  horizontal scroll. The floating side bubble is absolutely positioned in the
  centred document column's right gutter, which only fits on very wide screens.
  Replaced the window-based `useMediaQuery` check with a `ResizeObserver` that
  measures the actual document-area width and switches to the stacked, in-flow
  comment layout below ~1460px. This is correct for both surfaces that render
  this component (standalone review page and embedded workspace tab), and also
  stacks correctly when the comment-log sidebar is open. Removed unused
  `useMediaQuery` / `useTheme`.

## Testing

Verified live in a local Helix dev stack (seeded a design review + inline
comment):
- 1300px: comment stacked below the document, no horizontal scroll, labeled
  "Resolve" clearly visible.
- 1600px: side panel layout, no overflow, Resolve button fully within the
  viewport.
- Clicking Resolve resolves the comment (POST `.../resolve` → 200, bubble
  removed, unresolved count cleared).
- `tsc --noEmit` clean; production `vite build` succeeds.

## Screenshots

![Medium width — stacked, labeled Resolve, no horizontal scroll](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002184_on-less-wide-screens-its/screenshots/02-narrow-stacked.png)
![Wide — side panel, Resolve fully visible](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002184_on-less-wide-screens-its/screenshots/03-wide-side-panel.png)
![After resolving — comment cleared](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002184_on-less-wide-screens-its/screenshots/04-after-resolve.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwbykggk4c6pf71g7rhcxhzx)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002184_on-less-wide-screens-its/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002184_on-less-wide-screens-its/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002184_on-less-wide-screens-its/tasks.md)

🚀 Built with [Helix](https://helix.ml)