### PR TITLE
fix: recover a wedged external agent - unify the prompt queue, escalate stuck failures, restart into a fresh thread

### DIFF
--- a/api/pkg/server/restart_session_container_test.go
+++ b/api/pkg/server/restart_session_container_test.go
@@ -129,6 +129,61 @@ func (s *RestartSessionContainerSuite) TestRestartRecreatesContainerInOrder() {
 	}
 }
 
+// TestRestartClearsZedThread pins the crash-recovery semantics: restart opens a
+// FRESH thread rather than reattaching to the crashed one. A wedged agent often
+// poisons the thread itself, so reattaching reproduces the wedge; /resume is the
+// preserve-the-thread path. We assert the session's ZedThreadID is cleared and
+// persisted (UpdateSessionMetadata) before the container is recreated.
+func (s *RestartSessionContainerSuite) TestRestartClearsZedThread() {
+	ctx := context.Background()
+	const (
+		userID    = "user_op"
+		projectID = "prj_restart"
+		sessionID = "ses_restart"
+	)
+	user := &types.User{ID: userID}
+	session := zedSession(sessionID, userID, projectID)
+	session.Metadata.ZedThreadID = "poisoned-thread" // a crashed thread to escape
+
+	s.store.EXPECT().GetProject(gomock.Any(), projectID).Return(&types.Project{ID: projectID, UserID: userID}, nil).AnyTimes()
+	s.store.EXPECT().ListGitRepositories(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	// GetSession returns the same pointer we mutate, so resume's post-StartDesktop
+	// refetch sees the cleared thread (no open_thread goroutine into mocks).
+	s.store.EXPECT().GetSession(gomock.Any(), sessionID).Return(session, nil).AnyTimes()
+	s.store.EXPECT().UpdateSession(gomock.Any(), gomock.Any()).Return(session, nil).AnyTimes()
+
+	// The load-bearing assertion: the thread is cleared and persisted.
+	var clearedTo = "unset"
+	s.store.EXPECT().UpdateSessionMetadata(gomock.Any(), sessionID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, meta types.SessionMetadata) error {
+			clearedTo = meta.ZedThreadID
+			return nil
+		}).Times(1)
+
+	gomock.InOrder(
+		s.executor.EXPECT().StopDesktop(gomock.Any(), sessionID).Return(nil).Times(1),
+		s.executor.EXPECT().StartDesktop(gomock.Any(), gomock.Any()).Return(&types.DesktopAgentResponse{DevContainerID: "dev_new"}, nil).Times(1),
+	)
+	s.store.EXPECT().ResetCrashedPromptsForSession(gomock.Any(), sessionID).Return(1, nil).Times(1)
+
+	pumped := make(chan struct{})
+	s.store.EXPECT().GetAnyPendingPrompt(gomock.Any(), sessionID).DoAndReturn(
+		func(_ context.Context, _ string) (*types.PromptHistoryEntry, error) {
+			close(pumped)
+			return nil, nil
+		}).Times(1)
+
+	_, herr := s.server.restartSessionContainer(ctx, user, session)
+	s.Require().Nil(herr)
+	s.Equal("", clearedTo, "restart must clear ZedThreadID so Zed opens a fresh thread")
+
+	select {
+	case <-pumped:
+	case <-time.After(2 * time.Second):
+		s.Fail("processAnyPendingPrompt was not kicked after restart")
+	}
+}
+
 // TestRestartCrashedAgentThread_403WhenNotOwner pins authorization on
 // the in-chat endpoint: a user who doesn't own the (orgless) session
 // gets 403 and no container is touched.

