### PR TITLE
fix(api): expose external agent sessions in list API

### DIFF
--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -156,6 +156,7 @@ func (apiServer *HelixAPIServer) getSession(rw http.ResponseWriter, req *http.Re
 // @Param   search          query    string  false  "Search sessions by name"
 // @Param   project_id      query    string  false  "Project ID"
 // @Param   session_role    query    string  false  "Filter by session role (e.g. job)"
+// @Param   include_external_agents query bool false "Include external agent sessions"
 // @Success 200 {object} types.PaginatedSessionsList
 // @Router /api/v1/sessions [get]
 // @Security BearerAuth
@@ -170,6 +171,7 @@ func (apiServer *HelixAPIServer) listSessions(_ http.ResponseWriter, req *http.R
 		AppID:                  req.URL.Query().Get("app_id"),
 		ProjectID:              req.URL.Query().Get("project_id"),
 		SessionRole:            req.URL.Query().Get("session_role"),
+		IncludeExternalAgents:  req.URL.Query().Get("include_external_agents") == "true",
 	}
 	query.Owner = user.ID
 	query.OwnerType = user.Type

--- a/api/pkg/server/session_handlers_test.go
+++ b/api/pkg/server/session_handlers_test.go
@@ -694,6 +694,35 @@ func (s *SessionAuthzSuite) TestListSessions_OwnerNoOrg() {
 	s.Equal(int64(1), result.TotalCount)
 }
 
+func (s *SessionAuthzSuite) TestListSessions_IncludeExternalAgents() {
+	s.store.EXPECT().GetOrganization(gomock.Any(), &store.GetOrganizationQuery{
+		ID: s.orgID,
+	}).Return(&types.Organization{ID: s.orgID}, nil)
+	s.store.EXPECT().GetOrganizationMembership(gomock.Any(), &store.GetOrganizationMembershipQuery{
+		OrganizationID: s.orgID,
+		UserID:         s.userID,
+	}).Return(&types.OrganizationMembership{
+		OrganizationID: s.orgID,
+		UserID:         s.userID,
+		Role:           types.OrganizationRoleMember,
+	}, nil)
+	s.store.EXPECT().ListSessions(gomock.Any(), store.ListSessionsQuery{
+		Owner:                 s.userID,
+		OrganizationID:        s.orgID,
+		Page:                  0,
+		PerPage:               50,
+		IncludeExternalAgents: true,
+	}).Return([]*types.Session{}, int64(0), nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/sessions?org_id="+s.orgID+"&include_external_agents=true", http.NoBody)
+	req = req.WithContext(s.authCtx)
+
+	result, err := s.server.listSessions(httptest.NewRecorder(), req)
+
+	s.NoError(err)
+	s.Require().NotNil(result)
+}
+
 // 2. User is owner and org member, lists org sessions
 func (s *SessionAuthzSuite) TestListSessions_OwnerInOrg() {
 	s.store.EXPECT().GetOrganization(gomock.Any(), &store.GetOrganizationQuery{


### PR DESCRIPTION
## Summary
- add the `include_external_agents` query parameter to `GET /api/v1/sessions`
- forward the flag to the existing `ListSessionsQuery` store filter
- verify true and default false handler behavior through exact store expectations

## Testing
- `CGO_ENABLED=1 go test ./pkg/server -run "^TestSessionAuthzSuite$/^TestListSessions" -count=1`

## Live verification
Verified on Prime with a real live Zed planning session temporarily classified as `model_name=external_agent`:

- unpatched API with `include_external_agents=true`: target absent
- patched API without the flag: target absent
- patched API with `include_external_agents=true`: target returned exactly once with the expected organization, owner, spec task, and Zed thread metadata
- `./stack rebuild frontend api`: passed
- `./stack build-sandbox`: passed
- API, frontend, Postgres, and sandbox healthy; Prime returned HTTP 200
- original test-row `model_name` restored after verification

All Drone and CodeQL checks passed.