### PR TITLE
feat(frontend): improve org chart details and chat activity

### DIFF
--- a/api/pkg/server/claude_subscription_handlers.go
+++ b/api/pkg/server/claude_subscription_handlers.go
@@ -310,7 +310,7 @@ func (apiServer *HelixAPIServer) listClaudeModels(_ http.ResponseWriter, req *ht
 
 // SessionClaudeCredentialsResponse returns credentials in the appropriate format.
 type SessionClaudeCredentialsResponse struct {
-	CredentialType string                       `json:"credential_type"`            // "oauth" or "setup_token"
+	CredentialType string                        `json:"credential_type"` // "oauth" or "setup_token"
 	OAuthCreds     *types.ClaudeOAuthCredentials `json:"oauth_credentials,omitempty"`
 	SetupToken     string                        `json:"setup_token,omitempty"`
 }
@@ -525,9 +525,9 @@ func (apiServer *HelixAPIServer) startClaudeLogin(_ http.ResponseWriter, req *ht
 		OwnerType:      types.OwnerTypeUser,
 		OrganizationID: orgID,
 		Metadata: types.SessionMetadata{
-			Stream:       true,
-			AgentType:    "zed_external",
-			SessionRole:  "exploratory",
+			Stream:      true,
+			AgentType:   "zed_external",
+			SessionRole: "exploratory",
 		},
 	}
 

--- a/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
+++ b/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
@@ -371,10 +371,7 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
                             color={sub.status === 'active' ? 'success' : 'warning'}
                             size="small"
                           />
-                        )}
-                        {subIsSetupToken && (
-                          <Chip label="Setup Token" size="small" variant="outlined" />
-                        )}
+                        )}                        
                         {sub.subscription_type && (
                           <Chip label={sub.subscription_type} size="small" variant="outlined" />
                         )}
@@ -472,12 +469,6 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
                 {expiry.isExpiringSoon && !isExpired && <WarningAmberIcon sx={{ fontSize: 12 }} />}
                 {isExpired && <ErrorOutlineIcon sx={{ fontSize: 12 }} />}
                 {expiry.label}
-              </Typography>
-            )}
-            {isSetupToken && (
-              <Typography variant="caption" color="success.main" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                <CheckCircleIcon sx={{ fontSize: 12 }} />
-                Setup token
               </Typography>
             )}
           </Box>

--- a/frontend/src/components/helix-org/HelixOrgSideDrawer.tsx
+++ b/frontend/src/components/helix-org/HelixOrgSideDrawer.tsx
@@ -16,6 +16,7 @@ export type HelixOrgSideDrawerProps = {
   title: string
   /** Paper width in px. Default 460 (matches processor form). */
   width?: number
+  headerAction?: ReactNode
   children: ReactNode
 }
 
