### PR TITLE
refactor(org): make agents canonical in org chart

### DIFF
--- a/api/pkg/cli/org/bots.go
+++ b/api/pkg/cli/org/bots.go
@@ -18,9 +18,9 @@ import (
 
 func newBotsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "bots",
-		Short:   "List and manage helix-org bots",
-		Aliases: []string{"bot"},
+		Use:     "agents",
+		Short:   "List and manage helix-org agents",
+		Aliases: []string{"agent", "bots", "bot"},
 	}
 	cmd.AddCommand(newBotsListCmd())
 	cmd.AddCommand(newBotsGetCmd())

--- a/api/pkg/org/application/bots/bots.go
+++ b/api/pkg/org/application/bots/bots.go
@@ -91,6 +91,7 @@ type CreateParams struct {
 	ID              string
 	Name            string
 	Content         string
+	AgentAppID      string
 	Tools           []tool.Name
 	PreserveContext bool
 	// Kind, HelixUserID, Identity create a human placeholder when Kind ==
@@ -131,6 +132,9 @@ func (s *Bots) Create(ctx context.Context, orgID string, p CreateParams) (orgcha
 	if p.Name != "" {
 		bot = bot.WithName(p.Name)
 	}
+	if p.AgentAppID != "" {
+		bot = bot.WithAgentAppID(p.AgentAppID)
+	}
 	if p.PreserveContext {
 		bot = bot.WithPreserveContext(true)
 	}
@@ -153,6 +157,7 @@ func (s *Bots) Create(ctx context.Context, orgID string, p CreateParams) (orgcha
 // leaves the corresponding field unchanged — this is what preserves
 // Tools on a content-only update.
 type UpdateParams struct {
+	AgentAppID      *string
 	Name            *string
 	Content         *string
 	Tools           *[]tool.Name
@@ -172,6 +177,9 @@ func (s *Bots) Update(ctx context.Context, orgID string, id orgchart.BotID, p Up
 		return orgchart.Bot{}, err
 	}
 	updated := existing
+	if p.AgentAppID != nil {
+		updated = updated.WithAgentAppID(*p.AgentAppID)
+	}
 	if p.Name != nil {
 		updated = updated.WithName(*p.Name)
 	}

--- a/api/pkg/org/application/configregistry/default_agent.go
+++ b/api/pkg/org/application/configregistry/default_agent.go
@@ -22,3 +22,24 @@ func (r *Registry) GetDefaultAgentConfig(ctx context.Context, orgID string) (typ
 	cfg.Model, _ = r.GetString(ctx, orgID, "worker.model")
 	return cfg, nil
 }
+
+func (r *Registry) IsDefaultAgentConfigured(ctx context.Context, orgID string) bool {
+	return r.IsConfigured(ctx, orgID, DefaultAgentConfigKey) || r.IsConfigured(ctx, orgID, "worker.runtime")
+}
+
+func (r *Registry) IsDefaultAgentConfigComplete(ctx context.Context, orgID string) bool {
+	if !r.IsDefaultAgentConfigured(ctx, orgID) {
+		return false
+	}
+	cfg, err := r.GetDefaultAgentConfig(ctx, orgID)
+	if err != nil || cfg.CodeAgentRuntime == "" {
+		return false
+	}
+	credentials := cfg.CodeAgentCredentialType
+	if cfg.CodeAgentRuntime != types.CodeAgentRuntimeClaudeCode && cfg.CodeAgentRuntime != types.CodeAgentRuntimeCodexCLI {
+		credentials = types.CodeAgentCredentialTypeAPIKey
+	} else if credentials == "" {
+		credentials = types.CodeAgentCredentialTypeSubscription
+	}
+	return credentials == types.CodeAgentCredentialTypeSubscription || (cfg.Provider != "" && cfg.Model != "")
+}

--- a/api/pkg/org/application/lifecycle/agent_links_test.go
+++ b/api/pkg/org/application/lifecycle/agent_links_test.go
@@ -1,0 +1,292 @@
+package lifecycle_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/helixml/helix/api/pkg/org/application/bots"
+	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
+	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
+)
+
+type lifecycleRuntime struct {
+	store            *store.Store
+	projectErr       error
+	linkedErr        error
+	deleteAppErr     error
+	projectDeleted   bool
+	deletedApps      []string
+	cleanupCancelled bool
+	linkedCancelled  bool
+}
+
+func (r *lifecycleRuntime) DeleteProject(context.Context, string) error {
+	if r.projectDeleted {
+		return runtimehelix.ErrProjectNotFound
+	}
+	if r.projectErr == nil {
+		r.projectDeleted = true
+	}
+	return r.projectErr
+}
+
+func (r *lifecycleRuntime) DeleteApp(ctx context.Context, id string) error {
+	r.cleanupCancelled = ctx.Err() != nil
+	r.deletedApps = append(r.deletedApps, id)
+	return r.deleteAppErr
+}
+
+func (r *lifecycleRuntime) DeleteLinkedAgent(ctx context.Context, orgID string, botID orgchart.BotID, appID string) error {
+	r.linkedCancelled = ctx.Err() != nil
+	if r.linkedErr != nil {
+		return r.linkedErr
+	}
+	if r.store == nil {
+		return nil
+	}
+	if r.store.BotRuntimeState != nil {
+		if err := r.store.BotRuntimeState.Clear(ctx, orgID, botID, runtimehelix.Backend); err != nil {
+			return err
+		}
+	}
+	return r.store.Bots.Delete(ctx, orgID, botID)
+}
+
+type fixedAgentCreator struct {
+	id string
+}
+
+func (c fixedAgentCreator) CreateAgent(context.Context, string, string, string) (string, error) {
+	return c.id, nil
+}
+
+type cancellingReconciler struct {
+	cancel context.CancelFunc
+}
+
+func (r cancellingReconciler) Reconcile(context.Context, string, ...orgchart.BotID) error {
+	r.cancel()
+	return errors.New("reconcile failed")
+}
+
+type losingClaimBots struct {
+	store.Bots
+	winner string
+}
+
+type failingClaimBots struct {
+	store.Bots
+	err error
+}
+
+func (b failingClaimBots) ClaimAgentApp(context.Context, string, orgchart.BotID, string) (bool, error) {
+	return false, b.err
+}
+
+func (b losingClaimBots) ClaimAgentApp(ctx context.Context, orgID string, id orgchart.BotID, _ string) (bool, error) {
+	current, err := b.Bots.Get(ctx, orgID, id)
+	if err != nil {
+		return false, err
+	}
+	if err := b.Bots.Update(ctx, current.WithAgentAppID(b.winner)); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+func TestReconcileAgentLinksPreservesReplicaWinner(t *testing.T) {
+	st := memory.New()
+	ctx := context.Background()
+	bot, err := orgchart.NewBot("b-agent", "instructions", nil, time.Now().UTC(), "org-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Bots.Create(ctx, bot); err != nil {
+		t.Fatal(err)
+	}
+	copyStore := *st
+	copyStore.Bots = losingClaimBots{Bots: st.Bots, winner: "app-winner"}
+	runtime := &lifecycleRuntime{}
+	svc := &lifecycle.Service{
+		Store:  &copyStore,
+		Agents: fixedAgentCreator{id: "app-loser"},
+		Helix:  runtime,
+		Bots: bots.New(bots.Deps{
+			Bots:  copyStore.Bots,
+			Now:   func() time.Time { return time.Now().UTC() },
+			NewID: func() string { return "unused" },
+		}),
+	}
+
+	if err := svc.ReconcileAgentLinks(ctx, "org-test"); err != nil {
+		t.Fatalf("reconcile links: %v", err)
+	}
+	got, err := st.Bots.Get(ctx, "org-test", bot.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentAppID != "app-winner" {
+		t.Fatalf("winner = %q", got.AgentAppID)
+	}
+	if len(runtime.deletedApps) != 1 || runtime.deletedApps[0] != "app-loser" {
+		t.Fatalf("discarded apps = %v", runtime.deletedApps)
+	}
+}
+
+func TestReconcileAgentLinksReportsClaimAndCleanupFailures(t *testing.T) {
+	st := memory.New()
+	ctx := context.Background()
+	bot, err := orgchart.NewBot("b-agent", "instructions", nil, time.Now().UTC(), "org-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Bots.Create(ctx, bot); err != nil {
+		t.Fatal(err)
+	}
+	copyStore := *st
+	copyStore.Bots = failingClaimBots{Bots: st.Bots, err: errors.New("claim failed")}
+	runtime := &lifecycleRuntime{deleteAppErr: errors.New("cleanup failed")}
+	svc := &lifecycle.Service{
+		Store:  &copyStore,
+		Agents: fixedAgentCreator{id: "app-unlinked"},
+		Helix:  runtime,
+		Bots: bots.New(bots.Deps{
+			Bots:  copyStore.Bots,
+			Now:   func() time.Time { return time.Now().UTC() },
+			NewID: func() string { return "unused" },
+		}),
+	}
+
+	err = svc.ReconcileAgentLinks(ctx, "org-test")
+	if err == nil || !strings.Contains(err.Error(), "claim failed") || !strings.Contains(err.Error(), "cleanup failed") {
+		t.Fatalf("reconcile error = %v", err)
+	}
+}
+
+func TestDeleteFailuresPreserveGraphAnchorAndRetry(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		projectErr error
+		linkedErr  error
+	}{
+		{name: "project", projectErr: errors.New("project delete failed")},
+		{name: "app", linkedErr: errors.New("app delete failed")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := memory.New()
+			ctx := context.Background()
+			bot, err := orgchart.NewBot("b-agent", "instructions", nil, time.Now().UTC(), "org-test")
+			if err != nil {
+				t.Fatal(err)
+			}
+			bot = bot.WithAgentAppID("app-agent")
+			if err := st.Bots.Create(ctx, bot); err != nil {
+				t.Fatal(err)
+			}
+			if err := runtimehelix.SaveProject(ctx, st, "org-test", bot.ID, "project-agent", "app-agent", "repo-agent"); err != nil {
+				t.Fatal(err)
+			}
+			runtime := &lifecycleRuntime{store: st, projectErr: tc.projectErr, linkedErr: tc.linkedErr}
+			svc := &lifecycle.Service{Store: st, Helix: runtime}
+
+			if err := svc.Delete(ctx, "org-test", bot.ID); err == nil {
+				t.Fatal("delete succeeded despite runtime failure")
+			}
+			got, err := st.Bots.Get(ctx, "org-test", bot.ID)
+			if err != nil {
+				t.Fatalf("graph anchor removed: %v", err)
+			}
+			if got.AgentAppID != "app-agent" {
+				t.Fatalf("graph link = %q", got.AgentAppID)
+			}
+			state, err := runtimehelix.LoadState(ctx, st, "org-test", bot.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if state.ProjectID != "project-agent" || state.AgentAppID != "app-agent" {
+				t.Fatalf("runtime state changed: %+v", state)
+			}
+
+			runtime.projectErr = nil
+			runtime.linkedErr = nil
+			if err := svc.Delete(ctx, "org-test", bot.ID); err != nil {
+				t.Fatalf("retry delete: %v", err)
+			}
+			recreated := bot.WithAgentAppID("app-recreated")
+			if err := st.Bots.Create(ctx, recreated); err != nil {
+				t.Fatalf("recreate after delete: %v", err)
+			}
+		})
+	}
+}
+
+func TestCreateCleanupIgnoresCancelledRequestContext(t *testing.T) {
+	st := memory.New()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	existing, err := orgchart.NewBot("b-agent", "existing", nil, time.Now().UTC(), "org-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Bots.Create(context.Background(), existing); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &lifecycleRuntime{}
+	svc := &lifecycle.Service{
+		Store:  st,
+		Helix:  runtime,
+		Agents: fixedAgentCreator{id: "app-cleanup"},
+		Bots: bots.New(bots.Deps{
+			Bots:  st.Bots,
+			Now:   func() time.Time { return time.Now().UTC() },
+			NewID: func() string { return "unused" },
+		}),
+		Now:   func() time.Time { return time.Now().UTC() },
+		NewID: func() string { return "unused" },
+	}
+
+	if _, err := svc.Create(ctx, "org-test", lifecycle.CreateParams{ID: "b-agent", Content: "new"}); err == nil {
+		t.Fatal("duplicate create succeeded")
+	}
+	if runtime.cleanupCancelled {
+		t.Fatal("App cleanup inherited cancelled request context")
+	}
+	if len(runtime.deletedApps) != 1 || runtime.deletedApps[0] != "app-cleanup" {
+		t.Fatalf("cleaned apps = %v", runtime.deletedApps)
+	}
+}
+
+func TestCreateRollbackIgnoresCancelledRequestContext(t *testing.T) {
+	st := memory.New()
+	ctx, cancel := context.WithCancel(context.Background())
+	runtime := &lifecycleRuntime{store: st}
+	svc := &lifecycle.Service{
+		Store:          st,
+		Helix:          runtime,
+		Agents:         fixedAgentCreator{id: "app-cleanup"},
+		BotReconcilers: []lifecycle.BotReconciler{cancellingReconciler{cancel: cancel}},
+		Bots: bots.New(bots.Deps{
+			Bots:  st.Bots,
+			Now:   func() time.Time { return time.Now().UTC() },
+			NewID: func() string { return "unused" },
+		}),
+		Now:   func() time.Time { return time.Now().UTC() },
+		NewID: func() string { return "unused" },
+	}
+
+	if _, err := svc.Create(ctx, "org-test", lifecycle.CreateParams{ID: "b-agent", Content: "new"}); err == nil {
+		t.Fatal("create succeeded despite reconcile failure")
+	}
+	if runtime.linkedCancelled {
+		t.Fatal("lifecycle rollback inherited cancelled request context")
+	}
+	if _, err := st.Bots.Get(context.Background(), "org-test", "b-agent"); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("rolled back bot still exists: %v", err)
+	}
+}

--- a/api/pkg/org/application/lifecycle/hire_test.go
+++ b/api/pkg/org/application/lifecycle/hire_test.go
@@ -2,6 +2,7 @@ package lifecycle_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -15,6 +16,18 @@ import (
 )
 
 func hireClock() time.Time { return time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC) }
+
+type fakeAgentCreator struct{}
+
+func (fakeAgentCreator) CreateAgent(context.Context, string, string, string) (string, error) {
+	return "app-agent", nil
+}
+
+type failingBotReconciler struct{}
+
+func (failingBotReconciler) Reconcile(context.Context, string, ...orgchart.BotID) error {
+	return errors.New("reconcile failed")
+}
 
 // newHireService builds a lifecycle.Service wired only for Create (the
 // create half) against the in-memory store. Delete-only collaborators
@@ -33,6 +46,7 @@ func newHireService(st *store.Store) *lifecycle.Service {
 	return &lifecycle.Service{
 		Store:          st,
 		Bots:           botSvc,
+		Agents:         fakeAgentCreator{},
 		BotReconcilers: []lifecycle.BotReconciler{rec},
 		Now:            hireClock,
 		NewID:          func() string { return "id" },
@@ -61,6 +75,9 @@ func TestCreate_CreatesBotAndReconciles(t *testing.T) {
 	}
 	if res.Bot.ID != "w-new" {
 		t.Fatalf("bot id = %q", res.Bot.ID)
+	}
+	if res.Bot.AgentAppID != "app-agent" {
+		t.Fatalf("agent app id = %q, want app-agent", res.Bot.AgentAppID)
 	}
 	if _, err := st.Bots.Get(ctx, "org-test", "w-new"); err != nil {
 		t.Fatalf("bot not persisted: %v", err)
@@ -138,6 +155,22 @@ func TestCreate_UnknownParent(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Create with unknown parent: want error")
+	}
+}
+
+func TestCreate_RollsBackBotWhenReconcileFails(t *testing.T) {
+	t.Parallel()
+	st := memory.New()
+	svc := newHireService(st)
+	svc.BotReconcilers = []lifecycle.BotReconciler{failingBotReconciler{}}
+
+	_, err := svc.Create(context.Background(), "org-test", lifecycle.CreateParams{ID: "w-new", Content: "x"})
+
+	if err == nil {
+		t.Fatal("Create: want error")
+	}
+	if _, err := st.Bots.Get(context.Background(), "org-test", "w-new"); err == nil {
+		t.Fatal("failed create left bot row")
 	}
 }
 

--- a/api/pkg/org/application/lifecycle/hire_test.go
+++ b/api/pkg/org/application/lifecycle/hire_test.go
@@ -202,3 +202,31 @@ func TestCreate_AlwaysDispatchesActivation(t *testing.T) {
 		t.Fatalf("create should dispatch exactly one hire, got %d", disp.hires)
 	}
 }
+
+func TestCreate_DeferredDoesNotCreateOrDispatchActivation(t *testing.T) {
+	t.Parallel()
+	st := memory.New()
+	svc := newHireService(st)
+	disp := &recordingDispatcher{}
+	svc.Dispatcher = disp
+
+	res, err := svc.Create(context.Background(), "org-test", lifecycle.CreateParams{
+		ID: "w-new", Content: "x", DeferActivation: true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if res.ActivationID != "" {
+		t.Fatalf("deferred create activation = %q, want empty", res.ActivationID)
+	}
+	if disp.hires != 0 {
+		t.Fatalf("deferred create dispatched %d hires", disp.hires)
+	}
+	rows, err := st.Activations.ListForWorker(context.Background(), "org-test", res.Bot.ID, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("deferred activation rows = %v, want none", rows)
+	}
+}

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -152,6 +152,10 @@ type CreateParams struct {
 	Topics          []streaming.TopicID
 	ParentID        orgchart.BotID
 	PreserveContext bool
+	// DeferActivation creates the Agent and org topology without starting
+	// its runtime. Settings activation provisions it after the org default
+	// runtime is configured.
+	DeferActivation bool
 }
 
 // CreateResult carries the new Bot and the pre-allocated
@@ -291,6 +295,10 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 		if err := s.HireHook.OnHire(ctx, orgID, id, uid); err != nil {
 			return rollback(fmt.Errorf("create handler: %w", err))
 		}
+	}
+
+	if p.DeferActivation {
+		return CreateResult{Bot: bot}, nil
 	}
 
 	// Pre-create the create-Activation audit row so Create can return the

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/helixml/helix/api/pkg/org/application/bots"
@@ -52,6 +53,15 @@ type TopicSubscriber interface {
 type HelixRuntime interface {
 	DeleteProject(ctx context.Context, id string) error
 	DeleteApp(ctx context.Context, id string) error
+	DeleteLinkedAgent(ctx context.Context, orgID string, botID orgchart.BotID, appID string) error
+}
+
+type AgentCreator interface {
+	CreateAgent(ctx context.Context, orgID, name, instructions string) (string, error)
+}
+
+func cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 }
 
 // The lifecycle runs two kinds of reconciler after a structural change, and
@@ -85,6 +95,7 @@ type OrgReconciler interface {
 type Service struct {
 	Store  *store.Store
 	Helix  HelixRuntime
+	Agents AgentCreator
 	Logger *slog.Logger
 
 	// Bots is the bot-mutation service Create delegates the row creation
@@ -191,26 +202,57 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 		}
 	}
 
+	agentName := strings.TrimSpace(p.Name)
+	if agentName == "" {
+		agentName = strings.TrimSpace(p.ID)
+	}
+	if agentName == "" {
+		agentName = "Agent"
+	}
+	var agentAppID string
+	var err error
+	if s.Agents != nil {
+		agentAppID, err = s.Agents.CreateAgent(ctx, orgID, agentName, p.Content)
+		if err != nil {
+			return CreateResult{}, fmt.Errorf("create agent app: %w", err)
+		}
+	}
 	bot, err := s.Bots.Create(ctx, orgID, bots.CreateParams{
 		ID:              p.ID,
 		Name:            p.Name,
 		Content:         p.Content,
+		AgentAppID:      agentAppID,
 		Tools:           p.Tools,
 		PreserveContext: p.PreserveContext,
 	})
 	if err != nil {
+		if s.Helix != nil && agentAppID != "" {
+			cleanupCtx, cancel := cleanupContext(ctx)
+			defer cancel()
+			if cleanupErr := s.Helix.DeleteApp(cleanupCtx, agentAppID); cleanupErr != nil && !errors.Is(cleanupErr, helix.ErrProjectNotFound) {
+				return CreateResult{}, fmt.Errorf("%w; delete agent app: %v", err, cleanupErr)
+			}
+		}
 		return CreateResult{}, err
 	}
 	id := bot.ID
+	rollback := func(createErr error) (CreateResult, error) {
+		cleanupCtx, cancel := cleanupContext(ctx)
+		defer cancel()
+		if err := s.Delete(cleanupCtx, orgID, id); err != nil {
+			return CreateResult{}, fmt.Errorf("%w; rollback failed: %v", createErr, err)
+		}
+		return CreateResult{}, createErr
+	}
 
 	// Wire the initial reporting line now that both bot rows exist.
 	if parent != nil && s.Store.ReportingLines != nil {
 		line, err := orgchart.NewReportingLine(orgID, *parent, id)
 		if err != nil {
-			return CreateResult{}, err
+			return rollback(err)
 		}
 		if err := s.Store.ReportingLines.Add(ctx, line); err != nil {
-			return CreateResult{}, fmt.Errorf("add reporting line: %w", err)
+			return rollback(fmt.Errorf("add reporting line: %w", err))
 		}
 	}
 
@@ -223,7 +265,7 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 			continue
 		}
 		if err := rec.Reconcile(ctx, orgID, id); err != nil {
-			return CreateResult{}, fmt.Errorf("reconcile topology for bot %q: %w", id, err)
+			return rollback(fmt.Errorf("reconcile topology for bot %q: %w", id, err))
 		}
 	}
 
@@ -234,7 +276,7 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 	// that silently isn't listening is a broken create.
 	if s.Subscriber != nil && len(p.Topics) > 0 {
 		if err := s.Subscriber.SubscribeTopics(ctx, orgID, id, p.Topics); err != nil {
-			return CreateResult{}, fmt.Errorf("subscribe new bot %q to topics: %w", id, err)
+			return rollback(fmt.Errorf("subscribe new bot %q to topics: %w", id, err))
 		}
 	}
 
@@ -247,7 +289,7 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 	// BEFORE dispatch so the Spawner picks it up on its first call.
 	if uid := helix.UserIDFromContext(ctx); uid != "" && s.HireHook != nil {
 		if err := s.HireHook.OnHire(ctx, orgID, id, uid); err != nil {
-			return CreateResult{}, fmt.Errorf("create handler: %w", err)
+			return rollback(fmt.Errorf("create handler: %w", err))
 		}
 	}
 
@@ -260,10 +302,10 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 		actID = activation.ID("a-" + s.NewID())
 		act, err := activation.New(actID, id, []activation.Trigger{{Kind: activation.TriggerHire}}, s.Now(), orgID)
 		if err != nil {
-			return CreateResult{}, fmt.Errorf("build create activation: %w", err)
+			return rollback(fmt.Errorf("build create activation: %w", err))
 		}
 		if err := s.Store.Activations.Create(ctx, act); err != nil {
-			return CreateResult{}, fmt.Errorf("persist create activation: %w", err)
+			return rollback(fmt.Errorf("persist create activation: %w", err))
 		}
 	}
 	if s.Dispatcher != nil {
@@ -273,21 +315,62 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 	return CreateResult{Bot: bot, ActivationID: actID}, nil
 }
 
+func (s *Service) ReconcileAgentLinks(ctx context.Context, orgID string) error {
+	if s.Store == nil || s.Bots == nil || s.Agents == nil {
+		return nil
+	}
+	all, err := s.Store.Bots.List(ctx, orgID)
+	if err != nil {
+		return err
+	}
+	for _, bot := range all {
+		if bot.IsHuman() || bot.AgentAppID != "" {
+			continue
+		}
+		name := bot.Name
+		if name == "" {
+			name = string(bot.ID)
+		}
+		appID, err := s.Agents.CreateAgent(ctx, orgID, name, bot.Content)
+		if err != nil {
+			return fmt.Errorf("create agent app for %s: %w", bot.ID, err)
+		}
+		claimed, err := s.Store.Bots.ClaimAgentApp(ctx, orgID, bot.ID, appID)
+		if err != nil {
+			if s.Helix != nil {
+				cleanupCtx, cancel := cleanupContext(ctx)
+				cleanupErr := s.Helix.DeleteApp(cleanupCtx, appID)
+				cancel()
+				if cleanupErr != nil && !errors.Is(cleanupErr, helix.ErrProjectNotFound) {
+					return fmt.Errorf("link agent app for %s: %v; delete unlinked agent app %s: %w", bot.ID, err, appID, cleanupErr)
+				}
+			}
+			return fmt.Errorf("link agent app for %s: %w", bot.ID, err)
+		}
+		if !claimed {
+			if s.Helix != nil {
+				cleanupCtx, cancel := cleanupContext(ctx)
+				cleanupErr := s.Helix.DeleteApp(cleanupCtx, appID)
+				cancel()
+				if cleanupErr != nil && !errors.Is(cleanupErr, helix.ErrProjectNotFound) {
+					return fmt.Errorf("discard losing agent app %s: %w", appID, cleanupErr)
+				}
+			}
+			continue
+		}
+	}
+	return nil
+}
+
 // Delete tears down a Bot end-to-end:
 //
 //  1. Read the Helix-runtime state (project + app IDs) before clearing.
 //  2. DeleteProject on Helix — stops any active sessions.
-//  3. DeleteApp on Helix — removes the auto-provisioned agent app.
-//  4. Clear the BotRuntimeState sidecar.
-//  5. Delete the bot row (its subscriptions cascade with it; the
-//     org_reporting_lines ON DELETE CASCADE foreign keys drop its lines).
-//  6. Reconcile topology: tear down the deleted Bot's own activation +
+//  3. Atomically delete the agent app, BotRuntimeState, subscriptions, and
+//     bot row. The org_reporting_lines foreign keys drop its lines.
+//  4. Reconcile topology: tear down the deleted Bot's own activation +
 //     team Topics and collapse any ex-manager's team Topic that just
 //     lost its last report.
-//
-// Steps 2/3/6 are best-effort and logged on failure — a half-torn bot is
-// better than refusing to clean up partial state. Step 5 is the only step
-// whose error propagates (the row is the user-visible source of truth).
 //
 // Subscriptions are bot-anchored, so they die with the bot. Activation
 // events themselves are intentionally left behind as an audit trail; only
@@ -299,7 +382,8 @@ func (s *Service) Delete(ctx context.Context, orgID string, id orgchart.BotID) e
 	if s.Store == nil {
 		return errors.New("lifecycle: store is nil")
 	}
-	if _, err := s.Store.Bots.Get(ctx, orgID, id); err != nil {
+	bot, err := s.Store.Bots.Get(ctx, orgID, id)
+	if err != nil {
 		return fmt.Errorf("get bot %q: %w", id, err)
 	}
 
@@ -319,33 +403,32 @@ func (s *Service) Delete(ctx context.Context, orgID string, id orgchart.BotID) e
 
 	state, _ := helix.LoadState(ctx, s.Store, orgID, id)
 
-	if s.Mirror != nil {
-		s.Mirror.Stop(orgID, id)
-	}
-
 	if s.Helix != nil && state.ProjectID != "" {
 		if err := s.Helix.DeleteProject(ctx, state.ProjectID); err != nil && !errors.Is(err, helix.ErrProjectNotFound) {
-			s.logger().Warn("delete: delete helix project", "bot", id, "project", state.ProjectID, "err", err)
-		}
-	}
-	if s.Helix != nil && state.AgentAppID != "" {
-		if err := s.Helix.DeleteApp(ctx, state.AgentAppID); err != nil && !errors.Is(err, helix.ErrProjectNotFound) {
-			s.logger().Warn("delete: delete helix app", "bot", id, "app", state.AgentAppID, "err", err)
-		}
-	}
-	if s.Store.BotRuntimeState != nil {
-		if err := s.Store.BotRuntimeState.Clear(ctx, orgID, id, helix.Backend); err != nil {
-			s.logger().Warn("delete: clear runtime state", "bot", id, "err", err)
+			return fmt.Errorf("delete helix project %s: %w", state.ProjectID, err)
 		}
 	}
 
-	// The bot's subscriptions and every reporting line that references it
-	// are cascaded structurally when the bot row is deleted below
-	// (Bots.Delete drops the subs; the org_reporting_lines ON DELETE
-	// CASCADE foreign keys drop the lines). Nothing to drop explicitly.
-
-	if err := s.Store.Bots.Delete(ctx, orgID, id); err != nil {
-		return fmt.Errorf("delete bot row %q: %w", id, err)
+	agentAppID := bot.AgentAppID
+	if agentAppID == "" {
+		agentAppID = state.AgentAppID
+	}
+	if s.Helix != nil && agentAppID != "" {
+		if err := s.Helix.DeleteLinkedAgent(ctx, orgID, id, agentAppID); err != nil {
+			return fmt.Errorf("delete linked agent %s: %w", agentAppID, err)
+		}
+	} else {
+		if s.Store.BotRuntimeState != nil {
+			if err := s.Store.BotRuntimeState.Clear(ctx, orgID, id, helix.Backend); err != nil {
+				return fmt.Errorf("clear runtime state: %w", err)
+			}
+		}
+		if err := s.Store.Bots.Delete(ctx, orgID, id); err != nil {
+			return fmt.Errorf("delete bot row %q: %w", id, err)
+		}
+	}
+	if s.Mirror != nil {
+		s.Mirror.Stop(orgID, id)
 	}
 
 	// Settle the activation/team Topics now that the row (and its reporting

--- a/api/pkg/org/domain/orgchart/bot.go
+++ b/api/pkg/org/domain/orgchart/bot.go
@@ -56,6 +56,9 @@ const BotKindHuman BotKind = "human"
 type Bot struct {
 	ID             BotID
 	OrganizationID string
+	// AgentAppID is the canonical Helix Agent App backing this org node.
+	// It is required for agent nodes and empty for human placeholders.
+	AgentAppID string
 	// Name is the human-readable display label (e.g. "Chief of Staff").
 	// Free text, may be empty — the UI falls back to ID. Distinct from
 	// ID, which is the immutable handle.
@@ -120,6 +123,12 @@ func NewBot(id BotID, content string, tools []tool.Name, now time.Time, orgID st
 // replaced.
 func (b Bot) WithName(name string) Bot {
 	b.Name = name
+	return b
+}
+
+// WithAgentAppID returns a copy of the Bot linked to the canonical Agent App.
+func (b Bot) WithAgentAppID(agentAppID string) Bot {
+	b.AgentAppID = agentAppID
 	return b
 }
 

--- a/api/pkg/org/domain/store/store.go
+++ b/api/pkg/org/domain/store/store.go
@@ -50,6 +50,7 @@ type Bots interface {
 	Get(ctx context.Context, orgID string, id orgchart.BotID) (orgchart.Bot, error)
 	List(ctx context.Context, orgID string) ([]orgchart.Bot, error)
 	Update(ctx context.Context, bot orgchart.Bot) error
+	ClaimAgentApp(ctx context.Context, orgID string, id orgchart.BotID, appID string) (bool, error)
 	Delete(ctx context.Context, orgID string, id orgchart.BotID) error
 }
 

--- a/api/pkg/org/infrastructure/persistence/gorm/agent_app_migration_test.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/agent_app_migration_test.go
@@ -29,17 +29,21 @@ func TestBackfillAgentAppLinksRequiresSameOrganization(t *testing.T) {
 		)`,
 		`CREATE TABLE apps (
 			id TEXT PRIMARY KEY,
-			organization_id TEXT NOT NULL
+			organization_id TEXT NOT NULL,
+			config JSON NOT NULL
 		)`,
-		`INSERT INTO apps (id, organization_id) VALUES
-			('app-same-org', 'org-test'),
-			('app-other-org', 'org-other')`,
+		`INSERT INTO apps (id, organization_id, config) VALUES
+			('app-same-org', 'org-test', '{"helix":{"assistants":[{"name":"Agent"}]}}'),
+			('app-other-org', 'org-other', '{"helix":{"assistants":[{"name":"Agent"}]}}'),
+			('app-multiple', 'org-test', '{"helix":{"assistants":[{},{}]}}')`,
 		`INSERT INTO org_bots (org_id, id, kind) VALUES
 			('org-test', 'b-same-org', ''),
-			('org-test', 'b-other-org', '')`,
+			('org-test', 'b-other-org', ''),
+			('org-test', 'b-multiple', '')`,
 		`INSERT INTO org_bot_runtime_state (org_id, bot_id, backend, key, value) VALUES
 			('org-test', 'b-same-org', 'helix', 'agent_app_id', 'app-same-org'),
-			('org-test', 'b-other-org', 'helix', 'agent_app_id', 'app-other-org')`,
+			('org-test', 'b-other-org', 'helix', 'agent_app_id', 'app-other-org'),
+			('org-test', 'b-multiple', 'helix', 'agent_app_id', 'app-multiple')`,
 	} {
 		if err := db.Exec(statement).Error; err != nil {
 			t.Fatalf("seed migration fixture: %v", err)
@@ -50,7 +54,7 @@ func TestBackfillAgentAppLinksRequiresSameOrganization(t *testing.T) {
 		t.Fatalf("backfill agent links: %v", err)
 	}
 
-	var sameOrg, otherOrg struct {
+	var sameOrg, otherOrg, multiple struct {
 		AgentAppID *string
 	}
 	if err := db.Table("org_bots").Where("id = ?", "b-same-org").First(&sameOrg).Error; err != nil {
@@ -59,11 +63,17 @@ func TestBackfillAgentAppLinksRequiresSameOrganization(t *testing.T) {
 	if err := db.Table("org_bots").Where("id = ?", "b-other-org").First(&otherOrg).Error; err != nil {
 		t.Fatalf("read cross-org bot: %v", err)
 	}
+	if err := db.Table("org_bots").Where("id = ?", "b-multiple").First(&multiple).Error; err != nil {
+		t.Fatalf("read multiple-assistant bot: %v", err)
+	}
 	if sameOrg.AgentAppID == nil || *sameOrg.AgentAppID != "app-same-org" {
 		t.Fatalf("same-org link = %v", sameOrg.AgentAppID)
 	}
 	if otherOrg.AgentAppID != nil {
 		t.Fatalf("cross-org link was backfilled: %q", *otherOrg.AgentAppID)
+	}
+	if multiple.AgentAppID != nil {
+		t.Fatalf("multiple-assistant app was backfilled: %q", *multiple.AgentAppID)
 	}
 }
 
@@ -87,7 +97,8 @@ func TestBackfillProjectAgentAppsUpdatesProjectInPlace(t *testing.T) {
 		)`,
 		`CREATE TABLE apps (
 			id TEXT PRIMARY KEY,
-			organization_id TEXT NOT NULL
+			organization_id TEXT NOT NULL,
+			config JSON NOT NULL
 		)`,
 		`CREATE TABLE projects (
 			id TEXT PRIMARY KEY,
@@ -100,16 +111,18 @@ func TestBackfillProjectAgentAppsUpdatesProjectInPlace(t *testing.T) {
 			id TEXT PRIMARY KEY,
 			project_id TEXT NOT NULL
 		)`,
-		`INSERT INTO apps (id, organization_id) VALUES
-			('app-canonical', 'org-test'),
-			('app-cross-org', 'org-other'),
-			('app-conflict-a', 'org-test'),
-			('app-conflict-b', 'org-test')`,
+		`INSERT INTO apps (id, organization_id, config) VALUES
+			('app-canonical', 'org-test', '{"helix":{"assistants":[{"name":"Agent"}]}}'),
+			('app-cross-org', 'org-other', '{"helix":{"assistants":[{"name":"Agent"}]}}'),
+			('app-cross-project', 'org-test', '{"helix":{"assistants":[{"name":"Agent"}]}}'),
+			('app-deleted', 'org-test', '{"helix":{"assistants":[{"name":"Agent"}]}}'),
+			('app-conflict-a', 'org-test', '{"helix":{"assistants":[{"name":"Agent"}]}}'),
+			('app-conflict-b', 'org-test', '{"helix":{"assistants":[{"name":"Agent"}]}}')`,
 		`INSERT INTO org_bots (org_id, id, agent_app_id) VALUES
 			('org-test', 'b-agent', 'app-canonical'),
 			('org-test', 'b-cross-app', 'app-cross-org'),
-			('org-test', 'b-cross-project', 'app-canonical'),
-			('org-test', 'b-deleted', 'app-canonical'),
+			('org-test', 'b-cross-project', 'app-cross-project'),
+			('org-test', 'b-deleted', 'app-deleted'),
 			('org-test', 'b-conflict-a', 'app-conflict-a'),
 			('org-test', 'b-conflict-b', 'app-conflict-b')`,
 		`INSERT INTO org_bot_runtime_state (org_id, bot_id, backend, key, value)
@@ -214,5 +227,115 @@ func TestBackfillProjectAgentAppsUpdatesProjectInPlace(t *testing.T) {
 		if got.DefaultHelixAppID != wantAppID {
 			t.Fatalf("%s default app = %q, want unchanged %q", projectID, got.DefaultHelixAppID, wantAppID)
 		}
+	}
+}
+
+func TestBackfillProjectAgentAppsPreservesExplicitDefaultAndConvergesLinks(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	for _, statement := range []string{
+		`CREATE TABLE org_bots (
+			org_id TEXT NOT NULL,
+			id TEXT NOT NULL,
+			agent_app_id TEXT
+		)`,
+		`CREATE TABLE org_bot_runtime_state (
+			org_id TEXT NOT NULL,
+			bot_id TEXT NOT NULL,
+			backend TEXT NOT NULL,
+			key TEXT NOT NULL,
+			value TEXT NOT NULL,
+			updated_at DATETIME,
+			PRIMARY KEY (org_id, bot_id, backend, key)
+		)`,
+		`CREATE TABLE apps (
+			id TEXT PRIMARY KEY,
+			organization_id TEXT NOT NULL,
+			config JSON NOT NULL
+		)`,
+		`CREATE TABLE projects (
+			id TEXT PRIMARY KEY,
+			organization_id TEXT NOT NULL,
+			default_helix_app_id TEXT,
+			deleted_at DATETIME
+		)`,
+		`INSERT INTO apps (id, organization_id, config) VALUES
+			('app-explicit', 'org-test', '{"helix":{"assistants":[{"name":"Explicit"}]}}'),
+			('app-new', 'org-test', '{"helix":{"assistants":[{"name":"New"}]}}'),
+			('app-claimed', 'org-test', '{"helix":{"assistants":[{"name":"Claimed"}]}}'),
+			('app-target', 'org-test', '{"helix":{"assistants":[{"name":"Target"}]}}')`,
+		`INSERT INTO org_bots (org_id, id, agent_app_id)
+		 VALUES
+			('org-test', 'b-agent', 'app-new'),
+			('org-test', 'b-claimed-owner', 'app-claimed'),
+			('org-test', 'b-target', 'app-target'),
+			('org-test', 'b-ambiguous-linked', 'app-new'),
+			('org-test', 'b-ambiguous-empty', NULL)`,
+		`INSERT INTO org_bot_runtime_state (org_id, bot_id, backend, key, value) VALUES
+			('org-test', 'b-agent', 'helix', 'project_id', 'project-agent'),
+			('org-test', 'b-agent', 'helix', 'agent_app_id', 'app-legacy'),
+			('org-test', 'b-target', 'helix', 'project_id', 'project-claimed'),
+			('org-test', 'b-target', 'helix', 'agent_app_id', 'app-legacy-target'),
+			('org-test', 'b-ambiguous-linked', 'helix', 'project_id', 'project-ambiguous'),
+			('org-test', 'b-ambiguous-empty', 'helix', 'project_id', 'project-ambiguous')`,
+		`INSERT INTO projects (id, organization_id, default_helix_app_id, deleted_at)
+		 VALUES
+			('project-agent', 'org-test', 'app-explicit', NULL),
+			('project-claimed', 'org-test', 'app-claimed', NULL),
+			('project-ambiguous', 'org-test', '', NULL)`,
+	} {
+		if err := db.Exec(statement).Error; err != nil {
+			t.Fatalf("seed migration fixture: %v", err)
+		}
+	}
+
+	if err := backfillProjectAgentApps(db); err != nil {
+		t.Fatalf("backfill project agent apps: %v", err)
+	}
+
+	var project struct{ DefaultHelixAppID string }
+	if err := db.Table("projects").Where("id = ?", "project-agent").First(&project).Error; err != nil {
+		t.Fatal(err)
+	}
+	if project.DefaultHelixAppID != "app-explicit" {
+		t.Fatalf("project default = %q, want app-explicit", project.DefaultHelixAppID)
+	}
+	var bot struct{ AgentAppID string }
+	if err := db.Table("org_bots").Where("id = ?", "b-agent").First(&bot).Error; err != nil {
+		t.Fatal(err)
+	}
+	if bot.AgentAppID != "app-explicit" {
+		t.Fatalf("bot app = %q, want app-explicit", bot.AgentAppID)
+	}
+	var state struct{ Value string }
+	if err := db.Table("org_bot_runtime_state").
+		Where("bot_id = ? AND key = ?", "b-agent", "agent_app_id").
+		First(&state).Error; err != nil {
+		t.Fatal(err)
+	}
+	if state.Value != "app-explicit" {
+		t.Fatalf("runtime app = %q, want app-explicit", state.Value)
+	}
+
+	if err := db.Table("projects").Where("id = ?", "project-claimed").First(&project).Error; err != nil {
+		t.Fatal(err)
+	}
+	if project.DefaultHelixAppID != "app-target" {
+		t.Fatalf("claimed project default = %q, want app-target", project.DefaultHelixAppID)
+	}
+	if err := db.Table("org_bots").Where("id = ?", "b-target").First(&bot).Error; err != nil {
+		t.Fatal(err)
+	}
+	if bot.AgentAppID != "app-target" {
+		t.Fatalf("target bot app = %q, want app-target", bot.AgentAppID)
+	}
+
+	if err := db.Table("projects").Where("id = ?", "project-ambiguous").First(&project).Error; err != nil {
+		t.Fatal(err)
+	}
+	if project.DefaultHelixAppID != "" {
+		t.Fatalf("ambiguous project default = %q, want unchanged empty default", project.DefaultHelixAppID)
 	}
 }

--- a/api/pkg/org/infrastructure/persistence/gorm/agent_app_migration_test.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/agent_app_migration_test.go
@@ -1,0 +1,218 @@
+package gorm
+
+import (
+	"reflect"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestBackfillAgentAppLinksRequiresSameOrganization(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	for _, statement := range []string{
+		`CREATE TABLE org_bots (
+			org_id TEXT NOT NULL,
+			id TEXT NOT NULL,
+			kind TEXT NOT NULL,
+			agent_app_id TEXT
+		)`,
+		`CREATE TABLE org_bot_runtime_state (
+			org_id TEXT NOT NULL,
+			bot_id TEXT NOT NULL,
+			backend TEXT NOT NULL,
+			key TEXT NOT NULL,
+			value TEXT NOT NULL
+		)`,
+		`CREATE TABLE apps (
+			id TEXT PRIMARY KEY,
+			organization_id TEXT NOT NULL
+		)`,
+		`INSERT INTO apps (id, organization_id) VALUES
+			('app-same-org', 'org-test'),
+			('app-other-org', 'org-other')`,
+		`INSERT INTO org_bots (org_id, id, kind) VALUES
+			('org-test', 'b-same-org', ''),
+			('org-test', 'b-other-org', '')`,
+		`INSERT INTO org_bot_runtime_state (org_id, bot_id, backend, key, value) VALUES
+			('org-test', 'b-same-org', 'helix', 'agent_app_id', 'app-same-org'),
+			('org-test', 'b-other-org', 'helix', 'agent_app_id', 'app-other-org')`,
+	} {
+		if err := db.Exec(statement).Error; err != nil {
+			t.Fatalf("seed migration fixture: %v", err)
+		}
+	}
+
+	if err := backfillAgentAppLinks(db); err != nil {
+		t.Fatalf("backfill agent links: %v", err)
+	}
+
+	var sameOrg, otherOrg struct {
+		AgentAppID *string
+	}
+	if err := db.Table("org_bots").Where("id = ?", "b-same-org").First(&sameOrg).Error; err != nil {
+		t.Fatalf("read same-org bot: %v", err)
+	}
+	if err := db.Table("org_bots").Where("id = ?", "b-other-org").First(&otherOrg).Error; err != nil {
+		t.Fatalf("read cross-org bot: %v", err)
+	}
+	if sameOrg.AgentAppID == nil || *sameOrg.AgentAppID != "app-same-org" {
+		t.Fatalf("same-org link = %v", sameOrg.AgentAppID)
+	}
+	if otherOrg.AgentAppID != nil {
+		t.Fatalf("cross-org link was backfilled: %q", *otherOrg.AgentAppID)
+	}
+}
+
+func TestBackfillProjectAgentAppsUpdatesProjectInPlace(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	for _, statement := range []string{
+		`CREATE TABLE org_bots (
+			org_id TEXT NOT NULL,
+			id TEXT NOT NULL,
+			agent_app_id TEXT
+		)`,
+		`CREATE TABLE org_bot_runtime_state (
+			org_id TEXT NOT NULL,
+			bot_id TEXT NOT NULL,
+			backend TEXT NOT NULL,
+			key TEXT NOT NULL,
+			value TEXT NOT NULL
+		)`,
+		`CREATE TABLE apps (
+			id TEXT PRIMARY KEY,
+			organization_id TEXT NOT NULL
+		)`,
+		`CREATE TABLE projects (
+			id TEXT PRIMARY KEY,
+			organization_id TEXT NOT NULL,
+			default_helix_app_id TEXT,
+			default_repo_id TEXT,
+			deleted_at DATETIME
+		)`,
+		`CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			project_id TEXT NOT NULL
+		)`,
+		`INSERT INTO apps (id, organization_id) VALUES
+			('app-canonical', 'org-test'),
+			('app-cross-org', 'org-other'),
+			('app-conflict-a', 'org-test'),
+			('app-conflict-b', 'org-test')`,
+		`INSERT INTO org_bots (org_id, id, agent_app_id) VALUES
+			('org-test', 'b-agent', 'app-canonical'),
+			('org-test', 'b-cross-app', 'app-cross-org'),
+			('org-test', 'b-cross-project', 'app-canonical'),
+			('org-test', 'b-deleted', 'app-canonical'),
+			('org-test', 'b-conflict-a', 'app-conflict-a'),
+			('org-test', 'b-conflict-b', 'app-conflict-b')`,
+		`INSERT INTO org_bot_runtime_state (org_id, bot_id, backend, key, value)
+		 VALUES
+			('org-test', 'b-agent', 'helix', 'agent_app_id', 'app-canonical'),
+			('org-test', 'b-agent', 'helix', 'project_id', 'project-existing'),
+			('org-test', 'b-cross-app', 'helix', 'project_id', 'project-cross-app'),
+			('org-test', 'b-cross-project', 'helix', 'project_id', 'project-cross-project'),
+			('org-test', 'b-deleted', 'helix', 'project_id', 'project-deleted'),
+			('org-test', 'b-conflict-a', 'helix', 'project_id', 'project-conflict'),
+			('org-test', 'b-conflict-b', 'helix', 'project_id', 'project-conflict')`,
+		`INSERT INTO projects (id, organization_id, default_helix_app_id, default_repo_id, deleted_at)
+		 VALUES
+			('project-existing', 'org-test', 'app-legacy', 'repo-existing', NULL),
+			('project-cross-app', 'org-test', 'app-legacy-cross-app', 'repo-cross-app', NULL),
+			('project-cross-project', 'org-other', 'app-legacy-cross-project', 'repo-cross-project', NULL),
+			('project-deleted', 'org-test', 'app-legacy-deleted', 'repo-deleted', '2026-07-27 00:00:00'),
+			('project-conflict', 'org-test', 'app-legacy-conflict', 'repo-conflict', NULL)`,
+		`INSERT INTO sessions (id, project_id)
+		 VALUES ('session-existing', 'project-existing')`,
+	} {
+		if err := db.Exec(statement).Error; err != nil {
+			t.Fatalf("seed migration fixture: %v", err)
+		}
+	}
+
+	type projectRow struct {
+		ID                string
+		OrganizationID    string
+		DefaultHelixAppID string
+		DefaultRepoID     string
+	}
+	type sessionRow struct {
+		ID        string
+		ProjectID string
+	}
+	type stateRow struct {
+		OrgID   string
+		BotID   string
+		Backend string
+		Key     string
+		Value   string
+	}
+
+	var projectBefore projectRow
+	if err := db.Table("projects").Where("id = ?", "project-existing").First(&projectBefore).Error; err != nil {
+		t.Fatalf("read project before migration: %v", err)
+	}
+	var sessionBefore sessionRow
+	if err := db.Table("sessions").First(&sessionBefore).Error; err != nil {
+		t.Fatalf("read session before migration: %v", err)
+	}
+	var statesBefore []stateRow
+	if err := db.Table("org_bot_runtime_state").Order("bot_id, key, value").Find(&statesBefore).Error; err != nil {
+		t.Fatalf("read runtime state before migration: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		if err := backfillProjectAgentApps(db); err != nil {
+			t.Fatalf("backfill project agent apps pass %d: %v", i+1, err)
+		}
+	}
+
+	var projectAfter projectRow
+	if err := db.Table("projects").Where("id = ?", "project-existing").First(&projectAfter).Error; err != nil {
+		t.Fatalf("read project after migration: %v", err)
+	}
+	var sessionAfter sessionRow
+	if err := db.Table("sessions").First(&sessionAfter).Error; err != nil {
+		t.Fatalf("read session after migration: %v", err)
+	}
+	var statesAfter []stateRow
+	if err := db.Table("org_bot_runtime_state").Order("bot_id, key, value").Find(&statesAfter).Error; err != nil {
+		t.Fatalf("read runtime state after migration: %v", err)
+	}
+
+	if projectAfter.DefaultHelixAppID != "app-canonical" {
+		t.Fatalf("default app = %q, want app-canonical", projectAfter.DefaultHelixAppID)
+	}
+	if projectAfter.ID != projectBefore.ID ||
+		projectAfter.OrganizationID != projectBefore.OrganizationID ||
+		projectAfter.DefaultRepoID != projectBefore.DefaultRepoID {
+		t.Fatalf("project identity changed: before=%+v after=%+v", projectBefore, projectAfter)
+	}
+	if !reflect.DeepEqual(sessionAfter, sessionBefore) {
+		t.Fatalf("session changed: before=%+v after=%+v", sessionBefore, sessionAfter)
+	}
+	if !reflect.DeepEqual(statesAfter, statesBefore) {
+		t.Fatalf("runtime state changed: before=%+v after=%+v", statesBefore, statesAfter)
+	}
+
+	for projectID, wantAppID := range map[string]string{
+		"project-cross-app":     "app-legacy-cross-app",
+		"project-cross-project": "app-legacy-cross-project",
+		"project-deleted":       "app-legacy-deleted",
+		"project-conflict":      "app-legacy-conflict",
+	} {
+		var got projectRow
+		if err := db.Table("projects").Where("id = ?", projectID).First(&got).Error; err != nil {
+			t.Fatalf("read rejected project %s: %v", projectID, err)
+		}
+		if got.DefaultHelixAppID != wantAppID {
+			t.Fatalf("%s default app = %q, want unchanged %q", projectID, got.DefaultHelixAppID, wantAppID)
+		}
+	}
+}

--- a/api/pkg/org/infrastructure/persistence/gorm/bot.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/bot.go
@@ -3,6 +3,7 @@ package gorm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 type botRow struct {
 	ID              string   `gorm:"primaryKey;type:text"`
 	OrgID           string   `gorm:"primaryKey;type:text;index"`
+	AgentAppID      *string  `gorm:"type:text;index"`
 	Name            string   `gorm:"not null;default:''"`
 	Content         string   `gorm:"not null"`
 	Tools           []string `gorm:"serializer:json"`
@@ -53,9 +55,14 @@ func (botMapper) ToRow(b orgchart.Bot) (botRow, error) {
 	if len(tools) == 0 {
 		tools = nil
 	}
+	var agentAppID *string
+	if b.AgentAppID != "" {
+		agentAppID = &b.AgentAppID
+	}
 	return botRow{
 		ID:              string(b.ID),
 		OrgID:           b.OrganizationID,
+		AgentAppID:      agentAppID,
 		Name:            b.Name,
 		Content:         b.Content,
 		Tools:           tools,
@@ -77,9 +84,14 @@ func (botMapper) ToDomain(row botRow) (orgchart.Bot, error) {
 			tools = append(tools, tool.Name(t))
 		}
 	}
+	var agentAppID string
+	if row.AgentAppID != nil {
+		agentAppID = *row.AgentAppID
+	}
 	return orgchart.Bot{
 		ID:              orgchart.BotID(row.ID),
 		OrganizationID:  row.OrgID,
+		AgentAppID:      agentAppID,
 		Name:            row.Name,
 		Content:         row.Content,
 		Tools:           tools,
@@ -103,6 +115,17 @@ func newBotsRepo(db *gorm.DB) *botsRepo {
 		Repository: NewRepository[orgchart.Bot, botRow](db, botMapper{}, "bot"),
 		db:         db,
 	}
+}
+
+func (r *botsRepo) Create(ctx context.Context, b orgchart.Bot) error {
+	if b.IsHuman() {
+		if b.AgentAppID != "" {
+			return errors.New("create bot: human node cannot reference an agent app")
+		}
+	} else if b.AgentAppID == "" {
+		return errors.New("create bot: agent app id is required")
+	}
+	return r.Repository.Create(ctx, b)
 }
 
 func (r *botsRepo) Get(ctx context.Context, orgID string, id orgchart.BotID) (orgchart.Bot, error) {
@@ -142,6 +165,7 @@ func (r *botsRepo) Update(ctx context.Context, b orgchart.Bot) error {
 		store.WithID(row.ID),
 		store.WithUpdates(map[string]any{
 			"name":             row.Name,
+			"agent_app_id":     row.AgentAppID,
 			"content":          row.Content,
 			"tools":            string(toolsJSON),
 			"project_ids":      string(projectIDsJSON),
@@ -152,6 +176,17 @@ func (r *botsRepo) Update(ctx context.Context, b orgchart.Bot) error {
 			"updated_at":       row.UpdatedAt,
 		}),
 	)
+}
+
+func (r *botsRepo) ClaimAgentApp(ctx context.Context, orgID string, id orgchart.BotID, appID string) (bool, error) {
+	res := r.db.WithContext(ctx).
+		Model(&botRow{}).
+		Where("org_id = ? AND id = ? AND agent_app_id IS NULL", orgID, string(id)).
+		Update("agent_app_id", appID)
+	if res.Error != nil {
+		return false, fmt.Errorf("claim agent app: %w", res.Error)
+	}
+	return res.RowsAffected == 1, nil
 }
 
 // Delete removes the bot row and drops its bot-anchored subscriptions

--- a/api/pkg/org/infrastructure/persistence/gorm/gorm.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/gorm.go
@@ -110,6 +110,9 @@ func OpenWithDB(db *gorm.DB, opts Options) (*store.Store, error) {
 	if err := installReportingLineFKs(db); err != nil {
 		return nil, fmt.Errorf("install reporting-line FKs: %w", err)
 	}
+	if err := installAgentAppLinks(db); err != nil {
+		return nil, fmt.Errorf("install agent app links: %w", err)
+	}
 
 	bots := newBotsRepo(db)
 	return &store.Store{
@@ -125,6 +128,114 @@ func OpenWithDB(db *gorm.DB, opts Options) (*store.Store, error) {
 		ChartPositions:  newChartPositionsRepo(db),
 		DomainEvents:    newDomainEventsRepo(db),
 	}, nil
+}
+
+func installAgentAppLinks(db *gorm.DB) error {
+	if !db.Migrator().HasTable("org_bots") || !db.Migrator().HasTable("apps") {
+		return nil
+	}
+	if db.Migrator().HasTable("org_bot_runtime_state") {
+		if err := backfillAgentAppLinks(db); err != nil {
+			return err
+		}
+	}
+	if err := db.Exec(`
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_org_bots_agent_app
+		ON org_bots (org_id, agent_app_id)
+		WHERE agent_app_id IS NOT NULL
+	`).Error; err != nil {
+		return fmt.Errorf("add unique index: %w", err)
+	}
+	if err := db.Exec(`
+		DO $$ BEGIN
+			IF NOT EXISTS (
+				SELECT 1 FROM pg_constraint WHERE conname = 'fk_org_bots_agent_app'
+			) THEN
+				ALTER TABLE org_bots
+					ADD CONSTRAINT fk_org_bots_agent_app
+					FOREIGN KEY (agent_app_id)
+					REFERENCES apps(id)
+					ON DELETE RESTRICT;
+			END IF;
+		END $$;
+	`).Error; err != nil {
+		return fmt.Errorf("add foreign key: %w", err)
+	}
+	if err := backfillProjectAgentApps(db); err != nil {
+		return err
+	}
+	return nil
+}
+
+func backfillAgentAppLinks(db *gorm.DB) error {
+	if err := db.Exec(`
+		UPDATE org_bots AS b
+		SET agent_app_id = state.value
+		FROM org_bot_runtime_state AS state
+		JOIN apps AS a
+		  ON a.id = state.value
+		 AND a.organization_id = state.org_id
+		WHERE b.org_id = state.org_id
+		  AND b.id = state.bot_id
+		  AND b.kind <> 'human'
+		  AND b.agent_app_id IS NULL
+		  AND state.backend = 'helix'
+		  AND state.key = 'agent_app_id'
+		  AND state.value <> ''
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM org_bot_runtime_state AS other
+			WHERE other.org_id = state.org_id
+			  AND other.backend = state.backend
+			  AND other.key = state.key
+			  AND other.value = state.value
+			  AND other.bot_id <> state.bot_id
+		  )
+	`).Error; err != nil {
+		return fmt.Errorf("backfill links: %w", err)
+	}
+	return nil
+}
+
+func backfillProjectAgentApps(db *gorm.DB) error {
+	if !db.Migrator().HasTable("projects") ||
+		!db.Migrator().HasTable("org_bot_runtime_state") ||
+		!db.Migrator().HasTable("org_bots") ||
+		!db.Migrator().HasTable("apps") {
+		return nil
+	}
+	if err := db.Exec(`
+		WITH candidates AS (
+			SELECT project.id AS project_id,
+			       project.organization_id,
+			       MIN(bot.agent_app_id) AS agent_app_id
+			FROM projects AS project
+			JOIN org_bot_runtime_state AS state
+			  ON state.value = project.id
+			 AND state.backend = 'helix'
+			 AND state.key = 'project_id'
+			JOIN org_bots AS bot
+			  ON bot.org_id = state.org_id
+			 AND bot.id = state.bot_id
+			JOIN apps AS app
+			  ON app.id = bot.agent_app_id
+			 AND app.organization_id = bot.org_id
+			WHERE project.organization_id = bot.org_id
+			  AND project.deleted_at IS NULL
+			  AND bot.agent_app_id IS NOT NULL
+			GROUP BY project.id, project.organization_id
+			HAVING COUNT(DISTINCT bot.agent_app_id) = 1
+		)
+		UPDATE projects AS project
+		SET default_helix_app_id = candidates.agent_app_id
+		FROM candidates
+		WHERE project.id = candidates.project_id
+		  AND project.organization_id = candidates.organization_id
+		  AND project.default_helix_app_id IS DISTINCT FROM candidates.agent_app_id
+	`).Error; err != nil {
+		return fmt.Errorf("backfill project agent apps: %w", err)
+	}
+	return nil
 }
 
 // renamedTables maps an old table name to its current name for

--- a/api/pkg/org/infrastructure/persistence/gorm/gorm.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/gorm.go
@@ -8,11 +8,15 @@
 package gorm
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/types"
 )
 
 // orgRowTypes is the canonical list of org-* tables. Kept in one
@@ -168,17 +172,25 @@ func installAgentAppLinks(db *gorm.DB) error {
 }
 
 func backfillAgentAppLinks(db *gorm.DB) error {
-	if err := db.Exec(`
-		UPDATE org_bots AS b
-		SET agent_app_id = state.value
+	type candidate struct {
+		OrgID  string
+		BotID  string
+		AppID  string
+		Config string
+	}
+	var candidates []candidate
+	if err := db.Raw(`
+		SELECT state.org_id, state.bot_id, state.value AS app_id,
+		       CAST(a.config AS TEXT) AS config
 		FROM org_bot_runtime_state AS state
+		JOIN org_bots AS bot
+		  ON bot.org_id = state.org_id
+		 AND bot.id = state.bot_id
 		JOIN apps AS a
 		  ON a.id = state.value
 		 AND a.organization_id = state.org_id
-		WHERE b.org_id = state.org_id
-		  AND b.id = state.bot_id
-		  AND b.kind <> 'human'
-		  AND b.agent_app_id IS NULL
+		WHERE bot.kind <> 'human'
+		  AND bot.agent_app_id IS NULL
 		  AND state.backend = 'helix'
 		  AND state.key = 'agent_app_id'
 		  AND state.value <> ''
@@ -191,10 +203,23 @@ func backfillAgentAppLinks(db *gorm.DB) error {
 			  AND other.value = state.value
 			  AND other.bot_id <> state.bot_id
 		  )
-	`).Error; err != nil {
-		return fmt.Errorf("backfill links: %w", err)
+	`).Scan(&candidates).Error; err != nil {
+		return fmt.Errorf("list agent link candidates: %w", err)
 	}
-	return nil
+	return db.Transaction(func(tx *gorm.DB) error {
+		for _, candidate := range candidates {
+			var config types.AppConfig
+			if json.Unmarshal([]byte(candidate.Config), &config) != nil || len(config.Helix.Assistants) != 1 {
+				continue
+			}
+			if err := tx.Table("org_bots").
+				Where("org_id = ? AND id = ? AND agent_app_id IS NULL", candidate.OrgID, candidate.BotID).
+				Update("agent_app_id", candidate.AppID).Error; err != nil {
+				return fmt.Errorf("backfill link %s/%s: %w", candidate.OrgID, candidate.BotID, err)
+			}
+		}
+		return nil
+	})
 }
 
 func backfillProjectAgentApps(db *gorm.DB) error {
@@ -204,38 +229,132 @@ func backfillProjectAgentApps(db *gorm.DB) error {
 		!db.Migrator().HasTable("apps") {
 		return nil
 	}
-	if err := db.Exec(`
-		WITH candidates AS (
-			SELECT project.id AS project_id,
-			       project.organization_id,
-			       MIN(bot.agent_app_id) AS agent_app_id
-			FROM projects AS project
-			JOIN org_bot_runtime_state AS state
-			  ON state.value = project.id
-			 AND state.backend = 'helix'
-			 AND state.key = 'project_id'
-			JOIN org_bots AS bot
-			  ON bot.org_id = state.org_id
-			 AND bot.id = state.bot_id
-			JOIN apps AS app
-			  ON app.id = bot.agent_app_id
-			 AND app.organization_id = bot.org_id
-			WHERE project.organization_id = bot.org_id
-			  AND project.deleted_at IS NULL
-			  AND bot.agent_app_id IS NOT NULL
-			GROUP BY project.id, project.organization_id
-			HAVING COUNT(DISTINCT bot.agent_app_id) = 1
-		)
-		UPDATE projects AS project
-		SET default_helix_app_id = candidates.agent_app_id
-		FROM candidates
-		WHERE project.id = candidates.project_id
-		  AND project.organization_id = candidates.organization_id
-		  AND project.default_helix_app_id IS DISTINCT FROM candidates.agent_app_id
-	`).Error; err != nil {
-		return fmt.Errorf("backfill project agent apps: %w", err)
+	type candidate struct {
+		ProjectID       string
+		OrganizationID  string
+		DefaultAppID    string
+		BotID           string
+		BotAppID        string
+		RuntimeAgentApp string
 	}
-	return nil
+	return db.Transaction(func(tx *gorm.DB) error {
+		var candidates []candidate
+		if err := tx.Raw(`
+		SELECT project.id AS project_id,
+		       project.organization_id,
+		       COALESCE(project.default_helix_app_id, '') AS default_app_id,
+		       bot.id AS bot_id,
+		       COALESCE(bot.agent_app_id, '') AS bot_app_id,
+		       COALESCE(agent_state.value, '') AS runtime_agent_app
+		FROM projects AS project
+		JOIN org_bot_runtime_state AS project_state
+		  ON project_state.value = project.id
+		 AND project_state.backend = 'helix'
+		 AND project_state.key = 'project_id'
+		JOIN org_bots AS bot
+		  ON bot.org_id = project_state.org_id
+		 AND bot.id = project_state.bot_id
+		LEFT JOIN org_bot_runtime_state AS agent_state
+		  ON agent_state.org_id = project_state.org_id
+		 AND agent_state.bot_id = project_state.bot_id
+		 AND agent_state.backend = 'helix'
+		 AND agent_state.key = 'agent_app_id'
+		WHERE project.organization_id = bot.org_id
+		  AND project.deleted_at IS NULL
+		`).Scan(&candidates).Error; err != nil {
+			return fmt.Errorf("list project agent app candidates: %w", err)
+		}
+		projectApps := make(map[string]map[string]struct{})
+		projectBotCounts := make(map[string]int)
+		for _, candidate := range candidates {
+			projectKey := candidate.OrganizationID + "\x00" + candidate.ProjectID
+			projectBotCounts[projectKey]++
+			if projectApps[projectKey] == nil {
+				projectApps[projectKey] = make(map[string]struct{})
+			}
+			projectApps[projectKey][candidate.BotAppID] = struct{}{}
+		}
+		for _, candidate := range candidates {
+			projectKey := candidate.OrganizationID + "\x00" + candidate.ProjectID
+			if projectBotCounts[projectKey] != 1 || len(projectApps[projectKey]) != 1 {
+				continue
+			}
+			validApp := func(appID string) (bool, error) {
+				if appID == "" {
+					return false, nil
+				}
+				var app struct {
+					Config string
+				}
+				if err := tx.Table("apps").Select("CAST(config AS TEXT) AS config").
+					Where("id = ? AND organization_id = ?", appID, candidate.OrganizationID).
+					Take(&app).Error; err != nil {
+					if errors.Is(err, gorm.ErrRecordNotFound) {
+						return false, nil
+					}
+					return false, err
+				}
+				var config types.AppConfig
+				if err := json.Unmarshal([]byte(app.Config), &config); err != nil {
+					return false, nil
+				}
+				if len(config.Helix.Assistants) != 1 {
+					return false, nil
+				}
+				var claims int64
+				if err := tx.Table("org_bots").
+					Where("org_id = ? AND agent_app_id = ? AND id <> ?", candidate.OrganizationID, appID, candidate.BotID).
+					Count(&claims).Error; err != nil {
+					return false, err
+				}
+				return claims == 0, nil
+			}
+
+			canonicalAppID := candidate.DefaultAppID
+			defaultValid, err := validApp(canonicalAppID)
+			if err != nil {
+				return fmt.Errorf("validate project %s default app: %w", candidate.ProjectID, err)
+			}
+			if !defaultValid {
+				botValid, err := validApp(candidate.BotAppID)
+				if err != nil {
+					return fmt.Errorf("validate bot %s agent app: %w", candidate.BotID, err)
+				}
+				if !botValid {
+					continue
+				}
+				canonicalAppID = candidate.BotAppID
+			}
+
+			if candidate.DefaultAppID != canonicalAppID {
+				if err := tx.Table("projects").
+					Where("id = ? AND organization_id = ?", candidate.ProjectID, candidate.OrganizationID).
+					Update("default_helix_app_id", canonicalAppID).Error; err != nil {
+					return fmt.Errorf("backfill project %s agent app: %w", candidate.ProjectID, err)
+				}
+			}
+			if candidate.BotAppID != canonicalAppID {
+				if err := tx.Table("org_bots").
+					Where("org_id = ? AND id = ?", candidate.OrganizationID, candidate.BotID).
+					Update("agent_app_id", canonicalAppID).Error; err != nil {
+					return fmt.Errorf("backfill bot %s agent app: %w", candidate.BotID, err)
+				}
+			}
+			if candidate.RuntimeAgentApp != canonicalAppID {
+				state := botRuntimeStateRow{
+					OrgID: candidate.OrganizationID, BotID: candidate.BotID,
+					Backend: "helix", Key: "agent_app_id", Value: canonicalAppID,
+				}
+				if err := tx.Clauses(clause.OnConflict{
+					Columns:   []clause.Column{{Name: "org_id"}, {Name: "bot_id"}, {Name: "backend"}, {Name: "key"}},
+					DoUpdates: clause.AssignmentColumns([]string{"value", "updated_at"}),
+				}).Create(&state).Error; err != nil {
+					return fmt.Errorf("backfill bot %s runtime agent app: %w", candidate.BotID, err)
+				}
+			}
+		}
+		return nil
+	})
 }
 
 // renamedTables maps an old table name to its current name for

--- a/api/pkg/org/infrastructure/persistence/memory/memorystore.go
+++ b/api/pkg/org/infrastructure/persistence/memory/memorystore.go
@@ -221,6 +221,21 @@ func (r *botsRepo) Update(_ context.Context, b orgchart.Bot) error {
 	return nil
 }
 
+func (r *botsRepo) ClaimAgentApp(_ context.Context, orgID string, id orgchart.BotID, appID string) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	k := orgKey{OrgID: orgID, ID: string(id)}
+	b, ok := r.rows[k]
+	if !ok {
+		return false, fmt.Errorf("bot %q in org %q: %w", id, orgID, store.ErrNotFound)
+	}
+	if b.AgentAppID != "" {
+		return false, nil
+	}
+	r.rows[k] = b.WithAgentAppID(appID)
+	return true, nil
+}
+
 // Delete removes the bot and cascades the rows that reference it,
 // matching the gorm store: the bot's own subscriptions and every
 // reporting line where it is the manager or the report are dropped.

--- a/api/pkg/org/infrastructure/runtime/helix/mcp_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/mcp_test.go
@@ -224,6 +224,9 @@ func (noopProjectService) CreateBranch(_ context.Context, _, _, _ string) error 
 func (noopProjectService) GetAppConfig(_ context.Context, _ string) (types.AppConfig, error) {
 	return types.AppConfig{}, nil
 }
+func (noopProjectService) GetApp(_ context.Context, id string) (*types.App, error) {
+	return &types.App{ID: id}, nil
+}
 func (noopProjectService) UpdateAppConfig(_ context.Context, _ string, _ types.AppConfig) error {
 	return nil
 }

--- a/api/pkg/org/infrastructure/runtime/helix/project.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project.go
@@ -208,10 +208,24 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 	if err != nil {
 		return "", "", "", err
 	}
-	// The Bot IS the role: its Content is the prompt that lands in
-	// role.md, and its ID names the agent app.
 	roleContent := bot.Content
 	roleName := string(bot.ID)
+	botLabel := bot.Name
+	if bot.AgentAppID != "" {
+		cfg, err := a.Service.GetAppConfig(ctx, bot.AgentAppID)
+		if err != nil {
+			return "", "", "", fmt.Errorf("get linked agent app %s: %w", bot.AgentAppID, err)
+		}
+		if len(cfg.Helix.Assistants) != 1 {
+			return "", "", "", fmt.Errorf("linked agent app %s must contain exactly one assistant", bot.AgentAppID)
+		}
+		roleName = cfg.Helix.Assistants[0].Name
+		if roleName == "" {
+			roleName = cfg.Helix.Name
+		}
+		roleContent = cfg.Helix.Assistants[0].SystemPrompt
+		botLabel = roleName
+	}
 	runtime := a.Runtime
 	if runtime == "" {
 		runtime = Runtime
@@ -220,7 +234,6 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 	// rather than the bare slug. bot.Name may be empty (fall back to the
 	// ID); OrgDisplayName may be empty in bare/test wirings (fall back to
 	// just the bot label). Deterministic so upsert-by-name stays idempotent.
-	botLabel := bot.Name
 	if botLabel == "" {
 		botLabel = string(bot.ID)
 	}
@@ -236,8 +249,9 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 		// into another — the org parameter is the authority here.
 		OrganizationID: orgID,
 		Name:           projectName,
+		AgentAppID:     bot.AgentAppID,
 		Spec: types.ProjectSpec{
-			Description: bot.Content,
+			Description: roleContent,
 			Agent: &types.ProjectAgentSpec{
 				Name:        roleName,
 				Runtime:     runtime,
@@ -262,6 +276,18 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 				return "", "", "", fmt.Errorf("verify project %s for %s: %w", state.ProjectID, workerID, err)
 			}
 		} else {
+			if bot.AgentAppID != "" && existing.DefaultHelixAppID != bot.AgentAppID {
+				linkedAppID := bot.AgentAppID
+				updatedProject, err := a.Service.UpdateProject(ctx, state.ProjectID, types.ProjectUpdateRequest{DefaultHelixAppID: &linkedAppID})
+				if err != nil {
+					return "", "", "", fmt.Errorf("link canonical agent app %s to project %s: %w", linkedAppID, state.ProjectID, err)
+				}
+				existing = updatedProject
+				state.AgentAppID = linkedAppID
+				if err := SaveProject(ctx, a.Store, orgID, workerID, state.ProjectID, linkedAppID, state.RepoID); err != nil {
+					return "", "", "", fmt.Errorf("persist canonical agent app for %s: %w", workerID, err)
+				}
+			}
 			// Project already exists — fast path.
 			//
 			// The project is tracked by ID (state.ProjectID) but ApplyProject

--- a/api/pkg/org/infrastructure/runtime/helix/project.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project.go
@@ -110,6 +110,7 @@ type ProjectService interface {
 	// GetAppConfig returns the typed config for an App. Used to round-
 	// trip the helix.assistants[0] MCP list for MCP attachment.
 	GetAppConfig(ctx context.Context, id string) (types.AppConfig, error)
+	GetApp(ctx context.Context, id string) (*types.App, error)
 
 	// UpdateAppConfig persists a mutated app config. WorkerProject
 	// uses this to attach helix-org's MCP server to the auto-provisioned
@@ -208,6 +209,40 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 	if err != nil {
 		return "", "", "", err
 	}
+	var existingProject types.Project
+	var existingProjectErr error
+	if state.ProjectID != "" {
+		existingProject, existingProjectErr = a.Service.GetProject(ctx, state.ProjectID)
+		if existingProjectErr == nil && existingProject.DefaultHelixAppID != "" && existingProject.DefaultHelixAppID != bot.AgentAppID {
+			defaultApp, appErr := a.Service.GetApp(ctx, existingProject.DefaultHelixAppID)
+			if appErr != nil {
+				return "", "", "", fmt.Errorf("get project default agent app %s for %s: %w", existingProject.DefaultHelixAppID, workerID, appErr)
+			}
+			if defaultApp.OrganizationID == orgID && len(defaultApp.Config.Helix.Assistants) == 1 {
+				allBots, err := a.Store.Bots.List(ctx, orgID)
+				if err != nil {
+					return "", "", "", fmt.Errorf("check project default agent app claims for %s: %w", workerID, err)
+				}
+				claimed := false
+				for _, other := range allBots {
+					if other.ID != workerID && other.AgentAppID == defaultApp.ID {
+						claimed = true
+						break
+					}
+				}
+				if !claimed {
+					bot = bot.WithAgentAppID(defaultApp.ID)
+					if err := a.Store.Bots.Update(ctx, bot); err != nil {
+						return "", "", "", fmt.Errorf("link project default agent app %s to bot %s: %w", defaultApp.ID, workerID, err)
+					}
+					state.AgentAppID = defaultApp.ID
+					if err := SaveProject(ctx, a.Store, orgID, workerID, state.ProjectID, state.AgentAppID, state.RepoID); err != nil {
+						return "", "", "", fmt.Errorf("persist project default agent app for %s: %w", workerID, err)
+					}
+				}
+			}
+		}
+	}
 	roleContent := bot.Content
 	roleName := string(bot.ID)
 	botLabel := bot.Name
@@ -262,7 +297,7 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 		},
 	}
 	if state.ProjectID != "" {
-		existing, err := a.Service.GetProject(ctx, state.ProjectID)
+		existing, err := existingProject, existingProjectErr
 		if err != nil {
 			if errors.Is(err, ErrProjectNotFound) {
 				if clearErr := ClearProject(ctx, a.Store, orgID, workerID); clearErr != nil {
@@ -286,6 +321,11 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 				state.AgentAppID = linkedAppID
 				if err := SaveProject(ctx, a.Store, orgID, workerID, state.ProjectID, linkedAppID, state.RepoID); err != nil {
 					return "", "", "", fmt.Errorf("persist canonical agent app for %s: %w", workerID, err)
+				}
+			} else if bot.AgentAppID != "" && state.AgentAppID != bot.AgentAppID {
+				state.AgentAppID = bot.AgentAppID
+				if err := SaveProject(ctx, a.Store, orgID, workerID, state.ProjectID, state.AgentAppID, state.RepoID); err != nil {
+					return "", "", "", fmt.Errorf("repair runtime agent app for %s: %w", workerID, err)
 				}
 			}
 			// Project already exists — fast path.

--- a/api/pkg/org/infrastructure/runtime/helix/project_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_test.go
@@ -50,6 +50,7 @@ type fakeProjectService struct {
 	attachRepoErr           error
 	attachRepoCalls         int
 	getAppCalls             int
+	getAppErr               error
 	appConfig               types.AppConfig
 	updateAppCalls          int
 	updateAppLastCfg        types.AppConfig
@@ -104,6 +105,13 @@ func (f *fakeProjectService) GetProject(_ context.Context, _ string) (types.Proj
 	return f.getProjectResp, err
 }
 
+func (f *fakeProjectService) GetApp(_ context.Context, id string) (*types.App, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getAppCalls++
+	return &types.App{ID: id, OrganizationID: "org-test", Config: f.appConfig}, f.getAppErr
+}
+
 func (f *fakeProjectService) UpdateProject(_ context.Context, id string, patch types.ProjectUpdateRequest) (types.Project, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -121,6 +129,9 @@ func (f *fakeProjectService) UpdateProject(_ context.Context, id string, patch t
 	}
 	if patch.Metadata != nil {
 		updated.Metadata = *patch.Metadata
+	}
+	if patch.DefaultHelixAppID != nil {
+		updated.DefaultHelixAppID = *patch.DefaultHelixAppID
 	}
 	f.getProjectResp = updated
 	return updated, f.updateProjectErr
@@ -634,6 +645,172 @@ func TestEnsureFastPathPreservesAgentSpec(t *testing.T) {
 	defer svc.mu.Unlock()
 	if svc.applyCalls != 0 {
 		t.Fatalf("ApplyProject must not run for an existing app; got %d calls", svc.applyCalls)
+	}
+}
+
+func TestEnsureFastPathPreservesValidProjectDefaultAndConvergesLinks(t *testing.T) {
+	st, wid := newProjectTestStore(t, "# Role")
+	ctx := context.Background()
+	bot, err := st.Bots.Get(ctx, "org-test", wid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Bots.Update(ctx, bot.WithAgentAppID("app-new")); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveProject(ctx, st, "org-test", wid, "prj_existing", "app-legacy", "repo_existing"); err != nil {
+		t.Fatal(err)
+	}
+	svc := newFakeProjectService()
+	svc.getProjectResp = types.Project{
+		ID: "prj_existing", OrganizationID: "org-test",
+		DefaultHelixAppID: "app-explicit", DefaultRepoID: "repo_existing",
+	}
+
+	if _, agentAppID, _, err := newApplierGit(svc, newFakeGitForProject(), st).Ensure(ctx, "org-test", wid); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	} else if agentAppID != "app-explicit" {
+		t.Fatalf("returned app = %q, want app-explicit", agentAppID)
+	}
+	bot, err = st.Bots.Get(ctx, "org-test", wid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bot.AgentAppID != "app-explicit" {
+		t.Fatalf("bot app = %q, want app-explicit", bot.AgentAppID)
+	}
+	state, err := LoadState(ctx, st, "org-test", wid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.AgentAppID != "app-explicit" {
+		t.Fatalf("runtime app = %q, want app-explicit", state.AgentAppID)
+	}
+}
+
+func TestEnsureFastPathDoesNotAdoptProjectDefaultClaimedByAnotherBot(t *testing.T) {
+	st, wid := newProjectTestStore(t, "# Role")
+	ctx := context.Background()
+	bot, err := st.Bots.Get(ctx, "org-test", wid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Bots.Update(ctx, bot.WithAgentAppID("app-current")); err != nil {
+		t.Fatal(err)
+	}
+	other, err := orgchart.NewBot("w-other", "# Other", nil, time.Now().UTC(), "org-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Bots.Create(ctx, other.WithAgentAppID("app-claimed")); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveProject(ctx, st, "org-test", wid, "prj_existing", "app-legacy", "repo_existing"); err != nil {
+		t.Fatal(err)
+	}
+	svc := newFakeProjectService()
+	svc.getProjectResp = types.Project{
+		ID: "prj_existing", OrganizationID: "org-test",
+		DefaultHelixAppID: "app-claimed", DefaultRepoID: "repo_existing",
+	}
+
+	if _, agentAppID, _, err := newApplierGit(svc, newFakeGitForProject(), st).Ensure(ctx, "org-test", wid); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	} else if agentAppID != "app-current" {
+		t.Fatalf("returned app = %q, want app-current", agentAppID)
+	}
+	bot, err = st.Bots.Get(ctx, "org-test", wid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bot.AgentAppID != "app-current" {
+		t.Fatalf("bot app = %q, want app-current", bot.AgentAppID)
+	}
+	state, err := LoadState(ctx, st, "org-test", wid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.AgentAppID != "app-current" {
+		t.Fatalf("runtime app = %q, want app-current", state.AgentAppID)
+	}
+}
+
+func TestEnsureFastPathPreservesLinksWhenProjectDefaultAppReadFails(t *testing.T) {
+	st, wid := newProjectTestStore(t, "# Role")
+	ctx := context.Background()
+	bot, err := st.Bots.Get(ctx, "org-test", wid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Bots.Update(ctx, bot.WithAgentAppID("app-current")); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveProject(ctx, st, "org-test", wid, "prj_existing", "app-runtime", "repo_existing"); err != nil {
+		t.Fatal(err)
+	}
+	svc := newFakeProjectService()
+	svc.getProjectResp = types.Project{
+		ID: "prj_existing", OrganizationID: "org-test",
+		DefaultHelixAppID: "app-explicit", DefaultRepoID: "repo_existing",
+	}
+	svc.getAppErr = errors.New("database unavailable")
+
+	if _, _, _, err := newApplierGit(svc, newFakeGitForProject(), st).Ensure(ctx, "org-test", wid); err == nil ||
+		!strings.Contains(err.Error(), "get project default agent app app-explicit") {
+		t.Fatalf("Ensure error = %v", err)
+	}
+	bot, err = st.Bots.Get(ctx, "org-test", wid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bot.AgentAppID != "app-current" {
+		t.Fatalf("bot app changed to %q", bot.AgentAppID)
+	}
+	state, err := LoadState(ctx, st, "org-test", wid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.AgentAppID != "app-runtime" {
+		t.Fatalf("runtime app changed to %q", state.AgentAppID)
+	}
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	if svc.updateProjectCalls != 0 {
+		t.Fatalf("project updated %d times", svc.updateProjectCalls)
+	}
+	if svc.getProjectResp.DefaultHelixAppID != "app-explicit" {
+		t.Fatalf("project default changed to %q", svc.getProjectResp.DefaultHelixAppID)
+	}
+}
+
+func TestEnsureFastPathRepairsStaleRuntimeAgentApp(t *testing.T) {
+	st, wid := newProjectTestStore(t, "# Role")
+	ctx := context.Background()
+	bot, err := st.Bots.Get(ctx, "org-test", wid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Bots.Update(ctx, bot.WithAgentAppID("app-canonical")); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveProject(ctx, st, "org-test", wid, "prj_existing", "app-legacy", "repo_existing"); err != nil {
+		t.Fatal(err)
+	}
+	svc := newFakeProjectService()
+	svc.getProjectResp = types.Project{
+		ID: "prj_existing", OrganizationID: "org-test",
+		DefaultHelixAppID: "app-canonical", DefaultRepoID: "repo_existing",
+	}
+
+	if _, _, _, err := newApplierGit(svc, newFakeGitForProject(), st).Ensure(ctx, "org-test", wid); err != nil {
+		t.Fatalf("Ensure: %v", err)
+	}
+	state, err := LoadState(ctx, st, "org-test", wid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.AgentAppID != "app-canonical" {
+		t.Fatalf("runtime app = %q, want app-canonical", state.AgentAppID)
 	}
 }
 

--- a/api/pkg/org/infrastructure/runtime/helix/spawner.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner.go
@@ -290,7 +290,21 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 		}
 		mandate := cfg.SpecsMandate
 		if mandate == "" {
-			mandate = "=== Current role ===\n" + bot.Content
+			instructions := bot.Content
+			if bot.AgentAppID != "" {
+				if cfg.ProjectService == nil {
+					return errors.New("load canonical agent instructions: project service is nil")
+				}
+				appConfig, err := cfg.ProjectService.GetAppConfig(startupCtx, bot.AgentAppID)
+				if err != nil {
+					return fmt.Errorf("load canonical agent instructions: %w", err)
+				}
+				if len(appConfig.Helix.Assistants) != 1 {
+					return fmt.Errorf("linked agent app %s must contain exactly one assistant", bot.AgentAppID)
+				}
+				instructions = appConfig.Helix.Assistants[0].SystemPrompt
+			}
+			mandate = "=== Current role ===\n" + instructions
 		}
 		prompt := briefing.BuildPrompt(workerID, mandate, triggers)
 		sessionID, priorInteractionID, err := cfg.ensureSession(startupCtx, orgID, workerID, prompt, bot.PreserveContext, publish)

--- a/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
@@ -273,6 +273,39 @@ func TestSpawnerEmbedsFreshBotContentByDefault(t *testing.T) {
 	}
 }
 
+func TestSpawnerUsesLinkedAgentInstructions(t *testing.T) {
+	t.Parallel()
+	s, wid := newHelixTestStore(t)
+	bot, err := s.Bots.Get(context.Background(), "org-test", wid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Bots.Update(context.Background(), bot.WithAgentAppID("app_test")); err != nil {
+		t.Fatal(err)
+	}
+	fc := &fakeHelixClient{
+		startSessionID: "ses_new",
+		outputs:        []types.SessionOutputResponse{{Status: "complete", Output: "ok"}},
+	}
+	cfg := newHelixCfg(t, fc, s)
+	cfg.ProjectService.(*fakeProjectService).appConfig = types.AppConfig{Helix: types.AppHelixConfig{
+		Name: "Engineer",
+		Assistants: []types.AssistantConfig{{
+			Name:         "Engineer",
+			SystemPrompt: "# Canonical agent instructions",
+		}},
+	}}
+	if err := Spawner(cfg)(context.Background(), "org-test", wid, []activation.Trigger{{Kind: activation.TriggerHire}}); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if !strings.Contains(fc.lastStartParams.Prompt, "=== Current role ===\n# Canonical agent instructions") {
+		t.Fatalf("prompt did not use linked Agent instructions: %q", fc.lastStartParams.Prompt)
+	}
+	if strings.Contains(fc.lastStartParams.Prompt, "# Role: Engineer") {
+		t.Fatalf("prompt used legacy Bot.Content: %q", fc.lastStartParams.Prompt)
+	}
+}
+
 func TestSpawnerReadsBotAfterProjectEnsure(t *testing.T) {
 	t.Parallel()
 	s, wid := newHelixTestStore(t)

--- a/api/pkg/org/interfaces/mcptools/builtins.go
+++ b/api/pkg/org/interfaces/mcptools/builtins.go
@@ -34,6 +34,14 @@ type Clock func() time.Time
 // IDGen generates new unique string IDs. Tests override it.
 type IDGen func() string
 
+type AgentContentUpdater interface {
+	UpdateAgentContent(ctx context.Context, appID, content string) error
+}
+
+type AgentProfileReader interface {
+	AgentProfile(ctx context.Context, appID string) (name, instructions string, err error)
+}
+
 // EventDispatcher fans a freshly-published Event out to every subscribed
 // Bot as a separate Spawner activation. Tools call it after persisting
 // an Event. The interface keeps tools.Deps free of a dependency on the
@@ -83,7 +91,9 @@ type Deps struct {
 	// Workspace is the per-runtime file-mirror port: set_bot_content calls
 	// MirrorFile after the service persists, so the running session sees
 	// the change before the next activation.
-	Workspace runtime.WorkspaceSync
+	Workspace           runtime.WorkspaceSync
+	AgentContentUpdater AgentContentUpdater
+	AgentProfileReader  AgentProfileReader
 	// ProjectConfig backs get_bot_project + configure_bot_project
 	// (owner-only read/patch of a Bot's helix project config).
 	ProjectConfig runtime.ProjectConfig
@@ -127,15 +137,17 @@ type Deps struct {
 // Hub/Dispatcher are optional (nil → publish skips notify/dispatch).
 // Workspace defaults to a no-op for tests.
 type Config struct {
-	Store         *store.Store
-	Queries       *queries.Queries
-	Now           Clock
-	NewID         IDGen
-	Hub           *wakebus.Bus
-	Dispatcher    EventDispatcher
-	Workspace     runtime.WorkspaceSync
-	HireHook      runtime.HireHook
-	ProjectConfig runtime.ProjectConfig
+	Store               *store.Store
+	Queries             *queries.Queries
+	Now                 Clock
+	NewID               IDGen
+	Hub                 *wakebus.Bus
+	Dispatcher          EventDispatcher
+	Workspace           runtime.WorkspaceSync
+	AgentContentUpdater AgentContentUpdater
+	AgentProfileReader  AgentProfileReader
+	HireHook            runtime.HireHook
+	ProjectConfig       runtime.ProjectConfig
 	// SpecTasks is the runtime port the spec-task tools dispatch on. nil
 	// → Build defaults to runtime.NoopSpecTasks{} so the tools return a
 	// clear "not wired" error instead of nil-derefing.
@@ -183,6 +195,8 @@ func (c Config) Build() Deps {
 		Activations:         c.Activations,
 		Processors:          c.processorsService(),
 		Workspace:           c.Workspace,
+		AgentContentUpdater: c.AgentContentUpdater,
+		AgentProfileReader:  c.AgentProfileReader,
 		ProjectConfig:       c.ProjectConfig,
 		SpecTasks:           c.specTasksService(),
 		Projects:            c.projectsService(),

--- a/api/pkg/org/interfaces/mcptools/builtins_test.go
+++ b/api/pkg/org/interfaces/mcptools/builtins_test.go
@@ -37,6 +37,26 @@ func injectTestPublishing(cfg *mcptools.Config) {
 	cfg.Publishing = publishing.New(deps)
 }
 
+type recordingAgentContentUpdater struct {
+	appID   string
+	name    string
+	content string
+	err     error
+}
+
+func (u *recordingAgentContentUpdater) UpdateAgentContent(_ context.Context, appID, content string) error {
+	u.appID = appID
+	u.content = content
+	return u.err
+}
+
+func (u *recordingAgentContentUpdater) AgentProfile(_ context.Context, appID string) (string, string, error) {
+	if appID != u.appID {
+		return "", "", fmt.Errorf("unexpected app %s", appID)
+	}
+	return u.name, u.content, nil
+}
+
 // TestDemoOwnerCreatesCEO walks the "manager does the orchestration"
 // story over MCP: each tool does one primitive thing, and the test
 // drives the create ritual step by step.
@@ -122,11 +142,9 @@ func TestDemoOwnerCreatesCEO(t *testing.T) {
 	}
 }
 
-// TestSetBotContentIsDomainWrite pins the post-refactor contract:
-// set_bot_content is a pure DB mutation. The spawner is the only thing
-// that projects state into envs, so after a tool call the on-disk files
-// (if any) are stale and only the DB row reflects the change. Editing
-// content preserves the bot's tools.
+// TestSetBotContentIsDomainWrite pins content synchronization between the
+// org row and its canonical linked Agent App. Editing content preserves tools,
+// and an App update failure rolls the org row back.
 func TestSetBotContentIsDomainWrite(t *testing.T) {
 	t.Parallel()
 
@@ -134,6 +152,9 @@ func TestSetBotContentIsDomainWrite(t *testing.T) {
 
 	reg := mcptools.NewRegistry()
 	deps := mcptools.DefaultDeps(s)
+	agentUpdater := &recordingAgentContentUpdater{name: "Canonical Engineer"}
+	deps.AgentContentUpdater = agentUpdater
+	deps.AgentProfileReader = agentUpdater
 	injectTestPublishing(&deps)
 	if err := mcptools.RegisterBuiltins(reg, deps.Build()); err != nil {
 		t.Fatalf("register builtins: %v", err)
@@ -150,6 +171,8 @@ func TestSetBotContentIsDomainWrite(t *testing.T) {
 		[]tool.Name{
 			mcptools.CreateBotName,
 			mcptools.SetBotContentName,
+			mcptools.ListBotsName,
+			mcptools.GetBotName,
 		},
 		now,
 		"org-test",
@@ -172,6 +195,7 @@ func TestSetBotContentIsDomainWrite(t *testing.T) {
 		t.Fatalf("get b-eng: %v", err)
 	}
 	toolsBefore := append([]tool.Name(nil), created.Tools...)
+	mustCreate(t, s.Bots.Update(ctx, created.WithAgentAppID("app-eng")))
 
 	// set_bot_content rewrites Content and preserves Tools.
 	invokeExpectID(t, ownerSession, mcptools.SetBotContentName, map[string]any{
@@ -188,6 +212,94 @@ func TestSetBotContentIsDomainWrite(t *testing.T) {
 	}
 	if len(got.Tools) != len(toolsBefore) {
 		t.Fatalf("content-only update changed tools: before %v after %v", toolsBefore, got.Tools)
+	}
+	if agentUpdater.appID != "app-eng" || agentUpdater.content != "# Engineer v2\nBuild better stuff." {
+		t.Fatalf("agent update = (%q, %q)", agentUpdater.appID, agentUpdater.content)
+	}
+	listRaw, err := invokeTool(t, ownerSession, mcptools.ListBotsName, map[string]any{})
+	if err != nil {
+		t.Fatalf("list_bots after App update: %v", err)
+	}
+	var listResult struct {
+		Bots []struct {
+			ID      string `json:"id"`
+			Name    string `json:"name"`
+			Content string `json:"content"`
+		} `json:"bots"`
+	}
+	if err := json.Unmarshal(listRaw, &listResult); err != nil {
+		t.Fatalf("decode list_bots: %v", err)
+	}
+	var listedName, listedContent string
+	for _, listed := range listResult.Bots {
+		if listed.ID == "b-eng" {
+			listedName, listedContent = listed.Name, listed.Content
+		}
+	}
+	if listedName != agentUpdater.name || listedContent != agentUpdater.content {
+		t.Fatalf("list_bots canonical profile = (%q, %q)", listedName, listedContent)
+	}
+	getRaw, err := invokeTool(t, ownerSession, mcptools.GetBotName, map[string]any{"id": "b-eng"})
+	if err != nil {
+		t.Fatalf("get_bot after App update: %v", err)
+	}
+	var gotProfile struct {
+		Name    string `json:"name"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(getRaw, &gotProfile); err != nil {
+		t.Fatalf("decode get_bot: %v", err)
+	}
+	if gotProfile.Name != agentUpdater.name || gotProfile.Content != agentUpdater.content {
+		t.Fatalf("get_bot canonical profile = (%q, %q)", gotProfile.Name, gotProfile.Content)
+	}
+
+	agentUpdater.err = fmt.Errorf("app update failed")
+	if _, err := invokeTool(t, ownerSession, mcptools.SetBotContentName, map[string]any{
+		"botId":   "b-eng",
+		"content": "# Engineer v3\nMust not persist.",
+	}); err == nil {
+		t.Fatal("set_bot_content succeeded after App update failed")
+	}
+	got, err = s.Bots.Get(ctx, "org-test", "b-eng")
+	if err != nil {
+		t.Fatalf("get b-eng after rollback: %v", err)
+	}
+	if got.Content != "# Engineer v2\nBuild better stuff." {
+		t.Fatalf("rollback content = %q", got.Content)
+	}
+}
+
+func TestSetBotContentPreflightsLinkedAgentUpdater(t *testing.T) {
+	s := orggorm.GetOrgTestDB(t)
+	reg := mcptools.NewRegistry()
+	deps := mcptools.DefaultDeps(s)
+	injectTestPublishing(&deps)
+	if err := mcptools.RegisterBuiltins(reg, deps.Build()); err != nil {
+		t.Fatalf("register builtins: %v", err)
+	}
+	srv := httptest.NewServer(server.NewFromStore(s, reg, nil, nil, nil).Handler())
+	t.Cleanup(srv.Close)
+
+	ctx := context.Background()
+	owner, _ := orgchart.NewBot("b-owner", "owner", []tool.Name{mcptools.SetBotContentName}, time.Now().UTC(), "org-test")
+	target, _ := orgchart.NewBot("b-agent", "original", nil, time.Now().UTC(), "org-test")
+	target = target.WithAgentAppID("app-agent")
+	mustCreate(t, s.Bots.Create(ctx, owner))
+	mustCreate(t, s.Bots.Create(ctx, target))
+
+	session := connectMCP(t, srv.URL, "b-owner")
+	if _, err := invokeTool(t, session, mcptools.SetBotContentName, map[string]any{
+		"botId": "b-agent", "content": "must not persist",
+	}); err == nil {
+		t.Fatal("set_bot_content succeeded without linked Agent updater")
+	}
+	got, err := s.Bots.Get(ctx, "org-test", target.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Content != "original" {
+		t.Fatalf("content mutated before updater preflight: %q", got.Content)
 	}
 }
 

--- a/api/pkg/org/interfaces/mcptools/read_bots.go
+++ b/api/pkg/org/interfaces/mcptools/read_bots.go
@@ -55,6 +55,23 @@ func botViewOf(b orgchart.Bot, managers []orgchart.BotID) botView {
 	}
 }
 
+func canonicalBotView(ctx context.Context, deps Deps, b orgchart.Bot, managers []orgchart.BotID) (botView, error) {
+	view := botViewOf(b, managers)
+	if b.IsHuman() || b.AgentAppID == "" {
+		return view, nil
+	}
+	if deps.AgentProfileReader == nil {
+		return botView{}, fmt.Errorf("read canonical agent %s: profile reader is not wired", b.AgentAppID)
+	}
+	name, instructions, err := deps.AgentProfileReader.AgentProfile(ctx, b.AgentAppID)
+	if err != nil {
+		return botView{}, fmt.Errorf("read canonical agent %s: %w", b.AgentAppID, err)
+	}
+	view.Name = name
+	view.Content = instructions
+	return view, nil
+}
+
 // ListBots returns every Bot in the org.
 type ListBots struct {
 	deps Deps
@@ -97,7 +114,11 @@ func (t *ListBots) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMes
 	}
 	out := make([]botView, 0, len(all))
 	for _, b := range all {
-		out = append(out, botViewOf(b, managersByReport[b.ID]))
+		view, err := canonicalBotView(ctx, t.deps, b, managersByReport[b.ID])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, view)
 	}
 	return json.Marshal(map[string]any{"bots": out})
 }
@@ -148,7 +169,10 @@ func (t *GetBot) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessa
 			return nil, fmt.Errorf("list managers for %q: %w", args.ID, err)
 		}
 	}
-	view := botViewOf(b, managers)
+	view, err := canonicalBotView(ctx, t.deps, b, managers)
+	if err != nil {
+		return nil, err
+	}
 	// Best-effort: surface attached repos so callers don't have to know
 	// about list_bot_repositories. Humans never have a project.
 	if b.Kind != orgchart.BotKindHuman && t.deps.Repositories != nil {

--- a/api/pkg/org/interfaces/mcptools/set_bot_content.go
+++ b/api/pkg/org/interfaces/mcptools/set_bot_content.go
@@ -53,9 +53,25 @@ func (t *SetBotContent) Invoke(ctx context.Context, inv tool.Invocation) (json.R
 		return nil, fmt.Errorf("set_bot_content: caller has no OrgID")
 	}
 	botID := orgchart.BotID(args.BotID)
+	existing, err := t.deps.Queries.GetBot(ctx, orgID, botID)
+	if err != nil {
+		return nil, fmt.Errorf("get bot: %w", err)
+	}
+	if existing.AgentAppID != "" && t.deps.AgentContentUpdater == nil {
+		return nil, fmt.Errorf("update linked agent content: updater is not wired")
+	}
 	updated, err := t.deps.Bots.Update(ctx, orgID, botID, bots.UpdateParams{Content: &args.Content})
 	if err != nil {
 		return nil, fmt.Errorf("set bot content: %w", err)
+	}
+	if updated.AgentAppID != "" {
+		if err := t.deps.AgentContentUpdater.UpdateAgentContent(ctx, updated.AgentAppID, args.Content); err != nil {
+			_, rollbackErr := t.deps.Bots.Update(ctx, orgID, botID, bots.UpdateParams{Content: &existing.Content})
+			if rollbackErr != nil {
+				return nil, fmt.Errorf("update linked agent content: %v; rollback bot content: %w", err, rollbackErr)
+			}
+			return nil, fmt.Errorf("update linked agent content: %w", err)
+		}
 	}
 	// Mirror the new content into the bot's Environment so a running
 	// session sees it without waiting for the next activation.

--- a/api/pkg/org/interfaces/server/api/agents_openapi.go
+++ b/api/pkg/org/interfaces/server/api/agents_openapi.go
@@ -1,0 +1,183 @@
+package api
+
+import "net/http"
+
+// @Summary Helix-org: list agents
+// @Description List the canonical Agents in an organization, including their instructions, tools, runtime, model configuration, and reporting lines.
+// @Tags HelixOrg
+// @Produce json
+// @Param org path string true "Organization slug or ID"
+// @Success 200 {array} api.BotDTO
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/agents [get]
+func (a *apiHandler) listAgents(w http.ResponseWriter, r *http.Request) {
+	a.listBots(w, r)
+}
+
+// @Summary Helix-org: create an agent
+// @Description Create a canonical Agent with its org-chart position, communication topics, tools, and Agent App configuration.
+// @Tags HelixOrg
+// @Accept json
+// @Produce json
+// @Param org path string true "Organization slug or ID"
+// @Param payload body api.CreateBotRequest true "Agent specification"
+// @Success 201 {object} api.CreateBotResponse
+// @Failure 400 {object} api.ErrorResponse
+// @Failure 501 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/agents [post]
+func (a *apiHandler) createAgent(w http.ResponseWriter, r *http.Request) {
+	a.createBot(w, r)
+}
+
+// @Summary Helix-org: update an agent
+// @Description Update the canonical Agent instructions, tools, project access, runtime, provider, model, or reasoning configuration.
+// @Tags HelixOrg
+// @Accept json
+// @Param org path string true "Organization slug or ID"
+// @Param id path string true "Agent ID"
+// @Param payload body api.UpdateBotRequest true "Agent fields to update"
+// @Success 200 {object} api.BotDTO
+// @Failure 404 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/agents/{id} [patch]
+func (a *apiHandler) updateAgent(w http.ResponseWriter, r *http.Request) {
+	a.updateBot(w, r)
+}
+
+// @Summary Helix-org: delete an agent
+// @Description Delete an Agent after stopping its sessions and project, then atomically remove its Agent App, knowledge, runtime state, subscriptions, reporting lines, and org-chart row.
+// @Tags HelixOrg
+// @Param org path string true "Organization slug or ID"
+// @Param id path string true "Agent ID"
+// @Success 204
+// @Failure 404 {object} api.ErrorResponse
+// @Failure 409 {object} api.ErrorResponse
+// @Failure 501 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/agents/{id} [delete]
+func (a *apiHandler) deleteAgent(w http.ResponseWriter, r *http.Request) {
+	a.deleteBot(w, r)
+}
+
+// @Summary Helix-org: add an agent manager
+// @Tags HelixOrg
+// @Accept json
+// @Param org path string true "Organization slug or ID"
+// @Param id path string true "Agent ID of the direct report"
+// @Param payload body api.AddBotParentRequest true "Manager Agent ID"
+// @Success 204
+// @Failure 400 {object} api.ErrorResponse
+// @Failure 404 {object} api.ErrorResponse
+// @Failure 409 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/agents/{id}/parents [post]
+func (a *apiHandler) addAgentParent(w http.ResponseWriter, r *http.Request) {
+	a.addBotParent(w, r)
+}
+
+// @Summary Helix-org: remove an agent manager
+// @Tags HelixOrg
+// @Param org path string true "Organization slug or ID"
+// @Param id path string true "Agent ID of the direct report"
+// @Param parent_id path string true "Manager Agent ID"
+// @Success 204
+// @Failure 400 {object} api.ErrorResponse
+// @Failure 404 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/agents/{id}/parents/{parent_id} [delete]
+func (a *apiHandler) removeAgentParent(w http.ResponseWriter, r *http.Request) {
+	a.removeBotParent(w, r)
+}
+
+// @Summary Helix-org: provision an agent chat
+// @Tags HelixOrg
+// @Param org path string true "Organization slug or ID"
+// @Param id path string true "Agent ID"
+// @Success 200 {object} api.BotChatDTO
+// @Failure 404 {object} api.ErrorResponse
+// @Failure 501 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/agents/{id}/chat [post]
+func (a *apiHandler) ensureAgentChat(w http.ResponseWriter, r *http.Request) {
+	a.ensureBotChat(w, r)
+}
+
+// @Summary Helix-org: activate an agent
+// @Tags HelixOrg
+// @Param org path string true "Organization slug or ID"
+// @Param id path string true "Agent ID"
+// @Success 202 {object} api.BotActivateDTO
+// @Failure 404 {object} api.ErrorResponse
+// @Failure 501 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/agents/{id}/activate [post]
+func (a *apiHandler) activateAgent(w http.ResponseWriter, r *http.Request) {
+	a.activateBot(w, r)
+}
+
+// @Summary Helix-org: stop an agent desktop
+// @Tags HelixOrg
+// @Param org path string true "Organization slug or ID"
+// @Param id path string true "Agent ID"
+// @Success 204
+// @Failure 404 {object} api.ErrorResponse
+// @Failure 501 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/agents/{id}/stop-agent [post]
+func (a *apiHandler) stopAgent(w http.ResponseWriter, r *http.Request) {
+	a.stopBotAgent(w, r)
+}
+
+// @Summary Helix-org: restart an agent session
+// @Tags HelixOrg
+// @Param org path string true "Organization slug or ID"
+// @Param id path string true "Agent ID"
+// @Success 202 {object} api.BotActivateDTO
+// @Failure 404 {object} api.ErrorResponse
+// @Failure 500 {object} api.ErrorResponse
+// @Failure 501 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/agents/{id}/restart-agent [post]
+func (a *apiHandler) restartAgent(w http.ResponseWriter, r *http.Request) {
+	a.restartBotAgent(w, r)
+}
+
+// @Summary Helix-org: list an agent's subscriptions
+// @Tags HelixOrg
+// @Param org path string true "Organization slug or ID"
+// @Param id path string true "Agent ID"
+// @Success 200 {object} api.BotSubscriptionsResponse
+// @Failure 404 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/agents/{id}/subscriptions [get]
+func (a *apiHandler) listAgentSubscriptions(w http.ResponseWriter, r *http.Request) {
+	a.listBotSubscriptions(w, r)
+}
+
+// @Summary Helix-org: subscribe an agent to a topic
+// @Tags HelixOrg
+// @Param org path string true "Organization slug or ID"
+// @Param id path string true "Agent ID"
+// @Param payload body api.SubscribeBotRequest true "Topic to subscribe the Agent to"
+// @Success 200 {object} api.BotSubscriptionDTO
+// @Success 201 {object} api.BotSubscriptionDTO
+// @Failure 404 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/agents/{id}/subscriptions [post]
+func (a *apiHandler) subscribeAgent(w http.ResponseWriter, r *http.Request) {
+	a.subscribeBot(w, r)
+}
+
+// @Summary Helix-org: unsubscribe an agent from a topic
+// @Tags HelixOrg
+// @Param org path string true "Organization slug or ID"
+// @Param id path string true "Agent ID"
+// @Param topic_id path string true "Topic ID"
+// @Success 204
+// @Failure 404 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/agents/{id}/subscriptions/{topic_id} [delete]
+func (a *apiHandler) unsubscribeAgent(w http.ResponseWriter, r *http.Request) {
+	a.unsubscribeBot(w, r)
+}

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -28,6 +28,8 @@ import (
 	"github.com/helixml/helix/api/pkg/types"
 )
 
+var ErrInvalidAgentProfile = errors.New("invalid agent profile")
+
 // resolveOrgID returns the orgID stashed on ctx by the helix-org
 // middleware (withHelixOrgScope in api/pkg/server). Empty orgID
 // means no scope was set — handlers respond 400 and bail rather

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -25,6 +25,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/infrastructure/wakebus"
 	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
 	helixorgserver "github.com/helixml/helix/api/pkg/org/interfaces/server"
+	"github.com/helixml/helix/api/pkg/types"
 )
 
 // resolveOrgID returns the orgID stashed on ctx by the helix-org
@@ -140,7 +141,10 @@ type Deps struct {
 	// row, reporting lines, Helix project + app teardown, store
 	// cleanup, topology reconcile). nil disables POST /bots and
 	// DELETE /bots/{id} (returns 501).
-	Lifecycle *lifecycle.Service
+	Lifecycle           *lifecycle.Service
+	AgentUpdater        AgentUpdater
+	AgentReader         AgentReader
+	AgentDefaultApplier AgentDefaultApplier
 
 	// GitHubTokenResolver is the production hook for "reinstate the
 	// GitHub topic + reuse the existing GitHub integration for
@@ -197,6 +201,41 @@ type Deps struct {
 	// unset — the install-webhook handler refuses on localhost so
 	// operators don't paste an unreachable URL into a real repo.
 	PublicServerURL string
+}
+
+type AgentUpdater interface {
+	UpdateAgent(ctx context.Context, appID string, patch AgentConfigPatch, name, instructions *string) error
+}
+
+type AgentReader interface {
+	ReadAgent(ctx context.Context, appID string) (AgentProfile, error)
+}
+
+type AgentDefaultApplier interface {
+	ApplyAgentDefaults(ctx context.Context, appID string, defaults types.AssistantConfig) error
+}
+
+type AgentConfigPatch struct {
+	CodeAgentRuntime        *types.CodeAgentRuntime
+	CodeAgentCredentialType *types.CodeAgentCredentialType
+	Provider                *string
+	Model                   *string
+	ReasoningEffort         *string
+}
+
+func (p AgentConfigPatch) Empty() bool {
+	return p.CodeAgentRuntime == nil && p.CodeAgentCredentialType == nil &&
+		p.Provider == nil && p.Model == nil && p.ReasoningEffort == nil
+}
+
+type AgentProfile struct {
+	Name                    string
+	Instructions            string
+	CodeAgentRuntime        types.CodeAgentRuntime
+	CodeAgentCredentialType types.CodeAgentCredentialType
+	Provider                string
+	Model                   string
+	ReasoningEffort         string
 }
 
 // BotRuntimeInfo is the subset of a Bot's runtime-state sidecar the
@@ -293,6 +332,20 @@ func Routes(deps Deps) []Route {
 		// manager edges rather than replacing a single parent.
 		{Pattern: "POST /bots/{id}/parents", Handler: http.HandlerFunc(a.addBotParent)},
 		{Pattern: "DELETE /bots/{id}/parents/{parent_id}", Handler: http.HandlerFunc(a.removeBotParent)},
+		{Pattern: "GET /agents", Handler: http.HandlerFunc(a.listAgents)},
+		{Pattern: "POST /agents", Handler: http.HandlerFunc(a.createAgent)},
+		{Pattern: "GET /agents/{id}", Handler: http.HandlerFunc(a.getAgent)},
+		{Pattern: "PATCH /agents/{id}", Handler: http.HandlerFunc(a.updateAgent)},
+		{Pattern: "DELETE /agents/{id}", Handler: http.HandlerFunc(a.deleteAgent)},
+		{Pattern: "GET /agents/{id}/subscriptions", Handler: http.HandlerFunc(a.listAgentSubscriptions)},
+		{Pattern: "POST /agents/{id}/subscriptions", Handler: http.HandlerFunc(a.subscribeAgent)},
+		{Pattern: "DELETE /agents/{id}/subscriptions/{topic_id}", Handler: http.HandlerFunc(a.unsubscribeAgent)},
+		{Pattern: "POST /agents/{id}/chat", Handler: http.HandlerFunc(a.ensureAgentChat)},
+		{Pattern: "POST /agents/{id}/activate", Handler: http.HandlerFunc(a.activateAgent)},
+		{Pattern: "POST /agents/{id}/stop-agent", Handler: http.HandlerFunc(a.stopAgent)},
+		{Pattern: "POST /agents/{id}/restart-agent", Handler: http.HandlerFunc(a.restartAgent)},
+		{Pattern: "POST /agents/{id}/parents", Handler: http.HandlerFunc(a.addAgentParent)},
+		{Pattern: "DELETE /agents/{id}/parents/{parent_id}", Handler: http.HandlerFunc(a.removeAgentParent)},
 		{Pattern: "GET /tools", Handler: http.HandlerFunc(a.listTools)},
 		{Pattern: "GET /settings", Handler: http.HandlerFunc(a.listSettings)},
 		{Pattern: "PUT /settings/{key}", Handler: http.HandlerFunc(a.setSetting)},

--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -123,6 +123,7 @@ func (a *apiHandler) createBot(w http.ResponseWriter, r *http.Request) {
 	if req.Owner {
 		tools = mcptools.OwnerBotTools()
 	}
+	deferActivation := a.deps.Configs != nil && !a.deps.Configs.IsDefaultAgentConfigured(ctx, orgID)
 	// REST and chat-driven creates share lifecycle.Create — one
 	// implementation.
 	res, err := a.deps.Lifecycle.Create(ctx, orgID, lifecycle.CreateParams{
@@ -133,6 +134,7 @@ func (a *apiHandler) createBot(w http.ResponseWriter, r *http.Request) {
 		Topics:          toTopicIDs(req.Topics),
 		ParentID:        orgchart.BotID(strings.TrimSpace(req.ParentID)),
 		PreserveContext: req.PreserveContext,
+		DeferActivation: deferActivation,
 	})
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)

--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -57,7 +57,7 @@ func (a *apiHandler) listBots(w http.ResponseWriter, r *http.Request) {
 	out := make([]BotDTO, 0, len(bs))
 	for _, b := range bs {
 		dto := botDTO(b, managersByReport[b.ID])
-		if err := a.canonicalAgentProfile(ctx, b, &dto); err != nil {
+		if err := a.canonicalAgentProfile(ctx, b, &dto); err != nil && !errors.Is(err, ErrInvalidAgentProfile) {
 			writeError(w, http.StatusInternalServerError, err)
 			return
 		}

--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -57,6 +57,10 @@ func (a *apiHandler) listBots(w http.ResponseWriter, r *http.Request) {
 	out := make([]BotDTO, 0, len(bs))
 	for _, b := range bs {
 		dto := botDTO(b, managersByReport[b.ID])
+		if err := a.canonicalAgentProfile(ctx, b, &dto); err != nil {
+			writeError(w, http.StatusInternalServerError, err)
+			return
+		}
 		// Humans never run an agent sandbox — always "stopped". Agents
 		// get status from the runtime sidecar + session metadata.
 		dto.AgentStatus = "stopped"
@@ -166,6 +170,10 @@ func (a *apiHandler) getBot(w http.ResponseWriter, r *http.Request) {
 	}
 
 	dto := botDTO(b, a.managerIDs(ctx, orgID, id))
+	if err := a.canonicalAgentProfile(ctx, b, &dto); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
 	dto.AgentStatus = "stopped"
 	// Populate the agent app id + project id from the helix-runtime
 	// sidecar so the chart UI can deep-link "chat with bot" to the
@@ -175,17 +183,43 @@ func (a *apiHandler) getBot(w http.ResponseWriter, r *http.Request) {
 	// presence control on the bot detail page.
 	if a.deps.BotRuntime != nil {
 		if info, err := a.deps.BotRuntime.State(ctx, orgID, id); err == nil {
-			detail := BotDetailDTO{Bot: dto, AgentAppID: info.AgentAppID, ProjectID: info.ProjectID}
+			agentAppID := b.AgentAppID
+			if agentAppID == "" {
+				agentAppID = info.AgentAppID
+			}
+			detail := BotDetailDTO{Bot: dto, AgentAppID: agentAppID, ProjectID: info.ProjectID}
 			if info.AgentStatus != "" {
 				detail.Bot.AgentStatus = info.AgentStatus
 			}
 			detail.Bot.AgentRuntime = info.Runtime
 			detail.Bot.AgentModel = info.Model
-			writeJSON(w, http.StatusOK, detail)
+			if strings.Contains(r.URL.Path, "/agents/") {
+				writeJSON(w, http.StatusOK, AgentDetailDTO{BotDTO: detail.Bot, ProjectID: detail.ProjectID})
+			} else {
+				writeJSON(w, http.StatusOK, detail)
+			}
 			return
 		}
 	}
-	writeJSON(w, http.StatusOK, BotDetailDTO{Bot: dto})
+	if strings.Contains(r.URL.Path, "/agents/") {
+		writeJSON(w, http.StatusOK, AgentDetailDTO{BotDTO: dto})
+	} else {
+		writeJSON(w, http.StatusOK, BotDetailDTO{Bot: dto, AgentAppID: b.AgentAppID})
+	}
+}
+
+// @Summary Helix-org: get agent detail
+// @Description Get one canonical Agent with its instructions, tools, runtime, model configuration, project, and reporting lines.
+// @Tags HelixOrg
+// @Produce json
+// @Param org path string true "Organization slug or ID"
+// @Param id path string true "Agent ID"
+// @Success 200 {object} api.AgentDetailDTO
+// @Failure 404 {object} api.ErrorResponse
+// @Security ApiKeyAuth
+// @Router /api/v1/orgs/{org}/agents/{id} [get]
+func (a *apiHandler) getAgent(w http.ResponseWriter, r *http.Request) {
+	a.getBot(w, r)
 }
 
 // updateBot rewrites a Bot's content / tools / topics. A nil field is
@@ -242,9 +276,28 @@ func (a *apiHandler) updateBot(w http.ResponseWriter, r *http.Request) {
 		}
 		identityPatch = &req.Identity
 	}
+	namePatch := req.Name
+	contentPatch := req.Content
+	configPatch := AgentConfigPatch{
+		CodeAgentRuntime:        req.CodeAgentRuntime,
+		CodeAgentCredentialType: req.CodeAgentCredentialType,
+		Provider:                req.Provider,
+		Model:                   req.Model,
+		ReasoningEffort:         req.ReasoningEffort,
+	}
+	existing, err := a.deps.Queries.GetBot(ctx, orgID, id)
+	if err != nil {
+		writeError(w, errStatus(err), fmt.Errorf("get bot for update: %w", err))
+		return
+	}
+	canonicalChange := !configPatch.Empty() || namePatch != nil || contentPatch != nil
+	if !existing.IsHuman() && existing.AgentAppID != "" && canonicalChange && a.deps.AgentUpdater == nil {
+		writeError(w, http.StatusServiceUnavailable, errors.New("canonical agent updater is not available"))
+		return
+	}
 	updated, err := a.deps.Bots.Update(ctx, orgID, id, bots.UpdateParams{
-		Name:            req.Name,
-		Content:         req.Content,
+		Name:            namePatch,
+		Content:         contentPatch,
 		Tools:           toolsPatch,
 		ProjectIDs:      stringSlicePatch(req.ProjectIDs),
 		PreserveContext: req.PreserveContext,
@@ -254,7 +307,37 @@ func (a *apiHandler) updateBot(w http.ResponseWriter, r *http.Request) {
 		writeError(w, errStatus(err), fmt.Errorf("update bot: %w", err))
 		return
 	}
-	writeJSON(w, http.StatusOK, botDTO(updated, a.managerIDs(ctx, orgID, id)))
+	if !updated.IsHuman() && updated.AgentAppID != "" && canonicalChange {
+		if err := a.deps.AgentUpdater.UpdateAgent(ctx, updated.AgentAppID, configPatch, namePatch, contentPatch); err != nil {
+			tools := append([]tool.Name(nil), existing.Tools...)
+			projectIDs := append([]string(nil), existing.ProjectIDs...)
+			identity := make(map[string]string, len(existing.Identity))
+			for key, value := range existing.Identity {
+				identity[key] = value
+			}
+			preserveContext := existing.PreserveContext
+			_, rollbackErr := a.deps.Bots.Update(ctx, orgID, id, bots.UpdateParams{
+				Name:            &existing.Name,
+				Content:         &existing.Content,
+				Tools:           &tools,
+				ProjectIDs:      &projectIDs,
+				PreserveContext: &preserveContext,
+				Identity:        &identity,
+			})
+			if rollbackErr != nil {
+				writeError(w, http.StatusInternalServerError, fmt.Errorf("update agent: %v; rollback org profile: %w", err, rollbackErr))
+				return
+			}
+			writeError(w, errStatus(err), fmt.Errorf("update agent: %w", err))
+			return
+		}
+	}
+	dto := botDTO(updated, a.managerIDs(ctx, orgID, id))
+	if err := a.canonicalAgentProfile(ctx, updated, &dto); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, dto)
 }
 
 // deleteBot tears down a Bot via the lifecycle service. Cascades the
@@ -613,6 +696,7 @@ func (a *apiHandler) managerIDs(ctx context.Context, orgID string, id orgchart.B
 func botDTO(b orgchart.Bot, parentIDs []string) BotDTO {
 	dto := BotDTO{
 		ID:              string(b.ID),
+		AgentAppID:      b.AgentAppID,
 		Name:            b.Name,
 		Content:         b.Content,
 		ProjectIDs:      b.ProjectIDs,
@@ -636,6 +720,24 @@ func botDTO(b orgchart.Bot, parentIDs []string) BotDTO {
 	sort.Strings(tools)
 	dto.Tools = tools
 	return dto
+}
+
+func (a *apiHandler) canonicalAgentProfile(ctx context.Context, bot orgchart.Bot, dto *BotDTO) error {
+	if dto == nil || bot.IsHuman() || bot.AgentAppID == "" || a.deps.AgentReader == nil {
+		return nil
+	}
+	profile, err := a.deps.AgentReader.ReadAgent(ctx, bot.AgentAppID)
+	if err != nil {
+		return fmt.Errorf("read canonical agent %s for bot %s: %w", bot.AgentAppID, bot.ID, err)
+	}
+	dto.Name = profile.Name
+	dto.Content = profile.Instructions
+	dto.CodeAgentRuntime = profile.CodeAgentRuntime
+	dto.CodeAgentCredentialType = profile.CodeAgentCredentialType
+	dto.Provider = profile.Provider
+	dto.Model = profile.Model
+	dto.ReasoningEffort = profile.ReasoningEffort
+	return nil
 }
 
 func stringSlicePatch(in []string) *[]string {

--- a/api/pkg/org/interfaces/server/api/bots_rest_test.go
+++ b/api/pkg/org/interfaces/server/api/bots_rest_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +30,21 @@ func (failingAgentUpdater) UpdateAgent(context.Context, string, orgapi.AgentConf
 type recordingAgentPort struct {
 	profile orgapi.AgentProfile
 	patch   orgapi.AgentConfigPatch
+}
+
+type partialAgentReader struct{}
+
+func (partialAgentReader) ReadAgent(_ context.Context, appID string) (orgapi.AgentProfile, error) {
+	if appID == "app-invalid" {
+		return orgapi.AgentProfile{}, fmt.Errorf("%w: linked App must contain exactly one assistant", orgapi.ErrInvalidAgentProfile)
+	}
+	return orgapi.AgentProfile{Name: "Canonical valid", Instructions: "Valid instructions"}, nil
+}
+
+type failingAgentReader struct{}
+
+func (failingAgentReader) ReadAgent(context.Context, string) (orgapi.AgentProfile, error) {
+	return orgapi.AgentProfile{}, errors.New("database unavailable")
 }
 
 func (p *recordingAgentPort) ReadAgent(context.Context, string) (orgapi.AgentProfile, error) {
@@ -103,6 +120,64 @@ func TestRESTAgentResourceIsFlat(t *testing.T) {
 	if port.patch.CodeAgentRuntime == nil || *port.patch.CodeAgentRuntime != runtime ||
 		port.patch.Model == nil || *port.patch.Model != model {
 		t.Fatalf("flat patch = %#v", port.patch)
+	}
+}
+
+func TestRESTAgentListKeepsOtherAgentsWhenOneLinkedAppIsInvalid(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	ctx := context.Background()
+	for _, fixture := range []struct {
+		id, appID, content string
+	}{
+		{id: "b-invalid", appID: "app-invalid", content: "Bot fallback"},
+		{id: "b-valid", appID: "app-valid", content: "Stale"},
+	} {
+		bot, err := orgchart.NewBot(orgchart.BotID(fixture.id), fixture.content, nil, time.Now().UTC(), "org-test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := st.Bots.Create(ctx, bot.WithAgentAppID(fixture.appID)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	deps.AgentReader = partialAgentReader{}
+
+	rec := do(t, orgapi.Handler(deps), http.MethodGet, "/agents", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status = %d; body=%s", rec.Code, rec.Body)
+	}
+	var got []orgapi.BotDTO
+	decode(t, rec, &got)
+	if len(got) != 2 {
+		t.Fatalf("agents = %+v", got)
+	}
+	byID := map[string]orgapi.BotDTO{got[0].ID: got[0], got[1].ID: got[1]}
+	if byID["b-invalid"].Content != "Bot fallback" {
+		t.Fatalf("invalid fallback = %+v", byID["b-invalid"])
+	}
+	if byID["b-valid"].Name != "Canonical valid" || byID["b-valid"].Content != "Valid instructions" {
+		t.Fatalf("valid canonical profile = %+v", byID["b-valid"])
+	}
+}
+
+func TestRESTAgentListReportsOperationalAgentReadFailure(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	ctx := context.Background()
+	bot, err := orgchart.NewBot("b-agent", "Fallback", nil, time.Now().UTC(), "org-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Bots.Create(ctx, bot.WithAgentAppID("app-agent")); err != nil {
+		t.Fatal(err)
+	}
+	deps.AgentReader = failingAgentReader{}
+
+	rec := do(t, orgapi.Handler(deps), http.MethodGet, "/agents", nil)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("list status = %d, want 500; body=%s", rec.Code, rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), "database unavailable") {
+		t.Fatalf("list error = %s", rec.Body)
 	}
 }
 

--- a/api/pkg/org/interfaces/server/api/bots_rest_test.go
+++ b/api/pkg/org/interfaces/server/api/bots_rest_test.go
@@ -16,7 +16,95 @@ import (
 	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
 	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
 	orgapi "github.com/helixml/helix/api/pkg/org/interfaces/server/api"
+	"github.com/helixml/helix/api/pkg/types"
 )
+
+type failingAgentUpdater struct{}
+
+func (failingAgentUpdater) UpdateAgent(context.Context, string, orgapi.AgentConfigPatch, *string, *string) error {
+	return errors.New("agent update failed")
+}
+
+type recordingAgentPort struct {
+	profile orgapi.AgentProfile
+	patch   orgapi.AgentConfigPatch
+}
+
+func (p *recordingAgentPort) ReadAgent(context.Context, string) (orgapi.AgentProfile, error) {
+	return p.profile, nil
+}
+
+func (p *recordingAgentPort) UpdateAgent(_ context.Context, _ string, patch orgapi.AgentConfigPatch, name, instructions *string) error {
+	p.patch = patch
+	if name != nil {
+		p.profile.Name = *name
+	}
+	if instructions != nil {
+		p.profile.Instructions = *instructions
+	}
+	if patch.CodeAgentRuntime != nil {
+		p.profile.CodeAgentRuntime = *patch.CodeAgentRuntime
+	}
+	if patch.Model != nil {
+		p.profile.Model = *patch.Model
+	}
+	return nil
+}
+
+func TestRESTAgentResourceIsFlat(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	ctx := context.Background()
+	bot, err := orgchart.NewBot("b-agent", "stale", nil, time.Now().UTC(), "org-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bot = bot.WithAgentAppID("app-agent")
+	if err := st.Bots.Create(ctx, bot); err != nil {
+		t.Fatal(err)
+	}
+	port := &recordingAgentPort{profile: orgapi.AgentProfile{
+		Name:             "Canonical",
+		Instructions:     "Canonical instructions",
+		CodeAgentRuntime: types.CodeAgentRuntimeCodexCLI,
+		Model:            "gpt-5",
+	}}
+	deps.AgentReader = port
+	deps.AgentUpdater = port
+	handler := orgapi.Handler(deps)
+
+	rec := do(t, handler, http.MethodGet, "/agents/b-agent", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get status = %d; body=%s", rec.Code, rec.Body)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["name"] != "Canonical" || got["content"] != "Canonical instructions" ||
+		got["code_agent_runtime"] != "codex_cli" || got["model"] != "gpt-5" {
+		t.Fatalf("flat agent = %#v", got)
+	}
+	if _, nested := got["bot"]; nested {
+		t.Fatalf("canonical Agent response contains nested bot: %#v", got)
+	}
+	if _, nested := got["agent"]; nested {
+		t.Fatalf("canonical Agent response contains nested agent: %#v", got)
+	}
+
+	runtime := types.CodeAgentRuntimeClaudeCode
+	model := "opus"
+	rec = do(t, handler, http.MethodPatch, "/agents/b-agent", orgapi.UpdateBotRequest{
+		CodeAgentRuntime: &runtime,
+		Model:            &model,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch status = %d; body=%s", rec.Code, rec.Body)
+	}
+	if port.patch.CodeAgentRuntime == nil || *port.patch.CodeAgentRuntime != runtime ||
+		port.patch.Model == nil || *port.patch.Model != model {
+		t.Fatalf("flat patch = %#v", port.patch)
+	}
+}
 
 func injectMCPPublishing(cfg *mcptools.Config) {
 	deps := publishing.Deps{
@@ -77,6 +165,79 @@ func TestRESTUpdateNonHumanIdentityDoesNotRequireHumanAuthorization(t *testing.T
 	})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d; body=%s", rec.Code, rec.Body)
+	}
+}
+
+func TestRESTUpdateAgentRollsBackOrgProfile(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	ctx := context.Background()
+	bot, err := orgchart.NewBot("b-agent", "old content", []tool.Name{"old_tool"}, time.Now().UTC(), "org-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bot = bot.WithAgentAppID("app-agent").
+		WithName("Old name").
+		WithProjectIDs([]string{"prj-old"}).
+		WithPreserveContext(true).
+		WithIdentity(map[string]string{"old": "value"})
+	if err := st.Bots.Create(ctx, bot); err != nil {
+		t.Fatal(err)
+	}
+	deps.AgentUpdater = failingAgentUpdater{}
+	name := "New name"
+	content := "new content"
+	preserve := false
+	rec := do(t, orgapi.Handler(deps), http.MethodPatch, "/bots/b-agent", orgapi.UpdateBotRequest{
+		Name:            &name,
+		Content:         &content,
+		Tools:           []string{"new_tool"},
+		ProjectIDs:      []string{"prj-new"},
+		PreserveContext: &preserve,
+		Identity:        map[string]string{"new": "value"},
+	})
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", rec.Code, rec.Body)
+	}
+	got, err := st.Bots.Get(ctx, "org-test", "b-agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != bot.Name || got.Content != bot.Content || got.PreserveContext != bot.PreserveContext {
+		t.Fatalf("profile was not rolled back: %#v", got)
+	}
+	if !sameNames(got.Tools, bot.Tools) || len(got.ProjectIDs) != 1 || got.ProjectIDs[0] != "prj-old" || got.Identity["old"] != "value" {
+		t.Fatalf("profile collections were not rolled back: %#v", got)
+	}
+}
+
+func TestRESTUpdateLinkedAgentRequiresUpdaterBeforeMutation(t *testing.T) {
+	deps, st, _ := newDeps(t)
+	ctx := context.Background()
+	bot, err := orgchart.NewBot("b-agent", "old content", nil, time.Now().UTC(), "org-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bot = bot.WithAgentAppID("app-agent").WithName("Old name")
+	if err := st.Bots.Create(ctx, bot); err != nil {
+		t.Fatal(err)
+	}
+	name := "New name"
+	content := "new content"
+
+	rec := do(t, orgapi.Handler(deps), http.MethodPatch, "/bots/b-agent", orgapi.UpdateBotRequest{
+		Name:    &name,
+		Content: &content,
+	})
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body=%s", rec.Code, rec.Body)
+	}
+	got, err := st.Bots.Get(ctx, "org-test", "b-agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != bot.Name || got.Content != bot.Content {
+		t.Fatalf("missing updater mutated bot: %#v", got)
 	}
 }
 

--- a/api/pkg/org/interfaces/server/api/dto.go
+++ b/api/pkg/org/interfaces/server/api/dto.go
@@ -7,7 +7,10 @@
 // client-side.
 package api
 
-import "github.com/helixml/helix/api/pkg/org/application/publishing"
+import (
+	"github.com/helixml/helix/api/pkg/org/application/publishing"
+	"github.com/helixml/helix/api/pkg/types"
+)
 
 // BotBadge is a compact reference to a Bot on the org overview.
 type BotBadge struct {
@@ -37,7 +40,8 @@ type ToolDTO struct {
 // report to several managers. A Bot's subscriptions are not on the bot —
 // they live as (bot, topic) rows.
 type BotDTO struct {
-	ID string `json:"id"`
+	ID         string `json:"id"`
+	AgentAppID string `json:"agent_app_id,omitempty"`
 	// Name is the human-readable display label; empty means the UI falls
 	// back to ID. Distinct from ID, which is the immutable handle.
 	Name           string   `json:"name,omitempty"`
@@ -60,11 +64,16 @@ type BotDTO struct {
 	// AgentStatus is "running" when the bot's desktop sandbox is online,
 	// "stopped" otherwise (no session, paused, never activated). Drives
 	// the green/grey presence dot on the org chart.
-	AgentStatus  string `json:"agent_status,omitempty"`
-	AgentRuntime string `json:"agent_runtime,omitempty"`
-	AgentModel   string `json:"agent_model,omitempty"`
-	CreatedAt    string `json:"created_at,omitempty"`
-	UpdatedAt    string `json:"updated_at,omitempty"`
+	AgentStatus             string                        `json:"agent_status,omitempty"`
+	AgentRuntime            string                        `json:"agent_runtime,omitempty"`
+	AgentModel              string                        `json:"agent_model,omitempty"`
+	CodeAgentRuntime        types.CodeAgentRuntime        `json:"code_agent_runtime,omitempty"`
+	CodeAgentCredentialType types.CodeAgentCredentialType `json:"code_agent_credential_type,omitempty"`
+	Provider                string                        `json:"provider,omitempty"`
+	Model                   string                        `json:"model,omitempty"`
+	ReasoningEffort         string                        `json:"reasoning_effort,omitempty"`
+	CreatedAt               string                        `json:"created_at,omitempty"`
+	UpdatedAt               string                        `json:"updated_at,omitempty"`
 }
 
 // BotChatDTO is the POST /bots/{id}/chat response. AgentAppID is the
@@ -93,6 +102,11 @@ type BotDetailDTO struct {
 	// AgentAppID + ProjectID — see BotChatDTO comments.
 	AgentAppID string `json:"agent_app_id,omitempty"`
 	ProjectID  string `json:"project_id,omitempty"`
+}
+
+type AgentDetailDTO struct {
+	BotDTO
+	ProjectID string `json:"project_id,omitempty"`
 }
 
 // CreateBotRequest is the body of POST /bots. Mirrors the MCP
@@ -138,7 +152,12 @@ type UpdateBotRequest struct {
 	// Identity is the per-channel handle map for a human node (slack/github/
 	// email/…). When present it replaces the stored map; absent leaves it
 	// unchanged. Only meaningful for kind=human bots.
-	Identity map[string]string `json:"identity,omitempty"`
+	Identity                map[string]string              `json:"identity,omitempty"`
+	CodeAgentRuntime        *types.CodeAgentRuntime        `json:"code_agent_runtime,omitempty"`
+	CodeAgentCredentialType *types.CodeAgentCredentialType `json:"code_agent_credential_type,omitempty"`
+	Provider                *string                        `json:"provider,omitempty"`
+	Model                   *string                        `json:"model,omitempty"`
+	ReasoningEffort         *string                        `json:"reasoning_effort,omitempty"`
 }
 
 // AddBotParentRequest is the body of POST /bots/{id}/parents. ParentID

--- a/api/pkg/org/interfaces/server/api/settings.go
+++ b/api/pkg/org/interfaces/server/api/settings.go
@@ -7,7 +7,16 @@ import (
 	"strings"
 
 	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+	"github.com/rs/zerolog/log"
 )
+
+var agentProvisioningKeys = map[string]bool{
+	configregistry.DefaultAgentConfigKey: true,
+	"worker.runtime":                     true,
+	"worker.credentials":                 true,
+	"worker.provider":                    true,
+	"worker.model":                       true,
+}
 
 // ---- Settings -----------------------------------------------------------
 
@@ -92,7 +101,63 @@ func (a *apiHandler) setSetting(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
+	if agentProvisioningKeys[key] {
+		a.activateDeferredBotsAfterRuntimeChange(r.Context(), orgID)
+	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (a *apiHandler) activateDeferredBotsAfterRuntimeChange(ctx context.Context, orgID string) {
+	if a.deps.Queries == nil || !a.runtimeConfigComplete(ctx, orgID) {
+		return
+	}
+	bs, err := a.deps.Queries.ListBots(ctx, orgID)
+	if err != nil {
+		log.Warn().Err(err).Str("org", orgID).Msg("activate deferred bots after runtime change: list bots failed")
+		return
+	}
+	for _, b := range bs {
+		if b.IsHuman() {
+			continue
+		}
+		provisioned := true
+		if a.deps.BotRuntime != nil {
+			info, err := a.deps.BotRuntime.State(ctx, orgID, b.ID)
+			provisioned = err == nil && info.ProjectID != ""
+		}
+		if provisioned {
+			continue
+		}
+		if b.AgentAppID != "" {
+			if a.deps.AgentDefaultApplier == nil {
+				log.Warn().Str("org", orgID).Str("bot", string(b.ID)).
+					Msg("apply deferred agent defaults skipped: applier is not wired")
+				continue
+			}
+			defaults, err := a.deps.Configs.GetDefaultAgentConfig(ctx, orgID)
+			if err != nil {
+				log.Warn().Err(err).Str("org", orgID).Str("bot", string(b.ID)).
+					Msg("read deferred agent defaults failed")
+				continue
+			}
+			if err := a.deps.AgentDefaultApplier.ApplyAgentDefaults(ctx, b.AgentAppID, defaults); err != nil {
+				log.Warn().Err(err).Str("org", orgID).Str("bot", string(b.ID)).
+					Msg("apply deferred agent defaults failed")
+				continue
+			}
+		}
+		if a.deps.Activations == nil {
+			continue
+		}
+		if _, err := a.deps.Activations.Activate(ctx, orgID, b.ID); err != nil {
+			log.Warn().Err(err).Str("org", orgID).Str("bot", string(b.ID)).
+				Msg("activate deferred bot after runtime change failed")
+		}
+	}
+}
+
+func (a *apiHandler) runtimeConfigComplete(ctx context.Context, orgID string) bool {
+	return a.deps.Configs != nil && a.deps.Configs.IsDefaultAgentConfigComplete(ctx, orgID)
 }
 
 // deleteSetting removes the config row for the given key, falling back to defaults.

--- a/api/pkg/org/interfaces/server/api/settings_agent_defaults_test.go
+++ b/api/pkg/org/interfaces/server/api/settings_agent_defaults_test.go
@@ -1,0 +1,81 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/org/application/activations"
+	"github.com/helixml/helix/api/pkg/org/application/bots"
+	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	orgapi "github.com/helixml/helix/api/pkg/org/interfaces/server/api"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+type deferredRuntime struct{}
+
+func (deferredRuntime) State(context.Context, string, orgchart.BotID) (orgapi.BotRuntimeInfo, error) {
+	return orgapi.BotRuntimeInfo{}, errors.New("not provisioned")
+}
+
+type recordingDefaultApplier struct {
+	applied  bool
+	appID    string
+	defaults types.AssistantConfig
+}
+
+func (a *recordingDefaultApplier) ApplyAgentDefaults(_ context.Context, appID string, defaults types.AssistantConfig) error {
+	a.applied = true
+	a.appID = appID
+	a.defaults = defaults
+	return nil
+}
+
+type orderedEnsurer struct {
+	defaults *recordingDefaultApplier
+	called   bool
+}
+
+func (e *orderedEnsurer) Ensure(context.Context, string, orgchart.BotID) (string, string, string, error) {
+	if !e.defaults.applied {
+		return "", "", "", errors.New("provisioned before defaults were applied")
+	}
+	e.called = true
+	return "prj-agent", e.defaults.appID, "", nil
+}
+
+func TestSettingDefaultAppliesDeferredAgentBeforeActivation(t *testing.T) {
+	deps, st, reg := newDeps(t)
+	reg.Register(configregistry.Spec{Key: configregistry.DefaultAgentConfigKey, Type: configregistry.TypeObject})
+	ctx := context.Background()
+	created, err := deps.Bots.Create(ctx, "org-test", bots.CreateParams{
+		ID: "b-agent", Name: "Agent", Content: "instructions", AgentAppID: "app-agent",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	applier := &recordingDefaultApplier{}
+	ensurer := &orderedEnsurer{defaults: applier}
+	deps.AgentDefaultApplier = applier
+	deps.BotRuntime = deferredRuntime{}
+	deps = wireActivate(deps, st, ensurer, &fakeDispatcher{})
+
+	rec := do(t, orgapi.Handler(deps), http.MethodPut, "/settings/"+configregistry.DefaultAgentConfigKey, orgapi.SetSettingRequest{
+		Value: `{"code_agent_runtime":"codex_cli","code_agent_credential_type":"subscription","model":"gpt-5.6","reasoning_effort":"high"}`,
+	})
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d; body=%s", rec.Code, rec.Body)
+	}
+	if !ensurer.called {
+		t.Fatal("deferred Agent was not activated")
+	}
+	if applier.appID != created.AgentAppID ||
+		applier.defaults.CodeAgentRuntime != types.CodeAgentRuntimeCodexCLI ||
+		applier.defaults.Model != "gpt-5.6" {
+		t.Fatalf("applied defaults = app %q config %+v", applier.appID, applier.defaults)
+	}
+}
+
+var _ activations.ProjectEnsurer = (*orderedEnsurer)(nil)

--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -386,15 +386,12 @@ func (s *HelixAPIServer) markHelixOrgAgents(ctx context.Context, orgID string, a
 		return nil
 	}
 
-	// org_bot_runtime_state holds one row per (org, bot, backend, key).
-	// The "helix" backend's "agent_app_id" value is the App backing that
-	// Bot — see api/pkg/org/infrastructure/runtime/helix/state.go.
 	var agentAppIDs []string
 	if err := accessor.GormDB().WithContext(ctx).
-		Table("org_bot_runtime_state").
-		Where("org_id = ? AND backend = ? AND key = ? AND value <> ?", orgID, "helix", "agent_app_id", "").
-		Distinct("value").
-		Pluck("value", &agentAppIDs).Error; err != nil {
+		Table("org_bots").
+		Where("org_id = ? AND agent_app_id IS NOT NULL", orgID).
+		Distinct("agent_app_id").
+		Pluck("agent_app_id", &agentAppIDs).Error; err != nil {
 		return system.NewHTTPError500(fmt.Sprintf("failed to list helix-org agent apps: %s", err))
 	}
 
@@ -1111,6 +1108,21 @@ func (s *HelixAPIServer) updateApp(_ http.ResponseWriter, r *http.Request) (*typ
 		return nil, system.NewHTTPError403(err.Error())
 	}
 
+	if s.helixOrg != nil && s.helixOrg.store != nil && existing.OrganizationID != "" {
+		bots, listErr := s.helixOrg.store.Bots.List(r.Context(), existing.OrganizationID)
+		if listErr != nil {
+			return nil, system.NewHTTPError500(listErr.Error())
+		}
+		for _, bot := range bots {
+			if bot.AgentAppID == existing.ID {
+				if len(update.Config.Helix.Assistants) != 1 {
+					return nil, system.NewHTTPError400("org-linked agent must contain exactly one assistant")
+				}
+				update.Config.Helix.Assistants[0].Name = update.Config.Helix.Name
+			}
+		}
+	}
+
 	normalizeHelixAgentAssistantSpecs(&update)
 
 	err = s.validateProvidersAndModels(r.Context(), user, &update)
@@ -1206,29 +1218,47 @@ func (s *HelixAPIServer) deleteApp(_ http.ResponseWriter, r *http.Request) (*typ
 	if err != nil {
 		return nil, system.NewHTTPError403(err.Error())
 	}
+	if s.helixOrg != nil && s.helixOrg.store != nil && s.helixOrg.lifecycle != nil && existing.OrganizationID != "" {
+		bots, listErr := s.helixOrg.store.Bots.List(r.Context(), existing.OrganizationID)
+		if listErr != nil {
+			return nil, system.NewHTTPError500(listErr.Error())
+		}
+		for _, bot := range bots {
+			if bot.AgentAppID == id {
+				if keepKnowledge {
+					return nil, system.NewHTTPError400("keep_knowledge is not supported when deleting an org-linked agent")
+				}
+				if deleteErr := s.helixOrg.lifecycle.Delete(r.Context(), existing.OrganizationID, bot.ID); deleteErr != nil {
+					return nil, system.NewHTTPError500(deleteErr.Error())
+				}
+				return existing, nil
+			}
+		}
+	}
+	if err := s.deleteAppData(r.Context(), id, keepKnowledge); err != nil {
+		return nil, system.NewHTTPError500(err.Error())
+	}
+	return existing, nil
+}
 
+func (s *HelixAPIServer) deleteAppData(ctx context.Context, id string, keepKnowledge bool) error {
 	if !keepKnowledge {
-		knowledge, err := s.Store.ListKnowledge(r.Context(), &store.ListKnowledgeQuery{
+		knowledge, err := s.Store.ListKnowledge(ctx, &store.ListKnowledgeQuery{
 			AppID: id,
 		})
 		if err != nil {
-			return nil, system.NewHTTPError500(err.Error())
+			return err
 		}
 
 		for _, k := range knowledge {
-			err = s.Store.DeleteKnowledge(r.Context(), k.ID)
+			err = s.Store.DeleteKnowledge(ctx, k.ID)
 			if err != nil {
-				return nil, system.NewHTTPError500(err.Error())
+				return err
 			}
 		}
 	}
 
-	err = s.Store.DeleteApp(r.Context(), id)
-	if err != nil {
-		return nil, system.NewHTTPError500(err.Error())
-	}
-
-	return existing, nil
+	return s.Store.DeleteApp(ctx, id)
 }
 
 // getAppOAuthTokenEnv retrieves OAuth tokens for the app

--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -339,6 +339,12 @@ func (s *HelixAPIServer) listOrganizationApps(ctx context.Context, user *types.U
 		return nil, system.NewHTTPError403(err.Error())
 	}
 
+	if s.helixOrg != nil && s.helixOrg.lifecycle != nil {
+		if err := s.helixOrg.lifecycle.ReconcileAgentLinks(ctx, orgID); err != nil {
+			return nil, system.NewHTTPError500(fmt.Sprintf("failed to reconcile organization agents: %s", err))
+		}
+	}
+
 	apps, err := s.Store.ListApps(ctx, &store.ListAppsQuery{
 		OrganizationID: orgID,
 	})

--- a/api/pkg/server/app_handlers_test.go
+++ b/api/pkg/server/app_handlers_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/openai/manager"
+	orgbots "github.com/helixml/helix/api/pkg/org/application/bots"
+	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	orgmemory "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
 	"github.com/helixml/helix/api/pkg/store"
@@ -20,6 +22,14 @@ import (
 
 	"go.uber.org/mock/gomock"
 )
+
+type listingAgentCreator struct {
+	appID string
+}
+
+func (c listingAgentCreator) CreateAgent(context.Context, string, string, string) (string, error) {
+	return c.appID, nil
+}
 
 func TestUpdateAppRejectsInvalidLinkedOrgAgentShape(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -112,6 +122,46 @@ func Test_markHelixOrgAgents_NoOrg_NoOp(t *testing.T) {
 	httpErr := server.markHelixOrgAgents(context.Background(), "", apps)
 	require.Nil(t, httpErr)
 	assert.False(t, apps[0].IsHelixOrgAgent)
+}
+
+func TestListOrganizationAppsReconcilesUnlinkedAgentsBeforeQuery(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	helixStore := store.NewMockStore(ctrl)
+	orgStore := orgmemory.New()
+	ctx := context.Background()
+
+	bot, err := orgchart.NewBot("b-legacy", "Legacy instructions", nil, time.Now().UTC(), "org-test")
+	require.NoError(t, err)
+	require.NoError(t, orgStore.Bots.Create(ctx, bot))
+
+	user := &types.User{ID: "user-owner"}
+	helixStore.EXPECT().GetOrganizationMembership(gomock.Any(), gomock.Any()).Return(&types.OrganizationMembership{
+		UserID: user.ID, OrganizationID: "org-test", Role: types.OrganizationRoleOwner,
+	}, nil)
+	helixStore.EXPECT().ListApps(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(context.Context, *store.ListAppsQuery) ([]*types.App, error) {
+			linked, err := orgStore.Bots.Get(ctx, "org-test", bot.ID)
+			require.NoError(t, err)
+			require.Equal(t, "app-reconciled", linked.AgentAppID)
+			return []*types.App{{ID: linked.AgentAppID, OrganizationID: "org-test"}}, nil
+		},
+	)
+
+	botService := orgbots.New(orgbots.Deps{Bots: orgStore.Bots})
+	server := &HelixAPIServer{
+		Store: helixStore,
+		helixOrg: &helixOrgHandlers{
+			store: orgStore,
+			lifecycle: &lifecycle.Service{
+				Store: orgStore, Bots: botService, Agents: listingAgentCreator{appID: "app-reconciled"},
+			},
+		},
+	}
+
+	apps, httpErr := server.listOrganizationApps(ctx, user, "org-test")
+	require.Nil(t, httpErr)
+	require.Len(t, apps, 1)
+	require.Equal(t, "app-reconciled", apps[0].ID)
 }
 
 func Test_populateAppOwner_PopulateUser(t *testing.T) {

--- a/api/pkg/server/app_handlers_test.go
+++ b/api/pkg/server/app_handlers_test.go
@@ -1,12 +1,18 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/openai/manager"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	orgmemory "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -14,6 +20,55 @@ import (
 
 	"go.uber.org/mock/gomock"
 )
+
+func TestUpdateAppRejectsInvalidLinkedOrgAgentShape(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	helixStore := store.NewMockStore(ctrl)
+	orgStore := orgmemory.New()
+
+	bot, err := orgchart.NewBot("b-linked", "# Linked", nil, time.Now().UTC(), "org-test")
+	require.NoError(t, err)
+	require.NoError(t, orgStore.Bots.Create(context.Background(), bot.WithAgentAppID("app-linked")))
+
+	existing := &types.App{
+		ID:             "app-linked",
+		Owner:          "user-test",
+		OrganizationID: "org-test",
+		Config: types.AppConfig{Helix: types.AppHelixConfig{
+			Assistants: []types.AssistantConfig{{Name: "Linked"}},
+		}},
+	}
+	helixStore.EXPECT().GetApp(gomock.Any(), existing.ID).Return(existing, nil)
+	helixStore.EXPECT().GetOrganizationMembership(gomock.Any(), gomock.Any()).Return(&types.OrganizationMembership{
+		UserID:         existing.Owner,
+		OrganizationID: existing.OrganizationID,
+		Role:           types.OrganizationRoleMember,
+	}, nil)
+
+	server := &HelixAPIServer{
+		Store: helixStore,
+		helixOrg: &helixOrgHandlers{
+			store: orgStore,
+		},
+	}
+	body, err := json.Marshal(types.App{
+		ID: existing.ID,
+		Config: types.AppConfig{Helix: types.AppHelixConfig{
+			Assistants: nil,
+		}},
+	})
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPut, "/api/v1/apps/"+existing.ID, bytes.NewReader(body))
+	require.NoError(t, err)
+	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: existing.Owner}))
+
+	updated, httpErr := server.updateApp(nil, req)
+
+	require.Nil(t, updated)
+	require.NotNil(t, httpErr)
+	require.Equal(t, http.StatusBadRequest, httpErr.StatusCode)
+	require.Contains(t, httpErr.Message, "exactly one assistant")
+}
 
 // markHelixOrgAgents must be a no-op on a non-Postgres store: no app is
 // flagged and the database is never touched (the mock store does not

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -9544,6 +9544,713 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/orgs/{org}/agents": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "List the canonical Agents in an organization, including their instructions, tools, runtime, model configuration, and reporting lines.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: list agents",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.BotDTO"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Create a canonical Agent with its org-chart position, communication topics, tools, and Agent App configuration.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: create an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Agent specification",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.CreateBotRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/api.CreateBotResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Get one canonical Agent with its instructions, tools, runtime, model configuration, project, and reporting lines.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: get agent detail",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.AgentDetailDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Delete an Agent after stopping its sessions and project, then atomically remove its Agent App, knowledge, runtime state, subscriptions, reporting lines, and org-chart row.",
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: delete an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Update the canonical Agent instructions, tools, project access, runtime, provider, model, or reasoning configuration.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: update an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Agent fields to update",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.UpdateBotRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/activate": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: activate an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotActivateDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/chat": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: provision an agent chat",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotChatDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/parents": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: add an agent manager",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID of the direct report",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Manager Agent ID",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.AddBotParentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/parents/{parent_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: remove an agent manager",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID of the direct report",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Manager Agent ID",
+                        "name": "parent_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/restart-agent": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: restart an agent session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotActivateDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/stop-agent": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: stop an agent desktop",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/subscriptions": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: list an agent's subscriptions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotSubscriptionsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: subscribe an agent to a topic",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Topic to subscribe the Agent to",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.SubscribeBotRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotSubscriptionDTO"
+                        }
+                    },
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotSubscriptionDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/subscriptions/{topic_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: unsubscribe an agent from a topic",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Topic ID",
+                        "name": "topic_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/bots": {
             "get": {
                 "security": [
@@ -21764,6 +22471,96 @@ const docTemplate = `{
                 }
             }
         },
+        "api.AgentDetailDTO": {
+            "type": "object",
+            "properties": {
+                "agent_app_id": {
+                    "type": "string"
+                },
+                "agent_model": {
+                    "type": "string"
+                },
+                "agent_runtime": {
+                    "type": "string"
+                },
+                "agent_status": {
+                    "description": "AgentStatus is \"running\" when the bot's desktop sandbox is online,\n\"stopped\" otherwise (no session, paused, never activated). Drives\nthe green/grey presence dot on the org chart.",
+                    "type": "string"
+                },
+                "code_agent_credential_type": {
+                    "$ref": "#/definitions/types.CodeAgentCredentialType"
+                },
+                "code_agent_runtime": {
+                    "$ref": "#/definitions/types.CodeAgentRuntime"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "helix_user_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "identity": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "kind": {
+                    "description": "Kind is \"\" (agent) or \"human\". A human node is a person placeholder,\nnever activated; Identity holds their cross-system handles and\nHelixUserID optionally links them to a Helix org member. Identity is\nomitted for agent bots.",
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name is the human-readable display label; empty means the UI falls\nback to ID. Distinct from ID, which is the immutable handle.",
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "parent_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "preserve_context": {
+                    "description": "PreserveContext, when true, stops the runtime from wiping this\nBot's chat session before each re-activation, so it accumulates\ncontext across triggers (e.g. Slack). Defaults to false.",
+                    "type": "boolean"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "project_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "reasoning_effort": {
+                    "type": "string"
+                },
+                "tools": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "api.BotActivateDTO": {
             "type": "object",
             "properties": {
@@ -21803,6 +22600,9 @@ const docTemplate = `{
         "api.BotDTO": {
             "type": "object",
             "properties": {
+                "agent_app_id": {
+                    "type": "string"
+                },
                 "agent_model": {
                     "type": "string"
                 },
@@ -21812,6 +22612,12 @@ const docTemplate = `{
                 "agent_status": {
                     "description": "AgentStatus is \"running\" when the bot's desktop sandbox is online,\n\"stopped\" otherwise (no session, paused, never activated). Drives\nthe green/grey presence dot on the org chart.",
                     "type": "string"
+                },
+                "code_agent_credential_type": {
+                    "$ref": "#/definitions/types.CodeAgentCredentialType"
+                },
+                "code_agent_runtime": {
+                    "$ref": "#/definitions/types.CodeAgentRuntime"
                 },
                 "content": {
                     "type": "string"
@@ -21833,6 +22639,9 @@ const docTemplate = `{
                 },
                 "kind": {
                     "description": "Kind is \"\" (agent) or \"human\". A human node is a person placeholder,\nnever activated; Identity holds their cross-system handles and\nHelixUserID optionally links them to a Helix org member. Identity is\nomitted for agent bots.",
+                    "type": "string"
+                },
+                "model": {
                     "type": "string"
                 },
                 "name": {
@@ -21857,6 +22666,12 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "reasoning_effort": {
+                    "type": "string"
                 },
                 "tools": {
                     "type": "array",
@@ -22532,6 +23347,12 @@ const docTemplate = `{
         "api.UpdateBotRequest": {
             "type": "object",
             "properties": {
+                "code_agent_credential_type": {
+                    "$ref": "#/definitions/types.CodeAgentCredentialType"
+                },
+                "code_agent_runtime": {
+                    "$ref": "#/definitions/types.CodeAgentRuntime"
+                },
                 "content": {
                     "type": "string"
                 },
@@ -22541,6 +23362,9 @@ const docTemplate = `{
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "model": {
+                    "type": "string"
                 },
                 "name": {
                     "type": "string"
@@ -22553,6 +23377,12 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "reasoning_effort": {
+                    "type": "string"
                 },
                 "tools": {
                     "type": "array",
@@ -26751,7 +27581,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/types.AssistantCalculator"
                 },
                 "claude_subscription_model": {
-                    "description": "ClaudeSubscriptionModel is the Anthropic model to use when CodeAgentRuntime is\n\"claude_code\" and CodeAgentCredentialType is \"subscription\". It flows through\nCodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,\nwhich the claude-agent-acp package reads (resolveModelPreference) to pick the\nmodel — otherwise Claude Code defaults to Sonnet. Empty means \"opus\"\n(resolveModelPreference resolves this to the latest Opus version).",
+                    "description": "ClaudeSubscriptionModel is the Anthropic model to use when CodeAgentRuntime is\n\"claude_code\" and CodeAgentCredentialType is \"subscription\". It flows through\nCodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,\nwhich the claude-agent-acp package reads (resolveModelPreference) to pick the\nmodel — otherwise Claude Code defaults to Sonnet. Empty means \"opus[1m]\"\n(the 1M-context Opus; resolveModelPreference resolves the \"[1m]\" hint to the\n1M row, while a bare \"opus\" resolves to the 200k sibling).",
                     "type": "string"
                 },
                 "code_agent_credential_type": {
@@ -32177,6 +33007,9 @@ const docTemplate = `{
         "types.ProjectApplyRequest": {
             "type": "object",
             "properties": {
+                "agent_app_id": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/api/pkg/server/exploratory_session_activation_test.go
+++ b/api/pkg/server/exploratory_session_activation_test.go
@@ -309,6 +309,57 @@ func (s *ExploratorySessionActivationSuite) TestNoProjectStillMintsFreshSession(
 	s.Equal(got.ID, captured.SessionID)
 }
 
+func (s *ExploratorySessionActivationSuite) TestAppSessionPersistsAgentRuntimeBinding() {
+	ctx := context.Background()
+
+	const (
+		appID  = "app_agent"
+		userID = "user_op"
+	)
+
+	s.store.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(&types.User{
+		ID:   userID,
+		Type: types.OwnerTypeUser,
+	}, nil)
+	s.store.EXPECT().GetApp(gomock.Any(), appID).Return(&types.App{
+		ID: appID,
+		Config: types.AppConfig{Helix: types.AppHelixConfig{
+			Assistants: []types.AssistantConfig{{
+				ID:               "0",
+				AgentType:        types.AgentTypeZedExternal,
+				CodeAgentRuntime: types.CodeAgentRuntimeZedAgent,
+			}},
+		}},
+	}, nil)
+
+	var capturedSession *types.Session
+	s.store.EXPECT().GetSession(gomock.Any(), gomock.Any()).Return(nil, store.ErrNotFound).AnyTimes()
+	s.store.EXPECT().UpdateSession(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, session types.Session) (*types.Session, error) {
+			capturedSession = &session
+			return &session, nil
+		},
+	)
+	s.store.EXPECT().CreateInteractions(gomock.Any(), gomock.Any()).Return(nil)
+	s.executor.EXPECT().StartDesktop(gomock.Any(), gomock.Any()).Return(
+		&types.DesktopAgentResponse{DevContainerID: "dev_agent"}, nil,
+	)
+
+	got, err := s.server.StartExternalAgentSession(ctx, &types.SessionChatRequest{
+		AppID:     appID,
+		AgentType: "zed_external",
+		Messages: []*types.Message{{
+			Role:    "user",
+			Content: types.MessageContent{Parts: []any{"activate"}},
+		}},
+	}, userID)
+	s.Require().NoError(err)
+	s.Require().NotNil(got)
+	s.Require().NotNil(capturedSession)
+	s.Equal(types.CodeAgentRuntimeZedAgent, capturedSession.Metadata.CodeAgentRuntime)
+	s.Equal(types.CodeAgentRuntimeZedAgent.ZedAgentName(), capturedSession.Metadata.ZedAgentName)
+}
+
 // Case 4: different SessionRole → no reuse. The guard is gated on
 // SessionRole=="exploratory". A SessionRole="planning" request (or any
 // non-exploratory role) must mint a fresh id — GetProjectExploratorySession's

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -64,8 +64,10 @@ import (
 // mounted under /api/v1/orgs/{org}/. The React UI at
 // /orgs/:org_id/helix-org/* consumes those endpoints.
 type helixOrgHandlers struct {
-	api   http.Handler
-	scope *helixOrgScope
+	api       http.Handler
+	scope     *helixOrgScope
+	store     *helixorgstore.Store
+	lifecycle *lifecycle.Service
 	// seeder creates the membership-driven human nodes + the per-org Chief
 	// of Staff bot. Copied onto HelixAPIServer by mountHelixOrg so the
 	// org-lifecycle handlers (org create, membership add/remove) can drive it.
@@ -491,7 +493,9 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	//
 	// Request-scoped calls run as the authenticated user. Background calls
 	// resolve the owner of their organization in the adapter.
-	inProcClient := NewInProcHelixClient(cfg.APIServer)
+	inProcClient := NewInProcHelixClient(cfg.APIServer, configReg)
+	deps.AgentContentUpdater = inProcClient
+	deps.AgentProfileReader = inProcClient
 
 	// Build the single Workspace shared by the WorkerProject (for
 	// first-apply file pushes — agent.md / role.md / identity.md)
@@ -738,6 +742,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	lifecycleSvc := &lifecycle.Service{
 		Store:  st,
 		Helix:  inProcClient,
+		Agents: inProcClient,
 		Logger: logger,
 		// Bot-scoped reconcilers: the single topology reconciler (one owner
 		// of activation/team Topic lifecycle across create, reparent, and delete).
@@ -943,13 +948,16 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 			}
 			return t.HandleInbound()
 		},
-		Configs:        configReg,
-		Hub:            bc,
-		Dispatcher:     dispatcher,
-		DBPath:         orgRoot,
-		Lifecycle:      lifecycleSvc,
-		Tools:          reg,
-		ProjectEnsurer: projectApplier,
+		Configs:             configReg,
+		Hub:                 bc,
+		Dispatcher:          dispatcher,
+		DBPath:              orgRoot,
+		Lifecycle:           lifecycleSvc,
+		AgentUpdater:        inProcClient,
+		AgentReader:         inProcClient,
+		AgentDefaultApplier: inProcClient,
+		Tools:               reg,
+		ProjectEnsurer:      projectApplier,
 		// Production: the github topic transport's Token() falls
 		// back to whatever GitHub OAuth connection the org members
 		// have already authorised, so operators don't have to paste a
@@ -1109,12 +1117,17 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		if err := seeder.ReconcileHumans(ctx, orgID, members); err != nil {
 			return err
 		}
-		return seeder.SeedChiefOfStaff(ctx, orgID)
+		if err := seeder.SeedChiefOfStaff(ctx, orgID); err != nil {
+			return err
+		}
+		return lifecycleSvc.ReconcileAgentLinks(ctx, orgID)
 	}
 
 	return &helixOrgHandlers{
 		api:                          orgServer.Handler(extras...),
 		scope:                        scope,
+		store:                        st,
+		lifecycle:                    lifecycleSvc,
 		seeder:                       seeder,
 		streamCron:                   streamCronScheduler,
 		publicGitHubWebhook:          publicGitHubWebhook,

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -1006,7 +1006,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		Msg("helix-org mounted at /api/v1/orgs/{org}/helix-org/")
 	scope := newHelixOrgScope(configReg, st, helixStore, mirror, slackRouteReconciler, helixEventsReconciler)
 	scope.botRepair = func(ctx context.Context, orgID string) error {
-		return repairNeverActivatedBots(ctx, orgID, st, dispatcher)
+		return repairNeverActivatedBots(ctx, orgID, st, dispatcher, configReg, inProcClient)
 	}
 
 	// Public github webhook handler — mounted on the insecure router

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -127,7 +127,7 @@ func isDeferredAgentScaffold(assistant types.AssistantConfig) bool {
 		assistant.CodeAgentCredentialType == "" &&
 		assistant.Provider == "" &&
 		assistant.Model == "" &&
-		assistant.ReasoningEffort == "" &&
+		(assistant.ReasoningEffort == "" || assistant.ReasoningEffort == types.ReasoningEffortNone) &&
 		assistant.GenerationModelProvider == "" &&
 		assistant.GenerationModel == ""
 }

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -23,11 +23,16 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
+	"gorm.io/gorm"
 
+	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
 	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
 	helixorgserver "github.com/helixml/helix/api/pkg/org/interfaces/server"
+	orgapi "github.com/helixml/helix/api/pkg/org/interfaces/server/api"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 )
@@ -36,11 +41,231 @@ import (
 // runtimehelix.SpawnerClient by routing through the HelixAPIServer's
 // handler methods in-process.
 type inProcHelixClient struct {
-	server *HelixAPIServer
+	server  *HelixAPIServer
+	configs *configregistry.Registry
 }
 
-func NewInProcHelixClient(s *HelixAPIServer) *inProcHelixClient {
-	return &inProcHelixClient{server: s}
+func NewInProcHelixClient(s *HelixAPIServer, configs ...*configregistry.Registry) *inProcHelixClient {
+	client := &inProcHelixClient{server: s}
+	if len(configs) > 0 {
+		client.configs = configs[0]
+	}
+	return client
+}
+
+func (c *inProcHelixClient) CreateAgent(ctx context.Context, orgID, name, instructions string) (string, error) {
+	user, err := c.resolveUser(ctx)
+	if err != nil {
+		org, orgErr := c.server.lookupOrg(ctx, orgID)
+		if orgErr != nil {
+			return "", fmt.Errorf("resolve organization %s: %w", orgID, orgErr)
+		}
+		user, err = c.server.Store.GetUser(ctx, &store.GetUserQuery{ID: org.Owner})
+		if err != nil {
+			return "", fmt.Errorf("resolve owner %s for organization %s: %w", org.Owner, org.ID, err)
+		}
+		if user == nil {
+			return "", fmt.Errorf("resolve owner %s for organization %s: user not found", org.Owner, org.ID)
+		}
+	}
+	if user.ID == "" {
+		return "", errors.New("create agent: user is missing")
+	}
+	if name == "" {
+		return "", errors.New("create agent: name is missing")
+	}
+	assistant := types.AssistantConfig{
+		Name:             name,
+		SystemPrompt:     instructions,
+		AgentType:        types.AgentTypeZedExternal,
+		CodeAgentRuntime: types.CodeAgentRuntimeZedAgent,
+	}
+	if c.configs != nil && c.configs.IsDefaultAgentConfigured(ctx, orgID) {
+		defaults, configErr := c.configs.GetDefaultAgentConfig(ctx, orgID)
+		if configErr != nil {
+			return "", fmt.Errorf("read default agent config: %w", configErr)
+		}
+		applyResolvedAgentDefaults(&assistant, defaults)
+	}
+	app, err := c.server.Store.CreateApp(ctx, &types.App{
+		Owner:          user.ID,
+		OwnerType:      types.OwnerTypeUser,
+		OrganizationID: orgID,
+		Config: types.AppConfig{Helix: types.AppHelixConfig{
+			Name:                 name,
+			DefaultAgentType:     types.AgentTypeZedExternal,
+			ExternalAgentEnabled: true,
+			Assistants:           []types.AssistantConfig{assistant},
+		}},
+	})
+	if err != nil {
+		return "", err
+	}
+	return app.ID, nil
+}
+
+func (c *inProcHelixClient) ApplyAgentDefaults(ctx context.Context, appID string, defaults types.AssistantConfig) error {
+	app, err := c.server.Store.GetApp(ctx, appID)
+	if err != nil {
+		return err
+	}
+	if len(app.Config.Helix.Assistants) != 1 {
+		return errors.New("apply agent defaults: org-linked agent must contain exactly one assistant")
+	}
+	assistant := &app.Config.Helix.Assistants[0]
+	if !isDeferredAgentScaffold(*assistant) {
+		return nil
+	}
+	applyResolvedAgentDefaults(assistant, defaults)
+	_, err = c.server.Store.UpdateApp(ctx, app)
+	return err
+}
+
+func isDeferredAgentScaffold(assistant types.AssistantConfig) bool {
+	return assistant.AgentType == types.AgentTypeZedExternal &&
+		assistant.CodeAgentRuntime == types.CodeAgentRuntimeZedAgent &&
+		assistant.CodeAgentCredentialType == "" &&
+		assistant.Provider == "" &&
+		assistant.Model == "" &&
+		assistant.ReasoningEffort == "" &&
+		assistant.GenerationModelProvider == "" &&
+		assistant.GenerationModel == ""
+}
+
+func applyResolvedAgentDefaults(assistant *types.AssistantConfig, defaults types.AssistantConfig) {
+	runtime := defaults.CodeAgentRuntime
+	if runtime == "" {
+		runtime = types.CodeAgentRuntimeClaudeCode
+	}
+	credentials := defaults.CodeAgentCredentialType
+	if credentials == "" {
+		credentials = types.CodeAgentCredentialTypeSubscription
+	}
+	if !workerRuntimeSupportsSubscription(string(runtime)) {
+		credentials = types.CodeAgentCredentialTypeAPIKey
+	}
+	assistant.CodeAgentRuntime = runtime
+	assistant.CodeAgentCredentialType = credentials
+	assistant.Provider = ""
+	assistant.Model = ""
+	assistant.GenerationModelProvider = ""
+	assistant.GenerationModel = ""
+	if credentials == types.CodeAgentCredentialTypeAPIKey {
+		assistant.Provider = defaults.Provider
+		assistant.Model = defaults.Model
+		assistant.GenerationModelProvider = defaults.Provider
+		assistant.GenerationModel = defaults.Model
+	} else if runtime == types.CodeAgentRuntimeCodexCLI {
+		assistant.Model = defaults.Model
+	}
+	assistant.ReasoningEffort = defaults.ReasoningEffort
+}
+
+func (c *inProcHelixClient) UpdateAgent(ctx context.Context, appID string, patch orgapi.AgentConfigPatch, name, instructions *string) error {
+	user, err := c.resolveUser(ctx)
+	if err != nil {
+		return err
+	}
+	existing, err := c.server.Store.GetApp(ctx, appID)
+	if err != nil {
+		return err
+	}
+	priorJSON, err := json.Marshal(existing)
+	if err != nil {
+		return fmt.Errorf("snapshot agent app: %w", err)
+	}
+	var prior types.App
+	if err := json.Unmarshal(priorJSON, &prior); err != nil {
+		return fmt.Errorf("snapshot agent app: %w", err)
+	}
+	if err := c.server.authorizeUserToApp(ctx, user, existing, types.ActionUpdate); err != nil {
+		return err
+	}
+	update := existing
+	if len(update.Config.Helix.Assistants) != 1 {
+		return errors.New("update agent: org-linked agent must contain exactly one assistant")
+	}
+	assistant := &update.Config.Helix.Assistants[0]
+	if name != nil {
+		update.Config.Helix.Name = *name
+		assistant.Name = *name
+	}
+	if instructions != nil {
+		assistant.SystemPrompt = *instructions
+	}
+	if patch.CodeAgentRuntime != nil {
+		assistant.CodeAgentRuntime = *patch.CodeAgentRuntime
+	}
+	if patch.CodeAgentCredentialType != nil {
+		assistant.CodeAgentCredentialType = *patch.CodeAgentCredentialType
+	}
+	if patch.Provider != nil {
+		assistant.Provider = *patch.Provider
+	}
+	if patch.Model != nil {
+		assistant.Model = *patch.Model
+	}
+	if patch.ReasoningEffort != nil {
+		assistant.ReasoningEffort = *patch.ReasoningEffort
+	}
+	if patch.CodeAgentCredentialType != nil || patch.Provider != nil || patch.Model != nil {
+		if assistant.CodeAgentCredentialType == types.CodeAgentCredentialTypeAPIKey {
+			assistant.GenerationModelProvider = assistant.Provider
+			assistant.GenerationModel = assistant.Model
+		} else {
+			assistant.GenerationModelProvider = ""
+			assistant.GenerationModel = ""
+		}
+	}
+	r, err := c.newRequest(ctx, http.MethodPut, "/api/v1/apps/"+appID, update, map[string]string{"id": appID})
+	if err != nil {
+		return err
+	}
+	if _, herr := c.server.updateApp(nil, r); herr != nil {
+		rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		defer cancel()
+		if _, rollbackErr := c.server.Store.UpdateApp(rollbackCtx, &prior); rollbackErr != nil {
+			return fmt.Errorf("%s; restore agent app: %w", herr.Error(), rollbackErr)
+		}
+		return errors.New(herr.Error())
+	}
+	return nil
+}
+
+func (c *inProcHelixClient) UpdateAgentContent(ctx context.Context, appID, content string) error {
+	return c.UpdateAgent(ctx, appID, orgapi.AgentConfigPatch{}, nil, &content)
+}
+
+func (c *inProcHelixClient) ReadAgent(ctx context.Context, appID string) (orgapi.AgentProfile, error) {
+	app, err := c.server.Store.GetApp(ctx, appID)
+	if err != nil {
+		return orgapi.AgentProfile{}, err
+	}
+	if len(app.Config.Helix.Assistants) != 1 {
+		return orgapi.AgentProfile{}, errors.New("org-linked agent app must contain exactly one assistant")
+	}
+	assistant := app.Config.Helix.Assistants[0]
+	name := assistant.Name
+	if name == "" {
+		name = app.Config.Helix.Name
+	}
+	return orgapi.AgentProfile{
+		Name:                    name,
+		Instructions:            assistant.SystemPrompt,
+		CodeAgentRuntime:        assistant.CodeAgentRuntime,
+		CodeAgentCredentialType: assistant.CodeAgentCredentialType,
+		Provider:                assistant.Provider,
+		Model:                   assistant.Model,
+		ReasoningEffort:         assistant.ReasoningEffort,
+	}, nil
+}
+
+func (c *inProcHelixClient) AgentProfile(ctx context.Context, appID string) (string, string, error) {
+	profile, err := c.ReadAgent(ctx, appID)
+	if err != nil {
+		return "", "", err
+	}
+	return profile.Name, profile.Instructions, nil
 }
 
 // resolveUser returns the *types.User to attach to a handler-bound
@@ -437,7 +662,26 @@ func (c *inProcHelixClient) UpdateAppConfig(ctx context.Context, id string, cfg 
 // 404 from the underlying handler is mapped to ErrProjectNotFound so
 // callers can treat already-gone projects as success.
 func (c *inProcHelixClient) DeleteProject(ctx context.Context, id string) error {
-	r, err := c.newRequest(ctx, http.MethodDelete, "/api/v1/projects/"+id, nil, map[string]string{"id": id})
+	project, err := c.server.Store.GetProject(ctx, id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) || errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("%w: project %s", runtimehelix.ErrProjectNotFound, id)
+		}
+		return err
+	}
+	deleteCtx := ctx
+	if project.OrganizationID != "" {
+		org, err := c.server.Store.GetOrganization(ctx, &store.GetOrganizationQuery{ID: project.OrganizationID})
+		if err != nil {
+			return fmt.Errorf("resolve project organization %s: %w", project.OrganizationID, err)
+		}
+		owner, err := c.server.Store.GetUser(ctx, &store.GetUserQuery{ID: org.Owner})
+		if err != nil {
+			return fmt.Errorf("resolve project organization owner %s: %w", org.Owner, err)
+		}
+		deleteCtx = runtimehelix.WithUser(ctx, owner)
+	}
+	r, err := c.newRequest(deleteCtx, http.MethodDelete, "/api/v1/projects/"+id, nil, map[string]string{"id": id})
 	if err != nil {
 		return err
 	}
@@ -456,17 +700,55 @@ func (c *inProcHelixClient) DeleteProject(ctx context.Context, id string) error 
 // gone" semantics; we re-use the sentinel rather than minting a
 // second one for the cascade caller's sake).
 func (c *inProcHelixClient) DeleteApp(ctx context.Context, id string) error {
-	r, err := c.newRequest(ctx, http.MethodDelete, "/api/v1/apps/"+id, nil, map[string]string{"id": id})
-	if err != nil {
+	if _, err := c.server.Store.GetApp(ctx, id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("%w: app %s", runtimehelix.ErrProjectNotFound, id)
+		}
 		return err
 	}
-	if _, herr := c.server.deleteApp(nil, r); herr != nil {
-		if herr.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("%w: %s", runtimehelix.ErrProjectNotFound, herr.Message)
-		}
-		return fmt.Errorf("delete app %s: %s", id, herr.Error())
+	return c.server.deleteAppData(ctx, id, false)
+}
+
+func (c *inProcHelixClient) DeleteLinkedAgent(ctx context.Context, orgID string, botID orgchart.BotID, appID string) error {
+	accessor, ok := c.server.Store.(interface{ GormDB() *gorm.DB })
+	if !ok {
+		return fmt.Errorf("delete linked agent: store %T has no shared database", c.server.Store)
 	}
-	return nil
+	return accessor.GormDB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		knowledgeIDs := tx.Model(&types.Knowledge{}).Select("id").Where("app_id = ?", appID)
+		if err := tx.Where("knowledge_id IN (?)", knowledgeIDs).Delete(&types.KnowledgeVersion{}).Error; err != nil {
+			return fmt.Errorf("delete knowledge versions: %w", err)
+		}
+		if err := tx.Where("app_id = ?", appID).Delete(&types.Knowledge{}).Error; err != nil {
+			return fmt.Errorf("delete knowledge: %w", err)
+		}
+		if err := tx.Exec(
+			"DELETE FROM org_bot_runtime_state WHERE org_id = ? AND bot_id = ?",
+			orgID, string(botID),
+		).Error; err != nil {
+			return fmt.Errorf("delete runtime state: %w", err)
+		}
+		if err := tx.Exec(
+			"DELETE FROM org_subscriptions WHERE org_id = ? AND bot_id = ?",
+			orgID, string(botID),
+		).Error; err != nil {
+			return fmt.Errorf("delete subscriptions: %w", err)
+		}
+		result := tx.Exec(
+			"DELETE FROM org_bots WHERE org_id = ? AND id = ? AND agent_app_id = ?",
+			orgID, string(botID), appID,
+		)
+		if result.Error != nil {
+			return fmt.Errorf("delete bot: %w", result.Error)
+		}
+		if result.RowsAffected != 1 {
+			return fmt.Errorf("delete bot: linked graph node not found")
+		}
+		if err := tx.Delete(&types.App{ID: appID}).Error; err != nil {
+			return fmt.Errorf("delete app: %w", err)
+		}
+		return nil
+	})
 }
 
 // ---- runtimehelix.SpawnerClient ----

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -242,7 +242,7 @@ func (c *inProcHelixClient) ReadAgent(ctx context.Context, appID string) (orgapi
 		return orgapi.AgentProfile{}, err
 	}
 	if len(app.Config.Helix.Assistants) != 1 {
-		return orgapi.AgentProfile{}, errors.New("org-linked agent app must contain exactly one assistant")
+		return orgapi.AgentProfile{}, fmt.Errorf("%w: org-linked agent app must contain exactly one assistant", orgapi.ErrInvalidAgentProfile)
 	}
 	assistant := app.Config.Helix.Assistants[0]
 	name := assistant.Name
@@ -637,6 +637,10 @@ func (c *inProcHelixClient) GetAppConfig(ctx context.Context, id string) (types.
 		return types.AppConfig{}, fmt.Errorf("get app %s: nil response", id)
 	}
 	return app.Config, nil
+}
+
+func (c *inProcHelixClient) GetApp(ctx context.Context, id string) (*types.App, error) {
+	return c.server.Store.GetApp(ctx, id)
 }
 
 // UpdateAppConfig persists a mutated app config.

--- a/api/pkg/server/helix_org_inproc_test.go
+++ b/api/pkg/server/helix_org_inproc_test.go
@@ -129,6 +129,7 @@ func TestInProcClient_DeferredDefaultsApplyOnlyToUntouchedScaffold(t *testing.T)
 			Assistants: []types.AssistantConfig{{
 				Name: "Agent", AgentType: types.AgentTypeZedExternal,
 				CodeAgentRuntime: types.CodeAgentRuntimeZedAgent,
+				ReasoningEffort:  types.ReasoningEffortNone,
 			}},
 		}},
 	}
@@ -137,13 +138,16 @@ func TestInProcClient_DeferredDefaultsApplyOnlyToUntouchedScaffold(t *testing.T)
 	st.EXPECT().GetApp(gomock.Any(), app.ID).Return(app, nil)
 	client := NewInProcHelixClient(&HelixAPIServer{Store: st})
 	defaults := types.AssistantConfig{
-		CodeAgentRuntime:        types.CodeAgentRuntimeClaudeCode,
-		CodeAgentCredentialType: types.CodeAgentCredentialTypeSubscription,
+		CodeAgentRuntime:        types.CodeAgentRuntimeZedAgent,
+		CodeAgentCredentialType: types.CodeAgentCredentialTypeAPIKey,
+		Provider:                "anthropic",
+		Model:                   "claude-opus-4-6",
 		ReasoningEffort:         "high",
 	}
 
 	require.NoError(t, client.ApplyAgentDefaults(ctx, app.ID, defaults))
-	require.Equal(t, types.CodeAgentRuntimeClaudeCode, app.Config.Helix.Assistants[0].CodeAgentRuntime)
+	require.Equal(t, "anthropic", app.Config.Helix.Assistants[0].Provider)
+	require.Equal(t, "claude-opus-4-6", app.Config.Helix.Assistants[0].Model)
 
 	app.Config.Helix.Assistants[0].CodeAgentRuntime = types.CodeAgentRuntimeCodexCLI
 	app.Config.Helix.Assistants[0].Model = "user-selected"

--- a/api/pkg/server/helix_org_inproc_test.go
+++ b/api/pkg/server/helix_org_inproc_test.go
@@ -7,9 +7,16 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"gorm.io/gorm"
 
+	"github.com/helixml/helix/api/pkg/config"
+	"github.com/helixml/helix/api/pkg/controller"
+	"github.com/helixml/helix/api/pkg/org/application/configregistry"
+	orggorm "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/gorm"
 	runtimehelix "github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
+	orgapi "github.com/helixml/helix/api/pkg/org/interfaces/server/api"
 	"github.com/helixml/helix/api/pkg/pubsub"
+	"github.com/helixml/helix/api/pkg/server/helixorg"
 	helixstore "github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/store/memorystore"
 	"github.com/helixml/helix/api/pkg/types"
@@ -55,6 +62,155 @@ func TestInProcClient_ResolvesOrganizationOwnerWithoutAdmin(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Same(t, owner, got)
+}
+
+func TestInProcClient_CreateAgentUsesOrganizationOwnerWithoutRequestUser(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	st := helixstore.NewMockStore(ctrl)
+	owner := &types.User{ID: "usr_owner"}
+	st.EXPECT().GetOrganization(gomock.Any(), &helixstore.GetOrganizationQuery{ID: "org_test"}).
+		Return(&types.Organization{ID: "org_test", Owner: owner.ID}, nil)
+	st.EXPECT().GetUser(gomock.Any(), &helixstore.GetUserQuery{ID: owner.ID}).Return(owner, nil)
+	st.EXPECT().CreateApp(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, app *types.App) (*types.App, error) {
+			require.Equal(t, owner.ID, app.Owner)
+			require.Equal(t, "org_test", app.OrganizationID)
+			app.ID = "app_test"
+			return app, nil
+		},
+	)
+
+	client := NewInProcHelixClient(&HelixAPIServer{Store: st})
+	appID, err := client.CreateAgent(context.Background(), "org_test", "Chief of Staff", "Lead")
+
+	require.NoError(t, err)
+	require.Equal(t, "app_test", appID)
+}
+
+func TestInProcClient_CreateAgentUsesConfiguredOrgDefaults(t *testing.T) {
+	ctx := context.Background()
+	reg := configregistry.New(orggorm.GetOrgTestDB(t).Configs)
+	helixorg.RegisterConfigSpecs(reg)
+	err := reg.Set(ctx, "org-test", configregistry.DefaultAgentConfigKey,
+		`{"code_agent_runtime":"codex_cli","code_agent_credential_type":"subscription","model":"gpt-5.6","reasoning_effort":"high"}`)
+	require.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+	st := helixstore.NewMockStore(ctrl)
+	owner := &types.User{ID: "usr_owner"}
+	st.EXPECT().GetOrganization(gomock.Any(), &helixstore.GetOrganizationQuery{Name: "org-test"}).
+		Return(&types.Organization{ID: "org-test", Owner: owner.ID}, nil)
+	st.EXPECT().GetUser(gomock.Any(), &helixstore.GetUserQuery{ID: owner.ID}).Return(owner, nil)
+	st.EXPECT().CreateApp(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, app *types.App) (*types.App, error) {
+			assistant := app.Config.Helix.Assistants[0]
+			require.Equal(t, types.CodeAgentRuntimeCodexCLI, assistant.CodeAgentRuntime)
+			require.Equal(t, types.CodeAgentCredentialTypeSubscription, assistant.CodeAgentCredentialType)
+			require.Equal(t, "gpt-5.6", assistant.Model)
+			require.Equal(t, "high", assistant.ReasoningEffort)
+			app.ID = "app_test"
+			return app, nil
+		},
+	)
+
+	client := NewInProcHelixClient(&HelixAPIServer{Store: st}, reg)
+	_, err = client.CreateAgent(ctx, "org-test", "Engineer", "Build")
+	require.NoError(t, err)
+}
+
+func TestInProcClient_DeferredDefaultsApplyOnlyToUntouchedScaffold(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	st := helixstore.NewMockStore(ctrl)
+	ctx := context.Background()
+	app := &types.App{
+		ID:    "app-deferred",
+		Owner: "usr-owner",
+		Config: types.AppConfig{Helix: types.AppHelixConfig{
+			Assistants: []types.AssistantConfig{{
+				Name: "Agent", AgentType: types.AgentTypeZedExternal,
+				CodeAgentRuntime: types.CodeAgentRuntimeZedAgent,
+			}},
+		}},
+	}
+	st.EXPECT().GetApp(gomock.Any(), app.ID).Return(app, nil)
+	st.EXPECT().UpdateApp(gomock.Any(), app).Return(app, nil)
+	st.EXPECT().GetApp(gomock.Any(), app.ID).Return(app, nil)
+	client := NewInProcHelixClient(&HelixAPIServer{Store: st})
+	defaults := types.AssistantConfig{
+		CodeAgentRuntime:        types.CodeAgentRuntimeClaudeCode,
+		CodeAgentCredentialType: types.CodeAgentCredentialTypeSubscription,
+		ReasoningEffort:         "high",
+	}
+
+	require.NoError(t, client.ApplyAgentDefaults(ctx, app.ID, defaults))
+	require.Equal(t, types.CodeAgentRuntimeClaudeCode, app.Config.Helix.Assistants[0].CodeAgentRuntime)
+
+	app.Config.Helix.Assistants[0].CodeAgentRuntime = types.CodeAgentRuntimeCodexCLI
+	app.Config.Helix.Assistants[0].Model = "user-selected"
+	require.NoError(t, client.ApplyAgentDefaults(ctx, app.ID, defaults))
+	require.Equal(t, types.CodeAgentRuntimeCodexCLI, app.Config.Helix.Assistants[0].CodeAgentRuntime)
+	require.Equal(t, "user-selected", app.Config.Helix.Assistants[0].Model)
+}
+
+func TestInProcClient_DeleteProjectNormalizesGormNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	st := helixstore.NewMockStore(ctrl)
+	st.EXPECT().GetProject(gomock.Any(), "prj_deleted").Return(nil, gorm.ErrRecordNotFound)
+	client := NewInProcHelixClient(&HelixAPIServer{Store: st})
+
+	err := client.DeleteProject(context.Background(), "prj_deleted")
+
+	require.ErrorIs(t, err, runtimehelix.ErrProjectNotFound)
+}
+
+func TestInProcClient_UpdateAgentRestoresAppAfterPostSaveFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	st := helixstore.NewMockStore(ctrl)
+	user := &types.User{ID: "usr_owner", Type: types.OwnerTypeUser}
+	existing := &types.App{
+		ID:        "app_test",
+		Owner:     user.ID,
+		OwnerType: types.OwnerTypeUser,
+		Config: types.AppConfig{Helix: types.AppHelixConfig{
+			Name: "Agent",
+			Assistants: []types.AssistantConfig{{
+				Name:         "Agent",
+				SystemPrompt: "old instructions",
+			}},
+		}},
+	}
+	st.EXPECT().GetApp(gomock.Any(), existing.ID).Return(existing, nil).Times(2)
+	var savedPrompt, restoredPrompt string
+	st.EXPECT().UpdateApp(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, app *types.App) (*types.App, error) {
+			savedPrompt = app.Config.Helix.Assistants[0].SystemPrompt
+			return app, nil
+		},
+	)
+	st.EXPECT().ListKnowledge(gomock.Any(), &helixstore.ListKnowledgeQuery{AppID: existing.ID}).
+		Return([]*types.Knowledge{}, nil)
+	st.EXPECT().ListTriggerConfigurations(gomock.Any(), &helixstore.ListTriggerConfigurationsQuery{AppID: existing.ID}).
+		Return(nil, errors.New("trigger reconciliation failed"))
+	st.EXPECT().UpdateApp(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, app *types.App) (*types.App, error) {
+			restoredPrompt = app.Config.Helix.Assistants[0].SystemPrompt
+			return app, nil
+		},
+	)
+
+	client := NewInProcHelixClient(&HelixAPIServer{
+		Store:      st,
+		Cfg:        &config.ServerConfig{},
+		Controller: &controller.Controller{},
+	})
+	ctx := runtimehelix.WithUser(context.Background(), user)
+	instructions := "new instructions"
+
+	err := client.UpdateAgent(ctx, existing.ID, orgapi.AgentConfigPatch{}, nil, &instructions)
+
+	require.ErrorContains(t, err, "trigger reconciliation failed")
+	require.Equal(t, instructions, savedPrompt)
+	require.Equal(t, "old instructions", restoredPrompt)
 }
 
 // TestInProcProjectService_GetProject_NotFound_ReturnsErrProjectNotFound

--- a/api/pkg/server/helix_org_middleware.go
+++ b/api/pkg/server/helix_org_middleware.go
@@ -25,6 +25,7 @@ import (
 	helixorgserver "github.com/helixml/helix/api/pkg/org/interfaces/server"
 	"github.com/helixml/helix/api/pkg/server/helixorg"
 	helixstore "github.com/helixml/helix/api/pkg/store"
+	"github.com/helixml/helix/api/pkg/types"
 )
 
 // helixOrgScope bundles the per-org state the middleware needs to pass
@@ -184,9 +185,17 @@ func (s *helixOrgScope) ensureBootstrap(ctx context.Context, orgID string) error
 	return err
 }
 
-func repairNeverActivatedBots(ctx context.Context, orgID string, st *helixorgstore.Store, dispatcher lifecycle.CreateDispatcher) error {
-	if st == nil || dispatcher == nil {
+type repairAgentDefaultApplier interface {
+	ApplyAgentDefaults(ctx context.Context, appID string, defaults types.AssistantConfig) error
+}
+
+func repairNeverActivatedBots(ctx context.Context, orgID string, st *helixorgstore.Store, dispatcher lifecycle.CreateDispatcher, configs *configregistry.Registry, applier repairAgentDefaultApplier) error {
+	if st == nil || dispatcher == nil || configs == nil || !configs.IsDefaultAgentConfigComplete(ctx, orgID) {
 		return nil
+	}
+	defaults, err := configs.GetDefaultAgentConfig(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("read default agent config: %w", err)
 	}
 	bs, err := st.Bots.List(ctx, orgID)
 	if err != nil {
@@ -202,6 +211,14 @@ func repairNeverActivatedBots(ctx context.Context, orgID string, st *helixorgsto
 		}
 		if len(acts) > 0 {
 			continue
+		}
+		if b.AgentAppID != "" {
+			if applier == nil {
+				return fmt.Errorf("apply defaults to never-activated bot %s: applier is not wired", b.ID)
+			}
+			if err := applier.ApplyAgentDefaults(ctx, b.AgentAppID, defaults); err != nil {
+				return fmt.Errorf("apply defaults to never-activated bot %s: %w", b.ID, err)
+			}
 		}
 		actID := activation.ID("a-repair-" + string(b.ID))
 		act, err := activation.New(actID, b.ID, []activation.Trigger{{Kind: activation.TriggerHire}}, time.Now().UTC(), orgID)

--- a/api/pkg/server/helix_org_middleware_test.go
+++ b/api/pkg/server/helix_org_middleware_test.go
@@ -51,11 +51,29 @@ type helixOrgRouteTestStore struct {
 type bootstrapActivationDispatcher struct {
 	ids           []orgchart.BotID
 	activationIDs []activation.ID
+	defaults      *repairDefaultApplier
+	outOfOrder    bool
 }
 
 func (d *bootstrapActivationDispatcher) DispatchHire(_ context.Context, _ string, id orgchart.BotID, activationID activation.ID) {
+	if d.defaults != nil && !d.defaults.applied {
+		d.outOfOrder = true
+	}
 	d.ids = append(d.ids, id)
 	d.activationIDs = append(d.activationIDs, activationID)
+}
+
+type repairDefaultApplier struct {
+	applied bool
+	appID   string
+	config  types.AssistantConfig
+}
+
+func (a *repairDefaultApplier) ApplyAgentDefaults(_ context.Context, appID string, defaults types.AssistantConfig) error {
+	a.applied = true
+	a.appID = appID
+	a.config = defaults
+	return nil
 }
 
 func (s *helixOrgRouteTestStore) GetOrganization(_ context.Context, query *helixstore.GetOrganizationQuery) (*types.Organization, error) {
@@ -198,6 +216,33 @@ func TestEnsureBootstrapConcurrentCallsAllSucceed(t *testing.T) {
 	}
 }
 
+func TestEnsureBootstrapProvisionsServiceKeyBeforeGraphSeed(t *testing.T) {
+	t.Parallel()
+	orgStore := orgmemory.New()
+	configs := configregistry.New(orgStore.Configs)
+	configs.Register(configregistry.Spec{Key: "helix.api_key", Type: configregistry.TypeString})
+	scope := newHelixOrgScope(configs, orgStore, &bootstrapHelixStore{}, nil, nil, nil)
+	seeded := false
+	scope.humanReconcile = func(ctx context.Context, orgID string) error {
+		key, err := configs.GetString(ctx, orgID, "helix.api_key")
+		if err != nil {
+			return err
+		}
+		if key == "" {
+			return errors.New("graph seeded before service key")
+		}
+		seeded = true
+		return nil
+	}
+
+	if err := scope.ensureBootstrap(context.Background(), "org-race"); err != nil {
+		t.Fatalf("ensure bootstrap: %v", err)
+	}
+	if !seeded {
+		t.Fatal("graph seed hook was not called")
+	}
+}
+
 func TestEnsureBootstrapRetriesAfterServiceKeyFailure(t *testing.T) {
 	t.Parallel()
 	orgStore := orgmemory.New()
@@ -216,9 +261,11 @@ func TestRepairNeverActivatedBotsSkipsHumansAndActivatedBots(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	st := orgmemory.New()
+	configs := configregistry.New(st.Configs)
+	configs.Register(configregistry.Spec{Key: configregistry.DefaultAgentConfigKey, Type: configregistry.TypeObject})
 	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
 	for _, b := range []orgchart.Bot{
-		mustBot(t, "bot-legacy-a", "", now),
+		mustBot(t, "bot-legacy-a", "", now).WithAgentAppID("app-legacy-a"),
 		mustBot(t, "bot-legacy-b", "", now),
 		mustBot(t, "bot-created", "", now),
 		mustBot(t, "human-owner", orgchart.BotKindHuman, now),
@@ -236,8 +283,37 @@ func TestRepairNeverActivatedBotsSkipsHumansAndActivatedBots(t *testing.T) {
 	}
 
 	dispatcher := &bootstrapActivationDispatcher{}
-	if err := repairNeverActivatedBots(ctx, "org-test", st, dispatcher); err != nil {
+	if err := repairNeverActivatedBots(ctx, "org-test", st, dispatcher, configs, nil); err != nil {
+		t.Fatalf("repair without config: %v", err)
+	}
+	if len(dispatcher.ids) != 0 {
+		t.Fatalf("repair before config dispatched bots = %v", dispatcher.ids)
+	}
+	if err := configs.Set(ctx, "org-test", configregistry.DefaultAgentConfigKey,
+		`{"code_agent_runtime":"zed_agent","code_agent_credential_type":"api_key"}`); err != nil {
+		t.Fatalf("set incomplete default agent config: %v", err)
+	}
+	if err := repairNeverActivatedBots(ctx, "org-test", st, dispatcher, configs, nil); err != nil {
+		t.Fatalf("repair with incomplete config: %v", err)
+	}
+	if len(dispatcher.ids) != 0 {
+		t.Fatalf("repair before complete config dispatched bots = %v", dispatcher.ids)
+	}
+	if err := configs.Set(ctx, "org-test", configregistry.DefaultAgentConfigKey,
+		`{"code_agent_runtime":"zed_agent","code_agent_credential_type":"api_key","provider":"anthropic","model":"claude-opus-4-6"}`); err != nil {
+		t.Fatalf("set default agent config: %v", err)
+	}
+	applier := &repairDefaultApplier{}
+	dispatcher.defaults = applier
+	if err := repairNeverActivatedBots(ctx, "org-test", st, dispatcher, configs, applier); err != nil {
 		t.Fatalf("repair never-activated bots: %v", err)
+	}
+	if !applier.applied || applier.appID != "app-legacy-a" ||
+		applier.config.Provider != "anthropic" || applier.config.Model != "claude-opus-4-6" {
+		t.Fatalf("applied defaults = %+v", applier)
+	}
+	if dispatcher.outOfOrder {
+		t.Fatal("repair dispatched before applying Agent defaults")
 	}
 	if len(dispatcher.ids) != 2 || dispatcher.ids[0] != "bot-legacy-a" || dispatcher.ids[1] != "bot-legacy-b" {
 		t.Fatalf("activated bots = %v, want [bot-legacy-a bot-legacy-b]", dispatcher.ids)
@@ -256,7 +332,7 @@ func TestRepairNeverActivatedBotsSkipsHumansAndActivatedBots(t *testing.T) {
 	}
 
 	secondDispatcher := &bootstrapActivationDispatcher{}
-	if err := repairNeverActivatedBots(ctx, "org-test", st, secondDispatcher); err != nil {
+	if err := repairNeverActivatedBots(ctx, "org-test", st, secondDispatcher, configs, applier); err != nil {
 		t.Fatalf("repeat repair: %v", err)
 	}
 	if len(secondDispatcher.ids) != 0 {

--- a/api/pkg/server/org_graph_seed.go
+++ b/api/pkg/server/org_graph_seed.go
@@ -152,14 +152,16 @@ func (s *orgGraphSeeder) SeedChiefOfStaff(ctx context.Context, orgID string) err
 	if !errors.Is(err, store.ErrNotFound) {
 		return fmt.Errorf("check chief of staff: %w", err)
 	}
-	// The id is used exactly (`chief-of-staff`); a collision means
-	// already-seeded.
+	// Bootstrap has already provisioned the org service key, but activation
+	// waits for the operator's runtime selection so the scaffold App is
+	// configured before its first project/session.
 	if _, err := s.lifecycle.Create(ctx, orgID, lifecycle.CreateParams{
 		ID:              string(chiefOfStaffBotID),
 		Name:            "Chief of Staff",
 		Content:         chiefOfStaffContent,
 		Tools:           mcptools.OwnerBotTools(),
 		PreserveContext: true,
+		DeferActivation: true,
 	}); err != nil {
 		if _, getErr := s.botStore.Get(ctx, orgID, chiefOfStaffBotID); getErr == nil {
 			return nil // lost a seed race; CoS exists — fine

--- a/api/pkg/server/org_graph_seed_test.go
+++ b/api/pkg/server/org_graph_seed_test.go
@@ -40,11 +40,15 @@ func TestSeedChiefOfStaffPreservesContextForNewBotOnly(t *testing.T) {
 	if !created.PreserveContext {
 		t.Fatal("new chief of staff must preserve conversation context")
 	}
-	if len(dispatcher.ids) != 1 || dispatcher.ids[0] != chiefOfStaffBotID {
-		t.Fatalf("seed dispatched bots = %v, want [chief-of-staff]", dispatcher.ids)
+	if len(dispatcher.ids) != 0 {
+		t.Fatalf("seed dispatched bots = %v, want none before runtime selection", dispatcher.ids)
 	}
-	if len(dispatcher.activationIDs) != 1 || dispatcher.activationIDs[0] == "" {
-		t.Fatalf("seed activation ids = %v, want one non-empty id", dispatcher.activationIDs)
+	activations, err := st.Activations.ListForWorker(ctx, "org-new", chiefOfStaffBotID, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(activations) != 0 {
+		t.Fatalf("seed activations = %v, want none before runtime selection", activations)
 	}
 
 	if _, err := deps.Bots.Create(ctx, "org-existing", bots.CreateParams{

--- a/api/pkg/server/project_apply_handlers_test.go
+++ b/api/pkg/server/project_apply_handlers_test.go
@@ -568,6 +568,72 @@ func (s *ApplyProjectSuite) TestApply_PreservesExistingAgentSkills() {
 	s.Equal("1920x1080", updated.Config.Helix.ExternalAgentConfig.Resolution)
 }
 
+func (s *ApplyProjectSuite) TestApply_LinkedAgentPreservesCanonicalConfig() {
+	const appID = "app-linked"
+	existingProject := &types.Project{
+		ID:     "proj-linked",
+		Name:   "linked-project",
+		UserID: s.userID,
+	}
+	existingApp := &types.App{
+		ID: appID,
+		Config: types.AppConfig{Helix: types.AppHelixConfig{
+			Name:                 "Canonical",
+			DefaultAgentType:     types.AgentTypeZedExternal,
+			ExternalAgentEnabled: true,
+			ExternalAgentConfig: &types.ExternalAgentConfig{
+				Resolution:  "2560x1440",
+				DesktopType: "sway",
+			},
+			Assistants: []types.AssistantConfig{{
+				Name:                    "Canonical",
+				SystemPrompt:            "canonical instructions",
+				CodeAgentRuntime:        types.CodeAgentRuntimeCodexCLI,
+				CodeAgentCredentialType: types.CodeAgentCredentialTypeSubscription,
+				GenerationModelProvider: "openai",
+				GenerationModel:         "gpt-5.6-sol",
+				MCPs:                    []types.AssistantMCP{{Name: "custom", URL: "https://example.com/mcp"}},
+			}},
+		}},
+	}
+	before, err := json.Marshal(existingApp.Config)
+	s.Require().NoError(err)
+
+	req := types.ProjectApplyRequest{
+		Name:       existingProject.Name,
+		AgentAppID: appID,
+		Spec: types.ProjectSpec{Agent: &types.ProjectAgentSpec{
+			Name:        "ignored",
+			Runtime:     "zed_agent",
+			Provider:    "anthropic",
+			Model:       "claude-sonnet-4",
+			Credentials: "api_key",
+		}},
+	}
+
+	s.store.EXPECT().
+		ListProjects(gomock.Any(), &store.ListProjectsQuery{UserID: s.userID}).
+		Return([]*types.Project{existingProject}, nil)
+	s.store.EXPECT().
+		UpdateProject(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, project *types.Project) error {
+			if project.DefaultHelixAppID != "" {
+				s.Equal(appID, project.DefaultHelixAppID)
+			}
+			return nil
+		}).Times(2)
+	s.store.EXPECT().GetApp(gomock.Any(), appID).Return(existingApp, nil)
+
+	resp, httpErr := s.server.applyProject(httptest.NewRecorder(), s.applyRequest(req))
+
+	s.Nil(httpErr)
+	s.Require().NotNil(resp)
+	s.Equal(appID, resp.AgentAppID)
+	after, err := json.Marshal(existingApp.Config)
+	s.Require().NoError(err)
+	s.Equal(string(before), string(after))
+}
+
 // TestApply_ToolsFromSpecOverrideSkills: when the apply YAML sets tools.*,
 // those values win over previously-stored Browser/WebSearch/Calculator.
 func (s *ApplyProjectSuite) TestApply_ToolsFromSpecOverrideSkills() {

--- a/api/pkg/server/project_handlers.go
+++ b/api/pkg/server/project_handlers.go
@@ -2860,11 +2860,29 @@ func (s *HelixAPIServer) applyProject(_ http.ResponseWriter, r *http.Request) (*
 		}
 
 		var agentApp *types.App
-		if project.DefaultHelixAppID != "" {
+		if req.AgentAppID != "" {
+			linkedAgentApp, getErr := s.Store.GetApp(r.Context(), req.AgentAppID)
+			if getErr != nil {
+				return nil, system.NewHTTPError400(fmt.Sprintf("failed to get linked agent app: %v", getErr))
+			}
+			agentApp = linkedAgentApp
+			if agentApp.OrganizationID != orgID {
+				return nil, system.NewHTTPError400("linked agent app belongs to another organization")
+			}
+			if len(agentApp.Config.Helix.Assistants) != 1 {
+				return nil, system.NewHTTPError400("org-linked agent app must contain exactly one assistant")
+			}
+			project.DefaultHelixAppID = agentApp.ID
+			if err := s.Store.UpdateProject(r.Context(), project); err != nil {
+				return nil, system.NewHTTPError500(fmt.Sprintf("failed to link agent app to project: %v", err))
+			}
+		} else if project.DefaultHelixAppID != "" {
 			agentApp, _ = s.Store.GetApp(r.Context(), project.DefaultHelixAppID)
 		}
 
-		if agentApp != nil {
+		if req.AgentAppID != "" {
+			agentAppID = agentApp.ID
+		} else if agentApp != nil {
 			// Apply only owns name/runtime/provider/model/credentials/tools/
 			// display/goose. User-edited skill config (MCPs, APIs, Zapier, …)
 			// lives on the agent app via the Skills UI and must survive

--- a/api/pkg/server/session_handlers.go
+++ b/api/pkg/server/session_handlers.go
@@ -2870,6 +2870,24 @@ func (s *HelixAPIServer) StartExternalAgentSession(ctx context.Context, req *typ
 		session.Metadata.AutoRestartOnCrash = true
 	}
 
+	if req.AppID != "" {
+		app, err := s.Store.GetApp(ctx, req.AppID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get session app: %w", err)
+		}
+		assistant := data.GetAssistant(app, req.AssistantID)
+		if assistant == nil {
+			return nil, fmt.Errorf("assistant %q not found in app %s", req.AssistantID, req.AppID)
+		}
+		runtime := assistant.CodeAgentRuntime
+		if runtime == "" {
+			runtime = types.CodeAgentRuntimeZedAgent
+		}
+		session.Metadata.AssistantID = req.AssistantID
+		session.Metadata.CodeAgentRuntime = runtime
+		session.Metadata.ZedAgentName = runtime.ZedAgentName()
+	}
+
 	session, err = appendOrOverwrite(session, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to process session messages: %w", err)

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -9540,6 +9540,713 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/agents": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "List the canonical Agents in an organization, including their instructions, tools, runtime, model configuration, and reporting lines.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: list agents",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.BotDTO"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Create a canonical Agent with its org-chart position, communication topics, tools, and Agent App configuration.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: create an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Agent specification",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.CreateBotRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/api.CreateBotResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Get one canonical Agent with its instructions, tools, runtime, model configuration, project, and reporting lines.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: get agent detail",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.AgentDetailDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Delete an Agent after stopping its sessions and project, then atomically remove its Agent App, knowledge, runtime state, subscriptions, reporting lines, and org-chart row.",
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: delete an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Update the canonical Agent instructions, tools, project access, runtime, provider, model, or reasoning configuration.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: update an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Agent fields to update",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.UpdateBotRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/activate": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: activate an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotActivateDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/chat": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: provision an agent chat",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotChatDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/parents": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: add an agent manager",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID of the direct report",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Manager Agent ID",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.AddBotParentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/parents/{parent_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: remove an agent manager",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID of the direct report",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Manager Agent ID",
+                        "name": "parent_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/restart-agent": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: restart an agent session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotActivateDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/stop-agent": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: stop an agent desktop",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/subscriptions": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: list an agent's subscriptions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotSubscriptionsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: subscribe an agent to a topic",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Topic to subscribe the Agent to",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.SubscribeBotRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotSubscriptionDTO"
+                        }
+                    },
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotSubscriptionDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/subscriptions/{topic_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: unsubscribe an agent from a topic",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Topic ID",
+                        "name": "topic_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/bots": {
             "get": {
                 "security": [
@@ -21760,6 +22467,96 @@
                 }
             }
         },
+        "api.AgentDetailDTO": {
+            "type": "object",
+            "properties": {
+                "agent_app_id": {
+                    "type": "string"
+                },
+                "agent_model": {
+                    "type": "string"
+                },
+                "agent_runtime": {
+                    "type": "string"
+                },
+                "agent_status": {
+                    "description": "AgentStatus is \"running\" when the bot's desktop sandbox is online,\n\"stopped\" otherwise (no session, paused, never activated). Drives\nthe green/grey presence dot on the org chart.",
+                    "type": "string"
+                },
+                "code_agent_credential_type": {
+                    "$ref": "#/definitions/types.CodeAgentCredentialType"
+                },
+                "code_agent_runtime": {
+                    "$ref": "#/definitions/types.CodeAgentRuntime"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "helix_user_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "identity": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "kind": {
+                    "description": "Kind is \"\" (agent) or \"human\". A human node is a person placeholder,\nnever activated; Identity holds their cross-system handles and\nHelixUserID optionally links them to a Helix org member. Identity is\nomitted for agent bots.",
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name is the human-readable display label; empty means the UI falls\nback to ID. Distinct from ID, which is the immutable handle.",
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "parent_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "preserve_context": {
+                    "description": "PreserveContext, when true, stops the runtime from wiping this\nBot's chat session before each re-activation, so it accumulates\ncontext across triggers (e.g. Slack). Defaults to false.",
+                    "type": "boolean"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "project_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "reasoning_effort": {
+                    "type": "string"
+                },
+                "tools": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "api.BotActivateDTO": {
             "type": "object",
             "properties": {
@@ -21799,6 +22596,9 @@
         "api.BotDTO": {
             "type": "object",
             "properties": {
+                "agent_app_id": {
+                    "type": "string"
+                },
                 "agent_model": {
                     "type": "string"
                 },
@@ -21808,6 +22608,12 @@
                 "agent_status": {
                     "description": "AgentStatus is \"running\" when the bot's desktop sandbox is online,\n\"stopped\" otherwise (no session, paused, never activated). Drives\nthe green/grey presence dot on the org chart.",
                     "type": "string"
+                },
+                "code_agent_credential_type": {
+                    "$ref": "#/definitions/types.CodeAgentCredentialType"
+                },
+                "code_agent_runtime": {
+                    "$ref": "#/definitions/types.CodeAgentRuntime"
                 },
                 "content": {
                     "type": "string"
@@ -21829,6 +22635,9 @@
                 },
                 "kind": {
                     "description": "Kind is \"\" (agent) or \"human\". A human node is a person placeholder,\nnever activated; Identity holds their cross-system handles and\nHelixUserID optionally links them to a Helix org member. Identity is\nomitted for agent bots.",
+                    "type": "string"
+                },
+                "model": {
                     "type": "string"
                 },
                 "name": {
@@ -21853,6 +22662,12 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "reasoning_effort": {
+                    "type": "string"
                 },
                 "tools": {
                     "type": "array",
@@ -22528,6 +23343,12 @@
         "api.UpdateBotRequest": {
             "type": "object",
             "properties": {
+                "code_agent_credential_type": {
+                    "$ref": "#/definitions/types.CodeAgentCredentialType"
+                },
+                "code_agent_runtime": {
+                    "$ref": "#/definitions/types.CodeAgentRuntime"
+                },
                 "content": {
                     "type": "string"
                 },
@@ -22537,6 +23358,9 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "model": {
+                    "type": "string"
                 },
                 "name": {
                     "type": "string"
@@ -22549,6 +23373,12 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "reasoning_effort": {
+                    "type": "string"
                 },
                 "tools": {
                     "type": "array",
@@ -26747,7 +27577,7 @@
                     "$ref": "#/definitions/types.AssistantCalculator"
                 },
                 "claude_subscription_model": {
-                    "description": "ClaudeSubscriptionModel is the Anthropic model to use when CodeAgentRuntime is\n\"claude_code\" and CodeAgentCredentialType is \"subscription\". It flows through\nCodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,\nwhich the claude-agent-acp package reads (resolveModelPreference) to pick the\nmodel — otherwise Claude Code defaults to Sonnet. Empty means \"opus\"\n(resolveModelPreference resolves this to the latest Opus version).",
+                    "description": "ClaudeSubscriptionModel is the Anthropic model to use when CodeAgentRuntime is\n\"claude_code\" and CodeAgentCredentialType is \"subscription\". It flows through\nCodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,\nwhich the claude-agent-acp package reads (resolveModelPreference) to pick the\nmodel — otherwise Claude Code defaults to Sonnet. Empty means \"opus[1m]\"\n(the 1M-context Opus; resolveModelPreference resolves the \"[1m]\" hint to the\n1M row, while a bare \"opus\" resolves to the 200k sibling).",
                     "type": "string"
                 },
                 "code_agent_credential_type": {
@@ -32173,6 +33003,9 @@
         "types.ProjectApplyRequest": {
             "type": "object",
             "properties": {
+                "agent_app_id": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -4,6 +4,79 @@ definitions:
       parent_id:
         type: string
     type: object
+  api.AgentDetailDTO:
+    properties:
+      agent_app_id:
+        type: string
+      agent_model:
+        type: string
+      agent_runtime:
+        type: string
+      agent_status:
+        description: |-
+          AgentStatus is "running" when the bot's desktop sandbox is online,
+          "stopped" otherwise (no session, paused, never activated). Drives
+          the green/grey presence dot on the org chart.
+        type: string
+      code_agent_credential_type:
+        $ref: '#/definitions/types.CodeAgentCredentialType'
+      code_agent_runtime:
+        $ref: '#/definitions/types.CodeAgentRuntime'
+      content:
+        type: string
+      created_at:
+        type: string
+      helix_user_id:
+        type: string
+      id:
+        type: string
+      identity:
+        additionalProperties:
+          type: string
+        type: object
+      kind:
+        description: |-
+          Kind is "" (agent) or "human". A human node is a person placeholder,
+          never activated; Identity holds their cross-system handles and
+          HelixUserID optionally links them to a Helix org member. Identity is
+          omitted for agent bots.
+        type: string
+      model:
+        type: string
+      name:
+        description: |-
+          Name is the human-readable display label; empty means the UI falls
+          back to ID. Distinct from ID, which is the immutable handle.
+        type: string
+      organization_id:
+        type: string
+      parent_ids:
+        items:
+          type: string
+        type: array
+      preserve_context:
+        description: |-
+          PreserveContext, when true, stops the runtime from wiping this
+          Bot's chat session before each re-activation, so it accumulates
+          context across triggers (e.g. Slack). Defaults to false.
+        type: boolean
+      project_id:
+        type: string
+      project_ids:
+        items:
+          type: string
+        type: array
+      provider:
+        type: string
+      reasoning_effort:
+        type: string
+      tools:
+        items:
+          type: string
+        type: array
+      updated_at:
+        type: string
+    type: object
   api.BotActivateDTO:
     properties:
       activation_id:
@@ -29,6 +102,8 @@ definitions:
     type: object
   api.BotDTO:
     properties:
+      agent_app_id:
+        type: string
       agent_model:
         type: string
       agent_runtime:
@@ -39,6 +114,10 @@ definitions:
           "stopped" otherwise (no session, paused, never activated). Drives
           the green/grey presence dot on the org chart.
         type: string
+      code_agent_credential_type:
+        $ref: '#/definitions/types.CodeAgentCredentialType'
+      code_agent_runtime:
+        $ref: '#/definitions/types.CodeAgentRuntime'
       content:
         type: string
       created_at:
@@ -57,6 +136,8 @@ definitions:
           never activated; Identity holds their cross-system handles and
           HelixUserID optionally links them to a Helix org member. Identity is
           omitted for agent bots.
+        type: string
+      model:
         type: string
       name:
         description: |-
@@ -79,6 +160,10 @@ definitions:
         items:
           type: string
         type: array
+      provider:
+        type: string
+      reasoning_effort:
+        type: string
       tools:
         items:
           type: string
@@ -567,6 +652,10 @@ definitions:
     type: object
   api.UpdateBotRequest:
     properties:
+      code_agent_credential_type:
+        $ref: '#/definitions/types.CodeAgentCredentialType'
+      code_agent_runtime:
+        $ref: '#/definitions/types.CodeAgentRuntime'
       content:
         type: string
       identity:
@@ -577,6 +666,8 @@ definitions:
           email/…). When present it replaces the stored map; absent leaves it
           unchanged. Only meaningful for kind=human bots.
         type: object
+      model:
+        type: string
       name:
         type: string
       preserve_context:
@@ -585,6 +676,10 @@ definitions:
         items:
           type: string
         type: array
+      provider:
+        type: string
+      reasoning_effort:
+        type: string
       tools:
         items:
           type: string
@@ -3553,8 +3648,9 @@ definitions:
           "claude_code" and CodeAgentCredentialType is "subscription". It flows through
           CodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,
           which the claude-agent-acp package reads (resolveModelPreference) to pick the
-          model — otherwise Claude Code defaults to Sonnet. Empty means "opus"
-          (resolveModelPreference resolves this to the latest Opus version).
+          model — otherwise Claude Code defaults to Sonnet. Empty means "opus[1m]"
+          (the 1M-context Opus; resolveModelPreference resolves the "[1m]" hint to the
+          1M row, while a bare "opus" resolves to the 200k sibling).
         type: string
       code_agent_credential_type:
         allOf:
@@ -7473,6 +7569,8 @@ definitions:
     type: object
   types.ProjectApplyRequest:
     properties:
+      agent_app_id:
+        type: string
       name:
         type: string
       organization_id:
@@ -18407,6 +18505,463 @@ paths:
       summary: List sandbox tmux sessions
       tags:
       - Sandboxes
+  /api/v1/orgs/{org}/agents:
+    get:
+      description: List the canonical Agents in an organization, including their instructions,
+        tools, runtime, model configuration, and reporting lines.
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/api.BotDTO'
+            type: array
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: list agents'
+      tags:
+      - HelixOrg
+    post:
+      consumes:
+      - application/json
+      description: Create a canonical Agent with its org-chart position, communication
+        topics, tools, and Agent App configuration.
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent specification
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/api.CreateBotRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/api.CreateBotResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: create an agent'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}:
+    delete:
+      description: Delete an Agent after stopping its sessions and project, then atomically
+        remove its Agent App, knowledge, runtime state, subscriptions, reporting lines,
+        and org-chart row.
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: delete an agent'
+      tags:
+      - HelixOrg
+    get:
+      description: Get one canonical Agent with its instructions, tools, runtime,
+        model configuration, project, and reporting lines.
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.AgentDetailDTO'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: get agent detail'
+      tags:
+      - HelixOrg
+    patch:
+      consumes:
+      - application/json
+      description: Update the canonical Agent instructions, tools, project access,
+        runtime, provider, model, or reasoning configuration.
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Agent fields to update
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/api.UpdateBotRequest'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.BotDTO'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: update an agent'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}/activate:
+    post:
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/api.BotActivateDTO'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: activate an agent'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}/chat:
+    post:
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.BotChatDTO'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: provision an agent chat'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}/parents:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID of the direct report
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Manager Agent ID
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/api.AddBotParentRequest'
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: add an agent manager'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}/parents/{parent_id}:
+    delete:
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID of the direct report
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Manager Agent ID
+        in: path
+        name: parent_id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: remove an agent manager'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}/restart-agent:
+    post:
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/api.BotActivateDTO'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: restart an agent session'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}/stop-agent:
+    post:
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: stop an agent desktop'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}/subscriptions:
+    get:
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.BotSubscriptionsResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: list an agent''s subscriptions'
+      tags:
+      - HelixOrg
+    post:
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Topic to subscribe the Agent to
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/api.SubscribeBotRequest'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.BotSubscriptionDTO'
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/api.BotSubscriptionDTO'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: subscribe an agent to a topic'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}/subscriptions/{topic_id}:
+    delete:
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Topic ID
+        in: path
+        name: topic_id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: unsubscribe an agent from a topic'
+      tags:
+      - HelixOrg
   /api/v1/orgs/{org}/bots:
     get:
       produces:

--- a/api/pkg/types/project.go
+++ b/api/pkg/types/project.go
@@ -185,6 +185,7 @@ type ProjectApplyRequest struct {
 	OrganizationID string      `json:"organization_id"`
 	Name           string      `json:"name"`
 	Spec           ProjectSpec `json:"spec"`
+	AgentAppID     string      `json:"agent_app_id,omitempty"`
 }
 
 // ProjectApplyResponse is the response for PUT /api/v1/projects/apply.

--- a/design/2026-07-27-unify-helix-org-agents.md
+++ b/design/2026-07-27-unify-helix-org-agents.md
@@ -1,0 +1,213 @@
+# Unify Helix Org Bots with Agents
+
+**Date:** 2026-07-27
+**Status:** Implemented, pending review and connected-Zed verification
+
+## Summary
+
+- `types.App` is the canonical execution configuration for an Agent.
+- `org_bots` remains the org-graph membership row and links directly to its Agent App through `agent_app_id`.
+- The UI and CLI use "Agent"; old Bot URLs and commands remain compatibility aliases.
+
+## Decision
+
+An Agent has one execution configuration and may also participate in a Helix
+Org graph.
+
+`types.App` owns the execution configuration:
+
+- display name and system prompt
+- runtime, provider, model, credentials, and reasoning settings
+- the single Assistant used by the org runtime
+
+`org_bots` owns graph state:
+
+- stable graph handle
+- reporting lines
+- org MCP tool grants and subscriptions
+- project associations, identity, and context-preservation policy
+- the direct `agent_app_id` association
+
+Org-linked Agent Apps must contain exactly one Assistant. Human placeholders
+remain graph-only rows and do not have an Agent App.
+
+The existing `name` and `content` columns remain on `org_bots` for compatibility
+with legacy rows and internal graph APIs. Linked Agents are read from
+`types.App`, and writes update the App through the org endpoint. Removing the
+legacy columns and renaming internal Bot types is intentionally out of scope for
+this migration.
+
+## Data migration and invariants
+
+Startup migration adds nullable `org_bots.agent_app_id`.
+
+Existing links are backfilled from `org_bot_runtime_state` only when:
+
+- the runtime value references an existing App
+- the row is an Agent, not a human placeholder
+- no second Bot claims the same runtime App
+
+A partial unique index prevents two rows in one org from linking the same App.
+A foreign key requires the App to exist and uses `ON DELETE RESTRICT`, so the
+graph row must be removed before its App.
+
+After org seeding, reconciliation creates an Agent App for each non-human legacy
+row that still has no link, then writes `agent_app_id`. New Agent row creation
+is rejected by the repository when no App link is present. Human row creation
+is rejected when an App link is present.
+
+The same startup migration eagerly converges existing org-owned projects. It
+joins each Helix runtime `project_id` row to the Bot's canonical
+`agent_app_id`, then updates `projects.default_helix_app_id` in place. It does
+not recreate or change the project, repository, session, or runtime-state rows,
+so their IDs remain stable.
+
+A project is eligible only when:
+
+- the project exists, is not soft-deleted, and belongs to the Bot's org
+- the canonical App exists and belongs to the same org
+- every Bot runtime row naming that project resolves to one distinct canonical
+  App
+
+Cross-org, deleted, missing, ambiguous, and conflicting candidate rows are left
+unchanged. A stale existing `default_helix_app_id` is not treated as a conflict:
+it is the legacy value the unambiguous canonical link replaces.
+
+The runtime project path keeps the same in-place update as a safety fallback
+for rows skipped or missed at startup. Activation is therefore not required for
+eligible projects to converge, and the fallback does not create a replacement
+project.
+
+The service layer verifies that linked Apps belong to the requested org when
+applying projects. The database foreign key verifies existence, not matching
+organization ownership.
+
+## Lifecycle behavior
+
+### Create
+
+1. Create the canonical Agent App.
+2. Create the graph row with `agent_app_id`.
+3. Apply reporting lines, subscriptions, and optional activation.
+4. Run the shared delete lifecycle if any fatal post-create step fails.
+
+Project application reuses the linked App as `DefaultHelixAppID`; it no longer
+creates a second App for the org node. Runtime prompt construction reads the
+linked App's Assistant system prompt.
+
+When the org default Agent configuration is already complete, creation resolves
+the runtime, credential type, provider, model, and reasoning effort into the App
+before it is persisted, then activates the Agent immediately. Runtime and
+credential compatibility is normalized as part of that resolution.
+
+When the org default Agent configuration is not complete, creation still
+persists the App and graph row but defers project provisioning and activation.
+Once the configuration becomes complete, the settings flow applies the resolved
+defaults only if the App is still the untouched deferred scaffold, then
+activates it. User-edited Apps and already provisioned Apps are not overwritten
+by later org default changes.
+
+Creation is not one database transaction. A graph-row creation failure deletes
+the new App directly. A later reporting, topology, subscription, hire-hook, or
+activation-row failure runs the full delete lifecycle; a rollback failure is
+returned with the original error.
+
+### Update
+
+The org detail page sends one PATCH containing graph fields and the Agent App
+configuration. The server updates graph state and the canonical App in one user
+operation. If the App update fails, it restores the previous graph fields and
+returns an error.
+
+The MCP `set_bot_content` tool also updates the linked App's system prompt. If
+the canonical update is unavailable or fails, it restores the previous graph
+content and does not mirror the failed value into the running workspace.
+
+Updates through the standard Agent endpoint detect linked Apps, require exactly
+one Assistant, and normalize the Assistant name to the App name. This prevents
+the generic App surface from reintroducing a second name or an unsupported
+multi-Assistant shape.
+
+List and detail responses read name and instructions from the linked App, so
+changes made through the standard Agent surface appear in the org surface.
+
+### Delete
+
+Deleting an org Agent tears down its project first. The Helix adapter resolves
+the project's organization owner and executes project deletion as that owner.
+An already missing project is accepted so an interrupted deletion can be
+retried safely.
+
+After project teardown, one shared database transaction deletes the Agent's
+knowledge versions and knowledge, runtime state, subscriptions, graph row, and
+canonical App. Reporting lines cascade with graph-row deletion. Any failure
+rolls back the whole transaction, retaining the graph row and App. A retry can
+then complete the transaction even when the first attempt already deleted the
+project.
+
+Deleting the linked App through the standard Agent endpoint detects the org
+link and delegates to the same lifecycle, so the org chart cannot retain a
+dangling node. `keep_knowledge=true` is rejected for an org-linked Agent because
+the shared lifecycle performs full App cleanup.
+
+## UI and compatibility
+
+The Helix Org navigation, list, creation dialog, detail page, notifications,
+and delete confirmation use "Agent".
+
+Canonical routes are:
+
+```text
+/orgs/:org_id/helix-org/agents
+/orgs/:org_id/helix-org/agents/:bot_id
+```
+
+The previous `/helix-org/bots` routes redirect to the Agent routes.
+
+REST exposes `/agents` as the canonical flat resource. `GET /agents` returns
+flat Agent rows, and `GET /agents/{id}` returns the same configuration fields
+plus `project_id`; PATCH writes those flat fields. The compatibility `/bots`
+routes remain available, including the legacy nested detail response expected
+by older clients. The CLI command is `helix org agents`; `agent`, `bots`, and
+`bot` remain aliases.
+
+MCP tool names such as `create_bot`, `list_bots`, and `delete_bot` are
+intentionally unchanged. Renaming or duplicating them would expand the MCP
+capability surface and break stored tool allowlists and prompts. MCP naming can
+be migrated separately only with an explicit versioning and allowlist plan.
+
+## Verification
+
+Live create, list, rename, delete, and recreate passed against the implemented
+API.
+
+Live Zed activation provisioned the Agent's project, repository, and session
+row. The desktop Agent could not connect because the isolated alternate API
+used for the test had no Hydra RevDial connection. The connected-Zed message
+and thread-switch seam therefore remains unverified.
+
+## Rollout and verification risks
+
+- Run the migration against a Postgres copy containing valid, dangling,
+  duplicate, cross-org, soft-deleted, and conflicting runtime links. Verify
+  eligible project defaults change in place while skipped project, repository,
+  session, and runtime IDs remain unchanged. Ambiguous Bot links deliberately
+  remain unlinked and reconciliation creates new Apps; old runtime Apps may
+  then require orphan cleanup.
+- Deploy the schema and transactional linked-delete path together. Rolling old
+  application code back while retaining `ON DELETE RESTRICT` can break the old
+  App-first deletion path. A rollback must retain graph-before-App deletion or
+  remove the foreign key.
+- Inject failures after graph-row creation, during App update, and during App
+  deletion to verify compensation and surfaced errors.
+- Verify create, edit, and delete from both the Helix Org Agent page and the
+  standard Agent page. Confirm both surfaces show the same name, instructions,
+  runtime, and model after each edit.
+- Verify old UI URLs, REST `/bots` calls, and CLI `bots` commands still work.
+- Before activating a migrated Agent, confirm startup already updated its
+  existing project's default App without changing project, repository, session,
+  or runtime IDs. Then activate it and confirm the runtime fallback leaves the
+  same canonical `agent_app_id` in place.
+- Repeat the activation test against an API with a working Hydra RevDial
+  connection. Update the runtime, switch the active session, send the next
+  message, and verify no duplicate App or unintended thread switch is created.

--- a/design/2026-07-27-unify-helix-org-agents.md
+++ b/design/2026-07-27-unify-helix-org-agents.md
@@ -43,7 +43,8 @@ Startup migration adds nullable `org_bots.agent_app_id`.
 
 Existing links are backfilled from `org_bot_runtime_state` only when:
 
-- the runtime value references an existing App
+- the runtime value references an existing same-org App with exactly one
+  Assistant
 - the row is an Agent, not a human placeholder
 - no second Bot claims the same runtime App
 
@@ -56,22 +57,19 @@ row that still has no link, then writes `agent_app_id`. New Agent row creation
 is rejected by the repository when no App link is present. Human row creation
 is rejected when an App link is present.
 
-The same startup migration eagerly converges existing org-owned projects. It
-joins each Helix runtime `project_id` row to the Bot's canonical
-`agent_app_id`, then updates `projects.default_helix_app_id` in place. It does
-not recreate or change the project, repository, session, or runtime-state rows,
+Startup then converges each non-deleted same-org project associated with exactly
+one Bot. A valid, same-org, one-Assistant project default that is not claimed by
+another Bot has precedence: it is preserved and becomes the canonical App.
+Otherwise the migration uses the valid Bot App, including a link adopted from
+runtime state. The chosen App is written to the project default, Bot link, and
+runtime link in one database transaction. Projects associated with multiple
+Bots are ambiguous and skipped.
+
+Convergence is idempotent. The first org bootstrap creates Apps for remaining
+unlinked non-human rows; repeated startup and bootstrap runs leave established
+links unchanged. Missing, invalid, cross-org, and ambiguous candidates are not
+adopted. The migration does not recreate the project, repository, or session,
 so their IDs remain stable.
-
-A project is eligible only when:
-
-- the project exists, is not soft-deleted, and belongs to the Bot's org
-- the canonical App exists and belongs to the same org
-- every Bot runtime row naming that project resolves to one distinct canonical
-  App
-
-Cross-org, deleted, missing, ambiguous, and conflicting candidate rows are left
-unchanged. A stale existing `default_helix_app_id` is not treated as a conflict:
-it is the legacy value the unambiguous canonical link replaces.
 
 The runtime project path keeps the same in-place update as a safety fallback
 for rows skipped or missed at startup. Activation is therefore not required for
@@ -194,10 +192,10 @@ and thread-switch seam therefore remains unverified.
   session, and runtime IDs remain unchanged. Ambiguous Bot links deliberately
   remain unlinked and reconciliation creates new Apps; old runtime Apps may
   then require orphan cleanup.
-- Deploy the schema and transactional linked-delete path together. Rolling old
-  application code back while retaining `ON DELETE RESTRICT` can break the old
-  App-first deletion path. A rollback must retain graph-before-App deletion or
-  remove the foreign key.
+- Upgrade every backend API instance together before publishing the new
+  frontend. Mixed-version API deployment and downgrade are unsupported for
+  this migration because old instances use App-first deletion while the new
+  schema enforces graph-before-App deletion with `ON DELETE RESTRICT`.
 - Inject failures after graph-row creation, during App update, and during App
   deletion to verify compensation and surfaced errors.
 - Verify create, edit, and delete from both the Helix Org Agent page and the

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -13,6 +13,52 @@ export interface ApiAddBotParentRequest {
   parent_id?: string;
 }
 
+export interface ApiAgentDetailDTO {
+  agent_app_id?: string;
+  agent_model?: string;
+  agent_runtime?: string;
+  /**
+   * AgentStatus is "running" when the bot's desktop sandbox is online,
+   * "stopped" otherwise (no session, paused, never activated). Drives
+   * the green/grey presence dot on the org chart.
+   */
+  agent_status?: string;
+  code_agent_credential_type?: TypesCodeAgentCredentialType;
+  code_agent_runtime?: TypesCodeAgentRuntime;
+  content?: string;
+  created_at?: string;
+  helix_user_id?: string;
+  id?: string;
+  identity?: Record<string, string>;
+  /**
+   * Kind is "" (agent) or "human". A human node is a person placeholder,
+   * never activated; Identity holds their cross-system handles and
+   * HelixUserID optionally links them to a Helix org member. Identity is
+   * omitted for agent bots.
+   */
+  kind?: string;
+  model?: string;
+  /**
+   * Name is the human-readable display label; empty means the UI falls
+   * back to ID. Distinct from ID, which is the immutable handle.
+   */
+  name?: string;
+  organization_id?: string;
+  parent_ids?: string[];
+  /**
+   * PreserveContext, when true, stops the runtime from wiping this
+   * Bot's chat session before each re-activation, so it accumulates
+   * context across triggers (e.g. Slack). Defaults to false.
+   */
+  preserve_context?: boolean;
+  project_id?: string;
+  project_ids?: string[];
+  provider?: string;
+  reasoning_effort?: string;
+  tools?: string[];
+  updated_at?: string;
+}
+
 export interface ApiBotActivateDTO {
   activation_id?: string;
   agent_app_id?: string;
@@ -30,6 +76,7 @@ export interface ApiBotChatDTO {
 }
 
 export interface ApiBotDTO {
+  agent_app_id?: string;
   agent_model?: string;
   agent_runtime?: string;
   /**
@@ -38,6 +85,8 @@ export interface ApiBotDTO {
    * the green/grey presence dot on the org chart.
    */
   agent_status?: string;
+  code_agent_credential_type?: TypesCodeAgentCredentialType;
+  code_agent_runtime?: TypesCodeAgentRuntime;
   content?: string;
   created_at?: string;
   helix_user_id?: string;
@@ -50,6 +99,7 @@ export interface ApiBotDTO {
    * omitted for agent bots.
    */
   kind?: string;
+  model?: string;
   /**
    * Name is the human-readable display label; empty means the UI falls
    * back to ID. Distinct from ID, which is the immutable handle.
@@ -64,6 +114,8 @@ export interface ApiBotDTO {
    */
   preserve_context?: boolean;
   project_ids?: string[];
+  provider?: string;
+  reasoning_effort?: string;
   tools?: string[];
   updated_at?: string;
 }
@@ -387,6 +439,8 @@ export interface ApiTransportRequestField {
 }
 
 export interface ApiUpdateBotRequest {
+  code_agent_credential_type?: TypesCodeAgentCredentialType;
+  code_agent_runtime?: TypesCodeAgentRuntime;
   content?: string;
   /**
    * Identity is the per-channel handle map for a human node (slack/github/
@@ -394,9 +448,12 @@ export interface ApiUpdateBotRequest {
    * unchanged. Only meaningful for kind=human bots.
    */
   identity?: Record<string, string>;
+  model?: string;
   name?: string;
   preserve_context?: boolean;
   project_ids?: string[];
+  provider?: string;
+  reasoning_effort?: string;
   tools?: string[];
 }
 
@@ -2276,8 +2333,9 @@ export interface TypesAssistantConfig {
    * "claude_code" and CodeAgentCredentialType is "subscription". It flows through
    * CodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,
    * which the claude-agent-acp package reads (resolveModelPreference) to pick the
-   * model — otherwise Claude Code defaults to Sonnet. Empty means "opus"
-   * (resolveModelPreference resolves this to the latest Opus version).
+   * model — otherwise Claude Code defaults to Sonnet. Empty means "opus[1m]"
+   * (the 1M-context Opus; resolveModelPreference resolves the "[1m]" hint to the
+   * 1M row, while a bare "opus" resolves to the 200k sibling).
    */
   claude_subscription_model?: string;
   /**
@@ -4682,6 +4740,7 @@ export interface TypesProjectAgentTools {
 }
 
 export interface TypesProjectApplyRequest {
+  agent_app_id?: string;
   name?: string;
   organization_id?: string;
   spec?: TypesProjectSpec;
@@ -12441,6 +12500,262 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         method: "GET",
         secure: true,
         format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description List the canonical Agents in an organization, including their instructions, tools, runtime, model configuration, and reporting lines.
+     *
+     * @tags HelixOrg
+     * @name V1OrgsAgentsDetail
+     * @summary Helix-org: list agents
+     * @request GET:/api/v1/orgs/{org}/agents
+     * @secure
+     */
+    v1OrgsAgentsDetail: (org: string, params: RequestParams = {}) =>
+      this.request<ApiBotDTO[], any>({
+        path: `/api/v1/orgs/${org}/agents`,
+        method: "GET",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Create a canonical Agent with its org-chart position, communication topics, tools, and Agent App configuration.
+     *
+     * @tags HelixOrg
+     * @name V1OrgsAgentsCreate
+     * @summary Helix-org: create an agent
+     * @request POST:/api/v1/orgs/{org}/agents
+     * @secure
+     */
+    v1OrgsAgentsCreate: (org: string, payload: ApiCreateBotRequest, params: RequestParams = {}) =>
+      this.request<ApiCreateBotResponse, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/agents`,
+        method: "POST",
+        body: payload,
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Delete an Agent after stopping its sessions and project, then atomically remove its Agent App, knowledge, runtime state, subscriptions, reporting lines, and org-chart row.
+     *
+     * @tags HelixOrg
+     * @name V1OrgsAgentsDelete
+     * @summary Helix-org: delete an agent
+     * @request DELETE:/api/v1/orgs/{org}/agents/{id}
+     * @secure
+     */
+    v1OrgsAgentsDelete: (org: string, id: string, params: RequestParams = {}) =>
+      this.request<void, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/agents/${id}`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description Get one canonical Agent with its instructions, tools, runtime, model configuration, project, and reporting lines.
+     *
+     * @tags HelixOrg
+     * @name V1OrgsAgentsDetail2
+     * @summary Helix-org: get agent detail
+     * @request GET:/api/v1/orgs/{org}/agents/{id}
+     * @originalName v1OrgsAgentsDetail
+     * @duplicate
+     * @secure
+     */
+    v1OrgsAgentsDetail2: (org: string, id: string, params: RequestParams = {}) =>
+      this.request<ApiAgentDetailDTO, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/agents/${id}`,
+        method: "GET",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Update the canonical Agent instructions, tools, project access, runtime, provider, model, or reasoning configuration.
+     *
+     * @tags HelixOrg
+     * @name V1OrgsAgentsPartialUpdate
+     * @summary Helix-org: update an agent
+     * @request PATCH:/api/v1/orgs/{org}/agents/{id}
+     * @secure
+     */
+    v1OrgsAgentsPartialUpdate: (org: string, id: string, payload: ApiUpdateBotRequest, params: RequestParams = {}) =>
+      this.request<ApiBotDTO, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/agents/${id}`,
+        method: "PATCH",
+        body: payload,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsAgentsActivateCreate
+     * @summary Helix-org: activate an agent
+     * @request POST:/api/v1/orgs/{org}/agents/{id}/activate
+     * @secure
+     */
+    v1OrgsAgentsActivateCreate: (org: string, id: string, params: RequestParams = {}) =>
+      this.request<ApiBotActivateDTO, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/agents/${id}/activate`,
+        method: "POST",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsAgentsChatCreate
+     * @summary Helix-org: provision an agent chat
+     * @request POST:/api/v1/orgs/{org}/agents/{id}/chat
+     * @secure
+     */
+    v1OrgsAgentsChatCreate: (org: string, id: string, params: RequestParams = {}) =>
+      this.request<ApiBotChatDTO, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/agents/${id}/chat`,
+        method: "POST",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsAgentsParentsCreate
+     * @summary Helix-org: add an agent manager
+     * @request POST:/api/v1/orgs/{org}/agents/{id}/parents
+     * @secure
+     */
+    v1OrgsAgentsParentsCreate: (org: string, id: string, payload: ApiAddBotParentRequest, params: RequestParams = {}) =>
+      this.request<void, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/agents/${id}/parents`,
+        method: "POST",
+        body: payload,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsAgentsParentsDelete
+     * @summary Helix-org: remove an agent manager
+     * @request DELETE:/api/v1/orgs/{org}/agents/{id}/parents/{parent_id}
+     * @secure
+     */
+    v1OrgsAgentsParentsDelete: (org: string, id: string, parentId: string, params: RequestParams = {}) =>
+      this.request<void, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/agents/${id}/parents/${parentId}`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsAgentsRestartAgentCreate
+     * @summary Helix-org: restart an agent session
+     * @request POST:/api/v1/orgs/{org}/agents/{id}/restart-agent
+     * @secure
+     */
+    v1OrgsAgentsRestartAgentCreate: (org: string, id: string, params: RequestParams = {}) =>
+      this.request<ApiBotActivateDTO, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/agents/${id}/restart-agent`,
+        method: "POST",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsAgentsStopAgentCreate
+     * @summary Helix-org: stop an agent desktop
+     * @request POST:/api/v1/orgs/{org}/agents/{id}/stop-agent
+     * @secure
+     */
+    v1OrgsAgentsStopAgentCreate: (org: string, id: string, params: RequestParams = {}) =>
+      this.request<void, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/agents/${id}/stop-agent`,
+        method: "POST",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsAgentsSubscriptionsDetail
+     * @summary Helix-org: list an agent's subscriptions
+     * @request GET:/api/v1/orgs/{org}/agents/{id}/subscriptions
+     * @secure
+     */
+    v1OrgsAgentsSubscriptionsDetail: (org: string, id: string, params: RequestParams = {}) =>
+      this.request<ApiBotSubscriptionsResponse, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/agents/${id}/subscriptions`,
+        method: "GET",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsAgentsSubscriptionsCreate
+     * @summary Helix-org: subscribe an agent to a topic
+     * @request POST:/api/v1/orgs/{org}/agents/{id}/subscriptions
+     * @secure
+     */
+    v1OrgsAgentsSubscriptionsCreate: (
+      org: string,
+      id: string,
+      payload: ApiSubscribeBotRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<ApiBotSubscriptionDTO, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/agents/${id}/subscriptions`,
+        method: "POST",
+        body: payload,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags HelixOrg
+     * @name V1OrgsAgentsSubscriptionsDelete
+     * @summary Helix-org: unsubscribe an agent from a topic
+     * @request DELETE:/api/v1/orgs/{org}/agents/{id}/subscriptions/{topic_id}
+     * @secure
+     */
+    v1OrgsAgentsSubscriptionsDelete: (org: string, id: string, topicId: string, params: RequestParams = {}) =>
+      this.request<void, ApiErrorResponse>({
+        path: `/api/v1/orgs/${org}/agents/${id}/subscriptions/${topicId}`,
+        method: "DELETE",
+        secure: true,
         ...params,
       }),
 

--- a/frontend/src/components/helix-org/HelixOrgBotPanelTab.tsx
+++ b/frontend/src/components/helix-org/HelixOrgBotPanelTab.tsx
@@ -50,13 +50,13 @@ const HelixOrgBotPanelTab: FC<Props> = ({ botID, projectID }) => {
   )
 
   if (!projectID) {
-    return <EmptyState>This bot has no project for spec tasks.</EmptyState>
+    return <EmptyState>This agent has no project for spec tasks.</EmptyState>
   }
   if (tasksQuery.isLoading) {
     return <Box sx={{ m: 'auto' }}><CircularProgress size={24} /></Box>
   }
   if (tasksQuery.isError) {
-    return <EmptyState>Could not load this bot's project tasks.</EmptyState>
+    return <EmptyState>Could not load this agent's project tasks.</EmptyState>
   }
 
   return (
@@ -79,7 +79,7 @@ const HelixOrgBotPanelTab: FC<Props> = ({ botID, projectID }) => {
         <Box sx={{ p: 2.5, textAlign: 'center', border: '1px dashed', borderColor: 'divider', borderRadius: 1.5 }}>
           <PendingOutlinedIcon sx={{ color: 'text.disabled', mb: 0.5 }} />
           <Typography variant="body2" color="text.secondary">
-            {tasks.length === 0 ? 'No spec tasks are linked to this bot yet.' : 'No tasks match this status.'}
+            {tasks.length === 0 ? 'No spec tasks are linked to this agent yet.' : 'No tasks match this status.'}
           </Typography>
         </Box>
       ) : filteredTasks.map((task) => {

--- a/frontend/src/components/helix-org/HelixOrgChatPanel.tsx
+++ b/frontend/src/components/helix-org/HelixOrgChatPanel.tsx
@@ -250,7 +250,7 @@ const HelixOrgChatPanel: FC = () => {
           <SmartToyOutlinedIcon sx={{ fontSize: 18, color: 'text.secondary', flexShrink: 0 }} />
           <Box sx={{ flex: 1, minWidth: 0 }}>
             {agents.length === 0 ? (
-              <Typography variant="body2" color="text.secondary">No bots yet</Typography>
+              <Typography variant="body2" color="text.secondary">No agents yet</Typography>
             ) : (
               <Select
                 size="small"
@@ -289,7 +289,7 @@ const HelixOrgChatPanel: FC = () => {
             <>
               <IconButton
                 size="small"
-                aria-label="Bot actions"
+                aria-label="Agent actions"
                 onClick={openMenu}
                 disabled={!selectedBotId}
                 sx={{ flexShrink: 0 }}
@@ -391,7 +391,7 @@ const HelixOrgChatPanel: FC = () => {
         {!selectedBotId ? (
           <Box sx={{ p: 3, textAlign: 'center' }}>
             <Typography variant="body2" color="text.secondary">
-              Create a bot on the chart to start chatting.
+              Create an agent on the chart to start chatting.
             </Typography>
           </Box>
         ) : view === 'tasks' ? (

--- a/frontend/src/components/helix-org/HelixOrgTopNav.tsx
+++ b/frontend/src/components/helix-org/HelixOrgTopNav.tsx
@@ -29,8 +29,8 @@ const ITEMS: NavItem[] = [
     isActive: (n) => n === 'helix_org_chart' || n === 'helix_org_root',
   },
   {
-    id: 'bots',
-    label: 'Bots',
+    id: 'agents',
+    label: 'Agents',
     route: 'helix_org_bots',
     icon: <Bot size={16} />,
     isActive: (n) => n === 'helix_org_bots' || n === 'helix_org_bot_detail' || n === 'helix_org_human_detail',

--- a/frontend/src/components/helix-org/NewBotDialog.tsx
+++ b/frontend/src/components/helix-org/NewBotDialog.tsx
@@ -85,7 +85,7 @@ const NewBotDialog: FC<NewBotDialogProps> = ({ open, onClose, presetParentId }) 
   const submit = async () => {
     const trimmedId = id.trim()
     if (!trimmedId) {
-      snackbar.error('Bot ID is required')
+      snackbar.error('Agent ID is required')
       return
     }
     try {
@@ -96,21 +96,21 @@ const NewBotDialog: FC<NewBotDialogProps> = ({ open, onClose, presetParentId }) 
         ...(parentId ? { parent_id: parentId } : {}),
       })
       if (parentId) {
-        snackbar.success(`bot ${res.id ?? trimmedId} created, reporting to ${parentId}`)
+        snackbar.success(`agent ${res.id ?? trimmedId} created, reporting to ${parentId}`)
       } else {
-        snackbar.success(`bot ${res.id ?? trimmedId} created — drag an edge from a manager to set who it reports to`)
+        snackbar.success(`agent ${res.id ?? trimmedId} created - drag an edge from a manager to set who it reports to`)
       }
       onClose()
     } catch (err: any) {
-      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'create bot failed')
+      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'create agent failed')
     }
   }
 
   return (
-    <HelixOrgSideDrawer open={open} onClose={onClose} title="New bot" width={460}>
+    <HelixOrgSideDrawer open={open} onClose={onClose} title="New agent" width={460}>
       <Stack spacing={2}>
         <Typography variant="body2" color="text.secondary">
-          Create an agent bot. It appears on the org chart; set reporting lines
+          Create an agent. It appears on the org chart; set reporting lines
           here or by dragging edges on the chart.
         </Typography>
         <TextField
@@ -118,13 +118,13 @@ const NewBotDialog: FC<NewBotDialogProps> = ({ open, onClose, presetParentId }) 
           placeholder="Chief of Staff"
           value={name}
           onChange={(e) => onNameChange(e.target.value)}
-          helperText="Human-readable display name shown in the chart and bot page."
+          helperText="Human-readable display name shown in the chart and agent page."
           autoFocus
           fullWidth
           size="small"
         />
         <TextField
-          label="Bot ID"
+          label="Agent ID"
           placeholder="chief-of-staff"
           value={id}
           onChange={(e) => { setIdEdited(true); setId(e.target.value) }}
@@ -138,7 +138,7 @@ const NewBotDialog: FC<NewBotDialogProps> = ({ open, onClose, presetParentId }) 
             label="Reports to"
             value={presetParentId}
             InputProps={{ readOnly: true }}
-            helperText="Manager this bot reports to."
+            helperText="Manager this agent reports to."
             fullWidth
             size="small"
             sx={{ '& input': { fontFamily: 'monospace' } }}
@@ -149,7 +149,7 @@ const NewBotDialog: FC<NewBotDialogProps> = ({ open, onClose, presetParentId }) 
             label="Reports to (optional)"
             value={parentId}
             onChange={(e) => setParentId(e.target.value)}
-            helperText="Manager this bot reports to. Leave blank and wire later by dragging an edge in the Chart."
+          helperText="Manager this agent reports to. Leave blank and wire later by dragging an edge in the Chart."
             fullWidth
             size="small"
           >

--- a/frontend/src/components/helix-org/NewTopicDrawer.tsx
+++ b/frontend/src/components/helix-org/NewTopicDrawer.tsx
@@ -248,7 +248,7 @@ const NewTopicDrawer: FC<NewTopicDrawerProps> = ({ open, onClose }) => {
     <HelixOrgSideDrawer open={open} onClose={resetAndClose} title="New topic" width={480}>
       <Stack spacing={2}>
         <Typography variant="body2" color="text.secondary">
-          Topics are named message buses. Bots subscribe on the chart; transports
+          Topics are named message buses. Agents subscribe on the chart; transports
           (local, webhook, GitHub, …) bring events in.
         </Typography>
         <TextField

--- a/frontend/src/components/helix-org/ProcessorConfigDrawer.tsx
+++ b/frontend/src/components/helix-org/ProcessorConfigDrawer.tsx
@@ -500,7 +500,7 @@ const ProcessorConfigDrawer: FC<ProcessorConfigDrawerProps> = ({ open, onClose, 
                 label={<Typography variant="body2" sx={{ fontWeight: 600 }}>Keep people in the thread</Typography>}
               />
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                After a bot is pulled into a Slack thread (for example because they were named),
+                After an agent is pulled into a Slack thread (for example because they were named),
                 later messages in that same thread also go to them — even if they are not named again.
               </Typography>
             </Box>

--- a/frontend/src/pages/HelixOrgBotDetail.tsx
+++ b/frontend/src/pages/HelixOrgBotDetail.tsx
@@ -62,7 +62,6 @@ import RobustPromptInput from '../components/common/RobustPromptInput'
 
 import router5 from '../router'
 import useApi from '../hooks/useApi'
-import useApps from '../hooks/useApps'
 import useRouter from '../hooks/useRouter'
 import useSnackbar from '../hooks/useSnackbar'
 import { useListProjects } from '../services/projectService'
@@ -70,6 +69,7 @@ import { deriveDisplaySettings } from '../services/externalAgentDisplay'
 import { useStreaming } from '../contexts/streaming'
 import { SESSION_TYPE_TEXT } from '../types'
 import {
+  BotDTO,
   ToolDTO,
   useActivateBot,
   useDeleteBot,
@@ -95,7 +95,7 @@ const HelixOrgBotDetail: FC = () => {
   const api = useApi()
   const orgSlug = router.params.org_id as string | undefined
   const botId = router.params.bot_id as string | undefined
-  const breadcrumbs = useHelixOrgBreadcrumbs({ title: 'Bots', routeName: 'helix_org_bots' })
+  const breadcrumbs = useHelixOrgBreadcrumbs({ title: 'Agents', routeName: 'helix_org_bots' })
 
   const del = useDeleteBot()
   // Stop polling/refetching this bot once a delete is in flight or done —
@@ -109,7 +109,6 @@ const HelixOrgBotDetail: FC = () => {
   const activateAgent = useActivateBot()
   const stopAgent = useStopBotAgent()
   const restartAgent = useRestartBotAgent()
-  const apps = useApps()
   const { data: toolCatalogue } = useListHelixOrgTools()
   const [confirmingDelete, setConfirmingDelete] = useState(false)
   const [agentMenuEl, setAgentMenuEl] = useState<null | HTMLElement>(null)
@@ -124,8 +123,6 @@ const HelixOrgBotDetail: FC = () => {
   const projectID = data?.project_id
   const { data: projects = [] } = useListProjects(bot?.organization_id, { enabled: !!bot?.organization_id })
   const agentAppID = data?.agent_app_id
-  const agentApp = apps.apps?.find((app) => app.id === agentAppID)
-  const assistant = agentApp?.config.helix.assistants?.[0]
   // A human node is a person placeholder — it never runs, so the agent-only
   // surfaces (Project Desktop session, tools, preserve-context, restart) make
   // no sense for it and are hidden below.
@@ -162,13 +159,13 @@ const HelixOrgBotDetail: FC = () => {
 
   useEffect(() => {
     setRuntimeConfig({
-      runtime: assistant?.code_agent_runtime ?? '',
-      credentials: assistant?.code_agent_credential_type ?? 'api_key',
-      provider: assistant?.provider ?? '',
-      model: assistant?.model ?? '',
-      reasoning_effort: assistant?.reasoning_effort ?? 'none',
+      runtime: bot?.code_agent_runtime ?? '',
+      credentials: bot?.code_agent_credential_type ?? 'api_key',
+      provider: bot?.provider ?? '',
+      model: bot?.model ?? '',
+      reasoning_effort: bot?.reasoning_effort ?? 'none',
     })
-  }, [assistant?.code_agent_runtime, assistant?.code_agent_credential_type, assistant?.provider, assistant?.model, assistant?.reasoning_effort])
+  }, [bot?.code_agent_runtime, bot?.code_agent_credential_type, bot?.provider, bot?.model, bot?.reasoning_effort])
 
   // A human node is a person, not a bot — the agent detail page (desktop,
   // tools, activation) makes no sense for it. Redirect a direct hit on
@@ -202,50 +199,48 @@ const HelixOrgBotDetail: FC = () => {
     const savedProjectIDs = Array.from(new Set([...(bot.project_ids ?? []), ...(projectID ? [projectID] : [])])).sort()
     if (savedProjectIDs.join(',') !== [...projectIDs].sort().join(',')) return true
     if ((bot.preserve_context ?? false) !== preserveContext) return true
-    if ((assistant?.code_agent_runtime ?? '') !== runtimeConfig.runtime) return true
-    if ((assistant?.code_agent_credential_type ?? 'api_key') !== runtimeConfig.credentials) return true
-    if ((assistant?.provider ?? '') !== runtimeConfig.provider) return true
-    if ((assistant?.model ?? '') !== runtimeConfig.model) return true
-    if ((assistant?.reasoning_effort ?? 'none') !== (runtimeConfig.reasoning_effort ?? 'none')) return true
+    if ((bot.code_agent_runtime ?? '') !== runtimeConfig.runtime) return true
+    if ((bot.code_agent_credential_type ?? 'api_key') !== runtimeConfig.credentials) return true
+    if ((bot.provider ?? '') !== runtimeConfig.provider) return true
+    if ((bot.model ?? '') !== runtimeConfig.model) return true
+    if ((bot.reasoning_effort ?? 'none') !== (runtimeConfig.reasoning_effort ?? 'none')) return true
     return false
-  }, [bot, name, content, tools, projectIDs, projectID, preserveContext, assistant?.code_agent_runtime, assistant?.code_agent_credential_type, assistant?.provider, assistant?.model, assistant?.reasoning_effort, runtimeConfig.runtime, runtimeConfig.credentials, runtimeConfig.provider, runtimeConfig.model, runtimeConfig.reasoning_effort])
+  }, [bot, name, content, tools, projectIDs, projectID, preserveContext, runtimeConfig.runtime, runtimeConfig.credentials, runtimeConfig.provider, runtimeConfig.model, runtimeConfig.reasoning_effort])
 
   const handleSave = async () => {
     if (!botId) return
     const runtimeChanged =
-      (assistant?.code_agent_runtime ?? '') !== runtimeConfig.runtime
+      (bot?.code_agent_runtime ?? '') !== runtimeConfig.runtime
     try {
-      await updateBot.mutateAsync({ id: botId, name, content, tools, project_ids: projectIDs, preserve_context: preserveContext })
-      if (agentAppID && agentApp && assistant) {
-        const updatedAssistant = {
-          ...assistant,
-          code_agent_runtime: runtimeConfig.runtime as typeof assistant.code_agent_runtime,
-          code_agent_credential_type: runtimeConfig.credentials as typeof assistant.code_agent_credential_type,
-          provider: runtimeConfig.provider,
-          model: runtimeConfig.model,
-          reasoning_effort: runtimeConfig.reasoning_effort ?? 'none',
-          generation_model_provider: runtimeConfig.credentials === 'api_key' ? runtimeConfig.provider : '',
-          generation_model: runtimeConfig.credentials === 'api_key' ? runtimeConfig.model : '',
-        }
-        await apps.updateApp(agentAppID, {
-          ...agentApp,
-          config: {
-            ...agentApp.config,
-            helix: {
-              ...agentApp.config.helix,
-              assistants: [updatedAssistant, ...(agentApp.config.helix.assistants ?? []).slice(1)],
-            },
-          },
-        })
-      }
-      if (runtimeChanged && chatSessionId && agentAppID) {
-        await switchAgent.mutateAsync({ helix_app_id: agentAppID })
-        snackbar.success(`bot ${botId} saved — switching the active session to ${runtimeConfig.runtime}`)
-      } else {
-        snackbar.success(`bot ${botId} saved`)
-      }
+      await updateBot.mutateAsync({
+        id: botId,
+        name,
+        content,
+        tools,
+        project_ids: projectIDs,
+        preserve_context: preserveContext,
+        code_agent_runtime: runtimeConfig.runtime as NonNullable<BotDTO['code_agent_runtime']>,
+        code_agent_credential_type: runtimeConfig.credentials as NonNullable<BotDTO['code_agent_credential_type']>,
+        provider: runtimeConfig.provider,
+        model: runtimeConfig.model,
+        reasoning_effort: runtimeConfig.reasoning_effort ?? 'none',
+      })
+      await refetchBot()
     } catch (err: any) {
       snackbar.error(err?.response?.data?.error ?? err?.message ?? 'save failed')
+      return
+    }
+    if (runtimeChanged && chatSessionId && agentAppID) {
+      try {
+        await switchAgent.mutateAsync({ helix_app_id: agentAppID })
+        snackbar.success(`Agent ${botId} saved and the active session switched to ${runtimeConfig.runtime}`)
+      } catch (err: any) {
+        await refetchBot()
+        const message = err?.response?.data?.error ?? err?.message ?? 'session switch failed'
+        snackbar.error(`Agent saved, but active session switch failed: ${message}`)
+      }
+    } else {
+      snackbar.success(`Agent ${botId} saved`)
     }
   }
 
@@ -313,10 +308,7 @@ const HelixOrgBotDetail: FC = () => {
   // Desktop resolution / fps for the stream, derived from the bot's agent
   // app config (same helper the spec-task desktop uses). Falls back to
   // 1920x1080x60 when the app or config is missing.
-  const displaySettings = useMemo(
-    () => deriveDisplaySettings(apps.apps?.find((a) => a.id === agentAppID)),
-    [agentAppID, apps.apps],
-  )
+  const displaySettings = deriveDisplaySettings(undefined)
 
   // chatApi adapts the generated client to the read-only shape the
   // workerChatSession helper expects (we only GET the existing session
@@ -371,7 +363,7 @@ const HelixOrgBotDetail: FC = () => {
     } catch (err: any) {
       const status = err?.response?.status
       if (status === 409) {
-        snackbar.error('owner bot is protected and cannot be deleted')
+        snackbar.error('owner agent is protected and cannot be deleted')
       } else {
         snackbar.error(err?.response?.data?.error ?? err?.message ?? 'delete failed')
       }
@@ -380,7 +372,7 @@ const HelixOrgBotDetail: FC = () => {
     }
   }
 
-  const leafTitle = bot?.name || botId || 'Bot'
+  const leafTitle = bot?.name || botId || 'Agent'
 
   return (
     <HelixOrgShell
@@ -424,8 +416,8 @@ const HelixOrgBotDetail: FC = () => {
                 </Box>
 
                 {/* Session panel — Chat | Desktop toggle, both bound to the
-                    bot's Project Desktop exploratory session (the same views
-                    the spec-task page uses). Auto-loads when the bot already
+                    agent's Project Desktop exploratory session (the same views
+                    the spec-task page uses). Auto-loads when the agent already
                     has a session; otherwise shows an empty state. */}
                 <Paper variant="outlined" sx={{ p: 3 }}>
                   <Stack spacing={2} alignItems="flex-start">
@@ -518,8 +510,8 @@ const HelixOrgBotDetail: FC = () => {
                     </Stack>
                     <Typography variant="body2" color="text.secondary">
                       {sessionTab === 'chat'
-                        ? "Chat with this bot’s agent — messages include tool calls. Use the menu to start, stop, or restart the agent."
-                        : "Live desktop of the bot’s agent. Use the menu to start, stop, or restart the agent."}
+                        ? "Chat with this agent - messages include tool calls. Use the menu to start, stop, or restart it."
+                        : "Live desktop of this agent. Use the menu to start, stop, or restart it."}
                     </Typography>
 
                     {!agentOnline && !chatSessionId && (
@@ -710,7 +702,7 @@ const HelixOrgBotDetail: FC = () => {
                       <TextField
                         {...params}
                         placeholder="Select projects"
-                        helperText="The bot's own project is always allowed and is used when a tool omits project_id. Other projects must be selected here."
+                        helperText="The agent's own project is always allowed and is used when a tool omits project_id. Other projects must be selected here."
                       />
                     )}
                   />
@@ -769,8 +761,8 @@ const HelixOrgBotDetail: FC = () => {
                     renderInput={(params) => (
                       <TextField
                         {...params}
-                        placeholder={tools.length === 0 ? 'Pick the tools this bot can call' : ''}
-                        helperText="MCP tools this bot can call. Empty = no tools (the bot can still receive owner-chat)."
+                        placeholder={tools.length === 0 ? 'Pick the tools this agent can call' : ''}
+                        helperText="MCP tools this agent can call. Empty = no tools (the agent can still receive owner-chat)."
                       />
                     )}
                   />
@@ -787,12 +779,12 @@ const HelixOrgBotDetail: FC = () => {
                     label="Preserve context across triggers"
                   />
                   <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                    By default each trigger wipes the bot's session so every turn
+                    By default each trigger wipes the agent's session so every turn
                     starts on a fresh context window. Enable this to keep the
                     conversation across triggers — faster, more context-aware
                     follow-ups (e.g. for Slack), at the cost of the session
                     growing toward the model's context limit (where compaction
-                    kicks in). Durable state still belongs in the bot's git
+                    kicks in). Durable state still belongs in the agent's git
                     workspace, not the chat history.
                   </Typography>
                 </Box>
@@ -876,11 +868,12 @@ const HelixOrgBotDetail: FC = () => {
                     disabled={del.isPending}
                     fullWidth
                   >
-                    Delete bot
+                    Delete agent
                   </Button>
                   <Typography variant="caption" color="text.secondary">
-                    Tears down the bot's per-bot Helix project and deletes the row,
-                    dropping its subscriptions and reporting lines.
+                    Deletes the canonical Agent configuration and knowledge,
+                    tears down its Helix project, and drops its subscriptions
+                    and reporting lines.
                   </Typography>
                 </Stack>
               </Paper>
@@ -893,14 +886,16 @@ const HelixOrgBotDetail: FC = () => {
 
       {confirmingDelete && botId && (
         <DeleteConfirmWindow
-          title="bot"
+          title="agent"
           submitTitle="Delete"
           onSubmit={handleDelete}
           onCancel={() => setConfirmingDelete(false)}
         >
           <Typography variant="body1">
-            Deleting bot <b style={{ fontFamily: 'monospace' }}>{botId}</b> tears down its
-            per-bot Helix project + agent app and clears its runtime state. This is irreversible.
+            Deleting agent <b style={{ fontFamily: 'monospace' }}>{botId}</b> deletes its
+            canonical Agent configuration and knowledge sources, tears down its
+            Helix project, and clears its subscriptions, reporting lines, and runtime state.
+            This is irreversible.
           </Typography>
         </DeleteConfirmWindow>
       )}
@@ -986,7 +981,7 @@ const SubscriptionsPanel: FC<{ botID?: string }> = ({ botID }) => {
         renderInput={(params) => (
           <TextField
             {...params}
-            placeholder={subscribedTopics.length === 0 ? 'Subscribe this bot to a topic…' : ''}
+            placeholder={subscribedTopics.length === 0 ? 'Subscribe this agent to a topic...' : ''}
             variant="outlined"
             size="small"
           />
@@ -1007,7 +1002,7 @@ const SubscriptionsPanel: FC<{ botID?: string }> = ({ botID }) => {
         }
       />
       <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
-        Subscriptions are per-Bot — they die when this Bot is deleted.
+        Subscriptions belong to this agent and are removed when it is deleted.
       </Typography>
     </Box>
   )

--- a/frontend/src/pages/HelixOrgBots.tsx
+++ b/frontend/src/pages/HelixOrgBots.tsx
@@ -75,11 +75,11 @@ const HelixOrgBots: FC = () => {
     if (!deleting) return
     try {
       await deleteBot.mutateAsync(deleting.id ?? '')
-      snackbar.success(`deleted bot ${deleting.id}`)
+      snackbar.success(`deleted agent ${deleting.id}`)
     } catch (e: any) {
       const status = e?.response?.status
       if (status === 409) {
-        snackbar.error('owner bot is protected and cannot be deleted')
+        snackbar.error('owner agent is protected and cannot be deleted')
       } else {
         snackbar.error(e?.response?.data?.error ?? e?.message ?? 'delete failed')
       }
@@ -92,20 +92,24 @@ const HelixOrgBots: FC = () => {
     id: b.id,
     _data: b,
     name: (
-      <Typography variant="body1">
+      <Stack>
         <a
           style={{
             textDecoration: 'none',
             fontWeight: 'bold',
             color: theme.palette.mode === 'dark' ? theme.palette.text.primary : theme.palette.text.secondary,
-            fontFamily: 'monospace',
           }}
           href="#"
           onClick={(e) => { e.preventDefault(); e.stopPropagation(); openBot(b.id ?? '') }}
         >
-          {b.id}
+          {b.name || b.id}
         </a>
-      </Typography>
+        {b.name && (
+          <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+            {b.id}
+          </Typography>
+        )}
+      </Stack>
     ),
     contentPreview: (
       <Typography
@@ -148,14 +152,14 @@ const HelixOrgBots: FC = () => {
   }
 
   return (
-    <HelixOrgShell showChat={false} breadcrumbs={breadcrumbs} breadcrumbTitle="Bots">
+    <HelixOrgShell showChat={false} breadcrumbs={breadcrumbs} breadcrumbTitle="Agents">
       <Box sx={{ height: '100%', overflow: 'auto' }}>
       <Container maxWidth="xl" sx={{ mb: 4, pt: 3 }}>
         <Stack spacing={2}>
           <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={2}>
             <Box sx={{ flex: 1 }}>
               <Typography variant="body2" color="text.secondary">
-                Agents in this org. Click a bot to open its detail page — edit instructions,
+                Agents in this org. Click an agent to edit instructions,
                 tools and subscriptions.
               </Typography>
             </Box>
@@ -166,7 +170,7 @@ const HelixOrgBots: FC = () => {
               onClick={() => setNewBotOpen(true)}
               sx={{ flexShrink: 0, mt: 0.5 }}
             >
-              New bot
+              New agent
             </Button>
           </Stack>
 
@@ -175,7 +179,7 @@ const HelixOrgBots: FC = () => {
           ) : bots.length === 0 ? (
             <Box sx={{ textAlign: 'center', py: 8 }}>
               <Typography variant="body1" color="text.secondary" gutterBottom>
-                No bots defined yet.
+                No agents defined yet.
               </Typography>
               <Button
                 variant="contained"
@@ -184,15 +188,15 @@ const HelixOrgBots: FC = () => {
                 onClick={() => setNewBotOpen(true)}
                 sx={{ mt: 1 }}
               >
-                New bot
+                New agent
               </Button>
             </Box>
           ) : (
             <SimpleTable
               authenticated={true}
               fields={[
-                { name: 'name', title: 'ID' },
-                { name: 'contentPreview', title: 'Content' },
+                { name: 'name', title: 'Agent' },
+                { name: 'contentPreview', title: 'Instructions' },
                 { name: 'tools', title: 'Tools' },
                 { name: 'reportsTo', title: 'Reports to' },
                 { name: 'updated', title: 'Updated' },
@@ -229,15 +233,16 @@ const HelixOrgBots: FC = () => {
 
       {deleting && (
         <DeleteConfirmWindow
-          title="bot"
+          title="agent"
           submitTitle="Delete"
           onSubmit={handleDelete}
           onCancel={() => setDeleting(undefined)}
         >
           <Typography variant="body1">
-            Deleting bot <b style={{ fontFamily: 'monospace' }}>{deleting.id}</b> tears down its
-            per-bot Helix project + agent app, drops its subscriptions, and removes it as a
-            manager from its direct reports. This is irreversible.
+            Deleting agent <b style={{ fontFamily: 'monospace' }}>{deleting.id}</b> tears down its
+            Helix project, deletes its canonical Agent configuration and knowledge sources,
+            drops its subscriptions, and removes it as a manager from its direct reports.
+            This is irreversible.
           </Typography>
         </DeleteConfirmWindow>
       )}

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -477,7 +477,7 @@ const BotNode: FC<NodeProps<Node<BotNodeData>>> = ({ data }) => {
           <IconButton
             className={NO_DRAG_NO_PAN}
             size="small"
-            aria-label="Bot actions"
+            aria-label="Agent actions"
             onClick={(e) => {
               e.stopPropagation()
               setMenuEl(e.currentTarget)
@@ -543,7 +543,7 @@ const BotNode: FC<NodeProps<Node<BotNodeData>>> = ({ data }) => {
               }}
             >
               <PersonAddOutlinedIcon sx={{ mr: 1, fontSize: 20 }} />
-              New bot reporting here
+              New agent reporting here
             </MenuItem>
             <MenuItem
               onClick={() => {
@@ -552,7 +552,7 @@ const BotNode: FC<NodeProps<Node<BotNodeData>>> = ({ data }) => {
               }}
             >
               <DeleteOutlineIcon sx={{ mr: 1, fontSize: 20 }} />
-              Delete bot
+              Delete agent
             </MenuItem>
           </Menu>
         </Stack>
@@ -2364,7 +2364,7 @@ const HelixOrgChart: FC = () => {
     try {
       if (confirmDelete.kind === 'bot') {
         await deleteBot.mutateAsync(confirmDelete.id)
-        snackbar.success(`deleted bot ${confirmDelete.id}`)
+        snackbar.success(`deleted agent ${confirmDelete.id}`)
       } else if (confirmDelete.kind === 'topic') {
         await deleteTopic.mutateAsync(confirmDelete.id)
         snackbar.success(`deleted topic ${confirmDelete.id}`)
@@ -2413,8 +2413,8 @@ const HelixOrgChart: FC = () => {
     }
     const reports = flat.filter((b) => b.parentIds.includes(confirmDelete.id)).map((b) => b.id)
     return [
-      `Deleting bot ${confirmDelete.id} will cascade:`,
-      `  • stops sessions, deletes its project + agent app, drops its subscriptions`,
+      `Deleting agent ${confirmDelete.id} will cascade:`,
+      `  • stops sessions, deletes its project, canonical Agent configuration, knowledge sources, and subscriptions`,
       reports.length > 0
         ? `  • ${reports.length} direct report${reports.length === 1 ? '' : 's'} (${reports.join(', ')}) lose their manager`
         : `  • no direct reports`,
@@ -2462,7 +2462,7 @@ const HelixOrgChart: FC = () => {
               startIcon={<AddIcon />}
               onClick={() => setBotDialogOpen(true)}
             >
-              New bot
+              New agent
             </Button>
           </Stack>
 
@@ -2477,7 +2477,7 @@ const HelixOrgChart: FC = () => {
               }}
             >
               <Typography variant="body1" sx={{ color: subtitleColor }}>
-                No bots yet. Right-click the canvas or click <strong>New bot</strong> to get started.
+                No agents yet. Right-click the canvas or click <strong>New agent</strong> to get started.
               </Typography>
             </Box>
           ) : (
@@ -2531,7 +2531,7 @@ const HelixOrgChart: FC = () => {
           }}
         >
           <ListItemIcon><SmartToyOutlinedIcon fontSize="small" /></ListItemIcon>
-          <ListItemText>New bot</ListItemText>
+          <ListItemText>New agent</ListItemText>
         </MenuItem>
         <MenuItem
           onClick={() => {
@@ -2575,7 +2575,7 @@ const HelixOrgChart: FC = () => {
         title={
           confirmDelete?.kind === 'topic' ? 'Delete topic?' :
           confirmDelete?.kind === 'processor' ? 'Delete processor?' :
-          'Delete bot?'
+          'Delete agent?'
         }
         body={confirmBody}
         onConfirm={handleConfirmDelete}

--- a/frontend/src/pages/HelixOrgHumanDetail.tsx
+++ b/frontend/src/pages/HelixOrgHumanDetail.tsx
@@ -39,7 +39,7 @@ const HelixOrgHumanDetail: FC = () => {
   const router = useRouter()
   const snackbar = useSnackbar()
   const botId = router.params.bot_id as string | undefined
-  const breadcrumbs = useHelixOrgBreadcrumbs({ title: 'Bots', routeName: 'helix_org_bots' })
+  const breadcrumbs = useHelixOrgBreadcrumbs({ title: 'Agents', routeName: 'helix_org_bots' })
   const { data, isLoading } = useHelixOrgBot(botId)
   const bot = data?.bot
   const updateBot = useUpdateBot()
@@ -123,7 +123,7 @@ const HelixOrgHumanDetail: FC = () => {
             <Paper variant="outlined" sx={{ p: 2.5 }}>
               <Typography variant="subtitle2" sx={{ mb: 0.5 }}>Contact channels</Typography>
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
-                How the org reaches this person. Bots resolve these when they need to message them.
+                How the org reaches this person. Agents resolve these when they need to message them.
               </Typography>
               <Stack spacing={2}>
                 <FormControl size="small" fullWidth>

--- a/frontend/src/pages/HelixOrgSettings.tsx
+++ b/frontend/src/pages/HelixOrgSettings.tsx
@@ -44,10 +44,10 @@ const HelixOrgSettings: FC = () => {
   return (
     <Stack spacing={3}>
       <Stack spacing={1}>
-        <Typography variant="h6">Integrations and Bot Settings</Typography>
+        <Typography variant="h6">Integrations and Agent Settings</Typography>
         <Typography variant="body2" color="text.secondary">
-          Connect external services and configure how this org's Bots run.
-          Changes take effect on the next bot activation - no API restart needed.
+          Connect external services and configure how this org's agents run.
+          Changes take effect on the next agent activation - no API restart needed.
         </Typography>
       </Stack>
 

--- a/frontend/src/pages/HelixOrgTopicDetail.tsx
+++ b/frontend/src/pages/HelixOrgTopicDetail.tsx
@@ -399,7 +399,7 @@ export const TopicConfigSection: FC<TopicConfigSectionProps> = ({ topic, onSave,
               size="small"
               fullWidth
               placeholder="C012ABCDEF"
-              helperText="When set, this exact-channel topic owns inbound for that channel and basic publish messages go back to it. Subscribe the intended bots or wire processors to this topic. Leave empty for a workspace-wide inbound fallback used only when no exact-channel topic exists; Slack publishing is disabled."
+              helperText="When set, this exact-channel topic owns inbound for that channel and basic publish messages go back to it. Subscribe the intended agents or wire processors to this topic. Leave empty for a workspace-wide inbound fallback used only when no exact-channel topic exists; Slack publishing is disabled."
             />
           )}
           {topic.kind !== 'local' && topic.kind !== 'github' && topic.kind !== 'gitlab' && topic.kind !== 'cron' && topic.kind !== 'slack' && (

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -583,14 +583,36 @@ const routes: IApplicationRoute[] = [
   render: () => <HelixOrgChart />,
 }, {
   name: 'helix_org_bots',
-  path: '/orgs/:org_id/helix-org/bots',
-  meta: { drawer: false, title: 'Helix Org · Bots' },
+  path: '/orgs/:org_id/helix-org/agents',
+  meta: { drawer: false, title: 'Helix Org · Agents' },
   render: () => <HelixOrgBots />,
 }, {
   name: 'helix_org_bot_detail',
-  path: '/orgs/:org_id/helix-org/bots/:bot_id',
-  meta: { drawer: false, title: 'Helix Org · Bot' },
+  path: '/orgs/:org_id/helix-org/agents/:bot_id',
+  meta: { drawer: false, title: 'Helix Org · Agent' },
   render: () => <HelixOrgBotDetail />,
+}, {
+  name: 'helix_org_bots_legacy',
+  path: '/orgs/:org_id/helix-org/bots',
+  meta: { drawer: false, title: 'Helix Org · Agents' },
+  render: () => {
+    const { navigateReplace, params } = useRouter()
+    React.useEffect(() => {
+      navigateReplace('helix_org_bots', { org_id: params.org_id })
+    }, [params.org_id])
+    return null
+  },
+}, {
+  name: 'helix_org_bot_detail_legacy',
+  path: '/orgs/:org_id/helix-org/bots/:bot_id',
+  meta: { drawer: false, title: 'Helix Org · Agent' },
+  render: () => {
+    const { navigateReplace, params } = useRouter()
+    React.useEffect(() => {
+      navigateReplace('helix_org_bot_detail', { org_id: params.org_id, bot_id: params.bot_id })
+    }, [params.org_id, params.bot_id])
+    return null
+  },
 }, {
   name: 'helix_org_human_detail',
   path: '/orgs/:org_id/helix-org/humans/:bot_id',

--- a/frontend/src/services/helixOrgService.test.ts
+++ b/frontend/src/services/helixOrgService.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync('src/services/helixOrgService.ts', 'utf8')
+
+const count = (pattern: RegExp) => source.match(pattern)?.length ?? 0
+
+describe('Helix Org Agent API argument order', () => {
+  it('always passes organization ID before Agent and relationship IDs', () => {
+    expect(count(/v1OrgsAgents[A-Za-z0-9]*\(/g)).toBe(17)
+    expect(count(/v1OrgsAgentsDetail\(orgID\)/g)).toBe(1)
+    expect(count(/v1OrgsAgentsCreate\(orgID, payload\)/g)).toBe(1)
+    expect(count(/v1OrgsAgentsPartialUpdate\(orgID, id, body\)/g)).toBe(1)
+    expect(count(/v1OrgsAgentsChatCreate\(orgID, botId\)/g)).toBe(1)
+    expect(count(/v1OrgsAgentsActivateCreate\(orgID, botId\)/g)).toBe(1)
+    expect(count(/v1OrgsAgentsStopAgentCreate\(orgID, botId\)/g)).toBe(1)
+    expect(count(/v1OrgsAgentsRestartAgentCreate\(orgID, botId\)/g)).toBe(1)
+    expect(count(/v1OrgsAgentsDetail2\(orgID, botId\)/g)).toBe(2)
+    expect(count(/v1OrgsAgentsParentsCreate\(orgID, botID, \{ parent_id: parentID \}\)/g)).toBe(1)
+    expect(count(/v1OrgsAgentsParentsDelete\(orgID, botID, parentID\)/g)).toBe(1)
+    expect(count(/v1OrgsAgentsSubscriptionsDetail\(orgID, botID\)/g)).toBe(1)
+    expect(count(/v1OrgsAgentsSubscriptionsCreate\(orgID, botID, \{ topic_id: topicID \}\)/g)).toBe(2)
+    expect(count(/v1OrgsAgentsSubscriptionsDelete\(orgID, botID, topicID\)/g)).toBe(2)
+    expect(count(/v1OrgsAgentsDelete\(orgID, botId\)/g)).toBe(1)
+  })
+})

--- a/frontend/src/services/helixOrgService.ts
+++ b/frontend/src/services/helixOrgService.ts
@@ -4,6 +4,7 @@ import useApi from '../hooks/useApi'
 import useRouter from '../hooks/useRouter'
 import {
   ApiBotActivateDTO,
+  ApiAgentDetailDTO,
   ApiBotBadge,
   ApiBotChatDTO,
   ApiBotDTO,
@@ -37,6 +38,7 @@ import {
 export type BotBadge = ApiBotBadge
 export type BotDTO = ApiBotDTO
 export type BotDetailDTO = Omit<ApiBotDetailDTO, 'bot'> & { bot?: BotDTO }
+export type AgentDetailDTO = ApiAgentDetailDTO
 export type BotActivateDTO = ApiBotActivateDTO
 export type BotChatDTO = ApiBotChatDTO
 export type ToolDTO = ApiToolDTO
@@ -228,7 +230,7 @@ export function useEnsureBotChat() {
   const { orgID } = useHelixOrgBase()
   return useMutation({
     mutationFn: async (botId: string) => {
-      const res = await api.getApiClient().v1OrgsBotsChatCreate(botId, orgID)
+      const res = await api.getApiClient().v1OrgsAgentsChatCreate(orgID, botId)
       return res.data as BotChatDTO
     },
     onSuccess: (_data, botId) => {
@@ -246,7 +248,7 @@ export function useActivateBot(orgIDOverride?: string) {
   const orgID = orgIDOverride ?? baseOrgID
   return useMutation({
     mutationFn: async (botId: string) => {
-      const res = await api.getApiClient().v1OrgsBotsActivateCreate(botId, orgID)
+      const res = await api.getApiClient().v1OrgsAgentsActivateCreate(orgID, botId)
       return res.data as BotActivateDTO
     },
     onSuccess: (_data, botId) => {
@@ -260,16 +262,11 @@ export function useActivateBot(orgIDOverride?: string) {
 export function useStopBotAgent(orgIDOverride?: string) {
   const api = useApi()
   const qc = useQueryClient()
-  const { base, orgID: baseOrgID } = useHelixOrgBase()
+  const { orgID: baseOrgID } = useHelixOrgBase()
   const orgID = orgIDOverride ?? baseOrgID
   return useMutation({
     mutationFn: async (botId: string) => {
-      // Not yet on the generated OpenAPI client.
-      await axios.post(
-        `${base || `/api/v1/orgs/${encodeURIComponent(orgID)}`}/bots/${encodeURIComponent(botId)}/stop-agent`,
-        null,
-        { withCredentials: true },
-      )
+      await api.getApiClient().v1OrgsAgentsStopAgentCreate(orgID, botId)
     },
     onSuccess: (_data, botId) => {
       qc.invalidateQueries({ queryKey: QUERY_KEYS.bots(orgID) })
@@ -288,7 +285,7 @@ export function useRestartBotAgent(orgIDOverride?: string) {
   const orgID = orgIDOverride ?? baseOrgID
   return useMutation({
     mutationFn: async (botId: string) => {
-      const res = await api.getApiClient().v1OrgsBotsRestartAgentCreate(botId, orgID)
+      const res = await api.getApiClient().v1OrgsAgentsRestartAgentCreate(orgID, botId)
       return res.data as BotActivateDTO
     },
     onSuccess: (_data, botId) => {
@@ -304,7 +301,7 @@ export function useListHelixOrgBots(options?: { enabled?: boolean; refetchInterv
   return useQuery({
     queryKey: QUERY_KEYS.bots(orgID),
     queryFn: async () => {
-      const res = await api.getApiClient().v1OrgsBotsDetail(orgID)
+      const res = await api.getApiClient().v1OrgsAgentsDetail(orgID)
       return (res.data ?? []) as BotDTO[]
     },
     enabled: !!orgID && (options?.enabled ?? true),
@@ -319,8 +316,13 @@ export function useHelixOrgBot(botId: string | undefined, options?: { enabled?: 
     queryKey: QUERY_KEYS.bot(orgID, botId ?? ''),
     queryFn: async () => {
       if (!botId) return null
-      const res = await api.getApiClient().v1OrgsBotsDetail2(botId, orgID)
-      return res.data as BotDetailDTO
+      const res = await api.getApiClient().v1OrgsAgentsDetail2(orgID, botId)
+      const agent = res.data as AgentDetailDTO
+      return {
+        bot: agent as BotDTO,
+        agent_app_id: agent.agent_app_id,
+        project_id: agent.project_id,
+      } as BotDetailDTO
     },
     enabled: !!orgID && !!botId && (options?.enabled ?? true),
   })
@@ -340,8 +342,13 @@ export function useListHelixOrgBotDetails(
     queries: botIds.map((botId) => ({
       queryKey: QUERY_KEYS.bot(orgID, botId),
       queryFn: async () => {
-        const res = await api.getApiClient().v1OrgsBotsDetail2(botId, orgID)
-        return res.data as BotDetailDTO
+        const res = await api.getApiClient().v1OrgsAgentsDetail2(orgID, botId)
+        const agent = res.data as AgentDetailDTO
+        return {
+          bot: agent as BotDTO,
+          agent_app_id: agent.agent_app_id,
+          project_id: agent.project_id,
+        } as BotDetailDTO
       },
       enabled: enabled && !!botId,
       refetchInterval: options?.refetchInterval,
@@ -370,7 +377,7 @@ export function useCreateBot() {
   const { orgID } = useHelixOrgBase()
   return useMutation({
     mutationFn: async (payload: CreateBotRequest) => {
-      const res = await api.getApiClient().v1OrgsBotsCreate(orgID, payload)
+      const res = await api.getApiClient().v1OrgsAgentsCreate(orgID, payload)
       return res.data as CreateBotResponse
     },
     onSuccess: () => {
@@ -394,7 +401,7 @@ export function useUpdateBot() {
   return useMutation({
     mutationFn: async (payload: { id: string } & UpdateBotRequest) => {
       const { id, ...body } = payload
-      const res = await api.getApiClient().v1OrgsBotsPartialUpdate(orgID, id, body)
+      const res = await api.getApiClient().v1OrgsAgentsPartialUpdate(orgID, id, body)
       return res.data as BotDTO
     },
     onSuccess: (_data, payload) => {
@@ -419,7 +426,7 @@ export function useAddBotParent() {
   const { orgID } = useHelixOrgBase()
   return useMutation({
     mutationFn: async ({ botID, parentID }: { botID: string; parentID: string }) => {
-      await api.getApiClient().v1OrgsBotsParentsCreate(botID, orgID, { parent_id: parentID })
+      await api.getApiClient().v1OrgsAgentsParentsCreate(orgID, botID, { parent_id: parentID })
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: QUERY_KEYS.overview(orgID) })
@@ -441,7 +448,7 @@ export function useRemoveBotParent() {
   const { orgID } = useHelixOrgBase()
   return useMutation({
     mutationFn: async ({ botID, parentID }: { botID: string; parentID: string }) => {
-      await api.getApiClient().v1OrgsBotsParentsDelete(botID, parentID, orgID)
+      await api.getApiClient().v1OrgsAgentsParentsDelete(orgID, botID, parentID)
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: QUERY_KEYS.overview(orgID) })
@@ -461,7 +468,7 @@ export function useSubscribeBotAtChart() {
   const { orgID } = useHelixOrgBase()
   return useMutation({
     mutationFn: async ({ botID, topicID }: { botID: string; topicID: string }) => {
-      await api.getApiClient().v1OrgsBotsSubscriptionsCreate(botID, orgID, { topic_id: topicID })
+      await api.getApiClient().v1OrgsAgentsSubscriptionsCreate(orgID, botID, { topic_id: topicID })
     },
     onSuccess: (_data, { botID }) => {
       qc.invalidateQueries({ queryKey: QUERY_KEYS.botSubs(orgID, botID) })
@@ -480,7 +487,7 @@ export function useUnsubscribeBotAtChart() {
   const { orgID } = useHelixOrgBase()
   return useMutation({
     mutationFn: async ({ botID, topicID }: { botID: string; topicID: string }) => {
-      await api.getApiClient().v1OrgsBotsSubscriptionsDelete(botID, topicID, orgID)
+      await api.getApiClient().v1OrgsAgentsSubscriptionsDelete(orgID, botID, topicID)
     },
     onSuccess: (_data, { botID }) => {
       qc.invalidateQueries({ queryKey: QUERY_KEYS.botSubs(orgID, botID) })
@@ -496,7 +503,7 @@ export function useDeleteBot() {
   const { orgID } = useHelixOrgBase()
   return useMutation({
     mutationFn: async (botId: string) => {
-      await api.getApiClient().v1OrgsBotsDelete(botId, orgID)
+      await api.getApiClient().v1OrgsAgentsDelete(orgID, botId)
     },
     onSuccess: (_data, botId) => {
       // Evict the deleted bot's own queries (the bot key prefix-matches
@@ -882,7 +889,7 @@ export function useListBotSubscriptions(botID: string | undefined, options?: { e
     queryKey: QUERY_KEYS.botSubs(orgID, botID ?? ''),
     queryFn: async () => {
       if (!botID) return null
-      const res = await api.getApiClient().v1OrgsBotsSubscriptionsDetail(botID, orgID)
+      const res = await api.getApiClient().v1OrgsAgentsSubscriptionsDetail(orgID, botID)
       return res.data as BotSubscriptionsResponse
     },
     enabled: !!orgID && !!botID && (options?.enabled ?? true),
@@ -896,7 +903,7 @@ export function useSubscribeBot(botID: string | undefined) {
   return useMutation({
     mutationFn: async (topicID: string) => {
       if (!botID) throw new Error('botID is required to subscribe')
-      const res = await api.getApiClient().v1OrgsBotsSubscriptionsCreate(botID, orgID, { topic_id: topicID })
+      const res = await api.getApiClient().v1OrgsAgentsSubscriptionsCreate(orgID, botID, { topic_id: topicID })
       return res.data as BotSubscription
     },
     onSuccess: () => {
@@ -916,7 +923,7 @@ export function useUnsubscribeBot(botID: string | undefined) {
   return useMutation({
     mutationFn: async (topicID: string) => {
       if (!botID) throw new Error('botID is required to unsubscribe')
-      await api.getApiClient().v1OrgsBotsSubscriptionsDelete(botID, topicID, orgID)
+      await api.getApiClient().v1OrgsAgentsSubscriptionsDelete(orgID, botID, topicID)
     },
     onSuccess: () => {
       if (botID) {

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -4,6 +4,79 @@ definitions:
       parent_id:
         type: string
     type: object
+  api.AgentDetailDTO:
+    properties:
+      agent_app_id:
+        type: string
+      agent_model:
+        type: string
+      agent_runtime:
+        type: string
+      agent_status:
+        description: |-
+          AgentStatus is "running" when the bot's desktop sandbox is online,
+          "stopped" otherwise (no session, paused, never activated). Drives
+          the green/grey presence dot on the org chart.
+        type: string
+      code_agent_credential_type:
+        $ref: '#/definitions/types.CodeAgentCredentialType'
+      code_agent_runtime:
+        $ref: '#/definitions/types.CodeAgentRuntime'
+      content:
+        type: string
+      created_at:
+        type: string
+      helix_user_id:
+        type: string
+      id:
+        type: string
+      identity:
+        additionalProperties:
+          type: string
+        type: object
+      kind:
+        description: |-
+          Kind is "" (agent) or "human". A human node is a person placeholder,
+          never activated; Identity holds their cross-system handles and
+          HelixUserID optionally links them to a Helix org member. Identity is
+          omitted for agent bots.
+        type: string
+      model:
+        type: string
+      name:
+        description: |-
+          Name is the human-readable display label; empty means the UI falls
+          back to ID. Distinct from ID, which is the immutable handle.
+        type: string
+      organization_id:
+        type: string
+      parent_ids:
+        items:
+          type: string
+        type: array
+      preserve_context:
+        description: |-
+          PreserveContext, when true, stops the runtime from wiping this
+          Bot's chat session before each re-activation, so it accumulates
+          context across triggers (e.g. Slack). Defaults to false.
+        type: boolean
+      project_id:
+        type: string
+      project_ids:
+        items:
+          type: string
+        type: array
+      provider:
+        type: string
+      reasoning_effort:
+        type: string
+      tools:
+        items:
+          type: string
+        type: array
+      updated_at:
+        type: string
+    type: object
   api.BotActivateDTO:
     properties:
       activation_id:
@@ -29,6 +102,8 @@ definitions:
     type: object
   api.BotDTO:
     properties:
+      agent_app_id:
+        type: string
       agent_model:
         type: string
       agent_runtime:
@@ -39,6 +114,10 @@ definitions:
           "stopped" otherwise (no session, paused, never activated). Drives
           the green/grey presence dot on the org chart.
         type: string
+      code_agent_credential_type:
+        $ref: '#/definitions/types.CodeAgentCredentialType'
+      code_agent_runtime:
+        $ref: '#/definitions/types.CodeAgentRuntime'
       content:
         type: string
       created_at:
@@ -57,6 +136,8 @@ definitions:
           never activated; Identity holds their cross-system handles and
           HelixUserID optionally links them to a Helix org member. Identity is
           omitted for agent bots.
+        type: string
+      model:
         type: string
       name:
         description: |-
@@ -79,6 +160,10 @@ definitions:
         items:
           type: string
         type: array
+      provider:
+        type: string
+      reasoning_effort:
+        type: string
       tools:
         items:
           type: string
@@ -567,6 +652,10 @@ definitions:
     type: object
   api.UpdateBotRequest:
     properties:
+      code_agent_credential_type:
+        $ref: '#/definitions/types.CodeAgentCredentialType'
+      code_agent_runtime:
+        $ref: '#/definitions/types.CodeAgentRuntime'
       content:
         type: string
       identity:
@@ -577,6 +666,8 @@ definitions:
           email/…). When present it replaces the stored map; absent leaves it
           unchanged. Only meaningful for kind=human bots.
         type: object
+      model:
+        type: string
       name:
         type: string
       preserve_context:
@@ -585,6 +676,10 @@ definitions:
         items:
           type: string
         type: array
+      provider:
+        type: string
+      reasoning_effort:
+        type: string
       tools:
         items:
           type: string
@@ -3553,8 +3648,9 @@ definitions:
           "claude_code" and CodeAgentCredentialType is "subscription". It flows through
           CodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,
           which the claude-agent-acp package reads (resolveModelPreference) to pick the
-          model — otherwise Claude Code defaults to Sonnet. Empty means "opus"
-          (resolveModelPreference resolves this to the latest Opus version).
+          model — otherwise Claude Code defaults to Sonnet. Empty means "opus[1m]"
+          (the 1M-context Opus; resolveModelPreference resolves the "[1m]" hint to the
+          1M row, while a bare "opus" resolves to the 200k sibling).
         type: string
       code_agent_credential_type:
         allOf:
@@ -7473,6 +7569,8 @@ definitions:
     type: object
   types.ProjectApplyRequest:
     properties:
+      agent_app_id:
+        type: string
       name:
         type: string
       organization_id:
@@ -18407,6 +18505,463 @@ paths:
       summary: List sandbox tmux sessions
       tags:
       - Sandboxes
+  /api/v1/orgs/{org}/agents:
+    get:
+      description: List the canonical Agents in an organization, including their instructions,
+        tools, runtime, model configuration, and reporting lines.
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/api.BotDTO'
+            type: array
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: list agents'
+      tags:
+      - HelixOrg
+    post:
+      consumes:
+      - application/json
+      description: Create a canonical Agent with its org-chart position, communication
+        topics, tools, and Agent App configuration.
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent specification
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/api.CreateBotRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/api.CreateBotResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: create an agent'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}:
+    delete:
+      description: Delete an Agent after stopping its sessions and project, then atomically
+        remove its Agent App, knowledge, runtime state, subscriptions, reporting lines,
+        and org-chart row.
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: delete an agent'
+      tags:
+      - HelixOrg
+    get:
+      description: Get one canonical Agent with its instructions, tools, runtime,
+        model configuration, project, and reporting lines.
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.AgentDetailDTO'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: get agent detail'
+      tags:
+      - HelixOrg
+    patch:
+      consumes:
+      - application/json
+      description: Update the canonical Agent instructions, tools, project access,
+        runtime, provider, model, or reasoning configuration.
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Agent fields to update
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/api.UpdateBotRequest'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.BotDTO'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: update an agent'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}/activate:
+    post:
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/api.BotActivateDTO'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: activate an agent'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}/chat:
+    post:
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.BotChatDTO'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: provision an agent chat'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}/parents:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID of the direct report
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Manager Agent ID
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/api.AddBotParentRequest'
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: add an agent manager'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}/parents/{parent_id}:
+    delete:
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID of the direct report
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Manager Agent ID
+        in: path
+        name: parent_id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: remove an agent manager'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}/restart-agent:
+    post:
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/api.BotActivateDTO'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: restart an agent session'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}/stop-agent:
+    post:
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+        "501":
+          description: Not Implemented
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: stop an agent desktop'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}/subscriptions:
+    get:
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.BotSubscriptionsResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: list an agent''s subscriptions'
+      tags:
+      - HelixOrg
+    post:
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Topic to subscribe the Agent to
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/api.SubscribeBotRequest'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.BotSubscriptionDTO'
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/api.BotSubscriptionDTO'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: subscribe an agent to a topic'
+      tags:
+      - HelixOrg
+  /api/v1/orgs/{org}/agents/{id}/subscriptions/{topic_id}:
+    delete:
+      parameters:
+      - description: Organization slug or ID
+        in: path
+        name: org
+        required: true
+        type: string
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Topic ID
+        in: path
+        name: topic_id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: 'Helix-org: unsubscribe an agent from a topic'
+      tags:
+      - HelixOrg
   /api/v1/orgs/{org}/bots:
     get:
       produces:

--- a/openapi.json
+++ b/openapi.json
@@ -11456,6 +11456,895 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/agents": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "List the canonical Agents in an organization, including their instructions, tools, runtime, model configuration, and reporting lines.",
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: list agents",
+                "parameters": [
+                    {
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/api.BotDTO"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Create a canonical Agent with its org-chart position, communication topics, tools, and Agent App configuration.",
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: create an agent",
+                "parameters": [
+                    {
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.CreateBotRequest"
+                            }
+                        }
+                    },
+                    "description": "Agent specification",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.CreateBotResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Get one canonical Agent with its instructions, tools, runtime, model configuration, project, and reporting lines.",
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: get agent detail",
+                "parameters": [
+                    {
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.AgentDetailDTO"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Delete an Agent after stopping its sessions and project, then atomically remove its Agent App, knowledge, runtime state, subscriptions, reporting lines, and org-chart row.",
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: delete an agent",
+                "parameters": [
+                    {
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Update the canonical Agent instructions, tools, project access, runtime, provider, model, or reasoning configuration.",
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: update an agent",
+                "parameters": [
+                    {
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.UpdateBotRequest"
+                            }
+                        }
+                    },
+                    "description": "Agent fields to update",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.BotDTO"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/activate": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: activate an agent",
+                "parameters": [
+                    {
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.BotActivateDTO"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/chat": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: provision an agent chat",
+                "parameters": [
+                    {
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.BotChatDTO"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/parents": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: add an agent manager",
+                "parameters": [
+                    {
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Agent ID of the direct report",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.AddBotParentRequest"
+                            }
+                        }
+                    },
+                    "description": "Manager Agent ID",
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/parents/{parent_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: remove an agent manager",
+                "parameters": [
+                    {
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Agent ID of the direct report",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Manager Agent ID",
+                        "name": "parent_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/restart-agent": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: restart an agent session",
+                "parameters": [
+                    {
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.BotActivateDTO"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/stop-agent": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: stop an agent desktop",
+                "parameters": [
+                    {
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/subscriptions": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: list an agent's subscriptions",
+                "parameters": [
+                    {
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.BotSubscriptionsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: subscribe an agent to a topic",
+                "parameters": [
+                    {
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.SubscribeBotRequest"
+                            }
+                        }
+                    },
+                    "description": "Topic to subscribe the Agent to",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.BotSubscriptionDTO"
+                                }
+                            }
+                        }
+                    },
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.BotSubscriptionDTO"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/subscriptions/{topic_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: unsubscribe an agent from a topic",
+                "parameters": [
+                    {
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Topic ID",
+                        "name": "topic_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/bots": {
             "get": {
                 "security": [
@@ -26139,6 +27028,96 @@
                     }
                 }
             },
+            "api.AgentDetailDTO": {
+                "type": "object",
+                "properties": {
+                    "agent_app_id": {
+                        "type": "string"
+                    },
+                    "agent_model": {
+                        "type": "string"
+                    },
+                    "agent_runtime": {
+                        "type": "string"
+                    },
+                    "agent_status": {
+                        "description": "AgentStatus is \"running\" when the bot's desktop sandbox is online,\n\"stopped\" otherwise (no session, paused, never activated). Drives\nthe green/grey presence dot on the org chart.",
+                        "type": "string"
+                    },
+                    "code_agent_credential_type": {
+                        "$ref": "#/components/schemas/types.CodeAgentCredentialType"
+                    },
+                    "code_agent_runtime": {
+                        "$ref": "#/components/schemas/types.CodeAgentRuntime"
+                    },
+                    "content": {
+                        "type": "string"
+                    },
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "helix_user_id": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "identity": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "kind": {
+                        "description": "Kind is \"\" (agent) or \"human\". A human node is a person placeholder,\nnever activated; Identity holds their cross-system handles and\nHelixUserID optionally links them to a Helix org member. Identity is\nomitted for agent bots.",
+                        "type": "string"
+                    },
+                    "model": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Name is the human-readable display label; empty means the UI falls\nback to ID. Distinct from ID, which is the immutable handle.",
+                        "type": "string"
+                    },
+                    "organization_id": {
+                        "type": "string"
+                    },
+                    "parent_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "preserve_context": {
+                        "description": "PreserveContext, when true, stops the runtime from wiping this\nBot's chat session before each re-activation, so it accumulates\ncontext across triggers (e.g. Slack). Defaults to false.",
+                        "type": "boolean"
+                    },
+                    "project_id": {
+                        "type": "string"
+                    },
+                    "project_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "provider": {
+                        "type": "string"
+                    },
+                    "reasoning_effort": {
+                        "type": "string"
+                    },
+                    "tools": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "updated_at": {
+                        "type": "string"
+                    }
+                }
+            },
             "api.BotActivateDTO": {
                 "type": "object",
                 "properties": {
@@ -26178,6 +27157,9 @@
             "api.BotDTO": {
                 "type": "object",
                 "properties": {
+                    "agent_app_id": {
+                        "type": "string"
+                    },
                     "agent_model": {
                         "type": "string"
                     },
@@ -26187,6 +27169,12 @@
                     "agent_status": {
                         "description": "AgentStatus is \"running\" when the bot's desktop sandbox is online,\n\"stopped\" otherwise (no session, paused, never activated). Drives\nthe green/grey presence dot on the org chart.",
                         "type": "string"
+                    },
+                    "code_agent_credential_type": {
+                        "$ref": "#/components/schemas/types.CodeAgentCredentialType"
+                    },
+                    "code_agent_runtime": {
+                        "$ref": "#/components/schemas/types.CodeAgentRuntime"
                     },
                     "content": {
                         "type": "string"
@@ -26208,6 +27196,9 @@
                     },
                     "kind": {
                         "description": "Kind is \"\" (agent) or \"human\". A human node is a person placeholder,\nnever activated; Identity holds their cross-system handles and\nHelixUserID optionally links them to a Helix org member. Identity is\nomitted for agent bots.",
+                        "type": "string"
+                    },
+                    "model": {
                         "type": "string"
                     },
                     "name": {
@@ -26232,6 +27223,12 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "provider": {
+                        "type": "string"
+                    },
+                    "reasoning_effort": {
+                        "type": "string"
                     },
                     "tools": {
                         "type": "array",
@@ -26907,6 +27904,12 @@
             "api.UpdateBotRequest": {
                 "type": "object",
                 "properties": {
+                    "code_agent_credential_type": {
+                        "$ref": "#/components/schemas/types.CodeAgentCredentialType"
+                    },
+                    "code_agent_runtime": {
+                        "$ref": "#/components/schemas/types.CodeAgentRuntime"
+                    },
                     "content": {
                         "type": "string"
                     },
@@ -26916,6 +27919,9 @@
                         "additionalProperties": {
                             "type": "string"
                         }
+                    },
+                    "model": {
+                        "type": "string"
                     },
                     "name": {
                         "type": "string"
@@ -26928,6 +27934,12 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "provider": {
+                        "type": "string"
+                    },
+                    "reasoning_effort": {
+                        "type": "string"
                     },
                     "tools": {
                         "type": "array",
@@ -31126,7 +32138,7 @@
                         "$ref": "#/components/schemas/types.AssistantCalculator"
                     },
                     "claude_subscription_model": {
-                        "description": "ClaudeSubscriptionModel is the Anthropic model to use when CodeAgentRuntime is\n\"claude_code\" and CodeAgentCredentialType is \"subscription\". It flows through\nCodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,\nwhich the claude-agent-acp package reads (resolveModelPreference) to pick the\nmodel — otherwise Claude Code defaults to Sonnet. Empty means \"opus\"\n(resolveModelPreference resolves this to the latest Opus version).",
+                        "description": "ClaudeSubscriptionModel is the Anthropic model to use when CodeAgentRuntime is\n\"claude_code\" and CodeAgentCredentialType is \"subscription\". It flows through\nCodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,\nwhich the claude-agent-acp package reads (resolveModelPreference) to pick the\nmodel — otherwise Claude Code defaults to Sonnet. Empty means \"opus[1m]\"\n(the 1M-context Opus; resolveModelPreference resolves the \"[1m]\" hint to the\n1M row, while a bare \"opus\" resolves to the 200k sibling).",
                         "type": "string"
                     },
                     "code_agent_credential_type": {
@@ -36552,6 +37564,9 @@
             "types.ProjectApplyRequest": {
                 "type": "object",
                 "properties": {
+                    "agent_app_id": {
+                        "type": "string"
+                    },
                     "name": {
                         "type": "string"
                     },

--- a/swagger.json
+++ b/swagger.json
@@ -9540,6 +9540,713 @@
                 }
             }
         },
+        "/api/v1/orgs/{org}/agents": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "List the canonical Agents in an organization, including their instructions, tools, runtime, model configuration, and reporting lines.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: list agents",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.BotDTO"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Create a canonical Agent with its org-chart position, communication topics, tools, and Agent App configuration.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: create an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Agent specification",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.CreateBotRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/api.CreateBotResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Get one canonical Agent with its instructions, tools, runtime, model configuration, project, and reporting lines.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: get agent detail",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.AgentDetailDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Delete an Agent after stopping its sessions and project, then atomically remove its Agent App, knowledge, runtime state, subscriptions, reporting lines, and org-chart row.",
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: delete an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Update the canonical Agent instructions, tools, project access, runtime, provider, model, or reasoning configuration.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: update an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Agent fields to update",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.UpdateBotRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/activate": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: activate an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotActivateDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/chat": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: provision an agent chat",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotChatDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/parents": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: add an agent manager",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID of the direct report",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Manager Agent ID",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.AddBotParentRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/parents/{parent_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: remove an agent manager",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID of the direct report",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Manager Agent ID",
+                        "name": "parent_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/restart-agent": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: restart an agent session",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotActivateDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/stop-agent": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: stop an agent desktop",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Not Implemented",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/subscriptions": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: list an agent's subscriptions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotSubscriptionsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: subscribe an agent to a topic",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Topic to subscribe the Agent to",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.SubscribeBotRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotSubscriptionDTO"
+                        }
+                    },
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/api.BotSubscriptionDTO"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/orgs/{org}/agents/{id}/subscriptions/{topic_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "HelixOrg"
+                ],
+                "summary": "Helix-org: unsubscribe an agent from a topic",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization slug or ID",
+                        "name": "org",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Topic ID",
+                        "name": "topic_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/api.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/orgs/{org}/bots": {
             "get": {
                 "security": [
@@ -21760,6 +22467,96 @@
                 }
             }
         },
+        "api.AgentDetailDTO": {
+            "type": "object",
+            "properties": {
+                "agent_app_id": {
+                    "type": "string"
+                },
+                "agent_model": {
+                    "type": "string"
+                },
+                "agent_runtime": {
+                    "type": "string"
+                },
+                "agent_status": {
+                    "description": "AgentStatus is \"running\" when the bot's desktop sandbox is online,\n\"stopped\" otherwise (no session, paused, never activated). Drives\nthe green/grey presence dot on the org chart.",
+                    "type": "string"
+                },
+                "code_agent_credential_type": {
+                    "$ref": "#/definitions/types.CodeAgentCredentialType"
+                },
+                "code_agent_runtime": {
+                    "$ref": "#/definitions/types.CodeAgentRuntime"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "helix_user_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "identity": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "kind": {
+                    "description": "Kind is \"\" (agent) or \"human\". A human node is a person placeholder,\nnever activated; Identity holds their cross-system handles and\nHelixUserID optionally links them to a Helix org member. Identity is\nomitted for agent bots.",
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name is the human-readable display label; empty means the UI falls\nback to ID. Distinct from ID, which is the immutable handle.",
+                    "type": "string"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "parent_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "preserve_context": {
+                    "description": "PreserveContext, when true, stops the runtime from wiping this\nBot's chat session before each re-activation, so it accumulates\ncontext across triggers (e.g. Slack). Defaults to false.",
+                    "type": "boolean"
+                },
+                "project_id": {
+                    "type": "string"
+                },
+                "project_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "reasoning_effort": {
+                    "type": "string"
+                },
+                "tools": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "api.BotActivateDTO": {
             "type": "object",
             "properties": {
@@ -21799,6 +22596,9 @@
         "api.BotDTO": {
             "type": "object",
             "properties": {
+                "agent_app_id": {
+                    "type": "string"
+                },
                 "agent_model": {
                     "type": "string"
                 },
@@ -21808,6 +22608,12 @@
                 "agent_status": {
                     "description": "AgentStatus is \"running\" when the bot's desktop sandbox is online,\n\"stopped\" otherwise (no session, paused, never activated). Drives\nthe green/grey presence dot on the org chart.",
                     "type": "string"
+                },
+                "code_agent_credential_type": {
+                    "$ref": "#/definitions/types.CodeAgentCredentialType"
+                },
+                "code_agent_runtime": {
+                    "$ref": "#/definitions/types.CodeAgentRuntime"
                 },
                 "content": {
                     "type": "string"
@@ -21829,6 +22635,9 @@
                 },
                 "kind": {
                     "description": "Kind is \"\" (agent) or \"human\". A human node is a person placeholder,\nnever activated; Identity holds their cross-system handles and\nHelixUserID optionally links them to a Helix org member. Identity is\nomitted for agent bots.",
+                    "type": "string"
+                },
+                "model": {
                     "type": "string"
                 },
                 "name": {
@@ -21853,6 +22662,12 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "reasoning_effort": {
+                    "type": "string"
                 },
                 "tools": {
                     "type": "array",
@@ -22528,6 +23343,12 @@
         "api.UpdateBotRequest": {
             "type": "object",
             "properties": {
+                "code_agent_credential_type": {
+                    "$ref": "#/definitions/types.CodeAgentCredentialType"
+                },
+                "code_agent_runtime": {
+                    "$ref": "#/definitions/types.CodeAgentRuntime"
+                },
                 "content": {
                     "type": "string"
                 },
@@ -22537,6 +23358,9 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "model": {
+                    "type": "string"
                 },
                 "name": {
                     "type": "string"
@@ -22549,6 +23373,12 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "reasoning_effort": {
+                    "type": "string"
                 },
                 "tools": {
                     "type": "array",
@@ -26747,7 +27577,7 @@
                     "$ref": "#/definitions/types.AssistantCalculator"
                 },
                 "claude_subscription_model": {
-                    "description": "ClaudeSubscriptionModel is the Anthropic model to use when CodeAgentRuntime is\n\"claude_code\" and CodeAgentCredentialType is \"subscription\". It flows through\nCodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,\nwhich the claude-agent-acp package reads (resolveModelPreference) to pick the\nmodel — otherwise Claude Code defaults to Sonnet. Empty means \"opus\"\n(resolveModelPreference resolves this to the latest Opus version).",
+                    "description": "ClaudeSubscriptionModel is the Anthropic model to use when CodeAgentRuntime is\n\"claude_code\" and CodeAgentCredentialType is \"subscription\". It flows through\nCodeAgentConfig.Model into the container's /etc/claude-code/managed-settings.json,\nwhich the claude-agent-acp package reads (resolveModelPreference) to pick the\nmodel — otherwise Claude Code defaults to Sonnet. Empty means \"opus[1m]\"\n(the 1M-context Opus; resolveModelPreference resolves the \"[1m]\" hint to the\n1M row, while a bare \"opus\" resolves to the 200k sibling).",
                     "type": "string"
                 },
                 "code_agent_credential_type": {
@@ -32173,6 +33003,9 @@
         "types.ProjectApplyRequest": {
             "type": "object",
             "properties": {
+                "agent_app_id": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },


### PR DESCRIPTION
## Summary

- make the canonical Agent App the single configuration source for org chart Agents
- expose a flat `/agents` API while retaining `/bots` compatibility aliases
- migrate existing Agent and project links in place with retry-safe lifecycle handling
- update org UI journeys, terminology, generated clients, OpenAPI, and design documentation

## Verification

- affected Go package suites pass
- required Go builds pass
- OpenAPI regeneration and assertions pass
- frontend service regression test and full TypeScript check pass
- frontend production build passes
- live Playwright create, edit, cross-surface visibility, delete, project-provisioned delete, and recreate journeys pass

## Limitation

- a completed live Zed turn was not verified because the isolated API could not acquire the Hydra RevDial connection owned by another API instance; activation reached project, repository, App, and session provisioning before that boundary

## Design

- `design/2026-07-27-unify-helix-org-agents.md`