### PR TITLE
Add /embed/session/:sessionId route for live desktop embeds

### DIFF
--- a/frontend/src/pages/EmbedSessionPage.tsx
+++ b/frontend/src/pages/EmbedSessionPage.tsx
@@ -1,0 +1,33 @@
+import React, { FC } from 'react'
+import { useRoute } from 'react-router5'
+import { Box, useTheme } from '@mui/material'
+import ExternalAgentDesktopViewer from '../components/external-agent/ExternalAgentDesktopViewer'
+
+// EmbedSessionPage is the fullscreen, token-authenticated embed for a live desktop
+// SESSION (agent_type=zed_external), mirroring EmbedTaskPage but keyed on a session id
+// rather than a spec task. It is how HelixOS embeds a running bot / hypothesis /
+// candidate-search desktop in an iframe (see /embed/session/:sessionId).
+//
+// Auth: pages under /embed/* carry the Helix API key as ?access_token=... which
+// useApi lifts into the Authorization header (and strips from the URL). The key owns
+// the session it launched, so it's authorized to view the stream.
+const EmbedSessionPage: FC = () => {
+  const { route } = useRoute()
+  const theme = useTheme()
+  const sessionId = route.params.sessionId as string
+
+  // Embed contexts (iframes) have no parent body bg, so force the theme bg here.
+  const bg = theme.palette.background.default
+
+  return (
+    <Box sx={{ height: '100dvh', overflow: 'hidden', backgroundColor: bg }}>
+      <ExternalAgentDesktopViewer
+        sessionId={sessionId}
+        sandboxId={sessionId}
+        mode="stream"
+      />
+    </Box>
+  )
+}
+
+export default EmbedSessionPage

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -31,6 +31,7 @@ import SpecTaskDetailPage from './pages/SpecTaskDetailPage'
 import SpecTaskReviewPage from './pages/SpecTaskReviewPage'
 import TeamDesktopPage from './pages/TeamDesktopPage'
 import EmbedTaskPage from './pages/EmbedTaskPage'
+import EmbedSessionPage from './pages/EmbedSessionPage'
 import Projects from './pages/Projects'
 import Sandboxes from './pages/Sandboxes'
 import SandboxDetail from './pages/SandboxDetail'
@@ -529,6 +530,15 @@ const routes: IApplicationRoute[] = [
     title: 'Task',
   },
   render: () => <EmbedTaskPage />,
+}, {
+  name: 'embed_session',
+  path: '/embed/session/:sessionId',
+  meta: {
+    drawer: false,
+    fullscreen: true,
+    title: 'Session',
+  },
+  render: () => <EmbedSessionPage />,
 }, {
   name: 'login',
   path: '/login',


### PR DESCRIPTION
## Summary

Adds a fullscreen, token-authenticated embed page for a live desktop **session**
(`agent_type=zed_external`), mirroring the existing `/embed/task/:taskId` but keyed
on a session id rather than a spec task.

This is what HelixOS uses to iframe a running bot / hypothesis / candidate-search
desktop (those runs are desktop sessions, not spec tasks, so `/embed/task` doesn't
apply). It's the cross-repo prerequisite for the HelixOS PR on the same task branch.

## Changes
- New route `embed_session` at `/embed/session/:sessionId`
  (`frontend/src/router.tsx`, `drawer:false, fullscreen:true`), mirroring
  `embed_task`.
- New `frontend/src/pages/EmbedSessionPage.tsx` — renders
  `ExternalAgentDesktopViewer` (the same session viewer used by `TeamDesktopPage`),
  keyed on `sessionId`, `mode="stream"`, in the `EmbedTaskPage` fullscreen shell.

## Notes
- Auth is unchanged: `/embed/*` reads the Helix API key from `?access_token=…` into
  the Authorization header (`hooks/useApi.ts`) and strips it from the URL. The key
  owns the session it launched, so it's authorized to view the stream.
- No backend changes — the session stream/screenshot/upload endpoints already exist
  and are session-scoped.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kk95f1seff98mbxhfa31qj81/tasks/spt_01ky4ywx21y69g3mpdw1ar7npy)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002297_make-running-a-helixos/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002297_make-running-a-helixos/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002297_make-running-a-helixos/tasks.md)

🚀 Built with [Helix](https://helix.ml)