### PR TITLE
fix(api): stop replaying connected agent prompts

### DIFF
--- a/api/pkg/server/auto_wake_stuck_interactions.go
+++ b/api/pkg/server/auto_wake_stuck_interactions.go
@@ -1,122 +1,10 @@
 // Auto-wake worker for stuck `state=waiting` interactions.
 //
-// # Why this exists
-//
-// ACP (Agent Client Protocol) is request/response with streaming notifications
-// scoped to one user-driven turn. The protocol assumes that every agent
-// session_update notification is a downstream of the most recent
-// session/prompt — there is no first-class verb for "the agent has news that
-// didn't arise from a user prompt", no subscription channel, no long-poll
-// for unprompted events. See agentclientprotocol/agent-client-protocol#554.
-//
-// Modern Claude Code has many non-user-initiated triggers for agent activity:
-// background bash commands finishing, hooks firing, subagents completing,
-// compaction running, MCP servers emitting `tools/list_changed`, etc. The
-// `claude-agent-acp` wrapper has events the user needs to see and no
-// protocol-legal place to put them. So it buffers them on the outbound
-// JSON-RPC channel and only flushes them when the next session/prompt
-// arrives. The result, observed empirically: the user sends a prompt X,
-// nothing happens; the user types again; the *previous* turn's response
-// arrives attached to the new prompt's interaction (off-by-one delivery
-// via Helix's stale-request_id fallback in handleMessageCompleted). The
-// stuck interaction X never gets its own response.
-//
-// # What this worker does (in-place retry)
-//
-// Every ~10 s, scan for interactions matching:
-//
-//   - state = waiting
-//   - response_message = ''
-//   - response_entries IS NULL
-//   - created < now() - 30s
-//
-// For each candidate, IF the session has an active WebSocket connection
-// to the external agent, re-send X's own `prompt_message` over the wire
-// with a fresh request_id mapped back to X.ID, and bump X.auto_wake_count
-// via a targeted column UPDATE. We do *not* create a new interaction
-// for the wake-up. Two consequences:
-//
-//  1. The buffered head-of-queue at the wrapper drains under the kick
-//     of the new inbound RPC. Whatever arrives carries an old stale
-//     request_id; Helix's matcher fallback ("most recent waiting
-//     interaction") binds it to X — because X is still the only waiting
-//     interaction in the session. The off-by-one shift that would
-//     otherwise misroute the response is eliminated by not having
-//     a "next" interaction to be off by.
-//
-//  2. The wake-up does not pollute the user's chat history with extra
-//     "continue"/"retry" prompts. The frontend renders X with a
-//     "↻ Retried Nx" badge counted off `auto_wake_count`.
-//
-// After two unsuccessful retries (auto_wake_count >= 2 and X still in
-// state=waiting), X is marked state=error so subsequent scans don't
-// re-match it.
-//
-// # Why we re-send the original prompt content
-//
-// We tried "continue" first. User observation: "in the end only one
-// message ends up being sent to the agent" — the wrapper bounces or
-// drops most of our wake-ups. Whichever wake-up actually gets through
-// to Claude should carry the user's real intent, not "continue" (which
-// elicits "continue what?"). Re-sending X.prompt_message is idempotent
-// in intent: at worst the agent processes the same prompt twice.
-//
-// # Why we gate on WebSocket connection
-//
-// New sessions take "multiple minutes" to boot the desktop and bring the
-// claude-agent-acp wrapper up. During boot the spec planning prompt sits
-// in state=waiting because the agent hasn't connected yet. Without this
-// gate the worker fires every 10 s during the boot window — the
-// downstream sendCommandToExternalAgent would either trigger a redundant
-// auto-start of the dev container or fail with "no WebSocket connection
-// found", and either way wastes the retry budget on a non-issue. Skip
-// until the session has an active externalAgentWSManager connection.
-//
-// # Why we bypass sendChatMessageToExternalAgent
-//
-// Earlier versions of this worker called sendChatMessageToExternalAgent
-// (which creates a fresh interaction, then post-tagged it with
-// auto_wake_count via a separate UPDATE). The streaming path's
-// concurrent UpdateInteraction calls — which use GORM Save and so write
-// every column from their stale in-memory copy — raced against our
-// post-tag and overwrote auto_wake_count back to 0. The retry-cap
-// counter never engaged and the worker fired forever. Witnessed live on
-// spt_01kq2308n428ss3wrm67ta6mjd: 6 wake-ups in 70 seconds. Now we
-// inline the WS send and don't create a new interaction at all, so
-// there's no row for the streaming path to clobber.
-//
-// # Why we never set interrupt=true
-//
-// Routing through the queue's interrupt path triggers session/cancel,
-// which triggers claude-agent-acp#551 (cancel-then-prompt swallow): the
-// next 1-2 prompts return stopReason=end_turn immediately with 0 tokens.
-// Our wake-up itself would be one of the swallowed prompts. We send via
-// sendCommandToExternalAgent directly with a plain chat_message.
-//
-// # Coverage gap
-//
-// This worker only handles the case where Zed *did* relay the user
-// message to Helix but the response never came (interaction lands in
-// `state=waiting`). It does NOT cover the case where Zed accepts a
-// keystroke, displays it in its own UI, but never sends the
-// corresponding session/update to Helix at all. We have no signal to
-// detect that case from inside the API process. See the "A worse
-// failure mode: Zed-side silent drop" section of the design doc.
-//
-// # Expected lifetime
-//
-// Until either:
-//   - agentclientprotocol/agent-client-protocol#554 lands a turn-complete
-//     barrier, claude-agent-acp ships an honouring release, and Zed picks
-//     it up — at which point the wrapper's outbound buffer should drain
-//     deterministically and this worker becomes a no-op that we can
-//     feature-flag off; or
-//   - The protocol grows a real unparented event channel and the wrapper
-//     stops stuffing async events into the turn-scoped notification stream
-//     in the first place.
-//
-// Neither is imminent (see design doc "Where the ACP team is on this").
-// Plan to ship this with the codebase for months at least.
+// Sessions without an external-agent WebSocket may be stuck because the dev
+// container never started, so this worker retries the container auto-start.
+// Once an agent is connected, replaying the original prompt is unsafe because
+// the agent may already be processing it. The worker leaves connected
+// interactions waiting so a late completion can still settle them.
 
 package server
 
