### PR TITLE
Fix Claude-subscription UX: whose sub is used, cross-user agent edits, and legible auth errors

### DIFF
--- a/api/pkg/anthropic/subscription_probe.go
+++ b/api/pkg/anthropic/subscription_probe.go
@@ -1,0 +1,133 @@
+package anthropic
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/crypto"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+// subscriptionProbeURL is the Anthropic messages endpoint used for liveness
+// probes. It is a var (not const) so tests can point it at an httptest server.
+var subscriptionProbeURL = "https://api.anthropic.com/v1/messages"
+
+// oauthBetaHeader is mandatory when authenticating /v1/messages with a Claude
+// subscription OAuth / setup token. Without it Anthropic rejects the token with
+// "This credential is only authorized for use with Claude Code".
+// See design/2026-02-14-claude-subscription-provider.md.
+const oauthBetaHeader = "oauth-2025-04-20"
+
+// ProbeResult classifies the outcome of a liveness probe.
+type ProbeResult int
+
+const (
+	// ProbeValid means the token authenticated (HTTP 200 or 429 throttle).
+	ProbeValid ProbeResult = iota
+	// ProbeInvalid means the token was rejected (HTTP 401 authentication_failed).
+	ProbeInvalid
+	// ProbeInconclusive means the probe could not determine validity (network
+	// error, 5xx, or a credential that cannot be probed without a refresh).
+	ProbeInconclusive
+)
+
+// ProbeClaudeSubscription performs a cheap liveness probe of a Claude
+// subscription OAuth/setup token against Anthropic's messages API.
+//
+//	401         -> ProbeInvalid  (token is bad/expired/revoked)
+//	200 or 429  -> ProbeValid    (429 is just a throttle, the token still works)
+//	otherwise   -> ProbeInconclusive (network/5xx — don't punish the user)
+//
+// The returned detail string is a short human-readable reason (empty when valid).
+func ProbeClaudeSubscription(ctx context.Context, token string) (ProbeResult, string) {
+	if token == "" {
+		return ProbeInvalid, "no token"
+	}
+
+	body := []byte(`{"model":"claude-3-5-haiku-latest","max_tokens":1,"messages":[{"role":"user","content":"ping"}]}`)
+
+	ctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, subscriptionProbeURL, bytes.NewReader(body))
+	if err != nil {
+		return ProbeInconclusive, "failed to build probe request"
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("anthropic-beta", oauthBetaHeader)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("content-type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ProbeInconclusive, "network error probing Anthropic: " + err.Error()
+	}
+	defer resp.Body.Close()
+	// Drain a little so the connection can be reused; ignore errors.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized:
+		return ProbeInvalid, "invalid or expired token (401 from Anthropic)"
+	case resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusTooManyRequests:
+		return ProbeValid, ""
+	default:
+		return ProbeInconclusive, fmt.Sprintf("unexpected status %d from Anthropic", resp.StatusCode)
+	}
+}
+
+// ValidateSubscription decrypts the stored credentials for a Claude subscription,
+// selects the bearer token, probes it, and returns the outcome. It does NOT
+// persist anything — callers decide whether to write Status/LastError/
+// LastValidatedAt back via the store.
+//
+// For setup_token credentials a 401 is definitive. For oauth credentials whose
+// access token has already expired we return ProbeInconclusive rather than
+// probing: Claude Code refreshes those in-container, so a raw probe of the stale
+// access token would 401 and falsely read as invalid.
+func ValidateSubscription(ctx context.Context, sub *types.ClaudeSubscription) (ProbeResult, string) {
+	if sub == nil {
+		return ProbeInconclusive, "no subscription"
+	}
+
+	encKey, err := crypto.GetEncryptionKey()
+	if err != nil {
+		return ProbeInconclusive, "encryption key unavailable"
+	}
+	plaintext, err := crypto.DecryptAES256GCM(sub.EncryptedCredentials, encKey)
+	if err != nil {
+		return ProbeInconclusive, "failed to decrypt credentials"
+	}
+
+	credType := sub.CredentialType
+	if credType == "" {
+		credType = "oauth"
+	}
+
+	switch credType {
+	case "setup_token":
+		var tok types.ClaudeSetupTokenCredentials
+		if err := json.Unmarshal(plaintext, &tok); err != nil || tok.SetupToken == "" {
+			return ProbeInvalid, "malformed setup token credentials"
+		}
+		return ProbeClaudeSubscription(ctx, tok.SetupToken)
+	case "oauth":
+		var creds types.ClaudeOAuthCredentials
+		if err := json.Unmarshal(plaintext, &creds); err != nil || creds.AccessToken == "" {
+			return ProbeInvalid, "malformed oauth credentials"
+		}
+		// If the access token is expired but a refresh token exists, the
+		// in-container Claude Code will refresh it — don't mark it invalid.
+		if creds.ExpiresAt > 0 && time.UnixMilli(creds.ExpiresAt).Before(time.Now()) && creds.RefreshToken != "" {
+			return ProbeInconclusive, "access token expired (refreshable in-container)"
+		}
+		return ProbeClaudeSubscription(ctx, creds.AccessToken)
+	default:
+		return ProbeInconclusive, "unknown credential type"
+	}
+}

--- a/api/pkg/anthropic/subscription_probe_test.go
+++ b/api/pkg/anthropic/subscription_probe_test.go
@@ -1,0 +1,48 @@
+package anthropic
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProbeClaudeSubscription(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		token      string
+		want       ProbeResult
+	}{
+		{name: "401 is invalid", statusCode: http.StatusUnauthorized, token: "sk-ant-oat-x", want: ProbeInvalid},
+		{name: "200 is valid", statusCode: http.StatusOK, token: "sk-ant-oat-x", want: ProbeValid},
+		{name: "429 throttle is valid", statusCode: http.StatusTooManyRequests, token: "sk-ant-oat-x", want: ProbeValid},
+		{name: "500 is inconclusive", statusCode: http.StatusInternalServerError, token: "sk-ant-oat-x", want: ProbeInconclusive},
+		{name: "empty token is invalid", statusCode: http.StatusOK, token: "", want: ProbeInvalid},
+	}
+
+	orig := subscriptionProbeURL
+	defer func() { subscriptionProbeURL = orig }()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBeta string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotBeta = r.Header.Get("anthropic-beta")
+				w.WriteHeader(tc.statusCode)
+			}))
+			defer srv.Close()
+			subscriptionProbeURL = srv.URL
+
+			got, detail := ProbeClaudeSubscription(context.Background(), tc.token)
+			if got != tc.want {
+				t.Fatalf("ProbeClaudeSubscription() = %v (%q), want %v", got, detail, tc.want)
+			}
+			// The mandatory OAuth beta header must be sent whenever we actually
+			// reach the server (i.e. token was non-empty).
+			if tc.token != "" && gotBeta != oauthBetaHeader {
+				t.Fatalf("anthropic-beta header = %q, want %q", gotBeta, oauthBetaHeader)
+			}
+		})
+	}
+}

--- a/api/pkg/server/claude_subscription_handlers.go
+++ b/api/pkg/server/claude_subscription_handlers.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/helixml/helix/api/pkg/anthropic"
 	"github.com/helixml/helix/api/pkg/crypto"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/system"
