### PR TITLE
fix(org): clean up service connections on delete

### DIFF
--- a/api/pkg/orgstore/organizations.go
+++ b/api/pkg/orgstore/organizations.go
@@ -235,6 +235,10 @@ func (s *Store) DeleteOrganization(ctx context.Context, id string) error {
 			return err
 		}
 
+		if err := tx.Where("organization_id = ?", id).Delete(&types.ServiceConnection{}).Error; err != nil {
+			return err
+		}
+
 		// Finally delete the organization
 		return tx.Unscoped().Delete(&types.Organization{ID: id}).Error
 	})

--- a/api/pkg/store/organizations_test.go
+++ b/api/pkg/store/organizations_test.go
@@ -202,6 +202,48 @@ func (suite *OrganizationsTestSuite) TestDeleteOrganization_RemovesProjectsAndRe
 	suite.Empty(repositories)
 }
 
+func (suite *OrganizationsTestSuite) TestDeleteOrganization_RemovesServiceConnections() {
+	teamID := "T" + system.GenerateUUID()
+	orgA, err := suite.db.CreateOrganization(suite.ctx, &types.Organization{
+		ID:    system.GenerateOrganizationID(),
+		Name:  "Test Organization " + system.GenerateUUID(),
+		Owner: "test-user",
+	})
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.db.CreateServiceConnection(suite.ctx, &types.ServiceConnection{
+		ID:             system.GenerateUUID(),
+		OrganizationID: orgA.ID,
+		Name:           "Slack workspace",
+		Type:           types.ServiceConnectionTypeSlackWorkspace,
+		SlackTeamID:    teamID,
+	}))
+
+	suite.Require().NoError(suite.db.DeleteOrganization(suite.ctx, orgA.ID))
+
+	connections, err := suite.db.ListServiceConnections(suite.ctx, orgA.ID)
+	suite.Require().NoError(err)
+	suite.Empty(connections)
+
+	orgB, err := suite.db.CreateOrganization(suite.ctx, &types.Organization{
+		ID:    system.GenerateOrganizationID(),
+		Name:  "Test Organization " + system.GenerateUUID(),
+		Owner: "test-user",
+	})
+	suite.Require().NoError(err)
+	suite.T().Cleanup(func() {
+		suite.NoError(suite.db.DeleteOrganization(suite.ctx, orgB.ID))
+	})
+
+	suite.NoError(suite.db.CreateServiceConnection(suite.ctx, &types.ServiceConnection{
+		ID:             system.GenerateUUID(),
+		OrganizationID: orgB.ID,
+		Name:           "Slack workspace",
+		Type:           types.ServiceConnectionTypeSlackWorkspace,
+		SlackTeamID:    teamID,
+	}))
+}
+
 // TestDeleteOrganization_RemovesSpecTaskChildren guards the FK-violation
 // regression: a spec task with a work session (and zed thread) blocked org
 // deletion with fk_spec_tasks_work_sessions because those children carried


### PR DESCRIPTION
## Summary
- soft-delete organization-scoped service connections in the organization deletion transaction
- verify a deleted organization no longer blocks reconnecting the same Slack workspace elsewhere

## Testing
- `cd api && go test ./pkg/orgstore ./pkg/store -run '^$' -count=1`\n- `git diff --check`\n\nWARNING: The DB-backed regression test was not run locally because the local test Postgres was unavailable; CI must exercise it.