### PR TITLE
refactor(frontend): consolidate organization settings

### DIFF
--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -293,8 +293,8 @@ func buildOrgServices(st *helixorgstore.Store, deps mcptools.Config, bc *wakebus
 // callbacks on the insecure router, the org-scoped Slack endpoints and
 // the /orgs/{org}/ catch-all on the auth router, the org MCP backend,
 // plus the long-lived stream-cron and Socket Mode goroutines. Every
-// org-shaped route + lifecycle hook lives here. Access is gated per-user
-// by the `helix-org` alpha feature on the /orgs/{org}/ route.
+// org-shaped route + lifecycle hook lives here. Org-graph access is gated
+// per-user by the `helix-org` alpha feature.
 func (s *HelixAPIServer) registerHelixOrgRoutes(ctx context.Context, insecureRouter, authRouter *mux.Router) error {
 	orgHandlers, err := initHelixOrgHandler(helixOrgConfig{
 		LocalFSPath:          s.Cfg.FileStore.LocalFSPath,
@@ -391,18 +391,7 @@ func (s *HelixAPIServer) registerHelixOrgRoutes(ctx context.Context, insecureRou
 	authRouter.HandleFunc("/orgs/{org}/slack/workspaces", s.connectSlackWorkspace).Methods(http.MethodPost)
 	authRouter.HandleFunc("/orgs/{org}/slack/workspaces/{id}", s.deleteSlackWorkspace).Methods(http.MethodDelete)
 
-	// /api/v1/orgs/{org}/* — per-tenant surface for the org-graph
-	// resources. withHelixOrgScope resolves {org} (slug or org_id) to a
-	// canonical orgID, authorises org-membership, bootstraps the tenant on
-	// first request, and stashes orgID on ctx so downstream handlers + the
-	// store layer scope to it.
-	authRouter.PathPrefix("/orgs/{org}/").Handler(
-		requireFeature(helixorg.AlphaFeature)(
-			s.withHelixOrgScope(orgHandlers.scope,
-				stripOrgScopedPrefix(orgHandlers.api),
-			),
-		),
-	)
+	s.registerHelixOrgAuthenticatedRoutes(authRouter, orgHandlers)
 
 	// Expose helix-org's owner MCP through the standard Helix MCP gateway.
 	// Backend identifies tenants by URL prefix
@@ -411,6 +400,24 @@ func (s *HelixAPIServer) registerHelixOrgRoutes(ctx context.Context, insecureRou
 	// from the request before dispatching to the handler.
 	s.mcpGateway.RegisterBackend("helix-org", NewHelixOrgMCPBackend(s, orgHandlers))
 	return nil
+}
+
+func (s *HelixAPIServer) registerHelixOrgAuthenticatedRoutes(authRouter *mux.Router, orgHandlers *helixOrgHandlers) {
+	identityOnly := s.withHelixOrgIdentity(stripOrgScopedPrefix(orgHandlers.api))
+	authRouter.Handle("/orgs/{org}/settings", identityOnly).Methods(http.MethodGet)
+	authRouter.Handle("/orgs/{org}/settings/{key}", identityOnly).Methods(http.MethodPut, http.MethodDelete)
+	authRouter.Handle("/orgs/{org}/github/app-installation", identityOnly).Methods(http.MethodGet)
+	authRouter.Handle("/orgs/{org}/github/app-manifest", identityOnly).Methods(http.MethodPost)
+
+	// All remaining per-tenant org-graph routes require the alpha feature
+	// and bootstrap the graph before dispatch.
+	authRouter.PathPrefix("/orgs/{org}/").Handler(
+		requireFeature(helixorg.AlphaFeature)(
+			s.withHelixOrgScope(orgHandlers.scope,
+				stripOrgScopedPrefix(orgHandlers.api),
+			),
+		),
+	)
 }
 
 func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*helixOrgHandlers, error) {

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -461,8 +461,8 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 
 	// Operational config registry — chat backend creds, model
 	// selection, etc. Backed by the same Postgres rows so settings
-	// survive restarts. Surfaced via the React settings page at
-	// /orgs/:org_id/helix-org/settings (backed by
+	// survive restarts. Surfaced via Organization Settings at
+	// /orgs/:org_id/general (backed by
 	// /api/v1/orgs/{org}/settings). Constructed before the spawner
 	// so the spawner can read chat.app_id / helix.url at activation
 	// time.

--- a/api/pkg/server/helix_org_middleware.go
+++ b/api/pkg/server/helix_org_middleware.go
@@ -178,11 +178,22 @@ func (s *helixOrgScope) ensureBootstrap(ctx context.Context, orgID string) error
 	return err
 }
 
-// withHelixOrgScope wraps the helix-org handler chain. It resolves
-// the `{org}` URL segment (slug or org_id) via lookupOrg, authorises
-// the caller is a member of that org, ensures the bootstrap has run
-// for the org, and stashes the resolved orgID on the request context.
+// withHelixOrgScope adds org-graph bootstrap to the shared authenticated
+// organization context.
 func (s *HelixAPIServer) withHelixOrgScope(scope *helixOrgScope, next http.Handler) http.Handler {
+	return s.withHelixOrgIdentity(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		orgID := helixorgserver.OrgIDFromContext(r.Context())
+		if err := scope.ensureBootstrap(r.Context(), orgID); err != nil {
+			http.Error(w, "bootstrap: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		next.ServeHTTP(w, r)
+	}))
+}
+
+// withHelixOrgIdentity resolves the organization, checks membership, and
+// stores the canonical organization ID and authenticated user on context.
+func (s *HelixAPIServer) withHelixOrgIdentity(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		orgSlugOrID := mux.Vars(r)["org"]
 		if orgSlugOrID == "" {
@@ -201,10 +212,6 @@ func (s *HelixAPIServer) withHelixOrgScope(scope *helixOrgScope, next http.Handl
 		}
 		if _, err := s.authorizeOrgMember(r.Context(), user, org.ID); err != nil {
 			http.Error(w, err.Error(), http.StatusForbidden)
-			return
-		}
-		if err := scope.ensureBootstrap(r.Context(), org.ID); err != nil {
-			http.Error(w, "bootstrap: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 		ctx := helixorgserver.WithOrgID(r.Context(), org.ID)

--- a/api/pkg/server/helix_org_middleware_test.go
+++ b/api/pkg/server/helix_org_middleware_test.go
@@ -3,11 +3,16 @@ package server
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 
+	"github.com/gorilla/mux"
+
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
 	orgmemory "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
+	helixorgserver "github.com/helixml/helix/api/pkg/org/interfaces/server"
 	helixstore "github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 )
@@ -20,6 +25,88 @@ type missingOrganizationHelixStore struct {
 
 func (s *missingOrganizationHelixStore) GetOrganization(_ context.Context, _ *helixstore.GetOrganizationQuery) (*types.Organization, error) {
 	return nil, errors.New("organization not found")
+}
+
+type helixOrgRouteTestStore struct {
+	helixstore.Store
+}
+
+func (s *helixOrgRouteTestStore) GetOrganization(_ context.Context, query *helixstore.GetOrganizationQuery) (*types.Organization, error) {
+	if query.Name != "acme" {
+		return nil, errors.New("unexpected organization")
+	}
+	return &types.Organization{ID: "org_acme", Name: "acme"}, nil
+}
+
+func (s *helixOrgRouteTestStore) GetOrganizationMembership(_ context.Context, query *helixstore.GetOrganizationMembershipQuery) (*types.OrganizationMembership, error) {
+	return &types.OrganizationMembership{
+		OrganizationID: query.OrganizationID,
+		UserID:         query.UserID,
+		Role:           types.OrganizationRoleMember,
+	}, nil
+}
+
+func newHelixOrgRouteTestHandler(t *testing.T) (http.Handler, *helixOrgScope) {
+	t.Helper()
+	scope := &helixOrgScope{bootstrapped: map[string]bool{}}
+	api := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if orgID := helixorgserver.OrgIDFromContext(r.Context()); orgID != "org_acme" {
+			t.Errorf("org ID context = %q, want org_acme", orgID)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	server := &HelixAPIServer{Store: &helixOrgRouteTestStore{}}
+	root := mux.NewRouter()
+	router := root.PathPrefix(APIPrefix).Subrouter()
+	server.registerHelixOrgAuthenticatedRoutes(router, &helixOrgHandlers{api: api, scope: scope})
+	return root, scope
+}
+
+func helixOrgRouteRequest(handler http.Handler, method, path string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, nil)
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: "user-1"}))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHelixOrgSettingsRoutesDoNotRequireFeature(t *testing.T) {
+	handler, _ := newHelixOrgRouteTestHandler(t)
+	routes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/orgs/acme/settings"},
+		{http.MethodPut, "/api/v1/orgs/acme/settings/agent.default"},
+		{http.MethodDelete, "/api/v1/orgs/acme/settings/agent.default"},
+		{http.MethodGet, "/api/v1/orgs/acme/github/app-installation"},
+		{http.MethodPost, "/api/v1/orgs/acme/github/app-manifest"},
+	}
+	for _, route := range routes {
+		rec := helixOrgRouteRequest(handler, route.method, route.path)
+		if rec.Code != http.StatusNoContent {
+			t.Errorf("%s %s status = %d, want %d", route.method, route.path, rec.Code, http.StatusNoContent)
+		}
+	}
+}
+
+func TestHelixOrgChartRouteStillRequiresFeature(t *testing.T) {
+	handler, _ := newHelixOrgRouteTestHandler(t)
+	rec := helixOrgRouteRequest(handler, http.MethodGet, "/api/v1/orgs/acme/chart/positions")
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+}
+
+func TestHelixOrgSettingsRoutesDoNotBootstrap(t *testing.T) {
+	handler, scope := newHelixOrgRouteTestHandler(t)
+	rec := helixOrgRouteRequest(handler, http.MethodGet, "/api/v1/orgs/acme/settings")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+	if scope.bootstrapped["org_acme"] {
+		t.Fatal("settings request bootstrapped org graph")
+	}
 }
 
 // TestEnsureBootstrapConcurrentCallsAllSucceed pins the regression

--- a/api/pkg/server/helix_org_slack.go
+++ b/api/pkg/server/helix_org_slack.go
@@ -417,7 +417,7 @@ func (s *HelixAPIServer) slackRedirectURI() string {
 }
 
 func slackSettingsRedirectURL(orgID string, query url.Values) string {
-	return fmt.Sprintf("/orgs/%s/helix-org/settings?%s", url.PathEscape(orgID), query.Encode())
+	return fmt.Sprintf("/orgs/%s/general?%s", url.PathEscape(orgID), query.Encode())
 }
 
 func redirectSlackSettings(w http.ResponseWriter, r *http.Request, orgID, key, message string) {

--- a/api/pkg/server/helix_org_slack_workspace_test.go
+++ b/api/pkg/server/helix_org_slack_workspace_test.go
@@ -138,7 +138,7 @@ func TestSlackOAuthCallbackRedirectsSlackErrorToSettings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if location.Path != "/orgs/org-1/helix-org/settings" {
+	if location.Path != "/orgs/org-1/general" {
 		t.Fatalf("redirect path = %q", location.Path)
 	}
 	if got := location.Query().Get("slack_error"); got != "Slack authorization was cancelled. Try connecting the workspace again when you are ready." {
@@ -194,7 +194,7 @@ func TestSlackOAuthCallbackRedirectsMissingCodeToSettings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if location.Path != "/orgs/org-1/helix-org/settings" {
+	if location.Path != "/orgs/org-1/general" {
 		t.Fatalf("redirect path = %q", location.Path)
 	}
 	if got := location.Query().Get("slack_error"); got != "Slack did not return an authorization code. Try connecting the workspace again." {

--- a/frontend/src/components/helix-org/HelixOrgTopNav.tsx
+++ b/frontend/src/components/helix-org/HelixOrgTopNav.tsx
@@ -1,4 +1,4 @@
-// Elegant top-bar nav for helix-org (Chart / Bots / Topics / Settings).
+// Elegant top-bar nav for helix-org (Chart / Bots / Topics).
 // Renders next to theme + notifications on the Page AppBar.
 
 import { FC } from 'react'
@@ -6,7 +6,7 @@ import Box from '@mui/material/Box'
 import ButtonBase from '@mui/material/ButtonBase'
 import Tooltip from '@mui/material/Tooltip'
 import HubOutlinedIcon from '@mui/icons-material/HubOutlined'
-import { Bot, Network, Settings } from 'lucide-react'
+import { Bot, Network } from 'lucide-react'
 
 import useAccount from '../../hooks/useAccount'
 import useLightTheme from '../../hooks/useLightTheme'
@@ -42,13 +42,6 @@ const ITEMS: NavItem[] = [
     // Same hub glyph as topic cards on the org chart.
     icon: <HubOutlinedIcon sx={{ fontSize: 16 }} />,
     isActive: (n) => n === 'helix_org_topics' || n === 'helix_org_topic_detail',
-  },
-  {
-    id: 'settings',
-    label: 'Settings',
-    route: 'helix_org_settings',
-    icon: <Settings size={16} />,
-    isActive: (n) => n === 'helix_org_settings',
   },
 ]
 

--- a/frontend/src/components/helix-org/SlackIntegrationsPanel.test.tsx
+++ b/frontend/src/components/helix-org/SlackIntegrationsPanel.test.tsx
@@ -31,7 +31,7 @@ describe('SlackIntegrationsPanel', () => {
     openDialog.mockClear()
     snackbarError.mockClear()
     snackbarSuccess.mockClear()
-    window.history.replaceState({}, '', '/orgs/acme/helix-org/settings')
+    window.history.replaceState({}, '', '/orgs/acme/general')
   })
 
   it('shows admins a link to configure the Slack app', () => {
@@ -59,7 +59,7 @@ describe('SlackIntegrationsPanel', () => {
   })
 
   it('shows OAuth success feedback and removes the query parameter', async () => {
-    window.history.replaceState({}, '', '/orgs/acme/helix-org/settings?slack_installed=1&view=table')
+    window.history.replaceState({}, '', '/orgs/acme/general?slack_installed=1&view=table')
 
     render(<SlackIntegrationsPanel />)
 
@@ -68,7 +68,7 @@ describe('SlackIntegrationsPanel', () => {
   })
 
   it('shows OAuth error feedback and removes the query parameter', async () => {
-    window.history.replaceState({}, '', '/orgs/acme/helix-org/settings?slack_error=Try+again')
+    window.history.replaceState({}, '', '/orgs/acme/general?slack_error=Try+again')
 
     render(<SlackIntegrationsPanel />)
 

--- a/frontend/src/components/orgs/HelixOrgSidebar.tsx
+++ b/frontend/src/components/orgs/HelixOrgSidebar.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import HubOutlinedIcon from '@mui/icons-material/HubOutlined'
-import { Bot, Network, Settings } from 'lucide-react'
+import { Bot, Network } from 'lucide-react'
 
 import useRouter from '../../hooks/useRouter'
 import useAccount from '../../hooks/useAccount'
@@ -8,7 +8,7 @@ import ContextSidebar, { ContextSidebarSection } from '../system/ContextSidebar'
 
 // HelixOrgSidebar is the secondary navigation column for the
 // helix-org alpha. Sits between the primary org-menu rail and the
-// page body. Today: chart + bots + topics + settings.
+// page body. Today: chart + bots + topics.
 const HelixOrgSidebar: FC = () => {
   const router = useRouter()
   const account = useAccount()
@@ -49,13 +49,6 @@ const HelixOrgSidebar: FC = () => {
           icon: <HubOutlinedIcon sx={{ fontSize: 18 }} />,
           isActive: currentRouteName === 'helix_org_topics',
           onClick: () => navigateTo('helix_org_topics'),
-        },
-        {
-          id: 'settings',
-          label: 'Settings',
-          icon: <Settings size={18} />,
-          isActive: currentRouteName === 'helix_org_settings',
-          onClick: () => navigateTo('helix_org_settings'),
         },
       ],
     },

--- a/frontend/src/pages/HelixOrgSettings.tsx
+++ b/frontend/src/pages/HelixOrgSettings.tsx
@@ -1,23 +1,18 @@
-// HelixOrgSettings is the configuration surface for the helix-org alpha.
+// HelixOrgSettings is the helix-org section of Organization Settings.
 // The default agent config (runtime / credentials / provider / model)
-// now lives on the AI Providers page so it sits next
-// to the providers it references; everything else here falls back to a
-// generic text-input row driven by the same config registry the server
-// validates against.
+// is rendered separately above this section; everything else here falls
+// back to a generic text-input row driven by the same config registry the
+// server validates against.
 
 import { FC, useEffect, useState } from 'react'
-import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
-import Container from '@mui/material/Container'
 import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import SaveIcon from '@mui/icons-material/Save'
 
-import HelixOrgShell from '../components/helix-org/HelixOrgShell'
-import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrumbs'
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import useSnackbar from '../hooks/useSnackbar'
 import GitHubAppPanel from '../components/helix-org/GitHubAppPanel'
@@ -30,7 +25,7 @@ import {
 } from '../services/helixOrgService'
 
 // Registry keys we do NOT render as generic rows here:
-//  - agent.default and legacy worker.* config live on the Providers page.
+//  - agent.default and legacy worker.* config use the dedicated panel.
 //  - transport.github is auto-managed by the Helix GitHub App (it provisions
 //    the webhook secret and the token comes from the App installation), so
 //    there's nothing for an operator to paste.
@@ -44,40 +39,33 @@ const EXCLUDED_KEYS = new Set<string>([
 ])
 
 const HelixOrgSettings: FC = () => {
-
   const { data, isLoading } = useHelixOrgSettings()
-  const breadcrumbs = useHelixOrgBreadcrumbs()
 
   return (
-    <HelixOrgShell showChat={false} breadcrumbs={breadcrumbs} breadcrumbTitle="Settings">
-      <Box sx={{ height: '100%', overflow: 'auto' }}>
-      <Container maxWidth="md" sx={{ mb: 4, pt: 3 }}>
-        <Stack spacing={3}>
-          <Box>
-            <Typography variant="body2" color="text.secondary">
-              Configures how this org's Bots run. Changes take effect on the next bot
-              activation — no API restart needed.
-            </Typography>
-          </Box>
+    <Stack spacing={3}>
+      <Stack spacing={1}>
+        <Typography variant="h6">Integrations and Bot Settings</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Connect external services and configure how this org's Bots run.
+          Changes take effect on the next bot activation - no API restart needed.
+        </Typography>
+      </Stack>
 
-          {isLoading ? (
-            <LoadingSpinner />
-          ) : (
-            <>
-              <GitHubAppPanel />
+      {isLoading ? (
+        <LoadingSpinner />
+      ) : (
+        <>
+          <GitHubAppPanel />
 
-              <SlackIntegrationsPanel />
+          <SlackIntegrationsPanel />
 
-              {/* Generic spec rows — everything not excluded above */}
-              {(data?.specs ?? [])
-                .filter((s) => !EXCLUDED_KEYS.has(s.key))
-                .map((s) => <GenericSettingRow key={s.key} spec={s} />)}
-            </>
-          )}
-        </Stack>
-      </Container>
-      </Box>
-    </HelixOrgShell>
+          {/* Generic spec rows - everything not excluded above */}
+          {(data?.specs ?? [])
+            .filter((s) => !EXCLUDED_KEYS.has(s.key))
+            .map((s) => <GenericSettingRow key={s.key} spec={s} />)}
+        </>
+      )}
+    </Stack>
   )
 }
 

--- a/frontend/src/pages/HelixOrgTopicDetail.tsx
+++ b/frontend/src/pages/HelixOrgTopicDetail.tsx
@@ -497,10 +497,10 @@ interface GitHubWebhookStatusProps {
   orgSlug?: string
 }
 
-// SettingsLink is the actionable button on the loopback warning —
-// jumps the operator to the helix-org Settings page where
+// SettingsLink is the actionable button on the loopback warning.
+// It jumps the operator to Organization Settings where
 // `topics.public_url` can be set. Stops the user staring at
-// "what URL is wrong, where do I change it?" The Settings page
+// "what URL is wrong, where do I change it?" Organization Settings
 // has every per-org config including the new public_url override.
 const SettingsLink: FC<{ orgSlug?: string }> = ({ orgSlug }) => {
   const router = useRouter()
@@ -509,10 +509,10 @@ const SettingsLink: FC<{ orgSlug?: string }> = ({ orgSlug }) => {
     <Button
       size="small"
       variant="outlined"
-      onClick={() => router.navigate('helix_org_settings', { org_id: orgSlug })}
+      onClick={() => router.navigate('org_general', { org_id: orgSlug })}
       sx={{ color: 'warning.contrastText', borderColor: 'warning.contrastText' }}
     >
-      Open helix-org Settings →
+      Open Organization Settings
     </Button>
   )
 }
@@ -604,7 +604,7 @@ const GitHubWebhookStatus: FC<GitHubWebhookStatusProps> = ({ topic, orgSlug }) =
           </Typography>
           <Typography variant="caption" sx={{ display: 'block', mt: 0.5, mb: 1 }}>
             GitHub's servers can't reach this URL, so webhook deliveries won't arrive. Fix by either:
-            (a) setting <code>topics.public_url</code> on the helix-org Settings page to a publicly reachable host (cloudflared / ngrok / reverse proxy), or
+            (a) setting <code>topics.public_url</code> in Organization Settings to a publicly reachable host (cloudflared / ngrok / reverse proxy), or
             (b) editing <code>SERVER_URL</code> in helix's .env and restarting the api container.
           </Typography>
           <SettingsLink orgSlug={orgSlug} />

--- a/frontend/src/pages/OrgSettings.tsx
+++ b/frontend/src/pages/OrgSettings.tsx
@@ -21,6 +21,7 @@ import { TypesOrganization } from "../api/api";
 import useSnackbar from "../hooks/useSnackbar";
 import CopyButton from "../components/common/CopyButton";
 import DefaultAgentConfigPanel from "../components/helix-org/WorkerRuntimePanel";
+import HelixOrgSettings from "./HelixOrgSettings";
 
 const OrgSettings: FC = () => {
   // Get account context and router
@@ -341,6 +342,9 @@ const OrgSettings: FC = () => {
                     Agent settings copied to Bots when they are first provisioned.
                   </Typography>
                   <DefaultAgentConfigPanel />
+                  <Box sx={{ mt: 3 }}>
+                    <HelixOrgSettings />
+                  </Box>
                 </Box>
               )}
 

--- a/frontend/src/pages/OrgSettings.tsx
+++ b/frontend/src/pages/OrgSettings.tsx
@@ -44,10 +44,6 @@ const OrgSettings: FC = () => {
   }>({});
 
   const organization = account.organizationTools.organization;
-  // helix-org alpha gates the default agent config (its settings
-  // endpoint is behind the same feature flag).
-  const helixOrgEnabled =
-    account.user?.alpha_features?.includes("helix-org") ?? false;
   const isOrgOwner =
     !!account.user &&
     !!organization &&
@@ -329,24 +325,22 @@ const OrgSettings: FC = () => {
                 </Box>
               )}
 
-              {helixOrgEnabled && (
-                <Box sx={{ mt: 4 }}>
-                  <Typography variant="h6" gutterBottom>
-                    Default Agent Configuration
-                  </Typography>
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    sx={{ mb: 2 }}
-                  >
-                    Agent settings copied to Bots when they are first provisioned.
-                  </Typography>
-                  <DefaultAgentConfigPanel />
-                  <Box sx={{ mt: 3 }}>
-                    <HelixOrgSettings />
-                  </Box>
+              <Box sx={{ mt: 4 }}>
+                <Typography variant="h6" gutterBottom>
+                  Default Agent Configuration
+                </Typography>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ mb: 2 }}
+                >
+                  Agent settings copied to Bots when they are first provisioned.
+                </Typography>
+                <DefaultAgentConfigPanel />
+                <Box sx={{ mt: 3 }}>
+                  <HelixOrgSettings />
                 </Box>
-              )}
+              </Box>
 
               {isOrgOwner && (
                 <Paper

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -51,7 +51,6 @@ import HelixOrgChart from './pages/HelixOrgChart'
 import HelixOrgBots from './pages/HelixOrgBots'
 import HelixOrgBotDetail from './pages/HelixOrgBotDetail'
 import HelixOrgHumanDetail from './pages/HelixOrgHumanDetail'
-import HelixOrgSettings from './pages/HelixOrgSettings'
 import HelixOrgTopics from './pages/HelixOrgTopics'
 import HelixOrgTopicDetail from './pages/HelixOrgTopicDetail'
 import HelixOrgProcessorDetail from './pages/HelixOrgProcessorDetail'
@@ -562,11 +561,11 @@ const routes: IApplicationRoute[] = [
   },
   render: () => <AdminRunnerLogsPage />,
 }, {
-  // helix-org alpha — Other resources (bots, topics, settings) are
+  // helix-org alpha - Other resources (bots and topics) are
   // operated via MCP tools / API; the overview is the visual entry
   // point.
-  // drawer: false — secondary context sidebar is unused; Chart/Bots/Topics/
-  // Settings live in the AppBar (HelixOrgTopNav). The 64px org rail still shows.
+  // drawer: false - secondary context sidebar is unused; Chart/Bots/Topics
+  // live in the AppBar (HelixOrgTopNav). The 64px org rail still shows.
   name: 'helix_org_root',
   path: '/orgs/:org_id/helix-org',
   meta: { drawer: false, title: 'Helix Org' },
@@ -600,8 +599,14 @@ const routes: IApplicationRoute[] = [
 }, {
   name: 'helix_org_settings',
   path: '/orgs/:org_id/helix-org/settings',
-  meta: { drawer: false, title: 'Helix Org · Settings' },
-  render: () => <HelixOrgSettings />,
+  meta: { drawer: false },
+  render: () => {
+    const { navigateReplace, params } = useRouter()
+    React.useEffect(() => {
+      navigateReplace('org_general', { org_id: params.org_id })
+    }, [params.org_id])
+    return null
+  },
 }, {
   name: 'helix_org_topics',
   path: '/orgs/:org_id/helix-org/topics',


### PR DESCRIPTION
## Summary
- move Helix Org integrations and bot settings into Organization Settings
- remove the duplicate Settings entry from Helix Org navigation
- redirect legacy settings URLs and Slack callbacks to Organization Settings

## Testing
- go test -v ./pkg/server -run 'TestSlack(RedirectURI|OAuthCallback)' -count=1\n- yarn test SlackIntegrationsPanel.test.tsx\n- yarn tsc\n- yarn build\n- live Playwright verification of consolidated settings, legacy redirect, and Helix Org navigation