@@ -129,7 +17,6 @@ import (
 	"time"
 
 	"github.com/helixml/helix/api/pkg/hydra"
-	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/rs/zerolog/log"
 )
@@ -218,35 +105,16 @@ const (
 	// in place, the SQL filter has nothing to match on a healthy
 	// session — this threshold only matters for genuinely stuck rows.
 	//
-	// False-positive cost: if the Anthropic API takes >180 s before
-	// the first chunk on a slow turn, we re-send the user's prompt.
-	// For idempotent prompts that's a cosmetic duplicate. For
-	// destructive ones (`rm`, `git push`) it's a real risk — but the
-	// auto-wake re-sends the *same prompt* the user already
-	// authorised, so worst case the agent runs the destructive op
-	// twice on its own work directory. Bounded by autoWakeMaxRetries.
+	// After this threshold, automatic replay remains suppressed for a
+	// connected interaction because the agent may still be processing it.
+	// The row stays waiting so a late completion can still settle it.
 	//
 	// Override at runtime with HELIX_AUTO_WAKE_STUCK_THRESHOLD_SECONDS.
 	defaultAutoWakeStuckThreshold = 180 * time.Second
 
-	// autoWakeMaxRetries caps how many wake-ups we attempt for a single
-	// stuck interaction before giving up and marking it state=error.
+	// autoWakeMaxRetries caps how many cold-start kicks we attempt for a
+	// session without a WebSocket before marking the interaction state=error.
 	autoWakeMaxRetries = 2
-
-	// defaultAutoWakeSessionWedgeThreshold is the session-scoped circuit
-	// breaker. The per-interaction autoWakeMaxRetries cap is defeated by a
-	// wedged ACP thread: each wake-up makes the wrapper echo the user message
-	// back, handleMessageAdded mints a FRESH waiting interaction (auto_wake_count
-	// reset to 0), and the worker re-targets it — re-sending to the same wedged
-	// thread forever (see design/2026-06-15-wedged-acp-thread-autowake-flood.md,
-	// witnessed on spt_01kv5q5rz4gstfks14ng1p6qqq). Once this many interactions
-	// have errored since the session's last genuine completion, the thread is
-	// wedged and re-sending cannot help — stop waking it. A genuine completion
-	// resets the count (it walks back only to the most recent complete), so this
-	// never engages on a healthy session that is completing turns.
-	//
-	// Override with HELIX_AUTO_WAKE_SESSION_WEDGE_THRESHOLD.
-	defaultAutoWakeSessionWedgeThreshold = 3
 
 	// defaultColdStartGracePeriod is how long we wait for an in-flight
 	// container boot to bring up the dev container + Zed + claude-agent-acp
@@ -298,47 +166,6 @@ func autoWakeStuckThreshold() time.Duration {
 		}
 	}
 	return defaultAutoWakeStuckThreshold
-}
-
-// autoWakeSessionWedgeThreshold returns the session-scoped breaker threshold.
-func autoWakeSessionWedgeThreshold() int {
-	if raw := os.Getenv("HELIX_AUTO_WAKE_SESSION_WEDGE_THRESHOLD"); raw != "" {
-		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
-			return n
-		}
-	}
-	return defaultAutoWakeSessionWedgeThreshold
-}
-
-// sessionWedgedByConsecutiveErrors reports whether the session has accumulated
-// at least autoWakeSessionWedgeThreshold() errored interactions since its most
-// recent genuine completion — the signature of an ACP thread that re-sending
-// cannot recover. Walks newest→oldest and stops at the first completed
-// interaction, so a healthy session that keeps completing turns never trips.
-// In-flight (waiting) rows are ignored. Returns the count for logging.
-func (apiServer *HelixAPIServer) sessionWedgedByConsecutiveErrors(ctx context.Context, session *types.Session) (bool, int) {
-	list, _, err := apiServer.Store.ListInteractions(ctx, &types.ListInteractionsQuery{
-		SessionID:    session.ID,
-		GenerationID: session.GenerationID,
-		PerPage:      40,
-		Order:        "id DESC",
-	})
-	if err != nil {
-		log.Warn().Err(err).Str("session_id", session.ID).Msg("[AUTO_WAKE] wedge check: ListInteractions failed")
-		return false, 0
-	}
-	count := 0
-	for _, it := range list { // newest first
-		switch it.State {
-		case types.InteractionStateComplete:
-			return count >= autoWakeSessionWedgeThreshold(), count
-		case types.InteractionStateError:
-			count++
-		default:
-			// waiting/other in-flight rows don't reset or advance the count
-		}
-	}
-	return count >= autoWakeSessionWedgeThreshold(), count
 }
 
 // coldStartGracePeriod returns how long an in-flight `StartDesktop` is
