### PR TITLE
fix(api): unify bot creation so MCP-created bots reconcile the Slack auto-router

### DIFF
--- a/api/pkg/org/interfaces/mcptools/builtins.go
+++ b/api/pkg/org/interfaces/mcptools/builtins.go
@@ -127,13 +127,9 @@ type Config struct {
 	Projects            runtime.Projects
 	Reconciler          *reconcile.Reconciler
 	CredentialProviders map[string]credential.Provider
-	// Lifecycle is an optional pre-built bot-lifecycle service. When set,
-	// Build() uses it verbatim for the MCP tool surface instead of
-	// constructing a fresh one — this is how the composition root shares the
-	// ONE reconciler-complete lifecycle.Service (including OrgReconcilers, the
-	// Slack auto-router) with both the REST handlers and the MCP tools, so
-	// create semantics cannot drift between callers. nil → lifecycleService()
-	// builds the standalone service used by tests and reconciler-free runtimes.
+	// Lifecycle, when set, is used verbatim instead of building a fresh one,
+	// so the MCP tools share the composition root's reconciler-complete
+	// service. nil → lifecycleService() builds a standalone service.
 	Lifecycle *lifecycle.Service
 }
 
@@ -227,8 +223,6 @@ func (c Config) publishingService() *publishing.Publishing {
 // the REST POST /bots handler. The bots service is wired so the row
 // creation applies the base-read-tool union.
 func (c Config) lifecycleService() *lifecycle.Service {
-	// Prefer the injected, reconciler-complete service (composition root) so
-	// the MCP tools and REST handlers share one instance — no drift.
 	if c.Lifecycle != nil {
 		return c.Lifecycle
 	}

--- a/api/pkg/org/interfaces/mcptools/builtins.go
+++ b/api/pkg/org/interfaces/mcptools/builtins.go
@@ -127,6 +127,14 @@ type Config struct {
 	Projects            runtime.Projects
 	Reconciler          *reconcile.Reconciler
 	CredentialProviders map[string]credential.Provider
+	// Lifecycle is an optional pre-built bot-lifecycle service. When set,
+	// Build() uses it verbatim for the MCP tool surface instead of
+	// constructing a fresh one — this is how the composition root shares the
+	// ONE reconciler-complete lifecycle.Service (including OrgReconcilers, the
+	// Slack auto-router) with both the REST handlers and the MCP tools, so
+	// create semantics cannot drift between callers. nil → lifecycleService()
+	// builds the standalone service used by tests and reconciler-free runtimes.
+	Lifecycle *lifecycle.Service
 }
 
 // Build assembles the application services from the config and returns
@@ -219,6 +227,11 @@ func (c Config) publishingService() *publishing.Publishing {
 // the REST POST /bots handler. The bots service is wired so the row
 // creation applies the base-read-tool union.
 func (c Config) lifecycleService() *lifecycle.Service {
+	// Prefer the injected, reconciler-complete service (composition root) so
+	// the MCP tools and REST handlers share one instance — no drift.
+	if c.Lifecycle != nil {
+		return c.Lifecycle
+	}
 	svc := &lifecycle.Service{
 		Store:          c.Store,
 		Bots:           c.botsService(),

--- a/api/pkg/org/interfaces/mcptools/create_bot_slackrouting_test.go
+++ b/api/pkg/org/interfaces/mcptools/create_bot_slackrouting_test.go
@@ -14,9 +14,7 @@ import (
 	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
 )
 
-// spyOrgReconciler records Reconcile(orgID) calls. It satisfies
-// lifecycle.OrgReconciler — the whole-org reconciler contract the Slack
-// auto-router implements.
+// spyOrgReconciler records Reconcile(orgID) calls.
 type spyOrgReconciler struct {
 	mu     sync.Mutex
 	orgIDs []string
@@ -37,17 +35,9 @@ func (s *spyOrgReconciler) calls() []string {
 	return out
 }
 
-// TestCreateBotRunsInjectedOrgReconcilers is the regression guard for the
-// bug where a bot added via the MCP create_bot tool did not reconcile the
-// Slack auto-router: the MCP surface built its own lifecycle.Service with an
-// empty OrgReconcilers slice, so runOrgReconcilers was a silent no-op.
-//
-// The fix gives mcptools.Config a Lifecycle injection seam so the composition
-// root can share the one reconciler-complete lifecycle.Service with both the
-// REST handlers and the MCP tools. This test injects a lifecycle.Service whose
-// OrgReconcilers contains a spy, drives create_bot, and asserts the spy ran
-// once for the caller's org — proving MCP-created bots trigger the whole-org
-// (Slack auto-router) reconcile exactly as REST-created bots do.
+// TestCreateBotRunsInjectedOrgReconcilers guards the bug where MCP create_bot
+// skipped the Slack auto-router: it asserts create_bot runs the OrgReconcilers
+// on the injected (shared) lifecycle, as REST POST /bots does.
 func TestCreateBotRunsInjectedOrgReconcilers(t *testing.T) {
 	t.Parallel()
 	st := orggorm.GetOrgTestDB(t)
@@ -70,8 +60,6 @@ func TestCreateBotRunsInjectedOrgReconcilers(t *testing.T) {
 		Now: deps.Now, NewID: deps.NewID, BaseTools: BaseReadTools,
 	})
 	spy := &spyOrgReconciler{}
-	// The shared, reconciler-complete lifecycle.Service the composition root
-	// builds — here with just enough wired for Create + the spy org reconciler.
 	deps.Lifecycle = &lifecycle.Service{
 		Store:          st,
 		Bots:           botSvc,

--- a/api/pkg/org/interfaces/mcptools/create_bot_slackrouting_test.go
+++ b/api/pkg/org/interfaces/mcptools/create_bot_slackrouting_test.go
@@ -1,0 +1,100 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/application/bots"
+	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
+	"github.com/helixml/helix/api/pkg/org/application/reconcile"
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
+)
+
+// spyOrgReconciler records Reconcile(orgID) calls. It satisfies
+// lifecycle.OrgReconciler — the whole-org reconciler contract the Slack
+// auto-router implements.
+type spyOrgReconciler struct {
+	mu     sync.Mutex
+	orgIDs []string
+}
+
+func (s *spyOrgReconciler) Reconcile(_ context.Context, orgID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.orgIDs = append(s.orgIDs, orgID)
+	return nil
+}
+
+func (s *spyOrgReconciler) calls() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.orgIDs))
+	copy(out, s.orgIDs)
+	return out
+}
+
+// TestCreateBotRunsInjectedOrgReconcilers is the regression guard for the
+// bug where a bot added via the MCP create_bot tool did not reconcile the
+// Slack auto-router: the MCP surface built its own lifecycle.Service with an
+// empty OrgReconcilers slice, so runOrgReconcilers was a silent no-op.
+//
+// The fix gives mcptools.Config a Lifecycle injection seam so the composition
+// root can share the one reconciler-complete lifecycle.Service with both the
+// REST handlers and the MCP tools. This test injects a lifecycle.Service whose
+// OrgReconcilers contains a spy, drives create_bot, and asserts the spy ran
+// once for the caller's org — proving MCP-created bots trigger the whole-org
+// (Slack auto-router) reconcile exactly as REST-created bots do.
+func TestCreateBotRunsInjectedOrgReconcilers(t *testing.T) {
+	t.Parallel()
+	st := orggorm.GetOrgTestDB(t)
+	now := time.Now().UTC()
+
+	deps := DefaultDeps(st)
+	deps.Now = func() time.Time { return now }
+	var counter int
+	deps.NewID = func() string {
+		counter++
+		return "id" + string(rune('a'+counter-1))
+	}
+
+	rec := reconcile.New(reconcile.Deps{
+		Bots: st.Bots, ReportingLines: st.ReportingLines,
+		Topics: st.Topics, Subscriptions: st.Subscriptions, Now: deps.Now,
+	})
+	botSvc := bots.New(bots.Deps{
+		Bots: st.Bots, Lines: st.ReportingLines, Reconciler: rec,
+		Now: deps.Now, NewID: deps.NewID, BaseTools: BaseReadTools,
+	})
+	spy := &spyOrgReconciler{}
+	// The shared, reconciler-complete lifecycle.Service the composition root
+	// builds — here with just enough wired for Create + the spy org reconciler.
+	deps.Lifecycle = &lifecycle.Service{
+		Store:          st,
+		Bots:           botSvc,
+		BotReconcilers: []lifecycle.BotReconciler{rec},
+		OrgReconcilers: []lifecycle.OrgReconciler{spy},
+		Now:            deps.Now,
+		NewID:          deps.NewID,
+	}
+
+	tl := &CreateBot{deps: deps.Build()}
+	args, _ := json.Marshal(createBotArgs{ID: "b-alice", Content: "# Alice", Tools: []string{}, Topics: []string{}})
+	if _, err := tl.Invoke(context.Background(), tool.Invocation{
+		Caller: botCaller{id: "b-owner", orgID: "org-test"},
+		Args:   args,
+	}); err != nil {
+		t.Fatalf("Invoke create_bot: %v", err)
+	}
+
+	got := spy.calls()
+	if len(got) != 1 {
+		t.Fatalf("OrgReconciler.Reconcile calls = %d, want 1 (MCP create_bot must run the whole-org reconcilers)", len(got))
+	}
+	if got[0] != "org-test" {
+		t.Errorf("OrgReconciler.Reconcile orgID = %q, want org-test", got[0])
+	}
+}

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -649,13 +649,9 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		return nil, fmt.Errorf("register helix-org prompts: %w", err)
 	}
 
-	// NOTE: the MCP tool registry (reg) and orgServer are built LATER — after
-	// the shared lifecycle.Service is fully assembled below — so the MCP
-	// create_bot tool and the REST POST /bots handler drive the SAME
-	// reconciler-complete lifecycle (including the Slack auto-router
-	// OrgReconciler). Building them here would capture a lifecycle without the
-	// OrgReconcilers, which is exactly the bug that made MCP-created bots skip
-	// the Slack auto-router reconcile. See `deps.Lifecycle = lifecycleSvc` below.
+	// The MCP registry (reg) and orgServer are built later, after lifecycleSvc
+	// is assembled, so MCP create_bot shares the same reconciler-complete
+	// lifecycle as REST. See `deps.Lifecycle = lifecycleSvc` below.
 
 	// JSON handlers consumed by the React pages at
 	// /orgs/:org_id/helix-org/*. They mount under
@@ -776,12 +772,8 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	})
 	lifecycleSvc.OrgReconcilers = append(lifecycleSvc.OrgReconcilers, slackRouteReconciler)
 
