### PR TITLE
fix(frontend): keep projects first in navigation

### DIFF
--- a/frontend/src/components/orgs/UserOrgSelector.tsx
+++ b/frontend/src/components/orgs/UserOrgSelector.tsx
@@ -398,6 +398,13 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
         label: "Org Chart",
       }] : []),
       {
+        icon: <Kanban size={NAV_BUTTON_SIZE} />,
+        tooltip: "View projects",
+        isActive: isActive(['spec-tasks', 'projects', 'project']),
+        onClick: handleProjectsClick,
+        label: "Projects",
+      },
+      {
         icon: <Bot size={NAV_BUTTON_SIZE} />,
         tooltip: "View agents",
         isActive: isActive(['agents', 'agent']),
@@ -410,13 +417,6 @@ const UserOrgSelector: FC<UserOrgSelectorProps> = ({ sidebarVisible = false }) =
         isActive: isActive('chat'),
         onClick: () => orgNavigateTo('chat'),
         label: "Chat",
-      },
-      {
-        icon: <Kanban size={NAV_BUTTON_SIZE} />,
-        tooltip: "View projects",
-        isActive: isActive(['spec-tasks', 'projects', 'project']),
-        onClick: handleProjectsClick,
-        label: "Projects",
       },
       // Q&A now lives in the org Settings sub-nav (OrgSidebar -> Agent Q&A);
       // no longer a top-level rail entry.


### PR DESCRIPTION
## Summary
- keep Projects first when helix-org is disabled
- keep Org Chart first and Projects second when helix-org is enabled

## Verification
- yarn tsc
- yarn build
- COMPOSE_PROJECT_NAME=login-response-admin ./stack rebuild api frontend
- registered a fresh local user
- verified Projects, Agents, Chat, Tasks, Sandbox, Settings with no alpha features
- enabled helix-org and verified Org Chart, Projects, Agents, Chat, Tasks, Sandbox, Settings in Playwright