### PR TITLE
fix(release): publish charts after image manifests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2340,6 +2340,64 @@ steps:
 
 ---
 # ====================================================================
+# Publish Helm charts only after every release image manifest exists.
+# ====================================================================
+kind: pipeline
+type: docker
+name: publish-helm
+
+depends_on:
+  - default
+  - manifest-controlplane
+  - manifest-sandbox
+
+trigger:
+  ref:
+    include:
+      - refs/tags/*
+  status:
+    - success
+
+steps:
+  - name: publish-helm
+    image: google/cloud-sdk:slim
+    environment:
+      GCS_SERVICE_ACCOUNT_KEY:
+        from_secret: gcs_service_account_key
+    commands:
+      - apt-get update -qq
+      - apt-get install -y -qq curl > /dev/null
+      - curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash > /dev/null
+      - scripts/publish-helm-charts.sh
+
+  - name: rollback-partial-release
+    image: golang:1.25-bookworm
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+      R2_ACCESS_KEY_ID:
+        from_secret: r2_access_key_id
+      R2_SECRET_ACCESS_KEY:
+        from_secret: r2_secret_access_key
+      GCS_SERVICE_ACCOUNT_KEY:
+        from_secret: gcs_service_account_key
+      SLACK_WEBHOOK_URL:
+        from_secret: JANITOR_SLACK_WEBHOOK_URL
+    commands:
+      - curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
+      - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
+      - curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+      - echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list
+      - apt-get update -qq
+      - apt-get install -y -qq jq awscli gh google-cloud-cli > /dev/null
+      - curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash > /dev/null
+      - scripts/release-rollback.sh "$DRONE_TAG"
+    when:
+      status:
+        - failure
+
+---
+# ====================================================================
 # Release Rollback Pipeline
 # ====================================================================
 # Runs ONLY on tag events when any release pipeline fails.
@@ -2428,13 +2486,7 @@ type: docker
 name: deploy-prod
 
 depends_on:
-  - default
-  - build-controlplane-amd64
-  - build-controlplane-arm64
-  - manifest-controlplane
-  - build-sandbox-amd64
-  - build-sandbox-arm64
-  - manifest-sandbox
+  - publish-helm
 
 trigger:
   ref:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,29 +1,6 @@
 steps:
-
-# Generate Helm packages
-- name: 'ubuntu'
-  env:
-  - 'TAG_NAME=$TAG_NAME'
-  args: ['bash', './scripts/gen_packages.sh']
-  id: 'gen_packages'
-
-# Fetch charts and index.yaml from GCS bucket
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['rsync', 'gs://charts.helixml.tech', 'temp/']
-  id: 'fetch_charts_index'
-
-# Index repository
-- name: 'ubuntu'
-  env:
-  - 'REPO_URL=https://charts.helixml.tech'
-  args: ['bash', './scripts/index_repo.sh']
-
-# Upload charts to GCS bucket
-- name: gcr.io/cloud-builders/gsutil
-  args: ['rsync', 'temp/', 'gs://charts.helixml.tech']
-  id: 'upload_charts'
-
-# Disable caching on index.yaml so helm clients see updates immediately
-- name: 'gcr.io/cloud-builders/gsutil'
-  args: ['setmeta', '-h', 'Cache-Control:no-cache,no-store,max-age=0', 'gs://charts.helixml.tech/index.yaml']
-  id: 'disable_index_cache'
+- name: ubuntu
+  entrypoint: sh
+  args:
+    - -c
+    - echo "Helm chart publication is handled by the Drone publish-helm pipeline."

--- a/design/2026-07-21-helm-chart-publication-waits-for-images.md
+++ b/design/2026-07-21-helm-chart-publication-waits-for-images.md
@@ -1,0 +1,52 @@
+# Helm Chart Publication After Release Manifests
+
+## Root Cause
+
+The tag-triggered Cloud Build chart publisher raced the independent Drone image pipelines. It could expose a chart version before the matching multi-architecture images existed.
+
+Cloud Build is now neutralized: `cloudbuild.yaml` only reports that Drone owns Helm publication and writes nothing to the chart bucket.
+
+## Drone Release Order
+
+The tag-only `publish-helm` pipeline depends on:
+
+```text
+default
+manifest-controlplane
+manifest-sandbox
+```
+
+`manifest-controlplane` completes the controlplane release manifest. `manifest-sandbox` completes the `helix-sandbox`, `helix-sway`, and `helix-ubuntu` release manifests. Drone starts chart publication only after all three dependency pipelines succeed.
+
+`deploy-prod` now depends only on `publish-helm`, so production deployment cannot begin until the chart version is published successfully.
+
+## Fail-Closed Publication
+
+`scripts/publish-helm-charts.sh`:
+
+1. Validates the release tag and GCS credential.
+2. Fetches the existing `index.yaml`; a missing or failed fetch stops publication.
+3. Renders and packages exactly `helix-controlplane-$VERSION.tgz` and `helix-sandbox-$VERSION.tgz`.
+4. Uploads both exact archives.
+5. Merges the existing index and uploads `index.yaml` last with `Cache-Control:no-cache,no-store,max-age=0`.
+
+Uploading the index last makes it the atomic discovery point. A package upload failure leaves the existing index unchanged, so clients cannot discover the partial release.
+
+If chart publication fails, the pipeline runs the existing `scripts/release-rollback.sh` cleanup. Partially published image tags are intentionally retained: the failed release is removed from its tag, GitHub release, and Helm index, so it is undiscoverable through supported release channels, while deleting registry artifacts would add risky cleanup with no customer benefit.
+
+## Verification
+
+```text
+cd /Users/psamuel/helix/helix-worktrees/chart-after-images
+sh scripts/test-publish-helm-charts.sh
+publish helm charts test passed
+
+sh -n scripts/publish-helm-charts.sh scripts/test-publish-helm-charts.sh
+drone lint --trusted .drone.yml
+ruby -e 'require "yaml"; YAML.load_stream(File.read(".drone.yml")); YAML.load_file("cloudbuild.yaml")'
+git diff --check
+```
+
+The publisher test verifies the existing-index fetch, exact archive names, archive-before-index upload order, no-cache index upload, and fail-closed behavior when the existing index cannot be fetched. Shell syntax, trusted Drone lint, YAML parsing, and diff checks passed.
+
+NOT live tested: a real release tag still needs to verify Drone dependency scheduling, manifest completion, chart visibility, rollback on publication failure, and deployment only after `publish-helm` succeeds.

--- a/scripts/publish-helm-charts.sh
+++ b/scripts/publish-helm-charts.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -eu
+
+VERSION="${DRONE_TAG:-${TAG_NAME:-}}"
+VERSION="${VERSION#v}"
+GCS_BUCKET="gs://charts.helixml.tech"
+REPO_URL="https://charts.helixml.tech"
+
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+  echo "ERROR: release tag is not valid semver: ${VERSION:-<empty>}" >&2
+  exit 1
+fi
+
+if [ -z "${GCS_SERVICE_ACCOUNT_KEY:-}" ]; then
+  echo "ERROR: GCS_SERVICE_ACCOUNT_KEY is required" >&2
+  exit 1
+fi
+
+work=$(mktemp -d)
+key_file="$work/gcs-key.json"
+trap 'rm -r "$work"' EXIT
+
+printf '%s' "$GCS_SERVICE_ACCOUNT_KEY" | base64 -d > "$key_file"
+gcloud auth activate-service-account --key-file="$key_file" --quiet
+gsutil cp "$GCS_BUCKET/index.yaml" "$work/previous-index.yaml"
+
+DRONE_TAG="$VERSION" scripts/render-charts.sh
+
+for chart in helix-controlplane helix-sandbox; do
+  helm package --destination "$work" "charts/$chart"
+done
+
+for chart in helix-controlplane helix-sandbox; do
+  archive="$work/${chart}-${VERSION}.tgz"
+  if [ ! -f "$archive" ]; then
+    echo "ERROR: expected chart archive was not created: $archive" >&2
+    exit 1
+  fi
+  gsutil cp "$archive" "$GCS_BUCKET/${chart}-${VERSION}.tgz"
+done
+
+helm repo index --url "$REPO_URL" --merge "$work/previous-index.yaml" "$work"
+
+gsutil -h "Cache-Control:no-cache,no-store,max-age=0" cp \
+  "$work/index.yaml" "$GCS_BUCKET/index.yaml"

--- a/scripts/test-publish-helm-charts.sh
+++ b/scripts/test-publish-helm-charts.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -eu
+
+repo=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+work=$(mktemp -d)
+trap 'rm -r "$work"' EXIT
+
+mkdir -p "$work/repo/scripts" "$work/repo/charts/helix-controlplane" \
+  "$work/repo/charts/helix-sandbox" "$work/bin"
+cp "$repo/scripts/publish-helm-charts.sh" "$work/repo/scripts/"
+cp "$repo/scripts/render-charts.sh" "$work/repo/scripts/"
+
+for chart in helix-controlplane helix-sandbox; do
+  cp "$repo/charts/$chart/Chart.yaml.tmpl" "$work/repo/charts/$chart/"
+done
+
+cat > "$work/bin/gcloud" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+cat > "$work/bin/helm" <<'EOF'
+#!/bin/sh
+set -eu
+if [ "$1" = package ]; then
+  destination="$3"
+  chart="$4"
+  name=$(basename "$chart")
+  version=$(sed -n 's/^version: //p' "$chart/Chart.yaml")
+  : > "$destination/$name-$version.tgz"
+  exit 0
+fi
+if [ "$1 $2" = "repo index" ]; then
+  eval "directory=\${$#}"
+  : > "$directory/index.yaml"
+  exit 0
+fi
+exit 1
+EOF
+cat > "$work/bin/gsutil" <<'EOF'
+#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$CALLS"
+case "$*" in
+  "cp gs://charts.helixml.tech/index.yaml "*)
+    if [ "${FAIL_FETCH:-0}" = 1 ]; then
+      exit 1
+    fi
+    eval "destination=\${$#}"
+    : > "$destination"
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$work/bin/gcloud" "$work/bin/helm" "$work/bin/gsutil" \
+  "$work/repo/scripts/publish-helm-charts.sh" "$work/repo/scripts/render-charts.sh"
+
+(
+  cd "$work/repo"
+  PATH="$work/bin:$PATH" CALLS="$work/calls" DRONE_TAG=2.12.3 \
+    GCS_SERVICE_ACCOUNT_KEY=e30= scripts/publish-helm-charts.sh
+)
+
+index_fetch=$(sed -n '1p' "$work/calls")
+archive_one=$(sed -n '2p' "$work/calls")
+archive_two=$(sed -n '3p' "$work/calls")
+index_upload=$(sed -n '4p' "$work/calls")
+
+echo "$archive_one" | grep -q 'helix-controlplane-2.12.3.tgz gs://charts.helixml.tech/helix-controlplane-2.12.3.tgz$'
+echo "$archive_two" | grep -q 'helix-sandbox-2.12.3.tgz gs://charts.helixml.tech/helix-sandbox-2.12.3.tgz$'
+echo "$index_fetch" | grep -q '^cp gs://charts.helixml.tech/index.yaml '
+echo "$index_upload" | grep -q '^-h Cache-Control:no-cache,no-store,max-age=0 cp .*index.yaml gs://charts.helixml.tech/index.yaml$'
+
+if (
+  cd "$work/repo"
+  PATH="$work/bin:$PATH" CALLS="$work/fail-calls" FAIL_FETCH=1 DRONE_TAG=2.12.3 \
+    GCS_SERVICE_ACCOUNT_KEY=e30= scripts/publish-helm-charts.sh
+) >/dev/null 2>&1; then
+  echo "index fetch failure did not stop publication" >&2
+  exit 1
+fi
+[ "$(wc -l < "$work/fail-calls" | tr -d ' ')" -eq 1 ]
+grep -q '^cp gs://charts.helixml.tech/index.yaml ' "$work/fail-calls"
+
+echo "publish helm charts test passed"


### PR DESCRIPTION
## Summary

- move Helm chart publication from the independent Cloud Build trigger into Drone
- publish charts only after controlplane, sandbox, sway, and Ubuntu manifests succeed
- upload chart archives before atomically publishing `index.yaml`
- gate production deployment on successful chart publication
- retain partial image tags for failed, undiscoverable releases

## Verification

- `sh scripts/test-publish-helm-charts.sh`
- `sh -n scripts/publish-helm-charts.sh scripts/test-publish-helm-charts.sh`
- `drone lint --trusted .drone.yml`
- parsed `.drone.yml` and `cloudbuild.yaml` with Ruby YAML
- rendered and packaged both charts with version `2.12.3`
- `git diff --check`

## Remaining verification

- NOT live tested: a real release tag is required to verify cross-pipeline scheduling and chart visibility timing