### PR TITLE
Fix Zed theme not updating on repeated light/dark toggle

### DIFF
--- a/api/cmd/settings-sync-daemon/main.go
+++ b/api/cmd/settings-sync-daemon/main.go
@@ -1876,7 +1876,21 @@ func (d *SettingsDaemon) checkHelixUpdates() error {
 // DEPRECATED_FIELDS should be removed from settings.json (Zed doesn't support them)
 var DEPRECATED_FIELDS = []string{"default_agent", "external_sync"}
 
-// writeSettings atomically writes settings.json
+// writeSettings writes settings.json in place, preserving the file's inode.
+//
+// We deliberately do NOT write-to-temp + rename here. Zed watches the
+// settings.json *inode* via inotify (watch_config_file -> RealFs::watch only
+// adds a parent-directory watch for symlinks; a regular file is watched by its
+// own inode). An atomic rename replaces that inode on every write, and inotify
+// tears the watch down after the first replacement (IN_IGNORED) without
+// re-arming it. The daemon is the sole Helix-side writer of this file, so once
+// the watch dies Zed never sees another change — which is why a light/dark
+// toggle changed the theme on the first click but never again until restart.
+//
+// Truncating and rewriting the same inode keeps Zed's watch alive across every
+// write. Reads stay safe: Zed debounces file events ~100ms before loading, and
+// we write the (small) JSON in a single Write + Sync, so a reader never observes
+// a partially written file.
 func (d *SettingsDaemon) writeSettings(settings map[string]interface{}) error {
 	// Ensure directory exists
 	dir := filepath.Dir(SettingsPath)
@@ -1895,13 +1909,21 @@ func (d *SettingsDaemon) writeSettings(settings map[string]interface{}) error {
 		return err
 	}
 
-	// Atomic write (write to temp file, then rename)
-	tmpFile := SettingsPath + ".tmp"
-	if err := os.WriteFile(tmpFile, data, 0644); err != nil {
+	// In-place write that preserves the inode (O_TRUNC, not rename) so Zed's
+	// inotify watch on settings.json survives across repeated writes.
+	f, err := os.OpenFile(SettingsPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
 		return err
 	}
-
-	if err := os.Rename(tmpFile, SettingsPath); err != nil {
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
 		return err
 	}
 

--- a/api/cmd/settings-sync-daemon/main_test.go
+++ b/api/cmd/settings-sync-daemon/main_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -659,5 +661,49 @@ func TestComputeEffectiveTheme(t *testing.T) {
 			assert.Equal(t, tt.wantBranch, gotBranch, "branch label")
 			assert.Contains(t, gotOnDiskRepr, tt.wantOnDiskHint, "on-disk repr")
 		})
+	}
+}
+
+// TestWriteSettingsPreservesInode is the regression test for the dark<->light
+// "doesn't change back" bug. Zed watches settings.json by inode; the daemon used
+// to write via temp-file + rename, which replaces the inode on every write and
+// kills Zed's inotify watch after the first change. writeSettings must now keep
+// the inode stable across repeated writes so Zed keeps reloading on every toggle.
+func TestWriteSettingsPreservesInode(t *testing.T) {
+	origSettingsPath := SettingsPath
+	t.Cleanup(func() { SettingsPath = origSettingsPath })
+
+	dir := t.TempDir()
+	SettingsPath = filepath.Join(dir, "settings.json")
+
+	inodeOf := func(path string) uint64 {
+		info, err := os.Stat(path)
+		assert.NoError(t, err)
+		st, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			t.Fatalf("Sys() is not *syscall.Stat_t")
+		}
+		return st.Ino
+	}
+
+	d := &SettingsDaemon{}
+
+	// First write creates the file.
+	assert.NoError(t, d.writeSettings(map[string]interface{}{"theme": "Ayu Dark"}))
+	firstInode := inodeOf(SettingsPath)
+
+	// Repeated writes (simulating dark<->light<->dark toggles) must keep the SAME
+	// inode and write the correct contents each time.
+	for _, theme := range []string{"One Light", "Ayu Dark", "One Light"} {
+		assert.NoError(t, d.writeSettings(map[string]interface{}{"theme": theme}))
+
+		assert.Equal(t, firstInode, inodeOf(SettingsPath),
+			"settings.json inode must stay stable across writes (theme=%s)", theme)
+
+		data, err := os.ReadFile(SettingsPath)
+		assert.NoError(t, err)
+		var got map[string]interface{}
+		assert.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, theme, got["theme"], "written theme should be readable")
 	}
 }


### PR DESCRIPTION
## Summary
Clicking the Helix light/dark toggle (moon/sun) changed the embedded Zed editor's
theme on the first click but never again until Zed was restarted. The Helix side
of the pipeline was already writing the correct theme to `settings.json` on every
toggle — Zed simply stopped reading it after the first change.

Root cause: the settings-sync-daemon wrote `settings.json` via temp-file +
`os.Rename`, which **replaces the file's inode on every write**. Zed watches the
user `settings.json` by inode (its file watcher only adds a parent-directory
watch for symlinks; a regular file is watched by its own inode). inotify removes
that watch when the inode is replaced and never re-arms it, so only the first
daemon write per session was ever observed. This also explains why several prior
daemon-side fixes (HELIX_MANAGED_THEMES, effectiveTheme, USER_PREFERENCE_FIELDS)
never resolved it — the written value was never the problem.

Fix: `writeSettings` now writes in place (`O_WRONLY|O_CREATE|O_TRUNC` + `Write` +
`Sync`) instead of temp-file + rename, keeping the inode stable so Zed's inotify
watch survives across every write. Reads remain safe: Zed debounces file events
~100ms before loading and we write the small JSON in a single `Write`/`Sync`.

NOTE: trigger is the in-UI button driving the user's `color_scheme` preference —
not the OS appearance toggle. No OS/portal appearance path is touched.

## Changes
- `api/cmd/settings-sync-daemon/main.go`: `writeSettings` writes settings.json in
  place (inode-preserving) instead of atomic rename; comment explains why.
- `api/cmd/settings-sync-daemon/main_test.go`: add `TestWriteSettingsPreservesInode`
  asserting the inode stays stable and contents are correct across repeated writes.

## Testing
- `go test ./cmd/settings-sync-daemon/` passes (incl. the new inode test).
- End-to-end in helix-in-helix: rebuilt the desktop image (`build-ubuntu`), started
  a fresh spec-task session, toggled light/dark repeatedly and confirmed Zed's
  theme switches every time. (See task design doc for details.)

## Follow-up (not in this PR)
- Harden Zed's settings watcher to survive atomic-rename inode replacement (watch
  parent dir / re-arm) so manual external edits by atomic-saving editors are also
  covered. Upstream candidate.

## Screenshots
Live helix-in-helix verification — same session, after repeated light/dark toggles via the Helix UI button. Zed re-applies the theme every time (the inode stays stable so its inotify watch survives):

![Zed dark (Ayu Dark)](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002183_when-the-user-changes/screenshots/01-zed-dark.png)
![Zed light (One Light)](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002183_when-the-user-changes/screenshots/02-zed-light.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwbyjqrr85p21szr6nftc4rs)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002183_when-the-user-changes/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002183_when-the-user-changes/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002183_when-the-user-changes/tasks.md)

🚀 Built with [Helix](https://helix.ml)