### PR TITLE
fix(org): use organization owner for runtime identity

### DIFF
--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -471,14 +471,9 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	// owner-chat). The adapter calls HelixAPIServer's handler methods
 	// directly; no HTTP loopback.
 	//
-	// Returns nil only if there's no admin user available to use as the
-	// service identity — the alpha doesn't make sense without one, so
-	// we treat that as "feature disabled until an admin registers".
-	inProcClient := buildInProcHelixClient(context.Background(), cfg.APIServer, helixStore)
-	if inProcClient == nil {
-		log.Warn().Msg("helix-org disabled: in-proc adapter unavailable (no admin user found — register one before enabling the helix-org alpha)")
-		return nil, nil
-	}
+	// Request-scoped calls run as the authenticated user. Background calls
+	// resolve the owner of their organization in the adapter.
+	inProcClient := NewInProcHelixClient(cfg.APIServer)
 
 	// Build the single Workspace shared by the WorkerProject (for
 	// first-apply file pushes — agent.md / role.md / identity.md)
@@ -1239,34 +1234,6 @@ func workerRuntimeSupportsSubscription(runtime string) bool {
 	return runtime == "claude_code" || runtime == "codex_cli"
 }
 
-// buildInProcHelixClient resolves the service-account *types.User and
-// builds the in-process adapter that satisfies
-// runtimehelix.ProjectService, runtimehelix.SpawnerClient, and
-// chat.ChatBridgeClient. Returns nil when no admin user is available
-// to attribute the service identity to — callers treat that as
-// "feature disabled" (no production wiring without one).
-//
-// The service user mirrors ensureHelixOrgServiceAPIKey's owner-pick
-// (first admin user) so the auto-provisioned api_key and the
-// in-process adapter are attributed to the same identity.
-func buildInProcHelixClient(ctx context.Context, apiServer *HelixAPIServer, helixStore helixstore.Store) *inProcHelixClient {
-	admins, _, err := helixStore.ListUsers(ctx, &helixstore.ListUsersQuery{Admin: true})
-	if err != nil {
-		log.Warn().Err(err).Msg("helix-org in-proc adapter disabled — list admins failed")
-		return nil
-	}
-	if len(admins) == 0 {
-		log.Warn().Msg("helix-org in-proc adapter disabled — no admin user found (matches ensureHelixOrgServiceAPIKey's failure mode)")
-		return nil
-	}
-	owner := admins[0]
-	log.Info().
-		Str("owner_id", owner.ID).
-		Str("owner_email", owner.Email).
-		Msg("helix-org in-proc adapter wired (ProjectService + SpawnerClient + ChatBridgeClient)")
-	return NewInProcHelixClient(apiServer, owner)
-}
-
 // buildHelixOrgSpawnerConfig assembles the SpawnerConfig for
 // helix-org's production zed_external Spawner. The embedded SaaS
 // runs Workers on the `claude_code` runtime with subscription
