### PR TITLE
fix(agent): preserve native Zed thread across turns

### DIFF
--- a/api/pkg/server/session_switch_agent_handlers.go
+++ b/api/pkg/server/session_switch_agent_handlers.go
@@ -129,8 +129,11 @@ func (apiServer *HelixAPIServer) switchAgent(_ http.ResponseWriter, req *http.Re
 }
 
 func sessionUsesAgentRuntime(session *types.Session, runtime types.CodeAgentRuntime) bool {
-	return session.Metadata.CodeAgentRuntime == runtime &&
-		session.Metadata.ZedAgentName == runtime.ZedAgentName()
+	if session.Metadata.CodeAgentRuntime != runtime {
+		return false
+	}
+	return session.Metadata.ZedAgentName == runtime.ZedAgentName() ||
+		(runtime == types.CodeAgentRuntimeZedAgent && session.Metadata.ZedAgentName == "")
 }
 
 // switchAgentInPlace performs the in-place switch: snapshot the current

--- a/api/pkg/server/session_switch_agent_handlers_test.go
+++ b/api/pkg/server/session_switch_agent_handlers_test.go
@@ -96,6 +96,10 @@ func TestSessionUsesAgentRuntime_AcceptsNativeAgentName(t *testing.T) {
 	session.Metadata.ZedAgentName = "zed-agent"
 
 	assert.True(t, sessionUsesAgentRuntime(session, types.CodeAgentRuntimeZedAgent))
+
+	session.Metadata.ZedAgentName = ""
+	assert.True(t, sessionUsesAgentRuntime(session, types.CodeAgentRuntimeZedAgent),
+		"legacy native sessions must keep their existing thread")
 }
 
 func TestSwitchAgent_RepairsStaleAgentNameForCurrentApp(t *testing.T) {

--- a/api/pkg/server/session_switch_agent_handlers_test.go
+++ b/api/pkg/server/session_switch_agent_handlers_test.go
@@ -90,6 +90,14 @@ func TestSessionUsesAgentRuntime_RejectsStaleAgentName(t *testing.T) {
 	assert.True(t, sessionUsesAgentRuntime(session, types.CodeAgentRuntimeCodexCLI))
 }
 
+func TestSessionUsesAgentRuntime_AcceptsNativeAgentName(t *testing.T) {
+	session := newTestParentSession("user_a")
+	session.Metadata.CodeAgentRuntime = types.CodeAgentRuntimeZedAgent
+	session.Metadata.ZedAgentName = "zed-agent"
+
+	assert.True(t, sessionUsesAgentRuntime(session, types.CodeAgentRuntimeZedAgent))
+}
+
 func TestSwitchAgent_RepairsStaleAgentNameForCurrentApp(t *testing.T) {
 	srv, mem := newForkTestServer(t)
 	ctx := context.Background()

--- a/api/pkg/types/task_management.go
+++ b/api/pkg/types/task_management.go
@@ -185,7 +185,7 @@ func (c CodeAgentCredentialType) IsSubscription() bool {
 
 // ZedAgentName returns the agent name used in Zed for this runtime.
 // This is used when sending open_thread commands to tell Zed which agent to use.
-// For zed_agent (built-in), returns empty string (uses NativeAgent).
+// Zed accepts "zed-agent" as the explicit name for its built-in NativeAgent.
 func (r CodeAgentRuntime) ZedAgentName() string {
 	switch r {
 	case CodeAgentRuntimeQwenCode:
@@ -197,7 +197,7 @@ func (r CodeAgentRuntime) ZedAgentName() string {
 	case CodeAgentRuntimeCodexCLI:
 		return "codex"
 	default: // CodeAgentRuntimeZedAgent or empty
-		return "" // NativeAgent (built-in)
+		return "zed-agent"
 	}
 }
 

--- a/design/2026-07-14-native-zed-runtime-reconciliation.md
+++ b/design/2026-07-14-native-zed-runtime-reconciliation.md
@@ -12,6 +12,8 @@ Every user message in a native Zed Agent session inserted an "Agent switched to 
 
 Use `zed-agent` as the canonical native agent name. Zed explicitly maps that name to `NativeAgent` in its create, load, and reopen paths.
 
+Existing sessions that predate persisted agent names may still store an empty value. Runtime reconciliation accepts that legacy value for native Zed sessions so active spec tasks keep their current thread; all new writes use `zed-agent`.
+
 ## Verification
 
 - Focused server reconciliation tests pass.

--- a/design/2026-07-14-native-zed-runtime-reconciliation.md
+++ b/design/2026-07-14-native-zed-runtime-reconciliation.md
@@ -1,0 +1,19 @@
+# Native Zed Runtime Reconciliation
+
+## Symptom
+
+Every user message in a native Zed Agent session inserted an "Agent switched to zed_agent" interaction and opened a new Zed thread.
+
+## Root cause
+
+`CodeAgentRuntime.ZedAgentName()` returned an empty string for the native runtime, while Zed reported and Helix persisted the same runtime as `zed-agent`. Runtime reconciliation treated those two representations as different and cleared the thread before each turn.
+
+## Fix
+
+Use `zed-agent` as the canonical native agent name. Zed explicitly maps that name to `NativeAgent` in its create, load, and reopen paths.
+
+## Verification
+
+- Focused server reconciliation tests pass.
+- Affected Go packages build.
+- Live Zed test not run: the local Docker stack is absent and the UTM VM on port 2222 is not running.


### PR DESCRIPTION
## Summary
- use `zed-agent` as the canonical native Zed runtime identity
- prevent reconciliation from clearing the Zed thread before every user turn
- accept legacy empty native-agent metadata so existing spec tasks keep their current threads
- add regression coverage and a debugging note

## Tests
- `CGO_ENABLED=1 go test ./api/pkg/server -run "TestSessionUsesAgentRuntime|TestReconcileSessionAgentWithApp|TestSwitchAgent_RepairsStaleAgentNameForCurrentApp" -count=1`
- `go test ./api/pkg/types -count=1`
- `go build ./api/pkg/server/ ./api/pkg/store/ ./api/pkg/types/`

## Not tested
- Live Zed E2E: local Docker stack was absent and the UTM VM on port 2222 was not running.