### PR TITLE
feat(cli): make spectask start return immediately by default

### DIFF
--- a/api/pkg/cli/spectask/spectask.go
+++ b/api/pkg/cli/spectask/spectask.go
@@ -65,6 +65,7 @@ func newStartCommand() *cobra.Command {
 	var promptFile string
 	var attachFiles []string
 	var quiet bool
+	var wait bool
 	var noWait bool
 
 	cmd := &cobra.Command{
@@ -150,21 +151,28 @@ Example workflow:
 				fmt.Printf("✅ Task status: %s\n", task.Status)
 			}
 
-			// The task is created and planning is triggered — that is the durable
-			// outcome of `start`. Blocking to watch the sandbox boot is a
-			// convenience; --no-wait skips it entirely (scripting, or when the
-			// caller only needs the task id).
-			if noWait {
+			// Default: don't block on the sandbox. Creating the task and
+			// triggering planning is the durable outcome; the browser task page
+			// (known at creation time) shows the sandbox provisioning and streams
+			// the desktop as it comes up, so there is nothing for the CLI to wait
+			// on. --wait opts into blocking until the sandbox is up + printing
+			// session-level connect info. (--no-wait is now the default and kept
+			// only as a hidden no-op for back-compat.)
+			shouldWait := wait && !noWait
+			if !shouldWait {
 				if quiet {
 					fmt.Println(taskID)
 				} else {
-					fmt.Printf("\n✅ Task created and planning started: %s\n", taskID)
-					fmt.Printf("   Sandbox is provisioning in the background — check: helix spectask list\n")
+					fmt.Printf("\n✅ Task created — planning started: %s\n", taskID)
+					if taskURL := buildTaskURL(apiURL, task, projectID); taskURL != "" {
+						fmt.Printf("   Open in browser: %s\n", taskURL)
+					}
+					fmt.Printf("   The sandbox provisions in the background; the page shows it loading.\n")
 				}
 				return nil
 			}
 
-			// Poll for session to be created (sandbox takes ~10-15s to start)
+			// --wait: poll for the session to be created (sandbox takes ~10-15s).
 			if !quiet {
 				fmt.Printf("⏳ Waiting for sandbox to start (this takes ~15 seconds)...\n")
 			}
@@ -172,14 +180,16 @@ Example workflow:
 			if err != nil {
 				// A wait-timeout is NOT a failure of `start`: the task was already
 				// created and is still provisioning (slow image pull / busy host).
-				// Surface the task id and exit 0 rather than a misleading non-zero
-				// error. Real errors (HTTP failures etc.) still hard-fail.
+				// Surface the task id + URL and exit 0 rather than a misleading
+				// non-zero error. Real errors (HTTP failures etc.) still hard-fail.
 				if errors.Is(err, errSandboxWaitTimeout) {
 					if quiet {
 						fmt.Println(taskID)
 					} else {
 						fmt.Printf("\n⏳ Task created (%s) — sandbox still provisioning after 3m.\n", taskID)
-						fmt.Printf("   It keeps booting in the background; check: helix spectask list\n")
+						if taskURL := buildTaskURL(apiURL, task, projectID); taskURL != "" {
+							fmt.Printf("   Open in browser: %s\n", taskURL)
+						}
 					}
 					return nil
 				}
@@ -210,8 +220,10 @@ Example workflow:
 	cmd.Flags().StringVar(&prompt, "prompt", "", "Task prompt/description")
 	cmd.Flags().StringVar(&promptFile, "prompt-file", "", "Read the task prompt from a file (e.g. a design doc) — dispatch a full brief without committing it to the repo. Appended after --prompt if both are set.")
 	cmd.Flags().StringArrayVar(&attachFiles, "attach", nil, "Attach file(s) to the task (repeatable). Uploaded as spec-task attachments the agent reads at design/tasks/<task>/attachments/<name> — good for logs/large context without bloating the prompt.")
-	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Only output session ID")
-	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Don't block waiting for the sandbox to boot — create the task, trigger planning, print the task id, and return immediately")
+	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Only output the task ID (session ID with --wait)")
+	cmd.Flags().BoolVar(&wait, "wait", false, "Block until the sandbox has booted, then print session-level connect info (default: return immediately with the task URL — the browser page shows it loading)")
+	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Deprecated: no-wait is now the default; kept as a no-op for back-compat")
+	_ = cmd.Flags().MarkHidden("no-wait")
 
 	return cmd
 }
@@ -443,10 +455,28 @@ func getToken() string {
 }
 
 type SpecTask struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Status      string `json:"status"`
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Description    string `json:"description"`
+	Status         string `json:"status"`
+	OrganizationID string `json:"organization_id"`
+	ProjectID      string `json:"project_id"`
+}
+
+// buildTaskURL returns the frontend task-detail page URL, which is known the
+// instant the task is created — no need to wait for the sandbox. Opening it
+// shows the sandbox provisioning and streams the desktop as it comes up.
+// Returns "" if org/project can't be determined (caller prints the id alone).
+func buildTaskURL(apiURL string, task *SpecTask, projectFallback string) string {
+	proj := task.ProjectID
+	if proj == "" {
+		proj = projectFallback
+	}
+	if task.OrganizationID == "" || proj == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/orgs/%s/projects/%s/tasks/%s",
+		strings.TrimRight(apiURL, "/"), task.OrganizationID, proj, task.ID)
 }
 
 type Session struct {


### PR DESCRIPTION
## Motivation

`spectask start` blocked up to 3 minutes in `waitForTaskSession` before returning. But `start`'s durable outcome — task created + planning triggered — completes in ~1s, and the *only* thing the wait produced was a browser URL. That URL is derivable from the task the instant it's created (the frontend route `/orgs/:org_id/projects/:id/tasks/:taskId`), and the browser task page already shows the sandbox provisioning and streams the desktop as it comes up. **The browser is the waiting room; the CLI blocking adds nothing.**

This was also the source of the "spectask start always times out" folklore — callers wrapped it in a shell `timeout` shorter than the 3-min internal wait and treated the SIGTERM as normal.

## Change

- **Default → no-wait**: create, trigger planning, print the **task URL + id**, return immediately.
- **`--wait`**: opt into the previous behavior (block until the sandbox is up, print session-level connect info).
- **`--no-wait`** (added in #2811): demoted to a hidden no-op alias, since it's now the default.
- `SpecTask` gains `OrganizationID`/`ProjectID` so `buildTaskURL` can construct the task-page URL at creation time.

## Testing (live, on the dev stack)

- `go build ./...` + `go vet ./pkg/cli/spectask/` clean.
- **Default path**: returns in ~0s, **exit 0**, prints e.g.
  `Open in browser: http://localhost:8080/orgs/org_…/projects/prj_…/tasks/spt_…` — verified the URL matches the real frontend route.
- **`--wait` path**: confirmed it enters the blocking branch (`⏳ Waiting for sandbox to start…`); the remainder is the unchanged pre-existing connect-info code.
- All throwaway test tasks archived + sandboxes killed afterward.

Follows #2811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