@@ -146,14 +147,152 @@ func (apiServer *HelixAPIServer) createClaudeSubscription(_ http.ResponseWriter,
 		return nil, system.NewHTTPError500("failed to create subscription: " + err.Error())
 	}
 
+	// Liveness-probe the freshly connected credentials so Status reflects reality
+	// instead of an unconditional "active". A dead token is caught here rather
+	// than at the first agent turn.
+	created = apiServer.revalidateClaudeSubscription(req.Context(), created)
+
 	log.Info().
 		Str("subscription_id", created.ID).
 		Str("owner_id", ownerID).
 		Str("owner_type", string(ownerType)).
 		Str("credential_type", credentialType).
+		Str("status", created.Status).
 		Msg("Created Claude subscription")
 
 	return created, nil
+}
+
+// revalidateClaudeSubscription liveness-probes a subscription's stored token and
+// persists the outcome (Status, LastError, LastValidatedAt). A ProbeInconclusive
+// result (network error, or an oauth token that is expired-but-refreshable)
+// leaves the existing Status untouched — we never downgrade a subscription to
+// "error" on an ambiguous signal. Returns the updated row (or the input on
+// failure to persist).
+func (apiServer *HelixAPIServer) revalidateClaudeSubscription(ctx context.Context, sub *types.ClaudeSubscription) *types.ClaudeSubscription {
+	if sub == nil {
+		return sub
+	}
+	result, detail := anthropic.ValidateSubscription(ctx, sub)
+	now := time.Now()
+	switch result {
+	case anthropic.ProbeValid:
+		sub.Status = "active"
+		sub.LastError = ""
+		sub.LastValidatedAt = &now
+	case anthropic.ProbeInvalid:
+		sub.Status = "error"
+		sub.LastError = detail
+		sub.LastValidatedAt = &now
+	case anthropic.ProbeInconclusive:
+		// Leave Status/LastError as-is; record that we tried.
+		sub.LastValidatedAt = &now
+		log.Debug().Str("subscription_id", sub.ID).Str("detail", detail).Msg("Claude subscription probe inconclusive")
+	}
+	updated, err := apiServer.Store.UpdateClaudeSubscription(ctx, sub)
+	if err != nil {
+		log.Warn().Err(err).Str("subscription_id", sub.ID).Msg("failed to persist Claude subscription validation result")
+		return sub
+	}
+	return updated
+}
+
+// claudeSubscriptionStatusMaxAge bounds how stale a persisted validation result
+// can be before the owner-status endpoint re-probes. Keeps the settings display
+// honest without hammering Anthropic on every render.
+const claudeSubscriptionStatusMaxAge = 5 * time.Minute
+
+// AppClaudeSubscriptionStatus reports whether the account whose Claude
+// subscription would authenticate an app's sessions (the app owner) actually has
+// a working subscription connected. Backs the "whose subscription" callout and
+// the cross-user warning in agent settings.
+type AppClaudeSubscriptionStatus struct {
+	Connected             bool       `json:"connected"`                         // owner has a subscription connected at all
+	Valid                 bool       `json:"valid"`                             // that subscription passed its last liveness probe
+	OwnerID               string     `json:"owner_id"`                          // app owner (the likely session owner)
+	OwnerName             string     `json:"owner_name"`                        // human-readable owner (email / full name)
+	IsCurrentUser         bool       `json:"is_current_user"`                   // true when the editor IS the owner
+	SubscriptionOwnerType string     `json:"subscription_owner_type,omitempty"` // "user" or "org" — where the effective sub resolved
+	Status                string     `json:"status,omitempty"`
+	LastValidatedAt       *time.Time `json:"last_validated_at,omitempty"`
+	LastError             string     `json:"last_error,omitempty"`
+}
+
+// @Summary Get the Claude subscription status for an app's owner
+// @Description Reports whether the app owner (whose subscription authenticates the app's sessions) has a working Claude subscription
+// @Tags Claude
+// @Produce json
+// @Param id path string true "App ID"
+// @Success 200 {object} AppClaudeSubscriptionStatus
+// @Failure 401 {object} system.HTTPError
+// @Failure 403 {object} system.HTTPError
+// @Failure 404 {object} system.HTTPError
+// @Security BearerAuth
+// @Router /api/v1/apps/{id}/claude-subscription-status [get]
+func (apiServer *HelixAPIServer) getAppClaudeSubscriptionStatus(_ http.ResponseWriter, req *http.Request) (*AppClaudeSubscriptionStatus, *system.HTTPError) {
+	user := getRequestUser(req)
+	if user == nil {
+		return nil, system.NewHTTPError401("authentication required")
+	}
+
+	app, err := apiServer.Store.GetApp(req.Context(), getID(req))
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, system.NewHTTPError404(store.ErrNotFound.Error())
+		}
+		return nil, system.NewHTTPError500(err.Error())
+	}
+	if err := apiServer.authorizeUserToApp(req.Context(), user, app, types.ActionGet); err != nil {
+		return nil, system.NewHTTPError403(err.Error())
+	}
+
+	status := &AppClaudeSubscriptionStatus{
+		OwnerID:       app.Owner,
+		OwnerName:     apiServer.displayNameForUser(req.Context(), app.Owner),
+		IsCurrentUser: app.Owner == user.ID,
+	}
+
+	// Resolve the subscription exactly as a session owned by the app owner would
+	// (user-level first, then the app's org).
+	sub, err := apiServer.Store.GetEffectiveClaudeSubscription(req.Context(), app.Owner, app.OrganizationID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return status, nil // not connected
+		}
+		return nil, system.NewHTTPError500("failed to resolve subscription: " + err.Error())
+	}
+
+	// Re-probe if we've never validated it or the last result is stale.
+	if sub.LastValidatedAt == nil || time.Since(*sub.LastValidatedAt) > claudeSubscriptionStatusMaxAge {
+		sub = apiServer.revalidateClaudeSubscription(req.Context(), sub)
+	}
+
+	status.Connected = true
+	status.Valid = sub.Status == "active"
+	status.SubscriptionOwnerType = string(sub.OwnerType)
+	status.Status = sub.Status
+	status.LastValidatedAt = sub.LastValidatedAt
+	status.LastError = sub.LastError
+	return status, nil
+}
+
+// displayNameForUser returns a human-readable label for a user id, preferring
+// email then full name then the raw id. Best-effort — never errors.
+func (apiServer *HelixAPIServer) displayNameForUser(ctx context.Context, userID string) string {
+	if userID == "" {
+		return ""
+	}
+	u, err := apiServer.Store.GetUser(ctx, &store.GetUserQuery{ID: userID})
+	if err != nil || u == nil {
+		return userID
+	}
+	if u.Email != "" {
+		return u.Email
+	}
+	if u.FullName != "" {
+		return u.FullName
+	}
+	return userID
 }
 
 // @Summary List Claude subscriptions

