### PR TITLE
feat(org): seed a Chief of Staff starter bot on org creation

### DIFF
--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -15,6 +15,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/org/domain/streaming"
 	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
 )
 
 // ---- Bots ---------------------------------------------------------------
@@ -96,14 +97,21 @@ func (a *apiHandler) createBot(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, errors.New("content is required"))
 		return
 	}
+	// A manager Bot gets the canonical owner tool set (all mutations +
+	// read baseline) so it can hire and manage other Bots; otherwise the
+	// caller's tools are used. Either way the bots service unions the
+	// base read tools, so a "New Bot" dialog with no tools picker still
+	// gets a usable MCP surface.
+	tools := toToolNames(req.Tools)
+	if req.Owner {
+		tools = mcptools.OwnerBotTools()
+	}
 	// REST and chat-driven creates share lifecycle.Create — one
-	// implementation. The base read tools are unioned by the bots
-	// service so a "New Bot" dialog with no tools picker still gets a
-	// usable MCP surface.
+	// implementation.
 	res, err := a.deps.Lifecycle.Create(ctx, orgID, lifecycle.CreateParams{
 		ID:              strings.TrimSpace(req.ID),
 		Content:         req.Content,
-		Tools:           toToolNames(req.Tools),
+		Tools:           tools,
 		Topics:          toTopicIDs(req.Topics),
 		ParentID:        orgchart.BotID(strings.TrimSpace(req.ParentID)),
 		PreserveContext: req.PreserveContext,

--- a/api/pkg/org/interfaces/server/api/dto.go
+++ b/api/pkg/org/interfaces/server/api/dto.go
@@ -88,6 +88,12 @@ type CreateBotRequest struct {
 	Topics          []string `json:"topics,omitempty"`
 	ParentID        string   `json:"parent_id,omitempty"`
 	PreserveContext bool     `json:"preserve_context,omitempty"`
+	// Owner makes this a manager Bot: it receives the canonical owner
+	// tool set (every org-graph mutation — create_bot, delete_bot,
+	// set_bot_content, subscribe, … — plus the read baseline) so it can
+	// hire and manage other Bots. When true, Tools is ignored in favour
+	// of that set. Used to seed a starter/root Bot for a new org.
+	Owner bool `json:"owner,omitempty"`
 }
 
 // CreateBotResponse is the body of POST /bots on success.

--- a/api/pkg/org/interfaces/server/api/dto.go
+++ b/api/pkg/org/interfaces/server/api/dto.go
@@ -89,8 +89,8 @@ type CreateBotRequest struct {
 	ParentID        string   `json:"parent_id,omitempty"`
 	PreserveContext bool     `json:"preserve_context,omitempty"`
 	// Owner makes this a manager Bot: it receives the canonical owner
-	// tool set (every org-graph mutation — create_bot, delete_bot,
-	// set_bot_content, subscribe, … — plus the read baseline) so it can
+	// tool set (every org-graph mutation - create_bot, delete_bot,
+	// set_bot_content, subscribe, ... - plus the read baseline) so it can
 	// hire and manage other Bots. When true, Tools is ignored in favour
 	// of that set. Used to seed a starter/root Bot for a new org.
 	Owner bool `json:"owner,omitempty"`

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -9721,7 +9721,7 @@ const docTemplate = `{
                 "tags": [
                     "HelixOrg"
                 ],
-                "summary": "Helix-org: restart a bot's agent session (recreate desktop container)",
+                "summary": "Helix-org: restart a bot's agent session (fresh session + desktop)",
                 "parameters": [
                     {
                         "type": "string",
@@ -21240,6 +21240,10 @@ const docTemplate = `{
                 },
                 "id": {
                     "type": "string"
+                },
+                "owner": {
+                    "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation — create_bot, delete_bot,\nset_bot_content, subscribe, … — plus the read baseline) so it can\nhire and manage other Bots. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
+                    "type": "boolean"
                 },
                 "parent_id": {
                     "type": "string"

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -21242,7 +21242,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "owner": {
-                    "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation — create_bot, delete_bot,\nset_bot_content, subscribe, … — plus the read baseline) so it can\nhire and manage other Bots. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
+                    "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation - create_bot, delete_bot,\nset_bot_content, subscribe, ... - plus the read baseline) so it can\nhire and manage other Bots. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
                     "type": "boolean"
                 },
                 "parent_id": {

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -21238,7 +21238,7 @@
                     "type": "string"
                 },
                 "owner": {
-                    "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation — create_bot, delete_bot,\nset_bot_content, subscribe, … — plus the read baseline) so it can\nhire and manage other Bots. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
+                    "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation - create_bot, delete_bot,\nset_bot_content, subscribe, ... - plus the read baseline) so it can\nhire and manage other Bots. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
                     "type": "boolean"
                 },
                 "parent_id": {

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -9717,7 +9717,7 @@
                 "tags": [
                     "HelixOrg"
                 ],
-                "summary": "Helix-org: restart a bot's agent session (recreate desktop container)",
+                "summary": "Helix-org: restart a bot's agent session (fresh session + desktop)",
                 "parameters": [
                     {
                         "type": "string",
@@ -21236,6 +21236,10 @@
                 },
                 "id": {
                     "type": "string"
+                },
+                "owner": {
+                    "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation — create_bot, delete_bot,\nset_bot_content, subscribe, … — plus the read baseline) so it can\nhire and manage other Bots. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
+                    "type": "boolean"
                 },
                 "parent_id": {
                     "type": "string"

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -89,8 +89,8 @@ definitions:
       owner:
         description: |-
           Owner makes this a manager Bot: it receives the canonical owner
-          tool set (every org-graph mutation — create_bot, delete_bot,
-          set_bot_content, subscribe, … — plus the read baseline) so it can
+          tool set (every org-graph mutation - create_bot, delete_bot,
+          set_bot_content, subscribe, ... - plus the read baseline) so it can
           hire and manage other Bots. When true, Tools is ignored in favour
           of that set. Used to seed a starter/root Bot for a new org.
         type: boolean

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -86,6 +86,14 @@ definitions:
         type: string
       id:
         type: string
+      owner:
+        description: |-
+          Owner makes this a manager Bot: it receives the canonical owner
+          tool set (every org-graph mutation — create_bot, delete_bot,
+          set_bot_content, subscribe, … — plus the read baseline) so it can
+          hire and manage other Bots. When true, Tools is ignored in favour
+          of that set. Used to seed a starter/root Bot for a new org.
+        type: boolean
       parent_id:
         type: string
       preserve_context:
@@ -18136,7 +18144,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - ApiKeyAuth: []
-      summary: 'Helix-org: restart a bot''s agent session (recreate desktop container)'
+      summary: 'Helix-org: restart a bot''s agent session (fresh session + desktop)'
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/bots/{id}/subscriptions:

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -67,8 +67,8 @@ export interface ApiCreateBotRequest {
   id?: string;
   /**
    * Owner makes this a manager Bot: it receives the canonical owner
-   * tool set (every org-graph mutation — create_bot, delete_bot,
-   * set_bot_content, subscribe, … — plus the read baseline) so it can
+   * tool set (every org-graph mutation - create_bot, delete_bot,
+   * set_bot_content, subscribe, ... - plus the read baseline) so it can
    * hire and manage other Bots. When true, Tools is ignored in favour
    * of that set. Used to seed a starter/root Bot for a new org.
    */

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -65,6 +65,14 @@ export interface ApiBotSubscriptionsResponse {
 export interface ApiCreateBotRequest {
   content?: string;
   id?: string;
+  /**
+   * Owner makes this a manager Bot: it receives the canonical owner
+   * tool set (every org-graph mutation — create_bot, delete_bot,
+   * set_bot_content, subscribe, … — plus the read baseline) so it can
+   * hire and manage other Bots. When true, Tools is ignored in favour
+   * of that set. Used to seed a starter/root Bot for a new org.
+   */
+  owner?: boolean;
   parent_id?: string;
   preserve_context?: boolean;
   tools?: string[];
@@ -12199,7 +12207,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      *
      * @tags HelixOrg
      * @name V1OrgsBotsRestartAgentCreate
-     * @summary Helix-org: restart a bot's agent session (recreate desktop container)
+     * @summary Helix-org: restart a bot's agent session (fresh session + desktop)
      * @request POST:/api/v1/orgs/{org}/bots/{id}/restart-agent
      * @secure
      */

--- a/frontend/src/components/helix-org/NewBotDialog.tsx
+++ b/frontend/src/components/helix-org/NewBotDialog.tsx
@@ -73,10 +73,10 @@ const NewBotDialog: FC<NewBotDialogProps> = ({ open, onClose, presetParentId }) 
         <Stack spacing={2} sx={{ pt: 1 }}>
           <TextField
             label="Bot ID"
-            placeholder="b-engineer"
+            placeholder="engineer"
             value={id}
             onChange={(e) => setId(e.target.value)}
-            helperText="Convention: b-<kebab-case>. Stays as-is — the LLM and operator both refer to bots by this handle."
+            helperText="A short handle in kebab-case, e.g. engineer. Stays as-is — the LLM and operator both refer to the bot by it."
             autoFocus
             fullWidth
           />

--- a/frontend/src/components/helix-org/NewBotDialog.tsx
+++ b/frontend/src/components/helix-org/NewBotDialog.tsx
@@ -76,7 +76,7 @@ const NewBotDialog: FC<NewBotDialogProps> = ({ open, onClose, presetParentId }) 
             placeholder="engineer"
             value={id}
             onChange={(e) => setId(e.target.value)}
-            helperText="A short handle in kebab-case, e.g. engineer. Stays as-is — the LLM and operator both refer to the bot by it."
+            helperText="A short handle in kebab-case, e.g. engineer. Stays as-is - the LLM and operator both refer to the bot by it."
             autoFocus
             fullWidth
           />

--- a/frontend/src/components/orgs/EditOrgWindow.tsx
+++ b/frontend/src/components/orgs/EditOrgWindow.tsx
@@ -33,7 +33,7 @@ const DEFAULT_BOT_RUNTIME: BotRuntimeValue = {
 // Created with owner=true so it can set up and coordinate other Bots.
 const STARTER_BOT_CONTENT = `# Chief of Staff
 
-You are the Chief of Staff for this organization — the owner's right hand, here to support them and the team. When you first meet the owner, ask what this organization is for and what they want to accomplish. Then set things up: bring in assistant bots for the concrete pieces of work, give each a clear purpose, connect who works with whom, and subscribe them to the topics they need. Coordinate and keep things organized, and delegate the hands-on work to the assistants you bring in rather than doing it all yourself.`
+You are the Chief of Staff for this organization - the owner's right hand, here to support them and the team. When you first meet the owner, ask what this organization is for and what they want to accomplish. Then set things up: bring in assistant bots for the concrete pieces of work, give each a clear purpose, connect who works with whom, and subscribe them to the topics they need. Coordinate and keep things organized, and delegate the hands-on work to the assistants you bring in rather than doing it all yourself.`
 
 const EditOrgWindow: FC<EditOrgWindowProps> = ({
   open,
@@ -166,7 +166,7 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
         }
       }
 
-      // New alpha org → seed a starter manager Bot so the org chart isn't
+      // New alpha org: seed a starter manager Bot so the org chart isn't
       // blank. It gets the owner tool set (can hire + manage other Bots) and
       // inherits the org's default runtime. Best-effort.
       if (!org && helixOrgEnabled && created && created.name) {
@@ -177,7 +177,7 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
             owner: true,
           })
         } catch (e) {
-          snackbar.error('Organization created, but seeding the starter bot failed — add one from the Org Chart.')
+          snackbar.error('Organization created, but seeding the starter bot failed - add one from the Org Chart.')
         }
       }
 

--- a/frontend/src/components/orgs/EditOrgWindow.tsx
+++ b/frontend/src/components/orgs/EditOrgWindow.tsx
@@ -29,11 +29,11 @@ const DEFAULT_BOT_RUNTIME: BotRuntimeValue = {
   model: '',
 }
 
-// Identity for the starter manager Bot seeded into a new org so its chart
-// isn't blank. Created with owner=true so it can hire and manage other Bots.
-const STARTER_BOT_CONTENT = `# Root
+// Identity for the starter Bot seeded into a new org so its chart isn't blank.
+// Created with owner=true so it can set up and coordinate other Bots.
+const STARTER_BOT_CONTENT = `# Chief of Staff
 
-You are this organization's root manager. Hire, prompt, tool, and organize other Bots to get work done: create Bots for concrete responsibilities, set their identity, wire who reports to whom, and subscribe them to the topics they need. Delegate rather than doing everything yourself.`
+You are the Chief of Staff for this organization — the owner's right hand, here to support them and the team. When you first meet the owner, ask what this organization is for and what they want to accomplish. Then set things up: bring in assistant bots for the concrete pieces of work, give each a clear purpose, connect who works with whom, and subscribe them to the topics they need. Coordinate and keep things organized, and delegate the hands-on work to the assistants you bring in rather than doing it all yourself.`
 
 const EditOrgWindow: FC<EditOrgWindowProps> = ({
   open,
@@ -172,7 +172,7 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
       if (!org && helixOrgEnabled && created && created.name) {
         try {
           await api.getApiClient().v1OrgsBotsCreate(created.name, {
-            id: 'b-root',
+            id: 'chief-of-staff',
             content: STARTER_BOT_CONTENT,
             owner: true,
           })

--- a/frontend/src/components/orgs/EditOrgWindow.tsx
+++ b/frontend/src/components/orgs/EditOrgWindow.tsx
@@ -29,6 +29,12 @@ const DEFAULT_BOT_RUNTIME: BotRuntimeValue = {
   model: '',
 }
 
+// Identity for the starter manager Bot seeded into a new org so its chart
+// isn't blank. Created with owner=true so it can hire and manage other Bots.
+const STARTER_BOT_CONTENT = `# Root
+
+You are this organization's root manager. Hire, prompt, tool, and organize other Bots to get work done: create Bots for concrete responsibilities, set their identity, wire who reports to whom, and subscribe them to the topics they need. Delegate rather than doing everything yourself.`
+
 const EditOrgWindow: FC<EditOrgWindowProps> = ({
   open,
   org,
@@ -157,6 +163,21 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
           await persistBotDefaults(created.name)
         } catch (e) {
           snackbar.error('Organization created, but saving the default bot runtime failed — set it in Settings.')
+        }
+      }
+
+      // New alpha org → seed a starter manager Bot so the org chart isn't
+      // blank. It gets the owner tool set (can hire + manage other Bots) and
+      // inherits the org's default runtime. Best-effort.
+      if (!org && helixOrgEnabled && created && created.name) {
+        try {
+          await api.getApiClient().v1OrgsBotsCreate(created.name, {
+            id: 'b-root',
+            content: STARTER_BOT_CONTENT,
+            owner: true,
+          })
+        } catch (e) {
+          snackbar.error('Organization created, but seeding the starter bot failed — add one from the Org Chart.')
         }
       }
 

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -89,8 +89,8 @@ definitions:
       owner:
         description: |-
           Owner makes this a manager Bot: it receives the canonical owner
-          tool set (every org-graph mutation — create_bot, delete_bot,
-          set_bot_content, subscribe, … — plus the read baseline) so it can
+          tool set (every org-graph mutation - create_bot, delete_bot,
+          set_bot_content, subscribe, ... - plus the read baseline) so it can
           hire and manage other Bots. When true, Tools is ignored in favour
           of that set. Used to seed a starter/root Bot for a new org.
         type: boolean

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -86,6 +86,14 @@ definitions:
         type: string
       id:
         type: string
+      owner:
+        description: |-
+          Owner makes this a manager Bot: it receives the canonical owner
+          tool set (every org-graph mutation — create_bot, delete_bot,
+          set_bot_content, subscribe, … — plus the read baseline) so it can
+          hire and manage other Bots. When true, Tools is ignored in favour
+          of that set. Used to seed a starter/root Bot for a new org.
+        type: boolean
       parent_id:
         type: string
       preserve_context:
@@ -18136,7 +18144,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - ApiKeyAuth: []
-      summary: 'Helix-org: restart a bot''s agent session (recreate desktop container)'
+      summary: 'Helix-org: restart a bot''s agent session (fresh session + desktop)'
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/bots/{id}/subscriptions:

--- a/openapi.json
+++ b/openapi.json
@@ -11702,7 +11702,7 @@
                 "tags": [
                     "HelixOrg"
                 ],
-                "summary": "Helix-org: restart a bot's agent session (recreate desktop container)",
+                "summary": "Helix-org: restart a bot's agent session (fresh session + desktop)",
                 "parameters": [
                     {
                         "description": "Bot ID",
@@ -25539,6 +25539,10 @@
                     },
                     "id": {
                         "type": "string"
+                    },
+                    "owner": {
+                        "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation — create_bot, delete_bot,\nset_bot_content, subscribe, … — plus the read baseline) so it can\nhire and manage other Bots. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
+                        "type": "boolean"
                     },
                     "parent_id": {
                         "type": "string"

--- a/openapi.json
+++ b/openapi.json
@@ -25541,7 +25541,7 @@
                         "type": "string"
                     },
                     "owner": {
-                        "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation — create_bot, delete_bot,\nset_bot_content, subscribe, … — plus the read baseline) so it can\nhire and manage other Bots. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
+                        "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation - create_bot, delete_bot,\nset_bot_content, subscribe, ... - plus the read baseline) so it can\nhire and manage other Bots. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
                         "type": "boolean"
                     },
                     "parent_id": {

--- a/swagger.json
+++ b/swagger.json
@@ -21238,7 +21238,7 @@
                     "type": "string"
                 },
                 "owner": {
-                    "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation — create_bot, delete_bot,\nset_bot_content, subscribe, … — plus the read baseline) so it can\nhire and manage other Bots. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
+                    "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation - create_bot, delete_bot,\nset_bot_content, subscribe, ... - plus the read baseline) so it can\nhire and manage other Bots. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
                     "type": "boolean"
                 },
                 "parent_id": {

--- a/swagger.json
+++ b/swagger.json
@@ -9717,7 +9717,7 @@
                 "tags": [
                     "HelixOrg"
                 ],
-                "summary": "Helix-org: restart a bot's agent session (recreate desktop container)",
+                "summary": "Helix-org: restart a bot's agent session (fresh session + desktop)",
                 "parameters": [
                     {
                         "type": "string",
@@ -21236,6 +21236,10 @@
                 },
                 "id": {
                     "type": "string"
+                },
+                "owner": {
+                    "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation — create_bot, delete_bot,\nset_bot_content, subscribe, … — plus the read baseline) so it can\nhire and manage other Bots. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
+                    "type": "boolean"
                 },
                 "parent_id": {
                     "type": "string"


### PR DESCRIPTION
## What

New helix-org organizations get a **Chief of Staff** starter bot so the org chart isn't a blank slate. Follows the Default Bot Runtime work in #2787.

**Starter bot**
- On creating a new alpha org, `EditOrgWindow` seeds a `chief-of-staff` bot (best-effort, alpha-gated) with a support-framed identity: it introduces itself as the owner's right hand, interviews the owner on first contact ("what is this org for, what do you want done?"), then brings in assistant bots and coordinates them. Deliberately avoids "hire/fire/manage a workforce" framing.
- It's created with `owner=true` (see below) so it can set up and coordinate other bots, and it inherits the org's default runtime.

**`owner` flag on create-bot (backend)**
- New optional `owner` field on the create-bot REST request. When true, the handler applies the canonical `mcptools.OwnerBotTools()` set server-side (every org-graph mutation + the read baseline). This keeps the manager-tool policy in Go instead of hardcoding ~11 tool-name strings in the client.
- Regenerated the OpenAPI client for the new field.

**Terminology cleanup**
- Dropped the technical `b-` prefix from the New Bot dialog (placeholder `b-engineer` → `engineer`, and the helper text). The `b-` prefix isn't load-bearing — `FromPrincipal` classifies runtime workers by `w-`, and the backend already accepts arbitrary bot ids verbatim (it only auto-adds `b-` for a blank id).

## Gating / safety
- Everything is behind the `helix-org` alpha flag. Non-alpha users and default (env-off) deployments create orgs exactly as before — no starter bot, no extra calls.
- Starter-bot creation is best-effort: if it fails, the org still exists and the user gets a soft "add one from the Org Chart" notice.

## Not covered
- Topic (`s-`) form fields still show their prefix — only `b-` was in scope.
- Onboarding first-org flow (separate code path) doesn't seed a starter bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)