### PR TITLE
feat(org): add list_secrets tool for live project-secret reads

### DIFF
--- a/api/pkg/org/infrastructure/runtime/helix/mcp_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/mcp_test.go
@@ -207,6 +207,9 @@ func (noopProjectService) UpdateProject(_ context.Context, _ string, _ types.Pro
 	return types.Project{}, nil
 }
 func (noopProjectService) PutProjectSecret(_ context.Context, _, _, _ string) error { return nil }
+func (noopProjectService) ListProjectSecrets(_ context.Context, _ string) (map[string]string, error) {
+	return nil, nil
+}
 func (noopProjectService) CreateGitRepo(_ context.Context, _ types.GitRepositoryCreateRequest) (types.GitRepository, error) {
 	return types.GitRepository{}, nil
 }

--- a/api/pkg/org/infrastructure/runtime/helix/project.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project.go
@@ -75,6 +75,11 @@ type ProjectService interface {
 	// container at session start.
 	PutProjectSecret(ctx context.Context, projectID, name, value string) error
 
+	// ListProjectSecrets returns the project's dev-scoped secrets as a
+	// decrypted name→value map, read live. Backs list_secrets so a bot can
+	// pick up a secret added after its container booted.
+	ListProjectSecrets(ctx context.Context, projectID string) (map[string]string, error)
+
 	// CreateGitRepo creates a Helix-internal git repository. Used when
 	// project-apply doesn't auto-create one.
 	CreateGitRepo(ctx context.Context, req types.GitRepositoryCreateRequest) (types.GitRepository, error)

--- a/api/pkg/org/infrastructure/runtime/helix/project_config.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_config.go
@@ -69,6 +69,26 @@ func (c *ProjectConfig) GetWorkerProjectConfig(ctx context.Context, orgID string
 	}, nil
 }
 
+// ListWorkerProjectSecrets resolves the worker's project ID via the
+// helix runtime state, then returns the project's current secrets as a
+// name→value map. Read live on every call, so a secret added after the
+// worker's container booted is returned without a restart. Failure modes
+// match GetWorkerProjectConfig.
+func (c *ProjectConfig) ListWorkerProjectSecrets(ctx context.Context, orgID string, workerID orgchart.BotID) (map[string]string, error) {
+	state, err := LoadState(ctx, c.store, orgID, workerID)
+	if err != nil {
+		return nil, fmt.Errorf("load worker state: %w", err)
+	}
+	if state.ProjectID == "" {
+		return nil, fmt.Errorf("worker %s: %w", workerID, runtime.ErrProjectConfigUnsupported)
+	}
+	secrets, err := c.helix.ListProjectSecrets(ctx, state.ProjectID)
+	if err != nil {
+		return nil, fmt.Errorf("list project secrets for %s: %w", state.ProjectID, err)
+	}
+	return secrets, nil
+}
+
 // UpdateWorkerProjectConfig applies a partial patch to the
 // worker's helix project. Mirrors Helix's pointer convention:
 // nil fields on the runtime patch stay nil on the underlying

--- a/api/pkg/org/infrastructure/runtime/helix/project_config_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_config_test.go
@@ -106,6 +106,52 @@ func TestGetWorkerProjectConfig_NoProjectIDReturnsUnsupported(t *testing.T) {
 	}
 }
 
