### PR TITLE
fix(server): update wedge-breaker test to reworded error message

### DIFF
--- a/api/pkg/server/auto_wake_stuck_interactions_test.go
+++ b/api/pkg/server/auto_wake_stuck_interactions_test.go
@@ -415,7 +415,7 @@ func (s *AutoWakeWedgeBreakerSuite) TestBreakerTripsOnConsecutiveErrors() {
 
 	s.Require().NotNil(marked, "expected the stuck interaction to be marked")
 	s.Equal(types.InteractionStateError, marked.State)
-	s.Contains(marked.Error, "wedged")
+	s.Contains(marked.Error, "automatic retries stopped")
 }
 
 // TestBreakerDoesNotTripWhenRecentCompletion: a completion before the error run
@@ -450,5 +450,5 @@ func (s *AutoWakeWedgeBreakerSuite) TestBreakerDoesNotTripWhenRecentCompletion()
 
 	s.Require().NotNil(marked)
 	s.Equal(types.InteractionStateError, marked.State)
-	s.NotContains(marked.Error, "wedged", "should be the Gate 2 exhaustion error, not the breaker error")
+	s.NotContains(marked.Error, "automatic retries stopped", "should be the Gate 2 exhaustion error, not the breaker error")
 }


### PR DESCRIPTION
## Problem

`main` is red on every build (2771, 2772, 2774, ...): `TestAutoWakeWedgeBreakerSuite/TestBreakerTripsOnConsecutiveErrors` fails with

```
"Agent unresponsive: automatic retries stopped. Click Restart to recover." does not contain "wedged"
```

PR #2801 (`fix/agent-unresponsive`) reworded the breaker error message and dropped the word "wedged", but the test still asserted `Contains(marked.Error, "wedged")`.

## Fix

The suite uses a unique substring to tell the **breaker** error apart from the **Gate 2 exhaustion** error:

- breaker: `"Agent unresponsive: automatic retries stopped. ..."`
- exhaustion: `"Agent unresponsive: no response after automatic retries. ..."`

`"automatic retries stopped"` is present in the breaker message and absent from the exhaustion message, so it replaces `"wedged"` as the discriminator in both assertions (the positive `Contains` at line 418 and the negative `NotContains` at line 453).

## Verification

```
CGO_ENABLED=1 go test -run TestAutoWakeWedgeBreakerSuite ./pkg/server/ -count=1
ok  github.com/helixml/helix/api/pkg/server
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)