@@ -394,8 +221,7 @@ func (apiServer *HelixAPIServer) scanAndAutoWakeStuckInteractions(ctx context.Co
 	}
 }
 
-// maybeAutoWake fires an in-place retry for a single stuck interaction
-// if all gates pass. See the file header for the design rationale.
+// maybeAutoWake handles a single stuck interaction after the safety gates pass.
 func (apiServer *HelixAPIServer) maybeAutoWake(ctx context.Context, stuck *types.Interaction) {
 	threshold := autoWakeStuckThreshold()
 
@@ -485,7 +311,7 @@ func (apiServer *HelixAPIServer) maybeAutoWake(ctx context.Context, stuck *types
 	// Instead: skip only if the context exists AND its `lastPublish`
 	// (the most recent time we forwarded a chunk to the frontend) is
 	// within `threshold`. After `threshold` of in-context silence we
-	// treat the session as quiescent for wake-up purposes.
+	// treat the session as quiescent for replay-suppression logging.
 	//
 	// Caveat — this gate cannot see *inside* a long synchronous tool
 	// call. The agent emits ACP `session/update` events around tool
@@ -524,128 +350,10 @@ func (apiServer *HelixAPIServer) maybeAutoWake(ctx context.Context, stuck *types
 		return
 	}
 
-	// Gate 1c — session-scoped wedge breaker. The per-interaction cap below
-	// is defeated when the ACP thread is wedged: every wake echoes the user
-	// message back, handleMessageAdded mints a fresh waiting interaction with
-	// auto_wake_count=0, and we re-target it forever. If the session has piled
-	// up wedge errors with no completion in between, stop waking entirely and
-	// mark this row terminal — re-sending to the wedged thread cannot help.
-	// The user's prompt is independently crash-marked (Restart surfaces) by
-	// handleThreadLoadError once the wedge recurs.
-	// Background for maintainers: design/2026-06-15-wedged-acp-thread-autowake-flood.md
-	// (claude-agent-acp cancel/prompt swallow). Kept out of the user-facing string.
-	if wedged, n := apiServer.sessionWedgedByConsecutiveErrors(ctx, session); wedged {
-		stuck.State = types.InteractionStateError
-		stuck.Error = "Agent unresponsive: automatic retries stopped. Click Restart to recover."
-		stuck.Updated = time.Now()
-		stuck.Completed = time.Now()
-		if _, err := apiServer.Store.UpdateInteraction(ctx, stuck); err != nil {
-			log.Warn().Err(err).Str("interaction_id", stuck.ID).Msg("[AUTO_WAKE] Failed to mark wedged interaction as error")
-			return
-		}
-		log.Warn().
-			Str("session_id", stuck.SessionID).
-			Str("interaction_id", stuck.ID).
-			Int("consecutive_errors", n).
-			Int("threshold", autoWakeSessionWedgeThreshold()).
-			Msg("🧱 [AUTO_WAKE] Session wedge breaker tripped — stopped re-waking the wedged ACP thread")
-		return
-	}
-
-	// Gate 2 — retry cap. Read off the stuck row itself, atomically
-	// updated by IncrementInteractionAutoWakeCount on prior attempts.
-	// Background for maintainers: design/2026-04-25-zed-claude-async-event-flush-on-user-input.md
-	// (upstream ACP buffering). Kept out of the user-facing string.
-	if stuck.AutoWakeCount >= autoWakeMaxRetries {
-		stuck.State = types.InteractionStateError
-		stuck.Error = "Agent unresponsive: no response after automatic retries. Click Restart to recover."
-		stuck.Updated = time.Now()
-		stuck.Completed = time.Now()
-		if _, err := apiServer.Store.UpdateInteraction(ctx, stuck); err != nil {
-			log.Warn().Err(err).
-				Str("interaction_id", stuck.ID).
-				Msg("[AUTO_WAKE] Failed to mark exhausted interaction as error")
-			return
-		}
-		log.Warn().
-			Str("interaction_id", stuck.ID).
-			Str("session_id", stuck.SessionID).
-			Int("retries_attempted", stuck.AutoWakeCount).
-			Msg("⚠️ [AUTO_WAKE] Exhausted retries — marked stuck interaction as error")
-		return
-	}
-
-	// (`session` already loaded above for the activity-anchor check.)
-
-	// Skip if the stuck interaction has no prompt content to re-send.
-	// Pathological case (synthetic interactions, bad data) — don't try
-	// to invent a wake-up payload.
-	if stuck.PromptMessage == "" {
-		return
-	}
-
-	// Bump the counter *first* via a targeted column UPDATE. If the
-	// send below fails after this, the next scan tick will see the
-	// higher count and either retry once more or exhaust — strictly
-	// monotonic, no double-bump risk.
-	newCount, err := apiServer.Store.IncrementInteractionAutoWakeCount(ctx, stuck.ID)
-	if err != nil {
-		log.Warn().Err(err).
-			Str("interaction_id", stuck.ID).
-			Msg("[AUTO_WAKE] Failed to increment auto_wake_count; skipping send")
-		return
-	}
-
-	requestID := "autowake_" + system.GenerateUUID()
-
-	// Route any response that arrives for this request_id back to the
-	// stuck interaction (rather than letting Helix's fallback matcher
-	// invent some other binding). Note: even without this, the
-	// fallback would still find X as "most recent waiting" since we
-	// don't create a new interaction. This is belt-and-braces.
-	apiServer.contextMappingsMutex.Lock()
-	if apiServer.requestToInteractionMapping == nil {
-		apiServer.requestToInteractionMapping = make(map[string]string)
-	}
-	apiServer.requestToInteractionMapping[requestID] = stuck.ID
-	apiServer.contextMappingsMutex.Unlock()
-
-	var acpThreadID interface{} = nil
-	if session.Metadata.ZedThreadID != "" {
-		acpThreadID = session.Metadata.ZedThreadID
-	}
-	agentName := apiServer.getAgentNameForSession(ctx, session)
-
-	command := types.ExternalAgentCommand{
-		Type: "chat_message",
-		Data: map[string]interface{}{
-			"message":       stuck.PromptMessage,
-			"request_id":    requestID,
-			"acp_thread_id": acpThreadID,
-			"agent_name":    agentName,
-		},
-	}
-
-	log.Info().
-		Str("stuck_interaction_id", stuck.ID).
+	log.Debug().
+		Str("interaction_id", stuck.ID).
 		Str("session_id", stuck.SessionID).
-		Int("attempt", newCount).
-		Time("stuck_created_at", stuck.Created).
-		Str("request_id", requestID).
-		Msg("🔔 [AUTO_WAKE] Re-sending stuck interaction's prompt to unstick session — upstream ACP claude-agent-acp #551 / agent-client-protocol #554")
-
-	if err := apiServer.sendCommandToExternalAgent(stuck.SessionID, command); err != nil {
-		log.Warn().Err(err).
-			Str("stuck_interaction_id", stuck.ID).
-			Str("session_id", stuck.SessionID).
-			Msg("[AUTO_WAKE] sendCommandToExternalAgent failed (will retry on next tick if still stuck)")
-		return
-	}
-
-	log.Info().
-		Str("stuck_interaction_id", stuck.ID).
-		Int("attempt", newCount).
-		Msg("✅ [AUTO_WAKE] Wake-up sent in-place")
+		Msg("[AUTO_WAKE] Connected agent remained quiescent; automatic prompt replay suppressed")
 }
 
 // maybeKickColdStart handles stuck interactions on sessions with no live
@@ -658,8 +366,7 @@ func (apiServer *HelixAPIServer) maybeAutoWake(ctx context.Context, stuck *types
 // Why a column UPDATE instead of a Save: the streaming path concurrently
 // calls UpdateInteraction (which uses GORM Save and so writes every column
 // from its in-memory copy). A Save here would race-clobber AutoWakeCount
-// back to a stale value, and the cap would never engage. See the file
-// header at lines 75-86 for the original incident on spt_01kq2308n428ss3wrm67ta6mjd.
+// back to a stale value, and the cap would never engage.
 //
 // Container-state-aware retry budget: before bumping AutoWakeCount we look
 // at `session.Metadata.ExternalAgentStatus`. If the container is in any
@@ -707,12 +414,14 @@ func (apiServer *HelixAPIServer) maybeKickColdStart(ctx context.Context, stuck *
 				OrganizationID: session.OrganizationID,
 				Resource:       types.ResourceDesktop,
 			}); qErr == nil && resp != nil && resp.LimitReached {
-				stuck.State = types.InteractionStateError
-				stuck.Error = fmt.Sprintf("Desktop limit reached (%d). Stop a running desktop session, or raise your organization's concurrent-desktop limit, then retry.", resp.Limit)
-				stuck.Updated = time.Now()
-				stuck.Completed = time.Now()
-				if _, uErr := apiServer.Store.UpdateInteraction(ctx, stuck); uErr != nil {
+				reason := fmt.Sprintf("Desktop limit reached (%d). Stop a running desktop session, or raise your organization's concurrent-desktop limit, then retry.", resp.Limit)
+				transitioned, uErr := apiServer.Store.MarkInteractionErrorIfWaiting(ctx, stuck.ID, stuck.GenerationID, reason)
+				if uErr != nil {
 					log.Warn().Err(uErr).Str("interaction_id", stuck.ID).Msg("[AUTO_WAKE] Failed to mark interaction errored for desktop limit")
+					return
+				}
+				if !transitioned {
+					log.Debug().Str("interaction_id", stuck.ID).Msg("[AUTO_WAKE] Interaction already transitioned before desktop-limit error")
 					return
 				}
 				if _, clearErr := apiServer.Store.ClearSessionStartingStatus(ctx, stuck.SessionID); clearErr != nil {
@@ -745,8 +454,7 @@ func (apiServer *HelixAPIServer) maybeKickColdStart(ctx context.Context, stuck *
 	}
 
 	if stuck.AutoWakeCount >= autoWakeMaxRetries {
-		stuck.State = types.InteractionStateError
-		stuck.Error = "Agent never connected after auto-wake cold-start retries (no WebSocket — see helixml/helix#2397)"
+		reason := "Agent never connected after auto-wake cold-start retries (no WebSocket — see helixml/helix#2397)"
 		// Before giving up with the generic banner, see if the dev
 		// container's workspace-setup script wrote a failure sentinel.
 		// If it did, the real cause is in there (e.g. a clone 403) and
@@ -764,20 +472,23 @@ func (apiServer *HelixAPIServer) maybeKickColdStart(ctx context.Context, stuck *
 				if len(tail) > maxTail {
 					tail = "…" + tail[len(tail)-maxTail:]
 				}
-				stuck.Error = fmt.Sprintf("Workspace setup failed (exit code %d): %s", sentinel.ExitCode, tail)
+				reason = fmt.Sprintf("Workspace setup failed (exit code %d): %s", sentinel.ExitCode, tail)
 				log.Info().
 					Str("interaction_id", stuck.ID).
 					Str("session_id", stuck.SessionID).
 					Int("exit_code", sentinel.ExitCode).
-					Msg("[AUTO_WAKE] Surfaced workspace setup failure from sentinel")
+					Msg("[AUTO_WAKE] Found workspace setup failure sentinel")
 			}
 		}
-		stuck.Updated = time.Now()
-		stuck.Completed = time.Now()
-		if _, err := apiServer.Store.UpdateInteraction(ctx, stuck); err != nil {
+		transitioned, err := apiServer.Store.MarkInteractionErrorIfWaiting(ctx, stuck.ID, stuck.GenerationID, reason)
+		if err != nil {
 			log.Warn().Err(err).
 				Str("interaction_id", stuck.ID).
 				Msg("[AUTO_WAKE] Failed to mark cold-start-exhausted interaction as error")
+			return
+		}
+		if !transitioned {
+			log.Debug().Str("interaction_id", stuck.ID).Msg("[AUTO_WAKE] Interaction already transitioned before cold-start exhaustion")
 			return
 		}
 		// Revert any sync-time "starting" mark left behind by
@@ -805,7 +516,7 @@ func (apiServer *HelixAPIServer) maybeKickColdStart(ctx context.Context, stuck *
 	}
 
 	// Bump first via a targeted column UPDATE so the cap engages even
-	// if the auto-start fails. Same pattern as the in-place wake-up.
+	// if the auto-start fails.
 	newCount, err := apiServer.Store.IncrementInteractionAutoWakeCount(ctx, stuck.ID)
 	if err != nil {
 		log.Warn().Err(err).

--- a/api/pkg/server/auto_wake_stuck_interactions_test.go
+++ b/api/pkg/server/auto_wake_stuck_interactions_test.go
@@ -387,5 +387,6 @@ func (s *AutoWakeConnectedSuite) TestLeavesQuiescentInteractionWaitingWithoutRep
 	s.server.maybeAutoWake(context.Background(), stuck)
 
 	s.Equal(types.InteractionStateWaiting, stuck.State)
+	s.Zero(stuck.AutoWakeCount)
 	s.Empty(sendChan)
 }

--- a/api/pkg/server/auto_wake_stuck_interactions_test.go
+++ b/api/pkg/server/auto_wake_stuck_interactions_test.go
@@ -251,13 +251,12 @@ func (s *AutoWakeColdStartSuite) TestMarksAsErrorAfterMaxRetries() {
 	}
 	s.store.EXPECT().GetSession(gomock.Any(), "ses_exhausted").Return(session, nil).Times(1)
 
-	var captured *types.Interaction
-	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, in *types.Interaction) (*types.Interaction, error) {
-			captured = in
-			return in, nil
-		},
-	).Times(1)
+	var reason string
+	s.store.EXPECT().MarkInteractionErrorIfWaiting(gomock.Any(), "int-2", 0, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, _ int, in string) (bool, error) {
+			reason = in
+			return true, nil
+		})
 
 	// After marking the interaction as error, the worker also reverts any
 	// sync-time "starting" mark left by syncPromptHistory so the spinner
@@ -269,9 +268,7 @@ func (s *AutoWakeColdStartSuite) TestMarksAsErrorAfterMaxRetries() {
 
 	s.server.maybeAutoWake(context.Background(), stuck)
 
-	s.Require().NotNil(captured)
-	s.Equal(types.InteractionStateError, captured.State)
-	s.Contains(captured.Error, "helixml/helix#2397")
+	s.Contains(reason, "helixml/helix#2397")
 }
 
 // TestClearsStartingStatusOnExhaustion: when the worker exhausts cold-start
@@ -287,9 +284,17 @@ func (s *AutoWakeColdStartSuite) TestClearsStartingStatusOnExhaustion() {
 		},
 	}
 	s.store.EXPECT().GetSession(gomock.Any(), "ses_exh_clear").Return(session, nil).Times(1)
-	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).Return(stuck, nil).Times(1)
+	s.store.EXPECT().MarkInteractionErrorIfWaiting(gomock.Any(), "int-exh-clear", 0, gomock.Any()).Return(true, nil)
 	// Worker found a "starting" mark and cleared it.
 	s.store.EXPECT().ClearSessionStartingStatus(gomock.Any(), "ses_exh_clear").Return(true, nil).Times(1)
