### PR TITLE
fix(gitlab): preserve PAT authentication fallback

### DIFF
--- a/api/pkg/services/git_repository_service_pull_requests.go
+++ b/api/pkg/services/git_repository_service_pull_requests.go
@@ -43,6 +43,9 @@ func (s *GitRepositoryService) ValidateUserOAuth(ctx context.Context, repo *type
 	if userID == "" || (providerType != types.OAuthProviderTypeGitHub && providerType != types.OAuthProviderTypeGitLab) {
 		return nil
 	}
+	if providerType == types.OAuthProviderTypeGitLab && hasGitLabRepoPAT(repo) {
+		return nil
+	}
 	connections, err := s.store.ListOAuthConnections(ctx, &store.ListOAuthConnectionsQuery{
 		UserID: userID,
 	})
@@ -809,14 +812,18 @@ func (s *GitRepositoryService) getGitLabClient(ctx context.Context, repo *types.
 	if userID != "" {
 		connections, err := s.store.ListOAuthConnections(ctx, &store.ListOAuthConnectionsQuery{UserID: userID})
 		if err != nil {
-			return nil, fmt.Errorf("failed to look up user OAuth connections: %w", err)
+			if !hasGitLabRepoPAT(repo) {
+				return nil, fmt.Errorf("failed to look up user OAuth connections: %w", err)
+			}
 		}
 		for _, conn := range connections {
 			if oauthConnectionMatchesProvider(conn, types.OAuthProviderTypeGitLab) && conn.AccessToken != "" {
 				return gitlab.NewClientWithOAuth(baseURL, conn.AccessToken)
 			}
 		}
-		return nil, &OAuthRequiredError{ProviderType: "gitlab"}
+		if !hasGitLabRepoPAT(repo) {
+			return nil, &OAuthRequiredError{ProviderType: "gitlab"}
+		}
 	}
 
 	// First check for OAuth connection
@@ -846,6 +853,10 @@ func (s *GitRepositoryService) getGitLabClient(ctx context.Context, repo *types.
 	}
 
 	return nil, fmt.Errorf("no GitLab authentication configured - provide a Personal Access Token or connect via OAuth")
+}
+
+func hasGitLabRepoPAT(repo *types.GitRepository) bool {
+	return repo != nil && ((repo.GitLab != nil && repo.GitLab.PersonalAccessToken != "") || repo.Password != "")
 }
 
 func (s *GitRepositoryService) getGitLabProjectID(ctx context.Context, client *gitlab.Client, repo *types.GitRepository) (int, error) {

--- a/api/pkg/services/git_repository_service_pull_requests_test.go
+++ b/api/pkg/services/git_repository_service_pull_requests_test.go
@@ -178,23 +178,69 @@ func TestCreateGitLabMergeRequest_UserOAuthTakesPrecedence(t *testing.T) {
 	}
 }
 
-func TestGetGitLabClient_UserWithoutOAuthReturnsError(t *testing.T) {
+func TestCreateGitLabMergeRequest_UserWithoutOAuthFallsBackToPAT(t *testing.T) {
+	tests := []struct {
+		name     string
+		password string
+		pat      string
+	}{
+		{name: "provider PAT", pat: "repo-pat"},
+		{name: "legacy password", password: "repo-pat"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requestCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				if got := r.Header.Get("Private-Token"); got != "repo-pat" {
+					t.Errorf("expected repository PAT, got %q", got)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.Method == http.MethodGet:
+					fmt.Fprint(w, `{"id":123}`)
+				case r.Method == http.MethodPost:
+					fmt.Fprint(w, `{"iid":7}`)
+				default:
+					http.Error(w, "unexpected request", http.StatusMethodNotAllowed)
+				}
+			}))
+			defer server.Close()
+
+			repo := &types.GitRepository{
+				ExternalURL:  server.URL + "/org/repo",
+				ExternalType: types.ExternalRepositoryTypeGitLab,
+				Password:     tt.password,
+				GitLab: &types.GitLab{
+					BaseURL:             server.URL + "/api/v4/",
+					PersonalAccessToken: tt.pat,
+				},
+			}
+
+			mrID, err := newPRTestService(&prTestStore{}).createGitLabMergeRequest(
+				context.Background(), repo, "title", "description", "feature", "main", "user-x",
+			)
+			if err != nil {
+				t.Fatalf("expected repository PAT fallback, got: %v", err)
+			}
+			if mrID != "7" || requestCount != 2 {
+				t.Fatalf("expected MR 7 after two API requests, got MR %q and %d requests", mrID, requestCount)
+			}
+		})
+	}
+}
+
+func TestGetGitLabClient_UserWithoutOAuthOrRepoPATReturnsError(t *testing.T) {
 	repo := &types.GitRepository{
 		ExternalURL:  "https://gitlab.com/org/repo",
 		ExternalType: types.ExternalRepositoryTypeGitLab,
-		GitLab:       &types.GitLab{PersonalAccessToken: "repo-pat"},
 	}
 
 	_, err := newPRTestService(&prTestStore{}).getGitLabClient(context.Background(), repo, "user-x")
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
 	oauthErr, ok := err.(*OAuthRequiredError)
-	if !ok {
-		t.Fatalf("expected *OAuthRequiredError, got %T: %v", err, err)
-	}
-	if oauthErr.ProviderType != "gitlab" {
-		t.Fatalf("expected provider_type 'gitlab', got %q", oauthErr.ProviderType)
+	if !ok || oauthErr.ProviderType != "gitlab" {
+		t.Fatalf("expected GitLab OAuthRequiredError, got %T: %v", err, err)
 	}
 }
 

--- a/api/pkg/services/git_repository_service_push_test.go
+++ b/api/pkg/services/git_repository_service_push_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -30,30 +31,49 @@ func TestGitRepositoryPushSuiteADO(t *testing.T) {
 	suite.Run(t, new(GitRepositoryPushSuiteADO))
 }
 
-func TestPushBranchToRemote_GitLabUserWithoutOAuthReturnsErrorBeforePush(t *testing.T) {
-	mockStore := store.NewMockStore(gomock.NewController(t))
-	service := NewGitRepositoryService(mockStore, t.TempDir(), "http://localhost:8080", "test", "test@example.com")
-	repoPath := t.TempDir()
-	if err := giteagit.InitRepository(context.Background(), repoPath, true, "sha1"); err != nil {
-		t.Fatalf("failed to initialize test repository: %v", err)
+func TestPushBranchToRemote_GitLabUserWithoutOAuthFallsBackToPAT(t *testing.T) {
+	tests := []struct {
+		name     string
+		gitlab   *types.GitLab
+		username string
+		password string
+	}{
+		{name: "provider PAT", gitlab: &types.GitLab{PersonalAccessToken: "shared-pat"}},
+		{name: "legacy username and password", username: "gitlab-user", password: "shared-pat"},
 	}
-	repo := &types.GitRepository{
-		ID:            "gitlab-repo",
-		LocalPath:     repoPath,
-		IsExternal:    true,
-		ExternalURL:   "https://gitlab.com/org/repo",
-		ExternalType:  types.ExternalRepositoryTypeGitLab,
-		DefaultBranch: "master",
-		GitLab:        &types.GitLab{PersonalAccessToken: "shared-pat"},
-	}
-	mockStore.EXPECT().GetGitRepository(gomock.Any(), repo.ID).Return(repo, nil)
-	mockStore.EXPECT().ListOAuthConnections(gomock.Any(), &store.ListOAuthConnectionsQuery{UserID: "user-x"}).Return(nil, nil)
 
-	err := service.PushBranchToRemote(context.Background(), repo.ID, "feature", false, "user-x")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockStore := store.NewMockStore(gomock.NewController(t))
+			service := NewGitRepositoryService(mockStore, t.TempDir(), "http://localhost:8080", "test", "test@example.com")
+			repoPath := t.TempDir()
+			if err := giteagit.InitRepository(context.Background(), repoPath, true, "sha1"); err != nil {
+				t.Fatalf("failed to initialize test repository: %v", err)
+			}
+			repo := &types.GitRepository{
+				ID:            "gitlab-repo",
+				LocalPath:     repoPath,
+				IsExternal:    true,
+				ExternalURL:   "https://gitlab.com/org/repo",
+				ExternalType:  types.ExternalRepositoryTypeGitLab,
+				DefaultBranch: "master",
+				GitLab:        tt.gitlab,
+				Username:      tt.username,
+				Password:      tt.password,
+			}
+			mockStore.EXPECT().GetGitRepository(gomock.Any(), repo.ID).Return(repo, nil)
+			mockStore.EXPECT().ListOAuthConnections(gomock.Any(), &store.ListOAuthConnectionsQuery{UserID: "user-x"}).Return(nil, nil).Times(2)
 
-	oauthErr, ok := err.(*OAuthRequiredError)
-	if !ok || oauthErr.ProviderType != "gitlab" {
-		t.Fatalf("expected GitLab OAuthRequiredError, got %T: %v", err, err)
+			err := service.PushBranchToRemote(context.Background(), repo.ID, "feature", true, "user-x")
+
+			if err == nil {
+				t.Fatal("expected push to the test repository to fail")
+			}
+			var oauthErr *OAuthRequiredError
+			if errors.As(err, &oauthErr) {
+				t.Fatalf("expected GitLab PAT fallback, got %v", err)
+			}
+		})
 	}
 }
 

--- a/frontend/src/components/tasks/SpecTaskActionButtons.tsx
+++ b/frontend/src/components/tasks/SpecTaskActionButtons.tsx
@@ -289,7 +289,7 @@ export default function SpecTaskActionButtons({
 
   const handleOpenPR = (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (!isDirectPush && hasExternalRepo && (externalRepoType === "github" || externalRepoType === "gitlab") && !hasOAuthWithRequiredScopes) {
+    if (!isDirectPush && hasExternalRepo && externalRepoType === "github" && !hasOAuthWithRequiredScopes) {
       if (oauthProvider?.id) {
         startOAuthFlow({
           providerId: oauthProvider.id,


### PR DESCRIPTION
## Summary

- preserve configured GitLab PAT authentication when acting-user OAuth is unavailable
- support both provider-specific PATs and legacy repository passwords
- let GitLab Open PR actions reach backend credential selection

## Verification

- `go test ./pkg/services -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `yarn test src/utils/oauthProviders.test.ts --run`
- `yarn build`
- `git diff --check`

NOT live tested against a GitLab repository.