-	// The MCP tools and the REST handlers now share ONE reconciler-complete
-	// lifecycle.Service: inject it into the MCP tool deps so the chat-driven
-	// create_bot tool runs the same OrgReconcilers (Slack auto-router) the REST
-	// POST /bots handler does. Built here (not at line ~640) so the shared
-	// lifecycleSvc — with Bots, Subscriber and OrgReconcilers all wired — is
-	// captured, eliminating the UI-vs-MCP drift.
+	// Share the one lifecycleSvc with the MCP tools so create_bot runs the
+	// same OrgReconcilers (Slack auto-router) as REST POST /bots.
 	deps.Lifecycle = lifecycleSvc
 	reg := mcptools.NewRegistry()
 	if err := mcptools.RegisterBuiltins(reg, deps.Build()); err != nil {

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -20,13 +20,13 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/bots"
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
 	"github.com/helixml/helix/api/pkg/org/application/dispatch"
+	"github.com/helixml/helix/api/pkg/org/application/helixevents"
 	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
 	"github.com/helixml/helix/api/pkg/org/application/processing"
 	"github.com/helixml/helix/api/pkg/org/application/processors"
 	"github.com/helixml/helix/api/pkg/org/application/prompts"
 	"github.com/helixml/helix/api/pkg/org/application/publishing"
 	"github.com/helixml/helix/api/pkg/org/application/queries"
-	"github.com/helixml/helix/api/pkg/org/application/helixevents"
 	"github.com/helixml/helix/api/pkg/org/application/slackrouting"
 	"github.com/helixml/helix/api/pkg/org/application/subscriptions"
 	"github.com/helixml/helix/api/pkg/org/application/topics"
@@ -638,11 +638,6 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		return nil, fmt.Errorf("init streamcron scheduler: %w", err)
 	}
 
