### PR TITLE
fix(zed): stop rewriting anthropic model ids to -latest for zed_agent

### DIFF
--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -528,90 +528,6 @@ func getAPIKeyForProvider(provider string) string {
 	}
 }
 
-// normalizeModelIDForZed converts model IDs to the format Zed expects.
-// Zed's serde config only recognizes specific model aliases (e.g., "claude-3-5-haiku-latest"),
-// not dated versions (e.g., "claude-3-5-haiku-20241022"). This function strips dates
-// and converts to the -latest format.
-func normalizeModelIDForZed(modelID string) string {
-	// Already has -latest suffix, return as-is
-	if strings.HasSuffix(modelID, "-latest") {
-		return modelID
-	}
-
-	// Claude 4.8 models
-	if strings.HasPrefix(modelID, "claude-opus-4-8") {
-		return "claude-opus-4-8-latest"
-	}
-
-	// Claude 4.7 models
-	if strings.HasPrefix(modelID, "claude-opus-4-7") {
-		return "claude-opus-4-7-latest"
-	}
-
-	// Claude 4.6 models
-	if strings.HasPrefix(modelID, "claude-opus-4-6") {
-		return "claude-opus-4-6-latest"
-	}
-	if strings.HasPrefix(modelID, "claude-sonnet-4-6") {
-		return "claude-sonnet-4-6-latest"
-	}
-
-	// Claude 4.5 models
-	if strings.HasPrefix(modelID, "claude-opus-4-5") {
-		return "claude-opus-4-5-latest"
-	}
-	if strings.HasPrefix(modelID, "claude-sonnet-4-5") {
-		return "claude-sonnet-4-5-latest"
-	}
-	if strings.HasPrefix(modelID, "claude-haiku-4-5") {
-		return "claude-haiku-4-5-latest"
-	}
-
-	// Claude 4.1 models (must come before generic claude-opus-4 / claude-sonnet-4)
-	if strings.HasPrefix(modelID, "claude-opus-4-1") {
-		return "claude-opus-4-1-latest"
-	}
-
-	// Claude 4.0 models (generic — catches claude-opus-4-20250514, claude-sonnet-4-20250514, etc.)
-	if strings.HasPrefix(modelID, "claude-opus-4") {
-		return "claude-opus-4-latest"
-	}
-	if strings.HasPrefix(modelID, "claude-sonnet-4") {
-		return "claude-sonnet-4-latest"
-	}
-
-	// Claude 3.x models (old naming: claude-3-5-sonnet, claude-3-5-haiku, etc.)
-	if strings.HasPrefix(modelID, "claude-3-7-sonnet") {
-		return "claude-3-7-sonnet-latest"
-	}
-	if strings.HasPrefix(modelID, "claude-3-5-sonnet") {
-		return "claude-3-5-sonnet-latest"
-	}
-	if strings.HasPrefix(modelID, "claude-3-5-haiku") {
-		return "claude-3-5-haiku-latest"
-	}
-	if strings.HasPrefix(modelID, "claude-3-opus") {
-		return "claude-3-opus-latest"
-	}
-	if strings.HasPrefix(modelID, "claude-3-sonnet") {
-		return "claude-3-sonnet-latest"
-	}
-	if strings.HasPrefix(modelID, "claude-3-haiku") {
-		return "claude-3-haiku-latest"
-	}
-
-	// OpenAI models - these typically don't have date suffixes in settings
-	// but normalize common patterns just in case
-	if strings.HasPrefix(modelID, "gpt-4o-") && !strings.HasPrefix(modelID, "gpt-4o-mini") {
-		return "gpt-4o"
-	}
-	if strings.HasPrefix(modelID, "gpt-4o-mini-") {
-		return "gpt-4o-mini"
-	}
-
-	// Return unchanged for other models (Gemini, Qwen, etc. - these go through OpenAI provider)
-	return modelID
-}
 
 // ProviderRef is the minimal projection of a provider endpoint that the
 // agent-config code path needs: a stable ID (empty for env-baked globals,
