### PR TITLE
feat(external-agent): configurable auto-compaction threshold

### DIFF
--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -47,13 +47,24 @@ type WebsocketSyncConfig struct {
 }
 
 type AgentConfig struct {
-	DefaultModel           *ModelConfig `json:"default_model,omitempty"`
-	InlineAssistantModel   *ModelConfig `json:"inline_assistant_model,omitempty"`
-	CommitMessageModel     *ModelConfig `json:"commit_message_model,omitempty"`
-	ThreadSummaryModel     *ModelConfig `json:"thread_summary_model,omitempty"`
-	AlwaysAllowToolActions bool         `json:"always_allow_tool_actions"` // Deprecated: mapped to tool_permissions.default="allow" by handler
-	ShowOnboarding         bool         `json:"show_onboarding"`
-	AutoOpenPanel          bool         `json:"auto_open_panel"`
+	DefaultModel           *ModelConfig       `json:"default_model,omitempty"`
+	InlineAssistantModel   *ModelConfig       `json:"inline_assistant_model,omitempty"`
+	CommitMessageModel     *ModelConfig       `json:"commit_message_model,omitempty"`
+	ThreadSummaryModel     *ModelConfig       `json:"thread_summary_model,omitempty"`
+	AutoCompact            *AutoCompactConfig `json:"auto_compact,omitempty"`
+	AlwaysAllowToolActions bool               `json:"always_allow_tool_actions"` // Deprecated: mapped to tool_permissions.default="allow" by handler
+	ShowOnboarding         bool               `json:"show_onboarding"`
+	AutoOpenPanel          bool               `json:"auto_open_panel"`
+}
+
+// AutoCompactConfig controls Zed's automatic context compaction. Threshold is a
+// percentage string ("50%", measured against the model's context window) or a
+// positive integer token count; Zed compacts once active tokens cross it. A
+// percentage auto-scales per model, so a single value fits every window without
+// Helix computing a per-model number.
+type AutoCompactConfig struct {
+	Enabled   bool   `json:"enabled"`
+	Threshold string `json:"threshold"`
 }
 
 type LanguageModelConfig struct {
@@ -232,6 +243,18 @@ func GenerateZedMCPConfig(
 		config.Agent.InlineAssistantModel = &ModelConfig{Provider: zedProvider, Model: zedModel}
 		config.Agent.CommitMessageModel = &ModelConfig{Provider: zedProvider, Model: zedModel}
 		config.Agent.ThreadSummaryModel = &ModelConfig{Provider: zedProvider, Model: zedModel}
+	}
+
+	// Auto-compaction threshold. Zed's default fires at 90% of the context
+	// window, which for a long-lived thread on a slow/remote provider is too
+	// late: the compaction call itself must send the whole ~near-full thread to
+	// summarize, so it is as slow as the turns already timing out and it fails
+	// too, leaving the thread stuck. Firing earlier keeps both the context and
+	// the compaction call small enough to complete. Opt-in via
+	// HELIX_AGENT_AUTO_COMPACT_THRESHOLD ("50%" -> auto-scales per model, or a
+	// token count like "60000"); unset preserves Zed's default.
+	if threshold := strings.TrimSpace(os.Getenv("HELIX_AGENT_AUTO_COMPACT_THRESHOLD")); threshold != "" {
+		config.Agent.AutoCompact = &AutoCompactConfig{Enabled: true, Threshold: threshold}
 	}
 	config.Theme = "Ayu Dark"
 

--- a/design/2026-07-13-agent-auto-compact-threshold.md
+++ b/design/2026-07-13-agent-auto-compact-threshold.md
@@ -1,0 +1,71 @@
+# Configurable auto-compaction threshold for external agents (2026-07-13)
+
+## Problem
+
+Long-lived spec-task threads (real Zed native agent, model calls proxied through
+Helix to a remote provider) start failing after days/weeks with `504 Gateway
+Time-out` from the ingress. Investigation (design doc
+`2026-07-13-sandbox-agent-504-provider-slowness`) showed the 504 is
+`model_response_time > proxy_timeout`, and reproduced it end-to-end. Context size
+is harmless on a *fast* provider, but on a slower/remote provider a large thread's
+prefill eventually crosses the ingress timeout.
+
+Zed's native auto-compaction *is* enabled and runs every turn
+(`thread.rs::run_turn_internal -> perform_compaction_if_needed`), gated on the
+model window being >= 80k and firing at a **default 90%** of the window. The trap:
+at 90% of (e.g.) a 200k window the thread is ~180k tokens, and the compaction call
+itself must send that whole ~180k-token thread to the summary model. That call is
+exactly as large and slow as the turns already timing out, so **compaction 504s
+too** and the thread is stuck. That is why it becomes consistent once a task is old
+enough to approach the threshold.
+
+Helix writes no `auto_compact` setting, so every external agent inherits the 90%
+default.
+
+## Change
+
+Add an opt-in operator override, `HELIX_AGENT_AUTO_COMPACT_THRESHOLD`, written into
+the agent's Zed settings as `agent.auto_compact.threshold`. Firing compaction
+*earlier* keeps both the running context and the compaction call small enough to
+complete on a slow provider, so the thread never reaches the failure zone.
+
+Value is passed through to Zed, which already parses either form:
+- a **percentage** (`"50%"`) measured against the model's context window, or
+- a **token count** (`"60000"`).
+
+Unset preserves Zed's default (no behaviour change).
+
+## Why a percentage is the clean default
+
+A percentage **auto-scales per model** - `"50%"` is 100k on a 200k model, 64k on a
+128k model - so a single value fits every window and Helix does not need to compute
+a per-model number. Zed does the math from the model's window.
+
+## Related gap (not fixed here): Helix does not tell Zed the window
+
+`buildLanguageModels` writes only `{api_url}` per provider - no
+`available_models[].max_tokens`. So for a *custom* model Zed only knows the context
+window if the operator declared it in `available_models`. Zed needs the window both
+for the 80k eligibility gate and for a percentage threshold. Helix already knows
+each model's window via `ModelInfoProvider` (`model_info.json` + `dynamic_model_info`,
+which reads the provider `/models` `max_model_len`), so a follow-up should populate
+`available_models[].max_tokens` from that. Until then, a percentage threshold works
+wherever the window is known (as in the affected customer's config); a token-count
+threshold works regardless but does not auto-scale.
+
+## Non-goals
+
+- Not changing the global default (opt-in only). Whether to lower the default for
+  all external agents is a separate product decision.
+- Not the summary-model swap (rejected): a compaction call's cost is dominated by
+  its *input* (the whole thread), so a cheaper output model does not help. The
+  threshold (smaller input) is the correct lever.
+
+## Testing
+
+- `go build ./pkg/external-agent/` passes.
+- The change writes `agent.auto_compact.threshold`; Zed's threshold parsing and the
+  compaction trigger are already unit-tested upstream. Live confirmation that a
+  lowered threshold makes a compaction call appear in `llm_calls` (with the
+  `COMPACTION_PROMPT`) and drops the next turn's `prompt_tokens` is tracked
+  separately.


### PR DESCRIPTION
Replaces #2835 (summary-model swap, rejected). Same problem, correct lever.

## Problem

Long-lived spec-task threads (real Zed native agent, model calls proxied through Helix to a remote provider) start 504-ing after days/weeks. The 504 is `model_response_time > ingress_timeout`. Zed's auto-compaction **is** enabled and runs every turn, but at a **default 90%** of the context window. The trap: at ~90% of a 200k window the thread is ~180k tokens, and the compaction call must send that whole ~180k-token thread to summarize - so it is as slow as the turns already timing out, and it **504s too**. Context can't shrink, thread stuck. That's why it only bites once a task is old enough to approach the threshold.

Helix writes no `auto_compact` setting, so every external agent runs the 90% default.

## Change

Opt-in `HELIX_AGENT_AUTO_COMPACT_THRESHOLD` -> written as `agent.auto_compact.threshold`. Firing **earlier** keeps both the context and the compaction call small enough to complete on a slow provider. Zed already parses either:
- a **percentage** (`"50%"`, measured against the model window) - **auto-scales per model**, so one value fits every window and Helix computes nothing, or
- a **token count** (`"60000"`).

Unset preserves Zed's default (no behaviour change).

## Why this and not the summary model (#2835)

A compaction call's latency is dominated by its **input** - the whole thread it reads to summarize. A cheaper/smaller *output* model does nothing about a 180k-token prefill. Compacting *earlier* shrinks the input, which is the actual lever.

## Related gap (flagged, not fixed here)

`buildLanguageModels` writes only `{api_url}` - no `available_models[].max_tokens`. So Zed only knows a custom model's window if the operator declared it (needed for the 80k gate and for a percentage threshold). Helix already has each window via `ModelInfoProvider` (incl. the provider `/models` `max_model_len`); a follow-up should populate `available_models[].max_tokens` from it. Percentage works today where the window is known (the affected customer's config had it); token-count works regardless.

Design doc: `design/2026-07-13-agent-auto-compact-threshold.md`.

## Testing

- `go build ./pkg/external-agent/` passes.
- Live confirmation (a `COMPACTION_PROMPT` call appears in `llm_calls` at a lowered threshold, next turn's `prompt_tokens` drops) is being run separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)