### PR TITLE
fix: hydra RevDial panic on reconnect + harden daemon restart loops

### DIFF
--- a/api/pkg/revdial/revdial.go
+++ b/api/pkg/revdial/revdial.go
@@ -354,9 +354,8 @@ type Listener struct {
 	dial   func(context.Context, string) (*websocket.Conn, *http.Response, error)
 	writec chan<- []byte
 
-	mu      sync.Mutex // guards below, closing connc, and writing to rw
-	readErr error
-	closed  bool
+	mu     sync.Mutex // guards below and writing to rw
+	closed bool
 }
 
 type controlMsg struct {
@@ -458,6 +457,10 @@ func (ln *Listener) grabConn(path string) {
 	select {
 	case ln.connc <- wsconnadapter.New(wsConn):
 	case <-ln.donec:
+		// Listener closed while we were picking up — drop the connection
+		// instead of leaking it. (connc is never closed, so the send case
+		// above can never panic.)
+		wsConn.Close()
 	}
 }
 
@@ -468,19 +471,21 @@ func (ln *Listener) Closed() bool {
 	return ln.closed
 }
 
-// Accept blocks and returns a new connection, or an error.
+// Accept blocks and returns a new connection, or an error. connc is never
+// closed (see Close); closure is signalled by donec, so we select on both and
+// still drain any connection already buffered before closure.
 func (ln *Listener) Accept() (net.Conn, error) {
-	c, ok := <-ln.connc
-	if !ok {
-		ln.mu.Lock()
-		err, closed := ln.readErr, ln.closed
-		ln.mu.Unlock()
-		if err != nil && !closed {
-			return nil, fmt.Errorf("revdial: Listener closed; %v", err)
+	select {
+	case c := <-ln.connc:
+		return c, nil
+	case <-ln.donec:
+		select {
+		case c := <-ln.connc:
+			return c, nil
+		default:
+			return nil, ErrListenerClosed
 		}
-		return nil, ErrListenerClosed
 	}
-	return c, nil
 }
 
 // ErrListenerClosed is returned by Accept after Close has been called.
@@ -496,7 +501,10 @@ func (ln *Listener) Close() error {
 	}
 	go ln.sc.Close()
 	ln.closed = true
-	close(ln.connc)
+	// Signal closure via donec ONLY. We must never close connc: it has multiple
+	// concurrent senders (grabConn goroutines), and a send on a closed channel
+	// panics — even inside a select — which previously crashed hydra and took a
+	// whole runner offline. grabConn and Accept both select on donec instead.
 	close(ln.donec)
 	return nil
 }

--- a/sandbox/04-start-dockerd.sh
+++ b/sandbox/04-start-dockerd.sh
@@ -135,6 +135,11 @@ mkdir -p /var/log/helix-services 2>/dev/null || true
 
 (
     trap '' PIPE
+    # Restart loop must survive a non-zero exit of the supervised daemon. The
+    # sourced entrypoint's `set -e` leaks into this subshell and would otherwise
+    # abort it the moment dockerd crashes, leaving it dead and the runner wedged
+    # (same class of bug that took a runner offline via hydra — see 10-start-hydra).
+    set +e
     while true; do
         # Clean up stale PID files before each restart attempt
         rm -f /var/run/docker.pid /run/docker/containerd/containerd.pid 2>/dev/null || true

--- a/sandbox/05-start-dns-proxy.sh
+++ b/sandbox/05-start-dns-proxy.sh
@@ -64,6 +64,10 @@ done
 # log-tailer surfaces /var/log/helix-services/*.log in the Runner Logs stream.
 mkdir -p /var/log/helix-services 2>/dev/null || true
 (
+    # Restart loop must survive a non-zero exit; a sibling script's `set -e`
+    # leaks into this sourced subshell and would otherwise kill the loop on the
+    # first crash, leaving dns-proxy dead (see 10-start-hydra).
+    set +e
     while true; do
         dns-proxy -listen "${GATEWAY}:53" -upstream "${UPSTREAM_DNS}"
         echo "[$(date -Iseconds)] dns-proxy exited (code $?); restarting in 2s..."

--- a/sandbox/08-start-sandbox-heartbeat.sh
+++ b/sandbox/08-start-sandbox-heartbeat.sh
@@ -37,6 +37,10 @@ mkdir -p /var/log/helix-services 2>/dev/null || true
 
 (
     trap '' PIPE
+    # Restart loop must survive a non-zero exit; the sourced entrypoint's
+    # `set -e` leaks into this subshell and would otherwise kill the loop on the
+    # first crash, leaving the heartbeat dead (see 10-start-hydra).
+    set +e
     while true; do
         echo "[$(date -Iseconds)] Starting heartbeat daemon..."
         /usr/local/bin/sandbox-heartbeat

--- a/sandbox/10-start-hydra.sh
+++ b/sandbox/10-start-hydra.sh
@@ -22,8 +22,15 @@ echo "🐉 Starting Hydra multi-Docker isolation daemon..."
 mkdir -p /var/run/hydra/active
 mkdir -p /hydra-data
 
-# Start Hydra daemon in background with auto-restart
+# Start Hydra daemon in background with auto-restart.
 (
+    # CRITICAL: disable errexit inside the restart loop. This script is sourced
+    # by entrypoint.sh with `set -e` active (and it leaks into this subshell),
+    # so a non-zero hydra exit — e.g. a panic — would abort the subshell BEFORE
+    # `EXIT_CODE=$?`, killing the loop and leaving hydra dead until someone
+    # manually intervenes (this took a whole runner offline in prod). With
+    # `set +e` the loop always restarts hydra.
+    set +e
     while true; do
         echo "[$(date -Iseconds)] Starting Hydra daemon..."
         /usr/local/bin/hydra \

--- a/sandbox/12-start-compose-manager.sh
+++ b/sandbox/12-start-compose-manager.sh
@@ -55,6 +55,10 @@ mkdir -p /var/log/helix-services 2>/dev/null || true
     # lines are visible on `docker logs`. `-oL` forces line buffering
     # on tee's stdout writes so each line hits the file (and so the
     # tailer) immediately. Same fix in 04/08/14 scripts.
+    # Restart loop must survive a non-zero exit; the sourced entrypoint's
+    # `set -e` leaks into this subshell and would otherwise kill the loop on the
+    # first crash, leaving compose-manager dead (see 10-start-hydra).
+    set +e
     while true; do
         echo "[$(date -Iseconds)] Starting compose-manager..."
         HELIX_RUNNER_ID="$SANDBOX_INSTANCE_ID" \

--- a/sandbox/14-start-inference-proxy.sh
+++ b/sandbox/14-start-inference-proxy.sh
@@ -21,6 +21,10 @@ mkdir -p /var/log/helix-services 2>/dev/null || true
 
 (
     trap '' PIPE
+    # Restart loop must survive a non-zero exit; the sourced entrypoint's
+    # `set -e` leaks into this subshell and would otherwise kill the loop on the
+    # first crash, leaving inference-proxy dead (see 10-start-hydra).
+    set +e
     while true; do
         echo "[$(date -Iseconds)] Starting inference-proxy..."
         /usr/local/bin/inference-proxy --listen "$LISTEN" --compose "$ACTIVE_YAML"


### PR DESCRIPTION
## Prod incident this fixes

A runner's hydra **crashed and stayed dead**, wedging every web-service and session on it — find-ai flapped down, other sessions failed to resume (`RevDial: no connection`). Two independent bugs combined:

### 1. RevDial panic — `send on closed channel`
`Listener.Close()` did `close(ln.connc)` while multiple `grabConn` goroutines could still `ln.connc <- conn`. A send on a closed channel **panics even inside a `select`**, so a normal reconnect (`revdial: Listener closed` → reconnect) crashed hydra:
```
panic: send on closed channel
  api/pkg/revdial/revdial.go:458  (*Listener).grabConn
```
**Fix:** never close `connc` (it has multiple senders); signal closure via `donec` only. `Accept()` selects on `connc`/`donec` (still draining buffered conns); `grabConn` closes a picked-up conn if the listener closed mid-pickup. Removed the dead `readErr` field. **Passes `go test -race`.**

### 2. No supervision — one crash wedged the whole runner
The cont-init scripts run a `( while true; do <daemon>; done ) &` supervisor, but they're **sourced with `set -e` active** (it leaks into the subshell), so a non-zero daemon exit aborted the subshell **before** it could restart — leaving the daemon dead until someone SSHed in. That's why one hydra panic took the runner offline.

**Fix:** `set +e` inside each supervisor subshell — hydra **and** the same latent bug in **dockerd, dns-proxy, heartbeat, compose-manager, inference-proxy** (they already `trap '' PIPE` to keep the supervisor alive; this closes the errexit gap).

## Verification
- `go build ./...` ✅, `go vet ./pkg/revdial` ✅, `go test -race ./pkg/revdial` ✅
- `bash -n` on all six scripts ✅

Both ship in the `helix-sandbox` image → a release rolls them to all runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)