### PR TITLE
fix(org): stop starter bot booting Zed on the gpt default

### DIFF
--- a/api/pkg/org/application/lifecycle/hire_test.go
+++ b/api/pkg/org/application/lifecycle/hire_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/bots"
 	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
 	"github.com/helixml/helix/api/pkg/org/application/reconcile"
+	"github.com/helixml/helix/api/pkg/org/domain/activation"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/org/domain/store"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
@@ -105,5 +106,63 @@ func TestCreate_UnknownParent(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Create with unknown parent: want error")
+	}
+}
+
+type recordingDispatcher struct{ hires int }
+
+func (r *recordingDispatcher) DispatchHire(context.Context, string, orgchart.BotID, activation.ID) {
+	r.hires++
+}
+
+// TestCreate_DeferActivation: DeferActivation creates the bot row (and its
+// topology) but skips the hire — no activation row, no dispatch, empty
+// ActivationID. This is the "org has no runtime configured yet" path that
+// keeps a seeded bot from being provisioned on the gpt default.
+func TestCreate_DeferActivation(t *testing.T) {
+	t.Parallel()
+	st := memory.New()
+	svc := newHireService(st)
+	disp := &recordingDispatcher{}
+	svc.Dispatcher = disp
+	ctx := context.Background()
+
+	res, err := svc.Create(ctx, "org-test", lifecycle.CreateParams{
+		ID: "w-new", Content: "x", DeferActivation: true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := st.Bots.Get(ctx, "org-test", "w-new"); err != nil {
+		t.Fatalf("bot row should still exist when deferred: %v", err)
+	}
+	if res.ActivationID != "" {
+		t.Fatalf("deferred create should return empty ActivationID, got %q", res.ActivationID)
+	}
+	if disp.hires != 0 {
+		t.Fatalf("deferred create must not dispatch a hire, got %d", disp.hires)
+	}
+}
+
+// TestCreate_DispatchesWhenNotDeferred: the default path (runtime already
+// configured) still dispatches the hire so the bot provisions immediately.
+func TestCreate_DispatchesWhenNotDeferred(t *testing.T) {
+	t.Parallel()
+	st := memory.New()
+	svc := newHireService(st)
+	disp := &recordingDispatcher{}
+	svc.Dispatcher = disp
+
+	res, err := svc.Create(context.Background(), "org-test", lifecycle.CreateParams{
+		ID: "w-new", Content: "x",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if res.ActivationID == "" {
+		t.Fatal("non-deferred create should return an ActivationID")
+	}
+	if disp.hires != 1 {
+		t.Fatalf("non-deferred create should dispatch exactly one hire, got %d", disp.hires)
 	}
 }

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -140,6 +140,15 @@ type CreateParams struct {
 	Topics          []streaming.TopicID
 	ParentID        orgchart.BotID
 	PreserveContext bool
+	// DeferActivation creates the Bot row (so it shows on the chart) and
+	// wires its topology, but skips the hire activation that provisions the
+	// Helix project + agent app + desktop. Callers set this when the org has
+	// no runtime configured yet, so a Bot is never provisioned with the
+	// seed-time default (claude_code/subscription/no-model, which Zed renders
+	// as its built-in gpt). The deferred Bot is provisioned later, with the
+	// correct config, when the operator sets the Default Bot Runtime
+	// (settings handler re-runs activation for provision-less bots).
+	DeferActivation bool
 }
 
 // CreateResult carries the new Bot and the pre-allocated
@@ -248,6 +257,15 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 		if err := s.HireHook.OnHire(ctx, orgID, id, uid); err != nil {
 			return CreateResult{}, fmt.Errorf("create handler: %w", err)
 		}
+	}
+
+	// DeferActivation: the Bot row + topology exist (so the chart isn't
+	// blank), but we skip provisioning entirely. The operator hasn't picked a
+	// runtime yet, so provisioning now would bake the seed-time default into
+	// the agent app and boot a gpt desktop; the settings handler activates
+	// this Bot later, once a runtime is configured.
+	if p.DeferActivation {
+		return CreateResult{Bot: bot}, nil
 	}
 
 	// Pre-create the create-Activation audit row so Create can return the

--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -106,6 +106,14 @@ func (a *apiHandler) createBot(w http.ResponseWriter, r *http.Request) {
 	if req.Owner {
 		tools = mcptools.OwnerBotTools()
 	}
+	// Defer provisioning when the org has no runtime configured yet, so the
+	// Bot is never brought up on the seed-time default (claude_code /
+	// subscription / no model, which Zed renders as gpt). It provisions with
+	// the correct config once the operator sets the Default Bot Runtime — see
+	// reapplyBotsAfterRuntimeChange. When a runtime IS already configured
+	// (e.g. picked in the create-org dialog before seeding), the Bot
+	// provisions immediately with that config, correct from the first boot.
+	deferActivation := a.deps.Configs != nil && !a.deps.Configs.IsConfigured(ctx, orgID, "worker.runtime")
 	// REST and chat-driven creates share lifecycle.Create — one
 	// implementation.
 	res, err := a.deps.Lifecycle.Create(ctx, orgID, lifecycle.CreateParams{
@@ -115,6 +123,7 @@ func (a *apiHandler) createBot(w http.ResponseWriter, r *http.Request) {
 		Topics:          toTopicIDs(req.Topics),
 		ParentID:        orgchart.BotID(strings.TrimSpace(req.ParentID)),
 		PreserveContext: req.PreserveContext,
+		DeferActivation: deferActivation,
 	})
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)

--- a/api/pkg/org/interfaces/server/api/settings.go
+++ b/api/pkg/org/interfaces/server/api/settings.go
@@ -7,7 +7,21 @@ import (
 	"strings"
 
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+	"github.com/rs/zerolog/log"
 )
+
+// workerRuntimeKeys are the org-default "Default Bot Runtime" settings.
+// Changing any of them must re-apply every already-provisioned bot's agent
+// app, otherwise a bot seeded/provisioned before the operator picked a
+// runtime stays frozen on the seed-time default (claude_code/subscription
+// with no model, which Zed renders as its built-in gpt) and the operator's
+// later change never reaches the bot.
+var workerRuntimeKeys = map[string]bool{
+	"worker.runtime":     true,
+	"worker.credentials": true,
+	"worker.provider":    true,
+	"worker.model":       true,
+}
 
 // ---- Settings -----------------------------------------------------------
 
@@ -92,7 +106,105 @@ func (a *apiHandler) setSetting(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
+	// Propagate a Default Bot Runtime change to already-provisioned bots so
+	// they pick up the new runtime/model instead of staying frozen at the
+	// config that existed when they were first seeded. Config is committed
+	// above, so Ensure below reads the new value.
+	if workerRuntimeKeys[key] {
+		a.reapplyBotsAfterRuntimeChange(r.Context(), orgID)
+	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// reapplyBotsAfterRuntimeChange propagates a Default Bot Runtime change to
+// every Bot in the org:
+//
+//   - A Bot that was deferred at create (no project yet, because no runtime
+//     was configured) is activated now — it provisions for the FIRST time
+//     with the correct config, so its desktop never comes up on the gpt
+//     default.
+//   - A Bot that already has a project is re-applied in place (idempotent
+//     upsert-by-name that re-reads worker.*), rewriting its agent app's
+//     Runtime/Credentials/Provider/Model; a running desktop picks up the new
+//     model on its next settings-sync poll.
+//
+// Config is committed before this runs, so both paths read the new value.
+// Best-effort: per-bot failures are logged, not fatal — the settings write
+// already succeeded. A live runtime *switch* (e.g. claude_code -> goose_code)
+// on an already-running desktop still needs a session restart to swap the
+// in-sandbox agent binary; this only re-applies the stored config.
+func (a *apiHandler) reapplyBotsAfterRuntimeChange(ctx context.Context, orgID string) {
+	if a.deps.Queries == nil {
+		return
+	}
+	// The four worker.* keys are written as separate (often concurrent)
+	// requests by the UI. Wait until the runtime config is COMPLETE before
+	// provisioning anything, so a deferred bot is never brought up on a
+	// half-written config and then re-applied — it provisions exactly once,
+	// correct. Partial writes are no-ops; the write that completes the config
+	// does the work.
+	if !a.runtimeConfigComplete(ctx, orgID) {
+		return
+	}
+	bs, err := a.deps.Queries.ListBots(ctx, orgID)
+	if err != nil {
+		log.Warn().Err(err).Str("org", orgID).Msg("reapply bots after runtime change: list bots failed")
+		return
+	}
+	for _, b := range bs {
+		provisioned := true
+		if a.deps.BotRuntime != nil {
+			info, err := a.deps.BotRuntime.State(ctx, orgID, b.ID)
+			provisioned = err == nil && info.ProjectID != ""
+		}
+		if !provisioned {
+			// Deferred bot: activate it now so it provisions with the
+			// just-configured runtime (correct from its first boot).
+			if a.deps.Activations == nil {
+				continue
+			}
+			if _, err := a.deps.Activations.Activate(ctx, orgID, b.ID); err != nil {
+				log.Warn().Err(err).Str("org", orgID).Str("bot", string(b.ID)).
+					Msg("activate deferred bot after runtime change failed")
+			}
+			continue
+		}
+		if a.deps.ProjectEnsurer == nil {
+			continue
+		}
+		if _, _, _, err := a.deps.ProjectEnsurer.Ensure(ctx, orgID, b.ID); err != nil {
+			log.Warn().Err(err).Str("org", orgID).Str("bot", string(b.ID)).
+				Msg("reapply bot project after runtime change failed")
+		}
+	}
+}
+
+// runtimeConfigComplete reports whether the org's Default Bot Runtime has
+// every field a Bot needs to provision. It mirrors resolveWorkerAgentConfig's
+// coercion (server package): a non-claude runtime is always api_key and needs
+// a provider + model; claude_code defaults to subscription (no provider/model
+// needed) unless credentials is explicitly api_key. Used to hold off
+// provisioning until a half-written config is fully in place.
+func (a *apiHandler) runtimeConfigComplete(ctx context.Context, orgID string) bool {
+	if a.deps.Configs == nil {
+		return false
+	}
+	runtime, _ := a.deps.Configs.GetString(ctx, orgID, "worker.runtime")
+	if runtime == "" {
+		return false
+	}
+	credentials, _ := a.deps.Configs.GetString(ctx, orgID, "worker.credentials")
+	if runtime != "claude_code" {
+		credentials = "api_key" // subscription is only meaningful for claude_code
+	} else if credentials == "" {
+		credentials = "subscription"
+	}
+	if credentials == "subscription" {
+		return true // claude_code via OAuth — no provider/model needed
+	}
+	provider, _ := a.deps.Configs.GetString(ctx, orgID, "worker.provider")
+	model, _ := a.deps.Configs.GetString(ctx, orgID, "worker.model")
+	return provider != "" && model != ""
 }
 
 // deleteSetting removes the config row for the given key, falling back to defaults.


### PR DESCRIPTION
## Problem

A Bot auto-seeded into a new org (the Chief of Staff) was provisioned the moment the org was created, using whatever runtime config existed at that instant. On a brand-new org that is the default (`claude_code` / `subscription` / no model), so `GenerateZedMCPConfig` leaves `agent.default_model` unset and Zed boots on its built-in **gpt** default. Setting the org's Default Bot Runtime *afterwards* never reached the already-provisioned Bot, so it stayed on gpt.

Verified end-to-end on a dev stack: seed with no config → app is `claude_code`/`subscription`/empty-model (renders as gpt); set `worker.runtime=goose_code` + `provider=anthropic` + `model=claude-opus-4-5` first → app comes up as Claude.

## Fix (both ends)

**Defer provisioning.** `createBot` sets `CreateParams.DeferActivation` when the org has no `worker.runtime` configured. The Bot row + topology are created (so the chart isn't blank) but no project/app/desktop is provisioned — it is never brought up on the seed-time default. When a runtime is already configured (e.g. picked in the create-org dialog before seeding), the Bot provisions immediately with that config, correct from the first boot.

**Propagate on config change.** `setSetting` re-applies the org's bots when a `worker.*` runtime key changes: a deferred Bot is activated (provisions once, correct); an already-provisioned Bot is re-applied in place (idempotent) and a running desktop picks up the new model on its next settings-sync poll. Provisioning waits until the runtime config is *complete*, so the concurrent four-key write from the UI never brings a Bot up on a half-written config and then re-applies it.

## Verification

- `defer at seed` → no app/desktop provisioned, bot row present.
- `set runtime first, then provider, then model` → app count stays 0 until the config is complete, then provisions exactly once as `anthropic`/`claude-opus-4-5`/`goose_code`/`api_key`.
- `later change model to sonnet-4-5` → same app id re-applied in place, no duplicate.
- New unit tests: `TestCreate_DeferActivation`, `TestCreate_DispatchesWhenNotDeferred`. `go test ./pkg/org/application/lifecycle/ ./pkg/org/interfaces/server/api/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)