### PR TITLE
feat(org): configure cron messages and clear topic events

### DIFF
--- a/api/pkg/org/QA.md
+++ b/api/pkg/org/QA.md
@@ -180,6 +180,17 @@ direct report also gets an `s-team-<managerID>` broadcast topic
    newest-first.
 4. **Live SSE tail**: publish a new event. The new event appears
    at the top within ~1.5s without reload.
+5. **Inline configuration**: the side drawer and detail page show mutable
+   fields immediately, with no Edit step. Save is hidden until a field changes,
+   then appears in the secondary colour and disappears after a successful save.
+6. **Clear messages**: click **Clear messages**, cancel once, then confirm. The
+   retained count and event list become zero without deleting the Topic or its
+   subscribers. Publish another event immediately; it appears in the live tail
+   and the retained count increments again.
+7. **Cron message**: create a `cron` topic, enter a message alongside its
+   weekday/time or interval schedule, and save. Reopen the topic in both the
+   drawer and detail page; the message persists. When the scheduler fires,
+   the event body is the configured message.
 
 ## §7. GitHub topics — one-click setup
 

--- a/api/pkg/org/application/messages/messages.go
+++ b/api/pkg/org/application/messages/messages.go
@@ -1,0 +1,46 @@
+// Package messages owns mutations of the events retained on Topics.
+package messages
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/domain/streaming"
+)
+
+type Notifier interface {
+	Notify(orgID string, topicID streaming.TopicID)
+}
+
+type Messages struct {
+	topics   store.Topics
+	events   store.Events
+	notifier Notifier
+}
+
+type Deps struct {
+	Topics   store.Topics
+	Events   store.Events
+	Notifier Notifier
+}
+
+func New(deps Deps) *Messages {
+	return &Messages{topics: deps.Topics, events: deps.Events, notifier: deps.Notifier}
+}
+
+// Clear deletes every retained event on one Topic and wakes live readers so
+// they immediately receive the empty event list. The Topic itself and all
+// subscriptions remain unchanged.
+func (m *Messages) Clear(ctx context.Context, orgID string, topicID streaming.TopicID) error {
+	if _, err := m.topics.Get(ctx, orgID, topicID); err != nil {
+		return fmt.Errorf("get topic: %w", err)
+	}
+	if err := m.events.DeleteForTopic(ctx, orgID, topicID); err != nil {
+		return fmt.Errorf("delete topic messages: %w", err)
+	}
+	if m.notifier != nil {
+		m.notifier.Notify(orgID, topicID)
+	}
+	return nil
+}

--- a/api/pkg/org/domain/store/store.go
+++ b/api/pkg/org/domain/store/store.go
@@ -134,6 +134,10 @@ type Subscriptions interface {
 // Events persists entries published on a Topic.
 type Events interface {
 	Append(ctx context.Context, e streaming.Event) error
+	// DeleteForTopic removes every event belonging to one Topic. Clearing an
+	// already-empty Topic is successful; callers verify the Topic exists before
+	// invoking this repository operation.
+	DeleteForTopic(ctx context.Context, orgID string, topicID streaming.TopicID) error
 	ListForTopic(ctx context.Context, orgID string, topicID streaming.TopicID, limit int) ([]streaming.Event, error)
 	// PageForTopic returns a window of events on one Topic, newest
 	// first (same ordering as ListForTopic), skipping offset rows and

--- a/api/pkg/org/domain/transport/cron.go
+++ b/api/pkg/org/domain/transport/cron.go
@@ -27,7 +27,7 @@ const KindCron Kind = "cron"
 // up activation costs.
 const minCronInterval = 90 * time.Second
 
-// CronConfig carries the schedule for a KindCron topic. The UI
+// CronConfig carries the schedule and optional message for a KindCron topic. The UI
 // always submits a standard 5-field cron expression (optionally
 // prefixed by "CRON_TZ=<tz> " to pin the timezone, defaulting to UTC).
 // Preset buttons in the UI inject the literal cron form so users
@@ -39,6 +39,7 @@ const minCronInterval = 90 * time.Second
 // actively reject them, but the UI never produces them.
 type CronConfig struct {
 	Schedule string `json:"schedule"`
+	Message  string `json:"message,omitempty"`
 }
 
 // Validate enforces that Schedule parses as a standard 5-field cron

--- a/api/pkg/org/domain/transport/cron_test.go
+++ b/api/pkg/org/domain/transport/cron_test.go
@@ -159,3 +159,19 @@ func TestCronConfigParse(t *testing.T) {
 		})
 	}
 }
+
+func TestCronConfigParseMessage(t *testing.T) {
+	t.Parallel()
+
+	tr := transport.Transport{
+		Kind:   transport.KindCron,
+		Config: json.RawMessage(`{"schedule":"0 9 * * 1","message":"Prepare the report"}`),
+	}
+	cfg, err := tr.CronConfig()
+	if err != nil {
+		t.Fatalf("CronConfig() = %v, want nil", err)
+	}
+	if cfg.Message != "Prepare the report" {
+		t.Fatalf("Message = %q, want configured message", cfg.Message)
+	}
+}

--- a/api/pkg/org/infrastructure/persistence/gorm/event.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/event.go
@@ -64,6 +64,16 @@ func (r *eventsRepo) Append(ctx context.Context, e streaming.Event) error {
 	return r.Repository.Create(ctx, e)
 }
 
