### PR TITLE
fix(org): share bot sessions with organization members

### DIFF
--- a/api/pkg/org/infrastructure/runtime/helix/project.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project.go
@@ -285,6 +285,12 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 					return state.ProjectID, state.AgentAppID, state.RepoID, nil
 				}
 			}
+			if !existing.Metadata.OrgMembersAccess {
+				existing.Metadata.OrgMembersAccess = true
+				if _, err := a.Service.UpdateProject(ctx, state.ProjectID, types.ProjectUpdateRequest{Metadata: &existing.Metadata}); err != nil {
+					return "", "", "", fmt.Errorf("enable org member access to project %s for %s: %w", state.ProjectID, workerID, err)
+				}
+			}
 			// Runtime/model configuration is owned by the generated Helix app
 			// after initial provisioning. Do not re-apply the provisioning
 			// spec here: doing so would overwrite edits made through the app
@@ -326,6 +332,17 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 	if err != nil {
 		return "", "", "", fmt.Errorf("apply project for %s: %w", workerID, err)
 	}
+	project, err := a.Service.GetProject(ctx, resp.ProjectID)
+	if err != nil {
+		return "", "", "", fmt.Errorf("get applied project %s for %s: %w", resp.ProjectID, workerID, err)
+	}
+	if !project.Metadata.OrgMembersAccess {
+		project.Metadata.OrgMembersAccess = true
+		project, err = a.Service.UpdateProject(ctx, resp.ProjectID, types.ProjectUpdateRequest{Metadata: &project.Metadata})
+		if err != nil {
+			return "", "", "", fmt.Errorf("enable org member access to project %s for %s: %w", resp.ProjectID, workerID, err)
+		}
+	}
 	// Project secrets — env-var injection. The worker needs these to reach
 	// the org runtime, so a failure is worth surfacing (logged, not fatal:
 	// a re-apply on the next activation retries the upsert).
@@ -335,15 +352,7 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 	if err := a.Service.PutProjectSecret(ctx, resp.ProjectID, "HELIX_WORKER_ID", string(workerID)); err != nil && a.Logger != nil {
 		a.Logger.Warn("put project secret HELIX_WORKER_ID", "worker", workerID, "project", resp.ProjectID, "err", err)
 	}
-	// Discover the project's primary repo. A GetProject failure here just
-	// means we fall through to ensureWorkerRepo (which re-reads under the
-	// lock) — log it so the cause is visible if a repo is then created.
-	repoID = ""
-	if proj, err := a.Service.GetProject(ctx, resp.ProjectID); err == nil {
-		repoID = proj.DefaultRepoID
-	} else if a.Logger != nil {
-		a.Logger.Warn("discover project repo: GetProject failed", "worker", workerID, "project", resp.ProjectID, "err", err)
-	}
+	repoID = project.DefaultRepoID
 	// Helix's project-apply does NOT auto-create a default repo. We
 	// MUST create one and attach it as primary, because:
 	//

