### PR TITLE
feat(org): add bidirectional Slack human delivery

### DIFF
--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -166,10 +166,9 @@ type CreateResult struct {
 // This is the single implementation the MCP create_bot tool and the
 // REST POST /bots handler both call.
 //
-// State lives in the domain (DB) + the per-Bot repo's helix-specs git
-// branch (role.md / agent.md), which the agent pulls inside its sandbox
-// — there is no API-host workspace directory. A Bot's MCP tool surface
-// is derived live from Bot.Tools.
+// State lives in the domain DB, with role.md mirrored to the per-Bot
+// helix-specs branch for workspace workflows. A Bot's MCP tool surface is
+// derived live from Bot.Tools.
 func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (CreateResult, error) {
 	if s.NewID == nil || s.Now == nil {
 		return CreateResult{}, fmt.Errorf("lifecycle: clock/id-generator not wired")

--- a/api/pkg/org/application/slackrouting/threadfollow.go
+++ b/api/pkg/org/application/slackrouting/threadfollow.go
@@ -2,6 +2,7 @@ package slackrouting
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -101,6 +102,39 @@ func threadRoot(msg streaming.Message) string {
 	return msg.MessageID
 }
 
+// RecordParticipant registers a Worker as a participant in an outbound Slack
+// thread so the normal inbound thread-follow path delivers replies to it.
+func (f *ThreadFollower) RecordParticipant(ctx context.Context, orgID string, routerID processor.ProcessorID, root, workerID string) error {
+	if f == nil || f.events == nil {
+		return fmt.Errorf("Slack thread routing is not configured")
+	}
+	if orgID == "" || routerID == "" || root == "" || workerID == "" {
+		return fmt.Errorf("org, router, thread, and worker are required")
+	}
+	subject := threadSubject(routerID, root)
+	prior, err := f.events.ListBySubject(ctx, orgID, domainevent.TypeSlackThreadParticipant, subject, time.Time{})
+	if err != nil {
+		return fmt.Errorf("list Slack thread participants: %w", err)
+	}
+	for _, participant := range domainevent.Participants(prior) {
+		if participant == workerID {
+			return nil
+		}
+	}
+	return f.appendParticipant(ctx, orgID, subject, workerID, string(routerID))
+}
+
+func (f *ThreadFollower) appendParticipant(ctx context.Context, orgID, subject, workerID, routerID string) error {
+	ev, err := domainevent.New(f.mintID(), orgID, domainevent.TypeSlackThreadParticipant, subject, workerID, routerID, nil, f.now())
+	if err != nil {
+		return fmt.Errorf("build Slack thread participant: %w", err)
+	}
+	if err := f.events.Append(ctx, ev); err != nil {
+		return fmt.Errorf("append Slack thread participant: %w", err)
+	}
+	return nil
+}
+
 // AfterRoute records participation for the named recipients and, when
 // thread-follow is on, fans the message out to the thread's existing
 // members. Best-effort: failures are logged, never propagated — a routing
@@ -159,13 +193,8 @@ func (f *ThreadFollower) AfterRoute(ctx context.Context, p processor.Processor, 
 		if _, ok := priorSet[w]; ok {
 			continue
 		}
-		ev, err := domainevent.New(f.mintID(), orgID, domainevent.TypeSlackThreadParticipant, subject, w, string(p.ID), nil, f.now())
-		if err != nil {
-			f.logger.Warn("slackrouting.threadfollow: build event", "worker", w, "err", err)
-			continue
-		}
-		if err := f.events.Append(ctx, ev); err != nil {
-			f.logger.Warn("slackrouting.threadfollow: append member", "worker", w, "thread", root, "err", err)
+		if err := f.appendParticipant(ctx, orgID, subject, w, string(p.ID)); err != nil {
+			f.logger.Warn("slackrouting.threadfollow: record member", "worker", w, "thread", root, "err", err)
 		}
 	}
 

--- a/api/pkg/org/application/slackrouting/threadfollow.go
+++ b/api/pkg/org/application/slackrouting/threadfollow.go
@@ -2,6 +2,7 @@ package slackrouting
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"time"
@@ -124,6 +125,26 @@ func (f *ThreadFollower) RecordParticipant(ctx context.Context, orgID string, ro
 	return f.appendParticipant(ctx, orgID, subject, workerID, string(routerID))
 }
 
+// RecordDMRecipient records the Bot that should receive the next top-level
+// reply in a Slack DM channel. Unlike thread participation, every send is
+// appended so the newest replyable ask_human wins.
+func (f *ThreadFollower) RecordDMRecipient(ctx context.Context, orgID string, routerID processor.ProcessorID, channelID, workerID string) error {
+	if f == nil || f.events == nil {
+		return fmt.Errorf("Slack DM routing is not configured")
+	}
+	if orgID == "" || routerID == "" || channelID == "" || workerID == "" {
+		return fmt.Errorf("org, router, channel, and worker are required")
+	}
+	ev, err := domainevent.New(f.mintID(), orgID, domainevent.TypeSlackDMRecipient, threadSubject(routerID, channelID), workerID, string(routerID), nil, f.now())
+	if err != nil {
+		return fmt.Errorf("build Slack DM recipient: %w", err)
+	}
+	if err := f.events.Append(ctx, ev); err != nil {
+		return fmt.Errorf("append Slack DM recipient: %w", err)
+	}
+	return nil
+}
+
 func (f *ThreadFollower) appendParticipant(ctx context.Context, orgID, subject, workerID, routerID string) error {
 	ev, err := domainevent.New(f.mintID(), orgID, domainevent.TypeSlackThreadParticipant, subject, workerID, routerID, nil, f.now())
 	if err != nil {
@@ -195,6 +216,36 @@ func (f *ThreadFollower) AfterRoute(ctx context.Context, p processor.Processor, 
 		}
 		if err := f.appendParticipant(ctx, orgID, subject, w, string(p.ID)); err != nil {
 			f.logger.Warn("slackrouting.threadfollow: record member", "worker", w, "thread", root, "err", err)
+		}
+	}
+
+	// A top-level DM reply has no thread root to correlate with the outbound
+	// ask_human message. Route it to the Bot that most recently sent a
+	// replyable DM in this workspace/channel, unless the message named a Bot.
+	if len(matched) == 0 && msg.ThreadID == "" && f.publisher != nil {
+		var extra struct {
+			Channel     string `json:"slack_channel"`
+			ChannelType string `json:"slack_channel_type"`
+		}
+		if json.Unmarshal(msg.Extra, &extra) == nil && extra.ChannelType == "im" && extra.Channel != "" {
+			recipients, err := f.events.ListBySubject(ctx, orgID, domainevent.TypeSlackDMRecipient, threadSubject(p.ID, extra.Channel), since)
+			if err != nil {
+				f.logger.Warn("slackrouting.threadfollow: list DM recipients", "channel", extra.Channel, "err", err)
+			} else if len(recipients) > 0 {
+				workerID := recipients[0].Worker
+				if topic, ok := topicByWorker[workerID]; ok {
+					if _, err := f.publisher.Publish(ctx, orgID, topic, "", msg); err != nil {
+						f.logger.Warn("slackrouting.threadfollow: deliver DM reply", "worker", workerID, "topic", topic, "err", err)
+					} else {
+						matched[workerID] = struct{}{}
+						if _, ok := priorSet[workerID]; !ok {
+							if err := f.appendParticipant(ctx, orgID, subject, workerID, string(p.ID)); err != nil {
+								f.logger.Warn("slackrouting.threadfollow: record DM participant", "worker", workerID, "thread", root, "err", err)
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/api/pkg/org/application/slackrouting/threadfollow_test.go
+++ b/api/pkg/org/application/slackrouting/threadfollow_test.go
@@ -101,6 +101,24 @@ func TestThreadFollowRecordsNamedParticipant(t *testing.T) {
 	}
 }
 
+func TestRecordParticipantFeedsInboundThreadFollow(t *testing.T) {
+	ctx := context.Background()
+	box, f, pub := newFollower(t)
+	if err := f.RecordParticipant(ctx, org, "p-slack-router", "T1", "w-alice"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.RecordParticipant(ctx, org, "p-slack-router", "T1", "w-alice"); err != nil {
+		t.Fatal(err)
+	}
+	if parts := participants(t, box, "T1"); len(parts) != 1 || parts[0] != "w-alice" {
+		t.Fatalf("want one alice participant, got %v", parts)
+	}
+	f.AfterRoute(ctx, threadRouter(true), streaming.Message{ThreadID: "T1", MessageID: "T2", Body: "human reply"}, nil)
+	if len(pub.calls) != 1 || pub.calls[0] != "s-alice" {
+		t.Fatalf("want inbound reply delivered to alice, got %v", pub.calls)
+	}
+}
+
 func TestThreadFollowDeliversToPriorMembers(t *testing.T) {
 	ctx := context.Background()
 	box, f, pub := newFollower(t)

--- a/api/pkg/org/application/slackrouting/threadfollow_test.go
+++ b/api/pkg/org/application/slackrouting/threadfollow_test.go
@@ -77,6 +77,22 @@ func participantsFor(t *testing.T, s *store.Store, routerID, threadRoot string) 
 	return domainevent.Participants(evs)
 }
 
+func recordDMRecipient(t *testing.T, s *store.Store, routerID, channel, worker string, at time.Time) {
+	t.Helper()
+	ev, err := domainevent.New("dm-"+routerID+"-"+channel+"-"+worker, org, domainevent.TypeSlackDMRecipient, routerID+"/"+channel, worker, routerID, nil, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DomainEvents.Append(context.Background(), ev); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func slackMessage(channelType, channel, messageID, threadID string) streaming.Message {
+	extra, _ := json.Marshal(map[string]string{"slack_channel": channel, "slack_channel_type": channelType})
+	return streaming.Message{MessageID: messageID, ThreadID: threadID, Body: "reply", Extra: extra}
+}
+
 func TestDefaultConfigEnablesThreadFollow(t *testing.T) {
 	if !slackrouting.ThreadFollowEnabled(slackrouting.DefaultConfig()) {
 		t.Error("DefaultConfig should enable thread-follow (on by default)")
@@ -116,6 +132,21 @@ func TestRecordParticipantFeedsInboundThreadFollow(t *testing.T) {
 	f.AfterRoute(ctx, threadRouter(true), streaming.Message{ThreadID: "T1", MessageID: "T2", Body: "human reply"}, nil)
 	if len(pub.calls) != 1 || pub.calls[0] != "s-alice" {
 		t.Fatalf("want inbound reply delivered to alice, got %v", pub.calls)
+	}
+}
+
+func TestRecordDMRecipientAppendsRouterChannelEvent(t *testing.T) {
+	ctx := context.Background()
+	box, f, _ := newFollower(t)
+	if err := f.RecordDMRecipient(ctx, org, "p-slack-router", "D1", "w-alice"); err != nil {
+		t.Fatal(err)
+	}
+	events, err := box.DomainEvents.ListBySubject(ctx, org, domainevent.TypeSlackDMRecipient, "p-slack-router/D1", time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Worker != "w-alice" || events[0].Source != "p-slack-router" {
+		t.Fatalf("DM recipient events = %#v", events)
 	}
 }
 
@@ -199,5 +230,84 @@ func TestThreadFollowOffStillRecordsButNoFanout(t *testing.T) {
 	}
 	if len(participants(t, box, "T1")) != 1 {
 		t.Errorf("alice should still be recorded")
+	}
+}
+
+func TestDMReplyRoutesLatestRecipientAndRecordsParticipant(t *testing.T) {
+	ctx := context.Background()
+	box, f, pub := newFollower(t)
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	recordDMRecipient(t, box, "p-slack-router", "D1", "w-alice", now.Add(-time.Minute))
+	recordDMRecipient(t, box, "p-slack-router", "D1", "w-bob", now)
+
+	f.AfterRoute(ctx, threadRouter(true), slackMessage("im", "D1", "T1", ""), nameMatch("s-default"))
+
+	if len(pub.calls) != 1 || pub.calls[0] != "s-bob" {
+		t.Fatalf("want one delivery to latest recipient bob, got %v", pub.calls)
+	}
+	if got := participants(t, box, "T1"); len(got) != 1 || got[0] != "w-bob" {
+		t.Fatalf("new root participants = %v", got)
+	}
+}
+
+func TestDMReplyExplicitNameMatchWins(t *testing.T) {
+	box, f, pub := newFollower(t)
+	recordDMRecipient(t, box, "p-slack-router", "D1", "w-alice", time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC))
+
+	f.AfterRoute(context.Background(), threadRouter(true), slackMessage("im", "D1", "T1", ""), nameMatch("s-bob"))
+
+	if len(pub.calls) != 0 {
+		t.Fatalf("explicit match should suppress DM fallback, got %v", pub.calls)
+	}
+	if got := participants(t, box, "T1"); len(got) != 1 || got[0] != "w-bob" {
+		t.Fatalf("participants = %v", got)
+	}
+}
+
+func TestDMReplyFallbackOnlyAppliesToTopLevelIM(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		channelType string
+		threadID    string
+	}{
+		{name: "channel", channelType: "channel"},
+		{name: "group DM", channelType: "mpim"},
+		{name: "threaded DM", channelType: "im", threadID: "ROOT"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			box, f, pub := newFollower(t)
+			recordDMRecipient(t, box, "p-slack-router", "D1", "w-alice", time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC))
+
+			f.AfterRoute(context.Background(), threadRouter(true), slackMessage(tc.channelType, "D1", "T1", tc.threadID), nil)
+
+			if len(pub.calls) != 0 {
+				t.Fatalf("unexpected DM fallback: %v", pub.calls)
+			}
+		})
+	}
+}
+
+func TestDMReplyRecipientExpires(t *testing.T) {
+	box, f, pub := newFollower(t)
+	recordDMRecipient(t, box, "p-slack-router", "D1", "w-alice", time.Date(2026, 6, 19, 11, 59, 59, 0, time.UTC))
+
+	f.AfterRoute(context.Background(), threadRouter(true), slackMessage("im", "D1", "T1", ""), nil)
+
+	if len(pub.calls) != 0 {
+		t.Fatalf("expired recipient received fallback: %v", pub.calls)
+	}
+}
+
+func TestDMReplyRecipientIsolatedByRouterAndChannel(t *testing.T) {
+	box, f, pub := newFollower(t)
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	recordDMRecipient(t, box, "p-slack-router", "D1", "w-alice", now.Add(-time.Minute))
+	recordDMRecipient(t, box, "p-slack-router-2", "D1", "w-bob", now)
+	recordDMRecipient(t, box, "p-slack-router", "D2", "w-bob", now)
+
+	f.AfterRoute(context.Background(), threadRouter(true), slackMessage("im", "D1", "T1", ""), nil)
+
+	if len(pub.calls) != 1 || pub.calls[0] != "s-alice" {
+		t.Fatalf("want isolated alice recipient, got %v", pub.calls)
 	}
 }

--- a/api/pkg/org/domain/domainevent/domainevent.go
+++ b/api/pkg/org/domain/domainevent/domainevent.go
@@ -30,6 +30,10 @@ type Type = string
 // the thread root, Worker the participant, Source the router's processor id.
 const TypeSlackThreadParticipant Type = "slack.thread_participant"
 
+// TypeSlackDMRecipient records the Bot that most recently sent a replyable
+// ask_human DM. Subject is the workspace router and DM channel.
+const TypeSlackDMRecipient Type = "slack.dm_recipient"
+
 // DomainEvent is one recorded decision.
 //
 //   - Subject is the entity the event is keyed and queried on (for a Slack

--- a/api/pkg/org/infrastructure/runtime/helix/project.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project.go
@@ -149,10 +149,9 @@ type ProjectService interface {
 type WorkerProject struct {
 	Service ProjectService
 	// Workspace owns the on-branch file layout — WorkerProject
-	// delegates all file pushes (agent.md / role.md at first apply)
+	// delegates role.md pushes
 	// through it so there is exactly one place in the helix runtime
-	// that knows the `workers/<id>/.context/` / `.context/` path
-	// convention.
+	// that knows the `workers/<id>/.context/` path convention.
 	Workspace   *Workspace
 	Store       *store.Store
 	HelixOrgURL string
@@ -313,11 +312,9 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 					a.Logger.Warn("verify persisted repo failed; keeping existing id", "worker", workerID, "repo", repoID, "err", gerr)
 				}
 			}
-			// Re-publish canonical files so DB edits to the bot's content
-			// (role.md) and agent.md propagate to the helix-specs branch on
-			// every activation — that's the contract DefaultHelixSpecsMandate
-			// promises every Bot. Idempotent and cheap: CreateBranch
-			// and CreateOrUpdateFileContents both no-op on unchanged input.
+			// Keep the role.md workspace mirror current for tools and
+			// workflows that use the helix-specs branch. Activation prompts
+			// read Bot.Content directly. The writes are idempotent.
 			a.republishWorkerFiles(ctx, workerID, repoID, roleContent)
 			return state.ProjectID, state.AgentAppID, repoID, nil
 		}

--- a/api/pkg/org/infrastructure/runtime/helix/project_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_test.go
@@ -535,13 +535,11 @@ func TestEnsureFastPathReprovisionsDeletedRepo(t *testing.T) {
 //     CreateGitRepo / AttachRepoToProject calls)
 //   - leave the existing app configuration untouched; worker.* values
 //     are provisioning defaults and the app UI/API owns later edits.
-//   - re-publish canonical files (agent.md / role.md / identity.md)
-//     from the DB to the helix-specs branch so DB edits that don't
+//   - re-publish role.md from the DB to the helix-specs branch so DB edits that don't
 //     go through update_role / update_identity (e.g. direct store
 //     mutation, role-reconciler reseeding) still reach Workers
-//     without a fire+re-hire round trip. That contract is what
-//     DefaultHelixSpecsMandate promises every Worker; the original
-//     feature lived at commit 4a6cb33c51, regressed at 4f7837ac0c.
+//     without a fire+re-hire round trip. The original feature lived at
+//     commit 4a6cb33c51, regressed at 4f7837ac0c.
 //     See TestEnsureFastPathPropagatesRoleEdits for the propagation
 //     assertion.
 func TestEnsureWithPersistedProjectFastPaths(t *testing.T) {
@@ -627,10 +625,9 @@ func TestEnsureFastPathPreservesAgentSpec(t *testing.T) {
 // update_role MCP tool's MirrorFile push) must reach the helix-specs
 // branch on the next activation, without a fire+re-hire.
 //
-// This is the contract DefaultHelixSpecsMandate promises every Worker
-// and the contract the original feature commit 4a6cb33c51 validated
-// end-to-end. It silently regressed in commit 4f7837ac0c when the
-// fast-path republish was removed.
+// This is the contract the original feature commit 4a6cb33c51 validated
+// end-to-end. It silently regressed in commit 4f7837ac0c when the fast-path
+// republish was removed.
 func TestEnsureFastPathPropagatesRoleEdits(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/api/pkg/org/infrastructure/runtime/helix/spawner.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner.go
@@ -63,12 +63,8 @@ type SpawnerConfig struct {
 	// when HelixOrgURL routes through an auth-gated proxy (embedded
 	// SaaS alpha). Empty in standalone mode.
 	MCPAuthBearer string
-	// SpecsMandate is the activation-prompt directive that tells the
-	// agent how to find role.md / identity.md / agent.md on the
-	// helix-specs branch. Surfaced as an operator-editable config
-	// (helixSpecsMandate) so changes to the file layout or git-pull
-	// recipe don't require a deploy. Empty falls back to
-	// DefaultHelixSpecsMandate.
+	// SpecsMandate is an optional full activation mandate override.
+	// Empty uses the Bot's current Content.
 	SpecsMandate string
 	// BearerForUser, when non-nil, is called by the Spawner (and
 	// WorkerProject) on every activation to resolve the api_key that
@@ -174,12 +170,6 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 		if cfg.Store == nil {
 			return errors.New("helix spawner: store is nil")
 		}
-		mandate := cfg.SpecsMandate
-		if mandate == "" {
-			mandate = DefaultHelixSpecsMandate
-		}
-		prompt := briefing.BuildPrompt(workerID, mandate, triggers)
-
 		// Acquire global slot. The dispatcher serialises per-Worker, so
 		// blocking here only delays one Worker behind the rest of the
 		// org under burst load.
@@ -294,7 +284,16 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 			cfg.Mirror.Ensure(orgID, workerID)
 		}
 
-		sessionID, priorInteractionID, err := cfg.ensureSession(startupCtx, orgID, workerID, prompt, publish)
+		bot, err := cfg.Store.Bots.Get(startupCtx, orgID, workerID)
+		if err != nil {
+			return fmt.Errorf("load bot %s for activation: %w", workerID, err)
+		}
+		mandate := cfg.SpecsMandate
+		if mandate == "" {
+			mandate = "=== Current role ===\n" + bot.Content
+		}
+		prompt := briefing.BuildPrompt(workerID, mandate, triggers)
+		sessionID, priorInteractionID, err := cfg.ensureSession(startupCtx, orgID, workerID, prompt, bot.PreserveContext, publish)
 		if err != nil {
 			publish(activation.OutcomeFromError(err).Marker())
 			return err
@@ -344,45 +343,6 @@ func newActivationRecord(cfg SpawnerConfig, orgID string, workerID orgchart.BotI
 	}
 	return act
 }
-
-// DefaultHelixSpecsMandate points the agent at its role file, which the
-// project applier pushes to the per-Bot repo's `helix-specs` branch.
-// Surfaced through SpawnerConfig.SpecsMandate — operators override via
-// the `worker.specs_mandate` config key when the file layout or pull
-// recipe changes (no deploy required).
-//
-// A Bot has no separate identity file: its Content IS its prompt and
-// lands in role.md. There is no identity.md.
-//
-// Helix's workspace-setup script creates a worktree for the branch
-// at ~/work/helix-specs/ on every boot — but only when the branch
-// exists on the remote at boot time, so if the worktree is missing
-// the agent must materialise it itself.
-const DefaultHelixSpecsMandate = `Your org-wide policy and role files live on the
-**helix-specs** branch of your per-Bot repo. helix-org pushes them
-on hire and re-pushes them on every activation, so the remote always
-has the current owner-edited version. Path inside the branch:
-  .context/agent.md                                    (org-wide policy)
-  workers/${HELIX_WORKER_ID}/.context/role.md
-
-ALWAYS pull before reading — your local worktree is stale from prior
-activations and won't reflect owner edits made since:
-
-  if [ ! -d ~/work/helix-specs ]; then
-    cd ~/work/$(ls ~/work | grep -v helix-specs | head -1)
-    git fetch origin helix-specs
-    git worktree add ../helix-specs helix-specs
-  else
-    cd ~/work/helix-specs && git pull --ff-only origin helix-specs
-  fi
-
-Then read in this order — agent.md FIRST (it's the entrypoint that
-tells you how to be an agent at all), then role.md:
-  cat ~/work/helix-specs/.context/agent.md
-  cat ~/work/helix-specs/workers/${HELIX_WORKER_ID}/.context/role.md
-
-After meaningful work, persist state on helix-specs:
-  cd ~/work/helix-specs && git add -A && git commit -m 'checkpoint: <what>' && git push origin helix-specs`
 
 // ensureProject is a thin wrapper around WorkerProject
 // so the activation flow reads naturally. The Service / Git fields
@@ -459,7 +419,7 @@ func (c SpawnerConfig) ensureHelixOrgMCP(ctx context.Context, orgID string, work
 //     connect; if it does (hadWSError) we immediately re-queue the
 //     same prompt via the durable /messages endpoint so it lands as
 //     soon as the agent dials home.
-func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID orgchart.BotID, prompt string, _ func(string)) (string, string, error) {
+func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID orgchart.BotID, prompt string, preserveContext bool, _ func(string)) (string, string, error) {
 	state, err := LoadState(ctx, c.Store, orgID, workerID)
 	if err != nil {
 		return "", "", err
@@ -497,15 +457,7 @@ func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID
 	// own context-limit/compaction handling. Failing to read the Bot must
 	// not silently fall back to wiping a preserve-context Bot, so the
 	// error propagates.
-	preserve := false
-	if state.SessionID != "" {
-		bot, err := c.Store.Bots.Get(ctx, orgID, workerID)
-		if err != nil {
-			return "", "", fmt.Errorf("load bot %s for context policy: %w", workerID, err)
-		}
-		preserve = bot.PreserveContext
-	}
-	if state.SessionID != "" && !preserve {
+	if state.SessionID != "" && !preserveContext {
 		if err := c.Client.ClearSession(ctx, state.SessionID); err != nil {
 			return "", "", fmt.Errorf("clear session %s before re-activation: %w", state.SessionID, err)
 		}
@@ -513,7 +465,7 @@ func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID
 			c.Logger.Info("spawner: cleared session before re-activation",
 				"worker", workerID, "session", state.SessionID)
 		}
-	} else if state.SessionID != "" && preserve {
+	} else if state.SessionID != "" && preserveContext {
 		if c.Logger != nil {
 			c.Logger.Info("spawner: preserving session context across re-activation",
 				"worker", workerID, "session", state.SessionID)

--- a/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
@@ -218,6 +218,95 @@ func TestSpawnerStartsFreshAndPersistsSession(t *testing.T) {
 	}
 }
 
+func TestSpawnerSpecsMandateRemainsFullOverride(t *testing.T) {
+	t.Parallel()
+	s, wid := newHelixTestStore(t)
+	fc := &fakeHelixClient{
+		startSessionID: "ses_new",
+		outputs:        []types.SessionOutputResponse{{Status: "complete", Output: "ok"}},
+	}
+	cfg := newHelixCfg(t, fc, s)
+	cfg.SpecsMandate = "Operator policy: keep replies concise."
+	sp := Spawner(cfg)
+	if err := sp(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerHire}}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if !strings.Contains(fc.lastStartParams.Prompt, "Operator policy: keep replies concise.") {
+		t.Fatalf("prompt missing mandate override: %q", fc.lastStartParams.Prompt)
+	}
+	if strings.Contains(fc.lastStartParams.Prompt, "=== Current role ===") || strings.Contains(fc.lastStartParams.Prompt, "# Role: Engineer") {
+		t.Fatalf("explicit mandate must remain a full override: %q", fc.lastStartParams.Prompt)
+	}
+}
+
+func TestSpawnerEmbedsFreshBotContentByDefault(t *testing.T) {
+	t.Parallel()
+	s, wid := newHelixTestStore(t)
+	fc := &fakeHelixClient{
+		startSessionID: "ses_new",
+		outputs:        []types.SessionOutputResponse{{Status: "complete", Output: "ok"}},
+	}
+	sp := Spawner(newHelixCfg(t, fc, s))
+	if err := sp(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerHire}}); err != nil {
+		t.Fatalf("spawn 1: %v", err)
+	}
+	bot, err := s.Bots.Get(context.Background(), "org-test", wid)
+	if err != nil {
+		t.Fatalf("get bot: %v", err)
+	}
+	if err := s.Bots.Update(context.Background(), bot.WithContent("# Role: Principal Engineer")); err != nil {
+		t.Fatalf("update bot: %v", err)
+	}
+	if err := sp(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerEvent, EventID: "e-role"}}); err != nil {
+		t.Fatalf("spawn 2: %v", err)
+	}
+	fc.mu.Lock()
+	followUp := fc.lastSendBody
+	fc.mu.Unlock()
+	if !strings.Contains(followUp, "=== Current role ===\n# Role: Principal Engineer") {
+		t.Fatalf("follow-up prompt did not use fresh Bot.Content: %q", followUp)
+	}
+	for _, staleBootstrap := range []string{"agent.md", "git pull", "git worktree", "cat ~/work"} {
+		if strings.Contains(followUp, staleBootstrap) {
+			t.Errorf("follow-up prompt contains stale bootstrap %q: %q", staleBootstrap, followUp)
+		}
+	}
+}
+
+func TestSpawnerReadsBotAfterProjectEnsure(t *testing.T) {
+	t.Parallel()
+	s, wid := newHelixTestStore(t)
+	fc := &fakeHelixClient{
+		startSessionID: "ses_new",
+		outputs:        []types.SessionOutputResponse{{Status: "complete", Output: "ok"}},
+	}
+	cfg := newHelixCfg(t, fc, s)
+	project := cfg.ProjectService.(*fakeProjectService)
+	project.applyStarted = make(chan struct{}, 1)
+	project.applyContinue = make(chan struct{})
+	result := make(chan error, 1)
+	go func() {
+		result <- Spawner(cfg)(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerHire}})
+	}()
+	<-project.applyStarted
+	bot, err := s.Bots.Get(context.Background(), "org-test", wid)
+	if err != nil {
+		close(project.applyContinue)
+		t.Fatalf("get bot: %v", err)
+	}
+	if err := s.Bots.Update(context.Background(), bot.WithContent("# Role: Updated During Ensure")); err != nil {
+		close(project.applyContinue)
+		t.Fatalf("update bot: %v", err)
+	}
+	close(project.applyContinue)
+	if err := <-result; err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if !strings.Contains(fc.lastStartParams.Prompt, "# Role: Updated During Ensure") {
+		t.Fatalf("prompt used role read before project ensure: %q", fc.lastStartParams.Prompt)
+	}
+}
+
 // TestSpawnerAttachesHelixOrgMCPEveryActivation pins the bug-fix
 // invariant: the helix-org MCP is re-attached to the Worker's agent
 // app on every activation, after ensureProject runs. helix's project-

--- a/api/pkg/org/infrastructure/runtime/helix/workspace.go
+++ b/api/pkg/org/infrastructure/runtime/helix/workspace.go
@@ -20,8 +20,7 @@ import (
 // *services.GitRepositoryService so workspace tests don't have to
 // build a full GitRepositoryService.
 //
-// All file writes for Bot provisioning (canonical role.md /
-// agent.md plus any future per-Bot files) flow
+// All per-Bot workspace file writes flow
 // through the Workspace, which is the only place in the helix
 // runtime that knows the on-branch path layout. WorkerProject
 // delegates to Workspace for its first-apply file pushes rather
@@ -37,8 +36,7 @@ type WorkspaceGit interface {
 // the Worker's runtime state (set by WorkerProject at first
 // activation) and PUTs one file onto the configured branch at
 // `workers/<workerID>/.context/<name>` — the same path layout
-// WorkerProject.republishWorkerFiles writes and the activation
-// mandate tells the agent to `git pull` and `cat`.
+// WorkerProject.republishWorkerFiles writes.
 //
 // Workers that haven't been activated against a Helix project yet
 // (RepoID == "") are no-ops; callers don't have to gate on activation
@@ -100,23 +98,6 @@ func (w *Workspace) MirrorFile(ctx context.Context, orgID string, workerID orgch
 	}
 	if err := w.WriteWorkerFile(ctx, workerID, state.RepoID, name, content, message); err != nil {
 		return err
-	}
-	// Invalidate the bot's warm Helix chat session so the next
-	// activation opens a fresh one — which means a fresh Claude Code
-	// context that re-reads role.md from scratch rather than reusing the
-	// prior turn's cached content. Warm-session reuse is what makes
-	// routine activations fast, but it's also why a live content edit
-	// otherwise has no effect: Claude keeps acting on the content it
-	// cat'd on the first activation. Only invalidate on canonical
-	// role.md edits (the filename the activation mandate tells the agent
-	// to re-read) — checkpoint pushes or other in-bot writes keep the
-	// session warm.
-	if name == "role.md" {
-		if err := SaveSession(ctx, w.store, orgID, workerID, ""); err != nil {
-			// Non-fatal: the next activation will still pull the new
-			// content; it just won't re-read it from a fresh context.
-			return nil
-		}
 	}
 	return nil
 }

--- a/api/pkg/org/infrastructure/runtime/helix/workspace_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/workspace_test.go
@@ -118,11 +118,7 @@ func TestWorkspaceEmptyWorkerIDError(t *testing.T) {
 	}
 }
 
-// TestWorkspaceInvalidatesSessionOnRoleEdit verifies the warm-session
-// invalidation: editing role.md clears the persisted SessionID so the
-// next activation gets a fresh Claude context that re-reads role.md
-// from scratch.
-func TestWorkspaceInvalidatesSessionOnRoleEdit(t *testing.T) {
+func TestWorkspacePreservesSessionOnRoleEdit(t *testing.T) {
 	t.Parallel()
 	s, wid := newSeededStore(t, "repo-1")
 	if err := SaveSession(context.Background(), s, "org-test", wid, "ses_warm"); err != nil {
@@ -134,13 +130,13 @@ func TestWorkspaceInvalidatesSessionOnRoleEdit(t *testing.T) {
 		t.Fatalf("MirrorFile: %v", err)
 	}
 	state, _ := LoadState(context.Background(), s, "org-test", wid)
-	if state.SessionID != "" {
-		t.Errorf("session must be cleared after role edit; got %q", state.SessionID)
+	if state.SessionID != "ses_warm" {
+		t.Errorf("role edit must preserve warm session; got %q", state.SessionID)
 	}
 }
 
-// TestWorkspaceDoesNotInvalidateOnOtherFiles — checkpoint pushes leave
-// the warm session alone; only role.md invalidates.
+// TestWorkspaceDoesNotInvalidateOnOtherFiles verifies other workspace
+// writes also preserve the warm session.
 func TestWorkspaceDoesNotInvalidateOnOtherFiles(t *testing.T) {
 	t.Parallel()
 	s, wid := newSeededStore(t, "repo-1")

--- a/api/pkg/org/infrastructure/transports/slack/ingest.go
+++ b/api/pkg/org/infrastructure/transports/slack/ingest.go
@@ -47,8 +47,9 @@ func NewIngest(ws Workspaces, st *store.Store, pub Publisher, logger *slog.Logge
 // processor/filter predicates can route on channel/team and outbound
 // can stay self-consistent. Message bodies are never logged.
 type slackExtra struct {
-	Channel string `json:"slack_channel,omitempty"`
-	TeamID  string `json:"slack_team_id,omitempty"`
+	Channel     string `json:"slack_channel,omitempty"`
+	ChannelType string `json:"slack_channel_type,omitempty"`
+	TeamID      string `json:"slack_team_id,omitempty"`
 }
 
 // OnEvent is the slackcore.EventHandler the ingress sources call. It:
@@ -90,7 +91,7 @@ func (i *Ingest) OnEvent(ctx context.Context, teamID string, ev slackcore.Event)
 		return nil
 	}
 
-	extra, _ := json.Marshal(slackExtra{Channel: ev.Channel, TeamID: teamID})
+	extra, _ := json.Marshal(slackExtra{Channel: ev.Channel, ChannelType: ev.ChannelType, TeamID: teamID})
 	msg := streaming.Message{
 		From:      ev.User,
 		Body:      ev.Text,

--- a/api/pkg/org/infrastructure/transports/slack/ingest.go
+++ b/api/pkg/org/infrastructure/transports/slack/ingest.go
@@ -98,7 +98,7 @@ func (i *Ingest) OnEvent(ctx context.Context, teamID string, ev slackcore.Event)
 		ThreadID:  ev.ThreadTS,
 		MessageID: ev.TS,
 		Extra:     extra,
-		ReplyHint: replyHint(teamID, ev.Channel, ev.TS, ev.ThreadTS),
+		ReplyHint: replyHint(teamID, ev.Channel, ev.ChannelType, ev.TS, ev.ThreadTS),
 	}
 
 	for _, t := range topics {

--- a/api/pkg/org/infrastructure/transports/slack/ingest_test.go
+++ b/api/pkg/org/infrastructure/transports/slack/ingest_test.go
@@ -104,7 +104,7 @@ func TestIngest_AnyChannel_Published(t *testing.T) {
 	seedSlackTopic(t, s, "org1", "tp1", "sc1")
 
 	err := ing.OnEvent(context.Background(), "T1", slackcore.Event{
-		Channel: "C-random", User: "U1", Text: "!qa-bot help", TS: "1700.1", ThreadTS: "1699.9",
+		Channel: "C-random", ChannelType: "channel", User: "U1", Text: "!qa-bot help", TS: "1700.1", ThreadTS: "1699.9",
 	})
 	if err != nil {
 		t.Fatalf("OnEvent: %v", err)
@@ -123,8 +123,8 @@ func TestIngest_AnyChannel_Published(t *testing.T) {
 	if err := json.Unmarshal(c.msg.Extra, &ex); err != nil {
 		t.Fatalf("unmarshal extra: %v", err)
 	}
-	if ex.Channel != "C-random" {
-		t.Fatalf("Extra channel = %q, want C-random", ex.Channel)
+	if ex.Channel != "C-random" || ex.ChannelType != "channel" {
+		t.Fatalf("Extra Slack coordinates = %#v", ex)
 	}
 	// The transport stamps a ReplyHint carrying the concrete coordinates
 	// the agent needs to reply via the Slack API (no Role text required).

--- a/api/pkg/org/infrastructure/transports/slack/ingest_test.go
+++ b/api/pkg/org/infrastructure/transports/slack/ingest_test.go
@@ -133,6 +133,31 @@ func TestIngest_AnyChannel_Published(t *testing.T) {
 			t.Fatalf("ReplyHint %q missing %q", c.msg.ReplyHint, want)
 		}
 	}
+	for _, want := range []string{"Do not fetch Slack history by default", "Only when earlier thread context is necessary", "Only when channel-root context is genuinely necessary"} {
+		if !strings.Contains(c.msg.ReplyHint, want) {
+			t.Fatalf("ReplyHint %q missing conditional history guidance %q", c.msg.ReplyHint, want)
+		}
+	}
+}
+
+func TestReplyHint_TopLevelDMOmitsThreadTS(t *testing.T) {
+	hint := replyHint("T1", "D1", "im", "1700.1", "")
+	if !strings.Contains(hint, "omit thread_ts and reply at the DM root") {
+		t.Fatalf("top-level DM hint must stay at root: %q", hint)
+	}
+	if strings.Contains(hint, "thread_ts=1700.1") {
+		t.Fatalf("top-level DM hint must not invent a thread: %q", hint)
+	}
+}
+
+func TestReplyHint_ThreadedDMUsesIncomingThread(t *testing.T) {
+	hint := replyHint("T1", "D1", "im", "1700.2", "1699.9")
+	if !strings.Contains(hint, "thread_ts=1699.9") || !strings.Contains(hint, "conversations.replies with channel=D1 and ts=1699.9") {
+		t.Fatalf("threaded DM hint must preserve incoming root: %q", hint)
+	}
+	if strings.Contains(hint, "omit thread_ts") {
+		t.Fatalf("threaded DM hint must not instruct a root reply: %q", hint)
+	}
 }
 
 func TestIngest_WrongWorkspaceBinding_NotPublished(t *testing.T) {

--- a/api/pkg/org/infrastructure/transports/slack/ports.go
+++ b/api/pkg/org/infrastructure/transports/slack/ports.go
@@ -31,6 +31,8 @@ type Workspace struct {
 // matches. Treated as a drop (not an error) on the inbound path.
 var ErrNoWorkspace = errors.New("no slack workspace install for that id/team")
 
+var ErrAmbiguousWorkspace = errors.New("multiple Slack workspaces are installed; slack_team_id is required")
+
 // Workspaces resolves Slack workspace installs. Implemented at the
 // composition root over the helix ServiceConnection store (+ bot-token
 // decryption). The import edge stays one-directional — this package

--- a/api/pkg/org/infrastructure/transports/slack/reply_hint.go
+++ b/api/pkg/org/infrastructure/transports/slack/reply_hint.go
@@ -22,33 +22,36 @@ const helixSlackIconURL = "https://avatars.githubusercontent.com/u/149581110?v=4
 // reached via a processor needs nothing else; nothing about Slack lives in
 // the Worker's Role.
 //
-// A Worker is activated with ONLY the triggering message — not the
-// surrounding thread/channel. Rather than pre-loading a fixed history
-// window into every prompt, the hint tells the Worker how to read the rest
-// on demand (conversations.replies / conversations.history), so it pulls
-// exactly the context a task needs.
+// The trigger already carries the current message and routing correlation.
+// History APIs are fallbacks for tasks that genuinely need older context.
 //
-// threadTS is the thread root when the message is already in a thread,
-// empty otherwise; threadRoot (threadTS or the message ts) is what both a
-// threaded reply and a thread read key off, so replies land in the
-// existing thread rather than starting a sub-thread under one reply.
-func replyHint(teamID, channel, ts, threadTS string) string {
+// A top-level DM stays top-level. Existing DM threads and channel messages
+// use their thread root so replies remain correlated.
+func replyHint(teamID, channel, channelType, ts, threadTS string) string {
 	threadRoot := threadTS
 	if threadRoot == "" {
 		threadRoot = ts
+	}
+	replyTarget := fmt.Sprintf("channel=%s, thread_ts=%s (reply in this thread)", channel, threadRoot)
+	threadContext := fmt.Sprintf(
+		"Only when earlier thread context is necessary, call conversations.replies with channel=%s and ts=%s. ",
+		channel, threadRoot,
+	)
+	if channelType == "im" && threadTS == "" {
+		replyTarget = fmt.Sprintf("channel=%s; omit thread_ts and reply at the DM root", channel)
+		threadContext = ""
 	}
 	return fmt.Sprintf(
 		"This message is from Slack (workspace team %[1]s, channel %[2]s). Mint a bot token: call "+
 			"mint_credential with provider=\"slack\" and resource=\"%[1]s\", then use it for all the "+
 			"Slack Web API calls below.\n"+
-			"• Reply: POST https://slack.com/api/chat.postMessage with channel=%[2]s, thread_ts=%[3]s "+
-			"(reply in this thread; omit thread_ts to post at the channel root), username set to your "+
+			"- Reply: POST https://slack.com/api/chat.postMessage with %[3]s, username set to your "+
 			"own worker name (so people see which worker replied), and icon_url=%[4]s (the Helix avatar).\n"+
-			"• Read earlier messages: you are given ONLY this one message. To see the conversation so "+
-			"far, call conversations.replies with channel=%[2]s and ts=%[3]s (this thread), or "+
-			"conversations.history with channel=%[2]s (recent channel messages) — same token.\n"+
-			"• Richer responses: reactions.add, files.upload, etc. with the same token and channel.\n"+
-			"Do NOT use the publish tool to reply to Slack — it only routes inside Helix.",
-		teamID, channel, threadRoot, helixSlackIconURL,
+			"- Context: use the triggering message and routing details already in this prompt, plus any "+
+			"context in your existing conversation. Do not fetch Slack history by default. %[5]sOnly "+
+			"when channel-root context is genuinely necessary, call conversations.history with channel=%[2]s.\n"+
+			"- Richer responses: reactions.add, files.upload, etc. with the same token and channel.\n"+
+			"Do NOT use the publish tool to reply to Slack - it only routes inside Helix.",
+		teamID, channel, replyTarget, helixSlackIconURL, threadContext,
 	)
 }

--- a/api/pkg/org/interfaces/mcptools/ask_human.go
+++ b/api/pkg/org/interfaces/mcptools/ask_human.go
@@ -11,25 +11,17 @@ import (
 	"github.com/helixml/helix/api/pkg/org/domain/tool"
 )
 
-// HumanInbox delivers a bot's message to a person's in-app inbox (the
-// notification bell). Implemented at the composition root over the main
-// Helix attention-event service, so mcptools stays decoupled from it. When
-// nil, ask_human reports the inbox as unavailable.
-type HumanInbox interface {
-	// Notify writes an inbox item for the person's linked Helix user.
-	// fromBotID is the sending bot's id (routing / reply target); fromBotName is
-	// its display name (shown in the notification title). expectsReply=false
-	// delivers it as a read-only FYI (no Respond affordance) — for status
-	// updates and confirmations that don't need an answer.
-	Notify(ctx context.Context, orgID, userID, fromBotID, fromBotName, personName, message string, expectsReply bool) error
+// HumanDelivery delivers a bot's message through the person's configured
+// contact route. The composition root owns the concrete Helix and Slack APIs.
+type HumanDelivery interface {
+	Deliver(ctx context.Context, orgID string, person orgchart.Bot, fromBotID, fromBotName, message string, expectsReply bool) (string, error)
 }
 
 // AskHuman lets a bot reach a real person directly: it delivers the message to
 // the person's in-app inbox (the notification bell). Unlike `dm`, ANY bot can
 // reach ANY person — there is no reporting-line requirement, because reaching a
 // human is delivery, not a graph traversal. The person is a human node
-// (kind=human) linked to a Helix account. Reply routing + external channels
-// (email/Slack) are later stages; this is the in-app forward path.
+// (kind=human) with a configured contact identity.
 type AskHuman struct {
 	deps Deps
 }
@@ -41,8 +33,7 @@ var askHumanSchema = mustSchema[askHumanArgs]()
 func (t *AskHuman) Name() tool.Name                 { return AskHumanName }
 func (t *AskHuman) InputSchema() *jsonschema.Schema { return askHumanSchema }
 func (t *AskHuman) Description() string {
-	return "Reach a real person: deliver a message to their in-app inbox (the notification " +
-		"bell). Use this when you need a human's input, a decision, or to flag something to " +
+	return "Reach a real person through their preferred contact route. Use this when you need a human's input, a decision, or to flag something to " +
 		"them. `personId` is a person in the org — a human node whose id looks like `h-…`; " +
 		"find people with `read_bots` (they have kind=human). Unlike `dm`, any bot can reach " +
 		"any person directly — no reporting line needed. `message` is what to tell them. " +
@@ -70,8 +61,8 @@ func (t *AskHuman) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMes
 	if orgID == "" {
 		return nil, fmt.Errorf("ask_human: caller has no OrgID")
 	}
-	if t.deps.HumanInbox == nil {
-		return nil, fmt.Errorf("ask_human: inbox delivery is not configured")
+	if t.deps.HumanDelivery == nil {
+		return nil, fmt.Errorf("ask_human: human delivery is not configured")
 	}
 	person, err := t.deps.Queries.GetBot(ctx, orgID, orgchart.BotID(args.PersonID))
 	if err != nil {
@@ -80,13 +71,6 @@ func (t *AskHuman) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMes
 	if !person.IsHuman() {
 		return nil, fmt.Errorf("%q is not a person (kind=human)", args.PersonID)
 	}
-	if person.HelixUserID == "" {
-		return nil, fmt.Errorf("person %q has no linked Helix account — cannot deliver in-app", args.PersonID)
-	}
-	name := person.Name
-	if name == "" {
-		name = string(person.ID)
-	}
 	// Prefer the sending bot's display name for the notification title (e.g.
 	// "Chief of Staff", not "chief-of-staff"); fall back to its id.
 	fromBotName := inv.Caller.ID()
@@ -94,8 +78,9 @@ func (t *AskHuman) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMes
 		fromBotName = caller.Name
 	}
 	expectsReply := args.ExpectsReply == nil || *args.ExpectsReply
-	if err := t.deps.HumanInbox.Notify(ctx, orgID, person.HelixUserID, inv.Caller.ID(), fromBotName, name, args.Message, expectsReply); err != nil {
+	delivered, err := t.deps.HumanDelivery.Deliver(ctx, orgID, person, inv.Caller.ID(), fromBotName, args.Message, expectsReply)
+	if err != nil {
 		return nil, fmt.Errorf("deliver to %q: %w", args.PersonID, err)
 	}
-	return json.Marshal(map[string]string{"delivered": "inbox", "person": args.PersonID})
+	return json.Marshal(map[string]string{"delivered": delivered, "person": args.PersonID})
 }

--- a/api/pkg/org/interfaces/mcptools/ask_human_test.go
+++ b/api/pkg/org/interfaces/mcptools/ask_human_test.go
@@ -1,0 +1,49 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/org/application/bots"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
+)
+
+type fakeHumanDelivery struct {
+	person orgchart.Bot
+	route  string
+}
+
+func (f *fakeHumanDelivery) Deliver(_ context.Context, _ string, person orgchart.Bot, _, _, _ string, _ bool) (string, error) {
+	f.person = person
+	return f.route, nil
+}
+
+func TestAskHumanReturnsConfiguredDeliveryRoute(t *testing.T) {
+	ctx := context.Background()
+	st := memory.New()
+	cfg := DefaultDeps(st)
+	if _, err := cfg.botsService().Create(ctx, "org-test", bots.CreateParams{
+		ID: "h-owner", Kind: orgchart.BotKindHuman, Content: "Owner",
+		Identity: map[string]string{"preferred_contact": "slack", "slack_user_id": "U123"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	delivery := &fakeHumanDelivery{route: "slack_dm"}
+	cfg.HumanDelivery = delivery
+	target := &AskHuman{deps: cfg.Build()}
+	args, _ := json.Marshal(askHumanArgs{PersonID: "h-owner", Message: "hello"})
+	raw, err := target.Invoke(ctx, tool.Invocation{Caller: botCaller{id: "chief-of-staff", orgID: "org-test"}, Args: args})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var response map[string]string
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatal(err)
+	}
+	if response["delivered"] != "slack_dm" || delivery.person.Identity["slack_user_id"] != "U123" {
+		t.Fatalf("response/person = %#v/%#v", response, delivery.person.Identity)
+	}
+}

--- a/api/pkg/org/interfaces/mcptools/builtins.go
+++ b/api/pkg/org/interfaces/mcptools/builtins.go
@@ -112,10 +112,7 @@ type Deps struct {
 	// back to an unconstrained string array (still valid, just no enum).
 	ToolNames func() []tool.Name
 
-	// HumanInbox delivers ask_human messages to a person's in-app inbox
-	// (the notification bell). Wired at the composition root over the main
-	// Helix attention-event service; nil → ask_human reports unavailable.
-	HumanInbox HumanInbox
+	HumanDelivery HumanDelivery
 }
 
 // Config carries the construction seams the composition root supplies to
@@ -164,9 +161,8 @@ type Config struct {
 	// processor tools. Built at the composition root (needs topics
 	// provisioners). nil → Build() constructs one from Store when possible.
 	Processors *processors.Processors
-	// HumanInbox delivers ask_human messages to a person's in-app inbox.
-	// nil → ask_human reports the inbox as unavailable.
-	HumanInbox HumanInbox
+	// HumanDelivery sends ask_human messages through the person's configured route.
+	HumanDelivery HumanDelivery
 }
 
 // Build assembles the application services from the config and returns
@@ -188,7 +184,7 @@ func (c Config) Build() Deps {
 		Repositories:        c.repositoriesPort(),
 		CredentialProviders: c.CredentialProviders,
 		Hub:                 c.Hub,
-		HumanInbox:          c.HumanInbox,
+		HumanDelivery:       c.HumanDelivery,
 	}
 }
 
@@ -402,6 +398,7 @@ func RegisterBuiltins(reg *Registry, deps Deps) error {
 		&Publish{deps: deps},
 		&DM{deps: deps},
 		&AskHuman{deps: deps},
+		&SetHumanContact{deps: deps},
 		&ConfigureBotProject{deps: deps},
 		// Processors — topic transforms/filters/js. Mutations are
 		// OwnerBotTools; list/get are BaseReadTools.

--- a/api/pkg/org/interfaces/mcptools/builtins.go
+++ b/api/pkg/org/interfaces/mcptools/builtins.go
@@ -101,6 +101,9 @@ type Deps struct {
 	Repositories runtime.Repositories
 	// CredentialProviders is the registry mint_credential dispatches on.
 	CredentialProviders map[string]credential.Provider
+	// RecordCredential lets the host redact a minted token if the agent
+	// later echoes it into user-visible output.
+	RecordCredential func(orgID, provider, token string)
 	// Hub lets the long-poll read tools (read_events, bot_log) block on
 	// new events. It is a broadcaster, not a store.
 	Hub *wakebus.Bus
@@ -149,6 +152,7 @@ type Config struct {
 	Repositories        runtime.Repositories
 	Reconciler          *reconcile.Reconciler
 	CredentialProviders map[string]credential.Provider
+	RecordCredential    func(orgID, provider, token string)
 	// Lifecycle, when set, is used verbatim instead of building a fresh one,
 	// so the MCP tools share the composition root's reconciler-complete
 	// service. nil → lifecycleService() builds a standalone service.
@@ -183,6 +187,7 @@ func (c Config) Build() Deps {
 		Projects:            c.projectsService(),
 		Repositories:        c.repositoriesPort(),
 		CredentialProviders: c.CredentialProviders,
+		RecordCredential:    c.RecordCredential,
 		Hub:                 c.Hub,
 		HumanDelivery:       c.HumanDelivery,
 	}

--- a/api/pkg/org/interfaces/mcptools/defaults.go
+++ b/api/pkg/org/interfaces/mcptools/defaults.go
@@ -69,6 +69,7 @@ func OwnerBotTools() []tool.Name {
 		PublishName,
 		DMName,
 		AskHumanName,
+		SetHumanContactName,
 		// Processors: define topic transforms/filters/js and rewire them.
 		CreateProcessorName,
 		UpdateProcessorName,

--- a/api/pkg/org/interfaces/mcptools/mint_credential.go
+++ b/api/pkg/org/interfaces/mcptools/mint_credential.go
@@ -111,6 +111,9 @@ func (t *MintCredential) Invoke(ctx context.Context, inv tool.Invocation) (json.
 	if err != nil {
 		return nil, fmt.Errorf("mint %s credential: %w", args.Provider, err)
 	}
+	if t.deps.RecordCredential != nil {
+		t.deps.RecordCredential(orgID, args.Provider, cred.Token)
+	}
 	out := map[string]any{
 		"token": cred.Token,
 		"usage": cred.Usage,

--- a/api/pkg/org/interfaces/mcptools/mint_credential_test.go
+++ b/api/pkg/org/interfaces/mcptools/mint_credential_test.go
@@ -85,6 +85,28 @@ func TestMintCredential_HappyPath(t *testing.T) {
 	}
 }
 
+func TestMintCredential_RecordsRawTokenWithoutRedactingToolResult(t *testing.T) {
+	provider := &fakeProvider{name: "slack", credOut: credential.Credential{Token: "xoxb-test-secret"}}
+	var recorded string
+	mintTool := newMintTool(provider)
+	mintTool.deps.RecordCredential = func(orgID, provider, token string) {
+		recorded = orgID + ":" + provider + ":" + token
+	}
+	raw, err := mintTool.Invoke(context.Background(), tool.Invocation{
+		Caller: fakeCredCaller{id: "w-1", orgID: "org-1"},
+		Args:   json.RawMessage(`{"provider":"slack"}`),
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if recorded != "org-1:slack:xoxb-test-secret" {
+		t.Fatalf("recorded = %q", recorded)
+	}
+	if !strings.Contains(string(raw), "xoxb-test-secret") {
+		t.Fatalf("raw MCP result was redacted: %s", raw)
+	}
+}
+
 // The optional `resource` arg is passed through to the provider so it
 // can pick the right identity (e.g. the slack workspace team_id).
 func TestMintCredential_ResourcePassedThrough(t *testing.T) {

--- a/api/pkg/org/interfaces/mcptools/set_human_contact.go
+++ b/api/pkg/org/interfaces/mcptools/set_human_contact.go
@@ -1,0 +1,81 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"github.com/helixml/helix/api/pkg/org/application/bots"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+)
+
+type SetHumanContact struct {
+	deps Deps
+}
+
+const SetHumanContactName tool.Name = "set_human_contact"
+
+var setHumanContactSchema = mustSchema[setHumanContactArgs]()
+
+type setHumanContactArgs struct {
+	PersonID string            `json:"personId"`
+	Contact  map[string]string `json:"contact"`
+}
+
+func (t *SetHumanContact) Name() tool.Name                 { return SetHumanContactName }
+func (t *SetHumanContact) InputSchema() *jsonschema.Schema { return setHumanContactSchema }
+func (t *SetHumanContact) Description() string {
+	return "Patch a person's contact identity without replacing unrelated contact fields. " +
+		"Use preferred_contact=helix or slack. Slack delivery uses slack_user_id and optional " +
+		"slack_channel_id and slack_team_id. Empty values remove fields. Owner-only."
+}
+
+func (t *SetHumanContact) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	var args setHumanContactArgs
+	if err := json.Unmarshal(inv.Args, &args); err != nil {
+		return nil, fmt.Errorf("parse args: %w", err)
+	}
+	if args.PersonID == "" || len(args.Contact) == 0 {
+		return nil, fmt.Errorf("personId and contact are required")
+	}
+	orgID := inv.Caller.OrganizationID()
+	if orgID == "" {
+		return nil, fmt.Errorf("set_human_contact: caller has no OrgID")
+	}
+	person, err := t.deps.Queries.GetBot(ctx, orgID, orgchart.BotID(args.PersonID))
+	if err != nil {
+		return nil, fmt.Errorf("person %q: %w", args.PersonID, err)
+	}
+	if !person.IsHuman() {
+		return nil, fmt.Errorf("%q is not a person (kind=human)", args.PersonID)
+	}
+	identity := make(map[string]string, len(person.Identity)+len(args.Contact))
+	for key, value := range person.Identity {
+		identity[key] = value
+	}
+	for key, value := range args.Contact {
+		key, value = strings.TrimSpace(key), strings.TrimSpace(value)
+		if key == "" {
+			return nil, fmt.Errorf("contact keys cannot be empty")
+		}
+		if value == "" {
+			delete(identity, key)
+		} else {
+			identity[key] = value
+		}
+	}
+	if preferred := identity["preferred_contact"]; preferred != "" && preferred != "helix" && preferred != "slack" {
+		return nil, fmt.Errorf("preferred_contact must be helix or slack")
+	}
+	if identity["preferred_contact"] == "slack" && identity["slack_user_id"] == "" {
+		return nil, fmt.Errorf("slack_user_id is required when preferred_contact is slack")
+	}
+	if _, err := t.deps.Bots.Update(ctx, orgID, person.ID, bots.UpdateParams{Identity: &identity}); err != nil {
+		return nil, fmt.Errorf("set human contact: %w", err)
+	}
+	return json.Marshal(map[string]string{"id": args.PersonID})
+}

--- a/api/pkg/org/interfaces/mcptools/set_human_contact_test.go
+++ b/api/pkg/org/interfaces/mcptools/set_human_contact_test.go
@@ -1,0 +1,80 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/org/application/bots"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
+)
+
+func TestSetHumanContactPatchesIdentity(t *testing.T) {
+	ctx := context.Background()
+	st := memory.New()
+	cfg := DefaultDeps(st)
+	person, err := cfg.botsService().Create(ctx, "org-test", bots.CreateParams{
+		ID: "h-owner", Kind: orgchart.BotKindHuman, HelixUserID: "usr-owner",
+		Content: "Owner", Identity: map[string]string{"email": "owner@example.com", "github": "owner"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := &SetHumanContact{deps: cfg.Build()}
+	args, _ := json.Marshal(setHumanContactArgs{PersonID: string(person.ID), Contact: map[string]string{
+		"preferred_contact": "slack", "slack_user_id": "U123", "github": "",
+	}})
+	if _, err := target.Invoke(ctx, tool.Invocation{Caller: botCaller{id: "chief-of-staff", orgID: "org-test"}, Args: args}); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := st.Bots.Get(ctx, "org-test", person.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Identity["email"] != "owner@example.com" || updated.Identity["slack_user_id"] != "U123" {
+		t.Fatalf("identity patch lost or missed fields: %#v", updated.Identity)
+	}
+	if _, ok := updated.Identity["github"]; ok {
+		t.Fatalf("empty patch did not remove github: %#v", updated.Identity)
+	}
+}
+
+func TestOwnerBotToolsIncludesSetHumanContact(t *testing.T) {
+	for _, name := range OwnerBotTools() {
+		if name == SetHumanContactName {
+			return
+		}
+	}
+	t.Fatal("OwnerBotTools missing set_human_contact")
+}
+
+func TestSetHumanContactRejectsAgentAndIncompleteSlack(t *testing.T) {
+	ctx := context.Background()
+	st := memory.New()
+	cfg := DefaultDeps(st)
+	if _, err := cfg.botsService().Create(ctx, "org-test", bots.CreateParams{ID: "b-agent", Content: "Agent"}); err != nil {
+		t.Fatal(err)
+	}
+	target := &SetHumanContact{deps: cfg.Build()}
+	for _, tc := range []struct {
+		person  string
+		contact map[string]string
+		want    string
+	}{
+		{"b-agent", map[string]string{"preferred_contact": "helix"}, "not a person"},
+		{"h-owner", map[string]string{"preferred_contact": "slack"}, "slack_user_id is required"},
+		{"h-owner", map[string]string{"preferred_contact": "sms"}, "preferred_contact must be helix or slack"},
+	} {
+		if tc.person == "h-owner" {
+			_, _ = cfg.botsService().Create(ctx, "org-test", bots.CreateParams{ID: "h-owner", Kind: orgchart.BotKindHuman, Content: "Owner"})
+		}
+		args, _ := json.Marshal(setHumanContactArgs{PersonID: tc.person, Contact: tc.contact})
+		_, err := target.Invoke(ctx, tool.Invocation{Caller: botCaller{id: "chief-of-staff", orgID: "org-test"}, Args: args})
+		if err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Fatalf("error = %v, want %q", err, tc.want)
+		}
+	}
+}

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -187,6 +187,10 @@ type Deps struct {
 	// disables the "Create the Helix app" path.
 	GitHubManifestStart func(ctx context.Context, orgID, githubOrg, origin string) (GitHubManifestStartResponse, error)
 
+	// AuthorizeHumanContact allows only the person themself or an org owner
+	// to mutate a human node's identity map.
+	AuthorizeHumanContact func(ctx context.Context, orgID, humanUserID string) error
+
 	// PublicServerURL is the operator-configured external base URL
 	// (e.g. https://helix.example.com) that auto-installed GitHub
 	// webhooks should POST back to. Falls back to localhost when

--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -234,6 +234,21 @@ func (a *apiHandler) updateBot(w http.ResponseWriter, r *http.Request) {
 	}
 	var identityPatch *map[string]string
 	if req.Identity != nil {
+		target, err := a.deps.Queries.GetBot(ctx, orgID, id)
+		if err != nil {
+			writeError(w, errStatus(err), fmt.Errorf("get bot for identity update: %w", err))
+			return
+		}
+		if target.IsHuman() {
+			if a.deps.AuthorizeHumanContact == nil {
+				writeError(w, http.StatusForbidden, errors.New("human contact updates are not authorized"))
+				return
+			}
+			if err := a.deps.AuthorizeHumanContact(ctx, orgID, target.HelixUserID); err != nil {
+				writeError(w, http.StatusForbidden, err)
+				return
+			}
+		}
 		identityPatch = &req.Identity
 	}
 	updated, err := a.deps.Bots.Update(ctx, orgID, id, bots.UpdateParams{

--- a/api/pkg/org/interfaces/server/api/bots_rest_test.go
+++ b/api/pkg/org/interfaces/server/api/bots_rest_test.go
@@ -3,16 +3,67 @@ package api_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/helixml/helix/api/pkg/org/application/bots"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	"github.com/helixml/helix/api/pkg/org/domain/store"
 	"github.com/helixml/helix/api/pkg/org/domain/tool"
 	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
 	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
 	orgapi "github.com/helixml/helix/api/pkg/org/interfaces/server/api"
 )
+
+func TestRESTUpdateHumanIdentityAuthorization(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		authorize func(context.Context, string, string) error
+		want      int
+	}{
+		{"self", func(_ context.Context, _, humanUserID string) error {
+			if humanUserID != "usr-human" {
+				t.Fatalf("human user id = %q", humanUserID)
+			}
+			return nil
+		}, http.StatusOK},
+		{"owner", func(context.Context, string, string) error { return nil }, http.StatusOK},
+		{"other member", func(context.Context, string, string) error { return errors.New("forbidden") }, http.StatusForbidden},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			deps, st, _ := newDeps(t)
+			if _, err := deps.Bots.Create(context.Background(), "org-test", bots.CreateParams{
+				ID: "h-human", Kind: orgchart.BotKindHuman, HelixUserID: "usr-human", Content: "Human",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			deps.AuthorizeHumanContact = tc.authorize
+			rec := do(t, orgapi.Handler(deps), "PATCH", "/bots/h-human", orgapi.UpdateBotRequest{
+				Identity: map[string]string{"preferred_contact": "helix"},
+			})
+			if rec.Code != tc.want {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, tc.want, rec.Body)
+			}
+			updated, _ := st.Bots.Get(context.Background(), "org-test", "h-human")
+			if tc.want == http.StatusForbidden && len(updated.Identity) != 0 {
+				t.Fatalf("forbidden update changed identity: %#v", updated.Identity)
+			}
+		})
+	}
+}
+
+func TestRESTUpdateNonHumanIdentityDoesNotRequireHumanAuthorization(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	seedBot(t, st, context.Background(), "b-agent", "Agent")
+	rec := do(t, orgapi.Handler(deps), "PATCH", "/bots/b-agent", orgapi.UpdateBotRequest{
+		Identity: map[string]string{"external": "value"},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", rec.Code, rec.Body)
+	}
+}
 
 // mcpRegistry builds a tools registry over a fresh store with the given
 // deterministic clock/id, for driving MCP tools in parity tests.

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -450,6 +450,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	bc := wakebus.New(cfg.APIServer.pubsub)
 	deps := mcptools.DefaultDeps(st)
 	deps.Hub = bc
+	deps.RecordCredential = cfg.APIServer.recordCredential
 
 	// Operational config registry — chat backend creds, model
 	// selection, etc. Backed by the same Postgres rows so settings

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -51,6 +51,7 @@ import (
 	slackcore "github.com/helixml/helix/api/pkg/serviceconnection/slack"
 
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/processor"
 	"github.com/helixml/helix/api/pkg/org/domain/streaming"
 	"github.com/helixml/helix/api/pkg/pubsub"
 	helixstore "github.com/helixml/helix/api/pkg/store"
@@ -812,6 +813,14 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	// exactly like the outbound emitters above.
 	processorRunner := processing.New(st.Processors, svc.Publishing, logger)
 	dispatcher.RegisterProcessorRunner(processorRunner)
+	threadFollower := slackrouting.NewThreadFollower(slackrouting.ThreadFollowerDeps{
+		Events:    st.DomainEvents,
+		Publisher: svc.Publishing,
+		NewID:     deps.NewID,
+		Now:       deps.Now,
+		Logger:    logger,
+	})
+	processorRunner.RegisterPostRouter(threadFollower)
 
 	// Slack auto-router: a second reconciler (composition over the processors
 	// service) maintains one route per AI Worker on each Automated Slack
@@ -829,9 +838,18 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	// Share the one lifecycleSvc with the MCP tools so create_bot runs the
 	// same OrgReconcilers (Slack auto-router) as REST POST /bots.
 	deps.Lifecycle = lifecycleSvc
-	// ask_human delivers to a person's in-app inbox via the main Helix
-	// attention-event service (the notification bell).
-	deps.HumanInbox = humanInbox{store: helixStore}
+	deps.HumanDelivery = humanInbox{
+		store:           helixStore,
+		slackWorkspaces: slackWS,
+		threadFollower:  threadFollower,
+		ensureSlackRouter: func(ctx context.Context, orgID string, routerID processor.ProcessorID, workerID string) error {
+			router, err := svc.Processors.Get(ctx, orgID, routerID)
+			if err != nil {
+				return err
+			}
+			return validateSlackReplyRouter(router, strings.TrimPrefix(routerID, "p-slack-router-"), workerID)
+		},
+	}
 
 	// Activations owns start/stop/restart for REST and MCP. Built before
 	// RegisterBuiltins so start_bot / stop_bot / restart_bot share the same
@@ -859,17 +877,6 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	}
 	orgServer := helixorgserver.NewFromStore(st, reg, bc, dispatcher, logger).WithPrompts(promptReg)
 
-	// Thread-follow: the post-routing arm that records thread participation
-	// in the domain-event log and (when enabled) fans later thread messages
-	// out to existing participants. Registered late on the runner, like the
-	// dispatcher's other arms.
-	processorRunner.RegisterPostRouter(slackrouting.NewThreadFollower(slackrouting.ThreadFollowerDeps{
-		Events:    st.DomainEvents,
-		Publisher: svc.Publishing,
-		NewID:     deps.NewID,
-		Now:       deps.Now,
-		Logger:    logger,
-	}))
 	slackAutoRouter := &slackAutoRouter{procs: svc.Processors, routes: slackRouteReconciler, logger: logger}
 	apiDeps := helixorgapi.Deps{
 		Topics:        svc.Topics,
@@ -881,7 +888,20 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		Activations:   svc.Activations,
 		Processors:    svc.Processors,
 		ChartLayout:   chartlayout.New(chartlayout.Deps{Positions: st.ChartPositions, Now: deps.Now}),
-		BotRuntime:    workerRuntime,
+		AuthorizeHumanContact: func(ctx context.Context, orgID, humanUserID string) error {
+			callerID := runtimehelix.UserIDFromContext(ctx)
+			if callerID == "" {
+				return fmt.Errorf("authenticated user is missing")
+			}
+			if callerID == humanUserID {
+				return nil
+			}
+			if _, err := cfg.APIServer.authorizeOrgOwner(ctx, &types.User{ID: callerID}, orgID); err != nil {
+				return fmt.Errorf("only the person or an organization owner can update human contact details: %w", err)
+			}
+			return nil
+		},
+		BotRuntime: workerRuntime,
 		// Kept on apiDeps so legacy/tests that poke the ports directly still
 		// work; REST stop/restart now go through Activations.
 		BotSessionResetter: sessionResetter,

--- a/api/pkg/server/helix_org_slack.go
+++ b/api/pkg/server/helix_org_slack.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog/log"
+	goslack "github.com/slack-go/slack"
 
 	"github.com/helixml/helix/api/pkg/crypto"
 	"github.com/helixml/helix/api/pkg/org/application/processors"
@@ -213,10 +214,17 @@ func (w *slackWorkspaces) ByTeamID(ctx context.Context, teamID string) (slacktra
 	if err != nil {
 		return slacktransport.Workspace{}, err
 	}
+	var match *types.ServiceConnection
 	for _, conn := range conns {
 		if conn.SlackTeamID == teamID {
-			return w.toWorkspace(conn)
+			if match != nil {
+				return slacktransport.Workspace{}, slacktransport.ErrAmbiguousWorkspace
+			}
+			match = conn
 		}
+	}
+	if match != nil {
+		return w.toWorkspace(match)
 	}
 	return slacktransport.Workspace{}, slacktransport.ErrNoWorkspace
 }
@@ -405,7 +413,47 @@ func (s *HelixAPIServer) slackSigningSecrets(ctx context.Context) ([]string, err
 // after the admin approves the install. Must exactly match a Redirect
 // URL configured on the Slack app.
 func (s *HelixAPIServer) slackRedirectURI() string {
-	return s.Cfg.WebServer.URL + "/api/v1/slack/oauth/callback"
+	return strings.TrimRight(s.Cfg.WebServer.URL, "/") + "/api/v1/slack/oauth/callback"
+}
+
+func slackSettingsRedirectURL(orgID string, query url.Values) string {
+	return fmt.Sprintf("/orgs/%s/helix-org/settings?%s", url.PathEscape(orgID), query.Encode())
+}
+
+func redirectSlackSettings(w http.ResponseWriter, r *http.Request, orgID, key, message string) {
+	query := url.Values{key: []string{message}}
+	http.Redirect(w, r, slackSettingsRedirectURL(orgID, query), http.StatusFound)
+}
+
+func slackOAuthErrorMessage(code string) string {
+	if code == "access_denied" {
+		return "Slack authorization was cancelled. Try connecting the workspace again when you are ready."
+	}
+	return "Slack could not authorize the workspace. Try again or contact your Helix administrator."
+}
+
+func sanitizedSlackOAuthErrorCode(code string) string {
+	code = strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '-' {
+			return r
+		}
+		return -1
+	}, code)
+	if len(code) > 64 {
+		code = code[:64]
+	}
+	if code == "" {
+		return "unknown"
+	}
+	return code
+}
+
+func slackAuthTestError(err error) (int, string) {
+	var slackError goslack.SlackErrorResponse
+	if errors.As(err, &slackError) {
+		return http.StatusBadRequest, "Slack rejected the bot token. Check that it is an active xoxb- token for the workspace."
+	}
+	return http.StatusBadGateway, "Could not validate the bot token with Slack. Try again."
 }
 
 // listOrgSlackApps (GET /api/v1/orgs/{org}/slack/apps) lists the
@@ -514,8 +562,8 @@ func (s *HelixAPIServer) slackOAuthStart(w http.ResponseWriter, r *http.Request)
 func (s *HelixAPIServer) slackOAuthCallback(w http.ResponseWriter, r *http.Request) {
 	code := r.URL.Query().Get("code")
 	state := r.URL.Query().Get("state")
-	if code == "" || state == "" {
-		http.Error(w, "missing code or state", http.StatusBadRequest)
+	if state == "" {
+		http.Error(w, "missing state", http.StatusBadRequest)
 		return
 	}
 
@@ -530,37 +578,54 @@ func (s *HelixAPIServer) slackOAuthCallback(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	orgID, appConnID, _ := strings.Cut(string(stateBytes), "|")
+	if orgID == "" || appConnID == "" {
+		http.Error(w, "invalid state", http.StatusBadRequest)
+		return
+	}
+	if slackError := r.URL.Query().Get("error"); slackError != "" {
+		log.Warn().Str("org", orgID).Str("error_code", sanitizedSlackOAuthErrorCode(slackError)).Msg("slack oauth: authorization failed")
+		redirectSlackSettings(w, r, orgID, "slack_error", slackOAuthErrorMessage(slackError))
+		return
+	}
+	if code == "" {
+		redirectSlackSettings(w, r, orgID, "slack_error", "Slack did not return an authorization code. Try connecting the workspace again.")
+		return
+	}
 
 	app, err := s.resolveSlackApp(r.Context(), appConnID)
 	if err != nil {
-		http.Error(w, "Slack app not configured", http.StatusServiceUnavailable)
+		redirectSlackSettings(w, r, orgID, "slack_error", "The Slack app is not configured. Contact your Helix administrator.")
 		return
 	}
 	if app.SlackClientID == "" || app.SlackClientSecret == "" {
-		http.Error(w, "Slack app is missing client credentials", http.StatusServiceUnavailable)
+		redirectSlackSettings(w, r, orgID, "slack_error", "The Slack app is missing OAuth credentials. Contact your Helix administrator.")
 		return
 	}
 	clientSecret, err := crypto.DecryptAES256GCM(app.SlackClientSecret, key)
 	if err != nil {
-		http.Error(w, "Internal error", http.StatusInternalServerError)
+		log.Error().Err(err).Str("org", orgID).Msg("slack oauth: decrypt client secret")
+		redirectSlackSettings(w, r, orgID, "slack_error", "Helix could not read the Slack app credentials. Contact your Helix administrator.")
 		return
 	}
 
 	install, err := slackcore.CodeExchanger{}.ExchangeCode(r.Context(), app.SlackClientID, string(clientSecret), code, s.slackRedirectURI())
 	if err != nil {
 		log.Error().Err(err).Str("org", orgID).Msg("slack oauth: code exchange failed")
-		http.Error(w, "Slack install failed: "+err.Error(), http.StatusBadGateway)
+		redirectSlackSettings(w, r, orgID, "slack_error", "Slack could not complete the workspace connection. Try again.")
 		return
 	}
 
 	if err := s.upsertSlackWorkspace(r.Context(), orgID, install, app.ID); err != nil {
 		log.Error().Err(err).Str("org", orgID).Msg("slack oauth: persist workspace failed")
-		http.Error(w, "Failed to save Slack install", http.StatusInternalServerError)
+		if errors.Is(err, errSlackWorkspaceConflict) {
+			redirectSlackSettings(w, r, orgID, "slack_error", err.Error())
+			return
+		}
+		redirectSlackSettings(w, r, orgID, "slack_error", "Helix could not save the Slack workspace connection. Try again.")
 		return
 	}
 
-	// Redirect back to the org's integrations UI.
-	http.Redirect(w, r, fmt.Sprintf("/orgs/%s?slack_installed=1", url.PathEscape(orgID)), http.StatusFound)
+	redirectSlackSettings(w, r, orgID, "slack_installed", "1")
 }
 
 // connectSlackWorkspaceRequest is the body of the manual
@@ -619,7 +684,8 @@ func (s *HelixAPIServer) connectSlackWorkspace(w http.ResponseWriter, r *http.Re
 	// Verify the token and derive the workspace identity.
 	id, err := slackcore.AuthTest(r.Context(), slackcore.New(req.BotToken, ""))
 	if err != nil {
-		http.Error(w, "Bot token rejected by Slack: "+err.Error(), http.StatusBadGateway)
+		status, message := slackAuthTestError(err)
+		http.Error(w, message, status)
 		return
 	}
 
@@ -630,6 +696,10 @@ func (s *HelixAPIServer) connectSlackWorkspace(w http.ResponseWriter, r *http.Re
 		BotUserID: id.UserID,
 	}
 	if err := s.upsertSlackWorkspace(r.Context(), org.ID, install, req.AppConnectionID); err != nil {
+		if errors.Is(err, errSlackWorkspaceConflict) {
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
 		http.Error(w, "Failed to save workspace: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -645,6 +715,8 @@ func (s *HelixAPIServer) connectSlackWorkspace(w http.ResponseWriter, r *http.Re
 	}
 	w.WriteHeader(http.StatusCreated)
 }
+
+var errSlackWorkspaceConflict = errors.New("This Slack workspace is already connected to another Helix organization")
 
 // upsertSlackWorkspace creates or updates the org's slack_workspace
 // ServiceConnection for the installed team. Re-installing the same
@@ -668,29 +740,38 @@ func (s *HelixAPIServer) upsertSlackWorkspace(ctx context.Context, orgID string,
 		}
 	}
 
-	// Reuse an existing row for the same team in this org if present.
-	existing, _ := s.Store.ListServiceConnectionsByType(ctx, orgID, types.ServiceConnectionTypeSlackWorkspace)
+	existing, err := s.Store.ListServiceConnectionsByType(ctx, "", types.ServiceConnectionTypeSlackWorkspace)
+	if err != nil {
+		return err
+	}
+	var match *types.ServiceConnection
 	for _, conn := range existing {
-		if conn.SlackTeamID == install.TeamID {
-			conn.SlackTeamName = install.TeamName
-			conn.SlackBotUserID = install.BotUserID
-			conn.SlackAppID = install.AppID
-			conn.SlackBotToken = encToken
-			conn.Name = slackWorkspaceName(install)
-			if appConnID != "" {
-				conn.SlackAppConnectionID = appConnID
-			}
-			if err := s.Store.UpdateServiceConnection(ctx, conn); err != nil {
-				return err
-			}
-			s.helixOrg.slackTopics.ensure(ctx, orgID, conn.ID, conn.Name, appName)
-			// Re-install of an existing workspace: do NOT (re)create the
-			// router — a user-deleted router must stay deleted. Just reconcile
-			// routes (no-op if the router was deleted; picks up new Workers if
-			// it still exists).
-			s.helixOrg.slackAutoRouter.reconcile(ctx, orgID)
-			return nil
+		if conn.SlackTeamID != install.TeamID {
+			continue
 		}
+		if conn.OrganizationID != orgID {
+			return errSlackWorkspaceConflict
+		}
+		if match != nil {
+			return slacktransport.ErrAmbiguousWorkspace
+		}
+		match = conn
+	}
+	if match != nil {
+		match.SlackTeamName = install.TeamName
+		match.SlackBotUserID = install.BotUserID
+		match.SlackAppID = install.AppID
+		match.SlackBotToken = encToken
+		match.Name = slackWorkspaceName(install)
+		if appConnID != "" {
+			match.SlackAppConnectionID = appConnID
+		}
+		if err := s.Store.UpdateServiceConnection(ctx, match); err != nil {
+			return err
+		}
+		s.helixOrg.slackTopics.ensure(ctx, orgID, match.ID, match.Name, appName)
+		s.helixOrg.slackAutoRouter.reconcile(ctx, orgID)
+		return nil
 	}
 
 	conn := &types.ServiceConnection{

--- a/api/pkg/server/helix_org_slack.go
+++ b/api/pkg/server/helix_org_slack.go
@@ -159,10 +159,13 @@ var defaultSlackBotScopes = []string{
 	"groups:history",
 	"groups:read",
 	"im:history",
+	"im:write",
 	"chat:write",
 	"chat:write.customize",
 	"reactions:write",
 	"files:write",
+	"users:read",
+	"users:read.email",
 }
 
 // slackWorkspaces implements slacktransport.Workspaces over the helix
@@ -230,14 +233,31 @@ func (w *slackWorkspaces) resolveForOrg(ctx context.Context, orgID, teamID strin
 	if err != nil {
 		return slacktransport.Workspace{}, err
 	}
+	chosen, err := selectSlackWorkspace(conns, teamID)
+	if err != nil {
+		return slacktransport.Workspace{}, err
+	}
+	return w.toWorkspace(chosen)
+}
+
+func selectSlackWorkspace(conns []*types.ServiceConnection, teamID string) (*types.ServiceConnection, error) {
 	var candidates []*types.ServiceConnection
+	workspaces := map[string]bool{}
 	for _, c := range conns {
 		if teamID == "" || c.SlackTeamID == teamID {
 			candidates = append(candidates, c)
+			key := c.SlackTeamID
+			if key == "" {
+				key = c.ID
+			}
+			workspaces[key] = true
 		}
 	}
 	if len(candidates) == 0 {
-		return slacktransport.Workspace{}, slacktransport.ErrNoWorkspace
+		return nil, slacktransport.ErrNoWorkspace
+	}
+	if teamID == "" && len(workspaces) > 1 {
+		return nil, slacktransport.ErrAmbiguousWorkspace
 	}
 	chosen := candidates[0]
 	for _, c := range candidates {
@@ -246,7 +266,7 @@ func (w *slackWorkspaces) resolveForOrg(ctx context.Context, orgID, teamID strin
 			break
 		}
 	}
-	return w.toWorkspace(chosen)
+	return chosen, nil
 }
 
 // kickSlackSocket asks the Socket Mode manager to re-reconcile its

--- a/api/pkg/server/helix_org_slack_scopes_test.go
+++ b/api/pkg/server/helix_org_slack_scopes_test.go
@@ -1,0 +1,15 @@
+package server
+
+import "testing"
+
+func TestDefaultSlackBotScopesSupportHumanDelivery(t *testing.T) {
+	scopes := make(map[string]bool, len(defaultSlackBotScopes))
+	for _, scope := range defaultSlackBotScopes {
+		scopes[scope] = true
+	}
+	for _, scope := range []string{"chat:write", "im:write", "users:read", "users:read.email"} {
+		if !scopes[scope] {
+			t.Fatalf("default Slack scopes missing %q", scope)
+		}
+	}
+}

--- a/api/pkg/server/helix_org_slack_workspace_test.go
+++ b/api/pkg/server/helix_org_slack_workspace_test.go
@@ -1,12 +1,36 @@
 package server
 
 import (
+	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/crypto"
 	slacktransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/slack"
+	slackcore "github.com/helixml/helix/api/pkg/serviceconnection/slack"
+	helixstore "github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
+	goslack "github.com/slack-go/slack"
 )
+
+type slackWorkspaceTestStore struct {
+	helixstore.Store
+	connections []*types.ServiceConnection
+	updated     *types.ServiceConnection
+}
+
+func (s *slackWorkspaceTestStore) ListServiceConnectionsByType(_ context.Context, _ string, _ types.ServiceConnectionType) ([]*types.ServiceConnection, error) {
+	return s.connections, nil
+}
+
+func (s *slackWorkspaceTestStore) UpdateServiceConnection(_ context.Context, conn *types.ServiceConnection) error {
+	s.updated = conn
+	return nil
+}
 
 func TestSelectSlackWorkspaceRejectsAmbiguousDefault(t *testing.T) {
 	conns := []*types.ServiceConnection{
@@ -33,5 +57,158 @@ func TestSelectSlackWorkspaceKeepsSingleTeamConvenience(t *testing.T) {
 	}
 	if got.ID != "oauth" {
 		t.Fatalf("selected %q, want OAuth connection", got.ID)
+	}
+}
+
+func TestSlackWorkspaceByTeamIDRejectsLegacyDuplicates(t *testing.T) {
+	store := &slackWorkspaceTestStore{connections: []*types.ServiceConnection{
+		{ID: "conn-1", OrganizationID: "org-1", SlackTeamID: "T1"},
+		{ID: "conn-2", OrganizationID: "org-2", SlackTeamID: "T1"},
+	}}
+	workspaces := newSlackWorkspaces(store, func() ([]byte, error) { return make([]byte, 32), nil })
+
+	if _, err := workspaces.ByTeamID(context.Background(), "T1"); !errors.Is(err, slacktransport.ErrAmbiguousWorkspace) {
+		t.Fatalf("error = %v, want ErrAmbiguousWorkspace", err)
+	}
+}
+
+func TestUpsertSlackWorkspaceRejectsAnotherOrganization(t *testing.T) {
+	t.Setenv("HELIX_ENCRYPTION_KEY", "slack-workspace-test")
+	store := &slackWorkspaceTestStore{connections: []*types.ServiceConnection{
+		{ID: "conn-1", OrganizationID: "org-1", SlackTeamID: "T1"},
+	}}
+	server := &HelixAPIServer{Store: store}
+
+	err := server.upsertSlackWorkspace(context.Background(), "org-2", slackcore.Install{BotToken: "xoxb-new", TeamID: "T1"}, "")
+	if !errors.Is(err, errSlackWorkspaceConflict) {
+		t.Fatalf("error = %v, want errSlackWorkspaceConflict", err)
+	}
+	if err.Error() != "This Slack workspace is already connected to another Helix organization" {
+		t.Fatalf("error = %q", err)
+	}
+}
+
+func TestUpsertSlackWorkspaceRefreshesSameOrganization(t *testing.T) {
+	t.Setenv("HELIX_ENCRYPTION_KEY", "slack-workspace-test")
+	store := &slackWorkspaceTestStore{connections: []*types.ServiceConnection{
+		{ID: "conn-1", OrganizationID: "org-1", SlackTeamID: "T1", SlackBotToken: "old"},
+	}}
+	server := &HelixAPIServer{Store: store, helixOrg: &helixOrgHandlers{}}
+
+	err := server.upsertSlackWorkspace(context.Background(), "org-1", slackcore.Install{
+		BotToken: "xoxb-new",
+		TeamID:   "T1",
+		TeamName: "Acme",
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store.updated == nil || store.updated.Name != "Acme" || store.updated.SlackBotToken == "old" {
+		t.Fatalf("updated connection = %#v", store.updated)
+	}
+}
+
+func TestSlackRedirectURITrimsTrailingSlash(t *testing.T) {
+	server := &HelixAPIServer{Cfg: &config.ServerConfig{WebServer: config.WebServer{URL: "https://prime.helix.ml/"}}}
+	if got := server.slackRedirectURI(); got != "https://prime.helix.ml/api/v1/slack/oauth/callback" {
+		t.Fatalf("slackRedirectURI() = %q", got)
+	}
+}
+
+func TestSlackOAuthCallbackRedirectsSlackErrorToSettings(t *testing.T) {
+	t.Setenv("HELIX_ENCRYPTION_KEY", "slack-oauth-test")
+	key, err := crypto.GetEncryptionKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := crypto.EncryptAES256GCM([]byte("org-1|app-1"), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &HelixAPIServer{Cfg: &config.ServerConfig{WebServer: config.WebServer{URL: "https://prime.helix.ml/"}}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/slack/oauth/callback?error=access_denied&state="+url.QueryEscape(state), nil)
+	rec := httptest.NewRecorder()
+
+	server.slackOAuthCallback(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	location, err := url.Parse(rec.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if location.Path != "/orgs/org-1/helix-org/settings" {
+		t.Fatalf("redirect path = %q", location.Path)
+	}
+	if got := location.Query().Get("slack_error"); got != "Slack authorization was cancelled. Try connecting the workspace again when you are ready." {
+		t.Fatalf("slack_error = %q", got)
+	}
+}
+
+func TestSlackOAuthCallbackRejectsMissingState(t *testing.T) {
+	server := &HelixAPIServer{Cfg: &config.ServerConfig{}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/slack/oauth/callback", nil)
+	rec := httptest.NewRecorder()
+
+	server.slackOAuthCallback(rec, req)
+
+	if rec.Code != http.StatusBadRequest || rec.Body.String() != "missing state\n" {
+		t.Fatalf("status = %d, body = %q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSlackOAuthCallbackRejectsInvalidState(t *testing.T) {
+	t.Setenv("HELIX_ENCRYPTION_KEY", "slack-oauth-test")
+	server := &HelixAPIServer{Cfg: &config.ServerConfig{}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/slack/oauth/callback?state=invalid", nil)
+	rec := httptest.NewRecorder()
+
+	server.slackOAuthCallback(rec, req)
+
+	if rec.Code != http.StatusBadRequest || rec.Body.String() != "invalid state\n" {
+		t.Fatalf("status = %d, body = %q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSlackOAuthCallbackRedirectsMissingCodeToSettings(t *testing.T) {
+	t.Setenv("HELIX_ENCRYPTION_KEY", "slack-oauth-test")
+	key, err := crypto.GetEncryptionKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := crypto.EncryptAES256GCM([]byte("org-1|app-1"), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := &HelixAPIServer{Cfg: &config.ServerConfig{}}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/slack/oauth/callback?state="+url.QueryEscape(state), nil)
+	rec := httptest.NewRecorder()
+
+	server.slackOAuthCallback(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	location, err := url.Parse(rec.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if location.Path != "/orgs/org-1/helix-org/settings" {
+		t.Fatalf("redirect path = %q", location.Path)
+	}
+	if got := location.Query().Get("slack_error"); got != "Slack did not return an authorization code. Try connecting the workspace again." {
+		t.Fatalf("slack_error = %q", got)
+	}
+}
+
+func TestSlackAuthTestErrorClassifiesSlackResponse(t *testing.T) {
+	status, _ := slackAuthTestError(goslack.SlackErrorResponse{Err: "invalid_auth"})
+	if status != http.StatusBadRequest {
+		t.Fatalf("Slack API error status = %d", status)
+	}
+	status, _ = slackAuthTestError(errors.New("connection refused"))
+	if status != http.StatusBadGateway {
+		t.Fatalf("network error status = %d", status)
 	}
 }

--- a/api/pkg/server/helix_org_slack_workspace_test.go
+++ b/api/pkg/server/helix_org_slack_workspace_test.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"errors"
+	"testing"
+
+	slacktransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/slack"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+func TestSelectSlackWorkspaceRejectsAmbiguousDefault(t *testing.T) {
+	conns := []*types.ServiceConnection{
+		{ID: "conn-1", SlackTeamID: "T1"},
+		{ID: "conn-2", SlackTeamID: "T2"},
+	}
+	if _, err := selectSlackWorkspace(conns, ""); !errors.Is(err, slacktransport.ErrAmbiguousWorkspace) {
+		t.Fatalf("error = %v, want ErrAmbiguousWorkspace", err)
+	}
+	got, err := selectSlackWorkspace(conns, "T2")
+	if err != nil || got.ID != "conn-2" {
+		t.Fatalf("explicit team selected %#v, %v", got, err)
+	}
+}
+
+func TestSelectSlackWorkspaceKeepsSingleTeamConvenience(t *testing.T) {
+	conns := []*types.ServiceConnection{
+		{ID: "manual", SlackTeamID: "T1"},
+		{ID: "oauth", SlackTeamID: "T1", SlackAppConnectionID: "app-1"},
+	}
+	got, err := selectSlackWorkspace(conns, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "oauth" {
+		t.Fatalf("selected %q, want OAuth connection", got.ID)
+	}
+}

--- a/api/pkg/server/helixorg/config_specs.go
+++ b/api/pkg/server/helixorg/config_specs.go
@@ -45,7 +45,7 @@ func RegisterConfigSpecs(r *configregistry.Registry) {
 	r.Register(configregistry.Spec{
 		Key:         "worker.specs_mandate",
 		Type:        configregistry.TypeString,
-		Description: "Activation-prompt directive that tells every Worker how to find role.md / identity.md / agent.md on the helix-specs branch and how to checkpoint state back. The default (runtimehelix.DefaultHelixSpecsMandate) handles the standard layout; override when the file paths, the git-pull recipe, or the checkpoint convention change without redeploying. Use an empty string to fall back to the default.",
+		Description: "Optional full activation mandate override. When empty, every activation embeds the Worker's current role content.",
 	})
 	r.Register(configregistry.Spec{
 		Key:         "helix.url",

--- a/api/pkg/server/human_inbox.go
+++ b/api/pkg/server/human_inbox.go
@@ -39,6 +39,7 @@ type slackAPI interface {
 
 type slackThreadRecorder interface {
 	RecordParticipant(context.Context, string, processor.ProcessorID, string, string) error
+	RecordDMRecipient(context.Context, string, processor.ProcessorID, string, string) error
 }
 
 func validateSlackReplyRouter(router processor.Processor, workspaceID, workerID string) error {
@@ -145,8 +146,10 @@ func (h humanInbox) deliverSlack(ctx context.Context, orgID string, person orgch
 		message = fmt.Sprintf("<@%s> %s", userID, message)
 	}
 	text := fmt.Sprintf("*Message from %s*\n%s", fromBotName, message)
-	if expectsReply {
+	if expectsReply && delivered == "slack_channel" {
 		text += "\n\nReply in this thread to respond."
+	} else if expectsReply {
+		text += "\n\nReply here to respond."
 	}
 	_, timestamp, err := client.PostMessageContext(ctx, channelID, slack.MsgOptionText(text, false))
 	if err != nil {
@@ -158,6 +161,11 @@ func (h humanInbox) deliverSlack(ctx context.Context, orgID string, person orgch
 		}
 		if err := h.threadFollower.RecordParticipant(ctx, orgID, routerID, timestamp, fromBotID); err != nil {
 			return "", fmt.Errorf("register Slack reply routing: %w", err)
+		}
+		if delivered == "slack_dm" {
+			if err := h.threadFollower.RecordDMRecipient(ctx, orgID, routerID, channelID, fromBotID); err != nil {
+				return "", fmt.Errorf("register Slack DM reply routing: %w", err)
+			}
 		}
 	}
 	return delivered, nil

--- a/api/pkg/server/human_inbox.go
+++ b/api/pkg/server/human_inbox.go
@@ -6,20 +6,71 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/slack-go/slack"
+
+	"github.com/helixml/helix/api/pkg/org/application/slackrouting"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/processor"
+	slacktransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/slack"
+	slackcore "github.com/helixml/helix/api/pkg/serviceconnection/slack"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/types"
 )
 
-// humanInbox delivers ask_human messages to a person's in-app inbox by
-// writing an attention-event (the notification bell) for their linked Helix
-// user. Satisfies mcptools.HumanInbox. It is the composition-root adapter that
-// keeps the org MCP tools decoupled from the main Helix attention service.
+// humanInbox delivers ask_human messages through Helix or Slack according to
+// the person's preferred contact identity.
 type humanInbox struct {
-	store store.Store
+	store             store.Store
+	slackWorkspaces   slackWorkspaceResolver
+	slackClient       func(string) slackAPI
+	threadFollower    slackThreadRecorder
+	ensureSlackRouter func(context.Context, string, processor.ProcessorID, string) error
 }
 
-func (h humanInbox) Notify(ctx context.Context, orgID, userID, fromBotID, fromBotName, personName, message string, expectsReply bool) error {
+type slackWorkspaceResolver interface {
+	resolveForOrg(context.Context, string, string) (slacktransport.Workspace, error)
+}
+
+type slackAPI interface {
+	OpenConversationContext(context.Context, *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error)
+	PostMessageContext(context.Context, string, ...slack.MsgOption) (string, string, error)
+}
+
+type slackThreadRecorder interface {
+	RecordParticipant(context.Context, string, processor.ProcessorID, string, string) error
+}
+
+func validateSlackReplyRouter(router processor.Processor, workspaceID, workerID string) error {
+	if !router.Automated() || router.Kind != processor.KindFilter || router.InputTopicID != slackWorkspaceTopicID(workspaceID) {
+		return fmt.Errorf("processor is not the workspace's automated Slack router")
+	}
+	if !slackrouting.ThreadFollowEnabled(router.Config) {
+		return fmt.Errorf("thread follow is disabled")
+	}
+	for _, output := range router.Outputs {
+		if output.ManagedFor == workerID {
+			return nil
+		}
+	}
+	return fmt.Errorf("router has no route for worker %q", workerID)
+}
+
+func (h humanInbox) Deliver(ctx context.Context, orgID string, person orgchart.Bot, fromBotID, fromBotName, message string, expectsReply bool) (string, error) {
+	switch person.Identity["preferred_contact"] {
+	case "", "helix":
+		if err := h.notifyHelix(ctx, orgID, person.HelixUserID, fromBotID, fromBotName, person.Name, message, expectsReply); err != nil {
+			return "", err
+		}
+		return "helix", nil
+	case "slack":
+		return h.deliverSlack(ctx, orgID, person, fromBotID, fromBotName, message, expectsReply)
+	default:
+		return "", fmt.Errorf("unsupported preferred contact %q", person.Identity["preferred_contact"])
+	}
+}
+
+func (h humanInbox) notifyHelix(ctx context.Context, orgID, userID, fromBotID, fromBotName, personName, message string, expectsReply bool) error {
 	if userID == "" {
 		return fmt.Errorf("person has no linked Helix user")
 	}
@@ -49,9 +100,71 @@ func (h humanInbox) Notify(ctx context.Context, orgID, userID, fromBotID, fromBo
 	return nil
 }
 
+func (h humanInbox) deliverSlack(ctx context.Context, orgID string, person orgchart.Bot, fromBotID, fromBotName, message string, expectsReply bool) (string, error) {
+	userID := person.Identity["slack_user_id"]
+	if userID == "" {
+		return "", fmt.Errorf("person has no slack_user_id")
+	}
+	if h.slackWorkspaces == nil {
+		return "", fmt.Errorf("Slack delivery is not configured")
+	}
+	workspace, err := h.slackWorkspaces.resolveForOrg(ctx, orgID, person.Identity["slack_team_id"])
+	if err != nil {
+		return "", fmt.Errorf("resolve Slack workspace: %w", err)
+	}
+	routerID := slackAutoRouterID(workspace.ID)
+	if expectsReply {
+		if h.ensureSlackRouter == nil {
+			return "", fmt.Errorf("Slack reply routing is not configured")
+		}
+		if err := h.ensureSlackRouter(ctx, orgID, routerID, fromBotID); err != nil {
+			return "", fmt.Errorf("Slack reply router %q is unavailable: %w", routerID, err)
+		}
+		if h.threadFollower == nil {
+			return "", fmt.Errorf("Slack reply routing is not configured")
+		}
+	}
+	clientFactory := h.slackClient
+	if clientFactory == nil {
+		clientFactory = func(token string) slackAPI { return slackcore.New(token, "") }
+	}
+	client := clientFactory(workspace.BotToken)
+	channelID := person.Identity["slack_channel_id"]
+	delivered := "slack_channel"
+	if channelID == "" {
+		channel, _, _, err := client.OpenConversationContext(ctx, &slack.OpenConversationParameters{Users: []string{userID}})
+		if err != nil {
+			return "", fmt.Errorf("open Slack DM: %w", err)
+		}
+		if channel == nil || channel.ID == "" {
+			return "", fmt.Errorf("open Slack DM: Slack returned no channel")
+		}
+		channelID = channel.ID
+		delivered = "slack_dm"
+	} else {
+		message = fmt.Sprintf("<@%s> %s", userID, message)
+	}
+	text := fmt.Sprintf("*Message from %s*\n%s", fromBotName, message)
+	if expectsReply {
+		text += "\n\nReply in this thread to respond."
+	}
+	_, timestamp, err := client.PostMessageContext(ctx, channelID, slack.MsgOptionText(text, false))
+	if err != nil {
+		return "", fmt.Errorf("post Slack message: %w", err)
+	}
+	if expectsReply {
+		if timestamp == "" {
+			return "", fmt.Errorf("post Slack message: Slack returned no message timestamp for reply routing")
+		}
+		if err := h.threadFollower.RecordParticipant(ctx, orgID, routerID, timestamp, fromBotID); err != nil {
+			return "", fmt.Errorf("register Slack reply routing: %w", err)
+		}
+	}
+	return delivered, nil
+}
+
 // NotifyInfo writes an informational, no-reply message to a person's inbox (the
-// notification bell) — e.g. "the Chief of Staff is starting up". Unlike Notify
-// (an ask_human that expects a reply), the metadata carries no_reply so the UI
+// notification bell), e.g. "the Chief of Staff is starting up". The metadata carries no_reply so the UI
 // renders it as a read-only status, not a message to answer. Best-effort at the
 // call site: a failure must not block whatever it hangs off (e.g. org create).
 func (h humanInbox) NotifyInfo(ctx context.Context, orgID, userID, fromBot, title, message string) error {

--- a/api/pkg/server/human_inbox_test.go
+++ b/api/pkg/server/human_inbox_test.go
@@ -93,10 +93,18 @@ func (f *fakeSlackAPI) PostMessageContext(_ context.Context, channelID string, _
 }
 
 type fakeThreadRecorder struct {
-	router processor.ProcessorID
-	root   string
-	worker string
-	err    error
+	router    processor.ProcessorID
+	root      string
+	worker    string
+	dmChannel string
+	dmWorker  string
+	dmRouter  processor.ProcessorID
+	err       error
+}
+
+func (f *fakeThreadRecorder) RecordDMRecipient(_ context.Context, _ string, router processor.ProcessorID, channel, worker string) error {
+	f.dmRouter, f.dmChannel, f.dmWorker = router, channel, worker
+	return f.err
 }
 
 func (f *fakeThreadRecorder) RecordParticipant(_ context.Context, _ string, router processor.ProcessorID, root, worker string) error {
@@ -141,7 +149,53 @@ func TestHumanDeliverySlackDMAndChannel(t *testing.T) {
 			if recorder.router != "p-slack-router-conn-1" || recorder.root != api.postTS || recorder.worker != "b-sender" {
 				t.Fatalf("thread registration = %#v", recorder)
 			}
+			if tc.channelID == "" {
+				if recorder.dmRouter != "p-slack-router-conn-1" || recorder.dmChannel != "D123" || recorder.dmWorker != "b-sender" {
+					t.Fatalf("DM registration = %#v", recorder)
+				}
+			} else if recorder.dmChannel != "" {
+				t.Fatalf("channel delivery registered DM recipient: %#v", recorder)
+			}
 		})
+	}
+}
+
+func TestHumanDeliverySlackNoReplyDoesNotRecordDMRecipient(t *testing.T) {
+	api := &fakeSlackAPI{}
+	recorder := &fakeThreadRecorder{}
+	h := humanInbox{
+		slackWorkspaces: fakeSlackWorkspaces{workspace: slacktransport.Workspace{ID: "conn-1", BotToken: "xoxb-test"}},
+		slackClient:     func(string) slackAPI { return api },
+		threadFollower:  recorder,
+	}
+	person := orgchart.Bot{Identity: map[string]string{"preferred_contact": "slack", "slack_user_id": "U123"}}
+	if _, err := h.Deliver(context.Background(), "org-1", person, "b-sender", "Sender", "hello", false); err != nil {
+		t.Fatal(err)
+	}
+	if recorder.dmChannel != "" || recorder.root != "" {
+		t.Fatalf("no-reply delivery registered routing: %#v", recorder)
+	}
+}
+
+func TestHumanDeliverySlackPostFailureDoesNotRecordRouting(t *testing.T) {
+	api := &fakeSlackAPI{err: errors.New("post failed")}
+	recorder := &fakeThreadRecorder{}
+	h := humanInbox{
+		slackWorkspaces: fakeSlackWorkspaces{workspace: slacktransport.Workspace{ID: "conn-1", BotToken: "xoxb-test"}},
+		slackClient:     func(string) slackAPI { return api },
+		threadFollower:  recorder,
+		ensureSlackRouter: func(context.Context, string, processor.ProcessorID, string) error {
+			return nil
+		},
+	}
+	person := orgchart.Bot{Identity: map[string]string{
+		"preferred_contact": "slack", "slack_user_id": "U123", "slack_channel_id": "C123",
+	}}
+	if _, err := h.Deliver(context.Background(), "org-1", person, "b-sender", "Sender", "hello", true); err == nil {
+		t.Fatal("expected post failure")
+	}
+	if recorder.root != "" || recorder.dmChannel != "" {
+		t.Fatalf("failed post registered routing: %#v", recorder)
 	}
 }
 

--- a/api/pkg/server/human_inbox_test.go
+++ b/api/pkg/server/human_inbox_test.go
@@ -3,10 +3,16 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
+	"github.com/slack-go/slack"
 	"go.uber.org/mock/gomock"
 
+	"github.com/helixml/helix/api/pkg/org/application/slackrouting"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/processor"
+	slacktransport "github.com/helixml/helix/api/pkg/org/infrastructure/transports/slack"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 )
@@ -37,8 +43,9 @@ func TestHumanInboxNotifyExpectsReply(t *testing.T) {
 				})
 
 			h := humanInbox{store: mockStore}
-			if err := h.Notify(context.Background(), "org_1", "usr_1", "chief-of-staff", "Chief of Staff", "Priya", "hi", tc.expectsReply); err != nil {
-				t.Fatalf("Notify: %v", err)
+			person := orgchart.Bot{HelixUserID: "usr_1", Name: "Priya"}
+			if _, err := h.Deliver(context.Background(), "org_1", person, "chief-of-staff", "Chief of Staff", "hi", tc.expectsReply); err != nil {
+				t.Fatalf("Deliver: %v", err)
 			}
 
 			var meta map[string]string
@@ -53,5 +60,138 @@ func TestHumanInboxNotifyExpectsReply(t *testing.T) {
 				t.Fatalf("bot_id = %q, want chief-of-staff", meta["bot_id"])
 			}
 		})
+	}
+}
+
+type fakeSlackWorkspaces struct {
+	workspace slacktransport.Workspace
+	err       error
+}
+
+func (f fakeSlackWorkspaces) resolveForOrg(context.Context, string, string) (slacktransport.Workspace, error) {
+	return f.workspace, f.err
+}
+
+type fakeSlackAPI struct {
+	openedUser string
+	postedTo   string
+	postTS     string
+	err        error
+}
+
+func (f *fakeSlackAPI) OpenConversationContext(_ context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+	f.openedUser = params.Users[0]
+	if f.err != nil {
+		return nil, false, false, f.err
+	}
+	return &slack.Channel{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "D123"}}}, false, false, nil
+}
+
+func (f *fakeSlackAPI) PostMessageContext(_ context.Context, channelID string, _ ...slack.MsgOption) (string, string, error) {
+	f.postedTo = channelID
+	return channelID, f.postTS, f.err
+}
+
+type fakeThreadRecorder struct {
+	router processor.ProcessorID
+	root   string
+	worker string
+	err    error
+}
+
+func (f *fakeThreadRecorder) RecordParticipant(_ context.Context, _ string, router processor.ProcessorID, root, worker string) error {
+	f.router, f.root, f.worker = router, root, worker
+	return f.err
+}
+
+func TestHumanDeliverySlackDMAndChannel(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		channelID   string
+		wantRoute   string
+		wantChannel string
+	}{
+		{"dm", "", "slack_dm", "D123"},
+		{"channel", "C123", "slack_channel", "C123"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			api := &fakeSlackAPI{postTS: "1700000000.000100"}
+			recorder := &fakeThreadRecorder{}
+			h := humanInbox{
+				slackWorkspaces: fakeSlackWorkspaces{workspace: slacktransport.Workspace{ID: "conn-1", BotToken: "xoxb-test"}},
+				slackClient:     func(string) slackAPI { return api },
+				threadFollower:  recorder,
+				ensureSlackRouter: func(context.Context, string, processor.ProcessorID, string) error {
+					return nil
+				},
+			}
+			person := orgchart.Bot{Identity: map[string]string{
+				"preferred_contact": "slack", "slack_user_id": "U123", "slack_channel_id": tc.channelID,
+			}}
+			route, err := h.Deliver(context.Background(), "org-1", person, "b-sender", "Sender", "hello", true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if route != tc.wantRoute || api.postedTo != tc.wantChannel {
+				t.Fatalf("route/channel = %q/%q, want %q/%q", route, api.postedTo, tc.wantRoute, tc.wantChannel)
+			}
+			if tc.channelID == "" && api.openedUser != "U123" {
+				t.Fatalf("opened user = %q", api.openedUser)
+			}
+			if recorder.router != "p-slack-router-conn-1" || recorder.root != api.postTS || recorder.worker != "b-sender" {
+				t.Fatalf("thread registration = %#v", recorder)
+			}
+		})
+	}
+}
+
+func TestHumanDeliverySlackDoesNotFallback(t *testing.T) {
+	h := humanInbox{slackWorkspaces: fakeSlackWorkspaces{err: errors.New("not installed")}}
+	person := orgchart.Bot{HelixUserID: "usr-1", Identity: map[string]string{
+		"preferred_contact": "slack", "slack_user_id": "U123",
+	}}
+	if _, err := h.Deliver(context.Background(), "org-1", person, "b-sender", "Sender", "hello", false); err == nil {
+		t.Fatal("Slack failure must not fall back to Helix")
+	}
+}
+
+func TestHumanDeliverySlackRequiresReplyRouterBeforePosting(t *testing.T) {
+	api := &fakeSlackAPI{postTS: "1700000000.000100"}
+	h := humanInbox{
+		slackWorkspaces: fakeSlackWorkspaces{workspace: slacktransport.Workspace{ID: "conn-1", BotToken: "xoxb-test"}},
+		slackClient:     func(string) slackAPI { return api },
+		ensureSlackRouter: func(context.Context, string, processor.ProcessorID, string) error {
+			return errors.New("missing")
+		},
+	}
+	person := orgchart.Bot{Identity: map[string]string{"preferred_contact": "slack", "slack_user_id": "U123"}}
+	if _, err := h.Deliver(context.Background(), "org-1", person, "b-sender", "Sender", "hello", true); err == nil {
+		t.Fatal("expected missing reply router error")
+	}
+	if api.postedTo != "" {
+		t.Fatal("message posted before reply routing was validated")
+	}
+}
+
+func TestValidateSlackReplyRouter(t *testing.T) {
+	router := processor.Processor{
+		ID: "p-slack-router-conn-1", InputTopicID: "s-slack-ws-conn-1", Kind: processor.KindFilter,
+		CreatedBy: processor.SystemActor, Config: slackrouting.DefaultConfig(), Outputs: []processor.Output{{ManagedFor: "b-sender"}},
+	}
+	if err := validateSlackReplyRouter(router, "conn-1", "b-sender"); err != nil {
+		t.Fatal(err)
+	}
+	router.Config = nil
+	if err := validateSlackReplyRouter(router, "conn-1", "b-sender"); err == nil {
+		t.Fatal("disabled thread follow should be rejected")
+	}
+	router.Config = slackrouting.DefaultConfig()
+	router.CreatedBy = "human"
+	if err := validateSlackReplyRouter(router, "conn-1", "b-sender"); err == nil {
+		t.Fatal("non-automated processor should be rejected")
+	}
+	router.CreatedBy = processor.SystemActor
+	if err := validateSlackReplyRouter(router, "conn-1", "b-other"); err == nil {
+		t.Fatal("missing worker route should be rejected")
 	}
 }

--- a/api/pkg/server/org_graph_seed.go
+++ b/api/pkg/server/org_graph_seed.go
@@ -163,6 +163,7 @@ func (s *orgGraphSeeder) SeedChiefOfStaff(ctx context.Context, orgID string) err
 		Name:            "Chief of Staff",
 		Content:         chiefOfStaffContent,
 		Tools:           mcptools.OwnerBotTools(),
+		PreserveContext: true,
 		DeferActivation: true,
 	}); err != nil {
 		if _, getErr := s.botStore.Get(ctx, orgID, chiefOfStaffBotID); getErr == nil {

--- a/api/pkg/server/org_graph_seed.go
+++ b/api/pkg/server/org_graph_seed.go
@@ -27,12 +27,15 @@ You are the Chief of Staff for this organization - the owner's right hand, here 
 On your first activation you do not yet know what this organization is for. Find the owner and ask them - do NOT guess, and do NOT just write the question into your own transcript (they will not see that).
 
 1. Call ` + "`read_bots`" + ` and find the **person** - the node whose ` + "`kind`" + ` is ` + "`human`" + ` (its id looks like ` + "`h-…`" + `). On a new org there is exactly one: the owner who created it.
-2. Use ` + "`ask_human`" + ` with that person's id to deliver a message straight to their inbox (their notification bell). Ask them, in one friendly message:
+2. Use ` + "`ask_human`" + ` with that person's id to deliver the initial message through Helix notifications. Ask them, in one friendly message:
    - what this organization is for and what they want to accomplish,
    - who the key people are and what they are responsible for,
+   - whether future messages should arrive in Helix or Slack,
    - and anything else you need to set it up well.
 
 Keep it to a single, concise message - you can follow up once they reply.
+
+If they choose Slack, ask them to install the org's Slack workspace from the Helix Slack integration settings, then ask for their Slack email and, if they prefer a shared channel, its channel name. Do not make them find opaque Slack IDs. Use ` + "`mint_credential`" + ` with provider ` + "`slack`" + `, then call Slack's ` + "`users.lookupByEmail`" + ` and ` + "`conversations.list`" + ` APIs to resolve the canonical user, channel, and team IDs. Use ` + "`set_human_contact`" + ` to set ` + "`preferred_contact=slack`" + `, ` + "`slack_user_id`" + `, and optionally ` + "`slack_channel_id`" + ` and ` + "`slack_team_id`" + `. Ask for IDs only if lookup fails. If they choose Helix, set ` + "`preferred_contact=helix`" + `. Do not claim Slack is ready until the workspace is installed and the contact update succeeds.
 
 ## Then set things up
 When the owner answers, use what they told you to build the org: bring in assistant bots for the concrete pieces of work, give each a clear purpose, connect who works with whom, and subscribe them to the topics they need. Coordinate and keep things organized, and delegate the hands-on work to the assistants you bring in rather than doing it all yourself. Reach the owner again with ` + "`ask_human`" + ` whenever you need a decision or their input.

--- a/api/pkg/server/org_graph_seed_test.go
+++ b/api/pkg/server/org_graph_seed_test.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/org/application/bots"
+	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
+	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
+)
+
+func TestSeedChiefOfStaffPreservesContextForNewBotOnly(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := orggorm.GetOrgTestDB(t)
+	deps := mcptools.DefaultDeps(st).Build()
+	seeder := &orgGraphSeeder{lifecycle: deps.Lifecycle, bots: deps.Bots, botStore: st.Bots}
+
+	if err := seeder.SeedChiefOfStaff(ctx, "org-new"); err != nil {
+		t.Fatalf("seed new chief of staff: %v", err)
+	}
+	created, err := st.Bots.Get(ctx, "org-new", chiefOfStaffBotID)
+	if err != nil {
+		t.Fatalf("get new chief of staff: %v", err)
+	}
+	if !created.PreserveContext {
+		t.Fatal("new chief of staff must preserve conversation context")
+	}
+
+	if _, err := deps.Bots.Create(ctx, "org-existing", bots.CreateParams{
+		ID:      string(chiefOfStaffBotID),
+		Name:    "Chief of Staff",
+		Content: chiefOfStaffContent,
+	}); err != nil {
+		t.Fatalf("create existing chief of staff: %v", err)
+	}
+	if err := seeder.SeedChiefOfStaff(ctx, "org-existing"); err != nil {
+		t.Fatalf("reseed existing chief of staff: %v", err)
+	}
+	existing, err := st.Bots.Get(ctx, "org-existing", chiefOfStaffBotID)
+	if err != nil {
+		t.Fatalf("get existing chief of staff: %v", err)
+	}
+	if existing.PreserveContext {
+		t.Fatal("reseed must not override an existing chief of staff's context preference")
+	}
+}

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -134,6 +134,8 @@ type HelixAPIServer struct {
 	contextMappingsMutex        sync.RWMutex      // Mutex for contextMappings (and related mappings below)
 	requestToSessionMapping     map[string]string // request_id -> Helix session_id mapping (for chat_message routing)
 	requestToInteractionMapping map[string]string // request_id -> interaction_id (for routing message_added/completed to correct interaction)
+	credentialTokensMu          sync.RWMutex
+	credentialTokens            map[string]map[string]struct{} // org_id -> minted tokens
 	// (interaction → prompt link is now persisted on Interaction.PromptID
 	// so it survives API restart; the in-memory map was deleted in the
 	// 2026-04-30 stuck-queue fix.)
@@ -369,6 +371,7 @@ func NewServer(
 		contextMappings:            make(map[string]string),
 
 		requestToSessionMapping:     make(map[string]string),
+		credentialTokens:            make(map[string]map[string]struct{}),
 		pendingCancelChannels:       make(map[string]chan string),
 		externalAgentSessionMapping: make(map[string]string),
 		externalAgentUserMapping:    make(map[string]string),

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -60,6 +60,10 @@ func isMissingCodexRolloutError(errMsg string) bool {
 	return strings.Contains(errMsg, "no rollout found for thread id")
 }
 
+func isAuthoritativeMissingThreadError(errMsg string) bool {
+	return isMissingCodexRolloutError(errMsg) || strings.Contains(errMsg, `no thread found with ID: SessionId("`)
+}
+
 // acpWedgeCrashThreshold is how many prior retries a prompt must already have
 // accumulated before a recurring thread_load_error is treated as terminal
 // (crash-marked, surfacing Restart) rather than retried again. A thread_load_error
@@ -3540,6 +3544,72 @@ func truncateString(s string, maxLen int) string {
 	return s[:maxLen] + "..."
 }
 
+// recoverMissingThread clears an authoritative stale ACP thread and replays
+// its existing waiting interaction as the first message of a replacement
+// thread. The persisted thread ID prevents duplicate errors from replaying it.
+func (apiServer *HelixAPIServer) recoverMissingThread(ctx context.Context, sessionID, acpThreadID, requestID string) (bool, error) {
+	session, err := apiServer.Controller.Options.Store.GetSession(ctx, sessionID)
+	if err != nil {
+		return false, fmt.Errorf("load session for stale thread recovery: %w", err)
+	}
+	if session == nil || session.Metadata.ZedThreadID != acpThreadID {
+		return true, nil
+	}
+	session.Metadata.ZedThreadID = ""
+	if err := apiServer.Controller.Options.Store.UpdateSessionMetadata(ctx, sessionID, session.Metadata); err != nil {
+		return false, fmt.Errorf("clear stale ACP thread: %w", err)
+	}
+
+	apiServer.contextMappingsMutex.Lock()
+	delete(apiServer.contextMappings, acpThreadID)
+	interactionID := apiServer.requestToInteractionMapping[requestID]
+	apiServer.contextMappingsMutex.Unlock()
+	if interactionID == "" {
+		interactionID = requestID
+	}
+	if interactionID == "" {
+		return true, nil
+	}
+
+	interaction, err := apiServer.Controller.Options.Store.GetInteraction(ctx, interactionID)
+	if err != nil {
+		return false, fmt.Errorf("load interaction for stale thread recovery: %w", err)
+	}
+	if interaction == nil || interaction.State != types.InteractionStateWaiting || (interaction.SessionID != "" && interaction.SessionID != sessionID) {
+		return true, nil
+	}
+
+	apiServer.contextMappingsMutex.Lock()
+	apiServer.requestToSessionMapping[requestID] = sessionID
+	apiServer.requestToInteractionMapping[requestID] = interaction.ID
+	apiServer.contextMappingsMutex.Unlock()
+
+	message := interaction.PromptMessage
+	if interaction.SystemPrompt != "" {
+		message = interaction.SystemPrompt + "\n\n**User Request:**\n" + interaction.PromptMessage
+	}
+	command := types.ExternalAgentCommand{
+		Type: "chat_message",
+		Data: map[string]interface{}{
+			"message":    message,
+			"request_id": requestID,
+			"agent_name": apiServer.getAgentNameForSession(ctx, session),
+		},
+	}
+	if err := apiServer.sendCommandToExternalAgent(sessionID, command); err != nil {
+		if errors.Is(err, ErrNoExternalAgentWS) {
+			return true, nil
+		}
+		log.Warn().Err(err).Str("session_id", sessionID).Str("interaction_id", interaction.ID).
+			Msg("Failed to replay interaction after clearing stale ACP thread")
+		return false, fmt.Errorf("replay interaction after clearing stale ACP thread: %w", err)
+	}
+	log.Info().Str("session_id", sessionID).Str("stale_thread_id", acpThreadID).
+		Str("interaction_id", interaction.ID).Str("request_id", requestID).
+		Msg("Replayed interaction as first message after clearing stale ACP thread")
+	return true, nil
+}
+
 // handleThreadLoadError handles thread load failures from Zed
 // This happens when Zed tries to load an existing thread but fails (e.g., session already active via UI)
 // We need to treat this like a completion so the UI clears the text box and shows an error
@@ -3567,6 +3637,20 @@ func (apiServer *HelixAPIServer) handleThreadLoadError(sessionID string, syncMsg
 		apiServer.contextMappingsMutex.RLock()
 		helixSessionID = apiServer.contextMappings[acpThreadID]
 		apiServer.contextMappingsMutex.RUnlock()
+	}
+	if isAuthoritativeMissingThreadError(errorMsg) && acpThreadID != "" {
+		recoverySessionID := helixSessionID
+		if recoverySessionID == "" {
+			recoverySessionID = sessionID
+		}
+		helixSessionID = recoverySessionID
+		handled, err := apiServer.recoverMissingThread(context.Background(), recoverySessionID, acpThreadID, requestID)
+		if err != nil {
+			return err
+		}
+		if handled {
+			return nil
+		}
 	}
 
 	// If we have a request_id, try to send error to the done channel
@@ -3610,21 +3694,6 @@ func (apiServer *HelixAPIServer) handleThreadLoadError(sessionID string, syncMsg
 	if helixSessionID != "" {
 		helixSession, err := apiServer.Controller.Options.Store.GetSession(context.Background(), helixSessionID)
 		if err == nil && helixSession != nil {
-			// Older Codex desktops did not persist ~/.codex, so Zed can retain an
-			// ACP thread whose rollout disappeared with the previous container.
-			// Invalidate that thread before the normal prompt retry; the retry then
-			// sends first_message=true and Zed creates a fresh Codex rollout.
-			if isMissingCodexRolloutError(errorMsg) && helixSession.Metadata.ZedThreadID == acpThreadID {
-				helixSession.Metadata.ZedThreadID = ""
-				if err := apiServer.Controller.Options.Store.UpdateSessionMetadata(context.Background(), helixSessionID, helixSession.Metadata); err != nil {
-					return fmt.Errorf("clear missing Codex rollout thread: %w", err)
-				}
-				apiServer.contextMappingsMutex.Lock()
-				delete(apiServer.contextMappings, acpThreadID)
-				apiServer.contextMappingsMutex.Unlock()
-				log.Info().Str("session_id", helixSessionID).Str("acp_thread_id", acpThreadID).
-					Msg("Cleared stale Codex thread after missing rollout")
-			}
 			// A hard agent crash ("Claude Agent process exited", "Session not
 			// found") on an autonomous session must auto-recover regardless of how
 			// the crashing turn was sent — a queued planning prompt (PromptID set)

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -676,11 +676,13 @@ func (apiServer *HelixAPIServer) handleExternalAgentSender(ctx context.Context, 
 
 // processExternalAgentSyncMessage processes incoming sync messages from external agents
 func (apiServer *HelixAPIServer) processExternalAgentSyncMessage(sessionID string, syncMsg *types.SyncMessage) error {
-	log.Trace().
+	event := log.Trace().
 		Str("agent_session_id", sessionID).
-		Str("event_type", syncMsg.EventType).
-		Interface("data", syncMsg.Data).
-		Msg("[HELIX] Processing message from external agent")
+		Str("event_type", syncMsg.EventType)
+	if syncMsg.EventType != "message_added" {
+		event = event.Interface("data", syncMsg.Data)
+	}
+	event.Msg("[HELIX] Processing message from external agent")
 
 	// Process sync message directly
 	var err error
@@ -1242,6 +1244,10 @@ func (apiServer *HelixAPIServer) handleMessageAdded(sessionID string, syncMsg *t
 		}
 
 		helixSession := sctx.session
+		content = apiServer.redactCredentials(helixSession.OrganizationID, content)
+		toolName = apiServer.redactCredentials(helixSession.OrganizationID, toolName)
+		syncMsg.Data["content"] = content
+		syncMsg.Data["tool_name"] = toolName
 		targetInteraction := sctx.interaction
 
 		if targetInteraction != nil {
@@ -1514,6 +1520,34 @@ func (apiServer *HelixAPIServer) handleMessageAdded(sessionID string, syncMsg *t
 	}
 
 	return nil
+}
+
+func (apiServer *HelixAPIServer) recordCredential(orgID, _ string, token string) {
+	if orgID == "" || token == "" {
+		return
+	}
+	apiServer.credentialTokensMu.Lock()
+	defer apiServer.credentialTokensMu.Unlock()
+	if apiServer.credentialTokens == nil {
+		apiServer.credentialTokens = make(map[string]map[string]struct{})
+	}
+	if apiServer.credentialTokens[orgID] == nil {
+		apiServer.credentialTokens[orgID] = make(map[string]struct{})
+	}
+	apiServer.credentialTokens[orgID][token] = struct{}{}
+}
+
+func (apiServer *HelixAPIServer) redactCredentials(orgID, content string) string {
+	apiServer.credentialTokensMu.RLock()
+	tokens := make([]string, 0, len(apiServer.credentialTokens[orgID]))
+	for token := range apiServer.credentialTokens[orgID] {
+		tokens = append(tokens, token)
+	}
+	apiServer.credentialTokensMu.RUnlock()
+	for _, token := range tokens {
+		content = strings.ReplaceAll(content, token, "<redacted>")
+	}
+	return content
 }
 
 // getOrCreateStreamingContext returns a cached streaming context for the given

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -28,6 +28,16 @@ type WebSocketSyncSuite struct {
 	server *HelixAPIServer
 }
 
+type recordingPubSub struct {
+	*pubsub.NoopPubSub
+	payloads [][]byte
+}
+
+func (p *recordingPubSub) Publish(_ context.Context, _ string, payload []byte) error {
+	p.payloads = append(p.payloads, append([]byte(nil), payload...))
+	return nil
+}
+
 func TestWebSocketSyncSuite(t *testing.T) {
 	suite.Run(t, new(WebSocketSyncSuite))
 }
@@ -356,6 +366,63 @@ func (s *WebSocketSyncSuite) TestMessageAdded_AssistantFirstMessage() {
 
 	err := s.server.handleMessageAdded("agent-1", syncMsg)
 	s.NoError(err)
+}
+
+func (s *WebSocketSyncSuite) TestMessageAdded_RedactsMintedCredentialBeforeStorageAndPublish() {
+	const secret = "xoxb-test-secret"
+	s.server.contextMappings["thread-secret"] = "ses_secret"
+	s.server.recordCredential("org-1", "slack", secret)
+	recorder := &recordingPubSub{NoopPubSub: pubsub.NewNoop()}
+	s.server.pubsub = recorder
+	var hooked *types.SyncMessage
+	s.server.syncEventHook = func(_ string, msg *types.SyncMessage) { hooked = msg }
+
+	session := &types.Session{ID: "ses_secret", Owner: "user-1", OrganizationID: "org-1"}
+	interaction := &types.Interaction{ID: "int-secret", SessionID: "ses_secret", State: types.InteractionStateWaiting}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_secret").Return(session, nil)
+	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return([]*types.Interaction{interaction}, int64(1), nil)
+	s.store.EXPECT().UpdateInteractionStreamingFields(gomock.Any(), "int-secret", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), "msg-secret").DoAndReturn(
+		func(_ context.Context, _ string, _ int, responseMessage string, responseEntries datatypes.JSON, _ int, _ string) error {
+			s.NotContains(responseMessage, secret)
+			s.Contains(responseMessage, `{"token":"<redacted>"}`)
+			s.Contains(responseMessage, "Authorization: Bearer <redacted>")
+			s.NotContains(string(responseEntries), secret)
+			var entries []wsprotocol.ResponseEntry
+			s.NoError(json.Unmarshal(responseEntries, &entries))
+			s.Equal("curl -H 'Authorization: Bearer <redacted>'", entries[0].ToolName)
+			return nil
+		},
+	)
+	s.store.EXPECT().GetCommentByInteractionID(gomock.Any(), "int-secret").Return(nil, store.ErrNotFound).AnyTimes()
+	s.store.EXPECT().GetPendingCommentByPlanningSessionID(gomock.Any(), "ses_secret").Return(nil, nil).AnyTimes()
+
+	syncMsg := &types.SyncMessage{EventType: "message_added", Data: map[string]interface{}{
+		"acp_thread_id": "thread-secret",
+		"message_id":    "msg-secret",
+		"content":       `{"token":"` + secret + `"}\ncurl -H 'Authorization: Bearer ` + secret + `' https://slack.com/api/chat.postMessage`,
+		"role":          "assistant",
+		"entry_type":    "tool_call",
+		"tool_name":     "curl -H 'Authorization: Bearer " + secret + "'",
+	}}
+	s.NoError(s.server.processExternalAgentSyncMessage("agent-1", syncMsg))
+	s.NotContains(syncMsg.Data["content"], secret)
+	s.NotContains(syncMsg.Data["tool_name"], secret)
+	s.Same(syncMsg, hooked)
+	s.NotContains(hooked.Data["content"], secret)
+	s.NotContains(hooked.Data["tool_name"], secret)
+	s.NotEmpty(recorder.payloads)
+	for _, payload := range recorder.payloads {
+		s.NotContains(string(payload), secret)
+		s.Contains(string(payload), "redacted")
+	}
+}
+
+func (s *WebSocketSyncSuite) TestCredentialRedaction_LeavesOrdinaryContentUnchanged() {
+	s.server.recordCredential("org-1", "slack", "xoxb-old-secret")
+	s.server.recordCredential("org-1", "slack", "xoxb-new-secret")
+	s.Equal("<redacted> <redacted>", s.server.redactCredentials("org-1", "xoxb-old-secret xoxb-new-secret"))
+	const content = "ordinary assistant output with no credentials"
+	s.Equal(content, s.server.redactCredentials("org-1", content))
 }
 
 func (s *WebSocketSyncSuite) TestMessageAdded_AssistantSameMessageID_StreamingUpdate() {

--- a/api/pkg/server/websocket_external_agent_sync_test.go
+++ b/api/pkg/server/websocket_external_agent_sync_test.go
@@ -2027,7 +2027,7 @@ func (s *WebSocketSyncSuite) TestThreadLoadError_TransientError_StillUsesMarkAsF
 	// queue's exponential backoff can recover automatically.
 	s.server.contextMappings["thread-transient"] = "ses_transient"
 
-	session := &types.Session{ID: "ses_transient", GenerationID: 1}
+	session := &types.Session{ID: "ses_transient", GenerationID: 1, Metadata: types.SessionMetadata{ZedThreadID: "thread-transient"}}
 	s.store.EXPECT().GetSession(gomock.Any(), "ses_transient").Return(session, nil)
 	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
 		[]*types.Interaction{{ID: "int-transient", State: types.InteractionStateWaiting, PromptID: "prompt-transient"}}, int64(1), nil,
@@ -2052,9 +2052,12 @@ func (s *WebSocketSyncSuite) TestThreadLoadError_TransientError_StillUsesMarkAsF
 
 func (s *WebSocketSyncSuite) TestThreadLoadError_MissingCodexRolloutClearsThreadForRetry() {
 	s.server.contextMappings["thread-codex"] = "ses_codex"
+	sendChan := make(chan types.ExternalAgentCommand, 2)
+	s.server.externalAgentWSManager.registerConnection("ses_codex", &ExternalAgentWSConnection{SessionID: "ses_codex", SendChan: sendChan})
 
 	session := &types.Session{ID: "ses_codex", GenerationID: 1}
 	session.Metadata.ZedThreadID = "thread-codex"
+	session.Metadata.ZedAgentName = "codex"
 	s.store.EXPECT().GetSession(gomock.Any(), "ses_codex").Return(session, nil)
 	s.store.EXPECT().UpdateSessionMetadata(gomock.Any(), "ses_codex", gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ string, metadata types.SessionMetadata) error {
@@ -2062,13 +2065,9 @@ func (s *WebSocketSyncSuite) TestThreadLoadError_MissingCodexRolloutClearsThread
 			return nil
 		},
 	)
-	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
-		[]*types.Interaction{{ID: "int-codex", State: types.InteractionStateWaiting, PromptID: "prompt-codex"}}, int64(1), nil,
+	s.store.EXPECT().GetInteraction(gomock.Any(), "int-codex").Return(
+		&types.Interaction{ID: "int-codex", SessionID: "ses_codex", State: types.InteractionStateWaiting, PromptID: "prompt-codex", PromptMessage: "retry codex"}, nil,
 	)
-	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).Return(nil, nil)
-	s.store.EXPECT().GetPromptHistoryEntry(gomock.Any(), "prompt-codex").
-		Return(&types.PromptHistoryEntry{ID: "prompt-codex", RetryCount: 0}, nil)
-	s.store.EXPECT().MarkPromptAsFailed(gomock.Any(), "prompt-codex", gomock.Any()).Return(nil)
 
 	err := s.server.handleThreadLoadError("ses_codex", &types.SyncMessage{
 		EventType: "thread_load_error",
@@ -2084,6 +2083,85 @@ func (s *WebSocketSyncSuite) TestThreadLoadError_MissingCodexRolloutClearsThread
 	_, exists := s.server.contextMappings["thread-codex"]
 	s.server.contextMappingsMutex.RUnlock()
 	s.False(exists)
+	select {
+	case command := <-sendChan:
+		s.Equal("chat_message", command.Type)
+		s.Equal("retry codex", command.Data["message"])
+		_, hasThreadID := command.Data["acp_thread_id"]
+		s.False(hasThreadID)
+	default:
+		s.Fail("missing Codex replay command")
+	}
+}
+
+func (s *WebSocketSyncSuite) TestThreadLoadError_MissingZedThreadReplaysDirectInteractionOnce() {
+	const primeError = `no thread found with ID: SessionId("019cba1e-2994-77d0-bc27-fc350cfdc2c2")`
+	s.server.contextMappings["thread-prime"] = "ses_prime"
+	s.server.requestToInteractionMapping["req-prime"] = "int-prime"
+	sendChan := make(chan types.ExternalAgentCommand, 2)
+	s.server.externalAgentWSManager.registerConnection("ses_prime", &ExternalAgentWSConnection{SessionID: "ses_prime", SendChan: sendChan})
+
+	session := &types.Session{ID: "ses_prime", GenerationID: 1, Metadata: types.SessionMetadata{
+		ZedThreadID: "thread-prime", ZedAgentName: "claude",
+	}}
+	interaction := &types.Interaction{
+		ID: "int-prime", SessionID: "ses_prime", State: types.InteractionStateWaiting,
+		PromptMessage: "direct Prime request",
+	}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_prime").Return(session, nil).Times(2)
+	s.store.EXPECT().UpdateSessionMetadata(gomock.Any(), "ses_prime", gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, metadata types.SessionMetadata) error {
+			s.Empty(metadata.ZedThreadID)
+			return nil
+		},
+	)
+	s.store.EXPECT().GetInteraction(gomock.Any(), "int-prime").Return(interaction, nil)
+
+	syncMsg := &types.SyncMessage{EventType: "thread_load_error", Data: map[string]interface{}{
+		"acp_thread_id": "thread-prime",
+		"request_id":    "req-prime",
+		"error":         primeError,
+	}}
+	s.NoError(s.server.handleThreadLoadError("ses_prime", syncMsg))
+	duplicate := &types.SyncMessage{EventType: "thread_load_error", Data: map[string]interface{}{
+		"acp_thread_id": "thread-prime",
+		"request_id":    "open-thread-request",
+		"error":         primeError,
+	}}
+	s.NoError(s.server.handleThreadLoadError("ses_prime", duplicate))
+
+	s.Equal(types.InteractionStateWaiting, interaction.State)
+	s.Len(sendChan, 1)
+	command := <-sendChan
+	s.Equal("direct Prime request", command.Data["message"])
+	s.Equal("req-prime", command.Data["request_id"])
+	_, hasThreadID := command.Data["acp_thread_id"]
+	s.False(hasThreadID)
+	s.Equal("ses_prime", s.server.requestToSessionMapping["req-prime"])
+}
+
+func (s *WebSocketSyncSuite) TestThreadLoadError_ArbitraryLoadErrorDoesNotClearOrReplay() {
+	s.server.contextMappings["thread-arbitrary"] = "ses_arbitrary"
+	sendChan := make(chan types.ExternalAgentCommand, 1)
+	s.server.externalAgentWSManager.registerConnection("ses_arbitrary", &ExternalAgentWSConnection{SessionID: "ses_arbitrary", SendChan: sendChan})
+
+	session := &types.Session{ID: "ses_arbitrary", GenerationID: 1, Metadata: types.SessionMetadata{ZedThreadID: "thread-arbitrary"}}
+	interaction := &types.Interaction{ID: "int-arbitrary", State: types.InteractionStateWaiting}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_arbitrary").Return(session, nil)
+	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return([]*types.Interaction{interaction}, int64(1), nil)
+	s.store.EXPECT().UpdateInteraction(gomock.Any(), interaction).Return(interaction, nil)
+
+	s.NoError(s.server.handleThreadLoadError("ses_arbitrary", &types.SyncMessage{
+		EventType: "thread_load_error",
+		Data: map[string]interface{}{
+			"acp_thread_id": "thread-arbitrary",
+			"request_id":    "int-arbitrary",
+			"error":         "Failed to load thread: transport disconnected",
+		},
+	}))
+
+	s.Equal("thread-arbitrary", session.Metadata.ZedThreadID)
+	s.Empty(sendChan)
 }
 
 func (s *WebSocketSyncSuite) TestThreadLoadError_RecurringFailure_CrashesRegardlessOfWording() {

--- a/api/pkg/serviceconnection/slack/events.go
+++ b/api/pkg/serviceconnection/slack/events.go
@@ -18,6 +18,8 @@ import (
 type Event struct {
 	// Channel is the Slack channel id the message landed in.
 	Channel string
+	// ChannelType distinguishes DMs ("im") from channels and group DMs.
+	ChannelType string
 	// User is the Slack user id of the poster (carried as Message.From).
 	User string
 	// Text is the message body.
@@ -157,7 +159,7 @@ func verifyAny(header http.Header, body []byte, secrets []string) bool {
 func ToEvent(inner any) (Event, bool) {
 	switch m := inner.(type) {
 	case *slackevents.MessageEvent:
-		return Event{Channel: m.Channel, User: m.User, Text: m.Text, TS: m.TimeStamp, ThreadTS: m.ThreadTimeStamp, BotID: m.BotID}, true
+		return Event{Channel: m.Channel, ChannelType: m.ChannelType, User: m.User, Text: m.Text, TS: m.TimeStamp, ThreadTS: m.ThreadTimeStamp, BotID: m.BotID}, true
 	case *slackevents.AppMentionEvent:
 		return Event{Channel: m.Channel, User: m.User, Text: m.Text, TS: m.TimeStamp, ThreadTS: m.ThreadTimeStamp, BotID: m.BotID}, true
 	default:

--- a/api/pkg/serviceconnection/slack/events_test.go
+++ b/api/pkg/serviceconnection/slack/events_test.go
@@ -144,7 +144,7 @@ func TestEventsAPI_MessageEvent_DispatchedWithTeamID(t *testing.T) {
 	body := `{
 		"type":"event_callback",
 		"team_id":"T123",
-		"event":{"type":"message","channel":"C999","user":"U1","text":"hello bot","ts":"1700000000.000100"}
+		"event":{"type":"message","channel":"D999","channel_type":"im","user":"U1","text":"hello bot","ts":"1700000000.000100"}
 	}`
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, signedRequest(body))
@@ -155,7 +155,7 @@ func TestEventsAPI_MessageEvent_DispatchedWithTeamID(t *testing.T) {
 	if gotTeam != "T123" {
 		t.Fatalf("team = %q, want T123", gotTeam)
 	}
-	if gotEvent.Channel != "C999" || gotEvent.User != "U1" || gotEvent.Text != "hello bot" || gotEvent.TS != "1700000000.000100" {
+	if gotEvent.Channel != "D999" || gotEvent.ChannelType != "im" || gotEvent.User != "U1" || gotEvent.Text != "hello bot" || gotEvent.TS != "1700000000.000100" {
 		t.Fatalf("event mismatch: %+v", gotEvent)
 	}
 }

--- a/api/pkg/types/oauth.go
+++ b/api/pkg/types/oauth.go
@@ -300,7 +300,7 @@ type ServiceConnection struct {
 	SlackIngressMode   string `json:"slack_ingress_mode,omitempty"`      // "rest" | "socket"
 
 	// Slack workspace install (type=slack_workspace) — per-org.
-	SlackTeamID    string `json:"slack_team_id,omitempty"`
+	SlackTeamID    string `json:"slack_team_id,omitempty" gorm:"index:idx_service_connections_slack_workspace_team,unique,where:type = 'slack_workspace' AND deleted_at IS NULL AND slack_team_id <> ''"`
 	SlackTeamName  string `json:"slack_team_name,omitempty"`
 	SlackBotUserID string `json:"slack_bot_user_id,omitempty"`
 	SlackAppID     string `json:"slack_app_id,omitempty"`

--- a/design/2026-07-15-org-human-slack-delivery.md
+++ b/design/2026-07-15-org-human-slack-delivery.md
@@ -1,0 +1,167 @@
+# Org human Slack delivery
+
+Date: 2026-07-15
+Status: implemented, awaiting review
+Branch: feat/org-human-slack-delivery
+
+## Problem
+
+`ask_human` previously wrote only to the Helix notification inbox. Human org
+members already had an identity map and Helix already supported Slack workspace
+OAuth, Slack API credentials, an automated workspace router, and inbound thread
+following, but those capabilities were not connected into human delivery.
+
+The feature lets an org owner choose Helix or Slack as their preferred contact
+route. A Bot continues to call the single `ask_human` primitive; delivery code
+selects the configured route and reports whether it used Helix, a Slack DM, or a
+Slack channel.
+
+## Reused capabilities
+
+- Human nodes and their existing `Identity` map.
+- `ask_human` as the only Bot-facing delivery action.
+- Org-scoped Slack workspace connections and decrypted bot tokens.
+- `mint_credential` for the Chief of Staff to resolve user, team, and channel
+  IDs through Slack's API during setup.
+- The automated Slack router and its per-Worker managed outputs.
+- The domain-event-backed Slack thread participant log and inbound
+  thread-follow routing.
+- Helix attention events for notification-panel delivery.
+
+No new table, transport abstraction, or Slack-specific MCP sending tool was
+added.
+
+## Human identity and route selection
+
+The human node identity map uses these keys:
+
+| Key | Meaning |
+|---|---|
+| `preferred_contact` | `helix` or `slack`; missing is treated as `helix` |
+| `slack_user_id` | Canonical Slack user ID; required for Slack delivery |
+| `slack_channel_id` | Optional canonical channel ID; missing selects a DM |
+| `slack_team_id` | Optional canonical workspace ID used to select an org workspace |
+| `email` | Existing contact identity, preserved by contact patches |
+| `github` | Existing contact identity, preserved by contact patches |
+
+Route selection is exact:
+
+- Missing or `helix`: create the existing attention event for the linked Helix
+  user.
+- `slack` with no channel: open a DM with `slack_user_id`, then post there.
+- `slack` with a channel: post to `slack_channel_id` and mention
+  `slack_user_id` in the message.
+- Any other value: return an error.
+
+Slack failures do not fall back to Helix. A silent fallback would claim the
+person was contacted through their selected route when they were not.
+
+## `set_human_contact`
+
+The new MCP primitive patches a human node's identity map. It preserves keys
+not present in the patch, trims keys and values, and removes a key when its
+patched value is empty. It rejects non-human targets, unsupported preferred
+routes, and Slack preference without `slack_user_id`.
+
+The tool is included in `OwnerBotTools`, so the seeded Chief of Staff receives
+it and existing Chief of Staff Bots receive it during seed reconciliation. The
+restriction is capability-based: the tool implementation scopes all access to
+the caller's org, but it does not perform a second hard-coded caller-role check.
+Any Bot explicitly granted this tool can use it.
+
+## Slack delivery and replies
+
+Slack delivery resolves a workspace only from Slack service connections owned
+by the caller's org. When `slack_team_id` is present it must match that
+workspace. When it is absent, delivery accepts exactly one distinct Slack team,
+including when that team has duplicate connection rows, and rejects multiple
+distinct teams as ambiguous. For duplicate rows belonging to the selected team,
+an OAuth-installed connection is preferred over a manual-token connection.
+
+Messages include the sending Bot's display name. Replyable messages also tell
+the human to reply in the Slack thread. Before posting a replyable message,
+delivery verifies that the workspace's automated router exists, has thread
+following enabled, and has a managed output for the sending Bot. It fails
+before posting if that reply path is unavailable.
+
+After Slack returns the root message timestamp, delivery records the sending
+Bot as a participant under the existing router-scoped thread subject. The
+record operation is idempotent. A later inbound Slack thread reply then follows
+the existing thread-follow path to the Bot's managed output topic. Non-replyable
+messages do not require or register thread routing.
+
+If Slack accepts the post but participant recording fails, `ask_human` returns
+an error and does not fall back; the external message may already be visible.
+
+## Slack OAuth
+
+Both backend default scopes and the generated Slack manifest now include:
+
+- `chat:write` to post the message.
+- `im:write` to open a DM.
+- `users:read`, required by Slack alongside email-based user lookup.
+- `users:read.email` so setup can resolve the human's canonical Slack user ID
+  from the email they provide.
+
+Existing Slack installations must be reauthorized to grant newly added scopes.
+The Chief of Staff must not claim Slack setup is complete until the workspace
+is installed and `set_human_contact` succeeds.
+
+## Onboarding and UI
+
+The seeded Chief of Staff prompt now asks what the org is for, who its key
+people are, and whether future contact should use Helix or Slack. For Slack it
+asks for an email and optional channel name, then uses `mint_credential` and
+Slack's `users.lookupByEmail` and `conversations.list` APIs to resolve canonical
+IDs before calling `set_human_contact`.
+
+The human detail page adds a preferred-delivery selector and fields for Slack
+user, channel, and workspace IDs. It requires a Slack user ID when Slack is
+selected and preserves unrelated identity fields on save. This UI is a manual
+configuration surface; the conversational Chief of Staff flow avoids asking a
+human for opaque IDs unless Slack lookup fails.
+
+The REST mutation used by this UI permits a human to update their own identity
+or an org owner to update another human in the org. Other org members cannot
+change another person's contact route.
+
+## Security and multi-tenancy
+
+- Human lookup and mutation use the caller's org ID.
+- Human identity REST mutation is authorized only for the human themselves or
+  an owner of that org.
+- Slack workspace lookup lists connections for that same org and optionally
+  filters by `slack_team_id`; another org's bot token is never selected. An
+  omitted team ID is rejected when more than one distinct team is installed.
+- Reply-router validation uses the resolved workspace connection ID and the
+  sending Bot's managed route.
+- Slack tokens remain in the existing encrypted service-connection path and
+  are not stored in the human identity map.
+- Channel delivery mentions only the configured canonical Slack user ID.
+
+## Verification
+
+Run in `/Users/psamuel/helix/helix-worktrees/org-human-slack-delivery`:
+
+- `git diff --check`: passed.
+- ASCII check of this document: passed with no non-ASCII characters.
+- `go test ./api/pkg/org/interfaces/mcptools ./api/pkg/org/application/slackrouting ./api/pkg/server -count=1`: passed all three packages in 0.851 s, 0.498 s, and 3.670 s.
+- `go test ./api/pkg/org/interfaces/server/api ./api/pkg/server ./api/pkg/org/infrastructure/transports/slack -count=1`: passed all three packages in 1.967 s, 4.040 s, and 0.256 s.
+- `go build ./api/pkg/server/ ./api/pkg/store/ ./api/pkg/types/`: passed.
+- `cd frontend && yarn test --run src/components/dashboard/slackManifest.test.ts`: passed 1 file and 5 tests.
+- `cd frontend && yarn build`: passed, 21,709 modules in 18.41 s.
+
+The tests exercise contact patching and validation, route reporting, Helix
+reply metadata, Slack DM and channel selection, no-fallback behavior, reply
+router preflight, participant idempotency, inbound reply fan-out, and required
+OAuth scopes.
+
+## NOT tested
+
+- NOT tested: local browser end-to-end onboarding and human-detail UI. A
+  fresh-worktree `./stack start` successfully built Zed, then could not start
+  services because host networking and inotify setup required an interactive
+  macOS sudo password. Playwright MCP navigation was also attempted, but its
+  shared Chrome profile was already in use.
+- NOT tested: real Slack workspace installation, OAuth reauthorization, user or
+  channel lookup, DM/channel delivery, and a live threaded reply.

--- a/design/2026-07-15-org-human-slack-delivery.md
+++ b/design/2026-07-15-org-human-slack-delivery.md
@@ -125,6 +125,10 @@ The REST mutation used by this UI permits a human to update their own identity
 or an org owner to update another human in the org. Other org members cannot
 change another person's contact route.
 
+When org Settings has no Slack app available, deployment admins see a
+`Configure Slack app` action that opens Admin Panel -> Service Connections.
+Non-admins see explanatory empty-state text without the admin action.
+
 ## Security and multi-tenancy
 
 - Human lookup and mutation use the caller's org ID.
@@ -150,6 +154,8 @@ Run in `/Users/psamuel/helix/helix-worktrees/org-human-slack-delivery`:
 - `go build ./api/pkg/server/ ./api/pkg/store/ ./api/pkg/types/`: passed.
 - `cd frontend && yarn test --run src/components/dashboard/slackManifest.test.ts`: passed 1 file and 5 tests.
 - `cd frontend && yarn build`: passed, 21,709 modules in 18.41 s.
+- `cd frontend && yarn test --run src/components/dashboard/SlackIntegrationsPanel.test.tsx`: passed 1 file and 2 tests.
+- `cd frontend && yarn build`: passed, 21,709 modules in 16.40 s after the Slack empty-state change.
 
 The tests exercise contact patching and validation, route reporting, Helix
 reply metadata, Slack DM and channel selection, no-fallback behavior, reply

--- a/design/2026-07-15-org-human-slack-delivery.md
+++ b/design/2026-07-15-org-human-slack-delivery.md
@@ -90,6 +90,11 @@ record operation is idempotent. A later inbound Slack thread reply then follows
 the existing thread-follow path to the Bot's managed output topic. Non-replyable
 messages do not require or register thread routing.
 
+For an `expectsReply` Slack DM, a threaded human reply routes back to the Bot
+that sent the original message. A new top-level DM has no prior participant, so
+it must contain an exact Helix Bot ID to match a managed route. An unmatched
+top-level DM activates no Bot.
+
 If Slack accepts the post but participant recording fails, `ask_human` returns
 an error and does not fall back; the external message may already be visible.
 
@@ -103,9 +108,28 @@ Both backend default scopes and the generated Slack manifest now include:
 - `users:read.email` so setup can resolve the human's canonical Slack user ID
   from the email they provide.
 
+The generated manifest also enables writable Messages in the Slack App Home so
+users can send DMs to the app.
+
 Existing Slack installations must be reauthorized to grant newly added scopes.
 The Chief of Staff must not claim Slack setup is complete until the workspace
 is installed and `set_human_contact` succeeds.
+
+## Prime Cloudflare Tunnel deployment
+
+For Prime, configure a Cloudflare Tunnel public hostname to forward to
+`http://localhost:8080`, then set `SERVER_URL` to that public HTTPS origin.
+Configure the Slack app with these URLs on the same origin:
+
+- Redirect: `/api/v1/slack/oauth/callback`
+- Events: `/api/v1/slack/events`
+
+Cloudflare Access must bypass authentication for both endpoints so Slack can
+complete OAuth and deliver signed events. Recreate the Helix stack after the
+`SERVER_URL` environment change; a container restart alone does not apply the
+new environment. Then verify Slack accepts the event request URL and run a
+smoke test that sends an `expectsReply` message and confirms a threaded reply
+reaches the originating Bot.
 
 ## Onboarding and UI
 
@@ -114,6 +138,10 @@ people are, and whether future contact should use Helix or Slack. For Slack it
 asks for an email and optional channel name, then uses `mint_credential` and
 Slack's `users.lookupByEmail` and `conversations.list` APIs to resolve canonical
 IDs before calling `set_human_contact`.
+
+Slack app setup uses a deterministic official flow: copy the generated manifest,
+open Slack's `From a manifest` setup, and paste it. It does not depend on an
+unsupported `manifest_json` deep link.
 
 The human detail page adds a preferred-delivery selector and fields for Slack
 user, channel, and workspace IDs. It requires a Slack user ID when Slack is
@@ -156,6 +184,8 @@ Run in `/Users/psamuel/helix/helix-worktrees/org-human-slack-delivery`:
 - `cd frontend && yarn build`: passed, 21,709 modules in 18.41 s.
 - `cd frontend && yarn test --run src/components/dashboard/SlackIntegrationsPanel.test.tsx`: passed 1 file and 2 tests.
 - `cd frontend && yarn build`: passed, 21,709 modules in 16.40 s after the Slack empty-state change.
+- Frontend targeted tests: passed 2 files and 7 tests for the manifest setup and Slack integration flow.
+- `cd frontend && yarn build`: passed, 21,709 modules in 16.14 s after the manifest and DM-routing follow-up.
 
 The tests exercise contact patching and validation, route reporting, Helix
 reply metadata, Slack DM and channel selection, no-fallback behavior, reply

--- a/design/2026-07-15-org-human-slack-delivery.md
+++ b/design/2026-07-15-org-human-slack-delivery.md
@@ -115,6 +115,21 @@ Existing Slack installations must be reauthorized to grant newly added scopes.
 The Chief of Staff must not claim Slack setup is complete until the workspace
 is installed and `set_human_contact` succeeds.
 
+The org Settings OAuth action is `Connect workspace`. Connecting a Slack team
+already installed in the same Helix org refreshes that install and its token
+instead of creating a duplicate. A Slack team can belong to only one live
+Helix org because inbound Slack events identify the team but carry no Helix org
+ID. An attempt to connect a team already bound to another org returns a clear
+conflict instead of creating ambiguous inbound routing.
+
+The OAuth callback URL trims any trailing slash from `SERVER_URL` before adding
+`/api/v1/slack/oauth/callback`. After Slack succeeds, rejects authorization, or
+returns another handled setup error, the callback returns to
+`/orgs/:org_id/helix-org/settings` with success or error feedback for the UI.
+
+For manual bot-token connection, a token Slack explicitly rejects returns HTTP
+400. Network failures and other upstream validation failures return HTTP 502.
+
 ## Prime Cloudflare Tunnel deployment
 
 For Prime, configure a Cloudflare Tunnel public hostname to forward to
@@ -156,6 +171,7 @@ change another person's contact route.
 When org Settings has no Slack app available, deployment admins see a
 `Configure Slack app` action that opens Admin Panel -> Service Connections.
 Non-admins see explanatory empty-state text without the admin action.
+Once an app is available, the org owner uses `Connect workspace` to start OAuth.
 
 ## Security and multi-tenancy
 
@@ -165,6 +181,8 @@ Non-admins see explanatory empty-state text without the admin action.
 - Slack workspace lookup lists connections for that same org and optionally
   filters by `slack_team_id`; another org's bot token is never selected. An
   omitted team ID is rejected when more than one distinct team is installed.
+- A Slack team ID is globally unique across live Helix org workspace
+  connections, preventing inbound events from resolving to multiple orgs.
 - Reply-router validation uses the resolved workspace connection ID and the
   sending Bot's managed route.
 - Slack tokens remain in the existing encrypted service-connection path and

--- a/frontend/src/components/dashboard/SlackAppSetup.test.tsx
+++ b/frontend/src/components/dashboard/SlackAppSetup.test.tsx
@@ -1,0 +1,42 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SlackAppSetup from './SlackAppSetup'
+
+const writeText = vi.fn(() => Promise.resolve())
+
+vi.mock('../../hooks/useAccount', () => ({
+  default: () => ({ serverConfig: { server_url: 'https://helix.example' } }),
+}))
+
+describe('SlackAppSetup', () => {
+  beforeEach(() => {
+    writeText.mockClear()
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+  })
+
+  it('opens the base Slack creation flow and copies the complete manifest', async () => {
+    render(<SlackAppSetup open onClose={vi.fn()} ingressMode="rest" appName="Acme" />)
+
+    const link = screen.getByRole('link', { name: 'Open Slack app creation' })
+    expect(link).toHaveAttribute('href', 'https://api.slack.com/apps?new_app=1')
+    expect(link.getAttribute('href')).not.toContain('manifest_json')
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
+      await Promise.resolve()
+    })
+    const manifest = JSON.parse(writeText.mock.calls[0][0])
+
+    expect(manifest.features.bot_user.display_name).toBe('Acme')
+    expect(manifest.features.app_home).toEqual({
+      home_tab_enabled: false,
+      messages_tab_enabled: true,
+      messages_tab_read_only_enabled: false,
+    })
+    expect(manifest.oauth_config.scopes.bot.length).toBeGreaterThan(0)
+    expect(manifest.oauth_config.redirect_urls).toContain('https://helix.example/api/v1/slack/oauth/callback')
+    expect(manifest.settings.event_subscriptions.request_url).toBe('https://helix.example/api/v1/slack/events')
+    expect(manifest.settings.event_subscriptions.bot_events.length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/components/dashboard/SlackAppSetup.test.tsx
+++ b/frontend/src/components/dashboard/SlackAppSetup.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import SlackAppSetup from './SlackAppSetup'
 
-const writeText = vi.fn(() => Promise.resolve())
+const writeText = vi.fn((_: string) => Promise.resolve())
 
 vi.mock('../../hooks/useAccount', () => ({
   default: () => ({ serverConfig: { server_url: 'https://helix.example' } }),

--- a/frontend/src/components/dashboard/SlackAppSetup.tsx
+++ b/frontend/src/components/dashboard/SlackAppSetup.tsx
@@ -47,10 +47,8 @@ const SlackAppSetup: FC<SlackAppSetupProps> = ({ open, onClose, ingressMode, app
   const redirectURL = `${origin}/api/v1/slack/oauth/callback`
   const eventsURL = `${origin}/api/v1/slack/events`
   const manifest = useMemo(() => buildManifest(ingressMode, redirectURL, eventsURL, appName), [ingressMode, redirectURL, eventsURL, appName])
-  const createAppURL = `https://api.slack.com/apps?new_app=1&manifest_json=${encodeURIComponent(manifest)}`
-
-  const manifestFallback = (
-    <CopyableCodeBlock title="Prefer to paste the manifest yourself?" code={manifest} />
+  const manifestStep = (
+    <CopyableCodeBlock title="Copy this full app manifest" code={manifest} />
   )
 
   const distributionNote = 'Optional — only if orgs will install into workspaces other than the one that owns the app (e.g. a SaaS deployment): open "Manage Distribution" and activate public distribution.'
@@ -71,13 +69,13 @@ const SlackAppSetup: FC<SlackAppSetupProps> = ({ open, onClose, ingressMode, app
 
   const steps: SetupStep[] = ingressMode === 'rest'
     ? [
-        { step: 1, text: 'Click "Create the app in Slack" above. Slack opens its create screen pre-filled with the scopes, events, and your Helix request + redirect URLs — pick the workspace to own the app and click "Create". Slack verifies the Events Request URL on the spot, so Event Subscriptions are ready with no extra step.', image: createSlackAppManifest, below: manifestFallback },
+        { step: 1, text: 'Copy the full app manifest below, then open Slack app creation. Choose "From a manifest", select the workspace, choose JSON, paste the manifest, and click Next. Review the bot user, writable Messages tab for DMs and thread replies, scopes, event subscriptions, request URL, and redirect URL, then click Create.', image: createSlackAppManifest, below: manifestStep },
         iconStep,
         { step: 3, text: 'Open "Basic Information" → "App Credentials" and copy the Client ID, Client Secret, and Signing Secret into the form below, then Save.' },
         { step: 4, text: distributionNote },
       ]
     : [
-        { step: 1, text: 'Click "Create the app in Slack" above. Slack opens pre-filled (Socket Mode enabled + your redirect URL) — pick the workspace to own the app and click "Create".', image: createSlackAppManifest, below: manifestFallback },
+        { step: 1, text: 'Copy the full app manifest below, then open Slack app creation. Choose "From a manifest", select the workspace, choose JSON, paste the manifest, and click Next. Review the bot user, writable Messages tab for DMs and thread replies, scopes, Socket Mode, and redirect URL, then click Create.', image: createSlackAppManifest, below: manifestStep },
         iconStep,
         { step: 3, text: 'Open "Basic Information" → "App Credentials" and copy the Client ID and Client Secret into the form below.' },
         { step: 4, text: 'Open "Basic Information" → "App-Level Tokens", generate a token with the connections:write scope, and copy the xapp- token into the form below, then Save.', image: createSlackAppToken },
@@ -100,10 +98,10 @@ const SlackAppSetup: FC<SlackAppSetupProps> = ({ open, onClose, ingressMode, app
         </Typography>
 
         <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 2 }}>
-          <Button variant="contained" startIcon={<SlackLogo sx={{ fontSize: 18 }} />} href={createAppURL} target="_blank" rel="noopener noreferrer">
-            Create the app in Slack
+          <Button variant="contained" startIcon={<SlackLogo sx={{ fontSize: 18 }} />} href="https://api.slack.com/apps?new_app=1" target="_blank" rel="noopener noreferrer">
+            Open Slack app creation
           </Button>
-          <Typography variant="caption" color="text.secondary">Opens Slack pre-filled with this configuration.</Typography>
+          <Typography variant="caption" color="text.secondary">Copy the manifest in step 1 before opening Slack.</Typography>
         </Stack>
 
         <Box sx={{ mb: 2 }}>

--- a/frontend/src/components/dashboard/slackManifest.test.ts
+++ b/frontend/src/components/dashboard/slackManifest.test.ts
@@ -32,6 +32,17 @@ describe('buildManifest', () => {
     expect(m.oauth_config.scopes.bot).toContain('users:read.email')
   })
 
+  it('defines a bot user and non-empty bot scopes', () => {
+    const m = JSON.parse(buildManifest('rest', REDIRECT, EVENTS))
+    expect(m.features.bot_user.display_name).toBeTruthy()
+    expect(m.features.app_home).toEqual({
+      home_tab_enabled: false,
+      messages_tab_enabled: true,
+      messages_tab_read_only_enabled: false,
+    })
+    expect(m.oauth_config.scopes.bot.length).toBeGreaterThan(0)
+  })
+
   // Every subscribed message.* event must have its matching *:history scope
   // (Slack rejects an event whose scope is missing).
   it('derives bot_events only from requested *:history scopes', () => {

--- a/frontend/src/components/dashboard/slackManifest.test.ts
+++ b/frontend/src/components/dashboard/slackManifest.test.ts
@@ -27,6 +27,9 @@ describe('buildManifest', () => {
     const m = JSON.parse(buildManifest('rest', REDIRECT, EVENTS))
     expect(m.oauth_config.redirect_urls).toContain(REDIRECT)
     expect(m.oauth_config.scopes.bot).toContain('chat:write')
+    expect(m.oauth_config.scopes.bot).toContain('im:write')
+    expect(m.oauth_config.scopes.bot).toContain('users:read')
+    expect(m.oauth_config.scopes.bot).toContain('users:read.email')
   })
 
   // Every subscribed message.* event must have its matching *:history scope

--- a/frontend/src/components/dashboard/slackManifest.ts
+++ b/frontend/src/components/dashboard/slackManifest.ts
@@ -14,10 +14,13 @@ export const BOT_SCOPES = [
   'groups:history',
   'groups:read',
   'im:history',
+  'im:write',
   'chat:write',
   'chat:write.customize',
   'reactions:write',
   'files:write',
+  'users:read',
+  'users:read.email',
 ]
 
 // Each subscribed message.* event requires its matching *:history scope,

--- a/frontend/src/components/dashboard/slackManifest.ts
+++ b/frontend/src/components/dashboard/slackManifest.ts
@@ -68,7 +68,14 @@ export const buildManifest = (mode: 'rest' | 'socket', redirectURL: string, even
       // product's own theme (frontend/src/themes.tsx darkBackgroundColor).
       background_color: '#121214',
     },
-    features: { bot_user: { display_name: name, always_online: true } },
+    features: {
+      bot_user: { display_name: name, always_online: true },
+      app_home: {
+        home_tab_enabled: false,
+        messages_tab_enabled: true,
+        messages_tab_read_only_enabled: false,
+      },
+    },
     oauth_config: { scopes: { bot: BOT_SCOPES } },
     settings: {
       event_subscriptions: eventSubscriptions,

--- a/frontend/src/components/helix-org/SlackIntegrationsPanel.test.tsx
+++ b/frontend/src/components/helix-org/SlackIntegrationsPanel.test.tsx
@@ -1,21 +1,24 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import SlackIntegrationsPanel from './SlackIntegrationsPanel'
 
 const openDialog = vi.fn()
+const snackbarError = vi.fn()
+const snackbarSuccess = vi.fn()
 let admin = false
+let apps: any[] = []
 
 vi.mock('../../hooks/useAccount', () => ({ default: () => ({ admin }) }))
 vi.mock('../../contexts/settingsDialog', () => ({
   useSettingsDialog: () => ({ openDialog }),
 }))
 vi.mock('../../hooks/useSnackbar', () => ({
-  default: () => ({ error: vi.fn(), success: vi.fn() }),
+  default: () => ({ error: snackbarError, success: snackbarSuccess }),
 }))
 vi.mock('../../services/helixOrgService', () => ({
   useListSlackWorkspaces: () => ({ data: [], isLoading: false }),
-  useListSlackApps: () => ({ data: [] }),
+  useListSlackApps: () => ({ data: apps }),
   useStartSlackInstall: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useConnectSlackWorkspace: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useDisconnectSlackWorkspace: () => ({ mutateAsync: vi.fn() }),
@@ -24,7 +27,11 @@ vi.mock('../../services/helixOrgService', () => ({
 describe('SlackIntegrationsPanel', () => {
   beforeEach(() => {
     admin = false
+    apps = []
     openDialog.mockClear()
+    snackbarError.mockClear()
+    snackbarSuccess.mockClear()
+    window.history.replaceState({}, '', '/orgs/acme/helix-org/settings')
   })
 
   it('shows admins a link to configure the Slack app', () => {
@@ -41,5 +48,31 @@ describe('SlackIntegrationsPanel', () => {
 
     expect(screen.getByText('No Slack app has been configured by an administrator yet.')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Configure Slack app' })).not.toBeInTheDocument()
+  })
+
+  it('labels the Slack OAuth action Connect workspace', () => {
+    apps = [{ id: 'app-1', slack_client_id: 'client-1' }]
+
+    render(<SlackIntegrationsPanel />)
+
+    expect(screen.getByRole('button', { name: 'Connect workspace' })).toBeInTheDocument()
+  })
+
+  it('shows OAuth success feedback and removes the query parameter', async () => {
+    window.history.replaceState({}, '', '/orgs/acme/helix-org/settings?slack_installed=1&view=table')
+
+    render(<SlackIntegrationsPanel />)
+
+    await waitFor(() => expect(snackbarSuccess).toHaveBeenCalledWith('Slack workspace connected'))
+    expect(window.location.search).toBe('?view=table')
+  })
+
+  it('shows OAuth error feedback and removes the query parameter', async () => {
+    window.history.replaceState({}, '', '/orgs/acme/helix-org/settings?slack_error=Try+again')
+
+    render(<SlackIntegrationsPanel />)
+
+    await waitFor(() => expect(snackbarError).toHaveBeenCalledWith('Try again'))
+    expect(window.location.search).toBe('')
   })
 })

--- a/frontend/src/components/helix-org/SlackIntegrationsPanel.test.tsx
+++ b/frontend/src/components/helix-org/SlackIntegrationsPanel.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SlackIntegrationsPanel from './SlackIntegrationsPanel'
+
+const openDialog = vi.fn()
+let admin = false
+
+vi.mock('../../hooks/useAccount', () => ({ default: () => ({ admin }) }))
+vi.mock('../../contexts/settingsDialog', () => ({
+  useSettingsDialog: () => ({ openDialog }),
+}))
+vi.mock('../../hooks/useSnackbar', () => ({
+  default: () => ({ error: vi.fn(), success: vi.fn() }),
+}))
+vi.mock('../../services/helixOrgService', () => ({
+  useListSlackWorkspaces: () => ({ data: [], isLoading: false }),
+  useListSlackApps: () => ({ data: [] }),
+  useStartSlackInstall: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useConnectSlackWorkspace: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDisconnectSlackWorkspace: () => ({ mutateAsync: vi.fn() }),
+}))
+
+describe('SlackIntegrationsPanel', () => {
+  beforeEach(() => {
+    admin = false
+    openDialog.mockClear()
+  })
+
+  it('shows admins a link to configure the Slack app', () => {
+    admin = true
+    render(<SlackIntegrationsPanel />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Configure Slack app' }))
+
+    expect(openDialog).toHaveBeenCalledWith('admin', { tab: 'service_connections' })
+  })
+
+  it('keeps the empty state text-only for non-admins', () => {
+    render(<SlackIntegrationsPanel />)
+
+    expect(screen.getByText('No Slack app has been configured by an administrator yet.')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Configure Slack app' })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/helix-org/SlackIntegrationsPanel.tsx
+++ b/frontend/src/components/helix-org/SlackIntegrationsPanel.tsx
@@ -19,6 +19,8 @@ import { SlackLogo } from '../icons/ProviderIcons'
 import SimpleTable from '../widgets/SimpleTable'
 import DeleteConfirmWindow from '../widgets/DeleteConfirmWindow'
 import useSnackbar from '../../hooks/useSnackbar'
+import useAccount from '../../hooks/useAccount'
+import { useSettingsDialog } from '../../contexts/settingsDialog'
 import {
   useListSlackWorkspaces,
   useListSlackApps,
@@ -29,6 +31,8 @@ import {
 
 const SlackIntegrationsPanel: FC = () => {
   const snackbar = useSnackbar()
+  const account = useAccount()
+  const settingsDialog = useSettingsDialog()
   const { data: workspaces = [], isLoading } = useListSlackWorkspaces()
   const { data: apps = [] } = useListSlackApps()
   const startInstall = useStartSlackInstall()
@@ -153,9 +157,19 @@ const SlackIntegrationsPanel: FC = () => {
       <Stack spacing={2}>
         <Box sx={{ p: 2, borderRadius: 1, bgcolor: 'action.hover' }}>
           {apps.length === 0 ? (
-            <Typography variant="body2" color="text.secondary">
-              No Slack app has been configured by an administrator yet.
-            </Typography>
+            <Stack spacing={1} alignItems="flex-start">
+              <Typography variant="body2" color="text.secondary">
+                No Slack app has been configured by an administrator yet.
+              </Typography>
+              {account.admin && (
+                <Button
+                  size="small"
+                  onClick={() => settingsDialog.openDialog('admin', { tab: 'service_connections' })}
+                >
+                  Configure Slack app
+                </Button>
+              )}
+            </Stack>
           ) : (
             <Stack spacing={1.5}>
               {apps.length > 1 && (

--- a/frontend/src/components/helix-org/SlackIntegrationsPanel.tsx
+++ b/frontend/src/components/helix-org/SlackIntegrationsPanel.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useMemo, useCallback } from 'react'
+import { FC, useState, useMemo, useCallback, useEffect } from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Paper from '@mui/material/Paper'
@@ -49,6 +49,20 @@ const SlackIntegrationsPanel: FC = () => {
   const appId = selectedApp || (apps.length === 1 ? apps[0].id : '')
   const chosenApp = apps.find((a: any) => a.id === appId)
   const oauthAvailable = !!chosenApp?.slack_client_id
+
+  useEffect(() => {
+    const query = new URLSearchParams(window.location.search)
+    const error = query.get('slack_error')
+    const installed = query.get('slack_installed')
+    if (!error && !installed) return
+
+    if (error) snackbar.error(error)
+    if (installed) snackbar.success('Slack workspace connected')
+    query.delete('slack_error')
+    query.delete('slack_installed')
+    const search = query.toString()
+    window.history.replaceState({}, '', `${window.location.pathname}${search ? `?${search}` : ''}${window.location.hash}`)
+  }, [])
 
   const handleInstall = async () => {
     try {
@@ -190,7 +204,7 @@ const SlackIntegrationsPanel: FC = () => {
               ) : oauthAvailable ? (
                 <Stack spacing={1} alignItems="flex-start">
                   <Button variant="contained" startIcon={<SlackLogo sx={{ fontSize: 18 }} />} onClick={handleInstall} disabled={startInstall.isPending}>
-                    Install into your workspace
+                    Connect workspace
                   </Button>
                   <Typography variant="caption" color="text.secondary">
                     Opens Slack to pick the workspace and approve. Helix sets the bot token automatically — nothing to paste.

--- a/frontend/src/pages/HelixOrgHumanDetail.tsx
+++ b/frontend/src/pages/HelixOrgHumanDetail.tsx
@@ -3,7 +3,11 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
 import Container from '@mui/material/Container'
+import FormControl from '@mui/material/FormControl'
+import InputLabel from '@mui/material/InputLabel'
+import MenuItem from '@mui/material/MenuItem'
 import Paper from '@mui/material/Paper'
+import Select from '@mui/material/Select'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
@@ -20,7 +24,9 @@ import { useHelixOrgBot, useUpdateBot } from '../services/helixOrgService'
 // The contact channels surfaced as editable fields. Any other identity keys
 // the node happens to carry are preserved untouched on save.
 const CHANNELS: { key: string; label: string; placeholder: string }[] = [
-  { key: 'slack', label: 'Slack', placeholder: '@handle' },
+  { key: 'slack_user_id', label: 'Slack user ID', placeholder: 'U012ABCDEF' },
+  { key: 'slack_channel_id', label: 'Slack channel ID (optional)', placeholder: 'C012ABCDEF' },
+  { key: 'slack_team_id', label: 'Slack workspace ID (optional)', placeholder: 'T012ABCDEF' },
   { key: 'github', label: 'GitHub', placeholder: 'login' },
   { key: 'email', label: 'Email', placeholder: 'name@example.com' },
 ]
@@ -61,6 +67,10 @@ const HelixOrgHumanDetail: FC = () => {
 
   const handleSave = async () => {
     if (!bot?.id) return
+    if ((handles.preferred_contact ?? 'helix') === 'slack' && !handles.slack_user_id?.trim()) {
+      snackbar.error('Slack user ID is required for Slack delivery')
+      return
+    }
     // Rebuild the identity map from the current fields, dropping empties.
     const identity: Record<string, string> = {}
     for (const [k, v] of Object.entries(handles)) {
@@ -116,6 +126,18 @@ const HelixOrgHumanDetail: FC = () => {
                 How the org reaches this person. Bots resolve these when they need to message them.
               </Typography>
               <Stack spacing={2}>
+                <FormControl size="small" fullWidth>
+                  <InputLabel id="preferred-contact-label">Preferred delivery</InputLabel>
+                  <Select
+                    labelId="preferred-contact-label"
+                    label="Preferred delivery"
+                    value={handles.preferred_contact ?? 'helix'}
+                    onChange={(e) => setHandle('preferred_contact', e.target.value)}
+                  >
+                    <MenuItem value="helix">Helix notifications</MenuItem>
+                    <MenuItem value="slack">Slack</MenuItem>
+                  </Select>
+                </FormControl>
                 {CHANNELS.map((c) => (
                   <TextField
                     key={c.key}


### PR DESCRIPTION
## Summary

- add Slack as a human delivery channel for helix-org and guide administrators through app setup
- route threaded and top-level Slack DM replies back to the Worker that contacted the human
- keep direct-message conversations lightweight by embedding the current role, preserving new Chief of Staff context, and fetching Slack history only when needed
- redact minted credentials before agent output is logged, persisted, or published
- recover stale persisted Zed thread IDs when the external agent reports that the thread no longer exists

## Verification

- go test ./api/pkg/org/interfaces/mcptools -run TestMintCredential -count=1
- go test ./api/pkg/org/infrastructure/runtime/helix -count=1
- go test ./api/pkg/org/infrastructure/transports/slack -count=1
- go test ./api/pkg/server -run TestSeedChiefOfStaffPreservesContextForNewBotOnly -count=1
- go test ./api/pkg/server/helixorg -count=1
- go build ./api/pkg/server/ ./api/pkg/store/ ./api/pkg/types/
- manually verified Slack OAuth, outbound CoS DM delivery, top-level and threaded inbound Events API delivery, Worker routing, and Slack response on Prime