@@ -822,13 +738,13 @@ func buildLanguageModels(snapshot []ProviderRef, helixAPIURL string) map[string]
 // All other Helix providers (nebius, together, openrouter, etc.) are OpenAI-compatible and should use "openai".
 //
 // For the model name:
-// - Anthropic models: normalize to -latest format (e.g., claude-sonnet-4-5-latest)
+// - Anthropic models: passed through verbatim (see the anthropic case below)
 // - OpenAI-native models: use as-is (e.g., gpt-4o)
 // - All other providers: prefix with "provider/" so Helix's router can route to the correct backend
 //
 // Examples:
 //
-//	helixProvider="anthropic", model="claude-sonnet-4-5" → zedProvider="anthropic", zedModel="claude-sonnet-4-5-latest"
+//	helixProvider="anthropic", model="claude-opus-4-8" → zedProvider="anthropic", zedModel="claude-opus-4-8"
 //	helixProvider="openai", model="gpt-4o" → zedProvider="openai", zedModel="openai/gpt-4o"
 //	helixProvider="nebius", model="Qwen/Qwen3-Coder" → zedProvider="openai", zedModel="nebius/Qwen/Qwen3-Coder"
 func mapHelixToZedProvider(helixProvider, model string) (zedProvider, zedModel string) {
@@ -836,10 +752,14 @@ func mapHelixToZedProvider(helixProvider, model string) (zedProvider, zedModel s
 
 	switch provider {
 	case "anthropic":
-		// Anthropic uses Zed's native Anthropic provider which routes to Helix's Anthropic proxy.
-		// Model name is normalized to -latest format (required by Zed's serde config).
-		// No provider prefix needed since Anthropic API is separate from OpenAI API.
-		return "anthropic", normalizeModelIDForZed(model)
+		// Zed discovers Anthropic models from the provider's /v1/models listing
+		// (Helix's proxy) and resolves agent.default_model by exact id. The stored
+		// model id already comes from that same listing (the picker sources it), so
+		// pass it through verbatim. Do NOT rewrite to a "-latest" alias: Helix's
+		// listing returns bare/dated ids (e.g. "claude-opus-4-8"), the "-latest"
+		// form matches nothing, and Zed silently falls back to its built-in default
+		// (gpt-5-mini) — which has no Helix route, so the agent returns empty.
+		return "anthropic", model
 
 	default:
 		// All other providers (openai, nebius, together, openrouter, azure, google, etc.)

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -129,9 +129,9 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 				GenerationModel:         "claude-sonnet-4-5",
 			}},
 			snapshot:         []ProviderRef{globalAnthropic},
-			wantDefaultModel: &ModelConfig{Provider: "anthropic", Model: "claude-sonnet-4-5-latest"},
+			wantDefaultModel: &ModelConfig{Provider: "anthropic", Model: "claude-sonnet-4-5"},
 			wantMisconfig:    false,
-			why:              "control case: env-baked global (no ID) resolves by canonical name; -latest normalization applies",
+			why:              "control case: env-baked global (no ID) resolves by canonical name; anthropic model id passes through verbatim to match Zed's /v1/models listing",
 		},
 		{
 			name: "legacy_name_match_still_works_for_unsaved_agents",
@@ -227,54 +227,35 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 	}
 }
 