--- a/api/pkg/org/infrastructure/runtime/helix/project_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_test.go
@@ -32,6 +32,7 @@ type fakeProjectService struct {
 	getProjectCalls         int
 	getProjectResp          types.Project
 	getProjectErr           error
+	getProjectErrOnce       bool
 	updateProjectCalls      int
 	updateProjectPatchLast  types.ProjectUpdateRequest
 	updateProjectErr        error
@@ -96,7 +97,11 @@ func (f *fakeProjectService) GetProject(_ context.Context, _ string) (types.Proj
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.getProjectCalls++
-	return f.getProjectResp, f.getProjectErr
+	err := f.getProjectErr
+	if f.getProjectErrOnce {
+		f.getProjectErr = nil
+	}
+	return f.getProjectResp, err
 }
 
 func (f *fakeProjectService) UpdateProject(_ context.Context, id string, patch types.ProjectUpdateRequest) (types.Project, error) {
@@ -110,6 +115,12 @@ func (f *fakeProjectService) UpdateProject(_ context.Context, id string, patch t
 	updated := f.getProjectResp
 	if patch.StartupScript != nil {
 		updated.StartupScript = *patch.StartupScript
+	}
+	if patch.Name != nil {
+		updated.Name = *patch.Name
+	}
+	if patch.Metadata != nil {
+		updated.Metadata = *patch.Metadata
 	}
 	f.getProjectResp = updated
 	return updated, f.updateProjectErr
@@ -296,6 +307,9 @@ func TestEnsureFreshAppliesProjectAndPushesFiles(t *testing.T) {
 	defer svc.mu.Unlock()
 	if svc.applyCalls != 1 {
 		t.Errorf("ApplyProject calls = %d, want 1", svc.applyCalls)
+	}
+	if svc.updateProjectCalls != 1 || svc.updateProjectPatchLast.Metadata == nil || !svc.updateProjectPatchLast.Metadata.OrgMembersAccess {
+		t.Errorf("fresh project was not marked for org member access: calls=%d patch=%+v", svc.updateProjectCalls, svc.updateProjectPatchLast)
 	}
 	if svc.lastApplyReq.Name != "w-eng" {
 		t.Errorf("ApplyProject name = %q, want w-eng", svc.lastApplyReq.Name)
@@ -568,6 +582,9 @@ func TestEnsureWithPersistedProjectFastPaths(t *testing.T) {
 	if svc.applyCalls != 0 {
 		t.Errorf("ApplyProject must not overwrite existing app config; got %d calls", svc.applyCalls)
 	}
+	if svc.updateProjectCalls < 1 || svc.updateProjectPatchLast.Metadata == nil || !svc.updateProjectPatchLast.Metadata.OrgMembersAccess {
+		t.Errorf("existing project was not marked for org member access: calls=%d patch=%+v", svc.updateProjectCalls, svc.updateProjectPatchLast)
+	}
 	if svc.getProjectCalls < 1 {
 		t.Errorf("GetProject calls = %d, want >=1", svc.getProjectCalls)
 	}
@@ -694,6 +711,7 @@ func TestEnsureClearsStateOnGetProject404(t *testing.T) {
 	}
 	svc := newFakeProjectService()
 	svc.getProjectErr = ErrProjectNotFound
+	svc.getProjectErrOnce = true
 	git := newFakeGitForProject()
 	a := newApplierGit(svc, git, st)
 

--- a/api/pkg/server/authz.go
+++ b/api/pkg/server/authz.go
@@ -181,6 +181,9 @@ func (apiServer *HelixAPIServer) authorizeUserToProject(ctx context.Context, use
 	if orgMembership.Role == types.OrganizationRoleOwner {
 		return nil
 	}
+	if project.Metadata.OrgMembersAccess && (action == types.ActionGet || action == types.ActionList || action == types.ActionUseAction) {
+		return nil
+	}
 
 	return apiServer.authorizeUserToResource(ctx, user, project.OrganizationID, project.ID, types.ResourceProject, action)
 }
@@ -282,8 +285,15 @@ func (apiServer *HelixAPIServer) authorizeUserToSession(ctx context.Context, use
 		return fmt.Errorf("not authorized to access session without a project")
 	}
 
-	// Authorize the user based on project ID
-	return apiServer.authorizeUserToResource(ctx, user, session.OrganizationID, session.ProjectID, types.ResourceProject, action)
+	project, err := apiServer.Store.GetProject(ctx, session.ProjectID)
+	if err != nil {
+		return err
+	}
+	if project.Metadata.OrgMembersAccess && action == types.ActionUpdate {
+		return apiServer.authorizeUserToProject(ctx, user, project, types.ActionGet)
+	}
+
+	return apiServer.authorizeUserToProject(ctx, user, project, action)
 }
 
 // authorizeUserToResource evaluates the user's team + direct access grants for a

--- a/api/pkg/server/authz_test.go
+++ b/api/pkg/server/authz_test.go
@@ -804,6 +804,31 @@ func (s *AuthzProjectViaTeamSuite) TestTeamMembership_NoGrant_Denied() {
 	s.Error(err)
 }
 
+func (s *AuthzProjectViaTeamSuite) TestOrgMembersAccess_AllowsMemberGetButNotUpdate() {
+	s.project.Metadata.OrgMembersAccess = true
+	s.expectOrgMember()
+	s.expectTeamNoGrant()
+
+	s.NoError(s.server.authorizeUserToProject(context.Background(), s.user, s.project, types.ActionGet))
+	s.Error(s.server.authorizeUserToProject(context.Background(), s.user, s.project, types.ActionUpdate))
+}
+
+func (s *AuthzProjectViaTeamSuite) TestOrgMembersAccess_DoesNotAllowDelete() {
+	s.project.Metadata.OrgMembersAccess = true
+	s.expectOrgMember()
+	s.expectTeamNoGrant()
+
+	s.Error(s.server.authorizeUserToProject(context.Background(), s.user, s.project, types.ActionDelete))
+}
+
+func (s *AuthzProjectViaTeamSuite) TestOrgMembersAccess_DoesNotAllowNonMember() {
+	s.project.Metadata.OrgMembersAccess = true
+	s.mockStore.EXPECT().GetOrganizationMembership(gomock.Any(), gomock.Any()).
+		Return(nil, store.ErrNotFound)
+
+	s.Error(s.server.authorizeUserToProject(context.Background(), s.user, s.project, types.ActionGet))
+}
+
 // AuthzSessionSuite pins authorizeUserToSession, which startChatSessionHandler
 // uses to gate POST /sessions/chat on an existing session. The regression this
 // guards: the chat handler used a strict `session.Owner != user.ID` check, so an
@@ -884,6 +909,10 @@ func (s *AuthzSessionSuite) expectNoProjectGrant(projectID string) {
 	}).Return([]*types.AccessGrant{}, nil)
 }
 
+func (s *AuthzSessionSuite) expectProject(project *types.Project) {
+	s.mockStore.EXPECT().GetProject(gomock.Any(), project.ID).Return(project, nil)
+}
+
 // The literal session owner can always write to their session.
 func (s *AuthzSessionSuite) TestSessionOwnerAllowed() {
 	session := &types.Session{ID: "ses1", Owner: s.userID, OrganizationID: s.orgID, ProjectID: "prj1"}
@@ -913,6 +942,7 @@ func (s *AuthzSessionSuite) TestMemberWithProjectGrantAllowed() {
 	user := &types.User{ID: s.userID}
 
 	s.expectOrgMember(types.OrganizationRoleMember)
+	s.expectProject(&types.Project{ID: "prj1", OrganizationID: s.orgID, UserID: "someone_else"})
 	s.expectProjectGrant("prj1", types.ActionUpdate)
 
 	err := s.server.authorizeUserToSession(context.Background(), user, session, types.ActionUpdate)
@@ -926,10 +956,28 @@ func (s *AuthzSessionSuite) TestMemberWithoutGrantDenied() {
 	user := &types.User{ID: s.userID}
 
 	s.expectOrgMember(types.OrganizationRoleMember)
+	s.expectProject(&types.Project{ID: "prj1", OrganizationID: s.orgID, UserID: "someone_else"})
 	s.expectNoProjectGrant("prj1")
 
 	err := s.server.authorizeUserToSession(context.Background(), user, session, types.ActionUpdate)
 	s.Error(err)
+}
+
+func (s *AuthzSessionSuite) TestOrgMembersAccess_AllowsMemberGetAndUpdate() {
+	session := &types.Session{ID: "ses1", Owner: "someone_else", OrganizationID: s.orgID, ProjectID: "prj1"}
+	user := &types.User{ID: s.userID}
+	project := &types.Project{
+		ID:             "prj1",
+		OrganizationID: s.orgID,
+		UserID:         "someone_else",
+		Metadata:       types.ProjectMetadata{OrgMembersAccess: true},
+	}
+
+	s.expectOrgMember(types.OrganizationRoleMember)
+	s.mockStore.EXPECT().GetProject(gomock.Any(), "prj1").Return(project, nil).Times(2)
+
+	s.NoError(s.server.authorizeUserToSession(context.Background(), user, session, types.ActionGet))
+	s.NoError(s.server.authorizeUserToSession(context.Background(), user, session, types.ActionUpdate))
 }
 
 // A non-member of the org is denied outright.

--- a/api/pkg/server/exploratory_session_activation_test.go
+++ b/api/pkg/server/exploratory_session_activation_test.go
@@ -223,6 +223,44 @@ func (s *ExploratorySessionActivationSuite) TestExploratoryStatusReportsRunningW
 		"hydra session map populated → status must report running")
 }
 
+func (s *ExploratorySessionActivationSuite) TestOrgMemberCanGetBotExploratorySession() {
+	const (
+		projectID = "prj_bot"
+		orgID     = "org_test"
+		userID    = "user_member"
+		sessionID = "ses_bot"
+	)
+
+	project := &types.Project{
+		ID:             projectID,
+		UserID:         "user_creator",
+		OrganizationID: orgID,
+		Metadata:       types.ProjectMetadata{OrgMembersAccess: true},
+	}
+	session := &types.Session{ID: sessionID, ProjectID: projectID, Owner: "user_creator"}
+
+	s.store.EXPECT().GetProject(gomock.Any(), projectID).Return(project, nil)
+	s.store.EXPECT().GetOrganizationMembership(gomock.Any(), &store.GetOrganizationMembershipQuery{
+		OrganizationID: orgID,
+		UserID:         userID,
+	}).Return(&types.OrganizationMembership{
+		OrganizationID: orgID,
+		UserID:         userID,
+		Role:           types.OrganizationRoleMember,
+	}, nil)
+	s.store.EXPECT().GetProjectExploratorySession(gomock.Any(), projectID).Return(session, nil)
+	s.executor.EXPECT().GetSession(sessionID).Return(nil, errors.New("session not found"))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects/"+projectID+"/exploratory-session", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": projectID})
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: userID}))
+
+	got, herr := s.server.getProjectExploratorySession(nil, req)
+	s.Require().Nil(herr)
+	s.Require().NotNil(got)
+	s.Equal(sessionID, got.ID)
+}
+
 // Case 3: no project → no reuse. The guard is gated on ProjectID != "",
 // so a SessionRole="exploratory" request without a project must still
 // mint a fresh id (no GetProjectExploratorySession call). Confirms we

