### PR TITLE
refactor(agent): clearer, consistent "Agent unresponsive" error copy

### DIFF
--- a/api/pkg/server/auto_wake_stuck_interactions.go
+++ b/api/pkg/server/auto_wake_stuck_interactions.go
@@ -532,9 +532,11 @@ func (apiServer *HelixAPIServer) maybeAutoWake(ctx context.Context, stuck *types
 	// mark this row terminal — re-sending to the wedged thread cannot help.
 	// The user's prompt is independently crash-marked (Restart surfaces) by
 	// handleThreadLoadError once the wedge recurs.
+	// Background for maintainers: design/2026-06-15-wedged-acp-thread-autowake-flood.md
+	// (claude-agent-acp cancel/prompt swallow). Kept out of the user-facing string.
 	if wedged, n := apiServer.sessionWedgedByConsecutiveErrors(ctx, session); wedged {
 		stuck.State = types.InteractionStateError
-		stuck.Error = "Agent thread wedged (claude-agent-acp cancel/prompt swallow) — auto-wake stopped; click Restart to recover (see design/2026-06-15-wedged-acp-thread-autowake-flood.md)"
+		stuck.Error = "Agent unresponsive: automatic retries stopped. Click Restart to recover."
 		stuck.Updated = time.Now()
 		stuck.Completed = time.Now()
 		if _, err := apiServer.Store.UpdateInteraction(ctx, stuck); err != nil {
@@ -552,9 +554,11 @@ func (apiServer *HelixAPIServer) maybeAutoWake(ctx context.Context, stuck *types
 
 	// Gate 2 — retry cap. Read off the stuck row itself, atomically
 	// updated by IncrementInteractionAutoWakeCount on prior attempts.
+	// Background for maintainers: design/2026-04-25-zed-claude-async-event-flush-on-user-input.md
+	// (upstream ACP buffering). Kept out of the user-facing string.
 	if stuck.AutoWakeCount >= autoWakeMaxRetries {
 		stuck.State = types.InteractionStateError
-		stuck.Error = "Agent unresponsive after auto-wake retries (upstream ACP buffering — see design/2026-04-25-zed-claude-async-event-flush-on-user-input.md)"
+		stuck.Error = "Agent unresponsive: no response after automatic retries. Click Restart to recover."
 		stuck.Updated = time.Now()
 		stuck.Completed = time.Now()
 		if _, err := apiServer.Store.UpdateInteraction(ctx, stuck); err != nil {

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -2750,7 +2750,7 @@ func (apiServer *HelixAPIServer) handleMessageCompleted(sessionID string, syncMs
 			Msg("⚠️ [HELIX] message_completed with EMPTY response — marking as error and re-queuing")
 
 		targetInteraction.State = types.InteractionStateError
-		targetInteraction.Error = "Agent returned empty response (message bounced or content lost). The prompt will be retried."
+		targetInteraction.Error = "Agent unresponsive: it returned an empty response. Retrying automatically."
 		targetInteraction.Updated = time.Now()
 
 		if _, err := apiServer.Controller.Options.Store.UpdateInteraction(context.Background(), targetInteraction); err != nil {

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -1168,8 +1168,8 @@ func (s *WebSocketSyncSuite) TestMessageCompleted_EmitsAttentionWhenNoFollowup()
 // error to a legacy HTTP-streaming response channel that doesn't exist for
 // WebSocket-driven chat — the interaction was silently left in Waiting, then
 // handleMessageCompleted's empty-response branch overwrote it with the
-// generic "Agent returned empty response (message bounced or content lost).
-// The prompt will be retried." which buries the actual cause.
+// generic "Agent unresponsive: it returned an empty response. Retrying
+// automatically." which buries the actual cause.
 //
 // This test pins the desired behaviour: when an active interaction exists for
 // the failing request_id, the agent's error message MUST land on the


### PR DESCRIPTION
## What

The three agent-stall errors shown to users were inconsistent and leaked internals. Rewrite them for clarity. **No behaviour change** - copy only.

Grounded in [NN/g error-message guidelines](https://www.nngroup.com/articles/error-message-guidelines/): human-readable language, precise about the problem, a constructive next step, and don't expose implementation detail.

## Before → after

| Situation | Before | After |
|---|---|---|
| Empty response (auto-retrying) | `Agent returned empty response (message bounced or content lost). The prompt will be retried.` | `Agent unresponsive: it returned an empty response. Retrying automatically.` |
| Wedge breaker (terminal) | `Agent thread wedged (claude-agent-acp cancel/prompt swallow) — auto-wake stopped; click Restart to recover (see design/2026-06-15-...md)` | `Agent unresponsive: automatic retries stopped. Click Restart to recover.` |
| Retries exhausted (terminal) | `Agent unresponsive after auto-wake retries (upstream ACP buffering — see design/2026-04-25-...md)` | `Agent unresponsive: no response after automatic retries. Click Restart to recover.` |

## Why

- **One prefix** (`Agent unresponsive:`) so the three read as one class of problem, not three unrelated failures.
- **No design-doc links** - useless to an end user, and they exposed internal paths. Preserved as code comments for maintainers.
- **No internal jargon** - dropped `claude-agent-acp`, `cancel/prompt swallow`, `ACP buffering`, `bounced`.
- **Clear next step** - either "retrying automatically" (no action) or "click Restart to recover" (terminal).
- ASCII only - replaced the em dashes.

## Testing

`go build ./pkg/server/` passes. No assertions keyed on these strings; updated one descriptive test comment that quoted the old copy. Not fixing the underlying ACP stall - that's upstream and separately tracked; this only improves how it's surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)