### PR TITLE
fix(server): preserve upstream MCP schema through the external proxy

### DIFF
--- a/api/pkg/server/mcp_backend_external.go
+++ b/api/pkg/server/mcp_backend_external.go
@@ -372,7 +372,6 @@ func (b *ExternalMCPBackend) findMCPConfig(app *types.App, mcpName string) *type
 	return nil
 }
 
-// createToolHandler creates a handler that forwards tool calls to the external MCP server
 // buildProxyTool reconstructs the schema the proxy advertises to Zed for a
 // single upstream tool. It forwards the upstream input schema verbatim so
 // array/object/enum/nested params survive — a proxy transports schemas, it
@@ -391,6 +390,7 @@ func buildProxyTool(tool mcp.Tool) mcp.Tool {
 	return mcp.NewToolWithRawSchema(tool.Name, tool.Description, raw)
 }
 
+// createToolHandler creates a handler that forwards tool calls to the external MCP server
 func (b *ExternalMCPBackend) createToolHandler(client mcpclient.Client, toolName string) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		log.Debug().

--- a/api/pkg/server/mcp_backend_external.go
+++ b/api/pkg/server/mcp_backend_external.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"sync"
@@ -323,38 +324,7 @@ func (b *ExternalMCPBackend) getOrCreateServer(ctx context.Context, user *types.
 		// Create a handler that forwards to the external server
 		handler := b.createToolHandler(externalClient, tool.Name)
 
-		// Build tool options
-		var opts []mcp.ToolOption
-		opts = append(opts, mcp.WithDescription(tool.Description))
-
-		// Add parameters from the tool's input schema
-		// mcp.ToolInputSchema has Properties map[string]interface{} and Required []string
-		if tool.InputSchema.Properties != nil {
-			required := make(map[string]bool)
-			for _, r := range tool.InputSchema.Required {
-				required[r] = true
-			}
-
-			for propName, propDef := range tool.InputSchema.Properties {
-				propMap, ok := propDef.(map[string]interface{})
-				if !ok {
-					continue
-				}
-
-				desc := ""
-				if d, ok := propMap["description"].(string); ok {
-					desc = d
-				}
-
-				if required[propName] {
-					opts = append(opts, mcp.WithString(propName, mcp.Required(), mcp.Description(desc)))
-				} else {
-					opts = append(opts, mcp.WithString(propName, mcp.Description(desc)))
-				}
-			}
-		}
-
-		mcpTool := mcp.NewTool(tool.Name, opts...)
+		mcpTool := buildProxyTool(tool)
 		mcpServer.AddTool(mcpTool, handler)
 
 		log.Debug().
@@ -403,6 +373,24 @@ func (b *ExternalMCPBackend) findMCPConfig(app *types.App, mcpName string) *type
 }
 
 // createToolHandler creates a handler that forwards tool calls to the external MCP server
+// buildProxyTool reconstructs the schema the proxy advertises to Zed for a
+// single upstream tool. It forwards the upstream input schema verbatim so
+// array/object/enum/nested params survive — a proxy transports schemas, it
+// must not reinterpret them. The previous per-property rebuild flattened every
+// param to string, which made array params like create_bot.tools/topics and
+// subscribe.topicIds uncallable ("cannot unmarshal string into []string").
+// See helix-specs task 002204_the-one-blocker.
+func buildProxyTool(tool mcp.Tool) mcp.Tool {
+	raw, err := json.Marshal(tool.InputSchema)
+	if err != nil {
+		// Degrade to a description-only tool rather than a wrong (all-string)
+		// schema; log so the drop is visible.
+		log.Error().Err(err).Str("tool", tool.Name).Msg("marshal upstream MCP schema; serving description-only")
+		return mcp.NewTool(tool.Name, mcp.WithDescription(tool.Description))
+	}
+	return mcp.NewToolWithRawSchema(tool.Name, tool.Description, raw)
+}
+
 func (b *ExternalMCPBackend) createToolHandler(client mcpclient.Client, toolName string) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		log.Debug().

