### PR TITLE
fix(vcs): close remaining GitHub/GitLab reconnect gaps (PR clients + wizard scopes)

### DIFF
--- a/api/pkg/services/git_repository_service_pull_requests.go
+++ b/api/pkg/services/git_repository_service_pull_requests.go
@@ -633,6 +633,16 @@ func (s *GitRepositoryService) getGitHubClient(ctx context.Context, repo *types.
 		if err == nil && conn.AccessToken != "" {
 			return github.NewClientWithOAuthAndBaseURL(conn.AccessToken, baseURL), nil
 		}
+		// The pinned connection is gone (the owner disconnected/reconnected GitHub,
+		// which soft-deletes the old connection row). Self-heal to the repo owner's
+		// newest live connection for the same provider, matching the git-credential
+		// path in getCredentialsForRepo — otherwise PR operations fail with "no
+		// GitHub authentication configured" even though push works.
+		if repo.OwnerID != "" {
+			if token := s.newestLiveOAuthToken(ctx, repo.OwnerID, repo.ExternalType); token != "" {
+				return github.NewClientWithOAuthAndBaseURL(token, baseURL), nil
+			}
+		}
 	}
 
 	// Check for GitHub-specific PAT

--- a/api/pkg/services/git_repository_service_pull_requests.go
+++ b/api/pkg/services/git_repository_service_pull_requests.go
@@ -811,6 +811,14 @@ func (s *GitRepositoryService) getGitLabClient(ctx context.Context, repo *types.
 		if err == nil && conn.AccessToken != "" {
 			return gitlab.NewClientWithOAuth(baseURL, conn.AccessToken)
 		}
+		// Pinned connection is gone (owner disconnected/reconnected). Self-heal to
+		// the repo owner's newest live connection, matching getGitHubClient and the
+		// git-credential path in getCredentialsForRepo.
+		if repo.OwnerID != "" {
+			if token := s.newestLiveOAuthToken(ctx, repo.OwnerID, repo.ExternalType); token != "" {
+				return gitlab.NewClientWithOAuth(baseURL, token)
+			}
+		}
 	}
 
 	// Check for GitLab-specific PAT

--- a/frontend/src/components/project/SampleProjectWizard.tsx
+++ b/frontend/src/components/project/SampleProjectWizard.tsx
@@ -34,7 +34,7 @@ import {
 import { useQuery } from '@tanstack/react-query'
 import useApi from '../../hooks/useApi'
 import useSnackbar from '../../hooks/useSnackbar'
-import useOAuthFlow from '../../hooks/useOAuthFlow'
+import useOAuthFlow, { GITHUB_VCS_SCOPES } from '../../hooks/useOAuthFlow'
 import {
   TypesCheckSampleProjectAccessResponse,
   TypesRepositoryAccessCheck,
@@ -424,7 +424,12 @@ const SampleProjectWizard: FC<SampleProjectWizardProps> = ({
                   return
                 }
 
-                const scopes = sampleProject?.required_scopes || ['repo', 'read:user', 'user:email']
+                // Always request at least the full VCS baseline so connecting here
+                // can't downgrade an existing grant (GitHub replaces scopes on
+                // re-auth); union any sample-declared extras on top.
+                const scopes = Array.from(
+                  new Set([...GITHUB_VCS_SCOPES, ...(sampleProject?.required_scopes || [])])
+                )
                 await startOAuthFlow({
                   providerId: githubProvider.id,
                   scopes,


### PR DESCRIPTION
## Context

Follow-up audit after #2823/#2825 for **every** remaining path that breaks (or downgrades) after a GitHub disconnect/reconnect. Reconnect soft-deletes the old OAuth connection and mints a new one, so any code that pins `OAuthConnectionID` or requests a subset of scopes was still fragile.

## What this closes

**Credential self-heal (backend)** — when the pinned connection is soft-deleted, fall back to the repo owner's newest live connection (`newestLiveOAuthToken`, from #2823):
- `getGitHubClient` — GitHub PR list/create (this was the reported "no GitHub authentication configured" failure).
- `getGitLabClient` — GitLab MR ops had the identical gap.

**Scope-downgrade (frontend)**:
- `SampleProjectWizard` defaulted to `['repo','read:user','user:email']` (missing `workflow`/`read:org`); now unions `GITHUB_VCS_SCOPES` so onboarding can't shrink an existing grant.

## Audit result — everything else is clean

- `getCredentialsForRepo` (push/fetch) — already self-heals (#2823).
- `getAzureDevOpsClient` / `getBitbucketClient` — use PATs, no OAuth-connection pin.
- `shouldOpenPullRequest` — GitHub returns true regardless of the pin.
- `GetActingAccountHandle` — cosmetic push-attribution label only; dangling pin yields an empty label, non-breaking.
- All 8 frontend connect surfaces now request the full VCS scope set via the single `GITHUB_VCS_SCOPES` / `vcsScopesForProvider` source of truth.

## Testing

- `go build ./pkg/services/` and `yarn build` — pass.
- Deployed live on meta via hot-reload.

Follow-up to #2823 / #2825.

🤖 Generated with [Claude Code](https://claude.com/claude-code)