### PR TITLE
feat(org): name bot projects "<Bot> @ <Org>" and land on org chart

### DIFF
--- a/api/pkg/org/infrastructure/runtime/helix/project.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project.go
@@ -115,6 +115,13 @@ type WorkerProject struct {
 	Store       *store.Store
 	HelixOrgURL string
 	OrgID       string
+	// OrgDisplayName is the org's human label, used to build the
+	// project's display name (`<Bot> @ <Org>`). The host resolves it
+	// from the main store and stamps it here; empty falls back to a
+	// bare bot label. Both the owner-chat applier and the spawner MUST
+	// set it identically — the project is upserted by name, so a
+	// divergent value would create a duplicate project.
+	OrgDisplayName string
 	// Runtime overrides the default `zed_agent` runtime constant.
 	// Empty means "use the package-level Runtime const" (zed_agent),
 	// which routes inference back through Helix and honours
@@ -165,6 +172,18 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 	if runtime == "" {
 		runtime = Runtime
 	}
+	// Project display name: `<Bot> @ <Org>` (e.g. "Chief of Staff @ Acme")
+	// rather than the bare slug. bot.Name may be empty (fall back to the
+	// ID); OrgDisplayName may be empty in bare/test wirings (fall back to
+	// just the bot label). Deterministic so upsert-by-name stays idempotent.
+	botLabel := bot.Name
+	if botLabel == "" {
+		botLabel = string(bot.ID)
+	}
+	projectName := botLabel
+	if a.OrgDisplayName != "" {
+		projectName = fmt.Sprintf("%s @ %s", botLabel, a.OrgDisplayName)
+	}
 	applyReq := types.ProjectApplyRequest{
 		// Scope the project to the org this Ensure call was invoked for,
 		// not the struct's OrgID field. They are normally equal, but a
@@ -172,7 +191,7 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 		// from frozen config) must not be able to apply one org's project
 		// into another — the org parameter is the authority here.
 		OrganizationID: orgID,
-		Name:           string(workerID),
+		Name:           projectName,
 		Spec: types.ProjectSpec{
 			Description: bot.Content,
 			Agent: &types.ProjectAgentSpec{

--- a/api/pkg/org/infrastructure/runtime/helix/project.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project.go
@@ -204,7 +204,8 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 		},
 	}
 	if state.ProjectID != "" {
-		if _, err := a.Service.GetProject(ctx, state.ProjectID); err != nil {
+		existing, err := a.Service.GetProject(ctx, state.ProjectID)
+		if err != nil {
 			if errors.Is(err, ErrProjectNotFound) {
 				if clearErr := ClearProject(ctx, a.Store, orgID, workerID); clearErr != nil {
 					return "", "", "", fmt.Errorf("clear stale project state for %s: %w", workerID, clearErr)
@@ -219,6 +220,27 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 		} else {
 			// Project already exists — fast path.
 			//
+			// The project is tracked by ID (state.ProjectID) but ApplyProject
+			// upserts by NAME. When the desired display name has drifted from
+			// the tracked project's current name — an existing worker whose
+			// project predates the `<Bot> @ <Org>` scheme, or an org/bot
+			// rename — a bare ApplyProject would match nothing and FORK an
+			// orphan project, and the settings-drift refresh below would then
+			// target the orphan instead of the live agent app. Rename in place
+			// by ID first so ApplyProject matches the same project.
+			if existing.Name != projectName {
+				renamed := projectName
+				if _, err := a.Service.UpdateProject(ctx, state.ProjectID, types.ProjectUpdateRequest{Name: &renamed}); err != nil {
+					// Don't fork: skip the by-name refresh this activation and
+					// keep the worker running on its existing project. Retries
+					// next activation.
+					if a.Logger != nil {
+						a.Logger.Warn("project applier: rename to display name failed, skipping refresh to avoid orphan", "worker", workerID, "project", state.ProjectID, "want_name", projectName, "err", err)
+					}
+					a.republishWorkerFiles(ctx, workerID, state.RepoID, roleContent)
+					return state.ProjectID, state.AgentAppID, state.RepoID, nil
+				}
+			}
 			// We DO re-call ApplyProject so worker.* changes (runtime,
 			// credentials, provider, model) made on the Settings page
 			// after this worker was first provisioned propagate to the

--- a/api/pkg/org/infrastructure/runtime/helix/spawner.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner.go
@@ -82,6 +82,10 @@ type SpawnerConfig struct {
 	// OrgID is the Helix organisation each per-Worker project lives
 	// under. Empty for personal accounts.
 	OrgID string
+	// OrgDisplayName is the org's human label, forwarded to WorkerProject
+	// so the project is named `<Bot> @ <Org>`. Must match the applier's
+	// value (upsert-by-name).
+	OrgDisplayName string
 	// SessionStartupTimeout bounds how long ensureSession is allowed to
 	// take — creating / picking the session row, opening the Helix
 	// chat session, attaching the live transcript WebSocket. Five
@@ -385,16 +389,17 @@ After meaningful work, persist state on helix-specs:
 // must be wired by the embedding host (api/pkg/server/helix_org.go).
 func (c SpawnerConfig) ensureProject(ctx context.Context, orgID string, workerID orgchart.BotID) error {
 	a := &WorkerProject{
-		Service:     c.ProjectService,
-		Workspace:   c.Workspace,
-		Store:       c.Store,
-		HelixOrgURL: c.HelixOrgURL,
-		OrgID:       c.OrgID,
-		Runtime:     c.Runtime,
-		Provider:    c.Provider,
-		Model:       c.Model,
-		Credentials: c.Credentials,
-		Logger:      c.Logger,
+		Service:        c.ProjectService,
+		Workspace:      c.Workspace,
+		Store:          c.Store,
+		HelixOrgURL:    c.HelixOrgURL,
+		OrgID:          c.OrgID,
+		OrgDisplayName: c.OrgDisplayName,
+		Runtime:        c.Runtime,
+		Provider:       c.Provider,
+		Model:          c.Model,
+		Credentials:    c.Credentials,
+		Logger:         c.Logger,
 	}
 	_, _, _, err := a.Ensure(ctx, orgID, workerID)
 	return err

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -495,6 +495,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		cfg:        configReg,
 		projectSvc: inProcClient,
 		Store:      st,
+		helixStore: helixStore,
 		workspace:  orgWorkspace,
 		logger:     logger,
 	}
@@ -996,6 +997,9 @@ type dynamicProjectApplier struct {
 	cfg        *configregistry.Registry
 	projectSvc runtimehelix.ProjectService
 	Store      *helixorgstore.Store
+	// helixStore is the main Helix store, used only to resolve the org's
+	// display name for the `<Bot> @ <Org>` project label.
+	helixStore helixstore.Store
 	// workspace is the single on-branch Workspace shared with the
 	// update_role/update_identity tools. Injected here (rather than read
 	// from a package global) so initialisation order is explicit. nil is
@@ -1021,6 +1025,7 @@ func (d *dynamicProjectApplier) Ensure(ctx context.Context, orgID string, worker
 	if err != nil {
 		return "", "", "", err
 	}
+	applier.OrgDisplayName = orgDisplayName(ctx, d.helixStore, orgID)
 	projectID, agentAppID, repoID, err = applier.Ensure(ctx, orgID, workerID)
 	if err != nil {
 		return "", "", "", err
@@ -1052,6 +1057,24 @@ func (d *dynamicProjectApplier) Ensure(ctx context.Context, orgID string, worker
 // fallback bearer when no per-request bearer is on ctx. The bearer
 // is no longer carried on WorkerProject because Ensure doesn't touch
 // MCPs — MCP attachment is a separate, explicit step.
+// orgDisplayName resolves an org's human label for the `<Bot> @ <Org>`
+// project name. Prefers DisplayName, falls back to the slug Name, then
+// to "" (which makes WorkerProject use a bare bot label). Best-effort:
+// a lookup failure yields "" rather than breaking activation.
+func orgDisplayName(ctx context.Context, s helixstore.Store, orgID string) string {
+	if s == nil || orgID == "" {
+		return ""
+	}
+	org, err := s.GetOrganization(ctx, &helixstore.GetOrganizationQuery{ID: orgID})
+	if err != nil || org == nil {
+		return ""
+	}
+	if org.DisplayName != "" {
+		return org.DisplayName
+	}
+	return org.Name
+}
+
 func buildHelixOrgProjectApplier(
 	ctx context.Context,
 	orgID string,
@@ -1221,6 +1244,7 @@ func buildHelixOrgSpawnerConfig(ctx context.Context, orgID string, d spawnerDeps
 		ProjectService: d.ProjectSvc,
 		HelixOrgURL:    helixOrgURL,
 		OrgID:          orgID,
+		OrgDisplayName: orgDisplayName(ctx, d.HelixStore, orgID),
 		Runtime:        runtime,
 		Credentials:    credentials,
 		Provider:       provider,

--- a/frontend/src/components/orgs/EditOrgWindow.tsx
+++ b/frontend/src/components/orgs/EditOrgWindow.tsx
@@ -12,8 +12,11 @@ import Typography from '@mui/material/Typography'
 import { TypesOrganization } from '../../api/api'
 import useAccount from '../../hooks/useAccount'
 import useApi from '../../hooks/useApi'
+import useRouter from '../../hooks/useRouter'
 import useSnackbar from '../../hooks/useSnackbar'
 import BotRuntimeForm, { BotRuntimeValue } from '../helix-org/BotRuntimeForm'
+import { SELECTED_ORG_STORAGE_KEY } from '../../utils/localStorage'
+import { orgLandingRoute } from '../../utils/organizations'
 
 export interface EditOrgWindowProps {
   open: boolean
@@ -43,6 +46,7 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
 }) => {
   const account = useAccount()
   const api = useApi()
+  const router = useRouter()
   const snackbar = useSnackbar()
   const helixOrgEnabled = account.user?.alpha_features?.includes('helix-org') ?? false
 
@@ -180,6 +184,13 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
         } catch (e) {
           snackbar.error('Organization created, but seeding the starter bot failed - add one from the Org Chart.')
         }
+      }
+
+      // Land the operator on the freshly created org: the org chart when
+      // helix-org is enabled, otherwise projects.
+      if (!org && created && created.name) {
+        localStorage.setItem(SELECTED_ORG_STORAGE_KEY, created.name)
+        router.navigate(orgLandingRoute(account.user), { org_id: created.name })
       }
 
       onClose()

--- a/frontend/src/components/orgs/OrgsTable.tsx
+++ b/frontend/src/components/orgs/OrgsTable.tsx
@@ -29,7 +29,9 @@ import {
 } from '../../api/api'
 
 import useRouter from '../../hooks/useRouter'
+import useAccount from '../../hooks/useAccount'
 import { SELECTED_ORG_STORAGE_KEY } from '../../utils/localStorage'
+import { orgLandingRoute } from '../../utils/organizations'
 
 const formatDate = (dateStr?: string): string => {
   if (!dateStr) return '-'
@@ -144,6 +146,7 @@ const OrgCard: FC<{
   onMenuOpen: (event: React.MouseEvent<HTMLElement>, org: TypesOrganization) => void
 }> = ({ org, userID, onMenuOpen }) => {
   const router = useRouter()
+  const account = useAccount()
   const membership = computeMembershipState(org, userID)
   const isOwner = membership.kind === 'owner'
   const isNonMember = membership.kind === 'admin-view'
@@ -182,7 +185,7 @@ const OrgCard: FC<{
         }}
         onClick={() => {
           localStorage.setItem(SELECTED_ORG_STORAGE_KEY, org.name || '')
-          router.navigate('org_projects', { org_id: org.name })
+          router.navigate(orgLandingRoute(account.user), { org_id: org.name })
         }}
       >
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2, gap: 1 }}>

--- a/frontend/src/components/orgs/UserOrgSelector.tsx
+++ b/frontend/src/components/orgs/UserOrgSelector.tsx
@@ -42,6 +42,7 @@ import { styled, keyframes } from '@mui/material/styles'
 import LoginRegisterDialog from './LoginRegisterDialog'
 import { TypesAuthProvider } from '../../api/api'
 import { SELECTED_ORG_STORAGE_KEY } from '../../utils/localStorage'
+import { orgLandingRoute } from '../../utils/organizations'
 import { useSettingsDialog } from '../../contexts/settingsDialog'
 
 // Shimmer animation for login button
@@ -288,7 +289,7 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
   // Handle org select, also remember the last org user has been in
   const handleOrgSelect = (orgSlug: string) => {
     localStorage.setItem(SELECTED_ORG_STORAGE_KEY, orgSlug)
-    router.navigate('org_projects', { org_id: orgSlug })
+    router.navigate(orgLandingRoute(account.user), { org_id: orgSlug })
     setDialogOpen(false)
   }
 

--- a/frontend/src/components/orgs/UserOrgSelector.tsx
+++ b/frontend/src/components/orgs/UserOrgSelector.tsx
@@ -281,7 +281,7 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
     if (!firstAccessibleOrg) return
     const firstOrgSlug = firstAccessibleOrg.name
     localStorage.setItem(SELECTED_ORG_STORAGE_KEY, firstOrgSlug)
-    const useRouteName = router.name.startsWith('org_') ? router.name : 'org_projects'
+    const useRouteName = router.name.startsWith('org_') ? router.name : orgLandingRoute(account.user)
     const useParams = Object.assign({}, router.params, { org_id: firstOrgSlug })
     router.navigate(useRouteName, useParams)
   }, [listOrgs, account.user])

--- a/frontend/src/utils/organizations.ts
+++ b/frontend/src/utils/organizations.ts
@@ -1,5 +1,16 @@
 import { TypesOrganization, TypesOrganizationRole, TypesOrganizationMembership } from '../api/api'
 
+// True when the user has the helix-org alpha feature (the Org Chart surface).
+export function isHelixOrgEnabled(user?: { alpha_features?: string[] } | null): boolean {
+  return user?.alpha_features?.includes('helix-org') ?? false
+}
+
+// Route to land on after creating or selecting an org: the org chart when
+// helix-org is enabled, otherwise projects.
+export function orgLandingRoute(user?: { alpha_features?: string[] } | null): string {
+  return isHelixOrgEnabled(user) ? 'helix_org_chart' : 'org_projects'
+}
+
 /**
  * Gets a user's membership in an organization
  * @param organization - An organization object with memberships


### PR DESCRIPTION
## What

Two related helix-org UX changes:

### 1. Nicer bot-project names
Org-bot projects were named after the bare bot slug (`chief-of-staff`). They are now named **`<Bot> @ <Org>`** (e.g. `Chief of Staff @ Acme`).

- New `WorkerProject.OrgDisplayName` / `SpawnerConfig.OrgDisplayName` fields, resolved host-side from the main store via a new `orgDisplayName()` helper (prefers `DisplayName`, falls back to slug `Name`, then empty).
- Both the owner-chat applier and the spawner stamp the name identically. This matters because projects are **upserted by name** (`applyProject` matches on `p.Name == req.Name`), so a divergent value would create a duplicate project.
- Fallbacks keep it deterministic: empty `bot.Name` -> bot ID; empty `OrgDisplayName` -> bare bot label.

### 2. Land on the Org Chart tab
When the `helix-org` alpha feature is enabled, creating or selecting an org now lands on the Org Chart tab instead of Projects.

- Shared `orgLandingRoute(user)` / `isHelixOrgEnabled(user)` in `utils/organizations.ts` so all entry points agree on the route.
- Wired into: org **create** (`EditOrgWindow`), dropdown **switch** (`UserOrgSelector.handleOrgSelect`), org **card click** (`OrgsTable`), and the fresh-login **auto-select-first-org** default.
- Deliberately left alone: the module-load boot redirect in `router.tsx` (runs before `account.user` is loaded, so it can't read the alpha flag; it restores the last org on reload, which is session-restoration not an explicit action).

## Idempotency / rename handling
Projects are tracked by ID (`state.ProjectID`) but `applyProject` upserts by **name**. Because the name now derives from mutable display fields, the fast path renames the tracked project **in place by ID** (`UpdateProject`) before the by-name settings-refresh, so it matches the same project instead of forking an orphan. This covers both:
- existing workers whose project predates the `<Bot> @ <Org>` scheme, and
- any later org/bot rename.

On a rename failure the refresh is skipped (worker keeps running on its existing project, retries next activation) rather than forking.

Known narrow risk: two bots with the **same display name** in the same org would resolve to the same project name. Bot IDs are unique (`chief-of-staff`, `chief-of-staff-1`) but display names are not enforced unique. Out of scope here; seeding uses distinct names.

## Review
Reviewed by two subagents (Go backend + frontend). Backend review caught the orphan-fork/settings-drift regression above, now fixed. Frontend review confirmed routes valid, no bot-seed race, type-compatible, and closed the auto-select consistency gap.

## Testing
- Backend compiles (`go build ./api/pkg/server/ ./api/pkg/org/...`).
- Frontend tsc clean (no new errors vs baseline).
- **NOT yet browser-verified** end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)