### PR TITLE
fix(api): restart only resets the Zed thread when it is genuinely wedged

### DIFF
--- a/api/pkg/server/restart_session_container_test.go
+++ b/api/pkg/server/restart_session_container_test.go
@@ -253,8 +253,11 @@ func (s *RestartSessionContainerSuite) TestRestartPreservesThreadWhenNotReset() 
 
 // TestButtonPreservesHealthyThreadResetsWedged pins the human-button decision:
 // restartCrashedAgentThread inspects the session's last interaction and only
-// resets the thread when that turn did not finish cleanly. A completed last turn
-// → preserve (no metadata clear); a mid-turn/waiting last turn → reset.
+// resets the thread when it is GENUINELY WEDGED — the last turn errored with an
+// agent-crash / authoritative-missing-thread marker. A completed, interrupted, or
+// still-in-flight (waiting) last turn preserves the thread, and so does a turn
+// that errored on auth / provider (not a wedge). See
+// design/2026-07-21-restart-discards-thread-on-nonclean-turn.md.
 func (s *RestartSessionContainerSuite) TestButtonPreservesHealthyThreadResetsWedged() {
 	const (
 		userID    = "user_op"
@@ -265,12 +268,15 @@ func (s *RestartSessionContainerSuite) TestButtonPreservesHealthyThreadResetsWed
 	cases := []struct {
 		name      string
 		lastState types.InteractionState
+		lastError string
 		wantReset bool
 	}{
-		{"complete_last_turn_preserves", types.InteractionStateComplete, false},
-		{"interrupted_last_turn_preserves", types.InteractionStateInterrupted, false},
-		{"waiting_last_turn_resets", types.InteractionStateWaiting, true},
-		{"error_last_turn_resets", types.InteractionStateError, true},
+		{"complete_last_turn_preserves", types.InteractionStateComplete, "", false},
+		{"interrupted_last_turn_preserves", types.InteractionStateInterrupted, "", false},
+		{"waiting_in_flight_preserves", types.InteractionStateWaiting, "", false},
+		{"auth_error_preserves", types.InteractionStateError, "Failed to authenticate. API Error: 401 OAuth access token is invalid.", false},
+		{"agent_crash_resets", types.InteractionStateError, "Claude Agent process exited", true},
+		{"missing_thread_resets", types.InteractionStateError, `no thread found with ID: SessionId("bd5abc10")`, true},
 	}
 
 	for _, tc := range cases {
@@ -288,9 +294,9 @@ func (s *RestartSessionContainerSuite) TestButtonPreservesHealthyThreadResetsWed
 			s.store.EXPECT().ListGitRepositories(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 			s.store.EXPECT().UpdateSession(gomock.Any(), gomock.Any()).Return(session, nil).AnyTimes()
 
-			// The health probe: newest interaction carries tc.lastState.
+			// The health probe: newest interaction carries tc.lastState/lastError.
 			s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
-				[]*types.Interaction{{ID: "int_1", State: tc.lastState}}, int64(1), nil).AnyTimes()
+				[]*types.Interaction{{ID: "int_1", State: tc.lastState, Error: tc.lastError}}, int64(1), nil).AnyTimes()
 
 			cleared := false
 			s.store.EXPECT().UpdateSessionMetadata(gomock.Any(), sessionID, gomock.Any()).DoAndReturn(
@@ -321,41 +327,50 @@ func (s *RestartSessionContainerSuite) TestButtonPreservesHealthyThreadResetsWed
 	}
 }
 
-// TestLastInteractionCompletedCleanly pins the thread-health decision the human
-// Restart button keys off: a cleanly-finished last turn (complete / interrupted)
-// is safe to reattach → preserve; a mid-turn or errored one signals a possible
-// wedge → reset. Zero interactions and a query error both resolve to healthy so
-// we never discard conversation context we couldn't prove was poisoned.
-func (s *RestartSessionContainerSuite) TestLastInteractionCompletedCleanly() {
+// TestThreadIsWedged pins the thread-health decision the human Restart button
+// keys off: the thread is reset ONLY when the last turn errored with positive
+// wedge evidence (agent crash / authoritative missing thread). A clean, in-flight
+// (waiting), or auth/provider-errored last turn is preserved, as are zero
+// interactions and a query error — we never discard context we can't prove is
+// poisoned. See design/2026-07-21-restart-discards-thread-on-nonclean-turn.md.
+func (s *RestartSessionContainerSuite) TestThreadIsWedged() {
 	session := zedSession("ses_health", "user_op", "prj_x")
 
 	cases := []struct {
-		name   string
-		setup  func()
-		wantOK bool
+		name       string
+		setup      func()
+		wantWedged bool
 	}{
-		{"complete", func() {
+		{"complete_preserves", func() {
 			s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
 				[]*types.Interaction{{State: types.InteractionStateComplete}}, int64(1), nil)
-		}, true},
-		{"interrupted", func() {
+		}, false},
+		{"interrupted_preserves", func() {
 			s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
 				[]*types.Interaction{{State: types.InteractionStateInterrupted}}, int64(1), nil)
-		}, true},
-		{"waiting", func() {
+		}, false},
+		{"waiting_in_flight_preserves", func() {
 			s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
 				[]*types.Interaction{{State: types.InteractionStateWaiting}}, int64(1), nil)
 		}, false},
-		{"error", func() {
+		{"auth_error_preserves", func() {
 			s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
-				[]*types.Interaction{{State: types.InteractionStateError}}, int64(1), nil)
+				[]*types.Interaction{{State: types.InteractionStateError, Error: "Failed to authenticate. API Error: 401 OAuth access token is invalid."}}, int64(1), nil)
 		}, false},
-		{"no_interactions", func() {
+		{"agent_crash_error_wedges", func() {
+			s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
+				[]*types.Interaction{{State: types.InteractionStateError, Error: "Claude Agent process exited"}}, int64(1), nil)
+		}, true},
+		{"missing_thread_error_wedges", func() {
+			s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(
+				[]*types.Interaction{{State: types.InteractionStateError, Error: `no thread found with ID: SessionId("bd5abc10")`}}, int64(1), nil)
+		}, true},
+		{"no_interactions_preserves", func() {
 			s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(nil, int64(0), nil)
-		}, true},
-		{"query_error", func() {
+		}, false},
+		{"query_error_preserves", func() {
 			s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).Return(nil, int64(0), context.DeadlineExceeded)
-		}, true},
+		}, false},
 	}
 
 	for _, tc := range cases {
@@ -363,7 +378,7 @@ func (s *RestartSessionContainerSuite) TestLastInteractionCompletedCleanly() {
 			s.SetupTest()
 			defer s.ctrl.Finish()
 			tc.setup()
-			s.Equal(tc.wantOK, s.server.lastInteractionCompletedCleanly(context.Background(), session))
+			s.Equal(tc.wantWedged, s.server.threadIsWedged(context.Background(), session))
 		})
 	}
 }

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -2463,11 +2463,15 @@ func (s *HelixAPIServer) restartCrashedAgentThread(_ http.ResponseWriter, r *htt
 	}
 
 	// A human clicking Restart almost always means "reboot the container, keep my
