### PR TITLE
style(frontend): unify Review Spec & View PR button colours

### DIFF
--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -504,7 +504,7 @@ export default function SpecTaskActionButtons({
         <Box sx={{ display: "flex", gap: 1 }}>
           <CompactActionButton
             tooltip={isArchived ? "Task is archived" : ""}
-            color="info"
+            color="secondary"
             icon={
               isQueued || isReviewingSpec ? (
                 <CircularProgress size={18} color="inherit" />
@@ -522,8 +522,8 @@ export default function SpecTaskActionButtons({
             sx={{
               animation: "pulse-glow 2s infinite",
               "@keyframes pulse-glow": {
-                "0%, 100%": { boxShadow: "0 0 5px rgba(41, 182, 246, 0.5)" },
-                "50%": { boxShadow: "0 0 15px rgba(41, 182, 246, 0.8)" },
+                "0%, 100%": { boxShadow: "0 0 5px rgba(0, 213, 255, 0.5)" },
+                "50%": { boxShadow: "0 0 15px rgba(0, 213, 255, 0.8)" },
               },
             }}
           />
@@ -538,7 +538,7 @@ export default function SpecTaskActionButtons({
             <Button
               size={buttonSize}
               variant="contained"
-              color="info"
+              color="secondary"
               startIcon={
                 isQueued || isReviewingSpec ? (
                   <CircularProgress size={16} color="inherit" />
@@ -815,12 +815,9 @@ export default function SpecTaskActionButtons({
     if (pullRequests.length === 1) {
       const onlyPR = pullRequests[0];
       const prUrl = onlyPR.pr_url;
-      const prState = normalizePRState(onlyPR.pr_state);
       const prLabel = onlyPR.repository_name
         ? `PR: ${onlyPR.repository_name}`
         : "Pull Request";
-      const buttonColor: "secondary" | "success" | "inherit" =
-        prState === "merged" ? "success" : prState === "closed" ? "inherit" : "secondary";
 
       if (isInline) {
         return (
@@ -828,7 +825,7 @@ export default function SpecTaskActionButtons({
             <CompactActionButton
               tooltip={isArchived ? "Task is archived" : ""}
               variant="contained"
-              color={buttonColor}
+              color="secondary"
               disabled={isArchived}
               icon={<LaunchIcon sx={{ fontSize: 18 }} />}
               label={prLabel}
@@ -849,7 +846,7 @@ export default function SpecTaskActionButtons({
               <Button
                 size={buttonSize}
                 variant="contained"
-                color={buttonColor}
+                color="secondary"
                 startIcon={<LaunchIcon />}
                 component="a"
                 href={prUrl}


### PR DESCRIPTION
## Summary

The "Review Spec" and "View Pull Request" action buttons on spec tasks rendered
in slightly different colours from the primary "Create Task" button, in both
light and dark mode. This standardises them on the brand `secondary`
teal/cyan so all primary actions look consistent.

## Changes

All in `frontend/src/components/tasks/SpecTaskActionButtons.tsx`:

- "Review Spec" button: `color="info"` → `color="secondary"` (inline + stacked).
- "View Pull Request" button: dropped the PR-state colour ternary
  (`success` for merged / `inherit` for closed / `secondary` for open) and use a
  constant `color="secondary"` (inline + stacked). PR state is still shown by the
  adjacent `PRStateBadge`, so no information is lost. Removed the now-unused
  `prState` local.
- Retinted the "Review Spec" pulse-glow from blue `rgba(41,182,246,…)` to the
  brand cyan `rgba(0,213,255,…)` so the glow matches the new button colour.

The multiple-PRs button variant already used `secondary`, so it was unchanged.
The "Reopen" button (done phase) is intentionally left as-is.

## Verification

- `tsc --noEmit` clean; `vite build` transformed all modules successfully.
- Verified live in the dev stack (light + dark mode): Review Spec matches the
  "New Task" colour, and a merged PR's button is now teal/cyan (was green) with
  the "merged" badge still displayed.

## Screenshots

![Review Spec button (light) matches New Task](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002190_review-spec-and-view/screenshots/01-review-spec-light.png)
![View PR button, merged state (light)](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002190_review-spec-and-view/screenshots/02-view-pr-merged-light.png)
![View PR button, merged state (dark)](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002190_review-spec-and-view/screenshots/03-view-pr-merged-dark.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwcm944yn2ccexvydbmfksn1)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002190_review-spec-and-view/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002190_review-spec-and-view/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002190_review-spec-and-view/tasks.md)

🚀 Built with [Helix](https://helix.ml)