### PR TITLE
Org-wide project-manager bot: cross-project spec-task management

### DIFF
--- a/api/pkg/org/application/projects/projects.go
+++ b/api/pkg/org/application/projects/projects.go
@@ -1,0 +1,78 @@
+// Package projects is the org application service backing the MCP
+// project-discovery tools (list_projects, get_project). It is a thin
+// policy layer over the runtime.Projects port: it extracts the caller's
+// org + worker identity from the authenticated invocation (never from
+// tool args), optionally verifies the caller Bot is a member of that org,
+// and delegates to the port — which scopes every read to that org.
+package projects
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
+)
+
+// MemberVerifier confirms a Bot exists as a member of an org. *queries.Queries
+// satisfies it (via GetBot). Kept tiny so the service is unit-testable with a
+// fake and this package doesn't depend on queries.
+type MemberVerifier interface {
+	GetBot(ctx context.Context, orgID string, id orgchart.BotID) (orgchart.Bot, error)
+}
+
+// Service is the project-discovery application service.
+type Service struct {
+	port    runtime.Projects
+	members MemberVerifier
+}
+
+// New constructs the service over the given port. The port is required;
+// callers pass runtime.NoopProjects{} when no real runtime is wired. members
+// is optional: when set, every call verifies the caller Bot is a member of its
+// org (defensive depth — the MCP mount already enforces this); nil skips it.
+func New(port runtime.Projects, members MemberVerifier) *Service {
+	return &Service{port: port, members: members}
+}
+
+// callerIdentity extracts and validates the caller's org + worker IDs and,
+// when a MemberVerifier is wired, confirms the Bot is a member of that org.
+func (s *Service) callerIdentity(ctx context.Context, caller tool.Caller) (string, orgchart.BotID, error) {
+	if caller == nil {
+		return "", "", errors.New("caller missing on invocation")
+	}
+	orgID := caller.OrganizationID()
+	if orgID == "" {
+		return "", "", errors.New("caller has no organization id")
+	}
+	workerID := caller.ID()
+	if workerID == "" {
+		return "", "", errors.New("caller has no worker id")
+	}
+	if s.members != nil {
+		if _, err := s.members.GetBot(ctx, orgID, orgchart.BotID(workerID)); err != nil {
+			return "", "", fmt.Errorf("caller bot %s is not a member of org %s: %w", workerID, orgID, err)
+		}
+	}
+	return orgID, orgchart.BotID(workerID), nil
+}
+
+// List returns the projects in the caller's org.
+func (s *Service) List(ctx context.Context, caller tool.Caller) ([]runtime.ProjectView, error) {
+	orgID, _, err := s.callerIdentity(ctx, caller)
+	if err != nil {
+		return nil, err
+	}
+	return s.port.List(ctx, orgID)
+}
+
+// Get returns one project by id, scoped to the caller's org.
+func (s *Service) Get(ctx context.Context, caller tool.Caller, projectID string) (runtime.ProjectView, error) {
+	orgID, _, err := s.callerIdentity(ctx, caller)
+	if err != nil {
+		return runtime.ProjectView{}, err
+	}
+	return s.port.Get(ctx, orgID, projectID)
+}

