### PR TITLE
fix(frontend): make 404 page legible in light mode

### DIFF
--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -116,7 +116,10 @@ const NotFound: FC = () => {
         <GlitchText
           sx={{
             fontSize: { xs: '8rem', sm: '12rem' },
-            color: isLight ? 'rgba(0, 0, 0, 0.08)' : 'rgba(255, 255, 255, 0.08)',
+            // Dark mode: a near-transparent fill that reads as a bright number via
+            // the cyan glitch glow. On white that same faint fill is invisible
+            // (contrast ~1.2), so light mode uses a solid AA-safe brand teal.
+            color: isLight ? highlightColor : 'rgba(255, 255, 255, 0.08)',
           }}
         >
           404

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -7,6 +7,7 @@ import { Building2, Home, ArrowLeft } from 'lucide-react'
 
 import useAccount from '../hooks/useAccount'
 import useRouter from '../hooks/useRouter'
+import useLightTheme from '../hooks/useLightTheme'
 import { SELECTED_ORG_STORAGE_KEY } from '../utils/localStorage'
 
 const float = keyframes`
@@ -48,6 +49,11 @@ const GlitchText = styled(Typography)({
 const NotFound: FC = () => {
   const account = useAccount()
   const router = useRouter()
+  const { isLight, textColor, textColorFaded, border, highlightColor } = useLightTheme()
+
+  // Accent color for hover states — brand cyan is illegible on white, so use the
+  // theme's light-safe highlight color in light mode.
+  const accentColor = isLight ? highlightColor : '#00E5FF'
 
   const organizations = account.organizationTools.organizations
   const firstAccessibleOrg = useMemo(() => {
@@ -92,7 +98,9 @@ const NotFound: FC = () => {
           width: '600px',
           height: '600px',
           borderRadius: '50%',
-          background: 'radial-gradient(circle, rgba(0, 229, 255, 0.04) 0%, transparent 70%)',
+          background: isLight
+            ? 'radial-gradient(circle, rgba(14, 116, 144, 0.05) 0%, transparent 70%)'
+            : 'radial-gradient(circle, rgba(0, 229, 255, 0.04) 0%, transparent 70%)',
           animation: `${pulse} 4s ease-in-out infinite`,
           pointerEvents: 'none',
         }}
@@ -108,7 +116,7 @@ const NotFound: FC = () => {
         <GlitchText
           sx={{
             fontSize: { xs: '8rem', sm: '12rem' },
-            color: 'rgba(255, 255, 255, 0.08)',
+            color: isLight ? 'rgba(0, 0, 0, 0.08)' : 'rgba(255, 255, 255, 0.08)',
           }}
         >
           404
@@ -130,7 +138,7 @@ const NotFound: FC = () => {
           variant="h5"
           sx={{
             fontWeight: 600,
-            color: 'rgba(255, 255, 255, 0.85)',
+            color: isLight ? textColor : 'rgba(255, 255, 255, 0.85)',
             mb: 1,
           }}
         >
@@ -139,7 +147,7 @@ const NotFound: FC = () => {
         <Typography
           variant="body1"
           sx={{
-            color: 'rgba(255, 255, 255, 0.45)',
+            color: isLight ? textColorFaded : 'rgba(255, 255, 255, 0.45)',
             maxWidth: 400,
           }}
         >
@@ -182,14 +190,14 @@ const NotFound: FC = () => {
           startIcon={<Building2 size={18} />}
           onClick={handleGoToOrgs}
           sx={{
-            borderColor: 'rgba(255, 255, 255, 0.2)',
-            color: 'rgba(255, 255, 255, 0.7)',
+            borderColor: isLight ? border : 'rgba(255, 255, 255, 0.2)',
+            color: isLight ? textColorFaded : 'rgba(255, 255, 255, 0.7)',
             px: 3,
             py: 1.2,
             '&:hover': {
-              borderColor: '#00E5FF',
-              color: '#00E5FF',
-              bgcolor: 'rgba(0, 229, 255, 0.08)',
+              borderColor: accentColor,
+              color: accentColor,
+              bgcolor: isLight ? 'rgba(14, 116, 144, 0.08)' : 'rgba(0, 229, 255, 0.08)',
             },
           }}
         >
@@ -200,12 +208,12 @@ const NotFound: FC = () => {
           startIcon={<ArrowLeft size={18} />}
           onClick={handleGoBack}
           sx={{
-            color: 'rgba(255, 255, 255, 0.4)',
+            color: isLight ? textColorFaded : 'rgba(255, 255, 255, 0.4)',
             px: 3,
             py: 1.2,
             '&:hover': {
-              color: 'rgba(255, 255, 255, 0.7)',
-              bgcolor: 'rgba(255, 255, 255, 0.05)',
+              color: isLight ? textColor : 'rgba(255, 255, 255, 0.7)',
+              bgcolor: isLight ? 'rgba(0, 0, 0, 0.05)' : 'rgba(255, 255, 255, 0.05)',
             },
           }}
         >


### PR DESCRIPTION
## Summary
The 404 / Not Found page (`frontend/src/pages/NotFound.tsx`) was styled for dark
mode only — every color was hardcoded (white text at various opacities, cyan
accents). In light mode the "404" glyph, the "Page not found" heading, the body
text, and the outlined/text buttons were white-on-white (invisible) or failed
contrast. This makes the page theme-aware so it's legible in both modes.

## Changes
- Adopt the existing `useLightTheme()` hook to drive colors from
  `theme.palette.mode` (same pattern as `Create.tsx`).
- Branch each hardcoded color on `isLight`, keeping the exact original values in
  the dark branch (no dark-mode regression) and substituting legible light-mode
  values (`textColor`, `textColorFaded`, `border`, and `highlightColor` for
  accents — brand cyan is illegible on white).
- Light-mode background gradient uses a faint teal instead of cyan.
- The contained "Home" button (cyan bg + black text) and the glitch animation
  are unchanged — they work in both modes.

Single-file change: `frontend/src/pages/NotFound.tsx` (+20/-12).

## Testing
- `tsc --noEmit` passes.
- Verified end-to-end in the dev stack: rendered `/notfound` and toggled
  light/dark. Light mode is now fully legible; dark mode is unchanged.

## Screenshots
Light mode — before (the bug: heading/body/buttons invisible):
![Light before](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002202_404-page-looks-like-arse/screenshots/00-404-light-before.png)

Light mode — after (legible):
![Light after](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002202_404-page-looks-like-arse/screenshots/01-404-light-after.png)

Dark mode — after (unchanged):
![Dark after](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002202_404-page-looks-like-arse/screenshots/02-404-dark-after.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwf14gnsy6x56aa5ekd7jyxg)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002202_404-page-looks-like-arse/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002202_404-page-looks-like-arse/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002202_404-page-looks-like-arse/tasks.md)

🚀 Built with [Helix](https://helix.ml)