+// TestListWorkerProjectSecrets_ResolvesOwnProject pins the security
+// property: a worker's secrets are read from the project its OWN runtime
+// state points at, never a caller-supplied id. Seed the worker's state
+// with prj_01abc, script that project's secrets, and assert both the
+// values come back AND the read targeted prj_01abc.
+func TestListWorkerProjectSecrets_ResolvesOwnProject(t *testing.T) {
+	t.Parallel()
+	wrap := newOrgTestStoreForProjectConfig(t)
+	wid := orgchart.BotID("w-alice")
+	saveAllPointers(t, &wrap.Store, "org-test", wid, "prj_01abc", "app_x", "repo_y", "ses_z")
+
+	svc := newFakeProjectService()
+	svc.listSecretsResp = map[string]string{"DRONE_TOKEN": "abc", "DRONE_SERVER": "https://drone"}
+
+	pc, err := NewProjectConfig(&wrap.Store, svc)
+	if err != nil {
+		t.Fatalf("NewProjectConfig: %v", err)
+	}
+	got, err := pc.ListWorkerProjectSecrets(context.Background(), "org-test", wid)
+	if err != nil {
+		t.Fatalf("ListWorkerProjectSecrets: %v", err)
+	}
+	if svc.listSecretsProjectID != "prj_01abc" {
+		t.Errorf("read targeted project %q, want prj_01abc (worker's own project)", svc.listSecretsProjectID)
+	}
+	if got["DRONE_TOKEN"] != "abc" || got["DRONE_SERVER"] != "https://drone" {
+		t.Errorf("secrets = %#v, want the two DRONE_* entries", got)
+	}
+}
+
+// TestListWorkerProjectSecrets_NoProjectIDReturnsUnsupported pins that a
+// worker with no resolved project surfaces ErrProjectConfigUnsupported
+// rather than reading some other project's secrets.
+func TestListWorkerProjectSecrets_NoProjectIDReturnsUnsupported(t *testing.T) {
+	t.Parallel()
+	wrap := newOrgTestStoreForProjectConfig(t)
+	pc, err := NewProjectConfig(&wrap.Store, newFakeProjectService())
+	if err != nil {
+		t.Fatalf("NewProjectConfig: %v", err)
+	}
+	_, err = pc.ListWorkerProjectSecrets(context.Background(), "org-test", orgchart.BotID("w-noproject"))
+	if !errors.Is(err, runtime.ErrProjectConfigUnsupported) {
+		t.Errorf("err = %v, want ErrProjectConfigUnsupported", err)
+	}
+}
+
 // TestUpdateWorkerProjectConfig_PatchFlowsToHelix pins that a
 // pointer-set StartupScript on the patch reaches Helix's
 // ProjectUpdateRequest unchanged, and that the post-update