--- a/api/pkg/server/project_handlers.go
+++ b/api/pkg/server/project_handlers.go
@@ -655,6 +655,9 @@ func (s *HelixAPIServer) updateProject(_ http.ResponseWriter, r *http.Request) (
 		// AutoWarmDockerCache is a bool — always apply from the request
 		// since it's user-controlled.
 		project.Metadata.AutoWarmDockerCache = req.Metadata.AutoWarmDockerCache
+		if req.Metadata.OrgMembersAccess {
+			project.Metadata.OrgMembersAccess = true
+		}
 		// DockerCacheStatus is managed exclusively by GoldenBuildService — never overwrite from API request.
 	}
 	// Skills can be set directly (nil means "don't update")

--- a/api/pkg/server/session_handlers_test.go
+++ b/api/pkg/server/session_handlers_test.go
@@ -545,6 +545,11 @@ func (s *SessionAuthzSuite) TestDeleteSession_OrgMemberNotAuthorizedToProject() 
 		OrganizationID: s.orgID,
 		UserID:         s.userID,
 		Role:           types.OrganizationRoleMember,
+	}, nil).Times(2)
+	s.store.EXPECT().GetProject(gomock.Any(), session.ProjectID).Return(&types.Project{
+		ID:             session.ProjectID,
+		OrganizationID: s.orgID,
+		UserID:         "other_user",
 	}, nil)
 	// No teams
 	s.store.EXPECT().ListTeams(gomock.Any(), &store.ListTeamsQuery{
@@ -586,6 +591,11 @@ func (s *SessionAuthzSuite) TestDeleteSession_OrgMemberAuthorizedToProject() {
 		OrganizationID: s.orgID,
 		UserID:         s.userID,
 		Role:           types.OrganizationRoleMember,
+	}, nil).Times(2)
+	s.store.EXPECT().GetProject(gomock.Any(), session.ProjectID).Return(&types.Project{
+		ID:             session.ProjectID,
+		OrganizationID: s.orgID,
+		UserID:         "other_user",
 	}, nil)
 	// No teams
 	s.store.EXPECT().ListTeams(gomock.Any(), &store.ListTeamsQuery{

--- a/api/pkg/types/project.go
+++ b/api/pkg/types/project.go
@@ -448,6 +448,7 @@ type ProjectMetadata struct {
 	BoardSettings       *BoardSettings    `json:"board_settings,omitempty"`
 	AutoWarmDockerCache bool              `json:"auto_warm_docker_cache,omitempty"`
 	DockerCacheStatus   *DockerCacheState `json:"docker_cache_status,omitempty"`
+	OrgMembersAccess    bool              `json:"org_members_access,omitempty"`
 }
 
 // DockerCacheState tracks the current state of the golden Docker cache for a project,


### PR DESCRIPTION
## Summary

- mark per-bot projects as accessible to organization members
- backfill the marker when existing bot projects are activated
- authorize bot session interaction through the shared project policy without granting project update or delete access
- cover project, session, exploratory-session, and runtime provisioning paths

## Verification

- `go test ./pkg/server -count=1`
- `go test ./pkg/org/infrastructure/runtime/helix -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `git diff --check`
- Prime: second organization member received HTTP 200 for the bot exploratory session and session; chat POST passed authorization and reached the external agent

## Live-test caveat

The Prime chat request then failed inside the external agent because its Anthropic API key was invalid. That is independent of this authorization fix.