### PR TITLE
fix(external-agent): stop stale GenerationModel shadowing zed_external model pick

### DIFF
--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -121,16 +121,20 @@ func GenerateZedMCPConfig(
 	}
 	assistant := FindZedExternalAssistant(app)
 
-	// For zed_external agents, prefer GenerationModel fields (where UI stores the selection)
+	// For zed_external agents the runtime selection lives in Model/Provider
+	// (CodingAgentForm writes these). GenerationModel/-Provider are the
+	// helix_agent template defaults (gpt-4o/openai) and must NOT shadow the
+	// real pick — doing so made GLM/Goose agents boot as openai/gpt-4o while a
+	// sibling Claude agent (empty GenerationModel) worked.
 	var provider, model string
 	if assistant != nil {
-		provider = assistant.GenerationModelProvider
+		provider = assistant.Provider
 		if provider == "" {
-			provider = assistant.Provider
+			provider = assistant.GenerationModelProvider
 		}
-		model = assistant.GenerationModel
+		model = assistant.Model
 		if model == "" {
-			model = assistant.Model
+			model = assistant.GenerationModel
 		}
 	}
 
@@ -750,13 +754,17 @@ func ValidateAssistantModelConfig(app *types.App, snapshot []ProviderRef) string
 	if assistant.CodeAgentCredentialType.IsSubscription() && assistant.CodeAgentRuntime == types.CodeAgentRuntimeClaudeCode {
 		return ""
 	}
-	provider := assistant.GenerationModelProvider
+	// Mirror GenerateZedMCPConfig: Model/Provider is the zed_external source of
+	// truth; the GenerationModel quartet is helix_agent template default noise.
+	// The two must validate and route the same fields or the validator can
+	// green-light a stale provider the reader never uses.
+	provider := assistant.Provider
 	if provider == "" {
-		provider = assistant.Provider
+		provider = assistant.GenerationModelProvider
 	}
-	model := assistant.GenerationModel
+	model := assistant.Model
 	if model == "" {
-		model = assistant.Model
+		model = assistant.GenerationModel
 	}
 	if provider == "" || model == "" {
 		return fmt.Sprintf("agent %q is missing a provider or model selection — open the agent settings and pick a provider and model", app.ID)

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -35,6 +35,8 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 		dbScalewayID    = "pe_scaleway_01"
 		dbScaleway      = ProviderRef{ID: dbScalewayID, Name: "scaleway"}
 		dbScalewayPrime = ProviderRef{ID: dbScalewayID, Name: "scaleway-prime"} // same ID, renamed
+		dbGLMID         = "pe_glm_01"
+		dbGLM           = ProviderRef{ID: dbGLMID, Name: "glm-helix"}
 	)
 
 	cases := []struct {
@@ -99,6 +101,25 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "scaleway/qwen3-coder-480b"},
 			wantMisconfig:    false,
 			why:              "control case: agent stored ID resolves to canonical scaleway name",
