### PR TITLE
fix(macos): pin cloud image release directory

### DIFF
--- a/for-mac/scripts/provision-vm-light.sh
+++ b/for-mac/scripts/provision-vm-light.sh
@@ -36,7 +36,7 @@ VM_PASS="helix"
 HELIX_VERSION=""
 
 # Ubuntu 26.04 LTS (Resolute)
-UBUNTU_URL="https://cloud-images.ubuntu.com/releases/resolute/release/ubuntu-26.04-server-cloudimg-arm64.img"
+UBUNTU_URL="https://cloud-images.ubuntu.com/releases/resolute/release-20260713/ubuntu-26.04-server-cloudimg-arm64.img"
 UBUNTU_SHA256="b95c8625a2d524f7fa6e2b4583e5b56d92ed7212178b0c2c150a4f68e45830f2"
 UBUNTU_IMG="ubuntu-cloud.img"
 


### PR DESCRIPTION
## Summary

- pin the Ubuntu 26.04 ARM64 cloud image to the immutable `release-20260713` directory
- retain the existing SHA-256 pin for that dated image

## Failure

Release 2.11.54 Drone build 3025 failed in `build-macos-dmg` during `provision-vm` because the mutable `release/` directory advanced while the script retained the checksum for the 2026-07-13 image. Production deployment was skipped and rollback succeeded.

## Verification

- official dated `SHA256SUMS` entry matches `b95c8625a2d524f7fa6e2b4583e5b56d92ed7212178b0c2c150a4f68e45830f2`
- immutable image URL returns HTTP 200
- `bash -n for-mac/scripts/provision-vm-light.sh`
- `git diff --check`