### PR TITLE
Default Anthropic subscription mode to the 1M-context Opus

### DIFF
--- a/api/pkg/server/claude_subscription_handlers.go
+++ b/api/pkg/server/claude_subscription_handlers.go
@@ -439,8 +439,12 @@ type ClaudeModel struct {
 // @Security BearerAuth
 // @Router /api/v1/claude-subscriptions/models [get]
 func (apiServer *HelixAPIServer) listClaudeModels(_ http.ResponseWriter, req *http.Request) ([]*ClaudeModel, *system.HTTPError) {
+	// The "[1m]" context hint selects the 1M-context row of a tier; Claude
+	// Code's resolveModelPreference() canonicalizes "opus[1m]" to the 1M model
+	// while a bare "opus" resolves to the 200k row.
 	models := []*ClaudeModel{
-		{ID: "opus", Name: "Claude Opus", Description: "Most capable Claude model"},
+		{ID: "opus[1m]", Name: "Claude Opus (1M context)", Description: "Most capable Claude model, 1M-token context"},
+		{ID: "opus", Name: "Claude Opus (200k context)", Description: "Most capable Claude model, 200k-token context"},
 		{ID: "sonnet", Name: "Claude Sonnet", Description: "Best balance of speed and capability"},
 		{ID: "haiku", Name: "Claude Haiku", Description: "Fastest Claude model"},
 	}

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -684,7 +684,10 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.C
 			apiType = ""
 			model = assistant.ClaudeSubscriptionModel
 			if model == "" {
-				model = "opus"
+				// Default to the 1M-context Opus. The "[1m]" hint makes
+				// resolveModelPreference() pick the 1M row; a bare "opus"
+				// would resolve to the 200k sibling.
+				model = "opus[1m]"
 			}
 		} else {
 			// API key mode: route through Helix proxy.

--- a/api/pkg/server/zed_config_handlers_test.go
+++ b/api/pkg/server/zed_config_handlers_test.go
@@ -135,14 +135,14 @@ func TestBuildCodeAgentConfigFromAssistant(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "claude_code subscription mode - defaults to Opus",
+			name: "claude_code subscription mode - defaults to 1M-context Opus",
 			assistant: &types.AssistantConfig{
 				CodeAgentRuntime:        types.CodeAgentRuntimeClaudeCode,
 				CodeAgentCredentialType: types.CodeAgentCredentialTypeSubscription,
 			},
 			want: &types.CodeAgentConfig{
 				AgentName: "claude",
-				Model:     "opus",
+				Model:     "opus[1m]",
 				Runtime:   types.CodeAgentRuntimeClaudeCode,
 			},
 		},
@@ -169,7 +169,7 @@ func TestBuildCodeAgentConfigFromAssistant(t *testing.T) {
 			},
 			want: &types.CodeAgentConfig{
 				AgentName: "claude",
-				Model:     "opus",
+				Model:     "opus[1m]",
 				Runtime:   types.CodeAgentRuntimeClaudeCode,
 			},
 		},

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -1567,8 +1567,9 @@ type AssistantConfig struct {
 	// "claude_code" and CodeAgentCredentialType is "subscription". It flows through
 	// CodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,
 	// which the claude-agent-acp package reads (resolveModelPreference) to pick the
-	// model — otherwise Claude Code defaults to Sonnet. Empty means "opus"
-	// (resolveModelPreference resolves this to the latest Opus version).
+	// model — otherwise Claude Code defaults to Sonnet. Empty means "opus[1m]"
+	// (the 1M-context Opus; resolveModelPreference resolves the "[1m]" hint to the
+	// 1M row, while a bare "opus" resolves to the 200k sibling).
 	ClaudeSubscriptionModel string `json:"claude_subscription_model,omitempty" yaml:"claude_subscription_model,omitempty"`
 
 	// GooseRecipeRepoURL is the external git URL of the attached repository

--- a/frontend/src/components/agent/CodingAgentForm.tsx
+++ b/frontend/src/components/agent/CodingAgentForm.tsx
@@ -12,12 +12,16 @@ export type ClaudeCodeMode = 'subscription' | 'api_key'
 
 // Tier-level shorthand IDs for Claude subscription mode. Claude Code's
 // resolveModelPreference() resolves these to the latest version of each tier.
+// The "[1m]" context hint selects the 1M-context row of a tier (Claude Code
+// canonicalizes "opus[1m]" / "opus-1m" / "claude-opus-*-1m" to the same model);
+// a bare "opus" resolves to the 200k row.
 export const CLAUDE_SUBSCRIPTION_MODELS: { id: string; label: string }[] = [
-  { id: 'opus', label: 'Claude Opus (recommended)' },
+  { id: 'opus[1m]', label: 'Claude Opus (1M context, recommended)' },
+  { id: 'opus', label: 'Claude Opus (200k context)' },
   { id: 'sonnet', label: 'Claude Sonnet' },
   { id: 'haiku', label: 'Claude Haiku' },
 ]
-export const DEFAULT_CLAUDE_SUBSCRIPTION_MODEL = 'opus'
+export const DEFAULT_CLAUDE_SUBSCRIPTION_MODEL = 'opus[1m]'
 
 export const CODEX_SUBSCRIPTION_MODELS: { id: string; label: string }[] = [
   { id: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },


### PR DESCRIPTION
## Summary

In Anthropic subscription mode, Claude Code talks directly to Anthropic and picks
its model from the tier alias Helix writes into `managed-settings.json`. The
alias `"opus"` resolves to the **200k-context** Opus; the context-hinted alias
`"opus[1m]"` resolves to the **1M-context** Opus (Claude Code's
`resolveModelPreference` canonicalizes `opus[1m]` / `opus-1m` / `claude-opus-*-1m`
to the 1M row). This changes the default from `"opus"` to `"opus[1m]"` so new
subscription-mode agents get the 1M context, while keeping the 200k Opus
selectable.

## Changes

- Backend default: `api/pkg/server/zed_config_handlers.go` — subscription-branch
  empty-model default is now `"opus[1m]"` (was `"opus"`).
- Model picker API: `api/pkg/server/claude_subscription_handlers.go` —
  `listClaudeModels` now returns "Claude Opus (1M context)" (`opus[1m]`) and
  "Claude Opus (200k context)" (`opus`) alongside Sonnet/Haiku.
- Frontend: `frontend/src/components/agent/CodingAgentForm.tsx` — adds the
  `opus[1m]` option (labelled recommended) and sets
  `DEFAULT_CLAUDE_SUBSCRIPTION_MODEL = 'opus[1m]'`.
- Docs/comment: `api/pkg/types/types.go` — `ClaudeSubscriptionModel` doc updated
  to reflect the new default.
- Tests: `api/pkg/server/zed_config_handlers_test.go` — default cases updated to
  `"opus[1m]"`.

## Notes

- Users who explicitly select the 200k "Opus" still get 200k (override path
  unchanged).
- If a subscription's Claude Code list has no 1M Opus row, `resolveModelPreference`
  falls back to the best same-family (200k) row — no error.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kg02vqqyg178c1n2ydscn5fb/tasks/spt_01ky84nyfep1k188yz8erarxp5)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002331_on-anthropic/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002331_on-anthropic/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002331_on-anthropic/tasks.md)

🚀 Built with [Helix](https://helix.ml)