### PR TITLE
fix(openai): only apply dall-e model filter to real OpenAI endpoints

### DIFF
--- a/api/pkg/openai/list_models_gpt_filter_test.go
+++ b/api/pkg/openai/list_models_gpt_filter_test.go
@@ -10,33 +10,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// robertModelsResponse is the exact /models envelope a customer's
-// OpenAI-compatible provider (Scaleway) returned on 2026-07-01. It lists 18
-// models, one of which is gpt-oss-120b (OpenAI's open-weights model, served by
-// a NON-OpenAI provider). Pre-fix, the presence of a "gpt-"-prefixed id tripped
-// the OpenAI-only dall-e heuristic in ListModels and collapsed the whole
-// catalogue down to just gpt-oss-120b.
-const robertModelsResponse = `{
+// compatibleProviderModelsResponse is a representative /models envelope from an
+// OpenAI-compatible aggregator: a broad multi-vendor catalogue that happens to
+// include one gpt-prefixed id (gpt-oss-120b, OpenAI's open-weights model served
+// by a non-OpenAI backend). Pre-fix, that single gpt- id tripped the OpenAI-only
+// dall-e heuristic and collapsed the whole catalogue down to just that model.
+const compatibleProviderModelsResponse = `{
   "object": "list",
   "data": [
-    {"id":"llama-3.3-70b-instruct","object":"model","created":1736258559,"owned_by":"meta"},
-    {"id":"pixtral-12b-2409","object":"model","created":1730385501,"owned_by":"mistral"},
-    {"id":"gemma-3-27b-it","object":"model","created":1730385501,"owned_by":"google"},
-    {"id":"bge-multilingual-gemma2","object":"model","created":1730385501,"owned_by":"baai"},
-    {"id":"qwen3-235b-a22b-instruct-2507","object":"model","created":1754049528,"owned_by":"qwen"},
-    {"id":"mistral-small-3.2-24b-instruct-2506","object":"model","created":1755006551,"owned_by":"mistral"},
-    {"id":"qwen3-coder-30b-a3b-instruct","object":"model","created":1755006551,"owned_by":"qwen"},
-    {"id":"gpt-oss-120b","object":"model","created":1755093042,"owned_by":"openai"},
-    {"id":"voxtral-small-24b-2507","object":"model","created":1757330049,"owned_by":"mistral"},
-    {"id":"whisper-large-v3","object":"model","created":1722263169,"owned_by":"openai"},
-    {"id":"qwen3-embedding-8b","object":"model","created":1755006551,"owned_by":"qwen"},
-    {"id":"holo2-30b-a3b","object":"model","created":1755006551,"owned_by":"hcompany"},
-    {"id":"devstral-2-123b-instruct-2512","object":"model","created":1766496679,"owned_by":"mistral"},
-    {"id":"qwen3.5-397b-a17b","object":"model","created":1773394870,"owned_by":"qwen"},
-    {"id":"gemma-4-26b-a4b-it","object":"model","created":1777469299,"owned_by":"google"},
-    {"id":"qwen3.6-35b-a3b","object":"model","created":1778158991,"owned_by":"qwen"},
-    {"id":"mistral-medium-3.5-128b","object":"model","created":1778158991,"owned_by":"mistral"},
-    {"id":"glm-5.2","object":"model","created":1782376549,"owned_by":"zai"}
+    {"id":"llama-3.3-70b-instruct","object":"model","owned_by":"vendor-a"},
+    {"id":"vision-12b","object":"model","owned_by":"vendor-b"},
+    {"id":"small-27b-it","object":"model","owned_by":"vendor-c"},
+    {"id":"bge-multilingual","object":"model","owned_by":"vendor-d"},
+    {"id":"chat-235b-a22b-instruct","object":"model","owned_by":"vendor-e"},
+    {"id":"small-24b-instruct","object":"model","owned_by":"vendor-b"},
+    {"id":"coder-30b-a3b-instruct","object":"model","owned_by":"vendor-e"},
+    {"id":"gpt-oss-120b","object":"model","owned_by":"openai"},
+    {"id":"embedding-8b","object":"model","owned_by":"vendor-e"},
+    {"id":"agentic-30b-a3b","object":"model","owned_by":"vendor-f"},
+    {"id":"devcode-123b-instruct","object":"model","owned_by":"vendor-b"},
+    {"id":"chat-397b-a17b","object":"model","owned_by":"vendor-e"},
+    {"id":"small-26b-a4b-it","object":"model","owned_by":"vendor-c"},
+    {"id":"chat-35b-a3b","object":"model","owned_by":"vendor-e"},
+    {"id":"medium-128b","object":"model","owned_by":"vendor-b"},
+    {"id":"reasoning-5.2","object":"model","owned_by":"vendor-g"}
   ]
 }`
 
@@ -49,12 +46,12 @@ func newModelsTestServer(t *testing.T, body string) *httptest.Server {
 	}))
 }
 
-// TestListModels_NonOpenAIProviderKeepsAllModels is the regression test for the
-// customer report on 2026-07-01: a Scaleway endpoint serving gpt-oss-120b had
-// 17 of its 18 models silently dropped from the Helix picker because the
-// gpt-oss-120b id tripped the OpenAI-only dall-e filter heuristic.
+// TestListModels_NonOpenAIProviderKeepsAllModels is the regression test for a
+// report where an OpenAI-compatible provider serving gpt-oss-120b had all but
+// that one model silently dropped from the Helix picker, because the gpt-oss-120b
+// id tripped the OpenAI-only dall-e filter heuristic.
 func TestListModels_NonOpenAIProviderKeepsAllModels(t *testing.T) {
-	srv := newModelsTestServer(t, robertModelsResponse)
+	srv := newModelsTestServer(t, compatibleProviderModelsResponse)
 	defer srv.Close()
 
 	client := New("test-key", srv.URL, false)
@@ -67,13 +64,13 @@ func TestListModels_NonOpenAIProviderKeepsAllModels(t *testing.T) {
 	}
 
 	// The gpt filter must NOT fire for a non-OpenAI base URL. Every model the
-	// provider advertised must survive (none of the 18 match the audio/tts/
-	// realtime substrings filterUnsupportedModels drops).
-	require.Contains(t, ids, "glm-5.2", "the model the customer actually wanted must survive")
+	// provider advertised must survive (none match the audio/tts/realtime
+	// substrings filterUnsupportedModels drops).
+	require.Contains(t, ids, "reasoning-5.2", "a non-gpt model the user wants must survive")
 	require.Contains(t, ids, "llama-3.3-70b-instruct")
-	require.Contains(t, ids, "qwen3-coder-30b-a3b-instruct")
+	require.Contains(t, ids, "coder-30b-a3b-instruct")
 	require.Contains(t, ids, "gpt-oss-120b", "the gpt- model itself must still be present")
-	require.Len(t, ids, 18,
+	require.Len(t, ids, 16,
 		"a non-OpenAI provider must return its full catalogue; got %d models: %v", len(ids), ids)
 }
 
@@ -103,10 +100,10 @@ func TestApplyOpenAIDallEFilter_RealOpenAIStillFilters(t *testing.T) {
 func TestApplyOpenAIDallEFilter_NonOpenAIUntouched(t *testing.T) {
 	models := []types.OpenAIModel{
 		{ID: "gpt-oss-120b"},
-		{ID: "glm-5.2"},
+		{ID: "reasoning-5.2"},
 		{ID: "llama-3.3-70b-instruct"},
 	}
 
-	got := applyOpenAIDallEFilter(models, "https://api.scaleway.ai/v1")
+	got := applyOpenAIDallEFilter(models, "https://api.example-aggregator.ai/v1")
 	require.Len(t, got, 3, "non-OpenAI provider list must pass through untouched")
 }

--- a/api/pkg/openai/list_models_gpt_filter_test.go
+++ b/api/pkg/openai/list_models_gpt_filter_test.go
@@ -1,0 +1,112 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+// robertModelsResponse is the exact /models envelope a customer's
+// OpenAI-compatible provider (Scaleway) returned on 2026-07-01. It lists 18
+// models, one of which is gpt-oss-120b (OpenAI's open-weights model, served by
+// a NON-OpenAI provider). Pre-fix, the presence of a "gpt-"-prefixed id tripped
+// the OpenAI-only dall-e heuristic in ListModels and collapsed the whole
+// catalogue down to just gpt-oss-120b.
+const robertModelsResponse = `{
+  "object": "list",
+  "data": [
+    {"id":"llama-3.3-70b-instruct","object":"model","created":1736258559,"owned_by":"meta"},
+    {"id":"pixtral-12b-2409","object":"model","created":1730385501,"owned_by":"mistral"},
+    {"id":"gemma-3-27b-it","object":"model","created":1730385501,"owned_by":"google"},
+    {"id":"bge-multilingual-gemma2","object":"model","created":1730385501,"owned_by":"baai"},
+    {"id":"qwen3-235b-a22b-instruct-2507","object":"model","created":1754049528,"owned_by":"qwen"},
+    {"id":"mistral-small-3.2-24b-instruct-2506","object":"model","created":1755006551,"owned_by":"mistral"},
+    {"id":"qwen3-coder-30b-a3b-instruct","object":"model","created":1755006551,"owned_by":"qwen"},
+    {"id":"gpt-oss-120b","object":"model","created":1755093042,"owned_by":"openai"},
+    {"id":"voxtral-small-24b-2507","object":"model","created":1757330049,"owned_by":"mistral"},
+    {"id":"whisper-large-v3","object":"model","created":1722263169,"owned_by":"openai"},
+    {"id":"qwen3-embedding-8b","object":"model","created":1755006551,"owned_by":"qwen"},
+    {"id":"holo2-30b-a3b","object":"model","created":1755006551,"owned_by":"hcompany"},
+    {"id":"devstral-2-123b-instruct-2512","object":"model","created":1766496679,"owned_by":"mistral"},
+    {"id":"qwen3.5-397b-a17b","object":"model","created":1773394870,"owned_by":"qwen"},
+    {"id":"gemma-4-26b-a4b-it","object":"model","created":1777469299,"owned_by":"google"},
+    {"id":"qwen3.6-35b-a3b","object":"model","created":1778158991,"owned_by":"qwen"},
+    {"id":"mistral-medium-3.5-128b","object":"model","created":1778158991,"owned_by":"mistral"},
+    {"id":"glm-5.2","object":"model","created":1782376549,"owned_by":"zai"}
+  ]
+}`
+
+func newModelsTestServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/models", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// TestListModels_NonOpenAIProviderKeepsAllModels is the regression test for the
+// customer report on 2026-07-01: a Scaleway endpoint serving gpt-oss-120b had
+// 17 of its 18 models silently dropped from the Helix picker because the
+// gpt-oss-120b id tripped the OpenAI-only dall-e filter heuristic.
+func TestListModels_NonOpenAIProviderKeepsAllModels(t *testing.T) {
+	srv := newModelsTestServer(t, robertModelsResponse)
+	defer srv.Close()
+
+	client := New("test-key", srv.URL, false)
+	models, err := client.ListModels(context.Background())
+	require.NoError(t, err)
+
+	ids := make([]string, 0, len(models))
+	for _, m := range models {
+		ids = append(ids, m.ID)
+	}
+
+	// The gpt filter must NOT fire for a non-OpenAI base URL. Every model the
+	// provider advertised must survive (none of the 18 match the audio/tts/
+	// realtime substrings filterUnsupportedModels drops).
+	require.Contains(t, ids, "glm-5.2", "the model the customer actually wanted must survive")
+	require.Contains(t, ids, "llama-3.3-70b-instruct")
+	require.Contains(t, ids, "qwen3-coder-30b-a3b-instruct")
+	require.Contains(t, ids, "gpt-oss-120b", "the gpt- model itself must still be present")
+	require.Len(t, ids, 18,
+		"a non-OpenAI provider must return its full catalogue; got %d models: %v", len(ids), ids)
+}
+
+// TestApplyOpenAIDallEFilter_RealOpenAIStillFilters keeps the original heuristic
+// alive for actual api.openai.com endpoints: dall-e style rows we can't send
+// chat completions to must still be dropped, while gpt- / o-series / embeddings
+// survive.
+func TestApplyOpenAIDallEFilter_RealOpenAIStillFilters(t *testing.T) {
+	models := []types.OpenAIModel{
+		{ID: "gpt-4.1"},
+		{ID: "o3-mini"},
+		{ID: "dall-e-3"},
+		{ID: "text-embedding-3-small"},
+	}
+
+	got := applyOpenAIDallEFilter(models, "https://api.openai.com/v1")
+	ids := make([]string, 0, len(got))
+	for _, m := range got {
+		ids = append(ids, m.ID)
+	}
+	require.ElementsMatch(t, []string{"gpt-4.1", "o3-mini", "text-embedding-3-small"}, ids,
+		"real OpenAI endpoint must still drop dall-e-3 (non-chat) while keeping gpt/o-series/embeddings")
+}
+
+// TestApplyOpenAIDallEFilter_NonOpenAIUntouched pins the core of the fix at the
+// unit level: a non-OpenAI base URL is a no-op even when a gpt- model is present.
+func TestApplyOpenAIDallEFilter_NonOpenAIUntouched(t *testing.T) {
+	models := []types.OpenAIModel{
+		{ID: "gpt-oss-120b"},
+		{ID: "glm-5.2"},
+		{ID: "llama-3.3-70b-instruct"},
+	}
+
+	got := applyOpenAIDallEFilter(models, "https://api.scaleway.ai/v1")
+	require.Len(t, got, 3, "non-OpenAI provider list must pass through untouched")
+}

--- a/api/pkg/openai/openai_client.go
+++ b/api/pkg/openai/openai_client.go
@@ -367,39 +367,7 @@ func (c *RetryableClient) ListModels(ctx context.Context) ([]types.OpenAIModel, 
 		return models[i].ID < models[j].ID
 	})
 
-	// Hack to workaround that OpenAI returns models like dall-e-3, which we
-	// can't send chat completion requests to. Use a rough heuristic to
-	// filter out models we can't use.
-
-	// Check if any model starts with "gpt-"
-	hasGPTModel := false
-	for _, m := range models {
-		if strings.HasPrefix(m.ID, "gpt-") {
-			hasGPTModel = true
-			break
-		}
-	}
-
-	// If there's a GPT model, filter out non-GPT models (but keep embedding models)
-	if hasGPTModel {
-		filteredModels := make([]types.OpenAIModel, 0)
-		for _, m := range models {
-			if strings.HasPrefix(m.ID, "text-embedding-") {
-				m.Type = "embed"
-				filteredModels = append(filteredModels, m)
-			} else if strings.HasPrefix(m.ID, "gpt-") || strings.HasPrefix(m.ID, "o3") || strings.HasPrefix(m.ID, "o1") || strings.HasPrefix(m.ID, "o4") {
-				// Add the type chat. This is needed
-				// for UI to correctly allow filtering
-				m.Type = "chat"
-
-				// Set the context length
-				m.ContextLength = getOpenAIModelContextLength(m.ID)
-
-				filteredModels = append(filteredModels, m)
-			}
-		}
-		models = filteredModels
-	}
+	models = applyOpenAIDallEFilter(models, c.baseURL)
 
 	// Set the enabled field to true if the model is in the list of allowed models
 	for i := range models {
@@ -407,6 +375,50 @@ func (c *RetryableClient) ListModels(ctx context.Context) ([]types.OpenAIModel, 
 	}
 
 	return models, nil
+}
+
+// isOpenAIProvider reports whether the base URL points at OpenAI proper (as
+// opposed to any OpenAI-compatible aggregator like Scaleway, Together, Groq).
+func isOpenAIProvider(baseURL string) bool {
+	return strings.Contains(baseURL, "api.openai.com")
+}
+
+// applyOpenAIDallEFilter works around OpenAI returning models such as dall-e-3
+// on /models that can't take chat completions. It ONLY applies to real
+// api.openai.com endpoints. Other OpenAI-compatible providers legitimately
+// serve non-gpt models (llama, qwen, mistral, glm, ...) and must be returned
+// untouched, even when their catalogue happens to include a gpt-prefixed id
+// like gpt-oss-120b. Previously the mere presence of a gpt- model triggered the
+// filter for any provider, collapsing a full catalogue down to that one model.
+func applyOpenAIDallEFilter(models []types.OpenAIModel, baseURL string) []types.OpenAIModel {
+	if !isOpenAIProvider(baseURL) {
+		return models
+	}
+
+	hasGPTModel := false
+	for _, m := range models {
+		if strings.HasPrefix(m.ID, "gpt-") {
+			hasGPTModel = true
+			break
+		}
+	}
+	if !hasGPTModel {
+		return models
+	}
+
+	filteredModels := make([]types.OpenAIModel, 0)
+	for _, m := range models {
+		if strings.HasPrefix(m.ID, "text-embedding-") {
+			m.Type = "embed"
+			filteredModels = append(filteredModels, m)
+		} else if strings.HasPrefix(m.ID, "gpt-") || strings.HasPrefix(m.ID, "o3") || strings.HasPrefix(m.ID, "o1") || strings.HasPrefix(m.ID, "o4") {
+			// Type chat is needed for the UI to correctly allow filtering.
+			m.Type = "chat"
+			m.ContextLength = getOpenAIModelContextLength(m.ID)
+			filteredModels = append(filteredModels, m)
+		}
+	}
+	return filteredModels
 }
 
 func (c *RetryableClient) listOpenAIModels(ctx context.Context) ([]types.OpenAIModel, error) {

--- a/api/pkg/openai/openai_client_test.go
+++ b/api/pkg/openai/openai_client_test.go
@@ -471,34 +471,25 @@ func TestTrailingSlashStripped(t *testing.T) {
 	})
 }
 
-// TestListModels_GPTFilterKeepsEmbeddingModels verifies that when the OpenAI
-// model list contains GPT models (triggering the GPT filter), text-embedding-*
-// models are kept with type "embed", GPT/o-series models get type "chat", and
-// unrelated models (like dall-e) are filtered out.
+// TestListModels_GPTFilterKeepsEmbeddingModels verifies that for a real OpenAI
+// endpoint the dall-e filter keeps text-embedding-* models with type "embed",
+// gives GPT/o-series models type "chat", and drops non-chat rows (dall-e, tts,
+// whisper). Driven through applyOpenAIDallEFilter directly because the filter is
+// now gated on the api.openai.com base URL (an httptest URL is never OpenAI).
 func TestListModels_GPTFilterKeepsEmbeddingModels(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"data": []map[string]string{
-				{"id": "gpt-4o"},
-				{"id": "gpt-4.1-mini"},
-				{"id": "o3-mini"},
-				{"id": "text-embedding-3-small"},
-				{"id": "text-embedding-3-large"},
-				{"id": "text-embedding-ada-002"},
-				{"id": "dall-e-3"},
-				{"id": "tts-1"},
-				{"id": "whisper-1"},
-			},
-		})
-	})
+	input := []types.OpenAIModel{
+		{ID: "gpt-4o"},
+		{ID: "gpt-4.1-mini"},
+		{ID: "o3-mini"},
+		{ID: "text-embedding-3-small"},
+		{ID: "text-embedding-3-large"},
+		{ID: "text-embedding-ada-002"},
+		{ID: "dall-e-3"},
+		{ID: "tts-1"},
+		{ID: "whisper-1"},
+	}
 
-	ts := httptest.NewServer(handler)
-	defer ts.Close()
-
-	client := New("test-api-key", ts.URL, false)
-	models, err := client.ListModels(context.Background())
-	require.NoError(t, err)
+	models := applyOpenAIDallEFilter(input, "https://api.openai.com/v1")
 
 	// Build a map of model ID -> type for easy assertions
 	modelTypes := make(map[string]string)
@@ -516,11 +507,9 @@ func TestListModels_GPTFilterKeepsEmbeddingModels(t *testing.T) {
 	assert.Equal(t, "embed", modelTypes["text-embedding-3-large"], "text-embedding-3-large should have type embed")
 	assert.Equal(t, "embed", modelTypes["text-embedding-ada-002"], "text-embedding-ada-002 should have type embed")
 
-	// Unrelated models should be filtered out
+	// Unrelated / non-chat models should be filtered out by the allowlist
 	_, hasDallE := modelTypes["dall-e-3"]
 	assert.False(t, hasDallE, "dall-e-3 should be filtered out")
-
-	// tts and whisper are filtered by filterUnsupportedModels before the GPT filter
 	_, hasTTS := modelTypes["tts-1"]
 	assert.False(t, hasTTS, "tts-1 should be filtered out")
 	_, hasWhisper := modelTypes["whisper-1"]


### PR DESCRIPTION
## Problem

An OpenAI-compatible inference provider whose `/models` catalogue includes a `gpt-`-prefixed id (e.g. `gpt-oss-120b`, OpenAI's open-weights model served by a non-OpenAI backend) has **every other model silently dropped** from the Helix model picker, leaving only the `gpt-` one.

Reported by a user: their provider's `/models` returned 18 models; Helix surfaced 1.

## Root cause

`api/pkg/openai/openai_client.go` `ListModels` had a heuristic to hide non-chat rows OpenAI returns on `/models` (dall-e, etc.). It fired for **any** provider as soon as a single model id started with `gpt-`, then kept only ids matching `gpt-`/`o1`/`o3`/`o4`/`text-embedding-`. For a compatible aggregator serving `gpt-oss-120b`, that discards the entire llama/qwen/mistral/etc. catalogue.

## Fix

Gate the heuristic on the base URL actually being `api.openai.com`. Other OpenAI-compatible providers now return their full catalogue. Extracted the logic into `applyOpenAIDallEFilter` so it is unit-testable without the real OpenAI host.

## Tests

- `TestListModels_NonOpenAIProviderKeepsAllModels` - regression test driving a representative multi-vendor `/models` payload (incl. `gpt-oss-120b`) through the HTTP path; asserts the full catalogue survives. Fails on the pre-fix code (returns 1 model).
- `TestApplyOpenAIDallEFilter_RealOpenAIStillFilters` - real OpenAI endpoint still drops dall-e while keeping gpt/o-series/embeddings.
- `TestApplyOpenAIDallEFilter_NonOpenAIUntouched` - non-OpenAI base URL is a no-op even with a `gpt-` model present.
- Updated `TestListModels_GPTFilterKeepsEmbeddingModels` (previously encoded the cross-provider behaviour) to drive the filter through the OpenAI path.

Full `pkg/openai` suite passes.

## Note

Azure OpenAI (`*.openai.azure.com`) does not match `api.openai.com`, so it now returns its full deployment list too - arguably more correct for Azure users deploying non-OpenAI models, but flagging the behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)