### PR TITLE
fix(external-agent): reap waiting interactions when desktop stops

### DIFF
--- a/api/pkg/external-agent/idle_checker.go
+++ b/api/pkg/external-agent/idle_checker.go
@@ -54,6 +54,21 @@ func stopIdleDesktop(ctx context.Context, executor Executor, st store.Store, ses
 			Msg("failed to stop idle desktop")
 	}
 
+	// Reap any interaction left in state=waiting. The desktop we just stopped was
+	// the only agent that could ever have delivered its message_completed. Left
+	// waiting, it wedges the prompt-queue busy-check
+	// (processPendingPromptsForIdleSessions) into treating the session as
+	// perpetually busy — the next user message is never dispatched and the
+	// desktop is never allowed to resume: a permanent deadlock. Marking it
+	// interrupted lets the next message boot the desktop cleanly. This is the
+	// deterministic seam — we KNOW the agent is gone here, so there is no live
+	// turn worth preserving.
+	if reaped, reapErr := st.ReapWaitingInteractions(ctx, session.ID, types.InteractionStateInterrupted, "desktop idle-stopped mid-turn"); reapErr != nil {
+		log.Warn().Err(reapErr).Str("session_id", session.ID).Msg("failed to reap waiting interactions after idle desktop stop")
+	} else if len(reaped) > 0 {
+		log.Info().Str("session_id", session.ID).Int("count", len(reaped)).Msg("reaped waiting interactions after idle desktop stop")
+	}
+
 	// Re-fetch the session after StopDesktop — it saves PausedScreenshotPath
 	// to the DB. Using the stale pre-stop copy would overwrite that.
 	freshSession, err := st.GetSession(ctx, session.ID)

--- a/api/pkg/server/prompt_history_handlers.go
+++ b/api/pkg/server/prompt_history_handlers.go
@@ -14,6 +14,43 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// desktopResumeReapStaleThreshold is how long a state=waiting interaction with
+// no live WebSocket must have been idle before the queue-side liveness guard
+// treats it as an orphan (agent gone) and reaps it so the desktop can resume.
+// Sized above the auto-wake stuck threshold (180s) so a genuinely in-flight or
+// mid-boot turn is never mistaken for a dead one.
+const desktopResumeReapStaleThreshold = 3 * time.Minute
+
+// isOrphanedWaitingInteraction reports whether `latest` (the newest interaction
+// of `session`) is a state=waiting turn whose external agent has gone away and
+// will therefore never complete — the case that deadlocks the prompt-queue
+// busy-check and stops the desktop from resuming. Pure so it can be unit-tested
+// exhaustively against every branch of the boot/live/orphan matrix.
+//
+// All must hold to classify as orphaned (any failing → treat as busy, defer):
+//   - latest is state=waiting (nothing else can be actively streaming);
+//   - no live WebSocket to the agent (wsLive=false) — a live turn keeps one;
+//   - the thread is already established (ZedThreadID set) — an empty ZedThreadID
+//     is the very-first-message boot race, which must never be reaped (mirrors
+//     the THREAD-ESTABLISHMENT BARRIER in processPendingPromptsForIdleSessions);
+//   - the turn has been idle past desktopResumeReapStaleThreshold — a freshly
+//     created / mid-boot in-flight turn is protected by the staleness window.
+func isOrphanedWaitingInteraction(session *types.Session, latest *types.Interaction, wsLive bool, now time.Time) bool {
+	if session == nil || latest == nil {
+		return false
+	}
+	if latest.State != types.InteractionStateWaiting {
+		return false
+	}
+	if wsLive {
+		return false
+	}
+	if session.Metadata.ZedThreadID == "" {
+		return false
+	}
+	return now.Sub(latest.Updated) > desktopResumeReapStaleThreshold
+}
+
 // @Summary Sync prompt history
 // @Description Sync prompt history entries from the frontend (union merge - no deletes)
 // @Tags PromptHistory
