### PR TITLE
Fix cron triggers silently dropping every spec_task fire

### DIFF
--- a/api/cmd/helix/serve.go
+++ b/api/cmd/helix/serve.go
@@ -431,9 +431,9 @@ func serve(cmd *cobra.Command, cfg *config.ServerConfig) error {
 		}
 	}()
 
+	// Started below, AFTER server.NewServer has wired the spec task creator and
+	// external agent starter into it — starting here would race those setters.
 	trigger := trigger.NewTriggerManager(cfg, postgresStore, notifier, appController)
-	// Start integrations
-	go trigger.Start(ctx)
 
 	stripe := stripe.NewStripe(
 		cfg.Stripe,
@@ -488,6 +488,11 @@ func serve(cmd *cobra.Command, cfg *config.ServerConfig) error {
 	}
 
 	// Sandbox health monitoring is handled by the Hydra executor
+
+	// Start integrations. NewServer has now wired the spec task creator and the
+	// external agent starter into the manager, so cron triggers with
+	// action="spec_task" / agent_type="zed_external" can actually execute.
+	go trigger.Start(ctx)
 
 	log.Info().Msgf("Helix server listening on %s:%d", cfg.WebServer.Host, cfg.WebServer.Port)
 

--- a/api/pkg/server/app_trigger_handlers.go
+++ b/api/pkg/server/app_trigger_handlers.go
@@ -303,7 +303,7 @@ func (s *HelixAPIServer) executeAppTrigger(_ http.ResponseWriter, r *http.Reques
 	}
 
 	// Execute the trigger
-	response, err := cron.ExecuteCronTask(ctx, s.Store, s.Controller, s.Controller.Options.Notifier, nil, s, app, user.ID, triggerID, triggerConfig.Trigger.Cron, triggerConfig.Name)
+	response, err := cron.ExecuteCronTask(ctx, s.Store, s.Controller, s.Controller.Options.Notifier, s.specDrivenTaskService, s, app, user.ID, triggerID, triggerConfig.Trigger.Cron, triggerConfig.Name)
 	if err != nil {
 		return nil, system.NewHTTPError500(err.Error())
 	}

--- a/api/pkg/trigger/cron/trigger_cron.go
+++ b/api/pkg/trigger/cron/trigger_cron.go
@@ -33,14 +33,24 @@ type ExternalAgentStarter interface {
 	StartExternalAgentSession(ctx context.Context, req *types.SessionChatRequest, userID string) (*types.Session, error)
 }
 
+// SpecTaskCreatorProvider resolves the spec task creator when a job actually fires.
+// The scheduler starts before the API server has constructed the
+// SpecDrivenTaskService, so the creator MUST be resolved late — capturing it at
+// construction time captures nil and every spec_task trigger silently no-ops.
+type SpecTaskCreatorProvider func() SpecTaskCreator
+
+// ExternalAgentStarterProvider resolves the external agent starter at fire time,
+// for the same reason as SpecTaskCreatorProvider.
+type ExternalAgentStarterProvider func() ExternalAgentStarter
+
 type Cron struct {
-	cfg                   *config.ServerConfig
-	store                 store.Store
-	notifier              notification.Notifier
-	controller            *controller.Controller
-	specTaskCreator       SpecTaskCreator
-	externalAgentStarter  ExternalAgentStarter
-	cron                  gocron.Scheduler
+	cfg                  *config.ServerConfig
+	store                store.Store
+	notifier             notification.Notifier
+	controller           *controller.Controller
+	specTaskCreator      SpecTaskCreatorProvider
+	externalAgentStarter ExternalAgentStarterProvider
+	cron                 gocron.Scheduler
 }
 
 func NextRun(cron *types.CronTrigger) time.Time {
@@ -99,10 +109,17 @@ func extractTimezoneFromCron(schedule string) string {
 	return ""
 }
 
-func New(cfg *config.ServerConfig, store store.Store, notifier notification.Notifier, controller *controller.Controller, specTaskCreator SpecTaskCreator, externalAgentStarter ExternalAgentStarter) (*Cron, error) {
+func New(cfg *config.ServerConfig, store store.Store, notifier notification.Notifier, controller *controller.Controller, specTaskCreator SpecTaskCreatorProvider, externalAgentStarter ExternalAgentStarterProvider) (*Cron, error) {
 	s, err := gocron.NewScheduler()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create scheduler: %w", err)
+	}
+
+	if specTaskCreator == nil {
+		return nil, fmt.Errorf("spec task creator provider is required")
+	}
+	if externalAgentStarter == nil {
+		return nil, fmt.Errorf("external agent starter provider is required")
 	}
 
 	return &Cron{
@@ -373,18 +390,30 @@ func (c *Cron) createOrDeleteCronApps(ctx context.Context, cronApps []*cronApp, 
 
 func (c *Cron) getCronAppTask(ctx context.Context, cronApp *cronApp) gocron.Task {
 	return gocron.NewTask(func() {
-		log.Info().
-			Str("app_id", cronApp.App.ID).
-			Msg("running app cron job")
-
-		_, err := ExecuteCronTask(ctx, c.store, c.controller, c.notifier, c.specTaskCreator, c.externalAgentStarter, cronApp.App, cronApp.UserID, cronApp.ID, cronApp.Trigger, cronApp.Name)
-		if err != nil {
-			log.Error().Err(err).Msg("failed to execute cron task")
-			return
-		}
-
-		log.Info().Msg("cron task completed")
+		c.runCronApp(ctx, cronApp)
 	})
+}
+
+// runCronApp executes one scheduled job. Split out of getCronAppTask so the
+// late-resolution of specTaskCreator/externalAgentStarter is directly testable.
+func (c *Cron) runCronApp(ctx context.Context, cronApp *cronApp) {
+	log.Info().
+		Str("app_id", cronApp.App.ID).
+		Str("trigger_id", cronApp.ID).
+		Msg("running app cron job")
+
+	// Resolved here, not at construction time: the scheduler starts before the
+	// API server wires these in.
+	_, err := ExecuteCronTask(ctx, c.store, c.controller, c.notifier, c.specTaskCreator(), c.externalAgentStarter(), cronApp.App, cronApp.UserID, cronApp.ID, cronApp.Trigger, cronApp.Name)
+	if err != nil {
+		log.Error().Err(err).
+			Str("app_id", cronApp.App.ID).
+			Str("trigger_id", cronApp.ID).
+			Msg("failed to execute cron task")
+		return
+	}
+
+	log.Info().Msg("cron task completed")
 }
 
 func (c *Cron) listApps(ctx context.Context) ([]*types.App, error) {
@@ -706,15 +735,10 @@ func readInputFile(ctx context.Context, str store.Store, trigger *types.CronTrig
 }
 
 func executeSpecTaskAction(ctx context.Context, str store.Store, specTaskCreator SpecTaskCreator, notifier notification.Notifier, a *types.App, userID, triggerID string, trigger *types.CronTrigger, sessionName string) (string, error) {
-	if specTaskCreator == nil {
-		return "", fmt.Errorf("spec task creator not configured, cannot execute spec_task action")
-	}
-
-	if trigger.ProjectID == "" {
-		return "", fmt.Errorf("project_id is required for spec_task action")
-	}
-
-	// Create execution record
+	// Create execution record FIRST, before any validation, so a misconfigured
+	// trigger leaves a visible failed execution rather than disappearing. A fire
+	// that records nothing is indistinguishable from a fire that never happened —
+	// that is how a dead scheduler went unnoticed for months.
 	execution := &types.TriggerExecution{
 		ID:                     system.GenerateUUID(),
 		Name:                   sessionName,
@@ -731,6 +755,16 @@ func executeSpecTaskAction(ctx context.Context, str store.Store, specTaskCreator
 		return "", fmt.Errorf("failed to create trigger execution: %w", err)
 	}
 
+	if specTaskCreator == nil {
+		return "", recordSpecTaskFailure(ctx, str, notifier, execution, startedAt, a, triggerID, trigger.Emails,
+			fmt.Errorf("spec task creator not configured, cannot execute spec_task action"))
+	}
+
+	if trigger.ProjectID == "" {
+		return "", recordSpecTaskFailure(ctx, str, notifier, execution, startedAt, a, triggerID, trigger.Emails,
+			fmt.Errorf("project_id is required for spec_task action"))
+	}
+
 	task, err := specTaskCreator.CreateTaskFromPrompt(ctx, &types.CreateTaskRequest{
 		ProjectID: trigger.ProjectID,
 		Prompt:    trigger.Input,
@@ -740,39 +774,7 @@ func executeSpecTaskAction(ctx context.Context, str store.Store, specTaskCreator
 		AutoStart: true,
 	})
 	if err != nil {
-		log.Error().
-			Err(err).
-			Str("app_id", a.ID).
-			Str("project_id", trigger.ProjectID).
-			Msg("failed to create spec task from cron trigger")
-
-		// Send failure notification
-		notifyErr := notifier.Notify(ctx, &types.Notification{
-			Event:   types.EventCronTriggerFailed,
-			Message: err.Error(),
-			Emails:  trigger.Emails,
-		})
-		if notifyErr != nil {
-			log.Error().
-				Err(notifyErr).
-				Str("app_id", a.ID).
-				Msg("failed to send failure notification for spec task")
-		}
-
-		// Update execution with error
-		execution.Status = types.TriggerExecutionStatusError
-		execution.Error = err.Error()
-		execution.DurationMs = time.Since(startedAt).Milliseconds()
-
-		_, updateErr := str.UpdateTriggerExecution(ctx, execution)
-		if updateErr != nil {
-			log.Error().
-				Err(updateErr).
-				Str("execution_id", execution.ID).
-				Msg("failed to update execution")
-		}
-
-		return "", err
+		return "", recordSpecTaskFailure(ctx, str, notifier, execution, startedAt, a, triggerID, trigger.Emails, err)
 	}
 
 	output := fmt.Sprintf("Created spec task %s: %s", task.ID, task.Name)
@@ -810,4 +812,40 @@ func executeSpecTaskAction(ctx context.Context, str store.Store, specTaskCreator
 		Msg("spec task cron job completed")
 
 	return output, nil
+}
+
+// recordSpecTaskFailure marks the execution failed, notifies, and returns cause so
+// the caller can propagate it. Every spec_task failure path goes through here so a
+// fire that produced no task always leaves a row explaining why.
+func recordSpecTaskFailure(ctx context.Context, str store.Store, notifier notification.Notifier, execution *types.TriggerExecution, startedAt time.Time, a *types.App, triggerID string, emails []string, cause error) error {
+	log.Error().
+		Err(cause).
+		Str("app_id", a.ID).
+		Str("trigger_id", triggerID).
+		Msg("failed to create spec task from cron trigger")
+
+	if err := notifier.Notify(ctx, &types.Notification{
+		Event:   types.EventCronTriggerFailed,
+		Message: cause.Error(),
+		Emails:  emails,
+	}); err != nil {
+		log.Error().
+			Err(err).
+			Str("app_id", a.ID).
+			Str("trigger_id", triggerID).
+			Msg("failed to send failure notification for spec task")
+	}
+
+	execution.Status = types.TriggerExecutionStatusError
+	execution.Error = cause.Error()
+	execution.DurationMs = time.Since(startedAt).Milliseconds()
+
+	if _, err := str.UpdateTriggerExecution(ctx, execution); err != nil {
+		log.Error().
+			Err(err).
+			Str("execution_id", execution.ID).
+			Msg("failed to update execution")
+	}
+
+	return cause
 }

--- a/api/pkg/trigger/cron/trigger_cron_test.go
+++ b/api/pkg/trigger/cron/trigger_cron_test.go
@@ -868,6 +868,22 @@ func (suite *CronTestSuite) TestExecuteCronTask_SpecTaskAction_MissingProjectID(
 		},
 	}
 
+	// A misconfigured trigger must still leave a failed execution behind — a fire
+	// that records nothing looks identical to a scheduler that never fired.
+	suite.store.EXPECT().CreateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {
+			return execution, nil
+		},
+	)
+	suite.notifier.EXPECT().Notify(gomock.Any(), gomock.Any()).Return(nil)
+	suite.store.EXPECT().UpdateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {
+			suite.Equal(types.TriggerExecutionStatusError, execution.Status)
+			suite.Contains(execution.Error, "project_id is required")
+			return execution, nil
+		},
+	)
+
 	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, mockCreator, nil, app, "test-user", "trigger-123", trigger, "test-session")
 	suite.Error(err)
 	suite.Empty(result)
@@ -887,10 +903,98 @@ func (suite *CronTestSuite) TestExecuteCronTask_SpecTaskAction_NilCreator() {
 		ProjectID: "proj-456",
 	}
 
+	// The nil creator is the bug that silently killed every scheduled spec_task
+	// for months. It must now surface as a recorded, errored execution.
+	suite.store.EXPECT().CreateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {
+			return execution, nil
+		},
+	)
+	suite.notifier.EXPECT().Notify(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, n *notification.Notification) error {
+			suite.Equal(types.EventCronTriggerFailed, n.Event)
+			return nil
+		},
+	)
+	suite.store.EXPECT().UpdateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {
+			suite.Equal(types.TriggerExecutionStatusError, execution.Status)
+			suite.Contains(execution.Error, "spec task creator not configured")
+			return execution, nil
+		},
+	)
+
 	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, nil, nil, app, "test-user", "trigger-123", trigger, "test-session")
 	suite.Error(err)
 	suite.Empty(result)
 	suite.Contains(err.Error(), "spec task creator not configured")
+}
+
+// TestCronResolvesSpecTaskCreatorLate is the regression test for the bug where
+// every scheduled spec_task silently no-opped: the scheduler was constructed
+// during startup, BEFORE the API server built the SpecDrivenTaskService, so it
+// captured a nil creator forever. The provider must be called when the job fires,
+// not when the Cron is built.
+func (suite *CronTestSuite) TestCronResolvesSpecTaskCreatorLate() {
+	var wired SpecTaskCreator // nil at construction, exactly like real startup
+
+	c, err := New(
+		&config.ServerConfig{},
+		suite.store,
+		suite.notifier,
+		suite.controller,
+		func() SpecTaskCreator { return wired },
+		func() ExternalAgentStarter { return nil },
+	)
+	suite.NoError(err)
+
+	created := false
+	wired = &mockSpecTaskCreator{
+		createFunc: func(_ context.Context, req *types.CreateTaskRequest) (*types.SpecTask, error) {
+			created = true
+			suite.Equal("proj-456", req.ProjectID)
+			return &types.SpecTask{ID: "task-789", Name: "Scheduled run"}, nil
+		},
+	}
+
+	suite.store.EXPECT().CreateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {
+			return execution, nil
+		},
+	)
+	suite.notifier.EXPECT().Notify(gomock.Any(), gomock.Any()).Return(nil)
+	suite.store.EXPECT().UpdateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {
+			suite.Equal(types.TriggerExecutionStatusSuccess, execution.Status)
+			return execution, nil
+		},
+	)
+
+	c.runCronApp(suite.ctx, &cronApp{
+		ID:     "trigger-123",
+		UserID: "test-user",
+		Name:   "Scheduled run",
+		App:    &types.App{ID: "app-123", Owner: "test-user", OwnerType: types.OwnerTypeUser},
+		Trigger: &types.CronTrigger{
+			Enabled:   true,
+			Schedule:  "CRON_TZ=America/New_York 0 9 * * 1-5",
+			Input:     "Do the scheduled work",
+			Action:    "spec_task",
+			ProjectID: "proj-456",
+		},
+	})
+
+	suite.True(created, "cron job must resolve the spec task creator at fire time, not at construction")
+}
+
+// New must reject nil providers — the whole point is that the value can be nil
+// while the provider itself never is.
+func (suite *CronTestSuite) TestNewRequiresProviders() {
+	_, err := New(&config.ServerConfig{}, suite.store, suite.notifier, suite.controller, nil, func() ExternalAgentStarter { return nil })
+	suite.Error(err)
+
+	_, err = New(&config.ServerConfig{}, suite.store, suite.notifier, suite.controller, func() SpecTaskCreator { return nil }, nil)
+	suite.Error(err)
 }
 
 func TestExtractTimezoneFromCron(t *testing.T) {

--- a/api/pkg/trigger/trigger.go
+++ b/api/pkg/trigger/trigger.go
@@ -23,15 +23,19 @@ import (
 )
 
 type Manager struct {
-	cfg                  *config.ServerConfig
-	store                store.Store
-	controller           *controller.Controller
-	notifier             notification.Notifier
+	cfg             *config.ServerConfig
+	store           store.Store
+	controller      *controller.Controller
+	notifier        notification.Notifier
+	azureDevOps     *azure.AzureDevOps
+	teams           *teams.Teams
+	helixCodeReview *project.HelixCodeReviewTrigger
+
+	// Wired after construction (the API server builds them later), and read by the
+	// cron scheduler goroutine — guard both.
+	depsMu               sync.RWMutex
 	specTaskCreator      cron.SpecTaskCreator
 	externalAgentStarter cron.ExternalAgentStarter
-	azureDevOps          *azure.AzureDevOps
-	teams                *teams.Teams
-	helixCodeReview      *project.HelixCodeReviewTrigger
 
 	wg sync.WaitGroup
 }
@@ -51,11 +55,31 @@ func NewTriggerManager(cfg *config.ServerConfig, store store.Store, notifier not
 // SetSpecTaskCreator sets the spec task creator for cron triggers that use the "spec_task" action.
 // This is set after construction because the SpecDrivenTaskService is created later in the init sequence.
 func (t *Manager) SetSpecTaskCreator(specTaskCreator cron.SpecTaskCreator) {
+	t.depsMu.Lock()
+	defer t.depsMu.Unlock()
 	t.specTaskCreator = specTaskCreator
 }
 
 func (t *Manager) SetExternalAgentStarter(starter cron.ExternalAgentStarter) {
+	t.depsMu.Lock()
+	defer t.depsMu.Unlock()
 	t.externalAgentStarter = starter
+}
+
+// SpecTaskCreator returns the currently wired creator. The cron scheduler calls
+// this when a job fires rather than capturing the value at construction time —
+// it starts before the API server has wired anything in.
+func (t *Manager) SpecTaskCreator() cron.SpecTaskCreator {
+	t.depsMu.RLock()
+	defer t.depsMu.RUnlock()
+	return t.specTaskCreator
+}
+
+// ExternalAgentStarter returns the currently wired starter. See SpecTaskCreator.
+func (t *Manager) ExternalAgentStarter() cron.ExternalAgentStarter {
+	t.depsMu.RLock()
+	defer t.depsMu.RUnlock()
+	return t.externalAgentStarter
 }
 
 func (t *Manager) Start(ctx context.Context) {
@@ -135,7 +159,7 @@ func (t *Manager) runDiscord(ctx context.Context) {
 }
 
 func (t *Manager) runCron(ctx context.Context) {
-	cronTrigger, err := cron.New(t.cfg, t.store, t.notifier, t.controller, t.specTaskCreator, t.externalAgentStarter)
+	cronTrigger, err := cron.New(t.cfg, t.store, t.notifier, t.controller, t.SpecTaskCreator, t.ExternalAgentStarter)
 	if err != nil {
 		log.Err(err).Msg("failed to create cron trigger")
 		return


### PR DESCRIPTION
## Summary

Not a single `action=spec_task` cron trigger has ever fired on `meta.helix.ml`. The
triggers are all present, enabled, and show valid next-run times, but
`/api/v1/triggers/{id}/executions` is empty for every one of them — including
`Daily Deal Intelligence`, live since 2026-06-19 — and no cron-created spec task
exists in the target project.

**Root cause: a startup ordering race that made the failure invisible.**
`serve.go` ran `go trigger.Start(ctx)` *before* `server.NewServer` wired in the
`SpecDrivenTaskService`, so `cron.New` captured a **nil** `SpecTaskCreator` for the
life of the process (the `Cron` is built once, outside the retry loop). Every fire
then hit `executeSpecTaskAction`'s nil-guard, which returned **before** the
`TriggerExecution` record was written — no spec task, no execution row, no
notification. The only trace was a bare `failed to execute cron task` log line.

The manual "execute trigger" endpoint was passing `nil` for the same dependency, so
running a `spec_task` trigger by hand failed too.

## Changes

- `cron.New` takes **providers** (`func() SpecTaskCreator`, `func() ExternalAgentStarter`)
  resolved when a job fires instead of values captured at construction. Nil providers
  are rejected — the value may legitimately be nil during startup, the provider never is.
- `trigger.Manager` guards the late-wired dependencies with an `RWMutex`; the setters
  genuinely race the scheduler goroutine.
- `go trigger.Start(ctx)` moved to after `server.NewServer(...)`. Belt and braces with
  the providers, so the next late-wired dependency can't reintroduce this.
- `executeSpecTaskAction` creates the `TriggerExecution` row **before** the
  nil-creator and empty-`project_id` guards; all failure paths now go through
  `recordSpecTaskFailure`, which logs with `trigger_id` + `app_id`, notifies, and marks
  the execution errored. A fire that produces no task always leaves a row saying why.
- `executeAppTrigger` passes the real spec task creator.
- `getCronAppTask` split so the job body (`runCronApp`) is testable — `gocron.Task`
  values can't be invoked from outside the scheduler.

## Tests

- New `TestCronResolvesSpecTaskCreatorLate`: a `Cron` built with a nil creator still
  creates the spec task once the creator is wired later. This is the regression.
- New `TestNewRequiresProviders`.
- `TestExecuteCronTask_SpecTaskAction_NilCreator` / `..._MissingProjectID` updated —
  they asserted the old silent-failure behaviour, and now assert a recorded, errored
  execution.
- `go build ./...` clean; `go test ./pkg/trigger/...` green.
- **NOT tested end-to-end:** the local Helix dev stack is not running in this
  environment, and `-race` needs cgo/gcc which isn't installed here. Proof that
  scheduled tasks fire comes after deploy to meta.helix.ml — the first bot trigger
  should then produce a `TriggerExecution` with `status=success`.

---
🔗 [Open in Helix](https://meta.helix.ml/orgs/helix/projects/prj_01kk95f1seff98mbxhfa31qj81/tasks/spt_01kycnpqmdmhfbe2qqh9y80a2r)

📋 Spec:
- [Requirements](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002349_hello-help-me-figure-out/requirements.md)
- [Design](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002349_hello-help-me-figure-out/design.md)
- [Tasks](https://github.com/helixml/helix/blob/helix-specs/design/tasks/002349_hello-help-me-figure-out/tasks.md)

🚀 Built with [Helix](https://helix.ml)