### PR TITLE
Project VCS connection lozenge & loud push-failure surfacing

### DIFF
--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -9721,7 +9721,7 @@ const docTemplate = `{
                 "tags": [
                     "HelixOrg"
                 ],
-                "summary": "Helix-org: restart a bot's agent session (recreate desktop container)",
+                "summary": "Helix-org: restart a bot's agent session (fresh session + desktop)",
                 "parameters": [
                     {
                         "type": "string",
@@ -12737,6 +12737,71 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{id}/vcs-connections": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "One entry per distinct VCS provider present among the project's external repos, with the acting user, the account pushes are attributed to, and per-repo verified access. Backs the project board connection lozenge.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Projects"
+                ],
+                "summary": "Get project VCS connection status",
+                "operationId": "getProjectVCSConnections",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.VCSConnectionInfo"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/system.HTTPError"
                         }
@@ -31986,6 +32051,42 @@ const docTemplate = `{
                 }
             }
         },
+        "types.PushError": {
+            "type": "object",
+            "properties": {
+                "account": {
+                    "description": "VCS account the push was attempted as, e.g. \"@linuxrecruit\"",
+                    "type": "string"
+                },
+                "cause": {
+                    "description": "translated human-readable cause",
+                    "type": "string"
+                },
+                "failed_at": {
+                    "type": "string"
+                },
+                "next_step": {
+                    "description": "translated actionable next step",
+                    "type": "string"
+                },
+                "provider": {
+                    "description": "e.g. \"github\"",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.ExternalRepositoryType"
+                        }
+                    ]
+                },
+                "raw_message": {
+                    "description": "verbatim provider error",
+                    "type": "string"
+                },
+                "repo": {
+                    "description": "e.g. \"helixml/find-ai\"",
+                    "type": "string"
+                }
+            }
+        },
         "types.PushResponse": {
             "type": "object",
             "properties": {
@@ -34388,6 +34489,14 @@ const docTemplate = `{
                     "description": "Git tracking",
                     "type": "string"
                 },
+                "last_push_error": {
+                    "description": "Structured error from the last external (mirror) push. Set when a user-initiated\npush to the external repo fails and refs are rolled back; cleared (nil) on the\nnext successful push. Surfaced on the board so failures aren't silent.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PushError"
+                        }
+                    ]
+                },
                 "merge_commit_hash": {
                     "description": "Merge commit hash",
                     "type": "string"
@@ -35169,6 +35278,14 @@ const docTemplate = `{
                 "last_push_commit_hash": {
                     "description": "Git tracking",
                     "type": "string"
+                },
+                "last_push_error": {
+                    "description": "Structured error from the last external (mirror) push. Set when a user-initiated\npush to the external repo fails and refs are rolled back; cleared (nil) on the\nnext successful push. Surfaced on the board so failures aren't silent.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PushError"
+                        }
+                    ]
                 },
                 "merge_commit_hash": {
                     "description": "Merge commit hash",
@@ -37176,6 +37293,89 @@ const docTemplate = `{
                 },
                 "user": {
                     "$ref": "#/definitions/types.User"
+                }
+            }
+        },
+        "types.VCSActingUser": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.VCSConnectionInfo": {
+            "type": "object",
+            "properties": {
+                "acting_user": {
+                    "$ref": "#/definitions/types.VCSActingUser"
+                },
+                "missing_scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "provider": {
+                    "$ref": "#/definitions/types.ExternalRepositoryType"
+                },
+                "pushing_as": {
+                    "$ref": "#/definitions/types.VCSPushingAs"
+                },
+                "repos": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.VCSRepoAccess"
+                    }
+                },
+                "state": {
+                    "$ref": "#/definitions/types.VCSConnectionState"
+                }
+            }
+        },
+        "types.VCSConnectionState": {
+            "type": "string",
+            "enum": [
+                "verified",
+                "needs_attention",
+                "disconnected"
+            ],
+            "x-enum-varnames": [
+                "VCSConnectionVerified",
+                "VCSConnectionNeedsAttention",
+                "VCSConnectionDisconnected"
+            ]
+        },
+        "types.VCSPushingAs": {
+            "type": "object",
+            "properties": {
+                "connection_id": {
+                    "description": "OAuthConnection ID (for switch/disconnect)",
+                    "type": "string"
+                },
+                "username": {
+                    "description": "e.g. \"@tonychapman-prog\"",
+                    "type": "string"
+                }
+            }
+        },
+        "types.VCSRepoAccess": {
+            "type": "object",
+            "properties": {
+                "has_access": {
+                    "description": "true if the connection can reach it (or access is unverifiable for this provider)",
+                    "type": "boolean"
+                },
+                "repo": {
+                    "description": "\"owner/repo\"",
+                    "type": "string"
+                },
+                "verified": {
+                    "description": "true if we actually probed the provider (false = optimistic/unverifiable)",
+                    "type": "boolean"
                 }
             }
         },

--- a/api/pkg/server/sample_project_access_handlers.go
+++ b/api/pkg/server/sample_project_access_handlers.go
@@ -253,7 +253,13 @@ func (s *HelixAPIServer) forkSampleProjectRepositories(_ http.ResponseWriter, r 
 	}, nil
 }
 
-// GitHubRepoScopes are the scopes required for GitHub repository operations
+// GitHubRepoScopes is the hard operational MINIMUM validated when *using* an
+// existing connection — only "repo" (clone/push/PR) is strictly required, so we
+// don't reject connections made before the wider scope set was requested.
+// The full set to REQUEST at connect time (repo + read:user + user:email +
+// read:org, for identity and org-access verification) lives in the VCS
+// capability registry (vcs.RequiredScopes); missing identity/org scopes degrade
+// the lozenge gracefully rather than blocking the push.
 var GitHubRepoScopes = []string{"repo"}
 
 // getGitHubAccessToken retrieves a GitHub OAuth access token for the user

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1512,6 +1512,7 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	authRouter.HandleFunc("/projects/{id}", system.Wrapper(apiServer.updateProject)).Methods(http.MethodPut)
 	authRouter.HandleFunc("/projects/{id}", system.Wrapper(apiServer.deleteProject)).Methods(http.MethodDelete)
 	authRouter.HandleFunc("/projects/{id}/repositories", system.Wrapper(apiServer.getProjectRepositories)).Methods(http.MethodGet)
+	authRouter.HandleFunc("/projects/{id}/vcs-connections", system.Wrapper(apiServer.getProjectVCSConnections)).Methods(http.MethodGet)
 	authRouter.HandleFunc("/projects/{id}/goose-recipes", system.Wrapper(apiServer.listProjectGooseRecipes)).Methods(http.MethodGet)
 	authRouter.HandleFunc("/projects/{id}/repositories/{repo_id}/primary", system.Wrapper(apiServer.setProjectPrimaryRepository)).Methods(http.MethodPut)
 	authRouter.HandleFunc("/projects/{id}/repositories/{repo_id}/attach", system.Wrapper(apiServer.attachRepositoryToProject)).Methods(http.MethodPut)

--- a/api/pkg/server/simple_sample_projects.go
+++ b/api/pkg/server/simple_sample_projects.go
@@ -12,6 +12,7 @@ import (
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/types"
+	"github.com/helixml/helix/api/pkg/vcs"
 	"github.com/rs/zerolog/log"
 )
 
@@ -725,10 +726,13 @@ Use these tools to interact with GitHub:
 4. Fix the issues and push again
 `,
 
-		// Require GitHub authentication for push access to make PRs
+		// Require GitHub authentication for push access to make PRs.
 		RequiresGitHubAuth: true,
-		// Scopes needed: repo (for cloning/pushing/PRs), read:user (for identity)
-		RequiredScopes: []string{"repo", "read:user", "user:email"},
+		// Full connect scope set from the VCS capability registry:
+		//   repo (clone/push/PR), read:user + user:email (identity for the
+		//   lozenge), read:org (org repo visibility / access verification).
+		// See design root cause #6: storing only ["repo"] set users up to fail.
+		RequiredScopes: vcs.RequiredScopes(types.ExternalRepositoryTypeGitHub),
 		RequiredGitHubRepos: []RequiredGitHubRepo{
 			{
 				GitHubURL:     "github.com/helixml/helix",

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -9717,7 +9717,7 @@
                 "tags": [
                     "HelixOrg"
                 ],
-                "summary": "Helix-org: restart a bot's agent session (recreate desktop container)",
+                "summary": "Helix-org: restart a bot's agent session (fresh session + desktop)",
                 "parameters": [
                     {
                         "type": "string",
@@ -12733,6 +12733,71 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{id}/vcs-connections": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "One entry per distinct VCS provider present among the project's external repos, with the acting user, the account pushes are attributed to, and per-repo verified access. Backs the project board connection lozenge.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Projects"
+                ],
+                "summary": "Get project VCS connection status",
+                "operationId": "getProjectVCSConnections",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.VCSConnectionInfo"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/system.HTTPError"
                         }
@@ -31982,6 +32047,42 @@
                 }
             }
         },
+        "types.PushError": {
+            "type": "object",
+            "properties": {
+                "account": {
+                    "description": "VCS account the push was attempted as, e.g. \"@linuxrecruit\"",
+                    "type": "string"
+                },
+                "cause": {
+                    "description": "translated human-readable cause",
+                    "type": "string"
+                },
+                "failed_at": {
+                    "type": "string"
+                },
+                "next_step": {
+                    "description": "translated actionable next step",
+                    "type": "string"
+                },
+                "provider": {
+                    "description": "e.g. \"github\"",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.ExternalRepositoryType"
+                        }
+                    ]
+                },
+                "raw_message": {
+                    "description": "verbatim provider error",
+                    "type": "string"
+                },
+                "repo": {
+                    "description": "e.g. \"helixml/find-ai\"",
+                    "type": "string"
+                }
+            }
+        },
         "types.PushResponse": {
             "type": "object",
             "properties": {
@@ -34384,6 +34485,14 @@
                     "description": "Git tracking",
                     "type": "string"
                 },
+                "last_push_error": {
+                    "description": "Structured error from the last external (mirror) push. Set when a user-initiated\npush to the external repo fails and refs are rolled back; cleared (nil) on the\nnext successful push. Surfaced on the board so failures aren't silent.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PushError"
+                        }
+                    ]
+                },
                 "merge_commit_hash": {
                     "description": "Merge commit hash",
                     "type": "string"
@@ -35165,6 +35274,14 @@
                 "last_push_commit_hash": {
                     "description": "Git tracking",
                     "type": "string"
+                },
+                "last_push_error": {
+                    "description": "Structured error from the last external (mirror) push. Set when a user-initiated\npush to the external repo fails and refs are rolled back; cleared (nil) on the\nnext successful push. Surfaced on the board so failures aren't silent.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PushError"
+                        }
+                    ]
                 },
                 "merge_commit_hash": {
                     "description": "Merge commit hash",
@@ -37172,6 +37289,89 @@
                 },
                 "user": {
                     "$ref": "#/definitions/types.User"
+                }
+            }
+        },
+        "types.VCSActingUser": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.VCSConnectionInfo": {
+            "type": "object",
+            "properties": {
+                "acting_user": {
+                    "$ref": "#/definitions/types.VCSActingUser"
+                },
+                "missing_scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "provider": {
+                    "$ref": "#/definitions/types.ExternalRepositoryType"
+                },
+                "pushing_as": {
+                    "$ref": "#/definitions/types.VCSPushingAs"
+                },
+                "repos": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.VCSRepoAccess"
+                    }
+                },
+                "state": {
+                    "$ref": "#/definitions/types.VCSConnectionState"
+                }
+            }
+        },
+        "types.VCSConnectionState": {
+            "type": "string",
+            "enum": [
+                "verified",
+                "needs_attention",
+                "disconnected"
+            ],
+            "x-enum-varnames": [
+                "VCSConnectionVerified",
+                "VCSConnectionNeedsAttention",
+                "VCSConnectionDisconnected"
+            ]
+        },
+        "types.VCSPushingAs": {
+            "type": "object",
+            "properties": {
+                "connection_id": {
+                    "description": "OAuthConnection ID (for switch/disconnect)",
+                    "type": "string"
+                },
+                "username": {
+                    "description": "e.g. \"@tonychapman-prog\"",
+                    "type": "string"
+                }
+            }
+        },
+        "types.VCSRepoAccess": {
+            "type": "object",
+            "properties": {
+                "has_access": {
+                    "description": "true if the connection can reach it (or access is unverifiable for this provider)",
+                    "type": "boolean"
+                },
+                "repo": {
+                    "description": "\"owner/repo\"",
+                    "type": "string"
+                },
+                "verified": {
+                    "description": "true if we actually probed the provider (false = optimistic/unverifiable)",
+                    "type": "boolean"
                 }
             }
         },

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -7761,6 +7761,30 @@ definitions:
       success:
         type: boolean
     type: object