--- a/api/pkg/server/claude_subscription_reclassify_test.go
+++ b/api/pkg/server/claude_subscription_reclassify_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/suite"
+
+	"go.uber.org/mock/gomock"
+)
+
+type ReclassifySubAuthSuite struct {
+	suite.Suite
+	ctrl   *gomock.Controller
+	store  *store.MockStore
+	server *HelixAPIServer
+}
+
+func TestReclassifySubAuthSuite(t *testing.T) {
+	suite.Run(t, new(ReclassifySubAuthSuite))
+}
+
+func (s *ReclassifySubAuthSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.store = store.NewMockStore(s.ctrl)
+	s.server = &HelixAPIServer{Cfg: &config.ServerConfig{}, Store: s.store}
+}
+
+const genericAbort = "agent turn aborted: the ACP agent process exited mid-turn or hit max tokens (see Zed.log 'Error in run turn' for the cause)"
+
+func subscriptionApp() *types.App {
+	app := &types.App{ID: "app_1"}
+	app.Config.Helix.Assistants = []types.AssistantConfig{{
+		CodeAgentRuntime:        types.CodeAgentRuntimeClaudeCode,
+		CodeAgentCredentialType: types.CodeAgentCredentialTypeSubscription,
+	}}
+	return app
+}
+
+// A non-generic error is passed through untouched — we never rewrite a specific error.
+func (s *ReclassifySubAuthSuite) TestNonGenericErrorUnchanged() {
+	specific := "compilation failed: syntax error"
+	got := s.server.maybeReclassifySubscriptionAuthError(context.Background(), "ses_1", specific)
+	s.Equal(specific, got)
+}
+
+// Generic error + subscription-mode session whose owner has NO subscription -> legible message naming the owner.
+func (s *ReclassifySubAuthSuite) TestNoSubscriptionProducesLegibleError() {
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_1").Return(&types.Session{
+		ID: "ses_1", ParentApp: "app_1", Owner: "usr_chris", OrganizationID: "org_1",
+	}, nil)
+	s.store.EXPECT().GetApp(gomock.Any(), "app_1").Return(subscriptionApp(), nil)
+	s.store.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "usr_chris"}).
+		Return(&types.User{ID: "usr_chris", Email: "chris@helix.ml"}, nil)
+	s.store.EXPECT().GetEffectiveClaudeSubscription(gomock.Any(), "usr_chris", "org_1").
+		Return(nil, store.ErrNotFound)
+
+	got := s.server.maybeReclassifySubscriptionAuthError(context.Background(), "ses_1", genericAbort)
+	s.Contains(got, "chris@helix.ml")
+	s.Contains(got, "no Claude subscription connected")
+	s.NotContains(got, "exited mid-turn")
+}
+
+// Generic error but the agent is in API-key mode (not subscription) -> passed through untouched.
+func (s *ReclassifySubAuthSuite) TestApiKeyModeUnchanged() {
+	app := &types.App{ID: "app_1"}
+	app.Config.Helix.Assistants = []types.AssistantConfig{{
+		CodeAgentRuntime:        types.CodeAgentRuntimeClaudeCode,
+		CodeAgentCredentialType: types.CodeAgentCredentialTypeAPIKey,
+	}}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_1").Return(&types.Session{
+		ID: "ses_1", ParentApp: "app_1", Owner: "usr_chris",
+	}, nil)
+	s.store.EXPECT().GetApp(gomock.Any(), "app_1").Return(app, nil)
+
+	got := s.server.maybeReclassifySubscriptionAuthError(context.Background(), "ses_1", genericAbort)
+	s.Equal(genericAbort, got)
+	s.True(strings.Contains(got, "exited mid-turn"))
+}

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -2125,6 +2125,58 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/apps/{id}/claude-subscription-status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Reports whether the app owner (whose subscription authenticates the app's sessions) has a working Claude subscription",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Claude"
+                ],
+                "summary": "Get the Claude subscription status for an app's owner",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "App ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.AppClaudeSubscriptionStatus"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/apps/{id}/daily-usage": {
             "get": {
                 "security": [
@@ -16235,6 +16287,12 @@ const docTemplate = `{
                         "description": "Filter by session role (e.g. job)",
                         "name": "session_role",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Include external agent sessions",
+                        "name": "include_external_agents",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -17303,7 +17361,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Tears down the half-dead desktop container and brings up a fresh one\nvia the resume path. The session's ZedThreadID is cleared so Zed opens\na fresh thread: a crash often poisons the thread itself, so reattaching\nreproduces the wedge; use /sessions/{id}/resume to restart while keeping\nthe thread. The workspace volume persists, so files and the agent's own\nstate survive; only the conversation thread resets. Crashed prompts are\nreset to pending and the queue is kicked so they re-dispatch on the new\ncontainer.\nRequires the session to be an external Zed agent. Returns the count of\nprompts that were reset.",
+                "description": "Tears down the half-dead desktop container and brings up a fresh one\nvia the resume path. The conversation thread is PRESERVED when the\nsession's last turn completed cleanly (the common \"reboot to refresh\nthe environment\" case) so context is not lost; it is reset only when\nthe last turn is mid-flight or errored, which signals a possibly\npoisoned thread that would just reproduce the wedge on reattach. The\nworkspace volume persists, so files and the agent's own state survive\nregardless. Crashed prompts are reset to pending and the queue is\nkicked so they re-dispatch on the new container.\nRequires the session to be an external Zed agent. Returns the count of\nprompts that were reset.",
                 "produces": [
                     "application/json"
                 ],
@@ -23662,6 +23720,44 @@ const docTemplate = `{
                 }
             }
         },
