### PR TITLE
Reconcile stale dev container state after sandbox restart

### DIFF
--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -1607,7 +1607,11 @@ func (h *HydraExecutor) DiscoverContainersFromSandbox(ctx context.Context, sandb
 // entry evicted, so the derived SandboxState becomes "absent" instead of showing
 // a dead container as running.
 func (h *HydraExecutor) markMissingSessionsStopped(ctx context.Context, sandboxID string, liveSessionIDs map[string]bool, hydraClient *hydra.RevDialClient) {
-	if sandboxID == "" || sandboxID == "local" {
+	// Unlike the active_sandboxes counter (a multi-tenant autoscaler concern that
+	// skips "local"), session-status reconciliation applies to every sandbox
+	// including the single-node "local" one — a self-hosted CD redeploy destroys
+	// its containers just the same. Only skip the ambiguous empty id.
+	if sandboxID == "" {
 		return
 	}
 

--- a/api/pkg/external-agent/hydra_executor.go
+++ b/api/pkg/external-agent/hydra_executor.go
@@ -1451,6 +1451,21 @@ func (h *HydraExecutor) DiscoverContainersFromSandbox(ctx context.Context, sandb
 		}
 	}
 
+	// Reconcile the inverse of discovery: any session this control-plane still
+	// believes is "running" on this sandbox but that hydra no longer reports is
+	// stale (e.g. a CD redeploy restarted the sandbox and destroyed its dev
+	// containers). Mark those sessions stopped so the Kanban / task page stop
+	// showing a dead container as running. This MUST run even when hydra reports
+	// zero containers (the full-wipe case), so it sits before the empty-list
+	// early return below.
+	liveSessionIDs := make(map[string]bool, len(containerList.Containers))
+	for _, container := range containerList.Containers {
+		if container.SessionID != "" {
+			liveSessionIDs[container.SessionID] = true
+		}
+	}
+	h.markMissingSessionsStopped(ctx, sandboxID, liveSessionIDs, hydraClient)
+
 	if len(containerList.Containers) == 0 {
 		return nil
 	}
@@ -1580,6 +1595,99 @@ func (h *HydraExecutor) DiscoverContainersFromSandbox(ctx context.Context, sandb
 	}
 
 	return nil
+}
+
+// markMissingSessionsStopped downgrades sessions on the given sandbox that this
+// control-plane still marks "running" but that are absent from hydra's live set
+// (liveSessionIDs). For each candidate it authoritatively confirms the container
+// is gone with a per-session GetDevContainer probe — taken under the session's
+// creation lock so a concurrent StartDesktop that (re)created the container after
+// hydra's snapshot can't be wrongly torn down. Confirmed-dead sessions have their
+// container metadata cleared, status set to "stopped", and their stale in-memory
+// entry evicted, so the derived SandboxState becomes "absent" instead of showing
+// a dead container as running.
+func (h *HydraExecutor) markMissingSessionsStopped(ctx context.Context, sandboxID string, liveSessionIDs map[string]bool, hydraClient *hydra.RevDialClient) {
+	if sandboxID == "" || sandboxID == "local" {
+		return
+	}
+
+	sessions, err := h.store.ListSessionsBySandbox(ctx, sandboxID)
+	if err != nil {
+		log.Warn().Err(err).Str("sandbox_id", sandboxID).Msg("Failed to list sessions for stale-container reconcile")
+		return
+	}
+
+	for _, session := range sessions {
+		if liveSessionIDs[session.ID] {
+			continue // hydra confirms this container is alive
+		}
+		// Only downgrade sessions we believe are actively running with a
+		// container. Skip "starting" (StartDesktop may be mid-flight and not yet
+		// visible to hydra) and already-terminal states.
+		if session.Metadata.ExternalAgentStatus != "running" || session.Metadata.ContainerName == "" {
+			continue
+		}
+
+		// Serialize against StartDesktop for this session before making a
+		// decision, so the probe + downgrade is atomic wrt a concurrent start.
+		h.creationLocksMutex.Lock()
+		sessionLock, exists := h.creationLocks[session.ID]
+		if !exists {
+			sessionLock = &sync.Mutex{}
+			h.creationLocks[session.ID] = sessionLock
+		}
+		h.creationLocksMutex.Unlock()
+
+		sessionLock.Lock()
+
+		// Re-read under the lock: StartDesktop may have just (re)created it.
+		current, err := h.store.GetSession(ctx, session.ID)
+		if err != nil {
+			sessionLock.Unlock()
+			continue
+		}
+		if current.Metadata.ExternalAgentStatus != "running" || current.Metadata.ContainerName == "" {
+			sessionLock.Unlock()
+			continue
+		}
+
+		// Authoritatively confirm the container is gone before downgrading.
+		// hydra's list snapshot may pre-date a just-started container, so a
+		// direct live probe is the source of truth for the decision.
+		if hydraClient != nil {
+			if _, err := hydraClient.GetDevContainer(ctx, session.ID); err == nil {
+				sessionLock.Unlock()
+				continue // container actually exists; snapshot was just stale
+			}
+		}
+
+		current.Metadata.ContainerName = ""
+		current.Metadata.ContainerID = ""
+		current.Metadata.ContainerIP = ""
+		current.Metadata.ExternalAgentStatus = "stopped"
+		// Keep DesiredState + SandboxID so a reconciler can restart it here.
+
+		if _, err := h.store.UpdateSession(ctx, *current); err != nil {
+			log.Warn().Err(err).
+				Str("session_id", session.ID).
+				Str("sandbox_id", sandboxID).
+				Msg("Failed to mark stale dev container session stopped during discovery")
+			sessionLock.Unlock()
+			continue
+		}
+
+		// Evict the stale in-memory entry so GetSession/HasRunningContainer agree.
+		h.mutex.Lock()
+		delete(h.sessions, session.ID)
+		h.mutex.Unlock()
+
+		log.Info().
+			Str("session_id", session.ID).
+			Str("sandbox_id", sandboxID).
+			Msg("Marked stale dev container session stopped (not reported by hydra after reconnect)")
+
+		sessionLock.Unlock()
+	}
 }
 
 // ReconcileSandboxResources posts the DB-derived live-set to a connected

--- a/api/pkg/external-agent/reconcile_missing_sessions_test.go
+++ b/api/pkg/external-agent/reconcile_missing_sessions_test.go
@@ -1,0 +1,132 @@
+package external_agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+// newTestExecutor builds a HydraExecutor wired to a mock store, with the maps
+// markMissingSessionsStopped touches initialised. connman is left nil so the
+// method runs without a live sandbox; hydraClient is passed as nil by the tests
+// so the authoritative GetDevContainer probe is skipped (the snapshot is treated
+// as ground truth).
+func newTestExecutor(mockStore store.Store) *HydraExecutor {
+	return &HydraExecutor{
+		store:         mockStore,
+		sessions:      make(map[string]*ZedSession),
+		creationLocks: make(map[string]*sync.Mutex),
+	}
+}
+
+func runningSession(id string) *types.Session {
+	return &types.Session{
+		ID: id,
+		Metadata: types.SessionMetadata{
+			ExternalAgentStatus: "running",
+			ContainerName:       "ubuntu-external-" + id,
+			ContainerID:         "cid-" + id,
+			ContainerIP:         "10.0.0.5",
+		},
+	}
+}
+
+// Hydra reports a subset of the sessions the DB thinks are running: the missing
+// one is downgraded to stopped with cleared metadata, the live one is left alone,
+// and a "starting" session is never touched.
+func TestMarkMissingSessionsStopped_DowngradesMissingOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	h := newTestExecutor(mockStore)
+	// Stale in-memory entry for the gone session must be evicted.
+	h.sessions["ses_gone"] = &ZedSession{SessionID: "ses_gone", Status: "running"}
+
+	starting := runningSession("ses_starting")
+	starting.Metadata.ExternalAgentStatus = "starting"
+
+	mockStore.EXPECT().
+		ListSessionsBySandbox(gomock.Any(), "sbox_1").
+		Return([]*types.Session{
+			runningSession("ses_live"),
+			runningSession("ses_gone"),
+			starting,
+		}, nil)
+
+	// Only the gone session is re-read and updated.
+	mockStore.EXPECT().
+		GetSession(gomock.Any(), "ses_gone").
+		Return(runningSession("ses_gone"), nil)
+	mockStore.EXPECT().
+		UpdateSession(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, s types.Session) (*types.Session, error) {
+			assert.Equal(t, "ses_gone", s.ID)
+			assert.Equal(t, "stopped", s.Metadata.ExternalAgentStatus)
+			assert.Empty(t, s.Metadata.ContainerName)
+			assert.Empty(t, s.Metadata.ContainerID)
+			assert.Empty(t, s.Metadata.ContainerIP)
+			return &s, nil
+		})
+
+	live := map[string]bool{"ses_live": true}
+	h.markMissingSessionsStopped(context.Background(), "sbox_1", live, nil)
+
+	// Stale in-memory entry evicted.
+	h.mutex.RLock()
+	_, stillTracked := h.sessions["ses_gone"]
+	h.mutex.RUnlock()
+	assert.False(t, stillTracked, "stale in-memory session should be evicted")
+}
+
+// Full-wipe case: hydra reports zero containers, so every DB-running session on
+// the sandbox is downgraded.
+func TestMarkMissingSessionsStopped_ZeroContainersDowngradesAll(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	h := newTestExecutor(mockStore)
+
+	mockStore.EXPECT().
+		ListSessionsBySandbox(gomock.Any(), "sbox_1").
+		Return([]*types.Session{
+			runningSession("ses_a"),
+			runningSession("ses_b"),
+		}, nil)
+
+	for _, id := range []string{"ses_a", "ses_b"} {
+		mockStore.EXPECT().GetSession(gomock.Any(), id).Return(runningSession(id), nil)
+	}
+	updated := map[string]bool{}
+	mockStore.EXPECT().
+		UpdateSession(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, s types.Session) (*types.Session, error) {
+			assert.Equal(t, "stopped", s.Metadata.ExternalAgentStatus)
+			updated[s.ID] = true
+			return &s, nil
+		}).
+		Times(2)
+
+	h.markMissingSessionsStopped(context.Background(), "sbox_1", map[string]bool{}, nil)
+
+	assert.True(t, updated["ses_a"] && updated["ses_b"], "both sessions should be downgraded")
+}
+
+// A "local" sandbox is not container-counted and must be skipped entirely.
+func TestMarkMissingSessionsStopped_SkipsLocalSandbox(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	h := newTestExecutor(mockStore)
+
+	// No store calls expected.
+	h.markMissingSessionsStopped(context.Background(), "local", map[string]bool{}, nil)
+	h.markMissingSessionsStopped(context.Background(), "", map[string]bool{}, nil)
+}