+  types.PushError:
+    properties:
+      account:
+        description: VCS account the push was attempted as, e.g. "@linuxrecruit"
+        type: string
+      cause:
+        description: translated human-readable cause
+        type: string
+      failed_at:
+        type: string
+      next_step:
+        description: translated actionable next step
+        type: string
+      provider:
+        allOf:
+        - $ref: '#/definitions/types.ExternalRepositoryType'
+        description: e.g. "github"
+      raw_message:
+        description: verbatim provider error
+        type: string
+      repo:
+        description: e.g. "helixml/find-ai"
+        type: string
+    type: object
   types.PushResponse:
     properties:
       branch:
@@ -9608,6 +9632,13 @@ definitions:
       last_push_commit_hash:
         description: Git tracking
         type: string
+      last_push_error:
+        allOf:
+        - $ref: '#/definitions/types.PushError'
+        description: |-
+          Structured error from the last external (mirror) push. Set when a user-initiated
+          push to the external repo fails and refs are rolled back; cleared (nil) on the
+          next successful push. Surfaced on the board so failures aren't silent.
       merge_commit_hash:
         description: Merge commit hash
         type: string
@@ -10198,6 +10229,13 @@ definitions:
       last_push_commit_hash:
         description: Git tracking
         type: string
+      last_push_error:
+        allOf:
+        - $ref: '#/definitions/types.PushError'
+        description: |-
+          Structured error from the last external (mirror) push. Set when a user-initiated
+          push to the external repo fails and refs are rolled back; cleared (nil) on the
+          next successful push. Surfaced on the board so failures aren't silent.
       merge_commit_hash:
         description: Merge commit hash
         type: string
@@ -11624,6 +11662,64 @@ definitions:
         type: array
       user:
         $ref: '#/definitions/types.User'
+    type: object
+  types.VCSActingUser:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  types.VCSConnectionInfo:
+    properties:
+      acting_user:
+        $ref: '#/definitions/types.VCSActingUser'
+      missing_scopes:
+        items:
+          type: string
+        type: array
+      provider:
+        $ref: '#/definitions/types.ExternalRepositoryType'
+      pushing_as:
+        $ref: '#/definitions/types.VCSPushingAs'
+      repos:
+        items:
+          $ref: '#/definitions/types.VCSRepoAccess'
+        type: array
+      state:
+        $ref: '#/definitions/types.VCSConnectionState'
+    type: object
+  types.VCSConnectionState:
+    enum:
+    - verified
+    - needs_attention
+    - disconnected
+    type: string
+    x-enum-varnames:
+    - VCSConnectionVerified
+    - VCSConnectionNeedsAttention
+    - VCSConnectionDisconnected
+  types.VCSPushingAs:
+    properties:
+      connection_id:
+        description: OAuthConnection ID (for switch/disconnect)
+        type: string
+      username:
+        description: e.g. "@tonychapman-prog"
+        type: string
+    type: object
+  types.VCSRepoAccess:
+    properties:
+      has_access:
+        description: true if the connection can reach it (or access is unverifiable
+          for this provider)
+        type: boolean
+      repo:
+        description: '"owner/repo"'
+        type: string
+      verified:
+        description: true if we actually probed the provider (false = optimistic/unverifiable)
+        type: boolean
     type: object
   types.VHostRoute:
     properties:
@@ -18136,7 +18232,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - ApiKeyAuth: []
-      summary: 'Helix-org: restart a bot''s agent session (recreate desktop container)'
+      summary: 'Helix-org: restart a bot''s agent session (fresh session + desktop)'
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/bots/{id}/subscriptions:
@@ -19983,6 +20079,50 @@ paths:
       security:
       - BearerAuth: []
       summary: Get project token usage
+      tags:
+      - Projects
+  /api/v1/projects/{id}/vcs-connections:
+    get:
+      consumes:
+      - application/json
+      description: One entry per distinct VCS provider present among the project's
+        external repos, with the acting user, the account pushes are attributed to,
+        and per-repo verified access. Backs the project board connection lozenge.
+      operationId: getProjectVCSConnections
+      parameters:
+      - description: Project ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.VCSConnectionInfo'
+            type: array
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get project VCS connection status
       tags:
       - Projects
   /api/v1/projects/{id}/web-service:

