### PR TITLE
fix(webservice): stale build must not block health-monitor recovery forever

### DIFF
--- a/api/pkg/webservice/health_monitor.go
+++ b/api/pkg/webservice/health_monitor.go
@@ -24,6 +24,7 @@ type HealthMonitor struct {
 	probeTimeout  time.Duration
 	failThreshold int           // consecutive failed probes before recovery fires
 	cooldown      time.Duration // minimum gap between recoveries for one project
+	buildTimeout  time.Duration // a build older than this is treated as stuck/interrupted
 
 	mu        sync.Mutex
 	fails     map[string]int       // projectID -> consecutive probe failures
@@ -42,6 +43,7 @@ func NewHealthMonitor(s store.Store, c *Controller, sb *sandbox.Controller) *Hea
 		probeTimeout:  8 * time.Second,
 		failThreshold: 3,
 		cooldown:      5 * time.Minute,
+		buildTimeout:  15 * time.Minute,
 		fails:         map[string]int{},
 		lastRecov:     map[string]time.Time{},
 	}
@@ -89,15 +91,38 @@ func (m *HealthMonitor) runOnce(ctx context.Context) {
 }
 
 // deployInProgress reports whether the project's most recent web-service deploy
-// is still pending or building. ListWebServiceDeploys returns newest-first.
+// is genuinely still pending or building. ListWebServiceDeploys returns
+// newest-first.
+//
+// A build that has been pending/building for longer than buildTimeout was
+// almost certainly interrupted — e.g. the API or runner restarted during a CD
+// upgrade — and its status was never advanced to failed. Without the timeout
+// such a deploy would be treated as "in progress" forever, so the health
+// monitor would skip the project on every tick and never recover it (this is
+// exactly how a live web service silently stayed down for days after an
+// upgrade). When we see a stale in-flight deploy we mark it failed so it stops
+// blocking recovery and the UI stops reporting a phantom build.
 func (m *HealthMonitor) deployInProgress(ctx context.Context, projectID string) bool {
 	deploys, err := m.store.ListWebServiceDeploys(ctx, projectID, 1)
 	if err != nil || len(deploys) == 0 {
 		return false
 	}
-	switch deploys[0].Status {
+	d := deploys[0]
+	switch d.Status {
 	case types.WebServiceDeployStatusPending, types.WebServiceDeployStatusBuilding:
-		return true
+		if time.Since(d.StartedAt) < m.buildTimeout {
+			return true // genuinely in progress — don't disturb it
+		}
+		log.Warn().Str("project_id", projectID).Str("deploy_id", d.ID).
+			Str("status", string(d.Status)).Dur("age", time.Since(d.StartedAt)).
+			Msg("health-monitor: failing stale web-service deploy (interrupted build) so recovery can proceed")
+		if err := m.store.UpdateWebServiceDeploy(ctx, d.ID, map[string]interface{}{
+			"status": types.WebServiceDeployStatusFailed,
+		}); err != nil {
+			log.Warn().Err(err).Str("deploy_id", d.ID).
+				Msg("health-monitor: could not mark stale deploy failed")
+		}
+		return false
 	default:
 		return false
 	}

--- a/api/pkg/webservice/health_monitor_test.go
+++ b/api/pkg/webservice/health_monitor_test.go
@@ -3,6 +3,7 @@ package webservice
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
@@ -16,9 +17,11 @@ func TestHealthMonitorDeployInProgress(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	st := store.NewMockStore(ctrl)
-	m := &HealthMonitor{store: st}
+	m := &HealthMonitor{store: st, buildTimeout: 15 * time.Minute}
 	ctx := context.Background()
 
+	// Recent deploys: pending/building are genuinely in progress; terminal
+	// states are not.
 	cases := []struct {
 		name   string
 		status types.WebServiceDeployStatus
@@ -32,7 +35,7 @@ func TestHealthMonitorDeployInProgress(t *testing.T) {
 	}
 	for _, c := range cases {
 		st.EXPECT().ListWebServiceDeploys(gomock.Any(), c.name, 1).
-			Return([]*types.WebServiceDeploy{{Status: c.status}}, nil)
+			Return([]*types.WebServiceDeploy{{Status: c.status, StartedAt: time.Now()}}, nil)
 		if got := m.deployInProgress(ctx, c.name); got != c.want {
 			t.Errorf("%s: deployInProgress = %v, want %v", c.name, got, c.want)
 		}
@@ -42,5 +45,15 @@ func TestHealthMonitorDeployInProgress(t *testing.T) {
 	st.EXPECT().ListWebServiceDeploys(gomock.Any(), "none", 1).Return(nil, nil)
 	if m.deployInProgress(ctx, "none") {
 		t.Error("no deploys should not count as in-progress")
+	}
+
+	// A build stuck past buildTimeout (interrupted by a restart/upgrade) must
+	// NOT count as in-progress, and must be marked failed so recovery proceeds.
+	st.EXPECT().ListWebServiceDeploys(gomock.Any(), "stale", 1).
+		Return([]*types.WebServiceDeploy{{ID: "wsd_stale", Status: types.WebServiceDeployStatusBuilding, StartedAt: time.Now().Add(-time.Hour)}}, nil)
+	st.EXPECT().UpdateWebServiceDeploy(gomock.Any(), "wsd_stale",
+		map[string]interface{}{"status": types.WebServiceDeployStatusFailed}).Return(nil)
+	if m.deployInProgress(ctx, "stale") {
+		t.Error("a build stuck past buildTimeout should not count as in-progress")
 	}
 }


### PR DESCRIPTION
## What happened

`find-ai.apps.helix.ml` (web-service hosting enabled) was **down for ~2 days** after a CD upgrade, while the settings UI reported it **"live"**. The backing dev container was gone (`dev container not found`), yet auto-recovery never fired.

## Root cause

The upgrade interrupted an in-flight deploy, leaving it `building` forever (never transitioned to `failed`). The health monitor's `deployInProgress()` treats **any** `pending`/`building` deploy as "deploy in progress" **with no age cap** — so on every 30s tick it `reset`+`continue`d, **never probing or recovering the project**. One stale deploy row silently wedged recovery indefinitely. (And the UI "live" is derived from state/last-deploy, not a real probe — so it lied.)

## Fix

`deployInProgress` now has a **`buildTimeout` (15m)**: a deploy stuck `pending`/`building` longer than that is treated as interrupted — **marked `failed`** (so it stops blocking recovery *and* the UI stops showing a phantom build) and recovery proceeds. Genuine in-flight builds (< 15m) are still left undisturbed.

The common upgrade case (container recreated, no in-flight build) already self-heals within ~90s via the probe path; this closes the edge where an interrupted build wedged recovery forever.

## Verification

- Reproduced on prod: find-ai's newest deploy was `building` for 2 days; marking it `failed` made the monitor fire recovery within 90s and rebuild the service to `live` (verified HTTP 200). This PR makes that automatic.
- `go test ./pkg/webservice/` — updated `TestHealthMonitorDeployInProgress` (recent-timestamp in-progress cases + a new stale-build case asserting fail-and-unblock). Passes.

## Follow-ups (not in this PR)

- **UI honesty:** show real probe health, not `enabled`+last-deploy-state, so "live" can't lie.
- **Immediate post-upgrade recovery:** optionally fail orphaned in-flight deploys on API startup (vs waiting out buildTimeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)