### PR TITLE
fix(org): stop cross-tenant leak of ephemeral session keys in org API-key list

### DIFF
--- a/api/pkg/org/infrastructure/runtime/helix/spawner.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner.go
@@ -244,17 +244,26 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 		// Worker's footprint in Helix is attributed to the hiring
 		// user, not the service account. Empty / nil / error all
 		// degrade to "use the static client api_key".
-		if cfg.BearerForUser != nil {
-			bearerCtx, bearerCancel := context.WithTimeout(parentCtx, cfg.SessionStartupTimeout)
-			if state, err := LoadState(bearerCtx, cfg.Store, orgID, workerID); err == nil && state.HiringUserID != "" {
+		bearerCtx, bearerCancel := context.WithTimeout(parentCtx, cfg.SessionStartupTimeout)
+		if state, err := LoadState(bearerCtx, cfg.Store, orgID, workerID); err == nil && state.HiringUserID != "" {
+			// Attribute this activation to the hiring user for BOTH client
+			// paths. The in-proc client's resolveUser reads the user id
+			// (not the bearer), so WithUserID is what makes the Worker's
+			// session/project owned by the hiring human rather than the
+			// org-service identity — otherwise the ephemeral session key
+			// is owned by the first-admin and leaks into the tenant org's
+			// key list. The remote/HTTP client needs the bearer as an
+			// Authorization header, set below when the callback is wired.
+			parentCtx = WithUserID(parentCtx, state.HiringUserID)
+			if cfg.BearerForUser != nil {
 				if bearer, berr := cfg.BearerForUser(bearerCtx, state.HiringUserID); berr == nil && bearer != "" {
 					parentCtx = WithBearerToken(parentCtx, bearer)
 				} else if berr != nil && cfg.Logger != nil {
 					cfg.Logger.Warn("helix spawner: BearerForUser failed; falling back to service key", "worker", workerID, "user_id", state.HiringUserID, "err", berr.Error())
 				}
 			}
-			bearerCancel()
 		}
+		bearerCancel()
 
 		startupCtx, startupCancel := context.WithTimeout(parentCtx, cfg.SessionStartupTimeout)
 		defer startupCancel()

--- a/api/pkg/server/helix_org_middleware.go
+++ b/api/pkg/server/helix_org_middleware.go
@@ -180,6 +180,13 @@ func (s *HelixAPIServer) withHelixOrgScope(scope *helixOrgScope, next http.Handl
 			return
 		}
 		ctx := helixorgserver.WithOrgID(r.Context(), org.ID)
+		// Bridge the authenticated caller into the runtime-helix context
+		// so lifecycle.Create persists them as the Bot's hiring user
+		// (SaveHiringUser reads runtimehelix.UserIDFromContext). Without
+		// this every Bot's session falls back to the org-service identity
+		// (first admin), which cross-attributes another user's key into
+		// the tenant org's API-keys list.
+		ctx = runtimehelix.WithUserID(ctx, user.ID)
 		// Strip the /orgs/{org}/helix-org prefix so the downstream
 		// helix-org handler sees the same flat path it served from
 		// /api/v1/org/* before — keeps the org-graph server unaware

--- a/api/pkg/server/org_apikey_handlers.go
+++ b/api/pkg/server/org_apikey_handlers.go
@@ -59,11 +59,16 @@ func (apiServer *HelixAPIServer) listOrgAPIKeys(rw http.ResponseWriter, r *http.
 		return
 	}
 
-	// Filter out spec-task-scoped keys and collect unique owner IDs
+	// Filter out ephemeral session-scoped keys (spec-task and helix-org
+	// bot runtime keys both set SessionID) and collect unique owner IDs.
+	// These are minted per-session for the desktop/agent to authenticate
+	// and are revoked on shutdown — they are not user-managed keys and
+	// leak other members' identities (e.g. the helix-org service owner)
+	// into an org owner's key list. SpecTaskID alone missed bot sessions.
 	ownerIDs := make(map[string]struct{})
 	var filtered []*types.ApiKey
 	for _, key := range apiKeys {
-		if key.SpecTaskID != "" {
+		if key.SessionID != "" || key.SpecTaskID != "" {
 			continue
 		}
 		filtered = append(filtered, key)

--- a/api/pkg/server/org_apikey_handlers_test.go
+++ b/api/pkg/server/org_apikey_handlers_test.go
@@ -199,6 +199,59 @@ func TestListOrgAPIKeys_FiltersOutSpecTaskKeys(t *testing.T) {
 	require.Equal(t, "Another Regular", keys[1].Name)
 }
 
+func TestListOrgAPIKeys_FiltersOutSessionKeys(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	server := &HelixAPIServer{Store: mockStore}
+
+	orgID := "org_123"
+	userID := "user_owner"
+
+	expectResolveOrganizationByID(mockStore, orgID)
+
+	mockStore.EXPECT().GetOrganizationMembership(gomock.Any(), &store.GetOrganizationMembershipQuery{
+		OrganizationID: orgID,
+		UserID:         userID,
+	}).Return(&types.OrganizationMembership{
+		OrganizationID: orgID,
+		UserID:         userID,
+		Role:           types.OrganizationRoleOwner,
+	}, nil)
+
+	// The helix-org bot session key belongs to a different user (the
+	// org-service identity) and is scoped to this org. It must not leak
+	// into the owner's key list. It sets SessionID but not SpecTaskID,
+	// which the old SpecTaskID-only filter missed.
+	mockStore.EXPECT().ListAPIKeys(gomock.Any(), &store.ListAPIKeysQuery{
+		OrganizationID: orgID,
+		Type:           types.APIkeytypeAPI,
+	}).Return([]*types.ApiKey{
+		{Key: "key_1", Name: "Regular Key", Owner: userID, OrganizationID: orgID},
+		{Key: "key_2", Name: "Session key - ses_x", Owner: "user_service", OrganizationID: orgID, SessionID: "ses_x"},
+	}, nil)
+
+	mockStore.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: userID}).Return(&types.User{
+		ID: userID, Email: "owner@example.com",
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/organizations/"+orgID+"/api_keys", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": orgID})
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: userID}))
+
+	rr := httptest.NewRecorder()
+	server.listOrgAPIKeys(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var keys []orgAPIKeyResponse
+	err := json.Unmarshal(rr.Body.Bytes(), &keys)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Equal(t, "Regular Key", keys[0].Name)
+}
+
 func TestCreateOrgAPIKey_MemberCanCreate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
