### PR TITLE
feat(web-service): state-aware holding page (starting-up vs temporarily-unavailable)

### DIFF
--- a/api/pkg/server/vhost_middleware.go
+++ b/api/pkg/server/vhost_middleware.go
@@ -181,7 +181,7 @@ func (m *VHostMiddleware) dispatchSandboxPreview(w http.ResponseWriter, r *http.
 			http.Error(w, fmt.Sprintf("preview target sandbox not found: %s", err), http.StatusNotFound)
 			return
 		}
-		m.apiServer.proxyToContainer(w, r, sb.HostDeviceID, targetID, route.Port, r.URL.Path)
+		m.apiServer.proxyToContainer(w, r, sb.HostDeviceID, targetID, route.Port, r.URL.Path, "")
 		return
 	}
 	if strings.HasPrefix(targetID, "sbx_") {
@@ -192,7 +192,7 @@ func (m *VHostMiddleware) dispatchSandboxPreview(w http.ResponseWriter, r *http.
 		}
 		// Sandbox-API containers are registered in hydra under
 		// req.SessionID = sandbox.ID (see sandbox/controller_provision.go).
-		m.apiServer.proxyToContainer(w, r, sb.HostDeviceID, sb.ID, route.Port, r.URL.Path)
+		m.apiServer.proxyToContainer(w, r, sb.HostDeviceID, sb.ID, route.Port, r.URL.Path, "")
 		return
 	}
 	http.Error(w, "unrecognised preview target id format", http.StatusBadRequest)
@@ -229,7 +229,10 @@ func (m *VHostMiddleware) dispatchProjectWebService(w http.ResponseWriter, r *ht
 		http.Error(w, fmt.Sprintf("active sandbox not found: %s", err), http.StatusBadGateway)
 		return
 	}
-	m.apiServer.proxyToContainer(w, r, sb.HostDeviceID, sb.ID, route.Port, r.URL.Path)
+	// route.TargetID is the projectID for a web-service route → lets the holding
+	// page distinguish "starting up" (deploy in flight) from "temporarily
+	// unavailable" (down / crashed).
+	m.apiServer.proxyToContainer(w, r, sb.HostDeviceID, sb.ID, route.Port, r.URL.Path, route.TargetID)
 }
 
 // stripPort removes a trailing :port from a Host header value, taking

--- a/api/pkg/server/vhost_proxy.go
+++ b/api/pkg/server/vhost_proxy.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/helixml/helix/api/pkg/hydra"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/helixml/helix/api/pkg/webservice"
 	"github.com/rs/zerolog/log"
 )
 
@@ -42,6 +44,10 @@ func (apiServer *HelixAPIServer) proxyToContainer(
 	sandboxID, hydraContainerID string,
 	port int,
 	targetPath string,
+	// projectID identifies the web-service project so the holding page can be
+	// state-aware ("starting up" vs "temporarily unavailable"). Empty for
+	// sandbox previews, which always get the optimistic starting-up page.
+	projectID string,
 ) {
 	if sandboxID == "" {
 		http.Error(w, "no sandbox associated with route", http.StatusServiceUnavailable)
@@ -99,7 +105,7 @@ func (apiServer *HelixAPIServer) proxyToContainer(
 			Str("hydra_container_id", hydraContainerID).
 			Int("port", port).
 			Msg("vhost proxy error")
-		writeStartingUpPage(rw)
+		apiServer.serveHoldingPage(r.Context(), rw, projectID)
 	}
 
 	proxy.ServeHTTP(w, r)
@@ -142,6 +148,71 @@ const startingUpHTML = `<!DOCTYPE html>
     <div class="spinner"></div>
     <h1>This service is starting up</h1>
     <p>It’ll be ready in a moment — this page refreshes automatically.</p>
+  </div>
+</body>
+</html>`
+
+// serveHoldingPage picks the public holding page for an unreachable web service.
+// "Starting up" (optimistic, spinner, fast refresh) is only honest while a deploy
+// is genuinely in flight; a failed/crashed service that isn't being redeployed
+// gets "temporarily unavailable" instead. Sandbox previews (projectID == "")
+// always get the starting-up page since they are booting.
+func (apiServer *HelixAPIServer) serveHoldingPage(ctx context.Context, rw http.ResponseWriter, projectID string) {
+	if projectID != "" && !apiServer.webServiceDeployInFlight(ctx, projectID) {
+		writeUnavailablePage(rw)
+		return
+	}
+	writeStartingUpPage(rw)
+}
+
+// webServiceDeployInFlight reports whether the project's latest deploy is still
+// pending/building within the build window. Mirrors Controller.Health's
+// "deploying" state but without the live probe (we're already on the error path,
+// so the container is known-unreachable).
+func (apiServer *HelixAPIServer) webServiceDeployInFlight(ctx context.Context, projectID string) bool {
+	deploys, err := apiServer.Store.ListWebServiceDeploys(ctx, projectID, 1)
+	if err != nil || len(deploys) == 0 {
+		return false
+	}
+	d := deploys[0]
+	inflight := d.Status == types.WebServiceDeployStatusPending || d.Status == types.WebServiceDeployStatusBuilding
+	return inflight && time.Since(d.StartedAt) < webservice.DeployBuildTimeout
+}
+
+// writeUnavailablePage serves a branded holding page for a web service that is
+// down and NOT currently deploying. It still auto-refreshes (slower) so the page
+// recovers on its own once the owner redeploys, but it does not falsely claim the
+// service is "starting up". No failure detail is exposed — that stays private to
+// the project's Web Service tab.
+func writeUnavailablePage(rw http.ResponseWriter) {
+	rw.Header().Set("Content-Type", "text/html; charset=utf-8")
+	rw.Header().Set("Retry-After", "30")
+	rw.Header().Set("Cache-Control", "no-store")
+	rw.WriteHeader(http.StatusServiceUnavailable)
+	_, _ = io.WriteString(rw, unavailableHTML)
+}
+
+const unavailableHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="refresh" content="30">
+<title>Temporarily unavailable</title>
+<style>
+  html,body{height:100%;margin:0}
+  body{display:flex;align-items:center;justify-content:center;
+    font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    background:#0b0d12;color:#e6e9ef}
+  .card{text-align:center;max-width:32rem;padding:2rem}
+  h1{font-size:1.25rem;font-weight:600;margin:0 0 .5rem}
+  p{margin:0;color:#9aa4b2;font-size:.95rem;line-height:1.5}
+</style>
+</head>
+<body>
+  <div class="card">
+    <h1>This service is temporarily unavailable</h1>
+    <p>Please check back shortly.</p>
   </div>
 </body>
 </html>`


### PR DESCRIPTION
Follow-up to #2818. The leak-fix reused the "starting up" holding page for *every* unreachable web service, so a **failed/crashed** app (one that will never come up on its own) showed *"This service is starting up… ready in a moment"* and auto-refreshed forever — misleading.

Now the public holding page is **state-aware**:
- **Deploy in flight** (latest deploy `pending`/`building` within the build window) → "This service is starting up" (spinner, fast refresh).
- **Otherwise** (down / crashed, not being redeployed) → new "This service is temporarily unavailable" page (slower refresh, no false promise).

Neither page leaks failure detail — that stays private to the project's Web Service tab. Sandbox previews are unchanged (always starting-up, since they're booting).

## Testing (on meta)
- ✅ `deploy=failed` → **"temporarily unavailable"**.
- ✅ `deploy=building` (in-flight) → **"starting up"**.
- ✅ `go build` clean, no import cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)