### PR TITLE
fix(org): make default agent provisioning atomic

### DIFF
--- a/api/pkg/org/application/configregistry/default_agent.go
+++ b/api/pkg/org/application/configregistry/default_agent.go
@@ -1,0 +1,29 @@
+package configregistry
+
+import "context"
+
+const DefaultAgentConfigKey = "agent.default"
+
+type DefaultAgentConfig struct {
+	Runtime     string `json:"runtime"`
+	Credentials string `json:"credentials"`
+	Provider    string `json:"provider"`
+	Model       string `json:"model"`
+}
+
+func (r *Registry) GetDefaultAgentConfig(ctx context.Context, orgID string) (DefaultAgentConfig, error) {
+	var cfg DefaultAgentConfig
+	if r.IsConfigured(ctx, orgID, DefaultAgentConfigKey) {
+		return cfg, r.GetObject(ctx, orgID, DefaultAgentConfigKey, &cfg)
+	}
+
+	cfg.Runtime, _ = r.GetString(ctx, orgID, "worker.runtime")
+	cfg.Credentials, _ = r.GetString(ctx, orgID, "worker.credentials")
+	cfg.Provider, _ = r.GetString(ctx, orgID, "worker.provider")
+	cfg.Model, _ = r.GetString(ctx, orgID, "worker.model")
+	return cfg, nil
+}
+
+func (r *Registry) IsDefaultAgentConfigured(ctx context.Context, orgID string) bool {
+	return r.IsConfigured(ctx, orgID, DefaultAgentConfigKey) || r.IsConfigured(ctx, orgID, "worker.runtime")
+}

--- a/api/pkg/org/application/configregistry/default_agent.go
+++ b/api/pkg/org/application/configregistry/default_agent.go
@@ -1,24 +1,23 @@
 package configregistry
 
-import "context"
+import (
+	"context"
+
+	"github.com/helixml/helix/api/pkg/types"
+)
 
 const DefaultAgentConfigKey = "agent.default"
 
