### PR TITLE
feat(frontend): copy interaction debug context

### DIFF
--- a/frontend/src/components/helix-org/HelixOrgChatPanel.tsx
+++ b/frontend/src/components/helix-org/HelixOrgChatPanel.tsx
@@ -412,7 +412,12 @@ const HelixOrgChatPanel: FC = () => {
         ) : view === 'chat' ? (
           <>
             <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
-              <EmbeddedSessionView ref={sessionViewRef} sessionId={chatSessionId} autoScrollOnMount />
+              <EmbeddedSessionView
+                ref={sessionViewRef}
+                sessionId={chatSessionId}
+                autoScrollOnMount
+                enableInteractionDebugCopy
+              />
             </Box>
             <SessionPromptQueue sessionId={chatSessionId} />
             <Box sx={{ p: 1.5, flexShrink: 0 }}>

--- a/frontend/src/components/session/EmbeddedSessionView.tsx
+++ b/frontend/src/components/session/EmbeddedSessionView.tsx
@@ -56,6 +56,7 @@ import { SESSION_TYPE_TEXT } from "../../types";
 interface EmbeddedSessionViewProps {
   sessionId: string;
   onScrollToBottom?: () => void;
+  enableInteractionDebugCopy?: boolean;
   // When true, force the (otherwise persisted, globally-shared)
   // auto-scroll preference ON when this view mounts. Surfaces that want
   // the transcript to follow live output by default — e.g. the helix-org
@@ -94,7 +95,7 @@ export interface EmbeddedSessionViewHandle {
 const EmbeddedSessionView = forwardRef<
   EmbeddedSessionViewHandle,
   EmbeddedSessionViewProps
->(({ sessionId, onScrollToBottom, autoScrollOnMount }, ref) => {
+>(({ sessionId, onScrollToBottom, autoScrollOnMount, enableInteractionDebugCopy }, ref) => {
   const account = useAccount();
   const api = useApi();
   const lightTheme = useLightTheme();
@@ -725,6 +726,7 @@ const EmbeddedSessionView = forwardRef<
                 scrollToBottom={scrollToBottom}
                 session_id={sessionId}
                 sessionSteps={sessionSteps?.data || []}
+                enableDebugCopy={enableInteractionDebugCopy}
               >
                 {isLive && (isOwner || account.admin) && (
                   <InteractionLiveStream

--- a/frontend/src/components/session/Interaction.tsx
+++ b/frontend/src/components/session/Interaction.tsx
@@ -7,6 +7,7 @@ import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import EditIcon from "@mui/icons-material/Edit";
 import CopyButtonWithCheck from "./CopyButtonWithCheck";
+import InteractionDebugCopyButton from "./InteractionDebugCopyButton";
 import CollapsibleSystemPrefix, {
   splitSystemPrefix,
 } from "./CollapsibleSystemPrefix";
@@ -110,6 +111,22 @@ const ForkSeedDivider: FC<{ interaction: TypesInteraction }> = ({
 
 // Prop comparison function for React.memo
 const areEqual = (prevProps: InteractionProps, nextProps: InteractionProps) => {
+  if (prevProps.enableDebugCopy !== nextProps.enableDebugCopy) {
+    return false;
+  }
+
+  // Debug-enabled surfaces must keep the raw objects current because the
+  // copied bundle includes fields the transcript itself does not render
+  // (usage, runner, structured tool calls, model and routing metadata).
+  if (
+    nextProps.enableDebugCopy &&
+    (prevProps.interaction !== nextProps.interaction ||
+      prevProps.session !== nextProps.session ||
+      prevProps.sessionSteps !== nextProps.sessionSteps)
+  ) {
+    return false;
+  }
+
   // Compare serverConfig
   if (
     prevProps.serverConfig?.filestore_prefix !==
@@ -181,6 +198,7 @@ interface InteractionProps {
   session_id: string;
   onRegenerate?: (interactionID: string, message: string) => void;
   sessionSteps?: any[];
+  enableDebugCopy?: boolean;
 }
 
 export const Interaction: FC<InteractionProps> = ({
@@ -193,6 +211,7 @@ export const Interaction: FC<InteractionProps> = ({
   isLastInteraction,
   onRegenerate,
   sessionSteps = [],
+  enableDebugCopy = false,
 }) => {
   // Memoize computed values
   const displayData = useMemo(() => {
@@ -410,6 +429,14 @@ export const Interaction: FC<InteractionProps> = ({
                     transition: "opacity 0.2s ease-in-out",
                   }}
                 >
+                  {enableDebugCopy && (
+                    <InteractionDebugCopyButton
+                      interaction={interaction}
+                      session={session}
+                      sessionSteps={sessionSteps}
+                      serverConfig={serverConfig}
+                    />
+                  )}
                   <CopyButtonWithCheck
                     text={systemPrefix ? userMessageBody : userMessage}
                     alwaysVisible={isHovering}
@@ -514,6 +541,23 @@ export const Interaction: FC<InteractionProps> = ({
               </>
             )}
           </InteractionContainer>
+          {enableDebugCopy && (
+            <Box
+              sx={{
+                mt: 0.5,
+                opacity: isHovering ? 1 : 0,
+                pointerEvents: isHovering ? "auto" : "none",
+                transition: "opacity 0.2s ease-in-out",
+              }}
+            >
+              <InteractionDebugCopyButton
+                interaction={interaction}
+                session={session}
+                sessionSteps={sessionSteps}
+                serverConfig={serverConfig}
+              />
+            </Box>
+          )}
         </Box>
       )}
     </Box>

--- a/frontend/src/components/session/InteractionDebugCopyButton.test.tsx
+++ b/frontend/src/components/session/InteractionDebugCopyButton.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import InteractionDebugCopyButton from "./InteractionDebugCopyButton";
+
+vi.mock("../../contexts/streaming", () => ({
+  useStreaming: () => ({ currentResponses: new Map() }),
+}));
+
+describe("InteractionDebugCopyButton", () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    writeText.mockClear();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  it("copies a parseable debug bundle for the selected interaction", async () => {
+    render(
+      <InteractionDebugCopyButton
+        interaction={{ id: "int_1", session_id: "ses_1", error: "boom" }}
+        session={{ id: "ses_1", model_name: "test-model" }}
+        sessionSteps={[
+          { interaction_id: "int_1", name: "included" },
+          { interaction_id: "int_2", name: "excluded" },
+        ]}
+        serverConfig={{ version: "test-version" }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy interaction debug context" }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledOnce());
+    const copied = JSON.parse(writeText.mock.calls[0][0]);
+    expect(copied.interaction.id).toBe("int_1");
+    expect(copied.session.model_name).toBe("test-model");
+    expect(copied.session_steps).toEqual([
+      { interaction_id: "int_1", name: "included" },
+    ]);
+  });
+});

--- a/frontend/src/components/session/InteractionDebugCopyButton.tsx
+++ b/frontend/src/components/session/InteractionDebugCopyButton.tsx
@@ -1,0 +1,109 @@
+import React, { FC, useState } from "react";
+import BugReportOutlinedIcon from "@mui/icons-material/BugReportOutlined";
+import CheckIcon from "@mui/icons-material/Check";
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+
+import {
+  TypesInteraction,
+  TypesServerConfigForFrontend,
+  TypesSession,
+} from "../../api/api";
+import { useStreaming } from "../../contexts/streaming";
+import { buildInteractionDebugContext } from "./interactionDebugContext";
+
+interface InteractionDebugCopyButtonProps {
+  interaction: TypesInteraction;
+  session: TypesSession;
+  sessionSteps: unknown[];
+  serverConfig: TypesServerConfigForFrontend;
+}
+
+const fallbackCopy = (text: string) => {
+  const textArea = document.createElement("textarea");
+  textArea.value = text;
+  textArea.style.position = "fixed";
+  textArea.style.left = "-9999px";
+  document.body.appendChild(textArea);
+  textArea.select();
+  document.execCommand("copy");
+  document.body.removeChild(textArea);
+};
+
+const InteractionDebugCopyButton: FC<InteractionDebugCopyButtonProps> = ({
+  interaction,
+  session,
+  sessionSteps,
+  serverConfig,
+}) => {
+  const [copied, setCopied] = useState(false);
+  const { currentResponses } = useStreaming();
+
+  const liveInteraction = currentResponses.get(session.id || "");
+  const interactionForCopy =
+    liveInteraction?.id === interaction.id
+      ? ({ ...interaction, ...liveInteraction } as unknown as TypesInteraction)
+      : interaction;
+
+  const handleCopy = async (event: React.MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const context = buildInteractionDebugContext(
+      interactionForCopy,
+      session,
+      sessionSteps.filter(
+        (step) =>
+          typeof step === "object" &&
+          step !== null &&
+          "interaction_id" in step &&
+          (step as { interaction_id?: unknown }).interaction_id === interaction.id,
+      ),
+      serverConfig,
+      {
+        capturedAt: new Date().toISOString(),
+        sourceUrl: window.location.href,
+        userAgent: navigator.userAgent,
+      },
+    );
+
+    try {
+      if (!navigator.clipboard?.writeText) throw new Error("Clipboard API unavailable");
+      await navigator.clipboard.writeText(context);
+    } catch {
+      fallbackCopy(context);
+    }
+
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Tooltip
+      title={copied ? "Debug context copied" : "Copy interaction debug context"}
+      placement="bottom"
+    >
+      <IconButton
+        size="small"
+        onClick={handleCopy}
+        aria-label="Copy interaction debug context"
+        sx={(theme) => ({
+          mt: 0.5,
+          p: "2px",
+          color: theme.palette.mode === "light" ? "#888" : "#bbb",
+          "&:hover": {
+            color: theme.palette.mode === "light" ? "#000" : "#fff",
+          },
+        })}
+      >
+        {copied ? (
+          <CheckIcon sx={{ fontSize: 20 }} />
+        ) : (
+          <BugReportOutlinedIcon sx={{ fontSize: 20 }} />
+        )}
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+export default InteractionDebugCopyButton;

--- a/frontend/src/components/session/interactionDebugContext.test.ts
+++ b/frontend/src/components/session/interactionDebugContext.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  TypesCodeAgentRuntime,
+  TypesInteractionState,
+} from "../../api/api";
+import { buildInteractionDebugContext } from "./interactionDebugContext";
+
+describe("buildInteractionDebugContext", () => {
+  it("captures interaction, tool, error, model, and session routing details", () => {
+    const result = JSON.parse(
+      buildInteractionDebugContext(
+        {
+          id: "int_123",
+          session_id: "ses_123",
+          state: TypesInteractionState.InteractionStateError,
+          prompt_message: "Fix the failing build",
+          response_message: "I could not finish",
+          error: "agent disconnected",
+          runner: "runner-1",
+          usage: { total_tokens: 42 },
+          response_entries: [
+            {
+              type: "tool_call",
+              tool_name: "bash",
+              tool_status: "failed",
+              content: "exit 1",
+            },
+          ] as unknown as number[],
+        },
+        {
+          id: "ses_123",
+          model_name: "claude-opus-4-6",
+          provider: "anthropic",
+          config: {
+            code_agent_runtime: TypesCodeAgentRuntime.CodeAgentRuntimeClaudeCode,
+            spec_task_id: "st_123",
+            zed_thread_id: "thread-123",
+            callback_url: "https://example.test/private-callback",
+          },
+        },
+        [
+          {
+            id: "step-1",
+            interaction_id: "int_123",
+            details: { arguments: { command: "go test ./..." } },
+          },
+        ],
+        { version: "2.11.32", edition: "cloud" },
+        {
+          capturedAt: "2026-07-13T12:00:00.000Z",
+          sourceUrl: "https://app.example.test/spec-tasks/st_123",
+          userAgent: "test-browser",
+        },
+      ),
+    );
+
+    expect(result.format).toBe("helix-interaction-debug-context/v1");
+    expect(result.interaction.error).toBe("agent disconnected");
+    expect(result.interaction.response_entries[0].tool_name).toBe("bash");
+    expect(result.session.model_name).toBe("claude-opus-4-6");
+    expect(result.session.config.zed_thread_id).toBe("thread-123");
+    expect(result.session.config.callback_url).toBeUndefined();
+    expect(result.session_steps[0].details.arguments.command).toBe("go test ./...");
+  });
+});

--- a/frontend/src/components/session/interactionDebugContext.ts
+++ b/frontend/src/components/session/interactionDebugContext.ts
@@ -1,0 +1,96 @@
+import {
+  TypesInteraction,
+  TypesServerConfigForFrontend,
+  TypesSession,
+} from "../../api/api";
+
+export interface InteractionDebugEnvironment {
+  capturedAt: string;
+  sourceUrl: string;
+  userAgent: string;
+}
+
+export const buildInteractionDebugContext = (
+  interaction: TypesInteraction,
+  session: TypesSession,
+  sessionSteps: unknown[],
+  serverConfig: TypesServerConfigForFrontend,
+  environment: InteractionDebugEnvironment,
+): string => {
+  const config = session.config;
+
+  return JSON.stringify(
+    {
+      format: "helix-interaction-debug-context/v1",
+      captured_at: environment.capturedAt,
+      source_url: environment.sourceUrl,
+      browser_user_agent: environment.userAgent,
+      helix: {
+        version: serverConfig.version,
+        edition: serverConfig.edition,
+        deployment_id: serverConfig.deployment_id,
+      },
+      session: {
+        id: session.id,
+        name: session.name,
+        created: session.created,
+        updated: session.updated,
+        generation_id: session.generation_id,
+        mode: session.mode,
+        type: session.type,
+        trigger: session.trigger,
+        model_name: session.model_name,
+        provider: session.provider,
+        owner: session.owner,
+        owner_type: session.owner_type,
+        organization_id: session.organization_id,
+        project_id: session.project_id,
+        parent_session: session.parent_session,
+        sandbox_id: session.sandbox_id,
+        config: config
+          ? {
+              active_tools: config.active_tools,
+              agent_switched_at: config.agent_switched_at,
+              agent_type: config.agent_type,
+              assistant_id: config.assistant_id,
+              auto_restart_count: config.auto_restart_count,
+              auto_restart_on_crash: config.auto_restart_on_crash,
+              code_agent_runtime: config.code_agent_runtime,
+              container_id: config.container_id,
+              container_name: config.container_name,
+              dev_container_id: config.dev_container_id,
+              executor_mode: config.executor_mode,
+              external_agent_config: config.external_agent_config,
+              external_agent_id: config.external_agent_id,
+              external_agent_status: config.external_agent_status,
+              forked_at: config.forked_at,
+              forked_at_interaction_id: config.forked_at_interaction_id,
+              gpu_vendor: config.gpu_vendor,
+              helix_version: config.helix_version,
+              implementation_task_index: config.implementation_task_index,
+              last_auto_restart_at: config.last_auto_restart_at,
+              parent_session_id: config.parent_session_id,
+              paused: config.paused,
+              paused_at: config.paused_at,
+              paused_reason: config.paused_reason,
+              phase: config.phase,
+              project_id: config.project_id,
+              render_node: config.render_node,
+              session_role: config.session_role,
+              spec_task_id: config.spec_task_id,
+              status_message: config.status_message,
+              sway_version: config.sway_version,
+              work_session_id: config.work_session_id,
+              zed_agent_name: config.zed_agent_name,
+              zed_instance_id: config.zed_instance_id,
+              zed_thread_id: config.zed_thread_id,
+            }
+          : undefined,
+      },
+      interaction,
+      session_steps: sessionSteps,
+    },
+    null,
+    2,
+  );
+};

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -1996,6 +1996,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                 <EmbeddedSessionView
                   ref={sessionViewRef}
                   sessionId={activeSessionId}
+                  enableInteractionDebugCopy
                 />
                 <Box sx={{ p: 1.5, flexShrink: 0 }}>
                   <RobustPromptInput
@@ -2791,6 +2792,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
                 <EmbeddedSessionView
                   ref={sessionViewRef}
                   sessionId={activeSessionId}
+                  enableInteractionDebugCopy
                 />
                 <Box
                   sx={{


### PR DESCRIPTION
## What changed

- add a hover bug action to org and spec-task chat messages
- copy a structured interaction debug bundle with IDs, responses, errors, tool calls, usage, model and session routing metadata
- merge live streaming interaction state before copying
- exclude callback URLs and arbitrary query parameters from copied session metadata
- align the debug icon with existing chat actions

## Why

Operators need enough context to hand a failed or incorrect agent interaction to another AI agent without manually collecting identifiers, model details, errors, and tool-call data.

## Validation

- `yarn test interactionDebugContext.test.ts InteractionDebugCopyButton.test.tsx`
- `yarn tsc`
- `yarn build`
- local development stack returned HTTP 200
