### PR TITLE
Add Goose and Zed Agent to the README harness list

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Tasks run **in parallel** — each in its own sandbox — so you're not waiting 
 - OpenAI Codex
 - Gemini CLI
 - Qwen Code
+- Goose
+- Zed Agent
 - Anything that speaks **ACP (Agent Client Protocol)**
 
 **Source control** — connect your repositories and Helix opens pull requests where your code already lives:


### PR DESCRIPTION
## Summary
The README's "Works with your stack" harness list omitted two supported agent harnesses that the docs already cover in depth. This adds them so the README and docs agree on the full set of supported harnesses.

## Changes
- `README.md`: added **Goose** and **Zed Agent** to the agent-harness list (now Claude Code, OpenAI Codex, Gemini CLI, Qwen Code, Goose, Zed Agent, and any ACP-compatible agent). Edit confined to the list items.

## Notes
- The board-stage flow in the README (Backlog → Planning → Spec Review → In Progress → Pull Request → Merged) already matches the product UI (`SpecTaskKanbanBoard.tsx`), so no stage-name change was needed.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kk95f1seff98mbxhfa31qj81/tasks/spt_01kwxe2yxbp0atfjqg593j2r11)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002236_note-how-we-just-rewrote/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002236_note-how-we-just-rewrote/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002236_note-how-we-just-rewrote/tasks.md)

🚀 Built with [Helix](https://helix.ml)