-	// conversation" (e.g. to pick up a newly-cloned repo or refreshed env). Only
-	// treat it as a thread reset when the thread looks wedged — the last turn did
-	// not finish cleanly. Preserving a healthy thread avoids the silent, total
-	// context loss in design/2026-07-20-restart-clears-zed-thread-context-loss.md.
-	resetThread := !s.lastInteractionCompletedCleanly(ctx, session)
+	// conversation" — most often to apply a settings change (e.g. api_key →
+	// subscription, which needs the desktop recreated to pick up the new agent
+	// env). Only reset the thread on POSITIVE evidence it is genuinely wedged.
+	// An in-flight (waiting) turn or a turn that errored on auth / rate-limit /
+	// provider / transport / cancel leaves the conversation thread perfectly
+	// intact — resetting on those is silent, total context loss. See
+	// design/2026-07-21-restart-discards-thread-on-nonclean-turn.md (and the
+	// earlier design/2026-07-20-restart-clears-zed-thread-context-loss.md).
+	resetThread := s.threadIsWedged(ctx, session)
 
 	resetCount, herr := s.restartSessionContainer(ctx, user, session, resetThread)
 	if herr != nil {
@@ -2481,18 +2485,28 @@ func (s *HelixAPIServer) restartCrashedAgentThread(_ http.ResponseWriter, r *htt
 	}, nil
 }
 
