### PR TITLE
fix(hydra): periodic fstrim backstop + ZFS-misconfig warnings for prod

### DIFF
--- a/api/pkg/hydra/devcontainer.go
+++ b/api/pkg/hydra/devcontainer.go
@@ -112,6 +112,21 @@ func NewDevContainerManagerWithLogBuffer(manager *Manager, logBuffer *LogBuffer)
 	// the pool from ENOSPC corruption.
 	go dm.runDiskPressureMonitor()
 
+	// Return freed XFS blocks to the ZFS pool. The `discard` mount option only
+	// trims a freshly-mounted XFS and can't reclaim already-freed blocks, and
+	// operators may mount /container-docker without discard at all — so warn if
+	// so, and periodically fstrim the parent + mounted zvols as a backstop.
+	warnIfContainerDockerLacksDiscard()
+	go func() {
+		time.Sleep(10 * time.Minute) // don't compete with startup I/O
+		TrimContainerDockerStorage()
+		ticker := time.NewTicker(6 * time.Hour)
+		defer ticker.Stop()
+		for range ticker.C {
+			TrimContainerDockerStorage()
+		}
+	}()
+
 	return dm
 }
 

--- a/api/pkg/hydra/golden_zvol.go
+++ b/api/pkg/hydra/golden_zvol.go
@@ -6,11 +6,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/helixml/helix/api/pkg/types"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -40,8 +42,13 @@ const (
 	// affects newly-created zvols.
 	zvolBlockSize = "8K"
 
+	// containerDockerRoot is the in-container mount of CONTAINER_DOCKER_PATH —
+	// the parent XFS-on-zvol holding buildkit state, file-copy docker-data, and
+	// the zvol-mounts tree.
+	containerDockerRoot = "/container-docker"
+
 	// zvolMountBase is where cloned zvols are mounted.
