### PR TITLE
feat(org): Default Bot Runtime config on org General + creation

### DIFF
--- a/frontend/src/components/helix-org/BotRuntimeForm.tsx
+++ b/frontend/src/components/helix-org/BotRuntimeForm.tsx
@@ -170,11 +170,11 @@ export const BotRuntimeForm: FC<{
             displayMode="short"
           />
         </Box>
-      ) : (
+      ) : hasClaudeSubscription ? (
         <Typography variant="caption" color="text.secondary">
           Uses your connected Claude subscription — no model selection needed.
         </Typography>
-      )}
+      ) : null}
     </Stack>
   )
 }

--- a/frontend/src/components/helix-org/BotRuntimeForm.tsx
+++ b/frontend/src/components/helix-org/BotRuntimeForm.tsx
@@ -1,0 +1,182 @@
+// BotRuntimeForm is the controlled, presentational runtime/credentials/model
+// picker for a Bot. It mirrors the per-agent picker on the Agent settings page
+// (AppSettings) — same style and terms — but is state-agnostic: the parent
+// owns the value and decides how to persist it (auto-save to an org's config
+// on the settings page, or deferred-until-create in the new-org dialog).
+
+import { FC } from 'react'
+import Box from '@mui/material/Box'
+import FormControl from '@mui/material/FormControl'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import MenuItem from '@mui/material/MenuItem'
+import Radio from '@mui/material/Radio'
+import RadioGroup from '@mui/material/RadioGroup'
+import Select from '@mui/material/Select'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+
+import { AdvancedModelPicker } from '../create/AdvancedModelPicker'
+import { useClaudeSubscriptions } from '../account/ClaudeSubscriptionConnect'
+import { useHelixModelsForProvider, useHelixProviders } from '../../services/helixOrgService'
+
+export interface BotRuntimeValue {
+  runtime: string
+  credentials: string
+  provider: string
+  model: string
+}
+
+// Strong code-generation models to surface first in the picker.
+const RECOMMENDED_MODELS = [
+  'claude-opus-4-5-20251101',
+  'claude-sonnet-4-5-20250929',
+]
+
+export const BotRuntimeForm: FC<{
+  value: BotRuntimeValue
+  onChange: (patch: Partial<BotRuntimeValue>) => void
+}> = ({ value, onChange }) => {
+  const { data: providers } = useHelixProviders()
+  const { data: claudeSubscriptions } = useClaudeSubscriptions()
+  // Warm the models cache for the currently-selected provider.
+  useHelixModelsForProvider(value.provider, { enabled: !!value.provider })
+
+  const hasClaudeSubscription = (claudeSubscriptions?.length ?? 0) > 0
+  const hasAnthropicProvider = (providers ?? []).includes('anthropic')
+
+  const isClaude = value.runtime === 'claude_code'
+  // claude_code + subscription is the only mode that doesn't route through a
+  // provider/model; everything else does.
+  const apiKeyMode = !isClaude || value.credentials === 'api_key'
+
+  const onRuntime = (v: string) => {
+    const patch: Partial<BotRuntimeValue> = { runtime: v }
+    // Non-claude runtimes are always API-key routed; keep the stored value
+    // consistent with what the server coerces to.
+    if (v !== 'claude_code' && value.credentials !== 'api_key') {
+      patch.credentials = 'api_key'
+    }
+    onChange(patch)
+  }
+
+  return (
+    <Stack spacing={2}>
+      <Box>
+        <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+          Runtime
+        </Typography>
+        <FormControl fullWidth size="small">
+          <Select
+            value={value.runtime}
+            onChange={(e) => onRuntime(e.target.value)}
+            renderValue={(v) => {
+              if (v === 'claude_code') return 'Claude Code'
+              if (v === 'qwen_code') return 'Qwen Code'
+              if (v === 'goose_code') return 'Goose'
+              return 'Zed Agent'
+            }}
+          >
+            <MenuItem value="zed_agent">
+              <Box>
+                <Typography variant="body2">Zed Agent</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Built-in, Anthropic & OpenAI compatible
+                </Typography>
+              </Box>
+            </MenuItem>
+            <MenuItem value="qwen_code">
+              <Box>
+                <Typography variant="body2">Qwen Code</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Optimized for Qwen, including smaller models
+                </Typography>
+              </Box>
+            </MenuItem>
+            <MenuItem value="claude_code">
+              <Box>
+                <Typography variant="body2">Claude Code</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Anthropic's coding agent
+                </Typography>
+              </Box>
+            </MenuItem>
+            <MenuItem value="goose_code">
+              <Box>
+                <Typography variant="body2">Goose</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Open-source ACP agent (AAIF)
+                </Typography>
+              </Box>
+            </MenuItem>
+          </Select>
+        </FormControl>
+      </Box>
+
+      {isClaude && (
+        <Box>
+          <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+            Credentials
+          </Typography>
+          <FormControl>
+            <RadioGroup value={value.credentials} onChange={(e) => onChange({ credentials: e.target.value })}>
+              <FormControlLabel
+                value="subscription"
+                control={<Radio size="small" />}
+                disabled={!hasClaudeSubscription}
+                label={
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Typography variant="body2">Claude Subscription</Typography>
+                    {hasClaudeSubscription ? (
+                      <CheckCircleIcon sx={{ fontSize: 14, color: 'success.main' }} />
+                    ) : (
+                      <Typography variant="caption" color="text.secondary">(not connected)</Typography>
+                    )}
+                  </Box>
+                }
+              />
+              <FormControlLabel
+                value="api_key"
+                control={<Radio size="small" />}
+                disabled={!hasAnthropicProvider}
+                label={
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Typography variant="body2">Anthropic API Key</Typography>
+                    {hasAnthropicProvider ? (
+                      <CheckCircleIcon sx={{ fontSize: 14, color: 'success.main' }} />
+                    ) : (
+                      <Typography variant="caption" color="text.secondary">(not configured)</Typography>
+                    )}
+                  </Box>
+                }
+              />
+            </RadioGroup>
+          </FormControl>
+        </Box>
+      )}
+
+      {apiKeyMode ? (
+        <Box>
+          <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+            Model
+          </Typography>
+          <AdvancedModelPicker
+            recommendedModels={RECOMMENDED_MODELS}
+            hint="Select the model your Bots use by default"
+            selectedProvider={value.provider}
+            selectedModelId={value.model}
+            onSelectModel={(prov, modelId) => onChange({ provider: prov, model: modelId })}
+            currentType="text"
+            displayMode="short"
+          />
+        </Box>
+      ) : (
+        <Typography variant="caption" color="text.secondary">
+          Uses your connected Claude subscription — no model selection needed.
+        </Typography>
+      )}
+    </Stack>
+  )
+}
+
+export default BotRuntimeForm

