### PR TITLE
feat(webservice): real health status in API/UI + fail orphaned deploys on startup

### DIFF
--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -24499,6 +24499,10 @@ const docTemplate = `{
                         "$ref": "#/definitions/types.VHostRoute"
                     }
                 },
+                "health": {
+                    "description": "Health is the real, probe-based status of the web service — \"disabled\",\n\"deploying\", \"live\" or \"unhealthy\" — so the UI reflects whether the app\nactually answers, not just the last deploy row (which stays \"live\" long\nafter its container dies).",
+                    "type": "string"
+                },
                 "state": {
                     "$ref": "#/definitions/types.ProjectWebServiceState"
                 }

--- a/api/pkg/server/project_web_service_handlers.go
+++ b/api/pkg/server/project_web_service_handlers.go
@@ -31,6 +31,12 @@ type ProjectWebServiceResponse struct {
 	Domains []*types.VHostRoute           `json:"domains"`
 	Deploys []*types.WebServiceDeploy     `json:"deploys"`
 
+	// Health is the real, probe-based status of the web service — "disabled",
+	// "deploying", "live" or "unhealthy" — so the UI reflects whether the app
+	// actually answers, not just the last deploy row (which stays "live" long
+	// after its container dies).
+	Health string `json:"health"`
+
 	// CNAMETarget is the hostname customers should add as the value of
 	// their CNAME record when registering a custom domain — i.e. the
 	// canonical Helix hostname parsed from SERVER_URL. Empty when the
@@ -109,6 +115,7 @@ func (s *HelixAPIServer) getProjectWebService(_ http.ResponseWriter, r *http.Req
 		Domains:     domains,
 		Deploys:     deploys,
 		CNAMETarget: cnameTarget,
+		Health:      s.webServiceController.Health(r.Context(), project.ID),
 	}, nil
 }
 

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -739,7 +739,7 @@ func (apiServer *HelixAPIServer) ListenAndServe(ctx context.Context, _ *system.C
 
 	// Probe live web services and auto-recover any that stop responding
 	// (crashed/hung stack heals without a human).
-	go webservice.NewHealthMonitor(apiServer.Store, apiServer.webServiceController, apiServer.sandboxController).Start(ctx)
+	go webservice.NewHealthMonitor(apiServer.Store, apiServer.webServiceController).Start(ctx)
 
 	// Continuous delivery for agent-created apps: when a GitHub-hosted project's
 	// default branch advances (e.g. a PR is merged), redeploy its web service.

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -24495,6 +24495,10 @@
                         "$ref": "#/definitions/types.VHostRoute"
                     }
                 },
+                "health": {
+                    "description": "Health is the real, probe-based status of the web service — \"disabled\",\n\"deploying\", \"live\" or \"unhealthy\" — so the UI reflects whether the app\nactually answers, not just the last deploy row (which stays \"live\" long\nafter its container dies).",
+                    "type": "string"
+                },
                 "state": {
                     "$ref": "#/definitions/types.ProjectWebServiceState"
                 }

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -2370,6 +2370,13 @@ definitions:
         items:
           $ref: '#/definitions/types.VHostRoute'
         type: array
+      health:
+        description: |-
+          Health is the real, probe-based status of the web service — "disabled",
+          "deploying", "live" or "unhealthy" — so the UI reflects whether the app
+          actually answers, not just the last deploy row (which stays "live" long
+          after its container dies).
+        type: string
       state:
         $ref: '#/definitions/types.ProjectWebServiceState'
     type: object

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -912,6 +912,7 @@ type Store interface {
 	CreateWebServiceDeploy(ctx context.Context, d *types.WebServiceDeploy) error
 	UpdateWebServiceDeploy(ctx context.Context, id string, updates map[string]interface{}) error
 	ListWebServiceDeploys(ctx context.Context, projectID string, limit int) ([]*types.WebServiceDeploy, error)
+	FailInFlightWebServiceDeploys(ctx context.Context) (int64, error)
 	ListEnabledWebServiceProjectsByRepo(ctx context.Context, repoID string) ([]*types.Project, error)
 	ListActiveWebServices(ctx context.Context) ([]*types.ProjectWebServiceState, error)
 	ListPendingVHostRoutes(ctx context.Context, limit int) ([]*types.VHostRoute, error)

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -7006,6 +7006,21 @@ func (mr *MockStoreMockRecorder) UpdateWebServiceDeploy(ctx, id, updates any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWebServiceDeploy", reflect.TypeOf((*MockStore)(nil).UpdateWebServiceDeploy), ctx, id, updates)
 }
 
+// FailInFlightWebServiceDeploys mocks base method.
+func (m *MockStore) FailInFlightWebServiceDeploys(ctx context.Context) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailInFlightWebServiceDeploys", ctx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FailInFlightWebServiceDeploys indicates an expected call of FailInFlightWebServiceDeploys.
+func (mr *MockStoreMockRecorder) FailInFlightWebServiceDeploys(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailInFlightWebServiceDeploys", reflect.TypeOf((*MockStore)(nil).FailInFlightWebServiceDeploys), ctx)
+}
+
 // UpsertProjectWebServiceState mocks base method.
 func (m *MockStore) UpsertProjectWebServiceState(ctx context.Context, state *types.ProjectWebServiceState) error {
 	m.ctrl.T.Helper()

--- a/api/pkg/store/vhost.go
+++ b/api/pkg/store/vhost.go
@@ -221,6 +221,24 @@ func (s *PostgresStore) UpdateWebServiceDeploy(ctx context.Context, id string, u
 		Updates(updates).Error
 }
 
+// FailInFlightWebServiceDeploys marks every deploy still in a non-terminal
+// (pending/building) state as failed and returns the number updated. Called on
+// startup: a build cannot survive the process that was orchestrating it, so any
+// deploy left in-flight after a restart (e.g. a CD upgrade) is orphaned. Left
+// alone it would wedge the health monitor's recovery — deployInProgress treats
+// an in-flight deploy as "don't touch". Failing them lets a dead web service
+// recover on the first tick instead of waiting out the build timeout.
+func (s *PostgresStore) FailInFlightWebServiceDeploys(ctx context.Context) (int64, error) {
+	res := s.gdb.WithContext(ctx).
+		Model(&types.WebServiceDeploy{}).
+		Where("status IN ?", []types.WebServiceDeployStatus{
+			types.WebServiceDeployStatusPending,
+			types.WebServiceDeployStatusBuilding,
+		}).
+		Update("status", types.WebServiceDeployStatusFailed)
+	return res.RowsAffected, res.Error
+}
+
 // ListPendingVHostRoutes returns vhost routes that are waiting for DNS
 // ownership verification (verified_at IS NULL AND verification_token != '').
 // Caps at limit to avoid runaway sweeps.

--- a/api/pkg/webservice/controller.go
+++ b/api/pkg/webservice/controller.go
@@ -268,6 +268,55 @@ func (c *Controller) sandboxDockerAlive(ctx context.Context, sb *types.Sandbox) 
 	return true
 }
 
+// DeployBuildTimeout bounds how long a web-service deploy may sit
+// pending/building before it is treated as an interrupted (orphaned) build.
+// Shared by the health monitor (recovery) and the API (health reporting) so
+// they agree on what "still deploying" means.
+const DeployBuildTimeout = 15 * time.Minute
+
+// Probe reports whether the project's web service answers on its container port
+// through the hydra proxy right now. It is the single source of truth for "is
+// this web service actually live", used by both the health monitor and the API
+// so the UI reflects real health rather than the last deploy row.
+func (c *Controller) Probe(ctx context.Context, st *types.ProjectWebServiceState, timeout time.Duration) bool {
+	if st == nil || !st.Enabled || st.ActiveSandboxID == "" {
+		return false
+	}
+	sb, err := c.sandboxes.Get(ctx, st.ActiveSandboxID)
+	if err != nil || sb == nil || sb.Status != types.SandboxStatusRunning {
+		return false
+	}
+	hc, err := c.sandboxes.HydraClient(sb)
+	if err != nil {
+		return false
+	}
+	pctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return hc.ProbeDevContainerPort(pctx, sb.ID, st.ContainerPort) == nil
+}
+
+// Health returns the real, probe-based status of a project's web service:
+// "disabled", "deploying", "live" or "unhealthy". The API surfaces this so the
+// UI reflects actual health instead of trusting the last deploy row (a deploy
+// stays "live" long after its container dies).
+func (c *Controller) Health(ctx context.Context, projectID string) string {
+	st, err := c.store.GetProjectWebServiceState(ctx, projectID)
+	if err != nil || st == nil || !st.Enabled || st.ActiveSandboxID == "" {
+		return "disabled"
+	}
+	if deploys, _ := c.store.ListWebServiceDeploys(ctx, projectID, 1); len(deploys) > 0 {
+		d := deploys[0]
+		inflight := d.Status == types.WebServiceDeployStatusPending || d.Status == types.WebServiceDeployStatusBuilding
+		if inflight && time.Since(d.StartedAt) < DeployBuildTimeout {
+			return "deploying"
+		}
+	}
+	if c.Probe(ctx, st, 5*time.Second) {
+		return "live"
+	}
+	return "unhealthy"
+}
+
 // RecoverWebService brings a project's web service back to a serving state
 // after the health-monitor detects it down. It escalates:
 //  1. active sandbox row gone → Redeploy (provisions a fresh sandbox).

--- a/api/pkg/webservice/health_monitor.go
+++ b/api/pkg/webservice/health_monitor.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/helixml/helix/api/pkg/sandbox"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/rs/zerolog/log"
@@ -18,7 +17,6 @@ import (
 type HealthMonitor struct {
 	store      store.Store
 	controller *Controller
-	sandboxes  *sandbox.Controller
 
 	interval      time.Duration
 	probeTimeout  time.Duration
@@ -34,16 +32,15 @@ type HealthMonitor struct {
 // NewHealthMonitor builds a monitor with production-sane defaults: probe every
 // 30s, recover after ~90s of continuous failure, and don't re-recover the same
 // project more than once per 5 minutes (a cold redeploy can take minutes).
-func NewHealthMonitor(s store.Store, c *Controller, sb *sandbox.Controller) *HealthMonitor {
+func NewHealthMonitor(s store.Store, c *Controller) *HealthMonitor {
 	return &HealthMonitor{
 		store:         s,
 		controller:    c,
-		sandboxes:     sb,
 		interval:      30 * time.Second,
 		probeTimeout:  8 * time.Second,
 		failThreshold: 3,
 		cooldown:      5 * time.Minute,
-		buildTimeout:  15 * time.Minute,
+		buildTimeout:  DeployBuildTimeout,
 		fails:         map[string]int{},
 		lastRecov:     map[string]time.Time{},
 	}
@@ -51,6 +48,16 @@ func NewHealthMonitor(s store.Store, c *Controller, sb *sandbox.Controller) *Hea
 
 // Start runs the monitor on a ticker until ctx is cancelled.
 func (m *HealthMonitor) Start(ctx context.Context) {
+	// A build cannot survive the process that was orchestrating it. On startup
+	// (e.g. after a CD upgrade) fail any deploy still marked in-flight so a
+	// web service whose build was interrupted recovers on the first tick,
+	// instead of the stale in-flight row wedging recovery until buildTimeout.
+	if n, err := m.store.FailInFlightWebServiceDeploys(ctx); err != nil {
+		log.Warn().Err(err).Msg("web-service health-monitor: failing orphaned in-flight deploys on startup failed")
+	} else if n > 0 {
+		log.Info().Int64("count", n).Msg("web-service health-monitor: failed orphaned in-flight deploys on startup")
+	}
+
 	ticker := time.NewTicker(m.interval)
 	defer ticker.Stop()
 	log.Info().Dur("interval", m.interval).Msg("web-service health-monitor started")
@@ -129,20 +136,10 @@ func (m *HealthMonitor) deployInProgress(ctx context.Context, projectID string) 
 }
 
 // probe returns true if the project's web service answers on its container
-// port through the hydra proxy. ProbeDevContainerPort errors on transport
-// failure / 4xx / 5xx (see hydra doRequest), so any of those count as down.
+// port through the hydra proxy. Delegates to Controller.Probe — the single
+// source of truth shared with the API's health reporting.
 func (m *HealthMonitor) probe(ctx context.Context, st *types.ProjectWebServiceState) bool {
-	sb, err := m.sandboxes.Get(ctx, st.ActiveSandboxID)
-	if err != nil || sb == nil || sb.Status != types.SandboxStatusRunning {
-		return false
-	}
-	hc, err := m.sandboxes.HydraClient(sb)
-	if err != nil {
-		return false
-	}
-	pctx, cancel := context.WithTimeout(ctx, m.probeTimeout)
-	defer cancel()
-	return hc.ProbeDevContainerPort(pctx, sb.ID, st.ContainerPort) == nil
+	return m.controller.Probe(ctx, st, m.probeTimeout)
 }
 
 func (m *HealthMonitor) reset(projectID string) {

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1501,6 +1501,13 @@ export interface ServerProjectWebServiceResponse {
   cname_target?: string;
   deploys?: TypesWebServiceDeploy[];
   domains?: TypesVHostRoute[];
+  /**
+   * Health is the real, probe-based status of the web service — "disabled",
+   * "deploying", "live" or "unhealthy" — so the UI reflects whether the app
+   * actually answers, not just the last deploy row (which stays "live" long
+   * after its container dies).
+   */
+  health?: string;
   state?: TypesProjectWebServiceState;
 }
 

--- a/frontend/src/components/project/WebServiceTab.tsx
+++ b/frontend/src/components/project/WebServiceTab.tsx
@@ -47,6 +47,9 @@ const WebServiceTab: FC<WebServiceTabProps> = ({ projectId }) => {
   const { data, isLoading, error } = useQuery<ServerProjectWebServiceResponse>({
     queryKey: stateQueryKey,
     enabled: !!projectId,
+    // Health is a live probe — refetch while the panel is open so the status
+    // badge reflects reality (and a running deploy flips to Live when it lands).
+    refetchInterval: 20000,
     queryFn: async () => {
       const res = await apiClient.v1ProjectsWebServiceDetail(projectId)
       return res.data
@@ -57,6 +60,7 @@ const WebServiceTab: FC<WebServiceTabProps> = ({ projectId }) => {
   const domains = data?.domains ?? []
   const deploys = data?.deploys ?? []
   const cnameTarget = data?.cname_target ?? ''
+  const health = data?.health ?? ''
 
   const [containerPortDraft, setContainerPortDraft] = useState<string>('')
   const [newDomain, setNewDomain] = useState('')
@@ -135,6 +139,19 @@ const WebServiceTab: FC<WebServiceTabProps> = ({ projectId }) => {
           disabled={updateMutation.isPending}
         />
         <Typography>{enabled ? 'Enabled' : 'Disabled'}</Typography>
+        {enabled && health && (
+          <Chip
+            size="small"
+            color={health === 'live' ? 'success' : health === 'deploying' ? 'warning' : 'error'}
+            label={
+              health === 'live'
+                ? 'Live'
+                : health === 'deploying'
+                ? 'Deploying'
+                : 'Unhealthy'
+            }
+          />
+        )}
       </Box>
 
       {enabled && (

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -2370,6 +2370,13 @@ definitions:
         items:
           $ref: '#/definitions/types.VHostRoute'
         type: array
+      health:
+        description: |-
+          Health is the real, probe-based status of the web service — "disabled",
+          "deploying", "live" or "unhealthy" — so the UI reflects whether the app
+          actually answers, not just the last deploy row (which stays "live" long
+          after its container dies).
+        type: string
       state:
         $ref: '#/definitions/types.ProjectWebServiceState'
     type: object

--- a/openapi.json
+++ b/openapi.json
@@ -28798,6 +28798,10 @@
                             "$ref": "#/components/schemas/types.VHostRoute"
                         }
                     },
+                    "health": {
+                        "description": "Health is the real, probe-based status of the web service — \"disabled\",\n\"deploying\", \"live\" or \"unhealthy\" — so the UI reflects whether the app\nactually answers, not just the last deploy row (which stays \"live\" long\nafter its container dies).",
+                        "type": "string"
+                    },
                     "state": {
                         "$ref": "#/components/schemas/types.ProjectWebServiceState"
                     }

--- a/swagger.json
+++ b/swagger.json
@@ -24495,6 +24495,10 @@
                         "$ref": "#/definitions/types.VHostRoute"
                     }
                 },
+                "health": {
+                    "description": "Health is the real, probe-based status of the web service — \"disabled\",\n\"deploying\", \"live\" or \"unhealthy\" — so the UI reflects whether the app\nactually answers, not just the last deploy row (which stays \"live\" long\nafter its container dies).",
+                    "type": "string"
+                },
                 "state": {
                     "$ref": "#/definitions/types.ProjectWebServiceState"
                 }


### PR DESCRIPTION
Two follow-ups to #2766 (stale-build recovery), as requested.

## 1. UI honesty — status reflects real health, not deploy state
The settings UI showed a web service **"live"** from `enabled` + last-deploy-state, so it lied for ~2 days while the container was dead.

- **`Controller.Probe`** — a real probe of the container port via the hydra proxy, now the single source of truth shared by the health monitor *and* the API.
- **`Controller.Health`** → `disabled` / `deploying` / `live` / `unhealthy`, surfaced as `health` on the web-service response.
- **Frontend badge** next to the enable toggle, refreshed every 20s while the panel is open, so "live" can't lie.

## 2. Immediate post-upgrade recovery
- **`FailInFlightWebServiceDeploys`** marks any `pending`/`building` deploy failed on health-monitor **startup**. A build can't survive the process that orchestrated it, so an interrupted deploy (e.g. from a CD upgrade) is orphaned. Failing it lets a dead web service recover on the **first tick** instead of waiting out the 15m build timeout — closing the exact window that took find-ai down.

## Also
- Dedupes the probe (monitor delegates to `Controller.Probe`); shares `DeployBuildTimeout` between monitor and API.
- Regenerated the openapi client for the new `health` field.

## Verification
- `go build ./...` ✅, `go test ./pkg/webservice/` ✅, `yarn build` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)