### PR TITLE
fix(frontend): reconnect session WebSocket on tab focus / network restore

### DIFF
--- a/frontend/src/contexts/streaming.tsx
+++ b/frontend/src/contexts/streaming.tsx
@@ -621,7 +621,23 @@ export const StreamingContextProvider: React.FC<{ children: ReactNode }> = ({
     rws.addEventListener("open", openHandler);
     rws.addEventListener("close", closeHandler);
 
+    // After a laptop sleep / wifi switch the socket is frequently left half-open:
+    // the browser reports it OPEN but no data flows and no 'close' event fires, so
+    // reconnecting-websocket never retries and live streaming silently stalls until
+    // a manual page refresh. Proactively force a reconnect when the tab regains
+    // focus or the network comes back — the 'open' handler then clears stale state
+    // and refetches, and the server's late-joiner catch-up (websocket_server_user.go)
+    // resumes streaming, exactly as a refresh does today.
+    const forceReconnectOnResume = () => {
+      if (document.visibilityState === "visible") rws.reconnect();
+    };
+    const handleOnline = () => rws.reconnect();
+    document.addEventListener("visibilitychange", forceReconnectOnResume);
+    window.addEventListener("online", handleOnline);
+
     return () => {
+      document.removeEventListener("visibilitychange", forceReconnectOnResume);
+      window.removeEventListener("online", handleOnline);
       rws.removeEventListener("message", messageHandler);
       rws.removeEventListener("open", openHandler);
       rws.removeEventListener("close", closeHandler);

--- a/frontend/src/hooks/useWebsocket.ts
+++ b/frontend/src/hooks/useWebsocket.ts
@@ -38,7 +38,10 @@ export const useWebsocket = (
     const url = `${wsProtocol}//${wsHost}/api/v1/ws/user?session_id=${session_id}`
 
     const rws = new ReconnectingWebSocket(url, [], {
-      maxRetries: 10,
+      // Never permanently give up: a long offline stretch (laptop asleep, wifi
+      // down) would otherwise burn through a finite retry budget and leave the
+      // socket dead forever, forcing a manual page refresh to resume streaming.
+      maxRetries: Infinity,
       reconnectionDelayGrowFactor: 1.3,
       maxReconnectionDelay: 10000,
       minReconnectionDelay: 1000,
@@ -62,7 +65,20 @@ export const useWebsocket = (
 
     rws.addEventListener('message', messageHandler)
 
+    // After a laptop sleep / wifi switch the socket is often left half-open (the
+    // browser reports it OPEN but no data flows and no 'close' fires). Force a
+    // reconnect when the tab regains focus or the network returns so updates
+    // resume without a manual refresh.
+    const forceReconnectOnResume = () => {
+      if (document.visibilityState === 'visible') rws.reconnect()
+    }
+    const handleOnline = () => rws.reconnect()
+    document.addEventListener('visibilitychange', forceReconnectOnResume)
+    window.addEventListener('online', handleOnline)
+
     return () => {
+      document.removeEventListener('visibilitychange', forceReconnectOnResume)
+      window.removeEventListener('online', handleOnline)
       if (wsRef.current) {
         wsRef.current.removeEventListener('message', messageHandler)
         wsRef.current.close()


### PR DESCRIPTION
## Problem

Live chat output only appeared **at the end** of a turn after moving between wifi networks or closing the laptop lid. Investigated live on meta (`ses_01kxzn61524k6r3j5dr4hvarqg`).

**Server side was never at fault.** During the affected turn: **268** `External agent added message` (Zed→Helix), the interaction accumulated to 58 KB in memory and persisted to the DB. Delivery to the *browser* is what stalled.

**Root cause is client-side.** Streaming reaches the UI over the per-session `/ws/user` WebSocket. After a laptop suspend / wifi switch the socket is left **half-open** — the browser reports it `OPEN`, no data flows, and no `close` event fires — so `reconnecting-websocket` never retries and the stream silently stalls. A manual page refresh fixed it because the fresh connection triggers the server's **late-joiner catch-up snapshot** (`websocket_server_user.go:124`), which replays current state and resumes streaming. The user confirmed: refreshing reconnects and streams properly again.

## Fix

Force a reconnect on the events that signal "the user is back": tab refocus and network restore.

- **`streaming.tsx`** (live-chat path): `rws.reconnect()` on `visibilitychange`→visible and `window` `online`. The existing `open` handler already clears stale streaming state and refetches on reconnect, so the late-joiner catch-up resumes streaming exactly as a manual refresh does.
- **`useWebsocket.ts`**: same proactive reconnect, plus `maxRetries` `10` → `Infinity`. The finite budget meant a long offline stretch exhausted retries and killed the socket permanently until a refresh.

## Verification

- `yarn build` (tsc typecheck + vite) passes.
- Mechanism verified against live server logs + the confirmed "refresh works" behavior. Not yet exercised for the exact sleep/wifi runtime scenario in-browser — the reconnect path is the same one a refresh already proves works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)