+func (r *eventsRepo) DeleteForTopic(ctx context.Context, orgID string, topicID streaming.TopicID) error {
+	result := r.Repository.db.WithContext(ctx).
+		Where("org_id = ? AND topic_id = ?", orgID, string(topicID)).
+		Delete(&eventRow{})
+	if result.Error != nil {
+		return fmt.Errorf("delete events for topic: %w", result.Error)
+	}
+	return nil
+}
+
 func (r *eventsRepo) ListForTopic(ctx context.Context, orgID string, topicID streaming.TopicID, limit int) ([]streaming.Event, error) {
 	return r.Repository.Find(ctx,
 		store.WithOrg(orgID),

--- a/api/pkg/org/infrastructure/persistence/gorm/events_page_test.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/events_page_test.go
@@ -88,6 +88,49 @@ func TestEventsPageAndCountForTopic(t *testing.T) {
 	}
 }
 
+func TestEventsDeleteForTopic(t *testing.T) {
+	t.Parallel()
+	s := newStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+
+	for _, item := range []struct {
+		id, orgID, topicID string
+	}{
+		{"e-a-1", "org-test", "s-a"},
+		{"e-a-2", "org-test", "s-a"},
+		{"e-b", "org-test", "s-b"},
+		{"e-other-org", "org-other", "s-a"},
+	} {
+		ev, _ := streaming.NewEvent(streaming.EventID(item.id), streaming.TopicID(item.topicID), "w-owner", "body", now, item.orgID)
+		if err := s.Events.Append(ctx, ev); err != nil {
+			t.Fatalf("Append %s: %v", item.id, err)
+		}
+	}
+
+	if err := s.Events.DeleteForTopic(ctx, "org-test", "s-a"); err != nil {
+		t.Fatalf("DeleteForTopic: %v", err)
+	}
+	if count, err := s.Events.CountForTopic(ctx, "org-test", "s-a"); err != nil || count != 0 {
+		t.Fatalf("cleared count = %d, %v; want 0, nil", count, err)
+	}
+	if count, _ := s.Events.CountForTopic(ctx, "org-test", "s-b"); count != 1 {
+		t.Fatalf("other topic count = %d, want 1", count)
+	}
+	if count, _ := s.Events.CountForTopic(ctx, "org-other", "s-a"); count != 1 {
+		t.Fatalf("other org count = %d, want 1", count)
+	}
+
+	// Clearing must not poison the next normal append.
+	next, _ := streaming.NewEvent("e-next", "s-a", "w-owner", "next", now.Add(time.Second), "org-test")
+	if err := s.Events.Append(ctx, next); err != nil {
+		t.Fatalf("Append after clear: %v", err)
+	}
+	if count, _ := s.Events.CountForTopic(ctx, "org-test", "s-a"); count != 1 {
+		t.Fatalf("count after append = %d, want 1", count)
+	}
+}
+
 func ids(evs []streaming.Event) []streaming.EventID {
 	out := make([]streaming.EventID, len(evs))
 	for i, e := range evs {

--- a/api/pkg/org/infrastructure/persistence/memory/memorystore.go
+++ b/api/pkg/org/infrastructure/persistence/memory/memorystore.go
@@ -619,6 +619,19 @@ func (e *eventsRepo) Append(_ context.Context, ev streaming.Event) error {
 	return nil
 }
 
+func (e *eventsRepo) DeleteForTopic(_ context.Context, orgID string, topicID streaming.TopicID) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	kept := e.rows[:0]
+	for _, ev := range e.rows {
+		if ev.OrganizationID != orgID || ev.TopicID != topicID {
+			kept = append(kept, ev)
+		}
+	}
+	e.rows = kept
+	return nil
+}
+
 func (e *eventsRepo) ListForTopic(_ context.Context, orgID string, topicID streaming.TopicID, limit int) ([]streaming.Event, error) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()

--- a/api/pkg/org/infrastructure/streamcron/scheduler.go
+++ b/api/pkg/org/infrastructure/streamcron/scheduler.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -286,13 +287,33 @@ type scheduledBody struct {
 // tests can call it directly without going through gocron.
 func (c *Scheduler) fire(ctx context.Context, orgID string, topicID streaming.TopicID) error {
 	firedAt := c.now()
-	body, err := json.Marshal(scheduledBody{
-		Kind:    "scheduled",
-		FiredAt: firedAt.UTC().Format(time.RFC3339),
-		TopicID: string(topicID),
-	})
+	topic, err := c.store.Topics.Get(ctx, orgID, topicID)
 	if err != nil {
-		return fmt.Errorf("encode body: %w", err)
+		return fmt.Errorf("get topic: %w", err)
+	}
+	cfg, err := topic.Transport.CronConfig()
+	if err != nil {
+		return fmt.Errorf("parse cron config: %w", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("validate cron config: %w", err)
+	}
+
+	body := cfg.Message
+	bodyContentType := "text/plain"
+	if strings.TrimSpace(body) == "" {
+		// Preserve the structured payload for existing cron topics that do
+		// not have a configured message.
+		bodyBytes, err := json.Marshal(scheduledBody{
+			Kind:    "scheduled",
+			FiredAt: firedAt.UTC().Format(time.RFC3339),
+			TopicID: string(topicID),
+		})
+		if err != nil {
+			return fmt.Errorf("encode body: %w", err)
+		}
+		body = string(bodyBytes)
+		bodyContentType = "application/json"
 	}
 
 	// Wrap as a Message envelope so downstream readers (which always
@@ -302,7 +323,7 @@ func (c *Scheduler) fire(ctx context.Context, orgID string, topicID streaming.To
 		From:            "", // system-emitted
 		Subject:         "Scheduled trigger",
 		Body:            string(body),
-		BodyContentType: "application/json",
+		BodyContentType: bodyContentType,
 	}
 	event, err := streaming.NewMessageEvent(
 		streaming.EventID("e-"+c.newID()),

--- a/api/pkg/org/infrastructure/streamcron/scheduler_test.go
+++ b/api/pkg/org/infrastructure/streamcron/scheduler_test.go
@@ -57,8 +57,12 @@ func newTestScheduler(t *testing.T) (*Scheduler, *recordingDispatcher) {
 }
 
 func makeCronTopic(t *testing.T, s *Scheduler, orgID string, topicID streaming.TopicID, schedule string) {
+	makeCronTopicWithMessage(t, s, orgID, topicID, schedule, "")
+}
+
+func makeCronTopicWithMessage(t *testing.T, s *Scheduler, orgID string, topicID streaming.TopicID, schedule, message string) {
 	t.Helper()
-	cfg, err := json.Marshal(transport.CronConfig{Schedule: schedule})
+	cfg, err := json.Marshal(transport.CronConfig{Schedule: schedule, Message: message})
 	if err != nil {
 		t.Fatalf("marshal cron config: %v", err)
 	}
@@ -71,6 +75,37 @@ func makeCronTopic(t *testing.T, s *Scheduler, orgID string, topicID streaming.T
 	}
 	if err := s.store.Topics.Create(context.Background(), topic); err != nil {
 		t.Fatalf("Topics.Create: %v", err)
+	}
+}
+
+func TestFireUsesConfiguredMessage(t *testing.T) {
+	t.Parallel()
+
+	s, disp := newTestScheduler(t)
+	makeCronTopicWithMessage(t, s, "org-test", "s-cron", "@daily", "Prepare the daily status report")
+
+	if err := s.fire(context.Background(), "org-test", "s-cron"); err != nil {
+		t.Fatalf("fire: %v", err)
+	}
+	events, err := s.store.Events.ListForTopic(context.Background(), "org-test", "s-cron", 10)
+	if err != nil {
+		t.Fatalf("ListForTopic: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events on topic = %d, want 1", len(events))
+	}
+	msg, err := events[0].Message()
+	if err != nil {
+		t.Fatalf("Message: %v", err)
+	}
+	if msg.Body != "Prepare the daily status report" {
+		t.Fatalf("Body = %q, want configured message", msg.Body)
+	}
+	if msg.BodyContentType != "text/plain" {
+		t.Fatalf("BodyContentType = %q, want text/plain", msg.BodyContentType)
+	}
+	if len(disp.snapshot()) != 1 {
+		t.Fatalf("dispatched events = %d, want 1", len(disp.snapshot()))
 	}
 }
 

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -12,6 +12,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/chartlayout"
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
 	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
+	"github.com/helixml/helix/api/pkg/org/application/messages"
 	"github.com/helixml/helix/api/pkg/org/application/processors"
 	"github.com/helixml/helix/api/pkg/org/application/publishing"
 	"github.com/helixml/helix/api/pkg/org/application/queries"
@@ -70,7 +71,8 @@ type Deps struct {
 	// helper). The api package holds NO store.* repository, so the
 	// compiler now forbids any handler reaching past a service into the
 	// store (the Phase-D enforcement gate).
-	Topics *topics.Topics
+	Topics   *topics.Topics
+	Messages *messages.Messages
 	// Bots is the merged role+worker mutation service: content/tools
 	// updates (PATCH /bots/{id}) and reporting-line edges
 	// (AddParent/RemoveParent). Creation/deletion go through Lifecycle.
@@ -298,6 +300,7 @@ func Routes(deps Deps) []Route {
 		{Pattern: "DELETE /topics/{id}", Handler: http.HandlerFunc(a.deleteTopic)},
 		{Pattern: "GET /topics/{id}/events", Handler: http.HandlerFunc(a.topicEventsSSE)},
 		{Pattern: "GET /topics/{id}/messages", Handler: http.HandlerFunc(a.listTopicMessages)},
+		{Pattern: "DELETE /topics/{id}/messages", Handler: http.HandlerFunc(a.clearTopicMessages)},
 		{Pattern: "POST /topics/{id}/publish", Handler: http.HandlerFunc(a.publishToTopic)},
 		// Processors — JSON:API CRUD.
 		{Pattern: "GET /processors", Handler: http.HandlerFunc(a.listProcessors)},

--- a/api/pkg/org/interfaces/server/api/api_test.go
+++ b/api/pkg/org/interfaces/server/api/api_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/chartlayout"
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
 	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
+	"github.com/helixml/helix/api/pkg/org/application/messages"
 	"github.com/helixml/helix/api/pkg/org/application/processors"
 	"github.com/helixml/helix/api/pkg/org/application/publishing"
 	"github.com/helixml/helix/api/pkg/org/application/queries"
@@ -69,8 +70,9 @@ func newDepsClock(t *testing.T, clock func() time.Time, newID func() string) (or
 	})
 
 	deps := orgapi.Deps{
-		Topics: topics.New(topics.Deps{Topics: st.Topics, Now: clock, NewID: newID}),
-		Bots:   botsSvc,
+		Topics:   topics.New(topics.Deps{Topics: st.Topics, Now: clock, NewID: newID}),
+		Messages: messages.New(messages.Deps{Topics: st.Topics, Events: st.Events, Notifier: hub}),
+		Bots:     botsSvc,
 		// Create + Delete live on the lifecycle service. Bots is required
 		// for Create (row creation + base-tool union). BotReconcilers wires
 		// the topology reconcile. Helix/Mirror stay nil — the REST tests

--- a/api/pkg/org/interfaces/server/api/messages_test.go
+++ b/api/pkg/org/interfaces/server/api/messages_test.go
@@ -93,6 +93,54 @@ func TestListTopicMessages_FirstPage(t *testing.T) {
 	}
 }
 
+func TestClearTopicMessages(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	h := orgapi.Handler(deps)
+	seedTopicWithEvents(t, st, "s-clear", 3)
+	keep, _ := streaming.NewTopic("s-keep", "keep", "", "w-owner", time.Now(), transport.Transport{Kind: transport.KindLocal}, "org-test")
+	if err := st.Topics.Create(context.Background(), keep); err != nil {
+		t.Fatalf("create other topic: %v", err)
+	}
+	keepEvent, _ := streaming.NewEvent("e-keep", "s-keep", "w-owner", "keep", time.Now(), "org-test")
+	if err := st.Events.Append(context.Background(), keepEvent); err != nil {
+		t.Fatalf("append other topic event: %v", err)
+	}
+
+	rec := do(t, h, "DELETE", "/topics/s-clear/messages", nil)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status: got %d, want 204; body=%s", rec.Code, rec.Body)
+	}
+	if count, err := st.Events.CountForTopic(context.Background(), "org-test", "s-clear"); err != nil || count != 0 {
+		t.Fatalf("cleared count = %d, %v; want 0, nil", count, err)
+	}
+	if count, _ := st.Events.CountForTopic(context.Background(), "org-test", "s-keep"); count != 1 {
+		t.Fatalf("other topic count = %d, want 1", count)
+	}
+
+	// The immediately following normal operation must still work.
+	next, _ := streaming.NewEvent("e-next", "s-clear", "w-owner", `{"from":"w-owner","body":"next"}`, time.Now(), "org-test")
+	if err := st.Events.Append(context.Background(), next); err != nil {
+		t.Fatalf("append after clear: %v", err)
+	}
+	page := do(t, h, "GET", "/topics/s-clear/messages", nil)
+	if page.Code != http.StatusOK {
+		t.Fatalf("list after clear + append: status=%d body=%s", page.Code, page.Body)
+	}
+	var doc orgapi.MessagesDocument
+	decode(t, page, &doc)
+	if len(doc.Data) != 1 || doc.Data[0].ID != "e-next" {
+		t.Fatalf("messages after clear + append = %+v, want e-next", doc.Data)
+	}
+}
+
+func TestClearTopicMessages_NotFound(t *testing.T) {
+	deps, _, _ := newDeps(t)
+	rec := do(t, orgapi.Handler(deps), "DELETE", "/topics/missing/messages", nil)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404; body=%s", rec.Code, rec.Body)
+	}
+}
+
 // TestListTopicMessages_LastPartialPage pins the tail: the final page
 // holds the remainder, has prev, and no next. meta.total is unchanged.
 func TestListTopicMessages_LastPartialPage(t *testing.T) {

--- a/api/pkg/org/interfaces/server/api/streams.go
+++ b/api/pkg/org/interfaces/server/api/streams.go
@@ -488,6 +488,38 @@ func (a *apiHandler) listTopicMessages(w http.ResponseWriter, r *http.Request) {
 	jsonapi.Write(w, http.StatusOK, doc)
 }
 
+// clearTopicMessages permanently deletes every retained message on one Topic.
+// The Topic and its subscriptions remain intact.
+//
+// @Summary Helix-org: clear all messages from a topic
+// @Tags HelixOrg
+// @Param id path string true "Topic ID"
+// @Success 204
+// @Failure 404 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/topics/{id}/messages [delete]
+func (a *apiHandler) clearTopicMessages(w http.ResponseWriter, r *http.Request) {
+	orgID, err := resolveOrgID(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	id := streaming.TopicID(r.PathValue("id"))
+	if id == "" {
+		writeError(w, http.StatusBadRequest, errors.New("topic id is required"))
+		return
+	}
+	if a.deps.Messages == nil {
+		writeError(w, http.StatusServiceUnavailable, errors.New("topic messages service not configured"))
+		return
+	}
+	if err := a.deps.Messages.Clear(r.Context(), orgID, id); err != nil {
+		writeError(w, errStatus(err), fmt.Errorf("clear messages for %s: %w", id, err))
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // topicEventsSSE pushes EventCard JSON arrays on every Hub.Notify.
 //
 // Each SSE `data:` line is a JSON array of recent events (cap 50,

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -11209,6 +11209,37 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: clear all messages from a topic",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Topic ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/api/v1/orgs/{org}/topics/{id}/publish": {
@@ -30333,6 +30364,10 @@ const docTemplate = `{
                 },
                 "stream": {
                     "type": "boolean"
+                },
+                "time_to_first_token_ms": {
+                    "description": "TimeToFirstTokenMs is the wall time from request start to the first\nstreamed chunk. It isolates provider prefill / cold-start latency from\ngeneration time (a cold or overloaded provider shows a large TTFT while\ngeneration stays normal). 0 means no chunk was received (the call errored\nor was cut before the first token). For non-streaming calls it equals the\ntime to the full response.",
+                    "type": "integer"
                 },
                 "total_cost": {
                     "description": "Prompt + completion + cache read + cache write",

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -23,6 +23,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/dispatch"
 	"github.com/helixml/helix/api/pkg/org/application/helixevents"
 	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
+	"github.com/helixml/helix/api/pkg/org/application/messages"
 	"github.com/helixml/helix/api/pkg/org/application/processing"
 	"github.com/helixml/helix/api/pkg/org/application/processors"
 	"github.com/helixml/helix/api/pkg/org/application/prompts"
@@ -252,6 +253,7 @@ func (r botSessionResetter) ResetSession(ctx context.Context, orgID string, botI
 type orgServices struct {
 	Bots          *bots.Bots
 	Topics        *topics.Topics
+	Messages      *messages.Messages
 	Subscriptions *subscriptions.Subscriptions
 	Publishing    *publishing.Publishing
 	Queries       *queries.Queries
@@ -268,8 +270,9 @@ func buildOrgServices(st *helixorgstore.Store, deps mcptools.Config, bc *wakebus
 	botsSvc := bots.New(bots.Deps{Bots: st.Bots, Lines: st.ReportingLines, Reconciler: deps.Reconciler, Now: deps.Now, NewID: deps.NewID, BaseTools: mcptools.BaseReadTools})
 	topicsSvc := topics.New(topics.Deps{Topics: st.Topics, Now: deps.Now, NewID: deps.NewID, Provisioners: provisioners})
 	return orgServices{
-		Bots:   botsSvc,
-		Topics: topicsSvc,
+		Bots:     botsSvc,
+		Topics:   topicsSvc,
+		Messages: messages.New(messages.Deps{Topics: st.Topics, Events: st.Events, Notifier: bc}),
 		Processors: processors.New(processors.Deps{
 			Processors: st.Processors, Topics: topicsSvc, Now: deps.Now, NewID: deps.NewID,
 		}),
@@ -874,6 +877,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	slackAutoRouter := &slackAutoRouter{procs: svc.Processors, routes: slackRouteReconciler, logger: logger}
 	apiDeps := helixorgapi.Deps{
 		Topics:        svc.Topics,
+		Messages:      svc.Messages,
 		Bots:          svc.Bots,
 		Subscriptions: svc.Subscriptions,
 		Publishing:    svc.Publishing,

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -11205,6 +11205,37 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: clear all messages from a topic",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Topic ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/api/v1/orgs/{org}/topics/{id}/publish": {
@@ -30329,6 +30360,10 @@
                 },
                 "stream": {
                     "type": "boolean"
+                },
+                "time_to_first_token_ms": {
+                    "description": "TimeToFirstTokenMs is the wall time from request start to the first\nstreamed chunk. It isolates provider prefill / cold-start latency from\ngeneration time (a cold or overloaded provider shows a large TTFT while\ngeneration stays normal). 0 means no chunk was received (the call errored\nor was cut before the first token). For non-streaming calls it equals the\ntime to the full response.",
+                    "type": "integer"
                 },
                 "total_cost": {
                     "description": "Prompt + completion + cache read + cache write",

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -6278,6 +6278,15 @@ definitions:
         $ref: '#/definitions/types.LLMCallStep'
       stream:
         type: boolean
+      time_to_first_token_ms:
+        description: |-
+          TimeToFirstTokenMs is the wall time from request start to the first
+          streamed chunk. It isolates provider prefill / cold-start latency from
+          generation time (a cold or overloaded provider shows a large TTFT while
+          generation stays normal). 0 means no chunk was received (the call errored
+          or was cut before the first token). For non-streaming calls it equals the
+          time to the full response.
+        type: integer
       total_cost:
         description: Prompt + completion + cache read + cache write
         type: number
@@ -19321,6 +19330,25 @@ paths:
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/topics/{id}/messages:
+    delete:
+      parameters:
+      - description: Topic ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: clear all messages from a topic'
+      tags:
+      - HelixOrg
     get:
       parameters:
       - description: Topic ID

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -3974,6 +3974,15 @@ export interface TypesLLMCall {
   spec_task_id?: string;
   step?: TypesLLMCallStep;
   stream?: boolean;
+  /**
+   * TimeToFirstTokenMs is the wall time from request start to the first
+   * streamed chunk. It isolates provider prefill / cold-start latency from
+   * generation time (a cold or overloaded provider shows a large TTFT while
+   * generation stays normal). 0 means no chunk was received (the call errored
+   * or was cut before the first token). For non-streaming calls it equals the
+   * time to the full response.
+   */
+  time_to_first_token_ms?: number;
   /** Prompt + completion + cache read + cache write */
   total_cost?: number;
   total_tokens?: number;
@@ -13166,6 +13175,23 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         method: "GET",
         secure: true,
         format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsTopicsMessagesDelete
+     * @summary Helix-org: clear all messages from a topic
+     * @request DELETE:/api/v1/orgs/{org}/topics/{id}/messages
+     * @secure
+     */
+    v1OrgsTopicsMessagesDelete: (id: string, org: string, params: RequestParams = {}) =>
+      this.request<void, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/topics/${id}/messages`,
+        method: "DELETE",
+        secure: true,
         ...params,
       }),
 

--- a/frontend/src/components/helix-org/CronScheduleFields.tsx
+++ b/frontend/src/components/helix-org/CronScheduleFields.tsx
@@ -99,6 +99,9 @@ export type CronScheduleFieldsProps = {
   /** Current cron schedule (what gets stored on the topic). */
   value: string
   onChange: (schedule: string) => void
+  /** Optional message emitted into the topic on each scheduled run. */
+  message?: string
+  onMessageChange?: (message: string) => void
   disabled?: boolean
   /** Seed mode when value is empty (create form). */
   defaultMode?: CronScheduleMode
@@ -107,6 +110,8 @@ export type CronScheduleFieldsProps = {
 const CronScheduleFields: FC<CronScheduleFieldsProps> = ({
   value,
   onChange,
+  message = '',
+  onMessageChange,
   disabled = false,
   defaultMode = 'specific_time',
 }) => {
@@ -189,6 +194,20 @@ const CronScheduleFields: FC<CronScheduleFieldsProps> = ({
 
   return (
     <Stack spacing={1.5}>
+      {onMessageChange && (
+        <TextField
+          label="Message sent on each run (optional)"
+          placeholder="e.g. Prepare the daily status report"
+          value={message}
+          onChange={(e) => onMessageChange(e.target.value)}
+          multiline
+          minRows={2}
+          fullWidth
+          size="small"
+          helperText="This message is published into the topic when the schedule fires."
+          disabled={disabled}
+        />
+      )}
       <FormControl fullWidth size="small">
         <InputLabel id="cron-mode-label">Schedule type</InputLabel>
         <Select

--- a/frontend/src/components/helix-org/NewTopicDrawer.tsx
+++ b/frontend/src/components/helix-org/NewTopicDrawer.tsx
@@ -67,6 +67,7 @@ const NewTopicDrawer: FC<NewTopicDrawerProps> = ({ open, onClose }) => {
   // advanced cron). Stored as a standard 5-field expression (+ optional
   // CRON_TZ= prefix) on the topic config.
   const [cronSchedule, setCronSchedule] = useState<string>(defaultCronSchedule)
+  const [cronMessage, setCronMessage] = useState<string>('')
 
   // Probe GitHub on open — the result tells us whether to disable the
   // `github` transport option (no app install → operator gets a
@@ -106,6 +107,7 @@ const NewTopicDrawer: FC<NewTopicDrawerProps> = ({ open, onClose }) => {
     setGhEvents(['*'])
     setGhBranches(['*'])
     setCronSchedule(defaultCronSchedule())
+    setCronMessage('')
   }, [open])
 
   const helpFor = TRANSPORT_KINDS.find((k) => k.value === kind)?.help
@@ -127,6 +129,7 @@ const NewTopicDrawer: FC<NewTopicDrawerProps> = ({ open, onClose }) => {
     setGhEvents(['*'])
     setGhBranches(['*'])
     setCronSchedule(defaultCronSchedule())
+    setCronMessage('')
     onClose()
   }
 
@@ -160,6 +163,9 @@ const NewTopicDrawer: FC<NewTopicDrawerProps> = ({ open, onClose }) => {
         return
       }
       config = { schedule: sched }
+      if (cronMessage.trim()) {
+        config.message = cronMessage.trim()
+      }
     } else if (configText.trim()) {
       try {
         config = JSON.parse(configText)
@@ -289,6 +295,8 @@ const NewTopicDrawer: FC<NewTopicDrawerProps> = ({ open, onClose }) => {
             key={open ? 'cron-open' : 'cron-closed'}
             value={cronSchedule}
             onChange={setCronSchedule}
+            message={cronMessage}
+            onMessageChange={setCronMessage}
             defaultMode="specific_time"
           />
         )}

--- a/frontend/src/components/helix-org/ProcessorConfigDrawer.tsx
+++ b/frontend/src/components/helix-org/ProcessorConfigDrawer.tsx
@@ -70,6 +70,17 @@ function process(event, ctx) {
 `
 
 type FilterRow = { label: string; match: string }
+type ProcessorForm = {
+  name: string
+  kind: string
+  inputTopicId: string
+  template: string
+  jsCode: string
+  maxBytes: string
+  filterRows: FilterRow[]
+  threadFollow: boolean
+}
+
 const DEFAULT_FILTER_ROWS: FilterRow[] = [
   { label: 'vip', match: '{{ hasSuffix "@vip.com" .Message.from }}' },
   { label: 'default', match: '' },
@@ -249,6 +260,7 @@ const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, 
   const [filterRows, setFilterRows] = useState<FilterRow[]>(DEFAULT_FILTER_ROWS)
   const [threadFollow, setThreadFollow] = useState(false)
   const [showHelp, setShowHelp] = useState(false)
+  const [savedForm, setSavedForm] = useState<ProcessorForm | null>(null)
 
   // Most recent real message on the input topic (null = topic has none).
   const { data: sample, isFetching: sampleLoading } = useTopicSampleMessage(inputTopicId, { enabled: open && !!inputTopicId })
@@ -257,15 +269,24 @@ const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, 
   useEffect(() => {
     if (!open) return
     if (processor) {
-      setName(processor.name ?? '')
-      setKind(processor.kind ?? 'template')
-      setInputTopicId(processor.input_topic_id ?? '')
-      setTemplate((processor.config?.template as string) ?? DEFAULT_TEMPLATE)
-      setJsCode((processor.config?.code as string) ?? DEFAULT_JS_CODE)
-      setMaxBytes(String((processor.config?.max_bytes as number) ?? 500))
+      const nextName = processor.name ?? ''
+      const nextKind = processor.kind ?? 'template'
+      const nextInputTopicId = processor.input_topic_id ?? ''
+      const nextTemplate = (processor.config?.template as string) ?? DEFAULT_TEMPLATE
+      const nextJsCode = (processor.config?.code as string) ?? DEFAULT_JS_CODE
+      const nextMaxBytes = String((processor.config?.max_bytes as number) ?? 500)
       const rows = (processor.outputs ?? []).map((o) => ({ label: o.label ?? '', match: o.match ?? '' }))
-      setFilterRows(rows.length > 0 ? rows : DEFAULT_FILTER_ROWS)
-      setThreadFollow(Boolean(processor.config?.thread_follow))
+      const nextFilterRows = rows.length > 0 ? rows : DEFAULT_FILTER_ROWS
+      const nextThreadFollow = Boolean(processor.config?.thread_follow)
+      setName(nextName)
+      setKind(nextKind)
+      setInputTopicId(nextInputTopicId)
+      setTemplate(nextTemplate)
+      setJsCode(nextJsCode)
+      setMaxBytes(nextMaxBytes)
+      setFilterRows(nextFilterRows)
+      setThreadFollow(nextThreadFollow)
+      setSavedForm({ name: nextName, kind: nextKind, inputTopicId: nextInputTopicId, template: nextTemplate, jsCode: nextJsCode, maxBytes: nextMaxBytes, filterRows: nextFilterRows, threadFollow: nextThreadFollow })
     } else {
       setName('')
       setKind('template')
@@ -275,6 +296,7 @@ const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, 
       setMaxBytes('500')
       setFilterRows(DEFAULT_FILTER_ROWS)
       setThreadFollow(false)
+      setSavedForm(null)
     }
   }, [open, processor, presetInputTopicId])
 
@@ -292,6 +314,18 @@ const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, 
   // already participating, not just whoever is named. Hidden for ordinary
   // hand-built filters, where it has no effect.
   const showThreadFollow = kind === 'filter' && Boolean(processor?.automated)
+
+  const currentForm = useMemo<ProcessorForm>(() => ({
+    name,
+    kind,
+    inputTopicId,
+    template,
+    jsCode,
+    maxBytes,
+    filterRows,
+    threadFollow,
+  }), [name, kind, inputTopicId, template, jsCode, maxBytes, filterRows, threadFollow])
+  const dirty = !isEdit || !savedForm || JSON.stringify(currentForm) !== JSON.stringify(savedForm)
 
   // Filter/js multi-branch outputs carry labels (and filter predicates).
   // Transforms with a single output omit this (server defaults to one).
@@ -314,6 +348,7 @@ const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, 
     try {
       if (isEdit && processor) {
         await updateProc.mutateAsync({ id: processor.id, attrs: { name: name.trim(), kind, config, input_topic_id: inputTopicId } })
+        setSavedForm(currentForm)
         snackbar.success(`updated ${processor.id}`)
       } else {
         const created = await createProc.mutateAsync({
@@ -329,6 +364,10 @@ const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, 
     } catch (err: any) {
       snackbar.error(err?.response?.data?.errors?.[0]?.detail ?? err?.response?.data?.error ?? err?.message ?? 'save failed')
     }
+  }
+
+  const handleCancel = () => {
+    onClose()
   }
 
   const busy = createProc.isPending || updateProc.isPending
@@ -573,12 +612,14 @@ const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, 
             )}
           </Box>
 
-          <Stack direction="row" spacing={1} sx={{ pt: 1 }}>
-            <Button variant="contained" onClick={submit} disabled={busy || !canSubmit}>
-              {busy ? 'Saving…' : isEdit ? 'Save' : 'Create'}
-            </Button>
-            <Button variant="text" onClick={onClose}>Cancel</Button>
-          </Stack>
+          {dirty && (
+            <Stack direction="row" spacing={1} justifyContent="flex-end" sx={{ pt: 2, borderTop: '1px solid', borderColor: 'divider' }}>
+              <Button color="secondary" variant="contained" onClick={submit} disabled={busy || !canSubmit}>
+                {busy ? 'Saving…' : isEdit ? 'Save' : 'Create'}
+              </Button>
+              <Button variant="text" onClick={handleCancel} disabled={busy}>Cancel</Button>
+            </Stack>
+          )}
         </Stack>
     </HelixOrgSideDrawer>
   )

--- a/frontend/src/components/helix-org/TopicDetailDrawer.tsx
+++ b/frontend/src/components/helix-org/TopicDetailDrawer.tsx
@@ -9,7 +9,7 @@ import useSnackbar from '../../hooks/useSnackbar'
 import LoadingSpinner from '../widgets/LoadingSpinner'
 import CopyButtonWithCheck from '../session/CopyButtonWithCheck'
 import { useHelixOrgTopic, useUpdateHelixOrgTopic } from '../../services/helixOrgService'
-import { TopicConfigSection } from '../../pages/HelixOrgTopicDetail'
+import { ClearTopicMessagesButton, TopicConfigSection } from '../../pages/HelixOrgTopicDetail'
 import HelixOrgSideDrawer from './HelixOrgSideDrawer'
 
 type TopicDetailDrawerProps = {
@@ -57,6 +57,7 @@ const TopicDetailDrawer: FC<TopicDetailDrawerProps> = ({ topicId, consumerCount,
             {consumerCount ?? topic.subscribers?.length ?? 0} subscriber{(consumerCount ?? topic.subscribers?.length) === 1 ? '' : 's'}
           </Typography>
           <TopicConfigSection
+            key={topic.id}
             topic={topic}
             saving={updateTopic.isPending}
             onSave={async (payload) => {
@@ -70,6 +71,9 @@ const TopicDetailDrawer: FC<TopicDetailDrawerProps> = ({ topicId, consumerCount,
               }
             }}
           />
+          <Stack direction="row" justifyContent="flex-end">
+            <ClearTopicMessagesButton topic={topic} />
+          </Stack>
         </Stack>
       )}
     </HelixOrgSideDrawer>

--- a/frontend/src/components/helix-org/TopicDetailDrawer.tsx
+++ b/frontend/src/components/helix-org/TopicDetailDrawer.tsx
@@ -70,6 +70,7 @@ const TopicDetailDrawer: FC<TopicDetailDrawerProps> = ({ topicId, consumerCount,
                 return false
               }
             }}
+            onCancel={onClose}
           />
           <Stack direction="row" justifyContent="flex-end">
             <ClearTopicMessagesButton topic={topic} />

--- a/frontend/src/pages/HelixOrgTopicDetail.tsx
+++ b/frontend/src/pages/HelixOrgTopicDetail.tsx
@@ -342,7 +342,7 @@ export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave,
   }
 
   return (
-    <Paper variant="outlined" sx={{ p: 2 }}>
+    <Box>
       <Typography variant="h6" sx={{ mb: 2 }}>Configuration</Typography>
 
       <Stack spacing={2}>
@@ -417,7 +417,7 @@ export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave,
           </Button>
         </Stack>
       )}
-    </Paper>
+    </Box>
   )
 }
 

--- a/frontend/src/pages/HelixOrgTopicDetail.tsx
+++ b/frontend/src/pages/HelixOrgTopicDetail.tsx
@@ -17,14 +17,19 @@ import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
 import CircularProgress from '@mui/material/CircularProgress'
 import Container from '@mui/material/Container'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogContentText from '@mui/material/DialogContentText'
+import DialogTitle from '@mui/material/DialogTitle'
 import Divider from '@mui/material/Divider'
 import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
-import EditIcon from '@mui/icons-material/Edit'
 import SaveIcon from '@mui/icons-material/Save'
-import CloseIcon from '@mui/icons-material/Close'
+import DeleteSweepIcon from '@mui/icons-material/DeleteSweep'
+import { useQueryClient } from '@tanstack/react-query'
 
 import HelixOrgShell from '../components/helix-org/HelixOrgShell'
 import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
@@ -41,7 +46,9 @@ import useSnackbar from '../hooks/useSnackbar'
 import {
   EventCard,
   InstallWebhookFailedError,
+  QUERY_KEYS,
   TopicDTO,
+  useClearHelixOrgTopicMessages,
   useHelixOrgTopic,
   useGitHubWebhookStatus,
   useInstallGitHubWebhook,
@@ -59,6 +66,7 @@ const HelixOrgTopicDetail: FC = () => {
   const { data: topic, isLoading } = useHelixOrgTopic(topicId)
   const { data: messageCount } = useTopicMessageCount(topicId)
   const updateTopic = useUpdateHelixOrgTopic()
+  const queryClient = useQueryClient()
 
   // Live event list. Seeded from the initial GET so the page renders
   // immediately; replaced wholesale on every SSE push from
@@ -75,6 +83,7 @@ const HelixOrgTopicDetail: FC = () => {
   // `event: message` frames with a JSON-array payload of up to 50
   // events newest-first; we replace state on each.
   const orgID = account.organizationTools.organization?.id || orgSlug || ''
+  const queryOrgID = orgSlug || orgID
   const sseUrlRef = useRef<string | null>(null)
   useEffect(() => {
     if (!orgID || !topicId) return
@@ -84,7 +93,10 @@ const HelixOrgTopicDetail: FC = () => {
     const onMessage = (ev: MessageEvent) => {
       try {
         const arr = JSON.parse(ev.data) as EventCard[]
-        if (Array.isArray(arr)) setLiveEvents(arr)
+        if (Array.isArray(arr)) {
+          setLiveEvents(arr)
+          queryClient.invalidateQueries({ queryKey: QUERY_KEYS.topicMessageCount(queryOrgID, topicId) })
+        }
       } catch {
         // Malformed payload: drop, keep prior state. Next frame is
         // typically well-formed.
@@ -95,7 +107,7 @@ const HelixOrgTopicDetail: FC = () => {
       es.removeEventListener('message', onMessage)
       es.close()
     }
-  }, [orgID, topicId])
+  }, [orgID, queryOrgID, topicId])
 
   const subscribers = topic?.subscribers ?? []
 
@@ -150,6 +162,7 @@ const HelixOrgTopicDetail: FC = () => {
               <Divider />
 
               <TopicConfigSection
+                key={topic.id}
                 topic={topic}
                 onSave={async (payload) => {
                   try {
@@ -180,9 +193,16 @@ const HelixOrgTopicDetail: FC = () => {
                     <Typography variant="h6">Messages</Typography>
                     <MessageCountCard count={messageCount} />
                   </Stack>
-                  <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
-                    newest first · up to 50 · live
-                  </Typography>
+                  <Stack direction="row" spacing={1.5} alignItems="center">
+                    <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+                      newest first · up to 50 · live
+                    </Typography>
+                    <ClearTopicMessagesButton
+                      topic={topic}
+                      messageCount={messageCount}
+                      onCleared={() => setLiveEvents([])}
+                    />
+                  </Stack>
                 </Stack>
                 {events.length === 0 ? (
                   <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
@@ -205,12 +225,8 @@ const HelixOrgTopicDetail: FC = () => {
   )
 }
 
-// TopicConfigSection renders the topic's mutable configuration —
-// name, description, transport config — in a read-only Paper that
-// flips into edit mode when the operator clicks Edit. The transport
-// kind itself is NOT editable here (changing transport mid-flight
-// would orphan webhook deliveries, GitHub installations etc); spin
-// up a new topic and delete the old one for that.
+// The transport kind itself is immutable here: changing it mid-flight would
+// orphan provider-side resources such as GitHub webhooks.
 interface TopicConfigSectionProps {
   topic: TopicDTO
   onSave: (payload: {
@@ -221,49 +237,44 @@ interface TopicConfigSectionProps {
   saving: boolean
 }
 
+type TopicForm = {
+  name: string
+  description: string
+  configText: string
+  ghRepo: string
+  ghBranches: string[]
+  ghOriginalConfig: Record<string, unknown>
+  cronSchedule: string
+  cronMessage: string
+}
+
+const topicForm = (topic: TopicDTO): TopicForm => {
+  const config = (topic.config ?? {}) as Record<string, unknown>
+  return {
+    name: topic.name,
+    description: topic.description ?? '',
+    configText: topic.kind !== 'local' && topic.kind !== 'github' && topic.kind !== 'cron'
+      ? JSON.stringify(config, null, 2)
+      : '',
+    ghRepo: topic.kind === 'github' && typeof config.repo === 'string' ? config.repo : '',
+    ghBranches: topic.kind === 'github' && Array.isArray(config.branches) && config.branches.length > 0
+      ? config.branches as string[]
+      : ['*'],
+    ghOriginalConfig: topic.kind === 'github' ? config : {},
+    cronSchedule: topic.kind === 'cron' && typeof config.schedule === 'string' ? config.schedule : '',
+    cronMessage: topic.kind === 'cron' && typeof config.message === 'string' ? config.message : '',
+  }
+}
+
 export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave, saving }) => {
   const snackbar = useSnackbar()
-  const [editing, setEditing] = useState(false)
-
-  // Local edit-mode state. Seeded from the topic every time the
-  // user enters edit mode so cancel → re-edit starts from the
-  // current server state, not whatever the user last typed.
-  const [name, setName] = useState(topic.name)
-  const [description, setDescription] = useState(topic.description ?? '')
-  const [configText, setConfigText] = useState('')
-  const [ghRepo, setGhRepo] = useState('')
-  const [ghBranches, setGhBranches] = useState<string[]>([])
-  // The full github config as it was on the server when edit opened.
-  // We overlay only the operator-editable fields (repo, branches) on
-  // top of this at save time so server-managed fields — events (now
-  // owned by GitHub's webhook UI), webhook_id, webhook_html_url —
-  // survive the round-trip instead of being wiped.
-  const [ghOriginalConfig, setGhOriginalConfig] = useState<Record<string, unknown>>({})
-  const [cronSchedule, setCronSchedule] = useState('')
-
-  const enterEdit = () => {
-    setName(topic.name)
-    setDescription(topic.description ?? '')
-    if (topic.kind === 'github') {
-      const cfg = (topic.config ?? {}) as Record<string, unknown>
-      setGhOriginalConfig(cfg)
-      setGhRepo(typeof cfg.repo === 'string' ? cfg.repo : '')
-      setGhBranches(Array.isArray(cfg.branches) && cfg.branches.length > 0 ? (cfg.branches as string[]) : ['*'])
-    } else if (topic.kind === 'cron') {
-      const cfg = (topic.config ?? {}) as Record<string, unknown>
-      setCronSchedule(typeof cfg.schedule === 'string' ? cfg.schedule : '')
-    } else if (topic.config) {
-      setConfigText(JSON.stringify(topic.config, null, 2))
-    } else {
-      setConfigText('')
-    }
-    setEditing(true)
-  }
-
-  const cancelEdit = () => setEditing(false)
+  const initialForm = topicForm(topic)
+  const [form, setForm] = useState<TopicForm>(initialForm)
+  const [savedForm, setSavedForm] = useState<TopicForm>(initialForm)
+  const dirty = JSON.stringify(form) !== JSON.stringify(savedForm)
 
   const handleSave = async () => {
-    if (!name.trim()) {
+    if (!form.name.trim()) {
       snackbar.error('Name is required')
       return
     }
@@ -271,36 +282,39 @@ export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave,
       name: string
       description?: string
       transport?: { config?: Record<string, unknown> }
-    } = { name: name.trim(), description: description.trim() || undefined }
+    } = { name: form.name.trim(), description: form.description.trim() || undefined }
+
+    let saved = { ...form, name: form.name.trim(), description: form.description.trim() }
 
     if (topic.kind === 'github') {
-      if (!ghRepo.trim() || !GITHUB_REPO_PATTERN.test(ghRepo.trim())) {
+      if (!form.ghRepo.trim() || !GITHUB_REPO_PATTERN.test(form.ghRepo.trim())) {
         snackbar.error('GitHub repo is required and must be owner/name')
         return
       }
-      // Overlay the editable fields onto the original config so
-      // events (managed on GitHub now), webhook_id and webhook_html_url
-      // are preserved. The server's GitHubConfig.Validate requires a
-      // non-empty events list — dropping it here is what used to make
-      // the save silently fail.
-      const ghConfig: Record<string, unknown> = { ...ghOriginalConfig, repo: ghRepo.trim() }
-      const branches = ghBranches.map((b) => b.trim()).filter((b) => b.length > 0)
+      const ghConfig: Record<string, unknown> = { ...form.ghOriginalConfig, repo: form.ghRepo.trim() }
+      const branches = form.ghBranches.map((b) => b.trim()).filter((b) => b.length > 0)
       if (branches.length > 0) {
         ghConfig.branches = branches
       } else {
         delete ghConfig.branches
       }
       payload.transport = { config: ghConfig }
+      saved = { ...saved, ghRepo: form.ghRepo.trim(), ghBranches: branches, ghOriginalConfig: ghConfig }
     } else if (topic.kind === 'cron') {
-      const sched = cronSchedule.trim()
+      const sched = form.cronSchedule.trim()
       if (!sched) {
         snackbar.error('Schedule is required')
         return
       }
-      payload.transport = { config: { schedule: sched } }
-    } else if (topic.kind !== 'local' && configText.trim()) {
+      const cronConfig: Record<string, unknown> = { schedule: sched }
+      if (form.cronMessage.trim()) {
+        cronConfig.message = form.cronMessage.trim()
+      }
+      payload.transport = { config: cronConfig }
+      saved = { ...saved, cronSchedule: sched, cronMessage: form.cronMessage.trim() }
+    } else if (topic.kind !== 'local' && form.configText.trim()) {
       try {
-        const parsed = JSON.parse(configText)
+        const parsed = JSON.parse(form.configText)
         if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
           snackbar.error('Transport config must be a JSON object')
           return
@@ -315,86 +329,43 @@ export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave,
       payload.transport = { config: {} }
     }
     const ok = await onSave(payload)
-    if (ok) setEditing(false)
+    if (ok) {
+      setForm(saved)
+      setSavedForm(saved)
+    }
   }
-
-  const configPreview = useMemo(() => {
-    if (topic.kind === 'local') return null
-    if (!topic.config || Object.keys(topic.config).length === 0) return '(empty)'
-    return JSON.stringify(topic.config, null, 2)
-  }, [topic.kind, topic.config])
 
   return (
     <Paper variant="outlined" sx={{ p: 2 }}>
-      <Stack direction="row" alignItems="baseline" justifyContent="space-between" sx={{ mb: 1 }}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
         <Typography variant="h6">Configuration</Typography>
-        {!editing && (
-          <Button size="small" startIcon={<EditIcon />} onClick={enterEdit}>
-            Edit
+        {dirty && (
+          <Button
+            color="secondary"
+            variant="contained"
+            size="small"
+            startIcon={<SaveIcon />}
+            onClick={handleSave}
+            disabled={saving}
+          >
+            {saving ? 'Saving…' : 'Save'}
           </Button>
         )}
       </Stack>
 
-      {!editing ? (
-        <Stack spacing={1.5}>
-          <ReadOnlyRow label="Name" value={topic.name} />
-          <ReadOnlyRow label="Description" value={topic.description || '—'} />
-          <ReadOnlyRow label="Transport" value={topic.kind} mono />
-          {topic.kind === 'cron' && typeof topic.config?.schedule === 'string' && (
-            <Box>
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.75 }}>
-                Schedule
-              </Typography>
-              <CronScheduleFields
-                key={`cron-read-${topic.config.schedule}`}
-                value={topic.config.schedule}
-                onChange={() => undefined}
-                disabled
-              />
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{ display: 'block', mt: 0.75, fontFamily: 'monospace' }}
-              >
-                {topic.config.schedule}
-              </Typography>
-            </Box>
-          )}
-          {topic.kind !== 'local' && topic.kind !== 'cron' && (
-            <Box>
-              <Typography variant="caption" color="text.secondary">
-                Config
-              </Typography>
-              <Typography
-                component="pre"
-                variant="body2"
-                sx={{
-                  mt: 0.5, mb: 0, p: 1, borderRadius: 1,
-                  backgroundColor: 'action.hover',
-                  fontFamily: 'monospace',
-                  fontSize: '0.75rem',
-                  whiteSpace: 'pre-wrap', wordBreak: 'break-word',
-                }}
-              >
-                {configPreview}
-              </Typography>
-            </Box>
-          )}
-        </Stack>
-      ) : (
-        <Stack spacing={2}>
+      <Stack spacing={2}>
           <TextField
             label="Name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
+            value={form.name}
+            onChange={(e) => setForm((current) => ({ ...current, name: e.target.value }))}
             size="small"
             fullWidth
             required
           />
           <TextField
             label="Description (optional)"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
+            value={form.description}
+            onChange={(e) => setForm((current) => ({ ...current, description: e.target.value }))}
             multiline
             minRows={2}
             size="small"
@@ -402,8 +373,8 @@ export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave,
           />
           {topic.kind === 'github' && (
             <>
-              <GitHubRepoPicker value={ghRepo} onChange={setGhRepo} />
-              <GitHubBranchesField branches={ghBranches} onChange={setGhBranches} />
+              <GitHubRepoPicker value={form.ghRepo} onChange={(ghRepo) => setForm((current) => ({ ...current, ghRepo }))} />
+              <GitHubBranchesField branches={form.ghBranches} onChange={(ghBranches) => setForm((current) => ({ ...current, ghBranches }))} />
               <Typography variant="caption" color="text.secondary">
                 Which GitHub event types this webhook delivers is configured on GitHub,
                 not here — open the webhook on GitHub (below) to change it.
@@ -412,16 +383,17 @@ export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave,
           )}
           {topic.kind === 'cron' && (
             <CronScheduleFields
-              key={editing ? 'cron-edit' : 'cron-view'}
-              value={cronSchedule}
-              onChange={setCronSchedule}
+              value={form.cronSchedule}
+              onChange={(cronSchedule) => setForm((current) => ({ ...current, cronSchedule }))}
+              message={form.cronMessage}
+              onMessageChange={(cronMessage) => setForm((current) => ({ ...current, cronMessage }))}
             />
           )}
           {topic.kind !== 'local' && topic.kind !== 'github' && topic.kind !== 'cron' && (
             <TextField
               label="Transport config (JSON)"
-              value={configText}
-              onChange={(e) => setConfigText(e.target.value)}
+              value={form.configText}
+              onChange={(e) => setForm((current) => ({ ...current, configText: e.target.value }))}
               multiline
               minRows={4}
               size="small"
@@ -435,22 +407,62 @@ export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave,
               local transport has no config — nothing to edit beyond name/description.
             </Typography>
           )}
-          <Stack direction="row" spacing={1} justifyContent="flex-end">
-            <Button onClick={cancelEdit} startIcon={<CloseIcon />} disabled={saving}>
-              Cancel
-            </Button>
-            <Button
-              variant="contained"
-              startIcon={<SaveIcon />}
-              onClick={handleSave}
-              disabled={saving}
-            >
-              {saving ? 'Saving…' : 'Save'}
-            </Button>
-          </Stack>
-        </Stack>
-      )}
+      </Stack>
     </Paper>
+  )
+}
+
+export const ClearTopicMessagesButton: FC<{
+  topic: TopicDTO
+  messageCount?: number
+  onCleared?: () => void
+}> = ({ topic, messageCount, onCleared }) => {
+  const snackbar = useSnackbar()
+  const clearMessages = useClearHelixOrgTopicMessages()
+  const { data: queriedMessageCount } = useTopicMessageCount(topic.id)
+  const [confirming, setConfirming] = useState(false)
+  const count = messageCount ?? queriedMessageCount
+
+  const clear = async () => {
+    try {
+      await clearMessages.mutateAsync(topic.id)
+      onCleared?.()
+      setConfirming(false)
+      snackbar.success('topic messages cleared')
+    } catch (e: any) {
+      snackbar.error(e?.response?.data?.error || e?.message || 'failed to clear topic messages')
+    }
+  }
+
+  return (
+    <>
+      <Button
+        color="error"
+        variant="outlined"
+        size="small"
+        startIcon={<DeleteSweepIcon />}
+        onClick={() => setConfirming(true)}
+        disabled={count === 0}
+      >
+        Clear messages
+      </Button>
+      <Dialog open={confirming} onClose={() => !clearMessages.isPending && setConfirming(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>Clear all topic messages?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            This permanently deletes all messages retained on “{topic.name || topic.id}”. The topic and its subscribers will remain active.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirming(false)} disabled={clearMessages.isPending}>
+            Cancel
+          </Button>
+          <Button color="error" variant="contained" onClick={clear} disabled={clearMessages.isPending}>
+            {clearMessages.isPending ? 'Clearing…' : 'Clear messages'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
   )
 }
 
@@ -682,18 +694,6 @@ const MessageCountCard: FC<{ count: number | undefined }> = ({ count }) => (
       retained
     </Typography>
   </Paper>
-)
-
-const ReadOnlyRow: FC<{ label: string; value: string; mono?: boolean }> = ({ label, value, mono }) => (
-  <Box>
-    <Typography variant="caption" color="text.secondary">{label}</Typography>
-    <Typography
-      variant="body2"
-      sx={{ mt: 0.25, fontFamily: mono ? 'monospace' : undefined }}
-    >
-      {value}
-    </Typography>
-  </Box>
 )
 
 const EventRow: FC<{ ev: EventCard; formatTs: (iso: string) => string }> = ({ ev, formatTs }) => {

--- a/frontend/src/pages/HelixOrgTopicDetail.tsx
+++ b/frontend/src/pages/HelixOrgTopicDetail.tsx
@@ -235,6 +235,7 @@ interface TopicConfigSectionProps {
     transport?: { config?: Record<string, unknown> }
   }) => Promise<boolean>
   saving: boolean
+  onCancel?: () => void
 }
 
 type TopicForm = {
@@ -266,7 +267,7 @@ const topicForm = (topic: TopicDTO): TopicForm => {
   }
 }
 
-export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave, saving }) => {
+export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave, saving, onCancel }) => {
   const snackbar = useSnackbar()
   const initialForm = topicForm(topic)
   const [form, setForm] = useState<TopicForm>(initialForm)
@@ -335,23 +336,14 @@ export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave,
     }
   }
 
+  const handleCancel = () => {
+    setForm(savedForm)
+    onCancel?.()
+  }
+
   return (
     <Paper variant="outlined" sx={{ p: 2 }}>
-      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
-        <Typography variant="h6">Configuration</Typography>
-        {dirty && (
-          <Button
-            color="secondary"
-            variant="contained"
-            size="small"
-            startIcon={<SaveIcon />}
-            onClick={handleSave}
-            disabled={saving}
-          >
-            {saving ? 'Saving…' : 'Save'}
-          </Button>
-        )}
-      </Stack>
+      <Typography variant="h6" sx={{ mb: 2 }}>Configuration</Typography>
 
       <Stack spacing={2}>
           <TextField
@@ -408,6 +400,23 @@ export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave,
             </Typography>
           )}
       </Stack>
+      {dirty && (
+        <Stack direction="row" spacing={1} justifyContent="flex-end" sx={{ mt: 2, pt: 2, borderTop: '1px solid', borderColor: 'divider' }}>
+          <Button
+            color="secondary"
+            variant="contained"
+            size="small"
+            startIcon={<SaveIcon />}
+            onClick={handleSave}
+            disabled={saving}
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </Button>
+          <Button variant="text" size="small" onClick={handleCancel} disabled={saving}>
+            Cancel
+          </Button>
+        </Stack>
+      )}
     </Paper>
   )
 }

--- a/frontend/src/services/helixOrgService.ts
+++ b/frontend/src/services/helixOrgService.ts
@@ -784,6 +784,23 @@ export function useUpdateHelixOrgTopic() {
   })
 }
 
+export function useClearHelixOrgTopicMessages() {
+  const api = useApi()
+  const qc = useQueryClient()
+  const { orgID } = useHelixOrgBase()
+  return useMutation({
+    mutationFn: async (topicId: string) => {
+      await api.getApiClient().v1OrgsTopicsMessagesDelete(topicId, orgID)
+    },
+    onSuccess: (_data, topicId) => {
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.topic(orgID, topicId) })
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.topics(orgID) })
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.topicMessageCount(orgID, topicId) })
+      qc.invalidateQueries({ queryKey: QUERY_KEYS.overview(orgID) })
+    },
+  })
+}
+
 export function useDeleteHelixOrgTopic() {
   const api = useApi()
   const qc = useQueryClient()

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -6278,6 +6278,15 @@ definitions:
         $ref: '#/definitions/types.LLMCallStep'
       stream:
         type: boolean
+      time_to_first_token_ms:
+        description: |-
+          TimeToFirstTokenMs is the wall time from request start to the first
+          streamed chunk. It isolates provider prefill / cold-start latency from
+          generation time (a cold or overloaded provider shows a large TTFT while
+          generation stays normal). 0 means no chunk was received (the call errored
+          or was cut before the first token). For non-streaming calls it equals the
+          time to the full response.
+        type: integer
       total_cost:
         description: Prompt + completion + cache read + cache write
         type: number
@@ -19321,6 +19330,25 @@ paths:
       tags:
       - HelixOrg
   /api/v1/orgs/{org}/topics/{id}/messages:
+    delete:
+      parameters:
+      - description: Topic ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: clear all messages from a topic'
+      tags:
+      - HelixOrg
     get:
       parameters:
       - description: Topic ID

--- a/openapi.json
+++ b/openapi.json
@@ -13378,6 +13378,43 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: clear all messages from a topic",
+                "parameters": [
+                    {
+                        "description": "Topic ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/v1/orgs/{org}/topics/{id}/publish": {
@@ -34679,6 +34716,10 @@
                     },
                     "stream": {
                         "type": "boolean"
+                    },
+                    "time_to_first_token_ms": {
+                        "description": "TimeToFirstTokenMs is the wall time from request start to the first\nstreamed chunk. It isolates provider prefill / cold-start latency from\ngeneration time (a cold or overloaded provider shows a large TTFT while\ngeneration stays normal). 0 means no chunk was received (the call errored\nor was cut before the first token). For non-streaming calls it equals the\ntime to the full response.",
+                        "type": "integer"
                     },
                     "total_cost": {
                         "description": "Prompt + completion + cache read + cache write",

--- a/swagger.json
+++ b/swagger.json
@@ -11205,6 +11205,37 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: clear all messages from a topic",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Topic ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/api/v1/orgs/{org}/topics/{id}/publish": {
@@ -30329,6 +30360,10 @@
                 },
                 "stream": {
                     "type": "boolean"
+                },
+                "time_to_first_token_ms": {
+                    "description": "TimeToFirstTokenMs is the wall time from request start to the first\nstreamed chunk. It isolates provider prefill / cold-start latency from\ngeneration time (a cold or overloaded provider shows a large TTFT while\ngeneration stays normal). 0 means no chunk was received (the call errored\nor was cut before the first token). For non-streaming calls it equals the\ntime to the full response.",
+                    "type": "integer"
                 },
                 "total_cost": {
                     "description": "Prompt + completion + cache read + cache write",


### PR DESCRIPTION
## What changed

- Make cron topics configure an optional message alongside the human-friendly schedule editor.
- Publish the configured message on each cron tick while preserving the existing structured payload for older topics without a message.
- Make topic configuration immediately editable; show the secondary Save action only when dirty.
- Add a confirmed Clear messages action to the topic detail page and drawer, with scoped deletion and live count invalidation.
- Add persistence, API, scheduler, and transport tests plus QA coverage.

## Why

Cron topics previously emitted a fixed scheduled-tick payload, so operators could not tell a subscribed Worker what action to perform. Topic messages also had no safe, user-visible way to be cleared without deleting the topic.

## Validation

- `go test ./pkg/org/application/messages ./pkg/org/interfaces/server/api ./pkg/org/infrastructure/persistence/gorm ./pkg/org/domain/transport ./pkg/org/infrastructure/streamcron -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `cd frontend && yarn build`
- `git diff --check`
- Live API and browser smoke tests for inline editing, confirmed message clearing, and publish-after-clear were run against the local stack.
