### PR TITLE
feat(gitlab): attribute repository actions with OAuth

### DIFF
--- a/api/pkg/server/ensure_pull_request_test.go
+++ b/api/pkg/server/ensure_pull_request_test.go
@@ -76,8 +76,8 @@ func (f *fakeGitRepoService) SetKoditService(_ services.KoditServicer) {
 func (f *fakeGitRepoService) CloneRepositoryAsync(_ *types.GitRepository, _ ...func(string)) {
 	panic("CloneRepositoryAsync unexpected")
 }
-func (f *fakeGitRepoService) ValidateUserGitHubOAuth(_ context.Context, _ *types.GitRepository, _ string) error {
-	panic("ValidateUserGitHubOAuth unexpected")
+func (f *fakeGitRepoService) ValidateUserOAuth(_ context.Context, _ *types.GitRepository, _ string) error {
+	panic("ValidateUserOAuth unexpected")
 }
 func (f *fakeGitRepoService) CreateRepository(_ context.Context, _ *types.GitRepositoryCreateRequest) (*types.GitRepository, error) {
 	panic("CreateRepository unexpected")

--- a/api/pkg/server/git_repository_servicer.go
+++ b/api/pkg/server/git_repository_servicer.go
@@ -14,7 +14,7 @@ type gitRepositoryServicer interface {
 	Initialize(ctx context.Context) error
 	SetKoditService(koditService services.KoditServicer)
 	CloneRepositoryAsync(gitRepo *types.GitRepository, postClone ...func(localPath string))
-	ValidateUserGitHubOAuth(ctx context.Context, repo *types.GitRepository, userID string) error
+	ValidateUserOAuth(ctx context.Context, repo *types.GitRepository, userID string) error
 	CreateRepository(ctx context.Context, request *types.GitRepositoryCreateRequest) (*types.GitRepository, error)
 	GetRepository(ctx context.Context, repoID string) (*types.GitRepository, error)
 	UpdateRepository(ctx context.Context, repoID string, request *types.GitRepositoryUpdateRequest, koditAPIKey string) (*types.GitRepository, error)

--- a/api/pkg/server/spec_driven_task_handlers.go
+++ b/api/pkg/server/spec_driven_task_handlers.go
@@ -506,7 +506,7 @@ func (s *HelixAPIServer) approveSpecs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// When approving specs, validate the approver has GitHub OAuth so their
+	// When approving specs, validate the approver has provider OAuth so their
 	// credentials can be used for commits and push during implementation.
 	if req.Approved {
 		project, err := s.Store.GetProject(ctx, existingTask.ProjectID)
@@ -520,7 +520,7 @@ func (s *HelixAPIServer) approveSpecs(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, fmt.Sprintf("Failed to get repository: %v", err), http.StatusInternalServerError)
 				return
 			}
-			if err := s.gitRepositoryService.ValidateUserGitHubOAuth(ctx, repo, user.ID); err != nil {
+			if err := s.gitRepositoryService.ValidateUserOAuth(ctx, repo, user.ID); err != nil {
 				var oauthErr *services.OAuthRequiredError
 				if errors.As(err, &oauthErr) {
 					writeResponse(w, map[string]interface{}{
@@ -948,12 +948,12 @@ func (s *HelixAPIServer) startPlanning(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// The user who starts planning becomes the actor for planning-phase
-	// commits/pushes, so their GitHub OAuth must be connected up front.
+	// commits/pushes, so their provider OAuth must be connected up front.
 	// Otherwise the agent would push specs using either no credentials or
 	// the task creator's token — both are wrong.
 	if project, projErr := s.Store.GetProject(ctx, task.ProjectID); projErr == nil && project.DefaultRepoID != "" {
 		if repo, repoErr := s.Store.GetGitRepository(ctx, project.DefaultRepoID); repoErr == nil {
-			if err := s.gitRepositoryService.ValidateUserGitHubOAuth(ctx, repo, user.ID); err != nil {
+			if err := s.gitRepositoryService.ValidateUserOAuth(ctx, repo, user.ID); err != nil {
 				var oauthErr *services.OAuthRequiredError
 				if errors.As(err, &oauthErr) {
 					writeResponse(w, map[string]interface{}{

--- a/api/pkg/server/spec_task_design_review_handlers.go
+++ b/api/pkg/server/spec_task_design_review_handlers.go
@@ -319,14 +319,14 @@ func (s *HelixAPIServer) submitDesignReview(w http.ResponseWriter, r *http.Reque
 		switch specTask.Status {
 		case types.TaskStatusSpecReview, types.TaskStatusSpecRevision, types.TaskStatusSpecGeneration:
 			// Before advancing to implementation, validate the approver has
-			// GitHub OAuth so their credentials can be used for commits and
+			// provider OAuth so their credentials can be used for commits and
 			// push. Mirrors the check in approveSpecs/approveImplementation —
 			// the UI goes through this endpoint, so omitting the check here
 			// lets an approver without OAuth silently drive the task to
 			// implementation and commits would then fall back to the creator.
 			if project, projErr := s.Store.GetProject(ctx, specTask.ProjectID); projErr == nil && project.DefaultRepoID != "" {
 				if repo, repoErr := s.Store.GetGitRepository(ctx, project.DefaultRepoID); repoErr == nil {
-					if err := s.gitRepositoryService.ValidateUserGitHubOAuth(ctx, repo, user.ID); err != nil {
+					if err := s.gitRepositoryService.ValidateUserOAuth(ctx, repo, user.ID); err != nil {
 						var oauthErr *services.OAuthRequiredError
 						if errors.As(err, &oauthErr) {
 							writeResponse(w, map[string]interface{}{
@@ -1753,5 +1753,3 @@ func (s *HelixAPIServer) enqueueSpecTaskAgentMessage(ctx context.Context, task *
 	_, err := s.enqueueAgentMessage(ctx, task.PlanningSessionID, message, interrupt, notifyUserID, task.ID)
 	return err
 }
-
-

--- a/api/pkg/server/spec_task_workflow_handlers.go
+++ b/api/pkg/server/spec_task_workflow_handlers.go
@@ -141,10 +141,10 @@ func (s *HelixAPIServer) approveImplementation(w http.ResponseWriter, r *http.Re
 	// If repo is external, move to pull_request status (awaiting merge in external system)
 	// For internal repos, try merge first - only record approval if merge succeeds
 	if s.shouldOpenPullRequest(repo) {
-		// Validate user has GitHub OAuth before advancing task status.
+		// Validate user OAuth before advancing task status.
 		// This is a lightweight sync check (DB lookup only). The actual PR
 		// creation remains async.
-		if err := s.gitRepositoryService.ValidateUserGitHubOAuth(ctx, repo, user.ID); err != nil {
+		if err := s.gitRepositoryService.ValidateUserOAuth(ctx, repo, user.ID); err != nil {
 			var oauthErr *services.OAuthRequiredError
 			if errors.As(err, &oauthErr) {
 				writeResponse(w, map[string]interface{}{
@@ -781,12 +781,12 @@ func (s *HelixAPIServer) ensurePullRequestsForAllRepos(ctx context.Context, task
 			}
 			var oauthErr *services.OAuthRequiredError
 			if errors.As(err, &oauthErr) {
-				task.Metadata["error"] = "GitHub OAuth connection required to open a PR. Please connect your GitHub account and try again."
+				task.Metadata["error"] = fmt.Sprintf("%s OAuth connection required to open a PR. Please connect your account and try again.", oauthErr.ProviderType)
 			} else if strings.Contains(err.Error(), "Permission") && strings.Contains(err.Error(), "denied") {
-				task.Metadata["error"] = fmt.Sprintf("Permission denied: your GitHub account does not have write access to %s. Ask the repository owner to add you as a collaborator.", repo.Name)
+				task.Metadata["error"] = fmt.Sprintf("Permission denied: your %s account does not have write access to %s. Ask the repository owner to add you as a collaborator.", repo.ExternalType, repo.Name)
 			} else if strings.Contains(err.Error(), "rate limit") {
-				// GitHub API rate limit — transient, don't alarm the user
-				log.Warn().Err(err).Str("repo_name", repo.Name).Str("task_id", task.ID).Msg("GitHub API rate limit hit, will retry on next cycle")
+				// Provider API rate limits are transient, so retry on the next cycle.
+				log.Warn().Err(err).Str("repo_name", repo.Name).Str("task_id", task.ID).Msg("VCS API rate limit hit, will retry on next cycle")
 				// Preserve existing PR data but don't set a scary error message
 				for _, existing := range task.RepoPullRequests {
 					if existing.RepositoryID == repo.ID {

--- a/api/pkg/services/git_repository_service.go
+++ b/api/pkg/services/git_repository_service.go
@@ -2656,14 +2656,15 @@ func (s *GitRepositoryService) getCredentialsForRepo(ctx context.Context, gitRep
 	if len(userID) > 0 {
 		actingUserID = userID[0]
 	}
-	if actingUserID != "" && gitRepo.ExternalType == types.ExternalRepositoryTypeGitHub {
+	providerType := OAuthProviderTypeForRepo(gitRepo.ExternalType)
+	if actingUserID != "" && providerType != types.OAuthProviderTypeUnknown {
 		connections, err := s.store.ListOAuthConnections(ctx, &store.ListOAuthConnectionsQuery{
 			UserID: actingUserID,
 		})
 		if err == nil {
 			for _, conn := range connections {
-				if conn.Provider.Type == types.OAuthProviderTypeGitHub && conn.AccessToken != "" {
-					return "x-access-token", conn.AccessToken
+				if oauthConnectionMatchesProvider(conn, providerType) && conn.AccessToken != "" {
+					return oauthGitUsername(gitRepo.ExternalType), conn.AccessToken
 				}
 			}
 		}
@@ -2743,7 +2744,7 @@ func (s *GitRepositoryService) newestLiveOAuthToken(ctx context.Context, userID 
 	}
 	var newest *types.OAuthConnection
 	for _, conn := range conns {
-		if conn.Provider.Type != wantType || conn.AccessToken == "" {
+		if !oauthConnectionMatchesProvider(conn, wantType) || conn.AccessToken == "" {
 			continue
 		}
 		if newest == nil || conn.UpdatedAt.After(newest.UpdatedAt) {
@@ -2789,6 +2790,11 @@ func OAuthProviderTypeForRepo(t types.ExternalRepositoryType) types.OAuthProvide
 	}
 }
 
+func oauthConnectionMatchesProvider(conn *types.OAuthConnection, providerType types.OAuthProviderType) bool {
+	return conn != nil && (conn.Provider.Type == providerType ||
+		(conn.Provider.Type == types.OAuthProviderTypeCustom && strings.Contains(strings.ToLower(conn.Provider.Name), string(providerType))))
+}
+
 // RepoOwnerName returns the "owner/repo" slug parsed from a repo's external URL,
 // or "" if it can't be parsed.
 func RepoOwnerName(repo *types.GitRepository) string {
@@ -2817,7 +2823,7 @@ func (s *GitRepositoryService) GetActingAccountHandle(ctx context.Context, gitRe
 		conns, err := s.store.ListOAuthConnections(ctx, &store.ListOAuthConnectionsQuery{UserID: actingUserID})
 		if err == nil {
 			for _, conn := range conns {
-				if conn.Provider.Type == providerType && conn.ProviderUsername != "" {
+				if oauthConnectionMatchesProvider(conn, providerType) && conn.ProviderUsername != "" {
 					return "@" + conn.ProviderUsername
 				}
 			}

--- a/api/pkg/services/git_repository_service_ci_status.go
+++ b/api/pkg/services/git_repository_service_ci_status.go
@@ -76,7 +76,7 @@ func (s *GitRepositoryService) getGitHubCIStatus(ctx context.Context, repo *type
 }
 
 func (s *GitRepositoryService) getGitLabCIStatus(ctx context.Context, repo *types.GitRepository, headSHA string) (*types.CIStatus, error) {
-	client, err := s.getGitLabClient(ctx, repo)
+	client, err := s.getGitLabClient(ctx, repo, "")
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/services/git_repository_service_pull_requests.go
+++ b/api/pkg/services/git_repository_service_pull_requests.go
@@ -26,7 +26,7 @@ import (
 const rateLimitFallbackBackoff = 5 * time.Minute
 
 // OAuthRequiredError is returned when a user-initiated action requires
-// a GitHub OAuth connection that the acting user does not have.
+// a provider OAuth connection that the acting user does not have.
 type OAuthRequiredError struct {
 	ProviderType string
 }
@@ -35,11 +35,12 @@ func (e *OAuthRequiredError) Error() string {
 	return fmt.Sprintf("%s OAuth connection required to open a PR under your account", e.ProviderType)
 }
 
-// ValidateUserGitHubOAuth checks whether the acting user has a GitHub OAuth
-// connection. Returns OAuthRequiredError if the user needs to connect.
-// Returns nil for empty userID (agent path) or non-GitHub repos.
-func (s *GitRepositoryService) ValidateUserGitHubOAuth(ctx context.Context, repo *types.GitRepository, userID string) error {
-	if userID == "" || repo.ExternalType != types.ExternalRepositoryTypeGitHub {
+// ValidateUserOAuth checks whether the acting user has the OAuth connection
+// required by a GitHub or GitLab repository. Returns nil for automated paths
+// and repository types that do not use per-user OAuth attribution.
+func (s *GitRepositoryService) ValidateUserOAuth(ctx context.Context, repo *types.GitRepository, userID string) error {
+	providerType := OAuthProviderTypeForRepo(repo.ExternalType)
+	if userID == "" || (providerType != types.OAuthProviderTypeGitHub && providerType != types.OAuthProviderTypeGitLab) {
 		return nil
 	}
 	connections, err := s.store.ListOAuthConnections(ctx, &store.ListOAuthConnectionsQuery{
@@ -49,11 +50,11 @@ func (s *GitRepositoryService) ValidateUserGitHubOAuth(ctx context.Context, repo
 		return fmt.Errorf("failed to check OAuth connections: %w", err)
 	}
 	for _, conn := range connections {
-		if conn.Provider.Type == types.OAuthProviderTypeGitHub && conn.AccessToken != "" {
+		if oauthConnectionMatchesProvider(conn, providerType) && conn.AccessToken != "" {
 			return nil
 		}
 	}
-	return &OAuthRequiredError{ProviderType: "github"}
+	return &OAuthRequiredError{ProviderType: string(providerType)}
 }
 
 // CreatePullRequest opens a pull request in the external repository. Should be called after the changes are committed to the local repository and
@@ -79,7 +80,7 @@ func (s *GitRepositoryService) CreatePullRequest(ctx context.Context, repoID str
 	case types.ExternalRepositoryTypeGitHub:
 		return s.createGitHubPullRequest(ctx, repo, title, description, sourceBranch, targetBranch, userID)
 	case types.ExternalRepositoryTypeGitLab:
-		return s.createGitLabMergeRequest(ctx, repo, title, description, sourceBranch, targetBranch)
+		return s.createGitLabMergeRequest(ctx, repo, title, description, sourceBranch, targetBranch, userID)
 	case types.ExternalRepositoryTypeBitbucket:
 		return s.createBitbucketPullRequest(ctx, repo, title, description, sourceBranch, targetBranch)
 	default:
@@ -159,7 +160,7 @@ func (s *GitRepositoryService) updateAzureDevOpsPullRequest(ctx context.Context,
 }
 
 func (s *GitRepositoryService) updateGitLabMergeRequest(ctx context.Context, repo *types.GitRepository, mrIID int, title string, description string) error {
-	client, err := s.getGitLabClient(ctx, repo)
+	client, err := s.getGitLabClient(ctx, repo, "")
 	if err != nil {
 		return err
 	}
@@ -608,7 +609,7 @@ func (s *GitRepositoryService) getGitHubClient(ctx context.Context, repo *types.
 			return nil, fmt.Errorf("failed to look up user OAuth connections: %w", err)
 		}
 		for _, conn := range connections {
-			if conn.Provider.Type == types.OAuthProviderTypeGitHub && conn.AccessToken != "" {
+			if oauthConnectionMatchesProvider(conn, types.OAuthProviderTypeGitHub) && conn.AccessToken != "" {
 				return github.NewClientWithOAuthAndBaseURL(conn.AccessToken, baseURL), nil
 			}
 		}
@@ -792,7 +793,7 @@ func pullRequestStateFromGitHub(ghPR *gh.PullRequest) types.PullRequestState {
 
 // GitLab Merge Request Operations
 
-func (s *GitRepositoryService) getGitLabClient(ctx context.Context, repo *types.GitRepository) (*gitlab.Client, error) {
+func (s *GitRepositoryService) getGitLabClient(ctx context.Context, repo *types.GitRepository, userID string) (*gitlab.Client, error) {
 	// Determine base URL (empty for gitlab.com, custom for self-hosted)
 	var baseURL string
 	if repo.GitLab != nil && repo.GitLab.BaseURL != "" {
@@ -803,6 +804,19 @@ func (s *GitRepositoryService) getGitLabClient(ctx context.Context, repo *types.
 		if err == nil && parsedBaseURL != "" {
 			baseURL = parsedBaseURL
 		}
+	}
+
+	if userID != "" {
+		connections, err := s.store.ListOAuthConnections(ctx, &store.ListOAuthConnectionsQuery{UserID: userID})
+		if err != nil {
+			return nil, fmt.Errorf("failed to look up user OAuth connections: %w", err)
+		}
+		for _, conn := range connections {
+			if oauthConnectionMatchesProvider(conn, types.OAuthProviderTypeGitLab) && conn.AccessToken != "" {
+				return gitlab.NewClientWithOAuth(baseURL, conn.AccessToken)
+			}
+		}
+		return nil, &OAuthRequiredError{ProviderType: "gitlab"}
 	}
 
 	// First check for OAuth connection
@@ -848,8 +862,8 @@ func (s *GitRepositoryService) getGitLabProjectID(ctx context.Context, client *g
 	return project.ID, nil
 }
 
-func (s *GitRepositoryService) createGitLabMergeRequest(ctx context.Context, repo *types.GitRepository, title string, description string, sourceBranch string, targetBranch string) (string, error) {
-	client, err := s.getGitLabClient(ctx, repo)
+func (s *GitRepositoryService) createGitLabMergeRequest(ctx context.Context, repo *types.GitRepository, title string, description string, sourceBranch string, targetBranch string, userID string) (string, error) {
+	client, err := s.getGitLabClient(ctx, repo, userID)
 	if err != nil {
 		return "", err
 	}
@@ -874,7 +888,7 @@ func (s *GitRepositoryService) createGitLabMergeRequest(ctx context.Context, rep
 }
 
 func (s *GitRepositoryService) listGitLabMergeRequests(ctx context.Context, repo *types.GitRepository) ([]*types.PullRequest, error) {
-	client, err := s.getGitLabClient(ctx, repo)
+	client, err := s.getGitLabClient(ctx, repo, "")
 	if err != nil {
 		return nil, err
 	}
@@ -935,7 +949,7 @@ func pullRequestStateFromGitLab(glMR *gl.MergeRequest) types.PullRequestState {
 }
 
 func (s *GitRepositoryService) getGitLabMergeRequest(ctx context.Context, repo *types.GitRepository, mrIID int) (*types.PullRequest, error) {
-	client, err := s.getGitLabClient(ctx, repo)
+	client, err := s.getGitLabClient(ctx, repo, "")
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/services/git_repository_service_pull_requests_test.go
+++ b/api/pkg/services/git_repository_service_pull_requests_test.go
@@ -2,6 +2,9 @@ package services
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/helixml/helix/api/pkg/store"
@@ -102,5 +105,132 @@ func TestGetGitHubClient_UserWithoutOAuth_ReturnsError(t *testing.T) {
 	}
 	if oauthErr.ProviderType != "github" {
 		t.Fatalf("expected provider_type 'github', got '%s'", oauthErr.ProviderType)
+	}
+}
+
+func TestGetCredentialsForRepo_GitLabUserOAuthTakesPrecedence(t *testing.T) {
+	fs := &prTestStore{
+		oauthConnections: []*types.OAuthConnection{
+			{ID: "user-connection", UserID: "user-b", AccessToken: "user-token", Provider: types.OAuthProvider{Type: types.OAuthProviderTypeGitLab}},
+		},
+		oauthConnection: &types.OAuthConnection{
+			ID: "shared-connection", AccessToken: "shared-token", Provider: types.OAuthProvider{Type: types.OAuthProviderTypeGitLab},
+		},
+	}
+	repo := &types.GitRepository{
+		ExternalType:      types.ExternalRepositoryTypeGitLab,
+		OAuthConnectionID: "shared-connection",
+		GitLab:            &types.GitLab{PersonalAccessToken: "repo-pat"},
+	}
+
+	username, password := newPRTestService(fs).getCredentialsForRepo(context.Background(), repo, "user-b")
+
+	if username != "oauth2" || password != "user-token" {
+		t.Fatalf("expected acting GitLab OAuth credentials, got %q / %q", username, password)
+	}
+}
+
+func TestCreateGitLabMergeRequest_UserOAuthTakesPrecedence(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if got := r.Header.Get("Authorization"); got != "Bearer user-token" {
+			t.Errorf("expected acting user's bearer token, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet:
+			fmt.Fprint(w, `{"id":123}`)
+		case r.Method == http.MethodPost:
+			fmt.Fprint(w, `{"iid":7}`)
+		default:
+			http.Error(w, "unexpected request", http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	fs := &prTestStore{
+		oauthConnections: []*types.OAuthConnection{
+			{UserID: "user-b", AccessToken: "user-token", Provider: types.OAuthProvider{Type: types.OAuthProviderTypeCustom, Name: "Self-hosted GitLab"}},
+		},
+		oauthConnection: &types.OAuthConnection{
+			ID: "shared-connection", AccessToken: "shared-token", Provider: types.OAuthProvider{Type: types.OAuthProviderTypeGitLab},
+		},
+	}
+	repo := &types.GitRepository{
+		ExternalURL:       server.URL + "/org/repo",
+		ExternalType:      types.ExternalRepositoryTypeGitLab,
+		OAuthConnectionID: "shared-connection",
+		GitLab: &types.GitLab{
+			BaseURL:             server.URL + "/api/v4/",
+			PersonalAccessToken: "repo-pat",
+		},
+	}
+
+	mrID, err := newPRTestService(fs).createGitLabMergeRequest(
+		context.Background(), repo, "title", "description", "feature", "main", "user-b",
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if mrID != "7" || requestCount != 2 {
+		t.Fatalf("expected MR 7 after two API requests, got MR %q and %d requests", mrID, requestCount)
+	}
+}
+
+func TestGetGitLabClient_UserWithoutOAuthReturnsError(t *testing.T) {
+	repo := &types.GitRepository{
+		ExternalURL:  "https://gitlab.com/org/repo",
+		ExternalType: types.ExternalRepositoryTypeGitLab,
+		GitLab:       &types.GitLab{PersonalAccessToken: "repo-pat"},
+	}
+
+	_, err := newPRTestService(&prTestStore{}).getGitLabClient(context.Background(), repo, "user-x")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	oauthErr, ok := err.(*OAuthRequiredError)
+	if !ok {
+		t.Fatalf("expected *OAuthRequiredError, got %T: %v", err, err)
+	}
+	if oauthErr.ProviderType != "gitlab" {
+		t.Fatalf("expected provider_type 'gitlab', got %q", oauthErr.ProviderType)
+	}
+}
+
+func TestGetGitLabClient_AgentFallsBackToRepoCredentials(t *testing.T) {
+	repo := &types.GitRepository{
+		ExternalURL:  "https://gitlab.com/org/repo",
+		ExternalType: types.ExternalRepositoryTypeGitLab,
+		GitLab:       &types.GitLab{PersonalAccessToken: "repo-pat"},
+	}
+
+	client, err := newPRTestService(&prTestStore{}).getGitLabClient(context.Background(), repo, "")
+	if err != nil || client == nil {
+		t.Fatalf("expected repo credential fallback, got client %v and error %v", client, err)
+	}
+}
+
+func TestValidateUserOAuth_GitLabRequiresMatchingConnection(t *testing.T) {
+	fs := &prTestStore{oauthConnections: []*types.OAuthConnection{
+		{UserID: "user-x", AccessToken: "github-token", Provider: types.OAuthProvider{Type: types.OAuthProviderTypeGitHub}},
+	}}
+	repo := &types.GitRepository{ExternalType: types.ExternalRepositoryTypeGitLab}
+
+	err := newPRTestService(fs).ValidateUserOAuth(context.Background(), repo, "user-x")
+	oauthErr, ok := err.(*OAuthRequiredError)
+	if !ok || oauthErr.ProviderType != "gitlab" {
+		t.Fatalf("expected GitLab OAuthRequiredError, got %T: %v", err, err)
+	}
+}
+
+func TestValidateUserOAuth_AcceptsCustomGitLabProvider(t *testing.T) {
+	fs := &prTestStore{oauthConnections: []*types.OAuthConnection{
+		{UserID: "user-x", AccessToken: "gitlab-token", Provider: types.OAuthProvider{Type: types.OAuthProviderTypeCustom, Name: "Self-hosted GitLab"}},
+	}}
+	repo := &types.GitRepository{ExternalType: types.ExternalRepositoryTypeGitLab}
+
+	if err := newPRTestService(fs).ValidateUserOAuth(context.Background(), repo, "user-x"); err != nil {
+		t.Fatalf("expected custom GitLab provider to match, got: %v", err)
 	}
 }

--- a/api/pkg/services/git_repository_service_push.go
+++ b/api/pkg/services/git_repository_service_push.go
@@ -55,8 +55,13 @@ func (s *GitRepositoryService) PushBranchToRemote(ctx context.Context, repoID, b
 	if branchName == "" {
 		return fmt.Errorf("branch name is required")
 	}
+	if actingUserID != "" {
+		if err := s.ValidateUserOAuth(ctx, gitRepo, actingUserID); err != nil {
+			return err
+		}
+	}
 
-	// Get credentials for the external URL — use acting user's OAuth when available
+	// Get credentials for the external URL using the acting user's OAuth.
 	username, password := s.getCredentialsForRepo(ctx, gitRepo, actingUserID)
 	authType := "none"
 	if password != "" {

--- a/api/pkg/services/git_repository_service_push_test.go
+++ b/api/pkg/services/git_repository_service_push_test.go
@@ -30,6 +30,33 @@ func TestGitRepositoryPushSuiteADO(t *testing.T) {
 	suite.Run(t, new(GitRepositoryPushSuiteADO))
 }
 
+func TestPushBranchToRemote_GitLabUserWithoutOAuthReturnsErrorBeforePush(t *testing.T) {
+	mockStore := store.NewMockStore(gomock.NewController(t))
+	service := NewGitRepositoryService(mockStore, t.TempDir(), "http://localhost:8080", "test", "test@example.com")
+	repoPath := t.TempDir()
+	if err := giteagit.InitRepository(context.Background(), repoPath, true, "sha1"); err != nil {
+		t.Fatalf("failed to initialize test repository: %v", err)
+	}
+	repo := &types.GitRepository{
+		ID:            "gitlab-repo",
+		LocalPath:     repoPath,
+		IsExternal:    true,
+		ExternalURL:   "https://gitlab.com/org/repo",
+		ExternalType:  types.ExternalRepositoryTypeGitLab,
+		DefaultBranch: "master",
+		GitLab:        &types.GitLab{PersonalAccessToken: "shared-pat"},
+	}
+	mockStore.EXPECT().GetGitRepository(gomock.Any(), repo.ID).Return(repo, nil)
+	mockStore.EXPECT().ListOAuthConnections(gomock.Any(), &store.ListOAuthConnectionsQuery{UserID: "user-x"}).Return(nil, nil)
+
+	err := service.PushBranchToRemote(context.Background(), repo.ID, "feature", false, "user-x")
+
+	oauthErr, ok := err.(*OAuthRequiredError)
+	if !ok || oauthErr.ProviderType != "gitlab" {
+		t.Fatalf("expected GitLab OAuthRequiredError, got %T: %v", err, err)
+	}
+}
+
 func (suite *GitRepositoryPushSuiteADO) SetupTest() {
 	suite.store = store.NewMockStore(gomock.NewController(suite.T()))
 	suite.adoToken = os.Getenv("CI_ADO_TOKEN")

--- a/design/2026-07-21-gitlab-per-user-oauth-attribution.md
+++ b/design/2026-07-21-gitlab-per-user-oauth-attribution.md
@@ -1,0 +1,52 @@
+# GitLab Per-User OAuth Attribution
+
+## Customer Problem
+
+GitLab repositories configured with a shared personal access token use that credential for upstream pushes and merge-request API calls. GitLab therefore shows the repository setup user as the push and merge-request actor, even when another Helix user approved the work.
+
+Commit identity is separate. Helix can set the commit author's name and email in Git, but those fields do not choose the authenticated GitLab account used for transport or API requests. Correct customer-visible attribution requires the acting user's GitLab credential for both the push and merge-request creation.
+
+## Existing Support and Gap
+
+Helix already stores OAuth providers and per-user OAuth connections, including GitLab and custom/self-hosted providers. Repository-level GitLab OAuth or PAT credentials remain necessary for unattended repository operations.
+
+The acting-user path was GitHub-only:
+
+- OAuth validation required a per-user connection only for GitHub.
+- Git credential lookup preferred a GitHub acting-user token but not a GitLab token.
+- GitHub pull-request creation accepted the acting user, while GitLab merge-request creation always used repository credentials.
+- Task UI OAuth recovery assumed every `oauth_required` response meant GitHub.
+
+## Implemented Flow
+
+- Map GitHub and GitLab repositories to their OAuth provider types and require a matching per-user OAuth connection for user-initiated planning, approval, push, and PR/MR actions.
+- Prefer the acting user's OAuth token for upstream Git transport. GitLab uses username `oauth2` with that token.
+- Pass the acting user into GitLab merge-request creation and construct the GitLab API client with that user's bearer token.
+- Accept matching custom providers by provider name for self-hosted GitHub and GitLab.
+- Preserve automated behavior: an empty acting-user ID skips per-user enforcement and falls back to the repository OAuth connection or PAT.
+- Generalize frontend `oauth_required` handling across task planning, design approval, implementation approval, detail, board, and tab views. The backend `provider_type` selects GitHub or GitLab connection copy, provider, and scopes.
+- Add a GitLab admin-provider template using GitLab authorization, token, and user-info endpoints.
+- Request GitLab scopes `api`, `read_repository`, `write_repository`, and `read_user`. The `api` scope is required for merge-request API creation.
+
+No schema change is required. The feature uses the existing OAuth provider, OAuth connection, and repository credential fields.
+
+## Verification
+
+```text
+cd /Users/psamuel/helix/helix-worktrees/gitlab-oauth-attribution/api
+go test ./pkg/services -run 'Test(GetCredentialsForRepo_GitLabUserOAuthTakesPrecedence|CreateGitLabMergeRequest_UserOAuthTakesPrecedence|GetGitLabClient_UserWithoutOAuthReturnsError|GetGitLabClient_AgentFallsBackToRepoCredentials|ValidateUserOAuth_GitLabRequiresMatchingConnection|ValidateUserOAuth_AcceptsCustomGitLabProvider|PushBranchToRemote_GitLabUserWithoutOAuthReturnsErrorBeforePush)' -count=1
+ok github.com/helixml/helix/api/pkg/services 0.568s
+
+cd /Users/psamuel/helix/helix-worktrees/gitlab-oauth-attribution/frontend
+yarn test src/utils/oauthProviders.test.ts --run
+Test Files 1 passed (1); Tests 39 passed (39)
+
+yarn build
+vite: 21709 modules transformed; build completed in 16.75s
+```
+
+The backend tests verify acting-token precedence for Git transport and GitLab API calls, missing-user rejection before push, custom GitLab provider matching, and empty-user repository-credential fallback. The frontend test verifies inclusion of the GitLab `api` scope.
+
+## Remaining Live Verification
+
+NOT live tested: user-attributed upstream push and user-attributed merge-request creation require completing a task against a GitLab repository with a connected user OAuth account.

--- a/frontend/src/components/dashboard/OAuthProvidersTable.tsx
+++ b/frontend/src/components/dashboard/OAuthProvidersTable.tsx
@@ -60,6 +60,14 @@ const PROVIDER_SETUP_GUIDE: Record<string, {
       'Copy the Client ID and generate a Client Secret',
     ],
   },
+  gitlab: {
+    setupUrl: 'https://gitlab.com/-/user_settings/applications',
+    steps: [
+      'Go to GitLab -> Preferences -> Applications',
+      'Create an OAuth application and add the Helix callback URL',
+      'Copy the Application ID and Secret',
+    ],
+  },
   google: {
     setupUrl: 'https://console.cloud.google.com/apis/credentials',
     steps: [
@@ -123,6 +131,12 @@ export const PROVIDER_DEFAULTS: Record<string, {
     token_url: 'https://github.com/login/oauth/access_token',
     user_info_url: 'https://api.github.com/user',
     type: 'github'
+  },
+  gitlab: {
+    auth_url: 'https://gitlab.com/oauth/authorize',
+    token_url: 'https://gitlab.com/oauth/token',
+    user_info_url: 'https://gitlab.com/api/v4/user',
+    type: 'gitlab'
   },
   google: {
     auth_url: 'https://accounts.google.com/o/oauth2/v2/auth',
@@ -912,4 +926,4 @@ const OAuthProvidersTable: React.FC = () => {
   )
 }
 
-export default OAuthProvidersTable 
+export default OAuthProvidersTable

--- a/frontend/src/components/icons/ProviderIcons.tsx
+++ b/frontend/src/components/icons/ProviderIcons.tsx
@@ -112,6 +112,7 @@ export const CrispLogo = (props: any) => (
 // All built-in icons export
 export const PROVIDER_ICONS: Record<string, React.ReactNode> = {
   github: <GitHubIcon sx={{ fontSize: 30 }} />,
+  gitlab: <CodeIcon sx={{ fontSize: 30 }} />,
   google: <GoogleIcon sx={{ fontSize: 30 }} />,
   microsoft: <MicrosoftLogo sx={{ fontSize: 30 }} />,
   atlassian: <img src={atlassianLogo} style={{ width: 30, height: 30 }} alt="Atlassian" />,
@@ -128,6 +129,7 @@ export const PROVIDER_ICONS: Record<string, React.ReactNode> = {
 // Brand colors for all known provider types
 export const PROVIDER_COLORS: Record<string, string> = {
   github: '#24292e',
+  gitlab: '#FC6D26',
   google: '#4285F4',
   microsoft: '#00a1f1',
   atlassian: '#0052CC',
@@ -144,6 +146,7 @@ export const PROVIDER_COLORS: Record<string, string> = {
 // All known provider display names
 export const PROVIDER_TYPES: Record<string, string> = {
   github: 'GitHub',
+  gitlab: 'GitLab',
   google: 'Google',
   microsoft: 'Microsoft',
   atlassian: 'Atlassian',
@@ -169,6 +172,11 @@ export const BUILT_IN_PROVIDERS: PartialOAuthProvider[] = [
     type: 'github',
     name: 'GitHub',
     description: 'Connect to GitHub to access repositories and collaborate on code'
+  },
+  {
+    type: 'gitlab',
+    name: 'GitLab',
+    description: 'Connect to GitLab to access repositories and collaborate on code'
   },
   {
     type: 'google',

--- a/frontend/src/components/project/BrowseProvidersDialog.tsx
+++ b/frontend/src/components/project/BrowseProvidersDialog.tsx
@@ -417,12 +417,12 @@ const BrowseProvidersDialog: FC<BrowseProvidersDialogProps> = ({
       if (providerId) {
         // Request scopes based on provider type
         // GitHub needs 'repo' scope for read/write access to repositories
-        // GitLab needs 'read_repository,write_repository' scopes
+        // GitLab needs API and repository scopes for merge requests and pushes
         let scopesParam = "";
         if (selectedProvider === "github") {
           scopesParam = "?scopes=" + GITHUB_VCS_SCOPES.join(",");
         } else if (selectedProvider === "gitlab") {
-          scopesParam = "?scopes=read_repository,write_repository,read_user";
+          scopesParam = "?scopes=api,read_repository,write_repository,read_user";
         }
 
         try {

--- a/frontend/src/components/spec-tasks/DesignReviewContent.tsx
+++ b/frontend/src/components/spec-tasks/DesignReviewContent.tsx
@@ -60,9 +60,9 @@ import {
 import useSnackbar from "../../hooks/useSnackbar";
 import useApi from "../../hooks/useApi";
 import useAccount from "../../hooks/useAccount";
-import { useOAuthFlow, GITHUB_VCS_SCOPES } from "../../hooks/useOAuthFlow";
+import { useOAuthFlow } from "../../hooks/useOAuthFlow";
 import { useListOAuthProviders } from "../../services/oauthProvidersService";
-import { findOAuthProviderForType } from "../../utils/oauthProviders";
+import { findOAuthProviderForType, vcsScopesForProvider } from "../../utils/oauthProviders";
 import InlineCommentBubble from "./InlineCommentBubble";
 import InlineCommentForm from "./InlineCommentForm";
 import CommentLogSidebar from "./CommentLogSidebar";
@@ -233,12 +233,9 @@ export default function DesignReviewContent({
   const createCommentMutation = useCreateComment(specTaskId, reviewId);
   const resolveCommentMutation = useResolveComment(specTaskId, reviewId);
 
-  // OAuth flow is needed when an approver without GitHub OAuth tries to
-  // approve — the backend returns 422 with error=oauth_required, and we
-  // redirect them through the GitHub connection flow before they retry.
+  // Open the matching repository provider when approval requires OAuth.
   const { startOAuthFlow } = useOAuthFlow();
   const { data: oauthProviders } = useListOAuthProviders();
-  const gitHubProvider = findOAuthProviderForType(oauthProviders, "github");
 
   // Get queue status for streaming
   // Enable polling immediately when we create a comment (awaitingCommentResponse)
@@ -1088,24 +1085,25 @@ export default function DesignReviewContent({
         onClose();
       }
     } catch (error: any) {
-      // Backend returns 422 with error=oauth_required when the approver has
-      // no GitHub OAuth connection. Drop into the connect-GitHub flow rather
-      // than showing a generic failure — the user can retry once connected.
+      // Open the matching provider connection flow on OAuth enforcement.
       const respData = error?.response?.data;
       if (respData?.error === "oauth_required") {
         setShowSubmitDialog(false);
-        if (gitHubProvider?.id) {
-          snackbar.info("Connect GitHub to approve this design.");
+        const providerType = respData?.provider_type === "gitlab" ? "gitlab" : "github";
+        const providerName = providerType === "gitlab" ? "GitLab" : "GitHub";
+        const oauthProvider = findOAuthProviderForType(oauthProviders, providerType);
+        if (oauthProvider?.id) {
+          snackbar.info(`Connect ${providerName} to approve this design.`);
           startOAuthFlow({
-            providerId: gitHubProvider.id,
-            scopes: GITHUB_VCS_SCOPES,
+            providerId: oauthProvider.id,
+            scopes: vcsScopesForProvider(oauthProvider.type, oauthProvider.name),
             onSuccess: () => {
               snackbar.success(
-                "GitHub connected. Click Approve again to submit.",
+                `${providerName} connected. Click Approve again to submit.`,
               );
             },
             onError: (oauthError) => {
-              snackbar.error(`GitHub connection failed: ${oauthError}`);
+              snackbar.error(`${providerName} connection failed: ${oauthError}`);
             },
           });
         } else {
@@ -1113,7 +1111,7 @@ export default function DesignReviewContent({
           // error message is PR-centric and actionless for this user, so
           // override it with admin-direction guidance.
           snackbar.error(
-            "GitHub OAuth is not configured on this Helix instance. Ask your administrator to set it up before approving designs.",
+            `${providerName} OAuth is not configured on this Helix instance. Ask your administrator to set it up before approving designs.`,
           );
         }
         return;

--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -28,8 +28,8 @@ import {
 } from "../../services/specTaskWorkflowService";
 import { useUpdateSpecTask } from "../../services/specTaskService";
 import { useListOAuthProviders, useListOAuthConnections } from "../../services/oauthProvidersService";
-import { findOAuthProviderForType, findOAuthConnectionForProvider, hasRequiredScopes } from "../../utils/oauthProviders";
-import { useOAuthFlow, GITHUB_VCS_SCOPES } from "../../hooks/useOAuthFlow";
+import { findOAuthProviderForType, findOAuthConnectionForProvider, hasRequiredScopes, vcsScopesForProvider } from "../../utils/oauthProviders";
+import { useOAuthFlow } from "../../hooks/useOAuthFlow";
 import CIStatusIcon from "./CIStatusIcon";
 
 export interface RepoPR {
@@ -270,9 +270,12 @@ export default function SpecTaskActionButtons({
   const { data: oauthConnections } = useListOAuthConnections();
   const { startOAuthFlow, isLoading: isOAuthLoading } = useOAuthFlow();
 
-  const gitHubConnection = findOAuthConnectionForProvider(oauthConnections, 'github');
-  const hasGitHubOAuthWithRepoScope = !!gitHubConnection && hasRequiredScopes(gitHubConnection.scopes, ['repo']);
-  const gitHubProvider = findOAuthProviderForType(oauthProviders, 'github');
+  const oauthProviderType = externalRepoType === "gitlab" ? "gitlab" : "github";
+  const oauthProviderName = oauthProviderType === "gitlab" ? "GitLab" : "GitHub";
+  const oauthConnection = findOAuthConnectionForProvider(oauthConnections, oauthProviderType);
+  const oauthScopes = vcsScopesForProvider(oauthProviderType, null) || [];
+  const hasOAuthWithRequiredScopes = !!oauthConnection && hasRequiredScopes(oauthConnection.scopes, oauthScopes);
+  const oauthProvider = findOAuthProviderForType(oauthProviders, oauthProviderType);
 
   // Detect oauth_required error from the backend (enforcement fallback)
   useEffect(() => {
@@ -286,13 +289,11 @@ export default function SpecTaskActionButtons({
 
   const handleOpenPR = (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (!isDirectPush && hasExternalRepo && externalRepoType === "github" && !hasGitHubOAuthWithRepoScope) {
-      if (gitHubProvider?.id) {
-        // GitHub OAuth provider exists -- start the connection flow with the full
-        // VCS scope set (re-auth replaces scopes, so requesting a subset downgrades)
+    if (!isDirectPush && hasExternalRepo && (externalRepoType === "github" || externalRepoType === "gitlab") && !hasOAuthWithRequiredScopes) {
+      if (oauthProvider?.id) {
         startOAuthFlow({
-          providerId: gitHubProvider.id,
-          scopes: GITHUB_VCS_SCOPES,
+          providerId: oauthProvider.id,
+          scopes: oauthScopes,
           onSuccess: () => {
             setShowOAuthPrompt(false);
             approveImplementationMutation.mutate();
@@ -302,7 +303,6 @@ export default function SpecTaskActionButtons({
           },
         });
       } else {
-        // No GitHub OAuth provider configured -- show prompt
         setShowOAuthPrompt(true);
       }
       return;
@@ -579,20 +579,20 @@ export default function SpecTaskActionButtons({
       return (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 1, width: "100%" }}>
           <Alert severity="warning" sx={{ py: 0.5 }}>
-            {gitHubProvider?.id
-              ? "Connect your GitHub account to open PRs under your name."
-              : "GitHub OAuth is not configured. Ask your administrator to set it up so PRs can be opened under your name."}
+            {oauthProvider?.id
+              ? `Connect your ${oauthProviderName} account to open PRs under your name.`
+              : `${oauthProviderName} OAuth is not configured. Ask your administrator to set it up so PRs can be opened under your name.`}
           </Alert>
           <Box sx={{ display: "flex", gap: 1 }}>
-            {gitHubProvider?.id && (
+            {oauthProvider?.id && (
               <Button
                 variant="contained"
                 size="small"
                 disabled={isOAuthLoading}
                 onClick={() => {
                   startOAuthFlow({
-                    providerId: gitHubProvider.id!,
-                    scopes: GITHUB_VCS_SCOPES,
+                    providerId: oauthProvider.id!,
+                    scopes: oauthScopes,
                     onSuccess: () => {
                       setShowOAuthPrompt(false);
                       approveImplementationMutation.mutate();
@@ -603,7 +603,7 @@ export default function SpecTaskActionButtons({
                   });
                 }}
               >
-                {isOAuthLoading ? "Connecting..." : "Connect GitHub"}
+                {isOAuthLoading ? "Connecting..." : `Connect ${oauthProviderName}`}
               </Button>
             )}
             <Button

--- a/frontend/src/components/tasks/SpecTaskDetailContent.tsx
+++ b/frontend/src/components/tasks/SpecTaskDetailContent.tsx
@@ -64,9 +64,9 @@ import useSnackbar from "../../hooks/useSnackbar";
 import useAccount from "../../hooks/useAccount";
 import useApi from "../../hooks/useApi";
 import useRouter from "../../hooks/useRouter";
-import { useOAuthFlow, GITHUB_VCS_SCOPES } from "../../hooks/useOAuthFlow";
+import { useOAuthFlow } from "../../hooks/useOAuthFlow";
 import { useListOAuthProviders } from "../../services/oauthProvidersService";
-import { findOAuthProviderForType } from "../../utils/oauthProviders";
+import { findOAuthProviderForType, vcsScopesForProvider } from "../../utils/oauthProviders";
 import { getBrowserLocale } from "../../hooks/useBrowserLocale";
 import useApps from "../../hooks/useApps";
 import { deriveDisplaySettings } from "../../services/externalAgentDisplay";
@@ -162,12 +162,9 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
   const queryClient = useQueryClient();
   const router = useRouter();
 
-  // OAuth flow is needed when a user without GitHub OAuth tries to start
-  // planning — the backend returns 422 with error=oauth_required, and we
-  // drop them into the GitHub connect flow before they retry.
+  // OAuth flow is needed when a user lacks the repository provider connection.
   const { startOAuthFlow } = useOAuthFlow();
   const { data: oauthProviders } = useListOAuthProviders();
-  const gitHubProvider = findOAuthProviderForType(oauthProviders, "github");
 
   // Use md breakpoint (900px) to enable split view on tablets
   const isBigScreen = useIsBigScreen({ breakpoint: "md" });
@@ -691,25 +688,26 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
       });
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        // Backend returns 422 + oauth_required when the planner has no
-        // GitHub OAuth connection. Drop into the connect flow so the user
-        // can retry without hitting a dead-end error.
+        // Open the matching provider connection flow on OAuth enforcement.
         if (
           response.status === 422 &&
           errorData?.error === "oauth_required"
         ) {
-          if (gitHubProvider?.id) {
-            snackbar.info("Connect GitHub to start planning this task.");
+          const providerType = errorData?.provider_type === "gitlab" ? "gitlab" : "github";
+          const providerName = providerType === "gitlab" ? "GitLab" : "GitHub";
+          const oauthProvider = findOAuthProviderForType(oauthProviders, providerType);
+          if (oauthProvider?.id) {
+            snackbar.info(`Connect ${providerName} to start planning this task.`);
             startOAuthFlow({
-              providerId: gitHubProvider.id,
-              scopes: GITHUB_VCS_SCOPES,
+              providerId: oauthProvider.id,
+              scopes: vcsScopesForProvider(oauthProvider.type, oauthProvider.name),
               onSuccess: () => {
                 snackbar.success(
-                  "GitHub connected. Click Start Planning again to continue.",
+                  `${providerName} connected. Click Start Planning again to continue.`,
                 );
               },
               onError: (oauthError) => {
-                snackbar.error(`GitHub connection failed: ${oauthError}`);
+                snackbar.error(`${providerName} connection failed: ${oauthError}`);
               },
             });
           } else {
@@ -717,7 +715,7 @@ const SpecTaskDetailContent: FC<SpecTaskDetailContentProps> = ({
             // error message is PR-centric and actionless for this user, so
             // override it with admin-direction guidance.
             snackbar.error(
-              "GitHub OAuth is not configured on this Helix instance. Ask your administrator to set it up before starting planning.",
+              `${providerName} OAuth is not configured on this Helix instance. Ask your administrator to set it up before starting planning.`,
             );
           }
           return;

--- a/frontend/src/components/tasks/SpecTaskKanbanBoard.tsx
+++ b/frontend/src/components/tasks/SpecTaskKanbanBoard.tsx
@@ -97,9 +97,9 @@ import {
 } from "../../api/api";
 import { useGetProject, useUpdateProject } from "../../services/projectService";
 import useSnackbar from "../../hooks/useSnackbar";
-import { useOAuthFlow, GITHUB_VCS_SCOPES } from "../../hooks/useOAuthFlow";
+import { useOAuthFlow } from "../../hooks/useOAuthFlow";
 import { useListOAuthProviders } from "../../services/oauthProvidersService";
-import { findOAuthProviderForType } from "../../utils/oauthProviders";
+import { findOAuthProviderForType, vcsScopesForProvider } from "../../utils/oauthProviders";
 import BacklogTableView from "./BacklogTableView";
 import VCSConnectionLozenges from "./VCSConnectionLozenges";
 import { useCreateSampleRepository } from "../../services/gitRepositoryService";
@@ -685,12 +685,9 @@ const SpecTaskKanbanBoard: React.FC<SpecTaskKanbanBoardProps> = ({
   const queryClient = useQueryClient();
   const router = useRouter();
 
-  // OAuth flow — if the planner has no GitHub OAuth, the start-planning
-  // endpoint returns 422 with error=oauth_required. Drop into the connect
-  // flow rather than surfacing the raw error string.
+  // Open the matching repository provider when planning requires OAuth.
   const { startOAuthFlow } = useOAuthFlow();
   const { data: oauthProviders } = useListOAuthProviders();
-  const gitHubProvider = findOAuthProviderForType(oauthProviders, "github");
 
   // Track initial load to avoid showing loading spinner on refreshes
   const hasLoadedOnceRef = React.useRef(false);
@@ -1510,24 +1507,26 @@ const SpecTaskKanbanBoard: React.FC<SpecTaskKanbanBoardProps> = ({
       });
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        // 422 + oauth_required → the planner has no GitHub OAuth. Open the
-        // connect flow instead of throwing the raw error string.
+        // Open the matching provider connection flow on OAuth enforcement.
         if (
           response.status === 422 &&
           errorData?.error === "oauth_required"
         ) {
-          if (gitHubProvider?.id) {
-            snackbar.info("Connect GitHub to start planning this task.");
+          const providerType = errorData?.provider_type === "gitlab" ? "gitlab" : "github";
+          const providerName = providerType === "gitlab" ? "GitLab" : "GitHub";
+          const oauthProvider = findOAuthProviderForType(oauthProviders, providerType);
+          if (oauthProvider?.id) {
+            snackbar.info(`Connect ${providerName} to start planning this task.`);
             startOAuthFlow({
-              providerId: gitHubProvider.id,
-              scopes: GITHUB_VCS_SCOPES,
+              providerId: oauthProvider.id,
+              scopes: vcsScopesForProvider(oauthProvider.type, oauthProvider.name),
               onSuccess: () => {
                 snackbar.success(
-                  "GitHub connected. Click Start Planning again to continue.",
+                  `${providerName} connected. Click Start Planning again to continue.`,
                 );
               },
               onError: (oauthError) => {
-                snackbar.error(`GitHub connection failed: ${oauthError}`);
+                snackbar.error(`${providerName} connection failed: ${oauthError}`);
               },
             });
           } else {
@@ -1535,7 +1534,7 @@ const SpecTaskKanbanBoard: React.FC<SpecTaskKanbanBoardProps> = ({
             // error message is PR-centric and actionless for this user, so
             // override it with admin-direction guidance.
             snackbar.error(
-              "GitHub OAuth is not configured on this Helix instance. Ask your administrator to set it up before starting planning.",
+              `${providerName} OAuth is not configured on this Helix instance. Ask your administrator to set it up before starting planning.`,
             );
           }
           return;

--- a/frontend/src/components/tasks/TabsView.tsx
+++ b/frontend/src/components/tasks/TabsView.tsx
@@ -52,9 +52,9 @@ import {
 } from "../../api/api";
 import useSnackbar from "../../hooks/useSnackbar";
 import useApi from "../../hooks/useApi";
-import { useOAuthFlow, GITHUB_VCS_SCOPES } from "../../hooks/useOAuthFlow";
+import { useOAuthFlow } from "../../hooks/useOAuthFlow";
 import { useListOAuthProviders } from "../../services/oauthProvidersService";
-import { findOAuthProviderForType } from "../../utils/oauthProviders";
+import { findOAuthProviderForType, vcsScopesForProvider } from "../../utils/oauthProviders";
 import { useUpdateSpecTask, useSpecTask } from "../../services/specTaskService";
 import { useQuery } from "@tanstack/react-query";
 import { getBrowserLocale } from "../../hooks/useBrowserLocale";
@@ -770,12 +770,9 @@ const TaskPanel: React.FC<TaskPanelProps> = ({
   const account = useAccount();
   const streaming = useStreaming();
 
-  // OAuth flow — planner without GitHub OAuth gets 422 oauth_required from
-  // start-planning; open the connect flow instead of surfacing the raw
-  // string.
+  // Open the matching repository provider when planning requires OAuth.
   const { startOAuthFlow } = useOAuthFlow();
   const { data: oauthProviders } = useListOAuthProviders();
-  const gitHubProvider = findOAuthProviderForType(oauthProviders, "github");
 
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
   const [taskSearchQuery, setTaskSearchQuery] = useState("");
@@ -868,18 +865,21 @@ const TaskPanel: React.FC<TaskPanelProps> = ({
           response.status === 422 &&
           errorData?.error === "oauth_required"
         ) {
-          if (gitHubProvider?.id) {
-            snackbar.info("Connect GitHub to start planning this task.");
+          const providerType = errorData?.provider_type === "gitlab" ? "gitlab" : "github";
+          const providerName = providerType === "gitlab" ? "GitLab" : "GitHub";
+          const oauthProvider = findOAuthProviderForType(oauthProviders, providerType);
+          if (oauthProvider?.id) {
+            snackbar.info(`Connect ${providerName} to start planning this task.`);
             startOAuthFlow({
-              providerId: gitHubProvider.id,
-              scopes: GITHUB_VCS_SCOPES,
+              providerId: oauthProvider.id,
+              scopes: vcsScopesForProvider(oauthProvider.type, oauthProvider.name),
               onSuccess: () => {
                 snackbar.success(
-                  "GitHub connected. Click Start Planning again to continue.",
+                  `${providerName} connected. Click Start Planning again to continue.`,
                 );
               },
               onError: (oauthError) => {
-                snackbar.error(`GitHub connection failed: ${oauthError}`);
+                snackbar.error(`${providerName} connection failed: ${oauthError}`);
               },
             });
           } else {
@@ -887,7 +887,7 @@ const TaskPanel: React.FC<TaskPanelProps> = ({
             // error message is PR-centric and actionless for this user, so
             // override it with admin-direction guidance.
             snackbar.error(
-              "GitHub OAuth is not configured on this Helix instance. Ask your administrator to set it up before starting planning.",
+              `${providerName} OAuth is not configured on this Helix instance. Ask your administrator to set it up before starting planning.`,
             );
           }
           return;

--- a/frontend/src/utils/oauthProviders.test.ts
+++ b/frontend/src/utils/oauthProviders.test.ts
@@ -6,6 +6,7 @@ import {
   findOAuthProviderForType,
   mapProviderToRepoType,
   hasRequiredScopes,
+  vcsScopesForProvider,
 } from './oauthProviders'
 import { TypesOAuthConnection, TypesOAuthProvider, TypesExternalRepositoryType, TypesOAuthProviderType } from '../api/api'
 
@@ -239,5 +240,9 @@ describe('oauthProviders utilities', () => {
         expect(hasRequiredScopes(['repo'], null as any)).toBe(false)
       })
     })
+  })
+
+  it('requests the GitLab API scope for merge requests', () => {
+    expect(vcsScopesForProvider('gitlab', 'GitLab')).toContain('api')
   })
 })

--- a/frontend/src/utils/oauthProviders.ts
+++ b/frontend/src/utils/oauthProviders.ts
@@ -99,7 +99,7 @@ export const vcsScopesForProvider = (
   name: string | undefined | null,
 ): string[] | undefined => {
   if (matchesProviderType(type, name, 'github')) return GITHUB_VCS_SCOPES
-  if (matchesProviderType(type, name, 'gitlab')) return ['read_repository', 'write_repository', 'read_user']
+  if (matchesProviderType(type, name, 'gitlab')) return ['api', 'read_repository', 'write_repository', 'read_user']
   if (matchesProviderType(type, name, 'azure-devops')) return ['vso.code_write']
   if (matchesProviderType(type, name, 'bitbucket')) return ['repository', 'repository:write']
   return undefined


### PR DESCRIPTION
## Summary

- add a preconfigured GitLab OAuth provider and repository authorization flow
- use the acting user OAuth token for GitLab pushes and merge request creation
- preserve PAT authentication for unattended work and when OAuth is unavailable
- handle GitHub and GitLab OAuth requirements consistently in task workflows

## Verification

- `go test ./pkg/services -run 'Test(GetCredentialsForRepo_GitLabUserOAuthTakesPrecedence|CreateGitLabMergeRequest_UserOAuthTakesPrecedence|GetGitLabClient_UserWithoutOAuthReturnsError|GetGitLabClient_AgentFallsBackToRepoCredentials|ValidateUserOAuth_GitLabRequiresMatchingConnection|ValidateUserOAuth_AcceptsCustomGitLabProvider|PushBranchToRemote_GitLabUserWithoutOAuthReturnsErrorBeforePush)' -count=1`\n- `yarn test src/utils/oauthProviders.test.ts --run`\n- `yarn build`\n- deployed and exercised the GitLab OAuth/PAT selection flow on Prime\n\n## Remaining live verification\n\n- user-attributed upstream push and merge-request creation require completing a task with a connected GitLab user account