@@ -24,6 +25,7 @@ const HelixOrgSideDrawer: FC<HelixOrgSideDrawerProps> = ({
   onClose,
   title,
   width = 460,
+  headerAction,
   children,
 }) => (
   <Drawer
@@ -50,9 +52,12 @@ const HelixOrgSideDrawer: FC<HelixOrgSideDrawerProps> = ({
         sx={{ mb: 2, flexShrink: 0 }}
       >
         <Typography variant="h6">{title}</Typography>
-        <IconButton size="small" onClick={onClose} aria-label="Close">
-          <CloseIcon />
-        </IconButton>
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          {headerAction}
+          <IconButton size="small" onClick={onClose} aria-label="Close">
+            <CloseIcon />
+          </IconButton>
+        </Stack>
       </Stack>
       <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>{children}</Box>
     </Box>

--- a/frontend/src/components/helix-org/ProcessorConfigDrawer.tsx
+++ b/frontend/src/components/helix-org/ProcessorConfigDrawer.tsx
@@ -22,8 +22,10 @@ import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import CloseIcon from '@mui/icons-material/Close'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 
 import useSnackbar from '../../hooks/useSnackbar'
+import useRouter from '../../hooks/useRouter'
 import MonacoEditor from '../widgets/MonacoEditor'
 import HelixOrgSideDrawer from './HelixOrgSideDrawer'
 import {
@@ -231,6 +233,7 @@ const SyntaxHelp: FC<{ kind: string }> = ({ kind }) => {
 }
 
 const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, processor, presetInputTopicId }) => {
+  const router = useRouter()
   const snackbar = useSnackbar()
   const isEdit = Boolean(processor)
   const createProc = useCreateHelixOrgProcessor()
@@ -336,6 +339,18 @@ const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, 
       onClose={onClose}
       title={isEdit ? 'Edit processor' : 'New processor'}
       width={kind === 'js' ? 560 : 460}
+      headerAction={isEdit ? (
+        <Button
+          size="small"
+          endIcon={<OpenInNewIcon />}
+          onClick={() => router.navigate('helix_org_processor_detail', {
+            org_id: router.params.org_id,
+            processor_id: processor!.id,
+          })}
+        >
+          Full page
+        </Button>
+      ) : undefined}
     >
         <Stack spacing={1.5}>
           <Typography variant="body2" color="text.secondary">

--- a/frontend/src/components/helix-org/ProcessorConfigDrawer.tsx
+++ b/frontend/src/components/helix-org/ProcessorConfigDrawer.tsx
@@ -22,11 +22,11 @@ import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import CloseIcon from '@mui/icons-material/Close'
-import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 
 import useSnackbar from '../../hooks/useSnackbar'
 import useRouter from '../../hooks/useRouter'
 import MonacoEditor from '../widgets/MonacoEditor'
+import CopyButtonWithCheck from '../session/CopyButtonWithCheck'
 import HelixOrgSideDrawer from './HelixOrgSideDrawer'
 import {
   ProcessorDTO,
@@ -342,17 +342,25 @@ const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, 
       headerAction={isEdit ? (
         <Button
           size="small"
-          endIcon={<OpenInNewIcon />}
           onClick={() => router.navigate('helix_org_processor_detail', {
             org_id: router.params.org_id,
             processor_id: processor!.id,
           })}
         >
-          Full page
+          Details
         </Button>
       ) : undefined}
     >
         <Stack spacing={1.5}>
+          {isEdit && (
+            <Stack direction="row" spacing={0.5} alignItems="center">
+              <Typography variant="caption" color="text.secondary">Processor ID</Typography>
+              <Typography variant="body2" sx={{ fontFamily: 'monospace', overflowWrap: 'anywhere' }}>
+                {processor!.id}
+              </Typography>
+              <CopyButtonWithCheck text={processor!.id} />
+            </Stack>
+          )}
           <Typography variant="body2" color="text.secondary">
             A processor sits between topics: it reads messages from one topic,
             then rewrites, shortens, sorts, or runs JavaScript on them onto new topics that bots can subscribe to.

--- a/frontend/src/components/helix-org/TopicDetailDrawer.tsx
+++ b/frontend/src/components/helix-org/TopicDetailDrawer.tsx
@@ -3,11 +3,11 @@ import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
-import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 
 import useRouter from '../../hooks/useRouter'
 import useSnackbar from '../../hooks/useSnackbar'
 import LoadingSpinner from '../widgets/LoadingSpinner'
+import CopyButtonWithCheck from '../session/CopyButtonWithCheck'
 import { useHelixOrgTopic, useUpdateHelixOrgTopic } from '../../services/helixOrgService'
 import { TopicConfigSection } from '../../pages/HelixOrgTopicDetail'
 import HelixOrgSideDrawer from './HelixOrgSideDrawer'
@@ -33,13 +33,12 @@ const TopicDetailDrawer: FC<TopicDetailDrawerProps> = ({ topicId, consumerCount,
       headerAction={topicId ? (
         <Button
           size="small"
-          endIcon={<OpenInNewIcon />}
           onClick={() => router.navigate('helix_org_topic_detail', {
             org_id: router.params.org_id,
             topic_id: topicId,
           })}
         >
-          Full page
+          Details
         </Button>
       ) : undefined}
     >
@@ -51,6 +50,7 @@ const TopicDetailDrawer: FC<TopicDetailDrawerProps> = ({ topicId, consumerCount,
             <Typography variant="body2" sx={{ fontFamily: 'monospace', overflowWrap: 'anywhere' }}>
               {topic.id}
             </Typography>
+            <CopyButtonWithCheck text={topic.id} />
             <Chip label={topic.kind} size="small" />
           </Stack>
           <Typography variant="body2" color="text.secondary">

--- a/frontend/src/components/helix-org/TopicDetailDrawer.tsx
+++ b/frontend/src/components/helix-org/TopicDetailDrawer.tsx
@@ -1,0 +1,79 @@
+import { FC } from 'react'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+
+import useRouter from '../../hooks/useRouter'
+import useSnackbar from '../../hooks/useSnackbar'
+import LoadingSpinner from '../widgets/LoadingSpinner'
+import { useHelixOrgTopic, useUpdateHelixOrgTopic } from '../../services/helixOrgService'
+import { TopicConfigSection } from '../../pages/HelixOrgTopicDetail'
+import HelixOrgSideDrawer from './HelixOrgSideDrawer'
+
+type TopicDetailDrawerProps = {
+  topicId?: string
+  consumerCount?: number
+  onClose: () => void
+}
+
+const TopicDetailDrawer: FC<TopicDetailDrawerProps> = ({ topicId, consumerCount, onClose }) => {
+  const router = useRouter()
+  const snackbar = useSnackbar()
+  const { data: topic, isLoading } = useHelixOrgTopic(topicId)
+  const updateTopic = useUpdateHelixOrgTopic()
+
+  return (
+    <HelixOrgSideDrawer
+      open={Boolean(topicId)}
+      onClose={onClose}
+      title={topic?.name || topicId || 'Topic'}
+      width={560}
+      headerAction={topicId ? (
+        <Button
+          size="small"
+          endIcon={<OpenInNewIcon />}
+          onClick={() => router.navigate('helix_org_topic_detail', {
+            org_id: router.params.org_id,
+            topic_id: topicId,
+          })}
+        >
+          Full page
+        </Button>
+      ) : undefined}
+    >
+      {isLoading ? <LoadingSpinner /> : !topic ? (
+        <Typography color="text.secondary">Topic not found.</Typography>
+      ) : (
+        <Stack spacing={2}>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Typography variant="body2" sx={{ fontFamily: 'monospace', overflowWrap: 'anywhere' }}>
+              {topic.id}
+            </Typography>
+            <Chip label={topic.kind} size="small" />
+          </Stack>
+          <Typography variant="body2" color="text.secondary">
+            {consumerCount ?? topic.subscribers?.length ?? 0} subscriber{(consumerCount ?? topic.subscribers?.length) === 1 ? '' : 's'}
+          </Typography>
+          <TopicConfigSection
+            topic={topic}
+            saving={updateTopic.isPending}
+            onSave={async (payload) => {
+              try {
+                await updateTopic.mutateAsync({ topicId: topic.id, payload })
+                snackbar.success('topic updated')
+                return true
+              } catch (e: any) {
+                snackbar.error(e?.response?.data?.error || e?.message || 'update failed')
+                return false
+              }
+            }}
+          />
+        </Stack>
+      )}
+    </HelixOrgSideDrawer>
+  )
+}
+
+export default TopicDetailDrawer

--- a/frontend/src/components/orgs/OrgSidebar.tsx
+++ b/frontend/src/components/orgs/OrgSidebar.tsx
@@ -105,7 +105,7 @@ const OrgSidebar: FC = () => {
           id: 'providers',
           label: 'Providers',
           icon: <Plug size={20} />,
-          isActive: currentRouteName === 'org_providers',
+          isActive: currentRouteName === 'org_providers' || currentRouteName === 'org_provider_detail',
           onClick: () => handleNavigationClick('org_providers'),
         },
       ],

--- a/frontend/src/components/orgs/UserOrgSelector.tsx
+++ b/frontend/src/components/orgs/UserOrgSelector.tsx
@@ -464,6 +464,8 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
             'org_billing',
             'org_usage',
             'org_api_keys',
+            'org_providers',
+            'org_provider_detail',
             'org_qa',
             'org_qa-results',
           ]),

--- a/frontend/src/components/providers/AddProviderDialog.tsx
+++ b/frontend/src/components/providers/AddProviderDialog.tsx
@@ -2,6 +2,9 @@ import React, { useState, useEffect } from 'react';
 import {
   DialogContent,
   DialogActions,
+  Dialog,
+  DialogContentText,
+  DialogTitle,
   Button,
   Box,
   Typography,
@@ -81,6 +84,7 @@ const AddProviderDialog: React.FC<AddProviderDialogProps> = ({
   const [modelName, setModelName] = useState('');
   const [showApiKey, setShowApiKey] = useState(false);
   const [isFieldFocused, setIsFieldFocused] = useState(false);
+  const [disconnectConfirmationOpen, setDisconnectConfirmationOpen] = useState(false);
   const { mutateAsync: createProviderEndpoint, isPending: isCreating } = useCreateProviderEndpoint();
   const { mutateAsync: updateProviderEndpoint, isPending: isUpdating } = useUpdateProviderEndpoint();
   const { mutateAsync: deleteProviderEndpoint, isPending: isDeleting } = useDeleteProviderEndpoint();
@@ -121,6 +125,7 @@ const AddProviderDialog: React.FC<AddProviderDialogProps> = ({
     setModelName('');
     setError(null);
     setIsFieldFocused(false);
+    setDisconnectConfirmationOpen(false);
     onClose();
   };
 
@@ -223,29 +228,31 @@ const AddProviderDialog: React.FC<AddProviderDialogProps> = ({
       snackbarSuccess('Provider disconnected successfully');
       handleClose();
     } catch (err) {
+      setDisconnectConfirmationOpen(false);
       setError(err instanceof Error ? err.message : 'Failed to disconnect provider');
     }
   };
 
   return (
-    <DarkDialog 
-      open={open} 
-      onClose={handleClose} 
-      maxWidth="md" 
-      fullWidth
-      TransitionProps={{
-        onExited: () => {
-          setApiKey('');
-          setCustomName('');
-          setCustomNameError(null);
-          setBaseUrlError(null);
-          setModelName('');
-          setError(null);
-          setIsFieldFocused(false);
-          onClosed?.();
-        }
-      }}
-    >
+    <>
+      <DarkDialog
+        open={open}
+        onClose={handleClose}
+        maxWidth="md"
+        fullWidth
+        TransitionProps={{
+          onExited: () => {
+            setApiKey('');
+            setCustomName('');
+            setCustomNameError(null);
+            setBaseUrlError(null);
+            setModelName('');
+            setError(null);
+            setIsFieldFocused(false);
+            onClosed?.();
+          }
+        }}
+      >
       <DialogContent sx={lightTheme.scrollbar}>
         <Box sx={{ mt: 2 }}>
           <NameTypography>
@@ -380,7 +387,7 @@ const AddProviderDialog: React.FC<AddProviderDialogProps> = ({
           <Box sx={{ flex: 1 }} />
           {isEditing && (
             <Button
-              onClick={handleDisconnect}
+              onClick={() => setDisconnectConfirmationOpen(true)}
               size="small"
               variant="outlined"
               color="error"
@@ -401,8 +408,30 @@ const AddProviderDialog: React.FC<AddProviderDialogProps> = ({
           </Button>
         </Box>
       </DialogActions>
-    </DarkDialog>
+      </DarkDialog>
+      <Dialog
+        open={disconnectConfirmationOpen}
+        onClose={() => setDisconnectConfirmationOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Disconnect {provider.name}?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Helix will remove the stored API key and stop using this provider.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDisconnectConfirmationOpen(false)} disabled={isDeleting}>
+            Cancel
+          </Button>
+          <Button onClick={handleDisconnect} color="error" disabled={isDeleting}>
+            {isDeleting ? 'Disconnecting…' : 'Disconnect'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
   );
 };
 
-export default AddProviderDialog; 
+export default AddProviderDialog;

--- a/frontend/src/components/session/CollapsibleToolCall.test.tsx
+++ b/frontend/src/components/session/CollapsibleToolCall.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { ThemeProvider, createTheme } from '@mui/material/styles'
+import { describe, expect, it } from 'vitest'
+
+import { CollapsibleToolCall } from './CollapsibleToolCall'
+
+describe('CollapsibleToolCall', () => {
+  it('marks disclosure growth so the chat keeps the header in place', () => {
+    const { container } = render(
+      <div data-session-scroll-container>
+        <ThemeProvider theme={createTheme()}>
+          <CollapsibleToolCall toolName="inspect_topic" status="Completed" body="topic details" />
+        </ThemeProvider>
+      </div>,
+    )
+
+    fireEvent.click(screen.getByText('inspect_topic'))
+
+    expect(screen.getByText('topic details')).toBeInTheDocument()
+    expect(container.firstElementChild).toHaveAttribute('data-preserve-disclosure-expansion', 'true')
+  })
+})

--- a/frontend/src/components/session/CollapsibleToolCall.tsx
+++ b/frontend/src/components/session/CollapsibleToolCall.tsx
@@ -9,6 +9,7 @@ import BuildIcon from "@mui/icons-material/Build";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
+import { preserveDisclosureExpansion } from "./disclosureScroll";
 
 /**
  * Represents a parsed segment of a response message.
@@ -147,7 +148,10 @@ export const CollapsibleToolCall: FC<CollapsibleToolCallProps> = ({
     >
       {/* Collapsed header — always visible */}
       <Box
-        onClick={() => setExpanded(!expanded)}
+        onClick={(event) => {
+          if (!expanded) preserveDisclosureExpansion(event.currentTarget)
+          setExpanded(!expanded)
+        }}
         sx={{
           display: "flex",
           alignItems: "center",

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -371,6 +371,13 @@ const EmbeddedSessionView = forwardRef<
       // yank the viewport.
       if (newHeight <= prevHeight) return;
 
+      // Disclosure bodies grow below their clicked header. Do not treat that
+      // operator action as new chat output and yank the viewport to the bottom.
+      if (container.dataset.preserveDisclosureExpansion === "true") {
+        delete container.dataset.preserveDisclosureExpansion;
+        return;
+      }
+
       if (autoScrollRef.current) {
         container.scrollTop = container.scrollHeight;
         lastScrolledHeightRef.current = container.scrollHeight;
@@ -643,6 +650,7 @@ const EmbeddedSessionView = forwardRef<
       )}
       <Box
         ref={containerRef}
+        data-session-scroll-container
         onScroll={handleScroll}
         onWheel={handleWheel}
         onTouchStart={handleTouchStart}

--- a/frontend/src/components/session/ThinkingWidget.test.tsx
+++ b/frontend/src/components/session/ThinkingWidget.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { ThemeProvider, createTheme } from '@mui/material/styles'
+import { describe, expect, it } from 'vitest'
+
+import ThinkingWidget from './ThinkingWidget'
+
+const renderWidget = (isStreaming = false) => render(
+  <ThemeProvider theme={createTheme()}>
+    <ThinkingWidget text="Inspect the current subscription state" isStreaming={isStreaming} />
+  </ThemeProvider>,
+)
+
+describe('ThinkingWidget', () => {
+  it('uses a collapsed disclosure and reveals the thought on click', () => {
+    renderWidget()
+
+    expect(screen.getByText('Thoughts')).toBeInTheDocument()
+    expect(screen.queryByText('Inspect the current subscription state')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Thoughts'))
+
+    expect(screen.getByText('Inspect the current subscription state')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Collapse thoughts' })).toBeInTheDocument()
+  })
+
+  it('shows an active thinking status while streaming', () => {
+    renderWidget(true)
+
+    expect(screen.getByText(/^Thinking \d+:\d{2}$/)).toBeInTheDocument()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/session/ThinkingWidget.test.tsx
+++ b/frontend/src/components/session/ThinkingWidget.test.tsx
@@ -12,13 +12,20 @@ const renderWidget = (isStreaming = false) => render(
 
 describe('ThinkingWidget', () => {
   it('uses a collapsed disclosure and reveals the thought on click', () => {
-    renderWidget()
+    const { container } = render(
+      <div data-session-scroll-container>
+        <ThemeProvider theme={createTheme()}>
+          <ThinkingWidget text="Inspect the current subscription state" isStreaming={false} />
+        </ThemeProvider>
+      </div>,
+    )
 
     expect(screen.getByText('Thoughts')).toBeInTheDocument()
     expect(screen.queryByText('Inspect the current subscription state')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByText('Thoughts'))
 
+    expect(container.firstElementChild).toHaveAttribute('data-preserve-disclosure-expansion', 'true')
     expect(screen.getByText('Inspect the current subscription state')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Collapse thoughts' })).toBeInTheDocument()
   })

--- a/frontend/src/components/session/ThinkingWidget.tsx
+++ b/frontend/src/components/session/ThinkingWidget.tsx
@@ -7,6 +7,7 @@ import { useTheme } from '@mui/material/styles'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import LightbulbOutlinedIcon from '@mui/icons-material/LightbulbOutlined'
+import { preserveDisclosureExpansion } from './disclosureScroll'
 
 interface ThinkingWidgetProps {
   text: string
@@ -56,7 +57,10 @@ const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStre
       }}
     >
       <Box
-        onClick={() => setExpanded((value) => !value)}
+        onClick={(event) => {
+          if (!expanded) preserveDisclosureExpansion(event.currentTarget)
+          setExpanded((value) => !value)
+        }}
         sx={{
           display: 'flex',
           alignItems: 'center',

--- a/frontend/src/components/session/ThinkingWidget.tsx
+++ b/frontend/src/components/session/ThinkingWidget.tsx
@@ -1,237 +1,117 @@
-import React, { useEffect, useRef, useState } from 'react';
-import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
-import CircularProgress from '@mui/material/CircularProgress';
-import useLightTheme from '../../hooks/useLightTheme';
+import React, { useEffect, useRef, useState } from 'react'
+import Box from '@mui/material/Box'
+import CircularProgress from '@mui/material/CircularProgress'
+import IconButton from '@mui/material/IconButton'
+import Typography from '@mui/material/Typography'
+import { useTheme } from '@mui/material/styles'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import LightbulbOutlinedIcon from '@mui/icons-material/LightbulbOutlined'
 
 interface ThinkingWidgetProps {
-  text: string;
-  startTime?: number | Date;
-  isStreaming: boolean;
-  compact?: boolean;
+  text: string
+  startTime?: number | Date
+  isStreaming: boolean
+  compact?: boolean
 }
 
 function formatDuration(seconds: number) {
-  const m = Math.floor(seconds / 60);
-  const s = seconds % 60;
-  return `${m}:${s.toString().padStart(2, '0')}`;
+  const minutes = Math.floor(seconds / 60)
+  const remainder = seconds % 60
+  return `${minutes}:${remainder.toString().padStart(2, '0')}`
 }
 
-const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStreaming, compact = false }) => {
-  const [elapsed, setElapsed] = useState(0);
-  const [open, setOpen] = useState(false);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
-  const start = useRef<number>(
+const ThinkingWidget: React.FC<ThinkingWidgetProps> = ({ text, startTime, isStreaming }) => {
+  const [elapsed, setElapsed] = useState(0)
+  const [expanded, setExpanded] = useState(false)
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+  const startedAt = useRef(
     typeof startTime === 'number'
       ? startTime
       : startTime instanceof Date
-      ? startTime.getTime()
-      : Date.now()
-  );
-  const textContainerRef = useRef<HTMLDivElement | null>(null);
-  const lightTheme = useLightTheme();
+        ? startTime.getTime()
+        : Date.now(),
+  )
 
   useEffect(() => {
-    // Do not auto-expand/collapse based on isStreaming
-  }, [isStreaming]);
+    if (!isStreaming) return
+    const updateElapsed = () => setElapsed(Math.floor((Date.now() - startedAt.current) / 1000))
+    updateElapsed()
+    const interval = window.setInterval(updateElapsed, 1000)
+    return () => window.clearInterval(interval)
+  }, [isStreaming])
 
-  useEffect(() => {
-    intervalRef.current = setInterval(() => {
-      setElapsed(Math.floor((Date.now() - start.current) / 1000));
-    }, 1000);
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, []);
-
-  // Auto-scroll to bottom in collapsed mode when text changes
-  useEffect(() => {
-    if (!open && textContainerRef.current) {
-      textContainerRef.current.scrollTo({
-        top: textContainerRef.current.scrollHeight,
-        behavior: 'smooth',
-      });
-    }
-  }, [text, open]);
-
-  // Split text into lines for custom rendering
-  const lines = text.split('\n');
-
-  if (!open && !isStreaming) {
-    return (
-      <Box
-        sx={{
-          position: 'relative',
-          borderRadius: 3,
-          boxShadow: 3,
-          background: theme =>
-            theme.palette.mode === 'light'
-              ? 'rgba(245,245,250,0.95)'
-              : 'rgba(30,32,40,0.95)',
-          p: compact ? 1 : { xs: 2, sm: 3 },
-          my: compact ? 1 : 2,
-          overflow: 'hidden',
-          minHeight: compact ? 36 : 60,
-          width: '100%',
-          mx: 0,
-          cursor: 'pointer',
-        }}
-        onClick={() => setOpen(true)}
-      >
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}>
-          <Typography variant="subtitle2" sx={{ fontWeight: 600, color: 'primary.main' }}>
-            💡 Thoughts
-          </Typography>
-          <Typography variant="body2" sx={{ color: 'text.secondary', ml: 2 }}>
-            Expand for details
-          </Typography>
-        </Box>
-      </Box>
-    );
-  }
+  const borderColor = isDark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.12)'
+  const iconColor = isDark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.45)'
+  const textColor = isDark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.6)'
 
   return (
     <Box
       sx={{
-        position: 'relative',
-        borderRadius: 3,
-        boxShadow: 3,
-        background: theme =>
-          theme.palette.mode === 'light'
-            ? 'rgba(245,245,250,0.95)'
-            : 'rgba(30,32,40,0.95)',
-        p: compact ? 1 : { xs: 2, sm: 3 },
-        my: compact ? 1 : 2,
+        my: 1,
+        borderLeft: `3px solid ${borderColor}`,
+        borderRadius: '4px',
         overflow: 'hidden',
-        minHeight: compact ? 60 : 120,
-        width: '100%',
-        mx: 0,
       }}
     >
-      {/* Clickable top bar for collapse/expand */}
       <Box
+        onClick={() => setExpanded((value) => !value)}
         sx={{
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'space-between',
-          width: '100%',
+          gap: 0.75,
+          px: 1.5,
+          py: 0.75,
           cursor: 'pointer',
+          backgroundColor: isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.03)',
+          '&:hover': {
+            backgroundColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.06)',
+          },
+          transition: 'background-color 0.15s ease',
           userSelect: 'none',
-          minHeight: 40,          
         }}
-        onClick={() => setOpen(!open)}
       >
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <Typography variant="subtitle2" sx={{ fontWeight: 600, color: 'primary.main' }}>
-            💡 {isStreaming ? `Thinking ${formatDuration(elapsed)}` : `Thoughts`}
-          </Typography>
-          {isStreaming && (
-            <CircularProgress
-              size={16}
-              thickness={4}
-              sx={{ color: 'primary.main' }}
-            />
-          )}
-        </Box>
-        <Typography variant="body2" sx={{ color: 'text.secondary', ml: 2 }}>
-          {open ? 'Collapse details' : 'Expand for details'}
+        <LightbulbOutlinedIcon sx={{ fontSize: 16, color: iconColor }} />
+        <Typography
+          variant="body2"
+          sx={{ flex: 1, fontSize: '0.82rem', color: textColor, fontFamily: 'monospace' }}
+        >
+          {isStreaming ? `Thinking ${formatDuration(elapsed)}` : 'Thoughts'}
         </Typography>
+        {isStreaming && <CircularProgress size={16} thickness={4} color="warning" />}
+        <IconButton
+          size="small"
+          aria-label={expanded ? 'Collapse thoughts' : 'Expand thoughts'}
+          sx={{ p: 0, ml: 0.5 }}
+        >
+          {expanded
+            ? <ExpandLessIcon sx={{ fontSize: 18 }} />
+            : <ExpandMoreIcon sx={{ fontSize: 18 }} />}
+        </IconButton>
       </Box>
-      {/* Main content, show differently based on open state */}
-      {open ? (
+
+      {expanded && text && (
         <Box
           sx={{
-            position: 'relative',
-            zIndex: 2,
-            py: 2,
+            px: 1.5,
+            py: 1,
+            fontSize: '0.8rem',
+            fontFamily: 'monospace',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            color: isDark ? 'rgba(255,255,255,0.6)' : 'rgba(0,0,0,0.55)',
+            backgroundColor: isDark ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.015)',
+            borderTop: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}`,
+            maxHeight: '300px',
+            overflow: 'auto',
           }}
         >
-          <Typography
-            variant="body1"
-            sx={{
-              color: 'text.primary',
-              px: { xs: 0, sm: 2 },
-              maxHeight: compact ? 100 : 200,
-              overflowY: 'auto',
-              fontSize: 16,
-              fontFamily: 'inherit',
-              whiteSpace: 'pre-line',
-              ...lightTheme.scrollbar,
-            }}
-          >
-            {text}
-          </Typography>
-        </Box>
-      ) : (
-        <Box
-          sx={{
-            position: 'relative',
-            zIndex: 2,
-            py: compact ? 1 : 2,
-            height: compact ? 60 : 120,
-            overflow: 'hidden',
-          }}
-        >
-          {/* Blurred gradient overlays */}
-          <Box
-            sx={{
-              position: 'absolute',
-              left: 0,
-              right: 0,
-              top: 0,
-              height: '35%',
-              pointerEvents: 'none',
-              zIndex: 3,
-              background: theme =>
-                theme.palette.mode === 'light'
-                  ? 'linear-gradient(to bottom, rgba(245,245,250,0.95) 70%, rgba(245,245,250,0.0) 100%)'
-                  : 'linear-gradient(to bottom, rgba(30,32,40,0.95) 70%, rgba(30,32,40,0.0) 100%)',
-              backdropFilter: 'blur(1px)',
-            }}
-          />
-          <Box
-            sx={{
-              position: 'absolute',
-              left: 0,
-              right: 0,
-              bottom: 0,
-              height: '35%',
-              pointerEvents: 'none',
-              zIndex: 3,
-              background: theme =>
-                theme.palette.mode === 'light'
-                  ? 'linear-gradient(to top, rgba(245,245,250,0.95) 70%, rgba(245,245,250,0.0) 100%)'
-                  : 'linear-gradient(to top, rgba(30,32,40,0.95) 70%, rgba(30,32,40,0.0) 100%)',
-              backdropFilter: 'blur(1px)',
-            }}
-          />
-          <Box
-            ref={textContainerRef}
-            sx={{
-              height: '100%',
-              overflowY: 'auto',
-              zIndex: 2,
-              position: 'relative',
-              px: { xs: 0, sm: 2 },
-              ...lightTheme.scrollbar,
-            }}
-          >
-            <Typography
-              variant="body1"
-              sx={{
-                color: 'text.primary',
-                fontSize: 10,
-                fontFamily: 'inherit',
-                whiteSpace: 'pre-line',
-              }}
-            >
-              {text}
-            </Typography>
-          </Box>
+          {text}
         </Box>
       )}
     </Box>
-  );
-};
+  )
+}
 
-export default ThinkingWidget; 
+export default ThinkingWidget

--- a/frontend/src/components/session/disclosureScroll.ts
+++ b/frontend/src/components/session/disclosureScroll.ts
@@ -1,0 +1,6 @@
+export const SESSION_SCROLL_CONTAINER_ATTRIBUTE = 'data-session-scroll-container'
+
+export function preserveDisclosureExpansion(header: HTMLElement) {
+  const container = header.closest<HTMLElement>(`[${SESSION_SCROLL_CONTAINER_ATTRIBUTE}]`)
+  if (container) container.dataset.preserveDisclosureExpansion = 'true'
+}

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -73,6 +73,7 @@ import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrum
 import NewBotDialog from '../components/helix-org/NewBotDialog'
 import NewTopicDrawer from '../components/helix-org/NewTopicDrawer'
 import ProcessorConfigDrawer from '../components/helix-org/ProcessorConfigDrawer'
+import TopicDetailDrawer from '../components/helix-org/TopicDetailDrawer'
 import ProcessorNode, { ProcessorNodeData, PROC_W, procNodeHeight } from '../components/helix-org/ProcessorNode'
 import useAccount from '../hooks/useAccount'
 import useLightTheme from '../hooks/useLightTheme'
@@ -725,6 +726,7 @@ type TopicSummary = {
   kind: string
   created_by?: string
   subscribers?: string[]
+  processorConsumerCount?: number
   // Raw cron expression from transport config (kind=cron only).
   schedule?: string
   // Set to the owning processor id when this topic is that processor's
@@ -1012,7 +1014,7 @@ const buildGraph = (
           topicId: s.id,
           name: s.name,
           kind: s.kind,
-          subscriberCount: s.subscribers?.length ?? 0,
+          subscriberCount: (s.subscribers?.length ?? 0) + (s.processorConsumerCount ?? 0),
           messageCount: messageCounts[s.id] ?? 0,
           scheduleSummary: s.kind === 'cron' && s.schedule
             ? generateCronShortSummary(s.schedule)
@@ -1932,6 +1934,23 @@ const HelixOrgChart: FC = () => {
     [streamsData, ownedOutputTopics],
   )
 
+  const processorConsumerCounts = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const processor of processorsData ?? []) {
+      if (!processor.input_topic_id) continue
+      counts.set(processor.input_topic_id, (counts.get(processor.input_topic_id) ?? 0) + 1)
+    }
+    return counts
+  }, [processorsData])
+
+  const topicsWithConsumerCounts = useMemo<TopicSummary[]>(
+    () => topics.map((topic) => ({
+      ...topic,
+      processorConsumerCount: processorConsumerCounts.get(topic.id) ?? 0,
+    })),
+    [topics, processorConsumerCounts],
+  )
+
   // Per-topic waiting-message counts for the topic cards. One cached query
   // per topic id (shared with the detail page's count hook), so each
   // card's number refreshes independently. topicIds is memoized so the
@@ -1959,6 +1978,7 @@ const HelixOrgChart: FC = () => {
   const [selection, setSelection] = useState<Selection>({ kind: 'none' })
   const [botDialogOpen, setBotDialogOpen] = useState(false)
   const [topicDrawerOpen, setTopicDrawerOpen] = useState(false)
+  const [selectedTopicId, setSelectedTopicId] = useState<string>()
   // Processor drawer: { open, processor } — processor null = create mode.
   const [processorDrawer, setProcessorDrawer] = useState<{ open: boolean; processor: ProcessorDTO | null }>({ open: false, processor: null })
   const [confirmDelete, setConfirmDelete] = useState<
@@ -2055,10 +2075,9 @@ const HelixOrgChart: FC = () => {
   }, [restartBot, snackbar])
   const onSelectTopic = useCallback(
     (topicId: string) => {
-      if (!orgSlug) return
-      router.navigate('helix_org_topic_detail', { org_id: orgSlug, topic_id: topicId })
+      setSelectedTopicId(topicId)
     },
-    [router, orgSlug],
+    [],
   )
   const onDeleteTopic = useCallback((topicId: string) => setConfirmDelete({ kind: 'topic', id: topicId }), [])
   const onSelectProcessor = useCallback(
@@ -2310,7 +2329,7 @@ const HelixOrgChart: FC = () => {
                 onSetProcessorInput={onSetProcessorInput}
                 onLayoutSnapshot={onLayoutSnapshot}
                 onCanvasContextMenu={openCtxMenu}
-                topics={topics}
+                topics={topicsWithConsumerCounts}
                 messageCounts={messageCounts}
                 processors={processorSummaries}
                 savedPositions={savedPositions}
@@ -2374,6 +2393,14 @@ const HelixOrgChart: FC = () => {
       <NewTopicDrawer
         open={topicDrawerOpen}
         onClose={() => setTopicDrawerOpen(false)}
+      />
+      <TopicDetailDrawer
+        topicId={selectedTopicId}
+        consumerCount={selectedTopicId
+          ? (topics.find((topic) => topic.id === selectedTopicId)?.subscribers?.length ?? 0)
+            + (processorConsumerCounts.get(selectedTopicId) ?? 0)
+          : undefined}
+        onClose={() => setSelectedTopicId(undefined)}
       />
       <ConfirmDeleteDialog
         open={confirmDelete !== null}

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -700,10 +700,10 @@ const TopicNode: FC<NodeProps<Node<TopicNodeData>>> = ({ data }) => {
         <Typography variant="caption" sx={{ fontSize: '0.65rem', color: muted, minWidth: 0 }}>
           {data.kind} · {data.subscriberCount} sub{data.subscriberCount === 1 ? '' : 's'}
         </Typography>
-        {/* Waiting-message count. Kept deliberately tiny — the card is
+        {/* Retained-message count. Kept deliberately tiny — the card is
             already dense — and tinted with the topic accent so it reads as
             a topic stat rather than chrome. */}
-        <Tooltip title={`${data.messageCount} message${data.messageCount === 1 ? '' : 's'} waiting`}>
+        <Tooltip title={`${data.messageCount} retained message${data.messageCount === 1 ? '' : 's'}`}>
           <Typography
             variant="caption"
             sx={{ fontSize: '0.65rem', fontFamily: 'monospace', fontWeight: 700, color: accent, lineHeight: 1, flexShrink: 0 }}
@@ -1951,7 +1951,7 @@ const HelixOrgChart: FC = () => {
     [topics, processorConsumerCounts],
   )
 
-  // Per-topic waiting-message counts for the topic cards. One cached query
+  // Per-topic retained-message counts for the topic cards. One cached query
   // per topic id (shared with the detail page's count hook), so each
   // card's number refreshes independently. topicIds is memoized so the
   // fan-out only re-subscribes when the set of topics changes, not on

--- a/frontend/src/pages/HelixOrgProcessorDetail.tsx
+++ b/frontend/src/pages/HelixOrgProcessorDetail.tsx
@@ -1,0 +1,72 @@
+import { FC, useState } from 'react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import Container from '@mui/material/Container'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import EditIcon from '@mui/icons-material/Edit'
+
+import HelixOrgShell from '../components/helix-org/HelixOrgShell'
+import ProcessorConfigDrawer from '../components/helix-org/ProcessorConfigDrawer'
+import LoadingSpinner from '../components/widgets/LoadingSpinner'
+import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
+import useRouter from '../hooks/useRouter'
+import { useHelixOrgProcessor } from '../services/helixOrgService'
+
+const HelixOrgProcessorDetail: FC = () => {
+  const router = useRouter()
+  const processorId = router.params.processor_id as string | undefined
+  const { data: processor, isLoading } = useHelixOrgProcessor(processorId)
+  const [editing, setEditing] = useState(false)
+  const breadcrumbs = useHelixOrgBreadcrumbs({ title: 'Chart', routeName: 'helix_org_chart' })
+
+  return (
+    <HelixOrgShell showChat={false} breadcrumbs={breadcrumbs} breadcrumbTitle={processor?.name || processorId || 'Processor'}>
+      <Box sx={{ height: '100%', overflow: 'auto' }}>
+        <Container maxWidth="md" sx={{ py: 3 }}>
+          {isLoading ? <LoadingSpinner /> : !processor ? (
+            <Typography color="text.secondary">Processor not found.</Typography>
+          ) : (
+            <Stack spacing={2}>
+              <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Box>
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <Typography variant="h5">{processor.name}</Typography>
+                    <Chip label={processor.kind} size="small" />
+                  </Stack>
+                  <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+                    {processor.id}
+                  </Typography>
+                </Box>
+                <Button variant="contained" startIcon={<EditIcon />} onClick={() => setEditing(true)}>Edit</Button>
+              </Stack>
+              <Box>
+                <Typography variant="overline" color="text.secondary">Input topic</Typography>
+                <Typography sx={{ fontFamily: 'monospace' }}>{processor.input_topic_id}</Typography>
+              </Box>
+              <Box>
+                <Typography variant="overline" color="text.secondary">Outputs</Typography>
+                <Stack spacing={1}>
+                  {processor.outputs.map((output) => (
+                    <Box key={output.topic_id} sx={{ p: 1.5, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+                      <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>{output.topic_id}</Typography>
+                      {(output.label || output.match) && (
+                        <Typography variant="caption" color="text.secondary">
+                          {[output.label, output.match].filter(Boolean).join(' · ')}
+                        </Typography>
+                      )}
+                    </Box>
+                  ))}
+                </Stack>
+              </Box>
+            </Stack>
+          )}
+        </Container>
+      </Box>
+      <ProcessorConfigDrawer open={editing} processor={processor} onClose={() => setEditing(false)} />
+    </HelixOrgShell>
+  )
+}
+
+export default HelixOrgProcessorDetail

--- a/frontend/src/pages/HelixOrgTopicDetail.tsx
+++ b/frontend/src/pages/HelixOrgTopicDetail.tsx
@@ -649,7 +649,7 @@ const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ topic, orgSlug }) =
 }
 
 // MessageCountCard is the compact metric chip beside the Messages
-// header showing how many messages are waiting on the topic (meta.total
+// header showing how many messages are retained on the topic (meta.total
 // from the paginated messages endpoint). Undefined while the count query
 // is in flight — render an em-dash placeholder rather than 0 so a
 // loading state doesn't read as "empty topic".
@@ -670,7 +670,7 @@ const MessageCountCard: FC<{ count: number | undefined }> = ({ count }) => (
       {count === undefined ? '—' : count.toLocaleString()}
     </Typography>
     <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.6rem', textTransform: 'uppercase', letterSpacing: 0.4 }}>
-      waiting
+      retained
     </Typography>
   </Paper>
 )

--- a/frontend/src/pages/HelixOrgTopicDetail.tsx
+++ b/frontend/src/pages/HelixOrgTopicDetail.tsx
@@ -220,7 +220,7 @@ interface TopicConfigSectionProps {
   saving: boolean
 }
 
-const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave, saving }) => {
+export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave, saving }) => {
   const snackbar = useSnackbar()
   const [editing, setEditing] = useState(false)
 

--- a/frontend/src/pages/HelixOrgTopicDetail.tsx
+++ b/frontend/src/pages/HelixOrgTopicDetail.tsx
@@ -33,7 +33,7 @@ import CronScheduleFields from '../components/helix-org/CronScheduleFields'
 import { GitHubBranchesField } from '../components/helix-org/GitHubTopicConfigFields'
 import GitHubRepoPicker from '../components/helix-org/GitHubRepoPicker'
 import { GITHUB_REPO_PATTERN } from '../components/helix-org/githubTopicConstants'
-import { generateCronSummary } from '../utils/cronUtils'
+import CopyButtonWithCheck from '../components/session/CopyButtonWithCheck'
 
 import useAccount from '../hooks/useAccount'
 import useRouter from '../hooks/useRouter'
@@ -123,6 +123,7 @@ const HelixOrgTopicDetail: FC = () => {
               <Box>
                 <Stack direction="row" alignItems="baseline" spacing={2}>
                   <Typography variant="h5" sx={{ fontFamily: 'monospace' }}>{topic.id}</Typography>
+                  <CopyButtonWithCheck text={topic.id} />
                   <Chip label={topic.kind} size="small" sx={{ fontFamily: 'monospace' }} />
                 </Stack>
                 <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
@@ -320,9 +321,6 @@ export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave,
   const configPreview = useMemo(() => {
     if (topic.kind === 'local') return null
     if (!topic.config || Object.keys(topic.config).length === 0) return '(empty)'
-    if (topic.kind === 'cron' && typeof topic.config.schedule === 'string') {
-      return generateCronSummary(topic.config.schedule)
-    }
     return JSON.stringify(topic.config, null, 2)
   }, [topic.kind, topic.config])
 
@@ -342,10 +340,30 @@ export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave,
           <ReadOnlyRow label="Name" value={topic.name} />
           <ReadOnlyRow label="Description" value={topic.description || '—'} />
           <ReadOnlyRow label="Transport" value={topic.kind} mono />
-          {topic.kind !== 'local' && (
+          {topic.kind === 'cron' && typeof topic.config?.schedule === 'string' && (
+            <Box>
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.75 }}>
+                Schedule
+              </Typography>
+              <CronScheduleFields
+                key={`cron-read-${topic.config.schedule}`}
+                value={topic.config.schedule}
+                onChange={() => undefined}
+                disabled
+              />
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ display: 'block', mt: 0.75, fontFamily: 'monospace' }}
+              >
+                {topic.config.schedule}
+              </Typography>
+            </Box>
+          )}
+          {topic.kind !== 'local' && topic.kind !== 'cron' && (
             <Box>
               <Typography variant="caption" color="text.secondary">
-                {topic.kind === 'cron' ? 'Schedule' : 'Config'}
+                Config
               </Typography>
               <Typography
                 component="pre"
@@ -353,22 +371,13 @@ export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave,
                 sx={{
                   mt: 0.5, mb: 0, p: 1, borderRadius: 1,
                   backgroundColor: 'action.hover',
-                  fontFamily: topic.kind === 'cron' ? 'inherit' : 'monospace',
-                  fontSize: topic.kind === 'cron' ? '0.875rem' : '0.75rem',
+                  fontFamily: 'monospace',
+                  fontSize: '0.75rem',
                   whiteSpace: 'pre-wrap', wordBreak: 'break-word',
                 }}
               >
                 {configPreview}
               </Typography>
-              {topic.kind === 'cron' && typeof topic.config?.schedule === 'string' && (
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ display: 'block', mt: 0.5, fontFamily: 'monospace' }}
-                >
-                  {topic.config.schedule}
-                </Typography>
-              )}
             </Box>
           )}
         </Stack>

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -470,6 +470,7 @@ const Layout: FC<{
       case "org_usage":
       case "org_api_keys":
       case "org_providers":
+      case "org_provider_detail":
       case "org_qa":
       case "org_qa-results":
       case "team_people":

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -453,6 +453,7 @@ const Layout: FC<{
       case "helix_org_settings":
       case "helix_org_topics":
       case "helix_org_topic_detail":
+      case "helix_org_processor_detail":
         // Nav lives in the top AppBar (HelixOrgTopNav); chat is a left rail
         // inside HelixOrgShell — no middle ContextSidebar.
         return null;

--- a/frontend/src/pages/Providers.tsx
+++ b/frontend/src/pages/Providers.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useMemo } from 'react';
-import { Box, Grid, Card, CardHeader, CardContent, CardActions, Avatar, Typography, Button, Tooltip, Divider, Alert, Dialog, DialogTitle, DialogContent, DialogActions } from '@mui/material';
+import { Box, Grid, Card, CardHeader, CardContent, CardActions, Avatar, Typography, Button, Tooltip, Divider, Alert } from '@mui/material';
 import Container from '@mui/material/Container';
 import Page from '../components/system/Page';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import AddProviderDialog from '../components/providers/AddProviderDialog';
 
-import { useListProviders, useDetectLocalProviders, useCreateProviderEndpoint, useDeleteProviderEndpoint } from '../services/providersService';
-import { TypesProviderEndpoint, TypesProviderEndpointType } from '../api/api';
+import { useListProviders, useDetectLocalProviders, useCreateProviderEndpoint } from '../services/providersService';
+import { TypesProviderEndpointType } from '../api/api';
 import CircularProgress from '@mui/material/CircularProgress';
 import { Server } from 'lucide-react';
 import { useGetOrgByName } from '../services/orgService';
@@ -23,7 +23,6 @@ import CodexSubscriptionConnect from '../components/account/CodexSubscriptionCon
 import { useCodexSubscriptions } from '../services/codexSubscriptionsService';
 import { getTokenExpiryStatus } from '../components/account/claudeSubscriptionUtils';
 import LMStudioModels from '../components/providers/LMStudioModels';
-import useSnackbar from '../hooks/useSnackbar';
 
 const Providers: React.FC = () => {
   const router = useRouter()
@@ -32,12 +31,9 @@ const Providers: React.FC = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [localModelsEndpointId, setLocalModelsEndpointId] = useState<string | null>(null);
   const [connectingDetected, setConnectingDetected] = useState<string>("");
-  const [disconnectingProvider, setDisconnectingProvider] = useState<TypesProviderEndpoint | null>(null);
   const isMacDesktop = account.serverConfig?.edition === "mac-desktop";
-  const snackbar = useSnackbar();
   const { data: detectedProviders } = useDetectLocalProviders(true);
   const createProvider = useCreateProviderEndpoint();
-  const deleteProvider = useDeleteProviderEndpoint();
 
   const orgName = router.params.org_id
 
@@ -161,17 +157,6 @@ const Providers: React.FC = () => {
       });
     } finally {
       setConnectingDetected("");
-    }
-  };
-
-  const handleDisconnectProvider = async () => {
-    if (!disconnectingProvider?.id) return;
-    try {
-      await deleteProvider.mutateAsync(disconnectingProvider.id);
-      snackbar.success(`${disconnectingProvider.name || 'Provider'} disconnected`);
-      setDisconnectingProvider(null);
-    } catch (error) {
-      snackbar.error(error instanceof Error ? error.message : 'Failed to disconnect provider');
     }
   };
 
@@ -335,7 +320,6 @@ const Providers: React.FC = () => {
             // providers can coexist, and each existing one is shown as its own card below.
             const isConfigured = !provider.is_custom && allEndpoints.some(endpoint => endpoint.name === provider.id || endpoint.name === provider.id.replace('user/', ''));
             const existingProvider = provider.is_custom ? undefined : allEndpoints.find(endpoint => endpoint.name === provider.id || endpoint.name === provider.id.replace('user/', ''));
-            const userProvider = userEndpoints.find(endpoint => endpoint.name === provider.id || endpoint.name === provider.id.replace('user/', ''));
             return (
               <Grid item xs={12} sm={6} md={4} key={provider.id} display="flex" justifyContent="center">          
                 <Card
@@ -409,17 +393,6 @@ const Providers: React.FC = () => {
                         </Button>
                       </span>
                     </Tooltip>
-                    {editAllowed && userProvider?.id && (
-                      <Button
-                        size="small"
-                        variant="text"
-                        color="error"
-                        onClick={() => setDisconnectingProvider(userProvider)}
-                        disabled={deleteProvider.isPending}
-                      >
-                        Disconnect
-                      </Button>
-                    )}
                   </CardActions>
                 </Card>
               </Grid>
@@ -495,17 +468,6 @@ const Providers: React.FC = () => {
                     >
                       {endpoint.status === 'error' ? 'Fix Connection' : 'Connected'}
                     </Button>
-                    {editAllowed && endpoint.id && (
-                      <Button
-                        size="small"
-                        variant="text"
-                        color="error"
-                        onClick={() => setDisconnectingProvider(endpoint)}
-                        disabled={deleteProvider.isPending}
-                      >
-                        Disconnect
-                      </Button>
-                    )}
                   </CardActions>
                 </Card>
               </Grid>
@@ -518,25 +480,12 @@ const Providers: React.FC = () => {
             open={dialogOpen}
             onClose={handleCloseDialog}
             provider={selectedProvider}
-            existingProvider={userEndpoints.find(endpoint => endpoint.name === selectedProvider.id)}
+            existingProvider={userEndpoints.find(endpoint =>
+              endpoint.name === selectedProvider.id ||
+              endpoint.name === selectedProvider.id.replace('user/', '')
+            )}
           />
         )}
-        <Dialog open={!!disconnectingProvider} onClose={() => setDisconnectingProvider(null)} maxWidth="xs" fullWidth>
-          <DialogTitle>Disconnect provider?</DialogTitle>
-          <DialogContent>
-            <Typography color="text.secondary">
-              Helix will stop using {disconnectingProvider?.name || 'this provider'} and remove its stored credentials.
-            </Typography>
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setDisconnectingProvider(null)} disabled={deleteProvider.isPending}>
-              Cancel
-            </Button>
-            <Button onClick={handleDisconnectProvider} color="error" disabled={deleteProvider.isPending}>
-              {deleteProvider.isPending ? 'Disconnecting…' : 'Disconnect'}
-            </Button>
-          </DialogActions>
-        </Dialog>
       </Container>
     </Page>
   );

--- a/frontend/src/pages/Providers.tsx
+++ b/frontend/src/pages/Providers.tsx
@@ -318,8 +318,13 @@ const Providers: React.FC = () => {
           {PROVIDERS.map((provider) => {
             // The custom provider tile always opens a fresh "Add" dialog — many custom
             // providers can coexist, and each existing one is shown as its own card below.
-            const isConfigured = !provider.is_custom && allEndpoints.some(endpoint => endpoint.name === provider.id || endpoint.name === provider.id.replace('user/', ''));
-            const existingProvider = provider.is_custom ? undefined : allEndpoints.find(endpoint => endpoint.name === provider.id || endpoint.name === provider.id.replace('user/', ''));
+            // This section manages keys owned by the current user or organization.
+            // Synthetic global providers have id "-" and are configured by the server
+            // environment, so they cannot be disconnected from this dialog.
+            const existingProvider = provider.is_custom ? undefined : userEndpoints.find(
+              endpoint => endpoint.name === provider.id || endpoint.name === provider.id.replace('user/', '')
+            );
+            const isConfigured = !!existingProvider;
             return (
               <Grid item xs={12} sm={6} md={4} key={provider.id} display="flex" justifyContent="center">          
                 <Card

--- a/frontend/src/pages/Providers.tsx
+++ b/frontend/src/pages/Providers.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useMemo } from 'react';
-import { Box, Grid, Card, CardHeader, CardContent, CardActions, Avatar, Typography, Button, Tooltip, Divider, Alert, Dialog, DialogTitle, DialogContent } from '@mui/material';
+import { Box, Grid, Card, CardHeader, CardContent, CardActions, Avatar, Typography, Button, Tooltip, Divider, Alert, Dialog, DialogTitle, DialogContent, DialogActions } from '@mui/material';
 import Container from '@mui/material/Container';
 import Page from '../components/system/Page';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import AddProviderDialog from '../components/providers/AddProviderDialog';
 
-import { useListProviders, useDetectLocalProviders, useCreateProviderEndpoint } from '../services/providersService';
-import { TypesProviderEndpointType } from '../api/api';
+import { useListProviders, useDetectLocalProviders, useCreateProviderEndpoint, useDeleteProviderEndpoint } from '../services/providersService';
+import { TypesProviderEndpoint, TypesProviderEndpointType } from '../api/api';
 import CircularProgress from '@mui/material/CircularProgress';
 import { Server } from 'lucide-react';
 import { useGetOrgByName } from '../services/orgService';
@@ -23,6 +23,7 @@ import CodexSubscriptionConnect from '../components/account/CodexSubscriptionCon
 import { useCodexSubscriptions } from '../services/codexSubscriptionsService';
 import { getTokenExpiryStatus } from '../components/account/claudeSubscriptionUtils';
 import LMStudioModels from '../components/providers/LMStudioModels';
+import useSnackbar from '../hooks/useSnackbar';
 
 const Providers: React.FC = () => {
   const router = useRouter()
@@ -31,9 +32,12 @@ const Providers: React.FC = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [localModelsEndpointId, setLocalModelsEndpointId] = useState<string | null>(null);
   const [connectingDetected, setConnectingDetected] = useState<string>("");
+  const [disconnectingProvider, setDisconnectingProvider] = useState<TypesProviderEndpoint | null>(null);
   const isMacDesktop = account.serverConfig?.edition === "mac-desktop";
+  const snackbar = useSnackbar();
   const { data: detectedProviders } = useDetectLocalProviders(true);
   const createProvider = useCreateProviderEndpoint();
+  const deleteProvider = useDeleteProviderEndpoint();
 
   const orgName = router.params.org_id
 
@@ -64,10 +68,22 @@ const Providers: React.FC = () => {
   const { data: codexSubscriptions } = useCodexSubscriptions()
   const hasCodexSubscription = (codexSubscriptions?.length ?? 0) > 0
 
+  const pageProps = {
+    breadcrumbTitle: 'AI providers',
+    breadcrumbParent: {
+      title: 'Organizations',
+      routeName: 'orgs',
+      useOrgRouter: false,
+    },
+    breadcrumbShowHome: true,
+    orgBreadcrumbs: true,
+    topbarContent: null,
+  }
+
   // If providers management is disabled and user is not admin, show message
   if (!providersManagementEnabled && !account.admin) {
     return (
-      <Page breadcrumbTitle="Providers" topbarContent={null}>
+      <Page {...pageProps}>
         <Container maxWidth="md" sx={{ mt: 10, mb: 6, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
           <Typography variant="h4" sx={{ mb: 2, fontWeight: 600 }}>
             AI Providers
@@ -148,8 +164,19 @@ const Providers: React.FC = () => {
     }
   };
 
+  const handleDisconnectProvider = async () => {
+    if (!disconnectingProvider?.id) return;
+    try {
+      await deleteProvider.mutateAsync(disconnectingProvider.id);
+      snackbar.success(`${disconnectingProvider.name || 'Provider'} disconnected`);
+      setDisconnectingProvider(null);
+    } catch (error) {
+      snackbar.error(error instanceof Error ? error.message : 'Failed to disconnect provider');
+    }
+  };
+
   return (
-    <Page breadcrumbTitle="Providers" topbarContent={null}>
+    <Page {...pageProps}>
       <Container maxWidth="md" sx={{ mt: 10, mb: 6, display: 'flex', flexDirection: 'column', alignItems: 'left' }}>
         <Typography variant="h4" sx={{ mb: 2, fontWeight: 600 }}>
           AI Providers
@@ -197,15 +224,14 @@ const Providers: React.FC = () => {
           </Box>
         )}
 
-        {/* Claude Subscription Section */}
         <Typography variant="h6" sx={{ mb: 1.5 }}>
-          Claude Subscription
+          Subscriptions
         </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Sign in with your Claude account to use Claude Code as the coding agent in desktop sessions.
+          Connect an Anthropic or ChatGPT subscription for coding agents in desktop sessions.
         </Typography>
         <Grid container spacing={3} justifyContent="left" sx={{ mb: 4 }}>
-          <Grid item xs={12} sm={6} md={4} display="flex" justifyContent="center">
+          <Grid item xs={12} sm={6} display="flex" justifyContent="center">
             <Card
               sx={{
                 width: 320,
@@ -235,7 +261,7 @@ const Providers: React.FC = () => {
                     <AnthropicLogo style={{ width: 40, height: 40 }} />
                   </Avatar>
                 }
-                title="Claude Subscription"
+                title="Anthropic"
                 titleTypographyProps={{ variant: 'h6', align: 'center' }}
               />
               <CardContent sx={{ flexGrow: 1, textAlign: 'center' }}>
@@ -243,25 +269,16 @@ const Providers: React.FC = () => {
                   Use your Claude account with Claude Code inside desktop agents. Not an API key provider.
                 </Typography>
               </CardContent>
-              <CardActions sx={{ justifyContent: 'center', pb: 2 }}>
+              <CardActions sx={{ justifyContent: 'center', pb: 2, minHeight: 52, '& .MuiButton-root': { minWidth: 104, height: 36 } }}>
                 <ClaudeSubscriptionConnect variant="button" />
               </CardActions>
             </Card>
           </Grid>
-        </Grid>
-
-        <Typography variant="h6" sx={{ mb: 1.5 }}>
-          ChatGPT Subscription
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Sign in with ChatGPT to use Codex CLI as the coding agent in desktop sessions.
-        </Typography>
-        <Grid container spacing={3} justifyContent="left" sx={{ mb: 4 }}>
-          <Grid item xs={12} sm={6} md={4} display="flex" justifyContent="center">
+          <Grid item xs={12} sm={6} display="flex" justifyContent="center">
             <Card sx={{ width: 320, height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', boxShadow: 2, borderStyle: 'dashed', borderWidth: 1, borderColor: hasCodexSubscription ? 'success.main' : 'divider' }}>
               <CardHeader
                 avatar={<Avatar sx={{ bgcolor: 'white', width: 56, height: 56 }}><OpenAILogo style={{ width: 40, height: 40 }} /></Avatar>}
-                title="ChatGPT Subscription"
+                title="ChatGPT"
                 titleTypographyProps={{ variant: 'h6', align: 'center' }}
               />
               <CardContent sx={{ flexGrow: 1, textAlign: 'center' }}>
@@ -269,7 +286,7 @@ const Providers: React.FC = () => {
                   Use your ChatGPT account with Codex CLI inside desktop agents. Not an API key provider.
                 </Typography>
               </CardContent>
-              <CardActions sx={{ justifyContent: 'center', pb: 2 }}>
+              <CardActions sx={{ justifyContent: 'center', pb: 2, minHeight: 52, '& .MuiButton-root': { minWidth: 104, height: 36 } }}>
                 <CodexSubscriptionConnect orgId={org?.id} />
               </CardActions>
             </Card>
@@ -307,7 +324,7 @@ const Providers: React.FC = () => {
         <Divider sx={{ mb: 3 }} />
 
         <Typography variant="h6" sx={{ mb: 1.5 }}>
-          API Key Providers
+          AI Providers
         </Typography>
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
           Add API keys for chat, Zed Agent, Qwen Code, and other AI features.
@@ -318,6 +335,7 @@ const Providers: React.FC = () => {
             // providers can coexist, and each existing one is shown as its own card below.
             const isConfigured = !provider.is_custom && allEndpoints.some(endpoint => endpoint.name === provider.id || endpoint.name === provider.id.replace('user/', ''));
             const existingProvider = provider.is_custom ? undefined : allEndpoints.find(endpoint => endpoint.name === provider.id || endpoint.name === provider.id.replace('user/', ''));
+            const userProvider = userEndpoints.find(endpoint => endpoint.name === provider.id || endpoint.name === provider.id.replace('user/', ''));
             return (
               <Grid item xs={12} sm={6} md={4} key={provider.id} display="flex" justifyContent="center">          
                 <Card
@@ -391,6 +409,17 @@ const Providers: React.FC = () => {
                         </Button>
                       </span>
                     </Tooltip>
+                    {editAllowed && userProvider?.id && (
+                      <Button
+                        size="small"
+                        variant="text"
+                        color="error"
+                        onClick={() => setDisconnectingProvider(userProvider)}
+                        disabled={deleteProvider.isPending}
+                      >
+                        Disconnect
+                      </Button>
+                    )}
                   </CardActions>
                 </Card>
               </Grid>
@@ -466,6 +495,17 @@ const Providers: React.FC = () => {
                     >
                       {endpoint.status === 'error' ? 'Fix Connection' : 'Connected'}
                     </Button>
+                    {editAllowed && endpoint.id && (
+                      <Button
+                        size="small"
+                        variant="text"
+                        color="error"
+                        onClick={() => setDisconnectingProvider(endpoint)}
+                        disabled={deleteProvider.isPending}
+                      >
+                        Disconnect
+                      </Button>
+                    )}
                   </CardActions>
                 </Card>
               </Grid>
@@ -481,6 +521,22 @@ const Providers: React.FC = () => {
             existingProvider={userEndpoints.find(endpoint => endpoint.name === selectedProvider.id)}
           />
         )}
+        <Dialog open={!!disconnectingProvider} onClose={() => setDisconnectingProvider(null)} maxWidth="xs" fullWidth>
+          <DialogTitle>Disconnect provider?</DialogTitle>
+          <DialogContent>
+            <Typography color="text.secondary">
+              Helix will stop using {disconnectingProvider?.name || 'this provider'} and remove its stored credentials.
+            </Typography>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setDisconnectingProvider(null)} disabled={deleteProvider.isPending}>
+              Cancel
+            </Button>
+            <Button onClick={handleDisconnectProvider} color="error" disabled={deleteProvider.isPending}>
+              {deleteProvider.isPending ? 'Disconnecting…' : 'Disconnect'}
+            </Button>
+          </DialogActions>
+        </Dialog>
       </Container>
     </Page>
   );

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -192,7 +192,8 @@ const routes: IApplicationRoute[] = [
   name: 'org_provider_detail',
   path: '/orgs/:org_id/providers/:provider_id',
   meta: {
-    drawer: false,
+    drawer: true,
+    menu: 'orgs',
   },
   render: () => (
     <ProviderDetail />
@@ -201,7 +202,8 @@ const routes: IApplicationRoute[] = [
   name: 'org_providers',
   path: '/orgs/:org_id/providers',
   meta: {
-    drawer: false,
+    drawer: true,
+    menu: 'orgs',
   },
   render: () => (
     <Providers />

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -53,6 +53,7 @@ import HelixOrgHumanDetail from './pages/HelixOrgHumanDetail'
 import HelixOrgSettings from './pages/HelixOrgSettings'
 import HelixOrgTopics from './pages/HelixOrgTopics'
 import HelixOrgTopicDetail from './pages/HelixOrgTopicDetail'
+import HelixOrgProcessorDetail from './pages/HelixOrgProcessorDetail'
 import useRouter from './hooks/useRouter'
 import { recordNavRoute } from './lib/navHistory'
 
@@ -594,6 +595,11 @@ const routes: IApplicationRoute[] = [
   path: '/orgs/:org_id/helix-org/topics',
   meta: { drawer: false, title: 'Helix Org · Topics' },
   render: () => <HelixOrgTopics />,
+}, {
+  name: 'helix_org_processor_detail',
+  path: '/orgs/:org_id/helix-org/processors/:processor_id',
+  meta: { drawer: false, title: 'Helix Org · Processor' },
+  render: () => <HelixOrgProcessorDetail />,
 }, {
   name: 'helix_org_topic_detail',
   path: '/orgs/:org_id/helix-org/topics/:topic_id',

--- a/frontend/src/services/helixOrgService.ts
+++ b/frontend/src/services/helixOrgService.ts
@@ -603,7 +603,7 @@ export function useGitHubWebhookStatus(topicId: string | undefined, options?: { 
   })
 }
 
-// useTopicMessageCount reports the total number of messages waiting on
+// useTopicMessageCount reports the total number of retained messages on
 // a single topic via the paginated JSON:API messages endpoint. We only
 // need meta.total, so we request the smallest possible page (size 1) and
 // ignore the body — the count is the cheap part the server computes


### PR DESCRIPTION
## What changed

- open topic and processor details in side drawers from the org chart
- keep full-page navigation available from each drawer
- add a processor detail page
- count processor topic consumers alongside bot subscribers on chart cards
- restyle thought disclosures to match tool-call panels
- keep expanded thought/tool-call headers anchored while bodies open downward
- label topic message totals as retained history instead of a waiting backlog
- add focused thought disclosure tests

## Why

Navigating away from the chart made topology exploration and fixes cumbersome. Topic subscriber counts also ignored processors because processors consume via `input_topic_id`, not bot subscription rows. Message totals were incorrectly labelled "waiting" even though topics are durable retained logs. Thoughts used unrelated elevated-card styling, making the activity stream visually inconsistent.

## Impact

Operators can inspect and edit chart resources without losing chart context, subscription totals represent all consumers, and thoughts/tool calls now share a compact disclosure pattern that remains easy to collapse after expansion.

## Validation

- `yarn build`
- `yarn test ThinkingWidget.test.tsx CollapsibleToolCall.test.tsx`
- `git diff --check`
- local stack responds at `http://localhost:8080`
