### PR TITLE
fix(compute): drop sliceReference from YD node discovery query

### DIFF
--- a/api/pkg/sandbox/compute/yellowdog/node_discovery.go
+++ b/api/pkg/sandbox/compute/yellowdog/node_discovery.go
@@ -66,14 +66,15 @@ func fetchOnlineNodes(ctx context.Context, cfg Config) ([]node, error) {
 		}
 	}
 
-	// nodeSearch and sliceReference are both *required* query params on
-	// GET /workerPools/nodes per the scheduler OpenAPI; the server 400s
-	// without them. Both serialise as URL-encoded JSON strings, matching
-	// the convention searchWorkRequirements already uses for
-	// /work/requirements.
+	// nodeSearch is a URL-encoded JSON search object. sliceReference is an
+	// opaque base64 pagination cursor (slice ID) on this endpoint, NOT a
+	// JSON object - the /work/requirements convention does not apply here,
+	// and sending `{"size":200}` makes YD 400 ("Unable to decode slice ID").
+	// We read only the first page (deployments have <10 online nodes), so
+	// we omit it; YD returns the first slice by default.
+	// ponytail: first-page-only; add cursor paging if a deployment exceeds one slice
 	q := url.Values{}
 	q.Set("nodeSearch", `{"statuses":["RUNNING"]}`)
-	q.Set("sliceReference", `{"size":200}`)
 
 	var out sliceNode
 	if err := doJSON(ctx, httpc, creds, base, http.MethodGet, "/workerPools/nodes", q, nil, &out, retryConfig{maxAttempts: 3}); err != nil {


### PR DESCRIPTION
## Problem

The YellowDog-backed control plane shows **0 online runners** despite Floor=1 and a healthy provisioned YD worker pool.

Root cause: `GET /workerPools/nodes` on YellowDog now rejects our query with:

```
HTTP 400 {"detail":["Illegal base64 character 7b"],
          "errorType":"InvalidRequestException",
          "message":"Unable to decode slice ID: {\"size\":200}"}
```

On this endpoint `sliceReference` is an **opaque base64 pagination cursor**, not the JSON slice spec that the `/work/requirements` convention uses. `node_discovery.go` copied that convention and sent `sliceReference={"size":200}`; YD base64-decodes it, hits `{` (0x7b), and 400s.

Our request is **byte-identical since node discovery landed (2026-06-11)**, and `/work/requirements` still accepts the JSON form. So YD changed the `/workerPools/nodes` contract under us; this is a regression from that change, not a code change on our side.

## Impact

The 400 fires every reconcile (15s), so `PoolSupervisor.reconcile` logs `discovery failed; keeping current managers` and never creates a per-pool Manager. No Manager -> no work requirement submitted -> the idle worker node never runs helix-sandbox -> never phones home -> **0 online runners**. Confirmed live: a RUNNING worker node exists but there are **zero** work requirements.

Blast radius is discovery only. WR submission/search uses the `search` param on `/work/requirements`, which still returns 200.

## Fix

Send only `nodeSearch`; let YD return the first slice by default (deployments have <10 online nodes, so first-page-only is sufficient).

## Verification

- **Live against the real YD API:** dropping `sliceReference` returns **200** with the node list; the previous request returns **400**.
- `go build ./pkg/sandbox/compute/...` passes.
- **NOT yet verified end-to-end on deploy:** a runner has not been observed coming online after the fix. Expected chain once deployed: discovery 200 -> Manager created for the worker pool -> WR submitted -> idle worker runs helix-sandbox -> phones home -> online runner. If a runner does not appear, the next suspect is phone-home/bridge registration (no evidence points there currently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)