### PR TITLE
Raise spec-task attachment cap to 500 per task

### DIFF
--- a/api/pkg/server/spec_task_attachments_handlers.go
+++ b/api/pkg/server/spec_task_attachments_handlers.go
@@ -76,8 +76,11 @@ func (s *HelixAPIServer) uploadSpecTaskAttachments(w http.ResponseWriter, r *htt
 		return
 	}
 
-	// Enforce a request-body cap matching per-task budget (10 files * 10 MB + overhead).
-	if err := r.ParseMultipartForm(int64(types.SpecTaskAttachmentMaxPerTask) * types.SpecTaskAttachmentMaxBytes); err != nil {
+	// Keep the in-memory buffer bounded to one file's worth; larger uploads spill to
+	// temp files. This must NOT scale with SpecTaskAttachmentMaxPerTask, or a large cap
+	// (e.g. 500) would let the parser buffer gigabytes in memory. Per-file and per-task
+	// caps are still enforced below.
+	if err := r.ParseMultipartForm(types.SpecTaskAttachmentMaxBytes); err != nil {
 		http.Error(w, "invalid multipart form: "+err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/api/pkg/types/simple_spec_task.go
+++ b/api/pkg/types/simple_spec_task.go
@@ -458,7 +458,7 @@ func (SpecTaskAttachment) TableName() string {
 // SpecTask attachment limits
 const (
 	SpecTaskAttachmentMaxBytes   = 10 * 1024 * 1024 // 10 MB per file
-	SpecTaskAttachmentMaxPerTask = 10               // 10 files per task
+	SpecTaskAttachmentMaxPerTask = 500              // 500 files per task
 )
 
 // SpecTaskAttachmentAllowedMimeTypes is the allowlist of MIME types accepted for upload.


### PR DESCRIPTION
## Summary
The per-task spec-task attachment cap was hard-coded at 10 files, which is what
limited HelixOS to sending 10 transcripts per task. Raise it to 500.

## Changes
- `api/pkg/types/simple_spec_task.go`: `SpecTaskAttachmentMaxPerTask` 10 → 500.
  The upload handler's cumulative check and error message interpolate the
  constant, so they update automatically.
- `api/pkg/server/spec_task_attachments_handlers.go`: decouple the
  `ParseMultipartForm` in-memory buffer from the count cap. It previously sized
  the buffer as `MaxPerTask × MaxBytes`; at 500 × 10 MB that would be a 5 GB
  in-memory budget. It now uses one file's worth (`SpecTaskAttachmentMaxBytes`);
  larger uploads spill to temp files. Per-file and per-task caps are unchanged.

## Notes
- Verified: `go build ./pkg/types ./pkg/server` passes.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kk95f1seff98mbxhfa31qj81/tasks/spt_01ky0jhgx59gkbf94yzsg5zqz7)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002280_fix-this-stupid-limit/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002280_fix-this-stupid-limit/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002280_fix-this-stupid-limit/tasks.md)

🚀 Built with [Helix](https://helix.ml)