### PR TITLE
fix(org): activate every bot on creation

### DIFF
--- a/api/pkg/org/application/configregistry/default_agent.go
+++ b/api/pkg/org/application/configregistry/default_agent.go
@@ -22,7 +22,3 @@ func (r *Registry) GetDefaultAgentConfig(ctx context.Context, orgID string) (typ
 	cfg.Model, _ = r.GetString(ctx, orgID, "worker.model")
 	return cfg, nil
 }
-
-func (r *Registry) IsDefaultAgentConfigured(ctx context.Context, orgID string) bool {
-	return r.IsConfigured(ctx, orgID, DefaultAgentConfigKey) || r.IsConfigured(ctx, orgID, "worker.runtime")
-}

--- a/api/pkg/org/application/lifecycle/hire_test.go
+++ b/api/pkg/org/application/lifecycle/hire_test.go
@@ -147,38 +147,9 @@ func (r *recordingDispatcher) DispatchHire(context.Context, string, orgchart.Bot
 	r.hires++
 }
 
-// TestCreate_DeferActivation: DeferActivation creates the bot row (and its
-// topology) but skips the hire — no activation row, no dispatch, empty
-// ActivationID. This is the "org has no runtime configured yet" path that
-// keeps a seeded bot from being provisioned on the gpt default.
-func TestCreate_DeferActivation(t *testing.T) {
-	t.Parallel()
-	st := memory.New()
-	svc := newHireService(st)
-	disp := &recordingDispatcher{}
-	svc.Dispatcher = disp
-	ctx := context.Background()
-
-	res, err := svc.Create(ctx, "org-test", lifecycle.CreateParams{
-		ID: "w-new", Content: "x", DeferActivation: true,
-	})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-	if _, err := st.Bots.Get(ctx, "org-test", "w-new"); err != nil {
-		t.Fatalf("bot row should still exist when deferred: %v", err)
-	}
-	if res.ActivationID != "" {
-		t.Fatalf("deferred create should return empty ActivationID, got %q", res.ActivationID)
-	}
-	if disp.hires != 0 {
-		t.Fatalf("deferred create must not dispatch a hire, got %d", disp.hires)
-	}
-}
-
-// TestCreate_DispatchesWhenNotDeferred: the default path (runtime already
-// configured) still dispatches the hire so the bot provisions immediately.
-func TestCreate_DispatchesWhenNotDeferred(t *testing.T) {
+// TestCreate_AlwaysDispatchesActivation pins the creation contract: every
+// newly-created agent bot gets an activation row and an immediate hire.
+func TestCreate_AlwaysDispatchesActivation(t *testing.T) {
 	t.Parallel()
 	st := memory.New()
 	svc := newHireService(st)
@@ -192,9 +163,9 @@ func TestCreate_DispatchesWhenNotDeferred(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	if res.ActivationID == "" {
-		t.Fatal("non-deferred create should return an ActivationID")
+		t.Fatal("create should return an ActivationID")
 	}
 	if disp.hires != 1 {
-		t.Fatalf("non-deferred create should dispatch exactly one hire, got %d", disp.hires)
+		t.Fatalf("create should dispatch exactly one hire, got %d", disp.hires)
 	}
 }

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -141,15 +141,6 @@ type CreateParams struct {
 	Topics          []streaming.TopicID
 	ParentID        orgchart.BotID
 	PreserveContext bool
-	// DeferActivation creates the Bot row (so it shows on the chart) and
-	// wires its topology, but skips the hire activation that provisions the
-	// Helix project + agent app + desktop. Callers set this when the org has
-	// no runtime configured yet, so a Bot is never provisioned with the
-	// seed-time default (claude_code/subscription/no-model, which Zed renders
-	// as its built-in gpt). The deferred Bot is provisioned later, with the
-	// correct config, when the operator sets the default agent configuration
-	// (settings handler re-runs activation for provision-less bots).
-	DeferActivation bool
 }
 
 // CreateResult carries the new Bot and the pre-allocated
@@ -258,15 +249,6 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 		if err := s.HireHook.OnHire(ctx, orgID, id, uid); err != nil {
 			return CreateResult{}, fmt.Errorf("create handler: %w", err)
 		}
-	}
-
-	// DeferActivation: the Bot row + topology exist (so the chart isn't
-	// blank), but we skip provisioning entirely. The operator hasn't picked a
-	// runtime yet, so provisioning now would bake the seed-time default into
-	// the agent app and boot a gpt desktop; the settings handler activates
-	// this Bot later, once a runtime is configured.
-	if p.DeferActivation {
-		return CreateResult{Bot: bot}, nil
 	}
 
 	// Pre-create the create-Activation audit row so Create can return the

--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -119,14 +119,6 @@ func (a *apiHandler) createBot(w http.ResponseWriter, r *http.Request) {
 	if req.Owner {
 		tools = mcptools.OwnerBotTools()
 	}
-	// Defer provisioning when the org has no runtime configured yet, so the
-	// Bot is never brought up on the seed-time default (claude_code /
-	// subscription / no model, which Zed renders as gpt). It provisions with
-	// the correct config once the operator sets the default agent configuration - see
-	// reapplyBotsAfterRuntimeChange. When a runtime IS already configured
-	// (e.g. picked in the create-org dialog before seeding), the Bot
-	// provisions immediately with that config, correct from the first boot.
-	deferActivation := a.deps.Configs != nil && !a.deps.Configs.IsDefaultAgentConfigured(ctx, orgID)
 	// REST and chat-driven creates share lifecycle.Create — one
 	// implementation.
 	res, err := a.deps.Lifecycle.Create(ctx, orgID, lifecycle.CreateParams{
@@ -137,7 +129,6 @@ func (a *apiHandler) createBot(w http.ResponseWriter, r *http.Request) {
 		Topics:          toTopicIDs(req.Topics),
 		ParentID:        orgchart.BotID(strings.TrimSpace(req.ParentID)),
 		PreserveContext: req.PreserveContext,
-		DeferActivation: deferActivation,
 	})
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)

--- a/api/pkg/org/interfaces/server/api/settings.go
+++ b/api/pkg/org/interfaces/server/api/settings.go
@@ -7,18 +7,7 @@ import (
 	"strings"
 
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
-	"github.com/rs/zerolog/log"
 )
-
-// agentProvisioningKeys activate bots whose initial provisioning was deferred.
-// worker.* remains supported for clients predating the atomic agent.default key.
-var agentProvisioningKeys = map[string]bool{
-	configregistry.DefaultAgentConfigKey: true,
-	"worker.runtime":                     true,
-	"worker.credentials":                 true,
-	"worker.provider":                    true,
-	"worker.model":                       true,
-}
 
 // ---- Settings -----------------------------------------------------------
 
@@ -103,105 +92,7 @@ func (a *apiHandler) setSetting(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
-	// A complete initial configuration activates bots whose provisioning was
-	// deferred. Existing apps remain independently configurable.
-	if agentProvisioningKeys[key] {
-		a.activateDeferredBotsAfterRuntimeChange(r.Context(), orgID)
-	}
 	w.WriteHeader(http.StatusNoContent)
-}
-
-// activateDeferredBotsAfterRuntimeChange provisions bots that were created
-// before the org's initial runtime configuration was complete:
-//
-//   - A Bot that was deferred at create (no project yet, because no runtime
-//     was configured) is activated now — it provisions for the FIRST time
-//     with the correct config, so its desktop never comes up on the gpt
-//     default.
-//   - A Bot that already has a project is left unchanged. Runtime/model edits
-//     for an existing bot belong to its generated Helix app.
-//
-// Config is committed before this runs, so first provisioning reads it.
-// Best-effort: per-bot failures are logged, not fatal — the settings write
-// already succeeded.
-func (a *apiHandler) activateDeferredBotsAfterRuntimeChange(ctx context.Context, orgID string) {
-	if a.deps.Queries == nil {
-		return
-	}
-	// The four worker.* keys are written as separate (often concurrent)
-	// requests by the UI. Wait until the runtime config is COMPLETE before
-	// provisioning anything, so a deferred bot is never brought up on a
-	// half-written config and then re-applied — it provisions exactly once,
-	// correct. Partial writes are no-ops; the write that completes the config
-	// does the work.
-	if !a.runtimeConfigComplete(ctx, orgID) {
-		return
-	}
-	bs, err := a.deps.Queries.ListBots(ctx, orgID)
-	if err != nil {
-		log.Warn().Err(err).Str("org", orgID).Msg("activate deferred bots after runtime change: list bots failed")
-		return
-	}
-	for _, b := range bs {
-		// A human node is never provisioned/activated — skip it, or the
-		// runtime-change sweep would spin up a desktop for every person.
-		if b.IsHuman() {
-			continue
-		}
-		provisioned := true
-		if a.deps.BotRuntime != nil {
-			info, err := a.deps.BotRuntime.State(ctx, orgID, b.ID)
-			provisioned = err == nil && info.ProjectID != ""
-		}
-		if !provisioned {
-			// Deferred bot: activate it now so it provisions with the
-			// just-configured runtime (correct from its first boot).
-			if a.deps.Activations == nil {
-				continue
-			}
-			if _, err := a.deps.Activations.Activate(ctx, orgID, b.ID); err != nil {
-				log.Warn().Err(err).Str("org", orgID).Str("bot", string(b.ID)).
-					Msg("activate deferred bot after runtime change failed")
-			}
-			continue
-		}
-		// Existing apps are configured through the Helix app UI/API. The
-		// org defaults are provisioning inputs, not reconciliation policy.
-	}
-}
-
-// runtimeConfigComplete reports whether the org's default agent configuration has
-// every field a Bot needs to provision. It mirrors resolveWorkerAgentConfig's
-// coercion (server package): runtimes without subscription support are always
-// api_key and need a provider + model; claude_code and codex_cli default to
-// subscription unless credentials is explicitly api_key. Used to hold off
-// provisioning until a half-written config is fully in place.
-func (a *apiHandler) runtimeConfigComplete(ctx context.Context, orgID string) bool {
-	if a.deps.Configs == nil {
-		return false
-	}
-	cfg, err := a.deps.Configs.GetDefaultAgentConfig(ctx, orgID)
-	if err != nil {
-		return false
-	}
-	runtime := string(cfg.CodeAgentRuntime)
-	if runtime == "" {
-		return false
-	}
-	credentials := string(cfg.CodeAgentCredentialType)
-	if !runtimeSupportsSubscription(runtime) {
-		credentials = "api_key"
-	} else if credentials == "" {
-		credentials = "subscription"
-	}
-	if credentials == "subscription" {
-		return true
-	}
-	return cfg.Provider != "" && cfg.Model != ""
-}
-
-func runtimeSupportsSubscription(runtime string) bool {
-	return runtime == "claude_code" || runtime == "codex_cli"
 }
 
 // deleteSetting removes the config row for the given key, falling back to defaults.

--- a/api/pkg/org/interfaces/server/api/settings_runtime_test.go
+++ b/api/pkg/org/interfaces/server/api/settings_runtime_test.go
@@ -1,19 +1,37 @@
 package api
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 
-func TestRuntimeSupportsSubscription(t *testing.T) {
-	tests := map[string]bool{
-		"claude_code": true,
-		"codex_cli":   true,
-		"zed_agent":   false,
-		"goose_code":  false,
+	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+	orgmemory "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
+	helixorgserver "github.com/helixml/helix/api/pkg/org/interfaces/server"
+)
+
+func TestSetSettingStoresValue(t *testing.T) {
+	st := orgmemory.New()
+	configs := configregistry.New(st.Configs)
+	configs.Register(configregistry.Spec{Key: "test.setting", Type: configregistry.TypeString})
+	handler := &apiHandler{deps: Deps{Configs: configs}}
+	req := httptest.NewRequest(http.MethodPut, "/settings/test.setting", bytes.NewBufferString(`{"value":"\"configured\""}`))
+	req.SetPathValue("key", "test.setting")
+	req = req.WithContext(helixorgserver.WithOrgID(req.Context(), "org-test"))
+	rec := httptest.NewRecorder()
+
+	handler.setSetting(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
 	}
-	for runtime, want := range tests {
-		t.Run(runtime, func(t *testing.T) {
-			if got := runtimeSupportsSubscription(runtime); got != want {
-				t.Fatalf("runtimeSupportsSubscription(%q) = %v, want %v", runtime, got, want)
-			}
-		})
+	got, err := configs.GetString(context.Background(), "org-test", "test.setting")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "configured" {
+		t.Fatalf("setting = %q, want configured", got)
 	}
 }

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -997,6 +997,9 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		Int("json_api_routes", len(extras)).
 		Msg("helix-org mounted at /api/v1/orgs/{org}/helix-org/")
 	scope := newHelixOrgScope(configReg, st, helixStore, mirror, slackRouteReconciler, helixEventsReconciler)
+	scope.botRepair = func(ctx context.Context, orgID string) error {
+		return repairNeverActivatedBots(ctx, orgID, st, dispatcher)
+	}
 
 	// Public github webhook handler — mounted on the insecure router
 	// because GitHub deliveries authenticate via HMAC, not the helix

--- a/api/pkg/server/helix_org_middleware.go
+++ b/api/pkg/server/helix_org_middleware.go
@@ -2,9 +2,11 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog/log"
@@ -13,8 +15,10 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/bots"
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
 	"github.com/helixml/helix/api/pkg/org/application/helixevents"
+	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
 	"github.com/helixml/helix/api/pkg/org/application/reconcile"
 	"github.com/helixml/helix/api/pkg/org/application/slackrouting"
+	"github.com/helixml/helix/api/pkg/org/domain/activation"
 	helixorgstore "github.com/helixml/helix/api/pkg/org/domain/store"
 	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
 	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
@@ -48,6 +52,7 @@ type helixOrgScope struct {
 	// hooks — see org_graph_seed.go). nil when helix-org / the seeder isn't
 	// wired.
 	humanReconcile func(ctx context.Context, orgID string) error
+	botRepair      func(ctx context.Context, orgID string) error
 
 	mu           sync.Mutex
 	bootstrapped map[string]bool
@@ -75,8 +80,8 @@ func newHelixOrgScope(configs *configregistry.Registry, orgStore *helixorgstore.
 
 // ensureBootstrap runs the per-org first-request setup: provision the
 // helix.api_key into the org's config registry, converge any existing
-// graph, and start the transcript mirror. No owner is seeded — orgs
-// start empty. Runs once per org per process (guarded by bootstrapped).
+// graph, and start the transcript mirror. Runs once per org per process
+// (guarded by bootstrapped).
 func (s *helixOrgScope) ensureBootstrap(ctx context.Context, orgID string) error {
 	s.mu.Lock()
 	if s.bootstrapped[orgID] {
@@ -101,14 +106,15 @@ func (s *helixOrgScope) ensureBootstrap(ctx context.Context, orgID string) error
 			return nil, nil
 		}
 
-		// No owner is seeded — orgs start empty. The human creates the
-		// first Role + Worker from the chart UI. This first-request hook
-		// only provisions the per-org service api_key and converges any
-		// graph that already exists (a no-op on a brand-new empty org).
-
 		// Provision a per-org Helix service api_key for the organization owner.
 		if _, err := helixorg.NewHelixAPIKeys(s.helixStore, s.configs).Service(ctx, orgID); err != nil {
-			log.Warn().Err(err).Str("org_id", orgID).Msg("helix-org service api key not provisioned")
+			return nil, fmt.Errorf("provision helix-org service api key: %w", err)
+		}
+
+		if s.botRepair != nil {
+			if err := s.botRepair(ctx, orgID); err != nil {
+				return nil, fmt.Errorf("repair never-activated bots: %w", err)
+			}
 		}
 
 		// Converge the full topology for this org. Best-effort: a
@@ -176,6 +182,41 @@ func (s *helixOrgScope) ensureBootstrap(ctx context.Context, orgID string) error
 		return nil, nil
 	})
 	return err
+}
+
+func repairNeverActivatedBots(ctx context.Context, orgID string, st *helixorgstore.Store, dispatcher lifecycle.CreateDispatcher) error {
+	if st == nil || dispatcher == nil {
+		return nil
+	}
+	bs, err := st.Bots.List(ctx, orgID)
+	if err != nil {
+		return err
+	}
+	for _, b := range bs {
+		if b.IsHuman() {
+			continue
+		}
+		acts, err := st.Activations.ListForWorker(ctx, orgID, b.ID, 1)
+		if err != nil {
+			return fmt.Errorf("list activations for bot %s: %w", b.ID, err)
+		}
+		if len(acts) > 0 {
+			continue
+		}
+		actID := activation.ID("a-repair-" + string(b.ID))
+		act, err := activation.New(actID, b.ID, []activation.Trigger{{Kind: activation.TriggerHire}}, time.Now().UTC(), orgID)
+		if err != nil {
+			return fmt.Errorf("build repair activation for bot %s: %w", b.ID, err)
+		}
+		if err := st.Activations.Create(ctx, act); err != nil {
+			if _, getErr := st.Activations.Get(ctx, orgID, actID); getErr == nil {
+				continue
+			}
+			return fmt.Errorf("persist repair activation for bot %s: %w", b.ID, err)
+		}
+		dispatcher.DispatchHire(ctx, orgID, b.ID, actID)
+	}
+	return nil
 }
 
 // withHelixOrgScope adds org-graph bootstrap to the shared authenticated

--- a/api/pkg/server/helix_org_middleware_test.go
+++ b/api/pkg/server/helix_org_middleware_test.go
@@ -7,28 +7,55 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+	"github.com/helixml/helix/api/pkg/org/domain/activation"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	orgmemory "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
 	helixorgserver "github.com/helixml/helix/api/pkg/org/interfaces/server"
 	helixstore "github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 )
 
-// missingOrganizationHelixStore makes service-key provisioning fail;
-// bootstrap must remain best-effort.
-type missingOrganizationHelixStore struct {
+type bootstrapHelixStore struct {
 	helixstore.Store
 }
 
-func (s *missingOrganizationHelixStore) GetOrganization(_ context.Context, _ *helixstore.GetOrganizationQuery) (*types.Organization, error) {
-	return nil, errors.New("organization not found")
+func (s *bootstrapHelixStore) GetOrganization(_ context.Context, _ *helixstore.GetOrganizationQuery) (*types.Organization, error) {
+	return &types.Organization{ID: "org-race", Owner: "user-owner"}, nil
+}
+
+func (s *bootstrapHelixStore) GetUser(_ context.Context, _ *helixstore.GetUserQuery) (*types.User, error) {
+	return &types.User{ID: "user-owner", AlphaFeatures: []string{"helix-org"}}, nil
+}
+
+func (s *bootstrapHelixStore) CreateAPIKey(_ context.Context, key *types.ApiKey) (*types.ApiKey, error) {
+	return key, nil
+}
+
+type failingBootstrapHelixStore struct {
+	helixstore.Store
+}
+
+func (s *failingBootstrapHelixStore) GetOrganization(context.Context, *helixstore.GetOrganizationQuery) (*types.Organization, error) {
+	return nil, errors.New("organization unavailable")
 }
 
 type helixOrgRouteTestStore struct {
 	helixstore.Store
+}
+
+type bootstrapActivationDispatcher struct {
+	ids           []orgchart.BotID
+	activationIDs []activation.ID
+}
+
+func (d *bootstrapActivationDispatcher) DispatchHire(_ context.Context, _ string, id orgchart.BotID, activationID activation.ID) {
+	d.ids = append(d.ids, id)
+	d.activationIDs = append(d.activationIDs, activationID)
 }
 
 func (s *helixOrgRouteTestStore) GetOrganization(_ context.Context, query *helixstore.GetOrganizationQuery) (*types.Organization, error) {
@@ -133,10 +160,12 @@ func TestHelixOrgSettingsRoutesDoNotBootstrap(t *testing.T) {
 func TestEnsureBootstrapConcurrentCallsAllSucceed(t *testing.T) {
 	t.Parallel()
 	orgStore := orgmemory.New()
+	configs := configregistry.New(orgStore.Configs)
+	configs.Register(configregistry.Spec{Key: "helix.api_key", Type: configregistry.TypeString})
 	scope := newHelixOrgScope(
-		configregistry.New(orgStore.Configs),
+		configs,
 		orgStore,
-		&missingOrganizationHelixStore{},
+		&bootstrapHelixStore{},
 		nil, // mirror — nil is a safe no-op for this bootstrap-race test
 		nil, // slackRoutes — nil is a safe no-op
 		nil, // helixEvents — nil is a safe no-op
@@ -167,4 +196,79 @@ func TestEnsureBootstrapConcurrentCallsAllSucceed(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("concurrent ensureBootstrap returned %d errors; first: %v", len(errs), errs[0])
 	}
+}
+
+func TestEnsureBootstrapRetriesAfterServiceKeyFailure(t *testing.T) {
+	t.Parallel()
+	orgStore := orgmemory.New()
+	scope := newHelixOrgScope(configregistry.New(orgStore.Configs), orgStore, &failingBootstrapHelixStore{}, nil, nil, nil)
+	for range 2 {
+		if err := scope.ensureBootstrap(context.Background(), "org-retry"); err == nil {
+			t.Fatal("ensureBootstrap should fail while the service key cannot be provisioned")
+		}
+	}
+	if scope.bootstrapped["org-retry"] {
+		t.Fatal("failed bootstrap must remain retryable")
+	}
+}
+
+func TestRepairNeverActivatedBotsSkipsHumansAndActivatedBots(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := orgmemory.New()
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	for _, b := range []orgchart.Bot{
+		mustBot(t, "bot-legacy-a", "", now),
+		mustBot(t, "bot-legacy-b", "", now),
+		mustBot(t, "bot-created", "", now),
+		mustBot(t, "human-owner", orgchart.BotKindHuman, now),
+	} {
+		if err := st.Bots.Create(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+	createdActivation, err := activation.New("a-created", "bot-created", []activation.Trigger{{Kind: activation.TriggerHire}}, now, "org-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Activations.Create(ctx, createdActivation); err != nil {
+		t.Fatal(err)
+	}
+
+	dispatcher := &bootstrapActivationDispatcher{}
+	if err := repairNeverActivatedBots(ctx, "org-test", st, dispatcher); err != nil {
+		t.Fatalf("repair never-activated bots: %v", err)
+	}
+	if len(dispatcher.ids) != 2 || dispatcher.ids[0] != "bot-legacy-a" || dispatcher.ids[1] != "bot-legacy-b" {
+		t.Fatalf("activated bots = %v, want [bot-legacy-a bot-legacy-b]", dispatcher.ids)
+	}
+	if len(dispatcher.activationIDs) != 2 || dispatcher.activationIDs[0] == "" || dispatcher.activationIDs[1] == "" {
+		t.Fatalf("repair activation IDs = %v, want two durable IDs", dispatcher.activationIDs)
+	}
+	for i, id := range dispatcher.ids {
+		rows, err := st.Activations.ListForWorker(ctx, "org-test", id, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rows) != 1 || rows[0].ID != dispatcher.activationIDs[i] {
+			t.Fatalf("activation for %s = %v, want %s", id, rows, dispatcher.activationIDs[i])
+		}
+	}
+
+	secondDispatcher := &bootstrapActivationDispatcher{}
+	if err := repairNeverActivatedBots(ctx, "org-test", st, secondDispatcher); err != nil {
+		t.Fatalf("repeat repair: %v", err)
+	}
+	if len(secondDispatcher.ids) != 0 {
+		t.Fatalf("repeat repair dispatched bots = %v, want none", secondDispatcher.ids)
+	}
+}
+
+func mustBot(t *testing.T, id string, kind orgchart.BotKind, now time.Time) orgchart.Bot {
+	t.Helper()
+	b, err := orgchart.NewBot(orgchart.BotID(id), "test bot", nil, now, "org-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b.WithKind(kind)
 }

--- a/api/pkg/server/org_graph_seed.go
+++ b/api/pkg/server/org_graph_seed.go
@@ -152,19 +152,14 @@ func (s *orgGraphSeeder) SeedChiefOfStaff(ctx context.Context, orgID string) err
 	if !errors.Is(err, store.ErrNotFound) {
 		return fmt.Errorf("check chief of staff: %w", err)
 	}
-	// DeferActivation: a brand-new org has no bot runtime configured yet.
-	// Activating now would provision CoS on the seed-time default
-	// (claude_code/subscription/no-model → renders as gpt). The deferred bot
-	// shows on the chart and is provisioned correctly once the operator sets
-	// the default agent configuration. The id is used
-	// exactly (`chief-of-staff`); a collision means already-seeded.
+	// The id is used exactly (`chief-of-staff`); a collision means
+	// already-seeded.
 	if _, err := s.lifecycle.Create(ctx, orgID, lifecycle.CreateParams{
 		ID:              string(chiefOfStaffBotID),
 		Name:            "Chief of Staff",
 		Content:         chiefOfStaffContent,
 		Tools:           mcptools.OwnerBotTools(),
 		PreserveContext: true,
-		DeferActivation: true,
 	}); err != nil {
 		if _, getErr := s.botStore.Get(ctx, orgID, chiefOfStaffBotID); getErr == nil {
 			return nil // lost a seed race; CoS exists — fine

--- a/api/pkg/server/org_graph_seed_test.go
+++ b/api/pkg/server/org_graph_seed_test.go
@@ -5,15 +5,29 @@ import (
 	"testing"
 
 	"github.com/helixml/helix/api/pkg/org/application/bots"
+	"github.com/helixml/helix/api/pkg/org/domain/activation"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
 	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
 )
+
+type seedDispatcher struct {
+	ids           []orgchart.BotID
+	activationIDs []activation.ID
+}
+
+func (d *seedDispatcher) DispatchHire(_ context.Context, _ string, id orgchart.BotID, activationID activation.ID) {
+	d.ids = append(d.ids, id)
+	d.activationIDs = append(d.activationIDs, activationID)
+}
 
 func TestSeedChiefOfStaffPreservesContextForNewBotOnly(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	st := orggorm.GetOrgTestDB(t)
 	deps := mcptools.DefaultDeps(st).Build()
+	dispatcher := &seedDispatcher{}
+	deps.Lifecycle.Dispatcher = dispatcher
 	seeder := &orgGraphSeeder{lifecycle: deps.Lifecycle, bots: deps.Bots, botStore: st.Bots}
 
 	if err := seeder.SeedChiefOfStaff(ctx, "org-new"); err != nil {
@@ -25,6 +39,12 @@ func TestSeedChiefOfStaffPreservesContextForNewBotOnly(t *testing.T) {
 	}
 	if !created.PreserveContext {
 		t.Fatal("new chief of staff must preserve conversation context")
+	}
+	if len(dispatcher.ids) != 1 || dispatcher.ids[0] != chiefOfStaffBotID {
+		t.Fatalf("seed dispatched bots = %v, want [chief-of-staff]", dispatcher.ids)
+	}
+	if len(dispatcher.activationIDs) != 1 || dispatcher.activationIDs[0] == "" {
+		t.Fatalf("seed activation ids = %v, want one non-empty id", dispatcher.activationIDs)
 	}
 
 	if _, err := deps.Bots.Create(ctx, "org-existing", bots.CreateParams{

--- a/api/pkg/server/organization_handlers.go
+++ b/api/pkg/server/organization_handlers.go
@@ -321,17 +321,17 @@ func (apiServer *HelixAPIServer) createOrganization(rw http.ResponseWriter, r *h
 		return
 	}
 
-	// Seed the org graph: represent the creator as a human node and give the
-	// org a Chief of Staff bot. They are peers — no reporting line (humans
-	// stay out of the reporting graph). Best-effort: a failure must not block
-	// org creation (the graph re-converges on later bootstrap).
-	if apiServer.orgSeeder != nil {
-		if err := apiServer.orgSeeder.EnsureHumanNode(ctx, createdOrg.ID, user); err != nil {
-			log.Warn().Err(err).Str("org_id", createdOrg.ID).Msg("seed creator human node failed")
+	// Bootstrap after membership exists so the org service API key is
+	// provisioned before the Chief of Staff is seeded and activated.
+	bootstrapped := false
+	if apiServer.helixOrg != nil && apiServer.helixOrg.scope != nil {
+		if err := apiServer.helixOrg.scope.ensureBootstrap(ctx, createdOrg.ID); err != nil {
+			log.Warn().Err(err).Str("org_id", createdOrg.ID).Msg("bootstrap new org graph failed")
+		} else {
+			bootstrapped = true
 		}
-		if err := apiServer.orgSeeder.SeedChiefOfStaff(ctx, createdOrg.ID); err != nil {
-			log.Warn().Err(err).Str("org_id", createdOrg.ID).Msg("seed chief of staff failed")
-		}
+	}
+	if bootstrapped {
 		// Tell the creator their Chief of Staff is coming online, so a brand-new
 		// org isn't a silent wait while the agent boots before it asks its first
 		// question. Informational (no reply) — best-effort.


### PR DESCRIPTION
## Summary
- activate every newly created bot, including the seeded Chief of Staff
- provision the organization service key before seeding and activation
- remove the obsolete runtime-settings activation sweep
- repair legacy never-activated bots with durable activation records

## Verification
- go test ./pkg/org/application/configregistry ./pkg/org/application/lifecycle ./pkg/org/interfaces/server/api ./pkg/server -count=1
- go build ./pkg/server/...
- deployed to Prime and verified Chief of Staff is Running
- verified API restart and chart navigation do not queue a duplicate activation