### PR TITLE
fix(org): decouple app listing and finish node rename

### DIFF
--- a/api/pkg/org/application/lifecycle/agent_links_test.go
+++ b/api/pkg/org/application/lifecycle/agent_links_test.go
@@ -267,10 +267,10 @@ func TestCreateRollbackIgnoresCancelledRequestContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	runtime := &lifecycleRuntime{store: st}
 	svc := &lifecycle.Service{
-		Store:          st,
-		Helix:          runtime,
-		Agents:         fixedAgentCreator{id: "app-cleanup"},
-		BotReconcilers: []lifecycle.BotReconciler{cancellingReconciler{cancel: cancel}},
+		Store:           st,
+		Helix:           runtime,
+		Agents:          fixedAgentCreator{id: "app-cleanup"},
+		NodeReconcilers: []lifecycle.NodeReconciler{cancellingReconciler{cancel: cancel}},
 		Nodes: nodes.New(nodes.Deps{
 			Nodes: st.Nodes,
 			Now:   func() time.Time { return time.Now().UTC() },

--- a/api/pkg/org/application/lifecycle/hire_test.go
+++ b/api/pkg/org/application/lifecycle/hire_test.go
@@ -23,9 +23,9 @@ func (fakeAgentCreator) CreateAgent(context.Context, string, string, string) (st
 	return "app-agent", nil
 }
 
-type failingBotReconciler struct{}
+type failingNodeReconciler struct{}
 
-func (failingBotReconciler) Reconcile(context.Context, string, ...orgchart.NodeID) error {
+func (failingNodeReconciler) Reconcile(context.Context, string, ...orgchart.NodeID) error {
 	return errors.New("reconcile failed")
 }
 
@@ -44,12 +44,12 @@ func newHireService(st *store.Store) *lifecycle.Service {
 		NewID:      func() string { return "id" },
 	})
 	return &lifecycle.Service{
-		Store:          st,
-		Nodes:          botSvc,
-		Agents:         fakeAgentCreator{},
-		BotReconcilers: []lifecycle.BotReconciler{rec},
-		Now:            hireClock,
-		NewID:          func() string { return "id" },
+		Store:           st,
+		Nodes:           botSvc,
+		Agents:          fakeAgentCreator{},
+		NodeReconcilers: []lifecycle.NodeReconciler{rec},
+		Now:             hireClock,
+		NewID:           func() string { return "id" },
 	}
 }
 
@@ -73,11 +73,11 @@ func TestCreate_CreatesBotAndReconciles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if res.Bot.ID != "w-new" {
-		t.Fatalf("bot id = %q", res.Bot.ID)
+	if res.Node.ID != "w-new" {
+		t.Fatalf("node id = %q", res.Node.ID)
 	}
-	if res.Bot.AgentAppID != "app-agent" {
-		t.Fatalf("agent app id = %q, want app-agent", res.Bot.AgentAppID)
+	if res.Node.AgentAppID != "app-agent" {
+		t.Fatalf("agent app id = %q, want app-agent", res.Node.AgentAppID)
 	}
 	if _, err := st.Nodes.Get(ctx, "org-test", "w-new"); err != nil {
 		t.Fatalf("bot not persisted: %v", err)
@@ -162,7 +162,7 @@ func TestCreate_RollsBackBotWhenReconcileFails(t *testing.T) {
 	t.Parallel()
 	st := memory.New()
 	svc := newHireService(st)
-	svc.BotReconcilers = []lifecycle.BotReconciler{failingBotReconciler{}}
+	svc.NodeReconcilers = []lifecycle.NodeReconciler{failingNodeReconciler{}}
 
 	_, err := svc.Create(context.Background(), "org-test", lifecycle.CreateParams{ID: "w-new", Content: "x"})
 
@@ -222,7 +222,7 @@ func TestCreate_DeferredDoesNotCreateOrDispatchActivation(t *testing.T) {
 	if disp.hires != 0 {
 		t.Fatalf("deferred create dispatched %d hires", disp.hires)
 	}
-	rows, err := st.Activations.ListForWorker(context.Background(), "org-test", res.Bot.ID, 1)
+	rows, err := st.Activations.ListForWorker(context.Background(), "org-test", res.Node.ID, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -1,8 +1,8 @@
 // Package lifecycle owns the cross-cutting orchestration that
-// composes store + runtime when a Bot is created or destroyed.
+// composes store + runtime when a Node is created or destroyed.
 //
-// This package owns the two halves of the Bot lifecycle: Create (the
-// create cascade — bot row, reporting line, topology reconcile,
+// This package owns the two halves of the Node lifecycle: Create (the
+// create cascade - node row, reporting line, topology reconcile,
 // create-activation dispatch) and Delete (the destroy cascade — Helix
 // project/app teardown, store cleanup, topology reconcile). Both REST
 // and the MCP create_bot tool drive Create here, so the semantics
@@ -29,15 +29,15 @@ import (
 	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime/helix"
 )
 
-// CreateDispatcher fires the per-create activation for a new Bot. A
+// CreateDispatcher fires the per-create activation for a new Node. A
 // narrow interface so the lifecycle service doesn't import the tools
 // package. The composition root's dispatcher satisfies it.
 type CreateDispatcher interface {
 	DispatchHire(ctx context.Context, orgID string, botID orgchart.NodeID, activationID activation.ID)
 }
 
-// TopicSubscriber subscribes a Bot to Topics. Create uses it to subscribe
-// a new Bot to the topics named at creation, reusing the same subscription
+// TopicSubscriber subscribes a Node to Topics. Create uses it to subscribe
+// a new Node to the topics named at creation, reusing the same subscription
 // use case the standalone subscribe tool drives (DRY). A narrow interface
 // so lifecycle doesn't import the subscriptions package;
 // *subscriptions.Subscriptions satisfies it.
@@ -46,7 +46,7 @@ type TopicSubscriber interface {
 }
 
 // HelixRuntime is the slice of runtime/helix.ProjectService that the
-// Delete cascade needs to tear down a Bot's Helix-side project and
+// Delete cascade needs to tear down a Node's Helix-side project and
 // agent app. Production wiring satisfies this with the in-process
 // adapter used everywhere else; the interface exists so tests can
 // stub.
@@ -68,12 +68,12 @@ func cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
 // they are deliberately separate types because their CONTRACTS differ — not
 // just a comment, the compiler enforces which list a reconciler can join.
 //
-// BotReconciler is scoped to the Bot(s) that changed: callers pass the
+// NodeReconciler is scoped to the Node(s) that changed: callers pass the
 // affected ids and it converges only their neighbourhood (cheap, and it
 // no-ops on an empty set). It is structural — Create treats a failure as
-// FATAL (the new Bot's channels weren't set up), Delete as best-effort.
+// FATAL (the new Node's channels weren't set up), Delete as best-effort.
 // *reconcile.Reconciler (activation/team/DM Topics) is the implementer.
-type BotReconciler interface {
+type NodeReconciler interface {
 	Reconcile(ctx context.Context, orgID string, affected ...orgchart.NodeID) error
 }
 
@@ -89,7 +89,7 @@ type OrgReconciler interface {
 	Reconcile(ctx context.Context, orgID string) error
 }
 
-// Service composes the bot-lifecycle operations the REST/MCP layers
+// Service composes the node-lifecycle operations the REST/MCP layers
 // drive. All fields are required; pass nil HelixRuntime only in tests
 // that don't need the Helix-side teardown.
 type Service struct {
@@ -98,23 +98,23 @@ type Service struct {
 	Agents AgentCreator
 	Logger *slog.Logger
 
-	// Nodes is the bot-mutation service Create delegates the row creation
+	// Nodes is the node-mutation service Create delegates the row creation
 	// to, so the base-tool union and id minting are shared with the
 	// REST/MCP update path. Required for Create.
 	Nodes *nodes.Nodes
 
-	// Subscriber subscribes a new Bot to the topics named at creation
+	// Subscriber subscribes a new Node to the topics named at creation
 	// (CreateParams.Topics), reusing the shared subscription use case. nil
 	// → no creation-time subscription (create still succeeds).
 	Subscriber TopicSubscriber
 
-	// BotReconcilers are the Bot-scoped reconcilers (see the contract on
-	// BotReconciler) run on create (FATAL) and delete (best-effort) with
-	// the affected Bot ids. Today just the activation/team/DM topology
+	// NodeReconcilers are the Node-scoped reconcilers (see the contract on
+	// NodeReconciler) run on create (FATAL) and delete (best-effort) with
+	// the affected Node ids. Today just the activation/team/DM topology
 	// reconciler. Empty/nil is a no-op.
-	BotReconcilers []BotReconciler
+	NodeReconcilers []NodeReconciler
 
-	// Mirror is the transcript mirror; Delete stops the deleted Bot's
+	// Mirror is the transcript mirror; Delete stops the deleted Node's
 	// subscription so it doesn't leak. nil is a no-op.
 	Mirror *helix.Mirror
 
@@ -126,11 +126,11 @@ type Service struct {
 
 	// --- Create collaborators ---
 
-	// Dispatcher fires the per-create activation for a new Bot.
+	// Dispatcher fires the per-create activation for a new Node.
 	// nil → no activation is dispatched (tests / runtimes without a
 	// dispatcher).
 	Dispatcher CreateDispatcher
-	// HireHook runs runtime bookkeeping after the bot row exists — the
+	// HireHook runs runtime bookkeeping after the node row exists - the
 	// helix runtime persists the creating user. nil is a no-op.
 	HireHook runtime.HireHook
 	// Now / NewID seam the clock and id-generator. Both are required for
@@ -139,10 +139,10 @@ type Service struct {
 	NewID func() string
 }
 
-// CreateParams describes a new Bot. ID is optional — when empty the
-// bots service mints a fresh `b-<id>` (discouraged; callers should pass
-// a readable handle). ParentID is the manager this bot reports to
-// (empty only for the org root). Content is the bot's prompt; Tools and
+// CreateParams describes a new Node. ID is optional - when empty the
+// nodes service mints a fresh `b-<id>` (discouraged; callers should pass
+// a readable handle). ParentID is the manager this node reports to
+// (empty only for the org root). Content is the node's prompt; Tools and
 // Topics are its capability/manifest.
 type CreateParams struct {
 	ID              string
@@ -158,23 +158,23 @@ type CreateParams struct {
 	DeferActivation bool
 }
 
-// CreateResult carries the new Bot and the pre-allocated
+// CreateResult carries the new Node and the pre-allocated
 // create-activation id.
 type CreateResult struct {
-	Bot          orgchart.Node
+	Node         orgchart.Node
 	ActivationID activation.ID
 }
 
-// Create brings a Bot into existence: the bot row (content + tools, via
-// the bots service so the base-read-tool union is applied), the initial
+// Create brings a Node into existence: the node row (content + tools, via
+// the nodes service so the base-read-tool union is applied), the initial
 // reporting line, a topology reconcile, the creating-user bookkeeping,
 // and a pre-allocated create activation dispatched through the Spawner.
 // This is the single implementation the MCP create_bot tool and the
 // REST POST /bots handler both call.
 //
-// State lives in the domain DB, with role.md mirrored to the per-Bot
-// helix-specs branch for workspace workflows. A Bot's MCP tool surface is
-// derived live from Bot.Tools.
+// State lives in the domain DB, with role.md mirrored to the per-Node
+// helix-specs branch for workspace workflows. A Node's MCP tool surface is
+// derived live from Node.Tools.
 func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (CreateResult, error) {
 	if s.NewID == nil || s.Now == nil {
 		return CreateResult{}, fmt.Errorf("lifecycle: clock/id-generator not wired")
@@ -183,20 +183,20 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 		return CreateResult{}, errors.New("lifecycle: store is nil")
 	}
 	if s.Nodes == nil {
-		return CreateResult{}, errors.New("lifecycle: bots service not wired")
+		return CreateResult{}, errors.New("lifecycle: nodes service not wired")
 	}
 
 	var parent *orgchart.NodeID
 	if p.ParentID != "" {
 		if _, err := s.Store.Nodes.Get(ctx, orgID, p.ParentID); err != nil {
-			return CreateResult{}, fmt.Errorf("parent bot %q: %w", p.ParentID, err)
+			return CreateResult{}, fmt.Errorf("parent node %q: %w", p.ParentID, err)
 		}
 		parent = &p.ParentID
 	}
 
-	// Validate every requested topic exists BEFORE writing the bot row, so
-	// a bad topic id fails the create with no partially-created Bot. The
-	// actual subscription rows are created below, after the bot exists.
+	// Validate every requested topic exists BEFORE writing the node row, so
+	// a bad topic id fails the create with no partially-created Node. The
+	// actual subscription rows are created below, after the node exists.
 	for _, tid := range p.Topics {
 		if tid == "" {
 			return CreateResult{}, fmt.Errorf("topic id is empty")
@@ -221,7 +221,7 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 			return CreateResult{}, fmt.Errorf("create agent app: %w", err)
 		}
 	}
-	bot, err := s.Nodes.Create(ctx, orgID, nodes.CreateParams{
+	node, err := s.Nodes.Create(ctx, orgID, nodes.CreateParams{
 		ID:              p.ID,
 		Name:            p.Name,
 		Content:         p.Content,
@@ -239,7 +239,7 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 		}
 		return CreateResult{}, err
 	}
-	id := bot.ID
+	id := node.ID
 	rollback := func(createErr error) (CreateResult, error) {
 		cleanupCtx, cancel := cleanupContext(ctx)
 		defer cancel()
@@ -249,7 +249,7 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 		return CreateResult{}, createErr
 	}
 
-	// Wire the initial reporting line now that both bot rows exist.
+	// Wire the initial reporting line now that both node rows exist.
 	if parent != nil && s.Store.ReportingLines != nil {
 		line, err := orgchart.NewReportingLine(orgID, *parent, id)
 		if err != nil {
@@ -260,32 +260,32 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 		}
 	}
 
-	// Reconcile the activation/team Topics implied by the new Bot and its
-	// reporting line (mints the bot's transcript + the manager's team Topic
-	// from one declarative pass). FATAL: a Bot without its channels is a
-	// broken create. Bot-scoped to the new id.
-	for _, rec := range s.BotReconcilers {
+	// Reconcile the activation/team Topics implied by the new Node and its
+	// reporting line (mints the node's transcript + the manager's team Topic
+	// from one declarative pass). FATAL: a Node without its channels is a
+	// broken create. Node-scoped to the new id.
+	for _, rec := range s.NodeReconcilers {
 		if rec == nil {
 			continue
 		}
 		if err := rec.Reconcile(ctx, orgID, id); err != nil {
-			return rollback(fmt.Errorf("reconcile topology for bot %q: %w", id, err))
+			return rollback(fmt.Errorf("reconcile topology for node %q: %w", id, err))
 		}
 	}
 
-	// Subscribe the new Bot to the topics named at creation, reusing the
+	// Subscribe the new Node to the topics named at creation, reusing the
 	// shared subscription use case (the same one the subscribe tool drives).
 	// Topics were validated above, so this only fails on an infrastructure
-	// error — treat it as FATAL like the topology reconcile, since a Bot
+	// error - treat it as FATAL like the topology reconcile, since a Node
 	// that silently isn't listening is a broken create.
 	if s.Subscriber != nil && len(p.Topics) > 0 {
 		if err := s.Subscriber.SubscribeTopics(ctx, orgID, id, p.Topics); err != nil {
-			return rollback(fmt.Errorf("subscribe new bot %q to topics: %w", id, err))
+			return rollback(fmt.Errorf("subscribe new node %q to topics: %w", id, err))
 		}
 	}
 
 	// Run the whole-org reconcilers (Slack auto-router routes, …) for the new
-	// Bot. Best-effort: a failure must not abort the create — each is
+	// Node. Best-effort: a failure must not abort the create - each is
 	// idempotent and re-runs on the next create/delete and at startup.
 	s.runOrgReconcilers(ctx, orgID, "create", id)
 
@@ -298,13 +298,13 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 	}
 
 	if p.DeferActivation {
-		return CreateResult{Bot: bot}, nil
+		return CreateResult{Node: node}, nil
 	}
 
 	// Pre-create the create-Activation audit row so Create can return the
 	// id synchronously; the Spawner Completes it (matched by
-	// Trigger.ActivationID) rather than minting a sibling. Every bot is an
-	// agent, so every bot gets a create activation.
+	// Trigger.ActivationID) rather than minting a sibling. Every node is an
+	// agent, so every node gets a create activation.
 	var actID activation.ID
 	if s.Store.Activations != nil {
 		actID = activation.ID("a-" + s.NewID())
@@ -320,7 +320,7 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 		s.Dispatcher.DispatchHire(ctx, orgID, id, actID)
 	}
 
-	return CreateResult{Bot: bot, ActivationID: actID}, nil
+	return CreateResult{Node: node, ActivationID: actID}, nil
 }
 
 func (s *Service) ReconcileAgentLinks(ctx context.Context, orgID string) error {
@@ -331,29 +331,29 @@ func (s *Service) ReconcileAgentLinks(ctx context.Context, orgID string) error {
 	if err != nil {
 		return err
 	}
-	for _, bot := range all {
-		if bot.IsHuman() || bot.AgentAppID != "" {
+	for _, node := range all {
+		if node.IsHuman() || node.AgentAppID != "" {
 			continue
 		}
-		name := bot.Name
+		name := node.Name
 		if name == "" {
-			name = string(bot.ID)
+			name = string(node.ID)
 		}
-		appID, err := s.Agents.CreateAgent(ctx, orgID, name, bot.Content)
+		appID, err := s.Agents.CreateAgent(ctx, orgID, name, node.Content)
 		if err != nil {
-			return fmt.Errorf("create agent app for %s: %w", bot.ID, err)
+			return fmt.Errorf("create agent app for %s: %w", node.ID, err)
 		}
-		claimed, err := s.Store.Nodes.ClaimAgentApp(ctx, orgID, bot.ID, appID)
+		claimed, err := s.Store.Nodes.ClaimAgentApp(ctx, orgID, node.ID, appID)
 		if err != nil {
 			if s.Helix != nil {
 				cleanupCtx, cancel := cleanupContext(ctx)
 				cleanupErr := s.Helix.DeleteApp(cleanupCtx, appID)
 				cancel()
 				if cleanupErr != nil && !errors.Is(cleanupErr, helix.ErrProjectNotFound) {
-					return fmt.Errorf("link agent app for %s: %v; delete unlinked agent app %s: %w", bot.ID, err, appID, cleanupErr)
+					return fmt.Errorf("link agent app for %s: %v; delete unlinked agent app %s: %w", node.ID, err, appID, cleanupErr)
 				}
 			}
-			return fmt.Errorf("link agent app for %s: %w", bot.ID, err)
+			return fmt.Errorf("link agent app for %s: %w", node.ID, err)
 		}
 		if !claimed {
 			if s.Helix != nil {
@@ -370,33 +370,33 @@ func (s *Service) ReconcileAgentLinks(ctx context.Context, orgID string) error {
 	return nil
 }
 
-// Delete tears down a Bot end-to-end:
+// Delete tears down a Node end-to-end:
 //
 //  1. Read the Helix-runtime state (project + app IDs) before clearing.
 //  2. DeleteProject on Helix — stops any active sessions.
 //  3. Atomically delete the agent app, NodeRuntimeState, subscriptions, and
-//     bot row. The org_reporting_lines foreign keys drop its lines.
-//  4. Reconcile topology: tear down the deleted Bot's own activation +
+//     node row. The org_reporting_lines foreign keys drop its lines.
+//  4. Reconcile topology: tear down the deleted Node's own activation +
 //     team Topics and collapse any ex-manager's team Topic that just
 //     lost its last report.
 //
-// Subscriptions are bot-anchored, so they die with the bot. Activation
+// Subscriptions are node-anchored, so they die with the node. Activation
 // events themselves are intentionally left behind as an audit trail; only
 // the Topic row is dropped.
 func (s *Service) Delete(ctx context.Context, orgID string, id orgchart.NodeID) error {
 	if id == "" {
-		return errors.New("bot id is empty")
+		return errors.New("node id is empty")
 	}
 	if s.Store == nil {
 		return errors.New("lifecycle: store is nil")
 	}
-	bot, err := s.Store.Nodes.Get(ctx, orgID, id)
+	node, err := s.Store.Nodes.Get(ctx, orgID, id)
 	if err != nil {
-		return fmt.Errorf("get bot %q: %w", id, err)
+		return fmt.Errorf("get node %q: %w", id, err)
 	}
 
-	// Capture the deleted Bot's managers AND reports BEFORE deletion: the
-	// reporting lines cascade-drop with the bot row, so the List* calls
+	// Capture the deleted Node's managers AND reports BEFORE deletion: the
+	// reporting lines cascade-drop with the node row, so the List* calls
 	// return nothing afterward. We feed both sets to the topology reconcile
 	// below. The ex-managers let a manager's team Topic collapse when its
 	// last report leaves. The ex-reports are needed for DM teardown: the
@@ -417,7 +417,7 @@ func (s *Service) Delete(ctx context.Context, orgID string, id orgchart.NodeID) 
 		}
 	}
 
-	agentAppID := bot.AgentAppID
+	agentAppID := node.AgentAppID
 	if agentAppID == "" {
 		agentAppID = state.AgentAppID
 	}
@@ -432,7 +432,7 @@ func (s *Service) Delete(ctx context.Context, orgID string, id orgchart.NodeID) 
 			}
 		}
 		if err := s.Store.Nodes.Delete(ctx, orgID, id); err != nil {
-			return fmt.Errorf("delete bot row %q: %w", id, err)
+			return fmt.Errorf("delete node row %q: %w", id, err)
 		}
 	}
 	if s.Mirror != nil {
@@ -441,19 +441,19 @@ func (s *Service) Delete(ctx context.Context, orgID string, id orgchart.NodeID) 
 
 	// Settle the activation/team Topics now that the row (and its reporting
 	// lines) are gone. Best-effort: a failure leaves a dangling Topic row,
-	// not a half-deleted bot, so we log and continue.
+	// not a half-deleted node, so we log and continue.
 	affected := append([]orgchart.NodeID{id}, exManagers...)
 	affected = append(affected, exReports...)
-	for _, rec := range s.BotReconcilers {
+	for _, rec := range s.NodeReconcilers {
 		if rec == nil {
 			continue
 		}
 		if err := rec.Reconcile(ctx, orgID, affected...); err != nil {
-			s.logger().Warn("delete: reconcile topology", "bot", id, "err", err)
+			s.logger().Warn("delete: reconcile topology", "node", id, "err", err)
 		}
 	}
 
-	// Run the whole-org reconcilers so the deleted Bot's Slack auto-route is
+	// Run the whole-org reconcilers so the deleted Node's Slack auto-route is
 	// GC'd. Best-effort, like topology above.
 	s.runOrgReconcilers(ctx, orgID, "delete", id)
 	return nil
@@ -461,14 +461,14 @@ func (s *Service) Delete(ctx context.Context, orgID string, id orgchart.NodeID) 
 
 // runOrgReconcilers runs every whole-org reconciler best-effort, logging (not
 // propagating) failures so one reconciler can't abort the lifecycle mutation
-// or block the others. phase/bot are for the log line only.
-func (s *Service) runOrgReconcilers(ctx context.Context, orgID, phase string, bot orgchart.NodeID) {
+// or block the others. phase/node are for the log line only.
+func (s *Service) runOrgReconcilers(ctx context.Context, orgID, phase string, node orgchart.NodeID) {
 	for _, rec := range s.OrgReconcilers {
 		if rec == nil {
 			continue
 		}
 		if err := rec.Reconcile(ctx, orgID); err != nil {
-			s.logger().Warn(phase+": reconcile", "bot", bot, "err", err)
+			s.logger().Warn(phase+": reconcile", "node", node, "err", err)
 		}
 	}
 }

--- a/api/pkg/org/application/lifecycle/lifecycle_test.go
+++ b/api/pkg/org/application/lifecycle/lifecycle_test.go
@@ -59,7 +59,7 @@ func TestDelete_RemovesBotsTranscript(t *testing.T) {
 		t.Fatalf("precondition: transcript not seeded: %v", err)
 	}
 
-	svc := &lifecycle.Service{Store: st, BotReconcilers: []lifecycle.BotReconciler{reconcile.New(reconcile.Deps{Nodes: st.Nodes, ReportingLines: st.ReportingLines, Topics: st.Topics, Subscriptions: st.Subscriptions})}}
+	svc := &lifecycle.Service{Store: st, NodeReconcilers: []lifecycle.NodeReconciler{reconcile.New(reconcile.Deps{Nodes: st.Nodes, ReportingLines: st.ReportingLines, Topics: st.Topics, Subscriptions: st.Subscriptions})}}
 	if err := svc.Delete(ctx, orgID, bot.ID); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestDelete_CascadesReportingLinesAndSubscriptions(t *testing.T) {
 		t.Fatalf("create subscription: %v", err)
 	}
 
-	svc := &lifecycle.Service{Store: st, BotReconcilers: []lifecycle.BotReconciler{reconcile.New(reconcile.Deps{Nodes: st.Nodes, ReportingLines: st.ReportingLines, Topics: st.Topics, Subscriptions: st.Subscriptions})}}
+	svc := &lifecycle.Service{Store: st, NodeReconcilers: []lifecycle.NodeReconciler{reconcile.New(reconcile.Deps{Nodes: st.Nodes, ReportingLines: st.ReportingLines, Topics: st.Topics, Subscriptions: st.Subscriptions})}}
 	if err := svc.Delete(ctx, orgID, mgr.ID); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestDelete_TearsDownDMChannelToReports(t *testing.T) {
 		t.Fatalf("precondition: DM channel %q should exist after wiring the edge: %v", dm, err)
 	}
 
-	svc := &lifecycle.Service{Store: st, BotReconcilers: []lifecycle.BotReconciler{rec}}
+	svc := &lifecycle.Service{Store: st, NodeReconcilers: []lifecycle.NodeReconciler{rec}}
 	if err := svc.Delete(ctx, orgID, mgr.ID); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
@@ -222,8 +222,8 @@ func TestDelete_TearsDownDMChannelToReports(t *testing.T) {
 // Helix project/app, so the Delete cascade never calls into Helix).
 func newLifecycleSvc(st *store.Store) *lifecycle.Service {
 	return &lifecycle.Service{
-		Store:          st,
-		BotReconcilers: []lifecycle.BotReconciler{reconcile.New(reconcile.Deps{Nodes: st.Nodes, ReportingLines: st.ReportingLines, Topics: st.Topics, Subscriptions: st.Subscriptions})},
+		Store:           st,
+		NodeReconcilers: []lifecycle.NodeReconciler{reconcile.New(reconcile.Deps{Nodes: st.Nodes, ReportingLines: st.ReportingLines, Topics: st.Topics, Subscriptions: st.Subscriptions})},
 	}
 }
 
@@ -262,7 +262,7 @@ func TestDelete_ReconcilesSurvivingReport(t *testing.T) {
 
 	svc := newLifecycleSvc(st)
 	// Provision the channels the edge implies (team topic + DM channel).
-	if err := svc.BotReconcilers[0].Reconcile(ctx, orgID, "w-mgr", "w-ic"); err != nil {
+	if err := svc.NodeReconcilers[0].Reconcile(ctx, orgID, "w-mgr", "w-ic"); err != nil {
 		t.Fatalf("reconcile (wire edge): %v", err)
 	}
 	dm := channels.DMTopicID("w-mgr", "w-ic")

--- a/api/pkg/org/application/nodes/nodes.go
+++ b/api/pkg/org/application/nodes/nodes.go
@@ -1,13 +1,13 @@
-// Package bots is the application service that owns the structural Bot
+// Package nodes is the application service that owns the structural Node
 // use cases — Create, Update, the reporting-line edges (AddParent /
 // RemoveParent), and the base-tool Reconcile backfill. It is the single
-// home for the bot-mutation logic the MCP tools and REST handlers drive,
+// home for the node-mutation logic the MCP tools and REST handlers drive,
 // so the semantics cannot drift between callers.
 //
 // It is the merge of the former `roles` and `workers` application
-// services: now that a Bot IS its own job description (the former Role
-// and Worker collapsed into one aggregate), "edit a bot's content/tools"
-// and "wire a bot's reporting lines" are operations on the same entity.
+// services: now that a Node IS its own job description (the former Role
+// and Worker collapsed into one aggregate), content/tools and reporting
+// lines are operations on the same entity.
 //
 // Create/Update do a proper read-modify-write that preserves unpatched
 // fields (a content-only update keeps Tools/Topics). The service depends
@@ -39,9 +39,9 @@ var ErrReportingCycle = errors.New("reporting cycle")
 // repository is not wired. Adapters map it to 501.
 var ErrReportingLinesUnavailable = errors.New("reporting lines not wired")
 
-// Nodes owns the bot-mutation use cases.
+// Nodes owns the node-mutation use cases.
 type Nodes struct {
-	bots       store.Nodes
+	nodes      store.Nodes
 	lines      store.ReportingLines
 	reconciler *reconcile.Reconciler
 	now        func() time.Time
@@ -61,7 +61,7 @@ type Deps struct {
 	Now        func() time.Time
 	NewID      func() string
 	// BaseTools is the universal read baseline unioned into every
-	// created Bot so no Bot can miss the read primitives every Bot
+	// created Node so no Node can miss the read primitives every Node
 	// needs. Injected by the wiring (tools.BaseReadTools) to avoid an
 	// import cycle.
 	BaseTools []tool.Name
@@ -74,7 +74,7 @@ func New(deps Deps) *Nodes {
 		now = func() time.Time { return time.Now().UTC() }
 	}
 	return &Nodes{
-		bots:       deps.Nodes,
+		nodes:      deps.Nodes,
 		lines:      deps.Lines,
 		reconciler: deps.Reconciler,
 		now:        now,
@@ -83,10 +83,10 @@ func New(deps Deps) *Nodes {
 	}
 }
 
-// CreateParams describes a new Bot. ID is optional — when empty a fresh
+// CreateParams describes a new Node. ID is optional - when empty a fresh
 // `b-<id>` is minted. Tools is unioned with the injected base read
-// tools. Subscriptions are not part of the bot row — the lifecycle
-// service creates them as (bot, topic) rows from its own CreateParams.
+// tools. Subscriptions are not part of the node row - the lifecycle
+// service creates them as (node, topic) rows from its own CreateParams.
 type CreateParams struct {
 	ID              string
 	Name            string
@@ -102,7 +102,7 @@ type CreateParams struct {
 	Identity    map[string]string
 }
 
-// Create builds and persists a new Bot, returning the created
+// Create builds and persists a new Node, returning the created
 // aggregate. The caller's tools are unioned with the base read tools
 // (caller order preserved, baseline appended, deduped).
 func (s *Nodes) Create(ctx context.Context, orgID string, p CreateParams) (orgchart.Node, error) {
@@ -114,10 +114,10 @@ func (s *Nodes) Create(ctx context.Context, orgID string, p CreateParams) (orgch
 	// (id, org) primary key), so a clash means the id is already taken — return
 	// a clear error rather than silently mutating it. Deterministic-id callers
 	// (seeds) treat this as "already exists" after a Get.
-	if _, err := s.bots.Get(ctx, orgID, id); err == nil {
-		return orgchart.Node{}, fmt.Errorf("bot id %q already exists in this org", id)
+	if _, err := s.nodes.Get(ctx, orgID, id); err == nil {
+		return orgchart.Node{}, fmt.Errorf("node id %q already exists in this org", id)
 	} else if !errors.Is(err, store.ErrNotFound) {
-		return orgchart.Node{}, fmt.Errorf("check bot id %q: %w", id, err)
+		return orgchart.Node{}, fmt.Errorf("check node id %q: %w", id, err)
 	}
 	// A human placeholder gets no tools — it never makes an MCP request.
 	// An agent gets the caller's tools unioned with the read baseline.
@@ -125,35 +125,35 @@ func (s *Nodes) Create(ctx context.Context, orgID string, p CreateParams) (orgch
 	if p.Kind != orgchart.NodeKindHuman {
 		tools = MergeTools(p.Tools, s.baseTools)
 	}
-	bot, err := orgchart.NewNode(id, p.Content, tools, s.now(), orgID)
+	node, err := orgchart.NewNode(id, p.Content, tools, s.now(), orgID)
 	if err != nil {
 		return orgchart.Node{}, err
 	}
 	if p.Name != "" {
-		bot = bot.WithName(p.Name)
+		node = node.WithName(p.Name)
 	}
 	if p.AgentAppID != "" {
-		bot = bot.WithAgentAppID(p.AgentAppID)
+		node = node.WithAgentAppID(p.AgentAppID)
 	}
 	if p.PreserveContext {
-		bot = bot.WithPreserveContext(true)
+		node = node.WithPreserveContext(true)
 	}
 	if p.Kind != "" {
-		bot = bot.WithKind(p.Kind)
+		node = node.WithKind(p.Kind)
 	}
 	if p.HelixUserID != "" {
-		bot = bot.WithHelixUserID(p.HelixUserID)
+		node = node.WithHelixUserID(p.HelixUserID)
 	}
 	if len(p.Identity) > 0 {
-		bot = bot.WithIdentity(p.Identity)
+		node = node.WithIdentity(p.Identity)
 	}
-	if err := s.bots.Create(ctx, bot); err != nil {
+	if err := s.nodes.Create(ctx, node); err != nil {
 		return orgchart.Node{}, err
 	}
-	return bot, nil
+	return node, nil
 }
 
-// UpdateParams patches the mutable fields of a Bot. A nil pointer
+// UpdateParams patches the mutable fields of a Node. A nil pointer
 // leaves the corresponding field unchanged — this is what preserves
 // Tools on a content-only update.
 type UpdateParams struct {
@@ -163,16 +163,16 @@ type UpdateParams struct {
 	Tools           *[]tool.Name
 	ProjectIDs      *[]string
 	PreserveContext *bool
-	// Identity, when non-nil, replaces the bot's per-channel handle map
+	// Identity, when non-nil, replaces the node's per-channel handle map
 	// (human nodes only). nil leaves it unchanged.
 	Identity *map[string]string
 }
 
-// Update reads the existing Bot, applies the patch via the domain's
+// Update reads the existing Node, applies the patch via the domain's
 // With* builders, bumps UpdatedAt, and persists. Returns
 // store.ErrNotFound (wrapped) when the (orgID, id) row is absent.
 func (s *Nodes) Update(ctx context.Context, orgID string, id orgchart.NodeID, p UpdateParams) (orgchart.Node, error) {
-	existing, err := s.bots.Get(ctx, orgID, id)
+	existing, err := s.nodes.Get(ctx, orgID, id)
 	if err != nil {
 		return orgchart.Node{}, err
 	}
@@ -199,7 +199,7 @@ func (s *Nodes) Update(ctx context.Context, orgID string, id orgchart.NodeID, p 
 		updated = updated.WithIdentity(*p.Identity)
 	}
 	updated = updated.WithUpdatedAt(s.now())
-	if err := s.bots.Update(ctx, updated); err != nil {
+	if err := s.nodes.Update(ctx, updated); err != nil {
 		return orgchart.Node{}, err
 	}
 	return updated, nil
@@ -222,13 +222,13 @@ func normalizeProjectIDs(projectIDs []string) []string {
 	return out
 }
 
-// AttachTools grants the named tools to a Bot: the union of its current
+// AttachTools grants the named tools to a Node: the union of its current
 // tools and names (caller order preserved, new names appended, deduped),
-// persisted. Idempotent per name — names the Bot already has are no-ops,
+// persisted. Idempotent per name - names the Node already has are no-ops,
 // and a call that adds nothing writes nothing. Returns store.ErrNotFound
 // (wrapped) when the (orgID, id) row is absent.
 func (s *Nodes) AttachTools(ctx context.Context, orgID string, id orgchart.NodeID, names []tool.Name) (orgchart.Node, error) {
-	existing, err := s.bots.Get(ctx, orgID, id)
+	existing, err := s.nodes.Get(ctx, orgID, id)
 	if err != nil {
 		return orgchart.Node{}, err
 	}
@@ -237,14 +237,14 @@ func (s *Nodes) AttachTools(ctx context.Context, orgID string, id orgchart.NodeI
 		return existing, nil
 	}
 	updated := existing.WithTools(merged).WithUpdatedAt(s.now())
-	if err := s.bots.Update(ctx, updated); err != nil {
+	if err := s.nodes.Update(ctx, updated); err != nil {
 		return orgchart.Node{}, err
 	}
 	return updated, nil
 }
 
-// DetachTools removes the named tools from a Bot. Idempotent per name (a
-// name the Bot lacks is a no-op). It refuses to remove any universal
+// DetachTools removes the named tools from a Node. Idempotent per name (a
+// name the Node lacks is a no-op). It refuses to remove any universal
 // read-baseline tool — those are mandatory and the reconciler would
 // re-add them — failing the whole call before any write. Returns
 // store.ErrNotFound (wrapped) when the (orgID, id) row is absent.
@@ -260,7 +260,7 @@ func (s *Nodes) DetachTools(ctx context.Context, orgID string, id orgchart.NodeI
 		}
 		remove[n] = struct{}{}
 	}
-	existing, err := s.bots.Get(ctx, orgID, id)
+	existing, err := s.nodes.Get(ctx, orgID, id)
 	if err != nil {
 		return orgchart.Node{}, err
 	}
@@ -275,7 +275,7 @@ func (s *Nodes) DetachTools(ctx context.Context, orgID string, id orgchart.NodeI
 		return existing, nil
 	}
 	updated := existing.WithTools(kept).WithUpdatedAt(s.now())
-	if err := s.bots.Update(ctx, updated); err != nil {
+	if err := s.nodes.Update(ctx, updated); err != nil {
 		return orgchart.Node{}, err
 	}
 	return updated, nil
@@ -291,10 +291,10 @@ func (s *Nodes) AddParent(ctx context.Context, orgID string, reportID, managerID
 	if s.lines == nil {
 		return ErrReportingLinesUnavailable
 	}
-	if _, err := s.bots.Get(ctx, orgID, reportID); err != nil {
-		return fmt.Errorf("get bot %s: %w", reportID, err)
+	if _, err := s.nodes.Get(ctx, orgID, reportID); err != nil {
+		return fmt.Errorf("get node %s: %w", reportID, err)
 	}
-	if _, err := s.bots.Get(ctx, orgID, managerID); err != nil {
+	if _, err := s.nodes.Get(ctx, orgID, managerID); err != nil {
 		return fmt.Errorf("get manager %s: %w", managerID, err)
 	}
 	line, err := orgchart.NewReportingLine(orgID, managerID, reportID)
@@ -361,7 +361,7 @@ func (s *Nodes) RemoveParent(ctx context.Context, orgID string, reportID, manage
 }
 
 // Reconcile backfills the universal read baseline (the injected
-// BaseTools) onto every Bot in the org. Idempotent: a Bot already at the
+// BaseTools) onto every Node in the org. Idempotent: a Node already at the
 // baseline is left untouched (no write, no UpdatedAt bump). Order is
 // stable — caller tools first, baseline appended in BaseTools order —
 // because it reuses the same MergeTools the create path does.
@@ -369,19 +369,19 @@ func (s *Nodes) Reconcile(ctx context.Context, orgID string) error {
 	if s == nil {
 		return nil
 	}
-	all, err := s.bots.List(ctx, orgID)
+	all, err := s.nodes.List(ctx, orgID)
 	if err != nil {
-		return fmt.Errorf("list bots: %w", err)
+		return fmt.Errorf("list nodes: %w", err)
 	}
 	now := s.now()
-	for _, bot := range all {
-		merged := MergeTools(bot.Tools, s.baseTools)
-		if sameToolList(bot.Tools, merged) {
+	for _, node := range all {
+		merged := MergeTools(node.Tools, s.baseTools)
+		if sameToolList(node.Tools, merged) {
 			continue
 		}
-		updated := bot.WithTools(merged).WithUpdatedAt(now)
-		if err := s.bots.Update(ctx, updated); err != nil {
-			return fmt.Errorf("update bot %q: %w", bot.ID, err)
+		updated := node.WithTools(merged).WithUpdatedAt(now)
+		if err := s.nodes.Update(ctx, updated); err != nil {
+			return fmt.Errorf("update node %q: %w", node.ID, err)
 		}
 	}
 	return nil
@@ -406,7 +406,7 @@ func sameToolList(a, b []tool.Name) bool {
 // MergeTools returns the union of `existing` and `base`: the order of
 // `existing` is preserved, any `base` entries not already present are
 // appended in base order, and duplicates within `existing` are dropped.
-// It is the single dedup-union algorithm shared by bot creation and the
+// It is the single dedup-union algorithm shared by node creation and the
 // tools-package reconciler.
 func MergeTools(existing, base []tool.Name) []tool.Name {
 	seen := make(map[tool.Name]struct{}, len(existing)+len(base))

--- a/api/pkg/org/domain/orgchart/ids.go
+++ b/api/pkg/org/domain/orgchart/ids.go
@@ -1,13 +1,13 @@
-// Package orgchart owns the org-chart aggregate: Bot and ReportingLine.
-// A Bot is the single entity in the chart — the merge of the former
+// Package orgchart owns the org-chart aggregate: Node and ReportingLine.
+// A Node is the single entity in the chart - the merge of the former
 // Role and Worker into one concept with no identity beyond its name. A
-// Bot lists Tool names and Topic IDs; who reports to whom is a separate
-// many-to-many relation (ReportingLine), not a field on the Bot.
+// Node lists Tool names and Topic IDs; who reports to whom is a separate
+// many-to-many relation (ReportingLine), not a field on the Node.
 // Collapsing these into one Go package resolves the cycle that
 // per-entity packages produced.
 //
 // The ID type is a Go type alias (`type NodeID = string`) rather than a
-// distinct named type. This is deliberate: orgchart's Bot references
+// distinct named type. This is deliberate: orgchart's Node references
 // tool.Name and streaming.TopicID (so orgchart imports those packages),
 // and tool.Invocation.Caller needs a caller identity (which would
 // normally pull tool back to orgchart, closing the cycle). Defining the
@@ -16,7 +16,7 @@
 // thin adapter at the MCP boundary, without tool importing orgchart.
 package orgchart
 
-// NodeID identifies a Bot. Convention: `b-<kebab-case>` (e.g. `b-root`,
-// `b-software-engineer`). The bootstrap owner Bot is conventionally
+// NodeID identifies a Node. Convention: `b-<kebab-case>` (e.g. `b-root`,
+// `b-software-engineer`). The bootstrap owner Node is conventionally
 // `b-root`.
 type NodeID = string

--- a/api/pkg/org/domain/orgchart/node.go
+++ b/api/pkg/org/domain/orgchart/node.go
@@ -101,13 +101,13 @@ func NewNode(id NodeID, content string, tools []tool.Name, now time.Time, orgID 
 		return Node{}, err
 	}
 	if content == "" {
-		return Node{}, errors.New("bot content is empty")
+		return Node{}, errors.New("node content is empty")
 	}
 	if now.IsZero() {
-		return Node{}, errors.New("bot timestamp is zero")
+		return Node{}, errors.New("node timestamp is zero")
 	}
 	if orgID == "" {
-		return Node{}, errors.New("bot orgID is empty")
+		return Node{}, errors.New("node orgID is empty")
 	}
 	return Node{
 		ID:             id,
@@ -121,68 +121,68 @@ func NewNode(id NodeID, content string, tools []tool.Name, now time.Time, orgID 
 
 // WithName returns a copy of the Node with Name (the display label)
 // replaced.
-func (b Node) WithName(name string) Node {
-	b.Name = name
-	return b
+func (n Node) WithName(name string) Node {
+	n.Name = name
+	return n
 }
 
 // WithAgentAppID returns a copy of the Node linked to the canonical Agent App.
-func (b Node) WithAgentAppID(agentAppID string) Node {
-	b.AgentAppID = agentAppID
-	return b
+func (n Node) WithAgentAppID(agentAppID string) Node {
+	n.AgentAppID = agentAppID
+	return n
 }
 
 // WithContent returns a copy of the Node with Content replaced. The
 // With* builders are the supported way to mutate a Node outside the
 // domain package (immutability + tell-don't-ask) — the application
 // service composes them instead of poking exported fields in a handler.
-func (b Node) WithContent(content string) Node {
-	b.Content = content
-	return b
+func (n Node) WithContent(content string) Node {
+	n.Content = content
+	return n
 }
 
 // WithTools returns a copy of the Node with Tools replaced.
-func (b Node) WithTools(tools []tool.Name) Node {
-	b.Tools = tools
-	return b
+func (n Node) WithTools(tools []tool.Name) Node {
+	n.Tools = tools
+	return n
 }
 
 // WithProjectIDs returns a copy of the Node with its project allowlist replaced.
-func (b Node) WithProjectIDs(projectIDs []string) Node {
-	b.ProjectIDs = projectIDs
-	return b
+func (n Node) WithProjectIDs(projectIDs []string) Node {
+	n.ProjectIDs = projectIDs
+	return n
 }
 
 // WithUpdatedAt returns a copy of the Node with UpdatedAt replaced.
-func (b Node) WithUpdatedAt(t time.Time) Node {
-	b.UpdatedAt = t
-	return b
+func (n Node) WithUpdatedAt(t time.Time) Node {
+	n.UpdatedAt = t
+	return n
 }
 
 // WithPreserveContext returns a copy of the Node with PreserveContext
 // replaced.
-func (b Node) WithPreserveContext(preserve bool) Node {
-	b.PreserveContext = preserve
-	return b
+func (n Node) WithPreserveContext(preserve bool) Node {
+	n.PreserveContext = preserve
+	return n
 }
 
 // WithKind returns a copy of the Node with Kind replaced.
-func (b Node) WithKind(kind NodeKind) Node {
-	b.Kind = kind
-	return b
+func (n Node) WithKind(kind NodeKind) Node {
+	n.Kind = kind
+	return n
 }
 
 // WithHelixUserID returns a copy of the Node with HelixUserID replaced.
-func (b Node) WithHelixUserID(userID string) Node {
-	b.HelixUserID = userID
-	return b
+func (n Node) WithHelixUserID(userID string) Node {
+	n.HelixUserID = userID
+	return n
 }
 
 // WithIdentity returns a copy of the Node with Identity replaced.
-func (b Node) WithIdentity(identity map[string]string) Node {
-	b.Identity = identity
-	return b
+func (n Node) WithIdentity(identity map[string]string) Node {
+	n.Identity = identity
+	return n
 }
 
 // IsHuman reports whether this Node is a human placeholder.
-func (b Node) IsHuman() bool { return b.Kind == NodeKindHuman }
+func (n Node) IsHuman() bool { return n.Kind == NodeKindHuman }

--- a/api/pkg/org/domain/store/store.go
+++ b/api/pkg/org/domain/store/store.go
@@ -1,5 +1,5 @@
 // Package store defines the persistence contracts for the org-graph
-// subsystem (bots, topics, events,
+// subsystem (nodes, topics, events,
 // subscriptions, activations, configs). The concrete
 // implementation lives in the sibling gorm sub-package — dialect-
 // portable GORM, wired against helix's Postgres connection.
@@ -35,28 +35,28 @@ var ErrConflict = errors.New("already exists")
 // tenants. ErrNotFound is returned when the (orgID, id) pair doesn't
 // exist — even if the bare id exists under another org.
 
-// Nodes persists the org's bots — the single org-chart aggregate (the
-// merge of the former Role and Worker). A Bot carries its own content
+// Nodes persists the org's nodes - the single org-chart aggregate (the
+// merge of the former Role and Worker). A Node carries its own content
 // and tool list (its capability) and is the live participant in the
 // reporting graph. Update replaces the mutable fields (content, tools,
 // topics) wholesale.
 //
-// Delete removes the bot row and structurally cascades the rows that
-// reference it: its subscriptions (bot-anchored) and every reporting
+// Delete removes the node row and structurally cascades the rows that
+// reference it: its subscriptions (node-anchored) and every reporting
 // line where it is the manager or the report. See the gorm and memory
 // implementations.
 type Nodes interface {
-	Create(ctx context.Context, bot orgchart.Node) error
+	Create(ctx context.Context, node orgchart.Node) error
 	Get(ctx context.Context, orgID string, id orgchart.NodeID) (orgchart.Node, error)
 	List(ctx context.Context, orgID string) ([]orgchart.Node, error)
-	Update(ctx context.Context, bot orgchart.Node) error
+	Update(ctx context.Context, node orgchart.Node) error
 	ClaimAgentApp(ctx context.Context, orgID string, id orgchart.NodeID, appID string) (bool, error)
 	Delete(ctx context.Context, orgID string, id orgchart.NodeID) error
 }
 
 // ReportingLines persists the org's many-to-many reporting graph:
-// each row says ReportID reports to ManagerID. Bot-anchored on both
-// ends — deleting either endpoint Bot drops the line (the gorm store
+// each row says ReportID reports to ManagerID. Node-anchored on both
+// ends - deleting either endpoint Node drops the line (the gorm store
 // enforces this with ON DELETE CASCADE foreign keys; the memory store
 // mirrors it). The graph is a DAG; cycle prevention lives in the
 // add-parent handler, not here.
@@ -76,8 +76,8 @@ type ReportingLines interface {
 }
 
 // NodeRuntimeState is a sidecar key/value store keyed by
-// (orgID, botID, backend). Runtime backends (the Helix integration
-// today, future local containers, etc.) write whatever per-Bot
+// (orgID, nodeID, backend). Runtime backends (the Helix integration
+// today, future local containers, etc.) write whatever per-Node
 // pointers they need — Helix uses keys like "session_id", "project_id",
 // "agent_app_id", "repo_id" — without forcing the domain to grow a
 // field every time.
@@ -85,10 +85,10 @@ type ReportingLines interface {
 // The "backend" component is a free-form string the runtime owns
 // (e.g. "helix"); helix-org core never reads or writes it.
 type NodeRuntimeState interface {
-	Get(ctx context.Context, orgID string, botID orgchart.NodeID, backend string) (map[string]string, error)
-	Set(ctx context.Context, orgID string, botID orgchart.NodeID, backend, key, value string) error
-	SetMany(ctx context.Context, orgID string, botID orgchart.NodeID, backend string, kv map[string]string) error
-	Clear(ctx context.Context, orgID string, botID orgchart.NodeID, backend string) error
+	Get(ctx context.Context, orgID string, nodeID orgchart.NodeID, backend string) (map[string]string, error)
+	Set(ctx context.Context, orgID string, nodeID orgchart.NodeID, backend, key, value string) error
+	SetMany(ctx context.Context, orgID string, nodeID orgchart.NodeID, backend string, kv map[string]string) error
+	Clear(ctx context.Context, orgID string, nodeID orgchart.NodeID, backend string) error
 }
 
 // Topics persists named event sources. Topics are created explicitly

--- a/api/pkg/org/infrastructure/persistence/gorm/node.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/node.go
@@ -17,14 +17,14 @@ import (
 //	nodeRow has composite PK (id, org_id) so short readable handles
 //
 // (`b-root`, `b-engineer`) can repeat across helix tenants. OrgID
-// additionally carries a FK to organizations(id) ON DELETE CASCADE —
+// additionally carries a FK to organizations(id) ON DELETE CASCADE -
 // added out-of-band in OpenWithDB because GORM tag-driven FK creation
 // to a table owned by another package is fragile.
 //
-// A Bot is the merge of the former Role and Worker: it carries its own
+// A Node is the merge of the former Role and Worker: it carries its own
 // content + tool list (its capability) and is the live participant in
 // the reporting graph. Reporting lines (who reports to whom) are a
-// separate many-to-many relation — see reportingLineRow — so a Bot
+// separate many-to-many relation - see reportingLineRow - so a Node
 // carries no parent column.
 type nodeRow struct {
 	ID              string   `gorm:"primaryKey;type:text"`
@@ -49,32 +49,32 @@ func (nodeRow) TableName() string { return "org_bots" }
 
 type nodeMapper struct{}
 
-func (nodeMapper) ToRow(b orgchart.Node) (nodeRow, error) {
-	tools := make([]string, 0, len(b.Tools))
-	for _, t := range b.Tools {
+func (nodeMapper) ToRow(node orgchart.Node) (nodeRow, error) {
+	tools := make([]string, 0, len(node.Tools))
+	for _, t := range node.Tools {
 		tools = append(tools, string(t))
 	}
 	if len(tools) == 0 {
 		tools = nil
 	}
 	var agentAppID *string
-	if b.AgentAppID != "" {
-		agentAppID = &b.AgentAppID
+	if node.AgentAppID != "" {
+		agentAppID = &node.AgentAppID
 	}
 	return nodeRow{
-		ID:              string(b.ID),
-		OrgID:           b.OrganizationID,
+		ID:              string(node.ID),
+		OrgID:           node.OrganizationID,
 		AgentAppID:      agentAppID,
-		Name:            b.Name,
-		Content:         b.Content,
+		Name:            node.Name,
+		Content:         node.Content,
 		Tools:           tools,
-		ProjectIDs:      b.ProjectIDs,
-		PreserveContext: b.PreserveContext,
-		Kind:            b.Kind,
-		HelixUserID:     b.HelixUserID,
-		Identity:        b.Identity,
-		CreatedAt:       b.CreatedAt,
-		UpdatedAt:       b.UpdatedAt,
+		ProjectIDs:      node.ProjectIDs,
+		PreserveContext: node.PreserveContext,
+		Kind:            node.Kind,
+		HelixUserID:     node.HelixUserID,
+		Identity:        node.Identity,
+		CreatedAt:       node.CreatedAt,
+		UpdatedAt:       node.UpdatedAt,
 	}, nil
 }
 
@@ -114,20 +114,20 @@ type nodesRepo struct {
 
 func newNodesRepo(db *gorm.DB) *nodesRepo {
 	return &nodesRepo{
-		Repository: NewRepository[orgchart.Node, nodeRow](db, nodeMapper{}, "bot"),
+		Repository: NewRepository[orgchart.Node, nodeRow](db, nodeMapper{}, "node"),
 		db:         db,
 	}
 }
 
-func (r *nodesRepo) Create(ctx context.Context, b orgchart.Node) error {
-	if b.IsHuman() {
-		if b.AgentAppID != "" {
-			return errors.New("create bot: human node cannot reference an agent app")
+func (r *nodesRepo) Create(ctx context.Context, node orgchart.Node) error {
+	if node.IsHuman() {
+		if node.AgentAppID != "" {
+			return errors.New("create node: human node cannot reference an agent app")
 		}
-	} else if b.AgentAppID == "" {
-		return errors.New("create bot: agent app id is required")
+	} else if node.AgentAppID == "" {
+		return errors.New("create node: agent app id is required")
 	}
-	return r.Repository.Create(ctx, b)
+	return r.Repository.Create(ctx, node)
 }
 
 func (r *nodesRepo) Get(ctx context.Context, orgID string, id orgchart.NodeID) (orgchart.Node, error) {
@@ -138,10 +138,10 @@ func (r *nodesRepo) List(ctx context.Context, orgID string) ([]orgchart.Node, er
 	return r.Find(ctx, store.WithOrg(orgID), store.WithOrderAsc("id"))
 }
 
-func (r *nodesRepo) Update(ctx context.Context, b orgchart.Node) error {
-	row, err := nodeMapper{}.ToRow(b)
+func (r *nodesRepo) Update(ctx context.Context, node orgchart.Node) error {
+	row, err := nodeMapper{}.ToRow(node)
 	if err != nil {
-		return fmt.Errorf("map bot: %w", err)
+		return fmt.Errorf("map node: %w", err)
 	}
 	// Pre-marshal JSON columns so the Updates() map carries typed
 	// string literals; gorm's serializer:json tag works on full-row
@@ -191,23 +191,23 @@ func (r *nodesRepo) ClaimAgentApp(ctx context.Context, orgID string, id orgchart
 	return res.RowsAffected == 1, nil
 }
 
-// Delete removes the bot row and drops its bot-anchored subscriptions
-// in the same transaction. The reporting lines that reference this bot
+// Delete removes the node row and drops its node-anchored subscriptions
+// in the same transaction. The reporting lines that reference this node
 // (as manager or report) are removed by the ON DELETE CASCADE foreign
 // keys on org_reporting_lines (installed in OpenWithDB), so no app code
-// clears them — that's the whole point of the association table.
+// clears them - that's the whole point of the association table.
 func (r *nodesRepo) Delete(ctx context.Context, orgID string, id orgchart.NodeID) error {
 	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where("org_id = ? AND bot_id = ?", orgID, string(id)).
 			Delete(&subscriptionRow{}).Error; err != nil {
-			return fmt.Errorf("delete bot: drop subscriptions: %w", err)
+			return fmt.Errorf("delete node: drop subscriptions: %w", err)
 		}
 		res := tx.Where("org_id = ? AND id = ?", orgID, string(id)).Delete(&nodeRow{})
 		if res.Error != nil {
-			return fmt.Errorf("delete bot: %w", res.Error)
+			return fmt.Errorf("delete node: %w", res.Error)
 		}
 		if res.RowsAffected == 0 {
-			return fmt.Errorf("bot: %w", store.ErrNotFound)
+			return fmt.Errorf("node: %w", store.ErrNotFound)
 		}
 		return nil
 	})

--- a/api/pkg/org/interfaces/mcptools/builtins.go
+++ b/api/pkg/org/interfaces/mcptools/builtins.go
@@ -290,13 +290,13 @@ func (c Config) lifecycleService() *lifecycle.Service {
 		return c.Lifecycle
 	}
 	svc := &lifecycle.Service{
-		Store:          c.Store,
-		Nodes:          c.botsService(),
-		Subscriber:     c.subscriptionsService(),
-		BotReconcilers: []lifecycle.BotReconciler{c.Reconciler},
-		HireHook:       c.HireHook,
-		Now:            c.Now,
-		NewID:          c.NewID,
+		Store:           c.Store,
+		Nodes:           c.botsService(),
+		Subscriber:      c.subscriptionsService(),
+		NodeReconcilers: []lifecycle.NodeReconciler{c.Reconciler},
+		HireHook:        c.HireHook,
+		Now:             c.Now,
+		NewID:           c.NewID,
 	}
 	// c.Dispatcher (EventDispatcher) satisfies lifecycle.CreateDispatcher
 	// (DispatchHire); guard the typed-nil-in-interface case.

--- a/api/pkg/org/interfaces/mcptools/create_bot.go
+++ b/api/pkg/org/interfaces/mcptools/create_bot.go
@@ -111,7 +111,7 @@ func (t *CreateBot) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMe
 	if err != nil {
 		return nil, err
 	}
-	resp := map[string]string{"id": string(res.Bot.ID)}
+	resp := map[string]string{"id": string(res.Node.ID)}
 	if res.ActivationID != "" {
 		resp["activation_id"] = string(res.ActivationID)
 	}

--- a/api/pkg/org/interfaces/mcptools/create_bot_slackrouting_test.go
+++ b/api/pkg/org/interfaces/mcptools/create_bot_slackrouting_test.go
@@ -61,12 +61,12 @@ func TestCreateBotRunsInjectedOrgReconcilers(t *testing.T) {
 	})
 	spy := &spyOrgReconciler{}
 	deps.Lifecycle = &lifecycle.Service{
-		Store:          st,
-		Nodes:          botSvc,
-		BotReconcilers: []lifecycle.BotReconciler{rec},
-		OrgReconcilers: []lifecycle.OrgReconciler{spy},
-		Now:            deps.Now,
-		NewID:          deps.NewID,
+		Store:           st,
+		Nodes:           botSvc,
+		NodeReconcilers: []lifecycle.NodeReconciler{rec},
+		OrgReconcilers:  []lifecycle.OrgReconciler{spy},
+		Now:             deps.Now,
+		NewID:           deps.NewID,
 	}
 
 	tl := &CreateBot{deps: deps.Build()}

--- a/api/pkg/org/interfaces/server/api/api_test.go
+++ b/api/pkg/org/interfaces/server/api/api_test.go
@@ -75,11 +75,11 @@ func newDepsClock(t *testing.T, clock func() time.Time, newID func() string) (or
 		Messages: messages.New(messages.Deps{Topics: st.Topics, Events: st.Events, Notifier: hub}),
 		Nodes:    botsSvc,
 		// Create + Delete live on the lifecycle service. Nodes is required
-		// for Create (row creation + base-tool union). BotReconcilers wires
+		// for Create (row creation + base-tool union). NodeReconcilers wires
 		// the topology reconcile. Helix/Mirror stay nil — the REST tests
 		// don't exercise the Helix-side teardown.
 		Lifecycle: &lifecycle.Service{
-			Store: st, Nodes: botsSvc, BotReconcilers: []lifecycle.BotReconciler{topo},
+			Store: st, Nodes: botsSvc, NodeReconcilers: []lifecycle.NodeReconciler{topo},
 			Now: clock, NewID: newID,
 		},
 		Subscriptions: subscriptions.New(subscriptions.Deps{Subscriptions: st.Subscriptions, Topics: st.Topics, Nodes: st.Nodes, Now: clock}),

--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -140,7 +140,7 @@ func (a *apiHandler) createBot(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
-	writeJSON(w, http.StatusCreated, CreateBotResponse{ID: string(res.Bot.ID), ActivationID: string(res.ActivationID)})
+	writeJSON(w, http.StatusCreated, CreateBotResponse{ID: string(res.Node.ID), ActivationID: string(res.ActivationID)})
 }
 
 // getBot returns one Bot + the surrounding runtime context.

--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -30,7 +30,6 @@ import (
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/robfig/cron/v3"
 	"github.com/rs/zerolog/log"
-	"gorm.io/gorm"
 )
 
 // AlternativeModelOption represents a provider/model combination for fallback substitution
@@ -339,12 +338,6 @@ func (s *HelixAPIServer) listOrganizationApps(ctx context.Context, user *types.U
 		return nil, system.NewHTTPError403(err.Error())
 	}
 
-	if s.helixOrg != nil && s.helixOrg.lifecycle != nil {
-		if err := s.helixOrg.lifecycle.ReconcileAgentLinks(ctx, orgID); err != nil {
-			return nil, system.NewHTTPError500(fmt.Sprintf("failed to reconcile organization agents: %s", err))
-		}
-	}
-
 	apps, err := s.Store.ListApps(ctx, &store.ListAppsQuery{
 		OrganizationID: orgID,
 	})
@@ -384,30 +377,20 @@ func (s *HelixAPIServer) markHelixOrgAgents(ctx context.Context, orgID string, a
 		return nil
 	}
 
-	// helix-org shares helix's Postgres connection; reach the *gorm.DB via the
-	// same anonymous-interface accessor used by openOrgStore (helix_org.go).
-	accessor, ok := s.Store.(interface{ GormDB() *gorm.DB })
-	if !ok {
-		// A non-Postgres store means helix-org cannot be running either.
+	if s.helixOrg == nil || s.helixOrg.store == nil || s.helixOrg.store.Nodes == nil {
 		return nil
 	}
 
-	var agentAppIDs []string
-	if err := accessor.GormDB().WithContext(ctx).
-		Table("org_bots").
-		Where("org_id = ? AND agent_app_id IS NOT NULL", orgID).
-		Distinct("agent_app_id").
-		Pluck("agent_app_id", &agentAppIDs).Error; err != nil {
+	nodes, err := s.helixOrg.store.Nodes.List(ctx, orgID)
+	if err != nil {
 		return system.NewHTTPError500(fmt.Sprintf("failed to list helix-org agent apps: %s", err))
 	}
 
-	if len(agentAppIDs) == 0 {
-		return nil
-	}
-
-	orgAgents := make(map[string]struct{}, len(agentAppIDs))
-	for _, id := range agentAppIDs {
-		orgAgents[id] = struct{}{}
+	orgAgents := make(map[string]struct{}, len(nodes))
+	for _, node := range nodes {
+		if node.AgentAppID != "" {
+			orgAgents[node.AgentAppID] = struct{}{}
+		}
 	}
 	for _, app := range apps {
 		if _, ok := orgAgents[app.ID]; ok {
@@ -1090,8 +1073,14 @@ func (s *HelixAPIServer) updateApp(_ http.ResponseWriter, r *http.Request) (*typ
 		return nil, system.NewHTTPError400(fmt.Sprintf("failed to decode request body 2, error: %s", err))
 	}
 
+	id := getID(r)
+	if update.ID != "" && update.ID != id {
+		return nil, system.NewHTTPError400("app ID in request body does not match URL")
+	}
+	update.ID = id
+
 	// Getting existing app
-	existing, err := s.Store.GetApp(r.Context(), update.ID)
+	existing, err := s.Store.GetApp(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return nil, system.NewHTTPError404(store.ErrNotFound.Error())

--- a/api/pkg/server/app_handlers_test.go
+++ b/api/pkg/server/app_handlers_test.go
@@ -9,11 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/helixml/helix/api/pkg/config"
 	"github.com/helixml/helix/api/pkg/openai/manager"
 	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
 	orgbots "github.com/helixml/helix/api/pkg/org/application/nodes"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	orgstore "github.com/helixml/helix/api/pkg/org/domain/store"
 	orgmemory "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
@@ -23,12 +25,18 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-type listingAgentCreator struct {
-	appID string
+type failingAgentCreator struct{}
+
+func (failingAgentCreator) CreateAgent(context.Context, string, string, string) (string, error) {
+	return "", fmt.Errorf("reconcile failed")
 }
 
-func (c listingAgentCreator) CreateAgent(context.Context, string, string, string) (string, error) {
-	return c.appID, nil
+type failingNodes struct {
+	orgstore.Nodes
+}
+
+func (failingNodes) List(context.Context, string) ([]orgchart.Node, error) {
+	return nil, fmt.Errorf("list failed")
 }
 
 func TestUpdateAppRejectsInvalidLinkedOrgAgentShape(t *testing.T) {
@@ -62,7 +70,6 @@ func TestUpdateAppRejectsInvalidLinkedOrgAgentShape(t *testing.T) {
 		},
 	}
 	body, err := json.Marshal(types.App{
-		ID: existing.ID,
 		Config: types.AppConfig{Helix: types.AppHelixConfig{
 			Assistants: nil,
 		}},
@@ -70,6 +77,7 @@ func TestUpdateAppRejectsInvalidLinkedOrgAgentShape(t *testing.T) {
 	require.NoError(t, err)
 	req, err := http.NewRequest(http.MethodPut, "/api/v1/apps/"+existing.ID, bytes.NewReader(body))
 	require.NoError(t, err)
+	req = mux.SetURLVars(req, map[string]string{"id": existing.ID})
 	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: existing.Owner}))
 
 	updated, httpErr := server.updateApp(nil, req)
@@ -80,51 +88,60 @@ func TestUpdateAppRejectsInvalidLinkedOrgAgentShape(t *testing.T) {
 	require.Contains(t, httpErr.Message, "exactly one assistant")
 }
 
-// markHelixOrgAgents must be a no-op on a non-Postgres store: no app is
-// flagged and the database is never touched (the mock store does not
-// implement GormDB, so it can't be an org-chart backend). The positive path
-// (flagging an app that backs an org-chart Bot) requires a live Postgres
-// org_bot_runtime_state table and is verified end-to-end, not here.
-func Test_markHelixOrgAgents_NoGormStore_NoOp(t *testing.T) {
+func TestUpdateAppRejectsMismatchedBodyID(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	server := &HelixAPIServer{Store: store.NewMockStore(ctrl)}
+	body, err := json.Marshal(types.App{ID: "app-body"})
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPut, "/api/v1/apps/app-path", bytes.NewReader(body))
+	require.NoError(t, err)
+	req = mux.SetURLVars(req, map[string]string{"id": "app-path"})
+
+	updated, httpErr := server.updateApp(nil, req)
+
+	require.Nil(t, updated)
+	require.NotNil(t, httpErr)
+	require.Equal(t, http.StatusBadRequest, httpErr.StatusCode)
+	require.Contains(t, httpErr.Message, "does not match URL")
+}
+
+func Test_markHelixOrgAgents_UsesNodesRepository(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	orgStore := orgmemory.New()
+	node, err := orgchart.NewNode("b-linked", "# Linked", nil, time.Now().UTC(), "org_1")
+	require.NoError(t, err)
+	require.NoError(t, orgStore.Nodes.Create(context.Background(), node.WithAgentAppID("app_1")))
 
 	server := &HelixAPIServer{
 		Store: store.NewMockStore(ctrl),
 		Cfg:   &config.ServerConfig{},
+		helixOrg: &helixOrgHandlers{
+			store: orgStore,
+		},
 	}
 
-	apps := []*types.App{
-		{ID: "app_1"},
-		{ID: "app_2"},
-	}
+	apps := []*types.App{{ID: "app_1"}, {ID: "app_2"}}
 
 	httpErr := server.markHelixOrgAgents(context.Background(), "org_1", apps)
 	require.Nil(t, httpErr)
-	for _, app := range apps {
-		assert.False(t, app.IsHelixOrgAgent, "app %s should not be flagged when feature is off", app.ID)
-	}
+	assert.True(t, apps[0].IsHelixOrgAgent)
+	assert.False(t, apps[1].IsHelixOrgAgent)
 }
 
-// With an empty org id there are no org-chart Workers to consider, so it
-// stays a no-op and never queries the database.
-func Test_markHelixOrgAgents_NoOrg_NoOp(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
+func Test_markHelixOrgAgents_ReportsRepositoryFailure(t *testing.T) {
 	server := &HelixAPIServer{
-		Store: store.NewMockStore(ctrl),
-		Cfg:   &config.ServerConfig{},
+		helixOrg: &helixOrgHandlers{
+			store: &orgstore.Store{Nodes: failingNodes{}},
+		},
 	}
 
-	apps := []*types.App{{ID: "app_1"}}
-
-	httpErr := server.markHelixOrgAgents(context.Background(), "", apps)
-	require.Nil(t, httpErr)
-	assert.False(t, apps[0].IsHelixOrgAgent)
+	httpErr := server.markHelixOrgAgents(context.Background(), "org_1", []*types.App{{ID: "app_1"}})
+	require.NotNil(t, httpErr)
+	require.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+	require.Contains(t, httpErr.Message, "list failed")
 }
 
-func TestListOrganizationAppsReconcilesUnlinkedAgentsBeforeQuery(t *testing.T) {
+func TestListOrganizationAppsDoesNotReconcileAgentLinks(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	helixStore := store.NewMockStore(ctrl)
 	orgStore := orgmemory.New()
@@ -142,8 +159,8 @@ func TestListOrganizationAppsReconcilesUnlinkedAgentsBeforeQuery(t *testing.T) {
 		func(context.Context, *store.ListAppsQuery) ([]*types.App, error) {
 			linked, err := orgStore.Nodes.Get(ctx, "org-test", bot.ID)
 			require.NoError(t, err)
-			require.Equal(t, "app-reconciled", linked.AgentAppID)
-			return []*types.App{{ID: linked.AgentAppID, OrganizationID: "org-test"}}, nil
+			require.Empty(t, linked.AgentAppID)
+			return []*types.App{{ID: "app-existing", OrganizationID: "org-test"}}, nil
 		},
 	)
 
@@ -153,7 +170,7 @@ func TestListOrganizationAppsReconcilesUnlinkedAgentsBeforeQuery(t *testing.T) {
 		helixOrg: &helixOrgHandlers{
 			store: orgStore,
 			lifecycle: &lifecycle.Service{
-				Store: orgStore, Nodes: botService, Agents: listingAgentCreator{appID: "app-reconciled"},
+				Store: orgStore, Nodes: botService, Agents: failingAgentCreator{},
 			},
 		},
 	}
@@ -161,7 +178,7 @@ func TestListOrganizationAppsReconcilesUnlinkedAgentsBeforeQuery(t *testing.T) {
 	apps, httpErr := server.listOrganizationApps(ctx, user, "org-test")
 	require.Nil(t, httpErr)
 	require.Len(t, apps, 1)
-	require.Equal(t, "app-reconciled", apps[0].ID)
+	require.Equal(t, "app-existing", apps[0].ID)
 }
 
 func Test_populateAppOwner_PopulateUser(t *testing.T) {

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -744,10 +744,10 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 		Helix:  inProcClient,
 		Agents: inProcClient,
 		Logger: logger,
-		// Bot-scoped reconcilers: the single topology reconciler (one owner
+		// Node-scoped reconcilers: the single topology reconciler (one owner
 		// of activation/team Topic lifecycle across create, reparent, and delete).
-		BotReconcilers: []lifecycle.BotReconciler{deps.Reconciler},
-		Mirror:         mirror, // Delete stops the deleted bot's subscription
+		NodeReconcilers: []lifecycle.NodeReconciler{deps.Reconciler},
+		Mirror:          mirror, // Delete stops the deleted bot's subscription
 		// Hire collaborators (the create half of the lifecycle). REST POST
 		// /workers and the MCP hire_worker tool both drive Hire through
 		// this service, so the hire semantics live in one place.


### PR DESCRIPTION
## Summary

- remove `ReconcileAgentLinks` from organization App listing so one broken org Agent cannot make `GET /api/v1/apps` fail
- mark org-linked Apps through the existing Nodes repository instead of querying `org_bots` directly
- make `PUT /api/v1/apps/{id}` use the URL ID and reject mismatched body IDs
- finish the internal Bot-to-Node rename while retaining compatibility routes, MCP tool names, `b-*` IDs, DTOs, and the `org_bots` table

This addresses the Helix-side failure mode found while reviewing https://github.com/helixml/helixos/pull/86.

## Verification

- `go test ./pkg/server -run 'Test(UpdateAppRejectsInvalidLinkedOrgAgentShape|UpdateAppRejectsMismatchedBodyID|ListOrganizationAppsDoesNotReconcileAgentLinks)$|Test_markHelixOrgAgents_' -count=1 -v`
- `go test ./pkg/org/application/lifecycle ./pkg/org/application/nodes ./pkg/org/domain/orgchart ./pkg/org/infrastructure/persistence/gorm ./pkg/org/interfaces/server/api ./pkg/org/interfaces/mcptools -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- `git diff --check`
