### PR TITLE
feat(external-agent): declare each model's context window to Zed

### DIFF
--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strings"
 
-	modelinfo "github.com/helixml/helix/api/pkg/model"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/rs/zerolog/log"
@@ -117,7 +116,11 @@ func GenerateZedMCPConfig(
 	projectSkills *types.AssistantSkills,
 	oauthTokenGetter OAuthTokenGetter,
 	providerSnapshot []ProviderRef,
-	modelInfo modelinfo.ModelInfoProvider,
+	// windowResolver returns the model's context window in tokens (0 if unknown).
+	// Supplied by the handler, which resolves it from the provider's /v1/models
+	// (authoritative for custom models) with a static fallback. Nil on paths
+	// without a provider handle.
+	windowResolver func(provider, model string) int64,
 ) (*ZedMCPConfig, error) {
 	config := &ZedMCPConfig{
 		ContextServers: make(map[string]ContextServerConfig),
@@ -269,14 +272,15 @@ func GenerateZedMCPConfig(
 	// Declare the selected model's context window to Zed. Zed's built-in
 	// auto-compaction is gated on the model window (>= 80k) and fires relative
 	// to it, but for a custom OpenAI-compatible model Zed has no window unless we
-	// declare it in available_models. Helix already resolves each model's window
-	// via ModelInfoProvider (static model_info.json + provider /models), so we
-	// forward it and let Zed size compaction itself — no Helix-side threshold.
-	// Best-effort: only when the window is resolvable and the provider entry exists.
-	if modelInfo != nil && zedModel != "" {
-		if info, err := modelInfo.GetModelInfo(ctx, &modelinfo.ModelInfoRequest{Provider: provider, Model: model}); err == nil && info != nil && info.ContextLength > 0 {
+	// declare it in available_models. The handler resolves the window from the
+	// provider's /v1/models (authoritative for custom models like GLM) with a
+	// static fallback; we forward it and let Zed size compaction itself — no
+	// Helix-side threshold. Best-effort: only when the window resolves and the
+	// provider entry exists.
+	if windowResolver != nil && zedModel != "" {
+		if window := windowResolver(provider, model); window > 0 {
 			if lm, ok := config.LanguageModels[zedProvider]; ok {
-				lm.AvailableModels = []AvailableModel{{Name: zedModel, MaxTokens: int64(info.ContextLength)}}
+				lm.AvailableModels = []AvailableModel{{Name: zedModel, MaxTokens: window}}
 				config.LanguageModels[zedProvider] = lm
 			}
 		}

--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	modelinfo "github.com/helixml/helix/api/pkg/model"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/rs/zerolog/log"
@@ -57,8 +58,18 @@ type AgentConfig struct {
 }
 
 type LanguageModelConfig struct {
-	APIURL string `json:"api_url"`           // Custom API URL (empty = use default provider URL)
-	APIKey string `json:"api_key,omitempty"` // Deprecated: Zed reads from env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY)
+	APIURL          string           `json:"api_url"`                     // Custom API URL (empty = use default provider URL)
+	APIKey          string           `json:"api_key,omitempty"`           // Deprecated: Zed reads from env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY)
+	AvailableModels []AvailableModel `json:"available_models,omitempty"` // Declares custom models + their context window to Zed
+}
+
+// AvailableModel declares a custom model to Zed. MaxTokens is the context window;
+// Zed needs it to size auto-compaction (it is gated on the window and compacts
+// relative to it). Without it a custom OpenAI-compatible model has no declared
+// window and Zed cannot compact correctly.
+type AvailableModel struct {
+	Name      string `json:"name"`
+	MaxTokens int64  `json:"max_tokens"`
 }
 
 type AssistantSettings struct {
@@ -106,6 +117,7 @@ func GenerateZedMCPConfig(
 	projectSkills *types.AssistantSkills,
 	oauthTokenGetter OAuthTokenGetter,
 	providerSnapshot []ProviderRef,
+	modelInfo modelinfo.ModelInfoProvider,
 ) (*ZedMCPConfig, error) {
 	config := &ZedMCPConfig{
 		ContextServers: make(map[string]ContextServerConfig),
@@ -218,11 +230,12 @@ func GenerateZedMCPConfig(
 		ShowOnboarding:         false,
 		AutoOpenPanel:          true,
 	}
+	var zedProvider, zedModel string
 	if useAgentModel {
 		// Map Helix provider to Zed's provider type and format model name
 		// Zed only knows: anthropic, openai, google, ollama, copilot, lmstudio, deepseek
 		// All other providers (nebius, together, openrouter, etc.) use OpenAI-compatible API
-		zedProvider, zedModel := mapHelixToZedProvider(provider, model)
+		zedProvider, zedModel = mapHelixToZedProvider(provider, model)
 		// Set feature-specific models to prevent Zed from using its hardcoded
 		// gpt-4.1-mini default for "fast" operations (see
 		// zed-industries/zed#31420). If not set, these fall back to
@@ -252,6 +265,22 @@ func GenerateZedMCPConfig(
 	// "provider \"openai\" not found" from /v1/messages because Zed sends
 	// the wrong provider on the Anthropic-only endpoint.
 	config.LanguageModels = buildLanguageModels(providerSnapshot, helixAPIURL)
+
+	// Declare the selected model's context window to Zed. Zed's built-in
+	// auto-compaction is gated on the model window (>= 80k) and fires relative
+	// to it, but for a custom OpenAI-compatible model Zed has no window unless we
+	// declare it in available_models. Helix already resolves each model's window
+	// via ModelInfoProvider (static model_info.json + provider /models), so we
+	// forward it and let Zed size compaction itself — no Helix-side threshold.
+	// Best-effort: only when the window is resolvable and the provider entry exists.
+	if modelInfo != nil && zedModel != "" {
+		if info, err := modelInfo.GetModelInfo(ctx, &modelinfo.ModelInfoRequest{Provider: provider, Model: model}); err == nil && info != nil && info.ContextLength > 0 {
+			if lm, ok := config.LanguageModels[zedProvider]; ok {
+				lm.AvailableModels = []AvailableModel{{Name: zedModel, MaxTokens: int64(info.ContextLength)}}
+				config.LanguageModels[zedProvider] = lm
+			}
+		}
+	}
 
 	// 1. Add Helix native tools via HTTP MCP gateway (APIs, Knowledge, Zapier)
 	// Uses the unified MCP gateway at /api/v1/mcp/helix instead of helix-cli
@@ -863,7 +892,7 @@ func GetZedConfigForSession(ctx context.Context, s store.Store, sessionID string
 	// Runner-side path has no provider-manager handle, so we skip provider
 	// validation here. The handler-side callers (getZedConfig,
 	// getMergedZedSettings) do pass the live provider list.
-	config, err := GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, nil)
+	config, err := GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate Zed config: %w", err)
 	}

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -201,6 +201,7 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 				nil,
 				nil,
 				tc.snapshot,
+				nil,
 			)
 			assert.NoError(t, err)
 			if !assert.NotNil(t, cfg) || !assert.NotNil(t, cfg.Agent) {

--- a/api/pkg/openai/openai_client.go
+++ b/api/pkg/openai/openai_client.go
@@ -499,6 +499,15 @@ func (c *RetryableClient) listOpenAIModels(ctx context.Context) ([]types.OpenAIM
 		}
 	}
 
+	// vLLM and similar OpenAI-compatible servers advertise the context window as
+	// max_model_len on /v1/models. It is the authoritative window for a custom
+	// model that isn't in any static table, so surface it as ContextLength.
+	for i := range models {
+		if models[i].ContextLength == 0 && models[i].MaxModelLen > 0 {
+			models[i].ContextLength = models[i].MaxModelLen
+		}
+	}
+
 	return models, nil
 }
 

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -147,7 +147,7 @@ func (apiServer *HelixAPIServer) getZedConfig(_ http.ResponseWriter, req *http.R
 	// pulls don't race UpdateApp and runner traffic doesn't bump
 	// app.UpdatedAt — the in-memory rewrite still feeds Generate below.
 	apiServer.healLegacyProviderRefs(ctx, app, providerSnapshot, user.TokenType != types.TokenTypeRunner)
-	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, sandboxAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, providerSnapshot)
+	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, sandboxAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, providerSnapshot, apiServer.modelInfoProvider)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
 		return nil, system.NewHTTPError500("failed to generate Zed config")
@@ -487,7 +487,7 @@ func (apiServer *HelixAPIServer) getMergedZedSettings(_ http.ResponseWriter, req
 	// providerSnapshot=nil here: this endpoint only exposes context_servers,
 	// which don't depend on provider resolution or model validation. The
 	// daemon hits /zed-config separately and handles those concerns there.
-	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, apiServer.Cfg.Kodit.Enabled, projectSkills, oauthTokenGetter, nil)
+	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, apiServer.Cfg.Kodit.Enabled, projectSkills, oauthTokenGetter, nil, apiServer.modelInfoProvider)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
 		return nil, system.NewHTTPError500("failed to generate Zed config")

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -13,6 +13,7 @@ import (
 	external_agent "github.com/helixml/helix/api/pkg/external-agent"
 	"github.com/helixml/helix/api/pkg/goose"
 	modelPkg "github.com/helixml/helix/api/pkg/model"
+	"github.com/helixml/helix/api/pkg/openai/manager"
 	"github.com/helixml/helix/api/pkg/services"
 	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/types"
@@ -147,7 +148,31 @@ func (apiServer *HelixAPIServer) getZedConfig(_ http.ResponseWriter, req *http.R
 	// pulls don't race UpdateApp and runner traffic doesn't bump
 	// app.UpdatedAt — the in-memory rewrite still feeds Generate below.
 	apiServer.healLegacyProviderRefs(ctx, app, providerSnapshot, user.TokenType != types.TokenTypeRunner)
-	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, sandboxAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, providerSnapshot, apiServer.modelInfoProvider)
+	// resolveModelWindow returns the model's context window (0 if unknown) so
+	// GenerateZedMCPConfig can declare it to Zed. The provider's own /v1/models
+	// is authoritative for custom models (vLLM advertises max_model_len); fall
+	// back to the static model_info.json for known models.
+	resolveModelWindow := func(provider, modelID string) int64 {
+		if provider == "" || modelID == "" {
+			return 0
+		}
+		if client, cerr := apiServer.providerManager.GetClient(ctx, &manager.GetClientRequest{Provider: provider, Owner: session.Owner}); cerr == nil {
+			if models, merr := client.ListModels(ctx); merr == nil {
+				for _, m := range models {
+					if m.ID == modelID && m.ContextLength > 0 {
+						return int64(m.ContextLength)
+					}
+				}
+			}
+		}
+		if apiServer.modelInfoProvider != nil {
+			if info, ierr := apiServer.modelInfoProvider.GetModelInfo(ctx, &modelPkg.ModelInfoRequest{Provider: provider, Model: modelID}); ierr == nil && info != nil && info.ContextLength > 0 {
+				return int64(info.ContextLength)
+			}
+		}
+		return 0
+	}
+	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, sandboxAPIURL, helixToken, koditEnabled, projectSkills, oauthTokenGetter, providerSnapshot, resolveModelWindow)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
 		return nil, system.NewHTTPError500("failed to generate Zed config")
@@ -487,7 +512,7 @@ func (apiServer *HelixAPIServer) getMergedZedSettings(_ http.ResponseWriter, req
 	// providerSnapshot=nil here: this endpoint only exposes context_servers,
 	// which don't depend on provider resolution or model validation. The
 	// daemon hits /zed-config separately and handles those concerns there.
-	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, apiServer.Cfg.Kodit.Enabled, projectSkills, oauthTokenGetter, nil, apiServer.modelInfoProvider)
+	zedConfig, err := external_agent.GenerateZedMCPConfig(ctx, app, session.Owner, sessionID, helixAPIURL, helixToken, apiServer.Cfg.Kodit.Enabled, projectSkills, oauthTokenGetter, nil, nil)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to generate Zed config")
 		return nil, system.NewHTTPError500("failed to generate Zed config")

--- a/api/pkg/types/provider.go
+++ b/api/pkg/types/provider.go
@@ -114,6 +114,10 @@ type OpenAIModel struct {
 	Hide          bool               `json:"hide,omitempty"`
 	Type          string             `json:"type,omitempty"`
 	ContextLength int                `json:"context_length,omitempty"`
+	// MaxModelLen is the vLLM/OpenAI-compatible provider's advertised context
+	// window on /v1/models. Standard OpenAI omits it; vLLM and similar servers
+	// include it, and it is the authoritative window for a custom model.
+	MaxModelLen   int                `json:"max_model_len,omitempty"`
 	Enabled       bool               `json:"enabled,omitempty"`
 	ModelInfo     *ModelInfo         `json:"model_info,omitempty"`
 }

--- a/design/2026-07-13-declare-model-window-to-zed.md
+++ b/design/2026-07-13-declare-model-window-to-zed.md
@@ -1,0 +1,49 @@
+# Declare each model's context window to Zed (2026-07-13)
+
+## Problem
+
+Long-lived external-agent threads (real Zed native agent, model calls proxied
+through Helix) start failing with ingress `504`s after days/weeks as the thread
+grows. Zed has built-in auto-compaction that would bound the context, but it is
+**gated on the model's context window** (`>= 80_000`) and fires **relative to it**
+(default 90%). For a custom OpenAI-compatible model (e.g. GLM), Zed only knows the
+window if it is declared in `language_models.<provider>.available_models[].max_tokens`.
+
+**Helix never declares it.** `buildLanguageModels` writes only `{api_url}` per
+provider (confirmed: a live agent's settings had `available_models: None`). So for
+a custom model Zed has no window, and its compaction can't size itself.
+
+## Change
+
+Forward the window Helix already knows. `ModelInfoProvider` resolves each model's
+`ContextLength` (static `model_info.json` + dynamic provider `/models`), so we look
+it up for the selected `(provider, model)` and write
+`available_models: [{ name, max_tokens }]` into the model's provider block.
+
+`GenerateZedMCPConfig` gains a `model.ModelInfoProvider` parameter (nil on the
+runner-side path that has no model-manager handle). Best-effort: if the window
+can't be resolved, behaviour is unchanged (no `available_models` written).
+
+## Why this and not a Helix-side threshold
+
+We deliberately do **not** set `auto_compact.threshold`. Zed's compaction is a
+sensible upstream default; Helix's job is to integrate correctly by telling Zed the
+window, then let Zed size compaction. No magic number, and it auto-fits every model
+(the window is per-model). If a provider is later found so slow that even Zed's 90%
+default is too late (the compaction call itself times out), that is revisited as a
+separate, evidence-backed decision - not pre-empted with an override.
+
+## Caveat
+
+Resolution is only as good as `ModelInfoProvider`. If a custom model name doesn't
+match `model_info.json` and no dynamic entry carries a `ContextLength`, no window is
+written. A follow-up could ensure the provider `/models` `max_model_len` is captured
+into dynamic model info so arbitrary custom models resolve.
+
+## Testing
+
+- `go build ./pkg/external-agent/ ./pkg/server/` and `go test ./pkg/external-agent/`
+  pass.
+- End-to-end confirmation that, with the window declared, a long thread triggers a
+  Zed compaction call (a `COMPACTION_PROMPT` entry in `llm_calls`, next turn's
+  `prompt_tokens` drops) is tracked separately.


### PR DESCRIPTION
Follow-up to the compaction investigation. Replaces the threshold-knob approach (#2839, closed) with the cleaner fix you asked for: **pass the window to Zed and let it size compaction - no Helix-side threshold.**

## Problem

Zed's built-in auto-compaction would bound a long thread's context, but it's **gated on the model's context window** (`>= 80k`) and fires **relative to it** (default 90%). For a custom OpenAI-compatible model (GLM), Zed only knows the window if it's in `available_models[].max_tokens`. **Helix never wrote it** - `buildLanguageModels` emits only `{api_url}` (a live agent's settings showed `available_models: None`). So Zed had no window and couldn't size compaction; long threads grew unbounded and eventually 504'd on the provider.

## Change

Forward the window Helix already resolves via `ModelInfoProvider` (static `model_info.json` + dynamic provider `/models` `max_model_len`) into `available_models: [{name, max_tokens}]`. `GenerateZedMCPConfig` gains a `model.ModelInfoProvider` param (nil on the runner-side path). Best-effort: if the window can't be resolved, behaviour is unchanged.

## Why no threshold

Per discussion: we don't want a magic Helix-side `auto_compact.threshold`. Zed's compaction is a reasonable upstream default; Helix's job is to integrate correctly (tell Zed the window) and let Zed handle it. Auto-fits every model. If a provider later proves so slow that even 90% is too late, that's revisited with evidence - not pre-empted.

## Caveat

Only as good as `ModelInfoProvider`. If a custom model name doesn't match `model_info.json` and no dynamic entry carries a `ContextLength`, no window is written (unchanged behaviour). A follow-up can capture the provider `/models` `max_model_len` into dynamic model info so arbitrary custom models resolve.

Design doc: `design/2026-07-13-declare-model-window-to-zed.md`.

## Testing

- `go build ./pkg/external-agent/ ./pkg/server/` and `go test ./pkg/external-agent/` pass.
- E2E confirmation (a `COMPACTION_PROMPT` call appears in `llm_calls` once a thread crosses the window-relative threshold) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)