+        "server.AppClaudeSubscriptionStatus": {
+            "type": "object",
+            "properties": {
+                "connected": {
+                    "description": "owner has a subscription connected at all",
+                    "type": "boolean"
+                },
+                "is_current_user": {
+                    "description": "true when the editor IS the owner",
+                    "type": "boolean"
+                },
+                "last_error": {
+                    "type": "string"
+                },
+                "last_validated_at": {
+                    "type": "string"
+                },
+                "owner_id": {
+                    "description": "app owner (the likely session owner)",
+                    "type": "string"
+                },
+                "owner_name": {
+                    "description": "human-readable owner (email / full name)",
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "subscription_owner_type": {
+                    "description": "\"user\" or \"org\" — where the effective sub resolved",
+                    "type": "string"
+                },
+                "valid": {
+                    "description": "that subscription passed its last liveness probe",
+                    "type": "boolean"
+                }
+            }
+        },
         "server.AppCreateResponse": {
             "type": "object",
             "properties": {
@@ -27493,6 +27589,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "last_refreshed_at": {
+                    "type": "string"
+                },
+                "last_validated_at": {
+                    "description": "last time the token was liveness-probed against Anthropic",
                     "type": "string"
                 },
                 "name": {
@@ -32093,6 +32193,9 @@ const docTemplate = `{
                 },
                 "docker_cache_status": {
                     "$ref": "#/definitions/types.DockerCacheState"
+                },
+                "org_members_access": {
+                    "type": "boolean"
                 }
             }
         },

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1122,6 +1122,7 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	authRouter.HandleFunc("/apps/{id}", system.Wrapper(apiServer.getApp)).Methods(http.MethodGet)
 	authRouter.HandleFunc("/apps/{id}", system.Wrapper(apiServer.updateApp)).Methods(http.MethodPut)
 	authRouter.HandleFunc("/apps/{id}", system.Wrapper(apiServer.deleteApp)).Methods(http.MethodDelete)
+	authRouter.HandleFunc("/apps/{id}/claude-subscription-status", system.Wrapper(apiServer.getAppClaudeSubscriptionStatus)).Methods(http.MethodGet)
 	authRouter.HandleFunc("/apps/{id}/daily-usage", system.Wrapper(apiServer.getAppDailyUsage)).Methods(http.MethodGet)
 	authRouter.HandleFunc("/apps/{id}/users-daily-usage", system.Wrapper(apiServer.getAppUsersDailyUsage)).Methods(http.MethodGet)
 	authRouter.HandleFunc("/apps/{id}/llm-calls", system.Wrapper(apiServer.listAppLLMCalls)).Methods(http.MethodGet)

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -2121,6 +2121,58 @@
                 }
             }
         },
+        "/api/v1/apps/{id}/claude-subscription-status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Reports whether the app owner (whose subscription authenticates the app's sessions) has a working Claude subscription",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Claude"
+                ],
+                "summary": "Get the Claude subscription status for an app's owner",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "App ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.AppClaudeSubscriptionStatus"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/apps/{id}/daily-usage": {
             "get": {
                 "security": [
@@ -16231,6 +16283,12 @@
                         "description": "Filter by session role (e.g. job)",
                         "name": "session_role",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Include external agent sessions",
+                        "name": "include_external_agents",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -17299,7 +17357,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Tears down the half-dead desktop container and brings up a fresh one\nvia the resume path. The session's ZedThreadID is cleared so Zed opens\na fresh thread: a crash often poisons the thread itself, so reattaching\nreproduces the wedge; use /sessions/{id}/resume to restart while keeping\nthe thread. The workspace volume persists, so files and the agent's own\nstate survive; only the conversation thread resets. Crashed prompts are\nreset to pending and the queue is kicked so they re-dispatch on the new\ncontainer.\nRequires the session to be an external Zed agent. Returns the count of\nprompts that were reset.",
+                "description": "Tears down the half-dead desktop container and brings up a fresh one\nvia the resume path. The conversation thread is PRESERVED when the\nsession's last turn completed cleanly (the common \"reboot to refresh\nthe environment\" case) so context is not lost; it is reset only when\nthe last turn is mid-flight or errored, which signals a possibly\npoisoned thread that would just reproduce the wedge on reattach. The\nworkspace volume persists, so files and the agent's own state survive\nregardless. Crashed prompts are reset to pending and the queue is\nkicked so they re-dispatch on the new container.\nRequires the session to be an external Zed agent. Returns the count of\nprompts that were reset.",
                 "produces": [
                     "application/json"
                 ],
@@ -23658,6 +23716,44 @@
                 }
             }
         },
+        "server.AppClaudeSubscriptionStatus": {
+            "type": "object",
+            "properties": {
+                "connected": {
+                    "description": "owner has a subscription connected at all",
+                    "type": "boolean"
+                },
+                "is_current_user": {
+                    "description": "true when the editor IS the owner",
+                    "type": "boolean"
+                },
+                "last_error": {
+                    "type": "string"
+                },
+                "last_validated_at": {
+                    "type": "string"
+                },
+                "owner_id": {
+                    "description": "app owner (the likely session owner)",
+                    "type": "string"
+                },
+                "owner_name": {
+                    "description": "human-readable owner (email / full name)",
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "subscription_owner_type": {
+                    "description": "\"user\" or \"org\" — where the effective sub resolved",
+                    "type": "string"
+                },
+                "valid": {
+                    "description": "that subscription passed its last liveness probe",
+                    "type": "boolean"
+                }
+            }
+        },
         "server.AppCreateResponse": {
             "type": "object",
             "properties": {
@@ -27489,6 +27585,10 @@
                     "type": "string"
                 },
                 "last_refreshed_at": {
+                    "type": "string"
+                },
+                "last_validated_at": {
+                    "description": "last time the token was liveness-probed against Anthropic",
                     "type": "string"
                 },
                 "name": {
@@ -32089,6 +32189,9 @@
                 },
                 "docker_cache_status": {
                     "$ref": "#/definitions/types.DockerCacheState"
+                },
+                "org_members_access": {
+                    "type": "boolean"
                 }
             }
         },

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -1494,6 +1494,33 @@ definitions:
           $ref: '#/definitions/server.SandboxInstanceInfo'
         type: array
     type: object
+  server.AppClaudeSubscriptionStatus:
+    properties:
+      connected:
+        description: owner has a subscription connected at all
+        type: boolean
+      is_current_user:
+        description: true when the editor IS the owner
+        type: boolean
+      last_error:
+        type: string
+      last_validated_at:
+        type: string
+      owner_id:
+        description: app owner (the likely session owner)
+        type: string
+      owner_name:
+        description: human-readable owner (email / full name)
+        type: string
+      status:
+        type: string
+      subscription_owner_type:
+        description: '"user" or "org" — where the effective sub resolved'
+        type: string
+      valid:
+        description: that subscription passed its last liveness probe
+        type: boolean
+    type: object
   server.AppCreateResponse:
     properties:
       config:
@@ -4220,6 +4247,9 @@ definitions:
       last_error:
         type: string
       last_refreshed_at:
+        type: string
+      last_validated_at:
+        description: last time the token was liveness-probed against Anthropic
         type: string
       name:
         type: string
@@ -7497,6 +7527,8 @@ definitions:
         $ref: '#/definitions/types.BoardSettings'
       docker_cache_status:
         $ref: '#/definitions/types.DockerCacheState'
+      org_members_access:
+        type: boolean
     type: object
   types.ProjectRepositorySpec:
     properties:
@@ -13569,6 +13601,40 @@ paths:
       summary: Upload app avatar
       tags:
       - apps
+  /api/v1/apps/{id}/claude-subscription-status:
+    get:
+      description: Reports whether the app owner (whose subscription authenticates
+        the app's sessions) has a working Claude subscription
+      parameters:
+      - description: App ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.AppClaudeSubscriptionStatus'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get the Claude subscription status for an app's owner
+      tags:
+      - Claude
   /api/v1/apps/{id}/daily-usage:
     get:
       consumes:
@@ -22613,6 +22679,10 @@ paths:
         in: query
         name: session_role
         type: string
+      - description: Include external agent sessions
+        in: query
+        name: include_external_agents
+        type: boolean
       responses:
         "200":
           description: OK
@@ -23304,13 +23374,14 @@ paths:
     post:
       description: |-
         Tears down the half-dead desktop container and brings up a fresh one
-        via the resume path. The session's ZedThreadID is cleared so Zed opens
-        a fresh thread: a crash often poisons the thread itself, so reattaching
-        reproduces the wedge; use /sessions/{id}/resume to restart while keeping
-        the thread. The workspace volume persists, so files and the agent's own
-        state survive; only the conversation thread resets. Crashed prompts are
-        reset to pending and the queue is kicked so they re-dispatch on the new
-        container.
+        via the resume path. The conversation thread is PRESERVED when the
+        session's last turn completed cleanly (the common "reboot to refresh
+        the environment" case) so context is not lost; it is reset only when
+        the last turn is mid-flight or errored, which signals a possibly
+        poisoned thread that would just reproduce the wedge on reattach. The
+        workspace volume persists, so files and the agent's own state survive
+        regardless. Crashed prompts are reset to pending and the queue is
+        kicked so they re-dispatch on the new container.
         Requires the session to be an external Zed agent. Returns the count of
         prompts that were reset.
       parameters:

--- a/api/pkg/server/websocket_external_agent_sync.go
+++ b/api/pkg/server/websocket_external_agent_sync.go
@@ -3850,6 +3850,54 @@ func (apiServer *HelixAPIServer) handleThreadLoadError(sessionID string, syncMsg
 // legacy HTTP-stream response channel. Missing mappings degrade
 // silently — chat_response_error for an unknown request_id is a no-op
 // (e.g. desktop replay during reconnect).
+// genericACPAbortMarker identifies the generic mid-turn abort string that Zed
+// emits when an ACP turn errors without a cause (see
+// zed/crates/external_websocket_sync/src/thread_service.rs). It is the only
+// message we attempt to reclassify — specific errors are left untouched.
+const genericACPAbortMarker = "exited mid-turn or hit max tokens"
+
+// maybeReclassifySubscriptionAuthError rewrites the generic ACP mid-turn abort
+// message into a legible Claude-subscription auth error when (a) the message is
+// the generic one, (b) the session's agent runs Claude Code in subscription
+// mode, and (c) the session owner's subscription is missing or fails a fresh
+// liveness probe. Otherwise it returns errorMsg unchanged.
+func (apiServer *HelixAPIServer) maybeReclassifySubscriptionAuthError(ctx context.Context, helixSessionID, errorMsg string) string {
+	if !strings.Contains(errorMsg, genericACPAbortMarker) {
+		return errorMsg
+	}
+	session, err := apiServer.Store.GetSession(ctx, helixSessionID)
+	if err != nil || session == nil || session.ParentApp == "" {
+		return errorMsg
+	}
+	app, err := apiServer.Store.GetApp(ctx, session.ParentApp)
+	if err != nil || len(app.Config.Helix.Assistants) == 0 {
+		return errorMsg
+	}
+	asst := app.Config.Helix.Assistants[0]
+	if asst.CodeAgentRuntime != types.CodeAgentRuntimeClaudeCode || !asst.CodeAgentCredentialType.IsSubscription() {
+		return errorMsg
+	}
+
+	owner := apiServer.displayNameForUser(ctx, session.Owner)
+	sub, err := apiServer.Store.GetEffectiveClaudeSubscription(ctx, session.Owner, session.OrganizationID)
+	if errors.Is(err, store.ErrNotFound) || sub == nil {
+		return fmt.Sprintf("Claude subscription authentication failed: %s has no Claude subscription connected. "+
+			"Connect one in Settings, or switch the agent to API-key mode.", owner)
+	}
+	if err != nil {
+		return errorMsg
+	}
+
+	// Confirm it's really an auth problem before rewriting. revalidate persists
+	// the fresh Status/LastError so Settings reflects it too.
+	sub = apiServer.revalidateClaudeSubscription(ctx, sub)
+	if sub.Status == "error" {
+		return fmt.Sprintf("Claude subscription authentication failed for %s (invalid or expired token). "+
+			"Reconnect the subscription in Settings.", owner)
+	}
+	return errorMsg
+}
+
 func (apiServer *HelixAPIServer) handleChatResponseError(sessionID string, syncMsg *types.SyncMessage) error {
 	requestID, ok := syncMsg.Data["request_id"].(string)
 	if !ok {
@@ -3871,6 +3919,14 @@ func (apiServer *HelixAPIServer) handleChatResponseError(sessionID string, syncM
 			log.Warn().Err(err).Str("session_id", sessionID).Str("request_id", requestID).
 				Str("interaction_id", interactionID).Msg("chat_response_error: load interaction failed")
 		} else if interaction != nil {
+			// When a subscription-mode Claude Code session aborts with the
+			// generic ACP mid-turn message, the real cause is often an invalid
+			// subscription token (401) that Zed only logs. Re-probe the owner's
+			// subscription and, if it's genuinely bad, replace the useless
+			// generic string with a legible auth error. interaction.SessionID is
+			// the helix session id (the handler's sessionID param can be the
+			// agent session id, which differs).
+			errorMsg = apiServer.maybeReclassifySubscriptionAuthError(context.Background(), interaction.SessionID, errorMsg)
 			interaction.State = types.InteractionStateError
 			interaction.Error = errorMsg
 			interaction.Updated = time.Now()

--- a/api/pkg/types/claude_subscription.go
+++ b/api/pkg/types/claude_subscription.go
@@ -24,6 +24,7 @@ type ClaudeSubscription struct {
 	AccessTokenExpiresAt time.Time      `json:"access_token_expires_at"`
 	Status               string         `json:"status"`                    // "active", "expired", "error"
 	LastRefreshedAt      *time.Time     `json:"last_refreshed_at,omitempty"`
+	LastValidatedAt      *time.Time     `json:"last_validated_at,omitempty"` // last time the token was liveness-probed against Anthropic
 	LastError            string         `json:"last_error,omitempty"`
 	CreatedBy            string         `json:"created_by" gorm:"not null"`
 }

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -989,6 +989,24 @@ export interface ServerAgentSandboxesDebugResponse {
   sandboxes?: ServerSandboxInstanceInfo[];
 }
 
+export interface ServerAppClaudeSubscriptionStatus {
+  /** owner has a subscription connected at all */
+  connected?: boolean;
+  /** true when the editor IS the owner */
+  is_current_user?: boolean;
+  last_error?: string;
+  last_validated_at?: string;
+  /** app owner (the likely session owner) */
+  owner_id?: string;
+  /** human-readable owner (email / full name) */
+  owner_name?: string;
+  status?: string;
+  /** "user" or "org" — where the effective sub resolved */
+  subscription_owner_type?: string;
+  /** that subscription passed its last liveness probe */
+  valid?: boolean;
+}
+
 export interface ServerAppCreateResponse {
   config?: TypesAppConfig;
   created?: string;
@@ -2690,6 +2708,8 @@ export interface TypesClaudeSubscription {
   id?: string;
   last_error?: string;
   last_refreshed_at?: string;
+  /** last time the token was liveness-probed against Anthropic */
+  last_validated_at?: string;
   name?: string;
   owner_id?: string;
   /** "user" or "org" */
@@ -4693,6 +4713,7 @@ export interface TypesProjectMetadata {
   auto_warm_docker_cache?: boolean;
   board_settings?: TypesBoardSettings;
   docker_cache_status?: TypesDockerCacheState;
+  org_members_access?: boolean;
 }
 
 export interface TypesProjectRepositorySpec {
@@ -8685,6 +8706,24 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         body: image,
         secure: true,
         type: ContentType.Text,
+        ...params,
+      }),
+
+    /**
+     * @description Reports whether the app owner (whose subscription authenticates the app's sessions) has a working Claude subscription
+     *
+     * @tags Claude
+     * @name V1AppsClaudeSubscriptionStatusDetail
+     * @summary Get the Claude subscription status for an app's owner
+     * @request GET:/api/v1/apps/{id}/claude-subscription-status
+     * @secure
+     */
+    v1AppsClaudeSubscriptionStatusDetail: (id: string, params: RequestParams = {}) =>
+      this.request<ServerAppClaudeSubscriptionStatus, SystemHTTPError>({
+        path: `/api/v1/apps/${id}/claude-subscription-status`,
+        method: "GET",
+        secure: true,
+        format: "json",
         ...params,
       }),
 
@@ -15340,6 +15379,8 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         project_id?: string;
         /** Filter by session role (e.g. job) */
         session_role?: string;
+        /** Include external agent sessions */
+        include_external_agents?: boolean;
       },
       params: RequestParams = {},
     ) =>
@@ -15785,7 +15826,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Tears down the half-dead desktop container and brings up a fresh one via the resume path. The session's ZedThreadID is cleared so Zed opens a fresh thread: a crash often poisons the thread itself, so reattaching reproduces the wedge; use /sessions/{id}/resume to restart while keeping the thread. The workspace volume persists, so files and the agent's own state survive; only the conversation thread resets. Crashed prompts are reset to pending and the queue is kicked so they re-dispatch on the new container. Requires the session to be an external Zed agent. Returns the count of prompts that were reset.
+     * @description Tears down the half-dead desktop container and brings up a fresh one via the resume path. The conversation thread is PRESERVED when the session's last turn completed cleanly (the common "reboot to refresh the environment" case) so context is not lost; it is reset only when the last turn is mid-flight or errored, which signals a possibly poisoned thread that would just reproduce the wedge on reattach. The workspace volume persists, so files and the agent's own state survive regardless. Crashed prompts are reset to pending and the queue is kicked so they re-dispatch on the new container. Requires the session to be an external Zed agent. Returns the count of prompts that were reset.
      *
      * @tags Sessions
      * @name V1SessionsRestartAgentCreate

--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -16,6 +16,7 @@ import Link from '@mui/material/Link'
 import Button from '@mui/material/Button'
 import Radio from '@mui/material/Radio'
 import RadioGroup from '@mui/material/RadioGroup'
+import Alert from '@mui/material/Alert'
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import Menu from '@mui/material/Menu'
@@ -287,8 +288,32 @@ const AppSettings: FC<AppSettingsProps> = ({
   })
   const { data: claudeSubscriptions } = useClaudeSubscriptions()
   const { data: codexSubscriptions } = useCodexSubscriptions()
-  const hasClaudeSubscription = (claudeSubscriptions?.length ?? 0) > 0
   const hasCodexSubscription = (codexSubscriptions?.length ?? 0) > 0
+
+  // Whose Claude subscription actually authenticates this agent? Sessions use the
+  // SESSION OWNER's subscription, not the editing user's. This endpoint resolves
+  // the APP OWNER's subscription status (the likely session owner) so the callout
+  // below can name the owner and warn when their subscription is missing/invalid —
+  // fixing the false "connected ✓" that showed the editor's own subscription.
+  const apiHookForClaude = useApi()
+  const { data: ownerClaudeStatus } = useQuery({
+    queryKey: ['app-claude-subscription-status', id],
+    queryFn: async () => {
+      const response = await apiHookForClaude.getApiClient().v1AppsClaudeSubscriptionStatusDetail(id)
+      return response.data
+    },
+    // Only meaningful for a saved Claude Code agent in subscription mode.
+    enabled: !!id && code_agent_runtime === 'claude_code',
+    staleTime: 30000,
+  })
+  // Fall back to the editor's own subscription list only until the owner-scoped
+  // status resolves (or for brand-new unsaved apps with no id).
+  const hasClaudeSubscription = ownerClaudeStatus !== undefined
+    ? !!ownerClaudeStatus.connected
+    : (claudeSubscriptions?.length ?? 0) > 0
+  const ownerClaudeValid = ownerClaudeStatus !== undefined
+    ? !!ownerClaudeStatus.valid
+    : (claudeSubscriptions?.length ?? 0) > 0
   const hasAnthropicProvider = providerEndpoints.some(ep => ep.name === 'anthropic')
   const hasOpenAIProvider = providerEndpoints.some(ep => ep.name === 'openai')
 
@@ -772,6 +797,38 @@ const AppSettings: FC<AppSettingsProps> = ({
                     <Typography variant="caption" color="warning.main" sx={{ display: 'block', mt: 0.5 }}>
                       Connect a {code_agent_runtime === 'claude_code' ? 'Claude' : 'ChatGPT'} subscription or add an {code_agent_runtime === 'claude_code' ? 'Anthropic' : 'OpenAI'} API key in Settings &gt; Providers.
                     </Typography>
+                  )}
+                  {/* Whose subscription authenticates the agent? Sessions use the
+                      session owner's subscription, not the editor's. */}
+                  {code_agent_runtime === 'claude_code' && claudeCodeMode === 'subscription' && (
+                    <Box sx={{ mt: 1 }}>
+                      <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                        Sessions from this agent authenticate with the <strong>session owner's</strong> connected
+                        Claude subscription. If someone else runs this agent, their own subscription is used — not yours.
+                      </Typography>
+                      {ownerClaudeStatus !== undefined && !ownerClaudeStatus.is_current_user && (
+                        ownerClaudeValid ? (
+                          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                            This agent is owned by <strong>{ownerClaudeStatus.owner_name || ownerClaudeStatus.owner_id}</strong>,
+                            who has an active Claude subscription connected.
+                          </Typography>
+                        ) : (
+                          <Alert severity="warning" sx={{ mt: 0.5, py: 0 }}>
+                            <strong>{ownerClaudeStatus.owner_name || ownerClaudeStatus.owner_id}</strong>{' '}
+                            {ownerClaudeStatus.connected
+                              ? `has a Claude subscription, but it isn't working${ownerClaudeStatus.last_error ? ` (${ownerClaudeStatus.last_error})` : ''}.`
+                              : 'has no working Claude subscription connected.'}{' '}
+                            The agent will fail to authenticate. Ask them to reconnect it, or use API-key mode.
+                          </Alert>
+                        )
+                      )}
+                      {ownerClaudeStatus !== undefined && ownerClaudeStatus.is_current_user && ownerClaudeStatus.connected && !ownerClaudeValid && (
+                        <Alert severity="warning" sx={{ mt: 0.5, py: 0 }}>
+                          Your Claude subscription isn't working{ownerClaudeStatus.last_error ? ` (${ownerClaudeStatus.last_error})` : ''}.
+                          Reconnect it in Settings, or use API-key mode.
+                        </Alert>
+                      )}
+                    </Box>
                   )}
                   {code_agent_runtime === 'claude_code' && claudeCodeMode === 'subscription' && (
                     <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mt: 1.5 }} alignItems="flex-start">

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -1494,6 +1494,33 @@ definitions:
           $ref: '#/definitions/server.SandboxInstanceInfo'
         type: array
     type: object