--- a/api/pkg/server/restart_session_container_test.go
+++ b/api/pkg/server/restart_session_container_test.go
@@ -152,18 +152,19 @@ func (s *RestartSessionContainerSuite) TestRestartClearsZedThread() {
 	s.store.EXPECT().GetSession(gomock.Any(), sessionID).Return(session, nil).AnyTimes()
 	s.store.EXPECT().UpdateSession(gomock.Any(), gomock.Any()).Return(session, nil).AnyTimes()
 
-	// The load-bearing assertion: the thread is cleared and persisted.
+	// The load-bearing assertion: the thread is cleared and persisted BEFORE the
+	// container is recreated. Ordering matters — a clear after StartDesktop would
+	// let the reconnect reload the stale thread from the DB, so pin it in the
+	// InOrder chain (StopDesktop → clear → StartDesktop), not as a bare EXPECT.
 	var clearedTo = "unset"
-	s.store.EXPECT().UpdateSessionMetadata(gomock.Any(), sessionID, gomock.Any()).DoAndReturn(
+	clearThread := s.store.EXPECT().UpdateSessionMetadata(gomock.Any(), sessionID, gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ string, meta types.SessionMetadata) error {
 			clearedTo = meta.ZedThreadID
 			return nil
 		}).Times(1)
-
-	gomock.InOrder(
-		s.executor.EXPECT().StopDesktop(gomock.Any(), sessionID).Return(nil).Times(1),
-		s.executor.EXPECT().StartDesktop(gomock.Any(), gomock.Any()).Return(&types.DesktopAgentResponse{DevContainerID: "dev_new"}, nil).Times(1),
-	)
+	stopDesktop := s.executor.EXPECT().StopDesktop(gomock.Any(), sessionID).Return(nil).Times(1)
+	startDesktop := s.executor.EXPECT().StartDesktop(gomock.Any(), gomock.Any()).Return(&types.DesktopAgentResponse{DevContainerID: "dev_new"}, nil).Times(1)
+	gomock.InOrder(stopDesktop, clearThread, startDesktop)
 	s.store.EXPECT().ResetCrashedPromptsForSession(gomock.Any(), sessionID).Return(1, nil).Times(1)
 
 	pumped := make(chan struct{})

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -2415,12 +2415,13 @@ func (s *HelixAPIServer) foregroundSessionThread(_ http.ResponseWriter, r *http.
 // restartCrashedAgentThread godoc
 // @Summary Restart the external agent after an in-container crash
 // @Description Tears down the half-dead desktop container and brings up a fresh one
-// @Description via the same resume path used by /sessions/{id}/resume. The session's
-// @Description ZedThreadID is preserved, so Zed reloads the existing thread from the
-// @Description persistent threads.db in the workspace volume and the underlying agent
-// @Description (claude-code, qwen, etc.) reloads its session from disk — prior
-// @Description conversation context is restored. Crashed prompts are reset to pending
-// @Description and the queue is kicked so they re-dispatch on the new container.
+// @Description via the resume path. The session's ZedThreadID is cleared so Zed opens
+// @Description a fresh thread: a crash often poisons the thread itself, so reattaching
+// @Description reproduces the wedge; use /sessions/{id}/resume to restart while keeping
+// @Description the thread. The workspace volume persists, so files and the agent's own
+// @Description state survive; only the conversation thread resets. Crashed prompts are
+// @Description reset to pending and the queue is kicked so they re-dispatch on the new
+// @Description container.
 // @Description Requires the session to be an external Zed agent. Returns the count of
 // @Description prompts that were reset.
 // @Tags Sessions

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -2473,10 +2473,12 @@ func (s *HelixAPIServer) restartCrashedAgentThread(_ http.ResponseWriter, r *htt
 // meaning of "restart" cannot diverge across surfaces again.
 //
 // Steps: validate it's an external Zed agent → StopDesktop (best-effort) →
-// resumeSessionInternal (StartDesktop, preserving ZedThreadID so conversation
-// context is restored) → reset crashed prompts → kick the queue. Returns the
-// count of prompts that were reset. Callers must have already authorized the
-// user against the session.
+// clear ZedThreadID so Zed opens a FRESH thread (a crash frequently poisons the
+// thread itself, so reattaching just reproduces the wedge; callers that want to
+// restart while keeping the thread use /sessions/{id}/resume) →
+// resumeSessionInternal (StartDesktop) → reset crashed prompts → kick the queue.
+// Returns the count of prompts that were reset. Callers must have already
+// authorized the user against the session.
 func (s *HelixAPIServer) restartSessionContainer(ctx context.Context, user *types.User, session *types.Session) (int, *system.HTTPError) {
 	sessionID := session.ID
 
@@ -2499,10 +2501,28 @@ func (s *HelixAPIServer) restartSessionContainer(ctx context.Context, user *type
 		log.Warn().Err(err).Str("session_id", sessionID).Msg("StopDesktop during crash-restart failed (continuing — container may already be gone)")
 	}
 
-	// Recreate the container via the shared resume path. ZedThreadID is preserved,
-	// so on reconnect Zed reloads the existing thread from threads.db and the
-	// agent (claude-code, qwen, gemini, codex, etc.) reloads its own session from
-	// the persistent workspace volume — full conversation context is restored.
+	// Clear the Zed thread so the restart opens a FRESH thread instead of
+	// reattaching to the crashed one. A crash frequently poisons the thread state
+	// itself (a wedged ACP turn, a half-written threads.db row), and reattaching
+	// just reproduces the wedge — verified on a live wedged session where a
+	// container recreate that preserved the thread never reached agent_ready, but
+	// a fresh thread came ready in seconds. The workspace volume still persists,
+	// so files and the agent's own state survive; only the conversation thread is
+	// reset. Persist the clear because the reconnect handler reloads the session
+	// from the store, so an in-memory clear alone would be overwritten by the
+	// stale thread id. On the first message Zed mints a new thread and
+	// thread_created repopulates ZedThreadID.
+	if previousThreadID != "" {
+		session.Metadata.ZedThreadID = ""
+		if err := s.Store.UpdateSessionMetadata(ctx, sessionID, session.Metadata); err != nil {
+			log.Error().Err(err).Str("session_id", sessionID).Msg("Failed to clear zed thread for crash-restart")
+			return 0, system.NewHTTPError500(fmt.Sprintf("failed to clear zed thread for restart: %s", err.Error()))
+		}
+	}
+
+	// Recreate the container via the shared resume path. With the thread cleared,
+	// Zed opens a fresh thread on reconnect; the agent still reloads its workspace
+	// volume, so files and state persist across the restart.
 	if _, err := s.resumeSessionInternal(ctx, user, session); err != nil {
 		log.Error().Err(err).Str("session_id", sessionID).Msg("Failed to resume session during crash-restart")
 		return 0, system.NewHTTPError500(fmt.Sprintf("failed to restart agent: %s", err.Error()))
@@ -2517,9 +2537,9 @@ func (s *HelixAPIServer) restartSessionContainer(ctx context.Context, user *type
 	log.Info().
 		Str("session_id", sessionID).
 		Str("user_id", user.ID).
-		Str("zed_thread_id", previousThreadID).
+		Str("previous_zed_thread_id", previousThreadID).
 		Int("prompts_reset", resetCount).
-		Msg("🔄 [HELIX] Restart agent session — recreated container, preserved ZedThreadID, reset crashed prompts")
+		Msg("🔄 [HELIX] Restart agent session — recreated container, cleared ZedThreadID (fresh thread), reset crashed prompts")
 
 	// Kick the queue so the reset prompts get dispatched on the new container.
 	go s.processAnyPendingPrompt(context.Background(), sessionID)

--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -367,16 +367,16 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
             <Box>
               <Typography variant="caption" sx={{ color: failColor, display: 'block', fontWeight: showRestart ? 600 : 'inherit' }}>
                 {isCrashed ? (
-                  'Agent crashed. Click restart to attempt to recover.'
+                  'The assistant stopped unexpectedly. Click Restart to recover.'
                 ) : isStuckTransient ? (
-                  "Agent isn't responding — click Restart to recover."
+                  "The assistant isn't responding. Click Restart to recover."
                 ) : entry.nextRetryAt ? (
                   (() => {
                     const secondsUntilRetry = Math.max(0, Math.ceil((entry.nextRetryAt - Date.now()) / 1000))
                     if (isTransientFailure) {
                       return secondsUntilRetry > 0
-                        ? `Waiting for agent — retrying in ${secondsUntilRetry}s`
-                        : 'Waiting for agent — retrying now...'
+                        ? `Waiting for the assistant — retrying in ${secondsUntilRetry}s`
+                        : 'Waiting for the assistant — retrying now...'
                     }
                     return secondsUntilRetry > 0
                       ? `Failed - retrying in ${secondsUntilRetry}s`

--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -383,7 +383,7 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
                       : 'Failed - retrying now...'
                   })()
                 ) : (
-                  isTransientFailure ? 'Waiting for agent' : 'Failed - will retry'
+                  isTransientFailure ? 'Waiting for the assistant' : 'Failed - will retry'
                 )}
               </Typography>
               {showRestart && (

--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -73,6 +73,7 @@ import {
 import { CSS } from '@dnd-kit/utilities'
 import { usePromptHistory, PromptHistoryEntry } from '../../hooks/usePromptHistory'
 import { Api } from '../../api/api'
+import { classifyPromptQueueEntry } from '../../utils/promptQueueStatus'
 
 // Attachment that's pending to be sent with the message
 // Supports offline queueing - file data is stored until upload completes
@@ -180,63 +181,14 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
   }
 
   const isFailed = entry.status === 'failed'
-
-  // A transient failure is one we expect to recover from automatically: the
-  // agent is sleeping/booting, the prior turn hasn't drained yet, the WebSocket
-  // is mid-reconnect, etc. The retry will land soon and the message will get
-  // through. These should look like a soft "still working on it" rather than a
-  // hard red error — they're not the user's problem and we don't want them to
-  // act on the warning. Anything else (auth failures, malformed payloads) stays
-  // red so it's visually distinct.
-  const transientErrorMarkers = [
-    'no WebSocket',
-    'no external agent WebSocket',
-    'became busy',
-    'deferring queue prompt',
-    'channel full',
-    'connection replaced',
-    'empty response',
-  ]
-  // A *crashed* failure is the terminal Claude Agent process death case. The
-  // backend detects these strings in handleThreadLoadError and calls
-  // MarkPromptAsCrashed (pinning next_retry_at far in the future) so the
-  // queue's auto-retry stops. The user has to click Restart to recover —
-  // restart clears ZedThreadID + re-sends, causing Zed to spawn a fresh thread
-  // and Claude Agent process. Detected by error_message marker (authoritative)
-  // rather than nextRetryAt timestamp comparison so the UI reacts immediately
-  // even before the polled prompt sync lands the new next_retry_at value.
-  // Authoritative crash signal: the backend's MarkPromptAsCrashed pins
-  // next_retry_at to a far-future sentinel (year 9999) to suppress auto-retry.
-  // Detecting that is robust to the many transport/wrapper error wordings a wedged
-  // or dead agent connection produces ("ede_diagnostic …", "response channel
-  // cancelled", "send failed because receiver is gone", …) — we don't have to
-  // enumerate them. See design/2026-06-15-wedged-acp-thread-autowake-flood.md.
-  const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000
-  const crashedBySentinel = isFailed && !!entry.nextRetryAt && entry.nextRetryAt > Date.now() + ONE_YEAR_MS
-  // Fast-path string markers (kept in sync with the backend agentCrashErrorMarkers)
-  // so the Restart affordance can render on the first failure, before the crashed
-  // next_retry_at sentinel has synced to the client.
-  const crashedErrorMarkers = [
-    'Claude Agent process exited',
-    'Session not found',
-    'ede_diagnostic',
-    'response channel cancelled',
-    'receiver is gone',
-  ]
-  const crashedByMarker = isFailed && !!entry.errorMessage &&
-    crashedErrorMarkers.some(marker => entry.errorMessage!.includes(marker))
-  const isCrashed = crashedBySentinel || crashedByMarker
-  const isTransientFailure = !isCrashed && isFailed && !!entry.errorMessage &&
-    transientErrorMarkers.some(marker => entry.errorMessage!.includes(marker))
-  // A transient failure that has retried this many times is NOT recovering —
-  // the agent thread is wedged (e.g. an "empty response" / upstream ACP
-  // buffering that never drains). Left as a plain transient it shows "Waiting
-  // for agent" forever with no way out, which is what strands the user.
-  // Escalate: surface the Restart affordance so they can recover. Auto-retry
-  // keeps running underneath; Restart is the manual escape hatch.
-  const STUCK_TRANSIENT_RETRY_THRESHOLD = 4
-  const isStuckTransient = isTransientFailure && (entry.retryCount ?? 0) >= STUCK_TRANSIENT_RETRY_THRESHOLD
-  const showRestart = isCrashed || isStuckTransient
+  // Classification (transient vs crashed vs stuck → Restart) is shared with
+  // SessionPromptQueue via classifyPromptQueueEntry so both queues agree.
+  const { isCrashed, isTransientFailure, isStuckTransient, showRestart } = classifyPromptQueueEntry({
+    status: entry.status,
+    errorMessage: entry.errorMessage,
+    nextRetryAtMs: entry.nextRetryAt,
+    retryCount: entry.retryCount,
+  })
   const failColor = showRestart ? 'error.main' : isTransientFailure ? 'warning.main' : 'error.main'
 
   // Force re-render every second for failed items with retry countdown
@@ -1271,8 +1223,11 @@ const RobustPromptInput: FC<RobustPromptInputProps> = ({
       data-prompt-input="true"
       sx={{ position: 'relative', width: '100%', minWidth: 0 }}
     >
-      {/* Queued messages display */}
-      <Collapse in={showQueue && queuedMessages.length > 0}>
+      {/* Queued messages display. Only rendered when this is an authoritative
+          backend-backed queue (spec-task). For plain sessions (org-chat,
+          team desktop) the local queue is a non-authoritative ghost — the
+          session-keyed SessionPromptQueue is the single source there. */}
+      <Collapse in={backendQueueEnabled && showQueue && queuedMessages.length > 0}>
         <Box
           sx={{
             mb: 1.5,

--- a/frontend/src/components/common/RobustPromptInput.tsx
+++ b/frontend/src/components/common/RobustPromptInput.tsx
@@ -228,7 +228,16 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
   const isCrashed = crashedBySentinel || crashedByMarker
   const isTransientFailure = !isCrashed && isFailed && !!entry.errorMessage &&
     transientErrorMarkers.some(marker => entry.errorMessage!.includes(marker))
-  const failColor = isCrashed ? 'error.main' : isTransientFailure ? 'warning.main' : 'error.main'
+  // A transient failure that has retried this many times is NOT recovering —
+  // the agent thread is wedged (e.g. an "empty response" / upstream ACP
+  // buffering that never drains). Left as a plain transient it shows "Waiting
+  // for agent" forever with no way out, which is what strands the user.
+  // Escalate: surface the Restart affordance so they can recover. Auto-retry
+  // keeps running underneath; Restart is the manual escape hatch.
+  const STUCK_TRANSIENT_RETRY_THRESHOLD = 4
+  const isStuckTransient = isTransientFailure && (entry.retryCount ?? 0) >= STUCK_TRANSIENT_RETRY_THRESHOLD
+  const showRestart = isCrashed || isStuckTransient
+  const failColor = showRestart ? 'error.main' : isTransientFailure ? 'warning.main' : 'error.main'
 
   // Force re-render every second for failed items with retry countdown
   const [, forceUpdate] = useState(0)
@@ -257,7 +266,7 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
             ? (theme) => alpha(theme.palette.info.main, 0.12)
             : isFailed
               ? (theme) => alpha(
-                  isTransientFailure ? theme.palette.warning.main : theme.palette.error.main,
+                  (isTransientFailure && !showRestart) ? theme.palette.warning.main : theme.palette.error.main,
                   0.08,
                 )
               : 'transparent',
@@ -404,9 +413,11 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
           </Box>
           {isFailed && (
             <Box>
-              <Typography variant="caption" sx={{ color: failColor, display: 'block', fontWeight: isCrashed ? 600 : 'inherit' }}>
+              <Typography variant="caption" sx={{ color: failColor, display: 'block', fontWeight: showRestart ? 600 : 'inherit' }}>
                 {isCrashed ? (
                   'Agent crashed. Click restart to attempt to recover.'
+                ) : isStuckTransient ? (
+                  "Agent isn't responding — click Restart to recover."
                 ) : entry.nextRetryAt ? (
                   (() => {
                     const secondsUntilRetry = Math.max(0, Math.ceil((entry.nextRetryAt - Date.now()) / 1000))
@@ -423,7 +434,7 @@ const SortableQueueItem: FC<SortableQueueItemProps> = ({
                   isTransientFailure ? 'Waiting for agent' : 'Failed - will retry'
                 )}
               </Typography>
-              {isCrashed && (
+              {showRestart && (
                 <Box sx={{ mt: 0.5 }}>
                   <Box
                     component="button"

--- a/frontend/src/components/session/SessionPromptQueue.tsx
+++ b/frontend/src/components/session/SessionPromptQueue.tsx
@@ -131,7 +131,9 @@ const SessionPromptQueue: React.FC<SessionPromptQueueProps> = ({ sessionId }) =>
                       ? 'The assistant stopped unexpectedly. Click Restart to recover.'
                       : status.isStuckTransient
                         ? "The assistant isn't responding. Click Restart to recover."
-                        : 'Waiting for the assistant — retrying…'}
+                        : status.isTransientFailure
+                          ? 'Waiting for the assistant — retrying…'
+                          : 'This message failed to send.'}
                   </Typography>
                   {status.showRestart && (
                     <Button

--- a/frontend/src/components/session/SessionPromptQueue.tsx
+++ b/frontend/src/components/session/SessionPromptQueue.tsx
@@ -1,37 +1,37 @@
 /**
- * SessionPromptQueue - read-only view of a session's pending prompt queue.
+ * SessionPromptQueue - the single queue view for a session that has no spec
+ * task (org-chat / bot sessions). It is session-keyed and DB-backed, so it is
+ * the authoritative queue: it surfaces prompts still waiting for the agent
+ * (pending/sending) AND failed prompts, including the ones auto-dispatched by
+ * the org graph (enqueueAgentMessage). Spec-task pages use RobustPromptInput's
+ * own backend-backed queue instead; plain sessions use this one.
  *
- * Surfaces the session-scoped prompt queue (org-chat / bot sessions that have no
- * spec task) so you can see what's queued for the agent. Automated / org-graph
- * dispatched messages are enqueued onto this same queue by the backend
- * (enqueueAgentMessage), deferred until the agent is idle; this shows them while
- * they wait and clears them once delivered.
- *
- * Read-only by design — full queue management (reorder / delete / interrupt
- * toggle) lives in RobustPromptInput for spec-task pages; parity here can be a
- * follow-up.
+ * Failed prompts are classified (via classifyPromptQueueEntry, shared with
+ * RobustPromptInput) so a wedged/crashed agent surfaces the same Restart
+ * affordance here as on spec-task pages.
  */
-import React from 'react'
-import { Box, Chip, Stack, Typography } from '@mui/material'
+import React, { useState } from 'react'
+import { Box, Button, Chip, Stack, Typography } from '@mui/material'
 import ScheduleIcon from '@mui/icons-material/Schedule'
+import RestartAltIcon from '@mui/icons-material/RestartAlt'
 import { useQuery } from '@tanstack/react-query'
 import useApi from '../../hooks/useApi'
 import { listSessionPromptHistory } from '../../services/promptHistoryService'
 import { TypesPromptHistoryEntry } from '../../api/api'
+import { classifyPromptQueueEntry } from '../../utils/promptQueueStatus'
 
 interface SessionPromptQueueProps {
   sessionId: string
 }
 
-// Only these statuses are "in the queue" (not yet delivered/streaming to the
-// agent). 'sending' is included so a just-dispatched-but-not-acknowledged prompt
-// stays visible until the agent actually starts streaming — matching the
-// spec-task queue's semantics.
-const QUEUED_STATUSES = new Set(['pending', 'sending'])
+// 'pending'/'sending' are still-in-flight; 'failed' is a stalled/errored prompt
+// that needs surfacing (with Restart when the agent is wedged).
+const VISIBLE_STATUSES = new Set(['pending', 'sending', 'failed'])
 
 const SessionPromptQueue: React.FC<SessionPromptQueueProps> = ({ sessionId }) => {
   const api = useApi()
   const apiClient = api.getApiClient()
+  const [isRestarting, setIsRestarting] = useState(false)
 
   const { data } = useQuery({
     queryKey: ['session-prompt-queue', sessionId],
@@ -42,11 +42,22 @@ const SessionPromptQueue: React.FC<SessionPromptQueueProps> = ({ sessionId }) =>
     queryFn: async () => listSessionPromptHistory(apiClient, sessionId),
   })
 
-  const queued: TypesPromptHistoryEntry[] = (data?.entries || []).filter(
-    (e) => e.status && QUEUED_STATUSES.has(e.status),
+  const visible: TypesPromptHistoryEntry[] = (data?.entries || []).filter(
+    (e) => e.status && VISIBLE_STATUSES.has(e.status),
   )
 
-  if (queued.length === 0) return null
+  if (visible.length === 0) return null
+
+  const handleRestart = () => {
+    if (!apiClient || !sessionId || isRestarting) return
+    setIsRestarting(true)
+    apiClient
+      .v1SessionsRestartAgentCreate(sessionId)
+      .catch((err: unknown) => console.error('Failed to restart agent thread:', err))
+      .finally(() => setIsRestarting(false))
+  }
+
+  const queuedCount = visible.filter((e) => e.status !== 'failed').length
 
   return (
     <Box
@@ -60,39 +71,86 @@ const SessionPromptQueue: React.FC<SessionPromptQueueProps> = ({ sessionId }) =>
       <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
         <ScheduleIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
         <Typography variant="caption" color="text.secondary">
-          {queued.length} queued — delivered when the agent is idle
+          {queuedCount > 0
+            ? `${queuedCount} queued — delivered when the agent is idle`
+            : 'Prompt queue'}
         </Typography>
       </Stack>
       <Stack spacing={0.5}>
-        {queued.map((e) => (
-          <Stack key={e.id} direction="row" alignItems="center" spacing={1}>
-            <Chip
-              label={e.status}
-              size="small"
-              sx={{ height: 18, fontSize: '0.65rem' }}
-              color={e.status === 'sending' ? 'primary' : 'default'}
-            />
-            {e.interrupt ? (
-              <Chip
-                label="interrupt"
-                size="small"
-                color="warning"
-                sx={{ height: 18, fontSize: '0.65rem' }}
-              />
-            ) : null}
-            <Typography
-              variant="body2"
-              color="text.secondary"
-              sx={{
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {e.content}
-            </Typography>
-          </Stack>
-        ))}
+        {visible.map((e) => {
+          const status = classifyPromptQueueEntry({
+            status: e.status,
+            errorMessage: e.error_message,
+            nextRetryAtMs: e.next_retry_at ? Date.parse(e.next_retry_at) : undefined,
+            retryCount: e.retry_count,
+          })
+          const isFailed = status.isFailed
+          return (
+            <Stack key={e.id} spacing={0.5}>
+              <Stack direction="row" alignItems="center" spacing={1}>
+                <Chip
+                  label={e.status}
+                  size="small"
+                  sx={{ height: 18, fontSize: '0.65rem' }}
+                  color={
+                    isFailed
+                      ? status.showRestart
+                        ? 'error'
+                        : 'warning'
+                      : e.status === 'sending'
+                        ? 'primary'
+                        : 'default'
+                  }
+                />
+                {e.interrupt ? (
+                  <Chip
+                    label="interrupt"
+                    size="small"
+                    color="warning"
+                    sx={{ height: 18, fontSize: '0.65rem' }}
+                  />
+                ) : null}
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                >
+                  {e.content}
+                </Typography>
+              </Stack>
+              {isFailed && (
+                <Stack direction="row" alignItems="center" spacing={1} sx={{ pl: 0.5 }}>
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      color: status.showRestart ? 'error.main' : 'warning.main',
+                      fontWeight: status.showRestart ? 600 : 'inherit',
+                    }}
+                  >
+                    {status.isCrashed
+                      ? 'Agent crashed. Click Restart to recover.'
+                      : status.isStuckTransient
+                        ? "Agent isn't responding — click Restart to recover."
+                        : 'Failed — retrying…'}
+                  </Typography>
+                  {status.showRestart && (
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      color="error"
+                      startIcon={<RestartAltIcon sx={{ fontSize: 16 }} />}
+                      disabled={isRestarting}
+                      onClick={handleRestart}
+                      sx={{ py: 0, minHeight: 24, fontSize: '0.7rem', textTransform: 'none' }}
+                    >
+                      {isRestarting ? 'Restarting…' : 'Restart'}
+                    </Button>
+                  )}
+                </Stack>
+              )}
+            </Stack>
+          )
+        })}
       </Stack>
     </Box>
   )

--- a/frontend/src/components/session/SessionPromptQueue.tsx
+++ b/frontend/src/components/session/SessionPromptQueue.tsx
@@ -128,10 +128,10 @@ const SessionPromptQueue: React.FC<SessionPromptQueueProps> = ({ sessionId }) =>
                     }}
                   >
                     {status.isCrashed
-                      ? 'Agent crashed. Click Restart to recover.'
+                      ? 'The assistant stopped unexpectedly. Click Restart to recover.'
                       : status.isStuckTransient
-                        ? "Agent isn't responding — click Restart to recover."
-                        : 'Failed — retrying…'}
+                        ? "The assistant isn't responding. Click Restart to recover."
+                        : 'Waiting for the assistant — retrying…'}
                   </Typography>
                   {status.showRestart && (
                     <Button

--- a/frontend/src/utils/promptQueueStatus.ts
+++ b/frontend/src/utils/promptQueueStatus.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared classification for a failed prompt-queue entry: is it a transient
+ * failure that will auto-recover, or a wedged/crashed one the user must
+ * Restart out of? This is the single source of truth for the Restart
+ * affordance, used by both queue renderers (RobustPromptInput's spec-task
+ * queue and SessionPromptQueue's session queue) so they behave identically.
+ */
+
+// A transient failure is one we expect to recover from automatically (agent
+// booting, prior turn draining, WebSocket reconnecting). Shown as a soft
+// "still working" state, not a hard error — the user need not act.
+const transientErrorMarkers = [
+  'no WebSocket',
+  'no external agent WebSocket',
+  'became busy',
+  'deferring queue prompt',
+  'channel full',
+  'connection replaced',
+  'empty response',
+]
+
+// Terminal Claude Agent process death. The backend's MarkPromptAsCrashed pins
+// next_retry_at to a far-future sentinel (year 9999) to suppress auto-retry;
+// detecting that is robust to the many transport error wordings. The string
+// markers are a fast path so Restart can render before the sentinel syncs.
+const crashedErrorMarkers = [
+  'Claude Agent process exited',
+  'Session not found',
+  'ede_diagnostic',
+  'response channel cancelled',
+  'receiver is gone',
+]
+
+const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000
+
+// A transient failure that has retried this many times is NOT recovering — the
+// thread is wedged. Escalate to surface Restart; auto-retry keeps running
+// underneath as the manual escape hatch.
+const STUCK_TRANSIENT_RETRY_THRESHOLD = 4
+
+export interface PromptQueueStatusInput {
+  status?: string
+  errorMessage?: string
+  // Epoch ms of the scheduled retry, or undefined/0 if none.
+  nextRetryAtMs?: number
+  retryCount?: number
+  // "now" in epoch ms — injectable for tests; defaults to Date.now().
+  nowMs?: number
+}
+
+export interface PromptQueueStatus {
+  isFailed: boolean
+  isCrashed: boolean
+  isTransientFailure: boolean
+  isStuckTransient: boolean
+  showRestart: boolean
+}
+
+export function classifyPromptQueueEntry(input: PromptQueueStatusInput): PromptQueueStatus {
+  const { status, errorMessage, nextRetryAtMs, retryCount } = input
+  const now = input.nowMs ?? Date.now()
+  const isFailed = status === 'failed'
+
+  const crashedBySentinel = isFailed && !!nextRetryAtMs && nextRetryAtMs > now + ONE_YEAR_MS
+  const crashedByMarker =
+    isFailed && !!errorMessage && crashedErrorMarkers.some((m) => errorMessage.includes(m))
+  const isCrashed = crashedBySentinel || crashedByMarker
+
+  const isTransientFailure =
+    !isCrashed && isFailed && !!errorMessage && transientErrorMarkers.some((m) => errorMessage.includes(m))
+  const isStuckTransient = isTransientFailure && (retryCount ?? 0) >= STUCK_TRANSIENT_RETRY_THRESHOLD
+
+  return {
+    isFailed,
+    isCrashed,
+    isTransientFailure,
+    isStuckTransient,
+    showRestart: isCrashed || isStuckTransient,
+  }
+}


### PR DESCRIPTION
## What

Makes a stuck or crashed external agent recoverable from the UI, and makes the prompt queue behave the same on every surface. Five commits, independent of the humans-in-the-org work (zero file overlap; cherry-picked straight onto main).

1. **Collapse the two prompt-queue renderers into one.** Plain sessions (org-chat / bot chats) had two queues with different data sources: `SessionPromptQueue` (session-keyed, DB-backed, but only rendered `pending`/`sending`) and `RobustPromptInput`'s own queue (spec-task-keyed, mostly local for a plain session, and the only one that showed `failed` + a Restart button). Net result: a DB-persisted failed prompt showed in neither. Now `SessionPromptQueue` is the single authoritative queue for plain sessions - it renders `failed` alongside `pending`/`sending` and shows Restart when the agent is wedged. `RobustPromptInput`'s local queue is a non-authoritative ghost when there is no spec task (no backend load/sync/poll runs), so it no longer renders for those sessions, gated on the existing `backendQueueEnabled` flag. Spec-task pages keep `RobustPromptInput`'s full queue unchanged. The transient/crashed/stuck classification is extracted to a shared `classifyPromptQueueEntry` so both surfaces agree.

2. **Escalate a stuck transient failure to a Restart button.** A transient failure that keeps retrying past a threshold is not recovering - the thread is wedged. It used to show "Waiting for the assistant" forever with no way out; now it escalates to the Restart affordance.

3. **Clear `ZedThreadID` on crash-restart.** `restartSessionContainer` preserved `ZedThreadID`, so a crash-restart reloaded the same (often poisoned) thread and reproduced the wedge. Verified live: a container recreate that kept the thread never reached `agent_ready`; a fresh thread came ready in seconds. The crash/restart path now clears and persists `ZedThreadID` before resume so Zed opens a fresh thread. `/sessions/{id}/resume` remains the preserve-the-thread path - a clean split (Restart = fresh, Resume = keep). This is what the frontend Restart affordance already claimed it did.

4. **Soften and unify the queue copy.** Both surfaces now say "The assistant stopped unexpectedly. Click Restart to recover." / "The assistant isn't responding..." instead of the more technical "Agent crashed...", and the wording matches across the two renderers.

5. **Review fixes** (from an internal review of this PR): correct the now-inverted restart-agent docstring; pin the thread-clear inside the `StopDesktop -> clear -> StartDesktop` ordering in the test so a regression that clears too late is caught; stop labelling a hard (non-retrying) failure as "retrying".

## Testing

- Verified end to end on a live org, signed in as the org owner: the failed prompt renders with the Restart button on both the org-chat and the spec-task surfaces; clicking Restart calls `restart-agent`, the backend stops and recreates the container, clears the old thread (`cleared ZedThreadID (fresh thread)` in the logs), and Zed mints a fresh one (confirmed in the session row).
- Go: `TestRestartClearsZedThread` added; the restart suite passes; `pkg/server` and `pkg/store` build.
- Frontend: `tsc --noEmit` clean on the touched files.

## Known follow-ups (not in this PR)

- **Desktop surfaces lose the local ghost queue.** Gating `RobustPromptInput`'s queue on `backendQueueEnabled` also removes it on the plain-session desktop panels (`TeamDesktopPage`, and `ExternalAgentDesktopViewer` in desktop mode). Those never had a DB-backed Restart (their queue was a local-only ghost), and messages still deliver via the pump, so there is no functional or data loss - but they no longer show a queue. The clean follow-up is to mount `SessionPromptQueue` on those surfaces so they get the authoritative queue + Restart too.
- The generated swagger files still carry the old restart-agent description; they update on the next `./stack update_openapi` (kept out of this PR to avoid conflicting with the humans-in-the-org PR, which regenerates them).
- Separate, pre-existing wedge found while testing: on one already-wedged session the agent produced no output even on a fresh thread - a deeper problem in the agent/model layer, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
