### PR TITLE
fix(vcs): request full scopes when reconnecting via connected-services modal

### DIFF
--- a/frontend/src/components/account/OAuthConnections.tsx
+++ b/frontend/src/components/account/OAuthConnections.tsx
@@ -33,6 +33,7 @@ import useAccount from '../../hooks/useAccount'
 import useRouter from '../../hooks/useRouter'
 import { useSettingsDialog } from '../../contexts/settingsDialog'
 import { formatDate } from '../../utils/format'
+import { vcsScopesForProvider } from '../../utils/oauthProviders'
 import { 
   PROVIDER_ICONS,
   PROVIDER_COLORS,
@@ -278,8 +279,18 @@ const OAuthConnections: React.FC<{}> = () => {
       const normalizedProviderId = providerId.toLowerCase();
       console.log('🍅 TOMATO: Using normalized provider ID:', normalizedProviderId);
       
-      console.log('🍅 TOMATO: Calling API endpoint:', `/api/v1/oauth/flow/start/${normalizedProviderId}`);
-      const response = await api.get(`/api/v1/oauth/flow/start/${normalizedProviderId}`)
+      // Request the full VCS scope set for the provider. GitHub (and other VCS
+      // providers) REPLACE a token's scopes on re-auth, so reconnecting here
+      // without scopes would downgrade an existing grant. Non-VCS providers get
+      // undefined → no scopes param → unchanged default behaviour.
+      const vcsScopes = vcsScopesForProvider(providerDetails?.type, providerDetails?.name);
+      let flowUrl = `/api/v1/oauth/flow/start/${normalizedProviderId}`;
+      if (vcsScopes && vcsScopes.length > 0) {
+        flowUrl += `?scopes=${encodeURIComponent(vcsScopes.join(','))}`;
+      }
+
+      console.log('🍅 TOMATO: Calling API endpoint:', flowUrl);
+      const response = await api.get(flowUrl)
       console.log('🍅 TOMATO: API response for OAuth flow:', response);
       
       // If the response is null or undefined, the provider likely doesn't exist in the database

--- a/frontend/src/hooks/useOAuthFlow.ts
+++ b/frontend/src/hooks/useOAuthFlow.ts
@@ -1,12 +1,10 @@
 import { useState, useCallback } from 'react'
 import useApi from './useApi'
 
-// Full GitHub scope set to request on EVERY VCS connect. GitHub REPLACES (does
-// not union) a token's scopes on re-authorization, so requesting a subset here
-// silently downgrades an existing full-scope grant — which strands repos that
-// need workflow/read:org/etc. and breaks push. Keep every GitHub VCS connect
-// entry point on this single set.
-export const GITHUB_VCS_SCOPES = ['repo', 'workflow', 'read:org', 'read:user', 'user:email']
+// Re-exported from utils/oauthProviders (single source of truth) so the many
+// callers that import it from this hook keep working. See vcsScopesForProvider
+// there for the per-provider connect scope sets.
+export { GITHUB_VCS_SCOPES } from '../utils/oauthProviders'
 
 interface StartOAuthFlowOptions {
   providerId: string

--- a/frontend/src/utils/oauthProviders.ts
+++ b/frontend/src/utils/oauthProviders.ts
@@ -82,6 +82,29 @@ export const mapProviderToRepoType = (provider: ProviderType): TypesExternalRepo
   }
 }
 
+// Full connect-time scope set for GitHub VCS. GitHub REPLACES (does not union) a
+// token's scopes on re-authorization, so every connect/reconnect entry point must
+// request the whole set or it silently downgrades an existing grant. Single source
+// of truth — re-exported from hooks/useOAuthFlow for existing importers.
+export const GITHUB_VCS_SCOPES = ['repo', 'workflow', 'read:org', 'read:user', 'user:email']
+
+/**
+ * Scopes to request when connecting/reconnecting a VCS provider, by provider
+ * type/name. Returns undefined for non-VCS (or unknown) providers so their default
+ * connect behaviour is left untouched. Mirrors the backend vcs.RequiredScopes plus
+ * GitHub's workflow scope, and matches BrowseProvidersDialog.
+ */
+export const vcsScopesForProvider = (
+  type: string | undefined | null,
+  name: string | undefined | null,
+): string[] | undefined => {
+  if (matchesProviderType(type, name, 'github')) return GITHUB_VCS_SCOPES
+  if (matchesProviderType(type, name, 'gitlab')) return ['read_repository', 'write_repository', 'read_user']
+  if (matchesProviderType(type, name, 'azure-devops')) return ['vso.code_write']
+  if (matchesProviderType(type, name, 'bitbucket')) return ['repository', 'repository:write']
+  return undefined
+}
+
 /**
  * Check if an OAuth connection has the required scopes.
  * Returns false if no scopes are present on the connection or if requiredScopes is empty.


### PR DESCRIPTION
## Problem

The **"Switch / reconnect / disconnect"** menu on the project VCS lozenge opens the connected-services dialog (`OAuthConnections.tsx`). Its reconnect called `/api/v1/oauth/flow/start/{provider}` with **no `scopes` param**, so GitHub was asked for the provider default (empty on our instances) and issued a **minimal token**. Reconnecting a working GitHub connection through this modal silently stripped its scopes — the same failure mode as the spec-task connect paths fixed in #2823, just a third surface.

## Fix

- New `vcsScopesForProvider(type, name)` in `utils/oauthProviders.ts` — the single source of truth for per-provider VCS connect scopes:
  - github → `repo, workflow, read:org, read:user, user:email`
  - gitlab → `read_repository, write_repository, read_user`
  - azure-devops → `vso.code_write`
  - bitbucket → `repository, repository:write`
  - anything else → `undefined` (no scopes param, default behaviour preserved for non-VCS providers)
- `GITHUB_VCS_SCOPES` moved here and re-exported from `hooks/useOAuthFlow` so the existing 7 importers are unaffected.
- The connected-services reconnect now appends the resolved scopes to the flow URL.

## Testing

- `yarn build` (tsc + vite) — passes.
- Deployed to meta (this host, hot-reload) for live verification.

Follow-up to #2823.

🤖 Generated with [Claude Code](https://claude.com/claude-code)