### PR TITLE
fix(specs): prevent false task merge detection

### DIFF
--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -1067,10 +1067,17 @@ func (s *HelixAPIServer) updateSpecTask(w http.ResponseWriter, r *http.Request) 
 
 	// Update fields if provided
 	if updateReq.Status != "" {
+		previousStatus := task.Status
 		task.Status = updateReq.Status
 		// Update StatusUpdatedAt so task appears at top of new column in Kanban
 		now := time.Now()
 		task.StatusUpdatedAt = &now
+		if previousStatus == types.TaskStatusDone && updateReq.Status != types.TaskStatusDone {
+			task.CompletedAt = nil
+			task.MergedToMain = false
+			task.MergedAt = nil
+			task.MergeCommitHash = ""
+		}
 
 		// When moving back to backlog, clear lifecycle fields so the task
 		// starts fresh. Without this, the orchestrator sees old specs and

--- a/api/pkg/server/spec_driven_task_keep_alive_test.go
+++ b/api/pkg/server/spec_driven_task_keep_alive_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/helixml/helix/api/pkg/config"
@@ -137,6 +138,40 @@ func (s *SpecTaskKeepAliveSuite) TestKeepAliveOff_OnRunningTask_DoesNotStopDeskt
 	keepAliveOff := false
 	rr := httptest.NewRecorder()
 	s.server.updateSpecTask(rr, s.makeUpdateRequest(types.SpecTaskUpdateRequest{KeepAlive: &keepAliveOff}))
+
+	s.Equal(http.StatusOK, rr.Code)
+}
+
+func (s *SpecTaskKeepAliveSuite) TestReopenDoneTask_ClearsTerminalFields() {
+	now := time.Now()
+	existingTask := &types.SpecTask{
+		ID:                s.taskID,
+		ProjectID:         "project_keepalive",
+		Status:            types.TaskStatusDone,
+		BranchName:        "feature/reopen",
+		PlanningSessionID: "session_keepalive",
+		CompletedAt:       &now,
+		MergedToMain:      true,
+		MergedAt:          &now,
+		MergeCommitHash:   "merge-sha",
+	}
+	project := &types.Project{ID: "project_keepalive", UserID: s.userID}
+
+	s.store.EXPECT().GetSpecTask(gomock.Any(), s.taskID).Return(existingTask, nil)
+	s.store.EXPECT().GetProject(gomock.Any(), "project_keepalive").Return(project, nil)
+	s.store.EXPECT().UpdateSpecTask(gomock.Any(), gomock.Any()).DoAndReturn(func(_ interface{}, task *types.SpecTask) error {
+		s.Equal(types.TaskStatusImplementation, task.Status)
+		s.Nil(task.CompletedAt)
+		s.False(task.MergedToMain)
+		s.Nil(task.MergedAt)
+		s.Empty(task.MergeCommitHash)
+		s.Equal("feature/reopen", task.BranchName)
+		s.Equal("session_keepalive", task.PlanningSessionID)
+		return nil
+	})
+
+	rr := httptest.NewRecorder()
+	s.server.updateSpecTask(rr, s.makeUpdateRequest(types.SpecTaskUpdateRequest{Status: types.TaskStatusImplementation}))
 
 	s.Equal(http.StatusOK, rr.Code)
 }

--- a/api/pkg/services/spec_task_orchestrator.go
+++ b/api/pkg/services/spec_task_orchestrator.go
@@ -1316,51 +1316,6 @@ func (o *SpecTaskOrchestrator) checkTaskForExternalPRActivity(ctx context.Contex
 		}
 	}
 
