### PR TITLE
fix(api): stage spec-task attachments on upload to fix planning race

### DIFF
--- a/api/pkg/server/spec_task_attachments_handlers.go
+++ b/api/pkg/server/spec_task_attachments_handlers.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/helixml/helix/api/pkg/system"
@@ -165,6 +166,21 @@ func (s *HelixAPIServer) uploadSpecTaskAttachments(w http.ResponseWriter, r *htt
 			return
 		}
 		created = append(created, row)
+	}
+
+	// Stage the uploaded attachments into the helix-specs branch immediately, so they
+	// land in design/tasks/<taskDir>/attachments/ regardless of when this upload happens
+	// relative to planning. This closes the race where a slow upload lost to start-planning
+	// and the file was never committed nor surfaced to the agent. Staging is idempotent and
+	// also notifies the agent if a planning session already exists. Failure here is
+	// non-fatal: the row + blob exist, and planning-time staging remains a backstop.
+	//
+	// Detach from the request context so a client disconnect after the multipart body was
+	// received doesn't abort the git commit.
+	stageCtx, cancel := detachContext(ctx, 60*time.Second)
+	defer cancel()
+	if err := s.specDrivenTaskService.StageUploadedAttachments(stageCtx, taskID); err != nil {
+		log.Warn().Err(err).Str("task_id", taskID).Msg("Failed to stage uploaded attachments into helix-specs (planning-time staging will retry)")
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/api/pkg/services/spec_task_attachments.go
+++ b/api/pkg/services/spec_task_attachments.go
@@ -90,6 +90,16 @@ func (s *SpecDrivenTaskService) StageUploadedAttachments(ctx context.Context, ta
 		return nil
 	}
 
+	// Snapshot which attachments are newly arriving (not yet staged) BEFORE we commit —
+	// these are the ones the planning prompt cannot have referenced yet. commitAttachments
+	// sets CommittedSHA in place, so this must be read first.
+	newlyArrived := make([]*types.SpecTaskAttachment, 0, len(attachments))
+	for _, a := range attachments {
+		if a.CommittedSHA == "" {
+			newlyArrived = append(newlyArrived, a)
+		}
+	}
+
 	// Stage into helix-specs if the project has a repo configured.
 	// commitAttachmentsToHelixSpecs is idempotent (skips rows whose CommittedSHA is set),
 	// so double-staging with the planning-time path is safe.
@@ -99,11 +109,12 @@ func (s *SpecDrivenTaskService) StageUploadedAttachments(ctx context.Context, ta
 		}
 	}
 