-func TestNormalizeModelIDForZed(t *testing.T) {
+// TestMapHelixToZedProvider guards the model id Helix writes into
+// agent.default_model. Zed resolves default_model by exact id against the
+// provider's /v1/models listing; the stored id already comes from that listing,
+// so anthropic models must pass through verbatim. Rewriting to a "-latest" alias
+// (the old behaviour) matches nothing in the listing and makes Zed silently fall
+// back to gpt-5-mini, which has no Helix route → empty agent responses.
+func TestMapHelixToZedProvider(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		expected string
+		name         string
+		provider     string
+		model        string
+		wantProvider string
+		wantModel    string
 	}{
-		// Already normalized — should pass through unchanged
-		{name: "already latest suffix", input: "claude-opus-4-6-latest", expected: "claude-opus-4-6-latest"},
-		{name: "already latest suffix sonnet", input: "claude-sonnet-4-5-latest", expected: "claude-sonnet-4-5-latest"},
+		// Anthropic — verbatim, NO -latest rewrite.
+		{name: "opus-4-8 verbatim", provider: "anthropic", model: "claude-opus-4-8", wantProvider: "anthropic", wantModel: "claude-opus-4-8"},
+		{name: "dated opus-4-5 verbatim", provider: "anthropic", model: "claude-opus-4-5-20251101", wantProvider: "anthropic", wantModel: "claude-opus-4-5-20251101"},
+		{name: "provider case-insensitive", provider: "Anthropic", model: "claude-sonnet-4-6", wantProvider: "anthropic", wantModel: "claude-sonnet-4-6"},
 
-		// Actual Anthropic API model IDs (from /v1/models with anthropic-version header)
-		{name: "claude-opus-4-8", input: "claude-opus-4-8", expected: "claude-opus-4-8-latest"},
-		{name: "claude-opus-4-7", input: "claude-opus-4-7", expected: "claude-opus-4-7-latest"},
-		{name: "claude-sonnet-4-6", input: "claude-sonnet-4-6", expected: "claude-sonnet-4-6-latest"},
-		{name: "claude-opus-4-6", input: "claude-opus-4-6", expected: "claude-opus-4-6-latest"},
-		{name: "claude-opus-4-5-20251101", input: "claude-opus-4-5-20251101", expected: "claude-opus-4-5-latest"},
-		{name: "claude-haiku-4-5-20251001", input: "claude-haiku-4-5-20251001", expected: "claude-haiku-4-5-latest"},
-		{name: "claude-sonnet-4-5-20250929", input: "claude-sonnet-4-5-20250929", expected: "claude-sonnet-4-5-latest"},
-		{name: "claude-opus-4-1-20250805", input: "claude-opus-4-1-20250805", expected: "claude-opus-4-1-latest"},
-		{name: "claude-opus-4-20250514", input: "claude-opus-4-20250514", expected: "claude-opus-4-latest"},
-		{name: "claude-sonnet-4-20250514", input: "claude-sonnet-4-20250514", expected: "claude-sonnet-4-latest"},
-		{name: "claude-3-haiku-20240307", input: "claude-3-haiku-20240307", expected: "claude-3-haiku-latest"},
-
-		// Bare model names (no date suffix)
-		{name: "bare claude-opus-4-1", input: "claude-opus-4-1", expected: "claude-opus-4-1-latest"},
-		{name: "bare claude-opus-4", input: "claude-opus-4", expected: "claude-opus-4-latest"},
-		{name: "bare claude-sonnet-4", input: "claude-sonnet-4", expected: "claude-sonnet-4-latest"},
-
-		// 3.x models
-		{name: "claude-3-5-sonnet date", input: "claude-3-5-sonnet-20241022", expected: "claude-3-5-sonnet-latest"},
-		{name: "claude-3-5-haiku date", input: "claude-3-5-haiku-20241022", expected: "claude-3-5-haiku-latest"},
-		{name: "claude-3-opus date", input: "claude-3-opus-20240229", expected: "claude-3-opus-latest"},
-		{name: "claude-3-7-sonnet date", input: "claude-3-7-sonnet-20250219", expected: "claude-3-7-sonnet-latest"},
-
-		// OpenAI models
-		{name: "gpt-4o with date", input: "gpt-4o-2024-11-20", expected: "gpt-4o"},
-		{name: "gpt-4o-mini with date", input: "gpt-4o-mini-2024-07-18", expected: "gpt-4o-mini"},
-		{name: "gpt-4o bare", input: "gpt-4o", expected: "gpt-4o"},
-
-		// Non-matching models pass through unchanged
-		{name: "qwen model", input: "helix/qwen3:8b", expected: "helix/qwen3:8b"},
-		{name: "gemini model", input: "gemini-2.0-flash", expected: "gemini-2.0-flash"},
+		// OpenAI-compatible providers — prefixed so Helix routes to the backend.
+		{name: "openai prefixed", provider: "openai", model: "gpt-4o", wantProvider: "openai", wantModel: "openai/gpt-4o"},
+		{name: "nebius prefixed", provider: "nebius", model: "Qwen/Qwen3-Coder", wantProvider: "openai", wantModel: "nebius/Qwen/Qwen3-Coder"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := normalizeModelIDForZed(tt.input)
-			assert.Equal(t, tt.expected, result)
+			gotProvider, gotModel := mapHelixToZedProvider(tt.provider, tt.model)
+			assert.Equal(t, tt.wantProvider, gotProvider)
+			assert.Equal(t, tt.wantModel, gotModel)
 		})
 	}
 }
