### PR TITLE
feat(agent): add reasoning effort controls

### DIFF
--- a/api/cmd/settings-sync-daemon/main.go
+++ b/api/cmd/settings-sync-daemon/main.go
@@ -75,9 +75,10 @@ type CodeAgentConfig struct {
 	AgentName       string `json:"agent_name"`
 	BaseURL         string `json:"base_url"`
 	APIType         string `json:"api_type"`
-	Runtime         string `json:"runtime"`           // "zed_agent" or "qwen_code" or "goose_code"
-	MaxTokens       int    `json:"max_tokens"`        // Model's context window size (0 if unknown)
-	MaxOutputTokens int    `json:"max_output_tokens"` // Model's max completion tokens (0 if unknown)
+	Runtime         string `json:"runtime"`                    // "zed_agent" or "qwen_code" or "goose_code"
+	ReasoningEffort string `json:"reasoning_effort,omitempty"` // Runtime/model reasoning effort; empty uses the upstream default
+	MaxTokens       int    `json:"max_tokens"`                 // Model's context window size (0 if unknown)
+	MaxOutputTokens int    `json:"max_output_tokens"`          // Model's max completion tokens (0 if unknown)
 
 	// Goose-specific fields (only populated when Runtime == "goose_code").
 	GooseRecipes       []GooseRecipe     `json:"goose_recipes,omitempty"`
@@ -251,6 +252,9 @@ func (d *SettingsDaemon) generateAgentServerConfig() map[string]interface{} {
 		if d.codeAgentConfig.Model != "" {
 			claudeACPConfig["default_model"] = d.codeAgentConfig.Model
 		}
+		if d.codeAgentConfig.ReasoningEffort != "" {
+			env["CLAUDE_CODE_EFFORT_LEVEL"] = d.codeAgentConfig.ReasoningEffort
+		}
 		return map[string]interface{}{
 			"claude-acp": claudeACPConfig,
 		}
@@ -284,6 +288,18 @@ func (d *SettingsDaemon) generateAgentServerConfig() map[string]interface{} {
 		}
 		if d.codeAgentConfig.Model != "" {
 			config["default_model"] = d.codeAgentConfig.Model
+		}
+		if d.codeAgentConfig.ReasoningEffort != "" {
+			codexConfig, err := json.Marshal(struct {
+				ModelReasoningEffort string `json:"model_reasoning_effort"`
+			}{
+				ModelReasoningEffort: d.codeAgentConfig.ReasoningEffort,
+			})
+			if err != nil {
+				log.Printf("Failed to encode Codex reasoning effort: %v", err)
+				return nil
+			}
+			env["CODEX_CONFIG"] = string(codexConfig)
 		}
 		return map[string]interface{}{"codex-acp": config}
 

--- a/api/cmd/settings-sync-daemon/main_test.go
+++ b/api/cmd/settings-sync-daemon/main_test.go
@@ -583,6 +583,43 @@ func TestCodexAgentServerUsesFullAccess(t *testing.T) {
 	assert.Equal(t, "danger-full-access", persisted["sandbox_mode"])
 }
 
+func TestClaudeAgentServerUsesConfiguredReasoningEffort(t *testing.T) {
+	d := &SettingsDaemon{codeAgentConfig: &CodeAgentConfig{
+		Runtime:         "claude_code",
+		Model:           "claude-opus-4-6",
+		BaseURL:         "http://api",
+		ReasoningEffort: "max",
+	}}
+
+	cfg := d.generateAgentServerConfig()
+	claude, ok := cfg["claude-acp"].(map[string]interface{})
+	assert.True(t, ok)
+	env, ok := claude["env"].(map[string]string)
+	assert.True(t, ok)
+	assert.Equal(t, "max", env["CLAUDE_CODE_EFFORT_LEVEL"])
+}
+
+func TestCodexAgentServerUsesConfiguredReasoningEffort(t *testing.T) {
+	originalPath := CodexConfigPath
+	CodexConfigPath = filepath.Join(t.TempDir(), "config.toml")
+	t.Cleanup(func() { CodexConfigPath = originalPath })
+
+	d := &SettingsDaemon{codeAgentConfig: &CodeAgentConfig{
+		Runtime:         "codex_cli",
+		BaseURL:         "http://api/v1",
+		ReasoningEffort: "ultra",
+	}}
+
+	cfg := d.generateAgentServerConfig()
+	codex, ok := cfg["codex-acp"].(map[string]interface{})
+	assert.True(t, ok)
+	env, ok := codex["env"].(map[string]interface{})
+	assert.True(t, ok)
+	codexConfig, ok := env["CODEX_CONFIG"].(string)
+	assert.True(t, ok)
+	assert.JSONEq(t, `{"model_reasoning_effort":"ultra"}`, codexConfig)
+}
+
 // TestComputeEffectiveTheme exercises every branch of the helper that decides
 // whether the daemon should write the API-supplied theme or preserve the user's
 // on-disk Zed-UI choice. Covers the structured-theme case (the 002056 hypothesis

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -27832,6 +27832,10 @@ const docTemplate = `{
                     "description": "Provider is the LLM provider name (e.g., \"anthropic\", \"openai\", \"openrouter\")",
                     "type": "string"
                 },
+                "reasoning_effort": {
+                    "description": "ReasoningEffort controls the selected Claude Code or Codex model's reasoning effort.\nEmpty means the runtime/model default.",
+                    "type": "string"
+                },
                 "runtime": {
                     "description": "Runtime specifies which code agent runtime to use: \"zed_agent\" or \"qwen_code\"",
                     "allOf": [

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -27828,6 +27828,10 @@
                     "description": "Provider is the LLM provider name (e.g., \"anthropic\", \"openai\", \"openrouter\")",
                     "type": "string"
                 },
+                "reasoning_effort": {
+                    "description": "ReasoningEffort controls the selected Claude Code or Codex model's reasoning effort.\nEmpty means the runtime/model default.",
+                    "type": "string"
+                },
                 "runtime": {
                     "description": "Runtime specifies which code agent runtime to use: \"zed_agent\" or \"qwen_code\"",
                     "allOf": [

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -4467,6 +4467,11 @@ definitions:
         description: Provider is the LLM provider name (e.g., "anthropic", "openai",
           "openrouter")
         type: string
+      reasoning_effort:
+        description: |-
+          ReasoningEffort controls the selected Claude Code or Codex model's reasoning effort.
+          Empty means the runtime/model default.
+        type: string
       runtime:
         allOf:
         - $ref: '#/definitions/types.CodeAgentRuntime'

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -752,9 +752,18 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.C
 		BaseURL:         baseURL,
 		APIType:         apiType,
 		Runtime:         runtime,
+		ReasoningEffort: normalizeCodeAgentReasoningEffort(assistant.ReasoningEffort),
 		MaxTokens:       maxTokens,
 		MaxOutputTokens: maxOutputTokens,
 	}
+}
+
+func normalizeCodeAgentReasoningEffort(effort string) string {
+	effort = strings.ToLower(strings.TrimSpace(effort))
+	if effort == "" || effort == types.ReasoningEffortNone || effort == "default" {
+		return ""
+	}
+	return effort
 }
 
 // resolveGooseRecipesIntoConfig populates cfg.GooseRecipes (and

--- a/api/pkg/server/zed_config_handlers_test.go
+++ b/api/pkg/server/zed_config_handlers_test.go
@@ -220,9 +220,10 @@ func TestBuildCodeAgentConfigFromAssistant(t *testing.T) {
 				GenerationModel:         "gpt-5.3-codex",
 				CodeAgentRuntime:        types.CodeAgentRuntimeCodexCLI,
 				CodeAgentCredentialType: types.CodeAgentCredentialTypeAPIKey,
+				ReasoningEffort:         "high",
 			},
 			want: &types.CodeAgentConfig{
-				Provider: "openai", Model: "gpt-5.3-codex", AgentName: "codex",
+				Provider: "openai", Model: "gpt-5.3-codex", AgentName: "codex", ReasoningEffort: "high",
 				BaseURL: "http://localhost:8080/v1", APIType: "openai", Runtime: types.CodeAgentRuntimeCodexCLI,
 			},
 		},

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -2337,6 +2337,9 @@ type CodeAgentConfig struct {
 	APIType string `json:"api_type"`
 	// Runtime specifies which code agent runtime to use: "zed_agent" or "qwen_code"
 	Runtime CodeAgentRuntime `json:"runtime"`
+	// ReasoningEffort controls the selected Claude Code or Codex model's reasoning effort.
+	// Empty means the runtime/model default.
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
 	// MaxTokens is the model's context window size (max input tokens)
 	// Looked up from model_info.json, 0 if not found
 	MaxTokens int `json:"max_tokens,omitempty"`

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -2850,6 +2850,11 @@ export interface TypesCodeAgentConfig {
   model?: string;
   /** Provider is the LLM provider name (e.g., "anthropic", "openai", "openrouter") */
   provider?: string;
+  /**
+   * ReasoningEffort controls the selected Claude Code or Codex model's reasoning effort.
+   * Empty means the runtime/model default.
+   */
+  reasoning_effort?: string;
   /** Runtime specifies which code agent runtime to use: "zed_agent" or "qwen_code" */
   runtime?: TypesCodeAgentRuntime;
 }

--- a/frontend/src/components/agent/CodeAgentEffortSelect.tsx
+++ b/frontend/src/components/agent/CodeAgentEffortSelect.tsx
@@ -1,0 +1,70 @@
+import { FC } from 'react'
+import Box from '@mui/material/Box'
+import FormControl from '@mui/material/FormControl'
+import MenuItem from '@mui/material/MenuItem'
+import Select from '@mui/material/Select'
+import Typography from '@mui/material/Typography'
+
+export type CodeAgentEffort = 'default' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra'
+
+type CodeAgentEffortOption = {
+  value: CodeAgentEffort
+  label: string
+  description: string
+}
+
+export const CLAUDE_CODE_EFFORT_OPTIONS: ReadonlyArray<CodeAgentEffortOption> = [
+  { value: 'default', label: 'Default', description: 'Use the model/runtime default' },
+  { value: 'low', label: 'Low', description: 'Faster responses with less reasoning' },
+  { value: 'medium', label: 'Medium', description: 'Balanced reasoning effort' },
+  { value: 'high', label: 'High', description: 'More thorough reasoning, usually slower' },
+  { value: 'xhigh', label: 'Extra High', description: 'Maximum persistent reasoning for supported models' },
+  { value: 'max', label: 'Max', description: 'Deepest reasoning for supported models' },
+]
+
+export const CODEX_EFFORT_OPTIONS: ReadonlyArray<CodeAgentEffortOption> = [
+  { value: 'default', label: 'Default', description: 'Use the model/runtime default' },
+  { value: 'low', label: 'Low', description: 'Faster responses with less reasoning' },
+  { value: 'medium', label: 'Medium', description: 'Balanced reasoning effort' },
+  { value: 'high', label: 'High', description: 'More thorough reasoning, usually slower' },
+  { value: 'xhigh', label: 'Extra High', description: 'Extra high reasoning depth for supported models' },
+  { value: 'max', label: 'Max', description: 'Maximum reasoning depth for supported models' },
+  { value: 'ultra', label: 'Ultra', description: 'Deepest reasoning for supported models' },
+]
+
+export const getCodeAgentEffortOptions = (runtime: string): ReadonlyArray<CodeAgentEffortOption> =>
+  runtime === 'claude_code' ? CLAUDE_CODE_EFFORT_OPTIONS : CODEX_EFFORT_OPTIONS
+
+export const CodeAgentEffortSelect: FC<{
+  options: ReadonlyArray<CodeAgentEffortOption>
+  value: string
+  onChange: (value: CodeAgentEffort) => void
+  disabled?: boolean
+}> = ({ options, value, onChange, disabled }) => (
+  <Box sx={{ minWidth: 170 }}>
+    <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+      Effort
+    </Typography>
+    <FormControl fullWidth size="small">
+      <Select
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value as CodeAgentEffort)}
+        renderValue={(selected) => options.find((option) => option.value === selected)?.label ?? selected}
+      >
+        {options.map((option) => (
+          <MenuItem key={option.value} value={option.value}>
+            <Box>
+              <Typography variant="body2">{option.label}</Typography>
+              <Typography variant="caption" color="text.secondary">
+                {option.description}
+              </Typography>
+            </Box>
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  </Box>
+)
+
+export default CodeAgentEffortSelect

--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -44,6 +44,7 @@ import {
   DEFAULT_CLAUDE_SUBSCRIPTION_MODEL,
   DEFAULT_CODEX_SUBSCRIPTION_MODEL,
 } from '../agent/CodingAgentForm'
+import CodeAgentEffortSelect, { getCodeAgentEffortOptions } from '../agent/CodeAgentEffortSelect'
 import GooseRecipesEditor from './GooseRecipesEditor'
 import Divider from '@mui/material/Divider'
 import { useListProviders } from '../../services/providersService'
@@ -302,6 +303,8 @@ const AppSettings: FC<AppSettingsProps> = ({
   const [reasoningEffort, setReasoningEffort] = useState(app.reasoning_effort ?? DEFAULT_VALUES.reasoning_effort)
   const [temperature, setTemperature] = useState(app.temperature ?? DEFAULT_VALUES.temperature)
   const [topP, setTopP] = useState(app.top_p ?? DEFAULT_VALUES.top_p)
+  const codeAgentEffort = reasoningEffort === '' || reasoningEffort === 'none' ? 'default' : reasoningEffort
+  const codeAgentEffortOptions = getCodeAgentEffortOptions(code_agent_runtime)
 
   // Track if component has been initialized
   const isInitialized = useRef(false)
@@ -771,82 +774,118 @@ const AppSettings: FC<AppSettingsProps> = ({
                     </Typography>
                   )}
                   {code_agent_runtime === 'claude_code' && claudeCodeMode === 'subscription' && (
-                    <Box sx={{ mt: 1.5 }}>
-                      <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
-                        Model
-                      </Typography>
-                      <FormControl fullWidth>
-                        <Select
-                          size="small"
-                          value={claudeSubscriptionModel}
-                          disabled={readOnly}
-                          onChange={(e) => {
-                            const nextModel = e.target.value
-                            setClaudeSubscriptionModel(nextModel)
-                            onUpdate({ claude_subscription_model: nextModel })
-                          }}
-                        >
-                          {CLAUDE_SUBSCRIPTION_MODELS.map((m) => (
-                            <MenuItem key={m.id} value={m.id}>
-                              <Typography variant="body2">{m.label}</Typography>
-                            </MenuItem>
-                          ))}
-                        </Select>
-                      </FormControl>
-                    </Box>
+                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mt: 1.5 }} alignItems="flex-start">
+                      <Box sx={{ flex: 1, width: '100%' }}>
+                        <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+                          Model
+                        </Typography>
+                        <FormControl fullWidth>
+                          <Select
+                            size="small"
+                            value={claudeSubscriptionModel}
+                            disabled={readOnly}
+                            onChange={(e) => {
+                              const nextModel = e.target.value
+                              setClaudeSubscriptionModel(nextModel)
+                              onUpdate({ claude_subscription_model: nextModel })
+                            }}
+                          >
+                            {CLAUDE_SUBSCRIPTION_MODELS.map((m) => (
+                              <MenuItem key={m.id} value={m.id}>
+                                <Typography variant="body2">{m.label}</Typography>
+                              </MenuItem>
+                            ))}
+                          </Select>
+                        </FormControl>
+                      </Box>
+                      <CodeAgentEffortSelect
+                        options={codeAgentEffortOptions}
+                        value={codeAgentEffort}
+                        disabled={readOnly}
+                        onChange={(value) => {
+                          const nextEffort = value === 'default' ? 'none' : value
+                          setReasoningEffort(nextEffort)
+                          onUpdate({ reasoning_effort: nextEffort })
+                        }}
+                      />
+                    </Stack>
                   )}
                   {code_agent_runtime === 'codex_cli' && claudeCodeMode === 'subscription' && (
-                    <Box sx={{ mt: 1.5 }}>
-                      <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
-                        Model
-                      </Typography>
-                      <FormControl fullWidth>
-                        <Select
-                          size="small"
-                          value={model || DEFAULT_CODEX_SUBSCRIPTION_MODEL}
-                          disabled={readOnly}
-                          onChange={(e) => {
-                            const nextModel = e.target.value
-                            setModel(nextModel)
-                            onUpdate({ model: nextModel })
-                          }}
-                        >
-                          {CODEX_SUBSCRIPTION_MODELS.map((supportedModel) => (
-                            <MenuItem key={supportedModel.id} value={supportedModel.id}>
-                              <Typography variant="body2">{supportedModel.label}</Typography>
-                            </MenuItem>
-                          ))}
-                        </Select>
-                      </FormControl>
-                    </Box>
+                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mt: 1.5 }} alignItems="flex-start">
+                      <Box sx={{ flex: 1, width: '100%' }}>
+                        <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+                          Model
+                        </Typography>
+                        <FormControl fullWidth>
+                          <Select
+                            size="small"
+                            value={model || DEFAULT_CODEX_SUBSCRIPTION_MODEL}
+                            disabled={readOnly}
+                            onChange={(e) => {
+                              const nextModel = e.target.value
+                              setModel(nextModel)
+                              onUpdate({ model: nextModel })
+                            }}
+                          >
+                            {CODEX_SUBSCRIPTION_MODELS.map((supportedModel) => (
+                              <MenuItem key={supportedModel.id} value={supportedModel.id}>
+                                <Typography variant="body2">{supportedModel.label}</Typography>
+                              </MenuItem>
+                            ))}
+                          </Select>
+                        </FormControl>
+                      </Box>
+                      <CodeAgentEffortSelect
+                        options={codeAgentEffortOptions}
+                        value={codeAgentEffort}
+                        disabled={readOnly}
+                        onChange={(value) => {
+                          const nextEffort = value === 'default' ? 'none' : value
+                          setReasoningEffort(nextEffort)
+                          onUpdate({ reasoning_effort: nextEffort })
+                        }}
+                      />
+                    </Stack>
                   )}
                 </Box>
 
                 {claudeCodeMode === 'api_key' && (
-                  <Box>
-                    <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
-                      Model
-                    </Typography>
-                    <AdvancedModelPicker
-                      recommendedModels={RECOMMENDED_MODELS.zedExternal}
-                      hint={`Select the ${code_agent_runtime === 'claude_code' ? 'Claude' : 'OpenAI'} model for code generation`}
-                      selectedProvider={code_agent_runtime === 'claude_code' ? generation_model_provider : provider}
-                      selectedModelId={code_agent_runtime === 'claude_code' ? generation_model : model}
-                      onSelectModel={(provider, modelId) => {
-                        if (code_agent_runtime === 'claude_code') {
-                          setGenerationModel(modelId)
-                          setGenerationModelProvider(provider)
-                          onUpdate({ generation_model: modelId, generation_model_provider: provider })
-                        } else {
-                          setModel(modelId)
-                          setProvider(provider)
-                          onUpdate({ model: modelId, provider })
-                        }
+                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="flex-start">
+                    <Box sx={{ flex: 1, width: '100%', minWidth: 0 }}>
+                      <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+                        Model
+                      </Typography>
+                      <AdvancedModelPicker
+                        recommendedModels={RECOMMENDED_MODELS.zedExternal}
+                        hint={`Select the ${code_agent_runtime === 'claude_code' ? 'Claude' : 'OpenAI'} model for code generation`}
+                        selectedProvider={code_agent_runtime === 'claude_code' ? generation_model_provider : provider}
+                        selectedModelId={code_agent_runtime === 'claude_code' ? generation_model : model}
+                        onSelectModel={(provider, modelId) => {
+                          if (code_agent_runtime === 'claude_code') {
+                            setGenerationModel(modelId)
+                            setGenerationModelProvider(provider)
+                            onUpdate({ generation_model: modelId, generation_model_provider: provider })
+                          } else {
+                            setModel(modelId)
+                            setProvider(provider)
+                            onUpdate({ model: modelId, provider })
+                          }
+                        }}
+                        currentType="text"
+                        displayMode="short"
+                      />
+                    </Box>
+                    <CodeAgentEffortSelect
+                      options={codeAgentEffortOptions}
+                      value={codeAgentEffort}
+                      disabled={readOnly}
+                      onChange={(value) => {
+                        const nextEffort = value === 'default' ? 'none' : value
+                        setReasoningEffort(nextEffort)
+                        onUpdate({ reasoning_effort: nextEffort })
                       }}
-                      currentType="text"
-                      displayMode="short"
                     />
-                  </Box>
+                  </Stack>
                 )}
               </>
             ) : (

--- a/frontend/src/components/helix-org/BotRuntimeForm.tsx
+++ b/frontend/src/components/helix-org/BotRuntimeForm.tsx
@@ -20,6 +20,7 @@ import { AdvancedModelPicker } from '../create/AdvancedModelPicker'
 import { useClaudeSubscriptions } from '../account/ClaudeSubscriptionConnect'
 import { useCodexSubscriptions } from '../../services/codexSubscriptionsService'
 import { CODEX_SUBSCRIPTION_MODELS, DEFAULT_CODEX_SUBSCRIPTION_MODEL } from '../agent/CodingAgentForm'
+import CodeAgentEffortSelect, { getCodeAgentEffortOptions } from '../agent/CodeAgentEffortSelect'
 import { useHelixModelsForProvider, useHelixProviders } from '../../services/helixOrgService'
 
 export interface BotRuntimeValue {
@@ -27,6 +28,7 @@ export interface BotRuntimeValue {
   credentials: string
   provider: string
   model: string
+  reasoning_effort?: string
 }
 
 // Strong code-generation models to surface first in the picker.
@@ -38,7 +40,8 @@ const RECOMMENDED_MODELS = [
 export const BotRuntimeForm: FC<{
   value: BotRuntimeValue
   onChange: (patch: Partial<BotRuntimeValue>) => void
-}> = ({ value, onChange }) => {
+  showReasoningEffort?: boolean
+}> = ({ value, onChange, showReasoningEffort = false }) => {
   const { data: providers } = useHelixProviders()
   const { data: claudeSubscriptions } = useClaudeSubscriptions()
   const { data: codexSubscriptions } = useCodexSubscriptions()
@@ -56,6 +59,13 @@ export const BotRuntimeForm: FC<{
   const hasRuntimeSubscription = isClaude ? hasClaudeSubscription : isCodex ? hasCodexSubscription : false
   const hasRuntimeAPIKey = isClaude ? hasAnthropicProvider : isCodex ? hasOpenAIProvider : false
   const apiKeyMode = !supportsSubscription || value.credentials === 'api_key'
+  const effortValue = !value.reasoning_effort || value.reasoning_effort === 'none' ? 'default' : value.reasoning_effort
+  const effortOptions = getCodeAgentEffortOptions(value.runtime)
+  const canConfigureEffort = showReasoningEffort && (isClaude || isCodex)
+
+  const onEffort = (effort: string) => {
+    onChange({ reasoning_effort: effort === 'default' ? 'none' : effort })
+  }
 
   const onRuntime = (v: string) => {
     const patch: Partial<BotRuntimeValue> = { runtime: v }
@@ -175,41 +185,56 @@ export const BotRuntimeForm: FC<{
       )}
 
       {apiKeyMode ? (
-        <Box>
-          <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
-            Model
-          </Typography>
-          <AdvancedModelPicker
-            recommendedModels={RECOMMENDED_MODELS}
-            hint="Select the model your Bots use by default"
-            selectedProvider={value.provider}
-            selectedModelId={value.model}
-            onSelectModel={(prov, modelId) => onChange({ provider: prov, model: modelId })}
-            currentType="text"
-            displayMode="short"
-          />
-        </Box>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="flex-start">
+          <Box sx={{ flex: 1, width: '100%', minWidth: 0 }}>
+            <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+              Model
+            </Typography>
+            <AdvancedModelPicker
+              recommendedModels={RECOMMENDED_MODELS}
+              hint="Select the model your Bots use by default"
+              selectedProvider={value.provider}
+              selectedModelId={value.model}
+              onSelectModel={(prov, modelId) => onChange({ provider: prov, model: modelId })}
+              currentType="text"
+              displayMode="short"
+            />
+          </Box>
+          {canConfigureEffort && (
+            <CodeAgentEffortSelect options={effortOptions} value={effortValue} onChange={onEffort} />
+          )}
+        </Stack>
       ) : hasRuntimeSubscription ? (
         isCodex ? (
-          <Box>
-            <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Model</Typography>
-            <FormControl fullWidth size="small">
-              <Select
-                value={value.model || DEFAULT_CODEX_SUBSCRIPTION_MODEL}
-                onChange={(event) => onChange({ model: event.target.value })}
-              >
-                {CODEX_SUBSCRIPTION_MODELS.map((supportedModel) => (
-                  <MenuItem key={supportedModel.id} value={supportedModel.id}>
-                    <Typography variant="body2">{supportedModel.label}</Typography>
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Box>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="flex-start">
+            <Box sx={{ flex: 1, width: '100%' }}>
+              <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>Model</Typography>
+              <FormControl fullWidth size="small">
+                <Select
+                  value={value.model || DEFAULT_CODEX_SUBSCRIPTION_MODEL}
+                  onChange={(event) => onChange({ model: event.target.value })}
+                >
+                  {CODEX_SUBSCRIPTION_MODELS.map((supportedModel) => (
+                    <MenuItem key={supportedModel.id} value={supportedModel.id}>
+                      <Typography variant="body2">{supportedModel.label}</Typography>
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
+            {canConfigureEffort && (
+              <CodeAgentEffortSelect options={effortOptions} value={effortValue} onChange={onEffort} />
+            )}
+          </Stack>
         ) : (
-          <Typography variant="caption" color="text.secondary">
-            Uses your connected Claude subscription — no model selection needed.
-          </Typography>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="flex-start">
+            <Typography variant="caption" color="text.secondary" sx={{ flex: 1, pt: 1 }}>
+              Uses your connected Claude subscription — no model selection needed.
+            </Typography>
+            {canConfigureEffort && (
+              <CodeAgentEffortSelect options={effortOptions} value={effortValue} onChange={onEffort} />
+            )}
+          </Stack>
         )
       ) : null}
     </Stack>

--- a/frontend/src/pages/HelixOrgBotDetail.tsx
+++ b/frontend/src/pages/HelixOrgBotDetail.tsx
@@ -147,6 +147,7 @@ const HelixOrgBotDetail: FC = () => {
     credentials: '',
     provider: '',
     model: '',
+    reasoning_effort: '',
   })
   useEffect(() => {
     setName(bot?.name ?? '')
@@ -161,8 +162,9 @@ const HelixOrgBotDetail: FC = () => {
       credentials: assistant?.code_agent_credential_type ?? 'api_key',
       provider: assistant?.provider ?? '',
       model: assistant?.model ?? '',
+      reasoning_effort: assistant?.reasoning_effort ?? 'none',
     })
-  }, [assistant?.code_agent_runtime, assistant?.code_agent_credential_type, assistant?.provider, assistant?.model])
+  }, [assistant?.code_agent_runtime, assistant?.code_agent_credential_type, assistant?.provider, assistant?.model, assistant?.reasoning_effort])
 
   // A human node is a person, not a bot — the agent detail page (desktop,
   // tools, activation) makes no sense for it. Redirect a direct hit on
@@ -198,8 +200,9 @@ const HelixOrgBotDetail: FC = () => {
     if ((assistant?.code_agent_credential_type ?? 'api_key') !== runtimeConfig.credentials) return true
     if ((assistant?.provider ?? '') !== runtimeConfig.provider) return true
     if ((assistant?.model ?? '') !== runtimeConfig.model) return true
+    if ((assistant?.reasoning_effort ?? 'none') !== (runtimeConfig.reasoning_effort ?? 'none')) return true
     return false
-  }, [bot, name, content, tools, preserveContext, assistant?.code_agent_runtime, assistant?.code_agent_credential_type, assistant?.provider, assistant?.model, runtimeConfig.runtime, runtimeConfig.credentials, runtimeConfig.provider, runtimeConfig.model])
+  }, [bot, name, content, tools, preserveContext, assistant?.code_agent_runtime, assistant?.code_agent_credential_type, assistant?.provider, assistant?.model, assistant?.reasoning_effort, runtimeConfig.runtime, runtimeConfig.credentials, runtimeConfig.provider, runtimeConfig.model, runtimeConfig.reasoning_effort])
 
   const handleSave = async () => {
     if (!botId) return
@@ -214,6 +217,7 @@ const HelixOrgBotDetail: FC = () => {
           code_agent_credential_type: runtimeConfig.credentials as typeof assistant.code_agent_credential_type,
           provider: runtimeConfig.provider,
           model: runtimeConfig.model,
+          reasoning_effort: runtimeConfig.reasoning_effort ?? 'none',
           generation_model_provider: runtimeConfig.credentials === 'api_key' ? runtimeConfig.provider : '',
           generation_model: runtimeConfig.credentials === 'api_key' ? runtimeConfig.model : '',
         }
@@ -626,6 +630,7 @@ const HelixOrgBotDetail: FC = () => {
                   <Box>
                     <BotRuntimeForm
                       value={runtimeConfig}
+                      showReasoningEffort
                       onChange={(patch) => setRuntimeConfig((current) => ({ ...current, ...patch }))}
                     />
                   </Box>

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -4467,6 +4467,11 @@ definitions:
         description: Provider is the LLM provider name (e.g., "anthropic", "openai",
           "openrouter")
         type: string
+      reasoning_effort:
+        description: |-
+          ReasoningEffort controls the selected Claude Code or Codex model's reasoning effort.
+          Empty means the runtime/model default.
+        type: string
       runtime:
         allOf:
         - $ref: '#/definitions/types.CodeAgentRuntime'

--- a/openapi.json
+++ b/openapi.json
@@ -32184,6 +32184,10 @@
                         "description": "Provider is the LLM provider name (e.g., \"anthropic\", \"openai\", \"openrouter\")",
                         "type": "string"
                     },
+                    "reasoning_effort": {
+                        "description": "ReasoningEffort controls the selected Claude Code or Codex model's reasoning effort.\nEmpty means the runtime/model default.",
+                        "type": "string"
+                    },
                     "runtime": {
                         "description": "Runtime specifies which code agent runtime to use: \"zed_agent\" or \"qwen_code\"",
                         "allOf": [

--- a/swagger.json
+++ b/swagger.json
@@ -27828,6 +27828,10 @@
                     "description": "Provider is the LLM provider name (e.g., \"anthropic\", \"openai\", \"openrouter\")",
                     "type": "string"
                 },
+                "reasoning_effort": {
+                    "description": "ReasoningEffort controls the selected Claude Code or Codex model's reasoning effort.\nEmpty means the runtime/model default.",
+                    "type": "string"
+                },
                 "runtime": {
                     "description": "Runtime specifies which code agent runtime to use: \"zed_agent\" or \"qwen_code\"",
                     "allOf": [


### PR DESCRIPTION
## Summary

- Add runtime-specific reasoning effort selectors for Claude Code and Codex beside model selection.
- Support Default, Low, Medium, High, Extra High, Max, and Codex Ultra where applicable.
- Persist the selected effort through assistant configuration.
- Pass Claude effort via `CLAUDE_CODE_EFFORT_LEVEL`.
- Pass Codex effort via `CODEX_CONFIG.model_reasoning_effort`.
- Add the same effort control to Helix Org bot details.

## Validation

- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- Focused Go tests for API mapping and Claude/Codex runtime configuration.
- `yarn tsc --noEmit`
- `yarn build`
- `git diff --check`

Browser click-through was not run because Chrome DevTools tooling was unavailable in the development session.
