### PR TITLE
Carry the credential owner into scheduled spec_task runs

### DIFF
--- a/api/pkg/trigger/cron/trigger_cron.go
+++ b/api/pkg/trigger/cron/trigger_cron.go
@@ -772,6 +772,13 @@ func executeSpecTaskAction(ctx context.Context, str store.Store, specTaskCreator
 		// Scheduled triggers explicitly want the task to run at the scheduled
 		// time, so skip backlog regardless of project AutoStartBacklogTasks.
 		AutoStart: true,
+		// A scheduled run must authenticate as the same person a hand-dispatched
+		// one does. Without this the agent falls back to the app owner — one
+		// service account for the whole fleet, so one expired token breaks every
+		// schedule at once and nobody can run their own agent on their own
+		// subscription. Empty keeps the old behaviour; the delegation check
+		// downstream still decides whether the grant actually exists.
+		CredentialOwnerID: trigger.CredentialOwnerID,
 	})
 	if err != nil {
 		return "", recordSpecTaskFailure(ctx, str, notifier, execution, startedAt, a, triggerID, trigger.Emails, err)

--- a/api/pkg/trigger/cron/trigger_cron_test.go
+++ b/api/pkg/trigger/cron/trigger_cron_test.go
@@ -757,6 +757,9 @@ func (suite *CronTestSuite) TestExecuteCronTask_SpecTaskAction() {
 			// Cron-scheduled tasks must auto-start so they skip backlog
 			// regardless of the project's AutoStartBacklogTasks setting.
 			suite.True(req.AutoStart, "cron-triggered spec tasks must be created with AutoStart=true")
+			// A trigger that names nobody must not invent a credential owner —
+			// the run keeps authenticating as the app owner, as it always has.
+			suite.Empty(req.CredentialOwnerID)
 			return &types.SpecTask{
 				ID:   "task-789",
 				Name: "Build the login page",
@@ -792,6 +795,51 @@ func (suite *CronTestSuite) TestExecuteCronTask_SpecTaskAction() {
 	)
 
 	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, mockCreator, nil, app, "test-user", "trigger-123", trigger, "test-session")
+	suite.NoError(err)
+	suite.Contains(result, "task-789")
+}
+
+// A scheduled run has to authenticate as the person it acts for, not as the one
+// service account whose key wrote every trigger. This pins the only link in that
+// chain that lives here: the owner named on the trigger reaches the task request,
+// where the delegation check downstream decides whether the grant is real.
+func (suite *CronTestSuite) TestExecuteCronTask_SpecTaskActionCarriesCredentialOwner() {
+	app := &types.App{
+		ID:        "app-123",
+		Owner:     "svc-account",
+		OwnerType: types.OwnerTypeUser,
+	}
+
+	trigger := &types.CronTrigger{
+		Input:             "Work the enterprise pipeline",
+		Action:            "spec_task",
+		ProjectID:         "proj-456",
+		CredentialOwnerID: "usr_chris",
+	}
+
+	mockCreator := &mockSpecTaskCreator{
+		createFunc: func(_ context.Context, req *types.CreateTaskRequest) (*types.SpecTask, error) {
+			suite.Equal("usr_chris", req.CredentialOwnerID)
+			// Credential resolution only — the task is still created by, and
+			// attributed to, the account that owns the app.
+			suite.Equal("svc-account", req.UserID)
+			return &types.SpecTask{ID: "task-789", Name: "Work the enterprise pipeline"}, nil
+		},
+	}
+
+	suite.store.EXPECT().CreateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {
+			return execution, nil
+		},
+	)
+	suite.notifier.EXPECT().Notify(gomock.Any(), gomock.Any()).Return(nil)
+	suite.store.EXPECT().UpdateTriggerExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, execution *types.TriggerExecution) (*types.TriggerExecution, error) {
+			return execution, nil
+		},
+	)
+
+	result, err := ExecuteCronTask(suite.ctx, suite.store, suite.controller, suite.notifier, mockCreator, nil, app, "svc-account", "trigger-123", trigger, "test-session")
 	suite.NoError(err)
 	suite.Contains(result, "task-789")
 }

--- a/api/pkg/types/types.go
+++ b/api/pkg/types/types.go
@@ -1808,6 +1808,16 @@ type CronTrigger struct {
 	CallbackURL string   `json:"callback_url,omitempty" yaml:"callback_url,omitempty"` // Webhook URL to POST on completion
 	Action      string   `json:"action,omitempty" yaml:"action,omitempty"`             // "session" (default) or "spec_task"
 	ProjectID   string   `json:"project_id,omitempty" yaml:"project_id,omitempty"`     // Target project for spec_task action
+
+	// CredentialOwnerID optionally names the user whose Claude subscription should
+	// authenticate the agent this trigger starts. An orchestrator writing triggers
+	// on people's behalf under one service API key sets it so a scheduled run
+	// authenticates as the person it acts for, exactly as CreateTaskRequest does
+	// for a run dispatched by hand. Credential resolution only: the task is still
+	// created by, owned by, and attributed to the trigger's app owner, and the
+	// named user must have delegated their subscription to this organization or it
+	// is ignored. Currently honoured by the spec_task action.
+	CredentialOwnerID string `json:"credential_owner_id,omitempty" yaml:"credential_owner_id,omitempty"`
 }
 
 // AzureDevOpsTrigger - once enabled, a trigger in the database will be created


### PR DESCRIPTION
Follow-up to #2899, which routed Claude credentials per owner but only for tasks
created through an orchestrator's dispatch call. That PR named the hole it left:

> **Known gap: scheduled runs are not routed.** HelixOS *scheduled* bot runs are
> Helix cron triggers: they fire inside Helix and create the task directly, so the
> field is never set […] This is a genuine hole, not a rounding error: it is the
> majority of runs.

This closes it.

## The change

`CronTrigger` gains `CredentialOwnerID`, and `executeSpecTaskAction` passes it to
`CreateTaskRequest` exactly as a hand-dispatched run does. Everything downstream
already works — the same delegation gate added in #2899 still decides whether the
grant is real, so a trigger naming someone who has not delegated their
subscription to the org falls back rather than borrowing their quota.

**Credential resolution only.** The task is still created by, owned by, and
attributed to the trigger's app owner; nothing runs *as* the credential owner.
Empty — which is every trigger that exists today — keeps current behaviour
exactly, so this is inert until something writes the field.

## Who sets it

Whatever writes the trigger. For HelixOS that is its reconciler, which knows each
bot's owner and writes it at reconcile time (paired PR in `helixml/helixos`).
Deriving it at fire time is not an option even in principle: Helix has no concept
of a HelixOS bot, so there is nothing on this side to derive an owner from. The
trigger row is the only thing that crosses the boundary.

Nothing in non-test server code constructs a `types.CronTrigger{}`, and the
trigger UI edits app-config triggers rather than the `TriggerConfiguration` rows
an orchestrator writes, so there is no path that would silently drop the field
back out on a round trip.

## Testing

`go build ./api/...`, `go vet`, and `go test ./pkg/trigger/cron/...` all pass.

- New `TestExecuteCronTask_SpecTaskActionCarriesCredentialOwner`: the owner named
  on the trigger reaches `CreateTaskRequest`, while `UserID` stays the app owner —
  pinning that this is credential routing and not an ownership change
- The existing spec_task test now also asserts that a trigger naming nobody does
  not invent an owner

**Not tested end to end.** No Helix stack was available, so no scheduled trigger
was fired against a live desktop to watch it pick up the named owner's
subscription. The link this PR adds is unit-tested; the resolution it hands off to
was covered by #2899.