--- a/api/pkg/org/application/projects/projects_test.go
+++ b/api/pkg/org/application/projects/projects_test.go
@@ -1,0 +1,90 @@
+package projects
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
+)
+
+// fakePort records the orgID it was called with and returns canned results.
+type fakePort struct {
+	lastOrg     string
+	lastProject string
+	views       []runtime.ProjectView
+	view        runtime.ProjectView
+	err         error
+}
+
+func (f *fakePort) List(_ context.Context, org string) ([]runtime.ProjectView, error) {
+	f.lastOrg = org
+	return f.views, f.err
+}
+func (f *fakePort) Get(_ context.Context, org, projectID string) (runtime.ProjectView, error) {
+	f.lastOrg, f.lastProject = org, projectID
+	return f.view, f.err
+}
+
+type fakeMembers struct{ err error }
+
+func (m *fakeMembers) GetBot(_ context.Context, org string, id orgchart.BotID) (orgchart.Bot, error) {
+	if m.err != nil {
+		return orgchart.Bot{}, m.err
+	}
+	return orgchart.Bot{ID: id, OrganizationID: org}, nil
+}
+
+type fakeCaller struct{ id, org string }
+
+func (c fakeCaller) ID() string             { return c.id }
+func (c fakeCaller) OrganizationID() string { return c.org }
+
+func TestList_ScopesToCallerOrg(t *testing.T) {
+	t.Parallel()
+	fp := &fakePort{views: []runtime.ProjectView{{ID: "prj_1"}}}
+	svc := New(fp, nil)
+	views, err := svc.List(context.Background(), fakeCaller{id: "w-pm", org: "org-1"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if fp.lastOrg != "org-1" {
+		t.Errorf("org passed = %q, want org-1", fp.lastOrg)
+	}
+	if len(views) != 1 || views[0].ID != "prj_1" {
+		t.Errorf("views = %+v", views)
+	}
+}
+
+func TestGet_ForwardsProjectID(t *testing.T) {
+	t.Parallel()
+	fp := &fakePort{view: runtime.ProjectView{ID: "prj_9"}}
+	svc := New(fp, nil)
+	if _, err := svc.Get(context.Background(), fakeCaller{id: "w-pm", org: "org-1"}, "prj_9"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if fp.lastOrg != "org-1" || fp.lastProject != "prj_9" {
+		t.Errorf("passed (%q,%q), want (org-1, prj_9)", fp.lastOrg, fp.lastProject)
+	}
+}
+
+func TestRejectsCallerWithoutOrg(t *testing.T) {
+	t.Parallel()
+	svc := New(&fakePort{}, nil)
+	if _, err := svc.List(context.Background(), fakeCaller{id: "w-pm", org: ""}); err == nil {
+		t.Error("expected error when caller has no org")
+	}
+}
+
+func TestRejectsNonMemberBot(t *testing.T) {
+	t.Parallel()
+	fp := &fakePort{}
+	svc := New(fp, &fakeMembers{err: errors.New("not found")})
+	if _, err := svc.List(context.Background(), fakeCaller{id: "w-intruder", org: "org-1"}); err == nil {
+		t.Error("expected error when caller bot is not a member of the org")
+	}
+	if fp.lastOrg != "" {
+		t.Errorf("port should not be called when membership fails, got org=%q", fp.lastOrg)
+	}
+}

--- a/api/pkg/org/application/prompts/builtins.go
+++ b/api/pkg/org/application/prompts/builtins.go
@@ -13,6 +13,7 @@ import "fmt"
 func RegisterBuiltins(reg *Registry) error {
 	for _, p := range []Prompt{
 		Role{},
+		PMBot{},
 	} {
 		if err := reg.Register(p); err != nil {
 			return fmt.Errorf("register %q: %w", p.Name(), err)

--- a/api/pkg/org/application/prompts/pm_bot.go
+++ b/api/pkg/org/application/prompts/pm_bot.go
@@ -1,0 +1,57 @@
+package prompts
+
+import (
+	"context"
+	_ "embed"
+	"strings"
+
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+)
+
+// PMBotName is the slash-command identifier for the project-manager-bot
+// design prompt — surfaced as `/pm-bot`. It drafts an org-wide bot that
+// manages the spec tasks of other projects in its org, following the
+// discover → draft → connect flow in templates/pm_bot.md.
+const PMBotName Name = "pm-bot"
+
+//go:embed templates/pm_bot.md
+var pmBotTemplate string
+
+// PMBot drafts and saves a project-manager bot. Like Role it is a thin
+// registration shell — all the guidance lives in templates/pm_bot.md. It
+// exists as its own prompt (rather than folding into /role) because a PM
+// bot has a specific, repeatable shape: discover projects, grant the
+// spec-task + discovery tools, subscribe to the projects' spec-task topics.
+type PMBot struct{}
+
+func (PMBot) Name() Name    { return PMBotName }
+func (PMBot) Title() string { return "Draft a project-manager bot" }
+
+func (PMBot) Description() string {
+	return "Drafts and saves an org-wide project-manager bot that watches one or " +
+		"more projects and drives their spec tasks. Lists the org's projects, asks " +
+		"which to manage, grants the spec-task tools, and subscribes to their events."
+}
+
+func (PMBot) Arguments() []Argument {
+	return []Argument{{
+		Name:        "hint",
+		Title:       "Projects or focus",
+		Description: "Optional: the projects to manage or the bot's focus in plain words. The LLM uses this to skip the discovery question.",
+		Required:    false,
+	}}
+}
+
+// RequiresTool gates the prompt on create_bot: without it the drafted bot
+// can't be saved, so surfacing the slash command would dead-end. Mirrors
+// Role; the literal keeps this package free of the MCP-tool adapter dep.
+func (PMBot) RequiresTool() tool.Name { return "create_bot" }
+
+func (PMBot) Render(_ context.Context, args map[string]string) ([]Message, error) {
+	body := pmBotTemplate
+	if hint := strings.TrimSpace(args["hint"]); hint != "" {
+		body += "\n\n---\n\n**Operator hint:** " + hint +
+			"\n\nUse this to pick the projects directly — keep the questions minimal.\n"
+	}
+	return []Message{{Role: "user", Text: body}}, nil
+}

--- a/api/pkg/org/application/prompts/templates/pm_bot.md
+++ b/api/pkg/org/application/prompts/templates/pm_bot.md
@@ -1,0 +1,51 @@
+You are drafting a **project-manager bot** for this organization and saving it
+with `create_bot`. A project-manager bot is an org-wide Bot that watches one or
+more Helix **projects** and drives their spec tasks — it manages projects other
+than its own, but only projects inside its own organization.
+
+Do this now, without a lengthy interview:
+
+## 1. Discover the projects
+
+Call `list_projects` to see the projects in this org. Show the operator the list
+(name + id) and ask **which projects** this bot should manage. If the operator
+already named them, skip the question.
+
+## 2. Draft the bot content (its system prompt)
+
+Write concise markdown describing the bot as a project manager. It MUST state:
+
+- **Scope:** it manages spec tasks only for the projects it was connected to,
+  and only within this organization. It never touches another org's projects.
+- **How work arrives:** it is triggered by spec-task events (spec ready for
+  review, PR ready, CI passed/failed, …) delivered on the topics it is
+  subscribed to. Each event carries a `subject`, a `thread_id` (the spec task
+  it concerns), and an `extra` payload with `event_type` and `project_id`. Use
+  `read_events` to see them and route your attention by those keys.
+- **How it acts:** it manages tasks with the spec-task tools, always passing the
+  target `project_id` (the managed project), e.g. `list_spectasks`,
+  `get_spectask`, `review_spectask_spec`, `approve_spectask_spec`,
+  `request_spectask_changes`, `create_spectask_prs`.
+
+## 3. Choose its tools
+
+Grant the discovery + spec-task tools plus the topic tools it needs to receive
+events:
+
+`list_projects`, `get_project`, `list_spectasks`, `get_spectask`,
+`create_spectask`, `start_spectask_planning`, `review_spectask_spec`,
+`approve_spectask_spec`, `request_spectask_changes`, `create_spectask_prs`,
+`list_topics`, `subscribe`.
+
+## 4. Connect it to the chosen projects
+
+Each project already streams its spec-task events on a topic named
+`Spec tasks: <projectId>` (created automatically). After `create_bot`, use
+`list_topics` to find those topics and `subscribe` the new bot to them (you can
+pass the topic ids to `create_bot` to subscribe at creation). To filter which
+events reach the bot (e.g. only `pr_ready`), create a filter topic/processor
+over the project topic — do not add any special "connect" tool; the ordinary
+topic + filter primitives are the mechanism.
+
+Save the bot with `create_bot`, then confirm to the operator which projects it
+is now watching.

--- a/api/pkg/org/application/spectasks/spectasks.go
+++ b/api/pkg/org/application/spectasks/spectasks.go
@@ -10,30 +10,44 @@ package spectasks
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/org/domain/tool"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
 )
 
+// MemberVerifier confirms a Bot exists as a member of an org. *queries.Queries
+// satisfies it (via GetBot). Kept as a tiny interface so the service can be
+// unit-tested with a fake and so this package doesn't depend on queries.
+type MemberVerifier interface {
+	GetBot(ctx context.Context, orgID string, id orgchart.BotID) (orgchart.Bot, error)
+}
+
 // Service is the spec-task application service. It is a thin policy layer
-// over the runtime.SpecTasks port: it never sees a project ID (the port
-// resolves that from the caller's worker state) and a Worker can only act
-// on its own project's tasks.
+// over the runtime.SpecTasks port. The caller's org + worker identity is
+// taken only from the authenticated invocation (never from tool args); an
+// optional projectID selects which project to act on (empty = the Worker's
+// own project), and the runtime port enforces that the project belongs to
+// the caller's org.
 type Service struct {
-	port runtime.SpecTasks
+	port    runtime.SpecTasks
+	members MemberVerifier
 }
 
 // New constructs the service over the given port. The port is required;
-// callers pass runtime.NoopSpecTasks{} when no real runtime is wired.
-func New(port runtime.SpecTasks) *Service {
-	return &Service{port: port}
+// callers pass runtime.NoopSpecTasks{} when no real runtime is wired. members
+// is optional: when set, every call verifies the caller Bot is a member of
+// its org (defensive depth — the MCP mount already enforces this); nil skips
+// the check (tests, non-MCP callers).
+func New(port runtime.SpecTasks, members MemberVerifier) *Service {
+	return &Service{port: port, members: members}
 }
 
-// callerIdentity extracts and validates the caller's org + worker IDs.
-// The worker is the subject of every call — there is no separate worker
-// argument, so a Worker can only manage its own project's tasks.
-func callerIdentity(caller tool.Caller) (string, orgchart.BotID, error) {
+// callerIdentity extracts and validates the caller's org + worker IDs and,
+// when a MemberVerifier is wired, confirms the Bot is a member of that org.
+// Identity is taken from the authenticated caller, never from tool args.
+func (s *Service) callerIdentity(ctx context.Context, caller tool.Caller) (string, orgchart.BotID, error) {
 	if caller == nil {
 		return "", "", errors.New("caller missing on invocation")
 	}
@@ -45,69 +59,74 @@ func callerIdentity(caller tool.Caller) (string, orgchart.BotID, error) {
 	if workerID == "" {
 		return "", "", errors.New("caller has no worker id")
 	}
+	if s.members != nil {
+		if _, err := s.members.GetBot(ctx, orgID, orgchart.BotID(workerID)); err != nil {
+			return "", "", fmt.Errorf("caller bot %s is not a member of org %s: %w", workerID, orgID, err)
+		}
+	}
 	return orgID, orgchart.BotID(workerID), nil
 }
 
-func (s *Service) Create(ctx context.Context, caller tool.Caller, in runtime.CreateSpecTaskInput) (runtime.SpecTaskView, error) {
-	orgID, workerID, err := callerIdentity(caller)
+func (s *Service) Create(ctx context.Context, caller tool.Caller, projectID string, in runtime.CreateSpecTaskInput) (runtime.SpecTaskView, error) {
+	orgID, workerID, err := s.callerIdentity(ctx, caller)
 	if err != nil {
 		return runtime.SpecTaskView{}, err
 	}
-	return s.port.Create(ctx, orgID, workerID, in)
+	return s.port.Create(ctx, orgID, workerID, projectID, in)
 }
 
-func (s *Service) List(ctx context.Context, caller tool.Caller, filter runtime.ListSpecTasksFilter) ([]runtime.SpecTaskView, error) {
-	orgID, workerID, err := callerIdentity(caller)
+func (s *Service) List(ctx context.Context, caller tool.Caller, projectID string, filter runtime.ListSpecTasksFilter) ([]runtime.SpecTaskView, error) {
+	orgID, workerID, err := s.callerIdentity(ctx, caller)
 	if err != nil {
 		return nil, err
 	}
-	return s.port.List(ctx, orgID, workerID, filter)
+	return s.port.List(ctx, orgID, workerID, projectID, filter)
 }
 
-func (s *Service) Get(ctx context.Context, caller tool.Caller, taskID string) (runtime.SpecTaskView, error) {
-	orgID, workerID, err := callerIdentity(caller)
+func (s *Service) Get(ctx context.Context, caller tool.Caller, projectID, taskID string) (runtime.SpecTaskView, error) {
+	orgID, workerID, err := s.callerIdentity(ctx, caller)
 	if err != nil {
 		return runtime.SpecTaskView{}, err
 	}
-	return s.port.Get(ctx, orgID, workerID, taskID)
+	return s.port.Get(ctx, orgID, workerID, projectID, taskID)
 }
 
-func (s *Service) StartPlanning(ctx context.Context, caller tool.Caller, taskID string) (runtime.SpecTaskView, error) {
-	orgID, workerID, err := callerIdentity(caller)
+func (s *Service) StartPlanning(ctx context.Context, caller tool.Caller, projectID, taskID string) (runtime.SpecTaskView, error) {
+	orgID, workerID, err := s.callerIdentity(ctx, caller)
 	if err != nil {
 		return runtime.SpecTaskView{}, err
 	}
-	return s.port.StartPlanning(ctx, orgID, workerID, taskID)
+	return s.port.StartPlanning(ctx, orgID, workerID, projectID, taskID)
 }
 
-func (s *Service) ReviewSpec(ctx context.Context, caller tool.Caller, taskID string) (runtime.SpecReviewView, error) {
-	orgID, workerID, err := callerIdentity(caller)
+func (s *Service) ReviewSpec(ctx context.Context, caller tool.Caller, projectID, taskID string) (runtime.SpecReviewView, error) {
+	orgID, workerID, err := s.callerIdentity(ctx, caller)
 	if err != nil {
 		return runtime.SpecReviewView{}, err
 	}
-	return s.port.ReviewSpec(ctx, orgID, workerID, taskID)
+	return s.port.ReviewSpec(ctx, orgID, workerID, projectID, taskID)
 }
 
-func (s *Service) ApproveSpec(ctx context.Context, caller tool.Caller, taskID string) (runtime.SpecTaskView, error) {
-	orgID, workerID, err := callerIdentity(caller)
+func (s *Service) ApproveSpec(ctx context.Context, caller tool.Caller, projectID, taskID string) (runtime.SpecTaskView, error) {
+	orgID, workerID, err := s.callerIdentity(ctx, caller)
 	if err != nil {
 		return runtime.SpecTaskView{}, err
 	}
-	return s.port.ApproveSpec(ctx, orgID, workerID, taskID)
+	return s.port.ApproveSpec(ctx, orgID, workerID, projectID, taskID)
 }
 
-func (s *Service) RequestChanges(ctx context.Context, caller tool.Caller, taskID, comment string) (runtime.SpecTaskView, error) {
-	orgID, workerID, err := callerIdentity(caller)
+func (s *Service) RequestChanges(ctx context.Context, caller tool.Caller, projectID, taskID, comment string) (runtime.SpecTaskView, error) {
+	orgID, workerID, err := s.callerIdentity(ctx, caller)
 	if err != nil {
 		return runtime.SpecTaskView{}, err
 	}
-	return s.port.RequestChanges(ctx, orgID, workerID, taskID, comment)
+	return s.port.RequestChanges(ctx, orgID, workerID, projectID, taskID, comment)
 }
 
-func (s *Service) CreatePullRequests(ctx context.Context, caller tool.Caller, taskID string) (runtime.SpecTaskView, error) {
-	orgID, workerID, err := callerIdentity(caller)
+func (s *Service) CreatePullRequests(ctx context.Context, caller tool.Caller, projectID, taskID string) (runtime.SpecTaskView, error) {
+	orgID, workerID, err := s.callerIdentity(ctx, caller)
 	if err != nil {
 		return runtime.SpecTaskView{}, err
 	}
-	return s.port.CreatePullRequests(ctx, orgID, workerID, taskID)
+	return s.port.CreatePullRequests(ctx, orgID, workerID, projectID, taskID)
 }

--- a/api/pkg/org/application/spectasks/spectasks_test.go
+++ b/api/pkg/org/application/spectasks/spectasks_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
 )
 
-// fakePort records the (orgID, workerID) it was called with and returns
-// canned results, so the service's caller-extraction and pass-through can
-// be asserted without a real runtime.
+// fakePort records the (orgID, workerID, projectID) it was called with and
+// returns canned results, so the service's caller-extraction and pass-through
+// can be asserted without a real runtime.
 type fakePort struct {
 	lastOrg     string
 	lastWorker  orgchart.BotID
+	lastProject string
 	createIn    runtime.CreateSpecTaskInput
 	view        runtime.SpecTaskView
 	review      runtime.SpecReviewView
@@ -23,40 +24,56 @@ type fakePort struct {
 	lastComment string
 }
 
-func (f *fakePort) Create(_ context.Context, org string, w orgchart.BotID, in runtime.CreateSpecTaskInput) (runtime.SpecTaskView, error) {
-	f.lastOrg, f.lastWorker, f.createIn = org, w, in
+func (f *fakePort) Create(_ context.Context, org string, w orgchart.BotID, projectID string, in runtime.CreateSpecTaskInput) (runtime.SpecTaskView, error) {
+	f.lastOrg, f.lastWorker, f.lastProject, f.createIn = org, w, projectID, in
 	return f.view, f.err
 }
-func (f *fakePort) List(_ context.Context, org string, w orgchart.BotID, _ runtime.ListSpecTasksFilter) ([]runtime.SpecTaskView, error) {
-	f.lastOrg, f.lastWorker = org, w
+func (f *fakePort) List(_ context.Context, org string, w orgchart.BotID, projectID string, _ runtime.ListSpecTasksFilter) ([]runtime.SpecTaskView, error) {
+	f.lastOrg, f.lastWorker, f.lastProject = org, w, projectID
 	if f.err != nil {
 		return nil, f.err
 	}
 	return []runtime.SpecTaskView{f.view}, nil
 }
-func (f *fakePort) Get(_ context.Context, org string, w orgchart.BotID, taskID string) (runtime.SpecTaskView, error) {
-	f.lastOrg, f.lastWorker, f.lastTaskID = org, w, taskID
+func (f *fakePort) Get(_ context.Context, org string, w orgchart.BotID, projectID, taskID string) (runtime.SpecTaskView, error) {
+	f.lastOrg, f.lastWorker, f.lastProject, f.lastTaskID = org, w, projectID, taskID
 	return f.view, f.err
 }
-func (f *fakePort) StartPlanning(_ context.Context, org string, w orgchart.BotID, taskID string) (runtime.SpecTaskView, error) {
-	f.lastOrg, f.lastWorker, f.lastTaskID = org, w, taskID
+func (f *fakePort) StartPlanning(_ context.Context, org string, w orgchart.BotID, projectID, taskID string) (runtime.SpecTaskView, error) {
+	f.lastOrg, f.lastWorker, f.lastProject, f.lastTaskID = org, w, projectID, taskID
 	return f.view, f.err
 }
-func (f *fakePort) ReviewSpec(_ context.Context, org string, w orgchart.BotID, taskID string) (runtime.SpecReviewView, error) {
-	f.lastOrg, f.lastWorker, f.lastTaskID = org, w, taskID
+func (f *fakePort) ReviewSpec(_ context.Context, org string, w orgchart.BotID, projectID, taskID string) (runtime.SpecReviewView, error) {
+	f.lastOrg, f.lastWorker, f.lastProject, f.lastTaskID = org, w, projectID, taskID
 	return f.review, f.err
 }
-func (f *fakePort) ApproveSpec(_ context.Context, org string, w orgchart.BotID, taskID string) (runtime.SpecTaskView, error) {
-	f.lastOrg, f.lastWorker, f.lastTaskID = org, w, taskID
+func (f *fakePort) ApproveSpec(_ context.Context, org string, w orgchart.BotID, projectID, taskID string) (runtime.SpecTaskView, error) {
+	f.lastOrg, f.lastWorker, f.lastProject, f.lastTaskID = org, w, projectID, taskID
 	return f.view, f.err
 }
-func (f *fakePort) RequestChanges(_ context.Context, org string, w orgchart.BotID, taskID, comment string) (runtime.SpecTaskView, error) {
-	f.lastOrg, f.lastWorker, f.lastTaskID, f.lastComment = org, w, taskID, comment
+func (f *fakePort) RequestChanges(_ context.Context, org string, w orgchart.BotID, projectID, taskID, comment string) (runtime.SpecTaskView, error) {
+	f.lastOrg, f.lastWorker, f.lastProject, f.lastTaskID, f.lastComment = org, w, projectID, taskID, comment
 	return f.view, f.err
 }
-func (f *fakePort) CreatePullRequests(_ context.Context, org string, w orgchart.BotID, taskID string) (runtime.SpecTaskView, error) {
-	f.lastOrg, f.lastWorker, f.lastTaskID = org, w, taskID
+func (f *fakePort) CreatePullRequests(_ context.Context, org string, w orgchart.BotID, projectID, taskID string) (runtime.SpecTaskView, error) {
+	f.lastOrg, f.lastWorker, f.lastProject, f.lastTaskID = org, w, projectID, taskID
 	return f.view, f.err
+}
+
+// fakeMembers satisfies MemberVerifier. err controls whether the caller Bot
+// is treated as a member of its org.
+type fakeMembers struct {
+	err        error
+	lastOrg    string
+	lastWorker orgchart.BotID
+}
+
+func (m *fakeMembers) GetBot(_ context.Context, org string, id orgchart.BotID) (orgchart.Bot, error) {
+	m.lastOrg, m.lastWorker = org, id
+	if m.err != nil {
+		return orgchart.Bot{}, m.err
+	}
+	return orgchart.Bot{ID: id, OrganizationID: org}, nil
 }
 
 // fakeCaller satisfies the minimal Worker surface (ID + OrganizationID).
@@ -71,8 +88,8 @@ func (c fakeCaller) OrganizationID() string { return c.org }
 func TestService_CreateExtractsCallerIdentity(t *testing.T) {
 	t.Parallel()
 	fp := &fakePort{view: runtime.SpecTaskView{ID: "task_1", Name: "x", Status: "backlog"}}
-	svc := New(fp)
-	view, err := svc.Create(context.Background(), fakeCaller{id: "w-alice", org: "org-1"}, runtime.CreateSpecTaskInput{Name: "x", Description: "y"})
+	svc := New(fp, nil)
+	view, err := svc.Create(context.Background(), fakeCaller{id: "w-alice", org: "org-1"}, "", runtime.CreateSpecTaskInput{Name: "x", Description: "y"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -84,27 +101,57 @@ func TestService_CreateExtractsCallerIdentity(t *testing.T) {
 	}
 }
 
+// TestService_ForwardsProjectID pins the cross-project pass-through: an
+// explicit project_id reaches the port unchanged (the port is where the
+// org-ownership check lives).
+func TestService_ForwardsProjectID(t *testing.T) {
+	t.Parallel()
+	fp := &fakePort{view: runtime.SpecTaskView{ID: "task_9"}}
+	svc := New(fp, nil)
+	if _, err := svc.Get(context.Background(), fakeCaller{id: "w-pm", org: "org-1"}, "prj_other", "task_9"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if fp.lastProject != "prj_other" {
+		t.Errorf("project passed = %q, want prj_other", fp.lastProject)
+	}
+}
+
 func TestService_RejectsCallerWithoutOrg(t *testing.T) {
 	t.Parallel()
-	svc := New(&fakePort{})
-	if _, err := svc.Create(context.Background(), fakeCaller{id: "w-alice", org: ""}, runtime.CreateSpecTaskInput{Name: "x", Description: "y"}); err == nil {
+	svc := New(&fakePort{}, nil)
+	if _, err := svc.Create(context.Background(), fakeCaller{id: "w-alice", org: ""}, "", runtime.CreateSpecTaskInput{Name: "x", Description: "y"}); err == nil {
 		t.Error("expected error when caller has no organization")
 	}
 }
 
 func TestService_RejectsNilCaller(t *testing.T) {
 	t.Parallel()
-	svc := New(&fakePort{})
-	if _, err := svc.Get(context.Background(), nil, "task_1"); err == nil {
+	svc := New(&fakePort{}, nil)
+	if _, err := svc.Get(context.Background(), nil, "", "task_1"); err == nil {
 		t.Error("expected error on nil caller")
+	}
+}
+
+// TestService_RejectsNonMemberBot pins the defensive membership check: when a
+// MemberVerifier is wired and the caller Bot is not found in its org, the call
+// is rejected before touching the port.
+func TestService_RejectsNonMemberBot(t *testing.T) {
+	t.Parallel()
+	fp := &fakePort{}
+	svc := New(fp, &fakeMembers{err: errors.New("bot not found")})
+	if _, err := svc.Get(context.Background(), fakeCaller{id: "w-intruder", org: "org-1"}, "", "task_1"); err == nil {
+		t.Error("expected error when caller bot is not a member of the org")
+	}
+	if fp.lastTaskID != "" {
+		t.Errorf("port should not be called when membership fails, got taskID=%q", fp.lastTaskID)
 	}
 }
 
 func TestService_PropagatesPortError(t *testing.T) {
 	t.Parallel()
 	sentinel := errors.New("boom")
-	svc := New(&fakePort{err: sentinel})
-	if _, err := svc.Get(context.Background(), fakeCaller{id: "w-alice", org: "org-1"}, "task_1"); !errors.Is(err, sentinel) {
+	svc := New(&fakePort{err: sentinel}, nil)
+	if _, err := svc.Get(context.Background(), fakeCaller{id: "w-alice", org: "org-1"}, "", "task_1"); !errors.Is(err, sentinel) {
 		t.Errorf("err = %v, want sentinel", err)
 	}
 }
@@ -112,8 +159,8 @@ func TestService_PropagatesPortError(t *testing.T) {
 func TestService_RequestChangesPassesComment(t *testing.T) {
 	t.Parallel()
 	fp := &fakePort{view: runtime.SpecTaskView{ID: "task_1", Status: "spec_revision"}}
-	svc := New(fp)
-	if _, err := svc.RequestChanges(context.Background(), fakeCaller{id: "w-alice", org: "org-1"}, "task_1", "fix scope"); err != nil {
+	svc := New(fp, nil)
+	if _, err := svc.RequestChanges(context.Background(), fakeCaller{id: "w-alice", org: "org-1"}, "", "task_1", "fix scope"); err != nil {
 		t.Fatalf("RequestChanges: %v", err)
 	}
 	if fp.lastComment != "fix scope" || fp.lastTaskID != "task_1" {
@@ -124,8 +171,8 @@ func TestService_RequestChangesPassesComment(t *testing.T) {
 func TestService_ReviewSpecReturnsReviewView(t *testing.T) {
 	t.Parallel()
 	fp := &fakePort{review: runtime.SpecReviewView{TaskID: "task_1", Requirements: "reqs"}}
-	svc := New(fp)
-	rv, err := svc.ReviewSpec(context.Background(), fakeCaller{id: "w-alice", org: "org-1"}, "task_1")
+	svc := New(fp, nil)
+	rv, err := svc.ReviewSpec(context.Background(), fakeCaller{id: "w-alice", org: "org-1"}, "", "task_1")
 	if err != nil {
 		t.Fatalf("ReviewSpec: %v", err)
 	}

--- a/api/pkg/org/domain/processor/filter_test.go
+++ b/api/pkg/org/domain/processor/filter_test.go
@@ -125,3 +125,46 @@ func keys(m map[string]bool) []string {
 	}
 	return out
 }
+
+// TestFilterRoutesSpecTaskEventsToBot confirms an org-wide PM Bot can be
+// wired to a project's spec-task events using ONLY the existing filter
+// processor — no dedicated connect tool. It mirrors the payload the
+// attention publisher emits (ThreadID = spec task id; Extra carries
+// event_type / project_id) and shows routing on both a first-class Message
+// field (thread_id) and an Extra key (event_type via printf %s).
+func TestFilterRoutesSpecTaskEventsToBot(t *testing.T) {
+	// Two branches: PRs for a specific project, and everything for one task.
+	p := newFilterProc(t, []processor.Output{
+		{TopicID: "s-pm-prs", Match: `{{ if and (contains "\"event_type\":\"pr_ready\"" (printf "%s" .Message.extra)) (contains "\"project_id\":\"prj_1\"" (printf "%s" .Message.extra)) }}1{{ end }}`},
+		{TopicID: "s-task-thread", Match: `{{ if eq .Message.thread_id "task_1" }}1{{ end }}`},
+	})
+
+	// A pr_ready event for task_1 in prj_1 — matches both branches.
+	prReady := streaming.Message{
+		Subject:  "PR ready",
+		Body:     "review it",
+		ThreadID: "task_1",
+		Extra:    []byte(`{"spec_task_id":"task_1","event_type":"pr_ready","project_id":"prj_1"}`),
+	}
+	res, err := p.Process(prReady)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	got := topicSet(res)
+	if !got["s-pm-prs"] || !got["s-task-thread"] {
+		t.Fatalf("pr_ready for task_1/prj_1 should route to both branches, got %v", keys(got))
+	}
+
+	// A ci_failed event for a different task/project — matches neither.
+	other := streaming.Message{
+		ThreadID: "task_2",
+		Extra:    []byte(`{"spec_task_id":"task_2","event_type":"ci_failed","project_id":"prj_2"}`),
+	}
+	res2, err := p.Process(other)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if len(res2) != 0 {
+		t.Fatalf("unrelated event should be dropped, got %v", keys(topicSet(res2)))
+	}
+}

--- a/api/pkg/org/infrastructure/runtime/helix/projects.go
+++ b/api/pkg/org/infrastructure/runtime/helix/projects.go
@@ -1,0 +1,78 @@
+package helix
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// ProjectStore is the slice of the Helix store the project-discovery
+// runtime impl needs. *store.PostgresStore satisfies it structurally, so
+// the server wires the real store with no adapter.
+type ProjectStore interface {
+	ListProjects(ctx context.Context, query *store.ListProjectsQuery) ([]*types.Project, error)
+	GetProject(ctx context.Context, id string) (*types.Project, error)
+}
+
+// Projects is the helix-runtime implementation of runtime.Projects. Every
+// read is scoped to the caller's org: List filters by org, Get asserts the
+// project belongs to the org before returning it (a project id from
+// another tenant is rejected). No existing helix code is modified.
+type Projects struct {
+	store ProjectStore
+}
+
+// NewProjects builds the impl. The store is required.
+func NewProjects(s ProjectStore) (*Projects, error) {
+	if s == nil {
+		return nil, errors.New("helix.NewProjects: store is nil")
+	}
+	return &Projects{store: s}, nil
+}
+
+var _ runtime.Projects = (*Projects)(nil)
+
+func (p *Projects) List(ctx context.Context, orgID string) ([]runtime.ProjectView, error) {
+	if orgID == "" {
+		return nil, errors.New("orgID is required")
+	}
+	projects, err := p.store.ListProjects(ctx, &store.ListProjectsQuery{OrganizationID: orgID})
+	if err != nil {
+		return nil, fmt.Errorf("list projects: %w", err)
+	}
+	out := make([]runtime.ProjectView, 0, len(projects))
+	for _, proj := range projects {
+		out = append(out, projectView(proj))
+	}
+	return out, nil
+}
+
+func (p *Projects) Get(ctx context.Context, orgID, projectID string) (runtime.ProjectView, error) {
+	if orgID == "" {
+		return runtime.ProjectView{}, errors.New("orgID is required")
+	}
+	proj, err := p.store.GetProject(ctx, projectID)
+	if err != nil {
+		return runtime.ProjectView{}, fmt.Errorf("get project: %w", err)
+	}
+	// Hard org scoping: never return another tenant's project.
+	if proj.OrganizationID != orgID {
+		return runtime.ProjectView{}, fmt.Errorf("project %s does not belong to this organization", projectID)
+	}
+	return projectView(proj), nil
+}
+
+func projectView(p *types.Project) runtime.ProjectView {
+	return runtime.ProjectView{
+		ID:             p.ID,
+		Name:           p.Name,
+		Description:    p.Description,
+		Status:         p.Status,
+		DefaultRepoID:  p.DefaultRepoID,
+		DefaultAgentID: p.DefaultHelixAppID,
+	}
+}

--- a/api/pkg/org/infrastructure/runtime/helix/projects_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/projects_test.go
@@ -1,0 +1,86 @@
+package helix
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// fakeProjectStore is an in-memory ProjectStore for the projects impl tests.
+type fakeProjectStore struct {
+	projects map[string]*types.Project
+}
+
+func newFakeProjectStore() *fakeProjectStore {
+	return &fakeProjectStore{projects: map[string]*types.Project{}}
+}
+
+func (f *fakeProjectStore) ListProjects(_ context.Context, q *store.ListProjectsQuery) ([]*types.Project, error) {
+	var out []*types.Project
+	for _, p := range f.projects {
+		if q.OrganizationID != "" && p.OrganizationID != q.OrganizationID {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+func (f *fakeProjectStore) GetProject(_ context.Context, id string) (*types.Project, error) {
+	p, ok := f.projects[id]
+	if !ok {
+		return nil, errors.New("project not found")
+	}
+	return p, nil
+}
+
+func TestProjects_RejectsNilStore(t *testing.T) {
+	t.Parallel()
+	if _, err := NewProjects(nil); err == nil {
+		t.Error("expected error on nil store")
+	}
+}
+
+func TestProjects_ListScopesToOrg(t *testing.T) {
+	t.Parallel()
+	fs := newFakeProjectStore()
+	fs.projects["prj_a"] = &types.Project{ID: "prj_a", OrganizationID: "org-1", Name: "A"}
+	fs.projects["prj_b"] = &types.Project{ID: "prj_b", OrganizationID: "org-2", Name: "B"}
+	p, err := NewProjects(fs)
+	if err != nil {
+		t.Fatalf("NewProjects: %v", err)
+	}
+	views, err := p.List(context.Background(), "org-1")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(views) != 1 || views[0].ID != "prj_a" {
+		t.Errorf("views = %+v, want only prj_a", views)
+	}
+}
+
+func TestProjects_GetSameOrg(t *testing.T) {
+	t.Parallel()
+	fs := newFakeProjectStore()
+	fs.projects["prj_a"] = &types.Project{ID: "prj_a", OrganizationID: "org-1", Name: "A", Status: "active"}
+	p, _ := NewProjects(fs)
+	view, err := p.Get(context.Background(), "org-1", "prj_a")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if view.ID != "prj_a" || view.Status != "active" {
+		t.Errorf("view = %+v", view)
+	}
+}
+
+func TestProjects_GetCrossOrgRejected(t *testing.T) {
+	t.Parallel()
+	fs := newFakeProjectStore()
+	fs.projects["prj_a"] = &types.Project{ID: "prj_a", OrganizationID: "org-2"}
+	p, _ := NewProjects(fs)
+	if _, err := p.Get(context.Background(), "org-1", "prj_a"); err == nil {
+		t.Error("expected cross-org rejection")
+	}
+}

--- a/api/pkg/org/infrastructure/runtime/helix/spectasks.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spectasks.go
@@ -37,6 +37,11 @@ type SpecTaskStore interface {
 type SpecTaskWorkflow interface {
 	ApproveSpecs(ctx context.Context, task *types.SpecTask) error
 	EnsurePullRequests(ctx context.Context, task *types.SpecTask, primaryRepoID, userID string) error
+	// RequestChanges delivers the reviewer's comment to the task's agent
+	// (the same revision-instruction the REST design-review path sends), so
+	// the comment isn't dropped on the MCP path. userID is the actor to
+	// attribute / notify (the Worker's hiring user).
+	RequestChanges(ctx context.Context, task *types.SpecTask, comment, userID string) error
 }
 
 // SpecTasks is the helix-runtime implementation of runtime.SpecTasks. It
@@ -281,7 +286,7 @@ func (s *SpecTasks) ApproveSpec(ctx context.Context, orgID string, workerID orgc
 }
 
 func (s *SpecTasks) RequestChanges(ctx context.Context, orgID string, workerID orgchart.BotID, requestedProjectID, taskID, comment string) (runtime.SpecTaskView, error) {
-	projectID, _, err := s.resolveProject(ctx, orgID, workerID, requestedProjectID)
+	projectID, hiringUserID, err := s.resolveProject(ctx, orgID, workerID, requestedProjectID)
 	if err != nil {
 		return runtime.SpecTaskView{}, err
 	}
@@ -292,14 +297,24 @@ func (s *SpecTasks) RequestChanges(ctx context.Context, orgID string, workerID o
 	if err != nil {
 		return runtime.SpecTaskView{}, err
 	}
-	// Send the spec back for revision. The full design-review-comment
-	// thread is the REST/UI path; here we make the same status transition
-	// the orchestrator reacts to and bump the revision count.
+	// Send the spec back for revision: the same status transition the
+	// orchestrator reacts to, plus a revision-count bump.
 	task.Status = types.TaskStatusSpecRevision
 	task.SpecRevisionCount++
 	task.UpdatedAt = time.Now()
 	if err := s.tasks.UpdateSpecTask(ctx, task); err != nil {
 		return runtime.SpecTaskView{}, fmt.Errorf("request changes: %w", err)
+	}
+	// Deliver the reviewer's comment to the task's agent — the same
+	// revision instruction the REST design-review path sends — so the
+	// comment isn't dropped on the MCP path. A delivery failure (e.g. no
+	// connected session) must not fail the transition: the status change is
+	// already persisted and the agent picks the feedback up on reconnect,
+	// matching the REST handler's best-effort semantics.
+	if derr := s.workflow.RequestChanges(ctx, task, comment, hiringUserID); derr != nil {
+		// Best-effort: swallow, mirroring the REST path which logs and
+		// continues. The transition above is the authoritative state.
+		_ = derr
 	}
 	return toView(task), nil
 }

--- a/api/pkg/org/infrastructure/runtime/helix/spectasks.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spectasks.go
@@ -67,18 +67,34 @@ func NewSpecTasks(orgStore *store.Store, tasks SpecTaskStore, workflow SpecTaskW
 
 var _ runtime.SpecTasks = (*SpecTasks)(nil)
 
-// project resolves the worker's project ID and hiring user from runtime
-// state. Returns ErrSpecTasksUnsupported when the worker has no project
-// (hired against a different runtime / not yet activated).
-func (s *SpecTasks) project(ctx context.Context, orgID string, workerID orgchart.BotID) (projectID, hiringUserID string, err error) {
+// resolveProject decides which project a call acts on and returns the
+// acting (hiring) user. When requestedProjectID is empty the call targets
+// the Worker's OWN project (resolved from runtime state) — the original
+// behaviour. When it is non-empty the call targets another project the
+// caller manages; we load that project and assert it belongs to the
+// caller's org, a HARD cross-org block (an org-wide PM Bot must never
+// reach another tenant's project by guessing an id). The acting user is
+// always the Worker's hiring user, so cross-project mutations are still
+// attributed to a real Helix user.
+func (s *SpecTasks) resolveProject(ctx context.Context, orgID string, workerID orgchart.BotID, requestedProjectID string) (projectID, hiringUserID string, err error) {
 	state, err := LoadState(ctx, s.orgStore, orgID, workerID)
 	if err != nil {
 		return "", "", fmt.Errorf("load worker state: %w", err)
 	}
-	if state.ProjectID == "" {
-		return "", "", fmt.Errorf("worker %s: %w", workerID, runtime.ErrSpecTasksUnsupported)
+	if requestedProjectID == "" {
+		if state.ProjectID == "" {
+			return "", "", fmt.Errorf("worker %s: %w", workerID, runtime.ErrSpecTasksUnsupported)
+		}
+		return state.ProjectID, state.HiringUserID, nil
 	}
-	return state.ProjectID, state.HiringUserID, nil
+	project, err := s.tasks.GetProject(ctx, requestedProjectID)
+	if err != nil {
+		return "", "", fmt.Errorf("get project: %w", err)
+	}
+	if project.OrganizationID != orgID {
+		return "", "", fmt.Errorf("project %s does not belong to this worker's organization", requestedProjectID)
+	}
+	return requestedProjectID, state.HiringUserID, nil
 }
 
 // ownedTask fetches a task and verifies it belongs to the caller's
@@ -94,8 +110,8 @@ func (s *SpecTasks) ownedTask(ctx context.Context, projectID, taskID string) (*t
 	return task, nil
 }
 
-func (s *SpecTasks) Create(ctx context.Context, orgID string, workerID orgchart.BotID, in runtime.CreateSpecTaskInput) (runtime.SpecTaskView, error) {
-	projectID, hiringUserID, err := s.project(ctx, orgID, workerID)
+func (s *SpecTasks) Create(ctx context.Context, orgID string, workerID orgchart.BotID, requestedProjectID string, in runtime.CreateSpecTaskInput) (runtime.SpecTaskView, error) {
+	projectID, hiringUserID, err := s.resolveProject(ctx, orgID, workerID, requestedProjectID)
 	if err != nil {
 		return runtime.SpecTaskView{}, err
 	}
@@ -157,8 +173,8 @@ func (s *SpecTasks) Create(ctx context.Context, orgID string, workerID orgchart.
 	return toView(task), nil
 }
 
-func (s *SpecTasks) List(ctx context.Context, orgID string, workerID orgchart.BotID, filter runtime.ListSpecTasksFilter) ([]runtime.SpecTaskView, error) {
-	projectID, _, err := s.project(ctx, orgID, workerID)
+func (s *SpecTasks) List(ctx context.Context, orgID string, workerID orgchart.BotID, requestedProjectID string, filter runtime.ListSpecTasksFilter) ([]runtime.SpecTaskView, error) {
+	projectID, _, err := s.resolveProject(ctx, orgID, workerID, requestedProjectID)
 	if err != nil {
 		return nil, err
 	}
@@ -178,8 +194,8 @@ func (s *SpecTasks) List(ctx context.Context, orgID string, workerID orgchart.Bo
 	return out, nil
 }
 
-func (s *SpecTasks) Get(ctx context.Context, orgID string, workerID orgchart.BotID, taskID string) (runtime.SpecTaskView, error) {
-	projectID, _, err := s.project(ctx, orgID, workerID)
+func (s *SpecTasks) Get(ctx context.Context, orgID string, workerID orgchart.BotID, requestedProjectID, taskID string) (runtime.SpecTaskView, error) {
+	projectID, _, err := s.resolveProject(ctx, orgID, workerID, requestedProjectID)
 	if err != nil {
 		return runtime.SpecTaskView{}, err
 	}
@@ -190,8 +206,8 @@ func (s *SpecTasks) Get(ctx context.Context, orgID string, workerID orgchart.Bot
 	return toView(task), nil
 }
 
-func (s *SpecTasks) StartPlanning(ctx context.Context, orgID string, workerID orgchart.BotID, taskID string) (runtime.SpecTaskView, error) {
-	projectID, _, err := s.project(ctx, orgID, workerID)
+func (s *SpecTasks) StartPlanning(ctx context.Context, orgID string, workerID orgchart.BotID, requestedProjectID, taskID string) (runtime.SpecTaskView, error) {
+	projectID, _, err := s.resolveProject(ctx, orgID, workerID, requestedProjectID)
 	if err != nil {
 		return runtime.SpecTaskView{}, err
 	}
@@ -213,8 +229,8 @@ func (s *SpecTasks) StartPlanning(ctx context.Context, orgID string, workerID or
 	return toView(task), nil
 }
 
-func (s *SpecTasks) ReviewSpec(ctx context.Context, orgID string, workerID orgchart.BotID, taskID string) (runtime.SpecReviewView, error) {
-	projectID, _, err := s.project(ctx, orgID, workerID)
+func (s *SpecTasks) ReviewSpec(ctx context.Context, orgID string, workerID orgchart.BotID, requestedProjectID, taskID string) (runtime.SpecReviewView, error) {
+	projectID, _, err := s.resolveProject(ctx, orgID, workerID, requestedProjectID)
 	if err != nil {
 		return runtime.SpecReviewView{}, err
 	}
@@ -234,8 +250,8 @@ func (s *SpecTasks) ReviewSpec(ctx context.Context, orgID string, workerID orgch
 	}, nil
 }
 
-func (s *SpecTasks) ApproveSpec(ctx context.Context, orgID string, workerID orgchart.BotID, taskID string) (runtime.SpecTaskView, error) {
-	projectID, hiringUserID, err := s.project(ctx, orgID, workerID)
+func (s *SpecTasks) ApproveSpec(ctx context.Context, orgID string, workerID orgchart.BotID, requestedProjectID, taskID string) (runtime.SpecTaskView, error) {
+	projectID, hiringUserID, err := s.resolveProject(ctx, orgID, workerID, requestedProjectID)
 	if err != nil {
 		return runtime.SpecTaskView{}, err
 	}
@@ -264,8 +280,8 @@ func (s *SpecTasks) ApproveSpec(ctx context.Context, orgID string, workerID orgc
 	return toView(task), nil
 }
 
-func (s *SpecTasks) RequestChanges(ctx context.Context, orgID string, workerID orgchart.BotID, taskID, comment string) (runtime.SpecTaskView, error) {
-	projectID, _, err := s.project(ctx, orgID, workerID)
+func (s *SpecTasks) RequestChanges(ctx context.Context, orgID string, workerID orgchart.BotID, requestedProjectID, taskID, comment string) (runtime.SpecTaskView, error) {
+	projectID, _, err := s.resolveProject(ctx, orgID, workerID, requestedProjectID)
 	if err != nil {
 		return runtime.SpecTaskView{}, err
 	}
@@ -288,8 +304,8 @@ func (s *SpecTasks) RequestChanges(ctx context.Context, orgID string, workerID o
 	return toView(task), nil
 }
 
-func (s *SpecTasks) CreatePullRequests(ctx context.Context, orgID string, workerID orgchart.BotID, taskID string) (runtime.SpecTaskView, error) {
-	projectID, hiringUserID, err := s.project(ctx, orgID, workerID)
+func (s *SpecTasks) CreatePullRequests(ctx context.Context, orgID string, workerID orgchart.BotID, requestedProjectID, taskID string) (runtime.SpecTaskView, error) {
+	projectID, hiringUserID, err := s.resolveProject(ctx, orgID, workerID, requestedProjectID)
 	if err != nil {
 		return runtime.SpecTaskView{}, err
 	}

--- a/api/pkg/org/infrastructure/runtime/helix/spectasks_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spectasks_test.go
@@ -71,10 +71,13 @@ func (f *fakeSpecTaskStore) IncrementGlobalTaskNumber(_ context.Context) (int, e
 
 // fakeSpecTaskWorkflow records the service-level calls.
 type fakeSpecTaskWorkflow struct {
-	approveCalls    []string
-	ensureCalls     []string
-	ensurePrimaryID string
-	ensureUserID    string
+	approveCalls        []string
+	ensureCalls         []string
+	ensurePrimaryID     string
+	ensureUserID        string
+	requestChangesCalls []string
+	lastComment         string
+	lastRequestUserID   string
 }
 
 func (f *fakeSpecTaskWorkflow) ApproveSpecs(_ context.Context, task *types.SpecTask) error {
@@ -87,6 +90,12 @@ func (f *fakeSpecTaskWorkflow) EnsurePullRequests(_ context.Context, task *types
 	f.ensureUserID = userID
 	// Simulate the system opening a PR.
 	task.RepoPullRequests = []types.RepoPR{{RepositoryName: "helix", PRURL: "https://example/pr/1", PRState: "open"}}
+	return nil
+}
+func (f *fakeSpecTaskWorkflow) RequestChanges(_ context.Context, task *types.SpecTask, comment, userID string) error {
+	f.requestChangesCalls = append(f.requestChangesCalls, task.ID)
+	f.lastComment = comment
+	f.lastRequestUserID = userID
 	return nil
 }
 
@@ -227,6 +236,40 @@ func TestSpecTasks_CrossOrgProjectRejected(t *testing.T) {
 	}
 	if _, err := st.Get(context.Background(), "org-test", wid, "prj_foreign", "task_f"); err == nil {
 		t.Error("expected cross-org rejection when targeting another org's project")
+	}
+}
+
+// TestSpecTasks_RequestChangesDeliversComment pins that the reviewer's
+// comment is delivered to the agent via the workflow (not dropped), and the
+// task transitions to spec_revision with a bumped count.
+func TestSpecTasks_RequestChangesDeliversComment(t *testing.T) {
+	t.Parallel()
+	wrap := newSpecTasksTestStore(t)
+	wid := orgchart.BotID("w-alice")
+	saveAllPointers(t, &wrap.Store, "org-test", wid, "prj_mine", "app_x", "repo_y", "ses_z")
+	if err := SaveHiringUser(context.Background(), &wrap.Store, "org-test", wid, "user_hiring"); err != nil {
+		t.Fatalf("SaveHiringUser: %v", err)
+	}
+
+	fs := newFakeSpecTaskStore()
+	fs.tasks["task_1"] = &types.SpecTask{ID: "task_1", ProjectID: "prj_mine", Status: types.TaskStatusSpecReview}
+	wf := &fakeSpecTaskWorkflow{}
+	st, err := NewSpecTasks(&wrap.Store, fs, wf)
+	if err != nil {
+		t.Fatalf("NewSpecTasks: %v", err)
+	}
+	if _, err := st.RequestChanges(context.Background(), "org-test", wid, "", "task_1", "tighten scope"); err != nil {
+		t.Fatalf("RequestChanges: %v", err)
+	}
+	if len(wf.requestChangesCalls) != 1 || wf.lastComment != "tighten scope" {
+		t.Errorf("workflow RequestChanges calls=%v comment=%q, want 1 call with the comment", wf.requestChangesCalls, wf.lastComment)
+	}
+	if wf.lastRequestUserID != "user_hiring" {
+		t.Errorf("actor = %q, want user_hiring", wf.lastRequestUserID)
+	}
+	got := fs.tasks["task_1"]
+	if got.Status != types.TaskStatusSpecRevision || got.SpecRevisionCount != 1 {
+		t.Errorf("status=%q count=%d, want spec_revision / 1", got.Status, got.SpecRevisionCount)
 	}
 }
 

--- a/api/pkg/org/infrastructure/runtime/helix/spectasks_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spectasks_test.go
@@ -119,7 +119,7 @@ func TestSpecTasks_NoProjectReturnsUnsupported(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSpecTasks: %v", err)
 	}
-	_, err = st.Create(context.Background(), "org-test", orgchart.BotID("w-noproject"), runtime.CreateSpecTaskInput{Name: "x", Description: "y"})
+	_, err = st.Create(context.Background(), "org-test", orgchart.BotID("w-noproject"), "", runtime.CreateSpecTaskInput{Name: "x", Description: "y"})
 	if !errors.Is(err, runtime.ErrSpecTasksUnsupported) {
 		t.Errorf("err = %v, want ErrSpecTasksUnsupported", err)
 	}
@@ -140,7 +140,7 @@ func TestSpecTasks_CreateInOwnProject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSpecTasks: %v", err)
 	}
-	view, err := st.Create(context.Background(), "org-test", wid, runtime.CreateSpecTaskInput{
+	view, err := st.Create(context.Background(), "org-test", wid, "", runtime.CreateSpecTaskInput{
 		Name: "Add login", Description: "Add a login page",
 	})
 	if err != nil {
@@ -178,8 +178,55 @@ func TestSpecTasks_GetForeignTaskRejected(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSpecTasks: %v", err)
 	}
-	if _, err := st.Get(context.Background(), "org-test", wid, "task_other"); err == nil {
+	if _, err := st.Get(context.Background(), "org-test", wid, "", "task_other"); err == nil {
 		t.Error("expected ownership error for foreign task")
+	}
+}
+
+// TestSpecTasks_CrossProjectSameOrgAllowed pins the org-wide PM path: a
+// Worker whose own project is prj_mine can act on a task in another
+// project (prj_other) in the SAME org by passing that project_id.
+func TestSpecTasks_CrossProjectSameOrgAllowed(t *testing.T) {
+	t.Parallel()
+	wrap := newSpecTasksTestStore(t)
+	wid := orgchart.BotID("w-pm")
+	saveAllPointers(t, &wrap.Store, "org-test", wid, "prj_mine", "app_x", "repo_y", "ses_z")
+
+	fs := newFakeSpecTaskStore()
+	fs.projects["prj_other"] = &types.Project{ID: "prj_other", OrganizationID: "org-test"}
+	fs.tasks["task_o"] = &types.SpecTask{ID: "task_o", ProjectID: "prj_other", Status: types.TaskStatusBacklog}
+	st, err := NewSpecTasks(&wrap.Store, fs, &fakeSpecTaskWorkflow{})
+	if err != nil {
+		t.Fatalf("NewSpecTasks: %v", err)
+	}
+	view, err := st.Get(context.Background(), "org-test", wid, "prj_other", "task_o")
+	if err != nil {
+		t.Fatalf("cross-project Get in same org should succeed: %v", err)
+	}
+	if view.ID != "task_o" {
+		t.Errorf("view.ID = %q, want task_o", view.ID)
+	}
+}
+
+// TestSpecTasks_CrossOrgProjectRejected pins the hard cross-org block: a
+// Worker cannot target a project that belongs to another org, even with a
+// valid project_id.
+func TestSpecTasks_CrossOrgProjectRejected(t *testing.T) {
+	t.Parallel()
+	wrap := newSpecTasksTestStore(t)
+	wid := orgchart.BotID("w-pm")
+	saveAllPointers(t, &wrap.Store, "org-test", wid, "prj_mine", "app_x", "repo_y", "ses_z")
+
+	fs := newFakeSpecTaskStore()
+	// Project exists but belongs to a DIFFERENT org.
+	fs.projects["prj_foreign"] = &types.Project{ID: "prj_foreign", OrganizationID: "org-other"}
+	fs.tasks["task_f"] = &types.SpecTask{ID: "task_f", ProjectID: "prj_foreign"}
+	st, err := NewSpecTasks(&wrap.Store, fs, &fakeSpecTaskWorkflow{})
+	if err != nil {
+		t.Fatalf("NewSpecTasks: %v", err)
+	}
+	if _, err := st.Get(context.Background(), "org-test", wid, "prj_foreign", "task_f"); err == nil {
+		t.Error("expected cross-org rejection when targeting another org's project")
 	}
 }
 
@@ -201,7 +248,7 @@ func TestSpecTasks_ApproveSpecSetsApproverAndDelegates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSpecTasks: %v", err)
 	}
-	if _, err := st.ApproveSpec(context.Background(), "org-test", wid, "task_1"); err != nil {
+	if _, err := st.ApproveSpec(context.Background(), "org-test", wid, "", "task_1"); err != nil {
 		t.Fatalf("ApproveSpec: %v", err)
 	}
 	if len(wf.approveCalls) != 1 {
@@ -225,7 +272,7 @@ func TestSpecTasks_RequestChangesTransitions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSpecTasks: %v", err)
 	}
-	view, err := st.RequestChanges(context.Background(), "org-test", wid, "task_1", "tighten scope")
+	view, err := st.RequestChanges(context.Background(), "org-test", wid, "", "task_1", "tighten scope")
 	if err != nil {
 		t.Fatalf("RequestChanges: %v", err)
 	}
@@ -254,7 +301,7 @@ func TestSpecTasks_CreatePullRequestsDelegatesAndMapsPRs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewSpecTasks: %v", err)
 	}
-	view, err := st.CreatePullRequests(context.Background(), "org-test", wid, "task_1")
+	view, err := st.CreatePullRequests(context.Background(), "org-test", wid, "", "task_1")
 	if err != nil {
 		t.Fatalf("CreatePullRequests: %v", err)
 	}

--- a/api/pkg/org/infrastructure/runtime/runtime.go
+++ b/api/pkg/org/infrastructure/runtime/runtime.go
@@ -309,3 +309,44 @@ func (NoopSpecTasks) CreatePullRequests(_ context.Context, _ string, _ orgchart.
 // ErrSpecTasksUnsupported is what the noop impl returns. Tools translate
 // it into a friendly MCP error.
 var ErrSpecTasksUnsupported = errors.New("spec task access not wired on this runtime")
+
+// Projects is the port the org MCP project-discovery tools use to list
+// and read the Helix projects in the caller's org — so an org-wide
+// project-manager Bot can discover which projects exist before deciding
+// which to manage. Reads are ALWAYS scoped to the caller's org: List
+// returns only that org's projects, and Get asserts the project belongs
+// to the org (a project id from another tenant returns an error, never
+// another org's data). Other runtimes plug in NoopProjects and the tools
+// surface ErrProjectsUnsupported.
+type Projects interface {
+	// List returns the projects in the caller's org.
+	List(ctx context.Context, orgID string) ([]ProjectView, error)
+	// Get returns one project by id; it must belong to the caller's org.
+	Get(ctx context.Context, orgID, projectID string) (ProjectView, error)
+}
+
+// ProjectView is the tool-facing projection of a Helix project. Append-only
+// from the JSON wire format so existing tool clients keep working.
+type ProjectView struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Description    string `json:"description,omitempty"`
+	Status         string `json:"status,omitempty"`
+	DefaultRepoID  string `json:"default_repo_id,omitempty"`
+	DefaultAgentID string `json:"default_helix_app_id,omitempty"`
+}
+
+// NoopProjects satisfies Projects without doing anything — the default for
+// tools.Deps so production paths that don't wire a real impl don't crash.
+type NoopProjects struct{}
+
+func (NoopProjects) List(_ context.Context, _ string) ([]ProjectView, error) {
+	return nil, ErrProjectsUnsupported
+}
+func (NoopProjects) Get(_ context.Context, _, _ string) (ProjectView, error) {
+	return ProjectView{}, ErrProjectsUnsupported
+}
+
+// ErrProjectsUnsupported is what the noop impl returns. Tools translate it
+// into a friendly MCP error.
+var ErrProjectsUnsupported = errors.New("project access not wired on this runtime")

--- a/api/pkg/org/infrastructure/runtime/runtime.go
+++ b/api/pkg/org/infrastructure/runtime/runtime.go
@@ -191,33 +191,38 @@ var ErrProjectConfigUnsupported = errors.New("project config access not wired on
 // approve, request changes, open PRs — rather than generic CRUD.
 //
 // Implementations key by orgID + workerID; the helix runtime impl
-// resolves worker→projectID via WorkerRuntimeState internally so MCP
-// tool callers never see (or supply) a project ID — a Worker can only
-// act on tasks in the project it is assigned to. Other runtimes plug in
-// NoopSpecTasks, and the tools surface ErrSpecTasksUnsupported.
+// resolves worker→projectID via WorkerRuntimeState internally. Every verb
+// also takes an optional projectID: empty means "the Worker's own
+// project" (the original behaviour — a Worker managing its own tasks); a
+// non-empty projectID targets another project the caller manages, and the
+// impl MUST assert that project belongs to the caller's org (a hard
+// cross-org block) before acting. This is what lets an org-wide project
+// manager Bot drive spec tasks across several projects in its org. Other
+// runtimes plug in NoopSpecTasks, and the tools surface
+// ErrSpecTasksUnsupported.
 type SpecTasks interface {
-	// Create makes a new spec task in the caller's project (status
+	// Create makes a new spec task in the target project (status
 	// backlog). Mirrors the REST create-from-prompt path.
-	Create(ctx context.Context, orgID string, workerID orgchart.BotID, in CreateSpecTaskInput) (SpecTaskView, error)
-	// List returns the caller's project's spec tasks, optionally filtered.
-	List(ctx context.Context, orgID string, workerID orgchart.BotID, filter ListSpecTasksFilter) ([]SpecTaskView, error)
-	// Get returns one spec task; it must belong to the caller's project.
-	Get(ctx context.Context, orgID string, workerID orgchart.BotID, taskID string) (SpecTaskView, error)
+	Create(ctx context.Context, orgID string, workerID orgchart.BotID, projectID string, in CreateSpecTaskInput) (SpecTaskView, error)
+	// List returns the target project's spec tasks, optionally filtered.
+	List(ctx context.Context, orgID string, workerID orgchart.BotID, projectID string, filter ListSpecTasksFilter) ([]SpecTaskView, error)
+	// Get returns one spec task; it must belong to the target project.
+	Get(ctx context.Context, orgID string, workerID orgchart.BotID, projectID, taskID string) (SpecTaskView, error)
 	// StartPlanning begins spec generation (or queues implementation
 	// when the task is in skip-planning / just-do-it mode).
-	StartPlanning(ctx context.Context, orgID string, workerID orgchart.BotID, taskID string) (SpecTaskView, error)
+	StartPlanning(ctx context.Context, orgID string, workerID orgchart.BotID, projectID, taskID string) (SpecTaskView, error)
 	// ReviewSpec returns the generated requirements/design/tasks for the
 	// caller to review before approving or requesting changes.
-	ReviewSpec(ctx context.Context, orgID string, workerID orgchart.BotID, taskID string) (SpecReviewView, error)
+	ReviewSpec(ctx context.Context, orgID string, workerID orgchart.BotID, projectID, taskID string) (SpecReviewView, error)
 	// ApproveSpec approves the generated spec, advancing the task toward
 	// implementation.
-	ApproveSpec(ctx context.Context, orgID string, workerID orgchart.BotID, taskID string) (SpecTaskView, error)
+	ApproveSpec(ctx context.Context, orgID string, workerID orgchart.BotID, projectID, taskID string) (SpecTaskView, error)
 	// RequestChanges sends the spec back for revision with a comment.
-	RequestChanges(ctx context.Context, orgID string, workerID orgchart.BotID, taskID, comment string) (SpecTaskView, error)
+	RequestChanges(ctx context.Context, orgID string, workerID orgchart.BotID, projectID, taskID, comment string) (SpecTaskView, error)
 	// CreatePullRequests tells the system the code is good and to open
 	// the pull request(s) — one per repo attached to the project. It
 	// does NOT merge/approve on GitHub.
-	CreatePullRequests(ctx context.Context, orgID string, workerID orgchart.BotID, taskID string) (SpecTaskView, error)
+	CreatePullRequests(ctx context.Context, orgID string, workerID orgchart.BotID, projectID, taskID string) (SpecTaskView, error)
 }
 
 // CreateSpecTaskInput is the create shape. Only Name and Description are
@@ -276,28 +281,28 @@ type SpecReviewView struct {
 // crash. Every verb returns ErrSpecTasksUnsupported.
 type NoopSpecTasks struct{}
 
-func (NoopSpecTasks) Create(_ context.Context, _ string, _ orgchart.BotID, _ CreateSpecTaskInput) (SpecTaskView, error) {
+func (NoopSpecTasks) Create(_ context.Context, _ string, _ orgchart.BotID, _ string, _ CreateSpecTaskInput) (SpecTaskView, error) {
 	return SpecTaskView{}, ErrSpecTasksUnsupported
 }
-func (NoopSpecTasks) List(_ context.Context, _ string, _ orgchart.BotID, _ ListSpecTasksFilter) ([]SpecTaskView, error) {
+func (NoopSpecTasks) List(_ context.Context, _ string, _ orgchart.BotID, _ string, _ ListSpecTasksFilter) ([]SpecTaskView, error) {
 	return nil, ErrSpecTasksUnsupported
 }
-func (NoopSpecTasks) Get(_ context.Context, _ string, _ orgchart.BotID, _ string) (SpecTaskView, error) {
+func (NoopSpecTasks) Get(_ context.Context, _ string, _ orgchart.BotID, _, _ string) (SpecTaskView, error) {
 	return SpecTaskView{}, ErrSpecTasksUnsupported
 }
-func (NoopSpecTasks) StartPlanning(_ context.Context, _ string, _ orgchart.BotID, _ string) (SpecTaskView, error) {
+func (NoopSpecTasks) StartPlanning(_ context.Context, _ string, _ orgchart.BotID, _, _ string) (SpecTaskView, error) {
 	return SpecTaskView{}, ErrSpecTasksUnsupported
 }
-func (NoopSpecTasks) ReviewSpec(_ context.Context, _ string, _ orgchart.BotID, _ string) (SpecReviewView, error) {
+func (NoopSpecTasks) ReviewSpec(_ context.Context, _ string, _ orgchart.BotID, _, _ string) (SpecReviewView, error) {
 	return SpecReviewView{}, ErrSpecTasksUnsupported
 }
-func (NoopSpecTasks) ApproveSpec(_ context.Context, _ string, _ orgchart.BotID, _ string) (SpecTaskView, error) {
+func (NoopSpecTasks) ApproveSpec(_ context.Context, _ string, _ orgchart.BotID, _, _ string) (SpecTaskView, error) {
 	return SpecTaskView{}, ErrSpecTasksUnsupported
 }
-func (NoopSpecTasks) RequestChanges(_ context.Context, _ string, _ orgchart.BotID, _, _ string) (SpecTaskView, error) {
+func (NoopSpecTasks) RequestChanges(_ context.Context, _ string, _ orgchart.BotID, _, _, _ string) (SpecTaskView, error) {
 	return SpecTaskView{}, ErrSpecTasksUnsupported
 }
-func (NoopSpecTasks) CreatePullRequests(_ context.Context, _ string, _ orgchart.BotID, _ string) (SpecTaskView, error) {
+func (NoopSpecTasks) CreatePullRequests(_ context.Context, _ string, _ orgchart.BotID, _, _ string) (SpecTaskView, error) {
 	return SpecTaskView{}, ErrSpecTasksUnsupported
 }
 

--- a/api/pkg/org/infrastructure/runtime/spectasks_test.go
+++ b/api/pkg/org/infrastructure/runtime/spectasks_test.go
@@ -17,28 +17,28 @@ func TestNoopSpecTasks_AllVerbsUnsupported(t *testing.T) {
 	org := "org-test"
 	wid := "w-alice"
 
-	if _, err := st.Create(ctx, org, wid, CreateSpecTaskInput{Name: "x", Description: "y"}); !errors.Is(err, ErrSpecTasksUnsupported) {
+	if _, err := st.Create(ctx, org, wid, "", CreateSpecTaskInput{Name: "x", Description: "y"}); !errors.Is(err, ErrSpecTasksUnsupported) {
 		t.Errorf("Create err = %v, want ErrSpecTasksUnsupported", err)
 	}
-	if _, err := st.List(ctx, org, wid, ListSpecTasksFilter{}); !errors.Is(err, ErrSpecTasksUnsupported) {
+	if _, err := st.List(ctx, org, wid, "", ListSpecTasksFilter{}); !errors.Is(err, ErrSpecTasksUnsupported) {
 		t.Errorf("List err = %v, want ErrSpecTasksUnsupported", err)
 	}
-	if _, err := st.Get(ctx, org, wid, "task_1"); !errors.Is(err, ErrSpecTasksUnsupported) {
+	if _, err := st.Get(ctx, org, wid, "", "task_1"); !errors.Is(err, ErrSpecTasksUnsupported) {
 		t.Errorf("Get err = %v, want ErrSpecTasksUnsupported", err)
 	}
-	if _, err := st.StartPlanning(ctx, org, wid, "task_1"); !errors.Is(err, ErrSpecTasksUnsupported) {
+	if _, err := st.StartPlanning(ctx, org, wid, "", "task_1"); !errors.Is(err, ErrSpecTasksUnsupported) {
 		t.Errorf("StartPlanning err = %v, want ErrSpecTasksUnsupported", err)
 	}
-	if _, err := st.ReviewSpec(ctx, org, wid, "task_1"); !errors.Is(err, ErrSpecTasksUnsupported) {
+	if _, err := st.ReviewSpec(ctx, org, wid, "", "task_1"); !errors.Is(err, ErrSpecTasksUnsupported) {
 		t.Errorf("ReviewSpec err = %v, want ErrSpecTasksUnsupported", err)
 	}
-	if _, err := st.ApproveSpec(ctx, org, wid, "task_1"); !errors.Is(err, ErrSpecTasksUnsupported) {
+	if _, err := st.ApproveSpec(ctx, org, wid, "", "task_1"); !errors.Is(err, ErrSpecTasksUnsupported) {
 		t.Errorf("ApproveSpec err = %v, want ErrSpecTasksUnsupported", err)
 	}
-	if _, err := st.RequestChanges(ctx, org, wid, "task_1", "please fix"); !errors.Is(err, ErrSpecTasksUnsupported) {
+	if _, err := st.RequestChanges(ctx, org, wid, "", "task_1", "please fix"); !errors.Is(err, ErrSpecTasksUnsupported) {
 		t.Errorf("RequestChanges err = %v, want ErrSpecTasksUnsupported", err)
 	}
-	if _, err := st.CreatePullRequests(ctx, org, wid, "task_1"); !errors.Is(err, ErrSpecTasksUnsupported) {
+	if _, err := st.CreatePullRequests(ctx, org, wid, "", "task_1"); !errors.Is(err, ErrSpecTasksUnsupported) {
 		t.Errorf("CreatePullRequests err = %v, want ErrSpecTasksUnsupported", err)
 	}
 }

--- a/api/pkg/org/interfaces/mcptools/builtins.go
+++ b/api/pkg/org/interfaces/mcptools/builtins.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/helixml/helix/api/pkg/org/application/bots"
 	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
+	"github.com/helixml/helix/api/pkg/org/application/projects"
 	"github.com/helixml/helix/api/pkg/org/application/publishing"
 	"github.com/helixml/helix/api/pkg/org/application/queries"
 	"github.com/helixml/helix/api/pkg/org/application/reconcile"
@@ -80,6 +81,10 @@ type Deps struct {
 	// spec-task tools (create/list/get/start/review/approve/request-changes/
 	// create-PRs) scoped to the calling Worker's own project.
 	SpecTasks *spectasks.Service
+	// Projects is the front-of-house application service backing the
+	// project-discovery tools (list_projects/get_project), scoped to the
+	// caller's org.
+	Projects *projects.Service
 	// CredentialProviders is the registry mint_credential dispatches on.
 	CredentialProviders map[string]credential.Provider
 	// Hub lets the long-poll read tools (read_events, bot_log) block on
@@ -115,7 +120,11 @@ type Config struct {
 	// SpecTasks is the runtime port the spec-task tools dispatch on. nil
 	// → Build defaults to runtime.NoopSpecTasks{} so the tools return a
 	// clear "not wired" error instead of nil-derefing.
-	SpecTasks           runtime.SpecTasks
+	SpecTasks runtime.SpecTasks
+	// Projects is the runtime port the project-discovery tools dispatch on.
+	// nil → Build defaults to runtime.NoopProjects{} so the tools return a
+	// clear "not wired" error instead of nil-derefing.
+	Projects            runtime.Projects
 	Reconciler          *reconcile.Reconciler
 	CredentialProviders map[string]credential.Provider
 }
@@ -133,9 +142,26 @@ func (c Config) Build() Deps {
 		Workspace:           c.Workspace,
 		ProjectConfig:       c.ProjectConfig,
 		SpecTasks:           c.specTasksService(),
+		Projects:            c.projectsService(),
 		CredentialProviders: c.CredentialProviders,
 		Hub:                 c.Hub,
 	}
+}
+
+// projectsService builds the project-discovery application service over the
+// configured runtime port, defaulting to NoopProjects when none is wired.
+// Queries satisfies projects.MemberVerifier (GetBot); pass it so every
+// project read verifies the caller Bot is a member of its org.
+func (c Config) projectsService() *projects.Service {
+	port := c.Projects
+	if port == nil {
+		port = runtime.NoopProjects{}
+	}
+	var members projects.MemberVerifier
+	if c.Queries != nil {
+		members = c.Queries
+	}
+	return projects.New(port, members)
 }
 
 // specTasksService builds the spec-task application service over the
@@ -247,6 +273,7 @@ func DefaultDeps(s *store.Store) Config {
 		HireHook:            runtime.NoopHireHook{},
 		ProjectConfig:       runtime.NoopProjectConfig{},
 		SpecTasks:           runtime.NoopSpecTasks{},
+		Projects:            runtime.NoopProjects{},
 		CredentialProviders: map[string]credential.Provider{},
 	}
 	c.Reconciler = reconcile.New(reconcile.Deps{
@@ -314,6 +341,11 @@ func RegisterBuiltins(reg *Registry, deps Deps) error {
 		&Managers{deps: deps},
 		&Reports{deps: deps},
 		&GetBotProject{deps: deps},
+		// Project discovery — an org-wide PM Bot lists/reads the projects in
+		// its org before deciding which to manage. Org-scoped reads; granted
+		// per-Role (not in BaseReadTools).
+		NewListProjects(deps),
+		NewGetProject(deps),
 		NewListSpecTasks(deps),
 		NewGetSpecTask(deps),
 		NewReviewSpecTaskSpec(deps),

--- a/api/pkg/org/interfaces/mcptools/builtins.go
+++ b/api/pkg/org/interfaces/mcptools/builtins.go
@@ -147,7 +147,14 @@ func (c Config) specTasksService() *spectasks.Service {
 	if port == nil {
 		port = runtime.NoopSpecTasks{}
 	}
-	return spectasks.New(port)
+	// Queries satisfies spectasks.MemberVerifier (GetBot); pass it so every
+	// spec-task call verifies the caller Bot is a member of its org. nil is
+	// tolerated (the check is then skipped — the MCP mount already enforces it).
+	var members spectasks.MemberVerifier
+	if c.Queries != nil {
+		members = c.Queries
+	}
+	return spectasks.New(port, members)
 }
 
 // subscriptionsService builds the subscription application service.

--- a/api/pkg/org/interfaces/mcptools/projects.go
+++ b/api/pkg/org/interfaces/mcptools/projects.go
@@ -1,0 +1,89 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+)
+
+// This file holds the MCP project-discovery tools — list_projects and
+// get_project — the surface an org-wide project-manager Bot uses to find
+// out which Helix projects exist in its org before deciding which to
+// manage. Both are thin adapters over the projects application service,
+// which scopes every read to the caller's org.
+
+// --- list_projects --------------------------------------------------------
+
+const ListProjectsName tool.Name = "list_projects"
+
+type ListProjects struct{ deps Deps }
+
+func NewListProjects(deps Deps) *ListProjects { return &ListProjects{deps: deps} }
+
+// listProjectsArgs is intentionally empty today (the org is taken from the
+// caller). Kept as a struct so the schema is a stable empty object and new
+// filters can be added later without changing the tool shape.
+type listProjectsArgs struct{}
+
+var listProjectsSchema = mustSchema[listProjectsArgs]()
+
+func (t *ListProjects) Name() tool.Name                 { return ListProjectsName }
+func (t *ListProjects) InputSchema() *jsonschema.Schema { return listProjectsSchema }
+func (t *ListProjects) Description() string {
+	return "List the Helix projects in your organization — id, name, description, and status. " +
+		"Use this to discover which projects exist so you can manage their spec tasks " +
+		"(pass a project's id as project_id to the spec-task tools)."
+}
+func (t *ListProjects) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	if t.deps.Projects == nil {
+		return nil, errors.New("project access not wired on this server")
+	}
+	views, err := t.deps.Projects.List(ctx, inv.Caller)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(views)
+}
+
+// --- get_project ----------------------------------------------------------
+
+const GetProjectName tool.Name = "get_project"
+
+type GetProject struct{ deps Deps }
+
+func NewGetProject(deps Deps) *GetProject { return &GetProject{deps: deps} }
+
+type getProjectArgs struct {
+	ProjectID string `json:"project_id"`
+}
+
+var getProjectSchema = mustSchema[getProjectArgs]()
+
+func (t *GetProject) Name() tool.Name                 { return GetProjectName }
+func (t *GetProject) InputSchema() *jsonschema.Schema { return getProjectSchema }
+func (t *GetProject) Description() string {
+	return "Get one Helix project in your organization by its project_id. Returns not-found " +
+		"for a project in another organization."
+}
+func (t *GetProject) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	var args getProjectArgs
+	if err := json.Unmarshal(inv.Args, &args); err != nil {
+		return nil, fmt.Errorf("parse args: %w", err)
+	}
+	if args.ProjectID == "" {
+		return nil, errors.New("project_id is required")
+	}
+	if t.deps.Projects == nil {
+		return nil, errors.New("project access not wired on this server")
+	}
+	view, err := t.deps.Projects.Get(ctx, inv.Caller, args.ProjectID)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(view)
+}

--- a/api/pkg/org/interfaces/mcptools/projects_mcp_test.go
+++ b/api/pkg/org/interfaces/mcptools/projects_mcp_test.go
@@ -1,0 +1,113 @@
+package mcptools_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
+	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
+	"github.com/helixml/helix/api/pkg/org/interfaces/server"
+)
+
+// stubProjectsPort is a runtime.Projects returning canned org projects, so
+// the MCP e2e can prove list_projects/get_project work through the whole
+// server → registry → tool → projects service → port path.
+type stubProjectsPort struct{ views []runtime.ProjectView }
+
+func (s stubProjectsPort) List(_ context.Context, _ string) ([]runtime.ProjectView, error) {
+	return s.views, nil
+}
+func (s stubProjectsPort) Get(_ context.Context, _, projectID string) (runtime.ProjectView, error) {
+	for _, v := range s.views {
+		if v.ID == projectID {
+			return v, nil
+		}
+	}
+	return runtime.ProjectView{}, fmt.Errorf("project %s not found", projectID)
+}
+
+// TestProjectDiscoveryOverMCP is the end-to-end check for the project
+// discovery surface: a Bot granted the tools connects to the real HTTP MCP
+// server and both tools are advertised and return the org's projects.
+func TestProjectDiscoveryOverMCP(t *testing.T) {
+	t.Parallel()
+
+	s := orggorm.GetOrgTestDB(t)
+
+	reg := mcptools.NewRegistry()
+	cfg := mcptools.DefaultDeps(s)
+	cfg.Projects = stubProjectsPort{views: []runtime.ProjectView{
+		{ID: "prj_1", Name: "Alpha", Status: "active"},
+		{ID: "prj_2", Name: "Beta", Status: "active"},
+	}}
+	if err := mcptools.RegisterBuiltins(reg, cfg.Build()); err != nil {
+		t.Fatalf("register builtins: %v", err)
+	}
+	srv := httptest.NewServer(server.NewFromStore(s, reg, nil, nil, nil).Handler())
+	t.Cleanup(srv.Close)
+
+	ctx := context.Background()
+
+	// Seed a PM bot granted the discovery tools.
+	bot, err := orgchart.NewBot(
+		"b-pm",
+		"# PM\nProject manager bot.",
+		[]tool.Name{mcptools.ListProjectsName, mcptools.GetProjectName},
+		time.Now().UTC(),
+		"org-test",
+	)
+	if err != nil {
+		t.Fatalf("new bot: %v", err)
+	}
+	mustCreate(t, s.Bots.Create(ctx, bot))
+
+	session := connectMCP(t, srv.URL, "b-pm")
+
+	// Both tools advertised.
+	tools, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	advertised := map[string]bool{}
+	for _, tl := range tools.Tools {
+		advertised[tl.Name] = true
+	}
+	if !advertised[string(mcptools.ListProjectsName)] || !advertised[string(mcptools.GetProjectName)] {
+		t.Fatalf("project tools not advertised: %v", advertised)
+	}
+
+	// list_projects returns the org's projects.
+	out, err := invokeTool(t, session, mcptools.ListProjectsName, map[string]any{})
+	if err != nil {
+		t.Fatalf("list_projects: %v", err)
+	}
+	var views []runtime.ProjectView
+	if err := json.Unmarshal(out, &views); err != nil {
+		t.Fatalf("unmarshal list_projects: %v (%s)", err, out)
+	}
+	if len(views) != 2 {
+		t.Fatalf("list_projects returned %d, want 2: %s", len(views), out)
+	}
+
+	// get_project returns the named project.
+	got, err := invokeTool(t, session, mcptools.GetProjectName, map[string]any{"project_id": "prj_2"})
+	if err != nil {
+		t.Fatalf("get_project: %v", err)
+	}
+	if !strings.Contains(string(got), "Beta") {
+		t.Errorf("get_project prj_2 missing name Beta: %s", got)
+	}
+
+	// get_project for an unknown id surfaces an error, not another project.
+	if _, err := invokeTool(t, session, mcptools.GetProjectName, map[string]any{"project_id": "prj_missing"}); err == nil {
+		t.Error("expected error for unknown project id")
+	}
+}

--- a/api/pkg/org/interfaces/mcptools/projects_registration_test.go
+++ b/api/pkg/org/interfaces/mcptools/projects_registration_test.go
@@ -1,0 +1,47 @@
+package mcptools_test
+
+import (
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
+	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
+)
+
+// projectToolNames is the set the project-discovery surface adds.
+var projectToolNames = []tool.Name{
+	mcptools.ListProjectsName,
+	mcptools.GetProjectName,
+}
+
+// TestProjectToolsRegistered pins that RegisterBuiltins registers the
+// project-discovery tools so a Role listing one resolves it.
+func TestProjectToolsRegistered(t *testing.T) {
+	t.Parallel()
+	s := orggorm.GetOrgTestDB(t)
+	reg := mcptools.NewRegistry()
+	if err := mcptools.RegisterBuiltins(reg, mcptools.DefaultDeps(s).Build()); err != nil {
+		t.Fatalf("RegisterBuiltins: %v", err)
+	}
+	for _, name := range projectToolNames {
+		if _, err := reg.Get(name); err != nil {
+			t.Errorf("tool %q not registered: %v", name, err)
+		}
+	}
+}
+
+// TestProjectToolsNotInBaseReadTools pins that project-discovery tools are
+// opt-in per Role (granted explicitly, e.g. to a PM bot), not handed to
+// every Worker via the universal baseline.
+func TestProjectToolsNotInBaseReadTools(t *testing.T) {
+	t.Parallel()
+	base := map[tool.Name]bool{}
+	for _, n := range mcptools.BaseReadTools {
+		base[n] = true
+	}
+	for _, name := range projectToolNames {
+		if base[name] {
+			t.Errorf("project tool %q must not be in BaseReadTools", name)
+		}
+	}
+}

--- a/api/pkg/org/interfaces/mcptools/spec_tasks.go
+++ b/api/pkg/org/interfaces/mcptools/spec_tasks.go
@@ -31,6 +31,7 @@ type CreateSpecTask struct{ deps Deps }
 func NewCreateSpecTask(deps Deps) *CreateSpecTask { return &CreateSpecTask{deps: deps} }
 
 type createSpecTaskArgs struct {
+	ProjectID      string   `json:"project_id,omitempty"`
 	Name           string   `json:"name"`
 	Description    string   `json:"description"`
 	Type           string   `json:"type,omitempty"`
@@ -45,8 +46,9 @@ var createSpecTaskSchema = mustSchema[createSpecTaskArgs]()
 func (t *CreateSpecTask) Name() tool.Name                 { return CreateSpecTaskName }
 func (t *CreateSpecTask) InputSchema() *jsonschema.Schema { return createSpecTaskSchema }
 func (t *CreateSpecTask) Description() string {
-	return "Create a new spec task in your project. Provide a short name and a high-level " +
-		"description of the desired outcome. Optional: type (feature|bug|refactor), priority " +
+	return "Create a new spec task. Provide a short name and a high-level " +
+		"description of the desired outcome. Optional: project_id (a project you manage in " +
+		"your org — omit to use your own project), type (feature|bug|refactor), priority " +
 		"(low|medium|high|critical), skip_planning (go straight to implementation), depends_on " +
 		"(task IDs). The task starts in backlog — call start_spectask_planning to begin work."
 }
@@ -55,7 +57,7 @@ func (t *CreateSpecTask) Invoke(ctx context.Context, inv tool.Invocation) (json.
 	if err := json.Unmarshal(inv.Args, &args); err != nil {
 		return nil, fmt.Errorf("parse args: %w", err)
 	}
-	view, err := t.deps.SpecTasks.Create(ctx, inv.Caller, runtime.CreateSpecTaskInput{
+	view, err := t.deps.SpecTasks.Create(ctx, inv.Caller, args.ProjectID, runtime.CreateSpecTaskInput{
 		Name:           args.Name,
 		Description:    args.Description,
 		Type:           args.Type,
@@ -79,9 +81,10 @@ type ListSpecTasks struct{ deps Deps }
 func NewListSpecTasks(deps Deps) *ListSpecTasks { return &ListSpecTasks{deps: deps} }
 
 type listSpecTasksArgs struct {
-	Status   string `json:"status,omitempty"`
-	Priority string `json:"priority,omitempty"`
-	Type     string `json:"type,omitempty"`
+	ProjectID string `json:"project_id,omitempty"`
+	Status    string `json:"status,omitempty"`
+	Priority  string `json:"priority,omitempty"`
+	Type      string `json:"type,omitempty"`
 }
 
 var listSpecTasksSchema = mustSchema[listSpecTasksArgs]()
@@ -89,14 +92,15 @@ var listSpecTasksSchema = mustSchema[listSpecTasksArgs]()
 func (t *ListSpecTasks) Name() tool.Name                 { return ListSpecTasksName }
 func (t *ListSpecTasks) InputSchema() *jsonschema.Schema { return listSpecTasksSchema }
 func (t *ListSpecTasks) Description() string {
-	return "List the spec tasks in your project, optionally filtered by status, priority, or type."
+	return "List spec tasks, optionally filtered by status, priority, or type. Pass project_id " +
+		"to list tasks in a project you manage in your org; omit it to list your own project's tasks."
 }
 func (t *ListSpecTasks) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
 	var args listSpecTasksArgs
 	if err := json.Unmarshal(inv.Args, &args); err != nil {
 		return nil, fmt.Errorf("parse args: %w", err)
 	}
-	views, err := t.deps.SpecTasks.List(ctx, inv.Caller, runtime.ListSpecTasksFilter{
+	views, err := t.deps.SpecTasks.List(ctx, inv.Caller, args.ProjectID, runtime.ListSpecTasksFilter{
 		Status:   args.Status,
 		Priority: args.Priority,
 		Type:     args.Type,
@@ -116,7 +120,8 @@ type GetSpecTask struct{ deps Deps }
 func NewGetSpecTask(deps Deps) *GetSpecTask { return &GetSpecTask{deps: deps} }
 
 type taskIDArgs struct {
-	TaskID string `json:"task_id"`
+	ProjectID string `json:"project_id,omitempty"`
+	TaskID    string `json:"task_id"`
 }
 
 var getSpecTaskSchema = mustSchema[taskIDArgs]()
@@ -124,14 +129,15 @@ var getSpecTaskSchema = mustSchema[taskIDArgs]()
 func (t *GetSpecTask) Name() tool.Name                 { return GetSpecTaskName }
 func (t *GetSpecTask) InputSchema() *jsonschema.Schema { return getSpecTaskSchema }
 func (t *GetSpecTask) Description() string {
-	return "Get the full details of one spec task in your project by its task_id."
+	return "Get the full details of one spec task by its task_id. Pass project_id when the task " +
+		"is in a project you manage in your org; omit it for your own project."
 }
 func (t *GetSpecTask) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
 	args, err := parseTaskID(inv.Args)
 	if err != nil {
 		return nil, err
 	}
-	view, err := t.deps.SpecTasks.Get(ctx, inv.Caller, args.TaskID)
+	view, err := t.deps.SpecTasks.Get(ctx, inv.Caller, args.ProjectID, args.TaskID)
 	if err != nil {
 		return nil, err
 	}
@@ -154,14 +160,15 @@ func (t *StartSpecTaskPlanning) Name() tool.Name                 { return StartS
 func (t *StartSpecTaskPlanning) InputSchema() *jsonschema.Schema { return startSpecTaskPlanningSchema }
 func (t *StartSpecTaskPlanning) Description() string {
 	return "Start a spec task: begin spec generation (or go straight to implementation if the " +
-		"task was created with skip_planning). Use after create_spectask."
+		"task was created with skip_planning). Use after create_spectask. Pass project_id for a " +
+		"task in a project you manage in your org; omit it for your own project."
 }
 func (t *StartSpecTaskPlanning) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
 	args, err := parseTaskID(inv.Args)
 	if err != nil {
 		return nil, err
 	}
-	view, err := t.deps.SpecTasks.StartPlanning(ctx, inv.Caller, args.TaskID)
+	view, err := t.deps.SpecTasks.StartPlanning(ctx, inv.Caller, args.ProjectID, args.TaskID)
 	if err != nil {
 		return nil, err
 	}
@@ -182,14 +189,15 @@ func (t *ReviewSpecTaskSpec) Name() tool.Name                 { return ReviewSpe
 func (t *ReviewSpecTaskSpec) InputSchema() *jsonschema.Schema { return reviewSpecTaskSpecSchema }
 func (t *ReviewSpecTaskSpec) Description() string {
 	return "Read the generated specification (requirements, design, implementation plan) for a " +
-		"spec task so you can review it before approving or requesting changes."
+		"spec task so you can review it before approving or requesting changes. Pass project_id " +
+		"for a task in a project you manage in your org; omit it for your own project."
 }
 func (t *ReviewSpecTaskSpec) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
 	args, err := parseTaskID(inv.Args)
 	if err != nil {
 		return nil, err
 	}
-	review, err := t.deps.SpecTasks.ReviewSpec(ctx, inv.Caller, args.TaskID)
+	review, err := t.deps.SpecTasks.ReviewSpec(ctx, inv.Caller, args.ProjectID, args.TaskID)
 	if err != nil {
 		return nil, err
 	}
@@ -210,14 +218,15 @@ func (t *ApproveSpecTaskSpec) Name() tool.Name                 { return ApproveS
 func (t *ApproveSpecTaskSpec) InputSchema() *jsonschema.Schema { return approveSpecTaskSpecSchema }
 func (t *ApproveSpecTaskSpec) Description() string {
 	return "Approve a spec task's generated specification. This advances the task toward " +
-		"implementation. Review the spec first with review_spectask_spec."
+		"implementation. Review the spec first with review_spectask_spec. Pass project_id for a " +
+		"task in a project you manage in your org; omit it for your own project."
 }
 func (t *ApproveSpecTaskSpec) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
 	args, err := parseTaskID(inv.Args)
 	if err != nil {
 		return nil, err
 	}
-	view, err := t.deps.SpecTasks.ApproveSpec(ctx, inv.Caller, args.TaskID)
+	view, err := t.deps.SpecTasks.ApproveSpec(ctx, inv.Caller, args.ProjectID, args.TaskID)
 	if err != nil {
 		return nil, err
 	}
@@ -235,8 +244,9 @@ func NewRequestSpecTaskChanges(deps Deps) *RequestSpecTaskChanges {
 }
 
 type requestChangesArgs struct {
-	TaskID  string `json:"task_id"`
-	Comment string `json:"comment"`
+	ProjectID string `json:"project_id,omitempty"`
+	TaskID    string `json:"task_id"`
+	Comment   string `json:"comment"`
 }
 
 var requestSpecTaskChangesSchema = mustSchema[requestChangesArgs]()
@@ -247,7 +257,8 @@ func (t *RequestSpecTaskChanges) InputSchema() *jsonschema.Schema {
 }
 func (t *RequestSpecTaskChanges) Description() string {
 	return "Send a spec task's specification back for revision with a comment explaining what " +
-		"needs to change. The task returns to revision and the agent regenerates the spec."
+		"needs to change. The task returns to revision and the agent regenerates the spec. Pass " +
+		"project_id for a task in a project you manage in your org; omit it for your own project."
 }
 func (t *RequestSpecTaskChanges) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
 	var args requestChangesArgs
@@ -260,7 +271,7 @@ func (t *RequestSpecTaskChanges) Invoke(ctx context.Context, inv tool.Invocation
 	if args.Comment == "" {
 		return nil, errors.New("comment is required")
 	}
-	view, err := t.deps.SpecTasks.RequestChanges(ctx, inv.Caller, args.TaskID, args.Comment)
+	view, err := t.deps.SpecTasks.RequestChanges(ctx, inv.Caller, args.ProjectID, args.TaskID, args.Comment)
 	if err != nil {
 		return nil, err
 	}
@@ -282,14 +293,15 @@ func (t *CreateSpecTaskPRs) InputSchema() *jsonschema.Schema { return createSpec
 func (t *CreateSpecTaskPRs) Description() string {
 	return "When you're happy with the implemented code, tell the system to open the pull " +
 		"request(s) for a spec task — one per repository attached to the project. This does NOT " +
-		"merge or approve on GitHub; the merge approval still happens on GitHub itself."
+		"merge or approve on GitHub; the merge approval still happens on GitHub itself. Pass " +
+		"project_id for a task in a project you manage in your org; omit it for your own project."
 }
 func (t *CreateSpecTaskPRs) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
 	args, err := parseTaskID(inv.Args)
 	if err != nil {
 		return nil, err
 	}
-	view, err := t.deps.SpecTasks.CreatePullRequests(ctx, inv.Caller, args.TaskID)
+	view, err := t.deps.SpecTasks.CreatePullRequests(ctx, inv.Caller, args.ProjectID, args.TaskID)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/org/interfaces/mcptools/spec_tasks_test.go
+++ b/api/pkg/org/interfaces/mcptools/spec_tasks_test.go
@@ -18,6 +18,7 @@ import (
 type recordingPort struct {
 	runtime.NoopSpecTasks
 	createIn    runtime.CreateSpecTaskInput
+	lastProject string
 	lastTaskID  string
 	lastComment string
 	lastFilter  runtime.ListSpecTasksFilter
@@ -26,44 +27,44 @@ type recordingPort struct {
 	err         error
 }
 
-func (p *recordingPort) Create(_ context.Context, _ string, _ orgchart.BotID, in runtime.CreateSpecTaskInput) (runtime.SpecTaskView, error) {
-	p.createIn = in
+func (p *recordingPort) Create(_ context.Context, _ string, _ orgchart.BotID, projectID string, in runtime.CreateSpecTaskInput) (runtime.SpecTaskView, error) {
+	p.lastProject, p.createIn = projectID, in
 	return p.view, p.err
 }
-func (p *recordingPort) List(_ context.Context, _ string, _ orgchart.BotID, f runtime.ListSpecTasksFilter) ([]runtime.SpecTaskView, error) {
-	p.lastFilter = f
+func (p *recordingPort) List(_ context.Context, _ string, _ orgchart.BotID, projectID string, f runtime.ListSpecTasksFilter) ([]runtime.SpecTaskView, error) {
+	p.lastProject, p.lastFilter = projectID, f
 	if p.err != nil {
 		return nil, p.err
 	}
 	return []runtime.SpecTaskView{p.view}, nil
 }
-func (p *recordingPort) Get(_ context.Context, _ string, _ orgchart.BotID, id string) (runtime.SpecTaskView, error) {
-	p.lastTaskID = id
+func (p *recordingPort) Get(_ context.Context, _ string, _ orgchart.BotID, projectID, id string) (runtime.SpecTaskView, error) {
+	p.lastProject, p.lastTaskID = projectID, id
 	return p.view, p.err
 }
-func (p *recordingPort) StartPlanning(_ context.Context, _ string, _ orgchart.BotID, id string) (runtime.SpecTaskView, error) {
-	p.lastTaskID = id
+func (p *recordingPort) StartPlanning(_ context.Context, _ string, _ orgchart.BotID, projectID, id string) (runtime.SpecTaskView, error) {
+	p.lastProject, p.lastTaskID = projectID, id
 	return p.view, p.err
 }
-func (p *recordingPort) ReviewSpec(_ context.Context, _ string, _ orgchart.BotID, id string) (runtime.SpecReviewView, error) {
-	p.lastTaskID = id
+func (p *recordingPort) ReviewSpec(_ context.Context, _ string, _ orgchart.BotID, projectID, id string) (runtime.SpecReviewView, error) {
+	p.lastProject, p.lastTaskID = projectID, id
 	return p.review, p.err
 }
-func (p *recordingPort) ApproveSpec(_ context.Context, _ string, _ orgchart.BotID, id string) (runtime.SpecTaskView, error) {
-	p.lastTaskID = id
+func (p *recordingPort) ApproveSpec(_ context.Context, _ string, _ orgchart.BotID, projectID, id string) (runtime.SpecTaskView, error) {
+	p.lastProject, p.lastTaskID = projectID, id
 	return p.view, p.err
 }
-func (p *recordingPort) RequestChanges(_ context.Context, _ string, _ orgchart.BotID, id, comment string) (runtime.SpecTaskView, error) {
-	p.lastTaskID, p.lastComment = id, comment
+func (p *recordingPort) RequestChanges(_ context.Context, _ string, _ orgchart.BotID, projectID, id, comment string) (runtime.SpecTaskView, error) {
+	p.lastProject, p.lastTaskID, p.lastComment = projectID, id, comment
 	return p.view, p.err
 }
-func (p *recordingPort) CreatePullRequests(_ context.Context, _ string, _ orgchart.BotID, id string) (runtime.SpecTaskView, error) {
-	p.lastTaskID = id
+func (p *recordingPort) CreatePullRequests(_ context.Context, _ string, _ orgchart.BotID, projectID, id string) (runtime.SpecTaskView, error) {
+	p.lastProject, p.lastTaskID = projectID, id
 	return p.view, p.err
 }
 
 func depsWithPort(p runtime.SpecTasks) mcptools.Deps {
-	return mcptools.Deps{SpecTasks: spectasks.New(p)}
+	return mcptools.Deps{SpecTasks: spectasks.New(p, nil)}
 }
 
 func callerInv(args string) tool.Invocation {
@@ -120,6 +121,18 @@ func TestListSpecTasksTool(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "task_1") {
 		t.Errorf("output missing task: %s", out)
+	}
+}
+
+func TestGetSpecTaskTool_ForwardsProjectID(t *testing.T) {
+	t.Parallel()
+	p := &recordingPort{view: runtime.SpecTaskView{ID: "task_9", Status: "backlog"}}
+	tl := mcptools.NewGetSpecTask(depsWithPort(p))
+	if _, err := tl.Invoke(context.Background(), callerInv(`{"project_id":"prj_other","task_id":"task_9"}`)); err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if p.lastProject != "prj_other" {
+		t.Errorf("project id = %q, want prj_other", p.lastProject)
 	}
 }
 

--- a/api/pkg/org/interfaces/mcptools/spectasks_deps_test.go
+++ b/api/pkg/org/interfaces/mcptools/spectasks_deps_test.go
@@ -4,11 +4,27 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
+	orgstore "github.com/helixml/helix/api/pkg/org/domain/store"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
 	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
 )
+
+// seedMemberBot creates a Bot row so the caller passes the service-level
+// org-membership check (DefaultDeps wires the Queries verifier).
+func seedMemberBot(t *testing.T, s *orgstore.Store, orgID, botID string) {
+	t.Helper()
+	bot, err := orgchart.NewBot(botID, "# bot", nil, time.Now().UTC(), orgID)
+	if err != nil {
+		t.Fatalf("new bot: %v", err)
+	}
+	if err := s.Bots.Create(context.Background(), bot); err != nil {
+		t.Fatalf("create bot: %v", err)
+	}
+}
 
 // TestDefaultDepsWiresSpecTasksNoop pins that DefaultDeps + Build produce
 // a non-nil SpecTasks application service backed by the noop port, so a
@@ -21,7 +37,8 @@ func TestDefaultDepsWiresSpecTasksNoop(t *testing.T) {
 	if deps.SpecTasks == nil {
 		t.Fatal("Deps.SpecTasks is nil; expected a non-nil service over the noop port")
 	}
-	_, err := deps.SpecTasks.Get(context.Background(), fakeWorker{id: "w-a", org: "org-1"}, "task_1")
+	seedMemberBot(t, s, "org-1", "w-a")
+	_, err := deps.SpecTasks.Get(context.Background(), fakeWorker{id: "w-a", org: "org-1"}, "", "task_1")
 	if !errors.Is(err, runtime.ErrSpecTasksUnsupported) {
 		t.Errorf("err = %v, want ErrSpecTasksUnsupported", err)
 	}
@@ -35,7 +52,8 @@ func TestConfigBuildUsesInjectedSpecTasksPort(t *testing.T) {
 	cfg := mcptools.DefaultDeps(s)
 	cfg.SpecTasks = stubPort{}
 	deps := cfg.Build()
-	view, err := deps.SpecTasks.Get(context.Background(), fakeWorker{id: "w-a", org: "org-1"}, "task_1")
+	seedMemberBot(t, s, "org-1", "w-a")
+	view, err := deps.SpecTasks.Get(context.Background(), fakeWorker{id: "w-a", org: "org-1"}, "", "task_1")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -56,6 +74,6 @@ func (w fakeWorker) OrganizationID() string { return w.org }
 // test can prove the injected port is wired through Build.
 type stubPort struct{ runtime.NoopSpecTasks }
 
-func (stubPort) Get(_ context.Context, _ string, _ string, _ string) (runtime.SpecTaskView, error) {
+func (stubPort) Get(_ context.Context, _ string, _ string, _, _ string) (runtime.SpecTaskView, error) {
 	return runtime.SpecTaskView{ID: "stub"}, nil
 }

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -472,6 +472,15 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	}
 	deps.SpecTasks = specTasks
 
+	// Projects backs the project-discovery MCP tools (list_projects,
+	// get_project) — org-scoped reads so an org-wide PM Bot can find the
+	// projects it manages. The helix store satisfies the port directly.
+	projectsPort, err := runtimehelix.NewProjects(helixStore)
+	if err != nil {
+		return nil, fmt.Errorf("init projects: %w", err)
+	}
+	deps.Projects = projectsPort
+
 	// Project applier — shared infra for owner-chat and Worker
 	// activations. Applies every Worker's project with the same
 	// `worker.runtime` (default `claude_code`) and the same MCP

--- a/api/pkg/server/spec_task_attention_publisher.go
+++ b/api/pkg/server/spec_task_attention_publisher.go
@@ -86,9 +86,23 @@ func (p *attentionTopicPublisher) PublishAttentionEvent(ctx context.Context, ev 
 }
 
 // ensureTopic returns the project's KindSpecTask topic, creating it on
-// first use (mirrors how Slack auto-creates its workspace topic).
+// first use. Thin wrapper over the shared EnsureSpecTaskTopic so the
+// publisher and any wiring path (e.g. pre-creating the input topic before
+// a bot is subscribed to it) agree on the topic's identity and config.
 func (p *attentionTopicPublisher) ensureTopic(ctx context.Context, orgID, projectID string) (streaming.TopicID, error) {
-	existing, err := p.topics.List(ctx, orgID)
+	return EnsureSpecTaskTopic(ctx, p.topics, p.newID, p.now, orgID, projectID)
+}
+
+// EnsureSpecTaskTopic find-or-creates the KindSpecTask topic for a project
+// (mirrors how Slack auto-creates its workspace topic). It is the single
+// source of truth for a project's spec-task topic identity + config, shared
+// by the attention publisher (which creates it lazily on the first event)
+// and any wiring path that needs the topic to exist deterministically
+// before an event has fired — e.g. subscribing an org-wide PM Bot to a
+// quiet project at creation time. Idempotent: a second call for the same
+// (org, project) returns the existing topic.
+func EnsureSpecTaskTopic(ctx context.Context, topics orgstore.Topics, newID func() string, now func() time.Time, orgID, projectID string) (streaming.TopicID, error) {
+	existing, err := topics.List(ctx, orgID)
 	if err != nil {
 		return "", fmt.Errorf("list topics: %w", err)
 	}
@@ -105,20 +119,20 @@ func (p *attentionTopicPublisher) ensureTopic(ctx context.Context, orgID, projec
 	if err != nil {
 		return "", fmt.Errorf("marshal topic config: %w", err)
 	}
-	id := streaming.TopicID(p.newID())
+	id := streaming.TopicID(newID())
 	topic, err := streaming.NewTopic(
 		id,
 		"Spec tasks: "+projectID,
 		"Spec-task state changes for project "+projectID,
 		"", // createdBy is optional (no worker context for automation)
-		p.now(),
+		now(),
 		transport.Transport{Kind: transport.KindSpecTask, Config: cfgJSON},
 		orgID,
 	)
 	if err != nil {
 		return "", fmt.Errorf("build topic: %w", err)
 	}
-	if err := p.topics.Create(ctx, topic); err != nil {
+	if err := topics.Create(ctx, topic); err != nil {
 		return "", fmt.Errorf("create topic: %w", err)
 	}
 	return id, nil

--- a/api/pkg/server/spec_task_attention_publisher.go
+++ b/api/pkg/server/spec_task_attention_publisher.go
@@ -32,11 +32,18 @@ type orgEventPublisher interface {
 }
 
 // specTaskEventExtra is the structured payload carried on the topic event
-// so an activated Worker knows what changed without an extra lookup.
+// so an activated Worker (or a filter processor's predicate over
+// .Message.extra) can route/react without an extra lookup. It holds the
+// keys that have no natural streaming.Message field (event_type, project_id)
+// plus denormalized display fields; the human-facing text and threading are
+// coerced onto first-class Message fields (Subject/Body/ThreadID/MessageID)
+// in PublishAttentionEvent.
 type specTaskEventExtra struct {
-	SpecTaskID string `json:"spec_task_id"`
-	EventType  string `json:"event_type"`
-	ProjectID  string `json:"project_id"`
+	SpecTaskID   string `json:"spec_task_id"`
+	EventType    string `json:"event_type"`
+	ProjectID    string `json:"project_id"`
+	ProjectName  string `json:"project_name,omitempty"`
+	SpecTaskName string `json:"spec_task_name,omitempty"`
 }
 
 // PublishAttentionEvent resolves (or creates) the project's spec-task
@@ -51,14 +58,25 @@ func (p *attentionTopicPublisher) PublishAttentionEvent(ctx context.Context, ev 
 		return fmt.Errorf("ensure spectask topic: %w", err)
 	}
 	extra, _ := json.Marshal(specTaskEventExtra{
-		SpecTaskID: ev.SpecTaskID,
-		EventType:  string(ev.EventType),
-		ProjectID:  ev.ProjectID,
+		SpecTaskID:   ev.SpecTaskID,
+		EventType:    string(ev.EventType),
+		ProjectID:    ev.ProjectID,
+		ProjectName:  ev.ProjectName,
+		SpecTaskName: ev.SpecTaskName,
 	})
+	// Coerce the notification's fields onto first-class Message fields so
+	// predicates and consumers use natural fields, not just Extra:
+	//   Title       → Subject
+	//   Description → Body
+	//   SpecTaskID  → ThreadID   (all events for one task thread together)
+	//   ID          → MessageID  (stable, unique id)
+	// event_type / project_id stay in Extra (no natural Message field).
 	msg := streaming.Message{
 		Subject:         ev.Title,
 		Body:            ev.Description,
 		BodyContentType: "text/plain",
+		ThreadID:        ev.SpecTaskID,
+		MessageID:       ev.ID,
 		Extra:           extra,
 	}
 	if _, err := p.publisher.Publish(ctx, ev.OrganizationID, topicID, "", msg); err != nil {

--- a/api/pkg/server/spec_task_attention_publisher_test.go
+++ b/api/pkg/server/spec_task_attention_publisher_test.go
@@ -143,6 +143,32 @@ func TestAttentionPublisher_ReusesExistingTopic(t *testing.T) {
 	}
 }
 
+// TestEnsureSpecTaskTopic_Idempotent pins that the shared helper creates
+// the topic once and returns the same id on a second call — so a wiring
+// path can pre-create a project's input topic without racing the publisher.
+func TestEnsureSpecTaskTopic_Idempotent(t *testing.T) {
+	t.Parallel()
+	topics := &fakeTopics{}
+	n := 0
+	newID := func() string { n++; return "top_ensure" }
+	now := func() time.Time { return time.Unix(1700000000, 0).UTC() }
+
+	first, err := EnsureSpecTaskTopic(context.Background(), topics, newID, now, "org-1", "prj_1")
+	if err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	second, err := EnsureSpecTaskTopic(context.Background(), topics, newID, now, "org-1", "prj_1")
+	if err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	if first != second {
+		t.Errorf("ids differ: %q vs %q", first, second)
+	}
+	if len(topics.created) != 1 {
+		t.Errorf("created %d topics, want 1 (idempotent)", len(topics.created))
+	}
+}
+
 // TestAttentionPublisher_SkipsWithoutOrgScope pins that an event without
 // an org (or project) is a no-op — nothing to route.
 func TestAttentionPublisher_SkipsWithoutOrgScope(t *testing.T) {

--- a/api/pkg/server/spec_task_attention_publisher_test.go
+++ b/api/pkg/server/spec_task_attention_publisher_test.go
@@ -103,6 +103,21 @@ func TestAttentionPublisher_CreatesTopicAndPublishes(t *testing.T) {
 	if !strings.Contains(pub.calls[0].msg.Body, "review it") {
 		t.Errorf("published body missing description: %q", pub.calls[0].msg.Body)
 	}
+	// Notification fields coerced onto first-class Message fields.
+	got := pub.calls[0].msg
+	if got.Subject != "PR ready" {
+		t.Errorf("Subject = %q, want %q", got.Subject, "PR ready")
+	}
+	if got.ThreadID != "task_1" {
+		t.Errorf("ThreadID = %q, want the spec task id task_1", got.ThreadID)
+	}
+	if got.MessageID != "ae_1" {
+		t.Errorf("MessageID = %q, want the attention event id ae_1", got.MessageID)
+	}
+	// Routing keys with no natural Message field stay in Extra.
+	if !strings.Contains(string(got.Extra), "pr_ready") || !strings.Contains(string(got.Extra), "prj_1") {
+		t.Errorf("Extra missing event_type/project_id: %s", got.Extra)
+	}
 }
 
 // TestAttentionPublisher_ReusesExistingTopic pins that a second event for

--- a/api/pkg/server/spec_tasks_org_wiring.go
+++ b/api/pkg/server/spec_tasks_org_wiring.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 
+	"github.com/helixml/helix/api/pkg/services"
 	"github.com/helixml/helix/api/pkg/types"
 )
 
@@ -21,4 +22,15 @@ func (w specTaskWorkflow) ApproveSpecs(ctx context.Context, task *types.SpecTask
 
 func (w specTaskWorkflow) EnsurePullRequests(ctx context.Context, task *types.SpecTask, primaryRepoID, userID string) error {
 	return w.apiServer.ensurePullRequestsForAllRepos(ctx, task, primaryRepoID, userID)
+}
+
+// RequestChanges delivers the reviewer's comment to the task's agent as a
+// revision instruction — the exact mechanism the REST design-review
+// "request_changes" branch uses (BuildRevisionInstructionPrompt +
+// sendMessageToSpecTaskAgent, interrupt=true). The status transition itself
+// is already persisted by the runtime impl; this only carries the comment.
+func (w specTaskWorkflow) RequestChanges(ctx context.Context, task *types.SpecTask, comment, userID string) error {
+	message := services.BuildRevisionInstructionPrompt(task, comment)
+	_, _, err := w.apiServer.sendMessageToSpecTaskAgent(ctx, task, message, userID, true)
+	return err
 }


### PR DESCRIPTION
## Summary
Completes the org-graph project-manager (PM) bot: an org-wide Bot that manages
the spec tasks of *other* projects in its own organization (never another org),
driven by the spec-task notification events those projects already emit.

The triggering side already existed (`AttentionService` → per-project
`KindSpecTask` topic → dispatch). The gap was the editing/discovery side: the
spec-task MCP tools were hard-scoped to the Bot's *own* project, there was no way
to discover projects, and the notification payload buried everything in `Extra`.

## Changes
- **Cross-project targeting:** every spec-task MCP tool now accepts an optional
  `project_id`. Empty = the Worker's own project (unchanged); non-empty targets
  another project, with a **hard cross-org block** enforced in
  `runtime/helix/spectasks.go` (`resolveProject` asserts
  `project.OrganizationID == caller org`; `ownedTask` chains task→project→org).
  The `projectID` is threaded through the `runtime.SpecTasks` port, the
  `application/spectasks` service, and the tool adapters.
- **Project discovery:** new `list_projects` / `get_project` MCP tools over a new
  `runtime.Projects` port (`runtime/helix/projects.go`) + `application/projects`
  service, both org-scoped (list filters by org; get asserts org).
- **Defensive org-membership check:** `application/spectasks` +
  `application/projects` verify the caller Bot is a member of its org
  (`GetBot`), taking identity only from the authenticated invocation. (Already
  enforced at the MCP mount; this is depth. Optional verifier — nil in tests.)
- **`request_spectask_changes` no longer drops the comment:** new
  `SpecTaskWorkflow.RequestChanges` delivers it to the task's agent via the exact
  REST design-review mechanism (`BuildRevisionInstructionPrompt` +
  `sendMessageToSpecTaskAgent`).
- **Notification field coercion:** `attentionTopicPublisher` now maps
  `Title→Subject`, `Description→Body`, `SpecTaskID→ThreadID`, `ID→MessageID`
  (keeping `event_type`/`project_id`/names in `Extra`) — so filter predicates and
  consumers use first-class `streaming.Message` fields.
- **Connection uses existing primitives (no new tools):** extracted
  `EnsureSpecTaskTopic` (shared, idempotent) so a project's topic can be
  pre-created; connection = existing `create_bot`/`subscribe` + optional filter
  processor. Added the `/pm-bot` prompt that drafts a PM bot: discover projects,
  grant the tools, subscribe to the projects' spec-task topics.

## Tests
- Unit + in-process HTTP MCP e2e (`TestProjectDiscoveryOverMCP`) covering
  cross-project/cross-org rejection, org-scoped discovery, membership rejection,
  filter routing of spec-task events, field coercion, comment delivery,
  `EnsureSpecTaskTopic` idempotency, and prompt/tool registration.
- Full `go build .` and `go test ./pkg/org/...` green.

## Live e2e (inner Helix)
Verified end-to-end against a running instance (helix-org enabled): an org-graph
`pm-bot` drove its live MCP endpoint — tools advertised with `project_id`,
`list_projects` org-scoped, and a **cross-project** `create_spectask(project_id=proj-a)`
landed a task in another project (confirmed in Postgres + the proj-a UI board).
Cross-org `get_project`/`create_spectask` against a second org's project were
hard-rejected ("does not belong to this organization"), 0 rows created.

## Screenshots
![proj-a board with cross-project task](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002209_ive-just-tried-to-create/screenshots/02-cross-project-task-in-proj-a.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwkmg2nngt66gs6kph6rrg2d)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002209_ive-just-tried-to-create/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002209_ive-just-tried-to-create/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002209_ive-just-tried-to-create/tasks.md)

🚀 Built with [Helix](https://helix.ml)