### PR TITLE
feat(cli): spectask start --attach (upload files as task attachments)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,11 +402,14 @@ export HELIX_API_KEY=<key from api_keys for the session owner>
   --agent app_01kw1n70xs2qq2y4ntzbqqmpff \
   -n "<task name>" \
   --prompt "Complete the task below end-to-end, testing live in this inner Helix." \
-  --prompt-file /path/to/brief.md          # appended after --prompt; no repo commit required
+  --prompt-file /path/to/brief.md \        # appended after --prompt; no repo commit required
+  --attach /path/to/big.log --attach /path/to/other.log   # repeatable
 ```
-`--prompt-file` reads a file straight into the task prompt (added to `spectask
-start` for exactly this — skips the write-doc → branch → PR → merge dance). You
-can also just inline it: `--prompt "$(cat brief.md)"`.
+`--prompt-file` reads a file straight into the task prompt (skips the write-doc →
+branch → PR → merge dance). You can also just inline it: `--prompt "$(cat brief.md)"`.
+`--attach` (repeatable) uploads files as spec-task **attachments** — the agent
+reads them at `design/tasks/<task>/attachments/<name>` inside the sandbox, so
+non-trivial logfiles/large context go there instead of bloating the prompt.
 
 `spectask start` **provisions a sandbox and the CLI will time out (~short) — the
 task is still created**; confirm via `spec_tasks` (order by `created_at`, not

--- a/api/pkg/cli/spectask/spectask.go
+++ b/api/pkg/cli/spectask/spectask.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -60,6 +62,7 @@ func newStartCommand() *cobra.Command {
 	var agentID string
 	var prompt string
 	var promptFile string
+	var attachFiles []string
 	var quiet bool
 
 	cmd := &cobra.Command{
@@ -120,6 +123,17 @@ Example workflow:
 						fmt.Printf("   Agent: %s\n", agentID)
 					}
 				}
+				// Attach files (e.g. logfiles) — the agent reads them at
+				// design/tasks/<task>/attachments/<name>, keeping large context
+				// out of the prompt.
+				if len(attachFiles) > 0 {
+					if err := uploadSpecTaskAttachments(apiURL, token, taskID, attachFiles); err != nil {
+						return fmt.Errorf("failed to upload attachments: %w", err)
+					}
+					if !quiet {
+						fmt.Printf("📎 Uploaded %d attachment(s)\n", len(attachFiles))
+					}
+				}
 			}
 
 			// Start planning - this triggers async session creation
@@ -166,6 +180,7 @@ Example workflow:
 	cmd.Flags().StringVarP(&agentID, "agent", "a", "", "Agent/App ID to use (e.g., app_01xxx)")
 	cmd.Flags().StringVar(&prompt, "prompt", "", "Task prompt/description")
 	cmd.Flags().StringVar(&promptFile, "prompt-file", "", "Read the task prompt from a file (e.g. a design doc) — dispatch a full brief without committing it to the repo. Appended after --prompt if both are set.")
+	cmd.Flags().StringArrayVar(&attachFiles, "attach", nil, "Attach file(s) to the task (repeatable). Uploaded as spec-task attachments the agent reads at design/tasks/<task>/attachments/<name> — good for logs/large context without bloating the prompt.")
 	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Only output session ID")
 
 	return cmd
@@ -461,6 +476,47 @@ func createSpecTask(apiURL, token, name, prompt, projectID, agentID string) (*Sp
 	}
 
 	return &task, nil
+}
+
+// uploadSpecTaskAttachments uploads local files as attachments on a spec task
+// (multipart, field name "files"). The agent can then read them inside the
+// sandbox at design/tasks/<task>/attachments/<name>.
+func uploadSpecTaskAttachments(apiURL, token, taskID string, files []string) error {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			return fmt.Errorf("read %q: %w", f, err)
+		}
+		part, err := w.CreateFormFile("files", filepath.Base(f))
+		if err != nil {
+			return err
+		}
+		if _, err := part.Write(data); err != nil {
+			return err
+		}
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s/api/v1/spec-tasks/%s/attachments", apiURL, taskID)
+	req, err := http.NewRequest("POST", url, &buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("attachments API returned %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
 }
 
 // triggerStartPlanning starts planning for a task (returns task, not session)


### PR DESCRIPTION
Adds `--attach` (repeatable) to `helix spectask start` — uploads local files (logfiles, large context) as spec-task attachments the agent reads at `design/tasks/<task>/attachments/<name>`, keeping big context out of the prompt. Complements `--prompt-file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)