### PR TITLE
Cap the delegation list height in the Claude subscription card

### DIFF
--- a/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
+++ b/frontend/src/components/account/ClaudeSubscriptionConnect.tsx
@@ -31,6 +31,7 @@ import useSnackbar from '../../hooks/useSnackbar'
 import useLightTheme from '../../hooks/useLightTheme'
 import useAccount from '../../hooks/useAccount'
 import { getTokenExpiryStatus } from './claudeSubscriptionUtils'
+import { matchesAllTokens } from '../../utils/searchUtils'
 
 interface ClaudeSubscriptionData {
   id: string
@@ -65,6 +66,103 @@ interface ClaudeSubscriptionConnectProps {
   variant?: 'button' | 'inline' | 'account'
   onConnected?: () => void
   orgId?: string
+}
+
+// Above this many orgs the list gets a filter box. Below it, scanning is faster
+// than typing.
+const DELEGATION_FILTER_THRESHOLD = 8
+
+interface DelegationPickerProps {
+  organizations: { id?: string; name?: string; display_name?: string }[]
+  delegatedOrgIDs: string[]
+  disabled: boolean
+  onToggle: (orgID: string, enabled: boolean) => void
+}
+
+// DelegationPicker lists the orgs whose agents may run on this subscription.
+// It is scroll-capped because membership is unbounded — someone in 27 orgs was
+// getting 27 stacked switches, which pushed the card's own buttons a screen and
+// a half down. Granted orgs sort to the top so the answer to "who can spend my
+// quota" is visible without scrolling or hunting.
+const DelegationPicker: FC<DelegationPickerProps> = ({
+  organizations,
+  delegatedOrgIDs,
+  disabled,
+  onToggle,
+}) => {
+  const [filter, setFilter] = useState('')
+
+  const withIDs = organizations.filter((org) => !!org.id)
+  const labelFor = (org: { id?: string; name?: string; display_name?: string }) =>
+    org.display_name || org.name || (org.id as string)
+
+  const sorted = [...withIDs].sort((a, b) => {
+    const aOn = delegatedOrgIDs.includes(a.id as string)
+    const bOn = delegatedOrgIDs.includes(b.id as string)
+    if (aOn !== bOn) return aOn ? -1 : 1
+    return labelFor(a).localeCompare(labelFor(b))
+  })
+  const visible = sorted.filter((org) => matchesAllTokens(filter, labelFor(org), org.id))
+  const grantedCount = withIDs.filter((org) => delegatedOrgIDs.includes(org.id as string)).length
+
+  return (
+    <Box sx={{ mt: 1.5 }}>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+        Let these organizations&apos; agents use this subscription when they run work on your
+        behalf — for example a bot you own that is launched by a shared service account. Without
+        this, your subscription is only used for sessions you own.
+      </Typography>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+        {grantedCount === 0
+          ? `Not shared with any of your ${withIDs.length} organizations.`
+          : `Shared with ${grantedCount} of ${withIDs.length} organizations.`}
+      </Typography>
+      {withIDs.length > DELEGATION_FILTER_THRESHOLD && (
+        <TextField
+          size="small"
+          fullWidth
+          placeholder="Filter organizations"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          sx={{ mt: 1, maxWidth: 320 }}
+        />
+      )}
+      <Box
+        sx={{
+          mt: 0.5,
+          // Caps the card at a readable height however many orgs you are in.
+          maxHeight: 200,
+          overflowY: 'auto',
+          pr: 1,
+        }}
+      >
+        <FormGroup>
+          {visible.map((org) => {
+            const orgID = org.id as string
+            return (
+              <FormControlLabel
+                key={orgID}
+                control={
+                  <Switch
+                    size="small"
+                    checked={delegatedOrgIDs.includes(orgID)}
+                    disabled={disabled}
+                    onChange={(e) => onToggle(orgID, e.target.checked)}
+                  />
+                }
+                label={<Typography variant="caption">{labelFor(org)}</Typography>}
+              />
+            )
+          })}
+        </FormGroup>
+        {visible.length === 0 && (
+          <Typography variant="caption" color="text.secondary">
+            No organizations match &quot;{filter}&quot;.
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  )
 }
 
 const SETUP_TOKEN_COMMAND = 'claude setup-token'
@@ -445,7 +543,11 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
                       borderColor: subIsExpired ? 'error.main' : subExpiry?.isExpiringSoon ? 'warning.main' : 'divider',
                       display: 'flex',
                       justifyContent: 'space-between',
-                      alignItems: 'center',
+                      // Top-aligned, not centred: the delegation list makes this row
+                      // tall, and centring stranded Update Token / delete halfway down
+                      // the card, far from the subscription they act on.
+                      alignItems: 'flex-start',
+                      gap: 2,
                       mb: 1,
                     }}
                   >
@@ -504,37 +606,12 @@ const ClaudeSubscriptionConnect: FC<ClaudeSubscriptionConnectProps> = ({
                         </Typography>
                       )}
                       {variant === 'account' && sub.owner_type === 'user' && organizations.length > 0 && (
-                        <Box sx={{ mt: 1.5 }}>
-                          <Typography variant="caption" color="text.secondary">
-                            Let these organizations&apos; agents use this subscription when they run
-                            work on your behalf — for example a bot you own that is launched by a
-                            shared service account. Without this, your subscription is only used for
-                            sessions you own.
-                          </Typography>
-                          <FormGroup>
-                            {organizations.filter((org) => !!org.id).map((org) => {
-                              const orgID = org.id as string
-                              return (
-                                <FormControlLabel
-                                  key={orgID}
-                                  control={
-                                    <Switch
-                                      size="small"
-                                      checked={(sub.delegated_org_ids || []).includes(orgID)}
-                                      disabled={delegationMutation.isPending}
-                                      onChange={(e) => toggleDelegation(sub, orgID, e.target.checked)}
-                                    />
-                                  }
-                                  label={
-                                    <Typography variant="caption">
-                                      {org.display_name || org.name || orgID}
-                                    </Typography>
-                                  }
-                                />
-                              )
-                            })}
-                          </FormGroup>
-                        </Box>
+                        <DelegationPicker
+                          organizations={organizations}
+                          delegatedOrgIDs={sub.delegated_org_ids || []}
+                          disabled={delegationMutation.isPending}
+                          onToggle={(orgID, enabled) => toggleDelegation(sub, orgID, enabled)}
+                        />
                       )}
                     </Box>
                     <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>


### PR DESCRIPTION
The delegation toggles added in #2899 render one switch per org with no bound
on the list. Membership is unbounded, so an account in 27 orgs gets a card about
a screen and a half tall — and because the row is `alignItems: center`, Update
Token and the delete button end up stranded halfway down it, nowhere near the
subscription they act on.

It also doesn't help you answer the question the panel exists for. Most of those
27 are test orgs (`test`, `test`, `pizza`, `dough`, `sluuug`); the two that
matter are somewhere in an unsorted alphabetical run, and whether *any* grant is
active takes a scroll to find out.

## Changes

- **Scroll-capped list** (`maxHeight: 200`) — the card stays a readable height
  however many orgs you're in
- **Granted orgs sort to the top**, so active grants are visible without scrolling
- **Count line** — "Shared with 2 of 27 organizations" / "Not shared with any of
  your 27 organizations", so the answer is readable without expanding anything
- **Filter box past 8 orgs** — below that, scanning beats typing. Uses
  `matchesAllTokens` per the repo's search convention, not raw `.includes`
- **Actions top-align** (`alignItems: 'flex-start'` + `gap`) so Update Token and
  delete sit next to the subscription name

Extracted to a `DelegationPicker` component. Not cosmetic tidying — the filter
needs its own state and the block renders inside a `.map()` over subscriptions,
so a hook can't live there.

No behaviour change to delegation itself: same toggle, same mutation, same
owner-only endpoint and consent semantics from #2899.

## Testing

`npx tsc --noEmit` clean — the only error in the tree is the pre-existing
`sampleProjectIcons.tsx` one, unrelated and untouched here.

**NOT rendered in a browser.** There's no Helix dev stack in this environment
(`localhost:8080` refuses connections, no compose project up), and reproducing
the failure mode needs a user with a connected personal subscription and ~27 org
memberships. Please eyeball it: the card should now be a fixed, modest height
with the actions beside the title, and the list should scroll internally.

Unrelated to the rest of this branch's history — it's here because the remote
restricts pushes to `feature/002391-fix-critical-helixos` and `helix-specs`.
Single commit, reviewable on its own.