@@ -279,10 +316,51 @@ func (apiServer *HelixAPIServer) processPendingPromptsForIdleSessions(ctx contex
 				apiServer.processInterruptPrompt(ctx, sessionID)
 			}
 		} else {
-			log.Debug().
-				Str("session_id", sessionID).
-				Int("queue_count", pending.queueCount).
-				Msg("Session is busy (interaction waiting), queue prompts will be processed after message_completed")
+			// Liveness guard for the busy branch. A Waiting latest interaction
+			// normally means an agent is actively streaming a turn, so we defer
+			// the queue until message_completed. BUT if the agent has gone away
+			// (desktop idle-stopped / crashed / restarted) that completion never
+			// arrives: the queue waits forever AND the desktop never resumes —
+			// the exact deadlock behind the "didn't boot when I sent a message"
+			// incident. The idle-checker reaps at stop time for the idle path;
+			// this net covers every OTHER way the desktop dies (OOM, crash,
+			// stack restart) where nothing reaped the dangling interaction.
+			//
+			// Reap ONLY when all three hold, so we never kill a live or mid-boot
+			// turn:
+			//   - no live WebSocket to the external agent (a live turn has one);
+			//   - the thread is already established (ZedThreadID set) — an empty
+			//     ZedThreadID means the very first message is mid-boot, which we
+			//     must not reap (mirrors the THREAD-ESTABLISHMENT BARRIER above);
+			//   - the waiting interaction is stale beyond the reap threshold — a
+			//     freshly-created in-flight turn is protected.
+			latest := interactions[0]
+			_, wsLive := apiServer.externalAgentWSManager.getConnection(sessionID)
+			if isOrphanedWaitingInteraction(session, latest, wsLive, time.Now()) {
+				reaped, reapErr := apiServer.Store.ReapWaitingInteractions(ctx, sessionID, types.InteractionStateInterrupted, "desktop stopped while turn in-flight; reaped so queue can resume")
+				if reapErr != nil {
+					log.Error().Err(reapErr).Str("session_id", sessionID).Msg("Failed to reap orphaned waiting interaction; queue still blocked")
+				} else {
+					log.Warn().
+						Str("session_id", sessionID).
+						Int("reaped_count", len(reaped)).
+						Time("latest_waiting_updated", latest.Updated).
+						Msg("♻️ [QUEUE] Reaped orphaned waiting interaction (no live agent) — dispatching queued prompt to resume desktop")
+					for _, in := range reaped {
+						apiServer.publishInteractionUpdateToFrontend(sessionID, session.Owner, in)
+					}
+					if pending.interruptCount > 0 {
+						apiServer.processInterruptPrompt(ctx, sessionID)
+					} else {
+						apiServer.processPromptQueue(ctx, sessionID)
+					}
+				}
+			} else {
+				log.Debug().
+					Str("session_id", sessionID).
+					Int("queue_count", pending.queueCount).
+					Msg("Session is busy (interaction waiting), queue prompts will be processed after message_completed")
+			}
 		}
 	}
 }

