### PR TITLE
feat(api): streaming LLM-call observability (mid-stream errors + time-to-first-token)

### DIFF
--- a/api/pkg/openai/logger/openai_logger.go
+++ b/api/pkg/openai/logger/openai_logger.go
@@ -138,6 +138,14 @@ func (m *LoggingMiddleware) CreateChatCompletionStream(ctx context.Context, requ
 
 		var resp = openai.ChatCompletionResponse{}
 
+		// A non-EOF error mid-stream (provider 5xx surfaced during the read,
+		// client/proxy disconnect -> context canceled, transport drop) must be
+		// recorded on the LLM call. Previously it was only logged to stderr and
+		// the call was written with error=nil, so a failed stream landed in the
+		// LLM logs as a phantom "success" with an empty response - invisible when
+		// filtering for errors.
+		var streamErr error
+
 		// Read from the upstream stream and write to the downstream stream
 		for {
 			msg, err := upstream.Recv()
@@ -145,6 +153,7 @@ func (m *LoggingMiddleware) CreateChatCompletionStream(ctx context.Context, requ
 				if err == io.EOF {
 					break
 				}
+				streamErr = err
 				log.Error().Err(err).Msg("failed to receive message from upstream stream")
 				break
 			}
@@ -159,7 +168,7 @@ func (m *LoggingMiddleware) CreateChatCompletionStream(ctx context.Context, requ
 		}
 
 		// Once the stream is done, close the downstream writer
-		m.logLLMCall(ctx, start, &request, &resp, nil, true, time.Since(start).Milliseconds())
+		m.logLLMCall(ctx, start, &request, &resp, streamErr, true, time.Since(start).Milliseconds())
 	}()
 
 	return downstream, nil

--- a/api/pkg/openai/logger/openai_logger.go
+++ b/api/pkg/openai/logger/openai_logger.go
@@ -90,7 +90,7 @@ func (m *LoggingMiddleware) CreateChatCompletion(ctx context.Context, request op
 	start := time.Now()
 	resp, err := m.client.CreateChatCompletion(ctx, request)
 	if err != nil {
-		m.logLLMCall(ctx, start, &request, &resp, err, false, time.Since(start).Milliseconds())
+		m.logLLMCall(ctx, start, &request, &resp, err, false, time.Since(start).Milliseconds(), 0)
 		return resp, err
 	}
 
@@ -104,7 +104,7 @@ func (m *LoggingMiddleware) CreateChatCompletion(ctx context.Context, request op
 
 		defer m.wg.Done()
 
-		m.logLLMCall(ctx, start, &request, &resp, nil, false, time.Since(start).Milliseconds())
+		m.logLLMCall(ctx, start, &request, &resp, nil, false, time.Since(start).Milliseconds(), time.Since(start).Milliseconds())
 	}()
 
 	return resp, nil
@@ -115,7 +115,7 @@ func (m *LoggingMiddleware) CreateChatCompletionStream(ctx context.Context, requ
 
 	upstream, err := m.client.CreateChatCompletionStream(ctx, request)
 	if err != nil {
-		m.logLLMCall(ctx, start, &request, nil, err, true, time.Since(start).Milliseconds())
+		m.logLLMCall(ctx, start, &request, nil, err, true, time.Since(start).Milliseconds(), 0)
 		return nil, err
 	}
 
@@ -146,6 +146,12 @@ func (m *LoggingMiddleware) CreateChatCompletionStream(ctx context.Context, requ
 		// filtering for errors.
 		var streamErr error
 
+		// Time-to-first-token: wall time until the first chunk arrives. Isolates
+		// provider prefill / cold-start latency from generation time. Stays 0 if
+		// the stream is cut before any chunk (e.g. a proxy read-timeout on a cold
+		// provider surfacing as context canceled).
+		var firstTokenMs int64
+
 		// Read from the upstream stream and write to the downstream stream
 		for {
 			msg, err := upstream.Recv()
@@ -158,6 +164,10 @@ func (m *LoggingMiddleware) CreateChatCompletionStream(ctx context.Context, requ
 				break
 			}
 
+			if firstTokenMs == 0 {
+				firstTokenMs = time.Since(start).Milliseconds()
+			}
+
 			// Add the message to the response
 			appendChunk(&resp, &msg)
 
@@ -168,7 +178,7 @@ func (m *LoggingMiddleware) CreateChatCompletionStream(ctx context.Context, requ
 		}
 
 		// Once the stream is done, close the downstream writer
-		m.logLLMCall(ctx, start, &request, &resp, streamErr, true, time.Since(start).Milliseconds())
+		m.logLLMCall(ctx, start, &request, &resp, streamErr, true, time.Since(start).Milliseconds(), firstTokenMs)
 	}()
 
 	return downstream, nil
@@ -236,7 +246,7 @@ func appendChunk(resp *openai.ChatCompletionResponse, chunk *openai.ChatCompleti
 	}
 }
 
-func (m *LoggingMiddleware) logLLMCall(ctx context.Context, createdAt time.Time, req *openai.ChatCompletionRequest, resp *openai.ChatCompletionResponse, apiError error, stream bool, durationMs int64) {
+func (m *LoggingMiddleware) logLLMCall(ctx context.Context, createdAt time.Time, req *openai.ChatCompletionRequest, resp *openai.ChatCompletionResponse, apiError error, stream bool, durationMs int64, firstTokenMs int64) {
 	// Remove the cancel function from the context
 	ctx = context.WithoutCancel(ctx)
 
@@ -363,7 +373,8 @@ func (m *LoggingMiddleware) logLLMCall(ctx context.Context, createdAt time.Time,
 		Request:          reqBts,
 		Response:         respBts,
 		Provider:         string(m.provider),
-		DurationMs:       durationMs,
+		DurationMs:         durationMs,
+		TimeToFirstTokenMs: firstTokenMs,
 		PromptTokens:     int64(promptTokens),
 		CompletionTokens: int64(completionTokens),
 		TotalTokens:      int64(totalTokens),

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -2450,7 +2450,14 @@ type LLMCall struct {
 	Request          datatypes.JSON `json:"request" gorm:"type:jsonb"`
 	Response         datatypes.JSON `json:"response" gorm:"type:jsonb"`
 	DurationMs       int64          `json:"duration_ms"`
-	PromptTokens     int64          `json:"prompt_tokens"`
+	// TimeToFirstTokenMs is the wall time from request start to the first
+	// streamed chunk. It isolates provider prefill / cold-start latency from
+	// generation time (a cold or overloaded provider shows a large TTFT while
+	// generation stays normal). 0 means no chunk was received (the call errored
+	// or was cut before the first token). For non-streaming calls it equals the
+	// time to the full response.
+	TimeToFirstTokenMs int64          `json:"time_to_first_token_ms"`
+	PromptTokens       int64          `json:"prompt_tokens"`
 	CompletionTokens int64          `json:"completion_tokens"`
 	TotalTokens      int64          `json:"total_tokens"`
 	CacheReadTokens  int64          `json:"cache_read_tokens"`  // prompt tokens served from provider cache (subset of PromptTokens)


### PR DESCRIPTION
Two related observability fixes to the LLM-call logging middleware (`api/pkg/openai/logger/openai_logger.go`), both motivated by a customer whose sandbox agent kept failing with `504` while the admin LLM logs showed nothing useful.

## 1. Record mid-stream provider errors (was: phantom successes)

The streaming path dropped mid-stream errors: a non-EOF `Recv()` error was only written to stderr, then the call was logged with `error=nil`. A stream that failed after it opened (provider 5xx during the read, a client/proxy disconnect surfacing as `context canceled`, a transport drop) was stored as a phantom **success** with an empty response - invisible when filtering `llm_calls` for errors. That is exactly why the failing agent showed no error rows.

Fix: capture the stream error and pass it to `logLLMCall`, matching the stream-creation (`:118`) and non-streaming (`:93`) paths. `io.EOF` still counts as a clean finish.

## 2. Add `time_to_first_token_ms`

`duration_ms` alone can't separate **provider prefill / cold-start latency** from generation time. A cold or scale-to-zero provider shows a large time-to-first-token while generation is normal - the single most diagnostic signal for the "provider went slow/cold" failure class, and one we had to reconstruct by hand during the investigation.

Adds `TimeToFirstTokenMs` to `LLMCall` (GORM AutoMigrate adds the nullable column), captured in the streaming loop at the first chunk. `0` = no chunk received (errored / cut before first token). Non-streaming calls set it to the full-response time.

## Testing

- `go build ./pkg/openai/logger/ ./pkg/types/` passes; `go test ./pkg/openai/logger/` passes.
- Behavioural repro of the mechanism (front-proxy timeout -> `context canceled`, duration pinned at the timeout) was reproduced end-to-end on a dev stack; see the investigation design doc.

## Impact

Observability only. No change to the stream returned to callers. After this, a failed stream lands in `llm_calls` with its error populated and `completion_tokens=0`, and every call carries a TTFT so cold-start latency is directly queryable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)