### PR TITLE
fix(auth): return admin status from login

### DIFF
--- a/api/pkg/server/auth.go
+++ b/api/pkg/server/auth.go
@@ -622,6 +622,7 @@ func (s *HelixAPIServer) login(w http.ResponseWriter, r *http.Request) {
 			ID:    user.ID,
 			Email: user.Email,
 			Name:  user.FullName,
+			Admin: user.Admin,
 		}
 		writeResponse(w, response, http.StatusOK)
 

--- a/api/pkg/server/auth_test.go
+++ b/api/pkg/server/auth_test.go
@@ -244,6 +244,33 @@ func (suite *AuthSuite) TestLogin() {
 	}
 }
 
+func (suite *AuthSuite) TestLoginReturnsAdmin() {
+	suite.server.Cfg.Auth.Provider = types.AuthProviderRegular
+	user := suite.createMockUser()
+	user.Admin = true
+
+	suite.store.EXPECT().
+		GetUser(gomock.Any(), &store.GetUserQuery{Email: testEmail}).
+		Return(user, nil)
+	suite.authenticator.EXPECT().
+		ValidatePassword(gomock.Any(), user, "password").
+		Return(nil)
+	suite.store.EXPECT().
+		CreateUserSession(gomock.Any(), gomock.Any()).
+		Return(&types.UserSession{ID: "session-123"}, nil)
+
+	body, err := json.Marshal(types.LoginRequest{Email: testEmail, Password: "password"})
+	suite.Require().NoError(err)
+	rec := httptest.NewRecorder()
+
+	suite.server.login(rec, suite.createTestRequest(http.MethodPost, "/api/v1/auth/login", body))
+
+	suite.Equal(http.StatusOK, rec.Code)
+	var response types.UserResponse
+	suite.Require().NoError(json.NewDecoder(rec.Body).Decode(&response))
+	suite.True(response.Admin)
+}
+
 func (suite *AuthSuite) TestCallback() {
 	testCases := []struct {
 		name           string


### PR DESCRIPTION
## Summary
- return the persisted admin status from regular login
- add a regression test for admin login responses

## Testing
- `go test ./api/pkg/server -run 'TestAuthSuite/TestLoginReturnsAdmin$' -count=1`\n- `go test ./api/pkg/server -run '^TestAuthSuite$' -count=1`\n- `cd api && go build ./pkg/server ./pkg/store ./pkg/types`\n- Playwright localhost login as admin and non-admin users