### PR TITLE
fix(compute): widen sandbox_instances.provider to varchar(255)

### DIFF
--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -3313,8 +3313,11 @@ type SandboxInstance struct {
 	// leave these empty.
 
 	// Provider is the Name() of the compute.Provider that owns this host.
-	// E.g. "yellowdog", "gcp", "lambda". Empty for self-registered hosts.
-	Provider string `json:"provider,omitempty" gorm:"type:varchar(50);index:idx_sandbox_provider_id,priority:1"`
+	// For pool-discovery providers this is a composite key baked from the
+	// deployment tag, worker tag and instance type (e.g.
+	// "yellowdog-helix-development-worker-psamuel-g5-xlarge-164e3a34"), so it
+	// needs the same width as ProviderID. Empty for self-registered hosts.
+	Provider string `json:"provider,omitempty" gorm:"type:varchar(255);index:idx_sandbox_provider_id,priority:1"`
 
 	// ProviderID is the upstream system's opaque identifier for this
 	// host (e.g. a YellowDog work-requirement YDID). Forms a composite


### PR DESCRIPTION
## Problem

Once YD pool discovery works, provisioning fails at the stub-row insert:

```
provision: insert stub row: ERROR: value too long for type character varying(50) (SQLSTATE 22001)
provider=yellowdog-helix-development-worker-psamuel-g5-xlarge-164e3a34
```

Pool-discovery providers build a composite `Name()` from the deployment tag, worker tag and instance type (`providerKind + "-" + cfg.n`), which is ~61 chars and is used as the row-ownership boundary (`provider.Name() = "yellowdog-"+n`). The `sandbox_instances.provider` column was `varchar(50)` - a limit from when provider names were short (`"yellowdog"`, `"stub"`) - so the insert overflows.

The name is intentionally long (shortening it would break ownership filtering), so the fix is to widen the column.

## Fix

`Provider` -> `varchar(255)`, matching `ProviderID` right below it (the two form a composite index). GORM AutoMigrate widens the column in place on deploy.

## Verification

- Reproduced live on a YD control plane after the discovery fix (2.11.45): every reconcile logged the SQLSTATE 22001 overflow and never provisioned.
- Manually `ALTER TABLE sandbox_instances ALTER COLUMN provider TYPE varchar(255)` on that box -> the next reconcile provisioned a host and submitted a work requirement, confirming the width is the only blocker.
- `go build ./pkg/types/ ./pkg/sandbox/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)