-	reg := mcptools.NewRegistry()
-	if err := mcptools.RegisterBuiltins(reg, deps.Build()); err != nil {
-		return nil, fmt.Errorf("register helix-org builtins: %w", err)
-	}
-
 	// Prompts registry — drives slash-command typeahead in the chat
 	// composer (/help, /role, /worker, …) and surfaces the same set as
 	// MCP prompts on each per-Worker MCP server. Without this the chat
@@ -654,7 +649,13 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		return nil, fmt.Errorf("register helix-org prompts: %w", err)
 	}
 
-	orgServer := helixorgserver.NewFromStore(st, reg, bc, dispatcher, logger).WithPrompts(promptReg)
+	// NOTE: the MCP tool registry (reg) and orgServer are built LATER — after
+	// the shared lifecycle.Service is fully assembled below — so the MCP
+	// create_bot tool and the REST POST /bots handler drive the SAME
+	// reconciler-complete lifecycle (including the Slack auto-router
+	// OrgReconciler). Building them here would capture a lifecycle without the
+	// OrgReconcilers, which is exactly the bug that made MCP-created bots skip
+	// the Slack auto-router reconcile. See `deps.Lifecycle = lifecycleSvc` below.
 
 	// JSON handlers consumed by the React pages at
 	// /orgs/:org_id/helix-org/*. They mount under