+  server.AppClaudeSubscriptionStatus:
+    properties:
+      connected:
+        description: owner has a subscription connected at all
+        type: boolean
+      is_current_user:
+        description: true when the editor IS the owner
+        type: boolean
+      last_error:
+        type: string
+      last_validated_at:
+        type: string
+      owner_id:
+        description: app owner (the likely session owner)
+        type: string
+      owner_name:
+        description: human-readable owner (email / full name)
+        type: string
+      status:
+        type: string
+      subscription_owner_type:
+        description: '"user" or "org" — where the effective sub resolved'
+        type: string
+      valid:
+        description: that subscription passed its last liveness probe
+        type: boolean
+    type: object
   server.AppCreateResponse:
     properties:
       config:
@@ -4220,6 +4247,9 @@ definitions:
       last_error:
         type: string
       last_refreshed_at:
+        type: string
+      last_validated_at:
+        description: last time the token was liveness-probed against Anthropic
         type: string
       name:
         type: string
@@ -7497,6 +7527,8 @@ definitions:
         $ref: '#/definitions/types.BoardSettings'
       docker_cache_status:
         $ref: '#/definitions/types.DockerCacheState'
+      org_members_access:
+        type: boolean
     type: object
   types.ProjectRepositorySpec:
     properties:
@@ -13569,6 +13601,40 @@ paths:
       summary: Upload app avatar
       tags:
       - apps
