### PR TITLE
fix(desktop): don't fail video stream on slow first frame

### DIFF
--- a/api/pkg/desktop/gst_pipeline.go
+++ b/api/pkg/desktop/gst_pipeline.go
@@ -400,8 +400,9 @@ func (g *GstPipeline) handleBusMessage(msg *gst.Message) {
 		if gerr != nil {
 			// Log error with full debug info - helps diagnose pipeline failures
 			errMsg := gerr.Error()
+			debugStr := gerr.DebugString()
 			fmt.Printf("[GST_PIPELINE] Error: %s\n", errMsg)
-			if debugStr := gerr.DebugString(); debugStr != "" {
+			if debugStr != "" {
 				fmt.Printf("[GST_PIPELINE] Debug: %s\n", debugStr)
 			}
 			// Log the element that produced the error
@@ -410,8 +411,9 @@ func (g *GstPipeline) handleBusMessage(msg *gst.Message) {
 				fmt.Printf("[GST_PIPELINE] Source: %s\n", srcName)
 			}
 
-			// Create a user-friendly error message for common failures
-			userErr := g.createUserFriendlyError(errMsg, srcName)
+			// Create a user-friendly error message for common failures, with the
+			// raw technical detail appended so it can be surfaced in the UI.
+			userErr := g.createUserFriendlyError(errMsg, debugStr, srcName)
 			// Non-blocking send to error channel (only first error matters)
 			select {
 			case g.errorCh <- userErr:
@@ -505,31 +507,57 @@ func (g *GstPipeline) Errors() <-chan error {
 	return g.errorCh
 }
 
-// createUserFriendlyError converts GStreamer error messages into user-friendly text.
-// Common errors like "NV_ENC_ERR_OUT_OF_MEMORY" become actionable messages.
-func (g *GstPipeline) createUserFriendlyError(errMsg, srcElement string) error {
-	// Map common GStreamer/NVENC errors to user-friendly messages
+// createUserFriendlyError converts GStreamer error messages into user-friendly
+// text, then appends a compact technical-detail block after a blank-line
+// delimiter ("\n\n"). The frontend renders the first paragraph prominently and
+// everything after the delimiter as smaller, monospaced technical detail, so the
+// underlying failure (element, raw error, GStreamer debug string) is diagnosable
+// from the UI instead of being flattened to a generic sentence.
+func (g *GstPipeline) createUserFriendlyError(errMsg, debugStr, srcElement string) error {
+	friendly := friendlyVideoError(errMsg)
+
+	// Assemble the technical detail: source element + raw error, plus the
+	// GStreamer debug string, which carries the element path and reason code
+	// (e.g. "gst_base_src_loop (): ... reason error (-5)") or — once the
+	// zero-copy source posts a descriptive error — the concrete cause such as a
+	// first-frame timeout.
+	tech := strings.TrimSpace(errMsg)
+	if srcElement != "" {
+		tech = srcElement + ": " + tech
+	}
+	if d := strings.TrimSpace(debugStr); d != "" {
+		tech = tech + "\n" + d
+	}
+	const maxTech = 600
+	if len(tech) > maxTech {
+		tech = tech[:maxTech] + "…"
+	}
+	if tech == "" {
+		return fmt.Errorf("%s", friendly)
+	}
+	return fmt.Errorf("%s\n\n%s", friendly, tech)
+}
+
+// friendlyVideoError maps common GStreamer/NVENC errors to a short human-readable
+// sentence. The technical detail is appended separately by createUserFriendlyError.
+func friendlyVideoError(errMsg string) string {
 	switch {
 	case containsIgnoreCase(errMsg, "NV_ENC_ERR_OUT_OF_MEMORY") || containsIgnoreCase(errMsg, "out of memory"):
-		return fmt.Errorf("GPU out of memory - too many sessions running. Please close some browser tabs or stop unused sessions.")
+		return "GPU out of memory - too many sessions running. Please close some browser tabs or stop unused sessions."
 	case containsIgnoreCase(errMsg, "NV_ENC_ERR_NO_ENCODE_DEVICE"):
-		return fmt.Errorf("No GPU encoder available. The GPU may be in use by another process.")
+		return "No GPU encoder available. The GPU may be in use by another process."
 	case containsIgnoreCase(errMsg, "NV_ENC_ERR"):
-		return fmt.Errorf("GPU encoder error: %s. Try closing other sessions.", errMsg)
+		return "GPU encoder error. Try closing other sessions."
 	case containsIgnoreCase(errMsg, "Could not get EOS"):
-		return fmt.Errorf("Video pipeline stopped unexpectedly. Please try reconnecting.")
+		return "Video pipeline stopped unexpectedly. Please try reconnecting."
 	case containsIgnoreCase(errMsg, "Resource not found"):
-		return fmt.Errorf("Video source not available. The session may have ended.")
+		return "Video source not available. The session may have ended."
 	case containsIgnoreCase(errMsg, "Permission denied"):
-		return fmt.Errorf("Permission denied accessing video source.")
-	case containsIgnoreCase(errMsg, "Internal data stream error"):
-		return fmt.Errorf("Video streaming error. Please try reconnecting.")
+		return "Permission denied accessing video source."
 	default:
-		// For unknown errors, include the source element for debugging
-		if srcElement != "" {
-			return fmt.Errorf("Video error from %s: %s", srcElement, errMsg)
-		}
-		return fmt.Errorf("Video error: %s", errMsg)
+		// Includes the first-frame-timeout case and the generic "Internal data
+		// stream error" — the specific cause rides along in the technical detail.
+		return "Video streaming error. Please try reconnecting."
 	}
 }
 

--- a/desktop/gst-pipewire-zerocopy/src/pipewiresrc/imp.rs
+++ b/desktop/gst-pipewire-zerocopy/src/pipewiresrc/imp.rs
@@ -23,7 +23,7 @@ use smithay::backend::allocator::Buffer;
 use smithay::backend::drm::{DrmNode, NodeType};
 use smithay::backend::egl::ffi::egl::types::EGLDisplay as RawEGLDisplay;
 use smithay::backend::egl::{EGLDevice, EGLDisplay};
-use std::sync::atomic::AtomicPtr;
+use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -33,6 +33,12 @@ use waylanddisplaycore::utils::allocator::cuda::{
     EGLImage, GstCudaContext, CAPS_FEATURE_MEMORY_CUDA_MEMORY,
 };
 use waylanddisplaycore::Fourcc as DrmFourcc;
+
+/// How long to wait for the FIRST video frame from the compositor before giving
+/// up. A freshly-started idle headless GNOME desktop can take a couple of seconds
+/// to produce its first ScreenCast buffer; failing at the short keepalive window
+/// tears the pipeline down and surfaces a spurious "Video streaming error".
+const FIRST_FRAME_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Convert DRM fourcc to GStreamer VideoFormat.
 /// Uses explicit byte-order formats for consistency across GStreamer versions.
@@ -342,6 +348,9 @@ impl Default for State {
 pub struct PipeWireZeroCopySrc {
     settings: Mutex<Settings>,
     state: Mutex<Option<State>>,
+    // Set by unlock() to interrupt a blocking first-frame wait in create() so
+    // shutdown/flush is prompt; cleared by unlock_stop() and start().
+    flushing: AtomicBool,
 }
 
 impl Default for PipeWireZeroCopySrc {
@@ -349,6 +358,7 @@ impl Default for PipeWireZeroCopySrc {
         Self {
             settings: Mutex::new(Settings::default()),
             state: Mutex::new(None),
+            flushing: AtomicBool::new(false),
         }
     }
 }
@@ -585,6 +595,9 @@ impl ElementImpl for PipeWireZeroCopySrc {
 
 impl BaseSrcImpl for PipeWireZeroCopySrc {
     fn start(&self) -> Result<(), gst::ErrorMessage> {
+        // Fresh start: clear any leftover flush flag from a previous cycle.
+        self.flushing.store(false, Ordering::Relaxed);
+
         let mut state_guard = self.state.lock();
         if state_guard.is_some() {
             return Ok(());
@@ -759,6 +772,21 @@ impl BaseSrcImpl for PipeWireZeroCopySrc {
         Ok(())
     }
 
+    // unlock() is called by GStreamer before stop()/flush to interrupt any
+    // blocking create(). Set the flush flag so the first-frame wait loop returns
+    // promptly (within one keepalive interval) instead of holding the streaming
+    // task for up to FIRST_FRAME_TIMEOUT.
+    fn unlock(&self) -> Result<(), gst::ErrorMessage> {
+        self.flushing.store(true, Ordering::Relaxed);
+        Ok(())
+    }
+
+    // unlock_stop() is called after flushing completes to resume normal operation.
+    fn unlock_stop(&self) -> Result<(), gst::ErrorMessage> {
+        self.flushing.store(false, Ordering::Relaxed);
+        Ok(())
+    }
+
     fn is_seekable(&self) -> bool {
         false
     }
@@ -845,10 +873,6 @@ impl PushSrcImpl for PipeWireZeroCopySrc {
         // Get keepalive time from settings
         let keepalive_time_ms = self.settings.lock().keepalive_time_ms;
 
-        let mut g = self.state.lock();
-        let state = g.as_mut().ok_or(gst::FlowError::Eos)?;
-        let stream = state.stream.as_ref().ok_or(gst::FlowError::Error)?;
-
         // Use keepalive time as timeout if configured, otherwise 30 seconds
         let timeout = if keepalive_time_ms > 0 {
             Duration::from_millis(keepalive_time_ms as u64)
@@ -856,21 +880,100 @@ impl PushSrcImpl for PipeWireZeroCopySrc {
             Duration::from_secs(30)
         };
 
-        // Wait for frame from PipeWire with timeout
-        let frame = match stream.recv_frame_timeout(timeout) {
-            Ok(f) => {
-                // Point B: inter-arrival at the GStreamer pull, i.e. after the
-                // bounded(8) channel (measure-only). Compare with Point A.
-                crate::metrics::CREATE.lock().tick();
-                Some(f)
-            }
-            Err(RecvError::Disconnected) => return Err(gst::FlowError::Eos),
-            Err(RecvError::Timeout) if keepalive_time_ms > 0 => {
-                // Timeout with keepalive enabled - resend last buffer
-                None // Signal to use last_buffer
-            }
-            Err(_) => return Err(gst::FlowError::Error),
+        // Whether we already have a buffer to resend during static periods. This
+        // is constant across this create() call (only we set it, after the first
+        // frame), so capture it once up front.
+        let have_last_buffer = {
+            let g = self.state.lock();
+            g.as_ref().ok_or(gst::FlowError::Eos)?.last_buffer.is_some()
         };
+
+        // Wait for a frame from PipeWire. For the FIRST frame (nothing to resend
+        // yet) be patient: a freshly-started idle headless desktop can take a few
+        // seconds to produce its first ScreenCast buffer, and treating that short
+        // wait as fatal used to tear the whole pipeline down and surface as an
+        // opaque "Internal data stream error (-5)". Keep waiting up to
+        // FIRST_FRAME_TIMEOUT so the user gets video instead of an error banner.
+        //
+        // The state lock is taken only for the duration of one bounded recv and
+        // released between iterations, so a long first-frame wait never blocks
+        // stop()/caps(); `flushing` (set by unlock()) breaks out promptly.
+        let mut first_frame_waited = Duration::ZERO;
+        let frame = loop {
+            let recv_result = {
+                let g = self.state.lock();
+                let state = g.as_ref().ok_or(gst::FlowError::Eos)?;
+                let stream = state.stream.as_ref().ok_or(gst::FlowError::Error)?;
+                stream.recv_frame_timeout(timeout)
+                // state lock released here, before we act on the result
+            };
+
+            match recv_result {
+                Ok(f) => {
+                    // Point B: inter-arrival at the GStreamer pull, i.e. after the
+                    // bounded(8) channel (measure-only). Compare with Point A.
+                    crate::metrics::CREATE.lock().tick();
+                    break Some(f);
+                }
+                Err(RecvError::Disconnected) => return Err(gst::FlowError::Eos),
+                Err(RecvError::Error(msg)) => {
+                    // The PipeWire producer thread failed (e.g. EGL import or CUDA
+                    // copy). Surface the concrete message on the bus instead of
+                    // letting it collapse into GStreamer's generic "Internal data
+                    // stream error (-5)".
+                    eprintln!("[PIPEWIRESRC] producer error: {}", msg);
+                    gst::element_error!(
+                        self.obj().upcast_ref::<gst::Element>(),
+                        gst::ResourceError::Read,
+                        ("video capture failed: {}", msg)
+                    );
+                    return Err(gst::FlowError::Error);
+                }
+                Err(RecvError::Timeout) => {
+                    // Interrupt promptly if the element is shutting down/flushing.
+                    if self.flushing.load(Ordering::Relaxed) {
+                        return Err(gst::FlowError::Flushing);
+                    }
+                    if have_last_buffer {
+                        // Steady-state static screen: resend the last buffer below.
+                        break None;
+                    }
+                    if keepalive_time_ms == 0 {
+                        // No keepalive configured: don't loop on the plain 30s
+                        // timeout — preserve the original fail-fast behaviour.
+                        return Err(gst::FlowError::Error);
+                    }
+                    // First frame hasn't arrived yet. Keep waiting until the
+                    // first-frame deadline, then give up with a clear message.
+                    first_frame_waited += timeout;
+                    if first_frame_waited >= FIRST_FRAME_TIMEOUT {
+                        eprintln!(
+                            "[PIPEWIRESRC] no first video frame within {:?}",
+                            first_frame_waited
+                        );
+                        gst::element_error!(
+                            self.obj().upcast_ref::<gst::Element>(),
+                            gst::ResourceError::Read,
+                            (
+                                "no video frame received from the compositor within {}s — the desktop may not be rendering (idle headless session) or ScreenCast is not producing frames",
+                                first_frame_waited.as_secs()
+                            )
+                        );
+                        return Err(gst::FlowError::Error);
+                    }
+                    eprintln!(
+                        "[PIPEWIRESRC] waiting for first video frame... {:?}/{:?}",
+                        first_frame_waited, FIRST_FRAME_TIMEOUT
+                    );
+                    // loop and keep waiting
+                }
+            }
+        };
+
+        // Re-acquire the state lock now that the (potentially long) wait is over,
+        // for frame processing / keepalive resend.
+        let mut g = self.state.lock();
+        let state = g.as_mut().ok_or(gst::FlowError::Eos)?;
 
         // Handle keepalive case - resend last buffer with updated PTS
         if frame.is_none() {
@@ -886,8 +989,8 @@ impl PushSrcImpl for PipeWireZeroCopySrc {
                 }
                 return Ok(CreateSuccess::NewBuffer(buf));
             } else {
-                // No last buffer yet, wait for first real frame
-                eprintln!("[KEEPALIVE] No last buffer available, waiting for first frame");
+                // Unreachable in practice: we only break with None when
+                // have_last_buffer was true, and nothing clears last_buffer.
                 return Err(gst::FlowError::Error);
             }
         }

--- a/frontend/src/components/external-agent/ConnectionOverlay.tsx
+++ b/frontend/src/components/external-agent/ConnectionOverlay.tsx
@@ -119,7 +119,37 @@ const ConnectionOverlay: React.FC<ConnectionOverlayProps> = ({
             </Button>
           }
         >
-          {error}
+          {(() => {
+            // The backend sends "<friendly sentence>\n\n<technical detail>".
+            // Render the friendly part prominently and the technical detail (if
+            // present) as smaller, monospaced, scrollable text so the underlying
+            // GStreamer failure is visible without cluttering the main message.
+            const [friendly, ...rest] = error.split('\n\n');
+            const technical = rest.join('\n\n').trim();
+            return (
+              <>
+                {friendly}
+                {technical && (
+                  <Typography
+                    component="pre"
+                    sx={{
+                      mt: 1,
+                      mb: 0,
+                      fontSize: '0.7rem',
+                      fontFamily: 'monospace',
+                      whiteSpace: 'pre-wrap',
+                      wordBreak: 'break-word',
+                      opacity: 0.75,
+                      maxHeight: 160,
+                      overflow: 'auto',
+                    }}
+                  >
+                    {technical}
+                  </Typography>
+                )}
+              </>
+            );
+          })()}
         </Alert>
       )}
     </Box>


### PR DESCRIPTION
## Problem

Desktop sessions intermittently showed **"Video streaming error. Please try reconnecting."** with no diagnosable cause. Root cause: the zero-copy PipeWire source treated a **first-frame timeout as fatal**. If the compositor didn't deliver its first frame within the 500ms keepalive window, `create()` returned a bare `FlowError::Error`, tearing down the pipeline. GStreamer then posted a generic *"Internal data stream error (-5)"*, which the UI flattened to the banner above — masking the real reason. A freshly-booted idle headless GNOME desktop can take a couple of seconds to produce its first ScreenCast buffer, so this fired spuriously.

Diagnosis writeup: the incident log showed `[KEEPALIVE] No last buffer available, waiting for first frame` immediately before every fatal `-5`.

## Changes

- **`desktop/gst-pipewire-zerocopy/src/pipewiresrc/imp.rs`** — wait up to `FIRST_FRAME_TIMEOUT` (10s) for the first frame instead of failing after one keepalive interval. The state lock is held only per bounded `recv` (released between iterations) so a long wait never blocks `stop()`/`caps()` and can't trip the Go-side 5s state-change watchdog. Added `unlock()`/`unlock_stop()` + a `flushing` atomic so shutdown/flush interrupts the wait promptly (`FlowError::Flushing`). Both terminal failures — the first-frame deadline and the producer-thread error (which was previously **discarded**) — now post descriptive `element_error!` messages instead of the opaque `-5`.
- **`api/pkg/desktop/gst_pipeline.go`** — append the raw GStreamer error + debug string + source element after the human-friendly sentence (via a `\n\n` delimiter) so the underlying failure is diagnosable from the UI.
- **`frontend/src/components/external-agent/ConnectionOverlay.tsx`** — render the friendly line prominently and the technical detail in a smaller monospace block. Backward-compatible (renders unchanged if the backend sends a single-line message).

## Testing

Built via `./stack build-ubuntu` (`helix-ubuntu:ea5782`) and tested on a live session:
- **4K zerocopy benchmark**: 53 fps, 1603 frames, 0 dropped, **0 errors** — no regression.
- **Cold connect to a freshly-booted idle desktop** (closest to the original failure): 684 frames, first frame <500ms, **0 errors**.

Not directly triggered: the 10s wait-then-recover branch itself (couldn't synthetically induce a >500ms first frame on healthy hardware) — verified by compile + the pinned-crate primitives (`RecvError` variants, `element_error!` form, `unlock`/`FlowError::Flushing`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)