### PR TITLE
feat(org): give bots a display name distinct from their id

### DIFF
--- a/api/pkg/org/application/bots/bots.go
+++ b/api/pkg/org/application/bots/bots.go
@@ -103,6 +103,14 @@ func (s *Bots) Create(ctx context.Context, orgID string, p CreateParams) (orgcha
 	if id == "" {
 		id = orgchart.BotID("b-" + s.newID())
 	}
+	// Ensure the id is unique within the org, suffixing on conflict (base,
+	// base-1, base-2, ...) — mirrors org-name uniqueness. Without this a
+	// second bot whose id collides (two "Chief of Staff" both slugify to
+	// chief-of-staff) fails on the composite (id, org) primary key.
+	id, err := s.uniqueBotID(ctx, orgID, id)
+	if err != nil {
+		return orgchart.Bot{}, err
+	}
 	bot, err := orgchart.NewBot(id, p.Content, MergeTools(p.Tools, s.baseTools), s.now(), orgID)
 	if err != nil {
 		return orgchart.Bot{}, err
@@ -117,6 +125,28 @@ func (s *Bots) Create(ctx context.Context, orgID string, p CreateParams) (orgcha
 		return orgchart.Bot{}, err
 	}
 	return bot, nil
+}
+
+// uniqueBotID returns base when it's free within the org, otherwise the
+// first free base-<n> (n from 1). Mirrors the org-name uniqueness
+// suffixing so a name-derived id collision (two bots named the same) is
+// resolved rather than erroring on the composite (id, org) primary key.
+// Bounded at 100 probes to avoid an unbounded loop on pathological input.
+func (s *Bots) uniqueBotID(ctx context.Context, orgID string, base orgchart.BotID) (orgchart.BotID, error) {
+	for i := 0; i < 100; i++ {
+		cand := base
+		if i > 0 {
+			cand = orgchart.BotID(fmt.Sprintf("%s-%d", base, i))
+		}
+		_, err := s.bots.Get(ctx, orgID, cand)
+		if errors.Is(err, store.ErrNotFound) {
+			return cand, nil
+		}
+		if err != nil {
+			return "", fmt.Errorf("check bot id uniqueness: %w", err)
+		}
+	}
+	return "", fmt.Errorf("could not derive a unique bot id from %q", base)
 }
 
 // UpdateParams patches the mutable fields of a Bot. A nil pointer

--- a/api/pkg/org/application/bots/bots.go
+++ b/api/pkg/org/application/bots/bots.go
@@ -89,6 +89,7 @@ func New(deps Deps) *Bots {
 // service creates them as (bot, topic) rows from its own CreateParams.
 type CreateParams struct {
 	ID              string
+	Name            string
 	Content         string
 	Tools           []tool.Name
 	PreserveContext bool
@@ -106,6 +107,9 @@ func (s *Bots) Create(ctx context.Context, orgID string, p CreateParams) (orgcha
 	if err != nil {
 		return orgchart.Bot{}, err
 	}
+	if p.Name != "" {
+		bot = bot.WithName(p.Name)
+	}
 	if p.PreserveContext {
 		bot = bot.WithPreserveContext(true)
 	}
@@ -119,6 +123,7 @@ func (s *Bots) Create(ctx context.Context, orgID string, p CreateParams) (orgcha
 // leaves the corresponding field unchanged — this is what preserves
 // Tools on a content-only update.
 type UpdateParams struct {
+	Name            *string
 	Content         *string
 	Tools           *[]tool.Name
 	PreserveContext *bool
@@ -133,6 +138,9 @@ func (s *Bots) Update(ctx context.Context, orgID string, id orgchart.BotID, p Up
 		return orgchart.Bot{}, err
 	}
 	updated := existing
+	if p.Name != nil {
+		updated = updated.WithName(*p.Name)
+	}
 	if p.Content != nil {
 		updated = updated.WithContent(*p.Content)
 	}

--- a/api/pkg/org/application/lifecycle/hire_test.go
+++ b/api/pkg/org/application/lifecycle/hire_test.go
@@ -74,6 +74,45 @@ func TestCreate_CreatesBotAndReconciles(t *testing.T) {
 	}
 }
 
+// TestBotsCreate_SuffixesDuplicateID pins the name-collision fix in
+// bots.Create: two bots whose ids collide (e.g. a second "Chief of Staff"
+// slugifying to the same handle) don't fail on the composite (id, org)
+// primary key — the second is suffixed base-1 rather than erroring.
+func TestBotsCreate_SuffixesDuplicateID(t *testing.T) {
+	t.Parallel()
+	st := memory.New()
+	botSvc := bots.New(bots.Deps{
+		Bots:  st.Bots,
+		Now:   hireClock,
+		NewID: func() string { return "id" },
+	})
+	ctx := context.Background()
+
+	first, err := botSvc.Create(ctx, "org-test", bots.CreateParams{ID: "chief-of-staff", Content: "# Chief of Staff"})
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	if first.ID != "chief-of-staff" {
+		t.Fatalf("first id = %q, want chief-of-staff", first.ID)
+	}
+
+	second, err := botSvc.Create(ctx, "org-test", bots.CreateParams{ID: "chief-of-staff", Content: "# Another"})
+	if err != nil {
+		t.Fatalf("second create should suffix, not error: %v", err)
+	}
+	if second.ID != "chief-of-staff-1" {
+		t.Fatalf("second id = %q, want chief-of-staff-1", second.ID)
+	}
+
+	// Both rows exist independently.
+	if _, err := st.Bots.Get(ctx, "org-test", "chief-of-staff"); err != nil {
+		t.Fatalf("first bot missing: %v", err)
+	}
+	if _, err := st.Bots.Get(ctx, "org-test", "chief-of-staff-1"); err != nil {
+		t.Fatalf("suffixed bot missing: %v", err)
+	}
+}
+
 // TestCreate_RejectsPathTraversalID pins the path-injection guard: a bot
 // id that would escape the envs directory is rejected before any
 // os.MkdirAll, and nothing is created under the temp envs root.

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -135,6 +135,7 @@ type Service struct {
 // Topics are its capability/manifest.
 type CreateParams struct {
 	ID              string
+	Name            string
 	Content         string
 	Tools           []tool.Name
 	Topics          []streaming.TopicID
@@ -193,6 +194,7 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 
 	bot, err := s.Bots.Create(ctx, orgID, bots.CreateParams{
 		ID:              p.ID,
+		Name:            p.Name,
 		Content:         p.Content,
 		Tools:           p.Tools,
 		PreserveContext: p.PreserveContext,

--- a/api/pkg/org/domain/orgchart/bot.go
+++ b/api/pkg/org/domain/orgchart/bot.go
@@ -8,9 +8,14 @@ import (
 )
 
 // Bot is the single org-chart aggregate: the merge of the former Role
-// and Worker. A Bot has no identity beyond its name (ID) — there is no
-// kind (human/ai), no separate identity description, and no role
-// binding. A Bot *is* its own job description.
+// and Worker. There is no kind (human/ai) and no role binding — a Bot
+// *is* its own job description.
+//
+// ID is the stable, filesystem-safe handle (it names the runtime env,
+// repo and agent app, and is referenced by MCP tools). Name is the
+// human-readable display label shown in the UI; it is free text and may
+// be empty (callers fall back to the ID). Renaming a Bot changes Name,
+// never ID.
 //
 // Content is the canonical markdown the Bot's agent reads on activation
 // (it lands in role.md inside the Bot's runtime environment). Tools is
@@ -31,8 +36,12 @@ import (
 type Bot struct {
 	ID             BotID
 	OrganizationID string
-	Content        string
-	Tools          []tool.Name
+	// Name is the human-readable display label (e.g. "Chief of Staff").
+	// Free text, may be empty — the UI falls back to ID. Distinct from
+	// ID, which is the immutable handle.
+	Name    string
+	Content string
+	Tools   []tool.Name
 	// PreserveContext, when true, tells the runtime spawner NOT to wipe
 	// the Bot's chat session before each re-activation. The default
 	// (false) keeps the existing behaviour: every trigger starts on a
@@ -70,6 +79,13 @@ func NewBot(id BotID, content string, tools []tool.Name, now time.Time, orgID st
 		CreatedAt:      now,
 		UpdatedAt:      now,
 	}, nil
+}
+
+// WithName returns a copy of the Bot with Name (the display label)
+// replaced.
+func (b Bot) WithName(name string) Bot {
+	b.Name = name
+	return b
 }
 
 // WithContent returns a copy of the Bot with Content replaced. The

--- a/api/pkg/org/infrastructure/persistence/gorm/bot.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/bot.go
@@ -27,6 +27,7 @@ import (
 type botRow struct {
 	ID              string   `gorm:"primaryKey;type:text"`
 	OrgID           string   `gorm:"primaryKey;type:text;index"`
+	Name            string   `gorm:"not null;default:''"`
 	Content         string   `gorm:"not null"`
 	Tools           []string `gorm:"serializer:json"`
 	PreserveContext bool     `gorm:"not null;default:false"`
@@ -49,6 +50,7 @@ func (botMapper) ToRow(b orgchart.Bot) (botRow, error) {
 	return botRow{
 		ID:              string(b.ID),
 		OrgID:           b.OrganizationID,
+		Name:            b.Name,
 		Content:         b.Content,
 		Tools:           tools,
 		PreserveContext: b.PreserveContext,
@@ -68,6 +70,7 @@ func (botMapper) ToDomain(row botRow) (orgchart.Bot, error) {
 	return orgchart.Bot{
 		ID:              orgchart.BotID(row.ID),
 		OrganizationID:  row.OrgID,
+		Name:            row.Name,
 		Content:         row.Content,
 		Tools:           tools,
 		PreserveContext: row.PreserveContext,
@@ -113,6 +116,7 @@ func (r *botsRepo) Update(ctx context.Context, b orgchart.Bot) error {
 		store.WithOrg(row.OrgID),
 		store.WithID(row.ID),
 		store.WithUpdates(map[string]any{
+			"name":             row.Name,
 			"content":          row.Content,
 			"tools":            string(toolsJSON),
 			"preserve_context": row.PreserveContext,

--- a/api/pkg/org/interfaces/mcptools/create_bot.go
+++ b/api/pkg/org/interfaces/mcptools/create_bot.go
@@ -58,13 +58,14 @@ func (t *CreateBot) InputSchema() *jsonschema.Schema {
 	return s
 }
 func (t *CreateBot) Description() string {
-	return "Create a new Bot in one call. `content` is the bot's prompt. `tools` is an " +
-		"array of MCP tool names to grant (the universal read baseline is added " +
-		"automatically; pass [] for baseline only) — use attach_tool/detach_tool to " +
-		"change them later. `topics` is an array of existing Topic ids to subscribe the " +
-		"new Bot to immediately (pass [] for none) — use subscribe/unsubscribe to change " +
-		"them later. `parentId` is the manager this bot reports to — omit it only for the " +
-		"org owner.\n\n" +
+	return "Create a new Bot in one call. `content` is the bot's prompt. `name` is the " +
+		"human-readable display label shown in the UI (e.g. \"Chief of Staff\", \"Sales " +
+		"Lead\"). `tools` is an array of MCP tool names to grant (the universal read " +
+		"baseline is added automatically; pass [] for baseline only) — use " +
+		"attach_tool/detach_tool to change them later. `topics` is an array of existing " +
+		"Topic ids to subscribe the new Bot to immediately (pass [] for none) — use " +
+		"subscribe/unsubscribe to change them later. `parentId` is the manager this bot " +
+		"reports to — omit it only for the org owner.\n\n" +
 		"Supply `id` as a short, real-sounding handle: a lowercase given name prefixed " +
 		"with `b-`, e.g. `b-mark`, `b-priya`. Pick a name that fits and isn't taken. Do " +
 		"NOT pass a UUID and do NOT omit `id` to let the server invent one. If your first " +
@@ -73,6 +74,7 @@ func (t *CreateBot) Description() string {
 
 type createBotArgs struct {
 	ID       string   `json:"id,omitempty"`
+	Name     string   `json:"name,omitempty"`
 	Content  string   `json:"content"`
 	Tools    []string `json:"tools"`
 	Topics   []string `json:"topics"`
@@ -100,6 +102,7 @@ func (t *CreateBot) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMe
 	// dispatches the create activation through the Spawner.
 	res, err := t.deps.Lifecycle.Create(ctx, orgID, lifecycle.CreateParams{
 		ID:       args.ID,
+		Name:     args.Name,
 		Content:  args.Content,
 		Tools:    args.Tools,
 		Topics:   args.Topics,

--- a/api/pkg/org/interfaces/mcptools/read_bots.go
+++ b/api/pkg/org/interfaces/mcptools/read_bots.go
@@ -19,6 +19,7 @@ import (
 // on the bot — read them via the topic/subscription read tools.
 type botView struct {
 	ID        orgchart.BotID   `json:"id"`
+	Name      string           `json:"name,omitempty"`
 	Content   string           `json:"content"`
 	Tools     []tool.Name      `json:"tools,omitempty"`
 	ParentIDs []orgchart.BotID `json:"parentIds,omitempty"`
@@ -29,6 +30,7 @@ type botView struct {
 func botViewOf(b orgchart.Bot, managers []orgchart.BotID) botView {
 	return botView{
 		ID:        b.ID,
+		Name:      b.Name,
 		Content:   b.Content,
 		Tools:     b.Tools,
 		ParentIDs: managers,

--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -110,6 +110,7 @@ func (a *apiHandler) createBot(w http.ResponseWriter, r *http.Request) {
 	// implementation.
 	res, err := a.deps.Lifecycle.Create(ctx, orgID, lifecycle.CreateParams{
 		ID:              strings.TrimSpace(req.ID),
+		Name:            strings.TrimSpace(req.Name),
 		Content:         req.Content,
 		Tools:           tools,
 		Topics:          toTopicIDs(req.Topics),
@@ -202,6 +203,7 @@ func (a *apiHandler) updateBot(w http.ResponseWriter, r *http.Request) {
 		toolsPatch = &t
 	}
 	updated, err := a.deps.Bots.Update(ctx, orgID, id, bots.UpdateParams{
+		Name:            req.Name,
 		Content:         req.Content,
 		Tools:           toolsPatch,
 		PreserveContext: req.PreserveContext,
@@ -555,6 +557,7 @@ func (a *apiHandler) managerIDs(ctx context.Context, orgID string, id orgchart.B
 func botDTO(b orgchart.Bot, parentIDs []string) BotDTO {
 	dto := BotDTO{
 		ID:              string(b.ID),
+		Name:            b.Name,
 		Content:         b.Content,
 		ParentIDs:       parentIDs,
 		OrganizationID:  b.OrganizationID,

--- a/api/pkg/org/interfaces/server/api/dto.go
+++ b/api/pkg/org/interfaces/server/api/dto.go
@@ -35,7 +35,10 @@ type ToolDTO struct {
 // report to several managers. A Bot's subscriptions are not on the bot —
 // they live as (bot, topic) rows.
 type BotDTO struct {
-	ID             string   `json:"id"`
+	ID string `json:"id"`
+	// Name is the human-readable display label; empty means the UI falls
+	// back to ID. Distinct from ID, which is the immutable handle.
+	Name           string   `json:"name,omitempty"`
 	Content        string   `json:"content"`
 	Tools          []string `json:"tools,omitempty"`
 	ParentIDs      []string `json:"parent_ids,omitempty"`
@@ -82,7 +85,10 @@ type BotDetailDTO struct {
 // topics the new Bot is subscribed to at creation (they must already
 // exist).
 type CreateBotRequest struct {
-	ID              string   `json:"id,omitempty"`
+	ID string `json:"id,omitempty"`
+	// Name is the human-readable display label (e.g. "Chief of Staff").
+	// Optional; the ID stays the immutable handle.
+	Name            string   `json:"name,omitempty"`
 	Content         string   `json:"content"`
 	Tools           []string `json:"tools,omitempty"`
 	Topics          []string `json:"topics,omitempty"`
@@ -108,6 +114,7 @@ type CreateBotResponse struct {
 // PreserveContext is a pointer for the same reason: nil leaves the current
 // setting alone.
 type UpdateBotRequest struct {
+	Name            *string  `json:"name,omitempty"`
 	Content         *string  `json:"content,omitempty"`
 	Tools           []string `json:"tools,omitempty"`
 	PreserveContext *bool    `json:"preserve_context,omitempty"`

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -21168,6 +21168,10 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "name": {
+                    "description": "Name is the human-readable display label; empty means the UI falls\nback to ID. Distinct from ID, which is the immutable handle.",
+                    "type": "string"
+                },
                 "organization_id": {
                     "type": "string"
                 },
@@ -21239,6 +21243,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name is the human-readable display label (e.g. \"Chief of Staff\").\nOptional; the ID stays the immutable handle.",
                     "type": "string"
                 },
                 "owner": {
@@ -21780,6 +21788,9 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "content": {
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 },
                 "preserve_context": {

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -21164,6 +21164,10 @@
                 "id": {
                     "type": "string"
                 },
+                "name": {
+                    "description": "Name is the human-readable display label; empty means the UI falls\nback to ID. Distinct from ID, which is the immutable handle.",
+                    "type": "string"
+                },
                 "organization_id": {
                     "type": "string"
                 },
@@ -21235,6 +21239,10 @@
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name is the human-readable display label (e.g. \"Chief of Staff\").\nOptional; the ID stays the immutable handle.",
                     "type": "string"
                 },
                 "owner": {
@@ -21776,6 +21784,9 @@
             "type": "object",
             "properties": {
                 "content": {
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 },
                 "preserve_context": {

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -35,6 +35,11 @@ definitions:
         type: string
       id:
         type: string
+      name:
+        description: |-
+          Name is the human-readable display label; empty means the UI falls
+          back to ID. Distinct from ID, which is the immutable handle.
+        type: string
       organization_id:
         type: string
       parent_ids:
@@ -85,6 +90,11 @@ definitions:
       content:
         type: string
       id:
+        type: string
+      name:
+        description: |-
+          Name is the human-readable display label (e.g. "Chief of Staff").
+          Optional; the ID stays the immutable handle.
         type: string
       owner:
         description: |-
@@ -483,6 +493,8 @@ definitions:
   api.UpdateBotRequest:
     properties:
       content:
+        type: string
+      name:
         type: string
       preserve_context:
         type: boolean

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -33,6 +33,11 @@ export interface ApiBotDTO {
   content?: string;
   created_at?: string;
   id?: string;
+  /**
+   * Name is the human-readable display label; empty means the UI falls
+   * back to ID. Distinct from ID, which is the immutable handle.
+   */
+  name?: string;
   organization_id?: string;
   parent_ids?: string[];
   /**
@@ -65,6 +70,11 @@ export interface ApiBotSubscriptionsResponse {
 export interface ApiCreateBotRequest {
   content?: string;
   id?: string;
+  /**
+   * Name is the human-readable display label (e.g. "Chief of Staff").
+   * Optional; the ID stays the immutable handle.
+   */
+  name?: string;
   /**
    * Owner makes this a manager Bot: it receives the canonical owner
    * tool set (every org-graph mutation - create_bot, delete_bot,
@@ -331,6 +341,7 @@ export interface ApiTransportRequestField {
 
 export interface ApiUpdateBotRequest {
   content?: string;
+  name?: string;
   preserve_context?: boolean;
   tools?: string[];
 }

--- a/frontend/src/components/helix-org/NewBotDialog.tsx
+++ b/frontend/src/components/helix-org/NewBotDialog.tsx
@@ -5,7 +5,7 @@
 // name but overridable), its content (markdown prompt), and an optional
 // parent bot it reports to.
 
-import { FC, useEffect, useState } from 'react'
+import { FC, useEffect, useMemo, useState } from 'react'
 import Button from '@mui/material/Button'
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
@@ -46,13 +46,28 @@ const NewBotDialog: FC<NewBotDialogProps> = ({ open, onClose, presetParentId }) 
   }, [open, presetParentId])
 
   const bots = botsData ?? []
+  const existingIds = useMemo(() => new Set(bots.map((b) => b.id)), [bots])
+
+  // Append -1, -2, ... to a base slug until it's free within the org. Matches
+  // the backend's suffix-on-conflict (bots.Create), so the previewed id is what
+  // actually gets stored.
+  const uniqueSlug = (base: string): string => {
+    if (!base || !existingIds.has(base)) return base
+    for (let i = 1; i < 100; i++) {
+      const cand = `${base}-${i}`
+      if (!existingIds.has(cand)) return cand
+    }
+    return base
+  }
 
   // Slugify a display name into a kebab-case handle for the id field, unless
-  // the operator has typed their own id.
+  // the operator has typed their own id. Two bots named the same (e.g. a second
+  // "Chief of Staff") would otherwise derive the same id and collide.
   const onNameChange = (value: string) => {
     setName(value)
     if (!idEdited) {
-      setId(value.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''))
+      const base = value.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+      setId(uniqueSlug(base))
     }
   }
 

--- a/frontend/src/components/helix-org/NewBotDialog.tsx
+++ b/frontend/src/components/helix-org/NewBotDialog.tsx
@@ -1,9 +1,9 @@
 // NewBotDialog is the shared "create bot" dialog used by the Chart
 // canvas's floating top-right button / per-node "new bot" affordance and
 // the Bots list's "+ New bot" header action. A Bot is created in one
-// step: an id, its content (markdown identity/prompt), and an optional
-// parent bot it reports to. There is no kind selector and no separate
-// identity field — a Bot's content IS its identity.
+// step: a display name, an id (the immutable handle, auto-derived from the
+// name but overridable), its content (markdown prompt), and an optional
+// parent bot it reports to.
 
 import { FC, useEffect, useState } from 'react'
 import Button from '@mui/material/Button'
@@ -30,18 +30,31 @@ const NewBotDialog: FC<NewBotDialogProps> = ({ open, onClose, presetParentId }) 
   const create = useCreateBot()
   const { data: botsData } = useListHelixOrgBots({ enabled: open })
 
+  const [name, setName] = useState('')
   const [id, setId] = useState('')
+  const [idEdited, setIdEdited] = useState(false)
   const [content, setContent] = useState('')
   const [parentId, setParentId] = useState(presetParentId ?? '')
 
   useEffect(() => {
     if (!open) return
+    setName('')
     setId('')
+    setIdEdited(false)
     setContent('')
     setParentId(presetParentId ?? '')
   }, [open, presetParentId])
 
   const bots = botsData ?? []
+
+  // Slugify a display name into a kebab-case handle for the id field, unless
+  // the operator has typed their own id.
+  const onNameChange = (value: string) => {
+    setName(value)
+    if (!idEdited) {
+      setId(value.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''))
+    }
+  }
 
   const submit = async () => {
     const trimmedId = id.trim()
@@ -52,6 +65,7 @@ const NewBotDialog: FC<NewBotDialogProps> = ({ open, onClose, presetParentId }) 
     try {
       const res = await create.mutateAsync({
         id: trimmedId,
+        name: name.trim(),
         content,
         ...(parentId ? { parent_id: parentId } : {}),
       })
@@ -72,13 +86,22 @@ const NewBotDialog: FC<NewBotDialogProps> = ({ open, onClose, presetParentId }) 
       <DialogContent>
         <Stack spacing={2} sx={{ pt: 1 }}>
           <TextField
-            label="Bot ID"
-            placeholder="engineer"
-            value={id}
-            onChange={(e) => setId(e.target.value)}
-            helperText="A short handle in kebab-case, e.g. engineer. Stays as-is - the LLM and operator both refer to the bot by it."
+            label="Name"
+            placeholder="Chief of Staff"
+            value={name}
+            onChange={(e) => onNameChange(e.target.value)}
+            helperText="Human-readable display name shown in the chart and bot page."
             autoFocus
             fullWidth
+          />
+          <TextField
+            label="Bot ID"
+            placeholder="chief-of-staff"
+            value={id}
+            onChange={(e) => { setIdEdited(true); setId(e.target.value) }}
+            helperText="Immutable kebab-case handle (auto-filled from the name). Referenced by the LLM, repos and MCP tools; can be anything."
+            fullWidth
+            sx={{ '& input': { fontFamily: 'monospace' } }}
           />
           {presetParentId ? (
             <TextField
@@ -100,8 +123,8 @@ const NewBotDialog: FC<NewBotDialogProps> = ({ open, onClose, presetParentId }) 
             >
               <MenuItem value="">(none)</MenuItem>
               {bots.map((b) => (
-                <MenuItem key={b.id} value={b.id ?? ''} sx={{ fontFamily: 'monospace' }}>
-                  {b.id}
+                <MenuItem key={b.id} value={b.id ?? ''}>
+                  {b.name || b.id}
                 </MenuItem>
               ))}
             </TextField>

--- a/frontend/src/components/helix-org/NewBotDialog.tsx
+++ b/frontend/src/components/helix-org/NewBotDialog.tsx
@@ -46,7 +46,13 @@ const NewBotDialog: FC<NewBotDialogProps> = ({ open, onClose, presetParentId }) 
   }, [open, presetParentId])
 
   const bots = botsData ?? []
-  const existingIds = useMemo(() => new Set(bots.map((b) => b.id)), [bots])
+  // Keyed on botsData (not the freshly-allocated `bots`) so it's stable while
+  // the query is loading and recomputes once, when the list arrives.
+  const existingIds = useMemo(() => new Set((botsData ?? []).map((b) => b.id)), [botsData])
+
+  // Slugify a display name into a kebab-case handle.
+  const slugify = (v: string): string =>
+    v.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
 
   // Append -1, -2, ... to a base slug until it's free within the org. Matches
   // the backend's suffix-on-conflict (bots.Create), so the previewed id is what
@@ -60,16 +66,24 @@ const NewBotDialog: FC<NewBotDialogProps> = ({ open, onClose, presetParentId }) 
     return base
   }
 
-  // Slugify a display name into a kebab-case handle for the id field, unless
-  // the operator has typed their own id. Two bots named the same (e.g. a second
-  // "Chief of Staff") would otherwise derive the same id and collide.
+  // Auto-derive the id from the name, unless the operator typed their own. Two
+  // bots named the same (e.g. a second "Chief of Staff") would otherwise derive
+  // the same id and collide.
   const onNameChange = (value: string) => {
     setName(value)
     if (!idEdited) {
-      const base = value.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
-      setId(uniqueSlug(base))
+      setId(uniqueSlug(slugify(value)))
     }
   }
+
+  // Re-derive the id once the org's bot list loads: if the user typed the name
+  // before useListHelixOrgBots resolved, the first derivation saw an empty set
+  // and may under-count collisions. Only while the id is still auto-derived.
+  useEffect(() => {
+    if (idEdited || !name) return
+    setId(uniqueSlug(slugify(name)))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [existingIds])
 
   const submit = async () => {
     const trimmedId = id.trim()

--- a/frontend/src/components/orgs/EditOrgWindow.tsx
+++ b/frontend/src/components/orgs/EditOrgWindow.tsx
@@ -173,6 +173,7 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
         try {
           await api.getApiClient().v1OrgsBotsCreate(created.name, {
             id: 'chief-of-staff',
+            name: 'Chief of Staff',
             content: STARTER_BOT_CONTENT,
             owner: true,
           })

--- a/frontend/src/pages/HelixOrgBotDetail.tsx
+++ b/frontend/src/pages/HelixOrgBotDetail.tsx
@@ -109,14 +109,16 @@ const HelixOrgBotDetail: FC = () => {
 
   // Editable content markdown + tools. Seeded from the bot every time it
   // loads/refreshes so a cancelled edit re-syncs to server state.
+  const [name, setName] = useState('')
   const [content, setContent] = useState('')
   const [tools, setTools] = useState<string[]>([])
   const [preserveContext, setPreserveContext] = useState(false)
   useEffect(() => {
+    setName(bot?.name ?? '')
     setContent(bot?.content ?? '')
     setTools(bot?.tools ?? [])
     setPreserveContext(bot?.preserve_context ?? false)
-  }, [bot?.content, bot?.tools, bot?.preserve_context])
+  }, [bot?.name, bot?.content, bot?.tools, bot?.preserve_context])
 
   // The Autocomplete needs Option objects, but the bot's tool list is
   // just a string[] of names. Render every catalogue entry plus any
@@ -134,16 +136,17 @@ const HelixOrgBotDetail: FC = () => {
 
   const dirty = useMemo(() => {
     if (!bot) return false
+    if ((bot.name ?? '') !== name) return true
     if ((bot.content ?? '') !== content) return true
     if ((bot.tools ?? []).join(',') !== tools.join(',')) return true
     if ((bot.preserve_context ?? false) !== preserveContext) return true
     return false
-  }, [bot, content, tools, preserveContext])
+  }, [bot, name, content, tools, preserveContext])
 
   const handleSave = async () => {
     if (!botId) return
     try {
-      await updateBot.mutateAsync({ id: botId, content, tools, preserve_context: preserveContext })
+      await updateBot.mutateAsync({ id: botId, name, content, tools, preserve_context: preserveContext })
       snackbar.success(`bot ${botId} saved`)
     } catch (err: any) {
       snackbar.error(err?.response?.data?.error ?? err?.message ?? 'save failed')
@@ -296,11 +299,16 @@ const HelixOrgBotDetail: FC = () => {
             <Grid item xs={12} md={9}>
               <Stack spacing={3}>
                 <Box>
-                  <Stack direction="row" alignItems="center" spacing={1}>
-                    <SmartToyOutlinedIcon />
-                    <Typography variant="h5" sx={{ fontFamily: 'monospace' }}>
-                      {bot.id}
+                  <Stack direction="row" alignItems="baseline" spacing={1}>
+                    <SmartToyOutlinedIcon sx={{ alignSelf: 'center' }} />
+                    <Typography variant="h5">
+                      {bot.name || bot.id}
                     </Typography>
+                    {bot.name && (
+                      <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+                        {bot.id}
+                      </Typography>
+                    )}
                   </Stack>
                 </Box>
 
@@ -417,6 +425,18 @@ const HelixOrgBotDetail: FC = () => {
                     )}
                   </Stack>
                 </Paper>
+
+                <Box>
+                  <Typography variant="subtitle2" sx={{ mb: 1 }}>Name</Typography>
+                  <TextField
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder={bot.id}
+                    fullWidth
+                    size="small"
+                    helperText="Human-readable display label. The id stays fixed."
+                  />
+                </Box>
 
                 <Box>
                   <Typography variant="subtitle2" sx={{ mb: 1 }}>Content (markdown)</Typography>

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -89,6 +89,8 @@ const BOT_GAP_Y = 90
 
 type FlatBot = {
   id: string
+  // Human-readable display label; empty falls back to the id.
+  name: string
   // Reporting is many-to-many: a Bot may report to several managers.
   parentIds: string[]
 }
@@ -97,6 +99,7 @@ type FlatBot = {
 
 type BotNodeData = {
   botId: string
+  botName: string
   onSelectBot: (botId: string) => void
   onNewBot: (parentBotId: string) => void
   onDeleteBot: (botId: string) => void
@@ -166,9 +169,9 @@ const BotNode: FC<NodeProps<Node<BotNodeData>>> = ({ data }) => {
           <SmartToyOutlinedIcon sx={{ fontSize: 18, color: muted }} />
           <Typography
             variant="body2"
-            sx={{ fontFamily: 'monospace', fontSize: '0.85rem', fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+            sx={{ fontSize: '0.85rem', fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
           >
-            {data.botId}
+            {data.botName || data.botId}
           </Typography>
         </Stack>
         <Stack direction="row" spacing={0.25}>
@@ -424,6 +427,7 @@ const buildGraph = (
       position: { x, y },
       data: {
         botId: b.id,
+        botName: b.name,
         onSelectBot: handlers.onSelectBot,
         onNewBot: handlers.onNewBot,
         onDeleteBot: handlers.onDeleteBot,
@@ -1001,6 +1005,7 @@ const HelixOrgChart: FC = () => {
   const flat = useMemo<FlatBot[]>(
     () => (botsData ?? []).map((b: BotDTO) => ({
       id: b.id ?? '',
+      name: b.name ?? '',
       parentIds: b.parent_ids ?? [],
     })),
     [botsData],

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -35,6 +35,11 @@ definitions:
         type: string
       id:
         type: string
+      name:
+        description: |-
+          Name is the human-readable display label; empty means the UI falls
+          back to ID. Distinct from ID, which is the immutable handle.
+        type: string
       organization_id:
         type: string
       parent_ids:
@@ -85,6 +90,11 @@ definitions:
       content:
         type: string
       id:
+        type: string
+      name:
+        description: |-
+          Name is the human-readable display label (e.g. "Chief of Staff").
+          Optional; the ID stays the immutable handle.
         type: string
       owner:
         description: |-
@@ -483,6 +493,8 @@ definitions:
   api.UpdateBotRequest:
     properties:
       content:
+        type: string
+      name:
         type: string
       preserve_context:
         type: boolean

--- a/openapi.json
+++ b/openapi.json
@@ -25467,6 +25467,10 @@
                     "id": {
                         "type": "string"
                     },
+                    "name": {
+                        "description": "Name is the human-readable display label; empty means the UI falls\nback to ID. Distinct from ID, which is the immutable handle.",
+                        "type": "string"
+                    },
                     "organization_id": {
                         "type": "string"
                     },
@@ -25538,6 +25542,10 @@
                         "type": "string"
                     },
                     "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Name is the human-readable display label (e.g. \"Chief of Staff\").\nOptional; the ID stays the immutable handle.",
                         "type": "string"
                     },
                     "owner": {
@@ -26079,6 +26087,9 @@
                 "type": "object",
                 "properties": {
                     "content": {
+                        "type": "string"
+                    },
+                    "name": {
                         "type": "string"
                     },
                     "preserve_context": {

--- a/swagger.json
+++ b/swagger.json
@@ -21164,6 +21164,10 @@
                 "id": {
                     "type": "string"
                 },
+                "name": {
+                    "description": "Name is the human-readable display label; empty means the UI falls\nback to ID. Distinct from ID, which is the immutable handle.",
+                    "type": "string"
+                },
                 "organization_id": {
                     "type": "string"
                 },
@@ -21235,6 +21239,10 @@
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name is the human-readable display label (e.g. \"Chief of Staff\").\nOptional; the ID stays the immutable handle.",
                     "type": "string"
                 },
                 "owner": {
@@ -21776,6 +21784,9 @@
             "type": "object",
             "properties": {
                 "content": {
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 },
                 "preserve_context": {


### PR DESCRIPTION
## What

Bots were shown by their raw slug id (`chief-of-staff`) in the org chart and on the bot page. Rather than paper over the id by humanizing it, this adds a proper **`name`** field on the Bot, separate from the id.

- **id** stays the immutable handle — it names repos, agent apps and is referenced by MCP tools, and can be anything.
- **name** is free-text, human-readable (`Chief of Staff`), editable, and what the UI shows. Empty falls back to the id, so existing bots are unaffected.

## Changes

- **Domain** — `Bot.Name` + `WithName`; orgchart doc clarifies id = handle, name = label.
- **Persistence** — `name` column on `org_bots` (GORM AutoMigrate), mapped both ways and in the `Update` patch.
- **Use cases / lifecycle** — `Name` on Create/Update params, threaded through.
- **Surfaces** — `create_bot` MCP tool takes `name`; `get_bot`/`list_bots` return it; REST `BotDTO`/Create/Update carry it; OpenAPI regenerated.
- **UI** — chart node and bot header show `name || id`; the New Bot dialog takes a Name (auto-deriving the id slug, still overridable); the bot page can rename; the seeded starter bot is created with name `Chief of Staff`.

## Verification

- Backend: `go build ./...` clean, 37 `pkg/org/...` test packages green.
- End-to-end on a dev stack: `name` column migrated; create-with-name, get, list and PATCH-rename all round-trip; a bot created without a name returns no `name` (omitempty) and the UI falls back to the id.
- Frontend `tsc --noEmit` adds 0 new errors.

Supersedes the earlier humanize-the-slug approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)