### PR TITLE
feat(web-service): surface deploy logs, friendly errors, stop public 502 leak

### DIFF
--- a/api/pkg/hydra/server.go
+++ b/api/pkg/hydra/server.go
@@ -581,7 +581,11 @@ func (s *Server) handleDevContainerProxy(w http.ResponseWriter, r *http.Request)
 			Int("port", port).
 			Str("target_url", targetURL).
 			Msg("Failed to proxy request to dev container")
-		http.Error(w, fmt.Sprintf("failed to connect to service: %s", err), http.StatusBadGateway)
+		// Signal upstream-unavailable to the API proxy (which serves a branded
+		// page on the public host) and NEVER echo the raw dial error — it carries
+		// the internal container IP. Detail stays in the log above.
+		w.Header().Set("X-Helix-Upstream-Unavailable", "1")
+		http.Error(w, "web service temporarily unavailable", http.StatusBadGateway)
 		return
 	}
 	defer resp.Body.Close()

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -13068,6 +13068,40 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/projects/{id}/web-service/logs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the tail of the project's web-service startup log (combined stdout/stderr of .helix/startup.sh in the active sandbox) so an authorized user can see why a deploy did or didn't come up. Never exposed on the public web-service host.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "Get web service deploy/startup logs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.ProjectWebServiceLogsResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/projects/{projectId}/labels": {
             "get": {
                 "description": "Returns a sorted list of unique labels across all spec tasks in a project",
@@ -24559,6 +24593,15 @@ const docTemplate = `{
                     }
                 },
                 "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "server.ProjectWebServiceLogsResponse": {
+            "type": "object",
+            "properties": {
+                "log": {
+                    "description": "Log is the combined stdout/stderr of the project's startup script — build\noutput, app logs, and the reason a deploy did or didn't come up. Empty\nwhen the service isn't deployed yet.",
                     "type": "string"
                 }
             }

--- a/api/pkg/server/project_web_service_handlers.go
+++ b/api/pkg/server/project_web_service_handlers.go
@@ -335,6 +335,38 @@ func (s *HelixAPIServer) deployProjectWebService(_ http.ResponseWriter, r *http.
 	return deploy, nil
 }
 
+// ProjectWebServiceLogsResponse carries the tail of the deploy/startup log.
+type ProjectWebServiceLogsResponse struct {
+	// Log is the combined stdout/stderr of the project's startup script — build
+	// output, app logs, and the reason a deploy did or didn't come up. Empty
+	// when the service isn't deployed yet.
+	Log string `json:"log"`
+}
+
+// getProjectWebServiceLogs godoc
+// @Summary Get web service deploy/startup logs
+// @Description Returns the tail of the project's web-service startup log (combined stdout/stderr of .helix/startup.sh in the active sandbox) so an authorized user can see why a deploy did or didn't come up. Never exposed on the public web-service host.
+// @Tags    projects
+// @Produce json
+// @Param   id path string true "Project ID"
+// @Success 200 {object} ProjectWebServiceLogsResponse
+// @Router  /api/v1/projects/{id}/web-service/logs [get]
+// @Security BearerAuth
+func (s *HelixAPIServer) getProjectWebServiceLogs(_ http.ResponseWriter, r *http.Request) (*ProjectWebServiceLogsResponse, *system.HTTPError) {
+	project, herr := s.requireProjectAccess(r, types.ActionGet)
+	if herr != nil {
+		return nil, herr
+	}
+	if s.webServiceController == nil {
+		return nil, system.NewHTTPError500("web service controller not initialised")
+	}
+	logText, err := s.webServiceController.DeployLog(r.Context(), project.ID)
+	if err != nil {
+		return nil, system.NewHTTPError500(err.Error())
+	}
+	return &ProjectWebServiceLogsResponse{Log: logText}, nil
+}
+
 // addProjectWebServiceDomain godoc
 // @Summary Add a custom domain to a project web service
 // @Description Insert an unverified domain row. Verification happens out-of-band via the .well-known endpoint.

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1536,6 +1536,7 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	authRouter.HandleFunc("/projects/{id}/web-service", system.Wrapper(apiServer.putProjectWebService)).Methods(http.MethodPut)
 	authRouter.HandleFunc("/projects/{id}/web-service/active-sandbox", system.Wrapper(apiServer.setActiveWebServiceSandbox)).Methods(http.MethodPost)
 	authRouter.HandleFunc("/projects/{id}/web-service/deploy", system.Wrapper(apiServer.deployProjectWebService)).Methods(http.MethodPost)
+	authRouter.HandleFunc("/projects/{id}/web-service/logs", system.Wrapper(apiServer.getProjectWebServiceLogs)).Methods(http.MethodGet)
 	authRouter.HandleFunc("/projects/{id}/web-service/domains", system.Wrapper(apiServer.addProjectWebServiceDomain)).Methods(http.MethodPost)
 	authRouter.HandleFunc("/projects/{id}/web-service/domains/{domain_id}", system.Wrapper(apiServer.deleteProjectWebServiceDomain)).Methods(http.MethodDelete)
 	authRouter.HandleFunc("/projects/{id}/move/preview", system.Wrapper(apiServer.moveProjectPreview)).Methods(http.MethodPost)

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -13064,6 +13064,40 @@
                 }
             }
         },
+        "/api/v1/projects/{id}/web-service/logs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the tail of the project's web-service startup log (combined stdout/stderr of .helix/startup.sh in the active sandbox) so an authorized user can see why a deploy did or didn't come up. Never exposed on the public web-service host.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "Get web service deploy/startup logs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.ProjectWebServiceLogsResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/projects/{projectId}/labels": {
             "get": {
                 "description": "Returns a sorted list of unique labels across all spec tasks in a project",
@@ -24555,6 +24589,15 @@
                     }
                 },
                 "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "server.ProjectWebServiceLogsResponse": {
+            "type": "object",
+            "properties": {
+                "log": {
+                    "description": "Log is the combined stdout/stderr of the project's startup script — build\noutput, app logs, and the reason a deploy did or didn't come up. Empty\nwhen the service isn't deployed yet.",
                     "type": "string"
                 }
             }

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -2375,6 +2375,15 @@ definitions:
       title:
         type: string
     type: object
+  server.ProjectWebServiceLogsResponse:
+    properties:
+      log:
+        description: |-
+          Log is the combined stdout/stderr of the project's startup script — build
+          output, app logs, and the reason a deploy did or didn't come up. Empty
+          when the service isn't deployed yet.
+        type: string
+    type: object
   server.ProjectWebServiceResponse:
     properties:
       acme_challenge_target:
@@ -20341,6 +20350,30 @@ paths:
       summary: Remove a custom domain from a project web service
       tags:
       - Projects
+  /api/v1/projects/{id}/web-service/logs:
+    get:
+      description: Returns the tail of the project's web-service startup log (combined
+        stdout/stderr of .helix/startup.sh in the active sandbox) so an authorized
+        user can see why a deploy did or didn't come up. Never exposed on the public
+        web-service host.
+      parameters:
+      - description: Project ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.ProjectWebServiceLogsResponse'
+      security:
+      - BearerAuth: []
+      summary: Get web service deploy/startup logs
+      tags:
+      - projects
   /api/v1/projects/{projectId}/labels:
     get:
       description: Returns a sorted list of unique labels across all spec tasks in

--- a/api/pkg/server/vhost_proxy.go
+++ b/api/pkg/server/vhost_proxy.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -14,6 +15,12 @@ import (
 	"github.com/helixml/helix/api/pkg/hydra"
 	"github.com/rs/zerolog/log"
 )
+
+// errUpstreamUnavailable signals that hydra reached us but could not reach the
+// app container (app down / still starting). ModifyResponse raises it so the
+// ErrorHandler serves the branded holding page instead of leaking hydra's 502
+// body (which carries the internal container IP) to the public.
+var errUpstreamUnavailable = errors.New("web service upstream unavailable")
 
 // proxyToContainer forwards an HTTP request to a port inside a sandbox
 // container via the hydra dev-container proxy, reached over RevDial.
@@ -68,6 +75,17 @@ func (apiServer *HelixAPIServer) proxyToContainer(
 		apiServer:  apiServer,
 		sandboxID:  sandboxID,
 		dialTimeout: 60 * time.Second,
+	}
+
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		// hydra reached us but couldn't reach the app container. Its 502 body
+		// names the internal container IP — never surface that on a customer's
+		// site. Signal the ErrorHandler to serve the branded holding page.
+		if resp.Header.Get("X-Helix-Upstream-Unavailable") != "" {
+			_ = resp.Body.Close()
+			return errUpstreamUnavailable
+		}
+		return nil
 	}
 
 	proxy.ErrorHandler = func(rw http.ResponseWriter, _ *http.Request, err error) {

--- a/api/pkg/webservice/controller.go
+++ b/api/pkg/webservice/controller.go
@@ -358,6 +358,48 @@ func (c *Controller) Health(ctx context.Context, projectID string) string {
 	return "unhealthy"
 }
 
+// DeployLog returns the tail of the web-service startup/deploy log
+// (/data/.helix-webservice.log) from the project's active sandbox. That file is
+// the combined stdout/stderr of .helix/startup.sh — build output, app logs, and
+// the reason a stack failed to come up. The startup mechanism is intentionally
+// generic (it is NOT assumed to be docker-compose), so this just returns whatever
+// the project's startup script logged. Authorized callers only (project access is
+// enforced by the handler). Returns "" (no error) when the service isn't deployed.
+func (c *Controller) DeployLog(ctx context.Context, projectID string) (string, error) {
+	st, err := c.store.GetProjectWebServiceState(ctx, projectID)
+	if err != nil {
+		return "", err
+	}
+	if st == nil || st.ActiveSandboxID == "" {
+		return "", nil
+	}
+	sb, err := c.sandboxes.Get(ctx, st.ActiveSandboxID)
+	if err != nil {
+		return "", fmt.Errorf("get sandbox: %w", err)
+	}
+	hydraClient, err := c.sandboxes.HydraClient(sb)
+	if err != nil {
+		return "", err
+	}
+	cctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	// Cap the tail (256 KiB) so a runaway log can't blow up the response.
+	resp, err := hydraClient.RunSandboxCommand(cctx, sb.ID, &hydra.ExecRequest{
+		SandboxID:      sb.ID,
+		Cmd:            "/bin/sh",
+		Args:           []string{"-c", "tail -c 262144 /data/.helix-webservice.log 2>/dev/null || true"},
+		Cwd:            "/",
+		TimeoutSeconds: 15,
+	})
+	if err != nil {
+		return "", fmt.Errorf("read deploy log: %w", err)
+	}
+	if resp == nil {
+		return "", nil
+	}
+	return resp.Stdout, nil
+}
+
 // RecoverWebService brings a project's web service back to a serving state
 // after the health-monitor detects it down. It escalates:
 //  1. active sandbox row gone → Redeploy (provisions a fresh sandbox).
@@ -772,10 +814,16 @@ func (c *Controller) waitForReady(ctx context.Context, sandboxID string, port in
 		case <-time.After(c.readinessPoll):
 		}
 	}
+	// User-facing message: don't leak the raw hydra/proxy error (it carries
+	// internal container IPs). Log the detail; tell the user what happened and
+	// where to look. The deploy log is surfaced in the Web Service tab.
 	if lastErr != nil {
-		return fmt.Errorf("app did not bind to port %d within %s: %w", port, c.readinessWait, lastErr)
+		log.Warn().Err(lastErr).Str("sandbox_id", sandboxID).Int("port", port).
+			Msg("web service: app never bound to its port within the readiness window")
 	}
-	return fmt.Errorf("app did not bind to port %d within %s", port, c.readinessWait)
+	return fmt.Errorf("the app never started listening on port %d (waited %s). "+
+		"This usually means the stack failed to build or crashed on startup, or it binds a "+
+		"different port. Check the deploy logs in the Web Service tab for the cause", port, c.readinessWait)
 }
 
 // resolvePrimaryRepo finds the project's primary git repository.

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1516,6 +1516,15 @@ export interface ServerProjectGooseRecipe {
   title?: string;
 }
 
+export interface ServerProjectWebServiceLogsResponse {
+  /**
+   * Log is the combined stdout/stderr of the project's startup script — build
+   * output, app logs, and the reason a deploy did or didn't come up. Empty
+   * when the service isn't deployed yet.
+   */
+  log?: string;
+}
+
 export interface ServerProjectWebServiceResponse {
   /**
    * ACMEChallengeTarget is the fixed CNAME value customers point
@@ -13690,6 +13699,24 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       this.request<Record<string, boolean>, any>({
         path: `/api/v1/projects/${id}/web-service/domains/${domainId}`,
         method: "DELETE",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Returns the tail of the project's web-service startup log (combined stdout/stderr of .helix/startup.sh in the active sandbox) so an authorized user can see why a deploy did or didn't come up. Never exposed on the public web-service host.
+     *
+     * @tags projects
+     * @name V1ProjectsWebServiceLogsDetail
+     * @summary Get web service deploy/startup logs
+     * @request GET:/api/v1/projects/{id}/web-service/logs
+     * @secure
+     */
+    v1ProjectsWebServiceLogsDetail: (id: string, params: RequestParams = {}) =>
+      this.request<ServerProjectWebServiceLogsResponse, any>({
+        path: `/api/v1/projects/${id}/web-service/logs`,
+        method: "GET",
         secure: true,
         format: "json",
         ...params,

--- a/frontend/src/components/project/WebServiceTab.tsx
+++ b/frontend/src/components/project/WebServiceTab.tsx
@@ -27,6 +27,7 @@ import useApi from '../../hooks/useApi'
 import useSnackbar from '../../hooks/useSnackbar'
 import {
   ServerProjectWebServiceResponse,
+  ServerProjectWebServiceLogsResponse,
   TypesProjectWebServiceState,
   TypesVHostRoute,
   TypesWebServiceDeploy,
@@ -56,9 +57,28 @@ const WebServiceTab: FC<WebServiceTabProps> = ({ projectId }) => {
     },
   })
 
+  const [showLogs, setShowLogs] = useState(false)
+
+  // Deploy/startup logs are fetched on demand (each fetch runs an exec in the
+  // sandbox), so only poll while the panel is open.
+  const {
+    data: logsData,
+    isFetching: logsFetching,
+    refetch: refetchLogs,
+  } = useQuery<ServerProjectWebServiceLogsResponse>({
+    queryKey: ['project-web-service-logs', projectId],
+    enabled: !!projectId && showLogs,
+    refetchInterval: showLogs ? 15000 : false,
+    queryFn: async () => {
+      const res = await apiClient.v1ProjectsWebServiceLogsDetail(projectId)
+      return res.data
+    },
+  })
+
   const state = data?.state
   const domains = data?.domains ?? []
   const deploys = data?.deploys ?? []
+  const latestDeploy = deploys[0]
   const cnameTarget = data?.cname_target ?? ''
   const acmeChallengeTarget = data?.acme_challenge_target ?? ''
   const health = data?.health ?? ''
@@ -394,7 +414,60 @@ const WebServiceTab: FC<WebServiceTabProps> = ({ projectId }) => {
             <Typography variant="subtitle1" gutterBottom>
               Recent deploys
             </Typography>
+
+            {latestDeploy?.status === 'failed' && latestDeploy?.error && (
+              <Alert severity="error" sx={{ mb: 2 }}>
+                <Typography variant="body2" sx={{ fontWeight: 600, mb: 0.5 }}>
+                  Last deploy didn’t come up
+                </Typography>
+                <Typography variant="body2">{latestDeploy.error}</Typography>
+              </Alert>
+            )}
+
             <DeploysTable deploys={deploys} hasActiveSandbox={!!state?.active_sandbox_id} />
+
+            <Box sx={{ mt: 2 }}>
+              <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+                <Button size="small" variant="outlined" onClick={() => setShowLogs((v) => !v)}>
+                  {showLogs ? 'Hide deploy logs' : 'View deploy logs'}
+                </Button>
+                {showLogs && (
+                  <Button size="small" onClick={() => refetchLogs()} disabled={logsFetching}>
+                    {logsFetching ? 'Refreshing…' : 'Refresh'}
+                  </Button>
+                )}
+              </Stack>
+              {showLogs && (
+                <Box
+                  sx={{
+                    bgcolor: '#0b0b0b',
+                    color: '#d0d0d0',
+                    fontFamily: 'monospace',
+                    fontSize: '0.75rem',
+                    p: 1.5,
+                    borderRadius: 1,
+                    maxHeight: 360,
+                    overflow: 'auto',
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-all',
+                  }}
+                >
+                  {logsFetching && !logsData ? (
+                    <CircularProgress size={16} />
+                  ) : logsData?.log ? (
+                    logsData.log
+                  ) : (
+                    <Typography variant="body2" color="text.secondary">
+                      No deploy logs yet — they appear once a deploy has run against the active sandbox.
+                    </Typography>
+                  )}
+                </Box>
+              )}
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                The combined output of your project's startup script (build output, app logs, and
+                startup errors) from the active sandbox. Only visible to authorized project members.
+              </Typography>
+            </Box>
           </Box>
         </>
       )}

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -2375,6 +2375,15 @@ definitions:
       title:
         type: string
     type: object
+  server.ProjectWebServiceLogsResponse:
+    properties:
+      log:
+        description: |-
+          Log is the combined stdout/stderr of the project's startup script — build
+          output, app logs, and the reason a deploy did or didn't come up. Empty
+          when the service isn't deployed yet.
+        type: string
+    type: object
   server.ProjectWebServiceResponse:
     properties:
       acme_challenge_target:
@@ -20341,6 +20350,30 @@ paths:
       summary: Remove a custom domain from a project web service
       tags:
       - Projects
+  /api/v1/projects/{id}/web-service/logs:
+    get:
+      description: Returns the tail of the project's web-service startup log (combined
+        stdout/stderr of .helix/startup.sh in the active sandbox) so an authorized
+        user can see why a deploy did or didn't come up. Never exposed on the public
+        web-service host.
+      parameters:
+      - description: Project ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.ProjectWebServiceLogsResponse'
+      security:
+      - BearerAuth: []
+      summary: Get web service deploy/startup logs
+      tags:
+      - projects
   /api/v1/projects/{projectId}/labels:
     get:
       description: Returns a sorted list of unique labels across all spec tasks in

--- a/openapi.json
+++ b/openapi.json
@@ -15635,6 +15635,43 @@
                 }
             }
         },
+        "/api/v1/projects/{id}/web-service/logs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the tail of the project's web-service startup log (combined stdout/stderr of .helix/startup.sh in the active sandbox) so an authorized user can see why a deploy did or didn't come up. Never exposed on the public web-service host.",
+                "tags": [
+                    "projects"
+                ],
+                "summary": "Get web service deploy/startup logs",
+                "parameters": [
+                    {
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/server.ProjectWebServiceLogsResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/projects/{projectId}/labels": {
             "get": {
                 "description": "Returns a sorted list of unique labels across all spec tasks in a project",
@@ -28876,6 +28913,15 @@
                         }
                     },
                     "title": {
+                        "type": "string"
+                    }
+                }
+            },
+            "server.ProjectWebServiceLogsResponse": {
+                "type": "object",
+                "properties": {
+                    "log": {
+                        "description": "Log is the combined stdout/stderr of the project's startup script — build\noutput, app logs, and the reason a deploy did or didn't come up. Empty\nwhen the service isn't deployed yet.",
                         "type": "string"
                     }
                 }

--- a/swagger.json
+++ b/swagger.json
@@ -13064,6 +13064,40 @@
                 }
             }
         },
+        "/api/v1/projects/{id}/web-service/logs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the tail of the project's web-service startup log (combined stdout/stderr of .helix/startup.sh in the active sandbox) so an authorized user can see why a deploy did or didn't come up. Never exposed on the public web-service host.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "summary": "Get web service deploy/startup logs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Project ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.ProjectWebServiceLogsResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/projects/{projectId}/labels": {
             "get": {
                 "description": "Returns a sorted list of unique labels across all spec tasks in a project",
@@ -24555,6 +24589,15 @@
                     }
                 },
                 "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "server.ProjectWebServiceLogsResponse": {
+            "type": "object",
+            "properties": {
+                "log": {
+                    "description": "Log is the combined stdout/stderr of the project's startup script — build\noutput, app logs, and the reason a deploy did or didn't come up. Empty\nwhen the service isn't deployed yet.",
                     "type": "string"
                 }
             }


### PR DESCRIPTION
## Why
When a hosted web service failed to come up (like the find-ai outage on 2026-07-09, root-caused to a `startup.sh` referencing a compose file that was never merged), the only signal was a terse *"app did not bind to port N: hydra API error (status 502)"* — and the **public host leaked hydra's raw dial error including the internal container IP** (`dial tcp 10.213.0.7:8080: connection refused`).

## What
- **Deploy logs endpoint** — `GET /projects/{id}/web-service/logs` tails `/data/.helix-webservice.log` (the combined stdout/stderr of the project's startup script) from the active sandbox via hydra exec. Authorized project members only; never exposed on the public web-service host. The startup mechanism stays **generic** — it is *not* assumed to be docker-compose.
- **Web Service tab UI** — a "last deploy didn't come up" banner with the failure reason, plus a collapsible deploy-log viewer with a refresh button.
- **Friendly readiness error** — rewritten to be user-facing ("the app never started listening on port N … check the deploy logs") and no longer carries the raw hydra/proxy error (internal IPs) into the stored deploy error.
- **Public leak fix** — hydra returns a generic 502 + `X-Helix-Upstream-Unavailable` header (detail stays in its logs); the API vhost proxy catches that header via `ModifyResponse` and serves the existing branded "starting up" holding page instead of passing hydra's body through.

## Testing (on meta)
- ✅ Log endpoint returns the real startup log including the exact failure reason.
- ✅ Public host: with the app container down, now serves the branded 503 "Starting up…" page with **no internal IP** (was a 502 leaking `10.213.0.x:8080`).
- ✅ `go build` (webservice/hydra/server) + `yarn build` clean.
- ⚠️ Frontend not visually tested (meta uses Google OIDC; couldn't log into the UI) — reviewer eyes welcome on the tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)