### PR TITLE
refactor(api): make agents canonical

### DIFF
--- a/api/pkg/cli/spectask/spectask.go
+++ b/api/pkg/cli/spectask/spectask.go
@@ -216,7 +216,7 @@ Example workflow:
 
 	cmd.Flags().StringVarP(&taskName, "name", "n", "CLI Test Task", "Task name")
 	cmd.Flags().StringVarP(&projectID, "project", "p", "", "Project ID (required when creating new task)")
-	cmd.Flags().StringVarP(&agentID, "agent", "a", "", "Agent/App ID to use (e.g., app_01xxx)")
+	cmd.Flags().StringVarP(&agentID, "agent", "a", "", "Agent ID to use (e.g., app_01xxx)")
 	cmd.Flags().StringVar(&prompt, "prompt", "", "Task prompt/description")
 	cmd.Flags().StringVar(&promptFile, "prompt-file", "", "Read the task prompt from a file (e.g. a design doc) — dispatch a full brief without committing it to the repo. Appended after --prompt if both are set.")
 	cmd.Flags().StringArrayVar(&attachFiles, "attach", nil, "Attach file(s) to the task (repeatable). Uploaded as spec-task attachments the agent reads at design/tasks/<task>/attachments/<name> — good for logs/large context without bloating the prompt.")
@@ -710,13 +710,13 @@ func newResumeCommand() *cobra.Command {
 	}
 }
 
-type App struct {
-	ID     string    `json:"id"`
-	Name   string    `json:"name"`
-	Config AppConfig `json:"config"`
+type Agent struct {
+	ID     string      `json:"id"`
+	Name   string      `json:"name"`
+	Config AgentConfig `json:"config"`
 }
 
-type AppConfig struct {
+type AgentConfig struct {
 	Helix HelixConfig `json:"helix"`
 }
 
@@ -731,13 +731,13 @@ type Assistant struct {
 	Model            string `json:"model"`
 }
 
-type AppsResponse struct {
-	Apps []App `json:"apps"`
+type AgentsResponse struct {
+	Agents []Agent `json:"apps"`
 }
 
 func newListAgentsCommand() *cobra.Command {
 	var (
-		orgFlag        string
+		orgFlag         string
 		zedExternalOnly bool
 	)
 	cmd := &cobra.Command{
@@ -773,7 +773,7 @@ agents.`,
 
 			q := url.Values{}
 			q.Set("organization_id", orgID)
-			endpoint := apiURL + "/api/v1/apps?" + q.Encode()
+			endpoint := apiURL + "/api/v1/agents?" + q.Encode()
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 			if err != nil {
@@ -788,35 +788,35 @@ agents.`,
 			}
 			defer resp.Body.Close()
 
-			var apps []App
-			if err := json.NewDecoder(resp.Body).Decode(&apps); err != nil {
-				return fmt.Errorf("failed to parse apps: %w", err)
+			var agents []Agent
+			if err := json.NewDecoder(resp.Body).Decode(&agents); err != nil {
+				return fmt.Errorf("failed to parse agents: %w", err)
 			}
 
 			fmt.Println("Available Agents:")
 			fmt.Println()
 
 			shown := 0
-			for _, app := range apps {
-				// Surface the most relevant assistant per app: prefer zed_external
+			for _, agent := range agents {
+				// Surface the most relevant assistant per agent: prefer zed_external
 				// (the only kind launchable via `spectask start` today), fall back
 				// to the first assistant otherwise so non-spec-task agents are
 				// still visible to the user.
 				var primary *Assistant
-				for i, assistant := range app.Config.Helix.Assistants {
+				for i, assistant := range agent.Config.Helix.Assistants {
 					if assistant.AgentType == "zed_external" {
-						primary = &app.Config.Helix.Assistants[i]
+						primary = &agent.Config.Helix.Assistants[i]
 						break
 					}
 				}
-				if primary == nil && len(app.Config.Helix.Assistants) > 0 {
+				if primary == nil && len(agent.Config.Helix.Assistants) > 0 {
 					if zedExternalOnly {
 						continue
 					}
-					primary = &app.Config.Helix.Assistants[0]
+					primary = &agent.Config.Helix.Assistants[0]
 				}
 				if primary == nil {
-					// App with no assistants at all - skip.
+					// Agent with no assistants at all - skip.
 					continue
 				}
 
@@ -827,8 +827,8 @@ agents.`,
 					marker = ""
 				}
 
-				fmt.Printf("App: %s%s\n", app.Name, marker)
-				fmt.Printf("  ID: %s\n", app.ID)
+				fmt.Printf("Agent: %s%s\n", agent.Name, marker)
+				fmt.Printf("  ID: %s\n", agent.ID)
 				fmt.Printf("  Assistant: %s\n", primary.Name)
 				if primary.AgentType != "" {
 					fmt.Printf("  Agent type: %s\n", primary.AgentType)
@@ -840,7 +840,7 @@ agents.`,
 					fmt.Printf("  Model: %s\n", primary.Model)
 				}
 				if usable {
-					fmt.Printf("  Usage: helix spectask start --project <prj_id> --agent %s -n \"Task name\"\n", app.ID)
+					fmt.Printf("  Usage: helix spectask start --project <prj_id> --agent %s -n \"Task name\"\n", agent.ID)
 				}
 				fmt.Println()
 			}
@@ -1691,7 +1691,6 @@ type videoStreamStats struct {
 	lastCursorHotspotX int // Last cursor hotspot X
 	lastCursorHotspotY int // Last cursor hotspot Y
 }
-
 
 // getContainerAppID fetches the placeholder app ID for a session
 // This is required for the AuthenticateAndInit message

--- a/api/pkg/client/app.go
+++ b/api/pkg/client/app.go
@@ -20,7 +20,7 @@ type AppFilter struct {
 func (c *HelixClient) ListApps(ctx context.Context, f *AppFilter) ([]*types.App, error) {
 	var apps []*types.App
 
-	path := "/apps"
+	path := "/agents"
 	if f.OrganizationID != "" {
 		path += "?organization_id=" + f.OrganizationID
 	}
@@ -34,7 +34,7 @@ func (c *HelixClient) ListApps(ctx context.Context, f *AppFilter) ([]*types.App,
 
 func (c *HelixClient) GetApp(ctx context.Context, appID string) (*types.App, error) {
 	var app types.App
-	err := c.makeRequest(ctx, http.MethodGet, "/apps/"+appID, nil, &app)
+	err := c.makeRequest(ctx, http.MethodGet, "/agents/"+appID, nil, &app)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (c *HelixClient) CreateApp(ctx context.Context, app *types.App) (*types.App
 	}
 
 	var createdApp types.App
-	err = c.makeRequest(ctx, http.MethodPost, "/apps", bytes.NewBuffer(bts), &createdApp)
+	err = c.makeRequest(ctx, http.MethodPost, "/agents", bytes.NewBuffer(bts), &createdApp)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (c *HelixClient) UpdateApp(ctx context.Context, app *types.App) (*types.App
 	}
 
 	var updatedApp types.App
-	err = c.makeRequest(ctx, http.MethodPut, "/apps/"+app.ID, bytes.NewBuffer(bts), &updatedApp)
+	err = c.makeRequest(ctx, http.MethodPut, "/agents/"+app.ID, bytes.NewBuffer(bts), &updatedApp)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (c *HelixClient) DeleteApp(ctx context.Context, appID string, deleteKnowled
 	query := url.Values{}
 	query.Add("knowledge", strconv.FormatBool(deleteKnowledge))
 
-	url := "/apps/" + appID + "?" + query.Encode()
+	url := "/agents/" + appID + "?" + query.Encode()
 
 	err := c.makeRequest(ctx, http.MethodDelete, url, nil, nil)
 	if err != nil {
@@ -127,7 +127,7 @@ func (c *HelixClient) RunAPIAction(ctx context.Context, appID string, action str
 	}
 
 	var resp types.RunAPIActionResponse
-	err = c.makeRequest(ctx, http.MethodPost, fmt.Sprintf("/apps/%s/api-actions", appID), bytes.NewBuffer(bts), &resp)
+	err = c.makeRequest(ctx, http.MethodPost, fmt.Sprintf("/agents/%s/api-actions", appID), bytes.NewBuffer(bts), &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/client/app_access_grants.go
+++ b/api/pkg/client/app_access_grants.go
@@ -17,7 +17,7 @@ type AppAccessGrantsFilter struct {
 func (c *HelixClient) ListAppAccessGrants(ctx context.Context, f *AppAccessGrantsFilter) ([]*types.AccessGrant, error) {
 	var apps []*types.AccessGrant
 
-	err := c.makeRequest(ctx, http.MethodGet, fmt.Sprintf("/apps/%s/access-grants", f.AppID), nil, &apps)
+	err := c.makeRequest(ctx, http.MethodGet, fmt.Sprintf("/agents/%s/access-grants", f.AppID), nil, &apps)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +31,7 @@ func (c *HelixClient) CreateAppAccessGrant(ctx context.Context, appID string, gr
 	}
 
 	var createdGrant types.AccessGrant
-	err = c.makeRequest(ctx, http.MethodPost, fmt.Sprintf("/apps/%s/access-grants", appID), bytes.NewBuffer(bts), &createdGrant)
+	err = c.makeRequest(ctx, http.MethodPost, fmt.Sprintf("/agents/%s/access-grants", appID), bytes.NewBuffer(bts), &createdGrant)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (c *HelixClient) CreateAppAccessGrant(ctx context.Context, appID string, gr
 }
 
 func (c *HelixClient) DeleteAppAccessGrant(ctx context.Context, appID string, grantID string) error {
-	err := c.makeRequest(ctx, http.MethodDelete, fmt.Sprintf("/apps/%s/access-grants/%s", appID, grantID), nil, nil)
+	err := c.makeRequest(ctx, http.MethodDelete, fmt.Sprintf("/agents/%s/access-grants/%s", appID, grantID), nil, nil)
 	if err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func (c *HelixClient) DeleteAppAccessGrant(ctx context.Context, appID string, gr
 
 func (c *HelixClient) GetAppUserAccess(ctx context.Context, appID string) (*types.UserAppAccessResponse, error) {
 	var response types.UserAppAccessResponse
-	err := c.makeRequest(ctx, http.MethodGet, fmt.Sprintf("/apps/%s/user-access", appID), nil, &response)
+	err := c.makeRequest(ctx, http.MethodGet, fmt.Sprintf("/agents/%s/user-access", appID), nil, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/org/application/activations/activations.go
+++ b/api/pkg/org/application/activations/activations.go
@@ -114,7 +114,7 @@ func New(deps Deps) *Activations {
 type ActivateResult struct {
 	ActivationID activation.ID
 	ProjectID    string
-	AgentAppID   string
+	AgentID      string
 	SessionID    string
 }
 
@@ -156,7 +156,7 @@ func (a *Activations) Activate(ctx context.Context, orgID string, workerID orgch
 	return ActivateResult{
 		ActivationID: activationID,
 		ProjectID:    projectID,
-		AgentAppID:   agentAppID,
+		AgentID:      agentAppID,
 		SessionID:    sessionID,
 	}, nil
 }

--- a/api/pkg/org/application/activations/activations_test.go
+++ b/api/pkg/org/application/activations/activations_test.go
@@ -47,8 +47,8 @@ func TestActivate_PreAllocatesAuditRow(t *testing.T) {
 	if res.ActivationID != "a-fixed" {
 		t.Fatalf("activation id = %q, want a-fixed", res.ActivationID)
 	}
-	if res.ProjectID != "prj-1" || res.AgentAppID != "app-1" {
-		t.Fatalf("project/agent ids = %q/%q, want prj-1/app-1", res.ProjectID, res.AgentAppID)
+	if res.ProjectID != "prj-1" || res.AgentID != "app-1" {
+		t.Fatalf("project/agent ids = %q/%q, want prj-1/app-1", res.ProjectID, res.AgentID)
 	}
 	if disp.gotID != "a-fixed" {
 		t.Fatalf("dispatcher got id %q, want a-fixed", disp.gotID)

--- a/api/pkg/org/application/lifecycle/agent_links_test.go
+++ b/api/pkg/org/application/lifecycle/agent_links_test.go
@@ -94,7 +94,7 @@ func (b losingClaimBots) ClaimAgentApp(ctx context.Context, orgID string, id org
 	if err != nil {
 		return false, err
 	}
-	if err := b.Nodes.Update(ctx, current.WithAgentAppID(b.winner)); err != nil {
+	if err := b.Nodes.Update(ctx, current.WithAgentID(b.winner)); err != nil {
 		return false, err
 	}
 	return false, nil
@@ -131,8 +131,8 @@ func TestReconcileAgentLinksPreservesReplicaWinner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.AgentAppID != "app-winner" {
-		t.Fatalf("winner = %q", got.AgentAppID)
+	if got.AgentID != "app-winner" {
+		t.Fatalf("winner = %q", got.AgentID)
 	}
 	if len(runtime.deletedApps) != 1 || runtime.deletedApps[0] != "app-loser" {
 		t.Fatalf("discarded apps = %v", runtime.deletedApps)
@@ -185,7 +185,7 @@ func TestDeleteFailuresPreserveGraphAnchorAndRetry(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			bot = bot.WithAgentAppID("app-agent")
+			bot = bot.WithAgentID("app-agent")
 			if err := st.Nodes.Create(ctx, bot); err != nil {
 				t.Fatal(err)
 			}
@@ -202,14 +202,14 @@ func TestDeleteFailuresPreserveGraphAnchorAndRetry(t *testing.T) {
 			if err != nil {
 				t.Fatalf("graph anchor removed: %v", err)
 			}
-			if got.AgentAppID != "app-agent" {
-				t.Fatalf("graph link = %q", got.AgentAppID)
+			if got.AgentID != "app-agent" {
+				t.Fatalf("graph link = %q", got.AgentID)
 			}
 			state, err := runtimehelix.LoadState(ctx, st, "org-test", bot.ID)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if state.ProjectID != "project-agent" || state.AgentAppID != "app-agent" {
+			if state.ProjectID != "project-agent" || state.AgentID != "app-agent" {
 				t.Fatalf("runtime state changed: %+v", state)
 			}
 
@@ -218,7 +218,7 @@ func TestDeleteFailuresPreserveGraphAnchorAndRetry(t *testing.T) {
 			if err := svc.Delete(ctx, "org-test", bot.ID); err != nil {
 				t.Fatalf("retry delete: %v", err)
 			}
-			recreated := bot.WithAgentAppID("app-recreated")
+			recreated := bot.WithAgentID("app-recreated")
 			if err := st.Nodes.Create(ctx, recreated); err != nil {
 				t.Fatalf("recreate after delete: %v", err)
 			}

--- a/api/pkg/org/application/lifecycle/hire_test.go
+++ b/api/pkg/org/application/lifecycle/hire_test.go
@@ -76,8 +76,8 @@ func TestCreate_CreatesBotAndReconciles(t *testing.T) {
 	if res.Node.ID != "w-new" {
 		t.Fatalf("node id = %q", res.Node.ID)
 	}
-	if res.Node.AgentAppID != "app-agent" {
-		t.Fatalf("agent app id = %q, want app-agent", res.Node.AgentAppID)
+	if res.Node.AgentID != "app-agent" {
+		t.Fatalf("agent app id = %q, want app-agent", res.Node.AgentID)
 	}
 	if _, err := st.Nodes.Get(ctx, "org-test", "w-new"); err != nil {
 		t.Fatalf("bot not persisted: %v", err)

--- a/api/pkg/org/application/lifecycle/lifecycle.go
+++ b/api/pkg/org/application/lifecycle/lifecycle.go
@@ -225,7 +225,7 @@ func (s *Service) Create(ctx context.Context, orgID string, p CreateParams) (Cre
 		ID:              p.ID,
 		Name:            p.Name,
 		Content:         p.Content,
-		AgentAppID:      agentAppID,
+		AgentID:         agentAppID,
 		Tools:           p.Tools,
 		PreserveContext: p.PreserveContext,
 	})
@@ -332,7 +332,7 @@ func (s *Service) ReconcileAgentLinks(ctx context.Context, orgID string) error {
 		return err
 	}
 	for _, node := range all {
-		if node.IsHuman() || node.AgentAppID != "" {
+		if node.IsHuman() || node.AgentID != "" {
 			continue
 		}
 		name := node.Name
@@ -417,9 +417,9 @@ func (s *Service) Delete(ctx context.Context, orgID string, id orgchart.NodeID) 
 		}
 	}
 
-	agentAppID := node.AgentAppID
+	agentAppID := node.AgentID
 	if agentAppID == "" {
-		agentAppID = state.AgentAppID
+		agentAppID = state.AgentID
 	}
 	if s.Helix != nil && agentAppID != "" {
 		if err := s.Helix.DeleteLinkedAgent(ctx, orgID, id, agentAppID); err != nil {

--- a/api/pkg/org/application/nodes/nodes.go
+++ b/api/pkg/org/application/nodes/nodes.go
@@ -91,7 +91,7 @@ type CreateParams struct {
 	ID              string
 	Name            string
 	Content         string
-	AgentAppID      string
+	AgentID         string
 	Tools           []tool.Name
 	PreserveContext bool
 	// Kind, HelixUserID, Identity create a human placeholder when Kind ==
@@ -132,8 +132,8 @@ func (s *Nodes) Create(ctx context.Context, orgID string, p CreateParams) (orgch
 	if p.Name != "" {
 		node = node.WithName(p.Name)
 	}
-	if p.AgentAppID != "" {
-		node = node.WithAgentAppID(p.AgentAppID)
+	if p.AgentID != "" {
+		node = node.WithAgentID(p.AgentID)
 	}
 	if p.PreserveContext {
 		node = node.WithPreserveContext(true)
@@ -157,7 +157,7 @@ func (s *Nodes) Create(ctx context.Context, orgID string, p CreateParams) (orgch
 // leaves the corresponding field unchanged — this is what preserves
 // Tools on a content-only update.
 type UpdateParams struct {
-	AgentAppID      *string
+	AgentID         *string
 	Name            *string
 	Content         *string
 	Tools           *[]tool.Name
@@ -177,8 +177,8 @@ func (s *Nodes) Update(ctx context.Context, orgID string, id orgchart.NodeID, p 
 		return orgchart.Node{}, err
 	}
 	updated := existing
-	if p.AgentAppID != nil {
-		updated = updated.WithAgentAppID(*p.AgentAppID)
+	if p.AgentID != nil {
+		updated = updated.WithAgentID(*p.AgentID)
 	}
 	if p.Name != nil {
 		updated = updated.WithName(*p.Name)

--- a/api/pkg/org/domain/orgchart/node.go
+++ b/api/pkg/org/domain/orgchart/node.go
@@ -56,9 +56,9 @@ const NodeKindHuman NodeKind = "human"
 type Node struct {
 	ID             NodeID
 	OrganizationID string
-	// AgentAppID is the canonical Helix Agent App backing this org node.
+	// AgentID is the canonical Helix Agent backing this org node.
 	// It is required for nodes and empty for human placeholders.
-	AgentAppID string
+	AgentID string
 	// Name is the human-readable display label (e.g. "Chief of Staff").
 	// Free text, may be empty — the UI falls back to ID. Distinct from
 	// ID, which is the immutable handle.
@@ -126,9 +126,9 @@ func (n Node) WithName(name string) Node {
 	return n
 }
 
-// WithAgentAppID returns a copy of the Node linked to the canonical Agent App.
-func (n Node) WithAgentAppID(agentAppID string) Node {
-	n.AgentAppID = agentAppID
+// WithAgentID returns a copy of the Node linked to the canonical Agent.
+func (n Node) WithAgentID(agentID string) Node {
+	n.AgentID = agentID
 	return n
 }
 

--- a/api/pkg/org/infrastructure/persistence/gorm/agent_app_migration_test.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/agent_app_migration_test.go
@@ -55,7 +55,7 @@ func TestBackfillAgentAppLinksRequiresSameOrganization(t *testing.T) {
 	}
 
 	var sameOrg, otherOrg, multiple struct {
-		AgentAppID *string
+		AgentID *string `gorm:"column:agent_app_id"`
 	}
 	if err := db.Table("org_bots").Where("id = ?", "b-same-org").First(&sameOrg).Error; err != nil {
 		t.Fatalf("read same-org bot: %v", err)
@@ -66,14 +66,14 @@ func TestBackfillAgentAppLinksRequiresSameOrganization(t *testing.T) {
 	if err := db.Table("org_bots").Where("id = ?", "b-multiple").First(&multiple).Error; err != nil {
 		t.Fatalf("read multiple-assistant bot: %v", err)
 	}
-	if sameOrg.AgentAppID == nil || *sameOrg.AgentAppID != "app-same-org" {
-		t.Fatalf("same-org link = %v", sameOrg.AgentAppID)
+	if sameOrg.AgentID == nil || *sameOrg.AgentID != "app-same-org" {
+		t.Fatalf("same-org link = %v", sameOrg.AgentID)
 	}
-	if otherOrg.AgentAppID != nil {
-		t.Fatalf("cross-org link was backfilled: %q", *otherOrg.AgentAppID)
+	if otherOrg.AgentID != nil {
+		t.Fatalf("cross-org link was backfilled: %q", *otherOrg.AgentID)
 	}
-	if multiple.AgentAppID != nil {
-		t.Fatalf("multiple-assistant app was backfilled: %q", *multiple.AgentAppID)
+	if multiple.AgentID != nil {
+		t.Fatalf("multiple-assistant app was backfilled: %q", *multiple.AgentID)
 	}
 }
 
@@ -302,12 +302,14 @@ func TestBackfillProjectAgentAppsPreservesExplicitDefaultAndConvergesLinks(t *te
 	if project.DefaultHelixAppID != "app-explicit" {
 		t.Fatalf("project default = %q, want app-explicit", project.DefaultHelixAppID)
 	}
-	var bot struct{ AgentAppID string }
+	var bot struct {
+		AgentID string `gorm:"column:agent_app_id"`
+	}
 	if err := db.Table("org_bots").Where("id = ?", "b-agent").First(&bot).Error; err != nil {
 		t.Fatal(err)
 	}
-	if bot.AgentAppID != "app-explicit" {
-		t.Fatalf("bot app = %q, want app-explicit", bot.AgentAppID)
+	if bot.AgentID != "app-explicit" {
+		t.Fatalf("bot app = %q, want app-explicit", bot.AgentID)
 	}
 	var state struct{ Value string }
 	if err := db.Table("org_bot_runtime_state").
@@ -328,8 +330,8 @@ func TestBackfillProjectAgentAppsPreservesExplicitDefaultAndConvergesLinks(t *te
 	if err := db.Table("org_bots").Where("id = ?", "b-target").First(&bot).Error; err != nil {
 		t.Fatal(err)
 	}
-	if bot.AgentAppID != "app-target" {
-		t.Fatalf("target bot app = %q, want app-target", bot.AgentAppID)
+	if bot.AgentID != "app-target" {
+		t.Fatalf("target bot app = %q, want app-target", bot.AgentID)
 	}
 
 	if err := db.Table("projects").Where("id = ?", "project-ambiguous").First(&project).Error; err != nil {

--- a/api/pkg/org/infrastructure/persistence/gorm/node.go
+++ b/api/pkg/org/infrastructure/persistence/gorm/node.go
@@ -29,7 +29,7 @@ import (
 type nodeRow struct {
 	ID              string   `gorm:"primaryKey;type:text"`
 	OrgID           string   `gorm:"primaryKey;type:text;index"`
-	AgentAppID      *string  `gorm:"type:text;index"`
+	AgentID         *string  `gorm:"column:agent_app_id;type:text;index"`
 	Name            string   `gorm:"not null;default:''"`
 	Content         string   `gorm:"not null"`
 	Tools           []string `gorm:"serializer:json"`
@@ -57,14 +57,14 @@ func (nodeMapper) ToRow(node orgchart.Node) (nodeRow, error) {
 	if len(tools) == 0 {
 		tools = nil
 	}
-	var agentAppID *string
-	if node.AgentAppID != "" {
-		agentAppID = &node.AgentAppID
+	var agentID *string
+	if node.AgentID != "" {
+		agentID = &node.AgentID
 	}
 	return nodeRow{
 		ID:              string(node.ID),
 		OrgID:           node.OrganizationID,
-		AgentAppID:      agentAppID,
+		AgentID:         agentID,
 		Name:            node.Name,
 		Content:         node.Content,
 		Tools:           tools,
@@ -86,14 +86,14 @@ func (nodeMapper) ToDomain(row nodeRow) (orgchart.Node, error) {
 			tools = append(tools, tool.Name(t))
 		}
 	}
-	var agentAppID string
-	if row.AgentAppID != nil {
-		agentAppID = *row.AgentAppID
+	var agentID string
+	if row.AgentID != nil {
+		agentID = *row.AgentID
 	}
 	return orgchart.Node{
 		ID:              orgchart.NodeID(row.ID),
 		OrganizationID:  row.OrgID,
-		AgentAppID:      agentAppID,
+		AgentID:         agentID,
 		Name:            row.Name,
 		Content:         row.Content,
 		Tools:           tools,
@@ -121,10 +121,10 @@ func newNodesRepo(db *gorm.DB) *nodesRepo {
 
 func (r *nodesRepo) Create(ctx context.Context, node orgchart.Node) error {
 	if node.IsHuman() {
-		if node.AgentAppID != "" {
+		if node.AgentID != "" {
 			return errors.New("create node: human node cannot reference an agent app")
 		}
-	} else if node.AgentAppID == "" {
+	} else if node.AgentID == "" {
 		return errors.New("create node: agent app id is required")
 	}
 	return r.Repository.Create(ctx, node)
@@ -167,7 +167,7 @@ func (r *nodesRepo) Update(ctx context.Context, node orgchart.Node) error {
 		store.WithID(row.ID),
 		store.WithUpdates(map[string]any{
 			"name":             row.Name,
-			"agent_app_id":     row.AgentAppID,
+			"agent_app_id":     row.AgentID,
 			"content":          row.Content,
 			"tools":            string(toolsJSON),
 			"project_ids":      string(projectIDsJSON),

--- a/api/pkg/org/infrastructure/persistence/memory/memorystore.go
+++ b/api/pkg/org/infrastructure/persistence/memory/memorystore.go
@@ -229,10 +229,10 @@ func (r *nodesRepo) ClaimAgentApp(_ context.Context, orgID string, id orgchart.N
 	if !ok {
 		return false, fmt.Errorf("bot %q in org %q: %w", id, orgID, store.ErrNotFound)
 	}
-	if b.AgentAppID != "" {
+	if b.AgentID != "" {
 		return false, nil
 	}
-	r.rows[k] = b.WithAgentAppID(appID)
+	r.rows[k] = b.WithAgentID(appID)
 	return true, nil
 }
 

--- a/api/pkg/org/infrastructure/runtime/helix/project.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project.go
@@ -213,7 +213,7 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 	var existingProjectErr error
 	if state.ProjectID != "" {
 		existingProject, existingProjectErr = a.Service.GetProject(ctx, state.ProjectID)
-		if existingProjectErr == nil && existingProject.DefaultHelixAppID != "" && existingProject.DefaultHelixAppID != bot.AgentAppID {
+		if existingProjectErr == nil && existingProject.DefaultHelixAppID != "" && existingProject.DefaultHelixAppID != bot.AgentID {
 			defaultApp, appErr := a.Service.GetApp(ctx, existingProject.DefaultHelixAppID)
 			if appErr != nil {
 				return "", "", "", fmt.Errorf("get project default agent app %s for %s: %w", existingProject.DefaultHelixAppID, workerID, appErr)
@@ -225,18 +225,18 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 				}
 				claimed := false
 				for _, other := range allBots {
-					if other.ID != workerID && other.AgentAppID == defaultApp.ID {
+					if other.ID != workerID && other.AgentID == defaultApp.ID {
 						claimed = true
 						break
 					}
 				}
 				if !claimed {
-					bot = bot.WithAgentAppID(defaultApp.ID)
+					bot = bot.WithAgentID(defaultApp.ID)
 					if err := a.Store.Nodes.Update(ctx, bot); err != nil {
 						return "", "", "", fmt.Errorf("link project default agent app %s to bot %s: %w", defaultApp.ID, workerID, err)
 					}
-					state.AgentAppID = defaultApp.ID
-					if err := SaveProject(ctx, a.Store, orgID, workerID, state.ProjectID, state.AgentAppID, state.RepoID); err != nil {
+					state.AgentID = defaultApp.ID
+					if err := SaveProject(ctx, a.Store, orgID, workerID, state.ProjectID, state.AgentID, state.RepoID); err != nil {
 						return "", "", "", fmt.Errorf("persist project default agent app for %s: %w", workerID, err)
 					}
 				}
@@ -246,13 +246,13 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 	roleContent := bot.Content
 	roleName := string(bot.ID)
 	botLabel := bot.Name
-	if bot.AgentAppID != "" {
-		cfg, err := a.Service.GetAppConfig(ctx, bot.AgentAppID)
+	if bot.AgentID != "" {
+		cfg, err := a.Service.GetAppConfig(ctx, bot.AgentID)
 		if err != nil {
-			return "", "", "", fmt.Errorf("get linked agent app %s: %w", bot.AgentAppID, err)
+			return "", "", "", fmt.Errorf("get linked agent %s: %w", bot.AgentID, err)
 		}
 		if len(cfg.Helix.Assistants) != 1 {
-			return "", "", "", fmt.Errorf("linked agent app %s must contain exactly one assistant", bot.AgentAppID)
+			return "", "", "", fmt.Errorf("linked agent %s must contain exactly one assistant", bot.AgentID)
 		}
 		roleName = cfg.Helix.Assistants[0].Name
 		if roleName == "" {
@@ -284,7 +284,7 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 		// into another — the org parameter is the authority here.
 		OrganizationID: orgID,
 		Name:           projectName,
-		AgentAppID:     bot.AgentAppID,
+		AgentAppID:     bot.AgentID,
 		Spec: types.ProjectSpec{
 			Description: roleContent,
 			Agent: &types.ProjectAgentSpec{
@@ -311,20 +311,20 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 				return "", "", "", fmt.Errorf("verify project %s for %s: %w", state.ProjectID, workerID, err)
 			}
 		} else {
-			if bot.AgentAppID != "" && existing.DefaultHelixAppID != bot.AgentAppID {
-				linkedAppID := bot.AgentAppID
+			if bot.AgentID != "" && existing.DefaultHelixAppID != bot.AgentID {
+				linkedAppID := bot.AgentID
 				updatedProject, err := a.Service.UpdateProject(ctx, state.ProjectID, types.ProjectUpdateRequest{DefaultHelixAppID: &linkedAppID})
 				if err != nil {
 					return "", "", "", fmt.Errorf("link canonical agent app %s to project %s: %w", linkedAppID, state.ProjectID, err)
 				}
 				existing = updatedProject
-				state.AgentAppID = linkedAppID
+				state.AgentID = linkedAppID
 				if err := SaveProject(ctx, a.Store, orgID, workerID, state.ProjectID, linkedAppID, state.RepoID); err != nil {
 					return "", "", "", fmt.Errorf("persist canonical agent app for %s: %w", workerID, err)
 				}
-			} else if bot.AgentAppID != "" && state.AgentAppID != bot.AgentAppID {
-				state.AgentAppID = bot.AgentAppID
-				if err := SaveProject(ctx, a.Store, orgID, workerID, state.ProjectID, state.AgentAppID, state.RepoID); err != nil {
+			} else if bot.AgentID != "" && state.AgentID != bot.AgentID {
+				state.AgentID = bot.AgentID
+				if err := SaveProject(ctx, a.Store, orgID, workerID, state.ProjectID, state.AgentID, state.RepoID); err != nil {
 					return "", "", "", fmt.Errorf("repair runtime agent app for %s: %w", workerID, err)
 				}
 			}
@@ -347,7 +347,7 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 						a.Logger.Warn("project applier: rename to display name failed, skipping refresh to avoid orphan", "worker", workerID, "project", state.ProjectID, "want_name", projectName, "err", err)
 					}
 					a.republishWorkerFiles(ctx, workerID, state.RepoID, roleContent)
-					return state.ProjectID, state.AgentAppID, state.RepoID, nil
+					return state.ProjectID, state.AgentID, state.RepoID, nil
 				}
 			}
 			if !existing.Metadata.OrgMembersAccess {
@@ -377,7 +377,7 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 						return "", "", "", fmt.Errorf("re-provision missing repo for %s: %w", workerID, rerr)
 					}
 					repoID = newRepoID
-					if serr := SaveProject(ctx, a.Store, orgID, workerID, state.ProjectID, state.AgentAppID, repoID); serr != nil {
+					if serr := SaveProject(ctx, a.Store, orgID, workerID, state.ProjectID, state.AgentID, repoID); serr != nil {
 						return "", "", "", fmt.Errorf("persist re-provisioned repo for %s: %w", workerID, serr)
 					}
 				} else if gerr != nil && a.Logger != nil {
@@ -388,7 +388,7 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 			// workflows that use the helix-specs branch. Activation prompts
 			// read Bot.Content directly. The writes are idempotent.
 			a.republishWorkerFiles(ctx, workerID, repoID, roleContent)
-			return state.ProjectID, state.AgentAppID, repoID, nil
+			return state.ProjectID, state.AgentID, repoID, nil
 		}
 	}
 	resp, err := a.Service.ApplyProject(ctx, applyReq)
@@ -457,7 +457,7 @@ func (a *WorkerProject) Ensure(ctx context.Context, orgID string, workerID orgch
 		a.Logger.Info("helix project applied",
 			"worker", workerID,
 			"project", resp.ProjectID,
-			"agent_app", resp.AgentAppID,
+			"agent", resp.AgentAppID,
 			"repo", repoID,
 			"created", resp.Created,
 		)

--- a/api/pkg/org/infrastructure/runtime/helix/project_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/project_test.go
@@ -352,7 +352,7 @@ func TestEnsureFreshAppliesProjectAndPushesFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadState: %v", err)
 	}
-	if state.ProjectID != "prj_test" || state.AgentAppID != "app_test" {
+	if state.ProjectID != "prj_test" || state.AgentID != "app_test" {
 		t.Errorf("state = %+v", state)
 	}
 	// RepoID is part of the contract — without it the desktop bringup
@@ -655,7 +655,7 @@ func TestEnsureFastPathPreservesValidProjectDefaultAndConvergesLinks(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := st.Nodes.Update(ctx, bot.WithAgentAppID("app-new")); err != nil {
+	if err := st.Nodes.Update(ctx, bot.WithAgentID("app-new")); err != nil {
 		t.Fatal(err)
 	}
 	if err := SaveProject(ctx, st, "org-test", wid, "prj_existing", "app-legacy", "repo_existing"); err != nil {
@@ -676,15 +676,15 @@ func TestEnsureFastPathPreservesValidProjectDefaultAndConvergesLinks(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bot.AgentAppID != "app-explicit" {
-		t.Fatalf("bot app = %q, want app-explicit", bot.AgentAppID)
+	if bot.AgentID != "app-explicit" {
+		t.Fatalf("bot app = %q, want app-explicit", bot.AgentID)
 	}
 	state, err := LoadState(ctx, st, "org-test", wid)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if state.AgentAppID != "app-explicit" {
-		t.Fatalf("runtime app = %q, want app-explicit", state.AgentAppID)
+	if state.AgentID != "app-explicit" {
+		t.Fatalf("runtime app = %q, want app-explicit", state.AgentID)
 	}
 }
 
@@ -695,14 +695,14 @@ func TestEnsureFastPathDoesNotAdoptProjectDefaultClaimedByAnotherBot(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := st.Nodes.Update(ctx, bot.WithAgentAppID("app-current")); err != nil {
+	if err := st.Nodes.Update(ctx, bot.WithAgentID("app-current")); err != nil {
 		t.Fatal(err)
 	}
 	other, err := orgchart.NewNode("w-other", "# Other", nil, time.Now().UTC(), "org-test")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := st.Nodes.Create(ctx, other.WithAgentAppID("app-claimed")); err != nil {
+	if err := st.Nodes.Create(ctx, other.WithAgentID("app-claimed")); err != nil {
 		t.Fatal(err)
 	}
 	if err := SaveProject(ctx, st, "org-test", wid, "prj_existing", "app-legacy", "repo_existing"); err != nil {
@@ -723,15 +723,15 @@ func TestEnsureFastPathDoesNotAdoptProjectDefaultClaimedByAnotherBot(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bot.AgentAppID != "app-current" {
-		t.Fatalf("bot app = %q, want app-current", bot.AgentAppID)
+	if bot.AgentID != "app-current" {
+		t.Fatalf("bot app = %q, want app-current", bot.AgentID)
 	}
 	state, err := LoadState(ctx, st, "org-test", wid)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if state.AgentAppID != "app-current" {
-		t.Fatalf("runtime app = %q, want app-current", state.AgentAppID)
+	if state.AgentID != "app-current" {
+		t.Fatalf("runtime app = %q, want app-current", state.AgentID)
 	}
 }
 
@@ -742,7 +742,7 @@ func TestEnsureFastPathPreservesLinksWhenProjectDefaultAppReadFails(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := st.Nodes.Update(ctx, bot.WithAgentAppID("app-current")); err != nil {
+	if err := st.Nodes.Update(ctx, bot.WithAgentID("app-current")); err != nil {
 		t.Fatal(err)
 	}
 	if err := SaveProject(ctx, st, "org-test", wid, "prj_existing", "app-runtime", "repo_existing"); err != nil {
@@ -763,15 +763,15 @@ func TestEnsureFastPathPreservesLinksWhenProjectDefaultAppReadFails(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bot.AgentAppID != "app-current" {
-		t.Fatalf("bot app changed to %q", bot.AgentAppID)
+	if bot.AgentID != "app-current" {
+		t.Fatalf("bot app changed to %q", bot.AgentID)
 	}
 	state, err := LoadState(ctx, st, "org-test", wid)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if state.AgentAppID != "app-runtime" {
-		t.Fatalf("runtime app changed to %q", state.AgentAppID)
+	if state.AgentID != "app-runtime" {
+		t.Fatalf("runtime app changed to %q", state.AgentID)
 	}
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
@@ -790,7 +790,7 @@ func TestEnsureFastPathRepairsStaleRuntimeAgentApp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := st.Nodes.Update(ctx, bot.WithAgentAppID("app-canonical")); err != nil {
+	if err := st.Nodes.Update(ctx, bot.WithAgentID("app-canonical")); err != nil {
 		t.Fatal(err)
 	}
 	if err := SaveProject(ctx, st, "org-test", wid, "prj_existing", "app-legacy", "repo_existing"); err != nil {
@@ -809,8 +809,8 @@ func TestEnsureFastPathRepairsStaleRuntimeAgentApp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if state.AgentAppID != "app-canonical" {
-		t.Fatalf("runtime app = %q, want app-canonical", state.AgentAppID)
+	if state.AgentID != "app-canonical" {
+		t.Fatalf("runtime app = %q, want app-canonical", state.AgentID)
 	}
 }
 

--- a/api/pkg/org/infrastructure/runtime/helix/spawner.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/helixml/helix/api/pkg/org/application/transcript"
@@ -406,8 +407,13 @@ func (c SpawnerConfig) ensureHelixOrgMCP(ctx context.Context, orgID string, work
 		return
 	}
 	if err := AttachHelixOrgMCP(ctx, c.ProjectService, state.AgentID, c.HelixOrgURL, workerID, c.MCPAuthBearer); err != nil && c.Logger != nil {
-		c.Logger.Warn("helix spawner: attach helix-org MCP", "worker", workerID, "agent", state.AgentID, "err", err)
+		c.Logger.Warn("helix spawner: attach helix-org MCP", "worker", workerID, "agent", state.AgentID, "err", sanitizeLogValue(err.Error()))
 	}
+}
+
+func sanitizeLogValue(value string) string {
+	value = strings.ReplaceAll(value, "\n", "")
+	return strings.ReplaceAll(value, "\r", "")
 }
 
 // ensureSession dispatches the activation prompt to the Worker's

--- a/api/pkg/org/infrastructure/runtime/helix/spawner.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner.go
@@ -291,16 +291,16 @@ func Spawner(cfg SpawnerConfig) runtime.Spawner {
 		mandate := cfg.SpecsMandate
 		if mandate == "" {
 			instructions := bot.Content
-			if bot.AgentAppID != "" {
+			if bot.AgentID != "" {
 				if cfg.ProjectService == nil {
 					return errors.New("load canonical agent instructions: project service is nil")
 				}
-				appConfig, err := cfg.ProjectService.GetAppConfig(startupCtx, bot.AgentAppID)
+				appConfig, err := cfg.ProjectService.GetAppConfig(startupCtx, bot.AgentID)
 				if err != nil {
 					return fmt.Errorf("load canonical agent instructions: %w", err)
 				}
 				if len(appConfig.Helix.Assistants) != 1 {
-					return fmt.Errorf("linked agent app %s must contain exactly one assistant", bot.AgentAppID)
+					return fmt.Errorf("linked agent %s must contain exactly one assistant", bot.AgentID)
 				}
 				instructions = appConfig.Helix.Assistants[0].SystemPrompt
 			}
@@ -402,11 +402,11 @@ func (c SpawnerConfig) ensureHelixOrgMCP(ctx context.Context, orgID string, work
 		}
 		return
 	}
-	if state.AgentAppID == "" {
+	if state.AgentID == "" {
 		return
 	}
-	if err := AttachHelixOrgMCP(ctx, c.ProjectService, state.AgentAppID, c.HelixOrgURL, workerID, c.MCPAuthBearer); err != nil && c.Logger != nil {
-		c.Logger.Warn("helix spawner: attach helix-org MCP", "worker", workerID, "app", state.AgentAppID, "err", err)
+	if err := AttachHelixOrgMCP(ctx, c.ProjectService, state.AgentID, c.HelixOrgURL, workerID, c.MCPAuthBearer); err != nil && c.Logger != nil {
+		c.Logger.Warn("helix spawner: attach helix-org MCP", "worker", workerID, "agent", state.AgentID, "err", err)
 	}
 }
 
@@ -511,7 +511,7 @@ func (c SpawnerConfig) ensureSession(ctx context.Context, orgID string, workerID
 		// gets a 403 loading the worker's chat. The owner-chat bridge path
 		// sets this via EnsureAndSend too; the activation path must match.
 		OrganizationID: orgID,
-		AppID:          state.AgentAppID,
+		AppID:          state.AgentID,
 		AgentType:      AgentType,
 		Prompt:         prompt,
 	})

--- a/api/pkg/org/infrastructure/runtime/helix/spawner_log_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner_log_test.go
@@ -1,0 +1,10 @@
+package helix
+
+import "testing"
+
+func TestSanitizeLogValueRemovesLineBreaks(t *testing.T) {
+	got := sanitizeLogValue("upstream\r\nforged\nentry\rtail")
+	if got != "upstreamforgedentrytail" {
+		t.Fatalf("sanitizeLogValue() = %q", got)
+	}
+}

--- a/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
+++ b/api/pkg/org/infrastructure/runtime/helix/spawner_test.go
@@ -205,8 +205,8 @@ func TestSpawnerStartsFreshAndPersistsSession(t *testing.T) {
 	}
 	// The Worker should have its per-project IDs persisted from the
 	// fake's ApplyProject response.
-	if state.ProjectID != "prj_test" || state.AgentAppID != "app_test" {
-		t.Errorf("project IDs not persisted: project=%q agent_app=%q", state.ProjectID, state.AgentAppID)
+	if state.ProjectID != "prj_test" || state.AgentID != "app_test" {
+		t.Errorf("project IDs not persisted: project=%q agent_app=%q", state.ProjectID, state.AgentID)
 	}
 	// StartSession must point at the per-Worker project, not at any
 	// global one.
@@ -280,7 +280,7 @@ func TestSpawnerUsesLinkedAgentInstructions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.Nodes.Update(context.Background(), bot.WithAgentAppID("app_test")); err != nil {
+	if err := s.Nodes.Update(context.Background(), bot.WithAgentID("app_test")); err != nil {
 		t.Fatal(err)
 	}
 	fc := &fakeHelixClient{

--- a/api/pkg/org/infrastructure/runtime/helix/state.go
+++ b/api/pkg/org/infrastructure/runtime/helix/state.go
@@ -30,7 +30,7 @@ const (
 // WorkerState holds the per-Worker pointers the Helix runtime needs.
 type WorkerState struct {
 	ProjectID    string
-	AgentAppID   string
+	AgentID      string
 	RepoID       string
 	SessionID    string
 	HiringUserID string
@@ -38,7 +38,7 @@ type WorkerState struct {
 
 const (
 	keyProjectID    = "project_id"
-	keyAgentAppID   = "agent_app_id"
+	keyAgentID      = "agent_app_id"
 	keyRepoID       = "repo_id"
 	keySessionID    = "session_id"
 	keyHiringUserID = "hiring_user_id"
@@ -55,7 +55,7 @@ func LoadState(ctx context.Context, st *store.Store, orgID string, workerID orgc
 	}
 	return WorkerState{
 		ProjectID:    kv[keyProjectID],
-		AgentAppID:   kv[keyAgentAppID],
+		AgentID:      kv[keyAgentID],
 		RepoID:       kv[keyRepoID],
 		SessionID:    kv[keySessionID],
 		HiringUserID: kv[keyHiringUserID],
@@ -74,14 +74,14 @@ func SaveHiringUser(ctx context.Context, st *store.Store, orgID string, workerID
 }
 
 // SaveProject persists the per-Worker project triple.
-func SaveProject(ctx context.Context, st *store.Store, orgID string, workerID orgchart.NodeID, projectID, agentAppID, repoID string) error {
+func SaveProject(ctx context.Context, st *store.Store, orgID string, workerID orgchart.NodeID, projectID, agentID, repoID string) error {
 	if st == nil || st.NodeRuntimeState == nil {
 		return errors.New("helix state: store is nil")
 	}
 	return st.NodeRuntimeState.SetMany(ctx, orgID, workerID, Backend, map[string]string{
-		keyProjectID:  projectID,
-		keyAgentAppID: agentAppID,
-		keyRepoID:     repoID,
+		keyProjectID: projectID,
+		keyAgentID:   agentID,
+		keyRepoID:    repoID,
 	})
 }
 
@@ -99,9 +99,9 @@ func ClearProject(ctx context.Context, st *store.Store, orgID string, workerID o
 		return errors.New("helix state: store is nil")
 	}
 	return st.NodeRuntimeState.SetMany(ctx, orgID, workerID, Backend, map[string]string{
-		keyProjectID:  "",
-		keyAgentAppID: "",
-		keyRepoID:     "",
-		keySessionID:  "",
+		keyProjectID: "",
+		keyAgentID:   "",
+		keyRepoID:    "",
+		keySessionID: "",
 	})
 }

--- a/api/pkg/org/interfaces/mcptools/bot_agent.go
+++ b/api/pkg/org/interfaces/mcptools/bot_agent.go
@@ -143,18 +143,20 @@ func (t *RestartBot) Invoke(ctx context.Context, inv tool.Invocation) (json.RawM
 // --- helpers --------------------------------------------------------------
 
 type botActivateView struct {
-	ActivationID string `json:"activation_id,omitempty"`
-	ProjectID    string `json:"project_id,omitempty"`
-	AgentAppID   string `json:"agent_app_id,omitempty"`
-	SessionID    string `json:"session_id,omitempty"`
+	ActivationID  string `json:"activation_id,omitempty"`
+	ProjectID     string `json:"project_id,omitempty"`
+	AgentID       string `json:"agent_id,omitempty"`
+	LegacyAgentID string `json:"agent_app_id,omitempty"`
+	SessionID     string `json:"session_id,omitempty"`
 }
 
 func toBotActivateView(res activations.ActivateResult) botActivateView {
 	return botActivateView{
-		ActivationID: string(res.ActivationID),
-		ProjectID:    res.ProjectID,
-		AgentAppID:   res.AgentAppID,
-		SessionID:    res.SessionID,
+		ActivationID:  string(res.ActivationID),
+		ProjectID:     res.ProjectID,
+		AgentID:       res.AgentID,
+		LegacyAgentID: res.AgentID,
+		SessionID:     res.SessionID,
 	}
 }
 

--- a/api/pkg/org/interfaces/mcptools/builtins_test.go
+++ b/api/pkg/org/interfaces/mcptools/builtins_test.go
@@ -195,7 +195,7 @@ func TestSetBotContentIsDomainWrite(t *testing.T) {
 		t.Fatalf("get b-eng: %v", err)
 	}
 	toolsBefore := append([]tool.Name(nil), created.Tools...)
-	mustCreate(t, s.Nodes.Update(ctx, created.WithAgentAppID("app-eng")))
+	mustCreate(t, s.Nodes.Update(ctx, created.WithAgentID("app-eng")))
 
 	// set_bot_content rewrites Content and preserves Tools.
 	invokeExpectID(t, ownerSession, mcptools.SetBotContentName, map[string]any{
@@ -284,7 +284,7 @@ func TestSetBotContentPreflightsLinkedAgentUpdater(t *testing.T) {
 	ctx := context.Background()
 	owner, _ := orgchart.NewNode("b-owner", "owner", []tool.Name{mcptools.SetBotContentName}, time.Now().UTC(), "org-test")
 	target, _ := orgchart.NewNode("b-agent", "original", nil, time.Now().UTC(), "org-test")
-	target = target.WithAgentAppID("app-agent")
+	target = target.WithAgentID("app-agent")
 	mustCreate(t, s.Nodes.Create(ctx, owner))
 	mustCreate(t, s.Nodes.Create(ctx, target))
 

--- a/api/pkg/org/interfaces/mcptools/read_bots.go
+++ b/api/pkg/org/interfaces/mcptools/read_bots.go
@@ -57,15 +57,15 @@ func botViewOf(b orgchart.Node, managers []orgchart.NodeID) botView {
 
 func canonicalBotView(ctx context.Context, deps Deps, b orgchart.Node, managers []orgchart.NodeID) (botView, error) {
 	view := botViewOf(b, managers)
-	if b.IsHuman() || b.AgentAppID == "" {
+	if b.IsHuman() || b.AgentID == "" {
 		return view, nil
 	}
 	if deps.AgentProfileReader == nil {
-		return botView{}, fmt.Errorf("read canonical agent %s: profile reader is not wired", b.AgentAppID)
+		return botView{}, fmt.Errorf("read canonical agent %s: profile reader is not wired", b.AgentID)
 	}
-	name, instructions, err := deps.AgentProfileReader.AgentProfile(ctx, b.AgentAppID)
+	name, instructions, err := deps.AgentProfileReader.AgentProfile(ctx, b.AgentID)
 	if err != nil {
-		return botView{}, fmt.Errorf("read canonical agent %s: %w", b.AgentAppID, err)
+		return botView{}, fmt.Errorf("read canonical agent %s: %w", b.AgentID, err)
 	}
 	view.Name = name
 	view.Content = instructions

--- a/api/pkg/org/interfaces/mcptools/set_bot_content.go
+++ b/api/pkg/org/interfaces/mcptools/set_bot_content.go
@@ -57,15 +57,15 @@ func (t *SetBotContent) Invoke(ctx context.Context, inv tool.Invocation) (json.R
 	if err != nil {
 		return nil, fmt.Errorf("get bot: %w", err)
 	}
-	if existing.AgentAppID != "" && t.deps.AgentContentUpdater == nil {
+	if existing.AgentID != "" && t.deps.AgentContentUpdater == nil {
 		return nil, fmt.Errorf("update linked agent content: updater is not wired")
 	}
 	updated, err := t.deps.Nodes.Update(ctx, orgID, botID, nodes.UpdateParams{Content: &args.Content})
 	if err != nil {
 		return nil, fmt.Errorf("set bot content: %w", err)
 	}
-	if updated.AgentAppID != "" {
-		if err := t.deps.AgentContentUpdater.UpdateAgentContent(ctx, updated.AgentAppID, args.Content); err != nil {
+	if updated.AgentID != "" {
+		if err := t.deps.AgentContentUpdater.UpdateAgentContent(ctx, updated.AgentID, args.Content); err != nil {
 			_, rollbackErr := t.deps.Nodes.Update(ctx, orgID, botID, nodes.UpdateParams{Content: &existing.Content})
 			if rollbackErr != nil {
 				return nil, fmt.Errorf("update linked agent content: %v; rollback bot content: %w", err, rollbackErr)

--- a/api/pkg/org/interfaces/server/api/activate_bot_test.go
+++ b/api/pkg/org/interfaces/server/api/activate_bot_test.go
@@ -128,8 +128,8 @@ func TestActivateBot_HappyPath(t *testing.T) {
 
 	var resp orgapi.BotActivateDTO
 	decode(t, rec, &resp)
-	if resp.ProjectID != "prj_alice" || resp.AgentAppID != "app_alice" {
-		t.Errorf("IDs = (%q,%q), want (prj_alice, app_alice)", resp.ProjectID, resp.AgentAppID)
+	if resp.ProjectID != "prj_alice" || resp.AgentID != "app_alice" {
+		t.Errorf("IDs = (%q,%q), want (prj_alice, app_alice)", resp.ProjectID, resp.AgentID)
 	}
 	if resp.ActivationID == "" {
 		t.Errorf("ActivationID must be pre-allocated; got empty")

--- a/api/pkg/org/interfaces/server/api/api.go
+++ b/api/pkg/org/interfaces/server/api/api.go
@@ -244,11 +244,11 @@ type AgentProfile struct {
 // REST adapter surfaces: the per-project deep-link ids, the current
 // desktop session id, and whether that sandbox is online.
 type BotRuntimeInfo struct {
-	ProjectID  string
-	AgentAppID string
-	SessionID  string
-	Runtime    string
-	Model      string
+	ProjectID string
+	AgentID   string
+	SessionID string
+	Runtime   string
+	Model     string
 	// AgentStatus is "running" when the bot's exploratory-session
 	// desktop is online (external_agent_status == running), else
 	// "stopped". Empty when the status could not be resolved.

--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -185,11 +185,11 @@ func (a *apiHandler) getBot(w http.ResponseWriter, r *http.Request) {
 	// presence control on the bot detail page.
 	if a.deps.BotRuntime != nil {
 		if info, err := a.deps.BotRuntime.State(ctx, orgID, id); err == nil {
-			agentAppID := b.AgentAppID
-			if agentAppID == "" {
-				agentAppID = info.AgentAppID
+			agentID := b.AgentID
+			if agentID == "" {
+				agentID = info.AgentID
 			}
-			detail := BotDetailDTO{Bot: dto, AgentAppID: agentAppID, ProjectID: info.ProjectID}
+			detail := BotDetailDTO{Bot: dto, AgentID: agentID, LegacyAgentID: agentID, ProjectID: info.ProjectID}
 			if info.AgentStatus != "" {
 				detail.Bot.AgentStatus = info.AgentStatus
 			}
@@ -206,7 +206,7 @@ func (a *apiHandler) getBot(w http.ResponseWriter, r *http.Request) {
 	if strings.Contains(r.URL.Path, "/agents/") {
 		writeJSON(w, http.StatusOK, AgentDetailDTO{BotDTO: dto})
 	} else {
-		writeJSON(w, http.StatusOK, BotDetailDTO{Bot: dto, AgentAppID: b.AgentAppID})
+		writeJSON(w, http.StatusOK, BotDetailDTO{Bot: dto, AgentID: b.AgentID, LegacyAgentID: b.AgentID})
 	}
 }
 
@@ -293,7 +293,7 @@ func (a *apiHandler) updateBot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	canonicalChange := !configPatch.Empty() || namePatch != nil || contentPatch != nil
-	if !existing.IsHuman() && existing.AgentAppID != "" && canonicalChange && a.deps.AgentUpdater == nil {
+	if !existing.IsHuman() && existing.AgentID != "" && canonicalChange && a.deps.AgentUpdater == nil {
 		writeError(w, http.StatusServiceUnavailable, errors.New("canonical agent updater is not available"))
 		return
 	}
@@ -309,8 +309,8 @@ func (a *apiHandler) updateBot(w http.ResponseWriter, r *http.Request) {
 		writeError(w, errStatus(err), fmt.Errorf("update bot: %w", err))
 		return
 	}
-	if !updated.IsHuman() && updated.AgentAppID != "" && canonicalChange {
-		if err := a.deps.AgentUpdater.UpdateAgent(ctx, updated.AgentAppID, configPatch, namePatch, contentPatch); err != nil {
+	if !updated.IsHuman() && updated.AgentID != "" && canonicalChange {
+		if err := a.deps.AgentUpdater.UpdateAgent(ctx, updated.AgentID, configPatch, namePatch, contentPatch); err != nil {
 			tools := append([]tool.Name(nil), existing.Tools...)
 			projectIDs := append([]string(nil), existing.ProjectIDs...)
 			identity := make(map[string]string, len(existing.Identity))
@@ -518,7 +518,7 @@ func (a *apiHandler) ensureBotChat(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, fmt.Errorf("ensure bot chat: %w", err))
 		return
 	}
-	writeJSON(w, http.StatusOK, BotChatDTO{AgentAppID: agentAppID, ProjectID: projectID})
+	writeJSON(w, http.StatusOK, BotChatDTO{AgentID: agentAppID, LegacyAgentID: agentAppID, ProjectID: projectID})
 }
 
 // activateBot manually triggers an activation for a Bot. The bot
@@ -570,10 +570,11 @@ func (a *apiHandler) activateBot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusAccepted, BotActivateDTO{
-		ActivationID: string(res.ActivationID),
-		ProjectID:    res.ProjectID,
-		AgentAppID:   res.AgentAppID,
-		SessionID:    res.SessionID,
+		ActivationID:  string(res.ActivationID),
+		ProjectID:     res.ProjectID,
+		AgentID:       res.AgentID,
+		LegacyAgentID: res.AgentID,
+		SessionID:     res.SessionID,
 	})
 }
 
@@ -664,10 +665,11 @@ func (a *apiHandler) restartBotAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusAccepted, BotActivateDTO{
-		ActivationID: string(res.ActivationID),
-		ProjectID:    res.ProjectID,
-		AgentAppID:   res.AgentAppID,
-		SessionID:    res.SessionID,
+		ActivationID:  string(res.ActivationID),
+		ProjectID:     res.ProjectID,
+		AgentID:       res.AgentID,
+		LegacyAgentID: res.AgentID,
+		SessionID:     res.SessionID,
 	})
 }
 
@@ -698,7 +700,8 @@ func (a *apiHandler) managerIDs(ctx context.Context, orgID string, id orgchart.N
 func botDTO(b orgchart.Node, parentIDs []string) BotDTO {
 	dto := BotDTO{
 		ID:              string(b.ID),
-		AgentAppID:      b.AgentAppID,
+		AgentID:         b.AgentID,
+		LegacyAgentID:   b.AgentID,
 		Name:            b.Name,
 		Content:         b.Content,
 		ProjectIDs:      b.ProjectIDs,
@@ -725,12 +728,12 @@ func botDTO(b orgchart.Node, parentIDs []string) BotDTO {
 }
 
 func (a *apiHandler) canonicalAgentProfile(ctx context.Context, bot orgchart.Node, dto *BotDTO) error {
-	if dto == nil || bot.IsHuman() || bot.AgentAppID == "" || a.deps.AgentReader == nil {
+	if dto == nil || bot.IsHuman() || bot.AgentID == "" || a.deps.AgentReader == nil {
 		return nil
 	}
-	profile, err := a.deps.AgentReader.ReadAgent(ctx, bot.AgentAppID)
+	profile, err := a.deps.AgentReader.ReadAgent(ctx, bot.AgentID)
 	if err != nil {
-		return fmt.Errorf("read canonical agent %s for bot %s: %w", bot.AgentAppID, bot.ID, err)
+		return fmt.Errorf("read canonical agent %s for bot %s: %w", bot.AgentID, bot.ID, err)
 	}
 	dto.Name = profile.Name
 	dto.Content = profile.Instructions

--- a/api/pkg/org/interfaces/server/api/bots_rest_test.go
+++ b/api/pkg/org/interfaces/server/api/bots_rest_test.go
@@ -75,7 +75,7 @@ func TestRESTAgentResourceIsFlat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	bot = bot.WithAgentAppID("app-agent")
+	bot = bot.WithAgentID("app-agent")
 	if err := st.Nodes.Create(ctx, bot); err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +136,7 @@ func TestRESTAgentListKeepsOtherAgentsWhenOneLinkedAppIsInvalid(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := st.Nodes.Create(ctx, bot.WithAgentAppID(fixture.appID)); err != nil {
+		if err := st.Nodes.Create(ctx, bot.WithAgentID(fixture.appID)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -167,7 +167,7 @@ func TestRESTAgentListReportsOperationalAgentReadFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := st.Nodes.Create(ctx, bot.WithAgentAppID("app-agent")); err != nil {
+	if err := st.Nodes.Create(ctx, bot.WithAgentID("app-agent")); err != nil {
 		t.Fatal(err)
 	}
 	deps.AgentReader = failingAgentReader{}
@@ -250,7 +250,7 @@ func TestRESTUpdateAgentRollsBackOrgProfile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	bot = bot.WithAgentAppID("app-agent").
+	bot = bot.WithAgentID("app-agent").
 		WithName("Old name").
 		WithProjectIDs([]string{"prj-old"}).
 		WithPreserveContext(true).
@@ -292,7 +292,7 @@ func TestRESTUpdateLinkedAgentRequiresUpdaterBeforeMutation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	bot = bot.WithAgentAppID("app-agent").WithName("Old name")
+	bot = bot.WithAgentID("app-agent").WithName("Old name")
 	if err := st.Nodes.Create(ctx, bot); err != nil {
 		t.Fatal(err)
 	}

--- a/api/pkg/org/interfaces/server/api/dto.go
+++ b/api/pkg/org/interfaces/server/api/dto.go
@@ -8,6 +8,8 @@
 package api
 
 import (
+	"encoding/json"
+
 	"github.com/helixml/helix/api/pkg/org/application/publishing"
 	"github.com/helixml/helix/api/pkg/types"
 )
@@ -40,8 +42,9 @@ type ToolDTO struct {
 // report to several managers. A Bot's subscriptions are not on the bot —
 // they live as (bot, topic) rows.
 type BotDTO struct {
-	ID         string `json:"id"`
-	AgentAppID string `json:"agent_app_id,omitempty"`
+	ID            string `json:"id"`
+	AgentID       string `json:"agent_id,omitempty"`
+	LegacyAgentID string `json:"agent_app_id,omitempty"`
 	// Name is the human-readable display label; empty means the UI falls
 	// back to ID. Distinct from ID, which is the immutable handle.
 	Name           string   `json:"name,omitempty"`
@@ -76,32 +79,63 @@ type BotDTO struct {
 	UpdatedAt               string                        `json:"updated_at,omitempty"`
 }
 
-// BotChatDTO is the POST /bots/{id}/chat response. AgentAppID is the
+func (d BotDTO) MarshalJSON() ([]byte, error) {
+	type botDTO BotDTO
+	encoded := botDTO(d)
+	if encoded.AgentID == "" {
+		encoded.AgentID = encoded.LegacyAgentID
+	}
+	if encoded.LegacyAgentID == "" {
+		encoded.LegacyAgentID = encoded.AgentID
+	}
+	return json.Marshal(encoded)
+}
+
+func (d *BotDTO) UnmarshalJSON(data []byte) error {
+	type botDTO BotDTO
+	var decoded botDTO
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	if decoded.AgentID == "" {
+		decoded.AgentID = decoded.LegacyAgentID
+	}
+	if decoded.LegacyAgentID == "" {
+		decoded.LegacyAgentID = decoded.AgentID
+	}
+	*d = BotDTO(decoded)
+	return nil
+}
+
+// BotChatDTO is the POST /bots/{id}/chat response. AgentID is the
 // per-Bot Helix agent app id and ProjectID is the Helix project that
 // owns it — the chart UI prefers ProjectID for the "chat via Human
 // Desktop" deep-link (/orgs/<org>/projects/<id>/desktop/<session>),
 // falling back to /agent/<agent_app_id> only when the project's
 // exploratory session can't be reached.
 type BotChatDTO struct {
-	AgentAppID string `json:"agent_app_id"`
-	ProjectID  string `json:"project_id,omitempty"`
+	AgentID       string `json:"agent_id"`
+	LegacyAgentID string `json:"agent_app_id"`
+	ProjectID     string `json:"project_id,omitempty"`
 }
 
 // BotActivateDTO is the POST /bots/{id}/activate response.
 type BotActivateDTO struct {
-	ActivationID string `json:"activation_id,omitempty"`
-	ProjectID    string `json:"project_id,omitempty"`
-	AgentAppID   string `json:"agent_app_id,omitempty"`
-	SessionID    string `json:"session_id,omitempty"`
+	ActivationID  string `json:"activation_id,omitempty"`
+	ProjectID     string `json:"project_id,omitempty"`
+	AgentID       string `json:"agent_id,omitempty"`
+	LegacyAgentID string `json:"agent_app_id,omitempty"`
+	SessionID     string `json:"session_id,omitempty"`
 }
 
 // BotDetailDTO is the full GET /bots/{id} response — the Bot plus the
 // surrounding runtime context the UI's detail pane needs.
 type BotDetailDTO struct {
 	Bot BotDTO `json:"bot"`
-	// AgentAppID + ProjectID — see BotChatDTO comments.
-	AgentAppID string `json:"agent_app_id,omitempty"`
-	ProjectID  string `json:"project_id,omitempty"`
+	// AgentID + ProjectID — see BotChatDTO comments.
+	AgentID       string `json:"agent_id,omitempty"`
+	LegacyAgentID string `json:"agent_app_id,omitempty"`
+	ProjectID     string `json:"project_id,omitempty"`
 }
 
 type AgentDetailDTO struct {

--- a/api/pkg/org/interfaces/server/api/dto.go
+++ b/api/pkg/org/interfaces/server/api/dto.go
@@ -81,14 +81,7 @@ type BotDTO struct {
 
 func (d BotDTO) MarshalJSON() ([]byte, error) {
 	type botDTO BotDTO
-	encoded := botDTO(d)
-	if encoded.AgentID == "" {
-		encoded.AgentID = encoded.LegacyAgentID
-	}
-	if encoded.LegacyAgentID == "" {
-		encoded.LegacyAgentID = encoded.AgentID
-	}
-	return json.Marshal(encoded)
+	return json.Marshal(botDTO(canonicalBotDTO(d)))
 }
 
 func (d *BotDTO) UnmarshalJSON(data []byte) error {
@@ -97,14 +90,16 @@ func (d *BotDTO) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		return err
 	}
-	if decoded.AgentID == "" {
-		decoded.AgentID = decoded.LegacyAgentID
-	}
-	if decoded.LegacyAgentID == "" {
-		decoded.LegacyAgentID = decoded.AgentID
-	}
-	*d = BotDTO(decoded)
+	*d = canonicalBotDTO(BotDTO(decoded))
 	return nil
+}
+
+func canonicalBotDTO(d BotDTO) BotDTO {
+	if d.AgentID == "" {
+		d.AgentID = d.LegacyAgentID
+	}
+	d.LegacyAgentID = d.AgentID
+	return d
 }
 
 // BotChatDTO is the POST /bots/{id}/chat response. AgentID is the
@@ -141,6 +136,33 @@ type BotDetailDTO struct {
 type AgentDetailDTO struct {
 	BotDTO
 	ProjectID string `json:"project_id,omitempty"`
+}
+
+func (d AgentDetailDTO) MarshalJSON() ([]byte, error) {
+	type botDTO BotDTO
+	type agentDetailDTO struct {
+		botDTO
+		ProjectID string `json:"project_id,omitempty"`
+	}
+	return json.Marshal(agentDetailDTO{
+		botDTO:    botDTO(canonicalBotDTO(d.BotDTO)),
+		ProjectID: d.ProjectID,
+	})
+}
+
+func (d *AgentDetailDTO) UnmarshalJSON(data []byte) error {
+	type botDTO BotDTO
+	type agentDetailDTO struct {
+		botDTO
+		ProjectID string `json:"project_id,omitempty"`
+	}
+	var decoded agentDetailDTO
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	d.BotDTO = canonicalBotDTO(BotDTO(decoded.botDTO))
+	d.ProjectID = decoded.ProjectID
+	return nil
 }
 
 // CreateBotRequest is the body of POST /bots. Mirrors the MCP

--- a/api/pkg/org/interfaces/server/api/dto_agent_id_test.go
+++ b/api/pkg/org/interfaces/server/api/dto_agent_id_test.go
@@ -28,3 +28,66 @@ func TestBotDTOEmitsCanonicalAndLegacyAgentID(t *testing.T) {
 		t.Fatalf("agent id fields = %s", data)
 	}
 }
+
+func TestBotDTOCanonicalAgentIDWinsConflict(t *testing.T) {
+	var dto BotDTO
+	if err := json.Unmarshal([]byte(`{"agent_id":"agent_new","agent_app_id":"agent_old"}`), &dto); err != nil {
+		t.Fatal(err)
+	}
+	if dto.AgentID != "agent_new" || dto.LegacyAgentID != "agent_new" {
+		t.Fatalf("agent ids = (%q, %q)", dto.AgentID, dto.LegacyAgentID)
+	}
+
+	data, err := json.Marshal(BotDTO{AgentID: "agent_new", LegacyAgentID: "agent_old"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if fields["agent_id"] != "agent_new" || fields["agent_app_id"] != "agent_new" {
+		t.Fatalf("agent id fields = %s", data)
+	}
+}
+
+func TestAgentDetailDTOPreservesProjectID(t *testing.T) {
+	data, err := json.Marshal(AgentDetailDTO{
+		BotDTO: BotDTO{
+			ID:            "bot_test",
+			AgentID:       "agent_new",
+			LegacyAgentID: "agent_old",
+		},
+		ProjectID: "project_test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var fields map[string]any
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if fields["project_id"] != "project_test" {
+		t.Fatalf("project_id = %v, body = %s", fields["project_id"], data)
+	}
+	if fields["agent_id"] != "agent_new" || fields["agent_app_id"] != "agent_new" {
+		t.Fatalf("agent id fields = %s", data)
+	}
+
+	var decoded AgentDetailDTO
+	if err := json.Unmarshal([]byte(`{
+		"id":"bot_test",
+		"agent_id":"agent_new",
+		"agent_app_id":"agent_old",
+		"project_id":"project_test"
+	}`), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.ProjectID != "project_test" {
+		t.Fatalf("project_id = %q", decoded.ProjectID)
+	}
+	if decoded.AgentID != "agent_new" || decoded.LegacyAgentID != "agent_new" {
+		t.Fatalf("agent ids = (%q, %q)", decoded.AgentID, decoded.LegacyAgentID)
+	}
+}

--- a/api/pkg/org/interfaces/server/api/dto_agent_id_test.go
+++ b/api/pkg/org/interfaces/server/api/dto_agent_id_test.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBotDTOAcceptsLegacyAgentID(t *testing.T) {
+	var dto BotDTO
+	if err := json.Unmarshal([]byte(`{"agent_app_id":"app_test"}`), &dto); err != nil {
+		t.Fatal(err)
+	}
+	if dto.AgentID != "app_test" || dto.LegacyAgentID != "app_test" {
+		t.Fatalf("agent ids = (%q, %q)", dto.AgentID, dto.LegacyAgentID)
+	}
+}
+
+func TestBotDTOEmitsCanonicalAndLegacyAgentID(t *testing.T) {
+	data, err := json.Marshal(BotDTO{AgentID: "app_test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if fields["agent_id"] != "app_test" || fields["agent_app_id"] != "app_test" {
+		t.Fatalf("agent id fields = %s", data)
+	}
+}

--- a/api/pkg/org/interfaces/server/api/settings.go
+++ b/api/pkg/org/interfaces/server/api/settings.go
@@ -128,7 +128,7 @@ func (a *apiHandler) activateDeferredBotsAfterRuntimeChange(ctx context.Context,
 		if provisioned {
 			continue
 		}
-		if b.AgentAppID != "" {
+		if b.AgentID != "" {
 			if a.deps.AgentDefaultApplier == nil {
 				log.Warn().Str("org", orgID).Str("bot", string(b.ID)).
 					Msg("apply deferred agent defaults skipped: applier is not wired")
@@ -140,7 +140,7 @@ func (a *apiHandler) activateDeferredBotsAfterRuntimeChange(ctx context.Context,
 					Msg("read deferred agent defaults failed")
 				continue
 			}
-			if err := a.deps.AgentDefaultApplier.ApplyAgentDefaults(ctx, b.AgentAppID, defaults); err != nil {
+			if err := a.deps.AgentDefaultApplier.ApplyAgentDefaults(ctx, b.AgentID, defaults); err != nil {
 				log.Warn().Err(err).Str("org", orgID).Str("bot", string(b.ID)).
 					Msg("apply deferred agent defaults failed")
 				continue

--- a/api/pkg/org/interfaces/server/api/settings_agent_defaults_test.go
+++ b/api/pkg/org/interfaces/server/api/settings_agent_defaults_test.go
@@ -51,7 +51,7 @@ func TestSettingDefaultAppliesDeferredAgentBeforeActivation(t *testing.T) {
 	reg.Register(configregistry.Spec{Key: configregistry.DefaultAgentConfigKey, Type: configregistry.TypeObject})
 	ctx := context.Background()
 	created, err := deps.Nodes.Create(ctx, "org-test", nodes.CreateParams{
-		ID: "b-agent", Name: "Agent", Content: "instructions", AgentAppID: "app-agent",
+		ID: "b-agent", Name: "Agent", Content: "instructions", AgentID: "app-agent",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -71,7 +71,7 @@ func TestSettingDefaultAppliesDeferredAgentBeforeActivation(t *testing.T) {
 	if !ensurer.called {
 		t.Fatal("deferred Agent was not activated")
 	}
-	if applier.appID != created.AgentAppID ||
+	if applier.appID != created.AgentID ||
 		applier.defaults.CodeAgentRuntime != types.CodeAgentRuntimeCodexCLI ||
 		applier.defaults.Model != "gpt-5.6" {
 		t.Fatalf("applied defaults = app %q config %+v", applier.appID, applier.defaults)

--- a/api/pkg/server/access_grant_handlers.go
+++ b/api/pkg/server/access_grant_handlers.go
@@ -16,11 +16,11 @@ import (
 )
 
 // listAppAccessGrants godoc
-// @Summary List app access grants
-// @Description List access grants for an app (organization owners and members can list access grants)
-// @Tags    apps
+// @Summary List agent access grants
+// @Description List access grants for an agent (organization owners and members can list access grants)
+// @Tags    agents
 // @Success 200 {array} types.AccessGrant
-// @Router /api/v1/apps/{id}/access-grants [get]
+// @Router /api/v1/agents/{id}/access-grants [get]
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) listAppAccessGrants(rw http.ResponseWriter, r *http.Request) {
 	user := getRequestUser(r)
@@ -80,10 +80,10 @@ func (apiServer *HelixAPIServer) listAppAccessGrants(rw http.ResponseWriter, r *
 // createAppAccessGrant godoc
 // @Summary Grant access to an agent to a team or organization member
 // @Description Grant access to an agent to a team or organization member (organization owners can grant access to teams and organization members)
-// @Tags    apps
+// @Tags    agents
 // @Success 200 {object} types.AccessGrant
 // @Param request body types.CreateAccessGrantRequest true "Request body with team or organization member ID and role"
-// @Router /api/v1/apps/{id}/access-grants [post]
+// @Router /api/v1/agents/{id}/access-grants [post]
 // @Security BearerAuth
 func (apiServer *HelixAPIServer) createAppAccessGrant(rw http.ResponseWriter, r *http.Request) {
 	user := getRequestUser(r)

--- a/api/pkg/server/agent_routes.go
+++ b/api/pkg/server/agent_routes.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/helixml/helix/api/pkg/system"
+	"github.com/helixml/helix/api/pkg/types"
+)
+
+func (apiServer *HelixAPIServer) registerAgentRoutes(authRouter, insecureRouter *mux.Router) {
+	for _, resource := range []string{"agents", "apps"} {
+		base := "/" + resource
+		authRouter.HandleFunc(base, wrapWithETag[[]*types.Agent](apiServer.listAgents)).Methods(http.MethodGet)
+		authRouter.HandleFunc(base, system.Wrapper(apiServer.createAgent)).Methods(http.MethodPost)
+		authRouter.HandleFunc(base+"/{id}", system.Wrapper(apiServer.getAgent)).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{id}", system.Wrapper(apiServer.updateAgent)).Methods(http.MethodPut)
+		authRouter.HandleFunc(base+"/{id}", system.Wrapper(apiServer.deleteAgent)).Methods(http.MethodDelete)
+		authRouter.HandleFunc(base+"/{id}/claude-subscription-status", system.Wrapper(apiServer.getAppClaudeSubscriptionStatus)).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{id}/daily-usage", system.Wrapper(apiServer.getAppDailyUsage)).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{id}/users-daily-usage", system.Wrapper(apiServer.getAppUsersDailyUsage)).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{id}/llm-calls", system.Wrapper(apiServer.listAppLLMCalls)).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{id}/interactions", system.Wrapper(apiServer.listAppInteractions)).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{id}/step-info", system.Wrapper(apiServer.listAppStepInfo)).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{id}/api-actions", system.Wrapper(apiServer.appRunAPIAction)).Methods(http.MethodPost)
+		authRouter.HandleFunc(base+"/{id}/user-access", system.Wrapper(apiServer.getAppUserAccess)).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{id}/access-grants", apiServer.listAppAccessGrants).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{id}/access-grants", apiServer.createAppAccessGrant).Methods(http.MethodPost)
+		authRouter.HandleFunc(base+"/{id}/access-grants/{grant_id}", apiServer.deleteAppAccessGrant).Methods(http.MethodDelete)
+		authRouter.HandleFunc(base+"/{id}/duplicate", system.Wrapper(apiServer.duplicateApp)).Methods(http.MethodPost)
+		authRouter.HandleFunc(base+"/{id}/memories", system.Wrapper(apiServer.listAppMemories)).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{id}/memories/{memory_id}", system.Wrapper(apiServer.deleteAppMemory)).Methods(http.MethodDelete)
+		authRouter.HandleFunc(base+"/{agent_id}/triggers", system.Wrapper(apiServer.listAppTriggers)).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{id}/avatar", apiServer.uploadAppAvatar).Methods(http.MethodPost)
+		authRouter.HandleFunc(base+"/{id}/avatar", apiServer.deleteAppAvatar).Methods(http.MethodDelete)
+		insecureRouter.HandleFunc(base+"/{id}/avatar", apiServer.getAppAvatar).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{id}/trigger-status", apiServer.getAppTriggerStatus).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{id}/skills/{skill}/enable", system.Wrapper(apiServer.handleEnableSkill)).Methods(http.MethodPost)
+
+		authRouter.HandleFunc(base+"/{agent_id}/evaluation-suites", system.Wrapper(apiServer.listEvaluationSuites)).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{agent_id}/evaluation-suites", system.Wrapper(apiServer.createEvaluationSuite)).Methods(http.MethodPost)
+		authRouter.HandleFunc(base+"/{agent_id}/evaluation-suites/{id}", system.Wrapper(apiServer.getEvaluationSuite)).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{agent_id}/evaluation-suites/{id}", system.Wrapper(apiServer.updateEvaluationSuite)).Methods(http.MethodPut)
+		authRouter.HandleFunc(base+"/{agent_id}/evaluation-suites/{id}", system.Wrapper(apiServer.deleteEvaluationSuite)).Methods(http.MethodDelete)
+		authRouter.HandleFunc(base+"/{agent_id}/evaluation-suites/{id}/runs", system.Wrapper(apiServer.startEvaluationRun)).Methods(http.MethodPost)
+		authRouter.HandleFunc(base+"/{agent_id}/evaluation-suites/{id}/runs", system.Wrapper(apiServer.listEvaluationRuns)).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{agent_id}/evaluation-runs/{run_id}", system.Wrapper(apiServer.getEvaluationRun)).Methods(http.MethodGet)
+		authRouter.HandleFunc(base+"/{agent_id}/evaluation-runs/{run_id}", system.Wrapper(apiServer.deleteEvaluationRun)).Methods(http.MethodDelete)
+		authRouter.HandleFunc(base+"/{agent_id}/evaluation-runs/{run_id}/stream", apiServer.streamEvaluationRun).Methods(http.MethodGet)
+	}
+}

--- a/api/pkg/server/agent_routes_test.go
+++ b/api/pkg/server/agent_routes_test.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestAgentAndAppRoutesMatch(t *testing.T) {
+	authRouter := mux.NewRouter()
+	insecureRouter := mux.NewRouter()
+	new(HelixAPIServer).registerAgentRoutes(authRouter, insecureRouter)
+
+	collect := func(router *mux.Router, resource string) []string {
+		var routes []string
+		if err := router.Walk(func(route *mux.Route, _ *mux.Router, _ []*mux.Route) error {
+			path, err := route.GetPathTemplate()
+			if err != nil || !strings.HasPrefix(path, "/"+resource) {
+				return nil
+			}
+			methods, err := route.GetMethods()
+			if err != nil {
+				return err
+			}
+			routes = append(routes, strings.TrimPrefix(path, "/"+resource)+" "+strings.Join(methods, ","))
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		sort.Strings(routes)
+		return routes
+	}
+
+	for _, router := range []*mux.Router{authRouter, insecureRouter} {
+		if agents, apps := collect(router, "agents"), collect(router, "apps"); !reflect.DeepEqual(agents, apps) {
+			t.Fatalf("agent routes do not match app aliases:\nagents: %v\napps: %v", agents, apps)
+		}
+	}
+}

--- a/api/pkg/server/app_handlers.go
+++ b/api/pkg/server/app_handlers.go
@@ -54,15 +54,18 @@ type ModelSubstitution struct {
 	Reason           string `json:"reason"`
 }
 
-// AppCreateResponse extends the App type with additional creation metadata
-type AppCreateResponse struct {
-	*types.App
+// AgentCreateResponse extends the App type with additional creation metadata
+type AgentCreateResponse struct {
+	*types.Agent
 	ModelSubstitutions []ModelSubstitution `json:"model_substitutions,omitempty"`
 }
 
+// Deprecated: use AgentCreateResponse.
+type AppCreateResponse = AgentCreateResponse
+
 // applyModelSubstitutions applies model substitutions to the app configuration
 // Returns a list of substitutions that were made
-func (s *HelixAPIServer) applyModelSubstitutions(ctx context.Context, user *types.User, app *types.App, modelClasses []ModelClass) ([]ModelSubstitution, error) {
+func (s *HelixAPIServer) applyModelSubstitutions(ctx context.Context, user *types.User, app *types.Agent, modelClasses []ModelClass) ([]ModelSubstitution, error) {
 	var substitutions []ModelSubstitution
 
 	// Use the org-aware endpoint list so an org agent referencing the user's
@@ -204,7 +207,7 @@ func (s *HelixAPIServer) applyModelSubstitutions(ctx context.Context, user *type
 	return substitutions, nil
 }
 
-func normalizeHelixAgentAssistantSpecs(app *types.App) {
+func normalizeHelixAgentAssistantSpecs(app *types.Agent) {
 	if app == nil {
 		return
 	}
@@ -248,15 +251,15 @@ func (s *HelixAPIServer) findModelSubstitution(originalProvider, originalModel s
 	return nil
 }
 
-// listApps godoc
-// @Summary List apps
-// @Description List apps for the user. Apps are pre-configured to spawn sessions with specific tools and config.
-// @Tags    apps
-// @Success 200 {array} types.App
+// listAgents godoc
+// @Summary List agents
+// @Description List agents for the user. Agents are pre-configured to spawn sessions with specific tools and config.
+// @Tags    agents
+// @Success 200 {array} types.Agent
 // @Param organization_id query string false "Organization ID"
-// @Router /api/v1/apps [get]
+// @Router /api/v1/agents [get]
 // @Security BearerAuth
-func (s *HelixAPIServer) listApps(_ http.ResponseWriter, r *http.Request) ([]*types.App, *system.HTTPError) {
+func (s *HelixAPIServer) listAgents(_ http.ResponseWriter, r *http.Request) ([]*types.Agent, *system.HTTPError) {
 	ctx := r.Context()
 	user := getRequestUser(r)
 	orgID := r.URL.Query().Get("organization_id") // If filtering for a specific organization
@@ -281,7 +284,7 @@ func (s *HelixAPIServer) listApps(_ http.ResponseWriter, r *http.Request) ([]*ty
 	}
 
 	// remove global apps from the list in case this is the admin user who created the global app
-	nonGlobalUserApps := []*types.App{}
+	nonGlobalUserApps := []*types.Agent{}
 	for _, app := range userApps {
 		if !app.Global {
 			nonGlobalUserApps = append(nonGlobalUserApps, app)
@@ -302,7 +305,7 @@ func (s *HelixAPIServer) listApps(_ http.ResponseWriter, r *http.Request) ([]*ty
 	return filteredApps, nil
 }
 
-func (s *HelixAPIServer) populateAppOwner(ctx context.Context, apps []*types.App) []*types.App {
+func (s *HelixAPIServer) populateAppOwner(ctx context.Context, apps []*types.Agent) []*types.Agent {
 	userMap := make(map[string]*types.User)
 
 	for _, app := range apps {
@@ -332,7 +335,7 @@ func (s *HelixAPIServer) populateAppOwner(ctx context.Context, apps []*types.App
 }
 
 // listOrganizationApps lists apps for an organization based on the user's access grants
-func (s *HelixAPIServer) listOrganizationApps(ctx context.Context, user *types.User, orgID string) ([]*types.App, *system.HTTPError) {
+func (s *HelixAPIServer) listOrganizationApps(ctx context.Context, user *types.User, orgID string) ([]*types.Agent, *system.HTTPError) {
 	orgMembership, err := s.authorizeOrgMember(ctx, user, orgID)
 	if err != nil {
 		return nil, system.NewHTTPError403(err.Error())
@@ -358,7 +361,7 @@ func (s *HelixAPIServer) listOrganizationApps(ctx context.Context, user *types.U
 	}
 
 	// Non-owners only see apps they have access to (direct access or via project)
-	var authorizedApps []*types.App
+	var authorizedApps []*types.Agent
 	for _, app := range apps {
 		if err := s.authorizeUserToApp(ctx, user, app, types.ActionGet); err != nil {
 			continue
@@ -372,7 +375,7 @@ func (s *HelixAPIServer) listOrganizationApps(ctx context.Context, user *types.U
 // markHelixOrgAgents sets IsHelixOrgAgent on any app that backs a Helix
 // org-chart Worker for the given org. Org-chart Workers are always
 // org-scoped, so this is a no-op without an org id or apps.
-func (s *HelixAPIServer) markHelixOrgAgents(ctx context.Context, orgID string, apps []*types.App) *system.HTTPError {
+func (s *HelixAPIServer) markHelixOrgAgents(ctx context.Context, orgID string, apps []*types.Agent) *system.HTTPError {
 	if orgID == "" || len(apps) == 0 {
 		return nil
 	}
@@ -388,8 +391,8 @@ func (s *HelixAPIServer) markHelixOrgAgents(ctx context.Context, orgID string, a
 
 	orgAgents := make(map[string]struct{}, len(nodes))
 	for _, node := range nodes {
-		if node.AgentAppID != "" {
-			orgAgents[node.AgentAppID] = struct{}{}
+		if node.AgentID != "" {
+			orgAgents[node.AgentID] = struct{}{}
 		}
 	}
 	for _, app := range apps {
@@ -400,16 +403,16 @@ func (s *HelixAPIServer) markHelixOrgAgents(ctx context.Context, orgID string, a
 	return nil
 }
 
-// createApp godoc
-// @Summary Create new app
-// @Description Create new app. Helix apps are configured with tools and knowledge. Supports both legacy format and new structured format with YAML config.
-// @Tags    apps
+// createAgent godoc
+// @Summary Create new agent
+// @Description Create new agent. Helix agents are configured with tools and knowledge. Supports both legacy format and new structured format with YAML config.
+// @Tags    agents
 
-// @Success 200 {object} AppCreateResponse
-// @Param request    body types.App true "Request body with app configuration. Can be legacy App format or structured format with organization_id, global, and yaml_config fields.")
-// @Router /api/v1/apps [post]
+// @Success 200 {object} AgentCreateResponse
+// @Param request    body types.Agent true "Request body with agent configuration. Can be legacy Agent format or structured format with organization_id, global, and yaml_config fields.")
+// @Router /api/v1/agents [post]
 // @Security BearerAuth
-func (s *HelixAPIServer) createApp(_ http.ResponseWriter, r *http.Request) (*AppCreateResponse, *system.HTTPError) {
+func (s *HelixAPIServer) createAgent(_ http.ResponseWriter, r *http.Request) (*AgentCreateResponse, *system.HTTPError) {
 	user := getRequestUser(r)
 	ctx := r.Context()
 
@@ -426,7 +429,7 @@ func (s *HelixAPIServer) createApp(_ http.ResponseWriter, r *http.Request) (*App
 		ModelClasses   []ModelClass           `json:"model_classes"`
 	}
 
-	var app *types.App
+	var app *types.Agent
 	var modelClasses []ModelClass
 
 	// Try structured format first
@@ -438,10 +441,10 @@ func (s *HelixAPIServer) createApp(_ http.ResponseWriter, r *http.Request) (*App
 		}
 
 		// Build the app structure
-		app = &types.App{
+		app = &types.Agent{
 			OrganizationID: structuredReq.OrganizationID,
 			Global:         structuredReq.Global,
-			Config: types.AppConfig{
+			Config: types.AgentConfig{
 				Helix:          *helixConfig,
 				Secrets:        make(map[string]string),
 				AllowedDomains: []string{},
@@ -559,7 +562,7 @@ func (s *HelixAPIServer) createApp(_ http.ResponseWriter, r *http.Request) (*App
 		}
 	}
 
-	var created *types.App
+	var created *types.Agent
 
 	err = s.validateTriggers(app.Config.Helix.Triggers)
 	if err != nil {
@@ -626,15 +629,15 @@ func (s *HelixAPIServer) createApp(_ http.ResponseWriter, r *http.Request) (*App
 		return nil, system.NewHTTPError500(err.Error())
 	}
 
-	return &AppCreateResponse{
-		App:                created,
+	return &AgentCreateResponse{
+		Agent:              created,
 		ModelSubstitutions: modelSubstitutions,
 	}, nil
 }
 
 // validateProvidersAndModels checks if the provider and model are valid. Provider
 // can be empty, however model is required
-func (s *HelixAPIServer) validateProvidersAndModels(ctx context.Context, user *types.User, app *types.App) error {
+func (s *HelixAPIServer) validateProvidersAndModels(ctx context.Context, user *types.User, app *types.Agent) error {
 	endpoints, err := s.listEndpointsForApp(ctx, user.ID, app)
 	if err != nil {
 		log.Error().
@@ -796,7 +799,7 @@ func (s *HelixAPIServer) validateTriggers(triggers []types.Trigger) error {
 }
 
 // ensureKnowledge creates or updates knowledge config in the database
-func (s *HelixAPIServer) ensureKnowledge(ctx context.Context, app *types.App) error {
+func (s *HelixAPIServer) ensureKnowledge(ctx context.Context, app *types.Agent) error {
 	var knowledge []*types.AssistantKnowledge
 
 	// Get knowledge for all assistants
@@ -954,7 +957,7 @@ func (s *HelixAPIServer) ensureKnowledge(ctx context.Context, app *types.App) er
 }
 
 // ensureTriggerConfigurations ensures that the trigger configurations for the app are created in the database
-func (s *HelixAPIServer) ensureTriggerConfigurations(ctx context.Context, app *types.App) error {
+func (s *HelixAPIServer) ensureTriggerConfigurations(ctx context.Context, app *types.Agent) error {
 	// Check if we already have a trigger configuration for this app
 	existingTriggers, err := s.Store.ListTriggerConfigurations(ctx, &store.ListTriggerConfigurationsQuery{
 		AppID: app.ID,
@@ -976,7 +979,7 @@ func (s *HelixAPIServer) ensureTriggerConfigurations(ctx context.Context, app *t
 	return nil
 }
 
-func (s *HelixAPIServer) ensureAzureDevOpsTrigger(ctx context.Context, existingTriggers []*types.TriggerConfiguration, app *types.App, trigger types.Trigger) error {
+func (s *HelixAPIServer) ensureAzureDevOpsTrigger(ctx context.Context, existingTriggers []*types.TriggerConfiguration, app *types.Agent, trigger types.Trigger) error {
 	// Check if we already have this config
 	for _, t := range existingTriggers {
 		if t.Trigger.AzureDevOps != nil && t.Trigger.AzureDevOps.Enabled {
@@ -1015,26 +1018,16 @@ func determineInitialState(source types.KnowledgeSource) types.KnowledgeState {
 	return types.KnowledgeStatePending
 }
 
-// what the user can change about a github app fromm the frontend
-type AppUpdatePayload struct {
-	Name           string            `json:"name"`
-	Description    string            `json:"description"`
-	ActiveTools    []string          `json:"active_tools"`
-	Secrets        map[string]string `json:"secrets"`
-	AllowedDomains []string          `json:"allowed_domains"`
-	Global         bool              `json:"global"`
-}
+// getAgent godoc
+// @Summary Get agent by ID
+// @Description Get agent by ID.
+// @Tags    agents
 
-// getApp godoc
-// @Summary Get app by ID
-// @Description Get app by ID.
-// @Tags    apps
-
-// @Success 200 {object} types.App
-// @Param id path string true "App ID"
-// @Router /api/v1/apps/{id} [get]
+// @Success 200 {object} types.Agent
+// @Param id path string true "Agent ID"
+// @Router /api/v1/agents/{id} [get]
 // @Security BearerAuth
-func (s *HelixAPIServer) getApp(_ http.ResponseWriter, r *http.Request) (*types.App, *system.HTTPError) {
+func (s *HelixAPIServer) getAgent(_ http.ResponseWriter, r *http.Request) (*types.Agent, *system.HTTPError) {
 	user := getRequestUser(r)
 	id := getID(r)
 
@@ -1054,20 +1047,20 @@ func (s *HelixAPIServer) getApp(_ http.ResponseWriter, r *http.Request) (*types.
 	return app, nil
 }
 
-// updateApp godoc
-// @Summary Update an existing app
-// @Description Update existing app
-// @Tags    apps
+// updateAgent godoc
+// @Summary Update an existing agent
+// @Description Update existing agent
+// @Tags    agents
 
-// @Success 200 {object} types.App
-// @Param request    body types.App true "Request body with app configuration.")
+// @Success 200 {object} types.Agent
+// @Param request    body types.Agent true "Request body with agent configuration.")
 // @Param id path string true "Tool ID"
-// @Router /api/v1/apps/{id} [put]
+// @Router /api/v1/agents/{id} [put]
 // @Security BearerAuth
-func (s *HelixAPIServer) updateApp(_ http.ResponseWriter, r *http.Request) (*types.App, *system.HTTPError) {
+func (s *HelixAPIServer) updateAgent(_ http.ResponseWriter, r *http.Request) (*types.Agent, *system.HTTPError) {
 	user := getRequestUser(r)
 
-	var update types.App
+	var update types.Agent
 	err := json.NewDecoder(r.Body).Decode(&update)
 	if err != nil {
 		return nil, system.NewHTTPError400(fmt.Sprintf("failed to decode request body 2, error: %s", err))
@@ -1109,7 +1102,7 @@ func (s *HelixAPIServer) updateApp(_ http.ResponseWriter, r *http.Request) (*typ
 			return nil, system.NewHTTPError500(listErr.Error())
 		}
 		for _, bot := range bots {
-			if bot.AgentAppID == existing.ID {
+			if bot.AgentID == existing.ID {
 				if len(update.Config.Helix.Assistants) != 1 {
 					return nil, system.NewHTTPError400("org-linked agent must contain exactly one assistant")
 				}
@@ -1185,16 +1178,16 @@ func (s *HelixAPIServer) updateApp(_ http.ResponseWriter, r *http.Request) (*typ
 	return updated, nil
 }
 
-// deleteApp godoc
-// @Summary Delete app
-// @Description Delete app.
-// @Tags    apps
+// deleteAgent godoc
+// @Summary Delete agent
+// @Description Delete agent.
+// @Tags    agents
 
 // @Success 200
-// @Param id path string true "App ID"
-// @Router /api/v1/apps/{id} [delete]
+// @Param id path string true "Agent ID"
+// @Router /api/v1/agents/{id} [delete]
 // @Security BearerAuth
-func (s *HelixAPIServer) deleteApp(_ http.ResponseWriter, r *http.Request) (*types.App, *system.HTTPError) {
+func (s *HelixAPIServer) deleteAgent(_ http.ResponseWriter, r *http.Request) (*types.Agent, *system.HTTPError) {
 	user := getRequestUser(r)
 	id := getID(r)
 
@@ -1219,7 +1212,7 @@ func (s *HelixAPIServer) deleteApp(_ http.ResponseWriter, r *http.Request) (*typ
 			return nil, system.NewHTTPError500(listErr.Error())
 		}
 		for _, bot := range bots {
-			if bot.AgentAppID == id {
+			if bot.AgentID == id {
 				if keepKnowledge {
 					return nil, system.NewHTTPError400("keep_knowledge is not supported when deleting an org-linked agent")
 				}
@@ -1257,7 +1250,7 @@ func (s *HelixAPIServer) deleteAppData(ctx context.Context, id string, keepKnowl
 }
 
 // getAppOAuthTokenEnv retrieves OAuth tokens for the app
-func (s *HelixAPIServer) getAppOAuthTokenEnv(ctx context.Context, user *types.User, appRecord *types.App) map[string]string {
+func (s *HelixAPIServer) getAppOAuthTokenEnv(ctx context.Context, user *types.User, appRecord *types.Agent) map[string]string {
 	oauthTokens := make(map[string]string)
 
 	// Skip if OAuth manager is not available
@@ -1406,11 +1399,11 @@ func (s *HelixAPIServer) getAppOAuthTokenEnv(ctx context.Context, user *types.Us
 
 // appRunAPIAction godoc
 // @Summary Run an API action
-// @Description Runs an API action for an app
+// @Description Runs an API action for an agent
 // @Accept json
 // @Produce json
 // @Param request body types.RunAPIActionRequest true "Request"
-// @Router /api/v1/apps/{id}/api-actions [post]
+// @Router /api/v1/agents/{id}/api-actions [post]
 // @Success 200 {object} types.RunAPIActionResponse
 // @Failure 400 {object} system.HTTPError
 // @Failure 404 {object} system.HTTPError
@@ -1492,19 +1485,19 @@ func (s *HelixAPIServer) appRunAPIAction(_ http.ResponseWriter, r *http.Request)
 }
 
 // getAppUsage godoc
-// @Summary Get app usage
-// @Description Get app daily usage
+// @Summary Get agent usage
+// @Description Get agent daily usage
 // @Accept json
 // @Produce json
-// @Tags    apps
-// @Param   id path string true "App ID"
+// @Tags    agents
+// @Param   id path string true "Agent ID"
 // @Param   from query string false "Start date"
 // @Param   to query string false "End date"
 // @Success 200 {array} types.AggregatedUsageMetric
 // @Failure 400 {object} system.HTTPError
 // @Failure 404 {object} system.HTTPError
 // @Failure 500 {object} system.HTTPError
-// @Router /api/v1/apps/{id}/daily-usage [get]
+// @Router /api/v1/agents/{id}/daily-usage [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) getAppDailyUsage(_ http.ResponseWriter, r *http.Request) ([]*types.AggregatedUsageMetric, *system.HTTPError) {
 	user := getRequestUser(r)
@@ -1550,19 +1543,19 @@ func (s *HelixAPIServer) getAppDailyUsage(_ http.ResponseWriter, r *http.Request
 }
 
 // getAppUsersDailyUsage godoc
-// @Summary Get app users daily usage
-// @Description Get app users daily usage
+// @Summary Get agent users daily usage
+// @Description Get agent users daily usage
 // @Accept json
 // @Produce json
-// @Tags    apps
-// @Param   id path string true "App ID"
+// @Tags    agents
+// @Param   id path string true "Agent ID"
 // @Param   from query string false "Start date"
 // @Param   to query string false "End date"
 // @Success 200 {array} types.AggregatedUsageMetric
 // @Failure 400 {object} system.HTTPError
 // @Failure 404 {object} system.HTTPError
 // @Failure 500 {object} system.HTTPError
-// @Router /api/v1/apps/{id}/users-daily-usage [get]
+// @Router /api/v1/agents/{id}/users-daily-usage [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) getAppUsersDailyUsage(_ http.ResponseWriter, r *http.Request) ([]*types.UsersAggregatedUsageMetric, *system.HTTPError) {
 	user := getRequestUser(r)
@@ -1611,12 +1604,12 @@ func (s *HelixAPIServer) getAppUsersDailyUsage(_ http.ResponseWriter, r *http.Re
 }
 
 // getAppUserAccess godoc
-// @Summary Get current user's access level for an app
-// @Description Returns the access rights the current user has for this app
-// @Tags    apps
+// @Summary Get current user's access level for an agent
+// @Description Returns the access rights the current user has for this agent
+// @Tags    agents
 // @Success 200 {object} types.UserAppAccessResponse
-// @Param id path string true "App ID"
-// @Router /api/v1/apps/{id}/user-access [get]
+// @Param id path string true "Agent ID"
+// @Router /api/v1/agents/{id}/user-access [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) getAppUserAccess(_ http.ResponseWriter, r *http.Request) (*types.UserAppAccessResponse, *system.HTTPError) {
 	// Get current user and app ID
@@ -1696,19 +1689,19 @@ func (s *HelixAPIServer) getAppUserAccess(_ http.ResponseWriter, r *http.Request
 }
 
 // uploadAppAvatar godoc
-// @Summary Upload app avatar
-// @Description Upload a base64 encoded image as the app's avatar
-// @Tags    apps
+// @Summary Upload agent avatar
+// @Description Upload a base64 encoded image as the agent's avatar
+// @Tags    agents
 // @Accept  text/plain
 // @Produce json
-// @Param id path string true "App ID"
+// @Param id path string true "Agent ID"
 // @Param image body string true "Base64 encoded image data"
 // @Success 200
 // @Failure 400 {object} system.HTTPError
 // @Failure 403 {object} system.HTTPError
 // @Failure 404 {object} system.HTTPError
 // @Failure 500 {object} system.HTTPError
-// @Router /api/v1/apps/{id}/avatar [post]
+// @Router /api/v1/agents/{id}/avatar [post]
 // @Security BearerAuth
 func (s *HelixAPIServer) uploadAppAvatar(rw http.ResponseWriter, r *http.Request) {
 	user := getRequestUser(r)
@@ -1774,7 +1767,7 @@ func (s *HelixAPIServer) uploadAppAvatar(rw http.ResponseWriter, r *http.Request
 	}
 
 	// Update app config with avatar URL and content type
-	app.Config.Helix.Avatar = fmt.Sprintf("/api/v1/apps/%s/avatar", id)
+	app.Config.Helix.Avatar = fmt.Sprintf("/api/v1/agents/%s/avatar", id)
 	app.Config.Helix.AvatarContentType = contentType
 	_, err = s.Store.UpdateApp(r.Context(), app)
 	if err != nil {
@@ -1786,13 +1779,13 @@ func (s *HelixAPIServer) uploadAppAvatar(rw http.ResponseWriter, r *http.Request
 }
 
 // getAppTriggerStatus godoc
-// @Summary Get app trigger status
-// @Description Get the status of a specific trigger type for an app
-// @Tags    apps
+// @Summary Get agent trigger status
+// @Description Get the status of a specific trigger type for an agent
+// @Tags    agents
 // @Success 200 {object} types.TriggerStatus
-// @Param id path string true "App ID"
+// @Param id path string true "Agent ID"
 // @Param trigger_type query string true "Trigger type (e.g., slack)"
-// @Router /api/v1/apps/{id}/trigger-status [get]
+// @Router /api/v1/agents/{id}/trigger-status [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) getAppTriggerStatus(rw http.ResponseWriter, r *http.Request) {
 	user := getRequestUser(r)
@@ -1829,16 +1822,16 @@ func (s *HelixAPIServer) getAppTriggerStatus(rw http.ResponseWriter, r *http.Req
 }
 
 // deleteAppAvatar godoc
-// @Summary Delete app avatar
-// @Description Delete the app's avatar image
-// @Tags    apps
+// @Summary Delete agent avatar
+// @Description Delete the agent's avatar image
+// @Tags    agents
 // @Produce json
-// @Param id path string true "App ID"
+// @Param id path string true "Agent ID"
 // @Success 200
 // @Failure 403 {object} system.HTTPError
 // @Failure 404 {object} system.HTTPError
 // @Failure 500 {object} system.HTTPError
-// @Router /api/v1/apps/{id}/avatar [delete]
+// @Router /api/v1/agents/{id}/avatar [delete]
 // @Security BearerAuth
 func (s *HelixAPIServer) deleteAppAvatar(rw http.ResponseWriter, r *http.Request) {
 	user := getRequestUser(r)
@@ -1886,14 +1879,14 @@ func (s *HelixAPIServer) deleteAppAvatar(rw http.ResponseWriter, r *http.Request
 }
 
 // getAppAvatar godoc
-// @Summary Get app avatar
-// @Description Get the app's avatar image
-// @Tags    apps
+// @Summary Get agent avatar
+// @Description Get the agent's avatar image
+// @Tags    agents
 // @Produce image/*
-// @Param id path string true "App ID"
+// @Param id path string true "Agent ID"
 // @Success 200 {file} binary "Avatar image data"
 // @Failure 404 {object} system.HTTPError
-// @Router /api/v1/apps/{id}/avatar [get]
+// @Router /api/v1/agents/{id}/avatar [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) getAppAvatar(rw http.ResponseWriter, r *http.Request) {
 	id := getID(r)
@@ -2086,16 +2079,16 @@ func (s *HelixAPIServer) extractZipFile(ctx context.Context, file *zip.File, bas
 }
 
 // duplicateApp godoc
-// @Summary Duplicate app
-// @Description duplicate app.
-// @Tags    apps
+// @Summary Duplicate agent
+// @Description duplicate agent.
+// @Tags    agents
 
 // @Success 200
-// @Param id path string true "App ID"
-// @Param name query string false "Optional new name for the app"
-// @Router /api/v1/apps/{id}/duplicate [post]
+// @Param id path string true "Agent ID"
+// @Param name query string false "Optional new name for the agent"
+// @Router /api/v1/agents/{id}/duplicate [post]
 // @Security BearerAuth
-func (s *HelixAPIServer) duplicateApp(_ http.ResponseWriter, r *http.Request) (*types.App, *system.HTTPError) {
+func (s *HelixAPIServer) duplicateApp(_ http.ResponseWriter, r *http.Request) (*types.Agent, *system.HTTPError) {
 	user := getRequestUser(r)
 	id := getID(r)
 
@@ -2129,12 +2122,12 @@ func (s *HelixAPIServer) duplicateApp(_ http.ResponseWriter, r *http.Request) (*
 }
 
 // listAppMemories godoc
-// @Summary List app memories
-// @Description List memories for a specific app and user
+// @Summary List agent memories
+// @Description List memories for a specific agent and user
 // @Tags    memories
 // @Produce json
 // @Success 200 {array} types.Memory
-// @Router /api/v1/apps/{id}/memories [get]
+// @Router /api/v1/agents/{id}/memories [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) listAppMemories(_ http.ResponseWriter, r *http.Request) ([]*types.Memory, *system.HTTPError) {
 	appID := getID(r)
@@ -2167,14 +2160,14 @@ func (s *HelixAPIServer) listAppMemories(_ http.ResponseWriter, r *http.Request)
 }
 
 // deleteAppMemory godoc
-// @Summary Delete app memory
-// @Description Delete a specific memory for an app and user
+// @Summary Delete agent memory
+// @Description Delete a specific memory for an agent and user
 // @Tags    memories
 // @Produce json
 // @Success 200
-// @Param id path string true "App ID"
+// @Param id path string true "Agent ID"
 // @Param memory_id path string true "Memory ID"
-// @Router /api/v1/apps/{id}/memories/{memory_id} [delete]
+// @Router /api/v1/agents/{id}/memories/{memory_id} [delete]
 // @Security BearerAuth
 func (s *HelixAPIServer) deleteAppMemory(_ http.ResponseWriter, r *http.Request) (*types.Memory, *system.HTTPError) {
 	appID := getID(r)

--- a/api/pkg/server/app_handlers_test.go
+++ b/api/pkg/server/app_handlers_test.go
@@ -46,7 +46,7 @@ func TestUpdateAppRejectsInvalidLinkedOrgAgentShape(t *testing.T) {
 
 	bot, err := orgchart.NewNode("b-linked", "# Linked", nil, time.Now().UTC(), "org-test")
 	require.NoError(t, err)
-	require.NoError(t, orgStore.Nodes.Create(context.Background(), bot.WithAgentAppID("app-linked")))
+	require.NoError(t, orgStore.Nodes.Create(context.Background(), bot.WithAgentID("app-linked")))
 
 	existing := &types.App{
 		ID:             "app-linked",
@@ -80,7 +80,7 @@ func TestUpdateAppRejectsInvalidLinkedOrgAgentShape(t *testing.T) {
 	req = mux.SetURLVars(req, map[string]string{"id": existing.ID})
 	req = req.WithContext(setRequestUser(req.Context(), types.User{ID: existing.Owner}))
 
-	updated, httpErr := server.updateApp(nil, req)
+	updated, httpErr := server.updateAgent(nil, req)
 
 	require.Nil(t, updated)
 	require.NotNil(t, httpErr)
@@ -97,7 +97,7 @@ func TestUpdateAppRejectsMismatchedBodyID(t *testing.T) {
 	require.NoError(t, err)
 	req = mux.SetURLVars(req, map[string]string{"id": "app-path"})
 
-	updated, httpErr := server.updateApp(nil, req)
+	updated, httpErr := server.updateAgent(nil, req)
 
 	require.Nil(t, updated)
 	require.NotNil(t, httpErr)
@@ -110,7 +110,7 @@ func Test_markHelixOrgAgents_UsesNodesRepository(t *testing.T) {
 	orgStore := orgmemory.New()
 	node, err := orgchart.NewNode("b-linked", "# Linked", nil, time.Now().UTC(), "org_1")
 	require.NoError(t, err)
-	require.NoError(t, orgStore.Nodes.Create(context.Background(), node.WithAgentAppID("app_1")))
+	require.NoError(t, orgStore.Nodes.Create(context.Background(), node.WithAgentID("app_1")))
 
 	server := &HelixAPIServer{
 		Store: store.NewMockStore(ctrl),
@@ -159,7 +159,7 @@ func TestListOrganizationAppsDoesNotReconcileAgentLinks(t *testing.T) {
 		func(context.Context, *store.ListAppsQuery) ([]*types.App, error) {
 			linked, err := orgStore.Nodes.Get(ctx, "org-test", bot.ID)
 			require.NoError(t, err)
-			require.Empty(t, linked.AgentAppID)
+			require.Empty(t, linked.AgentID)
 			return []*types.App{{ID: "app-existing", OrganizationID: "org-test"}}, nil
 		},
 	)
@@ -299,7 +299,7 @@ func Test_handleDuplicateAppNames(t *testing.T) {
 	require.Equal(t, "", app3.Config.Helix.Name)
 }
 
-// Helper function to handle duplicate names (extracted from createApp handler)
+// Helper function to handle duplicate names (extracted from createAgent handler)
 func handleDuplicateAppNames(app *types.App, existingApps []*types.App) {
 	// Handle duplicate names by adding suffixes like (1), (2), etc.
 	if app.Config.Helix.Name != "" {

--- a/api/pkg/server/app_trigger_handlers.go
+++ b/api/pkg/server/app_trigger_handlers.go
@@ -16,7 +16,7 @@ import (
 // listTriggers godoc
 // @Summary List all triggers configurations for either user or the org or user within an org
 // @Description List all triggers configurations for either user or the org or user within an org
-// @Tags    apps
+// @Tags    agents
 // @Success 200 {array} types.TriggerConfiguration
 // @Param org_id query string false "Organization ID"
 // @Param trigger_type query string false "Trigger type, defaults to 'cron'"
@@ -76,16 +76,16 @@ func (s *HelixAPIServer) listTriggers(_ http.ResponseWriter, r *http.Request) ([
 }
 
 // listAppTriggers godoc
-// @Summary List app triggers
-// @Description List triggers for the app
-// @Tags    apps
+// @Summary List agent triggers
+// @Description List triggers for the agent
+// @Tags    agents
 // @Success 200 {array} types.TriggerConfiguration
-// @Param app_id path string true "App ID"
-// @Router /api/v1/apps/{app_id}/triggers [get]
+// @Param agent_id path string true "Agent ID"
+// @Router /api/v1/agents/{agent_id}/triggers [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) listAppTriggers(_ http.ResponseWriter, r *http.Request) ([]*types.TriggerConfiguration, *system.HTTPError) {
 	ctx := r.Context()
-	id := getID(r)
+	id := mux.Vars(r)["agent_id"]
 	user := getRequestUser(r)
 
 	app, err := s.Store.GetApp(r.Context(), id)
@@ -118,9 +118,9 @@ func (s *HelixAPIServer) listAppTriggers(_ http.ResponseWriter, r *http.Request)
 }
 
 // createAppTriggers godoc
-// @Summary Create app triggers
-// @Description Create triggers for the app. Used to create standalone trigger configurations such as cron tasks for agents that could be owned by a different user than the owner of the app
-// @Tags    apps
+// @Summary Create agent triggers
+// @Description Create triggers for the agent. Used to create standalone trigger configurations such as cron tasks for agents that could be owned by a different user than the owner of the agent
+// @Tags    agents
 // @Success 200 {object} types.TriggerConfiguration
 // @Param request body types.TriggerConfiguration true "Trigger configuration"
 // @Router /api/v1/triggers [post]
@@ -173,9 +173,9 @@ func (s *HelixAPIServer) createAppTrigger(_ http.ResponseWriter, r *http.Request
 }
 
 // deleteAppTriggers godoc
-// @Summary Delete app triggers
-// @Description Delete triggers for the app
-// @Tags    apps
+// @Summary Delete agent triggers
+// @Description Delete triggers for the agent
+// @Tags    agents
 // @Success 200 {object} types.TriggerConfiguration
 // @Param trigger_id path string true "Trigger ID"
 // @Router /api/v1/triggers/{trigger_id} [delete]
@@ -206,9 +206,9 @@ func (s *HelixAPIServer) deleteAppTrigger(_ http.ResponseWriter, r *http.Request
 }
 
 // updateAppTriggers godoc
-// @Summary Update app triggers
-// @Description Update triggers for the app, for example to change the cron schedule or enable/disable the trigger
-// @Tags    apps
+// @Summary Update agent triggers
+// @Description Update triggers for the agent, for example to change the cron schedule or enable/disable the trigger
+// @Tags    agents
 // @Success 200 {object} types.TriggerConfiguration
 // @Param trigger_id path string true "Trigger ID"
 // @Param request body types.TriggerConfiguration true "Trigger configuration"
@@ -269,9 +269,9 @@ func (s *HelixAPIServer) updateAppTrigger(_ http.ResponseWriter, r *http.Request
 }
 
 // executeAppTrigger godoc
-// @Summary Execute app trigger
-// @Description Update triggers for the app, for example to change the cron schedule or enable/disable the trigger
-// @Tags    apps
+// @Summary Execute agent trigger
+// @Description Update triggers for the agent, for example to change the cron schedule or enable/disable the trigger
+// @Tags    agents
 // @Success 200 {object} types.TriggerExecuteResponse
 // @Param trigger_id path string true "Trigger ID"
 // @Router /api/v1/triggers/{trigger_id}/execute [post]
@@ -316,7 +316,7 @@ func (s *HelixAPIServer) executeAppTrigger(_ http.ResponseWriter, r *http.Reques
 // listTriggerExecutions godoc
 // @Summary List trigger executions
 // @Description List executions for the trigger
-// @Tags    apps
+// @Tags    agents
 // @Success 200 {array} types.TriggerExecution
 // @Param trigger_id path string true "Trigger ID"
 // @Param offset query int false "Offset"

--- a/api/pkg/server/claude_subscription_handlers.go
+++ b/api/pkg/server/claude_subscription_handlers.go
@@ -218,17 +218,17 @@ type AppClaudeSubscriptionStatus struct {
 	LastError             string     `json:"last_error,omitempty"`
 }
 
-// @Summary Get the Claude subscription status for an app's owner
-// @Description Reports whether the app owner (whose subscription authenticates the app's sessions) has a working Claude subscription
+// @Summary Get the Claude subscription status for an agent's owner
+// @Description Reports whether the agent owner (whose subscription authenticates the agent's sessions) has a working Claude subscription
 // @Tags Claude
 // @Produce json
-// @Param id path string true "App ID"
+// @Param id path string true "Agent ID"
 // @Success 200 {object} AppClaudeSubscriptionStatus
 // @Failure 401 {object} system.HTTPError
 // @Failure 403 {object} system.HTTPError
 // @Failure 404 {object} system.HTTPError
 // @Security BearerAuth
-// @Router /api/v1/apps/{id}/claude-subscription-status [get]
+// @Router /api/v1/agents/{id}/claude-subscription-status [get]
 func (apiServer *HelixAPIServer) getAppClaudeSubscriptionStatus(_ http.ResponseWriter, req *http.Request) (*AppClaudeSubscriptionStatus, *system.HTTPError) {
 	user := getRequestUser(req)
 	if user == nil {

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -1114,6 +1114,1465 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/agents": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List agents for the user. Agents are pre-configured to spawn sessions with specific tools and config.",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "List agents",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization ID",
+                        "name": "organization_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.Agent"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "description": "Request body with agent configuration. Can be legacy Agent format or structured format with organization_id, global, and yaml_config fields.",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.Agent"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.AgentCreateResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/evaluation-runs/{run_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get evaluation run details",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Get an evaluation run",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Run ID",
+                        "name": "run_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationRun"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete an evaluation run",
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Delete an evaluation run",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Run ID",
+                        "name": "run_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/evaluation-suites": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List all evaluation suites for an agent",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "List evaluation suites for an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.EvaluationSuite"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new evaluation suite for an agent",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Create an evaluation suite",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Evaluation suite to create",
+                        "name": "suite",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationSuite"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationSuite"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/evaluation-suites/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get an evaluation suite by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Get an evaluation suite",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationSuite"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update an evaluation suite",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Update an evaluation suite",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated suite",
+                        "name": "suite",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationSuite"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationSuite"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete an evaluation suite",
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Delete an evaluation suite",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/evaluation-suites/{id}/runs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List evaluation runs for a suite",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "List evaluation runs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.EvaluationRun"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Start running an evaluation suite against an agent",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Start an evaluation run",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationRun"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/triggers": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List triggers for the agent",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "List agent triggers",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.TriggerConfiguration"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Agent"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "description": "Request body with agent configuration.",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.Agent"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Tool ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Agent"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/access-grants": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List access grants for an agent (organization owners and members can list access grants)",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "List agent access grants",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.AccessGrant"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Grant access to an agent to a team or organization member (organization owners can grant access to teams and organization members)",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Grant access to an agent to a team or organization member",
+                "parameters": [
+                    {
+                        "description": "Request body with team or organization member ID and role",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.CreateAccessGrantRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.AccessGrant"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/api-actions": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Runs an API action for an agent",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Run an API action",
+                "parameters": [
+                    {
+                        "description": "Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.RunAPIActionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.RunAPIActionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/avatar": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get the agent's avatar image",
+                "produces": [
+                    "image/*"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get agent avatar",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Avatar image data",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Upload a base64 encoded image as the agent's avatar",
+                "consumes": [
+                    "text/plain"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Upload agent avatar",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Base64 encoded image data",
+                        "name": "image",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete the agent's avatar image",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Delete agent avatar",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/claude-subscription-status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Reports whether the agent owner (whose subscription authenticates the agent's sessions) has a working Claude subscription",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Claude"
+                ],
+                "summary": "Get the Claude subscription status for an agent's owner",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.AppClaudeSubscriptionStatus"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/daily-usage": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get agent daily usage",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get agent usage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date",
+                        "name": "to",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.AggregatedUsageMetric"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/duplicate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Optional new name for the agent",
+                        "name": "name",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/interactions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List interactions with pagination and optional session filtering for a specific agent",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "interactions"
+                ],
+                "summary": "List interactions",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by session ID",
+                        "name": "session",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by interaction ID",
+                        "name": "interaction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Query by like/dislike",
+                        "name": "feedback",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedInteractions"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/llm-calls": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List user's LLM calls with pagination and optional session filtering for a specific agent",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "llm_calls"
+                ],
+                "summary": "List LLM calls",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by session ID",
+                        "name": "session",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by interaction ID",
+                        "name": "interaction",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedLLMCalls"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/memories": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List memories for a specific agent and user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "memories"
+                ],
+                "summary": "List agent memories",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.Memory"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/memories/{memory_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a specific memory for an agent and user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "memories"
+                ],
+                "summary": "Delete agent memory",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Memory ID",
+                        "name": "memory_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/skills/{skill}/enable": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Enable a marketplace skill on an agent. For autoProvision MCP skills the server generates URL and auth automatically.",
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Enable a marketplace skill on an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Skill name (e.g. code-intelligence)",
+                        "name": "skill",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Agent"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/step-info": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List step info for a specific agent and interaction ID, used to build the timeline of events",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "step_info"
+                ],
+                "summary": "List step info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Interaction ID",
+                        "name": "interactionId",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.StepInfo"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/trigger-status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get the status of a specific trigger type for an agent",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get agent trigger status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Trigger type (e.g., slack)",
+                        "name": "trigger_type",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.TriggerStatus"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/user-access": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the access rights the current user has for this agent",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get current user's access level for an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.UserAppAccessResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/users-daily-usage": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get agent users daily usage",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get agent users daily usage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date",
+                        "name": "to",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.AggregatedUsageMetric"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/api_keys": {
             "get": {
                 "security": [
@@ -1199,1465 +2658,6 @@ const docTemplate = `{
                         "description": "API key",
                         "schema": {
                             "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List apps for the user. Apps are pre-configured to spawn sessions with specific tools and config.",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "List apps",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization ID",
-                        "name": "organization_id",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.App"
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "description": "Request body with app configuration. Can be legacy App format or structured format with organization_id, global, and yaml_config fields.",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.App"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/server.AppCreateResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/evaluation-runs/{run_id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get evaluation run details",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Get an evaluation run",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Run ID",
-                        "name": "run_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationRun"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete an evaluation run",
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Delete an evaluation run",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Run ID",
-                        "name": "run_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/evaluation-suites": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List all evaluation suites for an app",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "List evaluation suites for an app",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.EvaluationSuite"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Create a new evaluation suite for an agent",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Create an evaluation suite",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Evaluation suite to create",
-                        "name": "suite",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationSuite"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationSuite"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/evaluation-suites/{id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get an evaluation suite by ID",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Get an evaluation suite",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationSuite"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Update an evaluation suite",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Update an evaluation suite",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Updated suite",
-                        "name": "suite",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationSuite"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationSuite"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete an evaluation suite",
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Delete an evaluation suite",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/evaluation-suites/{id}/runs": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List evaluation runs for a suite",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "List evaluation runs",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.EvaluationRun"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Start running an evaluation suite against an agent",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Start an evaluation run",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationRun"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/triggers": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List triggers for the app",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "List app triggers",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.TriggerConfiguration"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.App"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "description": "Request body with app configuration.",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.App"
-                        }
-                    },
-                    {
-                        "type": "string",
-                        "description": "Tool ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.App"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/access-grants": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List access grants for an app (organization owners and members can list access grants)",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "List app access grants",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.AccessGrant"
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Grant access to an agent to a team or organization member (organization owners can grant access to teams and organization members)",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Grant access to an agent to a team or organization member",
-                "parameters": [
-                    {
-                        "description": "Request body with team or organization member ID and role",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.CreateAccessGrantRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.AccessGrant"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/api-actions": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Runs an API action for an app",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Run an API action",
-                "parameters": [
-                    {
-                        "description": "Request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.RunAPIActionRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.RunAPIActionResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/avatar": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get the app's avatar image",
-                "produces": [
-                    "image/*"
-                ],
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get app avatar",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Avatar image data",
-                        "schema": {
-                            "type": "file"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Upload a base64 encoded image as the app's avatar",
-                "consumes": [
-                    "text/plain"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Upload app avatar",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Base64 encoded image data",
-                        "name": "image",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete the app's avatar image",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Delete app avatar",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/claude-subscription-status": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Reports whether the app owner (whose subscription authenticates the app's sessions) has a working Claude subscription",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Claude"
-                ],
-                "summary": "Get the Claude subscription status for an app's owner",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/server.AppClaudeSubscriptionStatus"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/daily-usage": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get app daily usage",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get app usage",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Start date",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "End date",
-                        "name": "to",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.AggregatedUsageMetric"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/duplicate": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Optional new name for the app",
-                        "name": "name",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/interactions": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List interactions with pagination and optional session filtering for a specific app",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "interactions"
-                ],
-                "summary": "List interactions",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by session ID",
-                        "name": "session",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by interaction ID",
-                        "name": "interaction",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Query by like/dislike",
-                        "name": "feedback",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedInteractions"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/llm-calls": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List user's LLM calls with pagination and optional session filtering for a specific app",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "llm_calls"
-                ],
-                "summary": "List LLM calls",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by session ID",
-                        "name": "session",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by interaction ID",
-                        "name": "interaction",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedLLMCalls"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/memories": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List memories for a specific app and user",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "memories"
-                ],
-                "summary": "List app memories",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.Memory"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/memories/{memory_id}": {
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete a specific memory for an app and user",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "memories"
-                ],
-                "summary": "Delete app memory",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Memory ID",
-                        "name": "memory_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/skills/{skill}/enable": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Enable a marketplace skill on an app. For autoProvision MCP skills the server generates URL and auth automatically.",
-                "tags": [
-                    "skills"
-                ],
-                "summary": "Enable a marketplace skill on an app",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Skill name (e.g. code-intelligence)",
-                        "name": "skill",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.App"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/step-info": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List step info for a specific app and interaction ID, used to build the timeline of events",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "step_info"
-                ],
-                "summary": "List step info",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Interaction ID",
-                        "name": "interactionId",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.StepInfo"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/trigger-status": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get the status of a specific trigger type for an app",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get app trigger status",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Trigger type (e.g., slack)",
-                        "name": "trigger_type",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.TriggerStatus"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/user-access": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Returns the access rights the current user has for this app",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get current user's access level for an app",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.UserAppAccessResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/users-daily-usage": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get app users daily usage",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get app users daily usage",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Start date",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "End date",
-                        "name": "to",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.AggregatedUsageMetric"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
                         }
                     }
                 }
@@ -11081,7 +11081,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Returns the flat set of Bots in the org for the helix-org React Overview page.",
+                "description": "Returns the flat set of Nodes in the org for the helix-org React Overview page.",
                 "produces": [
                     "application/json"
                 ],
@@ -20988,7 +20988,7 @@ const docTemplate = `{
                 ],
                 "description": "List all triggers configurations for either user or the org or user within an org",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
                 "summary": "List all triggers configurations for either user or the org or user within an org",
                 "parameters": [
@@ -21023,11 +21023,11 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Create triggers for the app. Used to create standalone trigger configurations such as cron tasks for agents that could be owned by a different user than the owner of the app",
+                "description": "Create triggers for the agent. Used to create standalone trigger configurations such as cron tasks for agents that could be owned by a different user than the owner of the agent",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
-                "summary": "Create app triggers",
+                "summary": "Create agent triggers",
                 "parameters": [
                     {
                         "description": "Trigger configuration",
@@ -21056,11 +21056,11 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update triggers for the app, for example to change the cron schedule or enable/disable the trigger",
+                "description": "Update triggers for the agent, for example to change the cron schedule or enable/disable the trigger",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
-                "summary": "Update app triggers",
+                "summary": "Update agent triggers",
                 "parameters": [
                     {
                         "type": "string",
@@ -21094,11 +21094,11 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Delete triggers for the app",
+                "description": "Delete triggers for the agent",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
-                "summary": "Delete app triggers",
+                "summary": "Delete agent triggers",
                 "parameters": [
                     {
                         "type": "string",
@@ -21125,11 +21125,11 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update triggers for the app, for example to change the cron schedule or enable/disable the trigger",
+                "description": "Update triggers for the agent, for example to change the cron schedule or enable/disable the trigger",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
-                "summary": "Execute app trigger",
+                "summary": "Execute agent trigger",
                 "parameters": [
                     {
                         "type": "string",
@@ -21158,7 +21158,7 @@ const docTemplate = `{
                 ],
                 "description": "List executions for the trigger",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
                 "summary": "List trigger executions",
                 "parameters": [
@@ -22477,6 +22477,9 @@ const docTemplate = `{
                 "agent_app_id": {
                     "type": "string"
                 },
+                "agent_id": {
+                    "type": "string"
+                },
                 "agent_model": {
                     "type": "string"
                 },
@@ -22570,6 +22573,9 @@ const docTemplate = `{
                 "agent_app_id": {
                     "type": "string"
                 },
+                "agent_id": {
+                    "type": "string"
+                },
                 "project_id": {
                     "type": "string"
                 },
@@ -22592,6 +22598,9 @@ const docTemplate = `{
                 "agent_app_id": {
                     "type": "string"
                 },
+                "agent_id": {
+                    "type": "string"
+                },
                 "project_id": {
                     "type": "string"
                 }
@@ -22601,6 +22610,9 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "agent_app_id": {
+                    "type": "string"
+                },
+                "agent_id": {
                     "type": "string"
                 },
                 "agent_model": {
@@ -22688,7 +22700,10 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "agent_app_id": {
-                    "description": "AgentAppID + ProjectID — see BotChatDTO comments.",
+                    "type": "string"
+                },
+                "agent_id": {
+                    "description": "AgentID + ProjectID — see BotChatDTO comments.",
                     "type": "string"
                 },
                 "bot": {
@@ -22767,7 +22782,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "owner": {
-                    "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation - create_bot, delete_bot,\nset_bot_content, subscribe, ... - plus the read baseline) so it can\nhire and manage other Bots. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
+                    "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation - create_bot, delete_bot,\nset_bot_content, subscribe, ... - plus the read baseline) so it can\nhire and manage other Nodes. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
                     "type": "boolean"
                 },
                 "parent_id": {
@@ -24653,6 +24668,59 @@ const docTemplate = `{
                 }
             }
         },
+        "server.AgentCreateResponse": {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "$ref": "#/definitions/types.AgentConfig"
+                },
+                "created": {
+                    "type": "string"
+                },
+                "global": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_helix_org_agent": {
+                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
+                    "type": "boolean"
+                },
+                "model_substitutions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/server.ModelSubstitution"
+                    }
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "owner": {
+                    "description": "uuid of user ID",
+                    "type": "string"
+                },
+                "owner_type": {
+                    "description": "e.g. user, system, org",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.OwnerType"
+                        }
+                    ]
+                },
+                "updated": {
+                    "type": "string"
+                },
+                "user": {
+                    "description": "Owner user struct, populated by the server for organization views",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.User"
+                        }
+                    ]
+                }
+            }
+        },
         "server.AgentSandboxesDebugResponse": {
             "type": "object",
             "properties": {
@@ -24714,59 +24782,6 @@ const docTemplate = `{
                 "valid": {
                     "description": "that subscription passed its last liveness probe",
                     "type": "boolean"
-                }
-            }
-        },
-        "server.AppCreateResponse": {
-            "type": "object",
-            "properties": {
-                "config": {
-                    "$ref": "#/definitions/types.AppConfig"
-                },
-                "created": {
-                    "type": "string"
-                },
-                "global": {
-                    "type": "boolean"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_helix_org_agent": {
-                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
-                    "type": "boolean"
-                },
-                "model_substitutions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/server.ModelSubstitution"
-                    }
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "owner": {
-                    "description": "uuid of user ID",
-                    "type": "string"
-                },
-                "owner_type": {
-                    "description": "e.g. user, system, org",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.OwnerType"
-                        }
-                    ]
-                },
-                "updated": {
-                    "type": "string"
-                },
-                "user": {
-                    "description": "Owner user struct, populated by the server for organization views",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.User"
-                        }
-                    ]
                 }
             }
         },
@@ -27190,6 +27205,122 @@ const docTemplate = `{
                 }
             }
         },
+        "types.Agent": {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "$ref": "#/definitions/types.AgentConfig"
+                },
+                "created": {
+                    "type": "string"
+                },
+                "global": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_helix_org_agent": {
+                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
+                    "type": "boolean"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "owner": {
+                    "description": "uuid of user ID",
+                    "type": "string"
+                },
+                "owner_type": {
+                    "description": "e.g. user, system, org",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.OwnerType"
+                        }
+                    ]
+                },
+                "updated": {
+                    "type": "string"
+                },
+                "user": {
+                    "description": "Owner user struct, populated by the server for organization views",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.User"
+                        }
+                    ]
+                }
+            }
+        },
+        "types.AgentConfig": {
+            "type": "object",
+            "properties": {
+                "allowed_domains": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "helix": {
+                    "$ref": "#/definitions/types.AgentHelixConfig"
+                },
+                "secrets": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "types.AgentHelixConfig": {
+            "type": "object",
+            "properties": {
+                "assistants": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.AssistantConfig"
+                    }
+                },
+                "avatar": {
+                    "type": "string"
+                },
+                "avatar_content_type": {
+                    "type": "string"
+                },
+                "default_agent_type": {
+                    "description": "Agent configuration",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.AgentType"
+                        }
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "external_agent_config": {
+                    "$ref": "#/definitions/types.ExternalAgentConfig"
+                },
+                "external_agent_enabled": {
+                    "type": "boolean"
+                },
+                "external_url": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "triggers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.Trigger"
+                    }
+                }
+            }
+        },
         "types.AgentType": {
             "type": "string",
             "enum": [
@@ -27320,122 +27451,6 @@ const docTemplate = `{
                 },
                 "type": {
                     "$ref": "#/definitions/types.APIKeyType"
-                }
-            }
-        },
-        "types.App": {
-            "type": "object",
-            "properties": {
-                "config": {
-                    "$ref": "#/definitions/types.AppConfig"
-                },
-                "created": {
-                    "type": "string"
-                },
-                "global": {
-                    "type": "boolean"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_helix_org_agent": {
-                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
-                    "type": "boolean"
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "owner": {
-                    "description": "uuid of user ID",
-                    "type": "string"
-                },
-                "owner_type": {
-                    "description": "e.g. user, system, org",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.OwnerType"
-                        }
-                    ]
-                },
-                "updated": {
-                    "type": "string"
-                },
-                "user": {
-                    "description": "Owner user struct, populated by the server for organization views",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.User"
-                        }
-                    ]
-                }
-            }
-        },
-        "types.AppConfig": {
-            "type": "object",
-            "properties": {
-                "allowed_domains": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "helix": {
-                    "$ref": "#/definitions/types.AppHelixConfig"
-                },
-                "secrets": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "types.AppHelixConfig": {
-            "type": "object",
-            "properties": {
-                "assistants": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.AssistantConfig"
-                    }
-                },
-                "avatar": {
-                    "type": "string"
-                },
-                "avatar_content_type": {
-                    "type": "string"
-                },
-                "default_agent_type": {
-                    "description": "Agent configuration",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.AgentType"
-                        }
-                    ]
-                },
-                "description": {
-                    "type": "string"
-                },
-                "external_agent_config": {
-                    "$ref": "#/definitions/types.ExternalAgentConfig"
-                },
-                "external_agent_enabled": {
-                    "type": "boolean"
-                },
-                "external_url": {
-                    "type": "string"
-                },
-                "image": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "triggers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.Trigger"
-                    }
                 }
             }
         },
@@ -29808,7 +29823,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "app_config_snapshot": {
-                    "$ref": "#/definitions/types.AppConfig"
+                    "$ref": "#/definitions/types.AgentConfig"
                 },
                 "app_id": {
                     "type": "string"

--- a/api/pkg/server/evaluation_handlers.go
+++ b/api/pkg/server/evaluation_handlers.go
@@ -41,20 +41,20 @@ func (s *HelixAPIServer) canAccessEvaluationSuite(ctx context.Context, user *typ
 // @Tags evaluations
 // @Accept json
 // @Produce json
-// @Param app_id path string true "App ID"
+// @Param agent_id path string true "Agent ID"
 // @Param suite body types.EvaluationSuite true "Evaluation suite to create"
 // @Success 201 {object} types.EvaluationSuite
 // @Failure 400 {object} system.HTTPError
 // @Failure 403 {object} system.HTTPError
 // @Failure 500 {object} system.HTTPError
-// @Router /api/v1/apps/{app_id}/evaluation-suites [post]
+// @Router /api/v1/agents/{agent_id}/evaluation-suites [post]
 // @Security BearerAuth
 func (s *HelixAPIServer) createEvaluationSuite(_ http.ResponseWriter, req *http.Request) (*types.EvaluationSuite, *system.HTTPError) {
 	ctx := req.Context()
 	user := getRequestUser(req)
-	appID := mux.Vars(req)["app_id"]
+	agentID := mux.Vars(req)["agent_id"]
 
-	app, httpErr := s.getAppForEvaluation(ctx, user, appID)
+	app, httpErr := s.getAppForEvaluation(ctx, user, agentID)
 	if httpErr != nil {
 		return nil, httpErr
 	}
@@ -69,7 +69,7 @@ func (s *HelixAPIServer) createEvaluationSuite(_ http.ResponseWriter, req *http.
 	}
 
 	suite.UserID = user.ID
-	suite.AppID = appID
+	suite.AppID = agentID
 	suite.OrganizationID = app.OrganizationID
 
 	// Ensure question IDs are set
@@ -92,12 +92,12 @@ func (s *HelixAPIServer) createEvaluationSuite(_ http.ResponseWriter, req *http.
 // @Description Get an evaluation suite by ID
 // @Tags evaluations
 // @Produce json
-// @Param app_id path string true "App ID"
+// @Param agent_id path string true "Agent ID"
 // @Param id path string true "Suite ID"
 // @Success 200 {object} types.EvaluationSuite
 // @Failure 403 {object} system.HTTPError
 // @Failure 404 {object} system.HTTPError
-// @Router /api/v1/apps/{app_id}/evaluation-suites/{id} [get]
+// @Router /api/v1/agents/{agent_id}/evaluation-suites/{id} [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) getEvaluationSuite(_ http.ResponseWriter, req *http.Request) (*types.EvaluationSuite, *system.HTTPError) {
 	ctx := req.Context()
@@ -125,14 +125,14 @@ func (s *HelixAPIServer) getEvaluationSuite(_ http.ResponseWriter, req *http.Req
 // @Tags evaluations
 // @Accept json
 // @Produce json
-// @Param app_id path string true "App ID"
+// @Param agent_id path string true "Agent ID"
 // @Param id path string true "Suite ID"
 // @Param suite body types.EvaluationSuite true "Updated suite"
 // @Success 200 {object} types.EvaluationSuite
 // @Failure 400 {object} system.HTTPError
 // @Failure 403 {object} system.HTTPError
 // @Failure 404 {object} system.HTTPError
-// @Router /api/v1/apps/{app_id}/evaluation-suites/{id} [put]
+// @Router /api/v1/agents/{agent_id}/evaluation-suites/{id} [put]
 // @Security BearerAuth
 func (s *HelixAPIServer) updateEvaluationSuite(_ http.ResponseWriter, req *http.Request) (*types.EvaluationSuite, *system.HTTPError) {
 	ctx := req.Context()
@@ -180,12 +180,12 @@ func (s *HelixAPIServer) updateEvaluationSuite(_ http.ResponseWriter, req *http.
 // @Summary Delete an evaluation suite
 // @Description Delete an evaluation suite
 // @Tags evaluations
-// @Param app_id path string true "App ID"
+// @Param agent_id path string true "Agent ID"
 // @Param id path string true "Suite ID"
 // @Success 200 {object} map[string]string
 // @Failure 403 {object} system.HTTPError
 // @Failure 404 {object} system.HTTPError
-// @Router /api/v1/apps/{app_id}/evaluation-suites/{id} [delete]
+// @Router /api/v1/agents/{agent_id}/evaluation-suites/{id} [delete]
 // @Security BearerAuth
 func (s *HelixAPIServer) deleteEvaluationSuite(_ http.ResponseWriter, req *http.Request) (map[string]string, *system.HTTPError) {
 	ctx := req.Context()
@@ -212,27 +212,27 @@ func (s *HelixAPIServer) deleteEvaluationSuite(_ http.ResponseWriter, req *http.
 }
 
 // listEvaluationSuites godoc
-// @Summary List evaluation suites for an app
-// @Description List all evaluation suites for an app
+// @Summary List evaluation suites for an agent
+// @Description List all evaluation suites for an agent
 // @Tags evaluations
 // @Produce json
-// @Param app_id path string true "App ID"
+// @Param agent_id path string true "Agent ID"
 // @Success 200 {array} types.EvaluationSuite
 // @Failure 403 {object} system.HTTPError
-// @Router /api/v1/apps/{app_id}/evaluation-suites [get]
+// @Router /api/v1/agents/{agent_id}/evaluation-suites [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) listEvaluationSuites(_ http.ResponseWriter, req *http.Request) ([]*types.EvaluationSuite, *system.HTTPError) {
 	ctx := req.Context()
 	user := getRequestUser(req)
-	appID := mux.Vars(req)["app_id"]
+	agentID := mux.Vars(req)["agent_id"]
 
-	_, httpErr := s.getAppForEvaluation(ctx, user, appID)
+	_, httpErr := s.getAppForEvaluation(ctx, user, agentID)
 	if httpErr != nil {
 		return nil, httpErr
 	}
 
 	suites, err := s.Store.ListEvaluationSuites(ctx, &types.ListEvaluationSuitesRequest{
-		AppID: appID,
+		AppID: agentID,
 	})
 	if err != nil {
 		return nil, system.NewHTTPError500(err.Error())
@@ -293,21 +293,21 @@ func removeRunListener(runID string, ch chan types.EvaluationRunProgress) {
 // @Tags evaluations
 // @Accept json
 // @Produce json
-// @Param app_id path string true "App ID"
+// @Param agent_id path string true "Agent ID"
 // @Param id path string true "Suite ID"
 // @Success 200 {object} types.EvaluationRun
 // @Failure 400 {object} system.HTTPError
 // @Failure 403 {object} system.HTTPError
 // @Failure 404 {object} system.HTTPError
-// @Router /api/v1/apps/{app_id}/evaluation-suites/{id}/runs [post]
+// @Router /api/v1/agents/{agent_id}/evaluation-suites/{id}/runs [post]
 // @Security BearerAuth
 func (s *HelixAPIServer) startEvaluationRun(_ http.ResponseWriter, req *http.Request) (*types.EvaluationRun, *system.HTTPError) {
 	ctx := req.Context()
 	user := getRequestUser(req)
-	appID := mux.Vars(req)["app_id"]
+	agentID := mux.Vars(req)["agent_id"]
 	suiteID := mux.Vars(req)["id"]
 
-	app, httpErr := s.getAppForEvaluation(ctx, user, appID)
+	app, httpErr := s.getAppForEvaluation(ctx, user, agentID)
 	if httpErr != nil {
 		return nil, httpErr
 	}
@@ -330,7 +330,7 @@ func (s *HelixAPIServer) startEvaluationRun(_ http.ResponseWriter, req *http.Req
 
 	run := &types.EvaluationRun{
 		SuiteID:           suiteID,
-		AppID:             appID,
+		AppID:             agentID,
 		UserID:            user.ID,
 		OrganizationID:    app.OrganizationID,
 		Status:            types.EvaluationRunStatusPending,
@@ -364,26 +364,26 @@ func (s *HelixAPIServer) startEvaluationRun(_ http.ResponseWriter, req *http.Req
 // @Description List evaluation runs for a suite
 // @Tags evaluations
 // @Produce json
-// @Param app_id path string true "App ID"
+// @Param agent_id path string true "Agent ID"
 // @Param id path string true "Suite ID"
 // @Success 200 {array} types.EvaluationRun
 // @Failure 403 {object} system.HTTPError
-// @Router /api/v1/apps/{app_id}/evaluation-suites/{id}/runs [get]
+// @Router /api/v1/agents/{agent_id}/evaluation-suites/{id}/runs [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) listEvaluationRuns(_ http.ResponseWriter, req *http.Request) ([]*types.EvaluationRun, *system.HTTPError) {
 	ctx := req.Context()
 	user := getRequestUser(req)
-	appID := mux.Vars(req)["app_id"]
+	agentID := mux.Vars(req)["agent_id"]
 	suiteID := mux.Vars(req)["id"]
 
-	_, httpErr := s.getAppForEvaluation(ctx, user, appID)
+	_, httpErr := s.getAppForEvaluation(ctx, user, agentID)
 	if httpErr != nil {
 		return nil, httpErr
 	}
 
 	runs, err := s.Store.ListEvaluationRuns(ctx, &types.ListEvaluationRunsRequest{
 		SuiteID: suiteID,
-		AppID:   appID,
+		AppID:   agentID,
 		Limit:   50,
 	})
 	if err != nil {
@@ -399,19 +399,19 @@ func (s *HelixAPIServer) listEvaluationRuns(_ http.ResponseWriter, req *http.Req
 // @Description Get evaluation run details
 // @Tags evaluations
 // @Produce json
-// @Param app_id path string true "App ID"
+// @Param agent_id path string true "Agent ID"
 // @Param run_id path string true "Run ID"
 // @Success 200 {object} types.EvaluationRun
 // @Failure 404 {object} system.HTTPError
-// @Router /api/v1/apps/{app_id}/evaluation-runs/{run_id} [get]
+// @Router /api/v1/agents/{agent_id}/evaluation-runs/{run_id} [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) getEvaluationRun(_ http.ResponseWriter, req *http.Request) (*types.EvaluationRun, *system.HTTPError) {
 	ctx := req.Context()
 	user := getRequestUser(req)
 	runID := mux.Vars(req)["run_id"]
-	appID := mux.Vars(req)["app_id"]
+	agentID := mux.Vars(req)["agent_id"]
 
-	_, httpErr := s.getAppForEvaluation(ctx, user, appID)
+	_, httpErr := s.getAppForEvaluation(ctx, user, agentID)
 	if httpErr != nil {
 		return nil, httpErr
 	}
@@ -431,20 +431,20 @@ func (s *HelixAPIServer) getEvaluationRun(_ http.ResponseWriter, req *http.Reque
 // @Summary Delete an evaluation run
 // @Description Delete an evaluation run
 // @Tags evaluations
-// @Param app_id path string true "App ID"
+// @Param agent_id path string true "Agent ID"
 // @Param run_id path string true "Run ID"
 // @Success 200 {object} map[string]string
 // @Failure 403 {object} system.HTTPError
 // @Failure 404 {object} system.HTTPError
-// @Router /api/v1/apps/{app_id}/evaluation-runs/{run_id} [delete]
+// @Router /api/v1/agents/{agent_id}/evaluation-runs/{run_id} [delete]
 // @Security BearerAuth
 func (s *HelixAPIServer) deleteEvaluationRun(_ http.ResponseWriter, req *http.Request) (map[string]string, *system.HTTPError) {
 	ctx := req.Context()
 	user := getRequestUser(req)
 	runID := mux.Vars(req)["run_id"]
-	appID := mux.Vars(req)["app_id"]
+	agentID := mux.Vars(req)["agent_id"]
 
-	_, httpErr := s.getAppForEvaluation(ctx, user, appID)
+	_, httpErr := s.getAppForEvaluation(ctx, user, agentID)
 	if httpErr != nil {
 		return nil, httpErr
 	}
@@ -464,9 +464,9 @@ func (s *HelixAPIServer) streamEvaluationRun(w http.ResponseWriter, req *http.Re
 	ctx := req.Context()
 	user := getRequestUser(req)
 	runID := mux.Vars(req)["run_id"]
-	appID := mux.Vars(req)["app_id"]
+	agentID := mux.Vars(req)["agent_id"]
 
-	_, httpErr := s.getAppForEvaluation(ctx, user, appID)
+	_, httpErr := s.getAppForEvaluation(ctx, user, agentID)
 	if httpErr != nil {
 		http.Error(w, httpErr.Message, httpErr.StatusCode)
 		return
@@ -490,12 +490,12 @@ func (s *HelixAPIServer) streamEvaluationRun(w http.ResponseWriter, req *http.Re
 		w.Header().Set("Connection", "keep-alive")
 
 		progress := types.EvaluationRunProgress{
-			RunID:          run.ID,
-			Status:         run.Status,
-			TotalQuestions: run.Summary.TotalQuestions,
+			RunID:           run.ID,
+			Status:          run.Status,
+			TotalQuestions:  run.Summary.TotalQuestions,
 			CurrentQuestion: run.Summary.TotalQuestions,
-			Summary:        &run.Summary,
-			Error:          run.Error,
+			Summary:         &run.Summary,
+			Error:           run.Error,
 		}
 		data, _ := json.Marshal(progress)
 		fmt.Fprintf(w, "data: %s\n\n", data)
@@ -546,12 +546,12 @@ func (s *HelixAPIServer) streamEvaluationRun(w http.ResponseWriter, req *http.Re
 
 // --- Helper ---
 
-func (s *HelixAPIServer) getAppForEvaluation(ctx context.Context, user *types.User, appID string) (*types.App, *system.HTTPError) {
-	if appID == "" {
-		return nil, system.NewHTTPError400("app_id is required")
+func (s *HelixAPIServer) getAppForEvaluation(ctx context.Context, user *types.User, agentID string) (*types.App, *system.HTTPError) {
+	if agentID == "" {
+		return nil, system.NewHTTPError400("agent_id is required")
 	}
 
-	app, err := s.Store.GetAppWithTools(ctx, appID)
+	app, err := s.Store.GetAppWithTools(ctx, agentID)
 	if err != nil {
 		if err == store.ErrNotFound {
 			return nil, system.NewHTTPError404("app not found")

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -168,12 +168,12 @@ func (o orgWorkerRuntime) State(ctx context.Context, orgID string, workerID orgc
 	}
 	info := helixorgapi.BotRuntimeInfo{
 		ProjectID:   s.ProjectID,
-		AgentAppID:  s.AgentAppID,
+		AgentID:     s.AgentID,
 		SessionID:   s.SessionID,
 		AgentStatus: "stopped",
 	}
-	if s.AgentAppID != "" && o.sessions != nil {
-		if app, err := o.sessions.GetApp(ctx, s.AgentAppID); err == nil && app != nil && len(app.Config.Helix.Assistants) > 0 {
+	if s.AgentID != "" && o.sessions != nil {
+		if app, err := o.sessions.GetApp(ctx, s.AgentID); err == nil && app != nil && len(app.Config.Helix.Assistants) > 0 {
 			assistant := app.Config.Helix.Assistants[0]
 			info.Runtime = string(assistant.CodeAgentRuntime)
 			info.Model = assistant.Model

--- a/api/pkg/server/helix_org_inproc.go
+++ b/api/pkg/server/helix_org_inproc.go
@@ -217,11 +217,11 @@ func (c *inProcHelixClient) UpdateAgent(ctx context.Context, appID string, patch
 			assistant.GenerationModel = ""
 		}
 	}
-	r, err := c.newRequest(ctx, http.MethodPut, "/api/v1/apps/"+appID, update, map[string]string{"id": appID})
+	r, err := c.newRequest(ctx, http.MethodPut, "/api/v1/agents/"+appID, update, map[string]string{"id": appID})
 	if err != nil {
 		return err
 	}
-	if _, herr := c.server.updateApp(nil, r); herr != nil {
+	if _, herr := c.server.updateAgent(nil, r); herr != nil {
 		rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 		defer cancel()
 		if _, rollbackErr := c.server.Store.UpdateApp(rollbackCtx, &prior); rollbackErr != nil {
@@ -625,11 +625,11 @@ func (c *inProcHelixClient) CreateBranch(ctx context.Context, repoID, branch, ba
 // GetAppConfig returns the typed config for an App. Used by
 // runtimehelix.AttachHelixOrgMCP to round-trip MCP entries.
 func (c *inProcHelixClient) GetAppConfig(ctx context.Context, id string) (types.AppConfig, error) {
-	r, err := c.newRequest(ctx, http.MethodGet, "/api/v1/apps/"+id, nil, map[string]string{"id": id})
+	r, err := c.newRequest(ctx, http.MethodGet, "/api/v1/agents/"+id, nil, map[string]string{"id": id})
 	if err != nil {
 		return types.AppConfig{}, err
 	}
-	app, herr := c.server.getApp(nil, r)
+	app, herr := c.server.getAgent(nil, r)
 	if herr != nil {
 		return types.AppConfig{}, fmt.Errorf("get app %s: %s", id, herr.Error())
 	}
@@ -645,17 +645,17 @@ func (c *inProcHelixClient) GetApp(ctx context.Context, id string) (*types.App, 
 
 // UpdateAppConfig persists a mutated app config.
 func (c *inProcHelixClient) UpdateAppConfig(ctx context.Context, id string, cfg types.AppConfig) error {
-	// updateApp reads the existing app to preserve immutable fields, so
+	// updateAgent reads the existing app to preserve immutable fields, so
 	// we only need to send {id, config}.
 	body := types.App{
 		ID:     id,
 		Config: cfg,
 	}
-	r, err := c.newRequest(ctx, http.MethodPut, "/api/v1/apps/"+id, body, map[string]string{"id": id})
+	r, err := c.newRequest(ctx, http.MethodPut, "/api/v1/agents/"+id, body, map[string]string{"id": id})
 	if err != nil {
 		return err
 	}
-	if _, herr := c.server.updateApp(nil, r); herr != nil {
+	if _, herr := c.server.updateAgent(nil, r); herr != nil {
 		return fmt.Errorf("update app %s: %s", id, herr.Error())
 	}
 	return nil

--- a/api/pkg/server/helix_org_middleware.go
+++ b/api/pkg/server/helix_org_middleware.go
@@ -212,11 +212,11 @@ func repairNeverActivatedBots(ctx context.Context, orgID string, st *helixorgsto
 		if len(acts) > 0 {
 			continue
 		}
-		if b.AgentAppID != "" {
+		if b.AgentID != "" {
 			if applier == nil {
 				return fmt.Errorf("apply defaults to never-activated bot %s: applier is not wired", b.ID)
 			}
-			if err := applier.ApplyAgentDefaults(ctx, b.AgentAppID, defaults); err != nil {
+			if err := applier.ApplyAgentDefaults(ctx, b.AgentID, defaults); err != nil {
 				return fmt.Errorf("apply defaults to never-activated bot %s: %w", b.ID, err)
 			}
 		}

--- a/api/pkg/server/helix_org_middleware_test.go
+++ b/api/pkg/server/helix_org_middleware_test.go
@@ -265,7 +265,7 @@ func TestRepairNeverActivatedBotsSkipsHumansAndActivatedBots(t *testing.T) {
 	configs.Register(configregistry.Spec{Key: configregistry.DefaultAgentConfigKey, Type: configregistry.TypeObject})
 	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
 	for _, b := range []orgchart.Node{
-		mustBot(t, "bot-legacy-a", "", now).WithAgentAppID("app-legacy-a"),
+		mustBot(t, "bot-legacy-a", "", now).WithAgentID("app-legacy-a"),
 		mustBot(t, "bot-legacy-b", "", now),
 		mustBot(t, "bot-created", "", now),
 		mustBot(t, "human-owner", orgchart.NodeKindHuman, now),

--- a/api/pkg/server/knowledge_handlers.go
+++ b/api/pkg/server/knowledge_handlers.go
@@ -40,7 +40,7 @@ func (s *HelixAPIServer) listKnowledge(_ http.ResponseWriter, r *http.Request) (
 	switch {
 	case appID != "":
 		// Knowledge is an app-scoped resource. Authorize against the app
-		// itself (the same way getApp does) instead of owner-equality, so
+		// itself (the same way getAgent does) instead of owner-equality, so
 		// everyone who can see the agent can see its knowledge — including
 		// org members editing a shared project agent they don't personally
 		// own. ensureKnowledge stamps each row with the app owner's id, so an

--- a/api/pkg/server/llm_calls_handlers.go
+++ b/api/pkg/server/llm_calls_handlers.go
@@ -66,7 +66,7 @@ func (s *HelixAPIServer) listLLMCalls(_ http.ResponseWriter, r *http.Request) (*
 
 // listAppLLMCalls godoc
 // @Summary List LLM calls
-// @Description List user's LLM calls with pagination and optional session filtering for a specific app
+// @Description List user's LLM calls with pagination and optional session filtering for a specific agent
 // @Tags    llm_calls
 // @Produce json
 // @Param   page          query    int     false  "Page number"
@@ -74,7 +74,7 @@ func (s *HelixAPIServer) listLLMCalls(_ http.ResponseWriter, r *http.Request) (*
 // @Param   session       query    string  false  "Filter by session ID"
 // @Param   interaction   query    string  false  "Filter by interaction ID"
 // @Success 200 {object} types.PaginatedLLMCalls
-// @Router /api/v1/apps/{id}/llm-calls [get]
+// @Router /api/v1/agents/{id}/llm-calls [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) listAppLLMCalls(_ http.ResponseWriter, r *http.Request) (*types.PaginatedLLMCalls, *system.HTTPError) {
 	appID := getID(r)
@@ -143,7 +143,7 @@ func (s *HelixAPIServer) listAppLLMCalls(_ http.ResponseWriter, r *http.Request)
 
 // listAppInteractions godoc
 // @Summary List interactions
-// @Description List interactions with pagination and optional session filtering for a specific app
+// @Description List interactions with pagination and optional session filtering for a specific agent
 // @Tags    interactions
 // @Produce json
 // @Param   page          query    int     false  "Page number"
@@ -152,7 +152,7 @@ func (s *HelixAPIServer) listAppLLMCalls(_ http.ResponseWriter, r *http.Request)
 // @Param   interaction   query    string  false  "Filter by interaction ID"
 // @Param   feedback      query    string  false  "Query by like/dislike"
 // @Success 200 {object} types.PaginatedInteractions
-// @Router /api/v1/apps/{id}/interactions [get]
+// @Router /api/v1/agents/{id}/interactions [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) listAppInteractions(_ http.ResponseWriter, r *http.Request) (*types.PaginatedInteractions, *system.HTTPError) {
 	appID := getID(r)
@@ -240,12 +240,12 @@ func (s *HelixAPIServer) listAppInteractions(_ http.ResponseWriter, r *http.Requ
 
 // listAppStepInfo godoc
 // @Summary List step info
-// @Description List step info for a specific app and interaction ID, used to build the timeline of events
+// @Description List step info for a specific agent and interaction ID, used to build the timeline of events
 // @Tags    step_info
 // @Produce json
 // @Param   interactionId query    string  false  "Interaction ID"
 // @Success 200 {array} types.StepInfo
-// @Router /api/v1/apps/{id}/step-info [get]
+// @Router /api/v1/agents/{id}/step-info [get]
 // @Security BearerAuth
 func (s *HelixAPIServer) listAppStepInfo(_ http.ResponseWriter, r *http.Request) ([]*types.StepInfo, *system.HTTPError) {
 	appID := getID(r)

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1054,18 +1054,6 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	authRouter.HandleFunc("/sessions/{id}/turns/{turn}", system.Wrapper(apiServer.getInteractionByTurn)).Methods(http.MethodGet)
 	authRouter.HandleFunc("/sessions/{id}/search", system.Wrapper(apiServer.searchSessionInteractions)).Methods(http.MethodGet)
 
-	// Evaluation suites & runs
-	authRouter.HandleFunc("/apps/{app_id}/evaluation-suites", system.Wrapper(apiServer.listEvaluationSuites)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/apps/{app_id}/evaluation-suites", system.Wrapper(apiServer.createEvaluationSuite)).Methods(http.MethodPost)
-	authRouter.HandleFunc("/apps/{app_id}/evaluation-suites/{id}", system.Wrapper(apiServer.getEvaluationSuite)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/apps/{app_id}/evaluation-suites/{id}", system.Wrapper(apiServer.updateEvaluationSuite)).Methods(http.MethodPut)
-	authRouter.HandleFunc("/apps/{app_id}/evaluation-suites/{id}", system.Wrapper(apiServer.deleteEvaluationSuite)).Methods(http.MethodDelete)
-	authRouter.HandleFunc("/apps/{app_id}/evaluation-suites/{id}/runs", system.Wrapper(apiServer.startEvaluationRun)).Methods(http.MethodPost)
-	authRouter.HandleFunc("/apps/{app_id}/evaluation-suites/{id}/runs", system.Wrapper(apiServer.listEvaluationRuns)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/apps/{app_id}/evaluation-runs/{run_id}", system.Wrapper(apiServer.getEvaluationRun)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/apps/{app_id}/evaluation-runs/{run_id}", system.Wrapper(apiServer.deleteEvaluationRun)).Methods(http.MethodDelete)
-	authRouter.HandleFunc("/apps/{app_id}/evaluation-runs/{run_id}/stream", apiServer.streamEvaluationRun).Methods(http.MethodGet)
-
 	authRouter.HandleFunc("/question-sets", system.Wrapper(apiServer.listQuestionSets)).Methods(http.MethodGet)
 	authRouter.HandleFunc("/question-sets", system.Wrapper(apiServer.createQuestionSet)).Methods(http.MethodPost)
 	authRouter.HandleFunc("/question-sets/{id}", system.Wrapper(apiServer.getQuestionSet)).Methods(http.MethodGet)
@@ -1117,27 +1105,7 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	authRouter.HandleFunc("/sessions/{id}/codex-credentials", system.Wrapper(apiServer.getSessionCodexCredentials)).Methods(http.MethodGet)
 	authRouter.HandleFunc("/sessions/{id}/codex-credentials", system.Wrapper(apiServer.updateSessionCodexCredentials)).Methods(http.MethodPut)
 
-	authRouter.HandleFunc("/apps", wrapWithETag[[]*types.App](apiServer.listApps)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/apps", system.Wrapper(apiServer.createApp)).Methods(http.MethodPost)
-	authRouter.HandleFunc("/apps/{id}", system.Wrapper(apiServer.getApp)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/apps/{id}", system.Wrapper(apiServer.updateApp)).Methods(http.MethodPut)
-	authRouter.HandleFunc("/apps/{id}", system.Wrapper(apiServer.deleteApp)).Methods(http.MethodDelete)
-	authRouter.HandleFunc("/apps/{id}/claude-subscription-status", system.Wrapper(apiServer.getAppClaudeSubscriptionStatus)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/apps/{id}/daily-usage", system.Wrapper(apiServer.getAppDailyUsage)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/apps/{id}/users-daily-usage", system.Wrapper(apiServer.getAppUsersDailyUsage)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/apps/{id}/llm-calls", system.Wrapper(apiServer.listAppLLMCalls)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/apps/{id}/interactions", system.Wrapper(apiServer.listAppInteractions)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/apps/{id}/step-info", system.Wrapper(apiServer.listAppStepInfo)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/apps/{id}/api-actions", system.Wrapper(apiServer.appRunAPIAction)).Methods(http.MethodPost)
-	authRouter.HandleFunc("/apps/{id}/user-access", system.Wrapper(apiServer.getAppUserAccess)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/apps/{id}/access-grants", apiServer.listAppAccessGrants).Methods(http.MethodGet)
-	authRouter.HandleFunc("/apps/{id}/access-grants", apiServer.createAppAccessGrant).Methods(http.MethodPost)
-	authRouter.HandleFunc("/apps/{id}/access-grants/{grant_id}", apiServer.deleteAppAccessGrant).Methods(http.MethodDelete)
-	authRouter.HandleFunc("/apps/{id}/duplicate", system.Wrapper(apiServer.duplicateApp)).Methods(http.MethodPost)
-	authRouter.HandleFunc("/apps/{id}/memories", system.Wrapper(apiServer.listAppMemories)).Methods(http.MethodGet)
-	authRouter.HandleFunc("/apps/{id}/memories/{memory_id}", system.Wrapper(apiServer.deleteAppMemory)).Methods(http.MethodDelete)
-
-	authRouter.HandleFunc("/apps/{id}/triggers", system.Wrapper(apiServer.listAppTriggers)).Methods(http.MethodGet)
+	apiServer.registerAgentRoutes(authRouter, insecureRouter)
 
 	// Triggers provide an ability for users to create recurring tasks for agents or
 	// to connect an agent built by another user to their own slack/dicord/etc.
@@ -1148,15 +1116,6 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	authRouter.HandleFunc("/triggers/{trigger_id}/execute", system.Wrapper(apiServer.executeAppTrigger)).Methods(http.MethodPost)
 
 	authRouter.HandleFunc("/triggers/{trigger_id}/executions", system.Wrapper(apiServer.listTriggerExecutions)).Methods(http.MethodGet)
-
-	// Avatar routes
-	authRouter.HandleFunc("/apps/{id}/avatar", apiServer.uploadAppAvatar).Methods(http.MethodPost)
-	authRouter.HandleFunc("/apps/{id}/avatar", apiServer.deleteAppAvatar).Methods(http.MethodDelete)
-	// Anyone can get the avatar
-	insecureRouter.HandleFunc("/apps/{id}/avatar", apiServer.getAppAvatar).Methods(http.MethodGet)
-
-	// Trigger status routes
-	authRouter.HandleFunc("/apps/{id}/trigger-status", apiServer.getAppTriggerStatus).Methods(http.MethodGet)
 
 	// Knowledge search endpoint (prompt= param)
 	authRouter.HandleFunc("/search", system.Wrapper(apiServer.knowledgeSearch)).Methods(http.MethodGet).Queries("prompt", "{prompt}")
@@ -1175,8 +1134,6 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	authRouter.HandleFunc("/skills/{id}", system.DefaultWrapper(apiServer.handleGetSkill)).Methods("GET")
 	authRouter.HandleFunc("/skills/reload", system.DefaultWrapper(apiServer.handleReloadSkills)).Methods("POST")
 	authRouter.HandleFunc("/skills/validate", system.DefaultWrapper(apiServer.handleValidateMcpSkill)).Methods("POST")
-	authRouter.HandleFunc("/apps/{id}/skills/{skill}/enable", system.Wrapper(apiServer.handleEnableSkill)).Methods("POST")
-
 	// External agent routes - desktop streaming and Zed agent communication
 	// Note: Session start/stop/resume use /sessions endpoints, not /external-agents
 	authRouter.HandleFunc("/external-agents/sync", apiServer.handleExternalAgentSync).Methods("GET")                                   // WebSocket: Zed agent bidirectional communication (chat, tool calls)

--- a/api/pkg/server/skills.go
+++ b/api/pkg/server/skills.go
@@ -198,13 +198,13 @@ func (s *HelixAPIServer) handleValidateMcpSkill(_ http.ResponseWriter, r *http.R
 // no user input is required.
 //
 // enableSkill godoc
-// @Summary Enable a marketplace skill on an app
-// @Description Enable a marketplace skill on an app. For autoProvision MCP skills the server generates URL and auth automatically.
+// @Summary Enable a marketplace skill on an agent
+// @Description Enable a marketplace skill on an agent. For autoProvision MCP skills the server generates URL and auth automatically.
 // @Tags    skills
-// @Param   id   path string true "App ID"
+// @Param   id   path string true "Agent ID"
 // @Param   skill path string true "Skill name (e.g. code-intelligence)"
-// @Success 200 {object} types.App
-// @Router /api/v1/apps/{id}/skills/{skill}/enable [post]
+// @Success 200 {object} types.Agent
+// @Router /api/v1/agents/{id}/skills/{skill}/enable [post]
 // @Security BearerAuth
 func (s *HelixAPIServer) handleEnableSkill(_ http.ResponseWriter, r *http.Request) (*types.App, *system.HTTPError) {
 	user := getRequestUser(r)

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -1110,6 +1110,1465 @@
                 }
             }
         },
+        "/api/v1/agents": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List agents for the user. Agents are pre-configured to spawn sessions with specific tools and config.",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "List agents",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization ID",
+                        "name": "organization_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.Agent"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "description": "Request body with agent configuration. Can be legacy Agent format or structured format with organization_id, global, and yaml_config fields.",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.Agent"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.AgentCreateResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/evaluation-runs/{run_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get evaluation run details",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Get an evaluation run",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Run ID",
+                        "name": "run_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationRun"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete an evaluation run",
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Delete an evaluation run",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Run ID",
+                        "name": "run_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/evaluation-suites": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List all evaluation suites for an agent",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "List evaluation suites for an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.EvaluationSuite"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new evaluation suite for an agent",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Create an evaluation suite",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Evaluation suite to create",
+                        "name": "suite",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationSuite"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationSuite"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/evaluation-suites/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get an evaluation suite by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Get an evaluation suite",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationSuite"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update an evaluation suite",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Update an evaluation suite",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated suite",
+                        "name": "suite",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationSuite"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationSuite"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete an evaluation suite",
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Delete an evaluation suite",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/evaluation-suites/{id}/runs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List evaluation runs for a suite",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "List evaluation runs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.EvaluationRun"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Start running an evaluation suite against an agent",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Start an evaluation run",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationRun"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/triggers": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List triggers for the agent",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "List agent triggers",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.TriggerConfiguration"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Agent"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "description": "Request body with agent configuration.",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.Agent"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Tool ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Agent"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/access-grants": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List access grants for an agent (organization owners and members can list access grants)",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "List agent access grants",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.AccessGrant"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Grant access to an agent to a team or organization member (organization owners can grant access to teams and organization members)",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Grant access to an agent to a team or organization member",
+                "parameters": [
+                    {
+                        "description": "Request body with team or organization member ID and role",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.CreateAccessGrantRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.AccessGrant"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/api-actions": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Runs an API action for an agent",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Run an API action",
+                "parameters": [
+                    {
+                        "description": "Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.RunAPIActionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.RunAPIActionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/avatar": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get the agent's avatar image",
+                "produces": [
+                    "image/*"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get agent avatar",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Avatar image data",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Upload a base64 encoded image as the agent's avatar",
+                "consumes": [
+                    "text/plain"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Upload agent avatar",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Base64 encoded image data",
+                        "name": "image",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete the agent's avatar image",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Delete agent avatar",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/claude-subscription-status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Reports whether the agent owner (whose subscription authenticates the agent's sessions) has a working Claude subscription",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Claude"
+                ],
+                "summary": "Get the Claude subscription status for an agent's owner",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.AppClaudeSubscriptionStatus"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/daily-usage": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get agent daily usage",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get agent usage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date",
+                        "name": "to",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.AggregatedUsageMetric"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/duplicate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Optional new name for the agent",
+                        "name": "name",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/interactions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List interactions with pagination and optional session filtering for a specific agent",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "interactions"
+                ],
+                "summary": "List interactions",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by session ID",
+                        "name": "session",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by interaction ID",
+                        "name": "interaction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Query by like/dislike",
+                        "name": "feedback",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedInteractions"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/llm-calls": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List user's LLM calls with pagination and optional session filtering for a specific agent",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "llm_calls"
+                ],
+                "summary": "List LLM calls",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by session ID",
+                        "name": "session",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by interaction ID",
+                        "name": "interaction",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedLLMCalls"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/memories": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List memories for a specific agent and user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "memories"
+                ],
+                "summary": "List agent memories",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.Memory"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/memories/{memory_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a specific memory for an agent and user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "memories"
+                ],
+                "summary": "Delete agent memory",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Memory ID",
+                        "name": "memory_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/skills/{skill}/enable": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Enable a marketplace skill on an agent. For autoProvision MCP skills the server generates URL and auth automatically.",
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Enable a marketplace skill on an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Skill name (e.g. code-intelligence)",
+                        "name": "skill",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Agent"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/step-info": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List step info for a specific agent and interaction ID, used to build the timeline of events",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "step_info"
+                ],
+                "summary": "List step info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Interaction ID",
+                        "name": "interactionId",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.StepInfo"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/trigger-status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get the status of a specific trigger type for an agent",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get agent trigger status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Trigger type (e.g., slack)",
+                        "name": "trigger_type",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.TriggerStatus"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/user-access": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the access rights the current user has for this agent",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get current user's access level for an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.UserAppAccessResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/users-daily-usage": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get agent users daily usage",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get agent users daily usage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date",
+                        "name": "to",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.AggregatedUsageMetric"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/api_keys": {
             "get": {
                 "security": [
@@ -1195,1465 +2654,6 @@
                         "description": "API key",
                         "schema": {
                             "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List apps for the user. Apps are pre-configured to spawn sessions with specific tools and config.",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "List apps",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization ID",
-                        "name": "organization_id",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.App"
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "description": "Request body with app configuration. Can be legacy App format or structured format with organization_id, global, and yaml_config fields.",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.App"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/server.AppCreateResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/evaluation-runs/{run_id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get evaluation run details",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Get an evaluation run",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Run ID",
-                        "name": "run_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationRun"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete an evaluation run",
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Delete an evaluation run",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Run ID",
-                        "name": "run_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/evaluation-suites": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List all evaluation suites for an app",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "List evaluation suites for an app",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.EvaluationSuite"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Create a new evaluation suite for an agent",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Create an evaluation suite",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Evaluation suite to create",
-                        "name": "suite",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationSuite"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationSuite"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/evaluation-suites/{id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get an evaluation suite by ID",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Get an evaluation suite",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationSuite"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Update an evaluation suite",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Update an evaluation suite",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Updated suite",
-                        "name": "suite",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationSuite"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationSuite"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete an evaluation suite",
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Delete an evaluation suite",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/evaluation-suites/{id}/runs": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List evaluation runs for a suite",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "List evaluation runs",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.EvaluationRun"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Start running an evaluation suite against an agent",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Start an evaluation run",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationRun"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/triggers": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List triggers for the app",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "List app triggers",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.TriggerConfiguration"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.App"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "description": "Request body with app configuration.",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.App"
-                        }
-                    },
-                    {
-                        "type": "string",
-                        "description": "Tool ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.App"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/access-grants": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List access grants for an app (organization owners and members can list access grants)",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "List app access grants",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.AccessGrant"
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Grant access to an agent to a team or organization member (organization owners can grant access to teams and organization members)",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Grant access to an agent to a team or organization member",
-                "parameters": [
-                    {
-                        "description": "Request body with team or organization member ID and role",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.CreateAccessGrantRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.AccessGrant"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/api-actions": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Runs an API action for an app",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Run an API action",
-                "parameters": [
-                    {
-                        "description": "Request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.RunAPIActionRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.RunAPIActionResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/avatar": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get the app's avatar image",
-                "produces": [
-                    "image/*"
-                ],
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get app avatar",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Avatar image data",
-                        "schema": {
-                            "type": "file"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Upload a base64 encoded image as the app's avatar",
-                "consumes": [
-                    "text/plain"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Upload app avatar",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Base64 encoded image data",
-                        "name": "image",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete the app's avatar image",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Delete app avatar",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/claude-subscription-status": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Reports whether the app owner (whose subscription authenticates the app's sessions) has a working Claude subscription",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Claude"
-                ],
-                "summary": "Get the Claude subscription status for an app's owner",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/server.AppClaudeSubscriptionStatus"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/daily-usage": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get app daily usage",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get app usage",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Start date",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "End date",
-                        "name": "to",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.AggregatedUsageMetric"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/duplicate": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Optional new name for the app",
-                        "name": "name",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/interactions": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List interactions with pagination and optional session filtering for a specific app",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "interactions"
-                ],
-                "summary": "List interactions",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by session ID",
-                        "name": "session",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by interaction ID",
-                        "name": "interaction",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Query by like/dislike",
-                        "name": "feedback",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedInteractions"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/llm-calls": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List user's LLM calls with pagination and optional session filtering for a specific app",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "llm_calls"
-                ],
-                "summary": "List LLM calls",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by session ID",
-                        "name": "session",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by interaction ID",
-                        "name": "interaction",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedLLMCalls"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/memories": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List memories for a specific app and user",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "memories"
-                ],
-                "summary": "List app memories",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.Memory"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/memories/{memory_id}": {
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete a specific memory for an app and user",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "memories"
-                ],
-                "summary": "Delete app memory",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Memory ID",
-                        "name": "memory_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/skills/{skill}/enable": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Enable a marketplace skill on an app. For autoProvision MCP skills the server generates URL and auth automatically.",
-                "tags": [
-                    "skills"
-                ],
-                "summary": "Enable a marketplace skill on an app",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Skill name (e.g. code-intelligence)",
-                        "name": "skill",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.App"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/step-info": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List step info for a specific app and interaction ID, used to build the timeline of events",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "step_info"
-                ],
-                "summary": "List step info",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Interaction ID",
-                        "name": "interactionId",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.StepInfo"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/trigger-status": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get the status of a specific trigger type for an app",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get app trigger status",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Trigger type (e.g., slack)",
-                        "name": "trigger_type",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.TriggerStatus"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/user-access": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Returns the access rights the current user has for this app",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get current user's access level for an app",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.UserAppAccessResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/users-daily-usage": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get app users daily usage",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get app users daily usage",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Start date",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "End date",
-                        "name": "to",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.AggregatedUsageMetric"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
                         }
                     }
                 }
@@ -11077,7 +11077,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Returns the flat set of Bots in the org for the helix-org React Overview page.",
+                "description": "Returns the flat set of Nodes in the org for the helix-org React Overview page.",
                 "produces": [
                     "application/json"
                 ],
@@ -20984,7 +20984,7 @@
                 ],
                 "description": "List all triggers configurations for either user or the org or user within an org",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
                 "summary": "List all triggers configurations for either user or the org or user within an org",
                 "parameters": [
@@ -21019,11 +21019,11 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Create triggers for the app. Used to create standalone trigger configurations such as cron tasks for agents that could be owned by a different user than the owner of the app",
+                "description": "Create triggers for the agent. Used to create standalone trigger configurations such as cron tasks for agents that could be owned by a different user than the owner of the agent",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
-                "summary": "Create app triggers",
+                "summary": "Create agent triggers",
                 "parameters": [
                     {
                         "description": "Trigger configuration",
@@ -21052,11 +21052,11 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update triggers for the app, for example to change the cron schedule or enable/disable the trigger",
+                "description": "Update triggers for the agent, for example to change the cron schedule or enable/disable the trigger",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
-                "summary": "Update app triggers",
+                "summary": "Update agent triggers",
                 "parameters": [
                     {
                         "type": "string",
@@ -21090,11 +21090,11 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Delete triggers for the app",
+                "description": "Delete triggers for the agent",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
-                "summary": "Delete app triggers",
+                "summary": "Delete agent triggers",
                 "parameters": [
                     {
                         "type": "string",
@@ -21121,11 +21121,11 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update triggers for the app, for example to change the cron schedule or enable/disable the trigger",
+                "description": "Update triggers for the agent, for example to change the cron schedule or enable/disable the trigger",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
-                "summary": "Execute app trigger",
+                "summary": "Execute agent trigger",
                 "parameters": [
                     {
                         "type": "string",
@@ -21154,7 +21154,7 @@
                 ],
                 "description": "List executions for the trigger",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
                 "summary": "List trigger executions",
                 "parameters": [
@@ -22473,6 +22473,9 @@
                 "agent_app_id": {
                     "type": "string"
                 },
+                "agent_id": {
+                    "type": "string"
+                },
                 "agent_model": {
                     "type": "string"
                 },
@@ -22566,6 +22569,9 @@
                 "agent_app_id": {
                     "type": "string"
                 },
+                "agent_id": {
+                    "type": "string"
+                },
                 "project_id": {
                     "type": "string"
                 },
@@ -22588,6 +22594,9 @@
                 "agent_app_id": {
                     "type": "string"
                 },
+                "agent_id": {
+                    "type": "string"
+                },
                 "project_id": {
                     "type": "string"
                 }
@@ -22597,6 +22606,9 @@
             "type": "object",
             "properties": {
                 "agent_app_id": {
+                    "type": "string"
+                },
+                "agent_id": {
                     "type": "string"
                 },
                 "agent_model": {
@@ -22684,7 +22696,10 @@
             "type": "object",
             "properties": {
                 "agent_app_id": {
-                    "description": "AgentAppID + ProjectID — see BotChatDTO comments.",
+                    "type": "string"
+                },
+                "agent_id": {
+                    "description": "AgentID + ProjectID — see BotChatDTO comments.",
                     "type": "string"
                 },
                 "bot": {
@@ -22763,7 +22778,7 @@
                     "type": "string"
                 },
                 "owner": {
-                    "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation - create_bot, delete_bot,\nset_bot_content, subscribe, ... - plus the read baseline) so it can\nhire and manage other Bots. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
+                    "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation - create_bot, delete_bot,\nset_bot_content, subscribe, ... - plus the read baseline) so it can\nhire and manage other Nodes. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
                     "type": "boolean"
                 },
                 "parent_id": {
@@ -24649,6 +24664,59 @@
                 }
             }
         },
+        "server.AgentCreateResponse": {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "$ref": "#/definitions/types.AgentConfig"
+                },
+                "created": {
+                    "type": "string"
+                },
+                "global": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_helix_org_agent": {
+                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
+                    "type": "boolean"
+                },
+                "model_substitutions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/server.ModelSubstitution"
+                    }
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "owner": {
+                    "description": "uuid of user ID",
+                    "type": "string"
+                },
+                "owner_type": {
+                    "description": "e.g. user, system, org",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.OwnerType"
+                        }
+                    ]
+                },
+                "updated": {
+                    "type": "string"
+                },
+                "user": {
+                    "description": "Owner user struct, populated by the server for organization views",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.User"
+                        }
+                    ]
+                }
+            }
+        },
         "server.AgentSandboxesDebugResponse": {
             "type": "object",
             "properties": {
@@ -24710,59 +24778,6 @@
                 "valid": {
                     "description": "that subscription passed its last liveness probe",
                     "type": "boolean"
-                }
-            }
-        },
-        "server.AppCreateResponse": {
-            "type": "object",
-            "properties": {
-                "config": {
-                    "$ref": "#/definitions/types.AppConfig"
-                },
-                "created": {
-                    "type": "string"
-                },
-                "global": {
-                    "type": "boolean"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_helix_org_agent": {
-                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
-                    "type": "boolean"
-                },
-                "model_substitutions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/server.ModelSubstitution"
-                    }
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "owner": {
-                    "description": "uuid of user ID",
-                    "type": "string"
-                },
-                "owner_type": {
-                    "description": "e.g. user, system, org",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.OwnerType"
-                        }
-                    ]
-                },
-                "updated": {
-                    "type": "string"
-                },
-                "user": {
-                    "description": "Owner user struct, populated by the server for organization views",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.User"
-                        }
-                    ]
                 }
             }
         },
@@ -27186,6 +27201,122 @@
                 }
             }
         },
+        "types.Agent": {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "$ref": "#/definitions/types.AgentConfig"
+                },
+                "created": {
+                    "type": "string"
+                },
+                "global": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_helix_org_agent": {
+                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
+                    "type": "boolean"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "owner": {
+                    "description": "uuid of user ID",
+                    "type": "string"
+                },
+                "owner_type": {
+                    "description": "e.g. user, system, org",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.OwnerType"
+                        }
+                    ]
+                },
+                "updated": {
+                    "type": "string"
+                },
+                "user": {
+                    "description": "Owner user struct, populated by the server for organization views",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.User"
+                        }
+                    ]
+                }
+            }
+        },
+        "types.AgentConfig": {
+            "type": "object",
+            "properties": {
+                "allowed_domains": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "helix": {
+                    "$ref": "#/definitions/types.AgentHelixConfig"
+                },
+                "secrets": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "types.AgentHelixConfig": {
+            "type": "object",
+            "properties": {
+                "assistants": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.AssistantConfig"
+                    }
+                },
+                "avatar": {
+                    "type": "string"
+                },
+                "avatar_content_type": {
+                    "type": "string"
+                },
+                "default_agent_type": {
+                    "description": "Agent configuration",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.AgentType"
+                        }
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "external_agent_config": {
+                    "$ref": "#/definitions/types.ExternalAgentConfig"
+                },
+                "external_agent_enabled": {
+                    "type": "boolean"
+                },
+                "external_url": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "triggers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.Trigger"
+                    }
+                }
+            }
+        },
         "types.AgentType": {
             "type": "string",
             "enum": [
@@ -27316,122 +27447,6 @@
                 },
                 "type": {
                     "$ref": "#/definitions/types.APIKeyType"
-                }
-            }
-        },
-        "types.App": {
-            "type": "object",
-            "properties": {
-                "config": {
-                    "$ref": "#/definitions/types.AppConfig"
-                },
-                "created": {
-                    "type": "string"
-                },
-                "global": {
-                    "type": "boolean"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_helix_org_agent": {
-                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
-                    "type": "boolean"
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "owner": {
-                    "description": "uuid of user ID",
-                    "type": "string"
-                },
-                "owner_type": {
-                    "description": "e.g. user, system, org",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.OwnerType"
-                        }
-                    ]
-                },
-                "updated": {
-                    "type": "string"
-                },
-                "user": {
-                    "description": "Owner user struct, populated by the server for organization views",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.User"
-                        }
-                    ]
-                }
-            }
-        },
-        "types.AppConfig": {
-            "type": "object",
-            "properties": {
-                "allowed_domains": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "helix": {
-                    "$ref": "#/definitions/types.AppHelixConfig"
-                },
-                "secrets": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "types.AppHelixConfig": {
-            "type": "object",
-            "properties": {
-                "assistants": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.AssistantConfig"
-                    }
-                },
-                "avatar": {
-                    "type": "string"
-                },
-                "avatar_content_type": {
-                    "type": "string"
-                },
-                "default_agent_type": {
-                    "description": "Agent configuration",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.AgentType"
-                        }
-                    ]
-                },
-                "description": {
-                    "type": "string"
-                },
-                "external_agent_config": {
-                    "$ref": "#/definitions/types.ExternalAgentConfig"
-                },
-                "external_agent_enabled": {
-                    "type": "boolean"
-                },
-                "external_url": {
-                    "type": "string"
-                },
-                "image": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "triggers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.Trigger"
-                    }
                 }
             }
         },
@@ -29804,7 +29819,7 @@
             "type": "object",
             "properties": {
                 "app_config_snapshot": {
-                    "$ref": "#/definitions/types.AppConfig"
+                    "$ref": "#/definitions/types.AgentConfig"
                 },
                 "app_id": {
                     "type": "string"

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -8,6 +8,8 @@ definitions:
     properties:
       agent_app_id:
         type: string
+      agent_id:
+        type: string
       agent_model:
         type: string
       agent_runtime:
@@ -83,6 +85,8 @@ definitions:
         type: string
       agent_app_id:
         type: string
+      agent_id:
+        type: string
       project_id:
         type: string
       session_id:
@@ -97,12 +101,16 @@ definitions:
     properties:
       agent_app_id:
         type: string
+      agent_id:
+        type: string
       project_id:
         type: string
     type: object
   api.BotDTO:
     properties:
       agent_app_id:
+        type: string
+      agent_id:
         type: string
       agent_model:
         type: string
@@ -174,7 +182,9 @@ definitions:
   api.BotDetailDTO:
     properties:
       agent_app_id:
-        description: AgentAppID + ProjectID — see BotChatDTO comments.
+        type: string
+      agent_id:
+        description: AgentID + ProjectID — see BotChatDTO comments.
         type: string
       bot:
         $ref: '#/definitions/api.BotDTO'
@@ -233,7 +243,7 @@ definitions:
           Owner makes this a manager Bot: it receives the canonical owner
           tool set (every org-graph mutation - create_bot, delete_bot,
           set_bot_content, subscribe, ... - plus the read baseline) so it can
-          hire and manage other Bots. When true, Tools is ignored in favour
+          hire and manage other Nodes. When true, Tools is ignored in favour
           of that set. Used to seed a starter/root Bot for a new org.
         type: boolean
       parent_id:
@@ -1613,6 +1623,42 @@ definitions:
       status:
         type: string
     type: object
+  server.AgentCreateResponse:
+    properties:
+      config:
+        $ref: '#/definitions/types.AgentConfig'
+      created:
+        type: string
+      global:
+        type: boolean
+      id:
+        type: string
+      is_helix_org_agent:
+        description: |-
+          IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
+          (see api/pkg/org). Computed at list time, not persisted, so the frontend
+          can hide org-chart agents from the spec-task agent switchers.
+        type: boolean
+      model_substitutions:
+        items:
+          $ref: '#/definitions/server.ModelSubstitution'
+        type: array
+      organization_id:
+        type: string
+      owner:
+        description: uuid of user ID
+        type: string
+      owner_type:
+        allOf:
+        - $ref: '#/definitions/types.OwnerType'
+        description: e.g. user, system, org
+      updated:
+        type: string
+      user:
+        allOf:
+        - $ref: '#/definitions/types.User'
+        description: Owner user struct, populated by the server for organization views
+    type: object
   server.AgentSandboxesDebugResponse:
     properties:
       dev_containers:
@@ -1656,42 +1702,6 @@ definitions:
       valid:
         description: that subscription passed its last liveness probe
         type: boolean
-    type: object
-  server.AppCreateResponse:
-    properties:
-      config:
-        $ref: '#/definitions/types.AppConfig'
-      created:
-        type: string
-      global:
-        type: boolean
-      id:
-        type: string
-      is_helix_org_agent:
-        description: |-
-          IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
-          (see api/pkg/org). Computed at list time, not persisted, so the frontend
-          can hide org-chart agents from the spec-task agent switchers.
-        type: boolean
-      model_substitutions:
-        items:
-          $ref: '#/definitions/server.ModelSubstitution'
-        type: array
-      organization_id:
-        type: string
-      owner:
-        description: uuid of user ID
-        type: string
-      owner_type:
-        allOf:
-        - $ref: '#/definitions/types.OwnerType'
-        description: e.g. user, system, org
-      updated:
-        type: string
-      user:
-        allOf:
-        - $ref: '#/definitions/types.User'
-        description: Owner user struct, populated by the server for organization views
     type: object
   server.BatchTaskProgressResponse:
     properties:
@@ -3371,6 +3381,82 @@ definitions:
       name:
         type: string
     type: object
+  types.Agent:
+    properties:
+      config:
+        $ref: '#/definitions/types.AgentConfig'
+      created:
+        type: string
+      global:
+        type: boolean
+      id:
+        type: string
+      is_helix_org_agent:
+        description: |-
+          IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
+          (see api/pkg/org). Computed at list time, not persisted, so the frontend
+          can hide org-chart agents from the spec-task agent switchers.
+        type: boolean
+      organization_id:
+        type: string
+      owner:
+        description: uuid of user ID
+        type: string
+      owner_type:
+        allOf:
+        - $ref: '#/definitions/types.OwnerType'
+        description: e.g. user, system, org
+      updated:
+        type: string
+      user:
+        allOf:
+        - $ref: '#/definitions/types.User'
+        description: Owner user struct, populated by the server for organization views
+    type: object
+  types.AgentConfig:
+    properties:
+      allowed_domains:
+        items:
+          type: string
+        type: array
+      helix:
+        $ref: '#/definitions/types.AgentHelixConfig'
+      secrets:
+        additionalProperties:
+          type: string
+        type: object
+    type: object
+  types.AgentHelixConfig:
+    properties:
+      assistants:
+        items:
+          $ref: '#/definitions/types.AssistantConfig'
+        type: array
+      avatar:
+        type: string
+      avatar_content_type:
+        type: string
+      default_agent_type:
+        allOf:
+        - $ref: '#/definitions/types.AgentType'
+        description: Agent configuration
+      description:
+        type: string
+      external_agent_config:
+        $ref: '#/definitions/types.ExternalAgentConfig'
+      external_agent_enabled:
+        type: boolean
+      external_url:
+        type: string
+      image:
+        type: string
+      name:
+        type: string
+      triggers:
+        items:
+          $ref: '#/definitions/types.Trigger'
+        type: array
+    type: object
   types.AgentType:
     enum:
     - helix_basic
@@ -3464,82 +3550,6 @@ definitions:
         type: string
       type:
         $ref: '#/definitions/types.APIKeyType'
-    type: object
-  types.App:
-    properties:
-      config:
-        $ref: '#/definitions/types.AppConfig'
-      created:
-        type: string
-      global:
-        type: boolean
-      id:
-        type: string
-      is_helix_org_agent:
-        description: |-
-          IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
-          (see api/pkg/org). Computed at list time, not persisted, so the frontend
-          can hide org-chart agents from the spec-task agent switchers.
-        type: boolean
-      organization_id:
-        type: string
-      owner:
-        description: uuid of user ID
-        type: string
-      owner_type:
-        allOf:
-        - $ref: '#/definitions/types.OwnerType'
-        description: e.g. user, system, org
-      updated:
-        type: string
-      user:
-        allOf:
-        - $ref: '#/definitions/types.User'
-        description: Owner user struct, populated by the server for organization views
-    type: object
-  types.AppConfig:
-    properties:
-      allowed_domains:
-        items:
-          type: string
-        type: array
-      helix:
-        $ref: '#/definitions/types.AppHelixConfig'
-      secrets:
-        additionalProperties:
-          type: string
-        type: object
-    type: object
-  types.AppHelixConfig:
-    properties:
-      assistants:
-        items:
-          $ref: '#/definitions/types.AssistantConfig'
-        type: array
-      avatar:
-        type: string
-      avatar_content_type:
-        type: string
-      default_agent_type:
-        allOf:
-        - $ref: '#/definitions/types.AgentType'
-        description: Agent configuration
-      description:
-        type: string
-      external_agent_config:
-        $ref: '#/definitions/types.ExternalAgentConfig'
-      external_agent_enabled:
-        type: boolean
-      external_url:
-        type: string
-      image:
-        type: string
-      name:
-        type: string
-      triggers:
-        items:
-          $ref: '#/definitions/types.Trigger'
-        type: array
     type: object
   types.AssistantAPI:
     properties:
@@ -5275,7 +5285,7 @@ definitions:
   types.EvaluationRun:
     properties:
       app_config_snapshot:
-        $ref: '#/definitions/types.AppConfig'
+        $ref: '#/definitions/types.AgentConfig'
       app_id:
         type: string
       created:
@@ -13097,6 +13107,934 @@ paths:
       summary: Activate a trial for a user (Admin, cloud only)
       tags:
       - users
+  /api/v1/agents:
+    get:
+      description: List agents for the user. Agents are pre-configured to spawn sessions
+        with specific tools and config.
+      parameters:
+      - description: Organization ID
+        in: query
+        name: organization_id
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.Agent'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List agents
+      tags:
+      - agents
+    post:
+      parameters:
+      - description: Request body with agent configuration. Can be legacy Agent format
+          or structured format with organization_id, global, and yaml_config fields.
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/types.Agent'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.AgentCreateResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/agents/{agent_id}/evaluation-runs/{run_id}:
+    delete:
+      description: Delete an evaluation run
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      - description: Run ID
+        in: path
+        name: run_id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Delete an evaluation run
+      tags:
+      - evaluations
+    get:
+      description: Get evaluation run details
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      - description: Run ID
+        in: path
+        name: run_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.EvaluationRun'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get an evaluation run
+      tags:
+      - evaluations
+  /api/v1/agents/{agent_id}/evaluation-suites:
+    get:
+      description: List all evaluation suites for an agent
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.EvaluationSuite'
+            type: array
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: List evaluation suites for an agent
+      tags:
+      - evaluations
+    post:
+      consumes:
+      - application/json
+      description: Create a new evaluation suite for an agent
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      - description: Evaluation suite to create
+        in: body
+        name: suite
+        required: true
+        schema:
+          $ref: '#/definitions/types.EvaluationSuite'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/types.EvaluationSuite'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Create an evaluation suite
+      tags:
+      - evaluations
+  /api/v1/agents/{agent_id}/evaluation-suites/{id}:
+    delete:
+      description: Delete an evaluation suite
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      - description: Suite ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Delete an evaluation suite
+      tags:
+      - evaluations
+    get:
+      description: Get an evaluation suite by ID
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      - description: Suite ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.EvaluationSuite'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get an evaluation suite
+      tags:
+      - evaluations
+    put:
+      consumes:
+      - application/json
+      description: Update an evaluation suite
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      - description: Suite ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Updated suite
+        in: body
+        name: suite
+        required: true
+        schema:
+          $ref: '#/definitions/types.EvaluationSuite'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.EvaluationSuite'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Update an evaluation suite
+      tags:
+      - evaluations
+  /api/v1/agents/{agent_id}/evaluation-suites/{id}/runs:
+    get:
+      description: List evaluation runs for a suite
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      - description: Suite ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.EvaluationRun'
+            type: array
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: List evaluation runs
+      tags:
+      - evaluations
+    post:
+      consumes:
+      - application/json
+      description: Start running an evaluation suite against an agent
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      - description: Suite ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.EvaluationRun'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Start an evaluation run
+      tags:
+      - evaluations
+  /api/v1/agents/{agent_id}/triggers:
+    get:
+      description: List triggers for the agent
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.TriggerConfiguration'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List agent triggers
+      tags:
+      - agents
+  /api/v1/agents/{id}:
+    delete:
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+      security:
+      - BearerAuth: []
+    get:
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Agent'
+      security:
+      - BearerAuth: []
+    put:
+      parameters:
+      - description: Request body with agent configuration.
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/types.Agent'
+      - description: Tool ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Agent'
+      security:
+      - BearerAuth: []
+  /api/v1/agents/{id}/access-grants:
+    get:
+      description: List access grants for an agent (organization owners and members
+        can list access grants)
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.AccessGrant'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List agent access grants
+      tags:
+      - agents
+    post:
+      description: Grant access to an agent to a team or organization member (organization
+        owners can grant access to teams and organization members)
+      parameters:
+      - description: Request body with team or organization member ID and role
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/types.CreateAccessGrantRequest'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.AccessGrant'
+      security:
+      - BearerAuth: []
+      summary: Grant access to an agent to a team or organization member
+      tags:
+      - agents
+  /api/v1/agents/{id}/api-actions:
+    post:
+      consumes:
+      - application/json
+      description: Runs an API action for an agent
+      parameters:
+      - description: Request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/types.RunAPIActionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.RunAPIActionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Run an API action
+  /api/v1/agents/{id}/avatar:
+    delete:
+      description: Delete the agent's avatar image
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Delete agent avatar
+      tags:
+      - agents
+    get:
+      description: Get the agent's avatar image
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - image/*
+      responses:
+        "200":
+          description: Avatar image data
+          schema:
+            type: file
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get agent avatar
+      tags:
+      - agents
+    post:
+      consumes:
+      - text/plain
+      description: Upload a base64 encoded image as the agent's avatar
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Base64 encoded image data
+        in: body
+        name: image
+        required: true
+        schema:
+          type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Upload agent avatar
+      tags:
+      - agents
+  /api/v1/agents/{id}/claude-subscription-status:
+    get:
+      description: Reports whether the agent owner (whose subscription authenticates
+        the agent's sessions) has a working Claude subscription
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.AppClaudeSubscriptionStatus'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get the Claude subscription status for an agent's owner
+      tags:
+      - Claude
+  /api/v1/agents/{id}/daily-usage:
+    get:
+      consumes:
+      - application/json
+      description: Get agent daily usage
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Start date
+        in: query
+        name: from
+        type: string
+      - description: End date
+        in: query
+        name: to
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.AggregatedUsageMetric'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get agent usage
+      tags:
+      - agents
+  /api/v1/agents/{id}/duplicate:
+    post:
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Optional new name for the agent
+        in: query
+        name: name
+        type: string
+      responses:
+        "200":
+          description: OK
+      security:
+      - BearerAuth: []
+  /api/v1/agents/{id}/interactions:
+    get:
+      description: List interactions with pagination and optional session filtering
+        for a specific agent
+      parameters:
+      - description: Page number
+        in: query
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        name: pageSize
+        type: integer
+      - description: Filter by session ID
+        in: query
+        name: session
+        type: string
+      - description: Filter by interaction ID
+        in: query
+        name: interaction
+        type: string
+      - description: Query by like/dislike
+        in: query
+        name: feedback
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.PaginatedInteractions'
+      security:
+      - BearerAuth: []
+      summary: List interactions
+      tags:
+      - interactions
+  /api/v1/agents/{id}/llm-calls:
+    get:
+      description: List user's LLM calls with pagination and optional session filtering
+        for a specific agent
+      parameters:
+      - description: Page number
+        in: query
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        name: pageSize
+        type: integer
+      - description: Filter by session ID
+        in: query
+        name: session
+        type: string
+      - description: Filter by interaction ID
+        in: query
+        name: interaction
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.PaginatedLLMCalls'
+      security:
+      - BearerAuth: []
+      summary: List LLM calls
+      tags:
+      - llm_calls
+  /api/v1/agents/{id}/memories:
+    get:
+      description: List memories for a specific agent and user
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.Memory'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List agent memories
+      tags:
+      - memories
+  /api/v1/agents/{id}/memories/{memory_id}:
+    delete:
+      description: Delete a specific memory for an agent and user
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Memory ID
+        in: path
+        name: memory_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      security:
+      - BearerAuth: []
+      summary: Delete agent memory
+      tags:
+      - memories
+  /api/v1/agents/{id}/skills/{skill}/enable:
+    post:
+      description: Enable a marketplace skill on an agent. For autoProvision MCP skills
+        the server generates URL and auth automatically.
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Skill name (e.g. code-intelligence)
+        in: path
+        name: skill
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Agent'
+      security:
+      - BearerAuth: []
+      summary: Enable a marketplace skill on an agent
+      tags:
+      - skills
+  /api/v1/agents/{id}/step-info:
+    get:
+      description: List step info for a specific agent and interaction ID, used to
+        build the timeline of events
+      parameters:
+      - description: Interaction ID
+        in: query
+        name: interactionId
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.StepInfo'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List step info
+      tags:
+      - step_info
+  /api/v1/agents/{id}/trigger-status:
+    get:
+      description: Get the status of a specific trigger type for an agent
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Trigger type (e.g., slack)
+        in: query
+        name: trigger_type
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.TriggerStatus'
+      security:
+      - BearerAuth: []
+      summary: Get agent trigger status
+      tags:
+      - agents
+  /api/v1/agents/{id}/user-access:
+    get:
+      description: Returns the access rights the current user has for this agent
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.UserAppAccessResponse'
+      security:
+      - BearerAuth: []
+      summary: Get current user's access level for an agent
+      tags:
+      - agents
+  /api/v1/agents/{id}/users-daily-usage:
+    get:
+      consumes:
+      - application/json
+      description: Get agent users daily usage
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Start date
+        in: query
+        name: from
+        type: string
+      - description: End date
+        in: query
+        name: to
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.AggregatedUsageMetric'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get agent users daily usage
+      tags:
+      - agents
   /api/v1/api_keys:
     delete:
       description: Delete an API key
@@ -13155,934 +14093,6 @@ paths:
       summary: Create a new API key
       tags:
       - api-keys
-  /api/v1/apps:
-    get:
-      description: List apps for the user. Apps are pre-configured to spawn sessions
-        with specific tools and config.
-      parameters:
-      - description: Organization ID
-        in: query
-        name: organization_id
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.App'
-            type: array
-      security:
-      - BearerAuth: []
-      summary: List apps
-      tags:
-      - apps
-    post:
-      parameters:
-      - description: Request body with app configuration. Can be legacy App format
-          or structured format with organization_id, global, and yaml_config fields.
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/types.App'
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/server.AppCreateResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/apps/{app_id}/evaluation-runs/{run_id}:
-    delete:
-      description: Delete an evaluation run
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Run ID
-        in: path
-        name: run_id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Delete an evaluation run
-      tags:
-      - evaluations
-    get:
-      description: Get evaluation run details
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Run ID
-        in: path
-        name: run_id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.EvaluationRun'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Get an evaluation run
-      tags:
-      - evaluations
-  /api/v1/apps/{app_id}/evaluation-suites:
-    get:
-      description: List all evaluation suites for an app
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.EvaluationSuite'
-            type: array
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: List evaluation suites for an app
-      tags:
-      - evaluations
-    post:
-      consumes:
-      - application/json
-      description: Create a new evaluation suite for an agent
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Evaluation suite to create
-        in: body
-        name: suite
-        required: true
-        schema:
-          $ref: '#/definitions/types.EvaluationSuite'
-      produces:
-      - application/json
-      responses:
-        "201":
-          description: Created
-          schema:
-            $ref: '#/definitions/types.EvaluationSuite'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Create an evaluation suite
-      tags:
-      - evaluations
-  /api/v1/apps/{app_id}/evaluation-suites/{id}:
-    delete:
-      description: Delete an evaluation suite
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Suite ID
-        in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Delete an evaluation suite
-      tags:
-      - evaluations
-    get:
-      description: Get an evaluation suite by ID
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Suite ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.EvaluationSuite'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Get an evaluation suite
-      tags:
-      - evaluations
-    put:
-      consumes:
-      - application/json
-      description: Update an evaluation suite
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Suite ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Updated suite
-        in: body
-        name: suite
-        required: true
-        schema:
-          $ref: '#/definitions/types.EvaluationSuite'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.EvaluationSuite'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Update an evaluation suite
-      tags:
-      - evaluations
-  /api/v1/apps/{app_id}/evaluation-suites/{id}/runs:
-    get:
-      description: List evaluation runs for a suite
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Suite ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.EvaluationRun'
-            type: array
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: List evaluation runs
-      tags:
-      - evaluations
-    post:
-      consumes:
-      - application/json
-      description: Start running an evaluation suite against an agent
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Suite ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.EvaluationRun'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Start an evaluation run
-      tags:
-      - evaluations
-  /api/v1/apps/{app_id}/triggers:
-    get:
-      description: List triggers for the app
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.TriggerConfiguration'
-            type: array
-      security:
-      - BearerAuth: []
-      summary: List app triggers
-      tags:
-      - apps
-  /api/v1/apps/{id}:
-    delete:
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-      security:
-      - BearerAuth: []
-    get:
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.App'
-      security:
-      - BearerAuth: []
-    put:
-      parameters:
-      - description: Request body with app configuration.
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/types.App'
-      - description: Tool ID
-        in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.App'
-      security:
-      - BearerAuth: []
-  /api/v1/apps/{id}/access-grants:
-    get:
-      description: List access grants for an app (organization owners and members
-        can list access grants)
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.AccessGrant'
-            type: array
-      security:
-      - BearerAuth: []
-      summary: List app access grants
-      tags:
-      - apps
-    post:
-      description: Grant access to an agent to a team or organization member (organization
-        owners can grant access to teams and organization members)
-      parameters:
-      - description: Request body with team or organization member ID and role
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/types.CreateAccessGrantRequest'
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.AccessGrant'
-      security:
-      - BearerAuth: []
-      summary: Grant access to an agent to a team or organization member
-      tags:
-      - apps
-  /api/v1/apps/{id}/api-actions:
-    post:
-      consumes:
-      - application/json
-      description: Runs an API action for an app
-      parameters:
-      - description: Request
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/types.RunAPIActionRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.RunAPIActionResponse'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Run an API action
-  /api/v1/apps/{id}/avatar:
-    delete:
-      description: Delete the app's avatar image
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Delete app avatar
-      tags:
-      - apps
-    get:
-      description: Get the app's avatar image
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - image/*
-      responses:
-        "200":
-          description: Avatar image data
-          schema:
-            type: file
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Get app avatar
-      tags:
-      - apps
-    post:
-      consumes:
-      - text/plain
-      description: Upload a base64 encoded image as the app's avatar
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Base64 encoded image data
-        in: body
-        name: image
-        required: true
-        schema:
-          type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Upload app avatar
-      tags:
-      - apps
-  /api/v1/apps/{id}/claude-subscription-status:
-    get:
-      description: Reports whether the app owner (whose subscription authenticates
-        the app's sessions) has a working Claude subscription
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/server.AppClaudeSubscriptionStatus'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Get the Claude subscription status for an app's owner
-      tags:
-      - Claude
-  /api/v1/apps/{id}/daily-usage:
-    get:
-      consumes:
-      - application/json
-      description: Get app daily usage
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Start date
-        in: query
-        name: from
-        type: string
-      - description: End date
-        in: query
-        name: to
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.AggregatedUsageMetric'
-            type: array
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Get app usage
-      tags:
-      - apps
-  /api/v1/apps/{id}/duplicate:
-    post:
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Optional new name for the app
-        in: query
-        name: name
-        type: string
-      responses:
-        "200":
-          description: OK
-      security:
-      - BearerAuth: []
-  /api/v1/apps/{id}/interactions:
-    get:
-      description: List interactions with pagination and optional session filtering
-        for a specific app
-      parameters:
-      - description: Page number
-        in: query
-        name: page
-        type: integer
-      - description: Page size
-        in: query
-        name: pageSize
-        type: integer
-      - description: Filter by session ID
-        in: query
-        name: session
-        type: string
-      - description: Filter by interaction ID
-        in: query
-        name: interaction
-        type: string
-      - description: Query by like/dislike
-        in: query
-        name: feedback
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.PaginatedInteractions'
-      security:
-      - BearerAuth: []
-      summary: List interactions
-      tags:
-      - interactions
-  /api/v1/apps/{id}/llm-calls:
-    get:
-      description: List user's LLM calls with pagination and optional session filtering
-        for a specific app
-      parameters:
-      - description: Page number
-        in: query
-        name: page
-        type: integer
-      - description: Page size
-        in: query
-        name: pageSize
-        type: integer
-      - description: Filter by session ID
-        in: query
-        name: session
-        type: string
-      - description: Filter by interaction ID
-        in: query
-        name: interaction
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.PaginatedLLMCalls'
-      security:
-      - BearerAuth: []
-      summary: List LLM calls
-      tags:
-      - llm_calls
-  /api/v1/apps/{id}/memories:
-    get:
-      description: List memories for a specific app and user
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.Memory'
-            type: array
-      security:
-      - BearerAuth: []
-      summary: List app memories
-      tags:
-      - memories
-  /api/v1/apps/{id}/memories/{memory_id}:
-    delete:
-      description: Delete a specific memory for an app and user
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Memory ID
-        in: path
-        name: memory_id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-      security:
-      - BearerAuth: []
-      summary: Delete app memory
-      tags:
-      - memories
-  /api/v1/apps/{id}/skills/{skill}/enable:
-    post:
-      description: Enable a marketplace skill on an app. For autoProvision MCP skills
-        the server generates URL and auth automatically.
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Skill name (e.g. code-intelligence)
-        in: path
-        name: skill
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.App'
-      security:
-      - BearerAuth: []
-      summary: Enable a marketplace skill on an app
-      tags:
-      - skills
-  /api/v1/apps/{id}/step-info:
-    get:
-      description: List step info for a specific app and interaction ID, used to build
-        the timeline of events
-      parameters:
-      - description: Interaction ID
-        in: query
-        name: interactionId
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.StepInfo'
-            type: array
-      security:
-      - BearerAuth: []
-      summary: List step info
-      tags:
-      - step_info
-  /api/v1/apps/{id}/trigger-status:
-    get:
-      description: Get the status of a specific trigger type for an app
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Trigger type (e.g., slack)
-        in: query
-        name: trigger_type
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.TriggerStatus'
-      security:
-      - BearerAuth: []
-      summary: Get app trigger status
-      tags:
-      - apps
-  /api/v1/apps/{id}/user-access:
-    get:
-      description: Returns the access rights the current user has for this app
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.UserAppAccessResponse'
-      security:
-      - BearerAuth: []
-      summary: Get current user's access level for an app
-      tags:
-      - apps
-  /api/v1/apps/{id}/users-daily-usage:
-    get:
-      consumes:
-      - application/json
-      description: Get app users daily usage
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Start date
-        in: query
-        name: from
-        type: string
-      - description: End date
-        in: query
-        name: to
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.AggregatedUsageMetric'
-            type: array
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Get app users daily usage
-      tags:
-      - apps
   /api/v1/attention-events:
     get:
       description: Returns attention events that need human action for the current
@@ -19483,7 +19493,7 @@ paths:
       - HelixOrg
   /api/v1/orgs/{org}/overview:
     get:
-      description: Returns the flat set of Bots in the org for the helix-org React
+      description: Returns the flat set of Nodes in the org for the helix-org React
         Overview page.
       produces:
       - application/json
@@ -25911,11 +25921,11 @@ paths:
       summary: List all triggers configurations for either user or the org or user
         within an org
       tags:
-      - apps
+      - agents
     post:
-      description: Create triggers for the app. Used to create standalone trigger
+      description: Create triggers for the agent. Used to create standalone trigger
         configurations such as cron tasks for agents that could be owned by a different
-        user than the owner of the app
+        user than the owner of the agent
       parameters:
       - description: Trigger configuration
         in: body
@@ -25930,12 +25940,12 @@ paths:
             $ref: '#/definitions/types.TriggerConfiguration'
       security:
       - BearerAuth: []
-      summary: Create app triggers
+      summary: Create agent triggers
       tags:
-      - apps
+      - agents
   /api/v1/triggers/{trigger_id}:
     delete:
-      description: Delete triggers for the app
+      description: Delete triggers for the agent
       parameters:
       - description: Trigger ID
         in: path
@@ -25949,11 +25959,11 @@ paths:
             $ref: '#/definitions/types.TriggerConfiguration'
       security:
       - BearerAuth: []
-      summary: Delete app triggers
+      summary: Delete agent triggers
       tags:
-      - apps
+      - agents
     put:
-      description: Update triggers for the app, for example to change the cron schedule
+      description: Update triggers for the agent, for example to change the cron schedule
         or enable/disable the trigger
       parameters:
       - description: Trigger ID
@@ -25974,12 +25984,12 @@ paths:
             $ref: '#/definitions/types.TriggerConfiguration'
       security:
       - BearerAuth: []
-      summary: Update app triggers
+      summary: Update agent triggers
       tags:
-      - apps
+      - agents
   /api/v1/triggers/{trigger_id}/execute:
     post:
-      description: Update triggers for the app, for example to change the cron schedule
+      description: Update triggers for the agent, for example to change the cron schedule
         or enable/disable the trigger
       parameters:
       - description: Trigger ID
@@ -25994,9 +26004,9 @@ paths:
             $ref: '#/definitions/types.TriggerExecuteResponse'
       security:
       - BearerAuth: []
-      summary: Execute app trigger
+      summary: Execute agent trigger
       tags:
-      - apps
+      - agents
   /api/v1/triggers/{trigger_id}/executions:
     get:
       description: List executions for the trigger
@@ -26025,7 +26035,7 @@ paths:
       - BearerAuth: []
       summary: List trigger executions
       tags:
-      - apps
+      - agents
   /api/v1/usage:
     get:
       consumes:

--- a/api/pkg/types/agent_test.go
+++ b/api/pkg/types/agent_test.go
@@ -1,0 +1,18 @@
+package types
+
+import (
+	"sync"
+	"testing"
+
+	"gorm.io/gorm/schema"
+)
+
+func TestAgentUsesAppsTable(t *testing.T) {
+	parsed, err := schema.Parse(&Agent{}, new(sync.Map), schema.NamingStrategy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Table != "apps" {
+		t.Fatalf("Agent table = %q, want %q", parsed.Table, "apps")
+	}
+}

--- a/api/pkg/types/evaluation.go
+++ b/api/pkg/types/evaluation.go
@@ -22,7 +22,7 @@ const (
 type EvaluationAssertion struct {
 	Type           EvaluationAssertionType `json:"type"`
 	Value          string                  `json:"value"`                      // Expected string, regex pattern, or skill name
-	LLMJudgePrompt string                 `json:"llm_judge_prompt,omitempty"` // Custom prompt for LLM judge mode
+	LLMJudgePrompt string                  `json:"llm_judge_prompt,omitempty"` // Custom prompt for LLM judge mode
 }
 
 // EvaluationQuestion is a question with assertions to check the response against
@@ -34,15 +34,15 @@ type EvaluationQuestion struct {
 
 // EvaluationSuite represents a test suite for evaluating an agent
 type EvaluationSuite struct {
-	ID             string               `json:"id" gorm:"primaryKey"`
-	Created        time.Time            `json:"created"`
-	Updated        time.Time            `json:"updated"`
-	UserID         string               `json:"user_id" gorm:"index"`
-	OrganizationID string               `json:"organization_id" gorm:"index"`
-	AppID          string               `json:"app_id" gorm:"index"`
-	Name           string               `json:"name"`
-	Description    string               `json:"description"`
-	Questions      EvaluationQuestions   `json:"questions" gorm:"type:jsonb;serializer:json"`
+	ID             string              `json:"id" gorm:"primaryKey"`
+	Created        time.Time           `json:"created"`
+	Updated        time.Time           `json:"updated"`
+	UserID         string              `json:"user_id" gorm:"index"`
+	OrganizationID string              `json:"organization_id" gorm:"index"`
+	AppID          string              `json:"app_id" gorm:"index"`
+	Name           string              `json:"name"`
+	Description    string              `json:"description"`
+	Questions      EvaluationQuestions `json:"questions" gorm:"type:jsonb;serializer:json"`
 }
 
 // EvaluationQuestions is a slice type for GORM JSON serialization
@@ -90,7 +90,7 @@ type EvaluationRunSummary struct {
 	TotalQuestions  int      `json:"total_questions"`
 	Passed          int      `json:"passed"`
 	Failed          int      `json:"failed"`
-	TotalDurationMs int64   `json:"total_duration_ms"`
+	TotalDurationMs int64    `json:"total_duration_ms"`
 	TotalTokens     int      `json:"total_tokens"`
 	TotalCost       float64  `json:"total_cost"`
 	SkillsUsed      []string `json:"skills_used"`
@@ -98,18 +98,18 @@ type EvaluationRunSummary struct {
 
 // EvaluationRun stores a single execution of an evaluation suite
 type EvaluationRun struct {
-	ID                string                     `json:"id" gorm:"primaryKey"`
-	Created           time.Time                  `json:"created"`
-	Updated           time.Time                  `json:"updated"`
-	SuiteID           string                     `json:"suite_id" gorm:"index"`
-	AppID             string                     `json:"app_id" gorm:"index"`
-	UserID            string                     `json:"user_id" gorm:"index"`
-	OrganizationID    string                     `json:"organization_id" gorm:"index"`
-	Status            EvaluationRunStatus        `json:"status"`
-	AppConfigSnapshot AppConfig                  `json:"app_config_snapshot" gorm:"type:jsonb;serializer:json"`
-	Summary           EvaluationRunSummary       `json:"summary" gorm:"type:jsonb;serializer:json"`
-	Results           EvaluationQuestionResults  `json:"results" gorm:"type:jsonb;serializer:json"`
-	Error             string                     `json:"error,omitempty"`
+	ID                string                    `json:"id" gorm:"primaryKey"`
+	Created           time.Time                 `json:"created"`
+	Updated           time.Time                 `json:"updated"`
+	SuiteID           string                    `json:"suite_id" gorm:"index"`
+	AppID             string                    `json:"app_id" gorm:"index"`
+	UserID            string                    `json:"user_id" gorm:"index"`
+	OrganizationID    string                    `json:"organization_id" gorm:"index"`
+	Status            EvaluationRunStatus       `json:"status"`
+	AppConfigSnapshot AgentConfig               `json:"app_config_snapshot" gorm:"type:jsonb;serializer:json"`
+	Summary           EvaluationRunSummary      `json:"summary" gorm:"type:jsonb;serializer:json"`
+	Results           EvaluationQuestionResults `json:"results" gorm:"type:jsonb;serializer:json"`
+	Error             string                    `json:"error,omitempty"`
 }
 
 // EvaluationQuestionResults is a slice type for GORM JSON serialization
@@ -119,13 +119,13 @@ func (EvaluationQuestionResults) GormDataType() string { return "json" }
 
 // EvaluationRunProgress is sent via SSE during a run
 type EvaluationRunProgress struct {
-	RunID            string                    `json:"run_id"`
-	Status           EvaluationRunStatus       `json:"status"`
-	CurrentQuestion  int                       `json:"current_question"`
-	TotalQuestions   int                       `json:"total_questions"`
-	LatestResult     *EvaluationQuestionResult `json:"latest_result,omitempty"`
-	Summary          *EvaluationRunSummary     `json:"summary,omitempty"`
-	Error            string                    `json:"error,omitempty"`
+	RunID           string                    `json:"run_id"`
+	Status          EvaluationRunStatus       `json:"status"`
+	CurrentQuestion int                       `json:"current_question"`
+	TotalQuestions  int                       `json:"total_questions"`
+	LatestResult    *EvaluationQuestionResult `json:"latest_result,omitempty"`
+	Summary         *EvaluationRunSummary     `json:"summary,omitempty"`
+	Error           string                    `json:"error,omitempty"`
 }
 
 // ListEvaluationSuitesRequest defines filters for listing suites

--- a/api/pkg/types/task_management.go
+++ b/api/pkg/types/task_management.go
@@ -221,7 +221,7 @@ func (a *AssistantConfig) IsAgentType(agentType AgentType) bool {
 }
 
 // GetDefaultAgentType returns the default agent type for an app
-func (a *AppHelixConfig) GetDefaultAgentType() AgentType {
+func (a *AgentHelixConfig) GetDefaultAgentType() AgentType {
 	if a.DefaultAgentType != "" {
 		return a.DefaultAgentType
 	}

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -1696,7 +1696,7 @@ type TestStep struct {
 	ExpectedOutput string `json:"expected_output" yaml:"expected_output"`
 }
 
-type AppHelixConfig struct {
+type AgentHelixConfig struct {
 	Name              string            `json:"name,omitempty" yaml:"name,omitempty"`
 	Description       string            `json:"description,omitempty" yaml:"description,omitempty"`
 	Avatar            string            `json:"avatar,omitempty" yaml:"avatar,omitempty"`
@@ -1714,15 +1714,15 @@ type AppHelixConfig struct {
 
 // Helper functions for agent type checking with backward compatibility
 
-type AppHelixConfigMetadata struct {
+type AgentHelixConfigMetadata struct {
 	Name string `json:"name" yaml:"name"`
 }
 
-type AppHelixConfigCRD struct {
-	APIVersion string                 `json:"apiVersion" yaml:"apiVersion"`
-	Kind       string                 `json:"kind" yaml:"kind"`
-	Metadata   AppHelixConfigMetadata `json:"metadata" yaml:"metadata"`
-	Spec       AppHelixConfig         `json:"spec" yaml:"spec"`
+type AgentHelixConfigCRD struct {
+	APIVersion string                   `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string                   `json:"kind" yaml:"kind"`
+	Metadata   AgentHelixConfigMetadata `json:"metadata" yaml:"metadata"`
+	Spec       AgentHelixConfig         `json:"spec" yaml:"spec"`
 }
 
 type AppGithubConfigUpdate struct {
@@ -1731,23 +1731,23 @@ type AppGithubConfigUpdate struct {
 	Error   string    `json:"error"`
 }
 
-type AppConfig struct {
+type AgentConfig struct {
 	AllowedDomains []string          `json:"allowed_domains" yaml:"allowed_domains"`
 	Secrets        map[string]string `json:"secrets" yaml:"secrets"`
-	Helix          AppHelixConfig    `json:"helix" yaml:"helix"`
+	Helix          AgentHelixConfig  `json:"helix" yaml:"helix"`
 }
 
-func (c AppConfig) Value() (driver.Value, error) {
+func (c AgentConfig) Value() (driver.Value, error) {
 	j, err := json.Marshal(c)
 	return j, err
 }
 
-func (c *AppConfig) Scan(src interface{}) error {
+func (c *AgentConfig) Scan(src interface{}) error {
 	source, ok := src.([]byte)
 	if !ok {
 		return errors.New("type assertion .([]byte) failed")
 	}
-	var result AppConfig
+	var result AgentConfig
 	if err := json.Unmarshal(source, &result); err != nil {
 		return err
 	}
@@ -1755,7 +1755,7 @@ func (c *AppConfig) Scan(src interface{}) error {
 	return nil
 }
 
-func (AppConfig) GormDataType() string {
+func (AgentConfig) GormDataType() string {
 	return "json"
 }
 
@@ -1866,7 +1866,7 @@ func (Triggers) GormDataType() string {
 	return "json"
 }
 
-type App struct {
+type Agent struct {
 	ID             string    `json:"id" gorm:"primaryKey"`
 	Created        time.Time `json:"created"`
 	Updated        time.Time `json:"updated"`
@@ -1874,9 +1874,9 @@ type App struct {
 	// uuid of user ID
 	Owner string `json:"owner" gorm:"index"`
 	// e.g. user, system, org
-	OwnerType OwnerType `json:"owner_type"`
-	Global    bool      `json:"global"`
-	Config    AppConfig `json:"config" gorm:"jsonb"`
+	OwnerType OwnerType   `json:"owner_type"`
+	Global    bool        `json:"global"`
+	Config    AgentConfig `json:"config" gorm:"jsonb"`
 
 	User User `json:"user" gorm:"-"` // Owner user struct, populated by the server for organization views
 
@@ -1885,6 +1885,23 @@ type App struct {
 	// can hide org-chart agents from the spec-task agent switchers.
 	IsHelixOrgAgent bool `json:"is_helix_org_agent" gorm:"-"`
 }
+
+func (Agent) TableName() string { return "apps" }
+
+// Deprecated: use Agent.
+type App = Agent
+
+// Deprecated: use AgentConfig.
+type AppConfig = AgentConfig
+
+// Deprecated: use AgentHelixConfig.
+type AppHelixConfig = AgentHelixConfig
+
+// Deprecated: use AgentHelixConfigMetadata.
+type AppHelixConfigMetadata = AgentHelixConfigMetadata
+
+// Deprecated: use AgentHelixConfigCRD.
+type AppHelixConfigCRD = AgentHelixConfigCRD
 
 type KeyPair struct {
 	Type       string
@@ -2437,42 +2454,42 @@ const (
 // LLMCall used to store the request and response of LLM calls
 // done by helix to LLM providers such as openai, togetherai or helix itself
 type LLMCall struct {
-	ID               string         `json:"id" gorm:"primaryKey"`
-	AppID            string         `json:"app_id" gorm:"index:idx_app_interaction,priority:1"`
-	OrganizationID   string         `json:"organization_id" gorm:"index"`
-	UserID           string         `json:"user_id" gorm:"index"`
-	Created          time.Time      `json:"created"`
-	Updated          time.Time      `json:"updated"`
-	SessionID        string         `json:"session_id" gorm:"index"`
-	InteractionID    string         `json:"interaction_id" gorm:"index:idx_app_interaction,priority:2"`
-	ProjectID        string         `json:"project_id" gorm:"index:idx_project_spec_task,priority:1"`
-	SpecTaskID       string         `json:"spec_task_id" gorm:"index:idx_project_spec_task,priority:2"`
-	Model            string         `json:"model"`
-	Provider         string         `json:"provider"`
-	Step             LLMCallStep    `json:"step" gorm:"index"`
-	OriginalRequest  datatypes.JSON `json:"original_request" gorm:"type:jsonb"`
-	Request          datatypes.JSON `json:"request" gorm:"type:jsonb"`
-	Response         datatypes.JSON `json:"response" gorm:"type:jsonb"`
-	DurationMs       int64          `json:"duration_ms"`
+	ID              string         `json:"id" gorm:"primaryKey"`
+	AppID           string         `json:"app_id" gorm:"index:idx_app_interaction,priority:1"`
+	OrganizationID  string         `json:"organization_id" gorm:"index"`
+	UserID          string         `json:"user_id" gorm:"index"`
+	Created         time.Time      `json:"created"`
+	Updated         time.Time      `json:"updated"`
+	SessionID       string         `json:"session_id" gorm:"index"`
+	InteractionID   string         `json:"interaction_id" gorm:"index:idx_app_interaction,priority:2"`
+	ProjectID       string         `json:"project_id" gorm:"index:idx_project_spec_task,priority:1"`
+	SpecTaskID      string         `json:"spec_task_id" gorm:"index:idx_project_spec_task,priority:2"`
+	Model           string         `json:"model"`
+	Provider        string         `json:"provider"`
+	Step            LLMCallStep    `json:"step" gorm:"index"`
+	OriginalRequest datatypes.JSON `json:"original_request" gorm:"type:jsonb"`
+	Request         datatypes.JSON `json:"request" gorm:"type:jsonb"`
+	Response        datatypes.JSON `json:"response" gorm:"type:jsonb"`
+	DurationMs      int64          `json:"duration_ms"`
 	// TimeToFirstTokenMs is the wall time from request start to the first
 	// streamed chunk. It isolates provider prefill / cold-start latency from
 	// generation time (a cold or overloaded provider shows a large TTFT while
 	// generation stays normal). 0 means no chunk was received (the call errored
 	// or was cut before the first token). For non-streaming calls it equals the
 	// time to the full response.
-	TimeToFirstTokenMs int64          `json:"time_to_first_token_ms"`
-	PromptTokens       int64          `json:"prompt_tokens"`
-	CompletionTokens int64          `json:"completion_tokens"`
-	TotalTokens      int64          `json:"total_tokens"`
-	CacheReadTokens  int64          `json:"cache_read_tokens"`  // prompt tokens served from provider cache (subset of PromptTokens)
-	CacheWriteTokens int64          `json:"cache_write_tokens"` // prompt tokens written to provider cache (Anthropic only; subset of PromptTokens)
-	PromptCost       float64        `json:"prompt_cost"`
-	CompletionCost   float64        `json:"completion_cost"`
-	CacheReadCost    float64        `json:"cache_read_cost"`
-	CacheWriteCost   float64        `json:"cache_write_cost"`
-	TotalCost        float64        `json:"total_cost"` // Prompt + completion + cache read + cache write
-	Stream           bool           `json:"stream"`
-	Error            string         `json:"error"`
+	TimeToFirstTokenMs int64   `json:"time_to_first_token_ms"`
+	PromptTokens       int64   `json:"prompt_tokens"`
+	CompletionTokens   int64   `json:"completion_tokens"`
+	TotalTokens        int64   `json:"total_tokens"`
+	CacheReadTokens    int64   `json:"cache_read_tokens"`  // prompt tokens served from provider cache (subset of PromptTokens)
+	CacheWriteTokens   int64   `json:"cache_write_tokens"` // prompt tokens written to provider cache (Anthropic only; subset of PromptTokens)
+	PromptCost         float64 `json:"prompt_cost"`
+	CompletionCost     float64 `json:"completion_cost"`
+	CacheReadCost      float64 `json:"cache_read_cost"`
+	CacheWriteCost     float64 `json:"cache_write_cost"`
+	TotalCost          float64 `json:"total_cost"` // Prompt + completion + cache read + cache write
+	Stream             bool    `json:"stream"`
+	Error              string  `json:"error"`
 }
 
 // SecretScope controls which environment a project secret is injected into.

--- a/demos/compliance-analyzer/src/lib/helix.ts
+++ b/demos/compliance-analyzer/src/lib/helix.ts
@@ -91,7 +91,7 @@ export interface CreatedApp {
  * Each analysis run gets its own app so documents are isolated.
  */
 export async function createApp(config: HelixConfig): Promise<CreatedApp> {
-  const response = await helixFetch(config, "/api/v1/apps", {
+  const response = await helixFetch(config, "/api/v1/agents", {
     method: "POST",
     body: JSON.stringify({
       config: {

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -15,6 +15,7 @@ export interface ApiAddBotParentRequest {
 
 export interface ApiAgentDetailDTO {
   agent_app_id?: string;
+  agent_id?: string;
   agent_model?: string;
   agent_runtime?: string;
   /**
@@ -62,6 +63,7 @@ export interface ApiAgentDetailDTO {
 export interface ApiBotActivateDTO {
   activation_id?: string;
   agent_app_id?: string;
+  agent_id?: string;
   project_id?: string;
   session_id?: string;
 }
@@ -72,11 +74,13 @@ export interface ApiBotBadge {
 
 export interface ApiBotChatDTO {
   agent_app_id?: string;
+  agent_id?: string;
   project_id?: string;
 }
 
 export interface ApiBotDTO {
   agent_app_id?: string;
+  agent_id?: string;
   agent_model?: string;
   agent_runtime?: string;
   /**
@@ -121,8 +125,9 @@ export interface ApiBotDTO {
 }
 
 export interface ApiBotDetailDTO {
-  /** AgentAppID + ProjectID — see BotChatDTO comments. */
   agent_app_id?: string;
+  /** AgentID + ProjectID — see BotChatDTO comments. */
+  agent_id?: string;
   bot?: ApiBotDTO;
   project_id?: string;
 }
@@ -161,7 +166,7 @@ export interface ApiCreateBotRequest {
    * Owner makes this a manager Bot: it receives the canonical owner
    * tool set (every org-graph mutation - create_bot, delete_bot,
    * set_bot_content, subscribe, ... - plus the read baseline) so it can
-   * hire and manage other Bots. When true, Tools is ignored in favour
+   * hire and manage other Nodes. When true, Tools is ignored in favour
    * of that set. Used to seed a starter/root Bot for a new org.
    */
   owner?: boolean;
@@ -1064,6 +1069,28 @@ export interface ServerAgentConfigAppliedResponse {
   status?: string;
 }
 
+export interface ServerAgentCreateResponse {
+  config?: TypesAgentConfig;
+  created?: string;
+  global?: boolean;
+  id?: string;
+  /**
+   * IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
+   * (see api/pkg/org). Computed at list time, not persisted, so the frontend
+   * can hide org-chart agents from the spec-task agent switchers.
+   */
+  is_helix_org_agent?: boolean;
+  model_substitutions?: ServerModelSubstitution[];
+  organization_id?: string;
+  /** uuid of user ID */
+  owner?: string;
+  /** e.g. user, system, org */
+  owner_type?: TypesOwnerType;
+  updated?: string;
+  /** Owner user struct, populated by the server for organization views */
+  user?: TypesUser;
+}
+
 export interface ServerAgentSandboxesDebugResponse {
   dev_containers?: ServerDevContainerWithClients[];
   gpus?: ServerGPUInfoWithSandbox[];
@@ -1087,28 +1114,6 @@ export interface ServerAppClaudeSubscriptionStatus {
   subscription_owner_type?: string;
   /** that subscription passed its last liveness probe */
   valid?: boolean;
-}
-
-export interface ServerAppCreateResponse {
-  config?: TypesAppConfig;
-  created?: string;
-  global?: boolean;
-  id?: string;
-  /**
-   * IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
-   * (see api/pkg/org). Computed at list time, not persisted, so the frontend
-   * can hide org-chart agents from the spec-task agent switchers.
-   */
-  is_helix_org_agent?: boolean;
-  model_substitutions?: ServerModelSubstitution[];
-  organization_id?: string;
-  /** uuid of user ID */
-  owner?: string;
-  /** e.g. user, system, org */
-  owner_type?: TypesOwnerType;
-  updated?: string;
-  /** Owner user struct, populated by the server for organization views */
-  user?: TypesUser;
 }
 
 export interface ServerBatchTaskProgressResponse {
@@ -2177,6 +2182,48 @@ export interface TypesAffectedProjectInfo {
   name?: string;
 }
 
+export interface TypesAgent {
+  config?: TypesAgentConfig;
+  created?: string;
+  global?: boolean;
+  id?: string;
+  /**
+   * IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
+   * (see api/pkg/org). Computed at list time, not persisted, so the frontend
+   * can hide org-chart agents from the spec-task agent switchers.
+   */
+  is_helix_org_agent?: boolean;
+  organization_id?: string;
+  /** uuid of user ID */
+  owner?: string;
+  /** e.g. user, system, org */
+  owner_type?: TypesOwnerType;
+  updated?: string;
+  /** Owner user struct, populated by the server for organization views */
+  user?: TypesUser;
+}
+
+export interface TypesAgentConfig {
+  allowed_domains?: string[];
+  helix?: TypesAgentHelixConfig;
+  secrets?: Record<string, string>;
+}
+
+export interface TypesAgentHelixConfig {
+  assistants?: TypesAssistantConfig[];
+  avatar?: string;
+  avatar_content_type?: string;
+  /** Agent configuration */
+  default_agent_type?: TypesAgentType;
+  description?: string;
+  external_agent_config?: TypesExternalAgentConfig;
+  external_agent_enabled?: boolean;
+  external_url?: string;
+  image?: string;
+  name?: string;
+  triggers?: TypesTrigger[];
+}
+
 export enum TypesAgentType {
   AgentTypeHelixBasic = "helix_basic",
   AgentTypeHelixAgent = "helix_agent",
@@ -2226,48 +2273,6 @@ export interface TypesApiKey {
   /** Used for isolation and metrics tracking */
   spec_task_id?: string;
   type?: TypesAPIKeyType;
-}
-
-export interface TypesApp {
-  config?: TypesAppConfig;
-  created?: string;
-  global?: boolean;
-  id?: string;
-  /**
-   * IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
-   * (see api/pkg/org). Computed at list time, not persisted, so the frontend
-   * can hide org-chart agents from the spec-task agent switchers.
-   */
-  is_helix_org_agent?: boolean;
-  organization_id?: string;
-  /** uuid of user ID */
-  owner?: string;
-  /** e.g. user, system, org */
-  owner_type?: TypesOwnerType;
-  updated?: string;
-  /** Owner user struct, populated by the server for organization views */
-  user?: TypesUser;
-}
-
-export interface TypesAppConfig {
-  allowed_domains?: string[];
-  helix?: TypesAppHelixConfig;
-  secrets?: Record<string, string>;
-}
-
-export interface TypesAppHelixConfig {
-  assistants?: TypesAssistantConfig[];
-  avatar?: string;
-  avatar_content_type?: string;
-  /** Agent configuration */
-  default_agent_type?: TypesAgentType;
-  description?: string;
-  external_agent_config?: TypesExternalAgentConfig;
-  external_agent_enabled?: boolean;
-  external_url?: string;
-  image?: string;
-  name?: string;
-  triggers?: TypesTrigger[];
 }
 
 export interface TypesAssistantAPI {
@@ -3355,7 +3360,7 @@ export interface TypesEvaluationQuestionResult {
 }
 
 export interface TypesEvaluationRun {
-  app_config_snapshot?: TypesAppConfig;
+  app_config_snapshot?: TypesAgentConfig;
   app_id?: string;
   created?: string;
   error?: string;
@@ -8343,6 +8348,677 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
+     * @description List agents for the user. Agents are pre-configured to spawn sessions with specific tools and config.
+     *
+     * @tags agents
+     * @name V1AgentsList
+     * @summary List agents
+     * @request GET:/api/v1/agents
+     * @secure
+     */
+    v1AgentsList: (
+      query?: {
+        /** Organization ID */
+        organization_id?: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesAgent[], any>({
+        path: `/api/v1/agents`,
+        method: "GET",
+        query: query,
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name V1AgentsCreate
+     * @request POST:/api/v1/agents
+     * @secure
+     */
+    v1AgentsCreate: (request: TypesAgent, params: RequestParams = {}) =>
+      this.request<ServerAgentCreateResponse, any>({
+        path: `/api/v1/agents`,
+        method: "POST",
+        body: request,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description Delete an evaluation run
+     *
+     * @tags evaluations
+     * @name V1AgentsEvaluationRunsDelete
+     * @summary Delete an evaluation run
+     * @request DELETE:/api/v1/agents/{agent_id}/evaluation-runs/{run_id}
+     * @secure
+     */
+    v1AgentsEvaluationRunsDelete: (agentId: string, runId: string, params: RequestParams = {}) =>
+      this.request<Record<string, string>, SystemHTTPError>({
+        path: `/api/v1/agents/${agentId}/evaluation-runs/${runId}`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description Get evaluation run details
+     *
+     * @tags evaluations
+     * @name V1AgentsEvaluationRunsDetail
+     * @summary Get an evaluation run
+     * @request GET:/api/v1/agents/{agent_id}/evaluation-runs/{run_id}
+     * @secure
+     */
+    v1AgentsEvaluationRunsDetail: (agentId: string, runId: string, params: RequestParams = {}) =>
+      this.request<TypesEvaluationRun, SystemHTTPError>({
+        path: `/api/v1/agents/${agentId}/evaluation-runs/${runId}`,
+        method: "GET",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description List all evaluation suites for an agent
+     *
+     * @tags evaluations
+     * @name V1AgentsEvaluationSuitesDetail
+     * @summary List evaluation suites for an agent
+     * @request GET:/api/v1/agents/{agent_id}/evaluation-suites
+     * @secure
+     */
+    v1AgentsEvaluationSuitesDetail: (agentId: string, params: RequestParams = {}) =>
+      this.request<TypesEvaluationSuite[], SystemHTTPError>({
+        path: `/api/v1/agents/${agentId}/evaluation-suites`,
+        method: "GET",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Create a new evaluation suite for an agent
+     *
+     * @tags evaluations
+     * @name V1AgentsEvaluationSuitesCreate
+     * @summary Create an evaluation suite
+     * @request POST:/api/v1/agents/{agent_id}/evaluation-suites
+     * @secure
+     */
+    v1AgentsEvaluationSuitesCreate: (agentId: string, suite: TypesEvaluationSuite, params: RequestParams = {}) =>
+      this.request<TypesEvaluationSuite, SystemHTTPError>({
+        path: `/api/v1/agents/${agentId}/evaluation-suites`,
+        method: "POST",
+        body: suite,
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Delete an evaluation suite
+     *
+     * @tags evaluations
+     * @name V1AgentsEvaluationSuitesDelete
+     * @summary Delete an evaluation suite
+     * @request DELETE:/api/v1/agents/{agent_id}/evaluation-suites/{id}
+     * @secure
+     */
+    v1AgentsEvaluationSuitesDelete: (agentId: string, id: string, params: RequestParams = {}) =>
+      this.request<Record<string, string>, SystemHTTPError>({
+        path: `/api/v1/agents/${agentId}/evaluation-suites/${id}`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description Get an evaluation suite by ID
+     *
+     * @tags evaluations
+     * @name V1AgentsEvaluationSuitesDetail2
+     * @summary Get an evaluation suite
+     * @request GET:/api/v1/agents/{agent_id}/evaluation-suites/{id}
+     * @originalName v1AgentsEvaluationSuitesDetail
+     * @duplicate
+     * @secure
+     */
+    v1AgentsEvaluationSuitesDetail2: (agentId: string, id: string, params: RequestParams = {}) =>
+      this.request<TypesEvaluationSuite, SystemHTTPError>({
+        path: `/api/v1/agents/${agentId}/evaluation-suites/${id}`,
+        method: "GET",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Update an evaluation suite
+     *
+     * @tags evaluations
+     * @name V1AgentsEvaluationSuitesUpdate
+     * @summary Update an evaluation suite
+     * @request PUT:/api/v1/agents/{agent_id}/evaluation-suites/{id}
+     * @secure
+     */
+    v1AgentsEvaluationSuitesUpdate: (
+      agentId: string,
+      id: string,
+      suite: TypesEvaluationSuite,
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesEvaluationSuite, SystemHTTPError>({
+        path: `/api/v1/agents/${agentId}/evaluation-suites/${id}`,
+        method: "PUT",
+        body: suite,
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description List evaluation runs for a suite
+     *
+     * @tags evaluations
+     * @name V1AgentsEvaluationSuitesRunsDetail
+     * @summary List evaluation runs
+     * @request GET:/api/v1/agents/{agent_id}/evaluation-suites/{id}/runs
+     * @secure
+     */
+    v1AgentsEvaluationSuitesRunsDetail: (agentId: string, id: string, params: RequestParams = {}) =>
+      this.request<TypesEvaluationRun[], SystemHTTPError>({
+        path: `/api/v1/agents/${agentId}/evaluation-suites/${id}/runs`,
+        method: "GET",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Start running an evaluation suite against an agent
+     *
+     * @tags evaluations
+     * @name V1AgentsEvaluationSuitesRunsCreate
+     * @summary Start an evaluation run
+     * @request POST:/api/v1/agents/{agent_id}/evaluation-suites/{id}/runs
+     * @secure
+     */
+    v1AgentsEvaluationSuitesRunsCreate: (agentId: string, id: string, params: RequestParams = {}) =>
+      this.request<TypesEvaluationRun, SystemHTTPError>({
+        path: `/api/v1/agents/${agentId}/evaluation-suites/${id}/runs`,
+        method: "POST",
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description List triggers for the agent
+     *
+     * @tags agents
+     * @name V1AgentsTriggersDetail
+     * @summary List agent triggers
+     * @request GET:/api/v1/agents/{agent_id}/triggers
+     * @secure
+     */
+    v1AgentsTriggersDetail: (agentId: string, params: RequestParams = {}) =>
+      this.request<TypesTriggerConfiguration[], any>({
+        path: `/api/v1/agents/${agentId}/triggers`,
+        method: "GET",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name V1AgentsDelete
+     * @request DELETE:/api/v1/agents/{id}
+     * @secure
+     */
+    v1AgentsDelete: (id: string, params: RequestParams = {}) =>
+      this.request<void, any>({
+        path: `/api/v1/agents/${id}`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name V1AgentsDetail
+     * @request GET:/api/v1/agents/{id}
+     * @secure
+     */
+    v1AgentsDetail: (id: string, params: RequestParams = {}) =>
+      this.request<TypesAgent, any>({
+        path: `/api/v1/agents/${id}`,
+        method: "GET",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name V1AgentsUpdate
+     * @request PUT:/api/v1/agents/{id}
+     * @secure
+     */
+    v1AgentsUpdate: (id: string, request: TypesAgent, params: RequestParams = {}) =>
+      this.request<TypesAgent, any>({
+        path: `/api/v1/agents/${id}`,
+        method: "PUT",
+        body: request,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description List access grants for an agent (organization owners and members can list access grants)
+     *
+     * @tags agents
+     * @name V1AgentsAccessGrantsDetail
+     * @summary List agent access grants
+     * @request GET:/api/v1/agents/{id}/access-grants
+     * @secure
+     */
+    v1AgentsAccessGrantsDetail: (id: string, params: RequestParams = {}) =>
+      this.request<TypesAccessGrant[], any>({
+        path: `/api/v1/agents/${id}/access-grants`,
+        method: "GET",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description Grant access to an agent to a team or organization member (organization owners can grant access to teams and organization members)
+     *
+     * @tags agents
+     * @name V1AgentsAccessGrantsCreate
+     * @summary Grant access to an agent to a team or organization member
+     * @request POST:/api/v1/agents/{id}/access-grants
+     * @secure
+     */
+    v1AgentsAccessGrantsCreate: (id: string, request: TypesCreateAccessGrantRequest, params: RequestParams = {}) =>
+      this.request<TypesAccessGrant, any>({
+        path: `/api/v1/agents/${id}/access-grants`,
+        method: "POST",
+        body: request,
+        secure: true,
+        type: ContentType.Json,
+        ...params,
+      }),
+
+    /**
+     * @description Runs an API action for an agent
+     *
+     * @name V1AgentsApiActionsCreate
+     * @summary Run an API action
+     * @request POST:/api/v1/agents/{id}/api-actions
+     * @secure
+     */
+    v1AgentsApiActionsCreate: (id: string, request: TypesRunAPIActionRequest, params: RequestParams = {}) =>
+      this.request<TypesRunAPIActionResponse, SystemHTTPError>({
+        path: `/api/v1/agents/${id}/api-actions`,
+        method: "POST",
+        body: request,
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Delete the agent's avatar image
+     *
+     * @tags agents
+     * @name V1AgentsAvatarDelete
+     * @summary Delete agent avatar
+     * @request DELETE:/api/v1/agents/{id}/avatar
+     * @secure
+     */
+    v1AgentsAvatarDelete: (id: string, params: RequestParams = {}) =>
+      this.request<void, SystemHTTPError>({
+        path: `/api/v1/agents/${id}/avatar`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description Get the agent's avatar image
+     *
+     * @tags agents
+     * @name V1AgentsAvatarDetail
+     * @summary Get agent avatar
+     * @request GET:/api/v1/agents/{id}/avatar
+     * @secure
+     */
+    v1AgentsAvatarDetail: (id: string, params: RequestParams = {}) =>
+      this.request<File, SystemHTTPError>({
+        path: `/api/v1/agents/${id}/avatar`,
+        method: "GET",
+        secure: true,
+        format: "blob",
+        ...params,
+      }),
+
+    /**
+     * @description Upload a base64 encoded image as the agent's avatar
+     *
+     * @tags agents
+     * @name V1AgentsAvatarCreate
+     * @summary Upload agent avatar
+     * @request POST:/api/v1/agents/{id}/avatar
+     * @secure
+     */
+    v1AgentsAvatarCreate: (id: string, image: string, params: RequestParams = {}) =>
+      this.request<void, SystemHTTPError>({
+        path: `/api/v1/agents/${id}/avatar`,
+        method: "POST",
+        body: image,
+        secure: true,
+        type: ContentType.Text,
+        ...params,
+      }),
+
+    /**
+     * @description Reports whether the agent owner (whose subscription authenticates the agent's sessions) has a working Claude subscription
+     *
+     * @tags Claude
+     * @name V1AgentsClaudeSubscriptionStatusDetail
+     * @summary Get the Claude subscription status for an agent's owner
+     * @request GET:/api/v1/agents/{id}/claude-subscription-status
+     * @secure
+     */
+    v1AgentsClaudeSubscriptionStatusDetail: (id: string, params: RequestParams = {}) =>
+      this.request<ServerAppClaudeSubscriptionStatus, SystemHTTPError>({
+        path: `/api/v1/agents/${id}/claude-subscription-status`,
+        method: "GET",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Get agent daily usage
+     *
+     * @tags agents
+     * @name V1AgentsDailyUsageDetail
+     * @summary Get agent usage
+     * @request GET:/api/v1/agents/{id}/daily-usage
+     * @secure
+     */
+    v1AgentsDailyUsageDetail: (
+      id: string,
+      query?: {
+        /** Start date */
+        from?: string;
+        /** End date */
+        to?: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesAggregatedUsageMetric[], SystemHTTPError>({
+        path: `/api/v1/agents/${id}/daily-usage`,
+        method: "GET",
+        query: query,
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @name V1AgentsDuplicateCreate
+     * @request POST:/api/v1/agents/{id}/duplicate
+     * @secure
+     */
+    v1AgentsDuplicateCreate: (
+      id: string,
+      query?: {
+        /** Optional new name for the agent */
+        name?: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<void, any>({
+        path: `/api/v1/agents/${id}/duplicate`,
+        method: "POST",
+        query: query,
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description List interactions with pagination and optional session filtering for a specific agent
+     *
+     * @tags interactions
+     * @name V1AgentsInteractionsDetail
+     * @summary List interactions
+     * @request GET:/api/v1/agents/{id}/interactions
+     * @secure
+     */
+    v1AgentsInteractionsDetail: (
+      id: string,
+      query?: {
+        /** Page number */
+        page?: number;
+        /** Page size */
+        pageSize?: number;
+        /** Filter by session ID */
+        session?: string;
+        /** Filter by interaction ID */
+        interaction?: string;
+        /** Query by like/dislike */
+        feedback?: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesPaginatedInteractions, any>({
+        path: `/api/v1/agents/${id}/interactions`,
+        method: "GET",
+        query: query,
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description List user's LLM calls with pagination and optional session filtering for a specific agent
+     *
+     * @tags llm_calls
+     * @name V1AgentsLlmCallsDetail
+     * @summary List LLM calls
+     * @request GET:/api/v1/agents/{id}/llm-calls
+     * @secure
+     */
+    v1AgentsLlmCallsDetail: (
+      id: string,
+      query?: {
+        /** Page number */
+        page?: number;
+        /** Page size */
+        pageSize?: number;
+        /** Filter by session ID */
+        session?: string;
+        /** Filter by interaction ID */
+        interaction?: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesPaginatedLLMCalls, any>({
+        path: `/api/v1/agents/${id}/llm-calls`,
+        method: "GET",
+        query: query,
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description List memories for a specific agent and user
+     *
+     * @tags memories
+     * @name V1AgentsMemoriesDetail
+     * @summary List agent memories
+     * @request GET:/api/v1/agents/{id}/memories
+     * @secure
+     */
+    v1AgentsMemoriesDetail: (id: string, params: RequestParams = {}) =>
+      this.request<TypesMemory[], any>({
+        path: `/api/v1/agents/${id}/memories`,
+        method: "GET",
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Delete a specific memory for an agent and user
+     *
+     * @tags memories
+     * @name V1AgentsMemoriesDelete
+     * @summary Delete agent memory
+     * @request DELETE:/api/v1/agents/{id}/memories/{memory_id}
+     * @secure
+     */
+    v1AgentsMemoriesDelete: (id: string, memoryId: string, params: RequestParams = {}) =>
+      this.request<void, any>({
+        path: `/api/v1/agents/${id}/memories/${memoryId}`,
+        method: "DELETE",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description Enable a marketplace skill on an agent. For autoProvision MCP skills the server generates URL and auth automatically.
+     *
+     * @tags skills
+     * @name V1AgentsSkillsEnableCreate
+     * @summary Enable a marketplace skill on an agent
+     * @request POST:/api/v1/agents/{id}/skills/{skill}/enable
+     * @secure
+     */
+    v1AgentsSkillsEnableCreate: (id: string, skill: string, params: RequestParams = {}) =>
+      this.request<TypesAgent, any>({
+        path: `/api/v1/agents/${id}/skills/${skill}/enable`,
+        method: "POST",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description List step info for a specific agent and interaction ID, used to build the timeline of events
+     *
+     * @tags step_info
+     * @name V1AgentsStepInfoDetail
+     * @summary List step info
+     * @request GET:/api/v1/agents/{id}/step-info
+     * @secure
+     */
+    v1AgentsStepInfoDetail: (
+      id: string,
+      query?: {
+        /** Interaction ID */
+        interactionId?: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesStepInfo[], any>({
+        path: `/api/v1/agents/${id}/step-info`,
+        method: "GET",
+        query: query,
+        secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Get the status of a specific trigger type for an agent
+     *
+     * @tags agents
+     * @name V1AgentsTriggerStatusDetail
+     * @summary Get agent trigger status
+     * @request GET:/api/v1/agents/{id}/trigger-status
+     * @secure
+     */
+    v1AgentsTriggerStatusDetail: (
+      id: string,
+      query: {
+        /** Trigger type (e.g., slack) */
+        trigger_type: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesTriggerStatus, any>({
+        path: `/api/v1/agents/${id}/trigger-status`,
+        method: "GET",
+        query: query,
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description Returns the access rights the current user has for this agent
+     *
+     * @tags agents
+     * @name V1AgentsUserAccessDetail
+     * @summary Get current user's access level for an agent
+     * @request GET:/api/v1/agents/{id}/user-access
+     * @secure
+     */
+    v1AgentsUserAccessDetail: (id: string, params: RequestParams = {}) =>
+      this.request<TypesUserAppAccessResponse, any>({
+        path: `/api/v1/agents/${id}/user-access`,
+        method: "GET",
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * @description Get agent users daily usage
+     *
+     * @tags agents
+     * @name V1AgentsUsersDailyUsageDetail
+     * @summary Get agent users daily usage
+     * @request GET:/api/v1/agents/{id}/users-daily-usage
+     * @secure
+     */
+    v1AgentsUsersDailyUsageDetail: (
+      id: string,
+      query?: {
+        /** Start date */
+        from?: string;
+        /** End date */
+        to?: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesAggregatedUsageMetric[], SystemHTTPError>({
+        path: `/api/v1/agents/${id}/users-daily-usage`,
+        method: "GET",
+        query: query,
+        secure: true,
+        type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
      * @description Delete an API key
      *
      * @tags api-keys
@@ -8404,677 +9080,6 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         method: "POST",
         body: request,
         type: ContentType.Json,
-        ...params,
-      }),
-
-    /**
-     * @description List apps for the user. Apps are pre-configured to spawn sessions with specific tools and config.
-     *
-     * @tags apps
-     * @name V1AppsList
-     * @summary List apps
-     * @request GET:/api/v1/apps
-     * @secure
-     */
-    v1AppsList: (
-      query?: {
-        /** Organization ID */
-        organization_id?: string;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<TypesApp[], any>({
-        path: `/api/v1/apps`,
-        method: "GET",
-        query: query,
-        secure: true,
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @name V1AppsCreate
-     * @request POST:/api/v1/apps
-     * @secure
-     */
-    v1AppsCreate: (request: TypesApp, params: RequestParams = {}) =>
-      this.request<ServerAppCreateResponse, any>({
-        path: `/api/v1/apps`,
-        method: "POST",
-        body: request,
-        secure: true,
-        type: ContentType.Json,
-        ...params,
-      }),
-
-    /**
-     * @description Delete an evaluation run
-     *
-     * @tags evaluations
-     * @name V1AppsEvaluationRunsDelete
-     * @summary Delete an evaluation run
-     * @request DELETE:/api/v1/apps/{app_id}/evaluation-runs/{run_id}
-     * @secure
-     */
-    v1AppsEvaluationRunsDelete: (appId: string, runId: string, params: RequestParams = {}) =>
-      this.request<Record<string, string>, SystemHTTPError>({
-        path: `/api/v1/apps/${appId}/evaluation-runs/${runId}`,
-        method: "DELETE",
-        secure: true,
-        ...params,
-      }),
-
-    /**
-     * @description Get evaluation run details
-     *
-     * @tags evaluations
-     * @name V1AppsEvaluationRunsDetail
-     * @summary Get an evaluation run
-     * @request GET:/api/v1/apps/{app_id}/evaluation-runs/{run_id}
-     * @secure
-     */
-    v1AppsEvaluationRunsDetail: (appId: string, runId: string, params: RequestParams = {}) =>
-      this.request<TypesEvaluationRun, SystemHTTPError>({
-        path: `/api/v1/apps/${appId}/evaluation-runs/${runId}`,
-        method: "GET",
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description List all evaluation suites for an app
-     *
-     * @tags evaluations
-     * @name V1AppsEvaluationSuitesDetail
-     * @summary List evaluation suites for an app
-     * @request GET:/api/v1/apps/{app_id}/evaluation-suites
-     * @secure
-     */
-    v1AppsEvaluationSuitesDetail: (appId: string, params: RequestParams = {}) =>
-      this.request<TypesEvaluationSuite[], SystemHTTPError>({
-        path: `/api/v1/apps/${appId}/evaluation-suites`,
-        method: "GET",
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Create a new evaluation suite for an agent
-     *
-     * @tags evaluations
-     * @name V1AppsEvaluationSuitesCreate
-     * @summary Create an evaluation suite
-     * @request POST:/api/v1/apps/{app_id}/evaluation-suites
-     * @secure
-     */
-    v1AppsEvaluationSuitesCreate: (appId: string, suite: TypesEvaluationSuite, params: RequestParams = {}) =>
-      this.request<TypesEvaluationSuite, SystemHTTPError>({
-        path: `/api/v1/apps/${appId}/evaluation-suites`,
-        method: "POST",
-        body: suite,
-        secure: true,
-        type: ContentType.Json,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Delete an evaluation suite
-     *
-     * @tags evaluations
-     * @name V1AppsEvaluationSuitesDelete
-     * @summary Delete an evaluation suite
-     * @request DELETE:/api/v1/apps/{app_id}/evaluation-suites/{id}
-     * @secure
-     */
-    v1AppsEvaluationSuitesDelete: (appId: string, id: string, params: RequestParams = {}) =>
-      this.request<Record<string, string>, SystemHTTPError>({
-        path: `/api/v1/apps/${appId}/evaluation-suites/${id}`,
-        method: "DELETE",
-        secure: true,
-        ...params,
-      }),
-
-    /**
-     * @description Get an evaluation suite by ID
-     *
-     * @tags evaluations
-     * @name V1AppsEvaluationSuitesDetail2
-     * @summary Get an evaluation suite
-     * @request GET:/api/v1/apps/{app_id}/evaluation-suites/{id}
-     * @originalName v1AppsEvaluationSuitesDetail
-     * @duplicate
-     * @secure
-     */
-    v1AppsEvaluationSuitesDetail2: (appId: string, id: string, params: RequestParams = {}) =>
-      this.request<TypesEvaluationSuite, SystemHTTPError>({
-        path: `/api/v1/apps/${appId}/evaluation-suites/${id}`,
-        method: "GET",
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Update an evaluation suite
-     *
-     * @tags evaluations
-     * @name V1AppsEvaluationSuitesUpdate
-     * @summary Update an evaluation suite
-     * @request PUT:/api/v1/apps/{app_id}/evaluation-suites/{id}
-     * @secure
-     */
-    v1AppsEvaluationSuitesUpdate: (
-      appId: string,
-      id: string,
-      suite: TypesEvaluationSuite,
-      params: RequestParams = {},
-    ) =>
-      this.request<TypesEvaluationSuite, SystemHTTPError>({
-        path: `/api/v1/apps/${appId}/evaluation-suites/${id}`,
-        method: "PUT",
-        body: suite,
-        secure: true,
-        type: ContentType.Json,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description List evaluation runs for a suite
-     *
-     * @tags evaluations
-     * @name V1AppsEvaluationSuitesRunsDetail
-     * @summary List evaluation runs
-     * @request GET:/api/v1/apps/{app_id}/evaluation-suites/{id}/runs
-     * @secure
-     */
-    v1AppsEvaluationSuitesRunsDetail: (appId: string, id: string, params: RequestParams = {}) =>
-      this.request<TypesEvaluationRun[], SystemHTTPError>({
-        path: `/api/v1/apps/${appId}/evaluation-suites/${id}/runs`,
-        method: "GET",
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Start running an evaluation suite against an agent
-     *
-     * @tags evaluations
-     * @name V1AppsEvaluationSuitesRunsCreate
-     * @summary Start an evaluation run
-     * @request POST:/api/v1/apps/{app_id}/evaluation-suites/{id}/runs
-     * @secure
-     */
-    v1AppsEvaluationSuitesRunsCreate: (appId: string, id: string, params: RequestParams = {}) =>
-      this.request<TypesEvaluationRun, SystemHTTPError>({
-        path: `/api/v1/apps/${appId}/evaluation-suites/${id}/runs`,
-        method: "POST",
-        secure: true,
-        type: ContentType.Json,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description List triggers for the app
-     *
-     * @tags apps
-     * @name V1AppsTriggersDetail
-     * @summary List app triggers
-     * @request GET:/api/v1/apps/{app_id}/triggers
-     * @secure
-     */
-    v1AppsTriggersDetail: (appId: string, params: RequestParams = {}) =>
-      this.request<TypesTriggerConfiguration[], any>({
-        path: `/api/v1/apps/${appId}/triggers`,
-        method: "GET",
-        secure: true,
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @name V1AppsDelete
-     * @request DELETE:/api/v1/apps/{id}
-     * @secure
-     */
-    v1AppsDelete: (id: string, params: RequestParams = {}) =>
-      this.request<void, any>({
-        path: `/api/v1/apps/${id}`,
-        method: "DELETE",
-        secure: true,
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @name V1AppsDetail
-     * @request GET:/api/v1/apps/{id}
-     * @secure
-     */
-    v1AppsDetail: (id: string, params: RequestParams = {}) =>
-      this.request<TypesApp, any>({
-        path: `/api/v1/apps/${id}`,
-        method: "GET",
-        secure: true,
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @name V1AppsUpdate
-     * @request PUT:/api/v1/apps/{id}
-     * @secure
-     */
-    v1AppsUpdate: (id: string, request: TypesApp, params: RequestParams = {}) =>
-      this.request<TypesApp, any>({
-        path: `/api/v1/apps/${id}`,
-        method: "PUT",
-        body: request,
-        secure: true,
-        type: ContentType.Json,
-        ...params,
-      }),
-
-    /**
-     * @description List access grants for an app (organization owners and members can list access grants)
-     *
-     * @tags apps
-     * @name V1AppsAccessGrantsDetail
-     * @summary List app access grants
-     * @request GET:/api/v1/apps/{id}/access-grants
-     * @secure
-     */
-    v1AppsAccessGrantsDetail: (id: string, params: RequestParams = {}) =>
-      this.request<TypesAccessGrant[], any>({
-        path: `/api/v1/apps/${id}/access-grants`,
-        method: "GET",
-        secure: true,
-        ...params,
-      }),
-
-    /**
-     * @description Grant access to an agent to a team or organization member (organization owners can grant access to teams and organization members)
-     *
-     * @tags apps
-     * @name V1AppsAccessGrantsCreate
-     * @summary Grant access to an agent to a team or organization member
-     * @request POST:/api/v1/apps/{id}/access-grants
-     * @secure
-     */
-    v1AppsAccessGrantsCreate: (id: string, request: TypesCreateAccessGrantRequest, params: RequestParams = {}) =>
-      this.request<TypesAccessGrant, any>({
-        path: `/api/v1/apps/${id}/access-grants`,
-        method: "POST",
-        body: request,
-        secure: true,
-        type: ContentType.Json,
-        ...params,
-      }),
-
-    /**
-     * @description Runs an API action for an app
-     *
-     * @name V1AppsApiActionsCreate
-     * @summary Run an API action
-     * @request POST:/api/v1/apps/{id}/api-actions
-     * @secure
-     */
-    v1AppsApiActionsCreate: (id: string, request: TypesRunAPIActionRequest, params: RequestParams = {}) =>
-      this.request<TypesRunAPIActionResponse, SystemHTTPError>({
-        path: `/api/v1/apps/${id}/api-actions`,
-        method: "POST",
-        body: request,
-        secure: true,
-        type: ContentType.Json,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Delete the app's avatar image
-     *
-     * @tags apps
-     * @name V1AppsAvatarDelete
-     * @summary Delete app avatar
-     * @request DELETE:/api/v1/apps/{id}/avatar
-     * @secure
-     */
-    v1AppsAvatarDelete: (id: string, params: RequestParams = {}) =>
-      this.request<void, SystemHTTPError>({
-        path: `/api/v1/apps/${id}/avatar`,
-        method: "DELETE",
-        secure: true,
-        ...params,
-      }),
-
-    /**
-     * @description Get the app's avatar image
-     *
-     * @tags apps
-     * @name V1AppsAvatarDetail
-     * @summary Get app avatar
-     * @request GET:/api/v1/apps/{id}/avatar
-     * @secure
-     */
-    v1AppsAvatarDetail: (id: string, params: RequestParams = {}) =>
-      this.request<File, SystemHTTPError>({
-        path: `/api/v1/apps/${id}/avatar`,
-        method: "GET",
-        secure: true,
-        format: "blob",
-        ...params,
-      }),
-
-    /**
-     * @description Upload a base64 encoded image as the app's avatar
-     *
-     * @tags apps
-     * @name V1AppsAvatarCreate
-     * @summary Upload app avatar
-     * @request POST:/api/v1/apps/{id}/avatar
-     * @secure
-     */
-    v1AppsAvatarCreate: (id: string, image: string, params: RequestParams = {}) =>
-      this.request<void, SystemHTTPError>({
-        path: `/api/v1/apps/${id}/avatar`,
-        method: "POST",
-        body: image,
-        secure: true,
-        type: ContentType.Text,
-        ...params,
-      }),
-
-    /**
-     * @description Reports whether the app owner (whose subscription authenticates the app's sessions) has a working Claude subscription
-     *
-     * @tags Claude
-     * @name V1AppsClaudeSubscriptionStatusDetail
-     * @summary Get the Claude subscription status for an app's owner
-     * @request GET:/api/v1/apps/{id}/claude-subscription-status
-     * @secure
-     */
-    v1AppsClaudeSubscriptionStatusDetail: (id: string, params: RequestParams = {}) =>
-      this.request<ServerAppClaudeSubscriptionStatus, SystemHTTPError>({
-        path: `/api/v1/apps/${id}/claude-subscription-status`,
-        method: "GET",
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Get app daily usage
-     *
-     * @tags apps
-     * @name V1AppsDailyUsageDetail
-     * @summary Get app usage
-     * @request GET:/api/v1/apps/{id}/daily-usage
-     * @secure
-     */
-    v1AppsDailyUsageDetail: (
-      id: string,
-      query?: {
-        /** Start date */
-        from?: string;
-        /** End date */
-        to?: string;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<TypesAggregatedUsageMetric[], SystemHTTPError>({
-        path: `/api/v1/apps/${id}/daily-usage`,
-        method: "GET",
-        query: query,
-        secure: true,
-        type: ContentType.Json,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * No description
-     *
-     * @name V1AppsDuplicateCreate
-     * @request POST:/api/v1/apps/{id}/duplicate
-     * @secure
-     */
-    v1AppsDuplicateCreate: (
-      id: string,
-      query?: {
-        /** Optional new name for the app */
-        name?: string;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<void, any>({
-        path: `/api/v1/apps/${id}/duplicate`,
-        method: "POST",
-        query: query,
-        secure: true,
-        ...params,
-      }),
-
-    /**
-     * @description List interactions with pagination and optional session filtering for a specific app
-     *
-     * @tags interactions
-     * @name V1AppsInteractionsDetail
-     * @summary List interactions
-     * @request GET:/api/v1/apps/{id}/interactions
-     * @secure
-     */
-    v1AppsInteractionsDetail: (
-      id: string,
-      query?: {
-        /** Page number */
-        page?: number;
-        /** Page size */
-        pageSize?: number;
-        /** Filter by session ID */
-        session?: string;
-        /** Filter by interaction ID */
-        interaction?: string;
-        /** Query by like/dislike */
-        feedback?: string;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<TypesPaginatedInteractions, any>({
-        path: `/api/v1/apps/${id}/interactions`,
-        method: "GET",
-        query: query,
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description List user's LLM calls with pagination and optional session filtering for a specific app
-     *
-     * @tags llm_calls
-     * @name V1AppsLlmCallsDetail
-     * @summary List LLM calls
-     * @request GET:/api/v1/apps/{id}/llm-calls
-     * @secure
-     */
-    v1AppsLlmCallsDetail: (
-      id: string,
-      query?: {
-        /** Page number */
-        page?: number;
-        /** Page size */
-        pageSize?: number;
-        /** Filter by session ID */
-        session?: string;
-        /** Filter by interaction ID */
-        interaction?: string;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<TypesPaginatedLLMCalls, any>({
-        path: `/api/v1/apps/${id}/llm-calls`,
-        method: "GET",
-        query: query,
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description List memories for a specific app and user
-     *
-     * @tags memories
-     * @name V1AppsMemoriesDetail
-     * @summary List app memories
-     * @request GET:/api/v1/apps/{id}/memories
-     * @secure
-     */
-    v1AppsMemoriesDetail: (id: string, params: RequestParams = {}) =>
-      this.request<TypesMemory[], any>({
-        path: `/api/v1/apps/${id}/memories`,
-        method: "GET",
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Delete a specific memory for an app and user
-     *
-     * @tags memories
-     * @name V1AppsMemoriesDelete
-     * @summary Delete app memory
-     * @request DELETE:/api/v1/apps/{id}/memories/{memory_id}
-     * @secure
-     */
-    v1AppsMemoriesDelete: (id: string, memoryId: string, params: RequestParams = {}) =>
-      this.request<void, any>({
-        path: `/api/v1/apps/${id}/memories/${memoryId}`,
-        method: "DELETE",
-        secure: true,
-        ...params,
-      }),
-
-    /**
-     * @description Enable a marketplace skill on an app. For autoProvision MCP skills the server generates URL and auth automatically.
-     *
-     * @tags skills
-     * @name V1AppsSkillsEnableCreate
-     * @summary Enable a marketplace skill on an app
-     * @request POST:/api/v1/apps/{id}/skills/{skill}/enable
-     * @secure
-     */
-    v1AppsSkillsEnableCreate: (id: string, skill: string, params: RequestParams = {}) =>
-      this.request<TypesApp, any>({
-        path: `/api/v1/apps/${id}/skills/${skill}/enable`,
-        method: "POST",
-        secure: true,
-        ...params,
-      }),
-
-    /**
-     * @description List step info for a specific app and interaction ID, used to build the timeline of events
-     *
-     * @tags step_info
-     * @name V1AppsStepInfoDetail
-     * @summary List step info
-     * @request GET:/api/v1/apps/{id}/step-info
-     * @secure
-     */
-    v1AppsStepInfoDetail: (
-      id: string,
-      query?: {
-        /** Interaction ID */
-        interactionId?: string;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<TypesStepInfo[], any>({
-        path: `/api/v1/apps/${id}/step-info`,
-        method: "GET",
-        query: query,
-        secure: true,
-        format: "json",
-        ...params,
-      }),
-
-    /**
-     * @description Get the status of a specific trigger type for an app
-     *
-     * @tags apps
-     * @name V1AppsTriggerStatusDetail
-     * @summary Get app trigger status
-     * @request GET:/api/v1/apps/{id}/trigger-status
-     * @secure
-     */
-    v1AppsTriggerStatusDetail: (
-      id: string,
-      query: {
-        /** Trigger type (e.g., slack) */
-        trigger_type: string;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<TypesTriggerStatus, any>({
-        path: `/api/v1/apps/${id}/trigger-status`,
-        method: "GET",
-        query: query,
-        secure: true,
-        ...params,
-      }),
-
-    /**
-     * @description Returns the access rights the current user has for this app
-     *
-     * @tags apps
-     * @name V1AppsUserAccessDetail
-     * @summary Get current user's access level for an app
-     * @request GET:/api/v1/apps/{id}/user-access
-     * @secure
-     */
-    v1AppsUserAccessDetail: (id: string, params: RequestParams = {}) =>
-      this.request<TypesUserAppAccessResponse, any>({
-        path: `/api/v1/apps/${id}/user-access`,
-        method: "GET",
-        secure: true,
-        ...params,
-      }),
-
-    /**
-     * @description Get app users daily usage
-     *
-     * @tags apps
-     * @name V1AppsUsersDailyUsageDetail
-     * @summary Get app users daily usage
-     * @request GET:/api/v1/apps/{id}/users-daily-usage
-     * @secure
-     */
-    v1AppsUsersDailyUsageDetail: (
-      id: string,
-      query?: {
-        /** Start date */
-        from?: string;
-        /** End date */
-        to?: string;
-      },
-      params: RequestParams = {},
-    ) =>
-      this.request<TypesAggregatedUsageMetric[], SystemHTTPError>({
-        path: `/api/v1/apps/${id}/users-daily-usage`,
-        method: "GET",
-        query: query,
-        secure: true,
-        type: ContentType.Json,
-        format: "json",
         ...params,
       }),
 
@@ -13143,7 +13148,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Returns the flat set of Bots in the org for the helix-org React Overview page.
+     * @description Returns the flat set of Nodes in the org for the helix-org React Overview page.
      *
      * @tags HelixOrg
      * @name V1OrgsOverviewDetail
@@ -17398,7 +17403,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List all triggers configurations for either user or the org or user within an org
      *
-     * @tags apps
+     * @tags agents
      * @name V1TriggersList
      * @summary List all triggers configurations for either user or the org or user within an org
      * @request GET:/api/v1/triggers
@@ -17422,11 +17427,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Create triggers for the app. Used to create standalone trigger configurations such as cron tasks for agents that could be owned by a different user than the owner of the app
+     * @description Create triggers for the agent. Used to create standalone trigger configurations such as cron tasks for agents that could be owned by a different user than the owner of the agent
      *
-     * @tags apps
+     * @tags agents
      * @name V1TriggersCreate
-     * @summary Create app triggers
+     * @summary Create agent triggers
      * @request POST:/api/v1/triggers
      * @secure
      */
@@ -17440,11 +17445,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Delete triggers for the app
+     * @description Delete triggers for the agent
      *
-     * @tags apps
+     * @tags agents
      * @name V1TriggersDelete
-     * @summary Delete app triggers
+     * @summary Delete agent triggers
      * @request DELETE:/api/v1/triggers/{trigger_id}
      * @secure
      */
@@ -17457,11 +17462,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Update triggers for the app, for example to change the cron schedule or enable/disable the trigger
+     * @description Update triggers for the agent, for example to change the cron schedule or enable/disable the trigger
      *
-     * @tags apps
+     * @tags agents
      * @name V1TriggersUpdate
-     * @summary Update app triggers
+     * @summary Update agent triggers
      * @request PUT:/api/v1/triggers/{trigger_id}
      * @secure
      */
@@ -17475,11 +17480,11 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Update triggers for the app, for example to change the cron schedule or enable/disable the trigger
+     * @description Update triggers for the agent, for example to change the cron schedule or enable/disable the trigger
      *
-     * @tags apps
+     * @tags agents
      * @name V1TriggersExecuteCreate
-     * @summary Execute app trigger
+     * @summary Execute agent trigger
      * @request POST:/api/v1/triggers/{trigger_id}/execute
      * @secure
      */
@@ -17494,7 +17499,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
     /**
      * @description List executions for the trigger
      *
-     * @tags apps
+     * @tags agents
      * @name V1TriggersExecutionsDetail
      * @summary List trigger executions
      * @request GET:/api/v1/triggers/{trigger_id}/executions

--- a/frontend/src/components/app/AppSettings.tsx
+++ b/frontend/src/components/app/AppSettings.tsx
@@ -299,7 +299,7 @@ const AppSettings: FC<AppSettingsProps> = ({
   const { data: ownerClaudeStatus } = useQuery({
     queryKey: ['app-claude-subscription-status', id],
     queryFn: async () => {
-      const response = await apiHookForClaude.getApiClient().v1AppsClaudeSubscriptionStatusDetail(id)
+      const response = await apiHookForClaude.getApiClient().v1AgentsClaudeSubscriptionStatusDetail(id)
       return response.data
     },
     // Only meaningful for a saved Claude Code agent in subscription mode.

--- a/frontend/src/components/app/AppearanceSettings.tsx
+++ b/frontend/src/components/app/AppearanceSettings.tsx
@@ -224,7 +224,7 @@ const AppearanceSettings: FC<AppearanceSettingsProps> = ({
                 >              
                   <Avatar
                     src={`${getFlatStateAvatarUrl(app, id)}${getFlatStateAvatarUrl(app, id).includes('?') ? '&' : '?'}t=${avatarUpdateKey}`}
-                    // src={`/api/v1/apps/${id}/avatar?t=${avatarUpdateKey}`}
+                    // src={`/api/v1/agents/${id}/avatar?t=${avatarUpdateKey}`}
                     sx={{
                       width: 200,
                       height: 200,

--- a/frontend/src/components/app/EvaluationTab.tsx
+++ b/frontend/src/components/app/EvaluationTab.tsx
@@ -104,7 +104,7 @@ const EvaluationTab: FC<EvaluationTabProps> = ({ appId }) => {
     const runId = activeRun.runId
     const suiteId = activeRun.suiteId
 
-    const es = new EventSource(`/api/v1/apps/${appId}/evaluation-runs/${runId}/stream`)
+    const es = new EventSource(`/api/v1/agents/${appId}/evaluation-runs/${runId}/stream`)
     eventSourceRef.current = es
 
     es.onmessage = (event) => {

--- a/frontend/src/components/app/Skills.tsx
+++ b/frontend/src/components/app/Skills.tsx
@@ -951,7 +951,7 @@ const Skills: React.FC<SkillsProps> = ({
     // autoProvision skills (e.g. code-intelligence) — enable via server endpoint, no dialog.
     if (skill.autoProvision && skill.backendSkillId && appId) {
       const client = api.getApiClient();
-      client.v1AppsSkillsEnableCreate(appId, skill.backendSkillId).then((response) => {
+      client.v1AgentsSkillsEnableCreate(appId, skill.backendSkillId).then((response) => {
         const updatedApp = response.data;
         onUpdate({
           ...app,

--- a/frontend/src/components/apps/AppsTable.tsx
+++ b/frontend/src/components/apps/AppsTable.tsx
@@ -118,7 +118,7 @@ const AppsDataGrid: FC<React.PropsWithChildren<{
   useEffect(() => {
     const fetchUsageData = async () => {
       const usagePromises = data.map(app => 
-        apiClient.v1AppsDailyUsageDetail(app.id)
+        apiClient.v1AgentsDailyUsageDetail(app.id)
           .then(response => ({ [app.id]: response.data as TypesAggregatedUsageMetric[] }))
           .catch(() => ({ [app.id]: null }))
       )

--- a/frontend/src/contexts/apps.tsx
+++ b/frontend/src/contexts/apps.tsx
@@ -186,7 +186,7 @@ export const useAppsContext = (): IAppsContext => {
 
     const organizationIdParam = account.organizationTools.organization?.id || ''
 
-    const result = await api.get<IApp[]>(`/api/v1/apps`, {
+    const result = await api.get<IApp[]>(`/api/v1/agents`, {
       params: {
         organization_id: organizationIdParam,
       }
@@ -199,7 +199,7 @@ export const useAppsContext = (): IAppsContext => {
 
   const loadApp = useCallback(async (id: string, showErrors: boolean = true) => {
     if(!id || !orgLoaded) return
-    const result = await api.get<IApp>(`/api/v1/apps/${id}`, undefined, {
+    const result = await api.get<IApp>(`/api/v1/agents/${id}`, undefined, {
       snackbar: showErrors,
     })
     if(!result || !mountedRef.current) return
@@ -212,7 +212,7 @@ export const useAppsContext = (): IAppsContext => {
       // Use the model from params, or fall back to generation_model if not provided
       const effectiveModel = params.model || params.generationModel || '';
 
-      const result = await api.post<Partial<IApp>, IApp>(`/api/v1/apps`, {
+      const result = await api.post<Partial<IApp>, IApp>(`/api/v1/agents`, {
         organization_id: params.organizationId || account.organizationTools.organization?.id || '',
         config: {
           helix: {
@@ -284,7 +284,7 @@ export const useAppsContext = (): IAppsContext => {
 
   const updateApp = useCallback(async (id: string, updatedApp: IAppUpdate): Promise<IApp | undefined> => {
     try {
-      const url = `/api/v1/apps/${id}`;
+      const url = `/api/v1/agents/${id}`;
       console.log("useApps: Request URL:", url);
       const result = await api.put<IAppUpdate, IApp>(url, updatedApp, {}, {
         snackbar: true,
@@ -306,7 +306,7 @@ export const useAppsContext = (): IAppsContext => {
   }, [api, loadApps]);
 
   const deleteApp = useCallback(async (id: string): Promise<boolean | undefined> => {
-    await api.delete(`/api/v1/apps/${id}`, {}, {
+    await api.delete(`/api/v1/agents/${id}`, {}, {
       snackbar: true,
     })
     await loadApps()

--- a/frontend/src/hooks/useApp.ts
+++ b/frontend/src/hooks/useApp.ts
@@ -217,7 +217,7 @@ export const useApp = (appId: string) => {
     
     try {
       // Fetch the app directly by ID
-      const loadedApp = await api.get<IApp>(`/api/v1/apps/${id}`, undefined, {
+      const loadedApp = await api.get<IApp>(`/api/v1/agents/${id}`, undefined, {
         snackbar: showErrors,
       })
 
@@ -542,7 +542,7 @@ export const useApp = (appId: string) => {
     setIsAppSaving(true)
     
     try {
-      const savedApp = await api.put<IApp>(`/api/v1/apps/${app.id}`, app)
+      const savedApp = await api.put<IApp>(`/api/v1/agents/${app.id}`, app)
       if (!savedApp) {
         return
       }
@@ -813,7 +813,7 @@ export const useApp = (appId: string) => {
     }
     
     try {
-      const grants = await api.get<IAccessGrant[]>(`/api/v1/apps/${appId}/access-grants`, {}, { snackbar: false })
+      const grants = await api.get<IAccessGrant[]>(`/api/v1/agents/${appId}/access-grants`, {}, { snackbar: false })
       setAccessGrants(grants || [])
     } catch (error) {
       console.error('Failed to load access grants:', error)
@@ -832,7 +832,7 @@ export const useApp = (appId: string) => {
     try {
       setIsAppSaving(true)
       // Explicitly specify both the request and response types
-      const newGrant = await api.post<CreateAccessGrantRequest, IAccessGrant>(`/api/v1/apps/${appId}/access-grants`, request)
+      const newGrant = await api.post<CreateAccessGrantRequest, IAccessGrant>(`/api/v1/agents/${appId}/access-grants`, request)
       
       if (!newGrant) {
         return null
@@ -862,7 +862,7 @@ export const useApp = (appId: string) => {
     try {
       setIsAppSaving(true)
 
-      await api.delete(`/api/v1/apps/${appId}/access-grants/${grantId}`)
+      await api.delete(`/api/v1/agents/${appId}/access-grants/${grantId}`)
       
       // Refresh the list of access grants
       await loadAccessGrants()

--- a/frontend/src/hooks/useOrganizations.ts
+++ b/frontend/src/hooks/useOrganizations.ts
@@ -587,7 +587,7 @@ export default function useOrganizations(): IOrganizationTools {
   const listAppAccessGrants = useCallback(async (appId: string): Promise<TypesAccessGrant[]> => {
     setLoadingAccessGrants(true)
     try {
-      const response = await api.getApiClient().v1AppsAccessGrantsDetail(appId)
+      const response = await api.getApiClient().v1AgentsAccessGrantsDetail(appId)
       setAppAccessGrants(response.data)
       return response.data
     } catch (error) {
@@ -601,7 +601,7 @@ export default function useOrganizations(): IOrganizationTools {
 
   const createAppAccessGrant = useCallback(async (appId: string, grant: TypesCreateAccessGrantRequest): Promise<boolean> => {
     try {
-      await api.getApiClient().v1AppsAccessGrantsCreate(appId, grant)
+      await api.getApiClient().v1AgentsAccessGrantsCreate(appId, grant)
       // Refresh the list to get updated data
       await listAppAccessGrants(appId)
       snackbar.success('Access grant created successfully')
@@ -637,7 +637,7 @@ export default function useOrganizations(): IOrganizationTools {
   const deleteAppAccessGrant = useCallback(async (appId: string, grantId: string): Promise<boolean> => {
     try {
       // The API client doesn't have this endpoint defined, so we'll make a direct axios call
-      await api.delete(`/api/v1/apps/${appId}/access-grants/${grantId}`)
+      await api.delete(`/api/v1/agents/${appId}/access-grants/${grantId}`)
       
       // Update the local state by filtering out the deleted grant
       setAppAccessGrants(prev => prev.filter(grant => grant.id !== grantId))

--- a/frontend/src/hooks/useUserAppAccess.ts
+++ b/frontend/src/hooks/useUserAppAccess.ts
@@ -37,7 +37,7 @@ export const useUserAppAccess = (appId: string | null): IUserAppAccessState => {
     
     try {
       // Call the new API endpoint to get user access rights
-      const accessResponse = await api.getApiClient().v1AppsUserAccessDetail(appId)
+      const accessResponse = await api.getApiClient().v1AgentsUserAccessDetail(appId)
           
       if (accessResponse.data) {
         setAccess(accessResponse.data)

--- a/frontend/src/lib/helix-stream/api.ts
+++ b/frontend/src/lib/helix-stream/api.ts
@@ -286,7 +286,7 @@ export async function apiWakeUp(api: Api, request: PostWakeUpRequest): Promise<v
 }
 
 export async function apiGetApps(api: Api, query: GetAppsQuery): Promise<Array<App>> {
-    const response = await fetchApi(api, "/apps", "get", { query }) as GetAppsResponse
+    const response = await fetchApi(api, "/agents", "get", { query }) as GetAppsResponse
 
     return response.apps
 }

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -63,7 +63,7 @@ const App: FC = () => {
   useEffect(() => {
     const checkAccess = async () => {
       try {
-        const result = await api.getApiClient().v1AppsDetail(params.app_id)        
+        const result = await api.getApiClient().v1AgentsDetail(params.app_id)
         if (!result) {
           setIsAccessDenied(true)
         }

--- a/frontend/src/pages/HelixOrgBotDetail.tsx
+++ b/frontend/src/pages/HelixOrgBotDetail.tsx
@@ -122,7 +122,7 @@ const HelixOrgBotDetail: FC = () => {
   const bot = data?.bot
   const projectID = data?.project_id
   const { data: projects = [] } = useListProjects(bot?.organization_id, { enabled: !!bot?.organization_id })
-  const agentAppID = data?.agent_app_id
+  const agentID = data?.agent_id ?? data?.agent_app_id
   // A human node is a person placeholder — it never runs, so the agent-only
   // surfaces (Project Desktop session, tools, preserve-context, restart) make
   // no sense for it and are hidden below.
@@ -230,9 +230,9 @@ const HelixOrgBotDetail: FC = () => {
       snackbar.error(err?.response?.data?.error ?? err?.message ?? 'save failed')
       return
     }
-    if (runtimeChanged && chatSessionId && agentAppID) {
+    if (runtimeChanged && chatSessionId && agentID) {
       try {
-        await switchAgent.mutateAsync({ helix_app_id: agentAppID })
+        await switchAgent.mutateAsync({ helix_app_id: agentID })
         snackbar.success(`Agent ${botId} saved and the active session switched to ${runtimeConfig.runtime}`)
       } catch (err: any) {
         await refetchBot()
@@ -624,7 +624,7 @@ const HelixOrgBotDetail: FC = () => {
                   />
                 </Box>
 
-                {agentAppID && (
+                {agentID && (
                   <Box>
                     <AgentConfigForm
                       value={runtimeConfig}
@@ -840,22 +840,22 @@ const HelixOrgBotDetail: FC = () => {
                       )}
                     </Box>
                   )}
-                  {agentAppID && (
+                  {agentID && (
                     <Box>
                       <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>Agent</Typography>
                       {orgSlug ? (
                         <Link
-                          href={router5.buildPath('org_agent', { org_id: orgSlug, app_id: agentAppID })}
+                          href={router5.buildPath('org_agent', { org_id: orgSlug, app_id: agentID })}
                           target="_blank"
                           rel="noopener noreferrer"
                           underline="hover"
                           sx={{ fontFamily: 'monospace', fontSize: '0.7rem', display: 'inline-flex', alignItems: 'center', gap: 0.5, wordBreak: 'break-all' }}
                         >
-                          {agentAppID}
+                          {agentID}
                           <OpenInNewIcon sx={{ fontSize: 14, flexShrink: 0 }} />
                         </Link>
                       ) : (
-                        <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.7rem', wordBreak: 'break-all' }}>{agentAppID}</Typography>
+                        <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.7rem', wordBreak: 'break-all' }}>{agentID}</Typography>
                       )}
                     </Box>
                   )}

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -2022,13 +2022,13 @@ const HelixOrgChart: FC = () => {
       if (!botId || !detail) return
 
       const botProjectID = detail.project_id ?? ''
-      const botAgentAppID = detail.agent_app_id ?? ''
+      const botAgentID = detail.agent_id ?? detail.agent_app_id ?? ''
       const botTasks = specTasks.filter((task) => {
         const taskProject = projectsByID.get(task.project_id ?? '')
-        const taskAgentAppID = task.helix_app_id || taskProject?.default_helix_app_id
+        const taskAgentID = task.helix_app_id || taskProject?.default_helix_app_id
         return (
           (!!botProjectID && task.project_id === botProjectID) ||
-          (!!botAgentAppID && taskAgentAppID === botAgentAppID)
+          (!!botAgentID && taskAgentID === botAgentID)
         )
       })
       tasksByBotId.set(botId, botTasks)

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -938,7 +938,7 @@ const Home: FC = () => {
                                   src={app?.config.helix.avatar ? (
                                     app.config.helix.avatar.startsWith('http://') || app.config.helix.avatar.startsWith('https://')
                                       ? app.config.helix.avatar
-                                      : `/api/v1/apps/${trigger.app_id}/avatar`
+                                      : `/api/v1/agents/${trigger.app_id}/avatar`
                                   ) : undefined}
                                 >
                                   {app?.config.helix.name && app.config.helix.name.length > 0
@@ -1115,7 +1115,7 @@ const Home: FC = () => {
                                 src={app.config.helix.avatar ? (
                                   app.config.helix.avatar.startsWith('http://') || app.config.helix.avatar.startsWith('https://')
                                     ? app.config.helix.avatar
-                                    : `/api/v1/apps/${app.id}/avatar`
+                                    : `/api/v1/agents/${app.id}/avatar`
                                 ) : undefined}
                               >
                                 {app.config.helix.name && app.config.helix.name.length > 0

--- a/frontend/src/pages/ImportAgent.tsx
+++ b/frontend/src/pages/ImportAgent.tsx
@@ -570,7 +570,7 @@ const ImportAgent: FC = () => {
 
     // Post to the API with structured format
     const result = await api.post<any, IAppCreateResponse>(
-      "/api/v1/apps",
+      "/api/v1/agents",
       appData,
       {
         params: {

--- a/frontend/src/pages/Onboarding.test.tsx
+++ b/frontend/src/pages/Onboarding.test.tsx
@@ -43,7 +43,7 @@ vi.mock('../hooks/useApi', () => ({
       v1ProjectsCreate: mockV1ProjectsCreate,
       v1SpecTasksFromPromptCreate: mockV1SpecTasksFromPromptCreate,
       v1ProviderEndpointsList: mockV1ProviderEndpointsList,
-      v1AppsUpdate: vi.fn().mockResolvedValue({}),
+      v1AgentsUpdate: vi.fn().mockResolvedValue({}),
     }),
   }),
 }))
@@ -527,7 +527,7 @@ describe('Onboarding', () => {
 
       await waitFor(() => {
         expect(mockApiGet).toHaveBeenCalledWith(
-          '/api/v1/apps',
+          '/api/v1/agents',
           expect.objectContaining({
             params: { organization_id: 'org-apps' },
           }),

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -559,7 +559,7 @@ export default function Onboarding() {
 
     api
       .get<IApp[]>(
-        "/api/v1/apps",
+        "/api/v1/agents",
         {
           params: { organization_id: createdOrg.id },
         },
@@ -847,7 +847,7 @@ export default function Onboarding() {
 
         // Update the agent with resolution config
         try {
-          await apiClient.v1AppsUpdate(agentId, {
+          await apiClient.v1AgentsUpdate(agentId, {
             ...createdAgent,
             config: {
               ...createdAgent.config,

--- a/frontend/src/services/appService.ts
+++ b/frontend/src/services/appService.ts
@@ -78,7 +78,7 @@ export function useListApps(orgId: string, options?: { enabled?: boolean }) {
   
   return useQuery({
     queryKey: appListQueryKey(orgId),
-    queryFn: () => apiClient.v1AppsList({ organization_id: orgId }),
+    queryFn: () => apiClient.v1AgentsList({ organization_id: orgId }),
     enabled: options?.enabled ?? true
   })
 }
@@ -89,7 +89,7 @@ export function useGetApp(appId: string, options?: { enabled?: boolean }) {
 
   return useQuery({
     queryKey: appDetailQueryKey(appId),
-    queryFn: () => apiClient.v1AppsDetail(appId),
+    queryFn: () => apiClient.v1AgentsDetail(appId),
     enabled: options?.enabled ?? true
   })
 }
@@ -102,7 +102,7 @@ export function useListAppSteps(appId: string, interactionId: string, options?: 
 
   return useQuery({
     queryKey: appStepsQueryKey(appId, interactionId),
-    queryFn: () => apiClient.v1AppsStepInfoDetail(appId, {interactionId}),
+    queryFn: () => apiClient.v1AgentsStepInfoDetail(appId, {interactionId}),
     enabled: options?.enabled ?? true,
     refetchInterval: options?.refetchInterval
   })
@@ -127,7 +127,7 @@ export function useListAppTriggers(appId: string, options?: { enabled?: boolean,
 
   return useQuery({
     queryKey: appTriggersListQueryKey(appId),
-    queryFn: () => apiClient.v1AppsTriggersDetail(appId),
+    queryFn: () => apiClient.v1AgentsTriggersDetail(appId),
     enabled: options?.enabled ?? true,
     refetchInterval: options?.refetchInterval
   })
@@ -212,7 +212,7 @@ export function useGetAppTriggerStatus(appId: string, triggerType: string, optio
 
   return useQuery({
     queryKey: appTriggerStatusQueryKey(appId, triggerType),
-    queryFn: () => apiClient.v1AppsTriggerStatusDetail(appId, { trigger_type: triggerType }),
+    queryFn: () => apiClient.v1AgentsTriggerStatusDetail(appId, { trigger_type: triggerType }),
     enabled: options?.enabled ?? true,
     refetchInterval: options?.refetchInterval
   })
@@ -239,7 +239,7 @@ export function useUpdateAppAvatar(appId: string) {
       reader.readAsDataURL(file)
       const base64Data = await base64Promise
       
-      return apiClient.v1AppsAvatarCreate(appId, base64Data)
+      return apiClient.v1AgentsAvatarCreate(appId, base64Data)
     },
     onSuccess: () => {
       // Invalidate any cached avatar data
@@ -254,7 +254,7 @@ export function useDeleteAppAvatar(appId: string) {
   const apiClient = api.getApiClient()
 
   return useMutation({
-    mutationFn: () => apiClient.v1AppsAvatarDelete(appId)
+    mutationFn: () => apiClient.v1AgentsAvatarDelete(appId)
   })
 }
 
@@ -265,7 +265,7 @@ export function useGetAppUsage(appId: string, from: string, to: string) {
   return useQuery({
     queryKey: appUsageQueryKey(appId, from, to), 
     queryFn: async () => {
-      const response = await apiClient.v1AppsUsersDailyUsageDetail(appId, { from, to })
+      const response = await apiClient.v1AgentsUsersDailyUsageDetail(appId, { from, to })
       return response.data as unknown as TypesUsersAggregatedUsageMetric[]
     },
   })
@@ -279,7 +279,7 @@ export function useDuplicateApp(orgId: string) {
 
   return useMutation({
     mutationFn: ({ appId, name }: { appId: string; name?: string }) => 
-      apiClient.v1AppsDuplicateCreate(appId, { name }),
+      apiClient.v1AgentsDuplicateCreate(appId, { name }),
     onSuccess: () => {
       // Invalidate the apps list to refresh the UI
       queryClient.invalidateQueries({ queryKey: appListQueryKey(orgId) })
@@ -294,7 +294,7 @@ export function useListAppMemories(appId: string, options?: { enabled?: boolean 
 
   return useQuery({
     queryKey: appMemoriesQueryKey(appId),
-    queryFn: () => apiClient.v1AppsMemoriesDetail(appId),
+    queryFn: () => apiClient.v1AgentsMemoriesDetail(appId),
     enabled: options?.enabled ?? true
   })
 }
@@ -306,7 +306,7 @@ export function useDeleteAppMemory(appId: string) {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (memoryId: string) => apiClient.v1AppsMemoriesDelete(appId, memoryId),
+    mutationFn: (memoryId: string) => apiClient.v1AgentsMemoriesDelete(appId, memoryId),
     onSuccess: () => {
       // Invalidate the memories list to refresh the UI
       queryClient.invalidateQueries({ queryKey: appMemoriesQueryKey(appId) })

--- a/frontend/src/services/evaluationService.ts
+++ b/frontend/src/services/evaluationService.ts
@@ -12,7 +12,7 @@ export function useListEvaluationSuites(appId: string) {
 
   return useQuery({
     queryKey: evaluationSuitesQueryKey(appId),
-    queryFn: () => apiClient.v1AppsEvaluationSuitesDetail(appId),
+    queryFn: () => apiClient.v1AgentsEvaluationSuitesDetail(appId),
     enabled: !!appId,
   })
 }
@@ -24,7 +24,7 @@ export function useCreateEvaluationSuite(appId: string) {
 
   return useMutation({
     mutationFn: (suite: TypesEvaluationSuite) =>
-      apiClient.v1AppsEvaluationSuitesCreate(appId, suite),
+      apiClient.v1AgentsEvaluationSuitesCreate(appId, suite),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: evaluationSuitesQueryKey(appId) })
     },
@@ -38,7 +38,7 @@ export function useUpdateEvaluationSuite(appId: string) {
 
   return useMutation({
     mutationFn: (suite: TypesEvaluationSuite) =>
-      apiClient.v1AppsEvaluationSuitesUpdate(appId, suite.id!, suite),
+      apiClient.v1AgentsEvaluationSuitesUpdate(appId, suite.id!, suite),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: evaluationSuitesQueryKey(appId) })
     },
@@ -52,7 +52,7 @@ export function useDeleteEvaluationSuite(appId: string) {
 
   return useMutation({
     mutationFn: (suiteId: string) =>
-      apiClient.v1AppsEvaluationSuitesDelete(appId, suiteId),
+      apiClient.v1AgentsEvaluationSuitesDelete(appId, suiteId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: evaluationSuitesQueryKey(appId) })
     },
@@ -66,7 +66,7 @@ export function useStartEvaluationRun(appId: string) {
 
   return useMutation({
     mutationFn: (suiteId: string) =>
-      apiClient.v1AppsEvaluationSuitesRunsCreate(appId, suiteId),
+      apiClient.v1AgentsEvaluationSuitesRunsCreate(appId, suiteId),
     onSuccess: (_data, suiteId) => {
       queryClient.invalidateQueries({ queryKey: evaluationRunsQueryKey(appId, suiteId) })
     },
@@ -79,7 +79,7 @@ export function useListEvaluationRuns(appId: string, suiteId: string) {
 
   return useQuery({
     queryKey: evaluationRunsQueryKey(appId, suiteId),
-    queryFn: () => apiClient.v1AppsEvaluationSuitesRunsDetail(appId, suiteId),
+    queryFn: () => apiClient.v1AgentsEvaluationSuitesRunsDetail(appId, suiteId),
     enabled: !!appId && !!suiteId,
   })
 }
@@ -91,7 +91,7 @@ export function useDeleteEvaluationRun(appId: string, suiteId: string) {
 
   return useMutation({
     mutationFn: (runId: string) =>
-      apiClient.v1AppsEvaluationRunsDelete(appId, runId),
+      apiClient.v1AgentsEvaluationRunsDelete(appId, runId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: evaluationRunsQueryKey(appId, suiteId) })
     },
@@ -104,7 +104,7 @@ export function useGetEvaluationRun(appId: string, runId: string) {
 
   return useQuery({
     queryKey: evaluationRunQueryKey(appId, runId),
-    queryFn: () => apiClient.v1AppsEvaluationRunsDetail(appId, runId),
+    queryFn: () => apiClient.v1AgentsEvaluationRunsDetail(appId, runId),
     enabled: !!appId && !!runId,
     refetchInterval: (query) => {
       const data = query.state.data?.data

--- a/frontend/src/services/helixOrgService.ts
+++ b/frontend/src/services/helixOrgService.ts
@@ -320,6 +320,7 @@ export function useHelixOrgBot(botId: string | undefined, options?: { enabled?: 
       const agent = res.data as AgentDetailDTO
       return {
         bot: agent as BotDTO,
+        agent_id: agent.agent_id ?? agent.agent_app_id,
         agent_app_id: agent.agent_app_id,
         project_id: agent.project_id,
       } as BotDetailDTO
@@ -346,6 +347,7 @@ export function useListHelixOrgBotDetails(
         const agent = res.data as AgentDetailDTO
         return {
           bot: agent as BotDTO,
+          agent_id: agent.agent_id ?? agent.agent_app_id,
           agent_app_id: agent.agent_app_id,
           project_id: agent.project_id,
         } as BotDetailDTO

--- a/frontend/src/services/interactionsService.ts
+++ b/frontend/src/services/interactionsService.ts
@@ -19,7 +19,7 @@ export function useListAppInteractions(appId: string, session: string, interacti
   return useQuery({
     queryKey: appInteractionsQueryKey(appId, session, interaction, feedback,page, pageSize),
     queryFn: async () => {
-      const response = await apiClient.v1AppsInteractionsDetail(appId, { session, interaction, feedback, page, pageSize })
+      const response = await apiClient.v1AgentsInteractionsDetail(appId, { session, interaction, feedback, page, pageSize })
       return response.data
     },
     enabled: options?.enabled ?? true,

--- a/frontend/src/services/llmCallsService.ts
+++ b/frontend/src/services/llmCallsService.ts
@@ -40,7 +40,7 @@ export function useListAppLLMCalls(appId: string, session: string, interaction: 
   return useQuery({
     queryKey: appLLMCallsQueryKey(appId, session, interaction),
     queryFn: async () => {
-      const response = await apiClient.v1AppsLlmCallsDetail(appId, {
+      const response = await apiClient.v1AgentsLlmCallsDetail(appId, {
         session,
         interaction,
         page: page,

--- a/frontend/src/utils/app.ts
+++ b/frontend/src/utils/app.ts
@@ -19,7 +19,7 @@ export const getFlatStateAvatarUrl = (app: IAppFlatState, appId: string): string
   }
   
   // Otherwise, assume it's an uploaded avatar and use the API endpoint
-  return `/api/v1/apps/${appId}/avatar`
+  return `/api/v1/agents/${appId}/avatar`
 }
 
 /**

--- a/frontend/src/utils/apps.ts
+++ b/frontend/src/utils/apps.ts
@@ -22,7 +22,7 @@ export const getAppAvatarUrl = (app: IApp): string => {
   }
   
   // Otherwise, assume it's an uploaded avatar and use the API endpoint
-  return `/api/v1/apps/${app.id}/avatar`
+  return `/api/v1/agents/${app.id}/avatar`
 }
 
 export const getAppName = (app: IApp): string => {

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -8,6 +8,8 @@ definitions:
     properties:
       agent_app_id:
         type: string
+      agent_id:
+        type: string
       agent_model:
         type: string
       agent_runtime:
@@ -83,6 +85,8 @@ definitions:
         type: string
       agent_app_id:
         type: string
+      agent_id:
+        type: string
       project_id:
         type: string
       session_id:
@@ -97,12 +101,16 @@ definitions:
     properties:
       agent_app_id:
         type: string
+      agent_id:
+        type: string
       project_id:
         type: string
     type: object
   api.BotDTO:
     properties:
       agent_app_id:
+        type: string
+      agent_id:
         type: string
       agent_model:
         type: string
@@ -174,7 +182,9 @@ definitions:
   api.BotDetailDTO:
     properties:
       agent_app_id:
-        description: AgentAppID + ProjectID — see BotChatDTO comments.
+        type: string
+      agent_id:
+        description: AgentID + ProjectID — see BotChatDTO comments.
         type: string
       bot:
         $ref: '#/definitions/api.BotDTO'
@@ -233,7 +243,7 @@ definitions:
           Owner makes this a manager Bot: it receives the canonical owner
           tool set (every org-graph mutation - create_bot, delete_bot,
           set_bot_content, subscribe, ... - plus the read baseline) so it can
-          hire and manage other Bots. When true, Tools is ignored in favour
+          hire and manage other Nodes. When true, Tools is ignored in favour
           of that set. Used to seed a starter/root Bot for a new org.
         type: boolean
       parent_id:
@@ -1613,6 +1623,42 @@ definitions:
       status:
         type: string
     type: object
+  server.AgentCreateResponse:
+    properties:
+      config:
+        $ref: '#/definitions/types.AgentConfig'
+      created:
+        type: string
+      global:
+        type: boolean
+      id:
+        type: string
+      is_helix_org_agent:
+        description: |-
+          IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
+          (see api/pkg/org). Computed at list time, not persisted, so the frontend
+          can hide org-chart agents from the spec-task agent switchers.
+        type: boolean
+      model_substitutions:
+        items:
+          $ref: '#/definitions/server.ModelSubstitution'
+        type: array
+      organization_id:
+        type: string
+      owner:
+        description: uuid of user ID
+        type: string
+      owner_type:
+        allOf:
+        - $ref: '#/definitions/types.OwnerType'
+        description: e.g. user, system, org
+      updated:
+        type: string
+      user:
+        allOf:
+        - $ref: '#/definitions/types.User'
+        description: Owner user struct, populated by the server for organization views
+    type: object
   server.AgentSandboxesDebugResponse:
     properties:
       dev_containers:
@@ -1656,42 +1702,6 @@ definitions:
       valid:
         description: that subscription passed its last liveness probe
         type: boolean
-    type: object
-  server.AppCreateResponse:
-    properties:
-      config:
-        $ref: '#/definitions/types.AppConfig'
-      created:
-        type: string
-      global:
-        type: boolean
-      id:
-        type: string
-      is_helix_org_agent:
-        description: |-
-          IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
-          (see api/pkg/org). Computed at list time, not persisted, so the frontend
-          can hide org-chart agents from the spec-task agent switchers.
-        type: boolean
-      model_substitutions:
-        items:
-          $ref: '#/definitions/server.ModelSubstitution'
-        type: array
-      organization_id:
-        type: string
-      owner:
-        description: uuid of user ID
-        type: string
-      owner_type:
-        allOf:
-        - $ref: '#/definitions/types.OwnerType'
-        description: e.g. user, system, org
-      updated:
-        type: string
-      user:
-        allOf:
-        - $ref: '#/definitions/types.User'
-        description: Owner user struct, populated by the server for organization views
     type: object
   server.BatchTaskProgressResponse:
     properties:
@@ -3371,6 +3381,82 @@ definitions:
       name:
         type: string
     type: object
+  types.Agent:
+    properties:
+      config:
+        $ref: '#/definitions/types.AgentConfig'
+      created:
+        type: string
+      global:
+        type: boolean
+      id:
+        type: string
+      is_helix_org_agent:
+        description: |-
+          IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
+          (see api/pkg/org). Computed at list time, not persisted, so the frontend
+          can hide org-chart agents from the spec-task agent switchers.
+        type: boolean
+      organization_id:
+        type: string
+      owner:
+        description: uuid of user ID
+        type: string
+      owner_type:
+        allOf:
+        - $ref: '#/definitions/types.OwnerType'
+        description: e.g. user, system, org
+      updated:
+        type: string
+      user:
+        allOf:
+        - $ref: '#/definitions/types.User'
+        description: Owner user struct, populated by the server for organization views
+    type: object
+  types.AgentConfig:
+    properties:
+      allowed_domains:
+        items:
+          type: string
+        type: array
+      helix:
+        $ref: '#/definitions/types.AgentHelixConfig'
+      secrets:
+        additionalProperties:
+          type: string
+        type: object
+    type: object
+  types.AgentHelixConfig:
+    properties:
+      assistants:
+        items:
+          $ref: '#/definitions/types.AssistantConfig'
+        type: array
+      avatar:
+        type: string
+      avatar_content_type:
+        type: string
+      default_agent_type:
+        allOf:
+        - $ref: '#/definitions/types.AgentType'
+        description: Agent configuration
+      description:
+        type: string
+      external_agent_config:
+        $ref: '#/definitions/types.ExternalAgentConfig'
+      external_agent_enabled:
+        type: boolean
+      external_url:
+        type: string
+      image:
+        type: string
+      name:
+        type: string
+      triggers:
+        items:
+          $ref: '#/definitions/types.Trigger'
+        type: array
+    type: object
   types.AgentType:
     enum:
     - helix_basic
@@ -3464,82 +3550,6 @@ definitions:
         type: string
       type:
         $ref: '#/definitions/types.APIKeyType'
-    type: object
-  types.App:
-    properties:
-      config:
-        $ref: '#/definitions/types.AppConfig'
-      created:
-        type: string
-      global:
-        type: boolean
-      id:
-        type: string
-      is_helix_org_agent:
-        description: |-
-          IsHelixOrgAgent is true when this app backs a Helix org-chart Worker
-          (see api/pkg/org). Computed at list time, not persisted, so the frontend
-          can hide org-chart agents from the spec-task agent switchers.
-        type: boolean
-      organization_id:
-        type: string
-      owner:
-        description: uuid of user ID
-        type: string
-      owner_type:
-        allOf:
-        - $ref: '#/definitions/types.OwnerType'
-        description: e.g. user, system, org
-      updated:
-        type: string
-      user:
-        allOf:
-        - $ref: '#/definitions/types.User'
-        description: Owner user struct, populated by the server for organization views
-    type: object
-  types.AppConfig:
-    properties:
-      allowed_domains:
-        items:
-          type: string
-        type: array
-      helix:
-        $ref: '#/definitions/types.AppHelixConfig'
-      secrets:
-        additionalProperties:
-          type: string
-        type: object
-    type: object
-  types.AppHelixConfig:
-    properties:
-      assistants:
-        items:
-          $ref: '#/definitions/types.AssistantConfig'
-        type: array
-      avatar:
-        type: string
-      avatar_content_type:
-        type: string
-      default_agent_type:
-        allOf:
-        - $ref: '#/definitions/types.AgentType'
-        description: Agent configuration
-      description:
-        type: string
-      external_agent_config:
-        $ref: '#/definitions/types.ExternalAgentConfig'
-      external_agent_enabled:
-        type: boolean
-      external_url:
-        type: string
-      image:
-        type: string
-      name:
-        type: string
-      triggers:
-        items:
-          $ref: '#/definitions/types.Trigger'
-        type: array
     type: object
   types.AssistantAPI:
     properties:
@@ -5275,7 +5285,7 @@ definitions:
   types.EvaluationRun:
     properties:
       app_config_snapshot:
-        $ref: '#/definitions/types.AppConfig'
+        $ref: '#/definitions/types.AgentConfig'
       app_id:
         type: string
       created:
@@ -13097,6 +13107,934 @@ paths:
       summary: Activate a trial for a user (Admin, cloud only)
       tags:
       - users
+  /api/v1/agents:
+    get:
+      description: List agents for the user. Agents are pre-configured to spawn sessions
+        with specific tools and config.
+      parameters:
+      - description: Organization ID
+        in: query
+        name: organization_id
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.Agent'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List agents
+      tags:
+      - agents
+    post:
+      parameters:
+      - description: Request body with agent configuration. Can be legacy Agent format
+          or structured format with organization_id, global, and yaml_config fields.
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/types.Agent'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.AgentCreateResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/agents/{agent_id}/evaluation-runs/{run_id}:
+    delete:
+      description: Delete an evaluation run
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      - description: Run ID
+        in: path
+        name: run_id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Delete an evaluation run
+      tags:
+      - evaluations
+    get:
+      description: Get evaluation run details
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      - description: Run ID
+        in: path
+        name: run_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.EvaluationRun'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get an evaluation run
+      tags:
+      - evaluations
+  /api/v1/agents/{agent_id}/evaluation-suites:
+    get:
+      description: List all evaluation suites for an agent
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.EvaluationSuite'
+            type: array
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: List evaluation suites for an agent
+      tags:
+      - evaluations
+    post:
+      consumes:
+      - application/json
+      description: Create a new evaluation suite for an agent
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      - description: Evaluation suite to create
+        in: body
+        name: suite
+        required: true
+        schema:
+          $ref: '#/definitions/types.EvaluationSuite'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/types.EvaluationSuite'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Create an evaluation suite
+      tags:
+      - evaluations
+  /api/v1/agents/{agent_id}/evaluation-suites/{id}:
+    delete:
+      description: Delete an evaluation suite
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      - description: Suite ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Delete an evaluation suite
+      tags:
+      - evaluations
+    get:
+      description: Get an evaluation suite by ID
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      - description: Suite ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.EvaluationSuite'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get an evaluation suite
+      tags:
+      - evaluations
+    put:
+      consumes:
+      - application/json
+      description: Update an evaluation suite
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      - description: Suite ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Updated suite
+        in: body
+        name: suite
+        required: true
+        schema:
+          $ref: '#/definitions/types.EvaluationSuite'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.EvaluationSuite'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Update an evaluation suite
+      tags:
+      - evaluations
+  /api/v1/agents/{agent_id}/evaluation-suites/{id}/runs:
+    get:
+      description: List evaluation runs for a suite
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      - description: Suite ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.EvaluationRun'
+            type: array
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: List evaluation runs
+      tags:
+      - evaluations
+    post:
+      consumes:
+      - application/json
+      description: Start running an evaluation suite against an agent
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      - description: Suite ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.EvaluationRun'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Start an evaluation run
+      tags:
+      - evaluations
+  /api/v1/agents/{agent_id}/triggers:
+    get:
+      description: List triggers for the agent
+      parameters:
+      - description: Agent ID
+        in: path
+        name: agent_id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.TriggerConfiguration'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List agent triggers
+      tags:
+      - agents
+  /api/v1/agents/{id}:
+    delete:
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+      security:
+      - BearerAuth: []
+    get:
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Agent'
+      security:
+      - BearerAuth: []
+    put:
+      parameters:
+      - description: Request body with agent configuration.
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/types.Agent'
+      - description: Tool ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Agent'
+      security:
+      - BearerAuth: []
+  /api/v1/agents/{id}/access-grants:
+    get:
+      description: List access grants for an agent (organization owners and members
+        can list access grants)
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.AccessGrant'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List agent access grants
+      tags:
+      - agents
+    post:
+      description: Grant access to an agent to a team or organization member (organization
+        owners can grant access to teams and organization members)
+      parameters:
+      - description: Request body with team or organization member ID and role
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/types.CreateAccessGrantRequest'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.AccessGrant'
+      security:
+      - BearerAuth: []
+      summary: Grant access to an agent to a team or organization member
+      tags:
+      - agents
+  /api/v1/agents/{id}/api-actions:
+    post:
+      consumes:
+      - application/json
+      description: Runs an API action for an agent
+      parameters:
+      - description: Request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/types.RunAPIActionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.RunAPIActionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Run an API action
+  /api/v1/agents/{id}/avatar:
+    delete:
+      description: Delete the agent's avatar image
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Delete agent avatar
+      tags:
+      - agents
+    get:
+      description: Get the agent's avatar image
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - image/*
+      responses:
+        "200":
+          description: Avatar image data
+          schema:
+            type: file
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get agent avatar
+      tags:
+      - agents
+    post:
+      consumes:
+      - text/plain
+      description: Upload a base64 encoded image as the agent's avatar
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Base64 encoded image data
+        in: body
+        name: image
+        required: true
+        schema:
+          type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Upload agent avatar
+      tags:
+      - agents
+  /api/v1/agents/{id}/claude-subscription-status:
+    get:
+      description: Reports whether the agent owner (whose subscription authenticates
+        the agent's sessions) has a working Claude subscription
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/server.AppClaudeSubscriptionStatus'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get the Claude subscription status for an agent's owner
+      tags:
+      - Claude
+  /api/v1/agents/{id}/daily-usage:
+    get:
+      consumes:
+      - application/json
+      description: Get agent daily usage
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Start date
+        in: query
+        name: from
+        type: string
+      - description: End date
+        in: query
+        name: to
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.AggregatedUsageMetric'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get agent usage
+      tags:
+      - agents
+  /api/v1/agents/{id}/duplicate:
+    post:
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Optional new name for the agent
+        in: query
+        name: name
+        type: string
+      responses:
+        "200":
+          description: OK
+      security:
+      - BearerAuth: []
+  /api/v1/agents/{id}/interactions:
+    get:
+      description: List interactions with pagination and optional session filtering
+        for a specific agent
+      parameters:
+      - description: Page number
+        in: query
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        name: pageSize
+        type: integer
+      - description: Filter by session ID
+        in: query
+        name: session
+        type: string
+      - description: Filter by interaction ID
+        in: query
+        name: interaction
+        type: string
+      - description: Query by like/dislike
+        in: query
+        name: feedback
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.PaginatedInteractions'
+      security:
+      - BearerAuth: []
+      summary: List interactions
+      tags:
+      - interactions
+  /api/v1/agents/{id}/llm-calls:
+    get:
+      description: List user's LLM calls with pagination and optional session filtering
+        for a specific agent
+      parameters:
+      - description: Page number
+        in: query
+        name: page
+        type: integer
+      - description: Page size
+        in: query
+        name: pageSize
+        type: integer
+      - description: Filter by session ID
+        in: query
+        name: session
+        type: string
+      - description: Filter by interaction ID
+        in: query
+        name: interaction
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.PaginatedLLMCalls'
+      security:
+      - BearerAuth: []
+      summary: List LLM calls
+      tags:
+      - llm_calls
+  /api/v1/agents/{id}/memories:
+    get:
+      description: List memories for a specific agent and user
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.Memory'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List agent memories
+      tags:
+      - memories
+  /api/v1/agents/{id}/memories/{memory_id}:
+    delete:
+      description: Delete a specific memory for an agent and user
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Memory ID
+        in: path
+        name: memory_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+      security:
+      - BearerAuth: []
+      summary: Delete agent memory
+      tags:
+      - memories
+  /api/v1/agents/{id}/skills/{skill}/enable:
+    post:
+      description: Enable a marketplace skill on an agent. For autoProvision MCP skills
+        the server generates URL and auth automatically.
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Skill name (e.g. code-intelligence)
+        in: path
+        name: skill
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Agent'
+      security:
+      - BearerAuth: []
+      summary: Enable a marketplace skill on an agent
+      tags:
+      - skills
+  /api/v1/agents/{id}/step-info:
+    get:
+      description: List step info for a specific agent and interaction ID, used to
+        build the timeline of events
+      parameters:
+      - description: Interaction ID
+        in: query
+        name: interactionId
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.StepInfo'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List step info
+      tags:
+      - step_info
+  /api/v1/agents/{id}/trigger-status:
+    get:
+      description: Get the status of a specific trigger type for an agent
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Trigger type (e.g., slack)
+        in: query
+        name: trigger_type
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.TriggerStatus'
+      security:
+      - BearerAuth: []
+      summary: Get agent trigger status
+      tags:
+      - agents
+  /api/v1/agents/{id}/user-access:
+    get:
+      description: Returns the access rights the current user has for this agent
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.UserAppAccessResponse'
+      security:
+      - BearerAuth: []
+      summary: Get current user's access level for an agent
+      tags:
+      - agents
+  /api/v1/agents/{id}/users-daily-usage:
+    get:
+      consumes:
+      - application/json
+      description: Get agent users daily usage
+      parameters:
+      - description: Agent ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Start date
+        in: query
+        name: from
+        type: string
+      - description: End date
+        in: query
+        name: to
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.AggregatedUsageMetric'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Get agent users daily usage
+      tags:
+      - agents
   /api/v1/api_keys:
     delete:
       description: Delete an API key
@@ -13155,934 +14093,6 @@ paths:
       summary: Create a new API key
       tags:
       - api-keys
-  /api/v1/apps:
-    get:
-      description: List apps for the user. Apps are pre-configured to spawn sessions
-        with specific tools and config.
-      parameters:
-      - description: Organization ID
-        in: query
-        name: organization_id
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.App'
-            type: array
-      security:
-      - BearerAuth: []
-      summary: List apps
-      tags:
-      - apps
-    post:
-      parameters:
-      - description: Request body with app configuration. Can be legacy App format
-          or structured format with organization_id, global, and yaml_config fields.
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/types.App'
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/server.AppCreateResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/apps/{app_id}/evaluation-runs/{run_id}:
-    delete:
-      description: Delete an evaluation run
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Run ID
-        in: path
-        name: run_id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Delete an evaluation run
-      tags:
-      - evaluations
-    get:
-      description: Get evaluation run details
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Run ID
-        in: path
-        name: run_id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.EvaluationRun'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Get an evaluation run
-      tags:
-      - evaluations
-  /api/v1/apps/{app_id}/evaluation-suites:
-    get:
-      description: List all evaluation suites for an app
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.EvaluationSuite'
-            type: array
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: List evaluation suites for an app
-      tags:
-      - evaluations
-    post:
-      consumes:
-      - application/json
-      description: Create a new evaluation suite for an agent
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Evaluation suite to create
-        in: body
-        name: suite
-        required: true
-        schema:
-          $ref: '#/definitions/types.EvaluationSuite'
-      produces:
-      - application/json
-      responses:
-        "201":
-          description: Created
-          schema:
-            $ref: '#/definitions/types.EvaluationSuite'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Create an evaluation suite
-      tags:
-      - evaluations
-  /api/v1/apps/{app_id}/evaluation-suites/{id}:
-    delete:
-      description: Delete an evaluation suite
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Suite ID
-        in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Delete an evaluation suite
-      tags:
-      - evaluations
-    get:
-      description: Get an evaluation suite by ID
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Suite ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.EvaluationSuite'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Get an evaluation suite
-      tags:
-      - evaluations
-    put:
-      consumes:
-      - application/json
-      description: Update an evaluation suite
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Suite ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Updated suite
-        in: body
-        name: suite
-        required: true
-        schema:
-          $ref: '#/definitions/types.EvaluationSuite'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.EvaluationSuite'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Update an evaluation suite
-      tags:
-      - evaluations
-  /api/v1/apps/{app_id}/evaluation-suites/{id}/runs:
-    get:
-      description: List evaluation runs for a suite
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Suite ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.EvaluationRun'
-            type: array
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: List evaluation runs
-      tags:
-      - evaluations
-    post:
-      consumes:
-      - application/json
-      description: Start running an evaluation suite against an agent
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      - description: Suite ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.EvaluationRun'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Start an evaluation run
-      tags:
-      - evaluations
-  /api/v1/apps/{app_id}/triggers:
-    get:
-      description: List triggers for the app
-      parameters:
-      - description: App ID
-        in: path
-        name: app_id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.TriggerConfiguration'
-            type: array
-      security:
-      - BearerAuth: []
-      summary: List app triggers
-      tags:
-      - apps
-  /api/v1/apps/{id}:
-    delete:
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-      security:
-      - BearerAuth: []
-    get:
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.App'
-      security:
-      - BearerAuth: []
-    put:
-      parameters:
-      - description: Request body with app configuration.
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/types.App'
-      - description: Tool ID
-        in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.App'
-      security:
-      - BearerAuth: []
-  /api/v1/apps/{id}/access-grants:
-    get:
-      description: List access grants for an app (organization owners and members
-        can list access grants)
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.AccessGrant'
-            type: array
-      security:
-      - BearerAuth: []
-      summary: List app access grants
-      tags:
-      - apps
-    post:
-      description: Grant access to an agent to a team or organization member (organization
-        owners can grant access to teams and organization members)
-      parameters:
-      - description: Request body with team or organization member ID and role
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/types.CreateAccessGrantRequest'
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.AccessGrant'
-      security:
-      - BearerAuth: []
-      summary: Grant access to an agent to a team or organization member
-      tags:
-      - apps
-  /api/v1/apps/{id}/api-actions:
-    post:
-      consumes:
-      - application/json
-      description: Runs an API action for an app
-      parameters:
-      - description: Request
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/types.RunAPIActionRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.RunAPIActionResponse'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Run an API action
-  /api/v1/apps/{id}/avatar:
-    delete:
-      description: Delete the app's avatar image
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Delete app avatar
-      tags:
-      - apps
-    get:
-      description: Get the app's avatar image
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - image/*
-      responses:
-        "200":
-          description: Avatar image data
-          schema:
-            type: file
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Get app avatar
-      tags:
-      - apps
-    post:
-      consumes:
-      - text/plain
-      description: Upload a base64 encoded image as the app's avatar
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Base64 encoded image data
-        in: body
-        name: image
-        required: true
-        schema:
-          type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Upload app avatar
-      tags:
-      - apps
-  /api/v1/apps/{id}/claude-subscription-status:
-    get:
-      description: Reports whether the app owner (whose subscription authenticates
-        the app's sessions) has a working Claude subscription
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/server.AppClaudeSubscriptionStatus'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Get the Claude subscription status for an app's owner
-      tags:
-      - Claude
-  /api/v1/apps/{id}/daily-usage:
-    get:
-      consumes:
-      - application/json
-      description: Get app daily usage
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Start date
-        in: query
-        name: from
-        type: string
-      - description: End date
-        in: query
-        name: to
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.AggregatedUsageMetric'
-            type: array
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Get app usage
-      tags:
-      - apps
-  /api/v1/apps/{id}/duplicate:
-    post:
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Optional new name for the app
-        in: query
-        name: name
-        type: string
-      responses:
-        "200":
-          description: OK
-      security:
-      - BearerAuth: []
-  /api/v1/apps/{id}/interactions:
-    get:
-      description: List interactions with pagination and optional session filtering
-        for a specific app
-      parameters:
-      - description: Page number
-        in: query
-        name: page
-        type: integer
-      - description: Page size
-        in: query
-        name: pageSize
-        type: integer
-      - description: Filter by session ID
-        in: query
-        name: session
-        type: string
-      - description: Filter by interaction ID
-        in: query
-        name: interaction
-        type: string
-      - description: Query by like/dislike
-        in: query
-        name: feedback
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.PaginatedInteractions'
-      security:
-      - BearerAuth: []
-      summary: List interactions
-      tags:
-      - interactions
-  /api/v1/apps/{id}/llm-calls:
-    get:
-      description: List user's LLM calls with pagination and optional session filtering
-        for a specific app
-      parameters:
-      - description: Page number
-        in: query
-        name: page
-        type: integer
-      - description: Page size
-        in: query
-        name: pageSize
-        type: integer
-      - description: Filter by session ID
-        in: query
-        name: session
-        type: string
-      - description: Filter by interaction ID
-        in: query
-        name: interaction
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.PaginatedLLMCalls'
-      security:
-      - BearerAuth: []
-      summary: List LLM calls
-      tags:
-      - llm_calls
-  /api/v1/apps/{id}/memories:
-    get:
-      description: List memories for a specific app and user
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.Memory'
-            type: array
-      security:
-      - BearerAuth: []
-      summary: List app memories
-      tags:
-      - memories
-  /api/v1/apps/{id}/memories/{memory_id}:
-    delete:
-      description: Delete a specific memory for an app and user
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Memory ID
-        in: path
-        name: memory_id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-      security:
-      - BearerAuth: []
-      summary: Delete app memory
-      tags:
-      - memories
-  /api/v1/apps/{id}/skills/{skill}/enable:
-    post:
-      description: Enable a marketplace skill on an app. For autoProvision MCP skills
-        the server generates URL and auth automatically.
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Skill name (e.g. code-intelligence)
-        in: path
-        name: skill
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.App'
-      security:
-      - BearerAuth: []
-      summary: Enable a marketplace skill on an app
-      tags:
-      - skills
-  /api/v1/apps/{id}/step-info:
-    get:
-      description: List step info for a specific app and interaction ID, used to build
-        the timeline of events
-      parameters:
-      - description: Interaction ID
-        in: query
-        name: interactionId
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.StepInfo'
-            type: array
-      security:
-      - BearerAuth: []
-      summary: List step info
-      tags:
-      - step_info
-  /api/v1/apps/{id}/trigger-status:
-    get:
-      description: Get the status of a specific trigger type for an app
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Trigger type (e.g., slack)
-        in: query
-        name: trigger_type
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.TriggerStatus'
-      security:
-      - BearerAuth: []
-      summary: Get app trigger status
-      tags:
-      - apps
-  /api/v1/apps/{id}/user-access:
-    get:
-      description: Returns the access rights the current user has for this app
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/types.UserAppAccessResponse'
-      security:
-      - BearerAuth: []
-      summary: Get current user's access level for an app
-      tags:
-      - apps
-  /api/v1/apps/{id}/users-daily-usage:
-    get:
-      consumes:
-      - application/json
-      description: Get app users daily usage
-      parameters:
-      - description: App ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Start date
-        in: query
-        name: from
-        type: string
-      - description: End date
-        in: query
-        name: to
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/types.AggregatedUsageMetric'
-            type: array
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Get app users daily usage
-      tags:
-      - apps
   /api/v1/attention-events:
     get:
       description: Returns attention events that need human action for the current
@@ -19483,7 +19493,7 @@ paths:
       - HelixOrg
   /api/v1/orgs/{org}/overview:
     get:
-      description: Returns the flat set of Bots in the org for the helix-org React
+      description: Returns the flat set of Nodes in the org for the helix-org React
         Overview page.
       produces:
       - application/json
@@ -25911,11 +25921,11 @@ paths:
       summary: List all triggers configurations for either user or the org or user
         within an org
       tags:
-      - apps
+      - agents
     post:
-      description: Create triggers for the app. Used to create standalone trigger
+      description: Create triggers for the agent. Used to create standalone trigger
         configurations such as cron tasks for agents that could be owned by a different
-        user than the owner of the app
+        user than the owner of the agent
       parameters:
       - description: Trigger configuration
         in: body
@@ -25930,12 +25940,12 @@ paths:
             $ref: '#/definitions/types.TriggerConfiguration'
       security:
       - BearerAuth: []
-      summary: Create app triggers
+      summary: Create agent triggers
       tags:
-      - apps
+      - agents
   /api/v1/triggers/{trigger_id}:
     delete:
-      description: Delete triggers for the app
+      description: Delete triggers for the agent
       parameters:
       - description: Trigger ID
         in: path
@@ -25949,11 +25959,11 @@ paths:
             $ref: '#/definitions/types.TriggerConfiguration'
       security:
       - BearerAuth: []
-      summary: Delete app triggers
+      summary: Delete agent triggers
       tags:
-      - apps
+      - agents
     put:
-      description: Update triggers for the app, for example to change the cron schedule
+      description: Update triggers for the agent, for example to change the cron schedule
         or enable/disable the trigger
       parameters:
       - description: Trigger ID
@@ -25974,12 +25984,12 @@ paths:
             $ref: '#/definitions/types.TriggerConfiguration'
       security:
       - BearerAuth: []
-      summary: Update app triggers
+      summary: Update agent triggers
       tags:
-      - apps
+      - agents
   /api/v1/triggers/{trigger_id}/execute:
     post:
-      description: Update triggers for the app, for example to change the cron schedule
+      description: Update triggers for the agent, for example to change the cron schedule
         or enable/disable the trigger
       parameters:
       - description: Trigger ID
@@ -25994,9 +26004,9 @@ paths:
             $ref: '#/definitions/types.TriggerExecuteResponse'
       security:
       - BearerAuth: []
-      summary: Execute app trigger
+      summary: Execute agent trigger
       tags:
-      - apps
+      - agents
   /api/v1/triggers/{trigger_id}/executions:
     get:
       description: List executions for the trigger
@@ -26025,7 +26035,7 @@ paths:
       - BearerAuth: []
       summary: List trigger executions
       tags:
-      - apps
+      - agents
   /api/v1/usage:
     get:
       consumes:

--- a/openapi.json
+++ b/openapi.json
@@ -1309,6 +1309,1760 @@
                 }
             }
         },
+        "/api/v1/agents": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List agents for the user. Agents are pre-configured to spawn sessions with specific tools and config.",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "List agents",
+                "parameters": [
+                    {
+                        "description": "Organization ID",
+                        "name": "organization_id",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/types.Agent"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/types.Agent"
+                            }
+                        }
+                    },
+                    "description": "Request body with agent configuration. Can be legacy Agent format or structured format with organization_id, global, and yaml_config fields.",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/server.AgentCreateResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/evaluation-runs/{run_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get evaluation run details",
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Get an evaluation run",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Run ID",
+                        "name": "run_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.EvaluationRun"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete an evaluation run",
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Delete an evaluation run",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Run ID",
+                        "name": "run_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/evaluation-suites": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List all evaluation suites for an agent",
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "List evaluation suites for an agent",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/types.EvaluationSuite"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new evaluation suite for an agent",
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Create an evaluation suite",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/types.EvaluationSuite"
+                            }
+                        }
+                    },
+                    "description": "Evaluation suite to create",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.EvaluationSuite"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/evaluation-suites/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get an evaluation suite by ID",
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Get an evaluation suite",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.EvaluationSuite"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update an evaluation suite",
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Update an evaluation suite",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/types.EvaluationSuite"
+                            }
+                        }
+                    },
+                    "description": "Updated suite",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.EvaluationSuite"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete an evaluation suite",
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Delete an evaluation suite",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/evaluation-suites/{id}/runs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List evaluation runs for a suite",
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "List evaluation runs",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/types.EvaluationRun"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Start running an evaluation suite against an agent",
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Start an evaluation run",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.EvaluationRun"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/triggers": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List triggers for the agent",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "List agent triggers",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/types.TriggerConfiguration"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.Agent"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "description": "Tool ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/types.Agent"
+                            }
+                        }
+                    },
+                    "description": "Request body with agent configuration.",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.Agent"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/access-grants": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List access grants for an agent (organization owners and members can list access grants)",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "List agent access grants",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/types.AccessGrant"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Grant access to an agent to a team or organization member (organization owners can grant access to teams and organization members)",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Grant access to an agent to a team or organization member",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/types.CreateAccessGrantRequest"
+                            }
+                        }
+                    },
+                    "description": "Request body with team or organization member ID and role",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.AccessGrant"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/api-actions": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Runs an API action for an agent",
+                "summary": "Run an API action",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/types.RunAPIActionRequest"
+                            }
+                        }
+                    },
+                    "description": "Request",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.RunAPIActionResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/avatar": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get the agent's avatar image",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get agent avatar",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Avatar image data",
+                        "content": {
+                            "image/*": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "image/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Upload a base64 encoded image as the agent's avatar",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Upload agent avatar",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "text/plain": {
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "description": "Base64 encoded image data",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete the agent's avatar image",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Delete agent avatar",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/claude-subscription-status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Reports whether the agent owner (whose subscription authenticates the agent's sessions) has a working Claude subscription",
+                "tags": [
+                    "Claude"
+                ],
+                "summary": "Get the Claude subscription status for an agent's owner",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/server.AppClaudeSubscriptionStatus"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/daily-usage": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get agent daily usage",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get agent usage",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Start date",
+                        "name": "from",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "End date",
+                        "name": "to",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/types.AggregatedUsageMetric"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/duplicate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Optional new name for the agent",
+                        "name": "name",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/interactions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List interactions with pagination and optional session filtering for a specific agent",
+                "tags": [
+                    "interactions"
+                ],
+                "summary": "List interactions",
+                "parameters": [
+                    {
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Page size",
+                        "name": "pageSize",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Filter by session ID",
+                        "name": "session",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by interaction ID",
+                        "name": "interaction",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Query by like/dislike",
+                        "name": "feedback",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.PaginatedInteractions"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/llm-calls": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List user's LLM calls with pagination and optional session filtering for a specific agent",
+                "tags": [
+                    "llm_calls"
+                ],
+                "summary": "List LLM calls",
+                "parameters": [
+                    {
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Page size",
+                        "name": "pageSize",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Filter by session ID",
+                        "name": "session",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter by interaction ID",
+                        "name": "interaction",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.PaginatedLLMCalls"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/memories": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List memories for a specific agent and user",
+                "tags": [
+                    "memories"
+                ],
+                "summary": "List agent memories",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/types.Memory"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/memories/{memory_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a specific memory for an agent and user",
+                "tags": [
+                    "memories"
+                ],
+                "summary": "Delete agent memory",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Memory ID",
+                        "name": "memory_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/skills/{skill}/enable": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Enable a marketplace skill on an agent. For autoProvision MCP skills the server generates URL and auth automatically.",
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Enable a marketplace skill on an agent",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Skill name (e.g. code-intelligence)",
+                        "name": "skill",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.Agent"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/step-info": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List step info for a specific agent and interaction ID, used to build the timeline of events",
+                "tags": [
+                    "step_info"
+                ],
+                "summary": "List step info",
+                "parameters": [
+                    {
+                        "description": "Interaction ID",
+                        "name": "interactionId",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/types.StepInfo"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/trigger-status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get the status of a specific trigger type for an agent",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get agent trigger status",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Trigger type (e.g., slack)",
+                        "name": "trigger_type",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.TriggerStatus"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/user-access": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the access rights the current user has for this agent",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get current user's access level for an agent",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.UserAppAccessResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/users-daily-usage": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get agent users daily usage",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get agent users daily usage",
+                "parameters": [
+                    {
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Start date",
+                        "name": "from",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "End date",
+                        "name": "to",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/types.AggregatedUsageMetric"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/api_keys": {
             "get": {
                 "security": [
@@ -1410,1760 +3164,6 @@
                             "*/*": {
                                 "schema": {
                                     "type": "string"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List apps for the user. Apps are pre-configured to spawn sessions with specific tools and config.",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "List apps",
-                "parameters": [
-                    {
-                        "description": "Organization ID",
-                        "name": "organization_id",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/types.App"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/types.App"
-                            }
-                        }
-                    },
-                    "description": "Request body with app configuration. Can be legacy App format or structured format with organization_id, global, and yaml_config fields.",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/server.AppCreateResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/evaluation-runs/{run_id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get evaluation run details",
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Get an evaluation run",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Run ID",
-                        "name": "run_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.EvaluationRun"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete an evaluation run",
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Delete an evaluation run",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Run ID",
-                        "name": "run_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/evaluation-suites": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List all evaluation suites for an app",
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "List evaluation suites for an app",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/types.EvaluationSuite"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Create a new evaluation suite for an agent",
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Create an evaluation suite",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/types.EvaluationSuite"
-                            }
-                        }
-                    },
-                    "description": "Evaluation suite to create",
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.EvaluationSuite"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/evaluation-suites/{id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get an evaluation suite by ID",
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Get an evaluation suite",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.EvaluationSuite"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Update an evaluation suite",
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Update an evaluation suite",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/types.EvaluationSuite"
-                            }
-                        }
-                    },
-                    "description": "Updated suite",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.EvaluationSuite"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete an evaluation suite",
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Delete an evaluation suite",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "object",
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/evaluation-suites/{id}/runs": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List evaluation runs for a suite",
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "List evaluation runs",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/types.EvaluationRun"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Start running an evaluation suite against an agent",
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Start an evaluation run",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.EvaluationRun"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/triggers": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List triggers for the app",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "List app triggers",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/types.TriggerConfiguration"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.App"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "description": "Tool ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/types.App"
-                            }
-                        }
-                    },
-                    "description": "Request body with app configuration.",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.App"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/access-grants": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List access grants for an app (organization owners and members can list access grants)",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "List app access grants",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/types.AccessGrant"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Grant access to an agent to a team or organization member (organization owners can grant access to teams and organization members)",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Grant access to an agent to a team or organization member",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/types.CreateAccessGrantRequest"
-                            }
-                        }
-                    },
-                    "description": "Request body with team or organization member ID and role",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.AccessGrant"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/api-actions": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Runs an API action for an app",
-                "summary": "Run an API action",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/types.RunAPIActionRequest"
-                            }
-                        }
-                    },
-                    "description": "Request",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.RunAPIActionResponse"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/avatar": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get the app's avatar image",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get app avatar",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Avatar image data",
-                        "content": {
-                            "image/*": {
-                                "schema": {
-                                    "type": "string",
-                                    "format": "binary"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "image/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Upload a base64 encoded image as the app's avatar",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Upload app avatar",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "text/plain": {
-                            "schema": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "description": "Base64 encoded image data",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete the app's avatar image",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Delete app avatar",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/claude-subscription-status": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Reports whether the app owner (whose subscription authenticates the app's sessions) has a working Claude subscription",
-                "tags": [
-                    "Claude"
-                ],
-                "summary": "Get the Claude subscription status for an app's owner",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/server.AppClaudeSubscriptionStatus"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/daily-usage": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get app daily usage",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get app usage",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Start date",
-                        "name": "from",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "End date",
-                        "name": "to",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/types.AggregatedUsageMetric"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/duplicate": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Optional new name for the app",
-                        "name": "name",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/interactions": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List interactions with pagination and optional session filtering for a specific app",
-                "tags": [
-                    "interactions"
-                ],
-                "summary": "List interactions",
-                "parameters": [
-                    {
-                        "description": "Page number",
-                        "name": "page",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer"
-                        }
-                    },
-                    {
-                        "description": "Page size",
-                        "name": "pageSize",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer"
-                        }
-                    },
-                    {
-                        "description": "Filter by session ID",
-                        "name": "session",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Filter by interaction ID",
-                        "name": "interaction",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Query by like/dislike",
-                        "name": "feedback",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.PaginatedInteractions"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/llm-calls": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List user's LLM calls with pagination and optional session filtering for a specific app",
-                "tags": [
-                    "llm_calls"
-                ],
-                "summary": "List LLM calls",
-                "parameters": [
-                    {
-                        "description": "Page number",
-                        "name": "page",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer"
-                        }
-                    },
-                    {
-                        "description": "Page size",
-                        "name": "pageSize",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer"
-                        }
-                    },
-                    {
-                        "description": "Filter by session ID",
-                        "name": "session",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Filter by interaction ID",
-                        "name": "interaction",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.PaginatedLLMCalls"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/memories": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List memories for a specific app and user",
-                "tags": [
-                    "memories"
-                ],
-                "summary": "List app memories",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/types.Memory"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/memories/{memory_id}": {
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete a specific memory for an app and user",
-                "tags": [
-                    "memories"
-                ],
-                "summary": "Delete app memory",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Memory ID",
-                        "name": "memory_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/skills/{skill}/enable": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Enable a marketplace skill on an app. For autoProvision MCP skills the server generates URL and auth automatically.",
-                "tags": [
-                    "skills"
-                ],
-                "summary": "Enable a marketplace skill on an app",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Skill name (e.g. code-intelligence)",
-                        "name": "skill",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.App"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/step-info": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List step info for a specific app and interaction ID, used to build the timeline of events",
-                "tags": [
-                    "step_info"
-                ],
-                "summary": "List step info",
-                "parameters": [
-                    {
-                        "description": "Interaction ID",
-                        "name": "interactionId",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/types.StepInfo"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/trigger-status": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get the status of a specific trigger type for an app",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get app trigger status",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Trigger type (e.g., slack)",
-                        "name": "trigger_type",
-                        "in": "query",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.TriggerStatus"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/user-access": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Returns the access rights the current user has for this app",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get current user's access level for an app",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/types.UserAppAccessResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/users-daily-usage": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get app users daily usage",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get app users daily usage",
-                "parameters": [
-                    {
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "Start date",
-                        "name": "from",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "End date",
-                        "name": "to",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/types.AggregatedUsageMetric"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/system.HTTPError"
                                 }
                             }
                         }
@@ -13348,7 +13348,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Returns the flat set of Bots in the org for the helix-org React Overview page.",
+                "description": "Returns the flat set of Nodes in the org for the helix-org React Overview page.",
                 "tags": [
                     "HelixOrg"
                 ],
@@ -25212,7 +25212,7 @@
                 ],
                 "description": "List all triggers configurations for either user or the org or user within an org",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
                 "summary": "List all triggers configurations for either user or the org or user within an org",
                 "parameters": [
@@ -25255,11 +25255,11 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Create triggers for the app. Used to create standalone trigger configurations such as cron tasks for agents that could be owned by a different user than the owner of the app",
+                "description": "Create triggers for the agent. Used to create standalone trigger configurations such as cron tasks for agents that could be owned by a different user than the owner of the agent",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
-                "summary": "Create app triggers",
+                "summary": "Create agent triggers",
                 "requestBody": {
                     "$ref": "#/components/requestBodies/types.TriggerConfiguration"
                 },
@@ -25284,11 +25284,11 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update triggers for the app, for example to change the cron schedule or enable/disable the trigger",
+                "description": "Update triggers for the agent, for example to change the cron schedule or enable/disable the trigger",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
-                "summary": "Update app triggers",
+                "summary": "Update agent triggers",
                 "parameters": [
                     {
                         "description": "Trigger ID",
@@ -25322,11 +25322,11 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Delete triggers for the app",
+                "description": "Delete triggers for the agent",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
-                "summary": "Delete app triggers",
+                "summary": "Delete agent triggers",
                 "parameters": [
                     {
                         "description": "Trigger ID",
@@ -25359,11 +25359,11 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update triggers for the app, for example to change the cron schedule or enable/disable the trigger",
+                "description": "Update triggers for the agent, for example to change the cron schedule or enable/disable the trigger",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
-                "summary": "Execute app trigger",
+                "summary": "Execute agent trigger",
                 "parameters": [
                     {
                         "description": "Trigger ID",
@@ -25398,7 +25398,7 @@
                 ],
                 "description": "List executions for the trigger",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
                 "summary": "List trigger executions",
                 "parameters": [
@@ -27034,6 +27034,9 @@
                     "agent_app_id": {
                         "type": "string"
                     },
+                    "agent_id": {
+                        "type": "string"
+                    },
                     "agent_model": {
                         "type": "string"
                     },
@@ -27127,6 +27130,9 @@
                     "agent_app_id": {
                         "type": "string"
                     },
+                    "agent_id": {
+                        "type": "string"
+                    },
                     "project_id": {
                         "type": "string"
                     },
@@ -27149,6 +27155,9 @@
                     "agent_app_id": {
                         "type": "string"
                     },
+                    "agent_id": {
+                        "type": "string"
+                    },
                     "project_id": {
                         "type": "string"
                     }
@@ -27158,6 +27167,9 @@
                 "type": "object",
                 "properties": {
                     "agent_app_id": {
+                        "type": "string"
+                    },
+                    "agent_id": {
                         "type": "string"
                     },
                     "agent_model": {
@@ -27245,7 +27257,10 @@
                 "type": "object",
                 "properties": {
                     "agent_app_id": {
-                        "description": "AgentAppID + ProjectID — see BotChatDTO comments.",
+                        "type": "string"
+                    },
+                    "agent_id": {
+                        "description": "AgentID + ProjectID — see BotChatDTO comments.",
                         "type": "string"
                     },
                     "bot": {
@@ -27324,7 +27339,7 @@
                         "type": "string"
                     },
                     "owner": {
-                        "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation - create_bot, delete_bot,\nset_bot_content, subscribe, ... - plus the read baseline) so it can\nhire and manage other Bots. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
+                        "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation - create_bot, delete_bot,\nset_bot_content, subscribe, ... - plus the read baseline) so it can\nhire and manage other Nodes. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
                         "type": "boolean"
                     },
                     "parent_id": {
@@ -29210,6 +29225,59 @@
                     }
                 }
             },
+            "server.AgentCreateResponse": {
+                "type": "object",
+                "properties": {
+                    "config": {
+                        "$ref": "#/components/schemas/types.AgentConfig"
+                    },
+                    "created": {
+                        "type": "string"
+                    },
+                    "global": {
+                        "type": "boolean"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "is_helix_org_agent": {
+                        "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
+                        "type": "boolean"
+                    },
+                    "model_substitutions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/server.ModelSubstitution"
+                        }
+                    },
+                    "organization_id": {
+                        "type": "string"
+                    },
+                    "owner": {
+                        "description": "uuid of user ID",
+                        "type": "string"
+                    },
+                    "owner_type": {
+                        "description": "e.g. user, system, org",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.OwnerType"
+                            }
+                        ]
+                    },
+                    "updated": {
+                        "type": "string"
+                    },
+                    "user": {
+                        "description": "Owner user struct, populated by the server for organization views",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.User"
+                            }
+                        ]
+                    }
+                }
+            },
             "server.AgentSandboxesDebugResponse": {
                 "type": "object",
                 "properties": {
@@ -29271,59 +29339,6 @@
                     "valid": {
                         "description": "that subscription passed its last liveness probe",
                         "type": "boolean"
-                    }
-                }
-            },
-            "server.AppCreateResponse": {
-                "type": "object",
-                "properties": {
-                    "config": {
-                        "$ref": "#/components/schemas/types.AppConfig"
-                    },
-                    "created": {
-                        "type": "string"
-                    },
-                    "global": {
-                        "type": "boolean"
-                    },
-                    "id": {
-                        "type": "string"
-                    },
-                    "is_helix_org_agent": {
-                        "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
-                        "type": "boolean"
-                    },
-                    "model_substitutions": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/server.ModelSubstitution"
-                        }
-                    },
-                    "organization_id": {
-                        "type": "string"
-                    },
-                    "owner": {
-                        "description": "uuid of user ID",
-                        "type": "string"
-                    },
-                    "owner_type": {
-                        "description": "e.g. user, system, org",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/types.OwnerType"
-                            }
-                        ]
-                    },
-                    "updated": {
-                        "type": "string"
-                    },
-                    "user": {
-                        "description": "Owner user struct, populated by the server for organization views",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/types.User"
-                            }
-                        ]
                     }
                 }
             },
@@ -31747,6 +31762,122 @@
                     }
                 }
             },
+            "types.Agent": {
+                "type": "object",
+                "properties": {
+                    "config": {
+                        "$ref": "#/components/schemas/types.AgentConfig"
+                    },
+                    "created": {
+                        "type": "string"
+                    },
+                    "global": {
+                        "type": "boolean"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "is_helix_org_agent": {
+                        "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
+                        "type": "boolean"
+                    },
+                    "organization_id": {
+                        "type": "string"
+                    },
+                    "owner": {
+                        "description": "uuid of user ID",
+                        "type": "string"
+                    },
+                    "owner_type": {
+                        "description": "e.g. user, system, org",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.OwnerType"
+                            }
+                        ]
+                    },
+                    "updated": {
+                        "type": "string"
+                    },
+                    "user": {
+                        "description": "Owner user struct, populated by the server for organization views",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.User"
+                            }
+                        ]
+                    }
+                }
+            },
+            "types.AgentConfig": {
+                "type": "object",
+                "properties": {
+                    "allowed_domains": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "helix": {
+                        "$ref": "#/components/schemas/types.AgentHelixConfig"
+                    },
+                    "secrets": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "types.AgentHelixConfig": {
+                "type": "object",
+                "properties": {
+                    "assistants": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/types.AssistantConfig"
+                        }
+                    },
+                    "avatar": {
+                        "type": "string"
+                    },
+                    "avatar_content_type": {
+                        "type": "string"
+                    },
+                    "default_agent_type": {
+                        "description": "Agent configuration",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.AgentType"
+                            }
+                        ]
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "external_agent_config": {
+                        "$ref": "#/components/schemas/types.ExternalAgentConfig"
+                    },
+                    "external_agent_enabled": {
+                        "type": "boolean"
+                    },
+                    "external_url": {
+                        "type": "string"
+                    },
+                    "image": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "triggers": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/types.Trigger"
+                        }
+                    }
+                }
+            },
             "types.AgentType": {
                 "type": "string",
                 "enum": [
@@ -31877,122 +32008,6 @@
                     },
                     "type": {
                         "$ref": "#/components/schemas/types.APIKeyType"
-                    }
-                }
-            },
-            "types.App": {
-                "type": "object",
-                "properties": {
-                    "config": {
-                        "$ref": "#/components/schemas/types.AppConfig"
-                    },
-                    "created": {
-                        "type": "string"
-                    },
-                    "global": {
-                        "type": "boolean"
-                    },
-                    "id": {
-                        "type": "string"
-                    },
-                    "is_helix_org_agent": {
-                        "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
-                        "type": "boolean"
-                    },
-                    "organization_id": {
-                        "type": "string"
-                    },
-                    "owner": {
-                        "description": "uuid of user ID",
-                        "type": "string"
-                    },
-                    "owner_type": {
-                        "description": "e.g. user, system, org",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/types.OwnerType"
-                            }
-                        ]
-                    },
-                    "updated": {
-                        "type": "string"
-                    },
-                    "user": {
-                        "description": "Owner user struct, populated by the server for organization views",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/types.User"
-                            }
-                        ]
-                    }
-                }
-            },
-            "types.AppConfig": {
-                "type": "object",
-                "properties": {
-                    "allowed_domains": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "helix": {
-                        "$ref": "#/components/schemas/types.AppHelixConfig"
-                    },
-                    "secrets": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "types.AppHelixConfig": {
-                "type": "object",
-                "properties": {
-                    "assistants": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/types.AssistantConfig"
-                        }
-                    },
-                    "avatar": {
-                        "type": "string"
-                    },
-                    "avatar_content_type": {
-                        "type": "string"
-                    },
-                    "default_agent_type": {
-                        "description": "Agent configuration",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/types.AgentType"
-                            }
-                        ]
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "external_agent_config": {
-                        "$ref": "#/components/schemas/types.ExternalAgentConfig"
-                    },
-                    "external_agent_enabled": {
-                        "type": "boolean"
-                    },
-                    "external_url": {
-                        "type": "string"
-                    },
-                    "image": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "triggers": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/types.Trigger"
-                        }
                     }
                 }
             },
@@ -34365,7 +34380,7 @@
                 "type": "object",
                 "properties": {
                     "app_config_snapshot": {
-                        "$ref": "#/components/schemas/types.AppConfig"
+                        "$ref": "#/components/schemas/types.AgentConfig"
                     },
                     "app_id": {
                         "type": "string"

--- a/operator/internal/controller/aiapp_controller.go
+++ b/operator/internal/controller/aiapp_controller.go
@@ -82,10 +82,10 @@ func (r *AIAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, nil
 	}
 
-	// Convert CRD to Helix App type
-	app := &types.App{
-		Config: types.AppConfig{
-			Helix: types.AppHelixConfig{
+	// Convert CRD to Helix Agent type
+	app := &types.Agent{
+		Config: types.AgentConfig{
+			Helix: types.AgentHelixConfig{
 				Name:        appID,
 				Description: aiapp.Spec.Description,
 				Avatar:      aiapp.Spec.Avatar,

--- a/scripts/k6/app.js
+++ b/scripts/k6/app.js
@@ -2,7 +2,7 @@ import { check } from 'k6';
 import http from 'k6/http';
 
 export default function () {
-  const url = 'http://localhost/api/v1/apps/script';
+  const url = 'http://localhost/api/v1/agents/script';
   const payload = JSON.stringify({
     file_path: '/scripts/hello.gpt',
     input: 'run this python',

--- a/swagger.json
+++ b/swagger.json
@@ -1110,6 +1110,1465 @@
                 }
             }
         },
+        "/api/v1/agents": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List agents for the user. Agents are pre-configured to spawn sessions with specific tools and config.",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "List agents",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Organization ID",
+                        "name": "organization_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.Agent"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "description": "Request body with agent configuration. Can be legacy Agent format or structured format with organization_id, global, and yaml_config fields.",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.Agent"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.AgentCreateResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/evaluation-runs/{run_id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get evaluation run details",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Get an evaluation run",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Run ID",
+                        "name": "run_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationRun"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete an evaluation run",
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Delete an evaluation run",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Run ID",
+                        "name": "run_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/evaluation-suites": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List all evaluation suites for an agent",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "List evaluation suites for an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.EvaluationSuite"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new evaluation suite for an agent",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Create an evaluation suite",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Evaluation suite to create",
+                        "name": "suite",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationSuite"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationSuite"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/evaluation-suites/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get an evaluation suite by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Get an evaluation suite",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationSuite"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Update an evaluation suite",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Update an evaluation suite",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Updated suite",
+                        "name": "suite",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationSuite"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationSuite"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete an evaluation suite",
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Delete an evaluation suite",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/evaluation-suites/{id}/runs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List evaluation runs for a suite",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "List evaluation runs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.EvaluationRun"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Start running an evaluation suite against an agent",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "evaluations"
+                ],
+                "summary": "Start an evaluation run",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Suite ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.EvaluationRun"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{agent_id}/triggers": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List triggers for the agent",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "List agent triggers",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.TriggerConfiguration"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Agent"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "description": "Request body with agent configuration.",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.Agent"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Tool ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Agent"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/access-grants": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List access grants for an agent (organization owners and members can list access grants)",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "List agent access grants",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.AccessGrant"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Grant access to an agent to a team or organization member (organization owners can grant access to teams and organization members)",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Grant access to an agent to a team or organization member",
+                "parameters": [
+                    {
+                        "description": "Request body with team or organization member ID and role",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.CreateAccessGrantRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.AccessGrant"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/api-actions": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Runs an API action for an agent",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Run an API action",
+                "parameters": [
+                    {
+                        "description": "Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.RunAPIActionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.RunAPIActionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/avatar": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get the agent's avatar image",
+                "produces": [
+                    "image/*"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get agent avatar",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Avatar image data",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Upload a base64 encoded image as the agent's avatar",
+                "consumes": [
+                    "text/plain"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Upload agent avatar",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Base64 encoded image data",
+                        "name": "image",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete the agent's avatar image",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Delete agent avatar",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/claude-subscription-status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Reports whether the agent owner (whose subscription authenticates the agent's sessions) has a working Claude subscription",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Claude"
+                ],
+                "summary": "Get the Claude subscription status for an agent's owner",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/server.AppClaudeSubscriptionStatus"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/daily-usage": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get agent daily usage",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get agent usage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date",
+                        "name": "to",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.AggregatedUsageMetric"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/duplicate": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Optional new name for the agent",
+                        "name": "name",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/interactions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List interactions with pagination and optional session filtering for a specific agent",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "interactions"
+                ],
+                "summary": "List interactions",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by session ID",
+                        "name": "session",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by interaction ID",
+                        "name": "interaction",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Query by like/dislike",
+                        "name": "feedback",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedInteractions"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/llm-calls": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List user's LLM calls with pagination and optional session filtering for a specific agent",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "llm_calls"
+                ],
+                "summary": "List LLM calls",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by session ID",
+                        "name": "session",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by interaction ID",
+                        "name": "interaction",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.PaginatedLLMCalls"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/memories": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List memories for a specific agent and user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "memories"
+                ],
+                "summary": "List agent memories",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.Memory"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/memories/{memory_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete a specific memory for an agent and user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "memories"
+                ],
+                "summary": "Delete agent memory",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Memory ID",
+                        "name": "memory_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/skills/{skill}/enable": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Enable a marketplace skill on an agent. For autoProvision MCP skills the server generates URL and auth automatically.",
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Enable a marketplace skill on an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Skill name (e.g. code-intelligence)",
+                        "name": "skill",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Agent"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/step-info": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "List step info for a specific agent and interaction ID, used to build the timeline of events",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "step_info"
+                ],
+                "summary": "List step info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Interaction ID",
+                        "name": "interactionId",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.StepInfo"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/trigger-status": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get the status of a specific trigger type for an agent",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get agent trigger status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Trigger type (e.g., slack)",
+                        "name": "trigger_type",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.TriggerStatus"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/user-access": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the access rights the current user has for this agent",
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get current user's access level for an agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.UserAppAccessResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/agents/{id}/users-daily-usage": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get agent users daily usage",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agents"
+                ],
+                "summary": "Get agent users daily usage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Agent ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start date",
+                        "name": "from",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End date",
+                        "name": "to",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.AggregatedUsageMetric"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/api_keys": {
             "get": {
                 "security": [
@@ -1195,1465 +2654,6 @@
                         "description": "API key",
                         "schema": {
                             "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List apps for the user. Apps are pre-configured to spawn sessions with specific tools and config.",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "List apps",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Organization ID",
-                        "name": "organization_id",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.App"
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "description": "Request body with app configuration. Can be legacy App format or structured format with organization_id, global, and yaml_config fields.",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.App"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/server.AppCreateResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/evaluation-runs/{run_id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get evaluation run details",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Get an evaluation run",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Run ID",
-                        "name": "run_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationRun"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete an evaluation run",
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Delete an evaluation run",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Run ID",
-                        "name": "run_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/evaluation-suites": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List all evaluation suites for an app",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "List evaluation suites for an app",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.EvaluationSuite"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Create a new evaluation suite for an agent",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Create an evaluation suite",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Evaluation suite to create",
-                        "name": "suite",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationSuite"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationSuite"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/evaluation-suites/{id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get an evaluation suite by ID",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Get an evaluation suite",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationSuite"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Update an evaluation suite",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Update an evaluation suite",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Updated suite",
-                        "name": "suite",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationSuite"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationSuite"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete an evaluation suite",
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Delete an evaluation suite",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/evaluation-suites/{id}/runs": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List evaluation runs for a suite",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "List evaluation runs",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.EvaluationRun"
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Start running an evaluation suite against an agent",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "evaluations"
-                ],
-                "summary": "Start an evaluation run",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Suite ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.EvaluationRun"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{app_id}/triggers": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List triggers for the app",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "List app triggers",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "app_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.TriggerConfiguration"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.App"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "description": "Request body with app configuration.",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.App"
-                        }
-                    },
-                    {
-                        "type": "string",
-                        "description": "Tool ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.App"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/access-grants": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List access grants for an app (organization owners and members can list access grants)",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "List app access grants",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.AccessGrant"
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Grant access to an agent to a team or organization member (organization owners can grant access to teams and organization members)",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Grant access to an agent to a team or organization member",
-                "parameters": [
-                    {
-                        "description": "Request body with team or organization member ID and role",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.CreateAccessGrantRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.AccessGrant"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/api-actions": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Runs an API action for an app",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Run an API action",
-                "parameters": [
-                    {
-                        "description": "Request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/types.RunAPIActionRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.RunAPIActionResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/avatar": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get the app's avatar image",
-                "produces": [
-                    "image/*"
-                ],
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get app avatar",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Avatar image data",
-                        "schema": {
-                            "type": "file"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Upload a base64 encoded image as the app's avatar",
-                "consumes": [
-                    "text/plain"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Upload app avatar",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Base64 encoded image data",
-                        "name": "image",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete the app's avatar image",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Delete app avatar",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/claude-subscription-status": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Reports whether the app owner (whose subscription authenticates the app's sessions) has a working Claude subscription",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Claude"
-                ],
-                "summary": "Get the Claude subscription status for an app's owner",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/server.AppClaudeSubscriptionStatus"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/daily-usage": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get app daily usage",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get app usage",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Start date",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "End date",
-                        "name": "to",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.AggregatedUsageMetric"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/duplicate": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Optional new name for the app",
-                        "name": "name",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/interactions": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List interactions with pagination and optional session filtering for a specific app",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "interactions"
-                ],
-                "summary": "List interactions",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by session ID",
-                        "name": "session",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by interaction ID",
-                        "name": "interaction",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Query by like/dislike",
-                        "name": "feedback",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedInteractions"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/llm-calls": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List user's LLM calls with pagination and optional session filtering for a specific app",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "llm_calls"
-                ],
-                "summary": "List LLM calls",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Page size",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by session ID",
-                        "name": "session",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filter by interaction ID",
-                        "name": "interaction",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.PaginatedLLMCalls"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/memories": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List memories for a specific app and user",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "memories"
-                ],
-                "summary": "List app memories",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.Memory"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/memories/{memory_id}": {
-            "delete": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Delete a specific memory for an app and user",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "memories"
-                ],
-                "summary": "Delete app memory",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Memory ID",
-                        "name": "memory_id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/skills/{skill}/enable": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Enable a marketplace skill on an app. For autoProvision MCP skills the server generates URL and auth automatically.",
-                "tags": [
-                    "skills"
-                ],
-                "summary": "Enable a marketplace skill on an app",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Skill name (e.g. code-intelligence)",
-                        "name": "skill",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.App"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/step-info": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List step info for a specific app and interaction ID, used to build the timeline of events",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "step_info"
-                ],
-                "summary": "List step info",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Interaction ID",
-                        "name": "interactionId",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.StepInfo"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/trigger-status": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get the status of a specific trigger type for an app",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get app trigger status",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Trigger type (e.g., slack)",
-                        "name": "trigger_type",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.TriggerStatus"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/user-access": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Returns the access rights the current user has for this app",
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get current user's access level for an app",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/types.UserAppAccessResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/apps/{id}/users-daily-usage": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get app users daily usage",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "apps"
-                ],
-                "summary": "Get app users daily usage",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "App ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Start date",
-                        "name": "from",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "End date",
-                        "name": "to",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.AggregatedUsageMetric"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/system.HTTPError"
                         }
                     }
                 }
@@ -11077,7 +11077,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Returns the flat set of Bots in the org for the helix-org React Overview page.",
+                "description": "Returns the flat set of Nodes in the org for the helix-org React Overview page.",
                 "produces": [
                     "application/json"
                 ],
@@ -20984,7 +20984,7 @@
                 ],
                 "description": "List all triggers configurations for either user or the org or user within an org",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
                 "summary": "List all triggers configurations for either user or the org or user within an org",
                 "parameters": [
@@ -21019,11 +21019,11 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Create triggers for the app. Used to create standalone trigger configurations such as cron tasks for agents that could be owned by a different user than the owner of the app",
+                "description": "Create triggers for the agent. Used to create standalone trigger configurations such as cron tasks for agents that could be owned by a different user than the owner of the agent",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
-                "summary": "Create app triggers",
+                "summary": "Create agent triggers",
                 "parameters": [
                     {
                         "description": "Trigger configuration",
@@ -21052,11 +21052,11 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update triggers for the app, for example to change the cron schedule or enable/disable the trigger",
+                "description": "Update triggers for the agent, for example to change the cron schedule or enable/disable the trigger",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
-                "summary": "Update app triggers",
+                "summary": "Update agent triggers",
                 "parameters": [
                     {
                         "type": "string",
@@ -21090,11 +21090,11 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Delete triggers for the app",
+                "description": "Delete triggers for the agent",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
-                "summary": "Delete app triggers",
+                "summary": "Delete agent triggers",
                 "parameters": [
                     {
                         "type": "string",
@@ -21121,11 +21121,11 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Update triggers for the app, for example to change the cron schedule or enable/disable the trigger",
+                "description": "Update triggers for the agent, for example to change the cron schedule or enable/disable the trigger",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
-                "summary": "Execute app trigger",
+                "summary": "Execute agent trigger",
                 "parameters": [
                     {
                         "type": "string",
@@ -21154,7 +21154,7 @@
                 ],
                 "description": "List executions for the trigger",
                 "tags": [
-                    "apps"
+                    "agents"
                 ],
                 "summary": "List trigger executions",
                 "parameters": [
@@ -22473,6 +22473,9 @@
                 "agent_app_id": {
                     "type": "string"
                 },
+                "agent_id": {
+                    "type": "string"
+                },
                 "agent_model": {
                     "type": "string"
                 },
@@ -22566,6 +22569,9 @@
                 "agent_app_id": {
                     "type": "string"
                 },
+                "agent_id": {
+                    "type": "string"
+                },
                 "project_id": {
                     "type": "string"
                 },
@@ -22588,6 +22594,9 @@
                 "agent_app_id": {
                     "type": "string"
                 },
+                "agent_id": {
+                    "type": "string"
+                },
                 "project_id": {
                     "type": "string"
                 }
@@ -22597,6 +22606,9 @@
             "type": "object",
             "properties": {
                 "agent_app_id": {
+                    "type": "string"
+                },
+                "agent_id": {
                     "type": "string"
                 },
                 "agent_model": {
@@ -22684,7 +22696,10 @@
             "type": "object",
             "properties": {
                 "agent_app_id": {
-                    "description": "AgentAppID + ProjectID — see BotChatDTO comments.",
+                    "type": "string"
+                },
+                "agent_id": {
+                    "description": "AgentID + ProjectID — see BotChatDTO comments.",
                     "type": "string"
                 },
                 "bot": {
@@ -22763,7 +22778,7 @@
                     "type": "string"
                 },
                 "owner": {
-                    "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation - create_bot, delete_bot,\nset_bot_content, subscribe, ... - plus the read baseline) so it can\nhire and manage other Bots. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
+                    "description": "Owner makes this a manager Bot: it receives the canonical owner\ntool set (every org-graph mutation - create_bot, delete_bot,\nset_bot_content, subscribe, ... - plus the read baseline) so it can\nhire and manage other Nodes. When true, Tools is ignored in favour\nof that set. Used to seed a starter/root Bot for a new org.",
                     "type": "boolean"
                 },
                 "parent_id": {
@@ -24649,6 +24664,59 @@
                 }
             }
         },
+        "server.AgentCreateResponse": {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "$ref": "#/definitions/types.AgentConfig"
+                },
+                "created": {
+                    "type": "string"
+                },
+                "global": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_helix_org_agent": {
+                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
+                    "type": "boolean"
+                },
+                "model_substitutions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/server.ModelSubstitution"
+                    }
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "owner": {
+                    "description": "uuid of user ID",
+                    "type": "string"
+                },
+                "owner_type": {
+                    "description": "e.g. user, system, org",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.OwnerType"
+                        }
+                    ]
+                },
+                "updated": {
+                    "type": "string"
+                },
+                "user": {
+                    "description": "Owner user struct, populated by the server for organization views",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.User"
+                        }
+                    ]
+                }
+            }
+        },
         "server.AgentSandboxesDebugResponse": {
             "type": "object",
             "properties": {
@@ -24710,59 +24778,6 @@
                 "valid": {
                     "description": "that subscription passed its last liveness probe",
                     "type": "boolean"
-                }
-            }
-        },
-        "server.AppCreateResponse": {
-            "type": "object",
-            "properties": {
-                "config": {
-                    "$ref": "#/definitions/types.AppConfig"
-                },
-                "created": {
-                    "type": "string"
-                },
-                "global": {
-                    "type": "boolean"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_helix_org_agent": {
-                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
-                    "type": "boolean"
-                },
-                "model_substitutions": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/server.ModelSubstitution"
-                    }
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "owner": {
-                    "description": "uuid of user ID",
-                    "type": "string"
-                },
-                "owner_type": {
-                    "description": "e.g. user, system, org",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.OwnerType"
-                        }
-                    ]
-                },
-                "updated": {
-                    "type": "string"
-                },
-                "user": {
-                    "description": "Owner user struct, populated by the server for organization views",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.User"
-                        }
-                    ]
                 }
             }
         },
@@ -27186,6 +27201,122 @@
                 }
             }
         },
+        "types.Agent": {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "$ref": "#/definitions/types.AgentConfig"
+                },
+                "created": {
+                    "type": "string"
+                },
+                "global": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_helix_org_agent": {
+                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
+                    "type": "boolean"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "owner": {
+                    "description": "uuid of user ID",
+                    "type": "string"
+                },
+                "owner_type": {
+                    "description": "e.g. user, system, org",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.OwnerType"
+                        }
+                    ]
+                },
+                "updated": {
+                    "type": "string"
+                },
+                "user": {
+                    "description": "Owner user struct, populated by the server for organization views",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.User"
+                        }
+                    ]
+                }
+            }
+        },
+        "types.AgentConfig": {
+            "type": "object",
+            "properties": {
+                "allowed_domains": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "helix": {
+                    "$ref": "#/definitions/types.AgentHelixConfig"
+                },
+                "secrets": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "types.AgentHelixConfig": {
+            "type": "object",
+            "properties": {
+                "assistants": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.AssistantConfig"
+                    }
+                },
+                "avatar": {
+                    "type": "string"
+                },
+                "avatar_content_type": {
+                    "type": "string"
+                },
+                "default_agent_type": {
+                    "description": "Agent configuration",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.AgentType"
+                        }
+                    ]
+                },
+                "description": {
+                    "type": "string"
+                },
+                "external_agent_config": {
+                    "$ref": "#/definitions/types.ExternalAgentConfig"
+                },
+                "external_agent_enabled": {
+                    "type": "boolean"
+                },
+                "external_url": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "triggers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.Trigger"
+                    }
+                }
+            }
+        },
         "types.AgentType": {
             "type": "string",
             "enum": [
@@ -27316,122 +27447,6 @@
                 },
                 "type": {
                     "$ref": "#/definitions/types.APIKeyType"
-                }
-            }
-        },
-        "types.App": {
-            "type": "object",
-            "properties": {
-                "config": {
-                    "$ref": "#/definitions/types.AppConfig"
-                },
-                "created": {
-                    "type": "string"
-                },
-                "global": {
-                    "type": "boolean"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "is_helix_org_agent": {
-                    "description": "IsHelixOrgAgent is true when this app backs a Helix org-chart Worker\n(see api/pkg/org). Computed at list time, not persisted, so the frontend\ncan hide org-chart agents from the spec-task agent switchers.",
-                    "type": "boolean"
-                },
-                "organization_id": {
-                    "type": "string"
-                },
-                "owner": {
-                    "description": "uuid of user ID",
-                    "type": "string"
-                },
-                "owner_type": {
-                    "description": "e.g. user, system, org",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.OwnerType"
-                        }
-                    ]
-                },
-                "updated": {
-                    "type": "string"
-                },
-                "user": {
-                    "description": "Owner user struct, populated by the server for organization views",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.User"
-                        }
-                    ]
-                }
-            }
-        },
-        "types.AppConfig": {
-            "type": "object",
-            "properties": {
-                "allowed_domains": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "helix": {
-                    "$ref": "#/definitions/types.AppHelixConfig"
-                },
-                "secrets": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "types.AppHelixConfig": {
-            "type": "object",
-            "properties": {
-                "assistants": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.AssistantConfig"
-                    }
-                },
-                "avatar": {
-                    "type": "string"
-                },
-                "avatar_content_type": {
-                    "type": "string"
-                },
-                "default_agent_type": {
-                    "description": "Agent configuration",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/types.AgentType"
-                        }
-                    ]
-                },
-                "description": {
-                    "type": "string"
-                },
-                "external_agent_config": {
-                    "$ref": "#/definitions/types.ExternalAgentConfig"
-                },
-                "external_agent_enabled": {
-                    "type": "boolean"
-                },
-                "external_url": {
-                    "type": "string"
-                },
-                "image": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "triggers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/types.Trigger"
-                    }
                 }
             }
         },
@@ -29804,7 +29819,7 @@
             "type": "object",
             "properties": {
                 "app_config_snapshot": {
-                    "$ref": "#/definitions/types.AppConfig"
+                    "$ref": "#/definitions/types.AgentConfig"
                 },
                 "app_id": {
                     "type": "string"


### PR DESCRIPTION
## Summary

- make Agent the canonical API model while retaining App as a deprecated source alias
- expose /api/v1/agents and retain /api/v1/apps as an undocumented runtime alias
- migrate Helix consumers and org links to canonical agent naming while preserving storage and wire compatibility

## Tests

- go test ./pkg/org/... -count=1
- targeted server, DTO, and GORM tests
- go build ./pkg/server/ ./pkg/store/ ./pkg/types/ ./pkg/cli/spectask/
- yarn tsc --noEmit
- yarn build
- deployed to Prime at fc9eacf47