+		},
+		{
+			// Regression (2026-07-02, meta.helix.ml): a GLM-on-Helix external
+			// agent booted Zed as openai/gpt-4o. The real pick lived in
+			// Model/Provider while the helix_agent template defaults
+			// (gpt-4o/openai) sat in the GenerationModel quartet. The reader
+			// preferred GenerationModel and shadowed the real selection.
+			name: "model_provider_wins_over_stale_generation_quartet",
+			assistants: []types.AssistantConfig{{
+				AgentType:               types.AgentTypeZedExternal,
+				Provider:                dbGLMID,
+				Model:                   "glm-5.1",
+				GenerationModelProvider: "openai", // stale template default
+				GenerationModel:         "gpt-4o", // stale template default
+			}},
+			snapshot:         []ProviderRef{dbGLM, globalOpenAI},
+			wantDefaultModel: &ModelConfig{Provider: "openai", Model: "glm-helix/glm-5.1"},
+			wantMisconfig:    false,
+			why:              "zed_external source of truth is Model/Provider; the GenerationModel quartet must not shadow it",
 		},
 		{
 			name: "configured_anthropic_passes_through",

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -439,15 +439,23 @@ func (s *HelixAPIServer) startChatSessionHandler(rw http.ResponseWriter, req *ht
 			}
 			assistant = data.GetAssistant(app, assistantID)
 
-			// Update the model if the assistant has one
-			// Prefer GenerationModel over Model (new field vs legacy field)
-			if assistant.GenerationModel != "" {
+			// Update the model if the assistant has one. For helix_agent the
+			// GenerationModel field carries the real selection; for external
+			// agents (zed_external) the source of truth is Model/Provider —
+			// GenerationModel there is a stale helix_agent template default
+			// (gpt-4o) that must not win.
+			if assistant.AgentType == types.AgentTypeHelixAgent && assistant.GenerationModel != "" {
 				startReq.Model = assistant.GenerationModel
 				if assistant.GenerationModelProvider != "" {
 					startReq.Provider = types.Provider(assistant.GenerationModelProvider)
 				}
 			} else if assistant.Model != "" {
 				startReq.Model = assistant.Model
+			} else if assistant.GenerationModel != "" {
+				startReq.Model = assistant.GenerationModel
+				if assistant.GenerationModelProvider != "" {
+					startReq.Provider = types.Provider(assistant.GenerationModelProvider)
+				}
 			}
 
 			// Override provider if explicitly set on assistant
@@ -465,13 +473,14 @@ func (s *HelixAPIServer) startChatSessionHandler(rw http.ResponseWriter, req *ht
 				generateSessionNameProvider = assistant.SmallGenerationModelProvider
 				generateSessionNameModel = assistant.SmallGenerationModel
 			} else {
-				// For basic mode, use generation model (or fall back to Model field)
-				if assistant.GenerationModel != "" {
-					generateSessionNameProvider = assistant.GenerationModelProvider
-					generateSessionNameModel = assistant.GenerationModel
-				} else if assistant.Model != "" {
+				// For basic/external mode, prefer Model/Provider (the real pick);
+				// fall back to GenerationModel only when Model is unset.
+				if assistant.Model != "" {
 					generateSessionNameProvider = assistant.Provider
 					generateSessionNameModel = assistant.Model
+				} else if assistant.GenerationModel != "" {
+					generateSessionNameProvider = assistant.GenerationModelProvider
+					generateSessionNameModel = assistant.GenerationModel
 				}
 			}
 		}

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -605,8 +605,10 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfig(ctx context.Context, app *
 }
 
 // buildCodeAgentConfigFromAssistant creates a CodeAgentConfig from an assistant configuration.
-// For zed_external agents, use GenerationModelProvider/GenerationModel - that's where the UI
-// stores the user's model selection for external agents.
+// For zed_external agents the user's model selection lives in Model/Provider; the
+// GenerationModel quartet holds helix_agent template defaults (gpt-4o/openai) that must
+// not shadow it. This must match GenerateZedMCPConfig's precedence or CodeAgentConfig.Model
+// (fed to Goose/qwen via agent_servers) disagrees with agent.default_model.
 // The CodeAgentRuntime determines how the LLM is configured in Zed (built-in agent vs qwen).
 func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.Context, assistant *types.AssistantConfig, helixURL string, providerSnapshot []external_agent.ProviderRef) *types.CodeAgentConfig {
 	// Get the code agent runtime, default to zed_agent
@@ -618,15 +620,15 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.C
 	// Check if this agent uses subscription-based credentials (e.g., Claude OAuth)
 	isSubscription := assistant.CodeAgentCredentialType.IsSubscription()
 
-	// For zed_external agents, use generation model fields (that's where the UI sets the model)
-	// Fall back to primary provider/model only if generation fields are empty.
-	providerName := assistant.GenerationModelProvider
+	// Model/Provider is the zed_external source of truth; GenerationModel is the
+	// stale helix_agent-template fallback (see doc comment above).
+	providerName := assistant.Provider
 	if providerName == "" {
-		providerName = assistant.Provider
+		providerName = assistant.GenerationModelProvider
 	}
-	modelName := assistant.GenerationModel
+	modelName := assistant.Model
 	if modelName == "" {
-		modelName = assistant.Model
+		modelName = assistant.GenerationModel
 	}
 
 	// Resolve the agent's stored provider token (ID or legacy name) to the

--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -434,6 +434,21 @@ const AppSettings: FC<AppSettingsProps> = ({
     if (config !== undefined) {
       updates.external_agent_config = config
     }
+    // The reasoning/generation quartet only applies to helix_agent. Clear it
+    // when switching to an external runtime so stale helix_agent defaults
+    // (e.g. gpt-4o) can't shadow the external agent's Model/Provider pick.
+    if (agentType === AGENT_TYPE_ZED_EXTERNAL) {
+      updates.reasoning_model = ''
+      updates.reasoning_model_provider = ''
+      updates.reasoning_model_effort = ''
+      updates.generation_model = ''
+      updates.generation_model_provider = ''
+      updates.small_reasoning_model = ''
+      updates.small_reasoning_model_provider = ''
+      updates.small_reasoning_model_effort = ''
+      updates.small_generation_model = ''
+      updates.small_generation_model_provider = ''
+    }
     onUpdate(updates)
   }
 


### PR DESCRIPTION
## Problem

On meta.helix.ml, an external agent configured with **Runtime Zed / model GLM 5.1 (Helix)** boots Zed showing **openai/gpt-4o**. Same with **Goose / GLM 5.1 (Bunka)**. A sibling Claude agent works fine.

## Root cause

For a `zed_external` agent the runtime selection is stored in the assistant's `Model`/`Provider` fields. Legacy rows (created via the since-removed agent wizard as `helix_agent`, then switched to `zed_external`) still carry the helix_agent template quartet with defaults `gpt-4o`/`openai` in `GenerationModel`/`GenerationModelProvider`.

Three readers preferred `GenerationModel` over `Model`, so the stale `gpt-4o` shadowed the real `glm-5.1` pick:

1. `GenerateZedMCPConfig` -> Zed's `settings.json` `default_model`
2. `ValidateAssistantModelConfig` -> the pre-flight validator (must agree with the reader)
3. `buildCodeAgentConfigFromAssistant` -> the runner-side `CodeAgentConfig` fed to Goose/qwen via `agent_servers` (its own comment requires it to match `default_model`)

Plus `session_handlers.go` set the session-record `Model` (and session-name model) from `GenerationModel`.

Evidence from the live broken app (`app_01kwhhq32...`):

| field | value |
|---|---|
| `model` | `glm-5.1` OK real pick |
| `provider` | `pe_01kvd360...` OK GLM/Helix endpoint |
| `generation_model` | `gpt-4o` STALE |
| `generation_model_provider` | `openai` STALE |

The working Claude agent had `generation_model = ""`, so it fell through to `model` and routed correctly.

## Fix

1. Flip the precedence to `Model`/`Provider` first, `GenerationModel` as fallback, in all three zed_external readers so they stay mutually consistent. In `session_handlers.go` the flip is **agent-type-aware**: native `helix_agent` keeps `GenerationModel`-first (that is its real field), external agents prefer `Model`/`Provider`.
2. Frontend: clear the reasoning/generation quartet in `AppSettings.handleAgentTypeChange` when switching an app to `zed_external`, so no stale helix_agent default lingers on the row to shadow the external pick.

No data migration needed: the readers stop trusting the stale field, which fixes existing broken agents on next config generation; the frontend clear keeps newly-switched rows clean.

## Test

Added regression case `model_provider_wins_over_stale_generation_quartet` (Model=glm-5.1 + stale GenerationModel=gpt-4o -> expects `glm-helix/glm-5.1`). `pkg/external-agent` suite green; `pkg/server` + `pkg/external-agent` build clean; frontend `yarn build` clean.

## Reviewed
Two review passes (correctness + data-origin). Correctness pass caught readers #3 and session_handlers, now fixed. Data-origin pass confirmed no current code path re-seeds gpt-4o onto zed_external (the stale quartet is legacy data), and identified the agent-type-switch clear now included above.

## Not tested
NOT yet validated end-to-end against a live Zed on meta. Recommend booting a fresh GLM external agent on meta after merge to confirm the picker shows GLM 5.1.

Generated with [Claude Code](https://claude.com/claude-code)