## Problem

An org owner viewing **Settings → API keys** saw an API key owned by a **different user** (the deployment's first-admin service identity) scoped into their org. Root cause: helix-org bot sessions were owned by the service identity but tagged with the tenant org, so the ephemeral per-session key inherited a foreign owner and surfaced in the org list. Confirmed on the deployment that **no bot, in any org, ever had `hiring_user_id` persisted** — attribution was broken end-to-end.

## Fix

Two layers:

**1. Stop the leak (`org_apikey_handlers.go`).** `listOrgAPIKeys` filtered only spec-task-scoped keys (`SpecTaskID`); helix-org bot session keys set `SessionID` with an empty `SpecTaskID` and slipped through. Now filters on `SessionID` too — every ephemeral runtime key (spec-task, bot session, **and sandbox** keys, which reuse the `SessionID` column) sets it, so this subsumes the old check. Hides the existing leaked rows on restart; no data migration.

**2. Fix attribution (`helix_org_middleware.go`, `spawner.go`).** Bot sessions are now owned by the user who created the bot, not the service identity:
- Hire-time: `withHelixOrgScope` bridges the authenticated caller into the runtime-helix context so `lifecycle.Create` → `SaveHiringUser` actually persists them (it was silently no-op'ing on an empty context user).
- Activation-time: the spawner stashes `WithUserID(HiringUserID)`, because the in-proc client's `resolveUser` reads the user id, not the bearer token the old code set.

## Behavior change (intentional)

`deleteBot`'s in-proc teardown now runs as the caller, so a **non-owner org member can no longer delete a bot they didn't create** (org owners are unaffected). This is more-correct RBAC — the old permissive behavior was a symptom of the same ownership bug.

## Not affected

- **MCP / live bots:** the sandbox's helix-org MCP calls authenticate with the fixed service key (which holds the `helix-org` alpha flag), not the session key — no 403s.
- **Existing bots:** they have no persisted `hiring_user_id`, so they keep the old service-owned behavior; only new bots get hiring-user ownership (project + repo + session all consistent).
- **Transcript viewing:** sessions stay org-tagged, so org-owner viewing via `authorizeUserToSession` still works.

## Test

- New `TestListOrgAPIKeys_FiltersOutSessionKeys`; existing org-apikey suite passes; both affected packages build; spawner package tests pass.
- Reviewed by three independent passes (correctness, cross-tenant security, blast-radius) — no correctness bugs; alpha-gate and leak-closure confirmed clean.
- NOT yet exercised end-to-end (fresh-bot activation attribution) — relying on CI + unit coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)