+  /api/v1/apps/{id}/claude-subscription-status:
+    get:
+      description: Reports whether the app owner (whose subscription authenticates
+        the app's sessions) has a working Claude subscription
+      parameters:
+      - description: App ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.AppClaudeSubscriptionStatus'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get the Claude subscription status for an app's owner
+      tags:
+      - Claude
   /api/v1/apps/{id}/daily-usage:
     get:
       consumes:
@@ -22613,6 +22679,10 @@ paths:
         in: query
         name: session_role
         type: string
+      - description: Include external agent sessions
+        in: query
+        name: include_external_agents
+        type: boolean
       responses:
         "200":
           description: OK
@@ -23304,13 +23374,14 @@ paths:
     post:
       description: |-
         Tears down the half-dead desktop container and brings up a fresh one
-        via the resume path. The session's ZedThreadID is cleared so Zed opens
-        a fresh thread: a crash often poisons the thread itself, so reattaching
-        reproduces the wedge; use /sessions/{id}/resume to restart while keeping
-        the thread. The workspace volume persists, so files and the agent's own
-        state survive; only the conversation thread resets. Crashed prompts are
-        reset to pending and the queue is kicked so they re-dispatch on the new
-        container.
+        via the resume path. The conversation thread is PRESERVED when the
+        session's last turn completed cleanly (the common "reboot to refresh
+        the environment" case) so context is not lost; it is reset only when
+        the last turn is mid-flight or errored, which signals a possibly
+        poisoned thread that would just reproduce the wedge on reattach. The
+        workspace volume persists, so files and the agent's own state survive
+        regardless. Crashed prompts are reset to pending and the queue is
+        kicked so they re-dispatch on the new container.
         Requires the session to be an external Zed agent. Returns the count of
         prompts that were reset.
       parameters:

--- a/openapi.json
+++ b/openapi.json
@@ -2535,6 +2535,73 @@
                 }
             }
         },
