### PR TITLE
fix(providers): stop stranding global endpoints as read-only "system"

### DIFF
--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -753,8 +753,14 @@ func (s *HelixAPIServer) updateProviderEndpoint(rw http.ResponseWriter, r *http.
 		return
 	}
 
-	// For global endpoints, only allow updates by admins
-	if updatedEndpoint.EndpointType == types.ProviderEndpointTypeGlobal && !user.Admin {
+	// For global endpoints, only allow updates by admins. Gate on the stored
+	// row, not the request payload: a global endpoint now retains its original
+	// (possibly non-admin) owner, so the ownership check above no longer blocks
+	// that owner. If we only checked updatedEndpoint.EndpointType, a request that
+	// omits endpoint_type would skip this gate entirely and let the owner edit a
+	// globally-shared endpoint.
+	if (existingEndpoint.EndpointType == types.ProviderEndpointTypeGlobal ||
+		updatedEndpoint.EndpointType == types.ProviderEndpointTypeGlobal) && !user.Admin {
 		http.Error(rw, "Only admins can update global endpoints", http.StatusForbidden)
 		return
 	}

--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -770,13 +770,17 @@ func (s *HelixAPIServer) updateProviderEndpoint(rw http.ResponseWriter, r *http.
 	// otherwise.
 	prevName, prevOwner := existingEndpoint.Name, existingEndpoint.Owner
 
-	// Apply endpoint type change and update ownership accordingly
+	// Apply endpoint type change. Keep the existing owner — global visibility is
+	// keyed on endpoint_type='global' in the store, not on owner, so there is no
+	// reason to reassign ownership. Stamping Owner="system" here made a real DB
+	// row indistinguishable from a synthetic env-var endpoint (ID="-", Owner=
+	// "system"), which the UI treats as read-only, permanently stranding it. This
+	// now matches createProviderEndpoint, which leaves a global endpoint owned by
+	// its admin creator.
 	if updatedEndpoint.EndpointType != "" && updatedEndpoint.EndpointType != existingEndpoint.EndpointType {
 		switch updatedEndpoint.EndpointType {
 		case types.ProviderEndpointTypeGlobal:
 			existingEndpoint.EndpointType = updatedEndpoint.EndpointType
-			existingEndpoint.Owner = string(types.OwnerTypeSystem)
-			existingEndpoint.OwnerType = types.OwnerTypeSystem
 		default:
 			http.Error(rw, fmt.Sprintf("Unsupported endpoint type switch to %q", updatedEndpoint.EndpointType), http.StatusBadRequest)
 			return

--- a/api/pkg/server/provider_handlers_test.go
+++ b/api/pkg/server/provider_handlers_test.go
@@ -654,8 +654,11 @@ func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_SwitchUserToGlobal() 
 	s.store.EXPECT().UpdateProviderEndpoint(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, ep *types.ProviderEndpoint) (*types.ProviderEndpoint, error) {
 			s.Equal(types.ProviderEndpointTypeGlobal, ep.EndpointType)
-			s.Equal(string(types.OwnerTypeSystem), ep.Owner)
-			s.Equal(types.OwnerTypeSystem, ep.OwnerType)
+			// Owner must stay the admin creator, NOT be reassigned to "system".
+			// Reassigning to "system" made the row look like a synthetic env-var
+			// endpoint and stranded it as read-only in the UI.
+			s.Equal("admin_id", ep.Owner)
+			s.Equal(types.OwnerTypeUser, ep.OwnerType)
 			return ep, nil
 		})
 

--- a/api/pkg/server/provider_handlers_test.go
+++ b/api/pkg/server/provider_handlers_test.go
@@ -717,6 +717,48 @@ func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_NonAdminCannotSwitchT
 	s.Contains(rr.Body.String(), "Only admins can update global endpoints")
 }
 
+// A non-admin who owns a global endpoint (e.g. one an admin switched to global,
+// which now retains the original owner) must not be able to edit it, even via a
+// request that omits endpoint_type. The gate keys on the stored row's type.
+func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_NonAdminCannotEditGlobal() {
+	s.server.Cfg.Providers.EnableCustomUserProviders = true
+	endpointID := "ep_123"
+
+	existing := &types.ProviderEndpoint{
+		ID:           endpointID,
+		Name:         "my-endpoint",
+		BaseURL:      "http://localhost:11434",
+		Owner:        "user_id",
+		OwnerType:    types.OwnerTypeUser,
+		EndpointType: types.ProviderEndpointTypeGlobal,
+	}
+
+	s.store.EXPECT().GetSystemSettings(gomock.Any()).Return(&types.SystemSettings{
+		ProvidersManagementEnabled: true,
+	}, nil)
+	s.store.EXPECT().GetProviderEndpoint(gomock.Any(), &store.GetProviderEndpointsQuery{
+		ID: endpointID,
+	}).Return(existing, nil)
+
+	// Payload deliberately omits endpoint_type — the attack that skipped the old
+	// payload-only gate.
+	update := types.UpdateProviderEndpoint{
+		Name:    "my-endpoint",
+		BaseURL: "http://evil.example.com",
+	}
+	body, _ := json.Marshal(update)
+
+	req := httptest.NewRequest(http.MethodPut, "/v1/provider-endpoints/"+endpointID, bytes.NewReader(body))
+	req = req.WithContext(s.authCtx)
+	req = mux.SetURLVars(req, map[string]string{"id": endpointID})
+
+	rr := httptest.NewRecorder()
+	s.server.updateProviderEndpoint(rr, req)
+
+	s.Equal(http.StatusForbidden, rr.Code)
+	s.Contains(rr.Body.String(), "Only admins can update global endpoints")
+}
+
 func (s *ProviderHandlersSuite) TestUpdateProviderEndpoint_SwitchToOrgRejected() {
 	s.server.Cfg.Providers.EnableCustomUserProviders = true
 	endpointID := "ep_123"

--- a/frontend/src/components/dashboard/ProviderEndpointsTable.tsx
+++ b/frontend/src/components/dashboard/ProviderEndpointsTable.tsx
@@ -144,7 +144,11 @@ const ProviderEndpointsTable: FC = () => {
   };
 
   const isSystemEndpoint = (endpoint: IProviderEndpoint) => {
-    return endpoint.endpoint_type === 'global' && endpoint.owner === 'system';
+    // Only synthetic env-var endpoints are read-only. They are injected from
+    // config with a sentinel id of "-" (no DB row to edit). A real DB row —
+    // including a global one — always has a real id and is admin-editable, even
+    // if a past bug stamped its owner as "system".
+    return endpoint.id === '-';
   };
 
   // Helper function to render owner information


### PR DESCRIPTION
## Problem (customer report)

Editing a global provider endpoint and toggling ownership permanently loses the ability to edit it — the row's action menu greys out with "System endpoints can only be configured through environment variables in your Helix instance". Repro: create endpoint as Global → Edit shows owner "User" → switch to Global → Edit/Delete now disabled forever.

## Root cause

`owner === 'system'` is overloaded. Genuine env-var endpoints are synthesized in-memory from config (`globalProviderEndpoint`, `provider_handlers.go:299`) with `ID = "-"` and `Owner = "system"` — no DB row, correctly read-only.

But `updateProviderEndpoint` (`provider_handlers.go:778`) also stamped `Owner = "system"` when switching a **real DB endpoint** to global. The frontend `isSystemEndpoint` (`ProviderEndpointsTable.tsx:147`) keyed on `endpoint_type === 'global' && owner === 'system'`, so the real row got treated as a synthetic system endpoint and had its actions disabled.

The reassignment was also pointless: the store surfaces global endpoints by `endpoint_type = 'global'` (`store_provider_endpoints.go:104`), **not** by owner. And it diverged from `createProviderEndpoint`, which leaves a global endpoint owned by its admin creator (so a freshly-created global endpoint stayed editable — hence the confusing "created Global but shows User" behaviour).

## Fix (two facets, one bug)

- **Backend:** on switch-to-global, keep the existing owner; only change `endpoint_type`. Matches create, preserves global visibility.
- **Frontend:** identify read-only endpoints by the `id === '-'` sentinel (the true "synthetic env-var endpoint" invariant), not by `owner === 'system'`. This also **recovers rows already stranded** by the old code — the customer's "Personal direct" endpoint becomes editable again.

## Testing

- `go build ./pkg/server/` passes.
- Updated `TestUpdateProviderEndpoint_SwitchUserToGlobal` to assert the owner stays the admin (`admin_id`/`user`) rather than being reassigned to `system`; passes.
- Frontend change is a one-line type-safe swap (`id` is already an `IProviderEndpoint` field); NOT run through `yarn build` (fresh worktree without node_modules) — flagging for the reviewer, though it's trivially valid TS.

## Not in scope

The customer also saw ACP agent wedge messages ("empty response", "thread wedged", "unresponsive after auto-wake"). Those are separate agent-runtime issues (each has its own design doc) and are most likely downstream noise or independent flakiness, not caused by this provider bug. Happy to investigate separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)