### PR TITLE
fix(for-mac): container-docker discard + boot fstrim + pull dedup entirely

### DIFF
--- a/for-mac/scripts/init-zfs-pool.sh
+++ b/for-mac/scripts/init-zfs-pool.sh
@@ -42,11 +42,17 @@ sudo zpool online -e helix $(sudo zpool status -P helix 2>/dev/null | awk '/\/de
 # Step 2: Create datasets
 # =========================================================================
 
-# Workspaces dataset (dedup + compression for user workspace data)
+# Workspaces dataset (lz4 compression; dedup OFF). Dedup was tempting here
+# (user git checkouts dedup well) but its pool-wide DDT is too RAM-costly and
+# hosed performance on production hosts — we pulled dedup entirely, so mirror
+# that here.
 if ! sudo zfs list helix/workspaces 2>/dev/null; then
     echo 'Creating helix/workspaces dataset...'
-    sudo zfs create -o dedup=on -o compression=lz4 -o atime=off -o mountpoint=/helix/workspaces helix/workspaces
+    sudo zfs create -o dedup=off -o compression=lz4 -o atime=off -o mountpoint=/helix/workspaces helix/workspaces
 fi
+# Roll-forward: turn dedup off on an existing workspaces dataset. Stops new
+# blocks being deduped; the DDT drains as old session checkouts are GC'd.
+sudo zfs set dedup=off helix/workspaces 2>/dev/null || true
 
 # Docker volumes dataset — persists user data (postgres, keycloak, etc.)
 # across root disk upgrades. Mounted at /var/lib/docker/volumes/ so Docker
@@ -64,7 +70,8 @@ fi
 # Container Docker zvol — stores per-session inner dockerd data and BuildKit state.
 # The sandbox's own Docker storage stays on the root disk (default named volume)
 # so desktop images baked during provisioning persist without transfer.
-# This zvol is for data that benefits from ZFS dedup+compression:
+# This zvol holds (lz4 compression; dedup is off — block sharing comes from
+# hydra's per-session ZFS clones, and dedup's DDT is too RAM-costly here):
 #   - Per-session inner dockerd (/helix/container-docker/sessions/{id}/docker/)
 #   - BuildKit state (/helix/container-docker/buildkit/)
 # Hydra bind-mounts these paths into desktop containers and the BuildKit container.
@@ -77,8 +84,8 @@ if ! sudo zfs list helix/container-docker 2>/dev/null; then
         sudo umount /helix/sandbox-docker 2>/dev/null || true
         sudo zfs rename helix/sandbox-docker helix/container-docker
     else
-        echo "Creating helix/container-docker zvol (${ZVOL_SIZE}, dedup + compression)..."
-        sudo zfs create -V "$ZVOL_SIZE" -s -o dedup=on -o compression=lz4 helix/container-docker
+        echo "Creating helix/container-docker zvol (${ZVOL_SIZE}, compression, no dedup)..."
+        sudo zfs create -V "$ZVOL_SIZE" -s -o dedup=off -o compression=lz4 helix/container-docker
         # Wait for device node
         for i in $(seq 1 10); do [ -e "$ZVOL_DEV" ] && break; sleep 1; done
         if [ ! -e "$ZVOL_DEV" ]; then
@@ -89,13 +96,31 @@ if ! sudo zfs list helix/container-docker 2>/dev/null; then
         sudo mkfs.ext4 -q -L container-docker "$ZVOL_DEV"
     fi
 fi
-# Mount the zvol
+# Disable dedup on the container-docker zvol. It is redundant here — block
+# sharing already comes from ZFS clones (hydra clones the golden snapshot per
+# session) — and dedup carries a large, pool-wide DDT RAM cost that degrades a
+# RAM-constrained VM. On an existing install this stops NEW blocks being
+# deduped; the DDT drains as old deduped data is freed (discard + hydra GC now
+# reclaim session data), so no destructive rewrite is needed. Idempotent.
+sudo zfs set dedup=off helix/container-docker 2>/dev/null || true
+# Mount the zvol WITH discard so blocks freed inside ext4 (deleted session
+# docker-data, buildkit churn) are returned to the ZFS pool. Without discard the
+# zvol grows unboundedly and eventually fills the pool. ext4 supports enabling
+# discard on an already-mounted filesystem via remount, so pre-existing installs
+# (mounted before this change) pick it up on the next boot too.
 if ! mountpoint -q /helix/container-docker 2>/dev/null; then
     sudo mkdir -p /helix/container-docker
     if [ -e "$ZVOL_DEV" ]; then
-        sudo mount "$ZVOL_DEV" /helix/container-docker
+        sudo mount -o discard "$ZVOL_DEV" /helix/container-docker
     fi
+elif ! grep -q ' /helix/container-docker [^ ]* [^ ]*discard' /proc/mounts 2>/dev/null; then
+    echo 'Enabling discard on existing container-docker mount...'
+    sudo mount -o remount,discard /helix/container-docker 2>/dev/null || true
 fi
+# Reclaim any blocks freed before discard was active (roll-forward for installs
+# that leaked while mounted without discard). Runs each boot; complements the
+# periodic fstrim backstop in hydra. No-op on a clean fs.
+sudo fstrim -v /helix/container-docker 2>/dev/null || true
 # Create subdirectories for Hydra
 sudo mkdir -p /helix/container-docker/sessions
 sudo mkdir -p /helix/container-docker/buildkit


### PR DESCRIPTION
## Why

The macOS VM's ZFS setup (`init-zfs-pool.sh`) mirrored two problems we hit in production:
1. `container-docker` (ext4 zvol) mounted **without `discard`** → freed blocks never return to the pool.
2. **`dedup=on`** on both `container-docker` and `workspaces` → a large pool-wide DDT. On our production host that DDT was **1.47M entries / 12.3 GB in core** — the kind of RAM cost that hoses a constrained VM.

## What (all in `init-zfs-pool.sh` — embedded via `go:embed`, runs each VM boot, so existing installs self-heal)

**Discard / TRIM**
- Mount `container-docker` with `-o discard`; remount existing installs with `discard` (ext4 allows it live); `fstrim` at boot to reclaim backlog.

**Pull dedup entirely** (mirrors the production decision)
- Create both `container-docker` and `workspaces` with `dedup=off`.
- `zfs set dedup=off` on existing datasets. Stops new dedup; the DDT drains as old data is freed by GC — no destructive rewrite.
- `container-docker` never needed dedup (hydra's per-session ZFS clones already share blocks); `workspaces` git-checkout dedup didn't justify the RAM.

## Also applied to meta

Set `dedup=off` on `prod/helix-workspaces` — it was the one dataset still `dedup=on`, keeping the whole 12.3 GB DDT alive. Now every meta dataset is `dedup=off`.

## Release surface

- hydra fixes (#2758/#2759/#2761) reach Mac via a `HELIX_VERSION` release (rebuilds `helix-sandbox`).
- This PR ships with the Mac app build (embedded script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)