--- a/api/pkg/server/vcs_connection_handlers.go
+++ b/api/pkg/server/vcs_connection_handlers.go
@@ -1,0 +1,166 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/helixml/helix/api/pkg/services"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/helixml/helix/api/pkg/vcs"
+	"github.com/rs/zerolog/log"
+)
+
+// getProjectVCSConnections godoc
+// @Summary Get project VCS connection status
+// @Description One entry per distinct VCS provider present among the project's external repos, with the acting user, the account pushes are attributed to, and per-repo verified access. Backs the project board connection lozenge.
+// @Tags Projects
+// @ID getProjectVCSConnections
+// @Accept json
+// @Produce json
+// @Param id path string true "Project ID"
+// @Success 200 {array} types.VCSConnectionInfo
+// @Failure 401 {object} system.HTTPError
+// @Failure 403 {object} system.HTTPError
+// @Failure 404 {object} system.HTTPError
+// @Failure 500 {object} system.HTTPError
+// @Security BearerAuth
+// @Router /api/v1/projects/{id}/vcs-connections [get]
+func (s *HelixAPIServer) getProjectVCSConnections(_ http.ResponseWriter, r *http.Request) ([]types.VCSConnectionInfo, *system.HTTPError) {
+	user := getRequestUser(r)
+	projectID := getID(r)
+
+	project, err := s.Store.GetProject(r.Context(), projectID)
+	if err != nil {
+		return nil, system.NewHTTPError404("project not found")
+	}
+	if err := s.authorizeUserToProject(r.Context(), user, project, types.ActionGet); err != nil {
+		return nil, system.NewHTTPError403(err.Error())
+	}
+
+	repos, err := s.Store.ListGitRepositories(r.Context(), &types.ListGitRepositoriesRequest{ProjectID: projectID})
+	if err != nil {
+		return nil, system.NewHTTPError500(err.Error())
+	}
+
+	// Presence axis: one lozenge per distinct provider present among the
+	// project's external repos. Local-only repos contribute nothing.
+	reposByProvider := map[types.ExternalRepositoryType][]*types.GitRepository{}
+	order := []types.ExternalRepositoryType{}
+	for _, repo := range repos {
+		if !repo.IsExternal || repo.ExternalType == "" {
+			continue
+		}
+		if _, seen := reposByProvider[repo.ExternalType]; !seen {
+			order = append(order, repo.ExternalType)
+		}
+		reposByProvider[repo.ExternalType] = append(reposByProvider[repo.ExternalType], repo)
+	}
+
+	conns, err := s.Store.ListOAuthConnections(r.Context(), &store.ListOAuthConnectionsQuery{UserID: user.ID})
+	if err != nil {
+		return nil, system.NewHTTPError500(err.Error())
+	}
+
+	acting := types.VCSActingUser{ID: user.ID, Name: userDisplayName(user)}
+
+	result := []types.VCSConnectionInfo{}
+	for _, providerType := range order {
+		info := types.VCSConnectionInfo{
+			Provider:      providerType,
+			ActingUser:    acting,
+			Repos:         []types.VCSRepoAccess{},
+			MissingScopes: []string{},
+		}
+
+		conn := findConnectionForProvider(conns, providerType)
+		if conn == nil {
+			info.State = types.VCSConnectionDisconnected
+			result = append(result, info)
+			continue
+		}
+
+		info.PushingAs = &types.VCSPushingAs{
+			Username:     vcs.IdentityHandle(conn),
+			ConnectionID: conn.ID,
+		}
+		info.MissingScopes = getMissingScopes(conn.Scopes, vcs.RequiredScopes(providerType))
+
+		// State axis: verified unless a repo probe definitively reports no access.
+		allAccessible := true
+		for _, repo := range reposByProvider[providerType] {
+			ownerRepo := services.RepoOwnerName(repo)
+			hasAccess, verified := s.verifyVCSRepoAccess(r.Context(), conn, providerType, ownerRepo)
+			if verified && !hasAccess {
+				allAccessible = false
+			}
+			info.Repos = append(info.Repos, types.VCSRepoAccess{
+				Repo:      ownerRepo,
+				HasAccess: hasAccess,
+				Verified:  verified,
+			})
+		}
+
+		if allAccessible {
+			info.State = types.VCSConnectionVerified
+		} else {
+			info.State = types.VCSConnectionNeedsAttention
+		}
+		result = append(result, info)
+	}
+
+	return result, nil
+}
+
+// verifyVCSRepoAccess probes the provider to check the connection can reach
+// owner/repo. Returns (hasAccess, verified). verified=false means we couldn't
+// definitively check (no probe for the provider, or the request couldn't be made)
+// — in that case hasAccess is reported optimistically as true so we don't false-
+// alarm. Only a real non-2xx response (e.g. GitHub's misleading 404 for a private
+// repo the account can't see) marks the repo inaccessible.
+func (s *HelixAPIServer) verifyVCSRepoAccess(ctx context.Context, conn *types.OAuthConnection, externalType types.ExternalRepositoryType, ownerRepo string) (hasAccess, verified bool) {
+	parts := strings.SplitN(ownerRepo, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return true, false
+	}
+	probeURL := vcs.AccessProbeURL(externalType, parts[0], parts[1])
+	if probeURL == "" {
+		return true, false // no probe for this provider — can't disprove access
+	}
+	provider, err := s.oauthManager.GetProvider(conn.ProviderID)
+	if err != nil {
+		log.Warn().Err(err).Str("connection_id", conn.ID).Msg("VCS verify: could not load provider")
+		return true, false
+	}
+	resp, err := provider.MakeAuthorizedRequest(ctx, conn, http.MethodGet, probeURL, nil)
+	if err != nil {
+		log.Warn().Err(err).Str("repo", ownerRepo).Msg("VCS verify: probe request failed (unverifiable)")
+		return true, false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300, true
+}
+
+// findConnectionForProvider returns the acting user's connection for a repo
+// provider type, mirroring the acting-user-first credential resolution.
+func findConnectionForProvider(conns []*types.OAuthConnection, externalType types.ExternalRepositoryType) *types.OAuthConnection {
+	want := services.OAuthProviderTypeForRepo(externalType)
+	for _, conn := range conns {
+		if conn.Provider.Type == want && conn.AccessToken != "" {
+			return conn
+		}
+	}
+	return nil
+}
+
+func userDisplayName(u *types.User) string {
+	if u.FullName != "" {
+		return u.FullName
+	}
+	if u.Username != "" {
+		return u.Username
+	}
+	return u.Email
+}

--- a/api/pkg/services/git_http_server.go
+++ b/api/pkg/services/git_http_server.go
@@ -652,9 +652,11 @@ func (s *GitHTTPServer) handleReceivePack(w http.ResponseWriter, r *http.Request
 		// Using the latest actor available means agent-initiated pushes at
 		// any phase carry a real user identity rather than anonymous creds.
 		var pushUserID string
+		var pushTaskID string
 		if restriction != nil && restriction.IsAgentKey {
 			rawKey := s.extractRawAPIKey(apiKey)
 			if keyRecord, err := s.store.GetAPIKey(context.Background(), &types.ApiKey{Key: rawKey}); err == nil && keyRecord.SpecTaskID != "" {
+				pushTaskID = keyRecord.SpecTaskID
 				if pushTask, err := s.store.GetSpecTask(context.Background(), keyRecord.SpecTaskID); err == nil {
 					pushUserID = pushTask.ImplementationApprovedBy
 					if pushUserID == "" {
@@ -668,6 +670,7 @@ func (s *GitHTTPServer) handleReceivePack(w http.ResponseWriter, r *http.Request
 		}
 
 		upstreamPushFailed := false
+		var pushErr error
 		for branch, isForce := range pushedBranchesMap {
 			// Create per-branch timeout so later branches don't get starved
 			branchCtx, branchCancel := context.WithTimeout(context.Background(), 90*time.Second)
@@ -679,6 +682,7 @@ func (s *GitHTTPServer) handleReceivePack(w http.ResponseWriter, r *http.Request
 			if err != nil {
 				log.Error().Err(err).Str("repo_id", repoID).Str("branch", branch).Bool("force", isForce).Msg("Failed to push branch to upstream - rolling back")
 				upstreamPushFailed = true
+				pushErr = err
 				break
 			}
 			log.Info().Str("repo_id", repoID).Str("branch", branch).Bool("force", isForce).Msg("Successfully pushed branch to upstream")
@@ -687,8 +691,14 @@ func (s *GitHTTPServer) handleReceivePack(w http.ResponseWriter, r *http.Request
 		if upstreamPushFailed {
 			log.Warn().Str("repo_id", repoID).Msg("Rolling back refs due to upstream push failure")
 			s.rollbackBranchRefs(repoPath, branchesBefore, pushedBranches)
+			// Persist a structured error on the task so the failure is surfaced
+			// instead of silently rolled back after the client already got 200.
+			s.recordPushError(context.Background(), pushTaskID, repo, pushUserID, pushErr)
 			return
 		}
+
+		// External push succeeded — clear any stale push error on the task.
+		s.clearPushError(context.Background(), pushTaskID)
 	}
 
 	// Trigger post-push hooks asynchronously
@@ -801,6 +811,47 @@ func (s *GitHTTPServer) rollbackBranchRefs(repoPath string, previousHashes map[s
 				log.Info().Str("branch", branch).Msg("Removed newly created branch ref")
 			}
 		}
+	}
+}
+
+// recordPushError persists a structured PushError on the spec task after a
+// user-initiated external push failed and its refs were rolled back. This is the
+// signal the board/agent reads instead of silently reporting success. Best-effort:
+// logs and returns on any error rather than failing the (already-completed) push.
+func (s *GitHTTPServer) recordPushError(ctx context.Context, taskID string, repo *types.GitRepository, actingUserID string, pushErr error) {
+	if taskID == "" || repo == nil {
+		return
+	}
+	task, err := s.store.GetSpecTask(ctx, taskID)
+	if err != nil {
+		log.Error().Err(err).Str("task_id", taskID).Msg("Could not load spec task to record push error")
+		return
+	}
+	rawMsg := ""
+	if pushErr != nil {
+		rawMsg = pushErr.Error()
+	}
+	account := s.gitRepoService.GetActingAccountHandle(ctx, repo, actingUserID)
+	task.LastPushError = types.NewPushError(repo.ExternalType, account, RepoOwnerName(repo), rawMsg, time.Now())
+	if err := s.store.UpdateSpecTask(ctx, task); err != nil {
+		log.Error().Err(err).Str("task_id", taskID).Msg("Failed to persist push error on spec task")
+		return
+	}
+	log.Warn().Str("task_id", taskID).Str("account", account).Str("repo", RepoOwnerName(repo)).Msg("Recorded external push failure on spec task")
+}
+
+// clearPushError removes a stale PushError from the task after a successful push.
+func (s *GitHTTPServer) clearPushError(ctx context.Context, taskID string) {
+	if taskID == "" {
+		return
+	}
+	task, err := s.store.GetSpecTask(ctx, taskID)
+	if err != nil || task.LastPushError == nil {
+		return
+	}
+	task.LastPushError = nil
+	if err := s.store.UpdateSpecTask(ctx, task); err != nil {
+		log.Error().Err(err).Str("task_id", taskID).Msg("Failed to clear push error on spec task")
 	}
 }
 

--- a/api/pkg/services/git_repository_service.go
+++ b/api/pkg/services/git_repository_service.go
@@ -2737,6 +2737,62 @@ func GetPullRequestURL(repo *types.GitRepository, pullRequestID string) string {
 	return ""
 }
 
+// OAuthProviderTypeForRepo maps a repo's external type to its OAuth provider type.
+func OAuthProviderTypeForRepo(t types.ExternalRepositoryType) types.OAuthProviderType {
+	switch t {
+	case types.ExternalRepositoryTypeGitHub:
+		return types.OAuthProviderTypeGitHub
+	case types.ExternalRepositoryTypeGitLab:
+		return types.OAuthProviderTypeGitLab
+	case types.ExternalRepositoryTypeADO:
+		return types.OAuthProviderTypeAzureDevOps
+	default:
+		return types.OAuthProviderTypeUnknown
+	}
+}
+
+// RepoOwnerName returns the "owner/repo" slug parsed from a repo's external URL,
+// or "" if it can't be parsed.
+func RepoOwnerName(repo *types.GitRepository) string {
+	if repo == nil || repo.ExternalURL == "" {
+		return ""
+	}
+	parsed, err := url.Parse(stripCredentialsFromURL(repo.ExternalURL))
+	if err != nil {
+		return ""
+	}
+	p := strings.Trim(strings.TrimSuffix(parsed.Path, ".git"), "/")
+	parts := strings.Split(p, "/")
+	if len(parts) < 2 {
+		return p
+	}
+	return strings.Join(parts[len(parts)-2:], "/")
+}
+
+// GetActingAccountHandle returns the VCS account handle (e.g. "@login") that a
+// user-initiated push would be attributed to for this repo, mirroring the
+// acting-user-first credential resolution in getCredentialsForRepo. Best-effort:
+// returns "" if it can't be resolved. Used to label push-failure messages.
+func (s *GitRepositoryService) GetActingAccountHandle(ctx context.Context, gitRepo *types.GitRepository, actingUserID string) string {
+	providerType := OAuthProviderTypeForRepo(gitRepo.ExternalType)
+	if actingUserID != "" {
+		conns, err := s.store.ListOAuthConnections(ctx, &store.ListOAuthConnectionsQuery{UserID: actingUserID})
+		if err == nil {
+			for _, conn := range conns {
+				if conn.Provider.Type == providerType && conn.ProviderUsername != "" {
+					return "@" + conn.ProviderUsername
+				}
+			}
+		}
+	}
+	if gitRepo.OAuthConnectionID != "" {
+		if conn, err := s.store.GetOAuthConnection(ctx, gitRepo.OAuthConnectionID); err == nil && conn.ProviderUsername != "" {
+			return "@" + conn.ProviderUsername
+		}
+	}
+	return ""
+}
+
 // stripCredentialsFromURL removes username:password@ or username@ from a URL
 func stripCredentialsFromURL(rawURL string) string {
 	parsed, err := url.Parse(rawURL)

--- a/api/pkg/types/push_error_test.go
+++ b/api/pkg/types/push_error_test.go
@@ -1,0 +1,73 @@
+package types
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewPushError(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name        string
+		raw         string
+		account     string
+		repo        string
+		wantCauseIn string // substring expected in Cause
+		wantNextIn  string // substring expected in NextStep
+	}{
+		{
+			name:        "github private repo 404",
+			raw:         "remote: Repository not found.\nfatal: repository 'https://github.com/helixml/find-ai.git/' not found",
+			account:     "@linuxrecruit",
+			repo:        "helixml/find-ai",
+			wantCauseIn: "@linuxrecruit can't access helixml/find-ai",
+			wantNextIn:  "Switch to a VCS account",
+		},
+		{
+			name:        "forbidden",
+			raw:         "remote: Permission to helixml/find-ai.git denied (403)",
+			account:     "@bob",
+			repo:        "helixml/find-ai",
+			wantCauseIn: "doesn't have write permission",
+			wantNextIn:  "write access",
+		},
+		{
+			name:        "auth failure",
+			raw:         "fatal: Authentication failed for 'https://github.com/x/y.git'",
+			account:     "@bob",
+			repo:        "x/y",
+			wantCauseIn: "Authentication failed",
+			wantNextIn:  "Reconnect",
+		},
+		{
+			name:        "unknown error, empty account",
+			raw:         "fatal: some other error",
+			account:     "",
+			repo:        "x/y",
+			wantCauseIn: "your connected account",
+			wantNextIn:  "switch accounts",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pe := NewPushError(ExternalRepositoryTypeGitHub, tc.account, tc.repo, tc.raw, now)
+			if pe.Provider != ExternalRepositoryTypeGitHub {
+				t.Errorf("provider = %q, want github", pe.Provider)
+			}
+			if pe.RawMessage != tc.raw {
+				t.Errorf("raw message not preserved verbatim")
+			}
+			if !pe.FailedAt.Equal(now) {
+				t.Errorf("FailedAt = %v, want %v", pe.FailedAt, now)
+			}
+			if !strings.Contains(pe.Cause, tc.wantCauseIn) {
+				t.Errorf("Cause = %q, want substring %q", pe.Cause, tc.wantCauseIn)
+			}
+			if !strings.Contains(pe.NextStep, tc.wantNextIn) {
+				t.Errorf("NextStep = %q, want substring %q", pe.NextStep, tc.wantNextIn)
+			}
+		})
+	}
+}

--- a/api/pkg/types/simple_spec_task.go
+++ b/api/pkg/types/simple_spec_task.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"gorm.io/datatypes"
@@ -199,6 +201,11 @@ type SpecTask struct {
 	MergedAt           *time.Time `json:"merged_at,omitempty"`                 // When merge happened
 	MergeCommitHash    string     `json:"merge_commit_hash,omitempty"`         // Merge commit hash
 
+	// Structured error from the last external (mirror) push. Set when a user-initiated
+	// push to the external repo fails and refs are rolled back; cleared (nil) on the
+	// next successful push. Surfaced on the board so failures aren't silent.
+	LastPushError *PushError `json:"last_push_error,omitempty" gorm:"type:jsonb;serializer:json"`
+
 	// Simple tracking
 	EstimatedHours    int        `json:"estimated_hours,omitempty"`
 	PlanningStartedBy string     `json:"planning_started_by,omitempty"` // User who kicked off planning (may differ from CreatedBy)
@@ -243,6 +250,59 @@ type SpecTask struct {
 	ZedThreads   []SpecTaskZedThread   `json:"zed_threads,omitempty" gorm:"foreignKey:SpecTaskID" swaggerignore:"true"`
 
 	PlanningOptions StartPlanningOptions `json:"planning_options,omitempty" gorm:"type:jsonb;serializer:json"`
+}
+
+// PushError captures a failed external (mirror) push so the failure is queryable
+// and shown on the task instead of being silently rolled back after the git
+// client already received its 200. Cleared (set to nil) on the next successful push.
+type PushError struct {
+	Provider   ExternalRepositoryType `json:"provider"`    // e.g. "github"
+	Account    string                 `json:"account"`     // VCS account the push was attempted as, e.g. "@linuxrecruit"
+	Repo       string                 `json:"repo"`        // e.g. "helixml/find-ai"
+	RawMessage string                 `json:"raw_message"` // verbatim provider error
+	Cause      string                 `json:"cause"`       // translated human-readable cause
+	NextStep   string                 `json:"next_step"`   // translated actionable next step
+	FailedAt   time.Time              `json:"failed_at"`
+}
+
+// NewPushError builds a PushError, translating the raw provider message into a
+// human-readable cause and next step. The motivating footgun: GitHub returns
+// "404 Repository not found" (not 403) for a private repo the token can't see,
+// which reads as "the repo doesn't exist" when the real cause is that the
+// connected account can't access it. We translate that into an actionable
+// switch-account prompt. Kept generic across providers via simple message matching.
+func NewPushError(provider ExternalRepositoryType, account, repo, rawMessage string, failedAt time.Time) *PushError {
+	pe := &PushError{
+		Provider:   provider,
+		Account:    account,
+		Repo:       repo,
+		RawMessage: rawMessage,
+		FailedAt:   failedAt,
+	}
+	acct := account
+	if acct == "" {
+		acct = "your connected account"
+	}
+	repoName := repo
+	if repoName == "" {
+		repoName = "the repository"
+	}
+	lower := strings.ToLower(rawMessage)
+	switch {
+	case strings.Contains(lower, "not found") || strings.Contains(lower, "404"):
+		pe.Cause = fmt.Sprintf("%s can't access %s. If the repo is private, this account isn't a member.", acct, repoName)
+		pe.NextStep = "Switch to a VCS account that has access to this repo, then retry."
+	case strings.Contains(lower, "forbidden") || strings.Contains(lower, "403") || strings.Contains(lower, "permission"):
+		pe.Cause = fmt.Sprintf("%s doesn't have write permission to %s.", acct, repoName)
+		pe.NextStep = "Switch to an account with write access, or ask an admin to grant it."
+	case strings.Contains(lower, "authentication") || strings.Contains(lower, "401") || strings.Contains(lower, "credentials"):
+		pe.Cause = fmt.Sprintf("Authentication failed for %s.", acct)
+		pe.NextStep = "Reconnect the VCS account, then retry."
+	default:
+		pe.Cause = fmt.Sprintf("Push to %s as %s failed.", repoName, acct)
+		pe.NextStep = "Check the account has access to the repo, or switch accounts, then retry."
+	}
+	return pe
 }
 
 // SampleSpecProject - simplified sample projects with proper spec-driven tasks

--- a/api/pkg/types/vcs_connection.go
+++ b/api/pkg/types/vcs_connection.go
@@ -1,0 +1,45 @@
+package types
+
+// VCSConnectionState is the per-provider lozenge state on the project board.
+type VCSConnectionState string
+
+const (
+	// VCSConnectionVerified — connected and the account can reach the project's repos.
+	VCSConnectionVerified VCSConnectionState = "verified"
+	// VCSConnectionNeedsAttention — connected but the account can't reach a repo
+	// (or is missing scopes). The lozenge prompts to switch/grant.
+	VCSConnectionNeedsAttention VCSConnectionState = "needs_attention"
+	// VCSConnectionDisconnected — no connection for this provider yet.
+	VCSConnectionDisconnected VCSConnectionState = "disconnected"
+)
+
+// VCSActingUser is the Helix user the board is rendered for (who you're acting as).
+type VCSActingUser struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// VCSPushingAs is the VCS account a user-initiated push would be attributed to.
+type VCSPushingAs struct {
+	Username     string `json:"username"`      // e.g. "@tonychapman-prog"
+	ConnectionID string `json:"connection_id"` // OAuthConnection ID (for switch/disconnect)
+}
+
+// VCSRepoAccess is the verified-access result for one of the project's repos.
+type VCSRepoAccess struct {
+	Repo      string `json:"repo"`       // "owner/repo"
+	HasAccess bool   `json:"has_access"` // true if the connection can reach it (or access is unverifiable for this provider)
+	Verified  bool   `json:"verified"`   // true if we actually probed the provider (false = optimistic/unverifiable)
+}
+
+// VCSConnectionInfo is one lozenge: a distinct VCS provider present among the
+// project's external repos, with the acting user, the account pushes go as, and
+// per-repo verified access. One entry is returned per provider the project uses.
+type VCSConnectionInfo struct {
+	Provider      ExternalRepositoryType `json:"provider"`
+	State         VCSConnectionState     `json:"state"`
+	ActingUser    VCSActingUser          `json:"acting_user"`
+	PushingAs     *VCSPushingAs          `json:"pushing_as,omitempty"`
+	Repos         []VCSRepoAccess        `json:"repos"`
+	MissingScopes []string               `json:"missing_scopes"`
+}

--- a/api/pkg/vcs/capability.go
+++ b/api/pkg/vcs/capability.go
@@ -1,0 +1,98 @@
+// Package vcs holds the generic, provider-agnostic capability registry used by
+// the project VCS connection lozenge and the push/verify paths. Everything
+// provider-specific (auth mechanism, required OAuth scopes, identity handle,
+// access-verify probe shape) lives in a per-provider Capability entry keyed by
+// types.ExternalRepositoryType. Adding a provider = adding an entry here; the
+// shared board component and push logic stay generic.
+package vcs
+
+import (
+	"fmt"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// Capability is the provider-specific metadata the generic lozenge/verify code
+// needs. Keep it declarative — behavior lives in the generic layer.
+type Capability struct {
+	// Type is the repo external type this entry describes.
+	Type types.ExternalRepositoryType
+	// Provider is the matching OAuth provider type (for connection lookups).
+	Provider types.OAuthProviderType
+	// AuthMechanism is the git credential username used with the OAuth token
+	// (e.g. "x-access-token" for GitHub, "oauth2" for GitLab).
+	AuthMechanism string
+	// RequiredScopes is the full scope set to REQUEST at connect time so the
+	// lozenge can display identity and verify access. Broader than the minimum
+	// needed to merely push — see design root cause #6.
+	RequiredScopes []string
+	// AccessProbePath is a printf-style template for the provider API path used
+	// to verify a connection can reach a repo, given "owner/repo" split. Used by
+	// the verify probe in the service layer via oauth.Provider.MakeAuthorizedRequest.
+	AccessProbePath string
+}
+
+// capabilities is the registry. GitHub is fully specified; the others carry
+// their scope/auth metadata so they render and verify without shared-code edits.
+var capabilities = map[types.ExternalRepositoryType]Capability{
+	types.ExternalRepositoryTypeGitHub: {
+		Type:            types.ExternalRepositoryTypeGitHub,
+		Provider:        types.OAuthProviderTypeGitHub,
+		AuthMechanism:   "x-access-token",
+		RequiredScopes:  []string{"repo", "read:user", "user:email", "read:org"},
+		AccessProbePath: "https://api.github.com/repos/%s/%s",
+	},
+	types.ExternalRepositoryTypeGitLab: {
+		Type:            types.ExternalRepositoryTypeGitLab,
+		Provider:        types.OAuthProviderTypeGitLab,
+		AuthMechanism:   "oauth2",
+		RequiredScopes:  []string{"api", "read_repository", "write_repository"},
+		AccessProbePath: "https://gitlab.com/api/v4/projects/%s%%2F%s",
+	},
+	types.ExternalRepositoryTypeADO: {
+		Type:           types.ExternalRepositoryTypeADO,
+		Provider:       types.OAuthProviderTypeAzureDevOps,
+		AuthMechanism:  "oauth2",
+		RequiredScopes: []string{"vso.code_write"},
+	},
+	types.ExternalRepositoryTypeBitbucket: {
+		Type:           types.ExternalRepositoryTypeBitbucket,
+		Provider:       types.OAuthProviderTypeUnknown,
+		AuthMechanism:  "",
+		RequiredScopes: []string{"repository", "repository:write"},
+	},
+}
+
+// For returns the capability entry for a repo external type.
+func For(t types.ExternalRepositoryType) (Capability, bool) {
+	c, ok := capabilities[t]
+	return c, ok
+}
+
+// RequiredScopes returns the full connect scope set for a provider, or nil if
+// the provider is unknown.
+func RequiredScopes(t types.ExternalRepositoryType) []string {
+	if c, ok := capabilities[t]; ok {
+		return c.RequiredScopes
+	}
+	return nil
+}
+
+// IdentityHandle returns the display handle for a connection (e.g. "@login"),
+// or "" if the connection has no username.
+func IdentityHandle(conn *types.OAuthConnection) string {
+	if conn == nil || conn.ProviderUsername == "" {
+		return ""
+	}
+	return "@" + conn.ProviderUsername
+}
+
+// AccessProbeURL builds the provider API URL to verify access to owner/repo,
+// or "" if the provider has no probe defined.
+func AccessProbeURL(t types.ExternalRepositoryType, owner, repo string) string {
+	c, ok := capabilities[t]
+	if !ok || c.AccessProbePath == "" {
+		return ""
+	}
+	return fmt.Sprintf(c.AccessProbePath, owner, repo)
+}

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -4835,6 +4835,22 @@ export interface TypesPullResponse {
   success?: boolean;
 }
 
+export interface TypesPushError {
+  /** VCS account the push was attempted as, e.g. "@linuxrecruit" */
+  account?: string;
+  /** translated human-readable cause */
+  cause?: string;
+  failed_at?: string;
+  /** translated actionable next step */
+  next_step?: string;
+  /** e.g. "github" */
+  provider?: TypesExternalRepositoryType;
+  /** verbatim provider error */
+  raw_message?: string;
+  /** e.g. "helixml/find-ai" */
+  repo?: string;
+}
+
 export interface TypesPushResponse {
   branch?: string;
   message?: string;
@@ -6021,6 +6037,12 @@ export interface TypesSpecTask {
   last_push_at?: string;
   /** Git tracking */
   last_push_commit_hash?: string;
+  /**
+   * Structured error from the last external (mirror) push. Set when a user-initiated
+   * push to the external repo fails and refs are rolled back; cleared (nil) on the
+   * next successful push. Surfaced on the board so failures aren't silent.
+   */
+  last_push_error?: TypesPushError;
   /** Merge commit hash */
   merge_commit_hash?: string;
   /** When merge happened */
@@ -6357,6 +6379,12 @@ export interface TypesSpecTaskWithProject {
   last_push_at?: string;
   /** Git tracking */
   last_push_commit_hash?: string;
+  /**
+   * Structured error from the last external (mirror) push. Set when a user-initiated
+   * push to the external repo fails and refs are rolled back; cleared (nil) on the
+   * next successful push. Surfaced on the board so failures aren't silent.
+   */
+  last_push_error?: TypesPushError;
   /** Merge commit hash */
   merge_commit_hash?: string;
   /** When merge happened */
@@ -7228,6 +7256,42 @@ export interface TypesUserTokenUsageResponse {
 export interface TypesUsersAggregatedUsageMetric {
   metrics?: TypesAggregatedUsageMetric[];
   user?: TypesUser;
+}
+
+export interface TypesVCSActingUser {
+  id?: string;
+  name?: string;
+}
+
+export interface TypesVCSConnectionInfo {
+  acting_user?: TypesVCSActingUser;
+  missing_scopes?: string[];
+  provider?: TypesExternalRepositoryType;
+  pushing_as?: TypesVCSPushingAs;
+  repos?: TypesVCSRepoAccess[];
+  state?: TypesVCSConnectionState;
+}
+
+export enum TypesVCSConnectionState {
+  VCSConnectionVerified = "verified",
+  VCSConnectionNeedsAttention = "needs_attention",
+  VCSConnectionDisconnected = "disconnected",
+}
+
+export interface TypesVCSPushingAs {
+  /** OAuthConnection ID (for switch/disconnect) */
+  connection_id?: string;
+  /** e.g. "@tonychapman-prog" */
+  username?: string;
+}
+
+export interface TypesVCSRepoAccess {
+  /** true if the connection can reach it (or access is unverifiable for this provider) */
+  has_access?: boolean;
+  /** "owner/repo" */
+  repo?: string;
+  /** true if we actually probed the provider (false = optimistic/unverifiable) */
+  verified?: boolean;
 }
 
 export interface TypesVHostRoute {
@@ -12199,7 +12263,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      *
      * @tags HelixOrg
      * @name V1OrgsBotsRestartAgentCreate
-     * @summary Helix-org: restart a bot's agent session (recreate desktop container)
+     * @summary Helix-org: restart a bot's agent session (fresh session + desktop)
      * @request POST:/api/v1/orgs/{org}/bots/{id}/restart-agent
      * @secure
      */
@@ -13439,6 +13503,25 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         path: `/api/v1/projects/${id}/usage`,
         method: "GET",
         query: query,
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description One entry per distinct VCS provider present among the project's external repos, with the acting user, the account pushes are attributed to, and per-repo verified access. Backs the project board connection lozenge.
+     *
+     * @tags Projects
+     * @name GetProjectVcsConnections
+     * @summary Get project VCS connection status
+     * @request GET:/api/v1/projects/{id}/vcs-connections
+     * @secure
+     */
+    getProjectVcsConnections: (id: string, params: RequestParams = {}) =>
+      this.request<TypesVCSConnectionInfo[], SystemHTTPError>({
+        path: `/api/v1/projects/${id}/vcs-connections`,
+        method: "GET",
         secure: true,
         type: ContentType.Json,
         format: "json",

--- a/frontend/src/components/tasks/SpecTaskKanbanBoard.tsx
+++ b/frontend/src/components/tasks/SpecTaskKanbanBoard.tsx
@@ -101,6 +101,7 @@ import { useOAuthFlow } from "../../hooks/useOAuthFlow";
 import { useListOAuthProviders } from "../../services/oauthProvidersService";
 import { findOAuthProviderForType } from "../../utils/oauthProviders";
 import BacklogTableView from "./BacklogTableView";
+import VCSConnectionLozenges from "./VCSConnectionLozenges";
 import { useCreateSampleRepository } from "../../services/gitRepositoryService";
 import { useSampleTypes } from "../../hooks/useSampleTypes";
 import { useAttentionEvents, AttentionEvent } from "../../hooks/useAttentionEvents";
@@ -1895,6 +1896,7 @@ const SpecTaskKanbanBoard: React.FC<SpecTaskKanbanBoardProps> = ({
             />
           )}
         </Box>
+        {projectId && <VCSConnectionLozenges projectId={projectId} />}
       </Box>
 
       {/* Mobile search bar */}

--- a/frontend/src/components/tasks/VCSConnectionLozenges.tsx
+++ b/frontend/src/components/tasks/VCSConnectionLozenges.tsx
@@ -1,0 +1,213 @@
+import React, { useState } from "react";
+import { Box, Chip, Menu, MenuItem, Tooltip, Typography } from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import LinkOffIcon from "@mui/icons-material/LinkOff";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import SettingsIcon from "@mui/icons-material/Settings";
+import { useQuery } from "@tanstack/react-query";
+
+import useApi from "../../hooks/useApi";
+import { useSettingsDialog } from "../../contexts/settingsDialog";
+import {
+  TypesVCSConnectionInfo,
+  TypesVCSConnectionState,
+} from "../../api/api";
+
+interface VCSConnectionLozengesProps {
+  projectId?: string;
+}
+
+const providerLabel = (provider?: string): string => {
+  switch (provider) {
+    case "github":
+      return "GitHub";
+    case "gitlab":
+      return "GitLab";
+    case "ado":
+      return "Azure DevOps";
+    case "bitbucket":
+      return "Bitbucket";
+    default:
+      return provider || "VCS";
+  }
+};
+
+// providerRepoURL builds a browsable URL for an "owner/repo" on the provider.
+const providerRepoURL = (provider?: string, repo?: string): string | null => {
+  if (!repo) return null;
+  switch (provider) {
+    case "github":
+      return `https://github.com/${repo}`;
+    case "gitlab":
+      return `https://gitlab.com/${repo}`;
+    case "bitbucket":
+      return `https://bitbucket.org/${repo}`;
+    default:
+      return null;
+  }
+};
+
+/**
+ * VCSConnectionLozenges renders one lozenge per distinct VCS provider present
+ * among the project's external repos, showing which account pushes are
+ * attributed to and whether that account can actually reach the repos. Backed by
+ * GET /api/v1/projects/{id}/vcs-connections. Renders nothing when the project
+ * has no external repos.
+ */
+const VCSConnectionLozenges: React.FC<VCSConnectionLozengesProps> = ({
+  projectId,
+}) => {
+  const api = useApi();
+  const { openDialog } = useSettingsDialog();
+  const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+  const [active, setActive] = useState<TypesVCSConnectionInfo | null>(null);
+
+  const { data: connections } = useQuery({
+    queryKey: ["project-vcs-connections", projectId],
+    queryFn: async () => {
+      const response = await api
+        .getApiClient()
+        .getProjectVcsConnections(projectId as string);
+      return (response.data || []) as TypesVCSConnectionInfo[];
+    },
+    enabled: !!projectId,
+    staleTime: 30000,
+  });
+
+  if (!connections || connections.length === 0) {
+    return null;
+  }
+
+  const openMenu = (
+    e: React.MouseEvent<HTMLElement>,
+    conn: TypesVCSConnectionInfo,
+  ) => {
+    e.stopPropagation();
+    setActive(conn);
+    setMenuAnchor(e.currentTarget);
+  };
+  const closeMenu = () => {
+    setMenuAnchor(null);
+    setActive(null);
+  };
+
+  const chipFor = (conn: TypesVCSConnectionInfo) => {
+    const label = providerLabel(conn.provider);
+    const user = conn.pushing_as?.username || "";
+    const inaccessible = (conn.repos || []).filter(
+      (r) => r.verified && !r.has_access,
+    );
+
+    let icon: React.ReactElement;
+    let color: "success" | "warning" | "default";
+    let text: string;
+    let tooltip: string;
+
+    switch (conn.state as TypesVCSConnectionState) {
+      case "verified":
+        icon = <CheckCircleIcon />;
+        color = "success";
+        text = user ? `${label} · ${user}` : label;
+        tooltip = `Pushing as ${user || "your connected account"} — access verified for ${
+          (conn.repos || []).map((r) => r.repo).join(", ") || "this project"
+        }`;
+        break;
+      case "needs_attention":
+        icon = <WarningAmberIcon />;
+        color = "warning";
+        text = user
+          ? `${user} · no access`
+          : `${label} · needs attention`;
+        tooltip = inaccessible.length
+          ? `${user || "Your account"} can't access ${inaccessible
+              .map((r) => r.repo)
+              .join(", ")}. Switch to an account with access.`
+          : `${label} connection needs attention.`;
+        break;
+      case "disconnected":
+      default:
+        icon = <LinkOffIcon />;
+        color = "default";
+        text = `Connect ${label}`;
+        tooltip = `No ${label} account connected for this project's repos.`;
+        break;
+    }
+
+    // Surface acting-as vs pushing-as when they differ (attribution clarity).
+    const actingName = conn.acting_user?.name;
+    const missing = conn.missing_scopes || [];
+    const detail = [
+      actingName && user && `acting as ${actingName} · pushing as ${user}`,
+      missing.length > 0 && `missing scopes: ${missing.join(", ")}`,
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    return (
+      <Tooltip
+        key={conn.provider}
+        title={
+          <Box sx={{ whiteSpace: "pre-line" }}>
+            <Typography variant="caption">{tooltip}</Typography>
+            {detail && (
+              <Typography
+                variant="caption"
+                sx={{ display: "block", mt: 0.5, opacity: 0.8 }}
+              >
+                {detail}
+              </Typography>
+            )}
+          </Box>
+        }
+        arrow
+      >
+        <Chip
+          icon={icon}
+          label={text}
+          color={color}
+          size="small"
+          variant={conn.state === "disconnected" ? "outlined" : "filled"}
+          onClick={(e) => openMenu(e, conn)}
+          sx={{ fontSize: "0.75rem", cursor: "pointer", maxWidth: 320 }}
+        />
+      </Tooltip>
+    );
+  };
+
+  const activeRepoURL = active
+    ? providerRepoURL(active.provider, active.repos?.[0]?.repo)
+    : null;
+
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+      {connections.map((conn) => chipFor(conn))}
+      <Menu anchorEl={menuAnchor} open={!!menuAnchor} onClose={closeMenu}>
+        <MenuItem
+          onClick={() => {
+            closeMenu();
+            openDialog("connected-services");
+          }}
+        >
+          <SettingsIcon sx={{ mr: 1, fontSize: 20 }} />
+          {active?.state === "disconnected"
+            ? "Connect account…"
+            : "Switch / reconnect / disconnect…"}
+        </MenuItem>
+        {activeRepoURL && (
+          <MenuItem
+            onClick={() => {
+              closeMenu();
+              window.open(activeRepoURL, "_blank", "noopener");
+            }}
+          >
+            <OpenInNewIcon sx={{ mr: 1, fontSize: 20 }} />
+            View on {providerLabel(active?.provider)}
+          </MenuItem>
+        )}
+      </Menu>
+    </Box>
+  );
+};
+
+export default VCSConnectionLozenges;

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -7761,6 +7761,30 @@ definitions:
       success:
         type: boolean
     type: object
+  types.PushError:
+    properties:
+      account:
+        description: VCS account the push was attempted as, e.g. "@linuxrecruit"
+        type: string
+      cause:
+        description: translated human-readable cause
+        type: string
+      failed_at:
+        type: string
+      next_step:
+        description: translated actionable next step
+        type: string
+      provider:
+        allOf:
+        - $ref: '#/definitions/types.ExternalRepositoryType'
+        description: e.g. "github"
+      raw_message:
+        description: verbatim provider error
+        type: string
+      repo:
+        description: e.g. "helixml/find-ai"
+        type: string
+    type: object
   types.PushResponse:
     properties:
       branch:
@@ -9608,6 +9632,13 @@ definitions:
       last_push_commit_hash:
         description: Git tracking
         type: string
+      last_push_error:
+        allOf:
+        - $ref: '#/definitions/types.PushError'
+        description: |-
+          Structured error from the last external (mirror) push. Set when a user-initiated
+          push to the external repo fails and refs are rolled back; cleared (nil) on the
+          next successful push. Surfaced on the board so failures aren't silent.
       merge_commit_hash:
         description: Merge commit hash
         type: string
@@ -10198,6 +10229,13 @@ definitions:
       last_push_commit_hash:
         description: Git tracking
         type: string
+      last_push_error:
+        allOf:
+        - $ref: '#/definitions/types.PushError'
+        description: |-
+          Structured error from the last external (mirror) push. Set when a user-initiated
+          push to the external repo fails and refs are rolled back; cleared (nil) on the
+          next successful push. Surfaced on the board so failures aren't silent.
       merge_commit_hash:
         description: Merge commit hash
         type: string
@@ -11624,6 +11662,64 @@ definitions:
         type: array
       user:
         $ref: '#/definitions/types.User'
+    type: object
+  types.VCSActingUser:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  types.VCSConnectionInfo:
+    properties:
+      acting_user:
+        $ref: '#/definitions/types.VCSActingUser'
+      missing_scopes:
+        items:
+          type: string
+        type: array
+      provider:
+        $ref: '#/definitions/types.ExternalRepositoryType'
+      pushing_as:
+        $ref: '#/definitions/types.VCSPushingAs'
+      repos:
+        items:
+          $ref: '#/definitions/types.VCSRepoAccess'
+        type: array
+      state:
+        $ref: '#/definitions/types.VCSConnectionState'
+    type: object
+  types.VCSConnectionState:
+    enum:
+    - verified
+    - needs_attention
+    - disconnected
+    type: string
+    x-enum-varnames:
+    - VCSConnectionVerified
+    - VCSConnectionNeedsAttention
+    - VCSConnectionDisconnected
+  types.VCSPushingAs:
+    properties:
+      connection_id:
+        description: OAuthConnection ID (for switch/disconnect)
+        type: string
+      username:
+        description: e.g. "@tonychapman-prog"
+        type: string
+    type: object
+  types.VCSRepoAccess:
+    properties:
+      has_access:
+        description: true if the connection can reach it (or access is unverifiable
+          for this provider)
+        type: boolean
+      repo:
+        description: '"owner/repo"'
+        type: string
+      verified:
+        description: true if we actually probed the provider (false = optimistic/unverifiable)
+        type: boolean
     type: object
   types.VHostRoute:
     properties:
@@ -18136,7 +18232,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - ApiKeyAuth: []
-      summary: 'Helix-org: restart a bot''s agent session (recreate desktop container)'
+      summary: 'Helix-org: restart a bot''s agent session (fresh session + desktop)'
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/bots/{id}/subscriptions:
@@ -19983,6 +20079,50 @@ paths:
       security:
       - BearerAuth: []
       summary: Get project token usage
+      tags:
+      - Projects
+  /api/v1/projects/{id}/vcs-connections:
+    get:
+      consumes:
+      - application/json
+      description: One entry per distinct VCS provider present among the project's
+        external repos, with the acting user, the account pushes are attributed to,
+        and per-repo verified access. Backs the project board connection lozenge.
+      operationId: getProjectVCSConnections
+      parameters:
+      - description: Project ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.VCSConnectionInfo'
+            type: array
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get project VCS connection status
       tags:
       - Projects
   /api/v1/projects/{id}/web-service:

--- a/openapi.json
+++ b/openapi.json
@@ -11702,7 +11702,7 @@
                 "tags": [
                     "HelixOrg"
                 ],
-                "summary": "Helix-org: restart a bot's agent session (recreate desktop container)",
+                "summary": "Helix-org: restart a bot's agent session (fresh session + desktop)",
                 "parameters": [
                     {
                         "description": "Bot ID",
@@ -15268,6 +15268,87 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{id}/vcs-connections": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "One entry per distinct VCS provider present among the project's external repos, with the acting user, the account pushes are attributed to, and per-repo verified access. Backs the project board connection lozenge.",
+                "tags": [
+                    "Projects"
+                ],
+                "summary": "Get project VCS connection status",
+                "operationId": "getProjectVCSConnections",
+                "parameters": [
+                    {
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/types.VCSConnectionInfo"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -36285,6 +36366,42 @@
                     }
                 }
             },
+            "types.PushError": {
+                "type": "object",
+                "properties": {
+                    "account": {
+                        "description": "VCS account the push was attempted as, e.g. \"@linuxrecruit\"",
+                        "type": "string"
+                    },
+                    "cause": {
+                        "description": "translated human-readable cause",
+                        "type": "string"
+                    },
+                    "failed_at": {
+                        "type": "string"
+                    },
+                    "next_step": {
+                        "description": "translated actionable next step",
+                        "type": "string"
+                    },
+                    "provider": {
+                        "description": "e.g. \"github\"",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.ExternalRepositoryType"
+                            }
+                        ]
+                    },
+                    "raw_message": {
+                        "description": "verbatim provider error",
+                        "type": "string"
+                    },
+                    "repo": {
+                        "description": "e.g. \"helixml/find-ai\"",
+                        "type": "string"
+                    }
+                }
+            },
             "types.PushResponse": {
                 "type": "object",
                 "properties": {
@@ -38687,6 +38804,14 @@
                         "description": "Git tracking",
                         "type": "string"
                     },
+                    "last_push_error": {
+                        "description": "Structured error from the last external (mirror) push. Set when a user-initiated\npush to the external repo fails and refs are rolled back; cleared (nil) on the\nnext successful push. Surfaced on the board so failures aren't silent.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.PushError"
+                            }
+                        ]
+                    },
                     "merge_commit_hash": {
                         "description": "Merge commit hash",
                         "type": "string"
@@ -39468,6 +39593,14 @@
                     "last_push_commit_hash": {
                         "description": "Git tracking",
                         "type": "string"
+                    },
+                    "last_push_error": {
+                        "description": "Structured error from the last external (mirror) push. Set when a user-initiated\npush to the external repo fails and refs are rolled back; cleared (nil) on the\nnext successful push. Surfaced on the board so failures aren't silent.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.PushError"
+                            }
+                        ]
                     },
                     "merge_commit_hash": {
                         "description": "Merge commit hash",
@@ -41475,6 +41608,89 @@
                     },
                     "user": {
                         "$ref": "#/components/schemas/types.User"
+                    }
+                }
+            },
+            "types.VCSActingUser": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "types.VCSConnectionInfo": {
+                "type": "object",
+                "properties": {
+                    "acting_user": {
+                        "$ref": "#/components/schemas/types.VCSActingUser"
+                    },
+                    "missing_scopes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "provider": {
+                        "$ref": "#/components/schemas/types.ExternalRepositoryType"
+                    },
+                    "pushing_as": {
+                        "$ref": "#/components/schemas/types.VCSPushingAs"
+                    },
+                    "repos": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/types.VCSRepoAccess"
+                        }
+                    },
+                    "state": {
+                        "$ref": "#/components/schemas/types.VCSConnectionState"
+                    }
+                }
+            },
+            "types.VCSConnectionState": {
+                "type": "string",
+                "enum": [
+                    "verified",
+                    "needs_attention",
+                    "disconnected"
+                ],
+                "x-enum-varnames": [
+                    "VCSConnectionVerified",
+                    "VCSConnectionNeedsAttention",
+                    "VCSConnectionDisconnected"
+                ]
+            },
+            "types.VCSPushingAs": {
+                "type": "object",
+                "properties": {
+                    "connection_id": {
+                        "description": "OAuthConnection ID (for switch/disconnect)",
+                        "type": "string"
+                    },
+                    "username": {
+                        "description": "e.g. \"@tonychapman-prog\"",
+                        "type": "string"
+                    }
+                }
+            },
+            "types.VCSRepoAccess": {
+                "type": "object",
+                "properties": {
+                    "has_access": {
+                        "description": "true if the connection can reach it (or access is unverifiable for this provider)",
+                        "type": "boolean"
+                    },
+                    "repo": {
+                        "description": "\"owner/repo\"",
+                        "type": "string"
+                    },
+                    "verified": {
+                        "description": "true if we actually probed the provider (false = optimistic/unverifiable)",
+                        "type": "boolean"
                     }
                 }
             },

--- a/stack
+++ b/stack
@@ -1086,7 +1086,7 @@ function transfer-desktop-to-sandbox() {
   docker tag "${IMAGE_NAME}:latest" "$REGISTRY_TAG"
 
   _tx_elapsed "📤 Pushing to local registry..."
-  if ! docker push "$REGISTRY_TAG" 2>&1 | grep -v "^$"; then
+  if ! docker push "$REGISTRY_TAG" 2>&1 | grep --line-buffered -v "^$"; then
     echo "❌ Failed to push to local registry"
     return 1
   fi
@@ -1095,7 +1095,7 @@ function transfer-desktop-to-sandbox() {
   _tx_elapsed "📥 Sandbox pulling from registry..."
   local PULL_OK=false
   for attempt in 1 2 3; do
-    if sandbox_docker exec "$SANDBOX_CONTAINER_NAME" docker pull "$SANDBOX_REGISTRY_TAG" 2>&1 | grep -v "^$"; then
+    if sandbox_docker exec "$SANDBOX_CONTAINER_NAME" docker pull "$SANDBOX_REGISTRY_TAG" 2>&1 | grep --line-buffered -v "^$"; then
       PULL_OK=true
       break
     fi
@@ -1136,7 +1136,7 @@ function transfer-desktop-to-sandbox() {
   # Post-rmi verification — if removing the registry tag also removed the image, re-pull and re-tag
   if ! sandbox_docker exec "$SANDBOX_CONTAINER_NAME" docker inspect "${IMAGE_NAME}:${IMAGE_TAG}" >/dev/null 2>&1; then
     echo "⚠️  Image disappeared after rmi — re-pulling and re-tagging..."
-    sandbox_docker exec "$SANDBOX_CONTAINER_NAME" docker pull "$SANDBOX_REGISTRY_TAG" 2>&1 | grep -v "^$" || true
+    sandbox_docker exec "$SANDBOX_CONTAINER_NAME" docker pull "$SANDBOX_REGISTRY_TAG" 2>&1 | grep --line-buffered -v "^$" || true
     sandbox_docker exec "$SANDBOX_CONTAINER_NAME" docker tag "$SANDBOX_REGISTRY_TAG" "${IMAGE_NAME}:${IMAGE_TAG}" 2>/dev/null || true
     sandbox_docker exec "$SANDBOX_CONTAINER_NAME" docker tag "$SANDBOX_REGISTRY_TAG" "${IMAGE_NAME}:latest" 2>/dev/null || true
     # Don't rmi the registry tag this time — leave it as a safety net
@@ -1173,7 +1173,7 @@ function transfer-desktop-to-sandbox() {
   # Final verification — if the image is gone after cleanup, re-pull as last resort
   if ! sandbox_docker exec "$SANDBOX_CONTAINER_NAME" docker inspect "${IMAGE_NAME}:${IMAGE_TAG}" >/dev/null 2>&1; then
     echo "❌ Image disappeared after cleanup! Re-pulling as last resort..."
-    sandbox_docker exec "$SANDBOX_CONTAINER_NAME" docker pull "$SANDBOX_REGISTRY_TAG" 2>&1 | grep -v "^$" || true
+    sandbox_docker exec "$SANDBOX_CONTAINER_NAME" docker pull "$SANDBOX_REGISTRY_TAG" 2>&1 | grep --line-buffered -v "^$" || true
     sandbox_docker exec "$SANDBOX_CONTAINER_NAME" docker tag "$SANDBOX_REGISTRY_TAG" "${IMAGE_NAME}:${IMAGE_TAG}" 2>/dev/null || true
     sandbox_docker exec "$SANDBOX_CONTAINER_NAME" docker tag "$SANDBOX_REGISTRY_TAG" "${IMAGE_NAME}:latest" 2>/dev/null || true
     if ! sandbox_docker exec "$SANDBOX_CONTAINER_NAME" docker inspect "${IMAGE_NAME}:${IMAGE_TAG}" >/dev/null 2>&1; then

--- a/swagger.json
+++ b/swagger.json
@@ -9717,7 +9717,7 @@
                 "tags": [
                     "HelixOrg"
                 ],
-                "summary": "Helix-org: restart a bot's agent session (recreate desktop container)",
+                "summary": "Helix-org: restart a bot's agent session (fresh session + desktop)",
                 "parameters": [
                     {
                         "type": "string",
@@ -12733,6 +12733,71 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{id}/vcs-connections": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "One entry per distinct VCS provider present among the project's external repos, with the acting user, the account pushes are attributed to, and per-repo verified access. Backs the project board connection lozenge.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Projects"
+                ],
+                "summary": "Get project VCS connection status",
+                "operationId": "getProjectVCSConnections",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.VCSConnectionInfo"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/system.HTTPError"
                         }
@@ -31982,6 +32047,42 @@
                 }
             }
         },
+        "types.PushError": {
+            "type": "object",
+            "properties": {
+                "account": {
+                    "description": "VCS account the push was attempted as, e.g. \"@linuxrecruit\"",
+                    "type": "string"
+                },
+                "cause": {
+                    "description": "translated human-readable cause",
+                    "type": "string"
+                },
+                "failed_at": {
+                    "type": "string"
+                },
+                "next_step": {
+                    "description": "translated actionable next step",
+                    "type": "string"
+                },
+                "provider": {
+                    "description": "e.g. \"github\"",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.ExternalRepositoryType"
+                        }
+                    ]
+                },
+                "raw_message": {
+                    "description": "verbatim provider error",
+                    "type": "string"
+                },
+                "repo": {
+                    "description": "e.g. \"helixml/find-ai\"",
+                    "type": "string"
+                }
+            }
+        },
         "types.PushResponse": {
             "type": "object",
             "properties": {
@@ -34384,6 +34485,14 @@
                     "description": "Git tracking",
                     "type": "string"
                 },
+                "last_push_error": {
+                    "description": "Structured error from the last external (mirror) push. Set when a user-initiated\npush to the external repo fails and refs are rolled back; cleared (nil) on the\nnext successful push. Surfaced on the board so failures aren't silent.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PushError"
+                        }
+                    ]
+                },
                 "merge_commit_hash": {
                     "description": "Merge commit hash",
                     "type": "string"
@@ -35165,6 +35274,14 @@
                 "last_push_commit_hash": {
                     "description": "Git tracking",
                     "type": "string"
+                },
+                "last_push_error": {
+                    "description": "Structured error from the last external (mirror) push. Set when a user-initiated\npush to the external repo fails and refs are rolled back; cleared (nil) on the\nnext successful push. Surfaced on the board so failures aren't silent.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PushError"
+                        }
+                    ]
                 },
                 "merge_commit_hash": {
                     "description": "Merge commit hash",
@@ -37172,6 +37289,89 @@
                 },
                 "user": {
                     "$ref": "#/definitions/types.User"
+                }
+            }
+        },
+        "types.VCSActingUser": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.VCSConnectionInfo": {
+            "type": "object",
+            "properties": {
+                "acting_user": {
+                    "$ref": "#/definitions/types.VCSActingUser"
+                },
+                "missing_scopes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "provider": {
+                    "$ref": "#/definitions/types.ExternalRepositoryType"
+                },
+                "pushing_as": {
+                    "$ref": "#/definitions/types.VCSPushingAs"
+                },
+                "repos": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.VCSRepoAccess"
+                    }
+                },
+                "state": {
+                    "$ref": "#/definitions/types.VCSConnectionState"
+                }
+            }
+        },
+        "types.VCSConnectionState": {
+            "type": "string",
+            "enum": [
+                "verified",
+                "needs_attention",
+                "disconnected"
+            ],
+            "x-enum-varnames": [
+                "VCSConnectionVerified",
+                "VCSConnectionNeedsAttention",
+                "VCSConnectionDisconnected"
+            ]
+        },
+        "types.VCSPushingAs": {
+            "type": "object",
+            "properties": {
+                "connection_id": {
+                    "description": "OAuthConnection ID (for switch/disconnect)",
+                    "type": "string"
+                },
+                "username": {
+                    "description": "e.g. \"@tonychapman-prog\"",
+                    "type": "string"
+                }
+            }
+        },
+        "types.VCSRepoAccess": {
+            "type": "object",
+            "properties": {
+                "has_access": {
+                    "description": "true if the connection can reach it (or access is unverifiable for this provider)",
+                    "type": "boolean"
+                },
+                "repo": {
+                    "description": "\"owner/repo\"",
+                    "type": "string"
+                },
+                "verified": {
+                    "description": "true if we actually probed the provider (false = optimistic/unverifiable)",
+                    "type": "boolean"
                 }
             }
         },