--- a/api/pkg/external-agent/reconcile_missing_sessions_test.go
+++ b/api/pkg/external-agent/reconcile_missing_sessions_test.go
@@ -118,8 +118,8 @@ func TestMarkMissingSessionsStopped_ZeroContainersDowngradesAll(t *testing.T) {
 	assert.True(t, updated["ses_a"] && updated["ses_b"], "both sessions should be downgraded")
 }
 
-// A "local" sandbox is not container-counted and must be skipped entirely.
-func TestMarkMissingSessionsStopped_SkipsLocalSandbox(t *testing.T) {
+// An empty sandbox id is ambiguous and must be skipped entirely (no store calls).
+func TestMarkMissingSessionsStopped_SkipsEmptySandbox(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -127,6 +127,32 @@ func TestMarkMissingSessionsStopped_SkipsLocalSandbox(t *testing.T) {
 	h := newTestExecutor(mockStore)
 
 	// No store calls expected.
-	h.markMissingSessionsStopped(context.Background(), "local", map[string]bool{}, nil)
 	h.markMissingSessionsStopped(context.Background(), "", map[string]bool{}, nil)
+}
+
+// The single-node "local" sandbox is NOT skipped — a self-hosted redeploy wipes
+// its containers too, so stale local sessions must also be downgraded.
+func TestMarkMissingSessionsStopped_ProcessesLocalSandbox(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	h := newTestExecutor(mockStore)
+
+	mockStore.EXPECT().
+		ListSessionsBySandbox(gomock.Any(), "local").
+		Return([]*types.Session{runningSession("ses_local")}, nil)
+	mockStore.EXPECT().GetSession(gomock.Any(), "ses_local").Return(runningSession("ses_local"), nil)
+
+	downgraded := false
+	mockStore.EXPECT().
+		UpdateSession(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, s types.Session) (*types.Session, error) {
+			assert.Equal(t, "stopped", s.Metadata.ExternalAgentStatus)
+			downgraded = true
+			return &s, nil
+		})
+
+	h.markMissingSessionsStopped(context.Background(), "local", map[string]bool{}, nil)
+	assert.True(t, downgraded, "local session should be downgraded")
 }


### PR DESCRIPTION
## Summary
After a continuous-delivery redeploy stops and restarts the sandbox, its dev
containers are destroyed but the control-plane kept reporting them as **running**.
The spec-task details page / Kanban then showed live cards whose desktop viewer
503s when opened ("Sandbox not connected"). The reconnect-time discovery was
**additive only** — it marked discovered containers running and fixed the counter,
but never marked now-missing sessions stopped. The only downgrade path
(`OnSandboxDisconnected`) requires the disconnect grace period to expire, which is
unreliable on a fast redeploy.

This makes the reconnect discovery symmetric: it now also downgrades sessions the
control-plane still believes are running on that sandbox but that hydra no longer
reports.

## Changes
- `api/pkg/external-agent/hydra_executor.go`
  - New `markMissingSessionsStopped(...)`, called from
    `DiscoverContainersFromSandbox` right after the container-count resync and
    **before** the empty-list early return (so the full-wipe case is covered).
  - For each DB session marked `running` on the sandbox that is absent from hydra's
    live snapshot, it takes the per-session **creation lock** (same lock
    `StartDesktop` uses), re-reads the session, and does an authoritative
    `GetDevContainer` probe. Only if the probe confirms the container is gone does
    it clear container metadata, set `ExternalAgentStatus = "stopped"`, and evict
    the stale in-memory entry. This avoids racing a concurrent `StartDesktop` that
    re-created the container after hydra's snapshot.
  - `starting` sessions are never touched; `DesiredState`/`SandboxID` are preserved
    so a reconciler can restart the session.
  - Applies to the single-node `local` sandbox too (only the ambiguous empty id is
    skipped) — a self-hosted redeploy wipes its containers the same way.
- `api/pkg/external-agent/reconcile_missing_sessions_test.go` — new gomock unit
  tests: subset → only missing session downgraded (+ in-memory eviction), live left
  alone, `starting` skipped; zero containers → all downgraded; `local` processed;
  empty id skipped.

## Testing
- Unit tests pass (`go test ./pkg/external-agent/ -run TestMarkMissingSessionsStopped`).
- `go build ./pkg/external-agent/ ./pkg/server/ ./pkg/store/ ./pkg/types/` — OK.
- E2E in inner Helix (sandbox_id=local): created a spec task with a live dev
  container, then killed the container + restarted hydra to force a reconnect with
  the container gone. The reconcile logged *"Marked stale dev container session
  stopped (not reported by hydra after reconnect)"*, the DB session flipped to
  `stopped` with container metadata cleared, and the Kanban card stopped showing a
  running/viewable desktop. The immediately-preceding healthy reconnect (container
  alive) did **not** downgrade — no false positives.

## Screenshots
![Kanban after reconcile](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002199_we-now-have-continuous/screenshots/01-kanban-after-reconcile.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwersvyz2vpn26kq76s4fca0)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002199_we-now-have-continuous/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002199_we-now-have-continuous/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002199_we-now-have-continuous/tasks.md)

🚀 Built with [Helix](https://helix.ml)