--- a/api/pkg/server/mcp_backend_external_schema_test.go
+++ b/api/pkg/server/mcp_backend_external_schema_test.go
@@ -1,0 +1,84 @@
+package server
+
+// Regression test for helix-specs task 002204_the-one-blocker.
+//
+// It exercises the REAL production helper buildProxyTool (extracted from
+// ExternalMCPBackend.getOrCreateServer) — the code path a zed_external org Bot
+// actually uses when it loads create_bot/subscribe over the external MCP proxy.
+//
+// The org MCP server publishes create_bot.tools as an array (proven by
+// TestSchemaWireArrayParams). This test asserts the proxy preserves that array
+// when re-advertising to Zed. Against the current WithString-only
+// reconstruction it FAILS (tools comes back type:"string") — the exact
+// "cannot unmarshal string into []string" blocker.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// upstreamCreateBotTool mimics what externalClient.ListTools() returns from the
+// org MCP server for create_bot: `tools` is a proper array-of-string.
+func upstreamCreateBotTool() mcp.Tool {
+	return mcp.Tool{
+		Name:        "create_bot",
+		Description: "Create a new Bot in one call.",
+		InputSchema: mcp.ToolInputSchema{
+			Type: "object",
+			Properties: map[string]any{
+				"content": map[string]any{
+					"type":        "string",
+					"description": "The bot's prompt.",
+				},
+				"tools": map[string]any{
+					"type":        "array",
+					"description": "MCP tools to grant.",
+					"items":       map[string]any{"type": "string"},
+				},
+			},
+			Required: []string{"content", "tools"},
+		},
+	}
+}
+
+// servedParamType marshals a proxied tool exactly as it goes over the wire to
+// Zed and returns properties.<param>.type as the client would parse it.
+func servedParamType(t *testing.T, tool mcp.Tool, param string) string {
+	t.Helper()
+	raw, err := json.Marshal(tool)
+	if err != nil {
+		t.Fatalf("marshal served tool: %v", err)
+	}
+	var parsed struct {
+		InputSchema struct {
+			Properties map[string]struct {
+				Type json.RawMessage `json:"type"`
+				Items *struct {
+					Type string `json:"type"`
+				} `json:"items"`
+			} `json:"properties"`
+		} `json:"inputSchema"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal served tool: %v", err)
+	}
+	var typ string
+	_ = json.Unmarshal(parsed.InputSchema.Properties[param].Type, &typ)
+	return typ
+}
+
+// TestBuildProxyTool_PreservesArrayParams pins the blocker on the real
+// production helper. RED until buildProxyTool stops flattening arrays.
+func TestBuildProxyTool_PreservesArrayParams(t *testing.T) {
+	served := buildProxyTool(upstreamCreateBotTool())
+
+	if got := servedParamType(t, served, "tools"); got != "array" {
+		t.Fatalf("create_bot.tools re-advertised as %q, want \"array\" — the proxy flattened the array to string (cannot unmarshal string into []string)", got)
+	}
+	// Scalars must stay intact once the array is fixed.
+	if got := servedParamType(t, served, "content"); got != "string" {
+		t.Fatalf("create_bot.content = %q, want \"string\"", got)
+	}
+}


### PR DESCRIPTION
## Summary

`create_bot` and `subscribe` were uncallable by `zed_external` agents (org
Bots): their array params (`tools`, `topics`, `topicIds`) were advertised as
`type:"string"`, so passing a JSON array failed with
`cannot unmarshal string into []string`.

Root cause is the external MCP proxy, not the org server. `ExternalMCPBackend`
(the MCP proxy Zed connects to at `/api/v1/mcp/external/{name}`) rebuilt each
proxied tool's schema property-by-property as `mcp.WithString`, discarding
`type`, `items`, and `enum`. The org MCP server itself already publishes correct
arrays (verified by `TestSchemaWireArrayParams`). A prior fix (#2774) hardened a
different consumer (`pkg/agent/skill/mcp`, the in-process Go agent path) that
`zed_external` Bots never use — which is why rebuilding didn't help.

The fix forwards the upstream input schema verbatim, so arrays and nested
schemas survive. A proxy should transport schemas, not reinterpret them.

## Changes

- `api/pkg/server/mcp_backend_external.go`: extract `buildProxyTool` and forward
  the upstream schema verbatim via
  `mcp.NewToolWithRawSchema(name, description, json.Marshal(tool.InputSchema))`;
  on marshal error, log and serve a description-only tool (never an all-string
  schema). Adds the `encoding/json` import.
- `api/pkg/server/mcp_backend_external_schema_test.go`: regression test that
  calls the real `buildProxyTool` and asserts an upstream array param is
  re-advertised as `type:"array"` (fails against the old code, passes now).

## Testing

- `TestBuildProxyTool_PreservesArrayParams` — GREEN (RED against old code).
- `go test ./pkg/server/ -run 'MCP|External|Backend'` — ok.
- `go build ./pkg/server/` — clean. Org server `TestSchemaWireArrayParams` — ok.
- Note: `api/pkg/server` tests need `CGO_ENABLED=1` (tree-sitter).

Spec-Ref: 002204_the-one-blocker

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwfkzaz6jmbqt3dk3kft4m02)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002204_the-one-blocker/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002204_the-one-blocker/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002204_the-one-blocker/tasks.md)

🚀 Built with [Helix](https://helix.ml)