### PR DESCRIPTION
## Summary

Spec-task pushes to external repos could fail **silently**: the internal git
server returns 200 to the client before mirroring to the provider, and when the
mirror push fails the refs are rolled back with no signal — so the agent reported
"pushed and ready for review" while the UI showed nothing. This PR makes those
failures loud and adds a per-provider connection lozenge on the project board so
users can see which account they're pushing as and whether it can actually reach
the repo. Also bundles two Helix-in-Helix dev-startup fixes found during the work.

## Changes

**Loud push-failure surfacing (backend)**
- New `types.PushError` + `SpecTask.LastPushError` (jsonb); persisted on external
  push failure and cleared on the next success (`git_http_server.go`
  `recordPushError`/`clearPushError`).
- `types.NewPushError` translates raw provider errors (the misleading GitHub 404
  for private repos, 403, 401) into a human cause + next step. Unit-tested.
- Helpers in `git_repository_service.go`: `OAuthProviderTypeForRepo`,
  `RepoOwnerName`, `GetActingAccountHandle`.

**VCS connection lozenge (generic across providers)**
- New `api/pkg/vcs` capability registry (per-provider auth mechanism, required
  scopes, access-probe path). GitHub fully specified; GitLab/ADO/Bitbucket stubbed.
- New endpoint `GET /api/v1/projects/{id}/vcs-connections` — one entry per distinct
  provider among the project's external repos, with acting-user, pushing-as,
  per-repo verified access (via `oauth.Provider.MakeAuthorizedRequest`), and
  missing scopes.