@@ -1390,6 +1357,7 @@ func lazyHelixOrgSpawner(d spawnerDeps) runtime.Spawner {
 	// One inflight cap shared across every per-org spawner config.
 	sem := make(chan struct{}, runtimehelix.DefaultMaxInflight)
 	return func(ctx context.Context, orgID string, workerID orgchart.BotID, triggers []activation.Trigger) error {
+		ctx = helixorgserver.WithOrgID(ctx, orgID)
 		// Apply (or fast-path) the per-Worker project with the current
 		// worker.* settings before delegating.
 		if d.Applier != nil {

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -11,9 +11,7 @@
 // no HTTP loopback.
 //
 // Caller identity is resolved per request from runtimehelix's context
-// stashes (HelixIdentity → UserIDFromContext / BearerFromContext); when
-// none is present we fall back to the constructor-supplied service
-// user (the bearer-forwarding equivalent the middleware path uses).
+// stashes. Org-scoped background work uses the organization owner.
 package server
 
 import (
@@ -29,6 +27,7 @@ import (
 	"github.com/gorilla/mux"
 
 	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
+	helixorgserver "github.com/helixml/helix/api/pkg/org/interfaces/server"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 )
@@ -37,32 +36,16 @@ import (
 // runtimehelix.SpawnerClient by routing through the HelixAPIServer's
 // handler methods in-process.
 type inProcHelixClient struct {
-	server      *HelixAPIServer
-	serviceUser types.User
+	server *HelixAPIServer
 }
 
-// NewInProcHelixClient constructs an inProcHelixClient. The serviceUser
-// is the fallback identity used when the per-request context carries no
-// HelixIdentity (e.g. background dispatcher activations before a bearer
-// is minted via BearerForUser). Must be a real persisted user with the
-// access rights needed for the operations the embedded helix-org issues
-// (currently: project apply, git repo create, app update, session
-// create / output / stop) — typically the auto-provisioned
-// `helix-org-service` user.
-func NewInProcHelixClient(s *HelixAPIServer, serviceUser *types.User) *inProcHelixClient {
-	c := &inProcHelixClient{server: s}
-	if serviceUser != nil {
-		c.serviceUser = *serviceUser
-	}
-	return c
+func NewInProcHelixClient(s *HelixAPIServer) *inProcHelixClient {
+	return &inProcHelixClient{server: s}
 }
 
 // resolveUser returns the *types.User to attach to a handler-bound
-// request context. Priority: explicit *types.User stash > resolved
-// UserID from HelixIdentity / WithUserID > serviceUser fallback. When
-// the legacy stashes carry only an ID, look the user row up against
-// the store so the resulting *types.User has the email/full-name
-// fields handlers may read.
+// request context. Explicit users win; org-scoped background work runs
+// as the organization owner.
 func (c *inProcHelixClient) resolveUser(ctx context.Context) (*types.User, error) {
 	if u := runtimehelix.UserFromContext(ctx); u != nil {
 		return u, nil
@@ -76,11 +59,25 @@ func (c *inProcHelixClient) resolveUser(ctx context.Context) (*types.User, error
 		}
 		return &types.User{ID: uid}, nil
 	}
-	if c.serviceUser.ID != "" {
-		u := c.serviceUser
-		return &u, nil
+	orgID := runtimehelix.OrganizationIDFromContext(ctx)
+	if orgID == "" {
+		orgID = helixorgserver.OrgIDFromContext(ctx)
 	}
-	return nil, errors.New("inproc helix client: no user on context and no service user configured")
+	if orgID == "" {
+		return nil, errors.New("inproc helix client: no user or organization on context")
+	}
+	org, err := c.server.lookupOrg(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve organization %s: %w", orgID, err)
+	}
+	owner, err := c.server.Store.GetUser(ctx, &store.GetUserQuery{ID: org.Owner})
+	if err != nil {
+		return nil, fmt.Errorf("resolve owner %s for organization %s: %w", org.Owner, org.ID, err)
+	}
+	if owner == nil {
+		return nil, fmt.Errorf("resolve owner %s for organization %s: user not found", org.Owner, org.ID)
+	}
+	return owner, nil
 }
 
 // newRequest builds an *http.Request whose body is the JSON encoding

--- a/api/pkg/server/helix_org_inproc_test.go
+++ b/api/pkg/server/helix_org_inproc_test.go
@@ -6,15 +6,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
 	"github.com/helixml/helix/api/pkg/pubsub"
+	helixstore "github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/store/memorystore"
 	"github.com/helixml/helix/api/pkg/types"
 )
 
 // newInProcTestSetup builds a NewTestServer-backed HelixAPIServer + an
-// inProcHelixClient with a fixed service user. The single setup
+// inProcHelixClient with a request user. The single setup
 // covers every test in this file — each test seeds whatever store
 // state it needs against the returned memorystore.
 //
@@ -23,19 +25,36 @@ import (
 // fields (`applyProject` does, but it isn't covered in this test
 // suite — that handler's full happy path is exercised separately
 // via the in-Helix end-to-end tests).
-func newInProcTestSetup(t *testing.T) (*HelixAPIServer, *memorystore.MemoryStore, *inProcHelixClient, *types.User) {
+func newInProcTestSetup(t *testing.T) (*HelixAPIServer, *memorystore.MemoryStore, *inProcHelixClient, *types.User, context.Context) {
 	t.Helper()
 	store := memorystore.New()
 	server := NewTestServer(store, pubsub.NewNoop())
 	user := &types.User{
-		ID:        "usr_service",
-		Email:     "service@helix.local",
-		FullName:  "Service User",
+		ID:        "usr_request",
+		Email:     "request@helix.local",
+		FullName:  "Request User",
 		Type:      types.OwnerTypeUser,
 		TokenType: types.TokenTypeAPIKey,
 	}
-	client := NewInProcHelixClient(server, user)
-	return server, store, client, user
+	client := NewInProcHelixClient(server)
+	ctx := runtimehelix.WithUser(context.Background(), user)
+	return server, store, client, user, ctx
+}
+
+func TestInProcClient_ResolvesOrganizationOwnerWithoutAdmin(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	st := helixstore.NewMockStore(ctrl)
+	owner := &types.User{ID: "usr_owner", Admin: false}
+	st.EXPECT().GetOrganization(gomock.Any(), &helixstore.GetOrganizationQuery{ID: "org_test"}).
+		Return(&types.Organization{ID: "org_test", Owner: owner.ID}, nil)
+	st.EXPECT().GetUser(gomock.Any(), &helixstore.GetUserQuery{ID: owner.ID}).Return(owner, nil)
+
+	client := NewInProcHelixClient(&HelixAPIServer{Store: st})
+	ctx := runtimehelix.WithHelixIdentity(context.Background(), runtimehelix.HelixIdentity{OrganizationID: "org_test"})
+	got, err := client.resolveUser(ctx)
+
+	require.NoError(t, err)
+	require.Same(t, owner, got)
 }
 
 // TestInProcProjectService_GetProject_NotFound_ReturnsErrProjectNotFound
@@ -43,9 +62,9 @@ func newInProcTestSetup(t *testing.T) (*HelixAPIServer, *memorystore.MemoryStore
 // stale-pointer recovery path depends on (Ensure → GetProject errors.Is(…,
 // ErrProjectNotFound) → ClearProject + re-apply).
 func TestInProcProjectService_GetProject_NotFound_ReturnsErrProjectNotFound(t *testing.T) {
-	_, _, client, _ := newInProcTestSetup(t)
+	_, _, client, _, ctx := newInProcTestSetup(t)
 
-	_, err := client.GetProject(context.Background(), "proj_missing")
+	_, err := client.GetProject(ctx, "proj_missing")
 	require.Error(t, err)
 	require.True(t, errors.Is(err, runtimehelix.ErrProjectNotFound),
 		"expected ErrProjectNotFound, got %v", err)
@@ -54,18 +73,18 @@ func TestInProcProjectService_GetProject_NotFound_ReturnsErrProjectNotFound(t *t
 // TestInProcProjectService_GetProject_Found_ReturnsProject verifies the
 // happy path — a seeded project row round-trips through the inProc
 // adapter back to types.Project. Authorization passes because the
-// adapter resolves the service user as the project owner.
+// adapter resolves the request user as the project owner.
 func TestInProcProjectService_GetProject_Found_ReturnsProject(t *testing.T) {
-	_, store, client, user := newInProcTestSetup(t)
+	_, store, client, user, ctx := newInProcTestSetup(t)
 
 	store.SeedProject(&types.Project{
 		ID:     "proj_test_1",
 		Name:   "test-project",
-		UserID: user.ID, // owner == service user so authz passes
+		UserID: user.ID,
 		Status: "active",
 	})
 
-	got, err := client.GetProject(context.Background(), "proj_test_1")
+	got, err := client.GetProject(ctx, "proj_test_1")
 	require.NoError(t, err)
 	require.Equal(t, "proj_test_1", got.ID)
 	require.Equal(t, "test-project", got.Name)
@@ -75,11 +94,11 @@ func TestInProcProjectService_GetProject_Found_ReturnsProject(t *testing.T) {
 // + interactions and asserts GetOutput returns the data the handler
 // would have served via /api/v1/sessions/{id}/output.
 func TestInProcSpawnerClient_GetOutput_ReturnsStoreData(t *testing.T) {
-	_, store, client, user := newInProcTestSetup(t)
+	_, store, client, user, ctx := newInProcTestSetup(t)
 
 	session, err := store.CreateSession(context.Background(), types.Session{
 		ID:    "ses_test_1",
-		Owner: user.ID, // owner == service user so authz passes (no orgID)
+		Owner: user.ID,
 	})
 	require.NoError(t, err)
 
@@ -91,7 +110,7 @@ func TestInProcSpawnerClient_GetOutput_ReturnsStoreData(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	out, err := client.GetOutput(context.Background(), "ses_test_1")
+	out, err := client.GetOutput(ctx, "ses_test_1")
 	require.NoError(t, err)
 	require.Equal(t, "ses_test_1", out.SessionID)
 	// Status comes from the last interaction's State (set above).
@@ -103,7 +122,7 @@ func TestInProcSpawnerClient_GetOutput_ReturnsStoreData(t *testing.T) {
 // Validates the JSON shape Helix's handler emits matches what the
 // runtimehelix port expects (types.AppConfig directly, not raw JSON).
 func TestInProcProjectService_GetAppConfig_RoundTrips(t *testing.T) {
-	_, store, client, user := newInProcTestSetup(t)
+	_, store, client, user, ctx := newInProcTestSetup(t)
 
 	want := types.AppConfig{
 		AllowedDomains: []string{"example.test"},
@@ -114,11 +133,11 @@ func TestInProcProjectService_GetAppConfig_RoundTrips(t *testing.T) {
 	}
 	store.SeedApp(&types.App{
 		ID:     "app_test_1",
-		Owner:  user.ID, // owner == service user so authz passes (no orgID)
+		Owner:  user.ID,
 		Config: want,
 	})
 
-	got, err := client.GetAppConfig(context.Background(), "app_test_1")
+	got, err := client.GetAppConfig(ctx, "app_test_1")
 	require.NoError(t, err)
 	require.Equal(t, want.AllowedDomains, got.AllowedDomains)
 	require.Equal(t, want.Secrets, got.Secrets)
@@ -131,9 +150,9 @@ func TestInProcProjectService_GetAppConfig_RoundTrips(t *testing.T) {
 // sentinel needed since SpawnerClient.StopExternalAgent has no
 // sentinel-Is contract).
 func TestInProcSpawnerClient_StopExternalAgent_NoSession_ReturnsError(t *testing.T) {
-	_, _, client, _ := newInProcTestSetup(t)
+	_, _, client, _, ctx := newInProcTestSetup(t)
 
-	err := client.StopExternalAgent(context.Background(), "ses_does_not_exist")
+	err := client.StopExternalAgent(ctx, "ses_does_not_exist")
 	require.Error(t, err)
 }
 
@@ -144,11 +163,11 @@ func TestInProcSpawnerClient_StopExternalAgent_NoSession_ReturnsError(t *testing
 // session row itself. An internal (non-Zed) session has a no-op runtime
 // backend, so this exercises the shared DB clear in isolation.
 func TestInProcSpawnerClient_ClearSession_RemovesInteractionsKeepsSession(t *testing.T) {
-	_, store, client, user := newInProcTestSetup(t)
+	_, store, client, user, ctx := newInProcTestSetup(t)
 
 	session, err := store.CreateSession(context.Background(), types.Session{
 		ID:    "ses_clear_1",
-		Owner: user.ID, // owner == service user so authz passes (no orgID)
+		Owner: user.ID,
 	})
 	require.NoError(t, err)
 	_, err = store.CreateInteraction(context.Background(), &types.Interaction{
@@ -159,7 +178,7 @@ func TestInProcSpawnerClient_ClearSession_RemovesInteractionsKeepsSession(t *tes
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, client.ClearSession(context.Background(), "ses_clear_1"))
+	require.NoError(t, client.ClearSession(ctx, "ses_clear_1"))
 
 	// Session row preserved.
 	got, err := store.GetSession(context.Background(), "ses_clear_1")
@@ -178,9 +197,9 @@ func TestInProcSpawnerClient_ClearSession_RemovesInteractionsKeepsSession(t *tes
 // missing session surfaces as an error rather than silently succeeding,
 // so a stale persisted session pointer fails the activation loudly.
 func TestInProcSpawnerClient_ClearSession_NoSession_ReturnsError(t *testing.T) {
-	_, _, client, _ := newInProcTestSetup(t)
+	_, _, client, _, ctx := newInProcTestSetup(t)
 
-	err := client.ClearSession(context.Background(), "ses_does_not_exist")
+	err := client.ClearSession(ctx, "ses_does_not_exist")
 	require.Error(t, err)
 }
 

--- a/api/pkg/server/helix_org_middleware.go
+++ b/api/pkg/server/helix_org_middleware.go
@@ -106,9 +106,7 @@ func (s *helixOrgScope) ensureBootstrap(ctx context.Context, orgID string) error
 		// only provisions the per-org service api_key and converges any
 		// graph that already exists (a no-op on a brand-new empty org).
 
-		// Provision a per-org Helix service api_key. Tied to the
-		// first admin user found — see helixorg.HelixAPIKeys.Service for the
-		// idempotency story.
+		// Provision a per-org Helix service api_key for the organization owner.
 		if _, err := helixorg.NewHelixAPIKeys(s.helixStore, s.configs).Service(ctx, orgID); err != nil {
 			log.Warn().Err(err).Str("org_id", orgID).Msg("helix-org service api key not provisioned")
 		}
@@ -214,7 +212,7 @@ func (s *HelixAPIServer) withHelixOrgScope(scope *helixOrgScope, next http.Handl
 		// so lifecycle.Create persists them as the Bot's hiring user
 		// (SaveHiringUser reads runtimehelix.UserIDFromContext). Without
 		// this every Bot's session falls back to the org-service identity
-		// (first admin), which cross-attributes another user's key into
+		// (organization owner), which cross-attributes another user's key into
 		// the tenant org's API-keys list.
 		ctx = runtimehelix.WithUserID(ctx, user.ID)
 		// Strip the /orgs/{org}/helix-org prefix so the downstream

--- a/api/pkg/server/helix_org_middleware_test.go
+++ b/api/pkg/server/helix_org_middleware_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 
@@ -11,20 +12,14 @@ import (
 	"github.com/helixml/helix/api/pkg/types"
 )
 
-// noAdminHelixStore is a tiny stub that satisfies the bits of
-// helixstore.Store ensureHelixOrgServiceAPIKey touches when no
-// helix.api_key has been provisioned yet. ListUsers returns no admins,
-// which makes ensureHelixOrgServiceAPIKey fail with "no admin user
-// found" — the middleware swallows that into a Warn log so
-// ensureBootstrap still returns nil. The embedded nil store.Store
-// causes any other unexpected method call to panic with a clear
-// stack trace, surfacing surprises rather than hiding them.
-type noAdminHelixStore struct {
+// missingOrganizationHelixStore makes service-key provisioning fail;
+// bootstrap must remain best-effort.
+type missingOrganizationHelixStore struct {
 	helixstore.Store
 }
 
-func (s *noAdminHelixStore) ListUsers(_ context.Context, _ *helixstore.ListUsersQuery) ([]*types.User, int64, error) {
-	return nil, 0, nil
+func (s *missingOrganizationHelixStore) GetOrganization(_ context.Context, _ *helixstore.GetOrganizationQuery) (*types.Organization, error) {
+	return nil, errors.New("organization not found")
 }
 
 // TestEnsureBootstrapConcurrentCallsAllSucceed pins the regression
@@ -54,7 +49,7 @@ func TestEnsureBootstrapConcurrentCallsAllSucceed(t *testing.T) {
 	scope := newHelixOrgScope(
 		configregistry.New(orgStore.Configs),
 		orgStore,
-		&noAdminHelixStore{},
+		&missingOrganizationHelixStore{},
 		nil, // mirror — nil is a safe no-op for this bootstrap-race test
 		nil, // slackRoutes — nil is a safe no-op
 		nil, // helixEvents — nil is a safe no-op

--- a/api/pkg/server/helix_org_spawner_test.go
+++ b/api/pkg/server/helix_org_spawner_test.go
@@ -43,7 +43,7 @@ func TestBuildHelixOrgSpawnerConfig_WiresProjectService(t *testing.T) {
 	require.NoError(t, reg.Set(ctx, orgID, "helix.api_key", `"hlx-test-key"`))
 	require.NoError(t, reg.Set(ctx, orgID, "helix.url", `"http://helix.test"`))
 
-	_, _, projectSvc, _ := newInProcTestSetup(t)
+	_, _, projectSvc, _, _ := newInProcTestSetup(t)
 	hub := wakebus.New(pubsub.NewNoop())
 	logger := slog.Default()
 

--- a/api/pkg/server/helixorg/apikeys.go
+++ b/api/pkg/server/helixorg/apikeys.go
@@ -48,26 +48,29 @@ func NewHelixAPIKeys(st helixstore.Store, configs *configregistry.Registry) *Hel
 // re-checking the store. Stale keys (config row points at a deleted
 // api_keys row) are silently replaced.
 //
-// The owner of the minted key is the first admin user found in the Helix
-// DB. All gated alpha users currently drive the same owner Worker, so
-// co-tenanting on one service identity is consistent — multi-tenant
-// attribution is a future change.
+// The minted key belongs to the organization owner.
 func (k *HelixAPIKeys) Service(ctx context.Context, orgID string) (string, error) {
+	org, err := k.store.GetOrganization(ctx, &helixstore.GetOrganizationQuery{ID: orgID})
+	if err != nil {
+		return "", fmt.Errorf("get organization: %w", err)
+	}
+	if org == nil || org.Owner == "" {
+		return "", fmt.Errorf("organization %s has no owner", orgID)
+	}
 	if existing, _ := k.configs.GetString(ctx, orgID, "helix.api_key"); existing != "" {
-		if _, err := k.store.GetAPIKey(ctx, &types.ApiKey{Key: existing}); err == nil {
+		if key, err := k.store.GetAPIKey(ctx, &types.ApiKey{Key: existing}); err == nil && key != nil && key.Owner == org.Owner {
 			return existing, nil
 		}
-		log.Warn().Msg("helix-org helix.api_key in config no longer exists in helix DB — re-provisioning")
+		log.Warn().Msg("helix-org helix.api_key is missing or not owned by the organization owner — re-provisioning")
 	}
 
-	admins, _, err := k.store.ListUsers(ctx, &helixstore.ListUsersQuery{Admin: true})
+	owner, err := k.store.GetUser(ctx, &helixstore.GetUserQuery{ID: org.Owner})
 	if err != nil {
-		return "", fmt.Errorf("list admins: %w", err)
+		return "", fmt.Errorf("get organization owner: %w", err)
 	}
-	if len(admins) == 0 {
-		return "", fmt.Errorf("no admin user found — register one before opening the helix-org alpha")
+	if owner == nil {
+		return "", fmt.Errorf("organization owner %s not found", org.Owner)
 	}
-	owner := admins[0]
 
 	// Grant the alpha-feature flag to the service owner so the MCP
 	// gateway accepts requests authenticated by this key. Without it,

--- a/api/pkg/server/helixorg/apikeys_test.go
+++ b/api/pkg/server/helixorg/apikeys_test.go
@@ -70,16 +70,17 @@ func TestAPIKeys_User_MintsWhenNone(t *testing.T) {
 	}
 }
 
-// TestAPIKeys_Service_MintsAndGrantsFlag: first-run service provisioning
-// picks the admin, grants the alpha flag, mints a key, and caches it.
-func TestAPIKeys_Service_MintsAndGrantsFlag(t *testing.T) {
+// TestAPIKeys_Service_MintsForOrganizationOwner verifies service
+// provisioning uses the organization owner without requiring admin access.
+func TestAPIKeys_Service_MintsForOrganizationOwner(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	st := store.NewMockStore(ctrl)
 
-	admin := &types.User{ID: "usr-admin", Email: "admin@test", Admin: true}
-	st.EXPECT().ListUsers(gomock.Any(), &store.ListUsersQuery{Admin: true}).
-		Return([]*types.User{admin}, int64(1), nil)
+	owner := &types.User{ID: "usr-owner", Email: "owner@test"}
+	st.EXPECT().GetOrganization(gomock.Any(), &store.GetOrganizationQuery{ID: "org-test"}).
+		Return(&types.Organization{ID: "org-test", Owner: owner.ID}, nil)
+	st.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: owner.ID}).Return(owner, nil)
 	st.EXPECT().UpdateUser(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, u *types.User) (*types.User, error) {
 			var granted bool
@@ -111,16 +112,15 @@ func TestAPIKeys_Service_MintsAndGrantsFlag(t *testing.T) {
 	}
 }
 
-// TestAPIKeys_Service_NoAdmin: provisioning fails clearly when no admin
-// exists.
-func TestAPIKeys_Service_NoAdmin(t *testing.T) {
+func TestAPIKeys_Service_NoOrganizationOwner(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	st := store.NewMockStore(ctrl)
-	st.EXPECT().ListUsers(gomock.Any(), gomock.Any()).Return([]*types.User{}, int64(0), nil)
+	st.EXPECT().GetOrganization(gomock.Any(), &store.GetOrganizationQuery{ID: "org-test"}).
+		Return(&types.Organization{ID: "org-test"}, nil)
 
 	k := NewHelixAPIKeys(st, newTestConfigs(t))
 	if _, err := k.Service(context.Background(), "org-test"); err == nil {
-		t.Fatal("expected error when no admin user exists")
+		t.Fatal("expected error when the organization has no owner")
 	}
 }

--- a/api/pkg/server/helixorg/config_specs.go
+++ b/api/pkg/server/helixorg/config_specs.go
@@ -53,7 +53,7 @@ func RegisterConfigSpecs(r *configregistry.Registry) {
 	r.Register(configregistry.Spec{
 		Key:         "helix.api_key",
 		Type:        configregistry.TypeString,
-		Description: "Fallback bearer token for the embedded helix-org client when no logged-in user is on the request (rare — most calls forward the user's own api key). Auto-provisioned at startup against the first admin user.",
+		Description: "Fallback bearer token for the embedded helix-org client when no logged-in user is on the request. Auto-provisioned for the organization owner.",
 	})
 	// Transport-level secrets: every Stream whose transport is `postmark`
 	// or `github` reads these. Secrets are redacted on `config get` —

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -893,7 +893,7 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	// the `helix-org` alpha feature. See
 	// design/2026-05-17-helix-org-saas-alpha.md. All of its routing +
 	// lifecycle wiring lives in registerHelixOrgRoutes (helix_org.go). It
-	// no-ops gracefully on deployments with no admin user yet.
+	// Route registration does not depend on a deployment-wide service user.
 	if err := apiServer.registerHelixOrgRoutes(ctx, insecureRouter, authRouter); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- remove the first-admin dependency from Helix Org route initialization
- resolve org-scoped background identity from the organization owner
- provision and validate per-org service keys against the organization owner

## Testing
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `go test ./pkg/server/... -count=1`