-	zvolMountBase = "/container-docker/zvol-mounts"
+	zvolMountBase = containerDockerRoot + "/zvol-mounts"
 )
 
 var (
@@ -95,10 +102,22 @@ var (
 // Result is cached after first call.
 func ZFSAvailable() bool {
 	zfsAvailableOnce.Do(func() {
+		// When the operator has declared ZFS is configured (HELIX_EXPECT_ZFS),
+		// a silent fall-through to file-copy mode is a misconfiguration that
+		// leaks disk and slows session starts — escalate those logs to Error so
+		// it's visible/alertable instead of a single Info/Warn line.
+		expectZFS, _ := strconv.ParseBool(os.Getenv("HELIX_EXPECT_ZFS"))
+		fallbackLog := func() *zerolog.Event {
+			if expectZFS {
+				return log.Error()
+			}
+			return log.Info()
+		}
+
 		// Check if zfs binary exists and can list datasets
 		out, err := execCmdCombinedOutput("zfs", "list", "-H", "-o", "name")
 		if err != nil {
-			log.Info().Err(err).Str("output", string(out)).
+			fallbackLog().Err(err).Str("output", string(out)).Bool("expect_zfs", expectZFS).
 				Msg("ZFS not available, will use file-copy fallback for golden cache")
 			return
 		}
@@ -108,7 +127,8 @@ func ZFSAvailable() bool {
 		// a dedicated helix-zvols dataset exists under it for cleanliness.
 		poolRoot := detectPoolRoot()
 		if poolRoot == "" {
-			log.Warn().Msg("ZFS available but could not detect pool for container-docker, disabling zvol cloning")
+			fallbackLog().Bool("expect_zfs", expectZFS).Str("container_docker_path", os.Getenv("CONTAINER_DOCKER_PATH")).
+				Msg("ZFS available but could not detect pool for container-docker, disabling zvol cloning (falling back to file-copy)")
 			zfsAvailableFlag = false
 			return
 		}
@@ -996,6 +1016,75 @@ func fileCopyDirAge(dir string) time.Duration {
 		return 0
 	}
 	return time.Since(newest)
+}
+
+// TrimContainerDockerStorage runs fstrim over the /container-docker parent
+// mount and each mounted session/golden zvol, returning blocks freed inside
+// their XFS filesystems back to the ZFS pool. This is a periodic backstop:
+//   - the `discard` mount option only trims a freshly-mounted XFS and cannot
+//     retroactively reclaim blocks freed before it was set;
+//   - operators may mount the parent /container-docker without `discard` at all
+//     (Helix ships no parent mount with discard for Linux prod), so its buildkit
+//     churn and any file-copy docker-data would otherwise never be reclaimed.
+//
+// Errors (EOPNOTSUPP on a mount that doesn't support discard, or a busy fs) are
+// logged at debug and skipped — fstrim is advisory, never fatal.
+func TrimContainerDockerStorage() {
+	targets := []string{containerDockerRoot}
+	if data, err := readMountsFile(); err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 && strings.HasPrefix(fields[1], zvolMountBase+"/") {
+				targets = append(targets, fields[1])
+			}
+		}
+	}
+
+	trimmed := 0
+	for _, mp := range targets {
+		if execCmdRun("mountpoint", "-q", mp) != nil {
+			continue
+		}
+		out, err := execCmdCombinedOutput("fstrim", "-v", mp)
+		if err != nil {
+			log.Debug().Err(err).Str("mount", mp).Str("output", strings.TrimSpace(string(out))).
+				Msg("periodic fstrim skipped (no discard support or fs busy)")
+			continue
+		}
+		trimmed++
+		log.Debug().Str("mount", mp).Str("result", strings.TrimSpace(string(out))).Msg("periodic fstrim ok")
+	}
+	if trimmed > 0 {
+		log.Info().Int("mounts_trimmed", trimmed).Int("candidates", len(targets)).
+			Msg("periodic fstrim of container-docker storage completed")
+	}
+}
+
+// warnIfContainerDockerLacksDiscard logs a warning if /container-docker is a
+// zvol-backed mount without the `discard` option. Without discard (and absent
+// the periodic fstrim backstop above) blocks freed inside its XFS are never
+// returned to the ZFS pool and the zvol grows unboundedly — the leak that
+// filled a production pool. Diagnostic only; runs once at startup.
+func warnIfContainerDockerLacksDiscard() {
+	data, err := readMountsFile()
+	if err != nil {
+		return
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 || fields[1] != containerDockerRoot {
+			continue
+		}
+		dev := fields[0]
+		if !strings.HasPrefix(dev, "/dev/zvol/") && !strings.HasPrefix(dev, "/dev/zd") {
+			return // not zvol-backed — discard is not relevant
+		}
+		if !strings.Contains(","+fields[3]+",", ",discard,") {
+			log.Warn().Str("device", dev).Str("options", fields[3]).Str("mount", containerDockerRoot).
+				Msg("/container-docker is a zvol mounted WITHOUT 'discard' — freed blocks only return to the ZFS pool via the periodic fstrim backstop; mount it with 'discard' (and x-systemd.after=zfs-mount if in fstab) for immediate reclaim")
+		}
+		return
+	}
 }
 
 // GCStaleSnapshots destroys golden snapshots older than 7 days that have no


### PR DESCRIPTION
## Why

Follow-up to the ZFS disk-leak fixes (#2758 discard mounts, #2759 file-copy reaper). Those cover the *inner* zvols hydra creates — but a **ZFS Linux prod customer is still exposed**:

- `discard` only trims a **freshly-mounted** XFS; it can't reclaim blocks freed **before** it was set.
- Helix ships **no parent `/container-docker` mount with `discard`** for Linux prod — that's left to the operator's fstab. If they mount it without discard, the parent zvol (buildkit churn + any file-copy docker-data) leaks to the pool **forever**. This is exactly what filled our production pool.
- Hydra had **zero `fstrim`** anywhere, and the ZFS-detection fallback to file-copy was **silent** (a single Info/Warn line).

## What

- **`TrimContainerDockerStorage`** — periodic `fstrim` (every 6h, 10m after startup) over the `/container-docker` parent **and** each mounted session/golden zvol. Returns freed blocks to the pool regardless of how the operator mounted things, and is the *only* mechanism that reclaims blocks freed before discard was set. Errors (EOPNOTSUPP / busy) are debug-logged and skipped.
- **`warnIfContainerDockerLacksDiscard`** — startup warning if `/container-docker` is a zvol mounted without `discard`.
- **`HELIX_EXPECT_ZFS`** — when set, escalate the silent file-copy fallback (zfs missing / pool undetected) from Info/Warn → **Error**, so a ZFS misconfiguration is visible/alertable instead of leaking silently (how our own pool-fill went unnoticed).

## Verification

- `go build ./cmd/hydra` ✅, `go vet` clean, existing hydra suite passes (44s).
- Deployed to the meta sandbox, RevDial reconnected; the discard warning correctly does **not** fire (meta mounts with discard). The underlying `fstrim /container-docker` was verified by hand earlier (reclaimed ~119 G of leftover dead blocks).

## Not in this PR (recommended follow-ups)

- Ship a documented/scripted Linux-prod parent mount **with discard** (`install.sh` sets `CONTAINER_DOCKER_PATH` only on macOS today; `init-zfs-pool.sh` is macOS-only and mounts ext4 without discard). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)