+        "/api/v1/apps/{id}/claude-subscription-status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Reports whether the app owner (whose subscription authenticates the app's sessions) has a working Claude subscription",
+                "tags": [
+                    "Claude"
+                ],
+                "summary": "Get the Claude subscription status for an app's owner",
+                "parameters": [
+                    {
+                        "description": "App ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/server.AppClaudeSubscriptionStatus"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/apps/{id}/daily-usage": {
             "get": {
                 "security": [
@@ -19424,6 +19491,14 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "description": "Include external agent sessions",
+                        "name": "include_external_agents",
+                        "in": "query",
+                        "schema": {
+                            "type": "boolean"
+                        }
                     }
                 ],
                 "responses": {
@@ -20693,7 +20768,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Tears down the half-dead desktop container and brings up a fresh one\nvia the resume path. The session's ZedThreadID is cleared so Zed opens\na fresh thread: a crash often poisons the thread itself, so reattaching\nreproduces the wedge; use /sessions/{id}/resume to restart while keeping\nthe thread. The workspace volume persists, so files and the agent's own\nstate survive; only the conversation thread resets. Crashed prompts are\nreset to pending and the queue is kicked so they re-dispatch on the new\ncontainer.\nRequires the session to be an external Zed agent. Returns the count of\nprompts that were reset.",
+                "description": "Tears down the half-dead desktop container and brings up a fresh one\nvia the resume path. The conversation thread is PRESERVED when the\nsession's last turn completed cleanly (the common \"reboot to refresh\nthe environment\" case) so context is not lost; it is reset only when\nthe last turn is mid-flight or errored, which signals a possibly\npoisoned thread that would just reproduce the wedge on reattach. The\nworkspace volume persists, so files and the agent's own state survive\nregardless. Crashed prompts are reset to pending and the queue is\nkicked so they re-dispatch on the new container.\nRequires the session to be an external Zed agent. Returns the count of\nprompts that were reset.",
                 "tags": [
                     "Sessions"
                 ],
@@ -28014,6 +28089,44 @@
                     }
                 }
             },
+            "server.AppClaudeSubscriptionStatus": {
+                "type": "object",
+                "properties": {
+                    "connected": {
+                        "description": "owner has a subscription connected at all",
+                        "type": "boolean"
+                    },
+                    "is_current_user": {
+                        "description": "true when the editor IS the owner",
+                        "type": "boolean"
+                    },
+                    "last_error": {
+                        "type": "string"
+                    },
+                    "last_validated_at": {
+                        "type": "string"
+                    },
+                    "owner_id": {
+                        "description": "app owner (the likely session owner)",
+                        "type": "string"
+                    },
+                    "owner_name": {
+                        "description": "human-readable owner (email / full name)",
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "subscription_owner_type": {
+                        "description": "\"user\" or \"org\" — where the effective sub resolved",
+                        "type": "string"
+                    },
+                    "valid": {
+                        "description": "that subscription passed its last liveness probe",
+                        "type": "boolean"
+                    }
+                }
+            },
             "server.AppCreateResponse": {
                 "type": "object",
                 "properties": {
@@ -31845,6 +31958,10 @@
                         "type": "string"
                     },
                     "last_refreshed_at": {
+                        "type": "string"
+                    },
+                    "last_validated_at": {
+                        "description": "last time the token was liveness-probed against Anthropic",
                         "type": "string"
                     },
                     "name": {
@@ -36445,6 +36562,9 @@
                     },
                     "docker_cache_status": {
                         "$ref": "#/components/schemas/types.DockerCacheState"
+                    },
+                    "org_members_access": {
+                        "type": "boolean"
                     }
                 }
             },

--- a/swagger.json
+++ b/swagger.json
@@ -2121,6 +2121,58 @@
                 }
             }
         },
