### PR TITLE
fix(specs): preserve selected base branch

### DIFF
--- a/api/pkg/services/spec_driven_task_service.go
+++ b/api/pkg/services/spec_driven_task_service.go
@@ -1262,6 +1262,7 @@ func (s *SpecDrivenTaskService) ApproveSpecs(ctx context.Context, task *types.Sp
 
 		// Handle branch configuration based on mode
 		var branchName string
+		effectiveBaseBranch := repo.DefaultBranch
 		if task.BranchMode == types.BranchModeExisting && task.BranchName != "" {
 			// Existing mode: use the branch name that was set during task creation
 			branchName = task.BranchName
@@ -1281,6 +1282,9 @@ func (s *SpecDrivenTaskService) ApproveSpecs(ctx context.Context, task *types.Sp
 			// Set base branch if not already set
 			if task.BaseBranch == "" {
 				task.BaseBranch = repo.DefaultBranch
+			}
+			if task.BranchMode == types.BranchModeNew {
+				effectiveBaseBranch = task.BaseBranch
 			}
 		}
 
@@ -1370,11 +1374,13 @@ func (s *SpecDrivenTaskService) ApproveSpecs(ctx context.Context, task *types.Sp
 		// remote already has it. Errors are logged but don't block the
 		// transition: the existing pre-receive hook stops genuinely-bad
 		// pushes, and the agent prompt still names the right branch.
-		if err := s.ensureFeatureBranchInContainer(ctx, sessionID, repo.Name, branchName, repo.DefaultBranch); err != nil {
-			log.Error().Err(err).
-				Str("task_id", task.ID).Str("session_id", sessionID).
-				Str("repo", repo.Name).Str("branch", branchName).Str("base", repo.DefaultBranch).
-				Msg("Failed to check out feature branch in container at approval; agent may start on base branch")
+		if task.BranchMode == types.BranchModeNew {
+			if err := s.ensureFeatureBranchInContainer(ctx, sessionID, repo.Name, branchName, effectiveBaseBranch); err != nil {
+				log.Error().Err(err).
+					Str("task_id", task.ID).Str("session_id", sessionID).
+					Str("repo", repo.Name).Str("branch", branchName).Str("base", effectiveBaseBranch).
+					Msg("Failed to check out feature branch in container at approval; agent may start on base branch")
+			}
 		}
 
 		// Send instruction to existing agent session (reuse planning session)
@@ -1388,7 +1394,7 @@ func (s *SpecDrivenTaskService) ApproveSpecs(ctx context.Context, task *types.Sp
 				task.CreatedBy, // User who created the task
 				task,
 				branchName,
-				repo.DefaultBranch,
+				effectiveBaseBranch,
 				repo.Name,
 			)
 			if err != nil {
@@ -1404,6 +1410,7 @@ func (s *SpecDrivenTaskService) ApproveSpecs(ctx context.Context, task *types.Sp
 				Str("task_id", task.ID).
 				Str("session_id", sessionID).
 				Str("branch_name", branchName).
+				Str("base_branch", effectiveBaseBranch).
 				Msg("Specs approved - sent implementation instruction to existing agent")
 		} else {
 			log.Warn().

--- a/api/pkg/services/spec_driven_task_service_test.go
+++ b/api/pkg/services/spec_driven_task_service_test.go
@@ -378,6 +378,129 @@ func TestSpecDrivenTaskService_ApproveSpecs_NilSpecApprovalAndNilApprovedAt(t *t
 	require.NoError(t, err)
 }
 
+func TestSpecDrivenTaskService_ApproveSpecsUsesCustomBaseForNewBranch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	var checkoutCommand []string
+	var approvalPrompt string
+	service := NewSpecDrivenTaskService(
+		mockStore,
+		nil,
+		"test-helix-agent",
+		nil,
+		nil,
+		nil, nil, nil,
+		NewDisabledKoditService(),
+	)
+	service.ExecInDesktop = func(_ context.Context, _ string, command []string) error {
+		checkoutCommand = command
+		return nil
+	}
+	service.EnqueueMessageToAgent = func(_ context.Context, _ *types.SpecTask, message string, _ bool, _ string) error {
+		approvalPrompt = message
+		return nil
+	}
+
+	ctx := context.Background()
+	task := &types.SpecTask{
+		ID:                "task-custom-base",
+		ProjectID:         "project-1",
+		CreatedBy:         "user-1",
+		Status:            types.TaskStatusSpecApproved,
+		PlanningSessionID: "session-1",
+		SpecApproval:      &types.SpecApprovalResponse{Approved: true},
+		BranchMode:        types.BranchModeNew,
+		BaseBranch:        "release/2.0",
+		TaskNumber:        44,
+		Name:              "custom-base-task",
+	}
+	project := &types.Project{ID: "project-1", DefaultRepoID: "repo-1"}
+	repo := &types.GitRepository{ID: "repo-1", Name: "helix", DefaultBranch: "main"}
+
+	mockStore.EXPECT().GetSpecTask(ctx, task.ID).Return(task, nil)
+	mockStore.EXPECT().GetProject(gomock.Any(), project.ID).Return(project, nil).Times(2)
+	mockStore.EXPECT().GetGitRepository(ctx, repo.ID).Return(repo, nil)
+	mockStore.EXPECT().TransitionSpecTaskStatus(
+		ctx,
+		task.ID,
+		gomock.Any(),
+		types.TaskStatusImplementation,
+		gomock.Any(),
+	).DoAndReturn(func(_ context.Context, _ string, _ []types.SpecTaskStatus, _ types.SpecTaskStatus, fields map[string]any) (bool, error) {
+		assert.Equal(t, "release/2.0", fields["base_branch"])
+		return true, nil
+	})
+	mockStore.EXPECT().ListGitRepositories(gomock.Any(), gomock.Any()).Return([]*types.GitRepository{repo}, nil).Times(2)
+
+	err := service.ApproveSpecs(ctx, &types.SpecTask{ID: task.ID})
+	require.NoError(t, err)
+	require.Len(t, checkoutCommand, 3)
+	assert.Equal(t, "bash", checkoutCommand[0])
+	assert.Contains(t, checkoutCommand[2], "git fetch origin 'release/2.0'")
+	assert.Contains(t, checkoutCommand[2], "origin/'release/2.0'")
+	assert.NotContains(t, checkoutCommand[2], "origin/'main'")
+	assert.Contains(t, approvalPrompt, "git fetch origin release/2.0 && git merge origin/release/2.0")
+	assert.NotContains(t, approvalPrompt, "git fetch origin main && git merge origin/main")
+}
+
+func TestSpecDrivenTaskService_ApproveSpecsDoesNotCheckoutExistingBranch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := store.NewMockStore(ctrl)
+	execCalls := 0
+	service := NewSpecDrivenTaskService(
+		mockStore,
+		nil,
+		"test-helix-agent",
+		nil,
+		nil,
+		nil, nil, nil,
+		NewDisabledKoditService(),
+	)
+	service.ExecInDesktop = func(_ context.Context, _ string, _ []string) error {
+		execCalls++
+		return nil
+	}
+	service.EnqueueMessageToAgent = func(_ context.Context, _ *types.SpecTask, _ string, _ bool, _ string) error {
+		return nil
+	}
+
+	ctx := context.Background()
+	task := &types.SpecTask{
+		ID:                "task-existing-branch",
+		ProjectID:         "project-1",
+		CreatedBy:         "user-1",
+		Status:            types.TaskStatusSpecApproved,
+		PlanningSessionID: "session-1",
+		SpecApproval:      &types.SpecApprovalResponse{Approved: true},
+		BranchMode:        types.BranchModeExisting,
+		BranchName:        "existing-work",
+		TaskNumber:        45,
+		Name:              "existing-branch-task",
+	}
+	project := &types.Project{ID: "project-1", DefaultRepoID: "repo-1"}
+	repo := &types.GitRepository{ID: "repo-1", Name: "helix", DefaultBranch: "main"}
+
+	mockStore.EXPECT().GetSpecTask(ctx, task.ID).Return(task, nil)
+	mockStore.EXPECT().GetProject(gomock.Any(), project.ID).Return(project, nil).Times(2)
+	mockStore.EXPECT().GetGitRepository(ctx, repo.ID).Return(repo, nil)
+	mockStore.EXPECT().TransitionSpecTaskStatus(
+		ctx,
+		task.ID,
+		gomock.Any(),
+		types.TaskStatusImplementation,
+		gomock.Any(),
+	).Return(true, nil)
+	mockStore.EXPECT().ListGitRepositories(gomock.Any(), gomock.Any()).Return([]*types.GitRepository{repo}, nil).Times(2)
+
+	err := service.ApproveSpecs(ctx, &types.SpecTask{ID: task.ID})
+	require.NoError(t, err)
+	assert.Zero(t, execCalls)
+}
+
 // TestSpecDrivenTaskService_ApproveSpecs_LosesAtomicTransitionRace verifies the
 // authoritative race guard: if TransitionSpecTaskStatus reports it didn't update
 // the row (transitioned=false), ApproveSpecs must bail without sending the


### PR DESCRIPTION
## Summary

- preserve a task selected custom base branch when specs are approved
- create new feature branches from that selected base instead of the repository default
- avoid resetting continue-existing branches during approval
- send the same effective base branch to the implementation prompt

## Root cause

Task creation, persistence, and planning correctly used the selected base branch. `ApproveSpecs` later recreated the feature branch from `repo.DefaultBranch` and passed that default to the implementation prompt, contradicting the persisted task configuration.

## Verification

- `go test ./pkg/services -run "^TestSpecDrivenTaskService_ApproveSpecs(UsesCustomBaseForNewBranch|DoesNotCheckoutExistingBranch)$" -count=1`
- `go test ./pkg/services -run "^TestSpecDrivenTaskService_ApproveSpecs" -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `git diff --check`

NOT live tested on Prime before commit.