--- a/api/pkg/server/prompt_history_orphan_reap_test.go
+++ b/api/pkg/server/prompt_history_orphan_reap_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// TestIsOrphanedWaitingInteraction exercises every branch of the boot / live /
+// orphan matrix for the queue-side liveness guard that unwedges a session whose
+// desktop died mid-turn. The bug it protects against: a state=waiting turn whose
+// agent has gone away never gets message_completed, so the prompt-queue treats
+// the session as perpetually busy and the desktop never resumes.
+func TestIsOrphanedWaitingInteraction(t *testing.T) {
+	now := time.Date(2026, 7, 6, 18, 0, 0, 0, time.UTC)
+	stale := now.Add(-desktopResumeReapStaleThreshold - time.Minute) // comfortably past threshold
+	fresh := now.Add(-5 * time.Second)                               // just created / mid-boot
+
+	sessionWithThread := func() *types.Session {
+		s := &types.Session{}
+		s.Metadata.ZedThreadID = "ccc26138-d4dc-4cb5-9126-55424d500609"
+		return s
+	}
+	sessionNoThread := func() *types.Session {
+		s := &types.Session{}
+		s.Metadata.ZedThreadID = ""
+		return s
+	}
+	waiting := func(updated time.Time) *types.Interaction {
+		return &types.Interaction{State: types.InteractionStateWaiting, Updated: updated}
+	}
+
+	cases := []struct {
+		name    string
+		session *types.Session
+		latest  *types.Interaction
+		wsLive  bool
+		want    bool
+	}{
+		{
+			name:    "orphaned: stale waiting, no WS, thread established -> reap",
+			session: sessionWithThread(), latest: waiting(stale), wsLive: false, want: true,
+		},
+		{
+			name:    "live WS present -> genuinely busy, do not reap",
+			session: sessionWithThread(), latest: waiting(stale), wsLive: true, want: false,
+		},
+		{
+			name:    "boot race: thread not yet established -> never reap",
+			session: sessionNoThread(), latest: waiting(stale), wsLive: false, want: false,
+		},
+		{
+			name:    "fresh in-flight turn within staleness window -> protected",
+			session: sessionWithThread(), latest: waiting(fresh), wsLive: false, want: false,
+		},
+		{
+			name:    "latest interaction not waiting -> nothing to reap",
+			session: sessionWithThread(), latest: &types.Interaction{State: types.InteractionStateComplete, Updated: stale}, wsLive: false, want: false,
+		},
+		{
+			name:    "nil latest -> false",
+			session: sessionWithThread(), latest: nil, wsLive: false, want: false,
+		},
+		{
+			name:    "nil session -> false",
+			session: nil, latest: waiting(stale), wsLive: false, want: false,
+		},
+		{
+			name:    "exactly at threshold (not strictly past) -> not yet orphaned",
+			session: sessionWithThread(), latest: waiting(now.Add(-desktopResumeReapStaleThreshold)), wsLive: false, want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isOrphanedWaitingInteraction(tc.session, tc.latest, tc.wsLive, now)
+			if got != tc.want {
+				t.Fatalf("isOrphanedWaitingInteraction = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -317,6 +317,14 @@ type Store interface {
 	// change made). Used by the streaming transition handler so it cannot
 	// resurrect a cancelled or errored turn as falsely "complete".
 	MarkInteractionCompleteIfWaiting(ctx context.Context, interactionID string, generationID int) (bool, error)
+	// ReapWaitingInteractions transitions all state=waiting interactions for a
+	// session to newState (e.g. interrupted) when the external agent has gone
+	// away (desktop idle-stopped/crashed/found-stopped). This clears the
+	// prompt-queue busy-check so the desktop is allowed to resume instead of
+	// deadlocking on a turn that can never complete. Returns the reaped rows so
+	// callers can publish frontend updates. Distinct from auto-wake, which
+	// retries live turns rather than terminating dead ones.
+	ReapWaitingInteractions(ctx context.Context, sessionID string, newState types.InteractionState, reason string) ([]*types.Interaction, error)
 	UpdateInteractionSummary(ctx context.Context, interactionID string, summary string) error
 	DeleteInteraction(ctx context.Context, id string) error
 	// ClearSessionInteractions hard-deletes every interaction belonging to a

--- a/api/pkg/store/store_interactions.go
+++ b/api/pkg/store/store_interactions.go
@@ -287,6 +287,70 @@ func (s *PostgresStore) MarkInteractionCompleteIfWaiting(ctx context.Context, in
 	return result.RowsAffected > 0, nil
 }
 
+// ReapWaitingInteractions transitions every interaction still in state=waiting
+// for sessionID to newState (typically interrupted), stamping completed/updated.
+//
+// Used when the external agent that could have completed the turn has gone away
+// — the desktop was idle-stopped, crashed, or is found stopped when a new prompt
+// arrives. A waiting interaction with no live agent will never receive
+// message_completed; left alone it deadlocks the prompt-queue busy-check in
+// processPendingPromptsForIdleSessions (which treats "latest interaction waiting"
+// as "busy, defer") so the desktop is never allowed to resume.
+//
+// This is deliberately DIFFERENT from the auto-wake worker: auto-wake *retries*
+// zero-output waiting turns over a LIVE WebSocket, whereas here the agent is gone
+// and we cleanly TERMINATE the turn so the session can move on. The two never
+// overlap — auto-wake skips both partial-output turns and sessions with no WS.
+//
+// Targeted column UPDATE guarded on state=waiting (not a full-row Save) so it
+// cannot clobber a concurrent streaming write. Returns the reaped interactions
+// (with the new state reflected in the returned copies) so callers can publish
+// frontend updates.
+func (s *PostgresStore) ReapWaitingInteractions(ctx context.Context, sessionID string, newState types.InteractionState, reason string) ([]*types.Interaction, error) {
+	if sessionID == "" {
+		return nil, errors.New("session_id is required")
+	}
+	now := time.Now()
+	var reaped []*types.Interaction
+	err := s.gdb.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.
+			Where("session_id = ? AND state = ?", sessionID, types.InteractionStateWaiting).
+			Find(&reaped).Error; err != nil {
+			return err
+		}
+		if len(reaped) == 0 {
+			return nil
+		}
+		if err := tx.Model(&types.Interaction{}).
+			Where("session_id = ? AND state = ?", sessionID, types.InteractionStateWaiting).
+			Updates(map[string]interface{}{
+				"state":     newState,
+				"completed": now,
+				"updated":   now,
+			}).Error; err != nil {
+			return err
+		}
+		for _, in := range reaped {
+			in.State = newState
+			in.Completed = now
+			in.Updated = now
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(reaped) > 0 {
+		log.Info().
+			Str("session_id", sessionID).
+			Int("count", len(reaped)).
+			Str("new_state", string(newState)).
+			Str("reason", reason).
+			Msg("reaped waiting interactions (agent gone)")
+	}
+	return reaped, nil
+}
+
 // UpdateInteractionSummary updates just the summary field of an interaction
 func (s *PostgresStore) UpdateInteractionSummary(ctx context.Context, interactionID string, summary string) error {
 	now := time.Now()

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -2227,6 +2227,21 @@ func (mr *MockStoreMockRecorder) EnsureUserMeta(ctx, UserMeta any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureUserMeta", reflect.TypeOf((*MockStore)(nil).EnsureUserMeta), ctx, UserMeta)
 }
 
+// FailInFlightWebServiceDeploys mocks base method.
+func (m *MockStore) FailInFlightWebServiceDeploys(ctx context.Context) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailInFlightWebServiceDeploys", ctx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FailInFlightWebServiceDeploys indicates an expected call of FailInFlightWebServiceDeploys.
+func (mr *MockStoreMockRecorder) FailInFlightWebServiceDeploys(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailInFlightWebServiceDeploys", reflect.TypeOf((*MockStore)(nil).FailInFlightWebServiceDeploys), ctx)
+}
+
 // FindAvailableSandboxInstance mocks base method.
 func (m *MockStore) FindAvailableSandboxInstance(ctx context.Context, desktopType string) (*types.SandboxInstance, error) {
 	m.ctrl.T.Helper()
@@ -5601,6 +5616,21 @@ func (mr *MockStoreMockRecorder) ParseAndCreateImplementationTasks(ctx, specTask
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParseAndCreateImplementationTasks", reflect.TypeOf((*MockStore)(nil).ParseAndCreateImplementationTasks), ctx, specTaskID, implementationPlan)
 }
 
+// ReapWaitingInteractions mocks base method.
+func (m *MockStore) ReapWaitingInteractions(ctx context.Context, sessionID string, newState types.InteractionState, reason string) ([]*types.Interaction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReapWaitingInteractions", ctx, sessionID, newState, reason)
+	ret0, _ := ret[0].([]*types.Interaction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReapWaitingInteractions indicates an expected call of ReapWaitingInteractions.
+func (mr *MockStoreMockRecorder) ReapWaitingInteractions(ctx, sessionID, newState, reason any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReapWaitingInteractions", reflect.TypeOf((*MockStore)(nil).ReapWaitingInteractions), ctx, sessionID, newState, reason)
+}
+
 // ReconcileStuckSendingPrompts mocks base method.
 func (m *MockStore) ReconcileStuckSendingPrompts(ctx context.Context) (int, error) {
 	m.ctrl.T.Helper()
@@ -7004,21 +7034,6 @@ func (m *MockStore) UpdateWebServiceDeploy(ctx context.Context, id string, updat
 func (mr *MockStoreMockRecorder) UpdateWebServiceDeploy(ctx, id, updates any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWebServiceDeploy", reflect.TypeOf((*MockStore)(nil).UpdateWebServiceDeploy), ctx, id, updates)
-}
-
-// FailInFlightWebServiceDeploys mocks base method.
-func (m *MockStore) FailInFlightWebServiceDeploys(ctx context.Context) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FailInFlightWebServiceDeploys", ctx)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FailInFlightWebServiceDeploys indicates an expected call of FailInFlightWebServiceDeploys.
-func (mr *MockStoreMockRecorder) FailInFlightWebServiceDeploys(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailInFlightWebServiceDeploys", reflect.TypeOf((*MockStore)(nil).FailInFlightWebServiceDeploys), ctx)
 }
 
 // UpsertProjectWebServiceState mocks base method.


### PR DESCRIPTION
## Problem

A spec-task session could deadlock and **refuse to boot when the user sent a message** — the desktop never came back and the queued prompt was never processed. Observed live on `spt_01kwrt1nvtrvnsrxgteagg46mp`.

## Root cause — a three-link chain

1. **Trigger:** an interaction wedges in `state=waiting` — the agent never emits the terminal `message_completed` for a turn (partial response streamed, then the ACP agent goes silent; the recurring ACP wedge).
2. **Amplifier:** `ListIdleDesktops` measures idle purely by `MAX(interaction.updated)`, so a wedged `waiting` turn stops updating and looks **identical to a finished-and-idle desktop**. The idle-checker stops the desktop — the only agent that could ever complete the turn — and **leaves the interaction `waiting`**.
3. **Deadlock:** the prompt-queue busy-check treats "latest interaction = `waiting`" as "agent is actively streaming → defer until `message_completed`". With the desktop gone that event can never arrive, so the next message defers forever and the auto-resume (gated behind dispatch) never boots the desktop.

`ResetRunningInteractions` only clears these on **API startup**, so in production — where the API runs for days while the idle-checker runs continuously — the deadlock persists indefinitely.

This is **distinct from the auto-wake worker**, which *retries* zero-output turns over a **live** WS. Our case (partial output + dead desktop) sits in the exact intersection of auto-wake's two documented blind spots, so nothing recovered it.

## Fix

A shared store primitive `ReapWaitingInteractions` transitions dangling `waiting` turns to `interrupted` the moment their agent goes away, wired at the two deterministic seams:

- **`idle_checker`** — reap right after `StopDesktop` (the source of the reported bug; we *know* the agent is gone here).
- **Prompt-queue liveness net** — covers every *other* way a desktop dies (OOM / crash / `stack` restart) where nothing reaped. Guarded by a pure, unit-tested predicate `isOrphanedWaitingInteraction` so it **never** touches:
  - a live turn (has a WebSocket),
  - the first-message boot race (`ZedThreadID == ""`), or
  - a fresh in-flight turn (within the 3-min staleness window).

## Testing

- `go build ./...` clean.
- **Unit test `TestIsOrphanedWaitingInteraction` — 8/8**, covering the full boot / live / orphan matrix including the two safety-critical negatives (live-WS and boot-race → never reap).
- The incident session recovered end-to-end (desktop back up, queued message completed). ⚠️ That particular recovery was confounded by the deploy restarting the API (`ResetRunningInteractions`), so a clean live repro of the queue-net guard firing **without** a restart is being run separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
