### PR TITLE
fix(build): pin Kodit model artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,23 +16,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 ### Embedding model stage ###
 #----------------------------
-# Downloads and converts the st-codesearch-distilroberta-base model to ONNX format.
-# Uses kodit's download-model tool (Go binary that embeds the Python conversion script).
-FROM api-base AS embedding-model
-COPY --from=ghcr.io/astral-sh/uv:debian-slim /usr/local/bin/uv /usr/local/bin/uv
-# Cache the uv wheel downloads (~2GB of torch/transformers/cuda-* wheels) and
-# the HuggingFace model snapshot so re-running these stages on the same builder
-# doesn't re-download from PyPI / HF Hub each time.
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=cache,target=/root/.cache/huggingface \
-    go run github.com/helixml/kodit/cmd/download-model /build/models/flax-sentence-embeddings_st-codesearch-distilroberta-base
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=cache,target=/root/.cache/huggingface \
-    go run github.com/helixml/kodit/cmd/download-siglip2 /build/models/google_siglip2-base-patch16-512
+FROM registry.helixml.tech/helix/controlplane:2.11.52@sha256:58705ba01fc53a3af20099e44f1e3874550ca3242b736cdaa70d22693d86ca6a AS embedding-model
 
 ### Tokenizers library ###
 #-------------------------
@@ -57,7 +41,7 @@ COPY --from=tokenizers-lib /app/lib/libonnxruntime.so /usr/lib/
 # Tell kodit where to find the ORT library (see production stage comment for details)
 ENV ORT_LIB_DIR=/usr/lib
 # - Copy embedding models for kodit code intelligence
-COPY --from=embedding-model /build/models/ /kodit-models/
+COPY --from=embedding-model /kodit-models/ /kodit-models/
 # - Copy the files and run a build to make startup faster
 COPY api /app/api
 COPY helix-org /app/helix-org
@@ -132,7 +116,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=api-build-env /helix /helix
 COPY --from=ui-build-env /app/dist /www
 # Embedding model files for kodit code intelligence
-COPY --from=embedding-model /build/models/ /kodit-models/
+COPY --from=embedding-model /kodit-models/ /kodit-models/
 # ONNX Runtime library required by kodit's Hugot embedding provider (built with -tags ORT)
 COPY --from=tokenizers-lib /app/lib/libonnxruntime.so /usr/lib/
 # Tell kodit where to find the ORT library. Without this, kodit's auto-detection


### PR DESCRIPTION
## Summary
- source Kodit model artifacts from the immutable 2.11.52 control-plane image
- remove live Hugging Face downloads from normal control-plane builds
- preserve the existing text and SigLIP model files for amd64 and arm64

## Verification
- Dockerfile build check passed
- pinned manifest contains linux/amd64 and linux/arm64
- isolated model stage built successfully
- text and SigLIP ONNX model files verified
- Dockerfile contains no Hugging Face model download commands