-	// If planning already has a session, its prompt was (or is being) built and may not
-	// reference this attachment — tell the agent to look. When there is no session yet,
-	// the planning prompt will list it, so no note is needed.
-	if task.PlanningSessionID != "" && s.EnqueueMessageToAgent != nil {
-		note := buildAttachmentAddedNote(attachments, GetTaskDirName(task))
+	// If planning already has a session AND something new actually arrived, its prompt was
+	// (or is being) built without these files — tell the agent to look. When there is no
+	// session yet, the planning prompt will list them; when nothing is new (re-stage), the
+	// agent has already been told.
+	if len(newlyArrived) > 0 && task.PlanningSessionID != "" && s.EnqueueMessageToAgent != nil {
+		note := buildAttachmentAddedNote(newlyArrived, GetTaskDirName(task))
 		if err := s.EnqueueMessageToAgent(ctx, task, note, false, task.CreatedBy); err != nil {
 			return fmt.Errorf("enqueue attachment-added note: %w", err)
 		}

--- a/api/pkg/services/spec_task_attachments.go
+++ b/api/pkg/services/spec_task_attachments.go
@@ -53,6 +53,73 @@ func (s *SpecDrivenTaskService) stageAttachmentsAndBuildPromptSection(
 	return BuildAttachmentsSection(attachments, taskDirName), nil
 }
 
+// StageUploadedAttachments stages any un-staged attachments for the task into the
+// helix-specs branch immediately (reusing the idempotent commitAttachmentsToHelixSpecs),
+// and — if a planning session already exists — enqueues a note so the agent knows a new
+// attachment arrived after its planning prompt was built.
+//
+// This is called from the upload handler so an attachment lands in
+// design/tasks/<taskDir>/attachments/ regardless of when it is uploaded relative to
+// planning. Without it, staging only happened at planning time, so a slow upload that
+// lost the race against start-planning was never committed and the agent never saw it.
+//
+// Safe to call at any point in the task lifecycle:
+//   - Planning not started yet (no PlanningSessionID): the file is committed now, and
+//     the planning prompt (built later) lists it via ListSpecTaskAttachments — no note.
+//   - Planning already running (PlanningSessionID set): the prompt may already have been
+//     built without this file, so we enqueue an "attachment added" note.
+func (s *SpecDrivenTaskService) StageUploadedAttachments(ctx context.Context, taskID string) error {
+	task, err := s.store.GetSpecTask(ctx, taskID)
+	if err != nil {
+		return fmt.Errorf("get task: %w", err)
+	}
+
+	var project *types.Project
+	if task.ProjectID != "" {
+		project, err = s.store.GetProject(ctx, task.ProjectID)
+		if err != nil {
+			return fmt.Errorf("get project: %w", err)
+		}
+	}
+
+	attachments, err := s.store.ListSpecTaskAttachments(ctx, task.ID)
+	if err != nil {
+		return fmt.Errorf("list attachments: %w", err)
+	}
+	if len(attachments) == 0 {
+		return nil
+	}
+
+	// Stage into helix-specs if the project has a repo configured.
+	// commitAttachmentsToHelixSpecs is idempotent (skips rows whose CommittedSHA is set),
+	// so double-staging with the planning-time path is safe.
+	if project != nil && project.DefaultRepoID != "" && s.gitRepositoryService != nil {
+		if err := s.commitAttachmentsToHelixSpecs(ctx, task, project, attachments); err != nil {
+			return fmt.Errorf("commit attachments to helix-specs: %w", err)
+		}
+	}
+
+	// If planning already has a session, its prompt was (or is being) built and may not
+	// reference this attachment — tell the agent to look. When there is no session yet,
+	// the planning prompt will list it, so no note is needed.
+	if task.PlanningSessionID != "" && s.EnqueueMessageToAgent != nil {
+		note := buildAttachmentAddedNote(attachments, GetTaskDirName(task))
+		if err := s.EnqueueMessageToAgent(ctx, task, note, false, task.CreatedBy); err != nil {
+			return fmt.Errorf("enqueue attachment-added note: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// buildAttachmentAddedNote is the message enqueued to a running planning session when an
+// attachment arrives after the prompt was built. Reuses BuildAttachmentsSection so the
+// paths and wording match the initial planning prompt.
+func buildAttachmentAddedNote(attachments []*types.SpecTaskAttachment, taskDirName string) string {
+	return "A new attachment was added after this session started. Read it before continuing.\n\n" +
+		BuildAttachmentsSection(attachments, taskDirName)
+}
+
 // commitAttachmentsToHelixSpecs writes each un-staged attachment as a blob in the
 // helix-specs branch and updates its CommittedSHA. Uses a single WithExternalRepoWrite
 // session so all attachments land in one push.

--- a/api/pkg/services/spec_task_attachments_stage_test.go
+++ b/api/pkg/services/spec_task_attachments_stage_test.go
@@ -1,0 +1,186 @@
+package services
+
+import (
+	"context"
+
+	"code.gitea.io/gitea/modules/git/gitcmd"
+	"github.com/helixml/helix/api/pkg/types"
+	"go.uber.org/mock/gomock"
+)
+
+// stageEnqueue captures a call to the fake EnqueueMessageToAgent so tests can assert
+// whether (and how) the agent was notified about a late-arriving attachment.
+type stageEnqueue struct {
+	message      string
+	interrupt    bool
+	notifyUserID string
+}
+
+// newStageService builds a SpecDrivenTaskService wired to the suite's real git repo and
+// mock store, with a fake blob reader and a capturing enqueuer. Enqueue calls are appended
+// to *captured.
+func (s *GitIntegrationSuite) newStageService(captured *[]stageEnqueue) *SpecDrivenTaskService {
+	svc := &SpecDrivenTaskService{
+		store:                s.mockStore,
+		gitRepositoryService: s.gitRepoService,
+	}
+	svc.ReadAttachmentBlob = func(_ context.Context, path string) ([]byte, error) {
+		return []byte("fake-bytes-for-" + path), nil
+	}
+	svc.EnqueueMessageToAgent = func(_ context.Context, _ *types.SpecTask, message string, interrupt bool, notifyUserID string) error {
+		*captured = append(*captured, stageEnqueue{message: message, interrupt: interrupt, notifyUserID: notifyUserID})
+		return nil
+	}
+	return svc
+}
+
+// upstreamFileOnBranch returns the content of a file on a branch in the upstream bare repo,
+// and whether it exists. Used to prove the attachment actually reached the pushed repo.
+func (s *GitIntegrationSuite) upstreamFileOnBranch(branch, path string) (string, bool) {
+	stdout, _, err := gitcmd.NewCommand("show").
+		AddDynamicArguments(branch+":"+path).
+		RunStdString(s.ctx, &gitcmd.RunOpts{Dir: s.upstreamDir})
+	if err != nil {
+		return "", false
+	}
+	return stdout, true
+}
+
+// TestStageUploadedAttachments_RacingUploadAfterPlanning reproduces the bug: an attachment
+// is uploaded AFTER the planning session already exists (its prompt was built without the
+// file). StageUploadedAttachments must (a) commit the file to the helix-specs branch and
+// push it upstream, (b) set CommittedSHA, and (c) enqueue a non-interrupt note so the agent
+// is told to read it.
+func (s *GitIntegrationSuite) TestStageUploadedAttachments_RacingUploadAfterPlanning() {
+	require := s.Require()
+
+	project := &types.Project{ID: "proj-1", DefaultRepoID: "test-repo"}
+	task := &types.SpecTask{
+		ID:                "task-1",
+		ProjectID:         "proj-1",
+		CreatedBy:         "test-user",
+		DesignDocPath:     "000123_racing-task",
+		PlanningSessionID: "ses-1", // planning already running — the bug's precondition
+	}
+	att := &types.SpecTaskAttachment{
+		ID:            "att-1",
+		SpecTaskID:    "task-1",
+		Filename:      "screenshot.png",
+		MimeType:      "image/png",
+		SizeBytes:     2250000,
+		FilestorePath: "/filestore/att-1__screenshot.png",
+	}
+
+	s.mockStore.EXPECT().GetSpecTask(gomock.Any(), "task-1").Return(task, nil).AnyTimes()
+	s.mockStore.EXPECT().GetProject(gomock.Any(), "proj-1").Return(project, nil).AnyTimes()
+	s.mockStore.EXPECT().ListSpecTaskAttachments(gomock.Any(), "task-1").
+		Return([]*types.SpecTaskAttachment{att}, nil).AnyTimes()
+	s.mockStore.EXPECT().UpdateSpecTaskAttachment(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	var enqueued []stageEnqueue
+	svc := s.newStageService(&enqueued)
+
+	err := svc.StageUploadedAttachments(s.ctx, "task-1")
+	require.NoError(err)
+
+	// (a) file reached the pushed upstream repo under the task's attachments dir
+	content, ok := s.upstreamFileOnBranch(SpecsBranchName, "design/tasks/000123_racing-task/attachments/screenshot.png")
+	require.True(ok, "attachment must exist on helix-specs branch upstream")
+	require.Equal("fake-bytes-for-/filestore/att-1__screenshot.png", content)
+
+	// (b) CommittedSHA persisted on the row (idempotency marker)
+	require.NotEmpty(att.CommittedSHA, "CommittedSHA must be set after staging")
+
+	// (c) agent notified exactly once, non-interrupt, to the task creator, pointing at the dir
+	require.Len(enqueued, 1, "agent must be notified about the late attachment")
+	require.False(enqueued[0].interrupt, "note must not interrupt in-flight work")
+	require.Equal("test-user", enqueued[0].notifyUserID)
+	require.Contains(enqueued[0].message, "design/tasks/000123_racing-task/attachments/screenshot.png")
+}
+
+// TestStageUploadedAttachments_BacklogNoSession covers the case where planning has not
+// started yet (no PlanningSessionID). The file must still be committed so it is present
+// when the planning prompt is later built — but no note is enqueued (the prompt will list
+// it via ListSpecTaskAttachments).
+func (s *GitIntegrationSuite) TestStageUploadedAttachments_BacklogNoSession() {
+	require := s.Require()
+
+	project := &types.Project{ID: "proj-2", DefaultRepoID: "test-repo"}
+	task := &types.SpecTask{
+		ID:            "task-2",
+		ProjectID:     "proj-2",
+		CreatedBy:     "test-user",
+		DesignDocPath: "000124_backlog-task",
+		// PlanningSessionID intentionally empty
+	}
+	att := &types.SpecTaskAttachment{
+		ID:            "att-2",
+		SpecTaskID:    "task-2",
+		Filename:      "notes.md",
+		MimeType:      "text/markdown",
+		SizeBytes:     42,
+		FilestorePath: "/filestore/att-2__notes.md",
+	}
+
+	s.mockStore.EXPECT().GetSpecTask(gomock.Any(), "task-2").Return(task, nil).AnyTimes()
+	s.mockStore.EXPECT().GetProject(gomock.Any(), "proj-2").Return(project, nil).AnyTimes()
+	s.mockStore.EXPECT().ListSpecTaskAttachments(gomock.Any(), "task-2").
+		Return([]*types.SpecTaskAttachment{att}, nil).AnyTimes()
+	s.mockStore.EXPECT().UpdateSpecTaskAttachment(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	var enqueued []stageEnqueue
+	svc := s.newStageService(&enqueued)
+
+	err := svc.StageUploadedAttachments(s.ctx, "task-2")
+	require.NoError(err)
+
+	_, ok := s.upstreamFileOnBranch(SpecsBranchName, "design/tasks/000124_backlog-task/attachments/notes.md")
+	require.True(ok, "attachment must be committed even before planning starts")
+	require.NotEmpty(att.CommittedSHA)
+	require.Empty(enqueued, "no note should be enqueued when there is no planning session")
+}
+
+// TestStageUploadedAttachments_Idempotent proves double-staging is safe: an attachment whose
+// CommittedSHA is already set is not re-committed, and — because there is nothing new to
+// stage — the agent is not re-notified.
+func (s *GitIntegrationSuite) TestStageUploadedAttachments_Idempotent() {
+	require := s.Require()
+
+	project := &types.Project{ID: "proj-3", DefaultRepoID: "test-repo"}
+	task := &types.SpecTask{
+		ID:                "task-3",
+		ProjectID:         "proj-3",
+		CreatedBy:         "test-user",
+		DesignDocPath:     "000125_idem-task",
+		PlanningSessionID: "ses-3",
+	}
+	att := &types.SpecTaskAttachment{
+		ID:            "att-3",
+		SpecTaskID:    "task-3",
+		Filename:      "already.png",
+		MimeType:      "image/png",
+		SizeBytes:     100,
+		FilestorePath: "/filestore/att-3__already.png",
+	}
+
+	s.mockStore.EXPECT().GetSpecTask(gomock.Any(), "task-3").Return(task, nil).AnyTimes()
+	s.mockStore.EXPECT().GetProject(gomock.Any(), "proj-3").Return(project, nil).AnyTimes()
+	s.mockStore.EXPECT().ListSpecTaskAttachments(gomock.Any(), "task-3").
+		Return([]*types.SpecTaskAttachment{att}, nil).AnyTimes()
+	s.mockStore.EXPECT().UpdateSpecTaskAttachment(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	var enqueued []stageEnqueue
+	svc := s.newStageService(&enqueued)
+
+	// First call stages + notifies.
+	require.NoError(svc.StageUploadedAttachments(s.ctx, "task-3"))
+	require.Len(enqueued, 1)
+	firstSHA := att.CommittedSHA
+	require.NotEmpty(firstSHA)
+
+	// Second call: nothing pending → no re-commit, no re-notify. The note branch is gated
+	// on there being un-staged work, so a fully-committed set is a no-op for notification.
+	require.NoError(svc.StageUploadedAttachments(s.ctx, "task-3"))
+	require.Equal(firstSHA, att.CommittedSHA, "CommittedSHA must not change on re-stage")
+	require.Len(enqueued, 1, "a fully-staged attachment must not re-notify the agent")
+}


### PR DESCRIPTION
## Summary

Spec-task attachments uploaded from the UI could be lost when the upload raced
`start-planning`. Staging into the `helix-specs` branch happened **only** at
planning time, so a slow upload that finished after the planning prompt was built
was never committed to `design/tasks/<taskDir>/attachments/` and the agent was
never told about it. (The CLI `--attach` path was immune because it uploads before
triggering planning.)

This makes attachment staging independent of the planning race: attachments are
staged into `helix-specs` **at upload time**, and if a planning session already
exists, the agent is notified about the late arrival via the existing prompt
queue.

## Changes

- **`api/pkg/services/spec_task_attachments.go`** — add `StageUploadedAttachments`:
  stages any un-staged attachments into `helix-specs` by reusing the idempotent
  `commitAttachmentsToHelixSpecs`, and — only when a planning session already
  exists and something new actually arrived — enqueues a non-interrupt
  "attachment added" note (built from `BuildAttachmentsSection`) so the agent
  reads it.
- **`api/pkg/server/spec_task_attachments_handlers.go`** — after creating the
  attachment rows, `uploadSpecTaskAttachments` calls `StageUploadedAttachments`
  (detached context so a client disconnect can't abort the commit). Staging
  failure is non-fatal: the row + blob exist and planning-time staging remains a
  backstop.
- **`api/pkg/services/spec_task_attachments_stage_test.go`** — new integration
  tests against a real git repo covering the racing upload (stage + notify), the
  backlog case (stage, no notify), and idempotency (no double-commit, no
  re-notify).

## Why it closes the race

`PlanningSessionID` is the discriminator across all request orderings:

- **Upload before planning** (CLI, or UI wins): file staged now; planning lists it
  in the prompt (commit skipped as idempotent).
- **Upload after the planning prompt was built** (the bug): file staged now **and**
  a session exists → the agent is notified.
- **Upload while still in backlog** (no session yet): file staged now; the planning
  prompt lists it later.

## Testing

- **Unit/integration** (`api/pkg/services`, real git, `CGO_ENABLED=1`): all three
  scenarios pass.
- **Live E2E in dev Helix**: created a task with an attachment via the real UI on
  a project with a local repo. Backlog upload → `committed_sha` set and file
  present at `design/tasks/000001_e2e-test-verify/attachments/e2e-attach-proof.png`.
  Then, with a planning session present, a second upload → file staged **and** a
  `prompt_history_entries` row queued (status `pending`, `interrupt=false`) with
  the "A new attachment was added…" note. Confirmed via DB, git tree, and API
  logs (`Committed attachments to helix-specs branch` + `[QUEUE] Enqueued agent
  message`).

## Screenshots

See `design/tasks/002235_fix-the-bug-below-end-to/screenshots/` on the helix-specs
branch (`02-attachments-staged.png`).

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kwxdvkh4v0c9rn9r1c0w36xx)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002235_fix-the-bug-below-end-to/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002235_fix-the-bug-below-end-to/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002235_fix-the-bug-below-end-to/tasks.md)

🚀 Built with [Helix](https://helix.ml)