@@ -421,7 +402,7 @@ func TestMergeContextServers(t *testing.T) {
 
 	t.Run("non-context_servers user keys are ignored", func(t *testing.T) {
 		got := MergeContextServers(helix, map[string]interface{}{
-			"agent":          map[string]interface{}{"default_model": "claude"},
+			"agent":           map[string]interface{}{"default_model": "claude"},
 			"language_models": map[string]interface{}{},
 		})
 		assert.NotContains(t, got, "agent")


### PR DESCRIPTION
## Symptom

zed_agent bots configured with an Anthropic model (e.g. `claude-opus-4-8`) come up in Zed on **gpt-5-mini** and chatting returns *"Agent unresponsive: it returned an empty response. Retrying automatically."* Reproduced on meta.helix.ml with the `chief-of-staff` bot (org `ball`).

## Root cause

`normalizeModelIDForZed` rewrote the selected model id to a `-latest` alias (`claude-opus-4-8` -> `claude-opus-4-8-latest`) before writing `agent.default_model` into Zed's settings.json.

That matched Zed's *old* hardcoded model enum. The current Zed build discovers models dynamically from the provider's `/v1/models` listing and resolves `default_model` by **exact id**. Helix's Anthropic listing returns bare/dated ids (`claude-opus-4-8`, `claude-opus-4-5-20251101`, ...) with **no `-latest` variant**, so the rewritten id matched nothing and Zed silently fell back to its built-in default (`gpt-5-mini`) — which has no Helix route, hence the empty responses. This broke **every** Anthropic model on the zed_agent path (that's the "same issue as before" recurrence).

## Fix

Pass the Anthropic model id through verbatim. The stored id already comes from the same `/v1/models` listing (the model picker sources it), so it matches Zed's discovered models directly. Deleted the obsolete `normalizeModelIDForZed` helper.

## Verification (live, deployed Zed on meta / node01)

Controlled A/B, both on **fresh threads** (Zed locks a thread's model at creation, so existing threads had to be excluded):

| `agent.default_model` | Zed used | response |
|---|---|---|
| `claude-opus-4-8` (bare, this PR) | **Claude Opus 4.8** | real, `complete` |
| `claude-opus-4-8-latest` (current) | gpt-5-mini | empty, `error` |

`available_models` in settings was **not** required — Zed's `/v1/models` fetch already populates the model; the only variable was the `-latest` suffix.

## Rollout note

Zed stores a thread's model at **creation time** and never re-reads settings for it. Existing bot sessions will stay on gpt-5-mini until a **new thread** (session clear, or new session) is started after this deploys. Needs a meta deploy to take effect (`GenerateZedMCPConfig` is the writer; the settings-sync-daemon serves it to the sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)