### PR TITLE
Fix MCP array parameters published as string (create_bot tools/topics)

### DIFF
--- a/api/pkg/agent/skill/mcp/buildparameters_union_test.go
+++ b/api/pkg/agent/skill/mcp/buildparameters_union_test.go
@@ -1,0 +1,75 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	m3 "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/helixml/helix/api/pkg/util/jsonschema"
+)
+
+// TestBuildParametersNullableUnionType guards the create_bot "tools/topics
+// published as string" bug: when an MCP tool declares an array parameter
+// using the nullable-union form ("type": ["array","null"]) — the shape
+// reflection-based schema generators emit for Go slice/pointer fields —
+// buildParameters must resolve it to "array", not silently fall back to the
+// "string" default. A spec-honouring harness obeys the resulting type, so a
+// collapse to "string" makes the parameter uncallable with a real JSON array.
+func TestBuildParametersNullableUnionType(t *testing.T) {
+	raw := `{
+      "name":"create_bot",
+      "inputSchema":{
+        "type":"object",
+        "properties":{
+          "tools":{"type":["array","null"],"items":{"type":"string"},"description":"MCP tools to grant"},
+          "topics":{"type":["array","null"],"items":{"type":"string"},"description":"Existing Topic ids"}
+        },
+        "required":["tools","topics"]
+      }
+    }`
+	var tl m3.Tool
+	if err := json.Unmarshal([]byte(raw), &tl); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	def := buildParameters(tl.InputSchema)
+
+	for _, name := range []string{"tools", "topics"} {
+		prop, ok := def.Properties[name]
+		if !ok {
+			t.Fatalf("param %q missing from converted schema", name)
+		}
+		if prop.Type != jsonschema.Array {
+			t.Errorf("param %q: got type %q, want %q", name, prop.Type, jsonschema.Array)
+		}
+		if prop.Items == nil || prop.Items.Type != jsonschema.String {
+			t.Errorf("param %q: want items of type string, got %+v", name, prop.Items)
+		}
+	}
+}
+
+// TestConvertMapToDefinitionResolvesUnionType exercises the union resolution
+// directly across the type members we care about, including "null"-first
+// ordering, so the fix isn't accidentally order-dependent.
+func TestConvertMapToDefinitionResolvesUnionType(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]any
+		want jsonschema.DataType
+	}{
+		{"array+null", map[string]any{"type": []any{"array", "null"}, "items": map[string]any{"type": "string"}}, jsonschema.Array},
+		{"null+array", map[string]any{"type": []any{"null", "array"}, "items": map[string]any{"type": "string"}}, jsonschema.Array},
+		{"string+null", map[string]any{"type": []any{"string", "null"}}, jsonschema.String},
+		{"plain string", map[string]any{"type": "string"}, jsonschema.String},
+		{"plain array", map[string]any{"type": "array", "items": map[string]any{"type": "string"}}, jsonschema.Array},
+		{"missing type", map[string]any{"description": "x"}, jsonschema.String},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := convertMapToDefinition(tc.in).Type; got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/api/pkg/agent/skill/mcp/mcp_skill.go
+++ b/api/pkg/agent/skill/mcp/mcp_skill.go
@@ -190,31 +190,52 @@ func buildParameters(inputSchema mcp.ToolInputSchema) jsonschema.Definition {
 	return result
 }
 
+// resolveSchemaType returns the effective scalar JSON Schema type from a
+// `type` value that may be either a string or a nullable union such as
+// ["array","null"] / ["null","array"]. It returns the first non-"null"
+// string member; for a plain string it returns that string; otherwise "".
+// This lets array (and other) parameters declared with the union form
+// survive conversion instead of falling back to "string".
+func resolveSchemaType(raw any) string {
+	switch v := raw.(type) {
+	case string:
+		return v
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok && s != "" && s != "null" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
 // convertMapToDefinition recursively converts a map[string]any to jsonschema.Definition
 func convertMapToDefinition(data map[string]any) jsonschema.Definition {
 	def := jsonschema.Definition{}
 
-	// Handle type - ensure we always have a valid type
-	if typeVal, ok := data["type"].(string); ok && typeVal != "" {
-		switch typeVal {
-		case "string":
-			def.Type = jsonschema.String
-		case "integer":
-			def.Type = jsonschema.Integer
-		case "number":
-			def.Type = jsonschema.Number
-		case "boolean":
-			def.Type = jsonschema.Boolean
-		case "array":
-			def.Type = jsonschema.Array
-		case "object":
-			def.Type = jsonschema.Object
-		default:
-			def.Type = jsonschema.String // fallback for unknown types
-		}
-	} else {
-		// If no type is specified or it's empty, default to string
+	// Handle type - ensure we always have a valid type. `type` may be a
+	// scalar ("array") or a JSON Schema nullable union (["array","null"]),
+	// the shape reflection-based generators emit for slice/pointer fields.
+	// resolveSchemaType picks the effective non-null member so an array
+	// parameter survives as an array instead of collapsing to the string
+	// fallback below (which is what published create_bot's `tools`/`topics`
+	// as `type:"string"` and made them uncallable with a real JSON array).
+	switch resolveSchemaType(data["type"]) {
+	case "string":
 		def.Type = jsonschema.String
+	case "integer":
+		def.Type = jsonschema.Integer
+	case "number":
+		def.Type = jsonschema.Number
+	case "boolean":
+		def.Type = jsonschema.Boolean
+	case "array":
+		def.Type = jsonschema.Array
+	case "object":
+		def.Type = jsonschema.Object
+	default:
+		def.Type = jsonschema.String // fallback for missing/unknown types
 	}
 
 	// Handle title (convert to description if no description exists)

--- a/api/pkg/org/interfaces/mcptools/schema_wire_test.go
+++ b/api/pkg/org/interfaces/mcptools/schema_wire_test.go
@@ -1,0 +1,114 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+)
+
+// TestSchemaWireArrayParams guards against the "create_bot tools/topics
+// published as string" bug at the WIRE level: it serves each bulk tool over a
+// real go-sdk tools/list round-trip and asserts the array parameters arrive
+// as {type:"array", items:{type:"string"}}, never as a scalar "string" and
+// never as a nullable union like ["array","null"].
+//
+// The in-Go assertArrayProp check (bulk_tools_test.go) stayed green while the
+// reported bug was live because it inspects the *jsonschema.Schema directly;
+// this test inspects the bytes a client actually receives.
+func TestSchemaWireArrayParams(t *testing.T) {
+	names := func() []tool.Name {
+		return []tool.Name{"publish", "subscribe", "create_bot", "attach_tool", "detach_tool"}
+	}
+	deps := Deps{ToolNames: names}
+
+	// tool -> array params expected to publish as array-of-string.
+	specs := []struct {
+		tl     tool.Tool
+		params []string
+	}{
+		{NewCreateBot(deps), []string{"tools", "topics"}},
+		{&AttachTool{deps: deps}, []string{"tools"}},
+		{&DetachTool{deps: deps}, []string{"tools"}},
+		{&Subscribe{deps: deps}, []string{"topicIds"}},
+		{&Unsubscribe{deps: deps}, []string{"topicIds"}},
+	}
+
+	srv := mcp.NewServer(&mcp.Implementation{Name: "wire-test", Version: "0"}, nil)
+	for _, s := range specs {
+		s := s
+		srv.AddTool(&mcp.Tool{
+			Name:        string(s.tl.Name()),
+			Description: s.tl.Description(),
+			InputSchema: s.tl.InputSchema(),
+		}, func(context.Context, *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return &mcp.CallToolResult{}, nil
+		})
+	}
+
+	ct, st := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+	if _, err := srv.Connect(ctx, st, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	cli := mcp.NewClient(&mcp.Implementation{Name: "wire-test-client", Version: "0"}, nil)
+	sess, err := cli.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	res, err := sess.ListTools(ctx, &mcp.ListToolsParams{})
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+
+	wantParams := map[string][]string{}
+	for _, s := range specs {
+		wantParams[string(s.tl.Name())] = s.params
+	}
+
+	for _, tl := range res.Tools {
+		params, ok := wantParams[tl.Name]
+		if !ok {
+			continue
+		}
+		// Re-marshal the served schema to inspect it exactly as a client sees it.
+		raw, err := json.Marshal(tl.InputSchema)
+		if err != nil {
+			t.Fatalf("%s: marshal schema: %v", tl.Name, err)
+		}
+		var schema struct {
+			Properties map[string]struct {
+				Type  json.RawMessage `json:"type"`
+				Items *struct {
+					Type string `json:"type"`
+				} `json:"items"`
+			} `json:"properties"`
+		}
+		if err := json.Unmarshal(raw, &schema); err != nil {
+			t.Fatalf("%s: unmarshal schema: %v", tl.Name, err)
+		}
+		for _, p := range params {
+			prop, ok := schema.Properties[p]
+			if !ok {
+				t.Errorf("%s.%s: missing from served schema", tl.Name, p)
+				continue
+			}
+			// type must be the scalar JSON string "array" — not "string",
+			// and not a union array like ["array","null"].
+			var typeStr string
+			if err := json.Unmarshal(prop.Type, &typeStr); err != nil {
+				t.Errorf("%s.%s: type is not a scalar string (got %s) — harnesses that expect a scalar type would fall back to string", tl.Name, p, prop.Type)
+				continue
+			}
+			if typeStr != "array" {
+				t.Errorf("%s.%s: got type %q, want \"array\"", tl.Name, p, typeStr)
+			}
+			if prop.Items == nil || prop.Items.Type != "string" {
+				t.Errorf("%s.%s: want items.type \"string\", got %+v", tl.Name, p, prop.Items)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

A harness reported that `create_bot`'s `tools` and `topics` parameters were
published with `"type": "string"` instead of `"array"`. Because a
spec-honouring harness serializes whatever it puts in a `string` slot **to a
string**, arrays went on the wire as `"[\"a\",\"b\"]"` and the Go handler
(which wants `[]string`) rejected them — making the tool uncallable.

Root-causing (reproduced in-process across the full pipeline) showed the org
MCP server is **already correct**: it publishes `{type:"array",
items:{type:"string"}}` for all five bulk-tool array params, verified via a
go-sdk `tools/list` round-trip and after mark3labs client parsing.

The actual defect is in the **MCP client-consumption converter**
`convertMapToDefinition` (`api/pkg/agent/skill/mcp/mcp_skill.go`). When a
parameter's `type` arrives as the JSON Schema nullable **union**
`["array","null"]` — the shape reflection-based schema generators emit for Go
slice/pointer fields — the old `data["type"].(string)` type assertion failed
(the value is a `[]any`, not a string) and silently fell back to
`jsonschema.String`, collapsing the array to a scalar string. This is the
exact `type:"string"` symptom, and it affected *every* nullable/array MCP
parameter, not just `create_bot`.

## Changes

- `fix(agent)`: add `resolveSchemaType` and use it in `convertMapToDefinition`
  so a `type` that is a scalar string **or** a nullable union (`["array","null"]`,
  `["null","array"]`, …) resolves to its non-`null` member. Array params now
  survive as arrays instead of falling back to `string`.
- `test(agent)`: RED→GREEN regression tests — a create_bot-like schema with
  union-typed array params through `buildParameters`, plus a table covering
  union ordering, plain scalars, and missing type.
- `test(org)`: wire-level guard (`schema_wire_test.go`) that serves all five
  bulk tools over a go-sdk `tools/list` round-trip and asserts
  `create_bot.tools/topics`, `attach_tool.tools`, `detach_tool.tools`,
  `subscribe.topicIds`, `unsubscribe.topicIds` publish `type:"array"` +
  `items.type:"string"` — never `string` and never a union. This catches
  what the existing in-Go `assertArrayProp` check could not (it stayed green
  throughout the live bug because it inspects the schema struct, not the wire).

## Testing

- `go build ./pkg/agent/... ./pkg/org/...` — passes.
- `go test ./pkg/agent/skill/mcp/ ./pkg/org/interfaces/mcptools/` — green.
- Verified across the real consumption path reproduced in-process (go-sdk
  `tools/list` → mark3labs parse → `buildParameters`). Not exercised against a
  live LLM harness in the inner stack; the reproduced path is the code that
  produces the harness-visible schema.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwf4znsqze467117h9csch92)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002203_i-just-pulled-the-tool/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002203_i-just-pulled-the-tool/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002203_i-just-pulled-the-tool/tasks.md)

🚀 Built with [Helix](https://helix.ml)