### PR TITLE
fix(frontend): remove dark logo background in light mode

### DIFF
--- a/frontend/src/components/orgs/UserOrgSelector.tsx
+++ b/frontend/src/components/orgs/UserOrgSelector.tsx
@@ -617,7 +617,7 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
         sx={{
           width: 48,
           height: 48,
-          bgcolor: compactExpanded ? 'primary.dark' : '#1a1a1a',
+          bgcolor: compactExpanded ? 'primary.dark' : 'transparent',
           color: '#fff',
           fontWeight: 'bold',
           fontSize: '1.5rem',


### PR DESCRIPTION
## Summary
- remove the hardcoded dark background behind the compact Helix logo
- retain the expanded-state primary background

## Testing
- yarn build
- verified in Chrome in light mode