### PR TITLE
Surface WIP-queue block reason and fix the WIP gate formula

### DIFF
--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -35266,6 +35266,10 @@ const docTemplate = `{
                     "description": "Public sharing",
                     "type": "boolean"
                 },
+                "queue_reason": {
+                    "description": "Why a queued task hasn't started yet (WIP capacity or dependency); recomputed each read, never persisted",
+                    "type": "string"
+                },
                 "rebase_requested_at": {
                     "description": "Set when approveImplementation hits a divergent branch and asks the agent to rebase. Used to make the approve handler idempotent (no duplicate prompts) and to gate the Accept button until the agent's next push.",
                     "type": "string"
@@ -36062,6 +36066,10 @@ const docTemplate = `{
                 "public_design_docs": {
                     "description": "Public sharing",
                     "type": "boolean"
+                },
+                "queue_reason": {
+                    "description": "Why a queued task hasn't started yet (WIP capacity or dependency); recomputed each read, never persisted",
+                    "type": "string"
                 },
                 "rebase_requested_at": {
                     "description": "Set when approveImplementation hits a divergent branch and asks the agent to rebase. Used to make the approve handler idempotent (no duplicate prompts) and to gate the Accept button until the agent's next push.",

--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -19,6 +19,61 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// populateQueueReasons fills task.QueueReason for any tasks in the slice that are
+// in a queued state (queued_spec_generation / queued_implementation), explaining
+// why the orchestrator is holding them queued. The reason is transient and
+// recomputed on every read (it changes as the WIP queue drains), so it is never
+// persisted. It shares the exact gate logic used by the orchestrator via
+// services.PlanningQueueReason / services.ImplementationQueueReason.
+func (s *HelixAPIServer) populateQueueReasons(ctx context.Context, projectID string, tasks []*types.SpecTask) {
+	if projectID == "" {
+		return
+	}
+
+	// Fast path: only do the extra loads if something is actually queued.
+	hasQueued := false
+	for _, t := range tasks {
+		if t.Status == types.TaskStatusQueuedSpecGeneration || t.Status == types.TaskStatusQueuedImplementation {
+			hasQueued = true
+			break
+		}
+	}
+	if !hasQueued {
+		return
+	}
+
+	project, err := s.Store.GetProject(ctx, projectID)
+	if err != nil {
+		log.Warn().Err(err).Str("project_id", projectID).Msg("failed to load project for queue reason")
+		return
+	}
+	// Load the full project task list with dependencies: it is both the WIP-count
+	// basis and the source of each task's DependsOn (the incoming slice may not
+	// have dependencies loaded).
+	projectTasks, err := s.Store.ListSpecTasks(ctx, &types.SpecTaskFilters{ProjectID: projectID, WithDependsOn: true})
+	if err != nil {
+		log.Warn().Err(err).Str("project_id", projectID).Msg("failed to list tasks for queue reason")
+		return
+	}
+	depsByID := make(map[string][]types.SpecTask, len(projectTasks))
+	for _, t := range projectTasks {
+		depsByID[t.ID] = t.DependsOn
+	}
+
+	for _, t := range tasks {
+		switch t.Status {
+		case types.TaskStatusQueuedSpecGeneration:
+			probe := *t
+			probe.DependsOn = depsByID[t.ID]
+			t.QueueReason = services.PlanningQueueReason(project, projectTasks, &probe)
+		case types.TaskStatusQueuedImplementation:
+			probe := *t
+			probe.DependsOn = depsByID[t.ID]
+			t.QueueReason = services.ImplementationQueueReason(projectTasks, &probe)
+		}
+	}
+}
+
 // validateAssigneeIsOrgMember returns nil if assigneeID is empty (unassigned is valid)
 // or if the assignee is a member of the given organization. Returns the underlying
 // store error otherwise — callers are responsible for logging context (task_id /
@@ -180,6 +235,10 @@ func (s *HelixAPIServer) getTask(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Surface why a queued task hasn't started yet. getTask does not run the
+	// listTasks enrichment, so compute it explicitly here for the detail page.
+	s.populateQueueReasons(ctx, task.ProjectID, []*types.SpecTask{task})
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(task)
 }
@@ -289,6 +348,10 @@ func (s *HelixAPIServer) listTasks(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+
+	// Surface why any queued task hasn't started yet (WIP capacity / dependency).
+	// Recomputed each read so it clears as the queue drains.
+	s.populateQueueReasons(ctx, projectID, tasks)
 
 	// Populate SessionUpdatedAt and AgentWorkState for agent activity detection
 	// Collect all session IDs and batch query for efficiency

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -35262,6 +35262,10 @@
                     "description": "Public sharing",
                     "type": "boolean"
                 },
+                "queue_reason": {
+                    "description": "Why a queued task hasn't started yet (WIP capacity or dependency); recomputed each read, never persisted",
+                    "type": "string"
+                },
                 "rebase_requested_at": {
                     "description": "Set when approveImplementation hits a divergent branch and asks the agent to rebase. Used to make the approve handler idempotent (no duplicate prompts) and to gate the Accept button until the agent's next push.",
                     "type": "string"
@@ -36058,6 +36062,10 @@
                 "public_design_docs": {
                     "description": "Public sharing",
                     "type": "boolean"
+                },
+                "queue_reason": {
+                    "description": "Why a queued task hasn't started yet (WIP capacity or dependency); recomputed each read, never persisted",
+                    "type": "string"
                 },
                 "rebase_requested_at": {
                     "description": "Set when approveImplementation hits a divergent branch and asks the agent to rebase. Used to make the approve handler idempotent (no duplicate prompts) and to gate the Accept button until the agent's next push.",

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -9907,6 +9907,10 @@ definitions:
       public_design_docs:
         description: Public sharing
         type: boolean
+      queue_reason:
+        description: Why a queued task hasn't started yet (WIP capacity or dependency);
+          recomputed each read, never persisted
+        type: string
       rebase_requested_at:
         description: Set when approveImplementation hits a divergent branch and asks
           the agent to rebase. Used to make the approve handler idempotent (no duplicate
@@ -10510,6 +10514,10 @@ definitions:
       public_design_docs:
         description: Public sharing
         type: boolean
+      queue_reason:
+        description: Why a queued task hasn't started yet (WIP capacity or dependency);
+          recomputed each read, never persisted
+        type: string
       rebase_requested_at:
         description: Set when approveImplementation hits a divergent branch and asks
           the agent to rebase. Used to make the approve handler idempotent (no duplicate

--- a/api/pkg/services/spec_task_orchestrator.go
+++ b/api/pkg/services/spec_task_orchestrator.go
@@ -432,7 +432,7 @@ func (o *SpecTaskOrchestrator) handleBacklog(ctx context.Context, task *types.Sp
 				Msg("Skipping backlog task - planning column at WIP limit")
 			return nil
 		}
-		if planningCount+reviewCount >= reviewLimit {
+		if reviewCount >= reviewLimit {
 			log.Info().
 				Str("task_id", latestTask.ID).
 				Str("project_id", latestTask.ProjectID).
@@ -530,6 +530,77 @@ func countTasksByStatus(tasks []*types.SpecTask, statuses ...types.SpecTaskStatu
 	return count
 }
 
+// dependencyQueueReason returns "" if the task's dependencies are all ready,
+// otherwise a human-readable reason naming the blocking dependency. projectTasks
+// is used only to resolve the blocking task's display name.
+func dependencyQueueReason(projectTasks []*types.SpecTask, task *types.SpecTask) string {
+	ready, blockingID := areBacklogDependenciesReady(task.DependsOn)
+	if ready {
+		return ""
+	}
+	name := blockingID
+	for _, t := range projectTasks {
+		if t.ID == blockingID && t.Name != "" {
+			name = t.Name
+			break
+		}
+	}
+	if name == "" {
+		return "Waiting for a dependency task to finish."
+	}
+	return fmt.Sprintf("Waiting for dependency %q to finish.", name)
+}
+
+// PlanningQueueReason returns "" if the task could start planning (spec
+// generation) right now, otherwise a human-readable reason why it is being held
+// in queued_spec_generation. It is a pure function (no store access, no side
+// effects) so the orchestrator gate and the read handlers share ONE source of
+// truth for both the block decision and the message shown to the user.
+//
+// Semantics (each column limit is independent — see design note): a task is held
+// when planning is full (planningCount >= planningLimit) OR review is already at
+// its own limit (reviewCount >= reviewLimit). It is NOT gated on the sum of the
+// two columns, which previously made planningLimit dead.
+func PlanningQueueReason(project *types.Project, projectTasks []*types.SpecTask, task *types.SpecTask) string {
+	if reason := dependencyQueueReason(projectTasks, task); reason != "" {
+		return reason
+	}
+
+	planningLimit, reviewLimit, _ := getProjectWIPLimits(project)
+	planningCount := countTasksByStatus(projectTasks, types.TaskStatusSpecGeneration)
+	reviewCount := countTasksByStatus(projectTasks,
+		types.TaskStatusSpecReview,
+		types.TaskStatusSpecRevision,
+		types.TaskStatusSpecApproved,
+	)
+
+	if planningCount >= planningLimit {
+		return fmt.Sprintf("Waiting for planning capacity — %s already generating specs (limit %d).",
+			countPhrase(planningCount, "task"), planningLimit)
+	}
+	if reviewCount >= reviewLimit {
+		return fmt.Sprintf("Waiting for review capacity — %s awaiting review (limit %d). Approve or clear reviews in the Review column to start planning.",
+			countPhrase(reviewCount, "spec"), reviewLimit)
+	}
+	return ""
+}
+
+// ImplementationQueueReason returns "" if a queued_implementation task could
+// start now, otherwise the reason. The implementation-start transition has no
+// WIP gate of its own (the WIP reservation happens earlier, at backlog entry),
+// so the only block cause here is an unfinished dependency.
+func ImplementationQueueReason(projectTasks []*types.SpecTask, task *types.SpecTask) string {
+	return dependencyQueueReason(projectTasks, task)
+}
+
+// countPhrase renders "1 task is" / "3 tasks are" with correct grammar.
+func countPhrase(n int, noun string) string {
+	if n == 1 {
+		return fmt.Sprintf("1 %s is", noun)
+	}
+	return fmt.Sprintf("%d %ss are", n, noun)
+}
+
 // handleQueuedSpecGeneration handles tasks in queued spec generation
 func (o *SpecTaskOrchestrator) handleQueuedSpecGeneration(ctx context.Context, task *types.SpecTask) error {
 	dependenciesReady, blockingDependency := areBacklogDependenciesReady(task.DependsOn)
@@ -566,14 +637,14 @@ func (o *SpecTaskOrchestrator) handleQueuedSpecGeneration(ctx context.Context, t
 		return fmt.Errorf("failed to list project tasks for planning WIP check: %w", err)
 	}
 
-	planningLimit, reviewLimit, _ := getProjectWIPLimits(project)
-	planningCount := countTasksByStatus(projectTasks, types.TaskStatusSpecGeneration)
-	reviewCount := countTasksByStatus(projectTasks,
-		types.TaskStatusSpecReview,
-		types.TaskStatusSpecRevision,
-		types.TaskStatusSpecApproved,
-	)
-	if planningCount >= planningLimit || planningCount+reviewCount >= reviewLimit {
+	if reason := PlanningQueueReason(project, projectTasks, latestTask); reason != "" {
+		planningLimit, reviewLimit, _ := getProjectWIPLimits(project)
+		planningCount := countTasksByStatus(projectTasks, types.TaskStatusSpecGeneration)
+		reviewCount := countTasksByStatus(projectTasks,
+			types.TaskStatusSpecReview,
+			types.TaskStatusSpecRevision,
+			types.TaskStatusSpecApproved,
+		)
 		log.Info().
 			Str("task_id", latestTask.ID).
 			Str("project_id", latestTask.ProjectID).
@@ -581,7 +652,8 @@ func (o *SpecTaskOrchestrator) handleQueuedSpecGeneration(ctx context.Context, t
 			Int("planning_limit", planningLimit).
 			Int("review_count", reviewCount).
 			Int("review_limit", reviewLimit).
-			Msg("Leaving spec task queued - planning or reserved review capacity is full")
+			Str("queue_reason", reason).
+			Msg("Leaving spec task queued - planning or review capacity is full")
 		return nil
 	}
 

--- a/api/pkg/services/spec_task_orchestrator_test.go
+++ b/api/pkg/services/spec_task_orchestrator_test.go
@@ -132,7 +132,53 @@ func (s *SpecTaskOrchestratorTestSuite) TestHandleBacklog_RespectsPlanningLimit(
 	s.Require().NoError(err)
 }
 
-func (s *SpecTaskOrchestratorTestSuite) TestHandleBacklog_ReservesReviewCapacity() {
+// Review capacity is now gated on the Review column's OWN limit
+// (reviewCount >= reviewLimit), not the sum of planning+review. A Review column
+// at its limit blocks backlog tasks from entering planning; one planning task in
+// flight no longer counts against the review limit.
+func (s *SpecTaskOrchestratorTestSuite) TestHandleBacklog_SkipsWhenReviewColumnFull() {
+	ctx := context.Background()
+	eventTask := &types.SpecTask{
+		ID:        "task-123",
+		ProjectID: "project-123",
+		Status:    types.TaskStatusBacklog,
+	}
+	latestTask := &types.SpecTask{
+		ID:        eventTask.ID,
+		ProjectID: eventTask.ProjectID,
+		Status:    types.TaskStatusBacklog,
+	}
+	project := &types.Project{
+		ID:                    eventTask.ProjectID,
+		AutoStartBacklogTasks: true,
+		Metadata: types.ProjectMetadata{BoardSettings: &types.BoardSettings{
+			WIPLimits: types.WIPLimits{Planning: 3, Review: 2},
+		}},
+	}
+
+	s.store.EXPECT().GetSpecTask(ctx, eventTask.ID).Return(latestTask, nil)
+	s.store.EXPECT().GetProject(ctx, eventTask.ProjectID).Return(project, nil)
+	// Review column at its limit (2) → no review capacity → stay in backlog.
+	// No UpdateSpecTask expectation: gomock fails if the task is progressed.
+	s.store.EXPECT().ListSpecTasks(ctx, &types.SpecTaskFilters{
+		ProjectID:     eventTask.ProjectID,
+		WithDependsOn: true,
+	}).Return([]*types.SpecTask{
+		{ID: "review-1", Status: types.TaskStatusSpecReview},
+		{ID: "review-2", Status: types.TaskStatusSpecRevision},
+		latestTask,
+	}, nil)
+
+	err := s.orchestrator.handleBacklog(ctx, eventTask)
+	s.Require().NoError(err)
+	s.Equal(types.TaskStatusBacklog, latestTask.Status)
+}
+
+// Regression for Problem 2: previously a single planning task + empty Review
+// column tripped `planningCount+reviewCount >= reviewLimit` and wrongly blocked
+// the backlog task. With the fix (independent limits) it must progress into
+// queued_spec_generation.
+func (s *SpecTaskOrchestratorTestSuite) TestHandleBacklog_ProgressesWithPlanningInFlightAndReviewEmpty() {
 	ctx := context.Background()
 	eventTask := &types.SpecTask{
 		ID:        "task-123",
@@ -159,9 +205,12 @@ func (s *SpecTaskOrchestratorTestSuite) TestHandleBacklog_ReservesReviewCapacity
 		WithDependsOn: true,
 	}).Return([]*types.SpecTask{
 		{ID: "planning", Status: types.TaskStatusSpecGeneration},
-		{ID: "review", Status: types.TaskStatusSpecReview},
 		latestTask,
 	}, nil)
+	s.store.EXPECT().UpdateSpecTask(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, task *types.SpecTask) error {
+		s.Equal(types.TaskStatusQueuedSpecGeneration, task.Status)
+		return nil
+	})
 
 	err := s.orchestrator.handleBacklog(ctx, eventTask)
 	s.Require().NoError(err)
@@ -377,7 +426,11 @@ func (s *SpecTaskOrchestratorTestSuite) TestHandleQueuedSpecGeneration_RespectsR
 	s.Equal(types.TaskStatusQueuedSpecGeneration, task.Status)
 }
 
-func (s *SpecTaskOrchestratorTestSuite) TestHandleQueuedSpecGeneration_ReservesFutureReviewSlot() {
+// The planning limit is now effective (Problem 2): with the Planning column at
+// its limit, a queued task stays queued regardless of Review. Previously the
+// summed formula meant the review reservation always tripped first and this
+// limit was dead.
+func (s *SpecTaskOrchestratorTestSuite) TestHandleQueuedSpecGeneration_RespectsPlanningLimit() {
 	ctx := context.Background()
 	task := &types.SpecTask{
 		ID:        "task-queued",
@@ -387,15 +440,17 @@ func (s *SpecTaskOrchestratorTestSuite) TestHandleQueuedSpecGeneration_ReservesF
 	project := &types.Project{
 		ID: task.ProjectID,
 		Metadata: types.ProjectMetadata{BoardSettings: &types.BoardSettings{
-			WIPLimits: types.WIPLimits{Planning: 3, Review: 2},
+			WIPLimits: types.WIPLimits{Planning: 2, Review: 2},
 		}},
 	}
 
 	s.store.EXPECT().GetSpecTask(ctx, task.ID).Return(task, nil)
 	s.store.EXPECT().GetProject(ctx, task.ProjectID).Return(project, nil)
+	// 2 tasks generating specs == planning limit, empty Review → stay queued.
+	// No UpdateSpecTask expectation: gomock fails if the task is progressed.
 	s.store.EXPECT().ListSpecTasks(ctx, &types.SpecTaskFilters{ProjectID: task.ProjectID}).Return([]*types.SpecTask{
-		{ID: "planning", Status: types.TaskStatusSpecGeneration},
-		{ID: "review", Status: types.TaskStatusSpecReview},
+		{ID: "gen-1", Status: types.TaskStatusSpecGeneration},
+		{ID: "gen-2", Status: types.TaskStatusSpecGeneration},
 		task,
 	}, nil)
 
@@ -495,6 +550,97 @@ func TestBuildPlanningPrompt_NoRepos(t *testing.T) {
 	assert.Contains(t, prompt, "Add dark mode toggle")
 	assert.Contains(t, prompt, "helix-specs")
 	assert.Contains(t, prompt, "requirements.md")
+}
+
+// TestPlanningQueueReason is the table-driven test for the extracted pure gate
+// function. It is the single source of truth shared by the orchestrator and the
+// read handlers, so it must cover every block cause and the not-blocked case.
+func TestPlanningQueueReason(t *testing.T) {
+	proj := func(planning, review int) *types.Project {
+		return &types.Project{Metadata: types.ProjectMetadata{BoardSettings: &types.BoardSettings{
+			WIPLimits: types.WIPLimits{Planning: planning, Review: review},
+		}}}
+	}
+	queued := &types.SpecTask{ID: "t1", ProjectID: "p1", Status: types.TaskStatusQueuedSpecGeneration}
+
+	tests := []struct {
+		name         string
+		project      *types.Project
+		projectTasks []*types.SpecTask
+		task         *types.SpecTask
+		wantEmpty    bool
+		wantContains string
+	}{
+		{
+			name:    "not blocked - capacity available",
+			project: proj(3, 2),
+			projectTasks: []*types.SpecTask{
+				{ID: "a", Status: types.TaskStatusSpecGeneration},
+				{ID: "b", Status: types.TaskStatusSpecReview},
+				queued,
+			},
+			task:      queued,
+			wantEmpty: true,
+		},
+		{
+			name:    "planning full",
+			project: proj(3, 2),
+			projectTasks: []*types.SpecTask{
+				{ID: "a", Status: types.TaskStatusSpecGeneration},
+				{ID: "b", Status: types.TaskStatusSpecGeneration},
+				{ID: "c", Status: types.TaskStatusSpecGeneration},
+				queued,
+			},
+			task:         queued,
+			wantContains: "planning capacity",
+		},
+		{
+			name:    "review full",
+			project: proj(3, 2),
+			projectTasks: []*types.SpecTask{
+				{ID: "r1", Status: types.TaskStatusSpecReview},
+				{ID: "r2", Status: types.TaskStatusSpecRevision},
+				queued,
+			},
+			task:         queued,
+			wantContains: "review capacity",
+		},
+		{
+			name:    "dependency blocked names the blocking task",
+			project: proj(3, 2),
+			projectTasks: []*types.SpecTask{
+				{ID: "dep-1", Name: "Login flow", Status: types.TaskStatusImplementation},
+			},
+			task: &types.SpecTask{ID: "t2", ProjectID: "p1", Status: types.TaskStatusQueuedSpecGeneration,
+				DependsOn: []types.SpecTask{{ID: "dep-1", Status: types.TaskStatusImplementation}}},
+			wantContains: "Login flow",
+		},
+		{
+			// Problem 2 regression: 2 planning (< limit 3) + empty Review must NOT
+			// block. The old summed formula (planningCount+reviewCount >= reviewLimit)
+			// blocked here because 2 >= 2.
+			name:    "planning limit no longer dead",
+			project: proj(3, 2),
+			projectTasks: []*types.SpecTask{
+				{ID: "a", Status: types.TaskStatusSpecGeneration},
+				{ID: "b", Status: types.TaskStatusSpecGeneration},
+				queued,
+			},
+			task:      queued,
+			wantEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PlanningQueueReason(tt.project, tt.projectTasks, tt.task)
+			if tt.wantEmpty {
+				assert.Empty(t, got)
+			} else {
+				assert.Contains(t, got, tt.wantContains)
+			}
+		})
+	}
 }
 
 func TestSanitizeForBranchName(t *testing.T) {

--- a/api/pkg/types/simple_spec_task.go
+++ b/api/pkg/types/simple_spec_task.go
@@ -175,6 +175,7 @@ type SpecTask struct {
 	LastPromptContent    string         `json:"last_prompt_content,omitempty" gorm:"-"`    // Last prompt sent to agent (for continue functionality)
 	SandboxState         string         `json:"sandbox_state,omitempty" gorm:"-"`          // "absent", "running", "starting" — derived from session config in listTasks
 	SandboxStatusMessage string         `json:"sandbox_status_message,omitempty" gorm:"-"` // Transient startup message e.g. "Unpacking build cache"
+	QueueReason          string         `json:"queue_reason,omitempty" gorm:"-"`           // Why a queued task hasn't started yet (WIP capacity or dependency); recomputed each read, never persisted
 
 	// Multi-session support
 	ZedInstanceID   string         `json:"zed_instance_id,omitempty" gorm:"size:255;index"`

--- a/design/2026-07-14-wip-queue-reason.md
+++ b/design/2026-07-14-wip-queue-reason.md
@@ -1,0 +1,77 @@
+# WIP-queue block reason + gate formula fix
+
+## Problem
+
+A spec task could sit in `queued_spec_generation` indefinitely with no sandbox,
+session, or agent — the orchestrator was deliberately holding it behind a WIP
+limit, but the only record of *why* was a server log line. To the user the task
+detail page just looked stuck.
+
+Two problems, both fixed here:
+
+1. **Invisible block reason** — nothing in the UI explained a queued task.
+2. **Wrong WIP gate formula** — `planningCount + reviewCount >= reviewLimit`
+   compared the sum of two columns against the review limit alone. With defaults
+   `planningLimit=3, reviewLimit=2` the planning limit was dead (the review
+   reservation always tripped first) and a full Review column permanently
+   starved planning with zero user feedback.
+
+## Implementation
+
+### Backend
+- Added transient `SpecTask.QueueReason` (`gorm:"-"`, `json:"queue_reason"`),
+  recomputed each read — same pattern as `SandboxStatusMessage`. Never persisted.
+- Extracted a single pure source of truth in `spec_task_orchestrator.go`:
+  - `PlanningQueueReason(project, projectTasks, task) string` — dependency-not-ready,
+    planning-full, or review-full → human-readable reason, else "".
+  - `ImplementationQueueReason(projectTasks, task)` — dependency-only (the
+    implementation-start transition has no WIP gate of its own).
+  - `dependencyQueueReason` resolves the blocking task's name from `projectTasks`.
+- `handleQueuedSpecGeneration` now calls `PlanningQueueReason` (behaviour
+  identical: non-empty → stay queued + log).
+- **Problem 2 fix**: review capacity is gated on `reviewCount >= reviewLimit`
+  (the Review column's own limit), NOT the summed formula. Applied in both
+  `handleQueuedSpecGeneration` and the backlog→queued gate in `handleBacklog` so
+  the two sites agree and `planningLimit` regains effect.
+- `server.populateQueueReasons` fills `QueueReason` for queued tasks in both
+  `listTasks` (kanban) and `getTask` (detail page — it doesn't run the list
+  enrichment, so it's called explicitly there). It loads the project task list
+  `WithDependsOn: true` once, both as the WIP-count basis and to supply each
+  task's `DependsOn`.
+
+### Frontend
+- Regenerated OpenAPI client (`./stack update_openapi`) → `TypesSpecTask.queue_reason`.
+- `SpecTaskDetailContent.tsx`: info `<Alert>` ("Waiting to start" + reason) for
+  queued tasks with a reason.
+- `TaskCard.tsx`: queued card shows the reason inline (ellipsised) with a tooltip
+  and a schedule icon instead of the misleading "Starting desktop…" spinner.
+  Added `queue_reason` to the hand-maintained `SpecTaskWithExtras` interface.
+
+## Tests
+- `TestPlanningQueueReason` (table-driven): not-blocked, planning-full,
+  review-full, dependency-blocked, and the Problem-2 regression (2 planning under
+  limit 3 + empty review must NOT block — the old summed formula blocked here).
+- Updated two existing orchestrator tests that encoded the old summed-reservation
+  behaviour: `TestHandleBacklog_ReservesReviewCapacity` →
+  `SkipsWhenReviewColumnFull` + new `ProgressesWithPlanningInFlightAndReviewEmpty`;
+  `TestHandleQueuedSpecGeneration_ReservesFutureReviewSlot` →
+  `RespectsPlanningLimit`.
+
+## End-to-end verification (inner Helix, localhost:8080)
+Registered `test@helix.ml`, created org `testorg` + project `testproj`. Set Review
+WIP limit=1 via project metadata, seeded 2 `spec_review` tasks + 1
+`queued_spec_generation` task.
+
+- `GET /api/v1/spec-tasks?project_id=…` and `GET /api/v1/spec-tasks/{id}` both
+  returned: `"Waiting for review capacity — 2 specs are awaiting review (limit 1).
+  Approve or clear reviews in the Review column to start planning."`
+- Detail page rendered the "Waiting to start" banner; kanban card rendered the
+  reason inline with the Review column marked "FULL".
+- Archived the 2 review tasks → `queue_reason` cleared to empty on the next read,
+  and the orchestrator picked up the queued task within ~10s and attempted to
+  start planning (gate no longer blocks). The task then failed with "user_id is
+  required" because the minimal hand-seeded row lacked a full owner/app linkage —
+  an artifact of the seed, not the feature.
+
+Screenshots: `design/tasks/002256_complete-the-task-in-the/screenshots/` in the
+helix-specs branch.

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -6240,6 +6240,8 @@ export interface TypesSpecTask {
   project_path?: string;
   /** Public sharing */
   public_design_docs?: boolean;
+  /** Why a queued task hasn't started yet (WIP capacity or dependency); recomputed each read, never persisted */
+  queue_reason?: string;
   /** Set when approveImplementation hits a divergent branch and asks the agent to rebase. Used to make the approve handler idempotent (no duplicate prompts) and to gate the Accept button until the agent's next push. */
   rebase_requested_at?: string;
   /** Multi-repo PR tracking: list of PRs across all project repositories */
@@ -6585,6 +6587,8 @@ export interface TypesSpecTaskWithProject {
   project_path?: string;
   /** Public sharing */
   public_design_docs?: boolean;
+  /** Why a queued task hasn't started yet (WIP capacity or dependency); recomputed each read, never persisted */
+  queue_reason?: string;
   /** Set when approveImplementation hits a divergent branch and asks the agent to rebase. Used to make the approve handler idempotent (no duplicate prompts) and to gate the Accept button until the agent's next push. */
   rebase_requested_at?: string;
   /** Multi-repo PR tracking: list of PRs across all project repositories */

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -1095,6 +1095,25 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   // Render the details content (used in both desktop left panel and mobile/no-session view)
   const renderDetailsContent = () => (
     <>
+      {/* Queued task block reason — explains why a queued task hasn't started yet
+          (WIP capacity / dependency). Recomputed server-side each read, so it
+          clears automatically as the queue drains. */}
+      {(task?.status === "queued_spec_generation" ||
+        task?.status === "queued_implementation") &&
+        task?.queue_reason && (
+          <Alert severity="info" sx={{ mb: 3 }}>
+            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+              Waiting to start
+            </Typography>
+            <Typography
+              variant="caption"
+              sx={{ display: "block", color: "text.secondary" }}
+            >
+              {task.queue_reason}
+            </Typography>
+          </Alert>
+        )}
+
       {/* Completed task message */}
       {isTaskCompleted && (
         <Alert severity="success" sx={{ mb: 3 }}>

--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -37,6 +37,7 @@ import {
   Unarchive as UnarchiveIcon,
   RemoveCircleOutline as RemoveFromQueueIcon,
   Undo as UndoIcon,
+  Schedule as ScheduleIcon,
 } from "@mui/icons-material";
 import { EllipsisVertical, Wand2, UserCircle2 } from "lucide-react";
 import {
@@ -151,6 +152,7 @@ export interface SpecTaskWithExtras {
   // Sandbox state — populated by the listTasks backend handler, avoids per-card session polling
   sandbox_state?: string; // "absent" | "running" | "starting"
   sandbox_status_message?: string; // Transient startup message
+  queue_reason?: string; // Why a queued task hasn't started yet (WIP/dependency); recomputed each read
   // Status tracking
   status_updated_at?: string;
   // Task number for display
@@ -1151,25 +1153,59 @@ function TaskCardInner({
           </Box>
         )}
 
-        {/* Queued state: waiting for orchestrator to create session */}
+        {/* Queued state: waiting for orchestrator to create session.
+            If the orchestrator is deliberately holding the task behind a WIP
+            limit or dependency, task.queue_reason explains why — show it
+            compactly (tooltip) instead of a misleading "Starting desktop..."
+            spinner so the card doesn't look dead. */}
         {isQueued && !task.planning_session_id && (
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              gap: 1,
-              mt: 1,
-              px: 0.5,
-            }}
-          >
-            <CircularProgress size={10} thickness={5} />
-            <Typography
-              variant="caption"
-              sx={{ color: "text.secondary", fontSize: "0.7rem" }}
+          task.queue_reason ? (
+            <Tooltip title={task.queue_reason}>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  mt: 1,
+                  px: 0.5,
+                }}
+              >
+                <ScheduleIcon
+                  sx={{ fontSize: 12, color: "text.secondary" }}
+                />
+                <Typography
+                  variant="caption"
+                  sx={{
+                    color: "text.secondary",
+                    fontSize: "0.7rem",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {task.queue_reason}
+                </Typography>
+              </Box>
+            </Tooltip>
+          ) : (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                mt: 1,
+                px: 0.5,
+              }}
             >
-              Starting desktop...
-            </Typography>
-          </Box>
+              <CircularProgress size={10} thickness={5} />
+              <Typography
+                variant="caption"
+                sx={{ color: "text.secondary", fontSize: "0.7rem" }}
+              >
+                Starting desktop...
+              </Typography>
+            </Box>
+          )
         )}
 
         {/* Live screenshot for active sessions - click opens desktop viewer.

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -9907,6 +9907,10 @@ definitions:
       public_design_docs:
         description: Public sharing
         type: boolean
+      queue_reason:
+        description: Why a queued task hasn't started yet (WIP capacity or dependency);
+          recomputed each read, never persisted
+        type: string
       rebase_requested_at:
         description: Set when approveImplementation hits a divergent branch and asks
           the agent to rebase. Used to make the approve handler idempotent (no duplicate
@@ -10510,6 +10514,10 @@ definitions:
       public_design_docs:
         description: Public sharing
         type: boolean
+      queue_reason:
+        description: Why a queued task hasn't started yet (WIP capacity or dependency);
+          recomputed each read, never persisted
+        type: string
       rebase_requested_at:
         description: Set when approveImplementation hits a divergent branch and asks
           the agent to rebase. Used to make the approve handler idempotent (no duplicate

--- a/openapi.json
+++ b/openapi.json
@@ -39618,6 +39618,10 @@
                         "description": "Public sharing",
                         "type": "boolean"
                     },
+                    "queue_reason": {
+                        "description": "Why a queued task hasn't started yet (WIP capacity or dependency); recomputed each read, never persisted",
+                        "type": "string"
+                    },
                     "rebase_requested_at": {
                         "description": "Set when approveImplementation hits a divergent branch and asks the agent to rebase. Used to make the approve handler idempotent (no duplicate prompts) and to gate the Accept button until the agent's next push.",
                         "type": "string"
@@ -40414,6 +40418,10 @@
                     "public_design_docs": {
                         "description": "Public sharing",
                         "type": "boolean"
+                    },
+                    "queue_reason": {
+                        "description": "Why a queued task hasn't started yet (WIP capacity or dependency); recomputed each read, never persisted",
+                        "type": "string"
                     },
                     "rebase_requested_at": {
                         "description": "Set when approveImplementation hits a divergent branch and asks the agent to rebase. Used to make the approve handler idempotent (no duplicate prompts) and to gate the Accept button until the agent's next push.",

--- a/swagger.json
+++ b/swagger.json
@@ -35262,6 +35262,10 @@
                     "description": "Public sharing",
                     "type": "boolean"
                 },
+                "queue_reason": {
+                    "description": "Why a queued task hasn't started yet (WIP capacity or dependency); recomputed each read, never persisted",
+                    "type": "string"
+                },
                 "rebase_requested_at": {
                     "description": "Set when approveImplementation hits a divergent branch and asks the agent to rebase. Used to make the approve handler idempotent (no duplicate prompts) and to gate the Accept button until the agent's next push.",
                     "type": "string"
@@ -36058,6 +36062,10 @@
                 "public_design_docs": {
                     "description": "Public sharing",
                     "type": "boolean"
+                },
+                "queue_reason": {
+                    "description": "Why a queued task hasn't started yet (WIP capacity or dependency); recomputed each read, never persisted",
+                    "type": "string"
                 },
                 "rebase_requested_at": {
                     "description": "Set when approveImplementation hits a divergent branch and asks the agent to rebase. Used to make the approve handler idempotent (no duplicate prompts) and to gate the Accept button until the agent's next push.",


### PR DESCRIPTION
## Summary
A spec task could sit in `queued_spec_generation` indefinitely with no sandbox,
session, or agent — the orchestrator was deliberately holding it behind a WIP
limit, but the reason was only in a server log the user never sees, so the task
looked dead. This PR (1) surfaces a live, human-readable block reason in the UI,
and (2) fixes the WIP gate formula so the planning and review limits are each
meaningful.

## Problem 1 — invisible block reason
- New transient `SpecTask.QueueReason` (`gorm:"-"`, recomputed each read, never
  persisted — same pattern as `SandboxStatusMessage`).
- Single pure source of truth `PlanningQueueReason(project, projectTasks, task)`
  (+ `ImplementationQueueReason`) shared by the orchestrator gate and the read
  handlers, covering dependency-not-ready, planning-full and review-full.
- Populated for queued tasks in both `listTasks` (kanban) and `getTask` (detail
  page) via `populateQueueReasons`.
- Frontend: info banner on the task detail page and an inline reason + tooltip on
  the queued kanban card (replacing the misleading "Starting desktop…" spinner).

## Problem 2 — wrong gate formula
- `planningCount + reviewCount >= reviewLimit` compared the sum of two columns
  against the review limit alone, making `planningLimit` dead and letting a full
  Review column permanently starve planning.
- Now gated independently: planning on `planningCount >= planningLimit`, review on
  `reviewCount >= reviewLimit`. Fixed in both `handleQueuedSpecGeneration` and the
  backlog→queued gate in `handleBacklog`.

## Changes
- `api/pkg/types/simple_spec_task.go`: add `QueueReason` transient field.
- `api/pkg/services/spec_task_orchestrator.go`: extract `PlanningQueueReason` /
  `ImplementationQueueReason` / `dependencyQueueReason`; use in the gate; fix the
  formula in both gate sites.
- `api/pkg/server/spec_driven_task_handlers.go`: `populateQueueReasons` in
  `listTasks` and `getTask`.
- `frontend/src/components/tasks/SpecTaskDetailContent.tsx`: queued info banner.
- `frontend/src/components/tasks/TaskCard.tsx`: queued card reason + tooltip;
  add `queue_reason` to `SpecTaskWithExtras`.
- Regenerated OpenAPI client (`queue_reason`).
- Tests: `TestPlanningQueueReason` (table-driven) + reworked the two orchestrator
  tests that encoded the old summed-reservation behaviour.
- `design/2026-07-14-wip-queue-reason.md`.

## Testing
- `go build ./...` and `go test ./pkg/services/ -run 'TestSpecTaskOrchestratorTestSuite|TestPlanningQueueReason'` pass.
- Frontend `tsc --noEmit` clean; full `vite build` green (built to temp outDir —
  repo `dist/` is a root-owned prod bind-mount).
- End-to-end in the inner Helix: seeded a Review-full project; confirmed the
  reason appears on the detail banner and kanban card via both API endpoints, then
  drained Review and confirmed the reason clears and the task is picked up within
  ~10s. See the design note for the exact commands/observations.

## Screenshots
![Detail page banner](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002256_complete-the-task-in-the/screenshots/01-detail-banner.png)
![Kanban card + Review FULL](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002256_complete-the-task-in-the/screenshots/02-kanban-card.png)

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01kxg7j8sg030cecd733dwsv52)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002256_complete-the-task-in-the/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002256_complete-the-task-in-the/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002256_complete-the-task-in-the/tasks.md)

🚀 Built with [Helix](https://helix.ml)