--- a/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
+++ b/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
@@ -141,8 +141,29 @@ const WorkerRuntimePanel: FC = () => {
               <Select
                 value={runtime}
                 onChange={(e) => onRuntime(e.target.value)}
-                renderValue={(v) => (v === 'claude_code' ? 'Claude Code' : 'Zed Agent')}
+                renderValue={(v) => {
+                  if (v === 'claude_code') return 'Claude Code'
+                  if (v === 'qwen_code') return 'Qwen Code'
+                  if (v === 'goose_code') return 'Goose'
+                  return 'Zed Agent'
+                }}
               >
+                <MenuItem value="zed_agent">
+                  <Box>
+                    <Typography variant="body2">Zed Agent</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Built-in, Anthropic & OpenAI compatible
+                    </Typography>
+                  </Box>
+                </MenuItem>
+                <MenuItem value="qwen_code">
+                  <Box>
+                    <Typography variant="body2">Qwen Code</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Optimized for Qwen, including smaller models
+                    </Typography>
+                  </Box>
+                </MenuItem>
                 <MenuItem value="claude_code">
                   <Box>
                     <Typography variant="body2">Claude Code</Typography>
@@ -151,11 +172,11 @@ const WorkerRuntimePanel: FC = () => {
                     </Typography>
                   </Box>
                 </MenuItem>
-                <MenuItem value="zed_agent">
+                <MenuItem value="goose_code">
                   <Box>
-                    <Typography variant="body2">Zed Agent</Typography>
+                    <Typography variant="body2">Goose</Typography>
                     <Typography variant="caption" color="text.secondary">
-                      Built-in, Anthropic & OpenAI compatible
+                      Open-source ACP agent (AAIF)
                     </Typography>
                   </Box>
                 </MenuItem>

--- a/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
+++ b/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
@@ -19,7 +19,6 @@ import MenuItem from '@mui/material/MenuItem'
 import Paper from '@mui/material/Paper'
 import Select from '@mui/material/Select'
 import Stack from '@mui/material/Stack'
-import Typography from '@mui/material/Typography'
 import SaveIcon from '@mui/icons-material/Save'
 
 import LoadingSpinner from '../widgets/LoadingSpinner'
@@ -99,7 +98,6 @@ const WorkerRuntimePanel: FC = () => {
   return (
     <Paper variant="outlined" sx={{ p: 3 }}>
       <Stack spacing={2.5}>
-        <Typography variant="subtitle1">Worker runtime</Typography>
         {isLoading ? (
           <LoadingSpinner />
         ) : (
@@ -145,7 +143,7 @@ const RuntimeRow: FC<{ value: string; onChange: (v: string) => void }> = ({ valu
   const handleSave = async () => {
     try {
       await setMut.mutateAsync({ key: 'worker.runtime', value: encodeStringValue(value) })
-      snackbar.success('worker.runtime saved')
+      snackbar.success('Runtime saved')
     } catch (e: any) {
       snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
     }
@@ -153,11 +151,11 @@ const RuntimeRow: FC<{ value: string; onChange: (v: string) => void }> = ({ valu
   const helpFor = RUNTIME_OPTIONS.find((o) => o.value === value)?.help
   return (
     <FormControl fullWidth size="small">
-      <InputLabel id="runtime-label">worker.runtime</InputLabel>
+      <InputLabel id="runtime-label">Runtime</InputLabel>
       <Select
         labelId="runtime-label"
         value={value}
-        label="worker.runtime"
+        label="Runtime"
         onChange={(e) => onChange(e.target.value)}
       >
         {RUNTIME_OPTIONS.map((o) => (
@@ -183,7 +181,7 @@ const CredentialsRow: FC<{ value: string; onChange: (v: string) => void; runtime
   const handleSave = async () => {
     try {
       await setMut.mutateAsync({ key: 'worker.credentials', value: encodeStringValue(value) })
-      snackbar.success('worker.credentials saved')
+      snackbar.success('Credentials saved')
     } catch (e: any) {
       snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
     }
@@ -194,11 +192,11 @@ const CredentialsRow: FC<{ value: string; onChange: (v: string) => void; runtime
   const forcedToApiKey = runtime !== 'claude_code'
   return (
     <FormControl fullWidth size="small">
-      <InputLabel id="creds-label">worker.credentials</InputLabel>
+      <InputLabel id="creds-label">Credentials</InputLabel>
       <Select
         labelId="creds-label"
         value={forcedToApiKey ? 'api_key' : value}
-        label="worker.credentials"
+        label="Credentials"
         onChange={(e) => onChange(e.target.value)}
         disabled={forcedToApiKey}
       >
@@ -232,18 +230,18 @@ const ProviderRow: FC<{
   const handleSave = async () => {
     try {
       await setMut.mutateAsync({ key: 'worker.provider', value: encodeStringValue(value) })
-      snackbar.success('worker.provider saved')
+      snackbar.success('Provider saved')
     } catch (e: any) {
       snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
     }
   }
   return (
     <FormControl fullWidth size="small" disabled={disabled}>
-      <InputLabel id="provider-label">worker.provider</InputLabel>
+      <InputLabel id="provider-label">Provider</InputLabel>
       <Select
         labelId="provider-label"
         value={value}
-        label="worker.provider"
+        label="Provider"
         onChange={(e) => onChange(e.target.value)}
       >
         <MenuItem value=""><em>none</em></MenuItem>
@@ -278,7 +276,7 @@ const ModelRow: FC<{
   const handleSave = async () => {
     try {
       await setMut.mutateAsync({ key: 'worker.model', value: encodeStringValue(value) })
-      snackbar.success('worker.model saved')
+      snackbar.success('Model saved')
     } catch (e: any) {
       snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
     }
@@ -286,11 +284,11 @@ const ModelRow: FC<{
   const selected = models.find((m) => m.id === value)
   return (
     <FormControl fullWidth size="small" disabled={disabled}>
-      <InputLabel id="model-label">worker.model</InputLabel>
+      <InputLabel id="model-label">Model</InputLabel>
       <Select
         labelId="model-label"
         value={value}
-        label="worker.model"
+        label="Model"
         onChange={(e) => onChange(e.target.value)}
       >
         <MenuItem value=""><em>none</em></MenuItem>

--- a/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
+++ b/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
@@ -1,46 +1,20 @@
-// WorkerRuntimePanel is the org-level "Default Bot Runtime" config. It mirrors
-// the per-agent runtime picker on the Agent settings page (AppSettings) — same
-// style and terms (Runtime / Credentials / Model, friendly labels) so it
-// reads identically — but writes the org-level worker.* config registry keys
-// that new Bots inherit. Changes auto-save; org context is resolved from
+// WorkerRuntimePanel is the connected "Default Bot Runtime" config on the org
+// General settings page. It seeds BotRuntimeForm from the org's worker.* config
+// registry keys and auto-saves each change back. Org context is resolved from
 // router.params.org_id by the underlying hooks.
 
 import { FC, useEffect, useMemo, useState } from 'react'
-import Box from '@mui/material/Box'
-import FormControl from '@mui/material/FormControl'
-import FormControlLabel from '@mui/material/FormControlLabel'
-import MenuItem from '@mui/material/MenuItem'
 import Paper from '@mui/material/Paper'
-import Radio from '@mui/material/Radio'
-import RadioGroup from '@mui/material/RadioGroup'
-import Select from '@mui/material/Select'
-import Stack from '@mui/material/Stack'
-import Typography from '@mui/material/Typography'
-import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 
-import { AdvancedModelPicker } from '../create/AdvancedModelPicker'
-import { useClaudeSubscriptions } from '../account/ClaudeSubscriptionConnect'
+import BotRuntimeForm, { BotRuntimeValue } from './BotRuntimeForm'
 import LoadingSpinner from '../widgets/LoadingSpinner'
 import useSnackbar from '../../hooks/useSnackbar'
 import {
   SettingsSpecDTO,
-  useHelixModelsForProvider,
   useHelixOrgSettings,
-  useHelixProviders,
   useSetHelixOrgSetting,
 } from '../../services/helixOrgService'
 
-// Strong code-generation models to surface first in the picker.
-const RECOMMENDED_MODELS = [
-  'claude-opus-4-5-20251101',
-  'claude-sonnet-4-5-20250929',
-]
-
-// JSON-encode the value so it satisfies the registry's string-spec contract.
-const encodeStringValue = (raw: string): string => JSON.stringify(raw)
-
-// Read the persisted JSON value back into a plain string. Falls back to empty
-// when parsing fails (e.g. a masked value).
 const decodeStringValue = (v: string): string => {
   if (!v) return ''
   try {
@@ -51,15 +25,17 @@ const decodeStringValue = (v: string): string => {
   }
 }
 
+const LABELS: Record<string, string> = {
+  runtime: 'Runtime',
+  credentials: 'Credentials',
+  provider: 'Provider',
+  model: 'Model',
+}
+
 const WorkerRuntimePanel: FC = () => {
   const { data, isLoading } = useHelixOrgSettings()
-  const { data: providers } = useHelixProviders()
-  const { data: claudeSubscriptions } = useClaudeSubscriptions()
   const setMut = useSetHelixOrgSetting()
   const snackbar = useSnackbar()
-
-  const hasClaudeSubscription = (claudeSubscriptions?.length ?? 0) > 0
-  const hasAnthropicProvider = (providers ?? []).includes('anthropic')
 
   const specByKey = useMemo(() => {
     const m = new Map<string, SettingsSpecDTO>()
@@ -67,192 +43,35 @@ const WorkerRuntimePanel: FC = () => {
     return m
   }, [data])
 
-  const initialRuntime = decodeStringValue(specByKey.get('worker.runtime')?.value ?? '') || 'claude_code'
-  const initialCreds = decodeStringValue(specByKey.get('worker.credentials')?.value ?? '') || 'subscription'
-  const initialProvider = decodeStringValue(specByKey.get('worker.provider')?.value ?? '')
-  const initialModel = decodeStringValue(specByKey.get('worker.model')?.value ?? '')
+  const initial: BotRuntimeValue = {
+    runtime: decodeStringValue(specByKey.get('worker.runtime')?.value ?? '') || 'claude_code',
+    credentials: decodeStringValue(specByKey.get('worker.credentials')?.value ?? '') || 'subscription',
+    provider: decodeStringValue(specByKey.get('worker.provider')?.value ?? ''),
+    model: decodeStringValue(specByKey.get('worker.model')?.value ?? ''),
+  }
 
-  const [runtime, setRuntime] = useState<string>(initialRuntime)
-  const [credentials, setCredentials] = useState<string>(initialCreds)
-  const [provider, setProvider] = useState<string>(initialProvider)
-  const [model, setModel] = useState<string>(initialModel)
+  const [value, setValue] = useState<BotRuntimeValue>(initial)
 
   // Re-seed local state when the loaded data lands or refreshes.
   useEffect(() => {
     if (!data) return
-    setRuntime(initialRuntime)
-    setCredentials(initialCreds)
-    setProvider(initialProvider)
-    setModel(initialModel)
+    setValue(initial)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data])
 
-  // Warm the models cache for the picker's currently-selected provider.
-  useHelixModelsForProvider(provider, { enabled: !!provider })
-
-  const save = async (key: string, value: string, label: string) => {
-    try {
-      await setMut.mutateAsync({ key, value: encodeStringValue(value) })
-      snackbar.success(`${label} saved`)
-    } catch (e: any) {
-      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
+  const handlePatch = (patch: Partial<BotRuntimeValue>) => {
+    setValue((v) => ({ ...v, ...patch }))
+    for (const [k, val] of Object.entries(patch)) {
+      setMut
+        .mutateAsync({ key: `worker.${k}`, value: JSON.stringify(val) })
+        .then(() => snackbar.success(`${LABELS[k] ?? k} saved`))
+        .catch((e: any) => snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed'))
     }
   }
-
-  const onRuntime = (v: string) => {
-    setRuntime(v)
-    save('worker.runtime', v, 'Runtime')
-    // Non-claude runtimes are always API-key routed; persist that so the
-    // stored value matches what the server coerces to.
-    if (v !== 'claude_code' && credentials !== 'api_key') {
-      setCredentials('api_key')
-      save('worker.credentials', 'api_key', 'Credentials')
-    }
-  }
-
-  const onCredentials = (v: string) => {
-    setCredentials(v)
-    save('worker.credentials', v, 'Credentials')
-  }
-
-  const onSelectModel = (prov: string, modelId: string) => {
-    setProvider(prov)
-    setModel(modelId)
-    save('worker.provider', prov, 'Provider')
-    save('worker.model', modelId, 'Model')
-  }
-
-  const isClaude = runtime === 'claude_code'
-  // claude_code + subscription is the only mode that doesn't route through a
-  // provider/model; everything else does.
-  const apiKeyMode = !isClaude || credentials === 'api_key'
 
   return (
     <Paper variant="outlined" sx={{ p: 3 }}>
-      {isLoading ? (
-        <LoadingSpinner />
-      ) : (
-        <Stack spacing={2}>
-          <Box>
-            <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
-              Runtime
-            </Typography>
-            <FormControl fullWidth size="small">
-              <Select
-                value={runtime}
-                onChange={(e) => onRuntime(e.target.value)}
-                renderValue={(v) => {
-                  if (v === 'claude_code') return 'Claude Code'
-                  if (v === 'qwen_code') return 'Qwen Code'
-                  if (v === 'goose_code') return 'Goose'
-                  return 'Zed Agent'
-                }}
-              >
-                <MenuItem value="zed_agent">
-                  <Box>
-                    <Typography variant="body2">Zed Agent</Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      Built-in, Anthropic & OpenAI compatible
-                    </Typography>
-                  </Box>
-                </MenuItem>
-                <MenuItem value="qwen_code">
-                  <Box>
-                    <Typography variant="body2">Qwen Code</Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      Optimized for Qwen, including smaller models
-                    </Typography>
-                  </Box>
-                </MenuItem>
-                <MenuItem value="claude_code">
-                  <Box>
-                    <Typography variant="body2">Claude Code</Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      Anthropic's coding agent
-                    </Typography>
-                  </Box>
-                </MenuItem>
-                <MenuItem value="goose_code">
-                  <Box>
-                    <Typography variant="body2">Goose</Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      Open-source ACP agent (AAIF)
-                    </Typography>
-                  </Box>
-                </MenuItem>
-              </Select>
-            </FormControl>
-          </Box>
-
-          {isClaude && (
-            <Box>
-              <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
-                Credentials
-              </Typography>
-              <FormControl>
-                <RadioGroup value={credentials} onChange={(e) => onCredentials(e.target.value)}>
-                  <FormControlLabel
-                    value="subscription"
-                    control={<Radio size="small" />}
-                    disabled={!hasClaudeSubscription}
-                    label={
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        <Typography variant="body2">Claude Subscription</Typography>
-                        {hasClaudeSubscription ? (
-                          <CheckCircleIcon sx={{ fontSize: 14, color: 'success.main' }} />
-                        ) : (
-                          <Typography variant="caption" color="text.secondary">(not connected)</Typography>
-                        )}
-                      </Box>
-                    }
-                  />
-                  <FormControlLabel
-                    value="api_key"
-                    control={<Radio size="small" />}
-                    disabled={!hasAnthropicProvider}
-                    label={
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                        <Typography variant="body2">Anthropic API Key</Typography>
-                        {hasAnthropicProvider ? (
-                          <CheckCircleIcon sx={{ fontSize: 14, color: 'success.main' }} />
-                        ) : (
-                          <Typography variant="caption" color="text.secondary">(not configured)</Typography>
-                        )}
-                      </Box>
-                    }
-                  />
-                </RadioGroup>
-              </FormControl>
-              {!hasClaudeSubscription && !hasAnthropicProvider && (
-                <Typography variant="caption" color="warning.main" sx={{ display: 'block', mt: 0.5 }}>
-                  Connect a Claude subscription or add an Anthropic API key above in Providers.
-                </Typography>
-              )}
-            </Box>
-          )}
-
-          {apiKeyMode ? (
-            <Box>
-              <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
-                Model
-              </Typography>
-              <AdvancedModelPicker
-                recommendedModels={RECOMMENDED_MODELS}
-                hint="Select the model your Bots use by default"
-                selectedProvider={provider}
-                selectedModelId={model}
-                onSelectModel={onSelectModel}
-                currentType="text"
-                displayMode="short"
-              />
-            </Box>
-          ) : (
-            <Typography variant="caption" color="text.secondary">
-              Uses your connected Claude subscription — no model selection needed.
-            </Typography>
-          )}
-        </Stack>
-      )}
+      {isLoading ? <LoadingSpinner /> : <BotRuntimeForm value={value} onChange={handlePatch} />}
     </Paper>
   )
 }

--- a/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
+++ b/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
@@ -1,0 +1,318 @@
+// WorkerRuntimePanel renders the helix-org worker.* runtime config
+// (runtime / credentials / provider / model) as first-class dropdowns.
+// It lives on the AI Providers page so an operator configures providers
+// and then picks which one their Workers use in one place. Reads/writes
+// the same config registry the server validates against; org context is
+// resolved from router.params.org_id by the underlying hooks.
+//
+// The provider + model dropdowns pull their options from Helix's existing
+// /providers + /v1/models endpoints, so adding a provider is reflected
+// here without a redeploy.
+
+import { FC, useEffect, useMemo, useState } from 'react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import FormControl from '@mui/material/FormControl'
+import FormHelperText from '@mui/material/FormHelperText'
+import InputLabel from '@mui/material/InputLabel'
+import MenuItem from '@mui/material/MenuItem'
+import Paper from '@mui/material/Paper'
+import Select from '@mui/material/Select'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import SaveIcon from '@mui/icons-material/Save'
+
+import LoadingSpinner from '../widgets/LoadingSpinner'
+import useSnackbar from '../../hooks/useSnackbar'
+import {
+  SettingsSpecDTO,
+  useHelixModelsForProvider,
+  useHelixOrgSettings,
+  useHelixProviders,
+  useSetHelixOrgSetting,
+} from '../../services/helixOrgService'
+
+// Allowed values for the two dropdown-only knobs. The server validates
+// against the same set in api/pkg/server/helix_org.go::resolveWorkerAgentConfig.
+const RUNTIME_OPTIONS = [
+  { value: 'claude_code', label: 'claude_code', help: 'Anthropic Claude Code CLI inside the desktop. Authenticates via subscription OAuth or via Helix-routed API key.' },
+  { value: 'zed_agent', label: 'zed_agent', help: 'Native Zed agent — always routed through a Helix-managed provider (forces credentials=api_key).' },
+]
+
+const CREDENTIALS_OPTIONS = [
+  { value: 'subscription', label: 'subscription', help: 'Each operator authenticates with their own Claude OAuth subscription (only meaningful with runtime=claude_code).' },
+  { value: 'api_key', label: 'api_key', help: 'Inference routed through one of Helix\'s configured providers — pick provider + model below.' },
+]
+
+// JSON-encode the value the dropdown produced so it satisfies the
+// registry's string-spec contract.
+const encodeStringValue = (raw: string): string => JSON.stringify(raw)
+
+// Read the redacted/persisted JSON value back into a plain string for the
+// dropdowns. Falls back to empty when parsing fails (e.g. masked value).
+const decodeStringValue = (v: string): string => {
+  if (!v) return ''
+  try {
+    const parsed = JSON.parse(v)
+    return typeof parsed === 'string' ? parsed : ''
+  } catch {
+    return v
+  }
+}
+
+const WorkerRuntimePanel: FC = () => {
+  const { data, isLoading } = useHelixOrgSettings()
+  const { data: providers } = useHelixProviders()
+
+  const specByKey = useMemo(() => {
+    const m = new Map<string, SettingsSpecDTO>()
+    for (const s of data?.specs ?? []) m.set(s.key, s)
+    return m
+  }, [data])
+
+  const initialRuntime = decodeStringValue(specByKey.get('worker.runtime')?.value ?? '') || 'claude_code'
+  const initialCreds = decodeStringValue(specByKey.get('worker.credentials')?.value ?? '') || 'subscription'
+  const initialProvider = decodeStringValue(specByKey.get('worker.provider')?.value ?? '')
+  const initialModel = decodeStringValue(specByKey.get('worker.model')?.value ?? '')
+
+  const [runtime, setRuntime] = useState<string>(initialRuntime)
+  const [credentials, setCredentials] = useState<string>(initialCreds)
+  const [provider, setProvider] = useState<string>(initialProvider)
+  const [model, setModel] = useState<string>(initialModel)
+
+  // Re-seed local state when the loaded data lands or refreshes.
+  useEffect(() => {
+    if (!data) return
+    setRuntime(initialRuntime)
+    setCredentials(initialCreds)
+    setProvider(initialProvider)
+    setModel(initialModel)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data])
+
+  const { data: models } = useHelixModelsForProvider(provider, { enabled: credentials === 'api_key' })
+
+  // claude_code + subscription means provider+model are unused (the CLI
+  // handles OAuth itself), so we visually disable those rows.
+  const apiKeyMode = credentials === 'api_key'
+
+  return (
+    <Paper variant="outlined" sx={{ p: 3 }}>
+      <Stack spacing={2.5}>
+        <Typography variant="subtitle1">Worker runtime</Typography>
+        {isLoading ? (
+          <LoadingSpinner />
+        ) : (
+          <>
+            <RuntimeRow value={runtime} onChange={setRuntime} />
+            <CredentialsRow
+              value={credentials}
+              onChange={(v) => {
+                setCredentials(v)
+                // Switching to subscription wipes provider+model because
+                // they're meaningless in OAuth mode.
+                if (v === 'subscription' && runtime === 'claude_code') {
+                  setProvider('')
+                  setModel('')
+                }
+              }}
+              runtime={runtime}
+            />
+            <ProviderRow
+              value={provider}
+              onChange={(v) => { setProvider(v); setModel('') }}
+              providers={providers ?? []}
+              disabled={!apiKeyMode}
+            />
+            <ModelRow
+              value={model}
+              onChange={setModel}
+              models={models ?? []}
+              disabled={!apiKeyMode || !provider}
+              provider={provider}
+            />
+          </>
+        )}
+      </Stack>
+    </Paper>
+  )
+}
+
+// RuntimeRow is the worker.runtime dropdown.
+const RuntimeRow: FC<{ value: string; onChange: (v: string) => void }> = ({ value, onChange }) => {
+  const setMut = useSetHelixOrgSetting()
+  const snackbar = useSnackbar()
+  const handleSave = async () => {
+    try {
+      await setMut.mutateAsync({ key: 'worker.runtime', value: encodeStringValue(value) })
+      snackbar.success('worker.runtime saved')
+    } catch (e: any) {
+      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
+    }
+  }
+  const helpFor = RUNTIME_OPTIONS.find((o) => o.value === value)?.help
+  return (
+    <FormControl fullWidth size="small">
+      <InputLabel id="runtime-label">worker.runtime</InputLabel>
+      <Select
+        labelId="runtime-label"
+        value={value}
+        label="worker.runtime"
+        onChange={(e) => onChange(e.target.value)}
+      >
+        {RUNTIME_OPTIONS.map((o) => (
+          <MenuItem key={o.value} value={o.value} sx={{ fontFamily: 'monospace' }}>
+            {o.label}
+          </MenuItem>
+        ))}
+      </Select>
+      <FormHelperText>{helpFor}</FormHelperText>
+      <Box sx={{ mt: 1 }}>
+        <Button size="small" variant="contained" color="secondary" startIcon={<SaveIcon />} onClick={handleSave} disabled={setMut.isPending}>
+          {setMut.isPending ? 'Saving…' : 'Save runtime'}
+        </Button>
+      </Box>
+    </FormControl>
+  )
+}
+
+// CredentialsRow is the worker.credentials dropdown.
+const CredentialsRow: FC<{ value: string; onChange: (v: string) => void; runtime: string }> = ({ value, onChange, runtime }) => {
+  const setMut = useSetHelixOrgSetting()
+  const snackbar = useSnackbar()
+  const handleSave = async () => {
+    try {
+      await setMut.mutateAsync({ key: 'worker.credentials', value: encodeStringValue(value) })
+      snackbar.success('worker.credentials saved')
+    } catch (e: any) {
+      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
+    }
+  }
+  const helpFor = CREDENTIALS_OPTIONS.find((o) => o.value === value)?.help
+  // The backend coerces non-claude_code runtimes to api_key, but surface
+  // that so the page doesn't look broken on zed_agent + subscription.
+  const forcedToApiKey = runtime !== 'claude_code'
+  return (
+    <FormControl fullWidth size="small">
+      <InputLabel id="creds-label">worker.credentials</InputLabel>
+      <Select
+        labelId="creds-label"
+        value={forcedToApiKey ? 'api_key' : value}
+        label="worker.credentials"
+        onChange={(e) => onChange(e.target.value)}
+        disabled={forcedToApiKey}
+      >
+        {CREDENTIALS_OPTIONS.map((o) => (
+          <MenuItem key={o.value} value={o.value} sx={{ fontFamily: 'monospace' }}>
+            {o.label}
+          </MenuItem>
+        ))}
+      </Select>
+      <FormHelperText>
+        {forcedToApiKey ? `runtime=${runtime} forces api_key — only claude_code supports subscription.` : helpFor}
+      </FormHelperText>
+      <Box sx={{ mt: 1 }}>
+        <Button size="small" variant="contained" color="secondary" startIcon={<SaveIcon />} onClick={handleSave} disabled={setMut.isPending || forcedToApiKey}>
+          {setMut.isPending ? 'Saving…' : 'Save credentials'}
+        </Button>
+      </Box>
+    </FormControl>
+  )
+}
+
+// ProviderRow lists every provider configured on this Helix instance.
+const ProviderRow: FC<{
+  value: string
+  onChange: (v: string) => void
+  providers: string[]
+  disabled: boolean
+}> = ({ value, onChange, providers, disabled }) => {
+  const setMut = useSetHelixOrgSetting()
+  const snackbar = useSnackbar()
+  const handleSave = async () => {
+    try {
+      await setMut.mutateAsync({ key: 'worker.provider', value: encodeStringValue(value) })
+      snackbar.success('worker.provider saved')
+    } catch (e: any) {
+      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
+    }
+  }
+  return (
+    <FormControl fullWidth size="small" disabled={disabled}>
+      <InputLabel id="provider-label">worker.provider</InputLabel>
+      <Select
+        labelId="provider-label"
+        value={value}
+        label="worker.provider"
+        onChange={(e) => onChange(e.target.value)}
+      >
+        <MenuItem value=""><em>none</em></MenuItem>
+        {providers.map((p) => (
+          <MenuItem key={p} value={p} sx={{ fontFamily: 'monospace' }}>{p}</MenuItem>
+        ))}
+      </Select>
+      <FormHelperText>
+        {disabled
+          ? 'Pick credentials=api_key above to enable.'
+          : 'One of the providers configured above on this Helix instance.'}
+      </FormHelperText>
+      <Box sx={{ mt: 1 }}>
+        <Button size="small" variant="contained" color="secondary" startIcon={<SaveIcon />} onClick={handleSave} disabled={setMut.isPending || disabled}>
+          {setMut.isPending ? 'Saving…' : 'Save provider'}
+        </Button>
+      </Box>
+    </FormControl>
+  )
+}
+
+// ModelRow lists models the picked provider exposes.
+const ModelRow: FC<{
+  value: string
+  onChange: (v: string) => void
+  models: { id: string; name?: string; description?: string }[]
+  disabled: boolean
+  provider: string
+}> = ({ value, onChange, models, disabled, provider }) => {
+  const setMut = useSetHelixOrgSetting()
+  const snackbar = useSnackbar()
+  const handleSave = async () => {
+    try {
+      await setMut.mutateAsync({ key: 'worker.model', value: encodeStringValue(value) })
+      snackbar.success('worker.model saved')
+    } catch (e: any) {
+      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
+    }
+  }
+  const selected = models.find((m) => m.id === value)
+  return (
+    <FormControl fullWidth size="small" disabled={disabled}>
+      <InputLabel id="model-label">worker.model</InputLabel>
+      <Select
+        labelId="model-label"
+        value={value}
+        label="worker.model"
+        onChange={(e) => onChange(e.target.value)}
+      >
+        <MenuItem value=""><em>none</em></MenuItem>
+        {models.map((m) => (
+          <MenuItem key={m.id} value={m.id} sx={{ fontFamily: 'monospace' }}>
+            {m.id}{m.name ? ` — ${m.name}` : ''}
+          </MenuItem>
+        ))}
+      </Select>
+      <FormHelperText>
+        {disabled
+          ? (provider ? 'Pick credentials=api_key above to enable.' : 'Pick a provider first.')
+          : (selected?.description?.slice(0, 200) ?? `Models exposed by ${provider}.`)
+        }
+      </FormHelperText>
+      <Box sx={{ mt: 1 }}>
+        <Button size="small" variant="contained" color="secondary" startIcon={<SaveIcon />} onClick={handleSave} disabled={setMut.isPending || disabled}>
+          {setMut.isPending ? 'Saving…' : 'Save model'}
+        </Button>
+      </Box>
+    </FormControl>
+  )
+}
+
+export default WorkerRuntimePanel

--- a/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
+++ b/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
@@ -1,9 +1,8 @@
 // WorkerRuntimePanel renders the helix-org worker.* runtime config
 // (runtime / credentials / provider / model) as first-class dropdowns.
-// It lives on the AI Providers page so an operator configures providers
-// and then picks which one their Workers use in one place. Reads/writes
-// the same config registry the server validates against; org context is
-// resolved from router.params.org_id by the underlying hooks.
+// It lives on the org General settings page. Reads/writes the same config
+// registry the server validates against; org context is resolved from
+// router.params.org_id by the underlying hooks.
 //
 // The provider + model dropdowns pull their options from Helix's existing
 // /providers + /v1/models endpoints, so adding a provider is reflected
@@ -252,7 +251,7 @@ const ProviderRow: FC<{
       <FormHelperText>
         {disabled
           ? 'Pick credentials=api_key above to enable.'
-          : 'One of the providers configured above on this Helix instance.'}
+          : 'One of the providers configured on this Helix instance.'}
       </FormHelperText>
       <Box sx={{ mt: 1 }}>
         <Button size="small" variant="contained" color="secondary" startIcon={<SaveIcon />} onClick={handleSave} disabled={setMut.isPending || disabled}>

--- a/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
+++ b/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
@@ -1,6 +1,6 @@
 // WorkerRuntimePanel is the org-level "Default Bot Runtime" config. It mirrors
 // the per-agent runtime picker on the Agent settings page (AppSettings) — same
-// style and terms (Agent Runtime / Credentials / Model, friendly labels) so it
+// style and terms (Runtime / Credentials / Model, friendly labels) so it
 // reads identically — but writes the org-level worker.* config registry keys
 // that new Bots inherit. Changes auto-save; org context is resolved from
 // router.params.org_id by the underlying hooks.
@@ -135,7 +135,7 @@ const WorkerRuntimePanel: FC = () => {
         <Stack spacing={2}>
           <Box>
             <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
-              Agent Runtime
+              Runtime
             </Typography>
             <FormControl fullWidth size="small">
               <Select

--- a/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
+++ b/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
@@ -1,25 +1,25 @@
-// WorkerRuntimePanel renders the helix-org worker.* runtime config
-// (runtime / credentials / provider / model) as first-class dropdowns.
-// It lives on the org General settings page. Reads/writes the same config
-// registry the server validates against; org context is resolved from
+// WorkerRuntimePanel is the org-level "Default Bot Runtime" config. It mirrors
+// the per-agent runtime picker on the Agent settings page (AppSettings) — same
+// style and terms (Agent Runtime / Credentials / Model, friendly labels) so it
+// reads identically — but writes the org-level worker.* config registry keys
+// that new Bots inherit. Changes auto-save; org context is resolved from
 // router.params.org_id by the underlying hooks.
-//
-// The provider + model dropdowns pull their options from Helix's existing
-// /providers + /v1/models endpoints, so adding a provider is reflected
-// here without a redeploy.
 
 import { FC, useEffect, useMemo, useState } from 'react'
 import Box from '@mui/material/Box'
-import Button from '@mui/material/Button'
 import FormControl from '@mui/material/FormControl'
-import FormHelperText from '@mui/material/FormHelperText'
-import InputLabel from '@mui/material/InputLabel'
+import FormControlLabel from '@mui/material/FormControlLabel'
 import MenuItem from '@mui/material/MenuItem'
 import Paper from '@mui/material/Paper'
+import Radio from '@mui/material/Radio'
+import RadioGroup from '@mui/material/RadioGroup'
 import Select from '@mui/material/Select'
 import Stack from '@mui/material/Stack'
-import SaveIcon from '@mui/icons-material/Save'
+import Typography from '@mui/material/Typography'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 
+import { AdvancedModelPicker } from '../create/AdvancedModelPicker'
+import { useClaudeSubscriptions } from '../account/ClaudeSubscriptionConnect'
 import LoadingSpinner from '../widgets/LoadingSpinner'
 import useSnackbar from '../../hooks/useSnackbar'
 import {
@@ -30,24 +30,17 @@ import {
   useSetHelixOrgSetting,
 } from '../../services/helixOrgService'
 
-// Allowed values for the two dropdown-only knobs. The server validates
-// against the same set in api/pkg/server/helix_org.go::resolveWorkerAgentConfig.
-const RUNTIME_OPTIONS = [
-  { value: 'claude_code', label: 'claude_code', help: 'Anthropic Claude Code CLI inside the desktop. Authenticates via subscription OAuth or via Helix-routed API key.' },
-  { value: 'zed_agent', label: 'zed_agent', help: 'Native Zed agent — always routed through a Helix-managed provider (forces credentials=api_key).' },
+// Strong code-generation models to surface first in the picker.
+const RECOMMENDED_MODELS = [
+  'claude-opus-4-5-20251101',
+  'claude-sonnet-4-5-20250929',
 ]
 
-const CREDENTIALS_OPTIONS = [
-  { value: 'subscription', label: 'subscription', help: 'Each operator authenticates with their own Claude OAuth subscription (only meaningful with runtime=claude_code).' },
-  { value: 'api_key', label: 'api_key', help: 'Inference routed through one of Helix\'s configured providers — pick provider + model below.' },
-]
-
-// JSON-encode the value the dropdown produced so it satisfies the
-// registry's string-spec contract.
+// JSON-encode the value so it satisfies the registry's string-spec contract.
 const encodeStringValue = (raw: string): string => JSON.stringify(raw)
 
-// Read the redacted/persisted JSON value back into a plain string for the
-// dropdowns. Falls back to empty when parsing fails (e.g. masked value).
+// Read the persisted JSON value back into a plain string. Falls back to empty
+// when parsing fails (e.g. a masked value).
 const decodeStringValue = (v: string): string => {
   if (!v) return ''
   try {
@@ -61,6 +54,12 @@ const decodeStringValue = (v: string): string => {
 const WorkerRuntimePanel: FC = () => {
   const { data, isLoading } = useHelixOrgSettings()
   const { data: providers } = useHelixProviders()
+  const { data: claudeSubscriptions } = useClaudeSubscriptions()
+  const setMut = useSetHelixOrgSetting()
+  const snackbar = useSnackbar()
+
+  const hasClaudeSubscription = (claudeSubscriptions?.length ?? 0) > 0
+  const hasAnthropicProvider = (providers ?? []).includes('anthropic')
 
   const specByKey = useMemo(() => {
     const m = new Map<string, SettingsSpecDTO>()
@@ -88,227 +87,152 @@ const WorkerRuntimePanel: FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data])
 
-  const { data: models } = useHelixModelsForProvider(provider, { enabled: credentials === 'api_key' })
+  // Warm the models cache for the picker's currently-selected provider.
+  useHelixModelsForProvider(provider, { enabled: !!provider })
 
-  // claude_code + subscription means provider+model are unused (the CLI
-  // handles OAuth itself), so we visually disable those rows.
-  const apiKeyMode = credentials === 'api_key'
+  const save = async (key: string, value: string, label: string) => {
+    try {
+      await setMut.mutateAsync({ key, value: encodeStringValue(value) })
+      snackbar.success(`${label} saved`)
+    } catch (e: any) {
+      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
+    }
+  }
+
+  const onRuntime = (v: string) => {
+    setRuntime(v)
+    save('worker.runtime', v, 'Runtime')
+    // Non-claude runtimes are always API-key routed; persist that so the
+    // stored value matches what the server coerces to.
+    if (v !== 'claude_code' && credentials !== 'api_key') {
+      setCredentials('api_key')
+      save('worker.credentials', 'api_key', 'Credentials')
+    }
+  }
+
+  const onCredentials = (v: string) => {
+    setCredentials(v)
+    save('worker.credentials', v, 'Credentials')
+  }
+
+  const onSelectModel = (prov: string, modelId: string) => {
+    setProvider(prov)
+    setModel(modelId)
+    save('worker.provider', prov, 'Provider')
+    save('worker.model', modelId, 'Model')
+  }
+
+  const isClaude = runtime === 'claude_code'
+  // claude_code + subscription is the only mode that doesn't route through a
+  // provider/model; everything else does.
+  const apiKeyMode = !isClaude || credentials === 'api_key'
 
   return (
     <Paper variant="outlined" sx={{ p: 3 }}>
-      <Stack spacing={2.5}>
-        {isLoading ? (
-          <LoadingSpinner />
-        ) : (
-          <>
-            <RuntimeRow value={runtime} onChange={setRuntime} />
-            <CredentialsRow
-              value={credentials}
-              onChange={(v) => {
-                setCredentials(v)
-                // Switching to subscription wipes provider+model because
-                // they're meaningless in OAuth mode.
-                if (v === 'subscription' && runtime === 'claude_code') {
-                  setProvider('')
-                  setModel('')
-                }
-              }}
-              runtime={runtime}
-            />
-            <ProviderRow
-              value={provider}
-              onChange={(v) => { setProvider(v); setModel('') }}
-              providers={providers ?? []}
-              disabled={!apiKeyMode}
-            />
-            <ModelRow
-              value={model}
-              onChange={setModel}
-              models={models ?? []}
-              disabled={!apiKeyMode || !provider}
-              provider={provider}
-            />
-          </>
-        )}
-      </Stack>
+      {isLoading ? (
+        <LoadingSpinner />
+      ) : (
+        <Stack spacing={2}>
+          <Box>
+            <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+              Agent Runtime
+            </Typography>
+            <FormControl fullWidth size="small">
+              <Select
+                value={runtime}
+                onChange={(e) => onRuntime(e.target.value)}
+                renderValue={(v) => (v === 'claude_code' ? 'Claude Code' : 'Zed Agent')}
+              >
+                <MenuItem value="claude_code">
+                  <Box>
+                    <Typography variant="body2">Claude Code</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Anthropic's coding agent
+                    </Typography>
+                  </Box>
+                </MenuItem>
+                <MenuItem value="zed_agent">
+                  <Box>
+                    <Typography variant="body2">Zed Agent</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Built-in, Anthropic & OpenAI compatible
+                    </Typography>
+                  </Box>
+                </MenuItem>
+              </Select>
+            </FormControl>
+          </Box>
+
+          {isClaude && (
+            <Box>
+              <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+                Credentials
+              </Typography>
+              <FormControl>
+                <RadioGroup value={credentials} onChange={(e) => onCredentials(e.target.value)}>
+                  <FormControlLabel
+                    value="subscription"
+                    control={<Radio size="small" />}
+                    disabled={!hasClaudeSubscription}
+                    label={
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Typography variant="body2">Claude Subscription</Typography>
+                        {hasClaudeSubscription ? (
+                          <CheckCircleIcon sx={{ fontSize: 14, color: 'success.main' }} />
+                        ) : (
+                          <Typography variant="caption" color="text.secondary">(not connected)</Typography>
+                        )}
+                      </Box>
+                    }
+                  />
+                  <FormControlLabel
+                    value="api_key"
+                    control={<Radio size="small" />}
+                    disabled={!hasAnthropicProvider}
+                    label={
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Typography variant="body2">Anthropic API Key</Typography>
+                        {hasAnthropicProvider ? (
+                          <CheckCircleIcon sx={{ fontSize: 14, color: 'success.main' }} />
+                        ) : (
+                          <Typography variant="caption" color="text.secondary">(not configured)</Typography>
+                        )}
+                      </Box>
+                    }
+                  />
+                </RadioGroup>
+              </FormControl>
+              {!hasClaudeSubscription && !hasAnthropicProvider && (
+                <Typography variant="caption" color="warning.main" sx={{ display: 'block', mt: 0.5 }}>
+                  Connect a Claude subscription or add an Anthropic API key above in Providers.
+                </Typography>
+              )}
+            </Box>
+          )}
+
+          {apiKeyMode ? (
+            <Box>
+              <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+                Model
+              </Typography>
+              <AdvancedModelPicker
+                recommendedModels={RECOMMENDED_MODELS}
+                hint="Select the model your Bots use by default"
+                selectedProvider={provider}
+                selectedModelId={model}
+                onSelectModel={onSelectModel}
+                currentType="text"
+                displayMode="short"
+              />
+            </Box>
+          ) : (
+            <Typography variant="caption" color="text.secondary">
+              Uses your connected Claude subscription — no model selection needed.
+            </Typography>
+          )}
+        </Stack>
+      )}
     </Paper>
-  )
-}
-
-// RuntimeRow is the worker.runtime dropdown.
-const RuntimeRow: FC<{ value: string; onChange: (v: string) => void }> = ({ value, onChange }) => {
-  const setMut = useSetHelixOrgSetting()
-  const snackbar = useSnackbar()
-  const handleSave = async () => {
-    try {
-      await setMut.mutateAsync({ key: 'worker.runtime', value: encodeStringValue(value) })
-      snackbar.success('Runtime saved')
-    } catch (e: any) {
-      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
-    }
-  }
-  const helpFor = RUNTIME_OPTIONS.find((o) => o.value === value)?.help
-  return (
-    <FormControl fullWidth size="small">
-      <InputLabel id="runtime-label">Runtime</InputLabel>
-      <Select
-        labelId="runtime-label"
-        value={value}
-        label="Runtime"
-        onChange={(e) => onChange(e.target.value)}
-      >
-        {RUNTIME_OPTIONS.map((o) => (
-          <MenuItem key={o.value} value={o.value} sx={{ fontFamily: 'monospace' }}>
-            {o.label}
-          </MenuItem>
-        ))}
-      </Select>
-      <FormHelperText>{helpFor}</FormHelperText>
-      <Box sx={{ mt: 1 }}>
-        <Button size="small" variant="contained" color="secondary" startIcon={<SaveIcon />} onClick={handleSave} disabled={setMut.isPending}>
-          {setMut.isPending ? 'Saving…' : 'Save runtime'}
-        </Button>
-      </Box>
-    </FormControl>
-  )
-}
-
-// CredentialsRow is the worker.credentials dropdown.
-const CredentialsRow: FC<{ value: string; onChange: (v: string) => void; runtime: string }> = ({ value, onChange, runtime }) => {
-  const setMut = useSetHelixOrgSetting()
-  const snackbar = useSnackbar()
-  const handleSave = async () => {
-    try {
-      await setMut.mutateAsync({ key: 'worker.credentials', value: encodeStringValue(value) })
-      snackbar.success('Credentials saved')
-    } catch (e: any) {
-      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
-    }
-  }
-  const helpFor = CREDENTIALS_OPTIONS.find((o) => o.value === value)?.help
-  // The backend coerces non-claude_code runtimes to api_key, but surface
-  // that so the page doesn't look broken on zed_agent + subscription.
-  const forcedToApiKey = runtime !== 'claude_code'
-  return (
-    <FormControl fullWidth size="small">
-      <InputLabel id="creds-label">Credentials</InputLabel>
-      <Select
-        labelId="creds-label"
-        value={forcedToApiKey ? 'api_key' : value}
-        label="Credentials"
-        onChange={(e) => onChange(e.target.value)}
-        disabled={forcedToApiKey}
-      >
-        {CREDENTIALS_OPTIONS.map((o) => (
-          <MenuItem key={o.value} value={o.value} sx={{ fontFamily: 'monospace' }}>
-            {o.label}
-          </MenuItem>
-        ))}
-      </Select>
-      <FormHelperText>
-        {forcedToApiKey ? `runtime=${runtime} forces api_key — only claude_code supports subscription.` : helpFor}
-      </FormHelperText>
-      <Box sx={{ mt: 1 }}>
-        <Button size="small" variant="contained" color="secondary" startIcon={<SaveIcon />} onClick={handleSave} disabled={setMut.isPending || forcedToApiKey}>
-          {setMut.isPending ? 'Saving…' : 'Save credentials'}
-        </Button>
-      </Box>
-    </FormControl>
-  )
-}
-
-// ProviderRow lists every provider configured on this Helix instance.
-const ProviderRow: FC<{
-  value: string
-  onChange: (v: string) => void
-  providers: string[]
-  disabled: boolean
-}> = ({ value, onChange, providers, disabled }) => {
-  const setMut = useSetHelixOrgSetting()
-  const snackbar = useSnackbar()
-  const handleSave = async () => {
-    try {
-      await setMut.mutateAsync({ key: 'worker.provider', value: encodeStringValue(value) })
-      snackbar.success('Provider saved')
-    } catch (e: any) {
-      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
-    }
-  }
-  return (
-    <FormControl fullWidth size="small" disabled={disabled}>
-      <InputLabel id="provider-label">Provider</InputLabel>
-      <Select
-        labelId="provider-label"
-        value={value}
-        label="Provider"
-        onChange={(e) => onChange(e.target.value)}
-      >
-        <MenuItem value=""><em>none</em></MenuItem>
-        {providers.map((p) => (
-          <MenuItem key={p} value={p} sx={{ fontFamily: 'monospace' }}>{p}</MenuItem>
-        ))}
-      </Select>
-      <FormHelperText>
-        {disabled
-          ? 'Pick credentials=api_key above to enable.'
-          : 'One of the providers configured on this Helix instance.'}
-      </FormHelperText>
-      <Box sx={{ mt: 1 }}>
-        <Button size="small" variant="contained" color="secondary" startIcon={<SaveIcon />} onClick={handleSave} disabled={setMut.isPending || disabled}>
-          {setMut.isPending ? 'Saving…' : 'Save provider'}
-        </Button>
-      </Box>
-    </FormControl>
-  )
-}
-
-// ModelRow lists models the picked provider exposes.
-const ModelRow: FC<{
-  value: string
-  onChange: (v: string) => void
-  models: { id: string; name?: string; description?: string }[]
-  disabled: boolean
-  provider: string
-}> = ({ value, onChange, models, disabled, provider }) => {
-  const setMut = useSetHelixOrgSetting()
-  const snackbar = useSnackbar()
-  const handleSave = async () => {
-    try {
-      await setMut.mutateAsync({ key: 'worker.model', value: encodeStringValue(value) })
-      snackbar.success('Model saved')
-    } catch (e: any) {
-      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
-    }
-  }
-  const selected = models.find((m) => m.id === value)
-  return (
-    <FormControl fullWidth size="small" disabled={disabled}>
-      <InputLabel id="model-label">Model</InputLabel>
-      <Select
-        labelId="model-label"
-        value={value}
-        label="Model"
-        onChange={(e) => onChange(e.target.value)}
-      >
-        <MenuItem value=""><em>none</em></MenuItem>
-        {models.map((m) => (
-          <MenuItem key={m.id} value={m.id} sx={{ fontFamily: 'monospace' }}>
-            {m.id}{m.name ? ` — ${m.name}` : ''}
-          </MenuItem>
-        ))}
-      </Select>
-      <FormHelperText>
-        {disabled
-          ? (provider ? 'Pick credentials=api_key above to enable.' : 'Pick a provider first.')
-          : (selected?.description?.slice(0, 200) ?? `Models exposed by ${provider}.`)
-        }
-      </FormHelperText>
-      <Box sx={{ mt: 1 }}>
-        <Button size="small" variant="contained" color="secondary" startIcon={<SaveIcon />} onClick={handleSave} disabled={setMut.isPending || disabled}>
-          {setMut.isPending ? 'Saving…' : 'Save model'}
-        </Button>
-      </Box>
-    </FormControl>
   )
 }
 

--- a/frontend/src/components/orgs/EditOrgWindow.tsx
+++ b/frontend/src/components/orgs/EditOrgWindow.tsx
@@ -6,14 +6,27 @@ import DialogActions from '@mui/material/DialogActions'
 import Button from '@mui/material/Button'
 import TextField from '@mui/material/TextField'
 import Box from '@mui/material/Box'
+import Divider from '@mui/material/Divider'
+import Typography from '@mui/material/Typography'
 
 import { TypesOrganization } from '../../api/api'
+import useAccount from '../../hooks/useAccount'
+import useApi from '../../hooks/useApi'
+import useSnackbar from '../../hooks/useSnackbar'
+import BotRuntimeForm, { BotRuntimeValue } from '../helix-org/BotRuntimeForm'
 
 export interface EditOrgWindowProps {
   open: boolean
   org?: TypesOrganization
   onClose: () => void
-  onSubmit: (org: TypesOrganization) => Promise<void>
+  onSubmit: (org: TypesOrganization) => Promise<TypesOrganization | null | void>
+}
+
+const DEFAULT_BOT_RUNTIME: BotRuntimeValue = {
+  runtime: 'claude_code',
+  credentials: 'subscription',
+  provider: '',
+  model: '',
 }
 
 const EditOrgWindow: FC<EditOrgWindowProps> = ({
@@ -22,11 +35,22 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
   onClose,
   onSubmit,
 }) => {
+  const account = useAccount()
+  const api = useApi()
+  const snackbar = useSnackbar()
+  const helixOrgEnabled = account.user?.alpha_features?.includes('helix-org') ?? false
+
   const [slug, setSlug] = useState('')
   const [name, setName] = useState('')
   const [loading, setLoading] = useState(false)
   const [slugManuallyEdited, setSlugManuallyEdited] = useState(false)
   const [errors, setErrors] = useState<{slug?: string, name?: string}>({})
+
+  // Default Bot Runtime is optional at creation: untouched means "write
+  // nothing, use the backend defaults" — so an org with no providers or Claude
+  // subscription set up can still be created without picking anything.
+  const [botDefaults, setBotDefaults] = useState<BotRuntimeValue>(DEFAULT_BOT_RUNTIME)
+  const [botDirty, setBotDirty] = useState(false)
 
   // Reset state when modal opens/closes or org changes
   useEffect(() => {
@@ -39,6 +63,8 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
     }
     setSlugManuallyEdited(false)
     setErrors({})
+    setBotDefaults(DEFAULT_BOT_RUNTIME)
+    setBotDirty(false)
   }, [org, open])
 
   // Generate slug from name for new organizations
@@ -63,21 +89,40 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
   // Validate form before submission
   const validateForm = () => {
     const newErrors: {slug?: string, name?: string} = {}
-    
+
     // Validate name (required)
     if (!name) {
       newErrors.name = 'Name is required'
     }
-    
+
     // Validate slug (required and no spaces)
     if (!slug) {
       newErrors.slug = 'Slug is required'
     } else if (slug.includes(' ')) {
       newErrors.slug = 'Slug cannot contain spaces'
     }
-    
+
     setErrors(newErrors)
     return Object.keys(newErrors).length === 0
+  }
+
+  // Persist the chosen bot-runtime defaults to the freshly-created org. Only
+  // called on create, only when the operator actually touched the form, and
+  // only writes non-empty keys. Best-effort: a failure here doesn't undo the
+  // (already-created) org, so we surface it as a soft warning.
+  const persistBotDefaults = async (createdSlug: string) => {
+    const client = api.getApiClient()
+    const writes: Promise<unknown>[] = [
+      client.v1OrgsSettingsUpdate('worker.runtime', createdSlug, { value: JSON.stringify(botDefaults.runtime) }),
+      client.v1OrgsSettingsUpdate('worker.credentials', createdSlug, { value: JSON.stringify(botDefaults.credentials) }),
+    ]
+    if (botDefaults.provider) {
+      writes.push(client.v1OrgsSettingsUpdate('worker.provider', createdSlug, { value: JSON.stringify(botDefaults.provider) }))
+    }
+    if (botDefaults.model) {
+      writes.push(client.v1OrgsSettingsUpdate('worker.model', createdSlug, { value: JSON.stringify(botDefaults.model) }))
+    }
+    await Promise.all(writes)
   }
 
   const handleSubmit = async () => {
@@ -85,25 +130,36 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
     if (!validateForm()) {
       return
     }
-    
+
     try {
       setLoading(true)
-      
+
       // Create the updated organization object
       // If editing existing org, merge with original data
       // If creating new org, create minimal object
-      const updatedOrg = org 
+      const updatedOrg = org
         ? {
             ...org,            // Preserve all existing fields
             name: slug,        // Update the slug
             display_name: name // Update the display name
-          } 
+          }
         : {
             name: slug,        // 'name' field in API is our 'slug'
             display_name: name // 'display_name' in API is our 'name'
           } as TypesOrganization;
-      
-      await onSubmit(updatedOrg)
+
+      const created = await onSubmit(updatedOrg)
+
+      // New org + operator picked bot-runtime defaults → persist them against
+      // the real created slug (the backend may have suffixed it for uniqueness).
+      if (!org && botDirty && helixOrgEnabled && created && created.name) {
+        try {
+          await persistBotDefaults(created.name)
+        } catch (e) {
+          snackbar.error('Organization created, but saving the default bot runtime failed — set it in Settings.')
+        }
+      }
+
       onClose()
     } finally {
       setLoading(false)
@@ -135,7 +191,7 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
             helperText={errors.name || "Human-readable name for the organization"}
             sx={{ mb: 2 }}
           />
-          
+
           {/* Slug field (formerly Name) */}
           <TextField
             label="Slug"
@@ -147,6 +203,28 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
             error={!!errors.slug}
             helperText={errors.slug || "Unique identifier for the organization (no spaces allowed)"}
           />
+
+          {/* Default Bot Runtime — only when creating, and only for helix-org
+              alpha users. Optional: leave untouched to configure later. */}
+          {!org && helixOrgEnabled && (
+            <Box sx={{ mt: 3 }}>
+              <Divider sx={{ mb: 2 }} />
+              <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                Default Bot Runtime
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                Optional — how Bots in this org run by default. Leave as-is to configure
+                later in Settings.
+              </Typography>
+              <BotRuntimeForm
+                value={botDefaults}
+                onChange={(patch) => {
+                  setBotDefaults((v) => ({ ...v, ...patch }))
+                  setBotDirty(true)
+                }}
+              />
+            </Box>
+          )}
         </Box>
       </DialogContent>
       <DialogActions>
@@ -169,4 +247,4 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
   )
 }
 
-export default EditOrgWindow 
+export default EditOrgWindow

--- a/frontend/src/hooks/useOrganizations.ts
+++ b/frontend/src/hooks/useOrganizations.ts
@@ -16,7 +16,7 @@ export interface IOrganizationTools {
   loadingAccessGrants: boolean,
   // Organization methods
   loadOrganizations: () => Promise<void>,
-  createOrganization: (org: TypesOrganization) => Promise<boolean>,
+  createOrganization: (org: TypesOrganization) => Promise<TypesOrganization | null>,
   updateOrganization: (id: string, org: TypesOrganization) => Promise<boolean>,
   deleteOrganization: (id: string) => Promise<boolean>,
   loadOrganization: (id: string) => Promise<void>,
@@ -51,7 +51,7 @@ export const defaultOrganizationTools: IOrganizationTools = {
   appAccessGrants: [],
   loadingAccessGrants: false,
   loadOrganizations: async () => {},
-  createOrganization: async () => false,
+  createOrganization: async () => null,
   updateOrganization: async () => false,
   deleteOrganization: async () => false,
   loadOrganization: async () => {},
@@ -257,15 +257,15 @@ export default function useOrganizations(): IOrganizationTools {
 
   const createOrganization = useCallback(async (org: TypesOrganization) => {
     try {
-      await api.getApiClient().v1OrganizationsCreate(org)
+      const res = await api.getApiClient().v1OrganizationsCreate(org)
       snackbar.success('Organization created')
       await loadOrganizations()
-      return true
+      return res.data
     } catch (error) {
       console.error(error)
       const errorMessage = extractErrorMessage(error)
       snackbar.error(errorMessage || 'Error creating organization')
-      return false
+      return null
     }
   }, [])
 

--- a/frontend/src/pages/HelixOrgSettings.tsx
+++ b/frontend/src/pages/HelixOrgSettings.tsx
@@ -60,7 +60,7 @@ const HelixOrgSettings: FC = () => {
           <Box>
             <Typography variant="h5" sx={{ mb: 1 }}>Settings</Typography>
             <Typography variant="body2" color="text.secondary">
-              Configures how this org's Workers run. Changes take effect on the next worker
+              Configures how this org's Bots run. Changes take effect on the next bot
               activation — no API restart needed.
             </Typography>
           </Box>

--- a/frontend/src/pages/HelixOrgSettings.tsx
+++ b/frontend/src/pages/HelixOrgSettings.tsx
@@ -1,40 +1,24 @@
-// HelixOrgSettings is the configuration surface for the helix-org
-// alpha. The "headline" rows — worker.runtime / credentials / provider
-// / model — are rendered as first-class dropdowns so an operator can
-// switch between claude_code subscription mode (the SaaS default, each
-// operator OAuths their own Claude account) and api_key mode (inference
-// routed through one of Helix's configured providers) without having to
-// know the wire form. Everything else falls back to a generic
-// text-input row driven by the same config registry the server
+// HelixOrgSettings is the configuration surface for the helix-org alpha.
+// The worker.* runtime config (runtime / credentials / provider / model)
+// now lives on the AI Providers page (WorkerRuntimePanel) so it sits next
+// to the providers it references; everything else here falls back to a
+// generic text-input row driven by the same config registry the server
 // validates against.
-//
-// The provider + model dropdowns pull their options from Helix's
-// existing /providers + /v1/models endpoints, so changing or adding a
-// provider in the Helix admin surface is automatically reflected here
-// without a redeploy.
 
-import { FC, useEffect, useMemo, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
 import Container from '@mui/material/Container'
-import FormControl from '@mui/material/FormControl'
-import FormHelperText from '@mui/material/FormHelperText'
-import InputLabel from '@mui/material/InputLabel'
-import Link from '@mui/material/Link'
-import MenuItem from '@mui/material/MenuItem'
 import Paper from '@mui/material/Paper'
-import Select from '@mui/material/Select'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
-import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import SaveIcon from '@mui/icons-material/Save'
 
 import Page from '../components/system/Page'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import useAccount from '../hooks/useAccount'
-import useRouter from '../hooks/useRouter'
 import useSnackbar from '../hooks/useSnackbar'
 import GitHubAppPanel from '../components/helix-org/GitHubAppPanel'
 import SlackIntegrationsPanel from '../components/helix-org/SlackIntegrationsPanel'
@@ -42,103 +26,28 @@ import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrum
 import {
   SettingsSpecDTO,
   useDeleteHelixOrgSetting,
-  useHelixModelsForProvider,
   useHelixOrgSettings,
-  useHelixProviders,
   useSetHelixOrgSetting,
 } from '../services/helixOrgService'
 
-// Keys we render as first-class controls. Anything not in here falls
-// through to the generic TextField row below.
-const FIRST_CLASS_KEYS = new Set<string>([
+// Registry keys we do NOT render as generic rows here:
+//  - worker.* runtime config lives on the Providers page (WorkerRuntimePanel).
+//  - transport.github is auto-managed by the Helix GitHub App (it provisions
+//    the webhook secret and the token comes from the App installation), so
+//    there's nothing for an operator to paste.
+const EXCLUDED_KEYS = new Set<string>([
   'worker.runtime',
   'worker.credentials',
   'worker.provider',
   'worker.model',
-])
-
-// Keys we deliberately hide from the settings surface. transport.github
-// is auto-managed now: the Helix GitHub App provisions the webhook
-// secret (and the access token comes from the App installation), so
-// there's nothing for an operator to paste here. The key still exists
-// in the registry — it's just self-configured, not operator-facing.
-const HIDDEN_KEYS = new Set<string>([
   'transport.github',
 ])
 
-// Allowed values for the two dropdown-only knobs. The server
-// validates against the same set in
-// api/pkg/server/helix_org.go::resolveWorkerAgentConfig.
-const RUNTIME_OPTIONS = [
-  { value: 'claude_code', label: 'claude_code', help: 'Anthropic Claude Code CLI inside the desktop. Authenticates via subscription OAuth or via Helix-routed API key.' },
-  { value: 'zed_agent', label: 'zed_agent', help: 'Native Zed agent — always routed through a Helix-managed provider (forces credentials=api_key).' },
-]
-
-const CREDENTIALS_OPTIONS = [
-  { value: 'subscription', label: 'subscription', help: 'Each operator authenticates with their own Claude OAuth subscription (only meaningful with runtime=claude_code).' },
-  { value: 'api_key', label: 'api_key', help: 'Inference routed through one of Helix\'s configured providers — pick provider + model below.' },
-]
-
-// JSON-encode the value the dropdown produced so it satisfies the
-// registry's string-spec contract. Empty string → empty value (clears).
-const encodeStringValue = (raw: string): string => JSON.stringify(raw)
-
-// Read the redacted/persisted JSON value back into a plain string for
-// the dropdowns. Falls back to empty when parsing fails (e.g. the
-// stored value is masked).
-const decodeStringValue = (v: string): string => {
-  if (!v) return ''
-  try {
-    const parsed = JSON.parse(v)
-    return typeof parsed === 'string' ? parsed : ''
-  } catch {
-    return v
-  }
-}
-
 const HelixOrgSettings: FC = () => {
-  const router = useRouter()
   const account = useAccount()
-  const orgSlug = router.params.org_id as string | undefined
   const breadcrumbs = useHelixOrgBreadcrumbs()
 
   const { data, isLoading } = useHelixOrgSettings()
-  const { data: providers } = useHelixProviders()
-
-  const specByKey = useMemo(() => {
-    const m = new Map<string, SettingsSpecDTO>()
-    for (const s of data?.specs ?? []) m.set(s.key, s)
-    return m
-  }, [data])
-
-  // Initial values from the loaded settings — decoded from the
-  // registry's JSON wire form into plain strings the dropdowns can
-  // bind to.
-  const initialRuntime = decodeStringValue(specByKey.get('worker.runtime')?.value ?? '') || 'claude_code'
-  const initialCreds = decodeStringValue(specByKey.get('worker.credentials')?.value ?? '') || 'subscription'
-  const initialProvider = decodeStringValue(specByKey.get('worker.provider')?.value ?? '')
-  const initialModel = decodeStringValue(specByKey.get('worker.model')?.value ?? '')
-
-  const [runtime, setRuntime] = useState<string>(initialRuntime)
-  const [credentials, setCredentials] = useState<string>(initialCreds)
-  const [provider, setProvider] = useState<string>(initialProvider)
-  const [model, setModel] = useState<string>(initialModel)
-
-  // Re-seed local state when the loaded data lands or refreshes.
-  useEffect(() => {
-    if (!data) return
-    setRuntime(initialRuntime)
-    setCredentials(initialCreds)
-    setProvider(initialProvider)
-    setModel(initialModel)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data])
-
-  const { data: models } = useHelixModelsForProvider(provider, { enabled: credentials === 'api_key' })
-
-  // claude_code + subscription means provider+model are unused (the
-  // CLI handles OAuth itself), so we visually disable those rows.
-  const apiKeyMode = credentials === 'api_key'
 
   return (
     <Page
@@ -160,243 +69,19 @@ const HelixOrgSettings: FC = () => {
             <LoadingSpinner />
           ) : (
             <>
-              <Paper variant="outlined" sx={{ p: 3 }}>
-                <Stack spacing={2.5}>
-                  <Typography variant="subtitle1">Worker runtime</Typography>
-                  <RuntimeRow value={runtime} onChange={setRuntime} />
-                  <CredentialsRow
-                    value={credentials}
-                    onChange={(v) => {
-                      setCredentials(v)
-                      // Switching to subscription wipes provider+model
-                      // because they're meaningless in OAuth mode.
-                      if (v === 'subscription' && runtime === 'claude_code') {
-                        setProvider('')
-                        setModel('')
-                      }
-                    }}
-                    runtime={runtime}
-                  />
-                  <ProviderRow
-                    value={provider}
-                    onChange={(v) => { setProvider(v); setModel('') }}
-                    providers={providers ?? []}
-                    disabled={!apiKeyMode}
-                    orgSlug={orgSlug}
-                  />
-                  <ModelRow
-                    value={model}
-                    onChange={setModel}
-                    models={models ?? []}
-                    disabled={!apiKeyMode || !provider}
-                    provider={provider}
-                  />
-                </Stack>
-              </Paper>
-
               <GitHubAppPanel />
 
               <SlackIntegrationsPanel />
 
-              {/* Generic spec rows — everything not first-class or hidden */}
+              {/* Generic spec rows — everything not excluded above */}
               {(data?.specs ?? [])
-                .filter((s) => !FIRST_CLASS_KEYS.has(s.key) && !HIDDEN_KEYS.has(s.key))
+                .filter((s) => !EXCLUDED_KEYS.has(s.key))
                 .map((s) => <GenericSettingRow key={s.key} spec={s} />)}
             </>
           )}
         </Stack>
       </Container>
     </Page>
-  )
-}
-
-// RuntimeRow is the worker.runtime dropdown.
-const RuntimeRow: FC<{ value: string; onChange: (v: string) => void }> = ({ value, onChange }) => {
-  const setMut = useSetHelixOrgSetting()
-  const snackbar = useSnackbar()
-  const handleSave = async () => {
-    try {
-      await setMut.mutateAsync({ key: 'worker.runtime', value: encodeStringValue(value) })
-      snackbar.success('worker.runtime saved')
-    } catch (e: any) {
-      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
-    }
-  }
-  const helpFor = RUNTIME_OPTIONS.find((o) => o.value === value)?.help
-  return (
-    <FormControl fullWidth size="small">
-      <InputLabel id="runtime-label">worker.runtime</InputLabel>
-      <Select
-        labelId="runtime-label"
-        value={value}
-        label="worker.runtime"
-        onChange={(e) => onChange(e.target.value)}
-      >
-        {RUNTIME_OPTIONS.map((o) => (
-          <MenuItem key={o.value} value={o.value} sx={{ fontFamily: 'monospace' }}>
-            {o.label}
-          </MenuItem>
-        ))}
-      </Select>
-      <FormHelperText>{helpFor}</FormHelperText>
-      <Box sx={{ mt: 1 }}>
-        <Button size="small" variant="contained" color="secondary" startIcon={<SaveIcon />} onClick={handleSave} disabled={setMut.isPending}>
-          {setMut.isPending ? 'Saving…' : 'Save runtime'}
-        </Button>
-      </Box>
-    </FormControl>
-  )
-}
-
-// CredentialsRow is the worker.credentials dropdown.
-const CredentialsRow: FC<{ value: string; onChange: (v: string) => void; runtime: string }> = ({ value, onChange, runtime }) => {
-  const setMut = useSetHelixOrgSetting()
-  const snackbar = useSnackbar()
-  const handleSave = async () => {
-    try {
-      await setMut.mutateAsync({ key: 'worker.credentials', value: encodeStringValue(value) })
-      snackbar.success('worker.credentials saved')
-    } catch (e: any) {
-      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
-    }
-  }
-  const helpFor = CREDENTIALS_OPTIONS.find((o) => o.value === value)?.help
-  // The backend coerces non-claude_code runtimes to api_key, but
-  // surface that fact to the operator so the page doesn't look
-  // broken when they pick zed_agent + subscription.
-  const forcedToApiKey = runtime !== 'claude_code'
-  return (
-    <FormControl fullWidth size="small">
-      <InputLabel id="creds-label">worker.credentials</InputLabel>
-      <Select
-        labelId="creds-label"
-        value={forcedToApiKey ? 'api_key' : value}
-        label="worker.credentials"
-        onChange={(e) => onChange(e.target.value)}
-        disabled={forcedToApiKey}
-      >
-        {CREDENTIALS_OPTIONS.map((o) => (
-          <MenuItem key={o.value} value={o.value} sx={{ fontFamily: 'monospace' }}>
-            {o.label}
-          </MenuItem>
-        ))}
-      </Select>
-      <FormHelperText>
-        {forcedToApiKey ? `runtime=${runtime} forces api_key — only claude_code supports subscription.` : helpFor}
-      </FormHelperText>
-      <Box sx={{ mt: 1 }}>
-        <Button size="small" variant="contained" color="secondary" startIcon={<SaveIcon />} onClick={handleSave} disabled={setMut.isPending || forcedToApiKey}>
-          {setMut.isPending ? 'Saving…' : 'Save credentials'}
-        </Button>
-      </Box>
-    </FormControl>
-  )
-}
-
-// ProviderRow lists every provider configured on this Helix instance.
-const ProviderRow: FC<{
-  value: string
-  onChange: (v: string) => void
-  providers: string[]
-  disabled: boolean
-  orgSlug: string | undefined
-}> = ({ value, onChange, providers, disabled, orgSlug }) => {
-  const setMut = useSetHelixOrgSetting()
-  const snackbar = useSnackbar()
-  const handleSave = async () => {
-    try {
-      await setMut.mutateAsync({ key: 'worker.provider', value: encodeStringValue(value) })
-      snackbar.success('worker.provider saved')
-    } catch (e: any) {
-      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
-    }
-  }
-  return (
-    <FormControl fullWidth size="small" disabled={disabled}>
-      <InputLabel id="provider-label">worker.provider</InputLabel>
-      <Select
-        labelId="provider-label"
-        value={value}
-        label="worker.provider"
-        onChange={(e) => onChange(e.target.value)}
-      >
-        <MenuItem value=""><em>none</em></MenuItem>
-        {providers.map((p) => (
-          <MenuItem key={p} value={p} sx={{ fontFamily: 'monospace' }}>{p}</MenuItem>
-        ))}
-      </Select>
-      <FormHelperText>
-        {disabled ? (
-          'Pick credentials=api_key above to enable.'
-        ) : (
-          <span>
-            One of the providers configured on this Helix instance. Missing one?{' '}
-            <Link
-              href={orgSlug ? `/orgs/${orgSlug}/providers` : '#'}
-              underline="hover"
-              sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.25 }}
-            >
-              Manage providers <OpenInNewIcon sx={{ fontSize: 12 }} />
-            </Link>
-          </span>
-        )}
-      </FormHelperText>
-      <Box sx={{ mt: 1 }}>
-        <Button size="small" variant="contained" color="secondary" startIcon={<SaveIcon />} onClick={handleSave} disabled={setMut.isPending || disabled}>
-          {setMut.isPending ? 'Saving…' : 'Save provider'}
-        </Button>
-      </Box>
-    </FormControl>
-  )
-}
-
-// ModelRow lists models the picked provider exposes.
-const ModelRow: FC<{
-  value: string
-  onChange: (v: string) => void
-  models: { id: string; name?: string; description?: string }[]
-  disabled: boolean
-  provider: string
-}> = ({ value, onChange, models, disabled, provider }) => {
-  const setMut = useSetHelixOrgSetting()
-  const snackbar = useSnackbar()
-  const handleSave = async () => {
-    try {
-      await setMut.mutateAsync({ key: 'worker.model', value: encodeStringValue(value) })
-      snackbar.success('worker.model saved')
-    } catch (e: any) {
-      snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed')
-    }
-  }
-  const selected = models.find((m) => m.id === value)
-  return (
-    <FormControl fullWidth size="small" disabled={disabled}>
-      <InputLabel id="model-label">worker.model</InputLabel>
-      <Select
-        labelId="model-label"
-        value={value}
-        label="worker.model"
-        onChange={(e) => onChange(e.target.value)}
-      >
-        <MenuItem value=""><em>none</em></MenuItem>
-        {models.map((m) => (
-          <MenuItem key={m.id} value={m.id} sx={{ fontFamily: 'monospace' }}>
-            {m.id}{m.name ? ` — ${m.name}` : ''}
-          </MenuItem>
-        ))}
-      </Select>
-      <FormHelperText>
-        {disabled
-          ? (provider ? 'Pick credentials=api_key above to enable.' : 'Pick a provider first.')
-          : (selected?.description?.slice(0, 200) ?? `Models exposed by ${provider}.`)
-        }
-      </FormHelperText>
-      <Box sx={{ mt: 1 }}>
-        <Button size="small" variant="contained" color="secondary" startIcon={<SaveIcon />} onClick={handleSave} disabled={setMut.isPending || disabled}>
-          {setMut.isPending ? 'Saving…' : 'Save model'}
-        </Button>
-      </Box>
-    </FormControl>
   )
 }
 

--- a/frontend/src/pages/OrgSettings.tsx
+++ b/frontend/src/pages/OrgSettings.tsx
@@ -338,7 +338,7 @@ const OrgSettings: FC = () => {
                     color="text.secondary"
                     sx={{ mb: 2 }}
                   >
-                    How this org's Bots run by default — which runtime, and which
+                    How Bots in this org run by default — which runtime, and which
                     provider/model they route through.
                   </Typography>
                   <WorkerRuntimePanel />

--- a/frontend/src/pages/OrgSettings.tsx
+++ b/frontend/src/pages/OrgSettings.tsx
@@ -20,6 +20,7 @@ import useRouter from "../hooks/useRouter";
 import { TypesOrganization } from "../api/api";
 import useSnackbar from "../hooks/useSnackbar";
 import CopyButton from "../components/common/CopyButton";
+import WorkerRuntimePanel from "../components/helix-org/WorkerRuntimePanel";
 
 const OrgSettings: FC = () => {
   // Get account context and router
@@ -42,6 +43,10 @@ const OrgSettings: FC = () => {
   }>({});
 
   const organization = account.organizationTools.organization;
+  // helix-org alpha gates the Default Bot Runtime config (its settings
+  // endpoint is behind the same feature flag).
+  const helixOrgEnabled =
+    account.user?.alpha_features?.includes("helix-org") ?? false;
   const isOrgOwner =
     !!account.user &&
     !!organization &&
@@ -320,6 +325,23 @@ const OrgSettings: FC = () => {
                   >
                     Update Organization
                   </Button>
+                </Box>
+              )}
+
+              {helixOrgEnabled && (
+                <Box sx={{ mt: 4 }}>
+                  <Typography variant="h6" gutterBottom>
+                    Default Bot Runtime
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ mb: 2 }}
+                  >
+                    How this org's Bots run by default — which runtime, and which
+                    provider/model they route through.
+                  </Typography>
+                  <WorkerRuntimePanel />
                 </Box>
               )}
 

--- a/frontend/src/pages/Orgs.tsx
+++ b/frontend/src/pages/Orgs.tsx
@@ -40,9 +40,9 @@ const Orgs: FC = () => {
   const handleSubmit = async (org: TypesOrganization) => {
     if (org.id) {
       await account.organizationTools.updateOrganization(org.id, org)
-    } else {
-      await account.organizationTools.createOrganization(org)
+      return
     }
+    return await account.organizationTools.createOrganization(org)
   }
 
   const handleConfirmDelete = async () => {

--- a/frontend/src/pages/Providers.tsx
+++ b/frontend/src/pages/Providers.tsx
@@ -349,10 +349,10 @@ const Providers: React.FC = () => {
           <>
             <Divider sx={{ my: 4 }} />
             <Typography variant="h6" sx={{ mb: 1, fontWeight: 600 }}>
-              Worker runtime
+              Default Bot Runtime
             </Typography>
             <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
-              How this org's agent Workers run — which runtime, and which provider/model they route through.
+              How this org's Bots run by default — which runtime, and which provider/model they route through.
             </Typography>
             <WorkerRuntimePanel />
           </>

--- a/frontend/src/pages/Providers.tsx
+++ b/frontend/src/pages/Providers.tsx
@@ -16,6 +16,7 @@ import useAccount from '../hooks/useAccount';
 import AnthropicLogo from '../components/providers/logos/anthropic';
 import ClaudeSubscriptionConnect, { useClaudeSubscriptions } from '../components/account/ClaudeSubscriptionConnect';
 import { getTokenExpiryStatus } from '../components/account/claudeSubscriptionUtils';
+import WorkerRuntimePanel from '../components/helix-org/WorkerRuntimePanel';
 
 const Providers: React.FC = () => {
   const router = useRouter()
@@ -24,6 +25,10 @@ const Providers: React.FC = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
 
   const orgName = router.params.org_id
+
+  // helix-org alpha: only then is the worker-runtime config (and its
+  // settings endpoint) available for this org.
+  const helixOrgEnabled = account.user?.alpha_features?.includes('helix-org') ?? false
 
   // Check if providers management is enabled
   const providersManagementEnabled = account.serverConfig.providers_management_enabled
@@ -339,6 +344,20 @@ const Providers: React.FC = () => {
             );
           })}
         </Grid>
+
+        {orgName && helixOrgEnabled && (
+          <>
+            <Divider sx={{ my: 4 }} />
+            <Typography variant="h6" sx={{ mb: 1, fontWeight: 600 }}>
+              Worker runtime
+            </Typography>
+            <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+              How this org's agent Workers run — which runtime, and which provider/model they route through.
+            </Typography>
+            <WorkerRuntimePanel />
+          </>
+        )}
+
         {selectedProvider && editAllowed && (
           <AddProviderDialog
             orgId={org?.id || ''}

--- a/frontend/src/pages/Providers.tsx
+++ b/frontend/src/pages/Providers.tsx
@@ -16,7 +16,6 @@ import useAccount from '../hooks/useAccount';
 import AnthropicLogo from '../components/providers/logos/anthropic';
 import ClaudeSubscriptionConnect, { useClaudeSubscriptions } from '../components/account/ClaudeSubscriptionConnect';
 import { getTokenExpiryStatus } from '../components/account/claudeSubscriptionUtils';
-import WorkerRuntimePanel from '../components/helix-org/WorkerRuntimePanel';
 
 const Providers: React.FC = () => {
   const router = useRouter()
@@ -25,10 +24,6 @@ const Providers: React.FC = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
 
   const orgName = router.params.org_id
-
-  // helix-org alpha: only then is the worker-runtime config (and its
-  // settings endpoint) available for this org.
-  const helixOrgEnabled = account.user?.alpha_features?.includes('helix-org') ?? false
 
   // Check if providers management is enabled
   const providersManagementEnabled = account.serverConfig.providers_management_enabled
@@ -344,20 +339,6 @@ const Providers: React.FC = () => {
             );
           })}
         </Grid>
-
-        {orgName && helixOrgEnabled && (
-          <>
-            <Divider sx={{ my: 4 }} />
-            <Typography variant="h6" sx={{ mb: 1, fontWeight: 600 }}>
-              Default Bot Runtime
-            </Typography>
-            <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
-              How this org's Bots run by default — which runtime, and which provider/model they route through.
-            </Typography>
-            <WorkerRuntimePanel />
-          </>
-        )}
-
         {selectedProvider && editAllowed && (
           <AddProviderDialog
             orgId={org?.id || ''}


### PR DESCRIPTION
## What

Gives helix-org a single, product-consistent place to configure how an org's Bots run by default, and lets you set it when creating an org.

**Relocated + restyled**
- Moved the `worker.*` runtime config off the helix-org Settings page and onto **Settings → General** as a "Default Bot Runtime" section (briefly lived on Providers en route — see commit history).
- Restyled to match the per-agent runtime picker (`AppSettings`): **Runtime** select with friendly labels + descriptions, **Credentials** as radios with connection status, and the shared `AdvancedModelPicker` for provider/model. Auto-saves on change.
- Terms are now Bot/agent-facing (no raw `worker.runtime` / `claude_code` strings), to avoid confusing operators.
- Offers all four runtimes (Zed Agent, Qwen Code, Claude Code, Goose), matching the agent page — the backend forwards `worker.runtime` into the Bot's Agent App config, so the non-claude runtimes route through a provider just like Zed.

**Set defaults at org creation**
- **Create Organization** now shows the same form (alpha-gated, create-mode only).
- Optional: untouched = write nothing (so an org with no providers / Claude subscription can still be created); if touched, the `worker.*` settings are persisted to the freshly-created org using its real returned slug.
- `createOrganization` now returns the created org (was a bare boolean, discarded).

**Refactor**
- Extracted a controlled `BotRuntimeForm` (presentational, value + onChange) shared by the auto-saving settings panel and the deferred-save create dialog.

## Gating / safety
- All of it is behind the `helix-org` alpha flag (same gate as the Org Chart tab). Non-enrolled users and default (env-off) deployments see the unchanged General page and Create dialog — the panel and its API calls never mount.

## Notes
- Frontend-only; no backend/API changes. `worker.*` registry keys are unchanged.
- `yarn build` passes.
- Not covered here: the separate **onboarding** first-org flow (different code path) — can follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)