@@ -774,6 +775,20 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		Logger:        logger,
 	})
 	lifecycleSvc.OrgReconcilers = append(lifecycleSvc.OrgReconcilers, slackRouteReconciler)
+
+	// The MCP tools and the REST handlers now share ONE reconciler-complete
+	// lifecycle.Service: inject it into the MCP tool deps so the chat-driven
+	// create_bot tool runs the same OrgReconcilers (Slack auto-router) the REST
+	// POST /bots handler does. Built here (not at line ~640) so the shared
+	// lifecycleSvc — with Bots, Subscriber and OrgReconcilers all wired — is
+	// captured, eliminating the UI-vs-MCP drift.
+	deps.Lifecycle = lifecycleSvc
+	reg := mcptools.NewRegistry()
+	if err := mcptools.RegisterBuiltins(reg, deps.Build()); err != nil {
+		return nil, fmt.Errorf("register helix-org builtins: %w", err)
+	}
+	orgServer := helixorgserver.NewFromStore(st, reg, bc, dispatcher, logger).WithPrompts(promptReg)
+
 	// Thread-follow: the post-routing arm that records thread participation
 	// in the domain-event log and (when enabled) fans later thread messages
 	// out to existing participants. Registered late on the runner, like the


### PR DESCRIPTION
## Summary
The Slack auto-router was not reconciling when a bot was added **via MCP**
(the chat-driven `create_bot` tool), while bots added via the UI/REST worked.

Root cause: the MCP tool surface and the REST `POST /bots` handler each held a
**separate** `lifecycle.Service` instance. Only the REST one had the
`slackrouting` reconciler in its `OrgReconcilers`; the MCP one (built by
`mcptools.Config.Build()`) had an empty slice and no seam to wire one. Both
callers ran `lifecycle.Create` → `runOrgReconcilers`, but for the MCP instance
that iterated nothing — a silent no-op — so MCP-created bots never got a managed
route or subscription on the Automated Slack router.

The fix makes both surfaces share **one** reconciler-complete
`lifecycle.Service`, so the create semantics (Slack auto-router, and by
extension Dispatcher/Helix/Mirror) can never drift between the UI and chat paths
again.

## Changes
- `api/pkg/org/interfaces/mcptools/builtins.go`: add an optional
  `Lifecycle *lifecycle.Service` field to `Config`; `lifecycleService()` returns
  it verbatim when set, else falls back to the previous standalone construction
  (so tests / reconciler-free runtimes are unchanged).
- `api/pkg/server/helix_org.go`: build the MCP tool registry **after** the
  shared `lifecycleSvc` is fully assembled (with `OrgReconcilers`), and set
  `deps.Lifecycle = lifecycleSvc` before `deps.Build()`. The small registry
  block moved down (its `reg`/`orgServer` are only consumed much later), which
  is lower-risk than moving the services block up.
- `api/pkg/org/interfaces/mcptools/create_bot_slackrouting_test.go` (new):
  TDD red→green regression test — drives `create_bot` with a spy `OrgReconciler`
  injected via the new seam and asserts it runs once for the org.

## Testing
- Unit: red on HEAD (`deps.Lifecycle undefined`), green after the fix. Full
  `./pkg/org/...` suite (38 packages) passes.
- Live E2E (inner stack, `HELIX_ORG_ENABLED=true`): created bots via the
  helix-org UI with an Automated Slack router present; the router gained a
  managed route (`ManagedFor` + `mentions` predicate) and a subscription per
  bot; logs show `slackrouting: added route for bot`.

## Screenshots
![Bots created](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002221_please-investigate-why/screenshots/01-bots-created.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwm9p1dcec5q20q4rkhf5bw4)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002221_please-investigate-why/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002221_please-investigate-why/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002221_please-investigate-why/tasks.md)

🚀 Built with [Helix](https://helix.ml)