--- a/api/pkg/org/infrastructure/runtime/helix/project_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_test.go
@@ -35,6 +35,9 @@ type fakeProjectService struct {
 	updateProjectErr        error
 	putSecretCalls          int
 	putSecretLast           map[string]string
+	listSecretsProjectID    string
+	listSecretsResp         map[string]string
+	listSecretsErr          error
 	createGitRepoCalls      int
 	createGitRepoErr        error
 	createGitRepoNameReturn string // when set, CreateGitRepo returns this name (simulates auto-increment on collision)
@@ -110,13 +113,18 @@ func (f *fakeProjectService) PutProjectSecret(_ context.Context, _, name, value 
 	return nil
 }
 
-// ListProjectSecrets returns whatever was put via PutProjectSecret, so a
-// round-trip test can assert list_secrets surfaces them.
-func (f *fakeProjectService) ListProjectSecrets(_ context.Context, _ string) (map[string]string, error) {
+// ListProjectSecrets records the projectID it was asked for and returns
+// the scripted response, so a test can assert ListWorkerProjectSecrets
+// resolved the worker to the right project before reading.
+func (f *fakeProjectService) ListProjectSecrets(_ context.Context, projectID string) (map[string]string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	out := make(map[string]string, len(f.putSecretLast))
-	for k, v := range f.putSecretLast {
+	f.listSecretsProjectID = projectID
+	if f.listSecretsErr != nil {
+		return nil, f.listSecretsErr
+	}
+	out := make(map[string]string, len(f.listSecretsResp))
+	for k, v := range f.listSecretsResp {
 		out[k] = v
 	}
 	return out, nil

--- a/api/pkg/org/infrastructure/runtime/helix/project_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_test.go
@@ -110,6 +110,18 @@ func (f *fakeProjectService) PutProjectSecret(_ context.Context, _, name, value 
 	return nil
 }
 
+// ListProjectSecrets returns whatever was put via PutProjectSecret, so a
+// round-trip test can assert list_secrets surfaces them.
+func (f *fakeProjectService) ListProjectSecrets(_ context.Context, _ string) (map[string]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make(map[string]string, len(f.putSecretLast))
+	for k, v := range f.putSecretLast {
+		out[k] = v
+	}
+	return out, nil
+}
+
 func (f *fakeProjectService) CreateGitRepo(_ context.Context, req types.GitRepositoryCreateRequest) (types.GitRepository, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/api/pkg/org/infrastructure/runtime/runtime.go
+++ b/api/pkg/org/infrastructure/runtime/runtime.go
@@ -144,6 +144,12 @@ func (NoopHireHook) OnHire(_ context.Context, _ string, _ orgchart.BotID, _ stri
 type ProjectConfig interface {
 	GetWorkerProjectConfig(ctx context.Context, orgID string, workerID orgchart.BotID) (ProjectConfigSnapshot, error)
 	UpdateWorkerProjectConfig(ctx context.Context, orgID string, workerID orgchart.BotID, patch ProjectConfigPatch) (ProjectConfigSnapshot, error)
+	// ListWorkerProjectSecrets returns the worker's project secrets as a
+	// name→value map, read live so a secret added after the container
+	// booted is visible without a restart. Backs the list_secrets tool:
+	// the agent reads these and exports the ones it needs, the same way
+	// mint_credential feeds gh/git tokens into the shell.
+	ListWorkerProjectSecrets(ctx context.Context, orgID string, workerID orgchart.BotID) (map[string]string, error)
 }
 
 // ProjectConfigSnapshot is the read shape returned by
@@ -179,6 +185,10 @@ func (NoopProjectConfig) GetWorkerProjectConfig(_ context.Context, _ string, _ o
 
 func (NoopProjectConfig) UpdateWorkerProjectConfig(_ context.Context, _ string, _ orgchart.BotID, _ ProjectConfigPatch) (ProjectConfigSnapshot, error) {
 	return ProjectConfigSnapshot{}, ErrProjectConfigUnsupported
+}
+
+func (NoopProjectConfig) ListWorkerProjectSecrets(_ context.Context, _ string, _ orgchart.BotID) (map[string]string, error) {
+	return nil, ErrProjectConfigUnsupported
 }
 
 // ErrProjectConfigUnsupported is what the noop impl returns. Tools

--- a/api/pkg/org/interfaces/mcptools/builtins.go
+++ b/api/pkg/org/interfaces/mcptools/builtins.go
@@ -426,6 +426,7 @@ func RegisterBuiltins(reg *Registry, deps Deps) error {
 		&Managers{deps: deps},
 		&Reports{deps: deps},
 		&GetBotProject{deps: deps},
+		&ListSecrets{deps: deps},
 		// Project discovery — an org-wide PM Bot lists/reads the projects in
 		// its org before deciding which to manage. Org-scoped reads; granted
 		// per-Role (not in BaseReadTools).

--- a/api/pkg/org/interfaces/mcptools/configure_bot_project_test.go
+++ b/api/pkg/org/interfaces/mcptools/configure_bot_project_test.go
@@ -36,8 +36,20 @@ type fakeProjectConfig struct {
 	mu     sync.Mutex
 	get    func(orgID string, botID orgchart.BotID) (runtime.ProjectConfigSnapshot, error)
 	patch  func(orgID string, botID orgchart.BotID, p runtime.ProjectConfigPatch) (runtime.ProjectConfigSnapshot, error)
+	list   func(orgID string, botID orgchart.BotID) (map[string]string, error)
 	getN   int
 	patchN int
+	listN  int
+}
+
+func (f *fakeProjectConfig) ListWorkerProjectSecrets(_ context.Context, orgID string, botID orgchart.BotID) (map[string]string, error) {
+	f.mu.Lock()
+	f.listN++
+	f.mu.Unlock()
+	if f.list == nil {
+		return nil, errors.New("fakeProjectConfig: list not stubbed")
+	}
+	return f.list(orgID, botID)
 }
 
 func (f *fakeProjectConfig) GetWorkerProjectConfig(_ context.Context, orgID string, botID orgchart.BotID) (runtime.ProjectConfigSnapshot, error) {

--- a/api/pkg/org/interfaces/mcptools/create_bot_test.go
+++ b/api/pkg/org/interfaces/mcptools/create_bot_test.go
@@ -99,6 +99,7 @@ func TestCreateBotUnionWithCallerTools(t *testing.T) {
 		ReadEventsName,
 		BotLogName,
 		MintCredentialName,
+		ListSecretsName,
 		ListProcessorsName,
 		GetProcessorName,
 	}

--- a/api/pkg/org/interfaces/mcptools/defaults.go
+++ b/api/pkg/org/interfaces/mcptools/defaults.go
@@ -35,6 +35,10 @@ var BaseReadTools = []tool.Name{
 	ReadEventsName,
 	BotLogName,
 	MintCredentialName,
+	// Every bot can read its own project secrets (its own project only) so
+	// it can export a secret added after boot — the read sibling of
+	// mint_credential, same reason it belongs in the baseline.
+	ListSecretsName,
 	// Processor introspection — safe reads so any bot can discover the
 	// transform/filter/js nodes feeding topics it may subscribe to.
 	ListProcessorsName,

--- a/api/pkg/org/interfaces/mcptools/defaults_test.go
+++ b/api/pkg/org/interfaces/mcptools/defaults_test.go
@@ -24,6 +24,7 @@ func TestBaseReadToolsGolden(t *testing.T) {
 		ReadEventsName,
 		BotLogName,
 		MintCredentialName,
+		ListSecretsName,
 		ListProcessorsName,
 		GetProcessorName,
 	}
@@ -56,6 +57,7 @@ func TestBaseReadToolsAllRegistered(t *testing.T) {
 		ReadEventsName:      &ReadEvents{deps: deps},
 		BotLogName:          &BotLog{deps: deps},
 		MintCredentialName:  &MintCredential{deps: deps},
+		ListSecretsName:     &ListSecrets{deps: deps},
 		ListProcessorsName:  &ListProcessors{deps: deps},
 		GetProcessorName:    &GetProcessor{deps: deps},
 	}
@@ -105,6 +107,7 @@ func TestMergeBaseReadToolsPreservesCallerOrderAndDedups(t *testing.T) {
 		ReadEventsName,
 		BotLogName,
 		MintCredentialName,
+		ListSecretsName,
 		ListProcessorsName,
 		GetProcessorName,
 	}

--- a/api/pkg/org/interfaces/mcptools/list_secrets.go
+++ b/api/pkg/org/interfaces/mcptools/list_secrets.go
@@ -53,12 +53,9 @@ func (t *ListSecrets) Description() string {
 }
 
 func (t *ListSecrets) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
-	if inv.Caller == nil {
-		return nil, fmt.Errorf("caller missing on invocation")
-	}
-	orgID := inv.Caller.OrganizationID()
-	if orgID == "" {
-		return nil, fmt.Errorf("caller has no organization id")
+	orgID, err := projectConfigOrgID(inv)
+	if err != nil {
+		return nil, err
 	}
 	botID := inv.Caller.ID()
 	if botID == "" {

--- a/api/pkg/org/interfaces/mcptools/list_secrets.go
+++ b/api/pkg/org/interfaces/mcptools/list_secrets.go
@@ -1,0 +1,79 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
+)
+
+// ListSecrets returns the calling Bot's own project secrets as a
+// name→value map, read live. It is the read counterpart to the
+// container's boot-time env-var injection: a project secret added AFTER
+// the desktop booted is not in the running shell's environment (a
+// process's env is frozen at start), so the agent reads it here and
+// exports it — the same shape as mint_credential feeding gh/git tokens
+// into the shell.
+//
+// Scope is the caller only: orgID and botID both come from
+// inv.Caller, never from args, so a Bot can read its own project's
+// secrets and no other's. No new exposure — these are the exact secrets
+// the Bot already receives as env vars at boot.
+type ListSecrets struct {
+	deps Deps
+}
+
+const ListSecretsName tool.Name = "list_secrets"
+
+// NewListSecrets is the exported constructor so tests can build the tool
+// with a fake ProjectConfig without going through RegisterBuiltins.
+func NewListSecrets(deps Deps) *ListSecrets { return &ListSecrets{deps: deps} }
+
+type listSecretsArgs struct{}
+
+var listSecretsSchema = mustSchema[listSecretsArgs]()
+
+func (t *ListSecrets) Name() tool.Name                 { return ListSecretsName }
+func (t *ListSecrets) InputSchema() *jsonschema.Schema { return listSecretsSchema }
+
+func (t *ListSecrets) Description() string {
+	return "List your project's secrets as a name→value map (your own project only). " +
+		"Project secrets are injected as environment variables when your desktop starts, " +
+		"but a secret added AFTER your container booted is NOT yet in your shell — a running " +
+		"process's environment cannot change. Call this to read the current secrets and " +
+		"**export the ones you need before the command that uses them** " +
+		"(e.g. `export DRONE_TOKEN=$(list_secrets | jq -r '.secrets.DRONE_TOKEN')`). " +
+		"Re-read after you add or change a secret mid-session. " +
+		"Returns: { secrets: { NAME: value, ... } }."
+}
+
+func (t *ListSecrets) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	if inv.Caller == nil {
+		return nil, fmt.Errorf("caller missing on invocation")
+	}
+	orgID := inv.Caller.OrganizationID()
+	if orgID == "" {
+		return nil, fmt.Errorf("caller has no organization id")
+	}
+	botID := inv.Caller.ID()
+	if botID == "" {
+		return nil, fmt.Errorf("caller has no bot id")
+	}
+	cfg := t.deps.ProjectConfig
+	if cfg == nil {
+		return nil, runtime.ErrProjectConfigUnsupported
+	}
+	secrets, err := cfg.ListWorkerProjectSecrets(ctx, orgID, orgchart.BotID(botID))
+	if err != nil {
+		return nil, fmt.Errorf("list secrets: %w", err)
+	}
+	if secrets == nil {
+		secrets = map[string]string{}
+	}
+	return json.Marshal(map[string]any{"secrets": secrets})
+}

--- a/api/pkg/org/interfaces/mcptools/list_secrets_test.go
+++ b/api/pkg/org/interfaces/mcptools/list_secrets_test.go
@@ -1,0 +1,75 @@
+package mcptools_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	domainTool "github.com/helixml/helix/api/pkg/org/domain/tool"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
+	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
+)
+
+func invokeAsCaller(t *testing.T, tl domainTool.Tool) (json.RawMessage, error) {
+	t.Helper()
+	return tl.Invoke(context.Background(), domainTool.Invocation{
+		Args:   json.RawMessage(`{}`),
+		Caller: fakeOwnerCaller{},
+	})
+}
+
+func TestListSecrets_ReturnsNameValueMap(t *testing.T) {
+	t.Parallel()
+	fc := &fakeProjectConfig{
+		list: func(orgID string, botID orgchart.BotID) (map[string]string, error) {
+			if orgID != "org-test" {
+				t.Errorf("orgID = %q, want org-test", orgID)
+			}
+			// Scoped to the caller bot, never an arg.
+			if botID != "b-owner" {
+				t.Errorf("botID = %q, want b-owner", botID)
+			}
+			return map[string]string{"DRONE_TOKEN": "abc123", "DRONE_SERVER": "https://drone"}, nil
+		},
+	}
+	raw, err := invokeAsCaller(t, mcptools.NewListSecrets(mcptools.Deps{ProjectConfig: fc}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	var got struct {
+		Secrets map[string]string `json:"secrets"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Secrets["DRONE_TOKEN"] != "abc123" || got.Secrets["DRONE_SERVER"] != "https://drone" {
+		t.Fatalf("secrets = %#v, want the two DRONE_* entries", got.Secrets)
+	}
+	if fc.listN != 1 {
+		t.Fatalf("listN = %d, want 1", fc.listN)
+	}
+}
+
+func TestListSecrets_EmptyIsEmptyObjectNotNull(t *testing.T) {
+	t.Parallel()
+	fc := &fakeProjectConfig{
+		list: func(string, orgchart.BotID) (map[string]string, error) { return nil, nil },
+	}
+	raw, err := invokeAsCaller(t, mcptools.NewListSecrets(mcptools.Deps{ProjectConfig: fc}))
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if string(raw) != `{"secrets":{}}` {
+		t.Fatalf("raw = %s, want {\"secrets\":{}}", raw)
+	}
+}
+
+func TestListSecrets_UnwiredPortErrors(t *testing.T) {
+	t.Parallel()
+	_, err := invokeAsCaller(t, mcptools.NewListSecrets(mcptools.Deps{ProjectConfig: runtime.NoopProjectConfig{}}))
+	if !errors.Is(err, runtime.ErrProjectConfigUnsupported) {
+		t.Fatalf("err = %v, want ErrProjectConfigUnsupported", err)
+	}
+}

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -263,6 +263,28 @@ func (c *inProcHelixClient) PutProjectSecret(ctx context.Context, projectID, nam
 	return nil
 }
 
+// ListProjectSecrets returns the project's dev-scoped secrets as a
+// decrypted name→value map. Reuses GetProjectSecretsAsEnvVars (the same
+// resolver the desktop-boot injection uses) so scope filtering and
+// decryption stay in one place, then splits each `KEY=value` back into a
+// map. Dev scope matches the desktop container's environment — the bot
+// reads exactly what it would have had injected at boot.
+func (c *inProcHelixClient) ListProjectSecrets(ctx context.Context, projectID string) (map[string]string, error) {
+	envVars, err := c.server.GetProjectSecretsAsEnvVars(ctx, projectID, types.SecretScopeDev)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]string, len(envVars))
+	for _, kv := range envVars {
+		name, value, found := strings.Cut(kv, "=")
+		if !found || name == "" {
+			continue
+		}
+		out[name] = value
+	}
+	return out, nil
+}
+
 // CreateGitRepo creates an internal Helix git repository. The
 // createGitRepository handler writes its response directly to the
 // ResponseWriter (not the typed-handler shape), so we capture the

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -274,6 +274,15 @@ func (c *inProcHelixClient) ListProjectSecrets(ctx context.Context, projectID st
 	if err != nil {
 		return nil, err
 	}
+	return parseEnvVarsToMap(envVars), nil
+}
+
+// parseEnvVarsToMap splits `KEY=value` env-var strings back into a map.
+// Cut on the FIRST `=` so a value that itself contains `=` (base64, a
+// URL query, …) round-trips intact. Entries with no `=` or an empty name
+// are skipped — GetProjectSecretsAsEnvVars never emits those, but the
+// guard keeps a malformed entry from producing a `""` key.
+func parseEnvVarsToMap(envVars []string) map[string]string {
 	out := make(map[string]string, len(envVars))
 	for _, kv := range envVars {
 		name, value, found := strings.Cut(kv, "=")
@@ -282,7 +291,7 @@ func (c *inProcHelixClient) ListProjectSecrets(ctx context.Context, projectID st
 		}
 		out[name] = value
 	}
-	return out, nil
+	return out
 }
 
 // CreateGitRepo creates an internal Helix git repository. The

--- a/api/pkg/server/helix_org_inproc_test.go
+++ b/api/pkg/server/helix_org_inproc_test.go
@@ -184,6 +184,27 @@ func TestInProcSpawnerClient_ClearSession_NoSession_ReturnsError(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestParseEnvVarsToMap pins the KEY=value split that backs
+// ListProjectSecrets / list_secrets. A value containing `=` (base64,
+// tokens, URL query strings) must survive intact — Cut on the FIRST `=`
+// — and a malformed entry must never produce a "" key.
+func TestParseEnvVarsToMap(t *testing.T) {
+	got := parseEnvVarsToMap([]string{
+		"DRONE_TOKEN=abc",
+		"B64=a=b=c==",           // value with `=` — keep everything after the first
+		"URL=https://x?a=1&b=2", // query string with `=`
+		"EMPTY=",                // empty value is a valid secret
+		"=orphan",               // empty name — dropped
+		"NOEQUALS",              // no `=` — dropped
+	})
+	require.Equal(t, map[string]string{
+		"DRONE_TOKEN": "abc",
+		"B64":         "a=b=c==",
+		"URL":         "https://x?a=1&b=2",
+		"EMPTY":       "",
+	}, got)
+}
+
 // TODO: tests for StartSession / SendMessage. StartSession routes to
 // StartExternalAgentSession (starts a real dev container) and
 // SendMessage to sendSessionMessage (needs a connected external-agent


### PR DESCRIPTION
## What

Adds a `list_secrets` org MCP read tool so a bot can read its own project's secrets as a live `{name: value}` map and export the ones it needs. Fixes the bot side of HO-15 (project secrets don't hot-reload into a running bot container).

## Why

A running container's process environment is frozen at start, and the bot's shell tools (`bash`/`curl`/`gh`/`git`) run inside the agent harness's own shell — **not** through Helix's exec API. So a project secret added *after* the desktop booted never reaches a running bot, and there's no server-side hook that can push it in. This is the same constraint `mint_credential` already works around for `gh`/`git` tokens.

`list_secrets` follows that established pattern: the agent reads the current secrets and exports what it needs (`export DRONE_TOKEN=$(list_secrets | jq -r '.secrets.DRONE_TOKEN')`), re-reading after a secret changes. No restart.

## Design

- **Scoped to the caller**: `orgID` + `botID` both come from `inv.Caller`, never from args, so a bot can only read its *own* project's secrets. No new exposure — these are the exact secrets already injected as env vars at boot.
- **In `BaseReadTools`**: every bot gets it automatically, same rationale as `mint_credential`.
- **Reuses existing layering** (the path `get_bot_project` uses): new `ProjectConfig.ListWorkerProjectSecrets` port → `ProjectService.ListProjectSecrets` → `inProcHelixClient`, which reuses `GetProjectSecretsAsEnvVars` so scope filtering + decryption stay in one place.

## Not included (deliberate)

Per-exec injection into hydra `RunCommand` was considered but **does not serve HO-15** — that path only covers the Sandboxes API / API-driven desktop execs, not the bot's own harness shell. If the Sandboxes product wants live secrets, that's a separate change.

## Testing

- Full `api` build green; all `./pkg/org/...` unit tests pass.
- New `list_secrets_test.go`: happy path (name→value map, caller-scoped), empty-is-`{}`-not-null, unwired-port error.
- Golden-list tests (`BaseReadTools`, `create_bot` union, merge) + 3 test fakes updated.
- **NOT yet tested end-to-end against a live org bot** — needs a running stack + real bot session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)