### PR TITLE
feat(cli): spectask start --prompt-file (dispatch a brief without a repo commit)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,29 +384,30 @@ Helix stack runs **inside the UTM VM** (SSH: `ssh -p 2222 luke@127.0.0.1`). Only
 /tmp/helix spectask list|list-agents|start|resume|stop|screenshot|stream|benchmark|send|mcp|live
 ```
 
-### Dispatch an investigation to a helix-in-helix spec task (from a design doc)
+### Dispatch an investigation to a helix-in-helix spec task (from a local brief)
 When the **outer** instance can't be instrumented — e.g. Air won't hot-reload
 because the repo is a ZFS bind-mount (inotify doesn't cross it), or a headless
 browser/Google-auth is unavailable — hand the whole thing to a spec task. Its
 sandbox is a **full inner Helix at `localhost:8080` where Air hot-reload, Vite
-HMR, and the browser all work**. You can do this end-to-end from the CLI yourself:
+HMR, and the browser all work**. Do it end-to-end from the CLI, **no branch or
+merge needed** — pass the whole brief straight into the prompt:
 
 ```bash
-# 1. Write the brief as a design doc; merge it (design-doc only, admin, no CI wait):
-git checkout -b design/<slug> && git add design/<file>.md && git commit -m "..."
-git push -u origin design/<slug>
-gh pr create --repo helixml/helix -t "..." -b "..."
-gh pr merge <n> --repo helixml/helix --merge --admin      # so the spec task's clone has it
-
-# 2. Start a spec task that reads the doc and does the work in the inner Helix:
 export HELIX_URL=http://localhost:8080
 export HELIX_API_KEY=<key from api_keys for the session owner>
+
+# Write the brief to a local file (does NOT need to be committed), then:
 /tmp/helix-bin spectask start \
   --project prj_01kg02vqqyg178c1n2ydscn5fb \
   --agent app_01kw1n70xs2qq2y4ntzbqqmpff \
   -n "<task name>" \
-  --prompt "Read design/<file>.md and complete the task it describes end-to-end, testing live in this inner Helix."
+  --prompt "Complete the task below end-to-end, testing live in this inner Helix." \
+  --prompt-file /path/to/brief.md          # appended after --prompt; no repo commit required
 ```
+`--prompt-file` reads a file straight into the task prompt (added to `spectask
+start` for exactly this — skips the write-doc → branch → PR → merge dance). You
+can also just inline it: `--prompt "$(cat brief.md)"`.
+
 `spectask start` **provisions a sandbox and the CLI will time out (~short) — the
 task is still created**; confirm via `spec_tasks` (order by `created_at`, not
 `created`) and `docker exec helix-sandbox-nvidia-1 docker ps | grep ubuntu-external-<sid>`.

--- a/api/pkg/cli/spectask/spectask.go
+++ b/api/pkg/cli/spectask/spectask.go
@@ -59,6 +59,7 @@ func newStartCommand() *cobra.Command {
 	var projectID string
 	var agentID string
 	var prompt string
+	var promptFile string
 	var quiet bool
 
 	cmd := &cobra.Command{
@@ -91,6 +92,20 @@ Example workflow:
 					fmt.Println("Creating new spec task...")
 				}
 				taskPrompt := prompt
+				// --prompt-file lets you dispatch an entire brief (e.g. a design
+				// doc) as the task prompt without committing it to the repo.
+				// Appended after --prompt when both are given.
+				if promptFile != "" {
+					data, readErr := os.ReadFile(promptFile)
+					if readErr != nil {
+						return fmt.Errorf("failed to read --prompt-file %q: %w", promptFile, readErr)
+					}
+					if taskPrompt != "" {
+						taskPrompt = taskPrompt + "\n\n" + string(data)
+					} else {
+						taskPrompt = string(data)
+					}
+				}
 				if taskPrompt == "" {
 					taskPrompt = "Testing RevDial connectivity"
 				}
@@ -150,6 +165,7 @@ Example workflow:
 	cmd.Flags().StringVarP(&projectID, "project", "p", "", "Project ID (required when creating new task)")
 	cmd.Flags().StringVarP(&agentID, "agent", "a", "", "Agent/App ID to use (e.g., app_01xxx)")
 	cmd.Flags().StringVar(&prompt, "prompt", "", "Task prompt/description")
+	cmd.Flags().StringVar(&promptFile, "prompt-file", "", "Read the task prompt from a file (e.g. a design doc) — dispatch a full brief without committing it to the repo. Appended after --prompt if both are set.")
 	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Only output session ID")
 
 	return cmd


### PR DESCRIPTION
Adds `--prompt-file` to `helix spectask start` — reads a file straight into the task prompt (appended after `--prompt`). Lets you dispatch a full brief to a helix-in-helix spec task with no branch/PR/merge dance. Also updates the CLAUDE.md trick to this simpler flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)