### PR TITLE
fix(config): reject nested yaml app config

### DIFF
--- a/api/pkg/config/yaml_processor.go
+++ b/api/pkg/config/yaml_processor.go
@@ -22,6 +22,10 @@ func ProcessYAMLConfig(yamlContent []byte) (*types.AppHelixConfig, error) {
 // ProcessJSONConfig processes a parsed JSON/YAML map and returns an AppHelixConfig
 // This handles both AppHelixConfig & AppHelixConfigCRD formats
 func ProcessJSONConfig(rawMap map[string]interface{}) (*types.AppHelixConfig, error) {
+	if _, ok := rawMap["helix"]; ok {
+		return nil, fmt.Errorf(`yaml_config must directly contain AppHelixConfig fields or an AppHelixConfig CRD, not a top-level "helix" key; use "config" for legacy App requests`)
+	}
+
 	// Check if it has the CRD structure
 	_, hasAPIVersion := rawMap["apiVersion"]
 	_, hasKind := rawMap["kind"]

--- a/api/pkg/config/yaml_processor_test.go
+++ b/api/pkg/config/yaml_processor_test.go
@@ -1,12 +1,64 @@
 package config
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestProcessJSONConfigRejectsLegacyHelixWrapper(t *testing.T) {
+	config, err := ProcessJSONConfig(map[string]interface{}{
+		"helix": map[string]interface{}{
+			"name":        "e2e-test-coding-agent-001",
+			"description": "E2E test coding agent",
+			"assistants": []interface{}{
+				map[string]interface{}{
+					"name":          "default",
+					"provider":      "CosmoCloud",
+					"model":         "qwen-light",
+					"agent_type":    "coding_agent",
+					"system_prompt": "You are a coding agent.",
+				},
+			},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, config)
+	assert.Contains(t, err.Error(), `use "config" for legacy App requests`)
+}
+
+func TestProcessJSONConfigMatchesLegacyApp(t *testing.T) {
+	helix := map[string]interface{}{
+		"name":        "e2e-test-coding-agent-001",
+		"description": "E2E test coding agent",
+		"assistants": []interface{}{
+			map[string]interface{}{
+				"name":          "default",
+				"provider":      "CosmoCloud",
+				"model":         "qwen-light",
+				"agent_type":    "coding_agent",
+				"system_prompt": "You are a coding agent.",
+			},
+		},
+	}
+
+	structured, err := ProcessJSONConfig(helix)
+	require.NoError(t, err)
+	assert.Equal(t, "e2e-test-coding-agent-001", structured.Name)
+	require.Len(t, structured.Assistants, 1)
+
+	body, err := json.Marshal(map[string]interface{}{
+		"config": map[string]interface{}{"helix": helix},
+	})
+	require.NoError(t, err)
+	var legacy types.App
+	require.NoError(t, json.Unmarshal(body, &legacy))
+	assert.Equal(t, legacy.Config.Helix, *structured)
+}
 
 func TestProcessYAMLConfig_AgentMode(t *testing.T) {
 	yamlContent := `


### PR DESCRIPTION
## Summary
- reject unsupported `yaml_config.helix` requests instead of silently persisting an empty app config
- direct callers to use direct `yaml_config` fields or legacy `config`
- verify supported direct config matches equivalent legacy `config.helix`

## Testing
- `go test ./api/pkg/config -run 'TestProcessJSONConfig' -count=1`\n- `go test ./api/pkg/config -count=1`\n- `cd api && go build ./pkg/server ./pkg/store ./pkg/types`\n- localhost API and Playwright: nested shape returns 400; direct shape returns 200 and persists config