-// lastInteractionCompletedCleanly reports whether the session's most recent
-// interaction finished in a healthy terminal state (complete or interrupted),
-// which means the Zed thread is safe to reattach to on restart. A mid-turn or
-// errored last interaction (waiting / editing / error) indicates a possible
-// thread wedge, so the restart should reset the thread and open a fresh one.
+// threadIsWedged reports whether the session's Zed thread is genuinely wedged —
+// i.e. the ACP agent/thread itself can no longer be driven, so reattaching would
+// just reproduce the wedge and a fresh thread is the only recovery. This is the
+// ONLY condition under which a human Restart discards the conversation pointer.
 //
-// On a query error we assume healthy (preserve the thread): the failure mode of
-// a wrongly-preserved poisoned thread is a boot that hangs and can be retried,
-// whereas a wrongly-cleared healthy thread is silent, unrecoverable context loss
-// — always err toward keeping the conversation. Zero interactions is likewise
-// healthy: there is no wedged turn to reproduce and nothing to lose.
-func (s *HelixAPIServer) lastInteractionCompletedCleanly(ctx context.Context, session *types.Session) bool {
+// A thread is wedged only when the most recent interaction errored with positive
+// evidence of an agent crash or an authoritative missing-thread report (the same
+// signals autonomous crash recovery keys on). Everything else keeps the thread:
+//   - complete / interrupted → the turn finished cleanly.
+//   - waiting / editing → the turn is still in-flight; the reconnect open_thread
+//     reattaches, and if that in-flight turn is truly dead the lazy
+//     recoverMissingThread path cleans it up on the next thread_load_error —
+//     strictly better than pre-emptively zeroing a large, healthy thread.
+//   - error from auth (401), rate-limit (429), a provider outage, a transport
+//     drop, or a user-cancel → the LLM call failed, the thread did not.
+//
+// On a query error, or with zero interactions, we treat the thread as healthy
+// (preserve): a wrongly-preserved poisoned thread is a boot that hangs and can be
+// retried, whereas a wrongly-cleared healthy thread is silent, unrecoverable
+// context loss — always err toward keeping the conversation. See
+// design/2026-07-21-restart-discards-thread-on-nonclean-turn.md.
+func (s *HelixAPIServer) threadIsWedged(ctx context.Context, session *types.Session) bool {
 	interactions, _, err := s.Store.ListInteractions(ctx, &types.ListInteractionsQuery{
 		SessionID:    session.ID,
 		GenerationID: session.GenerationID,
@@ -2502,17 +2516,20 @@ func (s *HelixAPIServer) lastInteractionCompletedCleanly(ctx context.Context, se
 	if err != nil {
 		log.Warn().Err(err).Str("session_id", session.ID).
 			Msg("restart: could not read last interaction to assess thread health — assuming healthy to avoid discarding conversation context")
-		return true
-	}
-	if len(interactions) == 0 {
-		return true
-	}
-	switch interactions[0].State {
-	case types.InteractionStateComplete, types.InteractionStateInterrupted:
-		return true
-	default:
 		return false
 	}
+	if len(interactions) == 0 {
+		return false
+	}
+	last := interactions[0]
+	if last.State != types.InteractionStateError {
+		// Healthy or still in-flight — never a wedge. A red flag would be
+		// clearing a complete/waiting thread, which this branch prevents.
+		return false
+	}
+	// The last turn errored: reset ONLY if the error is a genuine thread/agent
+	// wedge. Auth/provider/rate-limit/transport/cancel errors are not.
+	return isAgentCrashError(last.Error) || isAuthoritativeMissingThreadError(last.Error)
 }
 
 // restartSessionContainer is the single canonical "restart the agent" backend

--- a/design/2026-07-21-restart-discards-thread-on-nonclean-turn.md
+++ b/design/2026-07-21-restart-discards-thread-on-nonclean-turn.md
@@ -1,0 +1,72 @@
+# Incident: "Restart" discards a healthy Zed thread when the last turn isn't cleanly complete
+
+**Date:** 2026-07-21
+**Severity:** High (silent, total context loss on a routine "restart to apply settings")
+**Status:** Root-caused from prod logs; fix implemented.
+**Affected:** spec task `spt_01kvtnrkgp5t2a7n4pwcv2cb8j` ("LinkedIn Outreach"),
+session `ses_01kvwezmrtnftx2mqxa13zxtbf`, Zed thread
+`bd5abc10-7155-420a-a87b-6658da6b88fd` (569 MB jsonl, ~869 messages). Prod =
+meta.helix.ml.
+**Related:** `design/2026-07-20-restart-clears-zed-thread-context-loss.md` (#2860,
+same path, earlier partial fix).
+
+## Summary
+
+A user switched the agent's model (Opus → 4.8) and flipped the app's credential
+type **api_key → subscription**, then clicked **Restart** to apply it (restarting
+is the correct way to pick up the new desktop env from `subscriptionEnvForSession`).
+The Restart cleared `config.zed_thread_id`; on reconnect the thread came up
+**blank before any message**, and the next message forked a new empty thread —
+total, silent loss of the agent's context.
+
+## Root cause (ground truth from prod logs)
+
+`restartCrashedAgentThread` computed `resetThread = !lastInteractionCompletedCleanly(session)`.
+`lastInteractionCompletedCleanly` returned true only for `complete`/`interrupted`
+and false for everything else. At the Restart (10:49:12Z) the last turn
+(`int_01ky24my9`, "summarise again") was still **in-flight (`waiting`)** — its
+`message_completed` flush landed at 10:49:24Z, *after* the restart — and it was
+failing on the just-applied invalid subscription token (`401 OAuth access token
+is invalid`, surfaced downstream on the forked thread). So `resetThread=true` →
+`ZedThreadID` cleared (`session_handlers.go` logged `thread_reset=true
+previous_zed_thread_id=bd5abc10…`). Reconnect showed `zed_thread_id=` empty →
+`open_thread` skipped → blank thread. Next message forked `2c1b6724`.
+
+The thread was never invalid: a later **DB-only** repoint to `bd5abc10`, desktop
+**still in subscription mode**, resumed the full 569 MB thread (`open_thread` →
+"Thread already loaded in registry" → `agent_ready` → `complete`,
+`last_zed_message_id=90`, no 401). Preserving the pointer is sufficient.
+
+This was **not** switch-agent, **not** `recoverMissingThread`, **not** a
+`thread_load_error` on `bd5abc10` (all such log lines are for other sessions).
+
+## The defect
+
+`lastInteractionCompletedCleanly` equated "last turn not cleanly complete" with
+"thread wedged". But a turn is non-`complete` for many reasons that leave the
+thread intact — an **in-flight `waiting`** turn (the incident, and the state a
+user is most likely in when they reach for Restart), or an `error` from auth
+(401) / rate-limit (429) / provider outage / transport drop / user-cancel.
+Resetting on those is catastrophic.
+
+## Fix
+
+Replace the reset predicate with `threadIsWedged` (`session_handlers.go`): the
+human Restart discards the thread **only** when the last interaction errored with
+positive wedge evidence — `isAgentCrashError` (`Claude Agent process exited`,
+`Session not found`) or `isAuthoritativeMissingThreadError` (`no thread found with
+ID: SessionId("…"`, `no rollout found for thread id`). `complete`, `interrupted`,
+`waiting`/in-flight, and non-wedge errors all **preserve** the thread; the
+reconnect `open_thread` reattaches, and a genuinely dead in-flight turn is cleaned
+up lazily by `recoverMissingThread` on the next `thread_load_error`.
+
+Autonomous crash recovery (`maybeAutoRestartCrashedAgent` →
+`restartSessionContainer(..., true)`) is unchanged: it is already gated on
+`isAgentCrashError`, so it stays consistent with the new wedge definition.
+
+## Tested
+
+Unit: `TestThreadIsWedged`, `TestButtonPreservesHealthyThreadResetsWedged`
+(waiting/auth-error preserve; agent-crash/missing-thread reset). Live: see the
+spec-task verification in the PR (restart on a non-clean turn preserves the
+thread; `last_zed_message_id` keeps climbing on the same `zed_thread_id`).


### PR DESCRIPTION
## Summary

A routine "edit the agent settings, then click **Restart** to apply them" flow
was silently discarding a healthy Zed conversation thread and all of its context.
On meta prod (2026-07-21) this wiped a 569 MB, ~869-message Claude Code thread
(`bd5abc10-…`): the operator flipped an app to subscription mode and hit Restart;
the thread pointer was cleared, the thread came up blank, and the next message
forked a new empty thread.

**Root cause (confirmed from prod logs).** `restartCrashedAgentThread` computed
`resetThread = !lastInteractionCompletedCleanly(session)`, which treated *any*
last interaction that was not `complete`/`interrupted` as a wedged thread. At the
Restart the last turn was still **in-flight (`waiting`)** (and failing on the
just-applied invalid subscription token), so the thread was reset and the
conversation lost. The thread itself was always healthy — a later DB-only repoint
resumed the full thread under subscription mode with no change to the jsonl.

An in-flight (`waiting`) turn, or an `error` from auth (401) / rate-limit (429) /
provider outage / transport drop / user-cancel, leaves the conversation thread
completely intact. Resetting on those is silent, total context loss.

## Changes

- Replace `lastInteractionCompletedCleanly` with **`threadIsWedged`**
  (`api/pkg/server/session_handlers.go`). The human Restart now discards the Zed
  thread pointer **only** when the last interaction errored with positive wedge
  evidence — `isAgentCrashError` (`Claude Agent process exited`, `Session not
  found`) or `isAuthoritativeMissingThreadError` (`no thread found with ID …`,
  `no rollout found for thread id`). `complete`, `interrupted`, in-flight
  `waiting`, and non-wedge errors all **preserve** the thread; the reconnect
  `open_thread` reattaches, and a genuinely unloadable thread is cleaned up lazily
  by the existing `recoverMissingThread` path.
- Autonomous crash recovery (`maybeAutoRestartCrashedAgent`) is unchanged — it is
  already gated on `isAgentCrashError`, consistent with the new definition.
- Unit tests updated: `TestThreadIsWedged`,
  `TestButtonPreservesHealthyThreadResetsWedged` (waiting/auth-error preserve;
  agent-crash / missing-thread reset).

## Testing

Unit tests pass. **Live-verified against a connected Zed** in the inner Helix
(spec task, real thread `69b7bfb6`):

- **Restart with an in-flight `waiting` last turn** (the incident) →
  `thread_reset=false`; reconnect logged `zed_thread_id=69b7bfb6…` + `open_thread`
  reattach (not blank); no new `thread_created`; a follow-up recalled the codeword
  taught before the restart, `last_zed_message_id` climbing on the same thread.
- **Restart with a `complete` last turn** → preserved (no #2860 regression).
- **Restart with no config change** on a non-clean turn → preserved.
- **Killed the ACP agent mid-turn + Restart** → preserved and **recovered full
  context** via `claude --resume` (codeword recalled). A process crash is now
  non-destructive; reset is reserved for a genuinely unloadable thread (unit
  test + lazy `recoverMissingThread`).

Full evidence: `design/tasks/002295_root-cause-and-fix-the/live-test-results.md`
in the helix-specs branch. Incident writeup:
`design/2026-07-21-restart-discards-thread-on-nonclean-turn.md`.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01ky28kvyr0s6c32wnmbj489jc)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002295_root-cause-and-fix-the/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002295_root-cause-and-fix-the/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002295_root-cause-and-fix-the/tasks.md)

🚀 Built with [Helix](https://helix.ml)