### PR TITLE
fix(frontend): suppress Chrome swipe-back gesture in desktop stream viewer

### DIFF
--- a/frontend/src/components/external-agent/DesktopStreamViewer.tsx
+++ b/frontend/src/components/external-agent/DesktopStreamViewer.tsx
@@ -2837,9 +2837,11 @@ const DesktopStreamViewer: React.FC<DesktopStreamViewerProps> = ({
   }, [containerSize, isConnected]);
 
   // Forward wheel events to remote desktop via WebSocketStream.
-  // No preventDefault needed — the container has overflow:hidden so there's nothing
-  // for the browser to scroll, and leaving the event unhandled lets Chrome's native
-  // swipe-to-navigate gesture (two-finger horizontal swipe for back/forward) work.
+  // We call preventDefault() (and register the listener as non-passive so it is
+  // honoured) to suppress Chrome/Safari's native swipe-to-navigate gesture
+  // (two-finger horizontal swipe for back/forward) inside the viewer. Otherwise
+  // scrolling here can accidentally navigate the whole page away from the session.
+  // This is scoped to the viewer container only — swipe-nav still works elsewhere.
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -2850,9 +2852,10 @@ const DesktopStreamViewer: React.FC<DesktopStreamViewerProps> = ({
           ? (streamRef.current as WebSocketStream).getInput()
           : null;
       input?.onMouseWheel(event);
+      event.preventDefault();
     };
 
-    container.addEventListener("wheel", wheelHandler);
+    container.addEventListener("wheel", wheelHandler, { passive: false });
 
     return () => {
       container.removeEventListener("wheel", wheelHandler);


### PR DESCRIPTION
## Summary

When scrolling inside the desktop streaming viewer, Chrome/Safari's native
two-finger horizontal "swipe back/forward" navigation gesture could fire,
accidentally navigating the whole page away from the session. This forwards
wheel events to the remote desktop as before but now calls `preventDefault()`
so the browser's swipe-nav gesture is suppressed — scoped to the viewer only.

## Changes

- `frontend/src/components/external-agent/DesktopStreamViewer.tsx`:
  - Call `event.preventDefault()` in the container wheel handler after forwarding
    the event to the remote desktop.
  - Register the wheel listener as non-passive (`{ passive: false }`) so
    `preventDefault()` is honoured.
  - Update the (now-inverted) comment to explain swipe-nav is intentionally
    suppressed inside the viewer.

The listener is attached to the viewer's own container ref, so swipe-to-navigate
continues to work everywhere else in the app.

## Testing

- `vite build` compiles cleanly (all modules transformed).
- Confirmed the inner-Helix dev server serves the change (`preventDefault()` +
  `{ passive: false }`).
- NOTE: the actual macOS trackpad swipe-back gesture is an OS/compositor gesture
  and is not reproducible via DevTools synthetic events on Linux — final
  user-facing confirmation should be done in macOS Chrome.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwe875vgdq6tav94z6w73eqj)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002193_when-scrolling-in-the/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002193_when-scrolling-in-the/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002193_when-scrolling-in-the/tasks.md)

🚀 Built with [Helix](https://helix.ml)