+        "/api/v1/apps/{id}/claude-subscription-status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Reports whether the app owner (whose subscription authenticates the app's sessions) has a working Claude subscription",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Claude"
+                ],
+                "summary": "Get the Claude subscription status for an app's owner",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "App ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.AppClaudeSubscriptionStatus"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/apps/{id}/daily-usage": {
             "get": {
                 "security": [
@@ -16231,6 +16283,12 @@
                         "description": "Filter by session role (e.g. job)",
                         "name": "session_role",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Include external agent sessions",
+                        "name": "include_external_agents",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -17299,7 +17357,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Tears down the half-dead desktop container and brings up a fresh one\nvia the resume path. The session's ZedThreadID is cleared so Zed opens\na fresh thread: a crash often poisons the thread itself, so reattaching\nreproduces the wedge; use /sessions/{id}/resume to restart while keeping\nthe thread. The workspace volume persists, so files and the agent's own\nstate survive; only the conversation thread resets. Crashed prompts are\nreset to pending and the queue is kicked so they re-dispatch on the new\ncontainer.\nRequires the session to be an external Zed agent. Returns the count of\nprompts that were reset.",
+                "description": "Tears down the half-dead desktop container and brings up a fresh one\nvia the resume path. The conversation thread is PRESERVED when the\nsession's last turn completed cleanly (the common \"reboot to refresh\nthe environment\" case) so context is not lost; it is reset only when\nthe last turn is mid-flight or errored, which signals a possibly\npoisoned thread that would just reproduce the wedge on reattach. The\nworkspace volume persists, so files and the agent's own state survive\nregardless. Crashed prompts are reset to pending and the queue is\nkicked so they re-dispatch on the new container.\nRequires the session to be an external Zed agent. Returns the count of\nprompts that were reset.",
                 "produces": [
                     "application/json"
                 ],
@@ -23658,6 +23716,44 @@
                 }
             }
         },
+        "server.AppClaudeSubscriptionStatus": {
+            "type": "object",
+            "properties": {
+                "connected": {
+                    "description": "owner has a subscription connected at all",
+                    "type": "boolean"
+                },
+                "is_current_user": {
+                    "description": "true when the editor IS the owner",
+                    "type": "boolean"
+                },
+                "last_error": {
+                    "type": "string"
+                },
+                "last_validated_at": {
+                    "type": "string"
+                },
+                "owner_id": {
+                    "description": "app owner (the likely session owner)",
+                    "type": "string"
+                },
+                "owner_name": {
+                    "description": "human-readable owner (email / full name)",
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "subscription_owner_type": {
+                    "description": "\"user\" or \"org\" — where the effective sub resolved",
+                    "type": "string"
+                },
+                "valid": {
+                    "description": "that subscription passed its last liveness probe",
+                    "type": "boolean"
+                }
+            }
+        },
         "server.AppCreateResponse": {
             "type": "object",
             "properties": {
@@ -27489,6 +27585,10 @@
                     "type": "string"
                 },
                 "last_refreshed_at": {
+                    "type": "string"
+                },
+                "last_validated_at": {
+                    "description": "last time the token was liveness-probed against Anthropic",
                     "type": "string"
                 },
                 "name": {
@@ -32089,6 +32189,9 @@
                 },
                 "docker_cache_status": {
                     "$ref": "#/definitions/types.DockerCacheState"
+                },
+                "org_members_access": {
+                    "type": "boolean"
                 }
             }
         },


### PR DESCRIPTION
## Summary
Fixes a real incident where User A switched User B's agent to Claude **subscription**
mode, expecting A's own subscription to be used. Sessions actually authenticate with
the **session owner's** subscription (B's), whose token was invalid — every turn
failed with a useless generic error (`the ACP agent process exited mid-turn or hit
max tokens`). There was no UI affordance for whose subscription is used, no
validation that it works, and no legible surfacing of the auth failure.

This PR makes "whose subscription" explicit, validates the token with a real
liveness probe, and reclassifies the generic turn-failure into a legible
subscription-auth error — all in the helix repo, no Zed change required.

## Changes
- **Liveness probe** (`api/pkg/anthropic/subscription_probe.go`): probes a Claude
  subscription token against `api.anthropic.com/v1/messages` with the mandatory
  `anthropic-beta: oauth-2025-04-20` header. 401 = invalid, 200/429 = valid,
  network/5xx = inconclusive (never downgrades status on an ambiguous signal).
- **Validate on connect** (`claude_subscription_handlers.go`): `Status` now reflects
  a real probe instead of an unconditional `"active"`; persists `Status`,
  `LastError`, and a new `LastValidatedAt` (`types.ClaudeSubscription`).
- **Owner-status endpoint** `GET /api/v1/apps/{id}/claude-subscription-status`:
  resolves the **app owner's** effective subscription (the likely session owner) and
  reports `connected/valid/owner_name/is_current_user/last_error`. Re-probes when
  stale (>5min).
- **Legible session error** (`websocket_external_agent_sync.go`):
  `maybeReclassifySubscriptionAuthError` rewrites the generic ACP mid-turn abort into
  *"Claude subscription authentication failed for <owner> (invalid or expired token).
  Reconnect the subscription in Settings."* — only for subscription-mode Claude Code
  sessions whose owner sub is missing/invalid; all other errors pass through.
- **Agent settings UI** (`frontend/src/components/app/AppSettings.tsx`): an always-on
  callout ("sessions use the session owner's subscription, not yours"); the
  subscription option's connected state now derives from the **owner's** status
  (fixing a false "connected ✓" that showed the editor's own subscription); a warning
  Alert naming the owner when their subscription is missing/invalid.
- Regenerated OpenAPI TS client; unit tests for the probe and the reclassification wiring.

## Verification
- **Live, against real Anthropic:** connecting an invalid `sk-ant-oat…` token → probe
  returned 401 → row persisted `status=error`,
  `last_error="invalid or expired token (401 from Anthropic)"`, `last_validated_at`.
- **Live UI** (see screenshots): own-agent invalid-sub warning, and the cross-user
  incident (User A editing User B's agent → "chris@helix.ml has no working Claude
  subscription connected", subscription option disabled/"(not connected)").
- **Unit:** `TestProbeClaudeSubscription`, `TestReclassifySubAuthSuite`.
- **Not shown live:** the end-to-end turn-failure screenshot — the inner-Helix
  desktop/Zed sandbox would not provision, so a real failing Zed turn couldn't be
  produced. The reclassification is unit-proven and the render path is unchanged.

## Screenshots
![Own agent, invalid subscription warning](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002296_implement-the/screenshots/01-own-agent-invalid-subscription-warning.png)
![Cross-user: editing another user's agent](https://github.com/helixml/helix/raw/helix-specs/design/tasks/002296_implement-the/screenshots/02-cross-user-agent-owner-no-subscription-warning.png)

## Notes / follow-ups
- Warn (not hard-block) at save time, per design Open Q1.
- Optional future work: propagate a real `error_kind` from Zed
  (`acp_thread`/`external_websocket_sync`) so non-subscription auth failures are also
  legible generically — deferred (needs a `helixml/zed` PR + `sandbox-versions.txt` bump).
- Mirroring the callout into the shared coding-agent config surfaces is a small follow-up.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01ky28m5yqnkx5fnxb579g7nf4)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002296_implement-the/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002296_implement-the/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002296_implement-the/tasks.md)

🚀 Built with [Helix](https://helix.ml)