+
+	s.server.maybeAutoWake(context.Background(), stuck)
+}
+
+func (s *AutoWakeColdStartSuite) TestDoesNotClearStartingStatusAfterConcurrentCompletion() {
+	stuck := stuckInteraction("int-exh-complete", "ses_exh_complete", autoWakeMaxRetries)
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_exh_complete").Return(&types.Session{ID: "ses_exh_complete"}, nil)
+	s.store.EXPECT().MarkInteractionErrorIfWaiting(gomock.Any(), "int-exh-complete", 0, gomock.Any()).Return(false, nil)
 
 	s.server.maybeAutoWake(context.Background(), stuck)
 }
@@ -339,23 +344,18 @@ func TestAutoWakeStuckThresholdOverride(t *testing.T) {
 	}
 }
 
-// AutoWakeWedgeBreakerSuite covers the session-scoped circuit breaker (Gate 1c):
-// once a session has accumulated >= threshold errored interactions since its last
-// completion, the wedged ACP thread cannot be recovered by re-sending, so the
-// worker stops waking it and marks the current row terminal. See
-// design/2026-06-15-wedged-acp-thread-autowake-flood.md.
-type AutoWakeWedgeBreakerSuite struct {
+type AutoWakeConnectedSuite struct {
 	suite.Suite
 	ctrl   *gomock.Controller
 	store  *store.MockStore
 	server *HelixAPIServer
 }
 
-func TestAutoWakeWedgeBreakerSuite(t *testing.T) {
-	suite.Run(t, new(AutoWakeWedgeBreakerSuite))
+func TestAutoWakeConnectedSuite(t *testing.T) {
+	suite.Run(t, new(AutoWakeConnectedSuite))
 }
 
-func (s *AutoWakeWedgeBreakerSuite) SetupTest() {
+func (s *AutoWakeConnectedSuite) SetupTest() {
 	s.ctrl = gomock.NewController(s.T())
 	s.store = store.NewMockStore(s.ctrl)
 	s.server = &HelixAPIServer{
@@ -368,87 +368,24 @@ func (s *AutoWakeWedgeBreakerSuite) SetupTest() {
 	}
 }
 
-func (s *AutoWakeWedgeBreakerSuite) TearDownTest() { s.ctrl.Finish() }
+func (s *AutoWakeConnectedSuite) TearDownTest() { s.ctrl.Finish() }
 
-// connectOldWS registers a live WS connection whose ConnectedAt is old enough to
-// pass Gate 1 + the activity anchor, so maybeAutoWake reaches the breaker.
-func (s *AutoWakeWedgeBreakerSuite) connectOldWS(sessionID string) {
-	s.server.externalAgentWSManager.registerConnection(sessionID, &ExternalAgentWSConnection{
-		SessionID:   sessionID,
+func (s *AutoWakeConnectedSuite) TestLeavesQuiescentInteractionWaitingWithoutReplay() {
+	sendChan := make(chan types.ExternalAgentCommand, 1)
+	s.server.externalAgentWSManager.registerConnection("ses_connected", &ExternalAgentWSConnection{
+		SessionID:   "ses_connected",
 		ConnectedAt: time.Now().Add(-10 * time.Minute),
-		SendChan:    make(chan types.ExternalAgentCommand, 10),
+		SendChan:    sendChan,
 	})
-}
-
-func errInteraction() *types.Interaction {
-	return &types.Interaction{State: types.InteractionStateError}
-}
-
-// TestBreakerTripsOnConsecutiveErrors: >= threshold errored interactions since
-// last completion → mark current row error, do NOT increment auto-wake count or
-// send anything.
-func (s *AutoWakeWedgeBreakerSuite) TestBreakerTripsOnConsecutiveErrors() {
-	s.connectOldWS("ses_wedge")
 	session := &types.Session{
-		ID:           "ses_wedge",
-		Owner:        "user-1",
-		GenerationID: 0,
-		Updated:      time.Now().Add(-10 * time.Minute),
-		Metadata:     types.SessionMetadata{AgentType: "zed_external", ZedThreadID: "t1"},
+		ID:      "ses_connected",
+		Updated: time.Now().Add(-10 * time.Minute),
 	}
-	s.store.EXPECT().GetSession(gomock.Any(), "ses_wedge").Return(session, nil).AnyTimes()
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_connected").Return(session, nil)
 
-	// Newest-first: 3 errors, no completion → wedged (default threshold 3).
-	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).
-		Return([]*types.Interaction{errInteraction(), errInteraction(), errInteraction()}, int64(3), nil)
-
-	var marked *types.Interaction
-	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, it *types.Interaction) (*types.Interaction, error) {
-			marked = it
-			return it, nil
-		})
-	// Strict controller: IncrementInteractionAutoWakeCount must NOT be called.
-
-	stuck := stuckInteraction("int-wedge", "ses_wedge", 0)
+	stuck := stuckInteraction("int-connected", "ses_connected", 0)
 	s.server.maybeAutoWake(context.Background(), stuck)
 
-	s.Require().NotNil(marked, "expected the stuck interaction to be marked")
-	s.Equal(types.InteractionStateError, marked.State)
-	s.Contains(marked.Error, "automatic retries stopped")
-}
-
-// TestBreakerDoesNotTripWhenRecentCompletion: a completion before the error run
-// means count resets below threshold → breaker does not trip; with the row at
-// the per-interaction cap it falls through to Gate 2 (exhaustion), which marks a
-// DIFFERENT error message.
-func (s *AutoWakeWedgeBreakerSuite) TestBreakerDoesNotTripWhenRecentCompletion() {
-	s.connectOldWS("ses_ok")
-	session := &types.Session{
-		ID:           "ses_ok",
-		Owner:        "user-1",
-		GenerationID: 0,
-		Updated:      time.Now().Add(-10 * time.Minute),
-		Metadata:     types.SessionMetadata{AgentType: "zed_external", ZedThreadID: "t1"},
-	}
-	s.store.EXPECT().GetSession(gomock.Any(), "ses_ok").Return(session, nil).AnyTimes()
-
-	// Newest-first: error, then a completion → only 1 error since completion (< 3).
-	s.store.EXPECT().ListInteractions(gomock.Any(), gomock.Any()).
-		Return([]*types.Interaction{errInteraction(), {State: types.InteractionStateComplete}, errInteraction()}, int64(3), nil)
-
-	var marked *types.Interaction
-	s.store.EXPECT().UpdateInteraction(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, it *types.Interaction) (*types.Interaction, error) {
-			marked = it
-			return it, nil
-		})
-
-	// At the per-interaction cap → Gate 2 exhaustion path fires (not the breaker).
-	stuck := stuckInteraction("int-ok", "ses_ok", autoWakeMaxRetries)
-	s.server.maybeAutoWake(context.Background(), stuck)
-
-	s.Require().NotNil(marked)
-	s.Equal(types.InteractionStateError, marked.State)
-	s.NotContains(marked.Error, "automatic retries stopped", "should be the Gate 2 exhaustion error, not the breaker error")
+	s.Equal(types.InteractionStateWaiting, stuck.State)
+	s.Empty(sendChan)
 }

--- a/api/pkg/store/memorystore/memorystore.go
+++ b/api/pkg/store/memorystore/memorystore.go
@@ -300,6 +300,27 @@ func (m *MemoryStore) MarkInteractionCompleteIfWaiting(_ context.Context, intera
 	return true, nil
 }
 
+func (m *MemoryStore) MarkInteractionErrorIfWaiting(_ context.Context, interactionID string, generationID int, reason string) (bool, error) {
+	m.mu.Lock()
+	existing, ok := m.interactions[interactionID]
+	if !ok || existing.GenerationID != generationID || existing.State != types.InteractionStateWaiting {
+		m.mu.Unlock()
+		return false, nil
+	}
+	existing.State = types.InteractionStateError
+	existing.Error = reason
+	existing.Completed = time.Now()
+	existing.Updated = time.Now()
+	cp := *existing
+	cb := m.OnInteractionUpdated
+	m.mu.Unlock()
+
+	if cb != nil {
+		cb(&cp)
+	}
+	return true, nil
+}
+
 func (m *MemoryStore) ListInteractions(_ context.Context, query *types.ListInteractionsQuery) ([]*types.Interaction, int64, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/api/pkg/store/store.go
+++ b/api/pkg/store/store.go
@@ -320,6 +320,10 @@ type Store interface {
 	// change made). Used by the streaming transition handler so it cannot
 	// resurrect a cancelled or errored turn as falsely "complete".
 	MarkInteractionCompleteIfWaiting(ctx context.Context, interactionID string, generationID int) (bool, error)
+	// MarkInteractionErrorIfWaiting atomically transitions an interaction
+	// from Waiting to Error. Returns false when another terminal transition
+	// already won.
+	MarkInteractionErrorIfWaiting(ctx context.Context, interactionID string, generationID int, reason string) (bool, error)
 	// ReapWaitingInteractions transitions all state=waiting interactions for a
 	// session to newState (e.g. interrupted) when the external agent has gone
 	// away (desktop idle-stopped/crashed/found-stopped). This clears the
@@ -337,7 +341,7 @@ type Store interface {
 	// ListStuckWaitingInteractions returns up to `limit` interactions that
 	// are in state=waiting, have produced no response or entries, and were
 	// created before `olderThan`. Used by the auto-wake worker to find
-	// candidates for a "continue" wake-up prompt.
+	// candidates for recovery or terminalization.
 	ListStuckWaitingInteractions(ctx context.Context, olderThan time.Time, limit int) ([]*types.Interaction, error)
 	// CountAutoWakeAttemptsSince returns the number of interactions in
 	// `sessionID` with auto_wake_count > 0 created strictly after `since`.

--- a/api/pkg/store/store_interactions.go
+++ b/api/pkg/store/store_interactions.go
@@ -287,6 +287,28 @@ func (s *PostgresStore) MarkInteractionCompleteIfWaiting(ctx context.Context, in
 	return result.RowsAffected > 0, nil
 }
 
+// MarkInteractionErrorIfWaiting atomically transitions an interaction from
+// Waiting to Error without clobbering a concurrent terminal transition.
+func (s *PostgresStore) MarkInteractionErrorIfWaiting(ctx context.Context, interactionID string, generationID int, reason string) (bool, error) {
+	if interactionID == "" {
+		return false, errors.New("id is required")
+	}
+	now := time.Now()
+	result := s.gdb.WithContext(ctx).
+		Model(&types.Interaction{}).
+		Where("id = ? AND generation_id = ? AND state = ?", interactionID, generationID, types.InteractionStateWaiting).
+		Updates(map[string]interface{}{
+			"state":     types.InteractionStateError,
+			"error":     sanitize.ForPostgres(reason),
+			"completed": now,
+			"updated":   now,
+		})
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected > 0, nil
+}
+
 // ReapWaitingInteractions transitions every interaction still in state=waiting
 // for sessionID to newState (typically interrupted), stamping completed/updated.
 //
@@ -297,10 +319,9 @@ func (s *PostgresStore) MarkInteractionCompleteIfWaiting(ctx context.Context, in
 // processPendingPromptsForIdleSessions (which treats "latest interaction waiting"
 // as "busy, defer") so the desktop is never allowed to resume.
 //
-// This is deliberately DIFFERENT from the auto-wake worker: auto-wake *retries*
-// zero-output waiting turns over a LIVE WebSocket, whereas here the agent is gone
-// and we cleanly TERMINATE the turn so the session can move on. The two never
-// overlap — auto-wake skips both partial-output turns and sessions with no WS.
+// This is deliberately different from the auto-wake worker: this bulk operation
+// handles a disconnected session, while auto-wake leaves connected interactions
+// waiting and retries cold-start when no WebSocket has connected.
 //
 // Targeted column UPDATE guarded on state=waiting (not a full-row Save) so it
 // cannot clobber a concurrent streaming write. Returns the reaped interactions

--- a/api/pkg/store/store_interactions_test.go
+++ b/api/pkg/store/store_interactions_test.go
@@ -148,6 +148,7 @@ func (suite *PostgresStoreTestSuite) TestPostgresStore_Interactions() {
 		SessionID:     session.ID,
 		GenerationID:  1,
 		UserID:        userID,
+		State:         types.InteractionStateWaiting,
 		PromptMessage: "hello",
 		PromptMessageContent: types.MessageContent{
 			ContentType: types.MessageContentTypeText,
@@ -194,6 +195,34 @@ func (suite *PostgresStoreTestSuite) TestPostgresStore_Interactions() {
 	suite.NoError(err)
 	suite.Equal(1, int(total))
 	suite.Equal(createdInteraction.ID, interactions[0].ID)
+
+	transitioned, err := suite.db.MarkInteractionCompleteIfWaiting(context.Background(), interaction.ID, interaction.GenerationID)
+	suite.NoError(err)
+	suite.True(transitioned)
+	transitioned, err = suite.db.MarkInteractionErrorIfWaiting(context.Background(), interaction.ID, interaction.GenerationID, "must not overwrite")
+	suite.NoError(err)
+	suite.False(transitioned)
+	gotInteraction, err = suite.db.GetInteraction(context.Background(), interaction.ID)
+	suite.NoError(err)
+	suite.Equal(types.InteractionStateComplete, gotInteraction.State)
+	suite.Equal("foobar2", gotInteraction.ResponseMessage)
+
+	waiting := &types.Interaction{
+		ID:           system.GenerateInteractionID(),
+		SessionID:    session.ID,
+		GenerationID: 1,
+		UserID:       userID,
+		State:        types.InteractionStateWaiting,
+	}
+	_, err = suite.db.CreateInteraction(context.Background(), waiting)
+	suite.NoError(err)
+	transitioned, err = suite.db.MarkInteractionErrorIfWaiting(context.Background(), waiting.ID, waiting.GenerationID, "agent unresponsive")
+	suite.NoError(err)
+	suite.True(transitioned)
+	gotInteraction, err = suite.db.GetInteraction(context.Background(), waiting.ID)
+	suite.NoError(err)
+	suite.Equal(types.InteractionStateError, gotInteraction.State)
+	suite.Equal("agent unresponsive", gotInteraction.Error)
 }
 
 func (suite *PostgresStoreTestSuite) TestPostgresStore_ClearSessionInteractions() {

--- a/api/pkg/store/store_mocks.go
+++ b/api/pkg/store/store_mocks.go
@@ -5634,6 +5634,21 @@ func (mr *MockStoreMockRecorder) MarkInteractionCompleteIfWaiting(ctx, interacti
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkInteractionCompleteIfWaiting", reflect.TypeOf((*MockStore)(nil).MarkInteractionCompleteIfWaiting), ctx, interactionID, generationID)
 }
 
+// MarkInteractionErrorIfWaiting mocks base method.
+func (m *MockStore) MarkInteractionErrorIfWaiting(ctx context.Context, interactionID string, generationID int, reason string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkInteractionErrorIfWaiting", ctx, interactionID, generationID, reason)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MarkInteractionErrorIfWaiting indicates an expected call of MarkInteractionErrorIfWaiting.
+func (mr *MockStoreMockRecorder) MarkInteractionErrorIfWaiting(ctx, interactionID, generationID, reason any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkInteractionErrorIfWaiting", reflect.TypeOf((*MockStore)(nil).MarkInteractionErrorIfWaiting), ctx, interactionID, generationID, reason)
+}
+
 // MarkPromptAsCrashed mocks base method.
 func (m *MockStore) MarkPromptAsCrashed(ctx context.Context, promptID, errorMsg string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary
- stop replaying the original prompt when a connected agent is silent
- keep connected interactions waiting so late completions and queue busy-state remain valid
- use atomic waiting-to-error transitions for definite disconnected failures

## Tests
- `CGO_ENABLED=1 go test ./api/pkg/server -count=1`
- `CGO_ENABLED=1 go build ./api/pkg/server/ ./api/pkg/store/ ./api/pkg/types/`

NOT tested live: reproducing requires a connected agent remaining silent past the configured threshold.