- Frontend `VCSConnectionLozenges` rendered in the board header (verified /
  needs-attention / disconnected states; acting-as vs pushing-as + missing scopes
  in the tooltip; menu links to Connected Services + View on provider).

**Scopes**
- GitHub connect now requests the full `repo, read:user, user:email, read:org`
  set from the registry (was `repo, read:user, user:email`). Hard validation kept
  at `repo` so existing connections aren't rejected.

**Dev-environment fixes**
- `stack`: `docker push/pull` output piped through `grep --line-buffered` so the
  desktop-image transfer no longer renders as truncated/hung bursts.

## Testing
- `go build ./pkg/...` green; `types` unit test for the error mapper passes.
- Frontend `tsc --noEmit` clean.
- E2E (inner Helix): board loads, calls the new endpoint → `200 []` for a
  non-external repo (no lozenge), zero console errors.
- NOT tested: verified/needs-attention lozenge states (needs a real connected
  GitHub account + external repo).

## Screenshots
![Board loads clean](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002205_implement-design2026-07/screenshots/05-board-loads-clean.png)

## Follow-ups (not in this PR)
- Force the provider account picker on switch/reconnect.
- Per-project "disconnect" (unbind without revoking the global token).
- Pre-flight verify before "Start planning".

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwhge6akaehrtthq7srm8qaw)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002205_implement-design2026-07/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002205_implement-design2026-07/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002205_implement-design2026-07/tasks.md)

🚀 Built with [Helix](https://helix.ml)