### PR TITLE
fix(vcs): request full GitHub scopes and self-heal dangling OAuth pins

### DIFF
--- a/api/pkg/services/git_repository_service.go
+++ b/api/pkg/services/git_repository_service.go
@@ -2669,19 +2669,22 @@ func (s *GitRepositoryService) getCredentialsForRepo(ctx context.Context, gitRep
 		}
 	}
 
-	// Repo-level credentials: check for OAuth connection
+	// Repo-level credentials: use the pinned OAuth connection.
 	if gitRepo.OAuthConnectionID != "" {
 		conn, err := s.store.GetOAuthConnection(ctx, gitRepo.OAuthConnectionID)
 		if err == nil && conn.AccessToken != "" {
-			switch gitRepo.ExternalType {
-			case types.ExternalRepositoryTypeGitHub:
-				return "x-access-token", conn.AccessToken
-			case types.ExternalRepositoryTypeGitLab:
-				return "oauth2", conn.AccessToken
-			case types.ExternalRepositoryTypeADO:
-				return "oauth2", conn.AccessToken
-			default:
-				return "oauth2", conn.AccessToken
+			return oauthGitUsername(gitRepo.ExternalType), conn.AccessToken
+		}
+		// The pinned connection is gone (GetOAuthConnection excludes soft-deleted
+		// rows). Disconnecting and reconnecting a provider soft-deletes the old
+		// connection and creates a new one, leaving OAuthConnectionID a dangling
+		// pointer that silently breaks auth — git then prompts for a username and
+		// fails with "could not read Username", which surfaces as a 409 on push.
+		// Self-heal to the repo owner's newest live connection for the same
+		// provider instead of stranding the repo.
+		if gitRepo.OwnerID != "" {
+			if token := s.newestLiveOAuthToken(ctx, gitRepo.OwnerID, gitRepo.ExternalType); token != "" {
+				return oauthGitUsername(gitRepo.ExternalType), token
 			}
 		}
 	}
@@ -2716,6 +2719,41 @@ func (s *GitRepositoryService) getCredentialsForRepo(ctx context.Context, gitRep
 	}
 
 	return "", ""
+}
+
+// oauthGitUsername returns the basic-auth username git expects when an OAuth
+// access token is embedded as the password, per provider.
+func oauthGitUsername(t types.ExternalRepositoryType) string {
+	if t == types.ExternalRepositoryTypeGitHub {
+		return "x-access-token"
+	}
+	return "oauth2"
+}
+
+// newestLiveOAuthToken returns the access token of the most-recently-updated,
+// non-deleted OAuth connection owned by userID whose provider matches the repo's
+// external type, or "" if none exists. Used to recover from a dangling
+// OAuthConnectionID after the repo owner disconnects/reconnects a provider (the
+// reconnect creates a new connection row and soft-deletes the pinned one).
+func (s *GitRepositoryService) newestLiveOAuthToken(ctx context.Context, userID string, externalType types.ExternalRepositoryType) string {
+	wantType := OAuthProviderTypeForRepo(externalType)
+	conns, err := s.store.ListOAuthConnections(ctx, &store.ListOAuthConnectionsQuery{UserID: userID})
+	if err != nil {
+		return ""
+	}
+	var newest *types.OAuthConnection
+	for _, conn := range conns {
+		if conn.Provider.Type != wantType || conn.AccessToken == "" {
+			continue
+		}
+		if newest == nil || conn.UpdatedAt.After(newest.UpdatedAt) {
+			newest = conn
+		}
+	}
+	if newest == nil {
+		return ""
+	}
+	return newest.AccessToken
 }
 
 func GetPullRequestURL(repo *types.GitRepository, pullRequestID string) string {

--- a/frontend/src/components/project/BrowseProvidersDialog.tsx
+++ b/frontend/src/components/project/BrowseProvidersDialog.tsx
@@ -60,6 +60,7 @@ import {
   TypesExternalRepositoryType,
 } from "../../api/api";
 import useApi from "../../hooks/useApi";
+import { GITHUB_VCS_SCOPES } from "../../hooks/useOAuthFlow";
 import useSnackbar from "../../hooks/useSnackbar";
 import useAccount from "../../hooks/useAccount";
 import useRouter from "../../hooks/useRouter";
@@ -419,7 +420,7 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
         // GitLab needs 'read_repository,write_repository' scopes
         let scopesParam = "";
         if (selectedProvider === "github") {
-          scopesParam = "?scopes=repo,workflow,read:org,read:user,user:email";
+          scopesParam = "?scopes=" + GITHUB_VCS_SCOPES.join(",");
         } else if (selectedProvider === "gitlab") {
           scopesParam = "?scopes=read_repository,write_repository,read_user";
         }

--- a/frontend/src/components/project/CreateProjectDialog.tsx
+++ b/frontend/src/components/project/CreateProjectDialog.tsx
@@ -40,6 +40,7 @@ import { useListOAuthConnections, useListOAuthProviders, useListOAuthConnectionR
 import useAccount from '../../hooks/useAccount'
 import useSnackbar from '../../hooks/useSnackbar'
 import useApi from '../../hooks/useApi'
+import { GITHUB_VCS_SCOPES } from '../../hooks/useOAuthFlow'
 import { AppsContext, CodeAgentRuntime, generateAgentName } from '../../contexts/apps'
 import { IApp, AGENT_TYPE_ZED_EXTERNAL } from '../../types'
 import { findOAuthConnectionForProvider, findOAuthProviderForType, hasRequiredScopes, PROVIDER_TYPES } from '../../utils/oauthProviders'
@@ -185,7 +186,7 @@ const CreateProjectDialog: FC<CreateProjectDialogProps> = ({
   const openOAuthPopup = useCallback(async (providerId: string) => {
     try {
       const response = await api.get(
-        `/api/v1/oauth/flow/start/${providerId}?scopes=repo,read:org,read:user,user:email`
+        `/api/v1/oauth/flow/start/${providerId}?scopes=${GITHUB_VCS_SCOPES.join(',')}`
       )
       const authUrl = response.auth_url || response?.data?.auth_url
       if (authUrl) {

--- a/frontend/src/components/spec-tasks/DesignReviewContent.tsx
+++ b/frontend/src/components/spec-tasks/DesignReviewContent.tsx
@@ -60,7 +60,7 @@ import {
 import useSnackbar from "../../hooks/useSnackbar";
 import useApi from "../../hooks/useApi";
 import useAccount from "../../hooks/useAccount";
-import { useOAuthFlow } from "../../hooks/useOAuthFlow";
+import { useOAuthFlow, GITHUB_VCS_SCOPES } from "../../hooks/useOAuthFlow";
 import { useListOAuthProviders } from "../../services/oauthProvidersService";
 import { findOAuthProviderForType } from "../../utils/oauthProviders";
 import InlineCommentBubble from "./InlineCommentBubble";
@@ -1098,7 +1098,7 @@ export default function DesignReviewContent({
           snackbar.info("Connect GitHub to approve this design.");
           startOAuthFlow({
             providerId: gitHubProvider.id,
-            scopes: ["repo"],
+            scopes: GITHUB_VCS_SCOPES,
             onSuccess: () => {
               snackbar.success(
                 "GitHub connected. Click Approve again to submit.",

--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -29,7 +29,7 @@ import {
 import { useUpdateSpecTask } from "../../services/specTaskService";
 import { useListOAuthProviders, useListOAuthConnections } from "../../services/oauthProvidersService";
 import { findOAuthProviderForType, findOAuthConnectionForProvider, hasRequiredScopes } from "../../utils/oauthProviders";
-import { useOAuthFlow } from "../../hooks/useOAuthFlow";
+import { useOAuthFlow, GITHUB_VCS_SCOPES } from "../../hooks/useOAuthFlow";
 import CIStatusIcon from "./CIStatusIcon";
 
 export interface RepoPR {
@@ -288,10 +288,11 @@ export default function SpecTaskActionButtons({
     e.stopPropagation();
     if (!isDirectPush && hasExternalRepo && externalRepoType === "github" && !hasGitHubOAuthWithRepoScope) {
       if (gitHubProvider?.id) {
-        // GitHub OAuth provider exists -- start the connection flow with repo scope
+        // GitHub OAuth provider exists -- start the connection flow with the full
+        // VCS scope set (re-auth replaces scopes, so requesting a subset downgrades)
         startOAuthFlow({
           providerId: gitHubProvider.id,
-          scopes: ['repo'],
+          scopes: GITHUB_VCS_SCOPES,
           onSuccess: () => {
             setShowOAuthPrompt(false);
             approveImplementationMutation.mutate();
@@ -591,7 +592,7 @@ export default function SpecTaskActionButtons({
                 onClick={() => {
                   startOAuthFlow({
                     providerId: gitHubProvider.id!,
-                    scopes: ['repo'],
+                    scopes: GITHUB_VCS_SCOPES,
                     onSuccess: () => {
                       setShowOAuthPrompt(false);
                       approveImplementationMutation.mutate();

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -64,7 +64,7 @@ import useSnackbar from "../../hooks/useSnackbar";
 import useAccount from "../../hooks/useAccount";
 import useApi from "../../hooks/useApi";
 import useRouter from "../../hooks/useRouter";
-import { useOAuthFlow } from "../../hooks/useOAuthFlow";
+import { useOAuthFlow, GITHUB_VCS_SCOPES } from "../../hooks/useOAuthFlow";
 import { useListOAuthProviders } from "../../services/oauthProvidersService";
 import { findOAuthProviderForType } from "../../utils/oauthProviders";
 import { getBrowserLocale } from "../../hooks/useBrowserLocale";
@@ -702,7 +702,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
             snackbar.info("Connect GitHub to start planning this task.");
             startOAuthFlow({
               providerId: gitHubProvider.id,
-              scopes: ["repo"],
+              scopes: GITHUB_VCS_SCOPES,
               onSuccess: () => {
                 snackbar.success(
                   "GitHub connected. Click Start Planning again to continue.",

--- a/frontend/src/components/tasks/SpecTaskKanbanBoard.tsx
+++ b/frontend/src/components/tasks/SpecTaskKanbanBoard.tsx
@@ -97,7 +97,7 @@ import {
 } from "../../api/api";
 import { useGetProject, useUpdateProject } from "../../services/projectService";
 import useSnackbar from "../../hooks/useSnackbar";
-import { useOAuthFlow } from "../../hooks/useOAuthFlow";
+import { useOAuthFlow, GITHUB_VCS_SCOPES } from "../../hooks/useOAuthFlow";
 import { useListOAuthProviders } from "../../services/oauthProvidersService";
 import { findOAuthProviderForType } from "../../utils/oauthProviders";
 import BacklogTableView from "./BacklogTableView";
@@ -1520,7 +1520,7 @@ const SpecTaskKanbanBoard: React.FC<SpecTaskKanbanBoardProps> = ({
             snackbar.info("Connect GitHub to start planning this task.");
             startOAuthFlow({
               providerId: gitHubProvider.id,
-              scopes: ["repo"],
+              scopes: GITHUB_VCS_SCOPES,
               onSuccess: () => {
                 snackbar.success(
                   "GitHub connected. Click Start Planning again to continue.",

--- a/frontend/src/components/tasks/TabsView.tsx
+++ b/frontend/src/components/tasks/TabsView.tsx
@@ -52,7 +52,7 @@ import {
 } from "../../api/api";
 import useSnackbar from "../../hooks/useSnackbar";
 import useApi from "../../hooks/useApi";
-import { useOAuthFlow } from "../../hooks/useOAuthFlow";
+import { useOAuthFlow, GITHUB_VCS_SCOPES } from "../../hooks/useOAuthFlow";
 import { useListOAuthProviders } from "../../services/oauthProvidersService";
 import { findOAuthProviderForType } from "../../utils/oauthProviders";
 import { useUpdateSpecTask, useSpecTask } from "../../services/specTaskService";
@@ -872,7 +872,7 @@ const TaskPanel: React.FC<TaskPanelProps> = ({
             snackbar.info("Connect GitHub to start planning this task.");
             startOAuthFlow({
               providerId: gitHubProvider.id,
-              scopes: ["repo"],
+              scopes: GITHUB_VCS_SCOPES,
               onSuccess: () => {
                 snackbar.success(
                   "GitHub connected. Click Start Planning again to continue.",

--- a/frontend/src/hooks/useOAuthFlow.ts
+++ b/frontend/src/hooks/useOAuthFlow.ts
@@ -1,6 +1,13 @@
 import { useState, useCallback } from 'react'
 import useApi from './useApi'
 
+// Full GitHub scope set to request on EVERY VCS connect. GitHub REPLACES (does
+// not union) a token's scopes on re-authorization, so requesting a subset here
+// silently downgrades an existing full-scope grant — which strands repos that
+// need workflow/read:org/etc. and breaks push. Keep every GitHub VCS connect
+// entry point on this single set.
+export const GITHUB_VCS_SCOPES = ['repo', 'workflow', 'read:org', 'read:user', 'user:email']
+
 interface StartOAuthFlowOptions {
   providerId: string
   scopes?: string[]


### PR DESCRIPTION
## Problem

Reconnecting GitHub on an instance silently broke `git push` for external repos with a **409 Conflict**. Diagnosed live on meta: 47 external repos were stranded after a disconnect/reconnect. Two independent bugs combined:

### Bug 1 — connect flows request only `repo` scope
Every spec-task GitHub connect path — **Start planning**, design-review approve, and open-PR — hardcoded `scopes: ['repo']`:
- `SpecTaskActionButtons.tsx` (×2), `SpecTaskDetailContent.tsx`, `TabsView.tsx`, `SpecTaskKanbanBoard.tsx`, `DesignReviewContent.tsx`

GitHub **replaces** (does not union) a token's scopes on re-authorization. Because the Helix OAuth app was already authorized, GitHub issued a fresh `repo`-only token with no consent prompt, dropping `read:org`/`read:user`/`user:email`/`workflow` from a previously full-scope grant.

### Bug 2 — dangling `o_auth_connection_id` after reconnect
`git_repositories.o_auth_connection_id` hard-pins one connection row. Disconnect/reconnect **soft-deletes** the old connection and creates a new one, leaving the pin dangling. `getCredentialsForRepo`'s repo-level lookup uses `GetOAuthConnection`, which excludes soft-deleted rows → returns no token → git gets a credential-less URL → `fatal: could not read Username for 'https://github.com'` → sync-before-push fails → **409**.

## Fix

1. **Single source of truth for VCS scopes.** New `GITHUB_VCS_SCOPES` constant (`repo, workflow, read:org, read:user, user:email`) in `useOAuthFlow.ts`, used at *every* GitHub VCS connect entry point (the 5 spec-task paths plus `BrowseProvidersDialog` and `CreateProjectDialog`) so no path can request a narrower set and downgrade a grant.

2. **Self-healing credential resolution.** When the pinned OAuth connection is gone, `getCredentialsForRepo` falls back to the repo owner's newest live connection for the same provider (`newestLiveOAuthToken`) instead of stranding the repo. Ends the dangling-pointer class of breakage on every reconnect.

## Testing

- `go build ./pkg/services/` — passes.
- `yarn build` (tsc + vite) — passes.
- Root cause confirmed against live meta data (soft-deleted connection `bb5455ae`, `could not read Username` in API logs). The 47 stranded repos on meta were unblocked by re-pointing to the live connection; this PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)