### PR TITLE
feat(api): add Open Questions section to spec planning prompt

### DIFF
--- a/api/pkg/services/spec_task_prompts.go
+++ b/api/pkg/services/spec_task_prompts.go
@@ -54,6 +54,14 @@ Create exactly 3 files in /home/retro/work/helix-specs/design/tasks/{{.TaskDirNa
 2. design.md - Architecture + key decisions
 3. tasks.md - Checklist of implementation tasks using [ ] format
 
+## Open Questions (requirements.md)
+
+End ` + "`requirements.md`" + ` with an ` + "`## Open Questions`" + ` section listing any genuine
+questions or uncertain assumptions you have for the user - anything you would
+otherwise have to guess. This surfaces guesses so the user can correct them at
+review time instead of them silently becoming the spec. Only list real
+uncertainties; if there are none, write "None".
+
 ## CRITICAL: Title Format
 
 Each of the three files MUST start with an H1 in this exact format:

--- a/api/pkg/services/spec_task_prompts_test.go
+++ b/api/pkg/services/spec_task_prompts_test.go
@@ -39,3 +39,31 @@ func TestBuildPlanningPrompt_TitleFormatRule(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildPlanningPrompt_OpenQuestions guards the instruction that tells the
+// planning agent to add an "## Open Questions" section to requirements.md. This
+// surfaces the agent's guesses for user review instead of letting invented
+// requirements silently become the spec. If a future edit drops the rule,
+// agents will stop listing their open questions.
+func TestBuildPlanningPrompt_OpenQuestions(t *testing.T) {
+	task := &types.SpecTask{
+		ID:            "spt_test",
+		ProjectID:     "prj_test",
+		Name:          "Add Dark Mode",
+		Type:          "feature",
+		Priority:      types.SpecTaskPriorityMedium,
+		DesignDocPath: "000001_add-dark-mode",
+	}
+
+	out := BuildPlanningPrompt(task, "", "", "", "")
+
+	mustContain := []string{
+		"## Open Questions (requirements.md)",
+		"`## Open Questions`",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(out, want) {
+			t.Errorf("planning prompt is missing required snippet %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The spec-driven planning agent tends to invent requirements when the user's
request is ambiguous. This adds a small, additive instruction to the planning
prompt telling the agent to end `requirements.md` with an `## Open Questions`
section listing genuine uncertainties for the user to correct at review time —
so guesses become visible instead of silently becoming the spec.

## Changes

- `api/pkg/services/spec_task_prompts.go`: add a concise `## Open Questions
  (requirements.md)` instruction to `planningPromptTemplate`, placed between the
  "Your Task Directory" list and the "Title Format" section. Agents are told to
  list only real uncertainties and to write "None" when there are none.
- `api/pkg/services/spec_task_prompts_test.go`: add
  `TestBuildPlanningPrompt_OpenQuestions` guarding the new instruction.

## Notes

- Placed at the end of `requirements.md` so it never interferes with H1 title
  parsing (`SpecTitleFromRequirements`), which reads the first non-empty line.
- Purely additive; no existing prompt wording removed. Build clean, tests pass.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwknmfybt93491mvmegcshzy)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002210_i-want-to-change-the/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002210_i-want-to-change-the/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002210_i-want-to-change-the/tasks.md)

🚀 Built with [Helix](https://helix.ml)