### PR TITLE
fix(macos): pin supported VM base image

### DIFF
--- a/design/2026-07-16-macos-dmg-builder-cloud-init-oom.md
+++ b/design/2026-07-16-macos-dmg-builder-cloud-init-oom.md
@@ -1,0 +1,74 @@
+# macOS DMG builder cloud-init OOM
+
+Date: 2026-07-16
+Status: root fix validated for provisioning; Resolute signed DMG validation pending
+
+## Drone 3011 evidence
+
+Drone build 3011 was not a release-wide failure:
+
+- Core build and deployment completed successfully.
+- The macOS DMG pipeline failed while provisioning its Linux guest.
+- The preserved runner `qemu-boot.log` showed `apt-get` reaching 32.27 GB RSS
+  and being OOM-killed inside the 32 GB guest.
+- The provisioning script waited only for its cloud-init ready marker. Its
+  eventual timeout reported that the marker never appeared but hid the actual
+  package-install failure.
+- The guest image was Ubuntu 25.10, which reached end of life on 2026-07-09.
+
+The failure was therefore in the DMG builder's disposable VM provisioning, not
+in the already-successful release or deployment steps.
+
+## Root fix
+
+Switch `for-mac/scripts/provision-vm-light.sh` from the Ubuntu 25.10 current
+image to the Ubuntu 26.04 LTS Resolute release image.
+
+The image URL is release-specific and its SHA-256 checksum is pinned. Provision
+must verify the downloaded image before creating the guest disk, delete a
+mismatched download, and fail immediately. This avoids both an EOL package
+source and silent changes to a floating cloud image.
+
+## Diagnostic hardening
+
+When the cloud-init ready marker times out, print the evidence needed to
+identify the failed stage:
+
+- `cloud-init status --long`
+- `systemctl status cloud-final.service`
+- Recent `journalctl` output for `cloud-final.service`
+- The tail of `/var/log/cloud-init-output.log`
+- The tail of the host-side `qemu-boot.log`
+
+These diagnostics do not replace the timeout. They make the timeout report the
+underlying cloud-init, package, service, or guest-kernel failure instead of only
+the missing marker.
+
+## Validation results
+
+### Fresh Ubuntu 26.04 provision
+
+A fresh isolated full provision ran from 10:32:16 to 10:35:38 and passed:
+
+- The pinned Ubuntu 26.04 image checksum passed.
+- Cloud-init completed in 31 seconds without the prior OOM.
+- ZFS 2.4.3 loaded on kernel 7.0.
+- Helix API health passed.
+- Sandbox Docker daemon readiness passed.
+- Guest shutdown, image trim, and compaction passed.
+- The full provisioning script completed successfully.
+
+The `helix-ubuntu` inner image pull failed after sandbox dockerd was ready with
+a host Docker socket error. The existing script treats that pull as a nonfatal
+warning, and the full provision still completed. This was not caused by the
+Ubuntu migration. Track it separately only if it reproduces as a user-visible
+failure.
+
+### Release pipeline
+
+The original Drone 3012 Questing retry passed completely, including the signed
+DMG, and unblocked release 2.11.53. That validates the existing DMG pipeline but
+not the new Resolute guest image.
+
+The next tagged pipeline must validate that the signed, notarized, stapled DMG
+also completes with the Ubuntu 26.04 Resolute provisioned artifact.

--- a/for-mac/scripts/provision-vm-light.sh
+++ b/for-mac/scripts/provision-vm-light.sh
@@ -35,8 +35,9 @@ VM_USER="ubuntu"
 VM_PASS="helix"
 HELIX_VERSION=""
 
-# Ubuntu 25.10 (Questing) - kernel 6.17+ for virtio-gpu multi-scanout
-UBUNTU_URL="https://cloud-images.ubuntu.com/questing/current/questing-server-cloudimg-arm64.img"
+# Ubuntu 26.04 LTS (Resolute)
+UBUNTU_URL="https://cloud-images.ubuntu.com/releases/resolute/release/ubuntu-26.04-server-cloudimg-arm64.img"
+UBUNTU_SHA256="b95c8625a2d524f7fa6e2b4583e5b56d92ed7212178b0c2c150a4f68e45830f2"
 UBUNTU_IMG="ubuntu-cloud.img"
 
 # UEFI firmware (from Homebrew QEMU)
@@ -171,11 +172,18 @@ boot_provisioning_vm() {
 
 if ! step_done "download"; then
     if [ ! -f "${VM_DIR}/${UBUNTU_IMG}" ]; then
-        log "Downloading Ubuntu 25.10 ARM64 cloud image..."
+        log "Downloading Ubuntu 26.04 LTS ARM64 cloud image..."
         curl -L -o "${VM_DIR}/${UBUNTU_IMG}" "$UBUNTU_URL"
     else
         log "Ubuntu cloud image already downloaded"
     fi
+    ACTUAL_SHA256=$(shasum -a 256 "${VM_DIR}/${UBUNTU_IMG}" | awk '{print $1}') || ACTUAL_SHA256=""
+    if [ "$ACTUAL_SHA256" != "$UBUNTU_SHA256" ]; then
+        log "ERROR: Ubuntu cloud image checksum mismatch"
+        rm -f "${VM_DIR}/${UBUNTU_IMG}"
+        exit 1
+    fi
+    log "Ubuntu cloud image checksum verified"
     mark_step "download"
 fi
 
@@ -489,6 +497,19 @@ if ! step_done "boot_setup"; then
 
     if [ $ELAPSED -ge $MAX_WAIT ]; then
         log "ERROR: Timed out waiting for cloud-init (${MAX_WAIT}s)"
+        ssh -o ConnectTimeout=3 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+            -p "$SSH_PORT" "${VM_USER}@localhost" "
+echo '=== cloud-init status --long ==='
+sudo cloud-init status --long || true
+echo '=== systemctl status cloud-final.service ==='
+sudo systemctl status cloud-final.service --no-pager || true
+echo '=== journalctl -u cloud-final.service ==='
+sudo journalctl -u cloud-final.service --no-pager -n 200 || true
+echo '=== tail /var/log/cloud-init-output.log ==='
+sudo tail -n 200 /var/log/cloud-init-output.log || true
+" || true
+        log "=== tail ${VM_DIR}/qemu-boot.log ==="
+        tail -n 200 "${VM_DIR}/qemu-boot.log" || true
         log "Check ${VM_DIR}/qemu-boot.log for details"
         exit 1
     fi


### PR DESCRIPTION
## Summary
- replace EOL Ubuntu 25.10 with checksum-pinned Ubuntu 26.04 LTS for macOS VM provisioning
- verify the cloud image before creating the VM disk
- print cloud-init and QEMU diagnostics when provisioning times out

## Root cause
Drone build 3011 reached SSH, but apt-get consumed 32.27 GB RSS inside the 32 GB guest and was OOM-killed. The existing sentinel poll hid the package failure behind a 600-second timeout.

## Verification
- fresh isolated provision completed on the flight macOS runner
- image checksum verified
- cloud-init completed in 31 seconds
- ZFS 2.4.3 on kernel 7.0 installed
- API health and sandbox dockerd checks passed
- shutdown, trim, and qcow2 compaction completed
- bash syntax and diff checks passed

The next tagged pipeline will validate signed DMG creation with the Resolute image.