-	// Fallback: check if branch has been merged to main in the primary repo
-	// (handles squash-merges or branch deletion after merge)
-	if project.DefaultRepoID == "" {
-		return nil
-	}
-	repo, err := o.gitService.GetRepository(ctx, project.DefaultRepoID)
-	if err != nil {
-		return fmt.Errorf("failed to get default repository: %w", err)
-	}
-	if !repo.IsExternal {
-		return nil
-	}
-
-	merged, err := o.gitService.IsBranchMerged(ctx, project.DefaultRepoID, task.BranchName, repo.DefaultBranch)
-	if err != nil {
-		if task.LastPushCommitHash != "" {
-			merged, err = o.gitService.IsCommitInBranch(ctx, project.DefaultRepoID, task.LastPushCommitHash, repo.DefaultBranch)
-			if err != nil {
-				log.Debug().Err(err).Str("task_id", task.ID).Msg("Failed to check if commit is in main branch")
-				return nil
-			}
-		} else {
-			return nil
-		}
-	}
-
-	if merged {
-		log.Info().
-			Str("task_id", task.ID).
-			Str("branch", task.BranchName).
-			Msg("Detected merged branch (no PR found), moving task to done status")
-
-		now := time.Now()
-		task.Status = types.TaskStatusDone
-		task.MergedToMain = true
-		task.MergedAt = &now
-		task.CompletedAt = &now
-		task.UpdatedAt = now
-		if err := o.store.UpdateSpecTask(ctx, task); err != nil {
-			return err
-		}
-		DismissTaskAttentionEvents(ctx, o.store, task.ID)
-		return nil
-	}
-
 	return nil
 }
 

--- a/api/pkg/services/spec_task_orchestrator_test.go
+++ b/api/pkg/services/spec_task_orchestrator_test.go
@@ -834,6 +834,34 @@ func (s *SpecTaskOrchestratorTestSuite) TestProcessExternalPullRequestStatus_All
 	assert.NotNil(s.T(), task.MergedAt)
 }
 
+func (s *SpecTaskOrchestratorTestSuite) TestCheckTaskForExternalPRActivity_NoPRDoesNotTreatBranchAsMerged() {
+	ctx := context.Background()
+	task := &types.SpecTask{
+		ID:         "task-new-branch",
+		ProjectID:  "project-1",
+		BranchName: "feature/new-task",
+		Status:     types.TaskStatusImplementation,
+	}
+
+	s.store.EXPECT().GetProject(ctx, "project-1").Return(&types.Project{
+		ID:            "project-1",
+		DefaultRepoID: "repo-1",
+	}, nil)
+	s.store.EXPECT().ListGitRepositories(ctx, &types.ListGitRepositoriesRequest{
+		ProjectID: "project-1",
+	}).Return([]*types.GitRepository{{
+		ID:          "repo-1",
+		IsExternal:  true,
+		ExternalURL: "https://github.com/helixml/helix",
+	}}, nil)
+	s.gitService.EXPECT().ListPullRequests(ctx, "repo-1").Return(nil, nil)
+
+	err := s.orchestrator.checkTaskForExternalPRActivity(ctx, task, map[string][]*types.PullRequest{})
+	s.Require().NoError(err)
+	s.Equal(types.TaskStatusImplementation, task.Status)
+	s.False(task.MergedToMain)
+}
+
 // Production-realistic case: task has a BranchName set, all PRs error, so
 // the IsBranchMerged fallback runs. With active PR branches (commits not
 // in default), IsBranchMerged returns false and the task correctly stays

--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -1528,9 +1528,9 @@ function TaskCardInner({
                     textAlign: "center",
                   }}
                 >
-                  Address review comments with agent.
+                  A PR was detected for this task's branch, so it appears here.
                   <br />
-                  Moves to Merged when PR closes.
+                  Moves to Merged when the PR is merged.
                 </Typography>
               </>
             ) : (


### PR DESCRIPTION
## Summary

- stop treating a newly created branch at the default branch HEAD as already merged
- clear terminal merge fields when reopening a completed task
- explain why tasks continued from branches with open PRs move to the PR column

## Verification

- `go test ./pkg/services -run TestSpecTaskOrchestratorTestSuite -count=1`
- `go test ./pkg/server -run TestSpecTaskKeepAliveSuite -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `cd frontend && yarn build`
- Prime live test: fresh task remained in Implementation across two PR polls
- Prime live test: reopen cleared terminal fields and the next agent operation succeeded
- Prime live test: continued branch with open GitLab MR moved to PR and showed the corrected explanation