### PR TITLE
feat(frontend): show active work on org chart bots

### DIFF
--- a/api/pkg/org/application/bots/bots.go
+++ b/api/pkg/org/application/bots/bots.go
@@ -156,6 +156,7 @@ type UpdateParams struct {
 	Name            *string
 	Content         *string
 	Tools           *[]tool.Name
+	ProjectIDs      *[]string
 	PreserveContext *bool
 	// Identity, when non-nil, replaces the bot's per-channel handle map
 	// (human nodes only). nil leaves it unchanged.
@@ -180,6 +181,9 @@ func (s *Bots) Update(ctx context.Context, orgID string, id orgchart.BotID, p Up
 	if p.Tools != nil {
 		updated = updated.WithTools(*p.Tools)
 	}
+	if p.ProjectIDs != nil {
+		updated = updated.WithProjectIDs(normalizeProjectIDs(*p.ProjectIDs))
+	}
 	if p.PreserveContext != nil {
 		updated = updated.WithPreserveContext(*p.PreserveContext)
 	}
@@ -191,6 +195,23 @@ func (s *Bots) Update(ctx context.Context, orgID string, id orgchart.BotID, p Up
 		return orgchart.Bot{}, err
 	}
 	return updated, nil
+}
+
+func normalizeProjectIDs(projectIDs []string) []string {
+	seen := make(map[string]struct{}, len(projectIDs))
+	out := make([]string, 0, len(projectIDs))
+	for _, projectID := range projectIDs {
+		projectID = strings.TrimSpace(projectID)
+		if projectID == "" {
+			continue
+		}
+		if _, ok := seen[projectID]; ok {
+			continue
+		}
+		seen[projectID] = struct{}{}
+		out = append(out, projectID)
+	}
+	return out
 }
 
 // AttachTools grants the named tools to a Bot: the union of its current

--- a/api/pkg/org/application/projects/projects.go
+++ b/api/pkg/org/application/projects/projects.go
@@ -23,56 +23,111 @@ type MemberVerifier interface {
 	GetBot(ctx context.Context, orgID string, id orgchart.BotID) (orgchart.Bot, error)
 }
 
+// OwnProjectResolver resolves the Bot's runtime-owned project. It is separate
+// from the explicit Bot.ProjectIDs allowlist because runtime provisioning owns
+// that project pointer.
+type OwnProjectResolver interface {
+	OwnProjectID(ctx context.Context, orgID string, botID orgchart.BotID) (string, error)
+}
+
 // Service is the project-discovery application service.
 type Service struct {
 	port    runtime.Projects
 	members MemberVerifier
+	access  OwnProjectResolver
 }
 
 // New constructs the service over the given port. The port is required;
 // callers pass runtime.NoopProjects{} when no real runtime is wired. members
 // is optional: when set, every call verifies the caller Bot is a member of its
 // org (defensive depth — the MCP mount already enforces this); nil skips it.
-func New(port runtime.Projects, members MemberVerifier) *Service {
-	return &Service{port: port, members: members}
+func New(port runtime.Projects, members MemberVerifier, access ...OwnProjectResolver) *Service {
+	var resolver OwnProjectResolver
+	if len(access) > 0 {
+		resolver = access[0]
+	}
+	return &Service{port: port, members: members, access: resolver}
 }
 
 // callerIdentity extracts and validates the caller's org + worker IDs and,
 // when a MemberVerifier is wired, confirms the Bot is a member of that org.
-func (s *Service) callerIdentity(ctx context.Context, caller tool.Caller) (string, orgchart.BotID, error) {
+func (s *Service) callerIdentity(ctx context.Context, caller tool.Caller) (string, orgchart.BotID, orgchart.Bot, error) {
 	if caller == nil {
-		return "", "", errors.New("caller missing on invocation")
+		return "", "", orgchart.Bot{}, errors.New("caller missing on invocation")
 	}
 	orgID := caller.OrganizationID()
 	if orgID == "" {
-		return "", "", errors.New("caller has no organization id")
+		return "", "", orgchart.Bot{}, errors.New("caller has no organization id")
 	}
 	workerID := caller.ID()
 	if workerID == "" {
-		return "", "", errors.New("caller has no worker id")
+		return "", "", orgchart.Bot{}, errors.New("caller has no worker id")
 	}
+	var bot orgchart.Bot
 	if s.members != nil {
-		if _, err := s.members.GetBot(ctx, orgID, orgchart.BotID(workerID)); err != nil {
-			return "", "", fmt.Errorf("caller bot %s is not a member of org %s: %w", workerID, orgID, err)
+		var err error
+		bot, err = s.members.GetBot(ctx, orgID, orgchart.BotID(workerID))
+		if err != nil {
+			return "", "", orgchart.Bot{}, fmt.Errorf("caller bot %s is not a member of org %s: %w", workerID, orgID, err)
 		}
 	}
-	return orgID, orgchart.BotID(workerID), nil
+	return orgID, orgchart.BotID(workerID), bot, nil
+}
+
+func (s *Service) allowedProjectIDs(ctx context.Context, orgID string, botID orgchart.BotID, bot orgchart.Bot) (map[string]struct{}, error) {
+	allowed := make(map[string]struct{}, len(bot.ProjectIDs)+1)
+	for _, projectID := range bot.ProjectIDs {
+		allowed[projectID] = struct{}{}
+	}
+	if s.access != nil {
+		ownProjectID, err := s.access.OwnProjectID(ctx, orgID, botID)
+		if err != nil {
+			return nil, fmt.Errorf("resolve bot's own project: %w", err)
+		}
+		if ownProjectID != "" {
+			allowed[ownProjectID] = struct{}{}
+		}
+	}
+	return allowed, nil
 }
 
 // List returns the projects in the caller's org.
 func (s *Service) List(ctx context.Context, caller tool.Caller) ([]runtime.ProjectView, error) {
-	orgID, _, err := s.callerIdentity(ctx, caller)
+	orgID, botID, bot, err := s.callerIdentity(ctx, caller)
 	if err != nil {
 		return nil, err
 	}
-	return s.port.List(ctx, orgID)
+	views, err := s.port.List(ctx, orgID)
+	if err != nil || s.access == nil {
+		return views, err
+	}
+	allowed, err := s.allowedProjectIDs(ctx, orgID, botID, bot)
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]runtime.ProjectView, 0, len(views))
+	for _, view := range views {
+		if _, ok := allowed[view.ID]; ok {
+			filtered = append(filtered, view)
+		}
+	}
+	return filtered, nil
 }
 
 // Get returns one project by id, scoped to the caller's org.
 func (s *Service) Get(ctx context.Context, caller tool.Caller, projectID string) (runtime.ProjectView, error) {
-	orgID, _, err := s.callerIdentity(ctx, caller)
+	orgID, botID, bot, err := s.callerIdentity(ctx, caller)
 	if err != nil {
 		return runtime.ProjectView{}, err
+	}
+	if s.access != nil {
+		allowed, err := s.allowedProjectIDs(ctx, orgID, botID, bot)
+		if err != nil {
+			return runtime.ProjectView{}, err
+		}
+		if _, ok := allowed[projectID]; !ok {
+			return runtime.ProjectView{}, fmt.Errorf("bot %s does not have access to project %s", botID, projectID)
+		}
 	}
 	return s.port.Get(ctx, orgID, projectID)
 }

--- a/api/pkg/org/application/projects/projects_test.go
+++ b/api/pkg/org/application/projects/projects_test.go
@@ -27,13 +27,25 @@ func (f *fakePort) Get(_ context.Context, org, projectID string) (runtime.Projec
 	return f.view, f.err
 }
 
-type fakeMembers struct{ err error }
+type fakeMembers struct {
+	err        error
+	projectIDs []string
+}
 
 func (m *fakeMembers) GetBot(_ context.Context, org string, id orgchart.BotID) (orgchart.Bot, error) {
 	if m.err != nil {
 		return orgchart.Bot{}, m.err
 	}
-	return orgchart.Bot{ID: id, OrganizationID: org}, nil
+	return orgchart.Bot{ID: id, OrganizationID: org, ProjectIDs: m.projectIDs}, nil
+}
+
+type fakeAccess struct {
+	projectID string
+	err       error
+}
+
+func (a fakeAccess) OwnProjectID(_ context.Context, _ string, _ orgchart.BotID) (string, error) {
+	return a.projectID, a.err
 }
 
 type fakeCaller struct{ id, org string }
@@ -54,6 +66,35 @@ func TestList_ScopesToCallerOrg(t *testing.T) {
 	}
 	if len(views) != 1 || views[0].ID != "prj_1" {
 		t.Errorf("views = %+v", views)
+	}
+}
+
+func TestList_FiltersToOwnAndExplicitProjects(t *testing.T) {
+	t.Parallel()
+	fp := &fakePort{views: []runtime.ProjectView{
+		{ID: "prj_own"},
+		{ID: "prj_allowed"},
+		{ID: "prj_denied"},
+	}}
+	svc := New(fp, &fakeMembers{projectIDs: []string{"prj_allowed"}}, fakeAccess{projectID: "prj_own"})
+	views, err := svc.List(context.Background(), fakeCaller{id: "w-pm", org: "org-1"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(views) != 2 || views[0].ID != "prj_own" || views[1].ID != "prj_allowed" {
+		t.Fatalf("views = %+v, want own and explicitly allowed projects", views)
+	}
+}
+
+func TestGet_RejectsProjectOutsideAccess(t *testing.T) {
+	t.Parallel()
+	fp := &fakePort{view: runtime.ProjectView{ID: "prj_denied"}}
+	svc := New(fp, &fakeMembers{}, fakeAccess{projectID: "prj_own"})
+	if _, err := svc.Get(context.Background(), fakeCaller{id: "w-pm", org: "org-1"}, "prj_denied"); err == nil {
+		t.Fatal("expected project access rejection")
+	}
+	if fp.lastProject != "" {
+		t.Fatalf("port called for denied project %q", fp.lastProject)
 	}
 }
 

--- a/api/pkg/org/domain/orgchart/bot.go
+++ b/api/pkg/org/domain/orgchart/bot.go
@@ -62,6 +62,10 @@ type Bot struct {
 	Name    string
 	Content string
 	Tools   []tool.Name
+	// ProjectIDs is the explicit allowlist of Helix projects this Bot may
+	// target through cross-project tools. The Bot's own runtime project is
+	// always allowed and remains the default when a tool omits project_id.
+	ProjectIDs []string
 	// PreserveContext, when true, tells the runtime spawner NOT to wipe
 	// the Bot's chat session before each re-activation. The default
 	// (false) keeps the existing behaviour: every trigger starts on a
@@ -131,6 +135,12 @@ func (b Bot) WithContent(content string) Bot {
 // WithTools returns a copy of the Bot with Tools replaced.
 func (b Bot) WithTools(tools []tool.Name) Bot {
 	b.Tools = tools
+	return b
+}
+
+// WithProjectIDs returns a copy of the Bot with its project allowlist replaced.
+func (b Bot) WithProjectIDs(projectIDs []string) Bot {
+	b.ProjectIDs = projectIDs
 	return b
 }
 

--- a/api/pkg/org/infrastructure/persistence/gorm/bot.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/bot.go
@@ -30,6 +30,7 @@ type botRow struct {
 	Name            string   `gorm:"not null;default:''"`
 	Content         string   `gorm:"not null"`
 	Tools           []string `gorm:"serializer:json"`
+	ProjectIDs      []string `gorm:"serializer:json"`
 	PreserveContext bool     `gorm:"not null;default:false"`
 	// Kind is "" (agent) or "human". HelixUserID / Identity are only
 	// populated for human placeholder rows.
@@ -58,6 +59,7 @@ func (botMapper) ToRow(b orgchart.Bot) (botRow, error) {
 		Name:            b.Name,
 		Content:         b.Content,
 		Tools:           tools,
+		ProjectIDs:      b.ProjectIDs,
 		PreserveContext: b.PreserveContext,
 		Kind:            b.Kind,
 		HelixUserID:     b.HelixUserID,
@@ -81,6 +83,7 @@ func (botMapper) ToDomain(row botRow) (orgchart.Bot, error) {
 		Name:            row.Name,
 		Content:         row.Content,
 		Tools:           tools,
+		ProjectIDs:      row.ProjectIDs,
 		PreserveContext: row.PreserveContext,
 		Kind:            row.Kind,
 		HelixUserID:     row.HelixUserID,
@@ -123,6 +126,10 @@ func (r *botsRepo) Update(ctx context.Context, b orgchart.Bot) error {
 	if err != nil {
 		return fmt.Errorf("marshal tools: %w", err)
 	}
+	projectIDsJSON, err := json.Marshal(row.ProjectIDs)
+	if err != nil {
+		return fmt.Errorf("marshal project ids: %w", err)
+	}
 	// Pre-marshal identity for the same reason as tools: the serializer:json
 	// tag does not apply on a map[string]any Updates, so pgx can't infer the
 	// jsonb column type from a bare map[string]string parameter.
@@ -137,6 +144,7 @@ func (r *botsRepo) Update(ctx context.Context, b orgchart.Bot) error {
 			"name":             row.Name,
 			"content":          row.Content,
 			"tools":            string(toolsJSON),
+			"project_ids":      string(projectIDsJSON),
 			"preserve_context": row.PreserveContext,
 			"kind":             row.Kind,
 			"helix_user_id":    row.HelixUserID,

--- a/api/pkg/org/infrastructure/runtime/helix/spectasks.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spectasks.go
@@ -93,6 +93,24 @@ func (s *SpecTasks) resolveProject(ctx context.Context, orgID string, workerID o
 		}
 		return state.ProjectID, state.HiringUserID, nil
 	}
+	// Passing the Bot's own project explicitly is equivalent to omitting it.
+	// Every other project must be present in the Bot's persisted allowlist.
+	if requestedProjectID != state.ProjectID {
+		bot, getErr := s.orgStore.Bots.Get(ctx, orgID, workerID)
+		if getErr != nil {
+			return "", "", fmt.Errorf("get worker project access: %w", getErr)
+		}
+		allowed := false
+		for _, projectID := range bot.ProjectIDs {
+			if projectID == requestedProjectID {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return "", "", fmt.Errorf("bot %s does not have access to project %s", workerID, requestedProjectID)
+		}
+	}
 	project, err := s.tasks.GetProject(ctx, requestedProjectID)
 	if err != nil {
 		return "", "", fmt.Errorf("get project: %w", err)

--- a/api/pkg/org/infrastructure/runtime/helix/spectasks.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spectasks.go
@@ -73,6 +73,15 @@ func NewSpecTasks(orgStore *store.Store, tasks SpecTaskStore, workflow SpecTaskW
 
 var _ runtime.SpecTasks = (*SpecTasks)(nil)
 
+// OwnProjectID exposes the runtime-owned project pointer to project discovery.
+func (s *SpecTasks) OwnProjectID(ctx context.Context, orgID string, workerID orgchart.BotID) (string, error) {
+	state, err := LoadState(ctx, s.orgStore, orgID, workerID)
+	if err != nil {
+		return "", fmt.Errorf("load worker state: %w", err)
+	}
+	return state.ProjectID, nil
+}
+
 // resolveProject decides which project a call acts on and returns the
 // acting (hiring) user. When requestedProjectID is empty the call targets
 // the Worker's OWN project (resolved from runtime state) — the original

--- a/api/pkg/org/infrastructure/runtime/helix/spectasks_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spectasks_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
@@ -205,6 +206,13 @@ func TestSpecTasks_CrossProjectSameOrgAllowed(t *testing.T) {
 	wrap := newSpecTasksTestStore(t)
 	wid := orgchart.BotID("w-pm")
 	saveAllPointers(t, &wrap.Store, "org-test", wid, "prj_mine", "app_x", "repo_y", "ses_z")
+	bot, err := orgchart.NewBot(wid, "# PM", nil, time.Now().UTC(), "org-test")
+	if err != nil {
+		t.Fatalf("NewBot: %v", err)
+	}
+	if err := wrap.Store.Bots.Create(context.Background(), bot.WithProjectIDs([]string{"prj_other"})); err != nil {
+		t.Fatalf("create bot: %v", err)
+	}
 
 	fs := newFakeSpecTaskStore()
 	fs.projects["prj_other"] = &types.Project{ID: "prj_other", OrganizationID: "org-test"}
@@ -222,6 +230,33 @@ func TestSpecTasks_CrossProjectSameOrgAllowed(t *testing.T) {
 	}
 }
 
+func TestSpecTasks_CrossProjectWithoutAccessRejected(t *testing.T) {
+	t.Parallel()
+	wrap := newSpecTasksTestStore(t)
+	wid := orgchart.BotID("w-pm")
+	saveAllPointers(t, &wrap.Store, "org-test", wid, "prj_mine", "app_x", "repo_y", "ses_z")
+	bot, err := orgchart.NewBot(wid, "# PM", nil, time.Now().UTC(), "org-test")
+	if err != nil {
+		t.Fatalf("NewBot: %v", err)
+	}
+	if err := wrap.Store.Bots.Create(context.Background(), bot); err != nil {
+		t.Fatalf("create bot: %v", err)
+	}
+
+	fs := newFakeSpecTaskStore()
+	fs.projects["prj_other"] = &types.Project{ID: "prj_other", OrganizationID: "org-test"}
+	st, err := NewSpecTasks(&wrap.Store, fs, &fakeSpecTaskWorkflow{})
+	if err != nil {
+		t.Fatalf("NewSpecTasks: %v", err)
+	}
+	if _, err := st.Create(context.Background(), "org-test", wid, "prj_other", runtime.CreateSpecTaskInput{Name: "x", Description: "y"}); err == nil {
+		t.Fatal("expected project access rejection")
+	}
+	if len(fs.created) != 0 {
+		t.Fatalf("created %d tasks after access rejection", len(fs.created))
+	}
+}
+
 // TestSpecTasks_CrossOrgProjectRejected pins the hard cross-org block: a
 // Worker cannot target a project that belongs to another org, even with a
 // valid project_id.
@@ -230,6 +265,13 @@ func TestSpecTasks_CrossOrgProjectRejected(t *testing.T) {
 	wrap := newSpecTasksTestStore(t)
 	wid := orgchart.BotID("w-pm")
 	saveAllPointers(t, &wrap.Store, "org-test", wid, "prj_mine", "app_x", "repo_y", "ses_z")
+	bot, err := orgchart.NewBot(wid, "# PM", nil, time.Now().UTC(), "org-test")
+	if err != nil {
+		t.Fatalf("NewBot: %v", err)
+	}
+	if err := wrap.Store.Bots.Create(context.Background(), bot.WithProjectIDs([]string{"prj_foreign"})); err != nil {
+		t.Fatalf("create bot: %v", err)
+	}
 
 	fs := newFakeSpecTaskStore()
 	// Project exists but belongs to a DIFFERENT org.

--- a/api/pkg/org/interfaces/mcptools/builtins.go
+++ b/api/pkg/org/interfaces/mcptools/builtins.go
@@ -144,6 +144,9 @@ type Config struct {
 	// nil → Build defaults to runtime.NoopProjects{} so the tools return a
 	// clear "not wired" error instead of nil-derefing.
 	Projects runtime.Projects
+	// ProjectAccess resolves the caller Bot's own runtime project so project
+	// discovery can combine it with the explicit per-Bot allowlist.
+	ProjectAccess projects.OwnProjectResolver
 	// Repositories is the runtime port for org git-repo list/attach/detach.
 	// nil → Build defaults to runtime.NoopRepositories{}.
 	Repositories        runtime.Repositories
@@ -229,7 +232,7 @@ func (c Config) projectsService() *projects.Service {
 	if c.Queries != nil {
 		members = c.Queries
 	}
-	return projects.New(port, members)
+	return projects.New(port, members, c.ProjectAccess)
 }
 
 // specTasksService builds the spec-task application service over the

--- a/api/pkg/org/interfaces/mcptools/projects_mcp_test.go
+++ b/api/pkg/org/interfaces/mcptools/projects_mcp_test.go
@@ -22,6 +22,12 @@ import (
 // server → registry → tool → projects service → port path.
 type stubProjectsPort struct{ views []runtime.ProjectView }
 
+type stubProjectAccess struct{ ownProjectID string }
+
+func (s stubProjectAccess) OwnProjectID(_ context.Context, _ string, _ orgchart.BotID) (string, error) {
+	return s.ownProjectID, nil
+}
+
 func (s stubProjectsPort) List(_ context.Context, _ string) ([]runtime.ProjectView, error) {
 	return s.views, nil
 }
@@ -47,7 +53,9 @@ func TestProjectDiscoveryOverMCP(t *testing.T) {
 	cfg.Projects = stubProjectsPort{views: []runtime.ProjectView{
 		{ID: "prj_1", Name: "Alpha", Status: "active"},
 		{ID: "prj_2", Name: "Beta", Status: "active"},
+		{ID: "prj_3", Name: "Hidden", Status: "active"},
 	}}
+	cfg.ProjectAccess = stubProjectAccess{ownProjectID: "prj_1"}
 	if err := mcptools.RegisterBuiltins(reg, cfg.Build()); err != nil {
 		t.Fatalf("register builtins: %v", err)
 	}
@@ -67,7 +75,7 @@ func TestProjectDiscoveryOverMCP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new bot: %v", err)
 	}
-	mustCreate(t, s.Bots.Create(ctx, bot))
+	mustCreate(t, s.Bots.Create(ctx, bot.WithProjectIDs([]string{"prj_2"})))
 
 	session := connectMCP(t, srv.URL, "b-pm")
 
@@ -104,6 +112,9 @@ func TestProjectDiscoveryOverMCP(t *testing.T) {
 	}
 	if !strings.Contains(string(got), "Beta") {
 		t.Errorf("get_project prj_2 missing name Beta: %s", got)
+	}
+	if _, err := invokeTool(t, session, mcptools.GetProjectName, map[string]any{"project_id": "prj_3"}); err == nil {
+		t.Error("expected access error for unselected project")
 	}
 
 	// get_project for an unknown id surfaces an error, not another project.

--- a/api/pkg/org/interfaces/server/api/api_test.go
+++ b/api/pkg/org/interfaces/server/api/api_test.go
@@ -281,7 +281,10 @@ func TestPatchBot_UpdatesContent(t *testing.T) {
 	seedBot(t, st, ctx, "b-alice", "# Owner\noriginal body")
 
 	content := "# Owner v2\nupdated body"
-	rec := do(t, h, "PATCH", "/bots/b-alice", orgapi.UpdateBotRequest{Content: &content})
+	rec := do(t, h, "PATCH", "/bots/b-alice", orgapi.UpdateBotRequest{
+		Content:    &content,
+		ProjectIDs: []string{"prj_own", "prj_extra"},
+	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("PATCH status: got %d, want 200; body=%s", rec.Code, rec.Body)
 	}
@@ -294,6 +297,9 @@ func TestPatchBot_UpdatesContent(t *testing.T) {
 	decode(t, rec, &detail)
 	if detail.Bot.Content != "# Owner v2\nupdated body" {
 		t.Errorf("bot content: got %q, want updated", detail.Bot.Content)
+	}
+	if got := strings.Join(detail.Bot.ProjectIDs, ","); got != "prj_own,prj_extra" {
+		t.Errorf("project ids: got %q, want prj_own,prj_extra", got)
 	}
 }
 

--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -240,6 +240,7 @@ func (a *apiHandler) updateBot(w http.ResponseWriter, r *http.Request) {
 		Name:            req.Name,
 		Content:         req.Content,
 		Tools:           toolsPatch,
+		ProjectIDs:      stringSlicePatch(req.ProjectIDs),
 		PreserveContext: req.PreserveContext,
 		Identity:        identityPatch,
 	})
@@ -608,6 +609,7 @@ func botDTO(b orgchart.Bot, parentIDs []string) BotDTO {
 		ID:              string(b.ID),
 		Name:            b.Name,
 		Content:         b.Content,
+		ProjectIDs:      b.ProjectIDs,
 		ParentIDs:       parentIDs,
 		OrganizationID:  b.OrganizationID,
 		PreserveContext: b.PreserveContext,
@@ -628,6 +630,13 @@ func botDTO(b orgchart.Bot, parentIDs []string) BotDTO {
 	sort.Strings(tools)
 	dto.Tools = tools
 	return dto
+}
+
+func stringSlicePatch(in []string) *[]string {
+	if in == nil {
+		return nil
+	}
+	return &in
 }
 
 func toToolNames(in []string) []tool.Name {

--- a/api/pkg/org/interfaces/server/api/dto.go
+++ b/api/pkg/org/interfaces/server/api/dto.go
@@ -41,6 +41,7 @@ type BotDTO struct {
 	Name           string   `json:"name,omitempty"`
 	Content        string   `json:"content"`
 	Tools          []string `json:"tools,omitempty"`
+	ProjectIDs     []string `json:"project_ids,omitempty"`
 	ParentIDs      []string `json:"parent_ids,omitempty"`
 	OrganizationID string   `json:"organization_id,omitempty"`
 	// PreserveContext, when true, stops the runtime from wiping this
@@ -130,6 +131,7 @@ type UpdateBotRequest struct {
 	Name            *string  `json:"name,omitempty"`
 	Content         *string  `json:"content,omitempty"`
 	Tools           []string `json:"tools,omitempty"`
+	ProjectIDs      []string `json:"project_ids,omitempty"`
 	PreserveContext *bool    `json:"preserve_context,omitempty"`
 	// Identity is the per-channel handle map for a human node (slack/github/
 	// email/…). When present it replaces the stored map; absent leaves it

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -21728,6 +21728,12 @@ const docTemplate = `{
                     "description": "PreserveContext, when true, stops the runtime from wiping this\nBot's chat session before each re-activation, so it accumulates\ncontext across triggers (e.g. Slack). Defaults to false.",
                     "type": "boolean"
                 },
+                "project_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "tools": {
                     "type": "array",
                     "items": {
@@ -22374,6 +22380,12 @@ const docTemplate = `{
                 },
                 "preserve_context": {
                     "type": "boolean"
+                },
+                "project_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "tools": {
                     "type": "array",

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -520,6 +520,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		return nil, fmt.Errorf("init spec tasks: %w", err)
 	}
 	deps.SpecTasks = specTasks
+	deps.ProjectAccess = specTasks
 
 	// Projects backs the project-discovery MCP tools (list_projects,
 	// get_project) — org-scoped reads so an org-wide PM Bot can find the

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -21724,6 +21724,12 @@
                     "description": "PreserveContext, when true, stops the runtime from wiping this\nBot's chat session before each re-activation, so it accumulates\ncontext across triggers (e.g. Slack). Defaults to false.",
                     "type": "boolean"
                 },
+                "project_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "tools": {
                     "type": "array",
                     "items": {
@@ -22370,6 +22376,12 @@
                 },
                 "preserve_context": {
                     "type": "boolean"
+                },
+                "project_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "tools": {
                     "type": "array",

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -75,6 +75,10 @@ definitions:
           Bot's chat session before each re-activation, so it accumulates
           context across triggers (e.g. Slack). Defaults to false.
         type: boolean
+      project_ids:
+        items:
+          type: string
+        type: array
       tools:
         items:
           type: string
@@ -549,6 +553,10 @@ definitions:
         type: string
       preserve_context:
         type: boolean
+      project_ids:
+        items:
+          type: string
+        type: array
       tools:
         items:
           type: string

--- a/api/pkg/services/spec_task_orchestrator.go
+++ b/api/pkg/services/spec_task_orchestrator.go
@@ -396,10 +396,15 @@ func (o *SpecTaskOrchestrator) handleBacklog(ctx context.Context, task *types.Sp
 		return nil
 	}
 
-	planningLimit, implementationLimit := getProjectWIPLimits(project)
+	planningLimit, reviewLimit, implementationLimit := getProjectWIPLimits(project)
 	planningCount := countTasksByStatus(allProjectTasks,
 		types.TaskStatusQueuedSpecGeneration,
 		types.TaskStatusSpecGeneration,
+	)
+	reviewCount := countTasksByStatus(allProjectTasks,
+		types.TaskStatusSpecReview,
+		types.TaskStatusSpecRevision,
+		types.TaskStatusSpecApproved,
 	)
 	implementationCount := countTasksByStatus(allProjectTasks,
 		types.TaskStatusQueuedImplementation,
@@ -417,14 +422,26 @@ func (o *SpecTaskOrchestrator) handleBacklog(ctx context.Context, task *types.Sp
 				Msg("Skipping backlog task - implementation column at WIP limit")
 			return nil
 		}
-	} else if planningCount >= planningLimit {
-		log.Info().
-			Str("task_id", latestTask.ID).
-			Str("project_id", latestTask.ProjectID).
-			Int("planning_count", planningCount).
-			Int("wip_limit", planningLimit).
-			Msg("Skipping backlog task - planning column at WIP limit")
-		return nil
+	} else {
+		if planningCount >= planningLimit {
+			log.Info().
+				Str("task_id", latestTask.ID).
+				Str("project_id", latestTask.ProjectID).
+				Int("planning_count", planningCount).
+				Int("wip_limit", planningLimit).
+				Msg("Skipping backlog task - planning column at WIP limit")
+			return nil
+		}
+		if planningCount+reviewCount >= reviewLimit {
+			log.Info().
+				Str("task_id", latestTask.ID).
+				Str("project_id", latestTask.ProjectID).
+				Int("planning_count", planningCount).
+				Int("review_count", reviewCount).
+				Int("wip_limit", reviewLimit).
+				Msg("Skipping backlog task - no review capacity available")
+			return nil
+		}
 	}
 
 	log.Info().
@@ -477,20 +494,24 @@ func (o *SpecTaskOrchestrator) getBacklogProjectLock(projectID string) (*sync.Mu
 	return lock.(*sync.Mutex), nil
 }
 
-func getProjectWIPLimits(project *types.Project) (int, int) {
+func getProjectWIPLimits(project *types.Project) (int, int, int) {
 	planningLimit := 3
+	reviewLimit := 2
 	implementationLimit := 5
 
 	if project.Metadata.BoardSettings != nil {
 		if project.Metadata.BoardSettings.WIPLimits.Planning > 0 {
 			planningLimit = project.Metadata.BoardSettings.WIPLimits.Planning
 		}
+		if project.Metadata.BoardSettings.WIPLimits.Review > 0 {
+			reviewLimit = project.Metadata.BoardSettings.WIPLimits.Review
+		}
 		if project.Metadata.BoardSettings.WIPLimits.Implementation > 0 {
 			implementationLimit = project.Metadata.BoardSettings.WIPLimits.Implementation
 		}
 	}
 
-	return planningLimit, implementationLimit
+	return planningLimit, reviewLimit, implementationLimit
 }
 
 func countTasksByStatus(tasks []*types.SpecTask, statuses ...types.SpecTaskStatus) int {
@@ -521,10 +542,63 @@ func (o *SpecTaskOrchestrator) handleQueuedSpecGeneration(ctx context.Context, t
 		return nil
 	}
 
+	projectLock, err := o.getBacklogProjectLock(task.ProjectID)
+	if err != nil {
+		return err
+	}
+	projectLock.Lock()
+	defer projectLock.Unlock()
+
+	latestTask, err := o.store.GetSpecTask(ctx, task.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get latest queued task: %w", err)
+	}
+	if latestTask.Status != types.TaskStatusQueuedSpecGeneration {
+		return nil
+	}
+
+	project, err := o.store.GetProject(ctx, latestTask.ProjectID)
+	if err != nil {
+		return fmt.Errorf("failed to get project for planning WIP check: %w", err)
+	}
+	projectTasks, err := o.store.ListSpecTasks(ctx, &types.SpecTaskFilters{ProjectID: latestTask.ProjectID})
+	if err != nil {
+		return fmt.Errorf("failed to list project tasks for planning WIP check: %w", err)
+	}
+
+	planningLimit, reviewLimit, _ := getProjectWIPLimits(project)
+	planningCount := countTasksByStatus(projectTasks, types.TaskStatusSpecGeneration)
+	reviewCount := countTasksByStatus(projectTasks,
+		types.TaskStatusSpecReview,
+		types.TaskStatusSpecRevision,
+		types.TaskStatusSpecApproved,
+	)
+	if planningCount >= planningLimit || planningCount+reviewCount >= reviewLimit {
+		log.Info().
+			Str("task_id", latestTask.ID).
+			Str("project_id", latestTask.ProjectID).
+			Int("planning_count", planningCount).
+			Int("planning_limit", planningLimit).
+			Int("review_count", reviewCount).
+			Int("review_limit", reviewLimit).
+			Msg("Leaving spec task queued - planning or reserved review capacity is full")
+		return nil
+	}
+
+	// Claim capacity before launching the goroutine. The status change is the
+	// reservation observed by subsequent queued tasks under the project lock.
+	now := time.Now()
+	latestTask.Status = types.TaskStatusSpecGeneration
+	latestTask.StatusUpdatedAt = &now
+	latestTask.UpdatedAt = now
+	if err := o.store.UpdateSpecTask(ctx, latestTask); err != nil {
+		return fmt.Errorf("failed to reserve planning WIP slot: %w", err)
+	}
+
 	o.wg.Add(1)
 	go func() {
 		defer o.wg.Done()
-		o.specTaskService.StartSpecGeneration(ctx, task)
+		o.specTaskService.StartSpecGeneration(ctx, latestTask)
 	}()
 
 	return nil
@@ -542,9 +616,6 @@ func (o *SpecTaskOrchestrator) handleQueuedImplementation(ctx context.Context, t
 		return nil
 	}
 
-	// Check if implementation session is complete
-	// This would integrate with existing SpecDrivenTaskService
-	// For now, we'll assume implementation is ready when all implementation tasks exist
 	o.wg.Add(1)
 	go func() {
 		defer o.wg.Done()

--- a/api/pkg/services/spec_task_orchestrator_test.go
+++ b/api/pkg/services/spec_task_orchestrator_test.go
@@ -132,6 +132,41 @@ func (s *SpecTaskOrchestratorTestSuite) TestHandleBacklog_RespectsPlanningLimit(
 	s.Require().NoError(err)
 }
 
+func (s *SpecTaskOrchestratorTestSuite) TestHandleBacklog_ReservesReviewCapacity() {
+	ctx := context.Background()
+	eventTask := &types.SpecTask{
+		ID:        "task-123",
+		ProjectID: "project-123",
+		Status:    types.TaskStatusBacklog,
+	}
+	latestTask := &types.SpecTask{
+		ID:        eventTask.ID,
+		ProjectID: eventTask.ProjectID,
+		Status:    types.TaskStatusBacklog,
+	}
+	project := &types.Project{
+		ID:                    eventTask.ProjectID,
+		AutoStartBacklogTasks: true,
+		Metadata: types.ProjectMetadata{BoardSettings: &types.BoardSettings{
+			WIPLimits: types.WIPLimits{Planning: 3, Review: 2},
+		}},
+	}
+
+	s.store.EXPECT().GetSpecTask(ctx, eventTask.ID).Return(latestTask, nil)
+	s.store.EXPECT().GetProject(ctx, eventTask.ProjectID).Return(project, nil)
+	s.store.EXPECT().ListSpecTasks(ctx, &types.SpecTaskFilters{
+		ProjectID:     eventTask.ProjectID,
+		WithDependsOn: true,
+	}).Return([]*types.SpecTask{
+		{ID: "planning", Status: types.TaskStatusSpecGeneration},
+		{ID: "review", Status: types.TaskStatusSpecReview},
+		latestTask,
+	}, nil)
+
+	err := s.orchestrator.handleBacklog(ctx, eventTask)
+	s.Require().NoError(err)
+}
+
 func (s *SpecTaskOrchestratorTestSuite) TestHandleBacklog_RespectsImplementationLimitForJustDoIt() {
 	ctx := context.Background()
 	eventTask := &types.SpecTask{
@@ -313,6 +348,60 @@ func (s *SpecTaskOrchestratorTestSuite) TestHandleQueuedSpecGeneration_SkipsWhen
 
 	err := s.orchestrator.handleQueuedSpecGeneration(ctx, task)
 	s.Require().NoError(err)
+}
+
+func (s *SpecTaskOrchestratorTestSuite) TestHandleQueuedSpecGeneration_RespectsReviewCapacity() {
+	ctx := context.Background()
+	task := &types.SpecTask{
+		ID:        "task-queued",
+		ProjectID: "project-123",
+		Status:    types.TaskStatusQueuedSpecGeneration,
+	}
+	project := &types.Project{
+		ID: task.ProjectID,
+		Metadata: types.ProjectMetadata{BoardSettings: &types.BoardSettings{
+			WIPLimits: types.WIPLimits{Planning: 3, Review: 2},
+		}},
+	}
+
+	s.store.EXPECT().GetSpecTask(ctx, task.ID).Return(task, nil)
+	s.store.EXPECT().GetProject(ctx, task.ProjectID).Return(project, nil)
+	s.store.EXPECT().ListSpecTasks(ctx, &types.SpecTaskFilters{ProjectID: task.ProjectID}).Return([]*types.SpecTask{
+		{ID: "review-1", Status: types.TaskStatusSpecReview},
+		{ID: "review-2", Status: types.TaskStatusSpecReview},
+		task,
+	}, nil)
+
+	err := s.orchestrator.handleQueuedSpecGeneration(ctx, task)
+	s.Require().NoError(err)
+	s.Equal(types.TaskStatusQueuedSpecGeneration, task.Status)
+}
+
+func (s *SpecTaskOrchestratorTestSuite) TestHandleQueuedSpecGeneration_ReservesFutureReviewSlot() {
+	ctx := context.Background()
+	task := &types.SpecTask{
+		ID:        "task-queued",
+		ProjectID: "project-123",
+		Status:    types.TaskStatusQueuedSpecGeneration,
+	}
+	project := &types.Project{
+		ID: task.ProjectID,
+		Metadata: types.ProjectMetadata{BoardSettings: &types.BoardSettings{
+			WIPLimits: types.WIPLimits{Planning: 3, Review: 2},
+		}},
+	}
+
+	s.store.EXPECT().GetSpecTask(ctx, task.ID).Return(task, nil)
+	s.store.EXPECT().GetProject(ctx, task.ProjectID).Return(project, nil)
+	s.store.EXPECT().ListSpecTasks(ctx, &types.SpecTaskFilters{ProjectID: task.ProjectID}).Return([]*types.SpecTask{
+		{ID: "planning", Status: types.TaskStatusSpecGeneration},
+		{ID: "review", Status: types.TaskStatusSpecReview},
+		task,
+	}, nil)
+
+	err := s.orchestrator.handleQueuedSpecGeneration(ctx, task)
+	s.Require().NoError(err)
+	s.Equal(types.TaskStatusQueuedSpecGeneration, task.Status)
 }
 
 func (s *SpecTaskOrchestratorTestSuite) TestHandleQueuedImplementation_SkipsWhenDependencyNotDone() {

--- a/design/2026-07-14-spec-task-wip-review-capacity.md
+++ b/design/2026-07-14-spec-task-wip-review-capacity.md
@@ -1,0 +1,68 @@
+# Spec-task review WIP capacity incident
+
+## Incident
+
+Project `prj_01kx8kxa6q5qzsgcgb1xjxa7y5` launched eight planning sessions on
+2026-07-14 and all eight reached `spec_review`. Each session kept its Zed
+desktop alive, producing eight independent gopls processes and exhausting host
+memory and swap.
+
+The eight tasks were created in 134 ms and their sessions were created in
+135 ms. They were started through the helix-org spec-task runtime while the
+project had `auto_start_backlog_tasks=false`. The UI displayed the default WIP
+limits (planning 3, review 2), but the runtime wrote every task directly to
+`queued_spec_generation`.
+
+## Root cause
+
+WIP enforcement existed only in the backlog auto-start path. The orchestrator
+treated `queued_spec_generation` as unconditional permission to launch a
+desktop, so callers that queued work directly bypassed the check.
+
+The review limit was not read by the backend. Planning slots were released as
+tasks entered review, allowing more planners to start even though review tasks
+retain the same live desktop.
+
+## Fix
+
+The orchestrator now enforces capacity at the queued-to-running boundary, the
+last common path before any planning desktop is launched. It serializes the
+check per project, reloads current task state, and changes the selected task to
+`spec_generation` before starting the asynchronous desktop launch. That status
+change reserves the slot for concurrent queued tasks.
+
+Planning admission also reserves future review capacity. A planning task may
+start only when both conditions hold:
+
+- active planning work is below the planning limit;
+- active planning plus review work is below the review limit.
+
+The second condition is required because every successful planner becomes a
+review task and keeps its desktop alive. With planning 3 and review 2, at most
+two planning/review desktops can be admitted before a reviewer advances one.
+
+## Verification
+
+- `go test ./pkg/services -count=1`
+- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
+- Regression tests cover backlog admission, direct queued-task admission, a
+  full review column, and reservation of the last future review slot.
+
+## Usage telemetry repair
+
+Tasks 230–236 had completed interactions and ACP `message_completed` events
+with exact token payloads, but no `usage_metrics` rows. ACP subscription usage
+recording was present in the checked-out code but the running API had not
+reloaded it before those tasks completed. The API restarted at 06:09 UTC and
+recorded task 237's next completion normally at 06:10 UTC.
+
+Eight missing completed-interaction rows (tasks 230–237) were backfilled from
+the exact API-log payload whose timestamp matched each interaction's persisted
+`completed` timestamp. The repair used the recorder's normal
+`acp/<session_id>:<interaction_id>` idempotency key. The authenticated batch
+usage endpoint then returned non-zero usage for all eight July 14 tasks,
+including 633,245 tokens for task 230.
+
+Task 217 completed on July 11 before Zed emitted an ACP usage payload. Its log
+contains no token counts, so it was deliberately not backfilled rather than
+inventing a value.

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -63,6 +63,7 @@ export interface ApiBotDTO {
    * context across triggers (e.g. Slack). Defaults to false.
    */
   preserve_context?: boolean;
+  project_ids?: string[];
   tools?: string[];
   updated_at?: string;
 }
@@ -378,6 +379,7 @@ export interface ApiUpdateBotRequest {
   identity?: Record<string, string>;
   name?: string;
   preserve_context?: boolean;
+  project_ids?: string[];
   tools?: string[];
 }
 

--- a/frontend/src/components/helix-org/BotDetailDrawer.tsx
+++ b/frontend/src/components/helix-org/BotDetailDrawer.tsx
@@ -1,0 +1,238 @@
+import { FC, useEffect, useMemo, useState } from 'react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
+import Divider from '@mui/material/Divider'
+import FormControl from '@mui/material/FormControl'
+import InputLabel from '@mui/material/InputLabel'
+import MenuItem from '@mui/material/MenuItem'
+import Select from '@mui/material/Select'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded'
+import CheckCircleOutlineRoundedIcon from '@mui/icons-material/CheckCircleOutlineRounded'
+import PendingOutlinedIcon from '@mui/icons-material/PendingOutlined'
+import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined'
+import WorkOutlineRoundedIcon from '@mui/icons-material/WorkOutlineRounded'
+
+import type { BotDTO } from '../../services/helixOrgService'
+import type { SpecTask } from '../../services/specTaskService'
+import type { TypesProject } from '../../api/api'
+import useRouter from '../../hooks/useRouter'
+import HelixOrgOverviewCard from './HelixOrgOverviewCard'
+import HelixOrgSideDrawer from './HelixOrgSideDrawer'
+
+type BotDetailDrawerProps = {
+  botId?: string
+  bot?: BotDTO
+  project?: TypesProject
+  tasks: SpecTask[]
+  onClose: () => void
+}
+
+const statusLabel = (status?: string): string => {
+  if (!status) return 'Unknown'
+  return status
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+const statusTone = (status?: string): 'default' | 'primary' | 'warning' | 'success' | 'error' => {
+  switch (status) {
+    case 'done':
+    case 'completed':
+      return 'success'
+    case 'implementation_review':
+    case 'spec_review':
+    case 'spec_revision':
+      return 'warning'
+    case 'implementation_failed':
+    case 'spec_failed':
+      return 'error'
+    case 'implementation':
+    case 'implementing':
+    case 'implementation_queued':
+    case 'queued_implementation':
+    case 'spec_generation':
+    case 'queued_spec_generation':
+      return 'primary'
+    default:
+      return 'default'
+  }
+}
+
+const BotDetailDrawer: FC<BotDetailDrawerProps> = ({ botId, bot, project, tasks, onClose }) => {
+  const router = useRouter()
+  const [statusFilter, setStatusFilter] = useState('all')
+  const open = Boolean(botId)
+
+  useEffect(() => {
+    setStatusFilter('all')
+  }, [botId])
+
+  const statusOptions = useMemo(
+    () => Array.from(new Set(tasks.map((task) => String(task.status ?? 'unknown'))))
+      .sort((a, b) => statusLabel(a).localeCompare(statusLabel(b))),
+    [tasks],
+  )
+  const filteredTasks = useMemo(
+    () => statusFilter === 'all'
+      ? tasks
+      : tasks.filter((task) => String(task.status ?? 'unknown') === statusFilter),
+    [statusFilter, tasks],
+  )
+
+  const navigateToTask = (task: SpecTask) => {
+    if (!task.id || !task.project_id) return
+    router.navigate('org_project-task-detail', {
+      org_id: router.params.org_id,
+      id: task.project_id,
+      taskId: task.id,
+    })
+  }
+
+  return (
+    <HelixOrgSideDrawer
+      open={open}
+      onClose={onClose}
+      title={bot?.name || botId || 'Bot'}
+      width={560}
+      allowInteractionBehind
+      headerAction={botId ? (
+        <Button
+          size="small"
+          onClick={() => router.navigate('helix_org_bot_detail', {
+            org_id: router.params.org_id,
+            bot_id: botId,
+          })}
+        >
+          Details
+        </Button>
+      ) : undefined}
+    >
+      {!bot ? (
+        <Typography color="text.secondary">Bot not found.</Typography>
+      ) : (
+        <Stack spacing={2.5}>
+          <HelixOrgOverviewCard
+            title={bot.name || bot.id || 'Bot'}
+            id={bot.id}
+            icon={<SmartToyOutlinedIcon sx={{ fontSize: 20 }} />}
+            status={(
+              <Chip
+                label={bot.agent_status === 'running' ? 'Online' : 'Offline'}
+                size="small"
+                sx={{
+                  color: 'common.white',
+                  backgroundColor: bot.agent_status === 'running' ? 'rgba(34,197,94,0.24)' : 'rgba(255,255,255,0.12)',
+                  border: '1px solid rgba(255,255,255,0.22)',
+                  flexShrink: 0,
+                }}
+              />
+            )}
+          >
+            <Chip
+              icon={<WorkOutlineRoundedIcon sx={{ color: 'inherit !important' }} />}
+              label={`${tasks.length} spec task${tasks.length === 1 ? '' : 's'}`}
+              size="small"
+              sx={{ color: 'common.white', backgroundColor: 'rgba(255,255,255,0.11)' }}
+            />
+            {project?.name && (
+              <Chip
+                label={project.name}
+                size="small"
+                sx={{ maxWidth: '60%', color: 'common.white', backgroundColor: 'rgba(255,255,255,0.11)', '& .MuiChip-label': { overflow: 'hidden', textOverflow: 'ellipsis' } }}
+              />
+            )}
+          </HelixOrgOverviewCard>
+
+          <Divider />
+
+          <Box>
+            <Stack direction="row" alignItems="center" justifyContent="space-between" spacing={1} sx={{ mb: 1.25 }}>
+              <Box>
+                <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>Project spec tasks</Typography>
+                {project?.name && (
+                  <Typography variant="caption" color="text.secondary">
+                    {project.name}
+                  </Typography>
+                )}
+              </Box>
+              <FormControl size="small" sx={{ minWidth: 145 }}>
+                <InputLabel id="bot-task-status-filter">Status</InputLabel>
+                <Select
+                  labelId="bot-task-status-filter"
+                  value={statusFilter}
+                  label="Status"
+                  onChange={(event) => setStatusFilter(event.target.value)}
+                >
+                  <MenuItem value="all">All statuses</MenuItem>
+                  {statusOptions.map((status) => <MenuItem key={status} value={status}>{statusLabel(status)}</MenuItem>)}
+                </Select>
+              </FormControl>
+            </Stack>
+
+            {filteredTasks.length === 0 ? (
+              <Box sx={{ p: 2.5, textAlign: 'center', border: '1px dashed', borderColor: 'divider', borderRadius: 1.5 }}>
+                <PendingOutlinedIcon sx={{ color: 'text.disabled', mb: 0.5 }} />
+                <Typography variant="body2" color="text.secondary">
+                  {tasks.length === 0 ? 'No spec tasks are linked to this bot yet.' : 'No tasks match this status.'}
+                </Typography>
+              </Box>
+            ) : (
+              <Stack spacing={1}>
+                {filteredTasks.map((task) => {
+                  const title = task.user_short_title || task.short_title || task.name || task.id || 'Untitled task'
+                  const status = String(task.status ?? 'unknown')
+                  return (
+                    <Box
+                      key={task.id}
+                      component="button"
+                      type="button"
+                      onClick={() => navigateToTask(task)}
+                      disabled={!task.id || !task.project_id}
+                      sx={{
+                        width: '100%',
+                        p: 1.25,
+                        display: 'block',
+                        textAlign: 'left',
+                        border: '1px solid',
+                        borderColor: 'divider',
+                        borderRadius: 1.5,
+                        backgroundColor: 'background.paper',
+                        color: 'inherit',
+                        cursor: task.id && task.project_id ? 'pointer' : 'default',
+                        transition: 'border-color 0.15s ease, background-color 0.15s ease, transform 0.15s ease',
+                        '&:hover:not(:disabled)': { borderColor: 'primary.main', backgroundColor: 'action.hover', transform: 'translateX(2px)' },
+                        '&:disabled': { opacity: 0.62 },
+                      }}
+                    >
+                      <Stack direction="row" spacing={1.25} alignItems="center">
+                        <Box sx={{ color: 'text.disabled', display: 'flex' }}>
+                          {status === 'done' || status === 'completed' ? <CheckCircleOutlineRoundedIcon color="success" /> : <PendingOutlinedIcon />}
+                        </Box>
+                        <Box sx={{ flex: 1, minWidth: 0 }}>
+                          <Typography variant="body2" sx={{ fontWeight: 650, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                            {title}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+                            {task.task_number ? `#${task.task_number}` : task.id}
+                          </Typography>
+                        </Box>
+                        <Chip label={statusLabel(status)} color={statusTone(status)} size="small" sx={{ maxWidth: 150 }} />
+                        <ArrowForwardRoundedIcon sx={{ fontSize: 18, color: 'text.disabled' }} />
+                      </Stack>
+                    </Box>
+                  )
+                })}
+              </Stack>
+            )}
+          </Box>
+        </Stack>
+      )}
+    </HelixOrgSideDrawer>
+  )
+}
+
+export default BotDetailDrawer

--- a/frontend/src/components/helix-org/BotDetailDrawer.tsx
+++ b/frontend/src/components/helix-org/BotDetailDrawer.tsx
@@ -68,6 +68,7 @@ const BotDetailDrawer: FC<BotDetailDrawerProps> = ({ botId, bot, project, tasks,
       title={bot?.name || botId || 'Bot'}
       width={560}
       allowInteractionBehind
+      closeOnEscape
       headerAction={botId ? (
         <Button
           size="small"

--- a/frontend/src/components/helix-org/BotDetailDrawer.tsx
+++ b/frontend/src/components/helix-org/BotDetailDrawer.tsx
@@ -21,6 +21,7 @@ import type { TypesProject } from '../../api/api'
 import useRouter from '../../hooks/useRouter'
 import HelixOrgOverviewCard from './HelixOrgOverviewCard'
 import HelixOrgSideDrawer from './HelixOrgSideDrawer'
+import SpecTaskStatusBadge, { formatSpecTaskStatus } from './SpecTaskStatusBadge'
 
 type BotDetailDrawerProps = {
   botId?: string
@@ -28,38 +29,6 @@ type BotDetailDrawerProps = {
   project?: TypesProject
   tasks: SpecTask[]
   onClose: () => void
-}
-
-const statusLabel = (status?: string): string => {
-  if (!status) return 'Unknown'
-  return status
-    .split('_')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ')
-}
-
-const statusTone = (status?: string): 'default' | 'primary' | 'warning' | 'success' | 'error' => {
-  switch (status) {
-    case 'done':
-    case 'completed':
-      return 'success'
-    case 'implementation_review':
-    case 'spec_review':
-    case 'spec_revision':
-      return 'warning'
-    case 'implementation_failed':
-    case 'spec_failed':
-      return 'error'
-    case 'implementation':
-    case 'implementing':
-    case 'implementation_queued':
-    case 'queued_implementation':
-    case 'spec_generation':
-    case 'queued_spec_generation':
-      return 'primary'
-    default:
-      return 'default'
-  }
 }
 
 const BotDetailDrawer: FC<BotDetailDrawerProps> = ({ botId, bot, project, tasks, onClose }) => {
@@ -73,7 +42,7 @@ const BotDetailDrawer: FC<BotDetailDrawerProps> = ({ botId, bot, project, tasks,
 
   const statusOptions = useMemo(
     () => Array.from(new Set(tasks.map((task) => String(task.status ?? 'unknown'))))
-      .sort((a, b) => statusLabel(a).localeCompare(statusLabel(b))),
+      .sort((a, b) => formatSpecTaskStatus(a).localeCompare(formatSpecTaskStatus(b))),
     [tasks],
   )
   const filteredTasks = useMemo(
@@ -168,7 +137,7 @@ const BotDetailDrawer: FC<BotDetailDrawerProps> = ({ botId, bot, project, tasks,
                   onChange={(event) => setStatusFilter(event.target.value)}
                 >
                   <MenuItem value="all">All statuses</MenuItem>
-                  {statusOptions.map((status) => <MenuItem key={status} value={status}>{statusLabel(status)}</MenuItem>)}
+                  {statusOptions.map((status) => <MenuItem key={status} value={status}>{formatSpecTaskStatus(status)}</MenuItem>)}
                 </Select>
               </FormControl>
             </Stack>
@@ -220,7 +189,7 @@ const BotDetailDrawer: FC<BotDetailDrawerProps> = ({ botId, bot, project, tasks,
                             {task.task_number ? `#${task.task_number}` : task.id}
                           </Typography>
                         </Box>
-                        <Chip label={statusLabel(status)} color={statusTone(status)} size="small" sx={{ maxWidth: 150 }} />
+                        <SpecTaskStatusBadge status={status} />
                         <ArrowForwardRoundedIcon sx={{ fontSize: 18, color: 'text.disabled' }} />
                       </Stack>
                     </Box>

--- a/frontend/src/components/helix-org/HelixOrgOverviewCard.tsx
+++ b/frontend/src/components/helix-org/HelixOrgOverviewCard.tsx
@@ -1,0 +1,54 @@
+import { FC, ReactNode } from 'react'
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+
+export type HelixOrgOverviewCardProps = {
+  title: string
+  id?: string
+  icon: ReactNode
+  status?: ReactNode
+  idAction?: ReactNode
+  children?: ReactNode
+}
+
+const HelixOrgOverviewCard: FC<HelixOrgOverviewCardProps> = ({ title, id, icon, status, idAction, children }) => (
+  <Box
+    sx={{
+      p: 2,
+      borderRadius: 1.5,
+      color: 'common.white',
+      background: 'linear-gradient(135deg, #123b4a 0%, #0b6073 52%, #087c93 100%)',
+      boxShadow: '0 6px 18px rgba(8, 112, 135, 0.16)',
+    }}
+  >
+    <Stack direction="row" alignItems="flex-start" justifyContent="space-between" spacing={2}>
+      <Stack direction="row" spacing={1.25} alignItems="center" sx={{ minWidth: 0 }}>
+        <Box sx={{ p: 1, borderRadius: 1.5, backgroundColor: 'rgba(255,255,255,0.14)', display: 'flex' }}>
+          {icon}
+        </Box>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography variant="h6" sx={{ fontWeight: 650, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {title}
+          </Typography>
+          {id && (
+            <Stack direction="row" spacing={0.25} alignItems="center" sx={{ minWidth: 0 }}>
+              <Typography variant="caption" sx={{ opacity: 0.78, fontFamily: 'monospace', overflowWrap: 'anywhere' }}>
+                {id}
+              </Typography>
+              {idAction}
+            </Stack>
+          )}
+        </Box>
+      </Stack>
+      {status}
+    </Stack>
+    {children && (
+      <Stack direction="row" spacing={1} sx={{ mt: 2, flexWrap: 'wrap', rowGap: 1 }}>
+        {children}
+      </Stack>
+    )}
+  </Box>
+)
+
+export default HelixOrgOverviewCard

--- a/frontend/src/components/helix-org/HelixOrgSideDrawer.test.tsx
+++ b/frontend/src/components/helix-org/HelixOrgSideDrawer.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import HelixOrgSideDrawer from './HelixOrgSideDrawer'
+
+describe('HelixOrgSideDrawer', () => {
+  it('closes a persistent drawer on Escape when enabled', () => {
+    const onClose = vi.fn()
+    render(
+      <HelixOrgSideDrawer
+        open
+        onClose={onClose}
+        title="Bot details"
+        allowInteractionBehind
+        closeOnEscape
+      >
+        Drawer content
+      </HelixOrgSideDrawer>,
+    )
+
+    expect(screen.getByText('Drawer content')).toBeInTheDocument()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/helix-org/HelixOrgSideDrawer.tsx
+++ b/frontend/src/components/helix-org/HelixOrgSideDrawer.tsx
@@ -2,7 +2,7 @@
 // (bots, topics, processors). Keeps title bar + close + width consistent
 // so every create flow feels like the same surface.
 
-import { FC, ReactNode } from 'react'
+import { FC, ReactNode, useEffect } from 'react'
 import Box from '@mui/material/Box'
 import Drawer from '@mui/material/Drawer'
 import IconButton from '@mui/material/IconButton'
@@ -19,6 +19,8 @@ export type HelixOrgSideDrawerProps = {
   headerAction?: ReactNode
   /** Keep the underlying chart interactive while this drawer is open. */
   allowInteractionBehind?: boolean
+  /** Close persistent drawers on Escape. Temporary drawers handle this through MUI. */
+  closeOnEscape?: boolean
   children: ReactNode
 }
 
@@ -29,49 +31,66 @@ const HelixOrgSideDrawer: FC<HelixOrgSideDrawerProps> = ({
   width = 460,
   headerAction,
   allowInteractionBehind = false,
+  closeOnEscape = false,
   children,
-}) => (
-  <Drawer
-    anchor="right"
-    variant={allowInteractionBehind ? 'persistent' : 'temporary'}
-    open={open}
-    onClose={onClose}
-    hideBackdrop={allowInteractionBehind}
-    ModalProps={allowInteractionBehind ? {
-      disableAutoFocus: true,
-      disableEnforceFocus: true,
-      disableRestoreFocus: true,
-    } : undefined}
-    PaperProps={{ sx: { backgroundImage: 'none' } }}
-  >
-    <Box
-      sx={{
-        p: 2.5,
-        width,
-        maxWidth: '100vw',
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        boxSizing: 'border-box',
-      }}
+}) => {
+  useEffect(() => {
+    if (!open || !closeOnEscape) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || event.defaultPrevented) return
+      // Let a nested menu/select/dialog consume Escape before closing the drawer.
+      if (document.querySelector('.MuiPopover-root, .MuiDialog-root')) return
+      onClose()
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [closeOnEscape, onClose, open])
+
+  return (
+    <Drawer
+      anchor="right"
+      variant={allowInteractionBehind ? 'persistent' : 'temporary'}
+      open={open}
+      onClose={onClose}
+      hideBackdrop={allowInteractionBehind}
+      ModalProps={allowInteractionBehind ? {
+        disableAutoFocus: true,
+        disableEnforceFocus: true,
+        disableRestoreFocus: true,
+      } : undefined}
+      PaperProps={{ sx: { backgroundImage: 'none' } }}
     >
-      <Stack
-        direction="row"
-        justifyContent="space-between"
-        alignItems="center"
-        sx={{ mb: 2, flexShrink: 0 }}
+      <Box
+        sx={{
+          p: 2.5,
+          width,
+          maxWidth: '100vw',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          boxSizing: 'border-box',
+        }}
       >
-        <Typography variant="h6">{title}</Typography>
-        <Stack direction="row" alignItems="center" spacing={0.5}>
-          {headerAction}
-          <IconButton size="small" onClick={onClose} aria-label="Close">
-            <CloseIcon />
-          </IconButton>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+          sx={{ mb: 2, flexShrink: 0 }}
+        >
+          <Typography variant="h6">{title}</Typography>
+          <Stack direction="row" alignItems="center" spacing={0.5}>
+            {headerAction}
+            <IconButton size="small" onClick={onClose} aria-label="Close">
+              <CloseIcon />
+            </IconButton>
+          </Stack>
         </Stack>
-      </Stack>
-      <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>{children}</Box>
-    </Box>
-  </Drawer>
-)
+        <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>{children}</Box>
+      </Box>
+    </Drawer>
+  )
+}
 
 export default HelixOrgSideDrawer

--- a/frontend/src/components/helix-org/HelixOrgSideDrawer.tsx
+++ b/frontend/src/components/helix-org/HelixOrgSideDrawer.tsx
@@ -17,6 +17,8 @@ export type HelixOrgSideDrawerProps = {
   /** Paper width in px. Default 460 (matches processor form). */
   width?: number
   headerAction?: ReactNode
+  /** Keep the underlying chart interactive while this drawer is open. */
+  allowInteractionBehind?: boolean
   children: ReactNode
 }
 
@@ -26,12 +28,20 @@ const HelixOrgSideDrawer: FC<HelixOrgSideDrawerProps> = ({
   title,
   width = 460,
   headerAction,
+  allowInteractionBehind = false,
   children,
 }) => (
   <Drawer
     anchor="right"
+    variant={allowInteractionBehind ? 'persistent' : 'temporary'}
     open={open}
     onClose={onClose}
+    hideBackdrop={allowInteractionBehind}
+    ModalProps={allowInteractionBehind ? {
+      disableAutoFocus: true,
+      disableEnforceFocus: true,
+      disableRestoreFocus: true,
+    } : undefined}
     PaperProps={{ sx: { backgroundImage: 'none' } }}
   >
     <Box

--- a/frontend/src/components/helix-org/ProcessorConfigDrawer.tsx
+++ b/frontend/src/components/helix-org/ProcessorConfigDrawer.tsx
@@ -11,6 +11,7 @@
 import { FC, useEffect, useMemo, useState } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
 import Collapse from '@mui/material/Collapse'
 import Divider from '@mui/material/Divider'
 import FormControlLabel from '@mui/material/FormControlLabel'
@@ -22,11 +23,13 @@ import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import CloseIcon from '@mui/icons-material/Close'
+import TransformIcon from '@mui/icons-material/Transform'
 
 import useSnackbar from '../../hooks/useSnackbar'
 import useRouter from '../../hooks/useRouter'
 import MonacoEditor from '../widgets/MonacoEditor'
 import CopyButtonWithCheck from '../session/CopyButtonWithCheck'
+import HelixOrgOverviewCard from './HelixOrgOverviewCard'
 import HelixOrgSideDrawer from './HelixOrgSideDrawer'
 import {
   ProcessorDTO,
@@ -391,15 +394,19 @@ const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, 
       ) : undefined}
     >
         <Stack spacing={1.5}>
-          {isEdit && (
-            <Stack direction="row" spacing={0.5} alignItems="center">
-              <Typography variant="caption" color="text.secondary">Processor ID</Typography>
-              <Typography variant="body2" sx={{ fontFamily: 'monospace', overflowWrap: 'anywhere' }}>
-                {processor!.id}
-              </Typography>
-              <CopyButtonWithCheck text={processor!.id} />
-            </Stack>
-          )}
+          <HelixOrgOverviewCard
+            title={name || (isEdit ? processor!.name : 'New processor') || 'Processor'}
+            id={isEdit ? processor!.id : 'new processor'}
+            idAction={isEdit ? <CopyButtonWithCheck text={processor!.id} /> : undefined}
+            icon={<TransformIcon sx={{ fontSize: 20 }} />}
+            status={<Chip label={kind} size="small" sx={{ color: 'common.white', backgroundColor: 'rgba(255,255,255,0.11)', border: '1px solid rgba(255,255,255,0.22)' }} />}
+          >
+            <Chip
+              label={`${kind === 'filter' || kind === 'js' ? filterRows.length : 1} output${(kind === 'filter' || kind === 'js') && filterRows.length !== 1 ? 's' : ''}`}
+              size="small"
+              sx={{ color: 'common.white', backgroundColor: 'rgba(255,255,255,0.11)' }}
+            />
+          </HelixOrgOverviewCard>
           <Typography variant="body2" color="text.secondary">
             A processor sits between topics: it reads messages from one topic,
             then rewrites, shortens, sorts, or runs JavaScript on them onto new topics that bots can subscribe to.

--- a/frontend/src/components/helix-org/SpecTaskStatusBadge.tsx
+++ b/frontend/src/components/helix-org/SpecTaskStatusBadge.tsx
@@ -1,0 +1,113 @@
+import { FC } from 'react'
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+
+type StatusTone = 'neutral' | 'queued' | 'active' | 'review' | 'success' | 'error' | 'pullRequest'
+
+export const formatSpecTaskStatus = (status?: string): string => {
+  if (!status) return 'Unknown'
+  return status
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+const statusTone = (status?: string): StatusTone => {
+  switch (status) {
+    case 'done':
+    case 'completed':
+    case 'implementation_complete':
+    case 'spec_approved':
+      return 'success'
+    case 'implementation_review':
+    case 'spec_review':
+    case 'spec_revision':
+      return 'review'
+    case 'implementation_failed':
+    case 'spec_failed':
+    case 'failed':
+      return 'error'
+    case 'implementation':
+    case 'implementing':
+    case 'implementation_in_progress':
+      return 'active'
+    case 'implementation_queued':
+    case 'queued_implementation':
+    case 'spec_generation':
+    case 'queued_spec_generation':
+    case 'ready':
+      return 'queued'
+    case 'pull_request':
+      return 'pullRequest'
+    default:
+      return 'neutral'
+  }
+}
+
+const palettes = {
+  neutral: {
+    light: { color: '#475569', background: 'rgba(100,116,139,0.10)', border: 'rgba(100,116,139,0.22)' },
+    dark: { color: '#cbd5e1', background: 'rgba(148,163,184,0.12)', border: 'rgba(148,163,184,0.24)' },
+  },
+  queued: {
+    light: { color: '#1d4ed8', background: 'rgba(59,130,246,0.10)', border: 'rgba(59,130,246,0.24)' },
+    dark: { color: '#93c5fd', background: 'rgba(59,130,246,0.14)', border: 'rgba(96,165,250,0.28)' },
+  },
+  active: {
+    light: { color: '#6d28d9', background: 'rgba(124,58,237,0.10)', border: 'rgba(124,58,237,0.24)' },
+    dark: { color: '#c4b5fd', background: 'rgba(139,92,246,0.14)', border: 'rgba(167,139,250,0.28)' },
+  },
+  review: {
+    light: { color: '#b45309', background: 'rgba(245,158,11,0.11)', border: 'rgba(245,158,11,0.28)' },
+    dark: { color: '#fcd34d', background: 'rgba(245,158,11,0.14)', border: 'rgba(251,191,36,0.28)' },
+  },
+  success: {
+    light: { color: '#047857', background: 'rgba(16,185,129,0.10)', border: 'rgba(16,185,129,0.24)' },
+    dark: { color: '#6ee7b7', background: 'rgba(16,185,129,0.14)', border: 'rgba(52,211,153,0.28)' },
+  },
+  error: {
+    light: { color: '#b91c1c', background: 'rgba(239,68,68,0.10)', border: 'rgba(239,68,68,0.24)' },
+    dark: { color: '#fca5a5', background: 'rgba(239,68,68,0.14)', border: 'rgba(248,113,113,0.28)' },
+  },
+  pullRequest: {
+    light: { color: '#0e7490', background: 'rgba(6,182,212,0.10)', border: 'rgba(6,182,212,0.24)' },
+    dark: { color: '#67e8f9', background: 'rgba(6,182,212,0.14)', border: 'rgba(34,211,238,0.28)' },
+  },
+} as const
+
+const SpecTaskStatusBadge: FC<{ status?: string }> = ({ status }) => {
+  const tone = statusTone(status)
+
+  return (
+    <Chip
+      icon={<Box sx={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: 'currentColor' }} />}
+      label={formatSpecTaskStatus(status)}
+      size="small"
+      sx={(theme) => {
+        const palette = palettes[tone][theme.palette.mode]
+        return {
+          maxWidth: 160,
+          height: 24,
+          color: palette.color,
+          backgroundColor: palette.background,
+          border: `1px solid ${palette.border}`,
+          borderRadius: '999px',
+          fontSize: '0.7rem',
+          fontWeight: 650,
+          letterSpacing: '0.01em',
+          '& .MuiChip-icon': {
+            color: 'inherit',
+            marginLeft: '8px',
+            marginRight: '-2px',
+          },
+          '& .MuiChip-label': {
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          },
+        }
+      }}
+    />
+  )
+}
+
+export default SpecTaskStatusBadge

--- a/frontend/src/components/helix-org/TopicDetailDrawer.tsx
+++ b/frontend/src/components/helix-org/TopicDetailDrawer.tsx
@@ -3,6 +3,7 @@ import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
+import HubOutlinedIcon from '@mui/icons-material/HubOutlined'
 
 import useRouter from '../../hooks/useRouter'
 import useSnackbar from '../../hooks/useSnackbar'
@@ -10,6 +11,7 @@ import LoadingSpinner from '../widgets/LoadingSpinner'
 import CopyButtonWithCheck from '../session/CopyButtonWithCheck'
 import { useHelixOrgTopic, useUpdateHelixOrgTopic } from '../../services/helixOrgService'
 import { ClearTopicMessagesButton, TopicConfigSection } from '../../pages/HelixOrgTopicDetail'
+import HelixOrgOverviewCard from './HelixOrgOverviewCard'
 import HelixOrgSideDrawer from './HelixOrgSideDrawer'
 
 type TopicDetailDrawerProps = {
@@ -46,16 +48,19 @@ const TopicDetailDrawer: FC<TopicDetailDrawerProps> = ({ topicId, consumerCount,
         <Typography color="text.secondary">Topic not found.</Typography>
       ) : (
         <Stack spacing={2}>
-          <Stack direction="row" spacing={1} alignItems="center">
-            <Typography variant="body2" sx={{ fontFamily: 'monospace', overflowWrap: 'anywhere' }}>
-              {topic.id}
-            </Typography>
-            <CopyButtonWithCheck text={topic.id} />
-            <Chip label={topic.kind} size="small" />
-          </Stack>
-          <Typography variant="body2" color="text.secondary">
-            {consumerCount ?? topic.subscribers?.length ?? 0} subscriber{(consumerCount ?? topic.subscribers?.length) === 1 ? '' : 's'}
-          </Typography>
+          <HelixOrgOverviewCard
+            title={topic.name || topic.id || 'Topic'}
+            id={topic.id}
+            idAction={<CopyButtonWithCheck text={topic.id || ''} />}
+            icon={<HubOutlinedIcon sx={{ fontSize: 20 }} />}
+            status={<Chip label={topic.kind} size="small" sx={{ color: 'common.white', backgroundColor: 'rgba(255,255,255,0.11)', border: '1px solid rgba(255,255,255,0.22)' }} />}
+          >
+            <Chip
+              label={`${consumerCount ?? topic.subscribers?.length ?? 0} subscriber${(consumerCount ?? topic.subscribers?.length) === 1 ? '' : 's'}`}
+              size="small"
+              sx={{ color: 'common.white', backgroundColor: 'rgba(255,255,255,0.11)' }}
+            />
+          </HelixOrgOverviewCard>
           <TopicConfigSection
             key={topic.id}
             topic={topic}

--- a/frontend/src/components/session/Interaction.tsx
+++ b/frontend/src/components/session/Interaction.tsx
@@ -413,6 +413,7 @@ export const Interaction: FC<InteractionProps> = ({
                   handleSave={handleSave}
                   isLastInteraction={isLastInteraction}
                   sessionSteps={sessionSteps}
+                  enableDebugCopy={false}
                 />
               </InteractionContainer>
               {/* Edit button floating below and right-aligned, only for user messages, not editing, and message present */}
@@ -501,6 +502,7 @@ export const Interaction: FC<InteractionProps> = ({
                   handleSave={() => {}}
                   isLastInteraction={isLastInteraction}
                   sessionSteps={sessionSteps}
+                  enableDebugCopy={enableDebugCopy}
                 />
                 {/* Show incomplete warning for waiting interactions that aren't actively streaming */}
                 {isLive && !children && !isLastInteraction && (
@@ -541,23 +543,6 @@ export const Interaction: FC<InteractionProps> = ({
               </>
             )}
           </InteractionContainer>
-          {enableDebugCopy && (
-            <Box
-              sx={{
-                mt: 0.5,
-                opacity: isHovering ? 1 : 0,
-                pointerEvents: isHovering ? "auto" : "none",
-                transition: "opacity 0.2s ease-in-out",
-              }}
-            >
-              <InteractionDebugCopyButton
-                interaction={interaction}
-                session={session}
-                sessionSteps={sessionSteps}
-                serverConfig={serverConfig}
-              />
-            </Box>
-          )}
         </Box>
       )}
     </Box>

--- a/frontend/src/components/session/InteractionInference.tsx
+++ b/frontend/src/components/session/InteractionInference.tsx
@@ -28,6 +28,7 @@ import Tooltip from "@mui/material/Tooltip";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import TextField from "@mui/material/TextField";
 import CopyButtonWithCheck from "./CopyButtonWithCheck";
+import InteractionDebugCopyButton from "./InteractionDebugCopyButton";
 import ToolStepsWidget from "./ToolStepsWidget";
 
 import { ThumbsUp, ThumbsDown, Download } from "lucide-react";
@@ -182,6 +183,7 @@ export const InteractionInference: FC<{
   handleSave?: () => void;
   isLastInteraction?: boolean;
   sessionSteps?: any[];
+  enableDebugCopy?: boolean;
 }> = ({
   imageURLs = [],
   message,
@@ -199,6 +201,7 @@ export const InteractionInference: FC<{
   handleSave: externalHandleSave,
   isLastInteraction,
   sessionSteps = [],
+  enableDebugCopy = false,
 }) => {
   const account = useAccount();
   const router = useRouter();
@@ -528,6 +531,15 @@ export const InteractionInference: FC<{
                           />
                         </IconButton>
                       </Tooltip>
+
+                      {enableDebugCopy && (
+                        <InteractionDebugCopyButton
+                          interaction={interaction}
+                          session={session}
+                          sessionSteps={sessionSteps}
+                          serverConfig={serverConfig}
+                        />
+                      )}
                     </Box>
                   )}
                 </Box>

--- a/frontend/src/pages/HelixOrgBotDetail.tsx
+++ b/frontend/src/pages/HelixOrgBotDetail.tsx
@@ -65,6 +65,7 @@ import useApi from '../hooks/useApi'
 import useApps from '../hooks/useApps'
 import useRouter from '../hooks/useRouter'
 import useSnackbar from '../hooks/useSnackbar'
+import { useListProjects } from '../services/projectService'
 import { deriveDisplaySettings } from '../services/externalAgentDisplay'
 import { useStreaming } from '../contexts/streaming'
 import { SESSION_TYPE_TEXT } from '../types'
@@ -121,6 +122,7 @@ const HelixOrgBotDetail: FC = () => {
 
   const bot = data?.bot
   const projectID = data?.project_id
+  const { data: projects = [] } = useListProjects(bot?.organization_id, { enabled: !!bot?.organization_id })
   const agentAppID = data?.agent_app_id
   const agentApp = apps.apps?.find((app) => app.id === agentAppID)
   const assistant = agentApp?.config.helix.assistants?.[0]
@@ -141,6 +143,7 @@ const HelixOrgBotDetail: FC = () => {
   const [name, setName] = useState('')
   const [content, setContent] = useState('')
   const [tools, setTools] = useState<string[]>([])
+  const [projectIDs, setProjectIDs] = useState<string[]>([])
   const [preserveContext, setPreserveContext] = useState(false)
   const [runtimeConfig, setRuntimeConfig] = useState<BotRuntimeValue>({
     runtime: '',
@@ -153,8 +156,9 @@ const HelixOrgBotDetail: FC = () => {
     setName(bot?.name ?? '')
     setContent(bot?.content ?? '')
     setTools(bot?.tools ?? [])
+    setProjectIDs(Array.from(new Set([...(bot?.project_ids ?? []), ...(projectID ? [projectID] : [])])))
     setPreserveContext(bot?.preserve_context ?? false)
-  }, [bot?.name, bot?.content, bot?.tools, bot?.preserve_context])
+  }, [bot?.name, bot?.content, bot?.tools, bot?.project_ids, bot?.preserve_context, projectID])
 
   useEffect(() => {
     setRuntimeConfig({
@@ -195,6 +199,8 @@ const HelixOrgBotDetail: FC = () => {
     if ((bot.name ?? '') !== name) return true
     if ((bot.content ?? '') !== content) return true
     if ((bot.tools ?? []).join(',') !== tools.join(',')) return true
+    const savedProjectIDs = Array.from(new Set([...(bot.project_ids ?? []), ...(projectID ? [projectID] : [])])).sort()
+    if (savedProjectIDs.join(',') !== [...projectIDs].sort().join(',')) return true
     if ((bot.preserve_context ?? false) !== preserveContext) return true
     if ((assistant?.code_agent_runtime ?? '') !== runtimeConfig.runtime) return true
     if ((assistant?.code_agent_credential_type ?? 'api_key') !== runtimeConfig.credentials) return true
@@ -202,14 +208,14 @@ const HelixOrgBotDetail: FC = () => {
     if ((assistant?.model ?? '') !== runtimeConfig.model) return true
     if ((assistant?.reasoning_effort ?? 'none') !== (runtimeConfig.reasoning_effort ?? 'none')) return true
     return false
-  }, [bot, name, content, tools, preserveContext, assistant?.code_agent_runtime, assistant?.code_agent_credential_type, assistant?.provider, assistant?.model, assistant?.reasoning_effort, runtimeConfig.runtime, runtimeConfig.credentials, runtimeConfig.provider, runtimeConfig.model, runtimeConfig.reasoning_effort])
+  }, [bot, name, content, tools, projectIDs, projectID, preserveContext, assistant?.code_agent_runtime, assistant?.code_agent_credential_type, assistant?.provider, assistant?.model, assistant?.reasoning_effort, runtimeConfig.runtime, runtimeConfig.credentials, runtimeConfig.provider, runtimeConfig.model, runtimeConfig.reasoning_effort])
 
   const handleSave = async () => {
     if (!botId) return
     const runtimeChanged =
       (assistant?.code_agent_runtime ?? '') !== runtimeConfig.runtime
     try {
-      await updateBot.mutateAsync({ id: botId, name, content, tools, preserve_context: preserveContext })
+      await updateBot.mutateAsync({ id: botId, name, content, tools, project_ids: projectIDs, preserve_context: preserveContext })
       if (agentAppID && agentApp && assistant) {
         const updatedAssistant = {
           ...assistant,
@@ -651,6 +657,62 @@ const HelixOrgBotDetail: FC = () => {
                     maxHeight={600}
                     autoHeight={true}
                     theme="helix-dark"
+                  />
+                </Box>
+
+                <Box>
+                  <Typography variant="subtitle2" sx={{ mb: 1 }}>Project access</Typography>
+                  <Autocomplete
+                    multiple
+                    disableCloseOnSelect
+                    options={projects}
+                    value={projects.filter((project) => !!project.id && projectIDs.includes(project.id))}
+                    onChange={(_e, value) => {
+                      const selected = value.map((project) => project.id).filter((id): id is string => !!id)
+                      setProjectIDs(Array.from(new Set([...(projectID ? [projectID] : []), ...selected])))
+                    }}
+                    getOptionDisabled={(project) => project.id === projectID}
+                    getOptionLabel={(project) => project.name || project.id || 'Unnamed project'}
+                    isOptionEqualToValue={(a, b) => a.id === b.id}
+                    renderOption={(props, option, { selected }) => {
+                      const { key, ...liProps } = props as typeof props & { key?: Key }
+                      return (
+                        <li key={key ?? option.id} {...liProps}>
+                          <Checkbox
+                            icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
+                            checkedIcon={<CheckBoxIcon fontSize="small" />}
+                            sx={{ mr: 1 }}
+                            checked={selected}
+                          />
+                          <Box sx={{ minWidth: 0 }}>
+                            <Typography variant="body2">{option.name || option.id}</Typography>
+                            <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+                              {option.id}{option.id === projectID ? ' · own project (default)' : ''}
+                            </Typography>
+                          </Box>
+                        </li>
+                      )
+                    }}
+                    renderTags={(value, getTagProps) => value.map((option, index) => {
+                      const { key, onDelete, ...tagProps } = getTagProps({ index })
+                      const ownProject = option.id === projectID
+                      return (
+                        <Chip
+                          key={key ?? option.id}
+                          {...tagProps}
+                          onDelete={ownProject ? undefined : onDelete}
+                          label={`${option.name || option.id}${ownProject ? ' (default)' : ''}`}
+                          size="small"
+                        />
+                      )
+                    })}
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        placeholder="Select projects"
+                        helperText="The bot's own project is always allowed and is used when a tool omits project_id. Other projects must be selected here."
+                      />
+                    )}
                   />
                 </Box>
 

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -1,6 +1,7 @@
 import { FC, Fragment, MouseEvent as ReactMouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
+import Chip from '@mui/material/Chip'
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
@@ -91,6 +92,7 @@ import {
   useDeleteHelixOrgTopic,
   useListChartPositions,
   useListHelixOrgBots,
+  useListHelixOrgBotDetails,
   useListHelixOrgTopics,
   useTopicMessageCounts,
   useListHelixOrgProcessors,
@@ -104,6 +106,9 @@ import {
   useUnsubscribeBotAtChart,
   useUpsertChartPositions,
 } from '../services/helixOrgService'
+import { useSpecTasksForProjects } from '../services/specTaskService'
+import type { SpecTask } from '../services/specTaskService'
+import { useListProjects } from '../services/projectService'
 import { generateCronShortSummary } from '../utils/cronUtils'
 
 // The chart visualises the org as a ReactFlow graph. Bots are plain
@@ -130,6 +135,14 @@ const BOT_GAP_Y = 90
 const STREAM_W = 180
 // Minimum topic card height; actual height grows with wrapped name/id.
 const STREAM_H = 80
+
+type ActiveBotTaskStatus = 'implementation' | 'implementation_review' | 'implementing'
+
+type ActiveBotTask = {
+  id: string
+  name: string
+  status: ActiveBotTaskStatus
+}
 
 // Rough height used by auto-layout before RF measures the real node.
 // Keeps stacked topics from overlapping when names wrap to multiple lines.
@@ -164,6 +177,7 @@ type FlatBot = {
   agentStatus: 'running' | 'stopped'
   agentRuntime: string
   agentModel: string
+  activeTasks: ActiveBotTask[]
 }
 
 // ---- Node renderers ----------------------------------------------------
@@ -175,6 +189,7 @@ type BotNodeData = {
   agentStatus: 'running' | 'stopped'
   agentRuntime: string
   agentModel: string
+  activeTasks: ActiveBotTask[]
   /** True when the left chat rail is focused on this bot. */
   selected: boolean
   /** Card body click — focus the left chat rail on this bot. */
@@ -357,6 +372,60 @@ const SubSideHandles: FC<{ size?: number }> = ({ size = 16 }) => (
   </Fragment>
 )
 
+const BotWorkPills: FC<{ tasks: ActiveBotTask[]; isLight: boolean }> = ({ tasks, isLight }) => {
+  if (tasks.length === 0) return null
+
+  const groups = [
+    {
+      key: 'implementation',
+      label: 'Implementing',
+      statuses: new Set<ActiveBotTaskStatus>(['implementation', 'implementing']),
+      color: isLight ? 'rgba(180,100,0,0.95)' : 'rgba(255,180,80,0.95)',
+      background: isLight ? 'rgba(180,100,0,0.10)' : 'rgba(255,180,80,0.14)',
+    },
+    {
+      key: 'review',
+      label: 'In review',
+      statuses: new Set<ActiveBotTaskStatus>(['implementation_review']),
+      color: isLight ? 'rgba(110,70,180,0.95)' : 'rgba(190,150,255,0.95)',
+      background: isLight ? 'rgba(110,70,180,0.10)' : 'rgba(190,150,255,0.14)',
+    },
+  ]
+
+  return (
+    <Stack direction="row" spacing={0.5} sx={{ minWidth: 0, overflow: 'hidden', mt: -0.25 }}>
+      {groups.map((group) => {
+        const matchingTasks = tasks.filter((task) => group.statuses.has(task.status))
+        if (matchingTasks.length === 0) return null
+        const taskNames = matchingTasks.map((task) => task.name || task.id).join('\n')
+        return (
+          <Tooltip key={group.key} title={taskNames}>
+            <Chip
+              className={NO_DRAG_NO_PAN}
+              label={matchingTasks.length === 1 ? group.label : `${group.label} · ${matchingTasks.length}`}
+              size="small"
+              sx={{
+                height: 18,
+                maxWidth: '100%',
+                color: group.color,
+                backgroundColor: group.background,
+                border: `1px solid ${group.color}`,
+                '& .MuiChip-label': {
+                  px: 0.6,
+                  fontSize: '0.58rem',
+                  lineHeight: 1,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                },
+              }}
+            />
+          </Tooltip>
+        )
+      })}
+    </Stack>
+  )
+}
+
 const BotNode: FC<NodeProps<Node<BotNodeData>>> = ({ data }) => {
   const lightTheme = useLightTheme()
   const muted = lightTheme.isLight ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.55)'
@@ -526,6 +595,7 @@ const BotNode: FC<NodeProps<Node<BotNodeData>>> = ({ data }) => {
           </Menu>
         </Stack>
       </Stack>
+      <BotWorkPills tasks={data.activeTasks} isLight={lightTheme.isLight} />
       <Typography
         variant="caption"
         sx={{ color: muted, fontSize: '0.65rem', mt: 'auto', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
@@ -866,6 +936,7 @@ const buildGraph = (
         agentStatus: b.agentStatus,
         agentRuntime: b.agentRuntime,
         agentModel: b.agentModel,
+        activeTasks: b.activeTasks,
         selected: selectedBotId !== '' && selectedBotId === b.id,
         onSelectBot: handlers.onSelectBot,
         onOpenBotDetails: handlers.onOpenBotDetails,
@@ -1860,6 +1931,8 @@ const HelixOrgChart: FC = () => {
   const lightTheme = useLightTheme()
   const snackbar = useSnackbar()
   const router = useRouter()
+  const account = useAccount()
+  const orgID = account.organizationTools.organization?.id ?? ''
   // Chart is the org root of helix-org — breadcrumb is just the org name.
   const breadcrumbs = useHelixOrgBreadcrumbs()
   // Poll bots so agent_status (green/grey sandbox dots) stays fresh while
@@ -1868,6 +1941,7 @@ const HelixOrgChart: FC = () => {
   const { data: streamsData } = useListHelixOrgTopics()
   const { data: processorsData } = useListHelixOrgProcessors()
   const { data: savedPositions = {} } = useListChartPositions()
+  const { data: projects = [] } = useListProjects(orgID, { enabled: !!orgID })
   const upsertPositions = useUpsertChartPositions()
   const clearPositions = useClearChartPositions()
   const deleteBot = useDeleteBot()
@@ -1882,6 +1956,54 @@ const HelixOrgChart: FC = () => {
   const stopBot = useStopBotAgent()
   const restartBot = useRestartBotAgent()
 
+  const botIds = useMemo(
+    () => (botsData ?? [])
+      .filter((bot: BotDTO) => bot.kind !== 'human')
+      .map((bot: BotDTO) => bot.id ?? '')
+      .filter(Boolean),
+    [botsData],
+  )
+  const botDetails = useListHelixOrgBotDetails(botIds, { refetchInterval: 5000 })
+  const projectIds = useMemo(
+    () => projects.map((project) => project.id ?? '').filter(Boolean),
+    [projects],
+  )
+  const specTasks = useSpecTasksForProjects(projectIds, {
+    enabled: !!orgID,
+    refetchInterval: 5000,
+  }) as SpecTask[]
+
+  const activeTasksByBotId = useMemo(() => {
+    const projectsByID = new Map(projects.map((project) => [project.id ?? '', project]))
+    const tasksByBotId = new Map<string, ActiveBotTask[]>()
+
+    botDetails.forEach((detail, index) => {
+      const botId = botIds[index]
+      if (botId) tasksByBotId.set(botId, [])
+      if (!botId || !detail) return
+
+      const botProjectID = detail.project_id ?? ''
+      const botAgentAppID = detail.agent_app_id ?? ''
+      const botTasks = specTasks.filter((task) => {
+        const status = String(task.status ?? '') as ActiveBotTaskStatus
+        if (!['implementation', 'implementation_review', 'implementing'].includes(status)) return false
+        const taskProject = projectsByID.get(task.project_id ?? '')
+        const taskAgentAppID = task.helix_app_id || taskProject?.default_helix_app_id
+        return (
+          (!!botProjectID && task.project_id === botProjectID) ||
+          (!!botAgentAppID && taskAgentAppID === botAgentAppID)
+        )
+      }).map((task) => ({
+        id: task.id ?? '',
+        name: task.user_short_title || task.short_title || task.name || task.id || 'Untitled task',
+        status: String(task.status) as ActiveBotTaskStatus,
+      }))
+      tasksByBotId.set(botId, botTasks)
+    })
+
+    return tasksByBotId
+  }, [botDetails, botIds, projects, specTasks])
+
   const flat = useMemo<FlatBot[]>(
     () => (botsData ?? [])
       // People (kind=human) are managed in the People tab, not on the agent
@@ -1894,8 +2016,9 @@ const HelixOrgChart: FC = () => {
         agentStatus: b.agent_status === 'running' ? 'running' as const : 'stopped' as const,
         agentRuntime: b.agent_runtime ?? '',
         agentModel: b.agent_model ?? '',
+        activeTasks: activeTasksByBotId.get(b.id ?? '') ?? [],
       })),
-    [botsData],
+    [activeTasksByBotId, botsData],
   )
 
   // People (kind=human) — shown in the docked PeoplePanel on the chart, not

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -72,6 +72,7 @@ import {
 import HelixOrgShell from '../components/helix-org/HelixOrgShell'
 import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
 import NewBotDialog from '../components/helix-org/NewBotDialog'
+import BotDetailDrawer from '../components/helix-org/BotDetailDrawer'
 import NewTopicDrawer from '../components/helix-org/NewTopicDrawer'
 import ProcessorConfigDrawer from '../components/helix-org/ProcessorConfigDrawer'
 import TopicDetailDrawer from '../components/helix-org/TopicDetailDrawer'
@@ -192,7 +193,7 @@ type BotNodeData = {
   activeTasks: ActiveBotTask[]
   /** True when the left chat rail is focused on this bot. */
   selected: boolean
-  /** Card body click — focus the left chat rail on this bot. */
+  /** Card body click — focus the left chat rail and open the bot drawer. */
   onSelectBot: (botId: string) => void
   /** ⋮ → Details — open the bot detail page. */
   onOpenBotDetails: (botId: string) => void
@@ -1973,9 +1974,9 @@ const HelixOrgChart: FC = () => {
     refetchInterval: 5000,
   }) as SpecTask[]
 
-  const activeTasksByBotId = useMemo(() => {
+  const tasksByBotId = useMemo(() => {
     const projectsByID = new Map(projects.map((project) => [project.id ?? '', project]))
-    const tasksByBotId = new Map<string, ActiveBotTask[]>()
+    const tasksByBotId = new Map<string, SpecTask[]>()
 
     botDetails.forEach((detail, index) => {
       const botId = botIds[index]
@@ -1985,24 +1986,32 @@ const HelixOrgChart: FC = () => {
       const botProjectID = detail.project_id ?? ''
       const botAgentAppID = detail.agent_app_id ?? ''
       const botTasks = specTasks.filter((task) => {
-        const status = String(task.status ?? '') as ActiveBotTaskStatus
-        if (!['implementation', 'implementation_review', 'implementing'].includes(status)) return false
         const taskProject = projectsByID.get(task.project_id ?? '')
         const taskAgentAppID = task.helix_app_id || taskProject?.default_helix_app_id
         return (
           (!!botProjectID && task.project_id === botProjectID) ||
           (!!botAgentAppID && taskAgentAppID === botAgentAppID)
         )
-      }).map((task) => ({
-        id: task.id ?? '',
-        name: task.user_short_title || task.short_title || task.name || task.id || 'Untitled task',
-        status: String(task.status) as ActiveBotTaskStatus,
-      }))
+      })
       tasksByBotId.set(botId, botTasks)
     })
 
     return tasksByBotId
   }, [botDetails, botIds, projects, specTasks])
+
+  const activeTasksByBotId = useMemo(() => {
+    const active = new Map<string, ActiveBotTask[]>()
+    tasksByBotId.forEach((tasks, botId) => {
+      active.set(botId, tasks
+        .filter((task) => ['implementation', 'implementation_review', 'implementing'].includes(String(task.status ?? '')))
+        .map((task) => ({
+          id: task.id ?? '',
+          name: task.user_short_title || task.short_title || task.name || task.id || 'Untitled task',
+          status: String(task.status) as ActiveBotTaskStatus,
+        })))
+    })
+    return active
+  }, [tasksByBotId])
 
   const flat = useMemo<FlatBot[]>(
     () => (botsData ?? [])
@@ -2100,6 +2109,7 @@ const HelixOrgChart: FC = () => {
 
   const [selection, setSelection] = useState<Selection>({ kind: 'none' })
   const [botDialogOpen, setBotDialogOpen] = useState(false)
+  const [botDrawerBotId, setBotDrawerBotId] = useState<string>()
   const [topicDrawerOpen, setTopicDrawerOpen] = useState(false)
   const [selectedTopicId, setSelectedTopicId] = useState<string>()
   // Processor drawer: { open, processor } — processor null = create mode.
@@ -2146,11 +2156,27 @@ const HelixOrgChart: FC = () => {
     window.addEventListener(CHAT_BOT_FOCUS_EVENT, onFocus)
     return () => window.removeEventListener(CHAT_BOT_FOCUS_EVENT, onFocus)
   }, [orgSlug])
-  // Card body click → focus left chat rail on this bot (stay on chart).
+  const botDetailsByID = useMemo(
+    () => new Map(botIds.map((botId, index) => [botId, botDetails[index]])),
+    [botDetails, botIds],
+  )
+  const selectedBot = useMemo(
+    () => (botsData ?? []).find((bot) => bot.id === botDrawerBotId),
+    [botDrawerBotId, botsData],
+  )
+  const selectedBotDetail = botDrawerBotId ? botDetailsByID.get(botDrawerBotId) : undefined
+  const selectedBotProject = useMemo(
+    () => projects.find((project) => project.id === selectedBotDetail?.project_id),
+    [projects, selectedBotDetail?.project_id],
+  )
+  const selectedBotTasks = botDrawerBotId ? tasksByBotId.get(botDrawerBotId) ?? [] : []
+
+  // Card body click → focus the left chat rail and open the bot drawer.
   const onSelectBot = useCallback(
     (botId: string) => {
       if (!orgSlug) return
       setSelectedBotId(botId)
+      setBotDrawerBotId(botId)
       focusChatBot(orgSlug, botId)
     },
     [orgSlug],
@@ -2512,6 +2538,13 @@ const HelixOrgChart: FC = () => {
         open={botDialogOpen || selection.kind === 'newBot'}
         onClose={() => { setBotDialogOpen(false); setSelection({ kind: 'none' }) }}
         presetParentId={selection.kind === 'newBot' ? selection.parentBotId : undefined}
+      />
+      <BotDetailDrawer
+        botId={botDrawerBotId}
+        bot={selectedBot}
+        project={selectedBotProject}
+        tasks={selectedBotTasks}
+        onClose={() => setBotDrawerBotId(undefined)}
       />
       <NewTopicDrawer
         open={topicDrawerOpen}

--- a/frontend/src/services/helixOrgService.ts
+++ b/frontend/src/services/helixOrgService.ts
@@ -322,6 +322,30 @@ export function useHelixOrgBot(botId: string | undefined, options?: { enabled?: 
   })
 }
 
+// The list endpoint intentionally stays compact and omits the runtime's
+// project/app identifiers. The chart needs those identifiers to correlate a
+// bot with the spec tasks using its agent, so fetch the details in parallel.
+export function useListHelixOrgBotDetails(
+  botIds: string[],
+  options?: { enabled?: boolean; refetchInterval?: number | false },
+): Array<BotDetailDTO | undefined> {
+  const api = useApi()
+  const { orgID } = useHelixOrgBase()
+  const enabled = !!orgID && (options?.enabled ?? true)
+  const results = useQueries({
+    queries: botIds.map((botId) => ({
+      queryKey: QUERY_KEYS.bot(orgID, botId),
+      queryFn: async () => {
+        const res = await api.getApiClient().v1OrgsBotsDetail2(botId, orgID)
+        return res.data as BotDetailDTO
+      },
+      enabled: enabled && !!botId,
+      refetchInterval: options?.refetchInterval,
+    })),
+  })
+  return results.map((result) => result.data as BotDetailDTO | undefined)
+}
+
 export function useListHelixOrgTools(options?: { enabled?: boolean }) {
   const api = useApi()
   const { orgID } = useHelixOrgBase()

--- a/frontend/src/services/specTaskService.ts
+++ b/frontend/src/services/specTaskService.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueries, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Api, TypesSpecTaskUpdateRequest } from "../api/api";
 import useApi from "../hooks/useApi";
 
@@ -91,6 +91,32 @@ export function useSpecTasks(options?: {
     refetchInterval:
       options?.refetchInterval !== undefined ? options.refetchInterval : 10000,
   });
+}
+
+// Fetch the task lists for several projects in parallel. The org chart uses
+// this to show work attached to each bot without making one request depend on
+// another project's response.
+export function useSpecTasksForProjects(
+  projectIds: string[],
+  options?: { enabled?: boolean; refetchInterval?: number | false },
+) {
+  const api = useApi();
+  const enabled = options?.enabled !== false;
+  const results = useQueries({
+    queries: projectIds.map((projectId) => ({
+      queryKey: QUERY_KEYS.specTasks(projectId),
+      queryFn: async () => {
+        const response = await api.getApiClient().v1SpecTasksList({
+          project_id: projectId,
+        });
+        return response.data || [];
+      },
+      enabled: enabled && !!projectId,
+      refetchInterval: options?.refetchInterval,
+    })),
+  });
+
+  return results.flatMap((result) => result.data || []);
 }
 
 // Custom hooks for SpecTask operations

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -75,6 +75,10 @@ definitions:
           Bot's chat session before each re-activation, so it accumulates
           context across triggers (e.g. Slack). Defaults to false.
         type: boolean
+      project_ids:
+        items:
+          type: string
+        type: array
       tools:
         items:
           type: string
@@ -549,6 +553,10 @@ definitions:
         type: string
       preserve_context:
         type: boolean
+      project_ids:
+        items:
+          type: string
+        type: array
       tools:
         items:
           type: string

--- a/openapi.json
+++ b/openapi.json
@@ -26080,6 +26080,12 @@
                         "description": "PreserveContext, when true, stops the runtime from wiping this\nBot's chat session before each re-activation, so it accumulates\ncontext across triggers (e.g. Slack). Defaults to false.",
                         "type": "boolean"
                     },
+                    "project_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "tools": {
                         "type": "array",
                         "items": {
@@ -26726,6 +26732,12 @@
                     },
                     "preserve_context": {
                         "type": "boolean"
+                    },
+                    "project_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "tools": {
                         "type": "array",

--- a/swagger.json
+++ b/swagger.json
@@ -21724,6 +21724,12 @@
                     "description": "PreserveContext, when true, stops the runtime from wiping this\nBot's chat session before each re-activation, so it accumulates\ncontext across triggers (e.g. Slack). Defaults to false.",
                     "type": "boolean"
                 },
+                "project_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "tools": {
                     "type": "array",
                     "items": {
@@ -22370,6 +22376,12 @@
                 },
                 "preserve_context": {
                     "type": "boolean"
+                },
+                "project_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "tools": {
                     "type": "array",


### PR DESCRIPTION
## What changed

- Show compact `Implementing` and `In review` pills on Helix Org chart bot cards.
- Correlate active spec tasks with each bot through the bot's provisioned agent app/project.
- Show task names in the pill tooltip and aggregate multiple tasks by status.

## Why

The chart previously showed bot runtime status but not whether the bot had implementation work or an implementation review in progress. The indicators make active work visible without opening each project.

## Validation

- `cd frontend && yarn build`
- `cd frontend && yarn tsc`
- `git diff --check`
- Local stack health check: `http://localhost:8080` returned 200.

Browser-level visual verification was not run because Chrome DevTools MCP tools were unavailable in this session.
