### PR TITLE
fix(specs): require branch for existing mode

### DIFF
--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -1099,6 +1099,7 @@ func (s *HelixAPIServer) updateSpecTask(w http.ResponseWriter, r *http.Request) 
 			task.MergeCommitHash = ""
 			task.RepoPullRequests = nil
 			task.BranchName = "" // Force fresh branch so orchestrator doesn't see the old merged branch
+			task.BranchMode = types.BranchModeNew
 			task.KeepAlive = false
 		}
 	}

--- a/api/pkg/server/spec_driven_task_keep_alive_test.go
+++ b/api/pkg/server/spec_driven_task_keep_alive_test.go
@@ -140,3 +140,30 @@ func (s *SpecTaskKeepAliveSuite) TestKeepAliveOff_OnRunningTask_DoesNotStopDeskt
 
 	s.Equal(http.StatusOK, rr.Code)
 }
+
+func (s *SpecTaskKeepAliveSuite) TestResetDoneExistingTaskToBacklogUsesNewBranchMode() {
+	existingTask := &types.SpecTask{
+		ID:         s.taskID,
+		ProjectID:  "project_keepalive",
+		Status:     types.TaskStatusDone,
+		BranchMode: types.BranchModeExisting,
+		BranchName: "merged-branch",
+	}
+	project := &types.Project{
+		ID:     "project_keepalive",
+		UserID: s.userID,
+	}
+
+	s.store.EXPECT().GetSpecTask(gomock.Any(), s.taskID).Return(existingTask, nil)
+	s.store.EXPECT().GetProject(gomock.Any(), "project_keepalive").Return(project, nil)
+	s.store.EXPECT().UpdateSpecTask(gomock.Any(), gomock.Any()).DoAndReturn(func(_ interface{}, task *types.SpecTask) error {
+		s.Empty(task.BranchName)
+		s.Equal(types.BranchModeNew, task.BranchMode)
+		return nil
+	})
+
+	rr := httptest.NewRecorder()
+	s.server.updateSpecTask(rr, s.makeUpdateRequest(types.SpecTaskUpdateRequest{Status: types.TaskStatusBacklog}))
+
+	s.Equal(http.StatusOK, rr.Code)
+}

--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -165,6 +165,9 @@ func (s *SpecDrivenTaskService) CreateTaskFromPrompt(ctx context.Context, req *t
 	if branchMode == "" {
 		branchMode = types.BranchModeNew
 	}
+	if branchMode == types.BranchModeExisting && strings.TrimSpace(req.WorkingBranch) == "" {
+		return nil, fmt.Errorf("working branch is required for existing branch mode")
+	}
 
 	// Determine organization ID from project if it belongs to an org
 	organizationID := ""

--- a/api/pkg/services/spec_driven_task_service_test.go
+++ b/api/pkg/services/spec_driven_task_service_test.go
@@ -91,6 +91,30 @@ func TestSpecDrivenTaskService_CreateTaskFromPrompt(t *testing.T) {
 	// Note: Goroutine will fail gracefully, we only test the synchronous part
 }
 
+func TestSpecDrivenTaskService_CreateTaskFromPromptRejectsBlankExistingBranch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := store.NewMockStore(ctrl)
+	service := NewSpecDrivenTaskService(
+		mockStore,
+		nil,
+		"test-helix-agent",
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		NewDisabledKoditService(),
+	)
+
+	task, err := service.CreateTaskFromPrompt(context.Background(), &types.CreateTaskRequest{
+		BranchMode:    types.BranchModeExisting,
+		WorkingBranch: "   ",
+	})
+
+	require.EqualError(t, err, "working branch is required for existing branch mode")
+	require.Nil(t, task)
+}
+
 func TestSpecDrivenTaskService_HandleSpecGenerationComplete(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/frontend/src/components/tasks/NewSpecTaskForm.tsx
+++ b/frontend/src/components/tasks/NewSpecTaskForm.tsx
@@ -1329,6 +1329,8 @@ const NewSpecTaskForm: React.FC<NewSpecTaskFormProps> = ({
             !taskPrompt.trim() ||
             isCreating ||
             creatingAgent ||
+            (branchMode === TypesBranchMode.BranchModeExisting &&
+              !workingBranch) ||
             (showCreateAgentForm &&
               !(
                 codeAgentRuntime === "claude_code" &&


### PR DESCRIPTION
## Summary

- reset reopened backlog tasks to new-branch mode when clearing their previous branch
- reject existing-branch tasks without a selected working branch at the API boundary
- disable task creation in the UI until an existing branch is selected

## Root cause

Reopening an existing-branch task cleared `BranchName` but retained `BranchMode=existing`. Workspace startup then received `HELIX_BRANCH_MODE=existing` without `HELIX_WORKING_BRANCH` and failed.

## Verification

- `go test ./pkg/server -run TestSpecTaskKeepAliveSuite/TestResetDoneExistingTaskToBacklogUsesNewBranchMode -count=1`
- `go test ./pkg/services -run TestSpecDrivenTaskService_CreateTaskFromPromptRejectsBlankExistingBranch -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `cd frontend && yarn build`
- `git diff --check`

NOT live tested on Prime before commit.