### PR TITLE
fix(sandbox): drop process substitution from dockerd init cleanup

### DIFF
--- a/sandbox/04-start-dockerd.sh
+++ b/sandbox/04-start-dockerd.sh
@@ -363,17 +363,19 @@ echo "🧹 Cleaning up old desktop images in nested Docker..."
 # hosted service falls off its fast self-heal path and into a slow full
 # redeploy. `docker container prune` has no negative label filter, so enumerate
 # exited containers and skip the helix.persistent=true ones explicitly.
-mapfile -t STOPPED_TO_REMOVE < <(
-    docker ps -aq --filter "status=exited" 2>/dev/null | while read -r cid; do
-        [ -z "$cid" ] && continue
-        if [ "$(docker inspect -f '{{ index .Config.Labels "helix.persistent" }}' "$cid" 2>/dev/null)" != "true" ]; then
-            echo "$cid"
-        fi
-    done
-)
-if [ "${#STOPPED_TO_REMOVE[@]}" -gt 0 ]; then
-    echo "   Removing ${#STOPPED_TO_REMOVE[@]} stopped container(s) (keeping persistent web-services)..."
-    docker rm -f "${STOPPED_TO_REMOVE[@]}" >/dev/null 2>&1 || true
+# ponytail: plain loop, not `mapfile < <(...)` — process substitution needs
+# /dev/fd/63 which isn't resolvable in the nested-DinD container (broke the
+# whole init under `set -e`, see 2.11.39-.41). Container IDs are hex, so a
+# space-joined string with unquoted expansion is safe.
+STOPPED_TO_REMOVE=""
+for cid in $(docker ps -aq --filter "status=exited" 2>/dev/null); do
+    if [ "$(docker inspect -f '{{ index .Config.Labels "helix.persistent" }}' "$cid" 2>/dev/null)" != "true" ]; then
+        STOPPED_TO_REMOVE="$STOPPED_TO_REMOVE $cid"
+    fi
+done
+if [ -n "$STOPPED_TO_REMOVE" ]; then
+    echo "   Removing stopped container(s) (keeping persistent web-services)..."
+    docker rm -f $STOPPED_TO_REMOVE >/dev/null 2>&1 || true
 fi
 
 # Build a list of expected versions and registry refs


### PR DESCRIPTION
## Problem

Sandboxes are broken in 2.11.39-.41 (last-good 2.11.38). Users see the sandbox container fail to start with:

```
🧹 Cleaning up old desktop images in nested Docker...
/etc/cont-init.d/40-start-dockerd.sh: line 366: /dev/fd/63: No such file or directory
```

## Root cause

Commit `818cd3a44` (shipped in 2.11.39) replaced a simple `docker container prune` with:

```bash
mapfile -t STOPPED_TO_REMOVE < <( ... )
```

Process substitution `< <(...)` opens `/dev/fd/63`, which is not resolvable inside the nested-DinD sandbox container. Because `04-start-dockerd.sh` runs under `set -e`, the failing redirect aborts the whole init script before dockerd finishes starting, so the sandbox never comes up. This is the only process substitution in any sandbox init script, which is why nothing else regressed.

## Fix

Replace the `mapfile < <(...)` with a plain `for` loop accumulator. No process substitution, no `mapfile`. Still skips `helix.persistent=true` containers so hosted web-services stay on their fast self-heal path. Container IDs are hex, so a space-joined string with unquoted expansion is safe.

## Testing

- `bash -n` syntax check passes.
- Stubbed-`docker` self-check confirms a `helix.persistent=true` container is kept while other exited containers are collected for removal.

NOT tested: live sandbox boot from a rebuilt image (`./stack build-sandbox`) — worth confirming end-to-end before/at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)