-type DefaultAgentConfig struct {
-	Runtime     string `json:"runtime"`
-	Credentials string `json:"credentials"`
-	Provider    string `json:"provider"`
-	Model       string `json:"model"`
-}
-
-func (r *Registry) GetDefaultAgentConfig(ctx context.Context, orgID string) (DefaultAgentConfig, error) {
-	var cfg DefaultAgentConfig
+func (r *Registry) GetDefaultAgentConfig(ctx context.Context, orgID string) (types.AssistantConfig, error) {
+	var cfg types.AssistantConfig
 	if r.IsConfigured(ctx, orgID, DefaultAgentConfigKey) {
 		return cfg, r.GetObject(ctx, orgID, DefaultAgentConfigKey, &cfg)
 	}
 
-	cfg.Runtime, _ = r.GetString(ctx, orgID, "worker.runtime")
-	cfg.Credentials, _ = r.GetString(ctx, orgID, "worker.credentials")
+	runtime, _ := r.GetString(ctx, orgID, "worker.runtime")
+	credentials, _ := r.GetString(ctx, orgID, "worker.credentials")
+	cfg.CodeAgentRuntime = types.CodeAgentRuntime(runtime)
+	cfg.CodeAgentCredentialType = types.CodeAgentCredentialType(credentials)
 	cfg.Provider, _ = r.GetString(ctx, orgID, "worker.provider")
 	cfg.Model, _ = r.GetString(ctx, orgID, "worker.model")
 	return cfg, nil

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -147,7 +147,7 @@ type CreateParams struct {
 	// no runtime configured yet, so a Bot is never provisioned with the
 	// seed-time default (claude_code/subscription/no-model, which Zed renders
 	// as its built-in gpt). The deferred Bot is provisioned later, with the
-	// correct config, when the operator sets the Default Bot Runtime
+	// correct config, when the operator sets the default agent configuration
 	// (settings handler re-runs activation for provision-less bots).
 	DeferActivation bool
 }

--- a/api/pkg/org/infrastructure/runtime/helix/project.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project.go
@@ -12,7 +12,8 @@ import (
 	"github.com/helixml/helix/api/pkg/types"
 )
 
-// repoEnsureMu serialises per-Worker repo creation across all activations. Two
+// projectEnsureMu serialises project provisioning; repoEnsureMu serialises
+// per-Worker repo creation. Two
 // activations for the same bot otherwise both observe DefaultRepoID=="" and each
 // create+attach a same-named repo — duplicates the desktop workspace setup then
 // clones into one path and fails on. A single global lock is fine: activation is
@@ -26,7 +27,11 @@ import (
 // the create fails cleanly and the loser re-fetches — that removes this lock
 // entirely and holds across replicas. Prod is single-replica today, so the lock
 // suffices for now.
-var repoEnsureMu sync.Mutex
+var (
+	// ponytail: global lock; use per-Bot or database locks if provisioning throughput matters.
+	projectEnsureMu sync.Mutex
+	repoEnsureMu    sync.Mutex
+)
 
 // ErrProjectNotFound is the sentinel a ProjectService impl must return
 // when GetProject is called against a project that no longer exists on
@@ -193,6 +198,9 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 	if a.Store == nil {
 		return "", "", "", errors.New("worker project applier: Store is nil")
 	}
+	projectEnsureMu.Lock()
+	defer projectEnsureMu.Unlock()
+
 	bot, err := a.Store.Bots.Get(ctx, orgID, workerID)
 	if err != nil {
 		return "", "", "", fmt.Errorf("get bot: %w", err)

--- a/api/pkg/org/infrastructure/runtime/helix/project_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_test.go
@@ -24,6 +24,8 @@ type fakeProjectService struct {
 	mu sync.Mutex
 
 	applyCalls              int
+	applyStarted            chan struct{}
+	applyContinue           chan struct{}
 	lastApplyReq            types.ProjectApplyRequest
 	applyResponse           types.ProjectApplyResponse
 	applyErr                error
@@ -76,10 +78,18 @@ func (f *fakeProjectService) WhoAmI(_ context.Context) (string, error) { return 
 
 func (f *fakeProjectService) ApplyProject(_ context.Context, req types.ProjectApplyRequest) (types.ProjectApplyResponse, error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.applyCalls++
 	f.lastApplyReq = req
-	return f.applyResponse, f.applyErr
+	resp, err := f.applyResponse, f.applyErr
+	started, continued := f.applyStarted, f.applyContinue
+	f.mu.Unlock()
+	if started != nil {
+		started <- struct{}{}
+	}
+	if continued != nil {
+		<-continued
+	}
+	return resp, err
 }
 
 func (f *fakeProjectService) GetProject(_ context.Context, _ string) (types.Project, error) {
@@ -329,6 +339,39 @@ func TestEnsureFreshAppliesProjectAndPushesFiles(t *testing.T) {
 	}
 	if repoID == "" {
 		t.Errorf("returned repoID is empty — same reasoning")
+	}
+}
+
+func TestEnsureConcurrentAppliesProjectOnce(t *testing.T) {
+	st, wid := newProjectTestStore(t, "# Role: engineer")
+	svc := newFakeProjectService()
+	svc.getProjectResp.Name = "w-eng"
+	svc.applyStarted = make(chan struct{}, 2)
+	svc.applyContinue = make(chan struct{})
+	a := newApplierGit(svc, newFakeGitForProject(), st)
+
+	done := make(chan error, 2)
+	go func() {
+		_, _, _, err := a.Ensure(context.Background(), "org-test", wid)
+		done <- err
+	}()
+	<-svc.applyStarted
+	go func() {
+		_, _, _, err := a.Ensure(context.Background(), "org-test", wid)
+		done <- err
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	close(svc.applyContinue)
+	for range 2 {
+		if err := <-done; err != nil {
+			t.Fatalf("Ensure: %v", err)
+		}
+	}
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	if svc.applyCalls != 1 {
+		t.Fatalf("ApplyProject calls = %d, want 1", svc.applyCalls)
 	}
 }
 

--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -122,11 +122,11 @@ func (a *apiHandler) createBot(w http.ResponseWriter, r *http.Request) {
 	// Defer provisioning when the org has no runtime configured yet, so the
 	// Bot is never brought up on the seed-time default (claude_code /
 	// subscription / no model, which Zed renders as gpt). It provisions with
-	// the correct config once the operator sets the Default Bot Runtime — see
+	// the correct config once the operator sets the default agent configuration - see
 	// reapplyBotsAfterRuntimeChange. When a runtime IS already configured
 	// (e.g. picked in the create-org dialog before seeding), the Bot
 	// provisions immediately with that config, correct from the first boot.
-	deferActivation := a.deps.Configs != nil && !a.deps.Configs.IsConfigured(ctx, orgID, "worker.runtime")
+	deferActivation := a.deps.Configs != nil && !a.deps.Configs.IsDefaultAgentConfigured(ctx, orgID)
 	// REST and chat-driven creates share lifecycle.Create — one
 	// implementation.
 	res, err := a.deps.Lifecycle.Create(ctx, orgID, lifecycle.CreateParams{

--- a/api/pkg/org/interfaces/server/api/settings.go
+++ b/api/pkg/org/interfaces/server/api/settings.go
@@ -184,11 +184,11 @@ func (a *apiHandler) runtimeConfigComplete(ctx context.Context, orgID string) bo
 	if err != nil {
 		return false
 	}
-	runtime := cfg.Runtime
+	runtime := string(cfg.CodeAgentRuntime)
 	if runtime == "" {
 		return false
 	}
-	credentials := cfg.Credentials
+	credentials := string(cfg.CodeAgentCredentialType)
 	if !runtimeSupportsSubscription(runtime) {
 		credentials = "api_key"
 	} else if credentials == "" {

--- a/api/pkg/org/interfaces/server/api/settings.go
+++ b/api/pkg/org/interfaces/server/api/settings.go
@@ -10,14 +10,14 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// workerProvisioningKeys are the org-default "Default Bot Runtime" settings.
-// Changing any of them activates bots whose initial provisioning was deferred.
-// Once a bot has an app, its app config owns runtime/model selection.
-var workerProvisioningKeys = map[string]bool{
-	"worker.runtime":     true,
-	"worker.credentials": true,
-	"worker.provider":    true,
-	"worker.model":       true,
+// agentProvisioningKeys activate bots whose initial provisioning was deferred.
+// worker.* remains supported for clients predating the atomic agent.default key.
+var agentProvisioningKeys = map[string]bool{
+	configregistry.DefaultAgentConfigKey: true,
+	"worker.runtime":                     true,
+	"worker.credentials":                 true,
+	"worker.provider":                    true,
+	"worker.model":                       true,
 }
 
 // ---- Settings -----------------------------------------------------------
@@ -105,7 +105,7 @@ func (a *apiHandler) setSetting(w http.ResponseWriter, r *http.Request) {
 	}
 	// A complete initial configuration activates bots whose provisioning was
 	// deferred. Existing apps remain independently configurable.
-	if workerProvisioningKeys[key] {
+	if agentProvisioningKeys[key] {
 		a.activateDeferredBotsAfterRuntimeChange(r.Context(), orgID)
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -170,7 +170,7 @@ func (a *apiHandler) activateDeferredBotsAfterRuntimeChange(ctx context.Context,
 	}
 }
 
-// runtimeConfigComplete reports whether the org's Default Bot Runtime has
+// runtimeConfigComplete reports whether the org's default agent configuration has
 // every field a Bot needs to provision. It mirrors resolveWorkerAgentConfig's
 // coercion (server package): runtimes without subscription support are always
 // api_key and need a provider + model; claude_code and codex_cli default to
@@ -180,11 +180,15 @@ func (a *apiHandler) runtimeConfigComplete(ctx context.Context, orgID string) bo
 	if a.deps.Configs == nil {
 		return false
 	}
-	runtime, _ := a.deps.Configs.GetString(ctx, orgID, "worker.runtime")
+	cfg, err := a.deps.Configs.GetDefaultAgentConfig(ctx, orgID)
+	if err != nil {
+		return false
+	}
+	runtime := cfg.Runtime
 	if runtime == "" {
 		return false
 	}
-	credentials, _ := a.deps.Configs.GetString(ctx, orgID, "worker.credentials")
+	credentials := cfg.Credentials
 	if !runtimeSupportsSubscription(runtime) {
 		credentials = "api_key"
 	} else if credentials == "" {
@@ -193,9 +197,7 @@ func (a *apiHandler) runtimeConfigComplete(ctx context.Context, orgID string) bo
 	if credentials == "subscription" {
 		return true
 	}
-	provider, _ := a.deps.Configs.GetString(ctx, orgID, "worker.provider")
-	model, _ := a.deps.Configs.GetString(ctx, orgID, "worker.model")
-	return provider != "" && model != ""
+	return cfg.Provider != "" && cfg.Model != ""
 }
 
 func runtimeSupportsSubscription(runtime string) bool {

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -1212,11 +1212,11 @@ func buildHelixOrgProjectApplier(
 // per-agent validator.
 func resolveWorkerAgentConfig(ctx context.Context, orgID string, cfg *configregistry.Registry) (runtime, credentials, provider, model string) {
 	agent, _ := cfg.GetDefaultAgentConfig(ctx, orgID)
-	runtime = agent.Runtime
+	runtime = string(agent.CodeAgentRuntime)
 	if runtime == "" {
 		runtime = "claude_code"
 	}
-	credentials = agent.Credentials
+	credentials = string(agent.CodeAgentCredentialType)
 	if credentials == "" {
 		credentials = "subscription"
 	}

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -1125,14 +1125,14 @@ func (d *dynamicProjectApplier) Ensure(ctx context.Context, orgID string, worker
 // buildHelixOrgProjectApplier constructs the WorkerProject that
 // both the chat bridge (owner-chat) and the spawner (AI Worker
 // activations) drive. Single source of truth for the embedded
-// SaaS's "Worker defaults" — `worker.runtime` from the config
-// registry (default `claude_code`), subscription credentials, and
+// SaaS's default agent configuration from the config registry,
+// subscription credentials, and
 // our MCP-gateway URL so each Worker's agent app phones home for
 // helix-org tools via Helix's auth-gated proxy rather than a
 // separate tunnel.
 //
 // Called per Ensure by dynamicProjectApplier so registry edits
-// (worker.runtime/credentials/provider/model, helix.url/api_key)
+// (agent.default and legacy worker.* keys, helix.url/api_key)
 // take effect immediately. The struct it returns is cheap to build
 // and short-lived — one apply call, then discarded.
 //
@@ -1198,7 +1198,8 @@ func buildHelixOrgProjectApplier(
 	}, apiKey, nil
 }
 
-// resolveWorkerAgentConfig reads the four `worker.*` knobs and normalises
+// resolveWorkerAgentConfig reads the atomic default agent config (or legacy
+// worker.* keys) and normalises
 // them into the (runtime, credentials, provider, model) tuple that
 // matches Helix's per-agent UI:
 //
@@ -1210,11 +1211,12 @@ func buildHelixOrgProjectApplier(
 // only mode that actually works for that runtime, mirroring Helix's
 // per-agent validator.
 func resolveWorkerAgentConfig(ctx context.Context, orgID string, cfg *configregistry.Registry) (runtime, credentials, provider, model string) {
-	runtime, _ = cfg.GetString(ctx, orgID, "worker.runtime")
+	agent, _ := cfg.GetDefaultAgentConfig(ctx, orgID)
+	runtime = agent.Runtime
 	if runtime == "" {
 		runtime = "claude_code"
 	}
-	credentials, _ = cfg.GetString(ctx, orgID, "worker.credentials")
+	credentials = agent.Credentials
 	if credentials == "" {
 		credentials = "subscription"
 	}
@@ -1222,10 +1224,10 @@ func resolveWorkerAgentConfig(ctx context.Context, orgID string, cfg *configregi
 		credentials = "api_key"
 	}
 	if credentials == "api_key" {
-		provider, _ = cfg.GetString(ctx, orgID, "worker.provider")
-		model, _ = cfg.GetString(ctx, orgID, "worker.model")
+		provider = agent.Provider
+		model = agent.Model
 	} else if runtime == "codex_cli" {
-		model, _ = cfg.GetString(ctx, orgID, "worker.model")
+		model = agent.Model
 	}
 	return runtime, credentials, provider, model
 }

--- a/api/pkg/server/helixorg/config_specs.go
+++ b/api/pkg/server/helixorg/config_specs.go
@@ -11,12 +11,15 @@ import (
 const AlphaFeature = "helix-org"
 
 // RegisterConfigSpecs declares the operational-config keys the
-// embedded helix-org honours. The embedded alpha has exactly one
-// user-facing knob: `worker.runtime` — the code-agent runtime every
-// Worker (owner included) gets provisioned with. Everything else is
-// derived. The `helix.*` keys are auto-managed plumbing the user
-// shouldn't normally touch.
+// embedded helix-org honours. agent.default is the user-facing default
+// copied into newly provisioned Bot apps. The worker.* keys remain readable
+// for orgs created before agent.default was introduced.
 func RegisterConfigSpecs(r *configregistry.Registry) {
+	r.Register(configregistry.Spec{
+		Key:         configregistry.DefaultAgentConfigKey,
+		Type:        configregistry.TypeObject,
+		Description: `Default agent configuration for newly provisioned Bots: {"runtime","credentials","provider","model"}. Existing Bot apps keep their own configuration.`,
+	})
 	r.Register(configregistry.Spec{
 		Key:         "worker.runtime",
 		Type:        configregistry.TypeString,

--- a/api/pkg/server/helixorg/config_specs.go
+++ b/api/pkg/server/helixorg/config_specs.go
@@ -18,7 +18,7 @@ func RegisterConfigSpecs(r *configregistry.Registry) {
 	r.Register(configregistry.Spec{
 		Key:         configregistry.DefaultAgentConfigKey,
 		Type:        configregistry.TypeObject,
-		Description: `Default agent configuration for newly provisioned Bots: {"runtime","credentials","provider","model"}. Existing Bot apps keep their own configuration.`,
+		Description: `Default AssistantConfig for newly provisioned Bots. Existing Bot apps keep their own configuration.`,
 	})
 	r.Register(configregistry.Spec{
 		Key:         "worker.runtime",

--- a/api/pkg/server/helixorg/config_specs_test.go
+++ b/api/pkg/server/helixorg/config_specs_test.go
@@ -97,11 +97,11 @@ func TestDefaultAgentConfigPrefersAtomicSettingAndReadsLegacy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("legacy config: %v", err)
 	}
-	if legacy.Runtime != "zed_agent" || legacy.Provider != "anthropic" {
+	if legacy.CodeAgentRuntime != "zed_agent" || legacy.Provider != "anthropic" {
 		t.Fatalf("legacy config = %+v", legacy)
 	}
 
-	const raw = `{"runtime":"codex_cli","credentials":"subscription","provider":"","model":"gpt-5.6"}`
+	const raw = `{"code_agent_runtime":"codex_cli","code_agent_credential_type":"subscription","provider":"","model":"gpt-5.6"}`
 	if err := reg.Set(ctx, "org-test", helixorgconfig.DefaultAgentConfigKey, raw); err != nil {
 		t.Fatalf("set default agent: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestDefaultAgentConfigPrefersAtomicSettingAndReadsLegacy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("default agent config: %v", err)
 	}
-	if agent.Runtime != "codex_cli" || agent.Credentials != "subscription" || agent.Model != "gpt-5.6" {
+	if agent.CodeAgentRuntime != "codex_cli" || agent.CodeAgentCredentialType != "subscription" || agent.Model != "gpt-5.6" {
 		t.Fatalf("default agent config = %+v", agent)
 	}
 }

--- a/api/pkg/server/helixorg/config_specs_test.go
+++ b/api/pkg/server/helixorg/config_specs_test.go
@@ -80,6 +80,40 @@ func TestRegisterHelixOrgConfigSpecs_RedactsPostmarkToken(t *testing.T) {
 	}
 }
 
+func TestDefaultAgentConfigPrefersAtomicSettingAndReadsLegacy(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	reg := helixorgconfig.New(orggorm.GetOrgTestDB(t).Configs)
+	RegisterConfigSpecs(reg)
+
+	if err := reg.Set(ctx, "org-test", "worker.runtime", `"zed_agent"`); err != nil {
+		t.Fatalf("set legacy runtime: %v", err)
+	}
+	if err := reg.Set(ctx, "org-test", "worker.provider", `"anthropic"`); err != nil {
+		t.Fatalf("set legacy provider: %v", err)
+	}
+	legacy, err := reg.GetDefaultAgentConfig(ctx, "org-test")
+	if err != nil {
+		t.Fatalf("legacy config: %v", err)
+	}
+	if legacy.Runtime != "zed_agent" || legacy.Provider != "anthropic" {
+		t.Fatalf("legacy config = %+v", legacy)
+	}
+
+	const raw = `{"runtime":"codex_cli","credentials":"subscription","provider":"","model":"gpt-5.6"}`
+	if err := reg.Set(ctx, "org-test", helixorgconfig.DefaultAgentConfigKey, raw); err != nil {
+		t.Fatalf("set default agent: %v", err)
+	}
+	agent, err := reg.GetDefaultAgentConfig(ctx, "org-test")
+	if err != nil {
+		t.Fatalf("default agent config: %v", err)
+	}
+	if agent.Runtime != "codex_cli" || agent.Credentials != "subscription" || agent.Model != "gpt-5.6" {
+		t.Fatalf("default agent config = %+v", agent)
+	}
+}
+
 func stringSliceContains(s []string, want string) bool {
 	for _, v := range s {
 		if v == want {

--- a/api/pkg/server/org_graph_seed.go
+++ b/api/pkg/server/org_graph_seed.go
@@ -153,7 +153,7 @@ func (s *orgGraphSeeder) SeedChiefOfStaff(ctx context.Context, orgID string) err
 	// Activating now would provision CoS on the seed-time default
 	// (claude_code/subscription/no-model → renders as gpt). The deferred bot
 	// shows on the chart and is provisioned correctly once the operator sets
-	// the Default Bot Runtime (reapplyBotsAfterRuntimeChange). The id is used
+	// the default agent configuration. The id is used
 	// exactly (`chief-of-staff`); a collision means already-seeded.
 	if _, err := s.lifecycle.Create(ctx, orgID, lifecycle.CreateParams{
 		ID:              string(chiefOfStaffBotID),

--- a/frontend/src/components/helix-org/BotRuntimeForm.tsx
+++ b/frontend/src/components/helix-org/BotRuntimeForm.tsx
@@ -1,5 +1,5 @@
-// BotRuntimeForm is the controlled, presentational runtime/credentials/model
-// picker for a Bot. It mirrors the per-agent picker on the Agent settings page
+// AgentConfigForm is the controlled, presentational agent configuration picker.
+// It mirrors the per-agent picker on the Agent settings page
 // (AppSettings) — same style and terms — but is state-agnostic: the parent
 // owns the value and decides how to persist it (auto-save to an org's config
 // on the settings page, or deferred-until-create in the new-org dialog).
@@ -23,7 +23,7 @@ import { CODEX_SUBSCRIPTION_MODELS, DEFAULT_CODEX_SUBSCRIPTION_MODEL } from '../
 import CodeAgentEffortSelect, { getCodeAgentEffortOptions } from '../agent/CodeAgentEffortSelect'
 import { useHelixModelsForProvider, useHelixProviders } from '../../services/helixOrgService'
 
-export interface BotRuntimeValue {
+export interface AgentConfigValue {
   runtime: string
   credentials: string
   provider: string
@@ -37,9 +37,9 @@ const RECOMMENDED_MODELS = [
   'claude-sonnet-4-5-20250929',
 ]
 
-export const BotRuntimeForm: FC<{
-  value: BotRuntimeValue
-  onChange: (patch: Partial<BotRuntimeValue>) => void
+export const AgentConfigForm: FC<{
+  value: AgentConfigValue
+  onChange: (patch: Partial<AgentConfigValue>) => void
   showReasoningEffort?: boolean
 }> = ({ value, onChange, showReasoningEffort = false }) => {
   const { data: providers } = useHelixProviders()
@@ -68,7 +68,7 @@ export const BotRuntimeForm: FC<{
   }
 
   const onRuntime = (v: string) => {
-    const patch: Partial<BotRuntimeValue> = { runtime: v }
+    const patch: Partial<AgentConfigValue> = { runtime: v }
     if (v === 'codex_cli' && !value.model) {
       patch.model = DEFAULT_CODEX_SUBSCRIPTION_MODEL
     }
@@ -192,7 +192,7 @@ export const BotRuntimeForm: FC<{
             </Typography>
             <AdvancedModelPicker
               recommendedModels={RECOMMENDED_MODELS}
-              hint="Select the model your Bots use by default"
+              hint="Select the default agent model"
               selectedProvider={value.provider}
               selectedModelId={value.model}
               onSelectModel={(prov, modelId) => onChange({ provider: prov, model: modelId })}
@@ -241,4 +241,4 @@ export const BotRuntimeForm: FC<{
   )
 }
 
-export default BotRuntimeForm
+export default AgentConfigForm

--- a/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
+++ b/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
@@ -1,12 +1,10 @@
-// WorkerRuntimePanel is the connected "Default Bot Runtime" config on the org
-// General settings page. It seeds BotRuntimeForm from the org's worker.* config
-// registry keys and auto-saves each change back. Org context is resolved from
-// router.params.org_id by the underlying hooks.
+// DefaultAgentConfigPanel edits the org's default agent configuration. New orgs use
+// the atomic agent.default object; legacy worker.* values remain readable.
 
 import { FC, useEffect, useMemo, useState } from 'react'
 import Paper from '@mui/material/Paper'
 
-import BotRuntimeForm, { BotRuntimeValue } from './BotRuntimeForm'
+import AgentConfigForm, { AgentConfigValue } from './BotRuntimeForm'
 import LoadingSpinner from '../widgets/LoadingSpinner'
 import useSnackbar from '../../hooks/useSnackbar'
 import {
@@ -25,14 +23,16 @@ const decodeStringValue = (v: string): string => {
   }
 }
 
-const LABELS: Record<string, string> = {
-  runtime: 'Runtime',
-  credentials: 'Credentials',
-  provider: 'Provider',
-  model: 'Model',
+const decodeAgentConfig = (v: string): AgentConfigValue | undefined => {
+  if (!v) return undefined
+  try {
+    return JSON.parse(v) as AgentConfigValue
+  } catch {
+    return undefined
+  }
 }
 
-const WorkerRuntimePanel: FC = () => {
+const DefaultAgentConfigPanel: FC = () => {
   const { data, isLoading } = useHelixOrgSettings()
   const setMut = useSetHelixOrgSetting()
   const snackbar = useSnackbar()
@@ -43,14 +43,14 @@ const WorkerRuntimePanel: FC = () => {
     return m
   }, [data])
 
-  const initial: BotRuntimeValue = {
+  const initial: AgentConfigValue = decodeAgentConfig(specByKey.get('agent.default')?.value ?? '') ?? {
     runtime: decodeStringValue(specByKey.get('worker.runtime')?.value ?? '') || 'claude_code',
     credentials: decodeStringValue(specByKey.get('worker.credentials')?.value ?? '') || 'subscription',
     provider: decodeStringValue(specByKey.get('worker.provider')?.value ?? ''),
     model: decodeStringValue(specByKey.get('worker.model')?.value ?? ''),
   }
 
-  const [value, setValue] = useState<BotRuntimeValue>(initial)
+  const [value, setValue] = useState<AgentConfigValue>(initial)
 
   // Re-seed local state when the loaded data lands or refreshes.
   useEffect(() => {
@@ -59,21 +59,20 @@ const WorkerRuntimePanel: FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data])
 
-  const handlePatch = (patch: Partial<BotRuntimeValue>) => {
-    setValue((v) => ({ ...v, ...patch }))
-    for (const [k, val] of Object.entries(patch)) {
-      setMut
-        .mutateAsync({ key: `worker.${k}`, value: JSON.stringify(val) })
-        .then(() => snackbar.success(`${LABELS[k] ?? k} saved`))
-        .catch((e: any) => snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed'))
-    }
+  const handlePatch = (patch: Partial<AgentConfigValue>) => {
+    const next = { ...value, ...patch }
+    setValue(next)
+    setMut
+      .mutateAsync({ key: 'agent.default', value: JSON.stringify(next) })
+      .then(() => snackbar.success('Default agent configuration saved'))
+      .catch((e: any) => snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed'))
   }
 
   return (
     <Paper variant="outlined" sx={{ p: 3 }}>
-      {isLoading ? <LoadingSpinner /> : <BotRuntimeForm value={value} onChange={handlePatch} />}
+      {isLoading ? <LoadingSpinner /> : <AgentConfigForm value={value} onChange={handlePatch} />}
     </Paper>
   )
 }
 
-export default WorkerRuntimePanel
+export default DefaultAgentConfigPanel

--- a/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
+++ b/frontend/src/components/helix-org/WorkerRuntimePanel.tsx
@@ -26,7 +26,13 @@ const decodeStringValue = (v: string): string => {
 const decodeAgentConfig = (v: string): AgentConfigValue | undefined => {
   if (!v) return undefined
   try {
-    return JSON.parse(v) as AgentConfigValue
+    const config = JSON.parse(v)
+    return {
+      runtime: config.code_agent_runtime ?? '',
+      credentials: config.code_agent_credential_type ?? '',
+      provider: config.provider ?? '',
+      model: config.model ?? '',
+    }
   } catch {
     return undefined
   }
@@ -63,7 +69,12 @@ const DefaultAgentConfigPanel: FC = () => {
     const next = { ...value, ...patch }
     setValue(next)
     setMut
-      .mutateAsync({ key: 'agent.default', value: JSON.stringify(next) })
+      .mutateAsync({ key: 'agent.default', value: JSON.stringify({
+        code_agent_runtime: next.runtime,
+        code_agent_credential_type: next.credentials,
+        provider: next.provider,
+        model: next.model,
+      }) })
       .then(() => snackbar.success('Default agent configuration saved'))
       .catch((e: any) => snackbar.error(e?.response?.data?.error ?? e?.message ?? 'save failed'))
   }

--- a/frontend/src/components/orgs/EditOrgWindow.tsx
+++ b/frontend/src/components/orgs/EditOrgWindow.tsx
@@ -14,7 +14,7 @@ import useAccount from '../../hooks/useAccount'
 import useApi from '../../hooks/useApi'
 import useRouter from '../../hooks/useRouter'
 import useSnackbar from '../../hooks/useSnackbar'
-import BotRuntimeForm, { BotRuntimeValue } from '../helix-org/BotRuntimeForm'
+import AgentConfigForm, { AgentConfigValue } from '../helix-org/BotRuntimeForm'
 import { SELECTED_ORG_STORAGE_KEY } from '../../utils/localStorage'
 import { orgLandingRoute } from '../../utils/organizations'
 
@@ -25,7 +25,7 @@ export interface EditOrgWindowProps {
   onSubmit: (org: TypesOrganization) => Promise<TypesOrganization | null | void>
 }
 
-const DEFAULT_BOT_RUNTIME: BotRuntimeValue = {
+const DEFAULT_AGENT_CONFIG: AgentConfigValue = {
   runtime: 'claude_code',
   credentials: 'subscription',
   provider: '',
@@ -50,11 +50,11 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
   const [slugManuallyEdited, setSlugManuallyEdited] = useState(false)
   const [errors, setErrors] = useState<{slug?: string, name?: string}>({})
 
-  // Default Bot Runtime is optional at creation: untouched means "write
-  // nothing, use the backend defaults" — so an org with no providers or Claude
+  // Default Agent Configuration is optional at creation: untouched means "write
+  // nothing, use the backend defaults" - so an org with no providers or Claude
   // subscription set up can still be created without picking anything.
-  const [botDefaults, setBotDefaults] = useState<BotRuntimeValue>(DEFAULT_BOT_RUNTIME)
-  const [botDirty, setBotDirty] = useState(false)
+  const [agentDefaults, setAgentDefaults] = useState<AgentConfigValue>(DEFAULT_AGENT_CONFIG)
+  const [agentDefaultsDirty, setAgentDefaultsDirty] = useState(false)
 
   // Reset state when modal opens/closes or org changes
   useEffect(() => {
@@ -67,8 +67,8 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
     }
     setSlugManuallyEdited(false)
     setErrors({})
-    setBotDefaults(DEFAULT_BOT_RUNTIME)
-    setBotDirty(false)
+    setAgentDefaults(DEFAULT_AGENT_CONFIG)
+    setAgentDefaultsDirty(false)
   }, [org, open])
 
   // Generate slug from name for new organizations
@@ -110,23 +110,13 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
     return Object.keys(newErrors).length === 0
   }
 
-  // Persist the chosen bot-runtime defaults to the freshly-created org. Only
+  // Persist the chosen default agent config to the freshly-created org. Only
   // called on create, only when the operator actually touched the form, and
-  // only writes non-empty keys. Best-effort: a failure here doesn't undo the
+  // writes the object once. Best-effort: a failure here doesn't undo the
   // (already-created) org, so we surface it as a soft warning.
-  const persistBotDefaults = async (createdSlug: string) => {
+  const persistAgentDefaults = async (createdSlug: string) => {
     const client = api.getApiClient()
-    const writes: Promise<unknown>[] = [
-      client.v1OrgsSettingsUpdate('worker.runtime', createdSlug, { value: JSON.stringify(botDefaults.runtime) }),
-      client.v1OrgsSettingsUpdate('worker.credentials', createdSlug, { value: JSON.stringify(botDefaults.credentials) }),
-    ]
-    if (botDefaults.provider) {
-      writes.push(client.v1OrgsSettingsUpdate('worker.provider', createdSlug, { value: JSON.stringify(botDefaults.provider) }))
-    }
-    if (botDefaults.model) {
-      writes.push(client.v1OrgsSettingsUpdate('worker.model', createdSlug, { value: JSON.stringify(botDefaults.model) }))
-    }
-    await Promise.all(writes)
+    await client.v1OrgsSettingsUpdate('agent.default', createdSlug, { value: JSON.stringify(agentDefaults) })
   }
 
   const handleSubmit = async () => {
@@ -154,13 +144,13 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
 
       const created = await onSubmit(updatedOrg)
 
-      // New org + operator picked bot-runtime defaults → persist them against
+      // New org + operator picked a default agent config: persist it against
       // the real created slug (the backend may have suffixed it for uniqueness).
-      if (!org && botDirty && helixOrgEnabled && created && created.name) {
+      if (!org && agentDefaultsDirty && helixOrgEnabled && created && created.name) {
         try {
-          await persistBotDefaults(created.name)
+          await persistAgentDefaults(created.name)
         } catch (e) {
-          snackbar.error('Organization created, but saving the default bot runtime failed — set it in Settings.')
+          snackbar.error('Organization created, but saving the default agent configuration failed - set it in Settings.')
         }
       }
 
@@ -219,23 +209,22 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
             helperText={errors.slug || "Unique identifier for the organization (no spaces allowed)"}
           />
 
-          {/* Default Bot Runtime — only when creating, and only for helix-org
+          {/* Default Agent Configuration - only when creating, and only for helix-org
               alpha users. Optional: leave untouched to configure later. */}
           {!org && helixOrgEnabled && (
             <Box sx={{ mt: 3 }}>
               <Divider sx={{ mb: 2 }} />
               <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-                Default Bot Runtime
+                Default Agent Configuration
               </Typography>
               <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                Optional — how Bots in this org run by default. Leave as-is to configure
-                later in Settings.
+                Optional agent settings copied to Bots when they are first provisioned.
               </Typography>
-              <BotRuntimeForm
-                value={botDefaults}
+              <AgentConfigForm
+                value={agentDefaults}
                 onChange={(patch) => {
-                  setBotDefaults((v) => ({ ...v, ...patch }))
-                  setBotDirty(true)
+                  setAgentDefaults((v) => ({ ...v, ...patch }))
+                  setAgentDefaultsDirty(true)
                 }}
               />
             </Box>

--- a/frontend/src/components/orgs/EditOrgWindow.tsx
+++ b/frontend/src/components/orgs/EditOrgWindow.tsx
@@ -116,7 +116,12 @@ const EditOrgWindow: FC<EditOrgWindowProps> = ({
   // (already-created) org, so we surface it as a soft warning.
   const persistAgentDefaults = async (createdSlug: string) => {
     const client = api.getApiClient()
-    await client.v1OrgsSettingsUpdate('agent.default', createdSlug, { value: JSON.stringify(agentDefaults) })
+    await client.v1OrgsSettingsUpdate('agent.default', createdSlug, { value: JSON.stringify({
+      code_agent_runtime: agentDefaults.runtime,
+      code_agent_credential_type: agentDefaults.credentials,
+      provider: agentDefaults.provider,
+      model: agentDefaults.model,
+    }) })
   }
 
   const handleSubmit = async () => {

--- a/frontend/src/pages/HelixOrgBotDetail.tsx
+++ b/frontend/src/pages/HelixOrgBotDetail.tsx
@@ -48,7 +48,7 @@ import StopIcon from '@mui/icons-material/Stop'
 import Tooltip from '@mui/material/Tooltip'
 
 import HelixOrgShell from '../components/helix-org/HelixOrgShell'
-import BotRuntimeForm, { BotRuntimeValue } from '../components/helix-org/BotRuntimeForm'
+import AgentConfigForm, { AgentConfigValue } from '../components/helix-org/BotRuntimeForm'
 import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import MonacoEditor from '../components/widgets/MonacoEditor'
@@ -145,7 +145,7 @@ const HelixOrgBotDetail: FC = () => {
   const [tools, setTools] = useState<string[]>([])
   const [projectIDs, setProjectIDs] = useState<string[]>([])
   const [preserveContext, setPreserveContext] = useState(false)
-  const [runtimeConfig, setRuntimeConfig] = useState<BotRuntimeValue>({
+  const [runtimeConfig, setRuntimeConfig] = useState<AgentConfigValue>({
     runtime: '',
     credentials: '',
     provider: '',
@@ -634,7 +634,7 @@ const HelixOrgBotDetail: FC = () => {
 
                 {agentAppID && (
                   <Box>
-                    <BotRuntimeForm
+                    <AgentConfigForm
                       value={runtimeConfig}
                       showReasoningEffort
                       onChange={(patch) => setRuntimeConfig((current) => ({ ...current, ...patch }))}

--- a/frontend/src/pages/HelixOrgSettings.tsx
+++ b/frontend/src/pages/HelixOrgSettings.tsx
@@ -1,6 +1,6 @@
 // HelixOrgSettings is the configuration surface for the helix-org alpha.
-// The worker.* runtime config (runtime / credentials / provider / model)
-// now lives on the AI Providers page (WorkerRuntimePanel) so it sits next
+// The default agent config (runtime / credentials / provider / model)
+// now lives on the AI Providers page so it sits next
 // to the providers it references; everything else here falls back to a
 // generic text-input row driven by the same config registry the server
 // validates against.
@@ -30,7 +30,7 @@ import {
 } from '../services/helixOrgService'
 
 // Registry keys we do NOT render as generic rows here:
-//  - worker.* runtime config lives on the Providers page (WorkerRuntimePanel).
+//  - agent.default and legacy worker.* config live on the Providers page.
 //  - transport.github is auto-managed by the Helix GitHub App (it provisions
 //    the webhook secret and the token comes from the App installation), so
 //    there's nothing for an operator to paste.
@@ -39,6 +39,7 @@ const EXCLUDED_KEYS = new Set<string>([
   'worker.credentials',
   'worker.provider',
   'worker.model',
+  'agent.default',
   'transport.github',
 ])
 

--- a/frontend/src/pages/OrgSettings.tsx
+++ b/frontend/src/pages/OrgSettings.tsx
@@ -20,7 +20,7 @@ import useRouter from "../hooks/useRouter";
 import { TypesOrganization } from "../api/api";
 import useSnackbar from "../hooks/useSnackbar";
 import CopyButton from "../components/common/CopyButton";
-import WorkerRuntimePanel from "../components/helix-org/WorkerRuntimePanel";
+import DefaultAgentConfigPanel from "../components/helix-org/WorkerRuntimePanel";
 
 const OrgSettings: FC = () => {
   // Get account context and router
@@ -43,7 +43,7 @@ const OrgSettings: FC = () => {
   }>({});
 
   const organization = account.organizationTools.organization;
-  // helix-org alpha gates the Default Bot Runtime config (its settings
+  // helix-org alpha gates the default agent config (its settings
   // endpoint is behind the same feature flag).
   const helixOrgEnabled =
     account.user?.alpha_features?.includes("helix-org") ?? false;
@@ -331,17 +331,16 @@ const OrgSettings: FC = () => {
               {helixOrgEnabled && (
                 <Box sx={{ mt: 4 }}>
                   <Typography variant="h6" gutterBottom>
-                    Default Bot Runtime
+                    Default Agent Configuration
                   </Typography>
                   <Typography
                     variant="body2"
                     color="text.secondary"
                     sx={{ mb: 2 }}
                   >
-                    How Bots in this org run by default — which runtime, and which
-                    provider/model they route through.
+                    Agent settings copied to Bots when they are first provisioned.
                   </Typography>
-                  <WorkerRuntimePanel />
+                  <DefaultAgentConfigPanel />
                 </Box>
               )}
 


### PR DESCRIPTION
## Summary

- replace four concurrent org runtime writes with one `agent.default` object
- retain legacy `worker.*` reads for existing organizations
- serialize Bot project provisioning to prevent duplicate agent apps
- rename the UI concept to Default Agent Configuration

## Tests

- `go test -count=1 ./pkg/org/infrastructure/runtime/helix ./pkg/server/helixorg ./pkg/org/interfaces/server/api`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `yarn build`

## Not tested

- live UI workflow; the Playwright browser profile was already in use