### PR TITLE
fix(test): update mock expectation to use GetSessionClaudeSubscription

### DIFF
--- a/api/pkg/server/claude_subscription_reclassify_test.go
+++ b/api/pkg/server/claude_subscription_reclassify_test.go
@@ -50,13 +50,14 @@ func (s *ReclassifySubAuthSuite) TestNonGenericErrorUnchanged() {
 
 // Generic error + subscription-mode session whose owner has NO subscription -> legible message naming the owner.
 func (s *ReclassifySubAuthSuite) TestNoSubscriptionProducesLegibleError() {
-	s.store.EXPECT().GetSession(gomock.Any(), "ses_1").Return(&types.Session{
+	session := &types.Session{
 		ID: "ses_1", ParentApp: "app_1", Owner: "usr_chris", OrganizationID: "org_1",
-	}, nil)
+	}
+	s.store.EXPECT().GetSession(gomock.Any(), "ses_1").Return(session, nil)
 	s.store.EXPECT().GetApp(gomock.Any(), "app_1").Return(subscriptionApp(), nil)
 	s.store.EXPECT().GetUser(gomock.Any(), &store.GetUserQuery{ID: "usr_chris"}).
 		Return(&types.User{ID: "usr_chris", Email: "chris@helix.ml"}, nil)
-	s.store.EXPECT().GetEffectiveClaudeSubscription(gomock.Any(), "usr_chris", "org_1").
+	s.store.EXPECT().GetSessionClaudeSubscription(gomock.Any(), session).
 		Return(nil, store.ErrNotFound)
 
 	got := s.server.maybeReclassifySubscriptionAuthError(context.Background(), "ses_1", genericAbort)


### PR DESCRIPTION
## Summary
The test `TestNoSubscriptionProducesLegibleError` in `claude_subscription_reclassify_test.go` expected `GetEffectiveClaudeSubscription` but commit e30bb10be changed the implementation in `websocket_external_agent_sync.go` to use `GetSessionClaudeSubscription`.

This updates the test mock expectation to match the current implementation.

## CI Failure
Build [#3156](https://drone.lukemarsden.net/helixml/helix/3156) failed with:
```
FAIL: github.com/helixml/helix/api/pkg/server / TestReclassifySubAuthSuite/TestNoSubscriptionProducesLegibleError
    Unexpected call to *store.MockStore.GetSessionClaudeSubscription([context.Background ...]) because: there are no expected calls of the method "GetSessionClaudeSubscription"
    missing call(s) to *store.MockStore.GetEffectiveClaudeSubscription(...)
```

## Root Cause
When commit e30bb10be (feat(api): route agent Claude auth to a delegated credential owner) introduced `GetSessionClaudeSubscription`, it updated the production code to use it, but did not update the test that was added earlier to mock the correct method.