### PR TITLE
Let an admin mint an API key on behalf of a user

### DIFF
--- a/api/pkg/server/admin_handlers_test.go
+++ b/api/pkg/server/admin_handlers_test.go
@@ -380,3 +380,134 @@ func TestAdminDeleteUser(t *testing.T) {
 		})
 	}
 }
+
+// The point of this endpoint is that an orchestrator stops putting a whole fleet
+// of people's agents on one shared account. These pin the three properties that
+// makes safe: only an admin may call it, the key really is owned by the target
+// user (not the caller), and it will not conjure an identity for someone who is
+// not already a Helix user — the boundary that still holds once the orchestrator
+// calling it is web-facing and anyone can sign up there.
+func TestAdminMintUserAPIKey(t *testing.T) {
+	admin := &types.User{ID: "admin-123", Email: "admin@example.com", Admin: true}
+
+	tests := []struct {
+		name           string
+		caller         *types.User
+		targetUserID   string
+		keyName        string
+		setupMocks     func(*store.MockStore)
+		expectedStatus int
+		expectedError  string
+		expectedKey    string
+	}{
+		{
+			name:         "mints a key owned by the target user",
+			caller:       admin,
+			targetUserID: "user-456",
+			keyName:      "helixos",
+			setupMocks: func(mockStore *store.MockStore) {
+				mockStore.EXPECT().
+					GetUser(gomock.Any(), &store.GetUserQuery{ID: "user-456"}).
+					Return(&types.User{ID: "user-456", Email: "chris@helix.ml"}, nil)
+				mockStore.EXPECT().
+					ListAPIKeys(gomock.Any(), gomock.Any()).
+					Return([]*types.ApiKey{}, nil)
+				mockStore.EXPECT().
+					CreateAPIKey(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, key *types.ApiKey) (*types.ApiKey, error) {
+						// The whole point: owned by them, not by the admin who asked.
+						assert.Equal(t, "user-456", key.Owner)
+						assert.Equal(t, types.OwnerTypeUser, key.OwnerType)
+						assert.Equal(t, "helixos", key.Name)
+						key.Key = "hl-minted"
+						return key, nil
+					})
+			},
+			expectedStatus: http.StatusOK,
+			expectedKey:    "hl-minted",
+		},
+		{
+			name:         "re-minting the same name returns the existing key",
+			caller:       admin,
+			targetUserID: "user-456",
+			keyName:      "helixos",
+			setupMocks: func(mockStore *store.MockStore) {
+				mockStore.EXPECT().
+					GetUser(gomock.Any(), &store.GetUserQuery{ID: "user-456"}).
+					Return(&types.User{ID: "user-456"}, nil)
+				mockStore.EXPECT().
+					ListAPIKeys(gomock.Any(), gomock.Any()).
+					Return([]*types.ApiKey{
+						{Key: "hl-existing", Name: "helixos", Owner: "user-456"},
+						{Key: "hl-other", Name: "cli", Owner: "user-456"},
+					}, nil)
+				// No CreateAPIKey: minting on every login must not pile up live
+				// credentials.
+			},
+			expectedStatus: http.StatusOK,
+			expectedKey:    "hl-existing",
+		},
+		{
+			name:           "non-admin is refused",
+			caller:         &types.User{ID: "user-789", Admin: false},
+			targetUserID:   "user-456",
+			keyName:        "helixos",
+			setupMocks:     func(_ *store.MockStore) {},
+			expectedStatus: http.StatusForbidden,
+			expectedError:  "only admins can mint API keys for other users",
+		},
+		{
+			name:         "will not mint for someone who is not a Helix user",
+			caller:       admin,
+			targetUserID: "signed-up-elsewhere",
+			keyName:      "helixos",
+			setupMocks: func(mockStore *store.MockStore) {
+				mockStore.EXPECT().
+					GetUser(gomock.Any(), &store.GetUserQuery{ID: "signed-up-elsewhere"}).
+					Return(nil, store.ErrNotFound)
+			},
+			expectedStatus: http.StatusNotFound,
+			expectedError:  "user not found",
+		},
+		{
+			name:           "name is required",
+			caller:         admin,
+			targetUserID:   "user-456",
+			keyName:        "",
+			setupMocks:     func(_ *store.MockStore) {},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "name is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockStore := store.NewMockStore(ctrl)
+			tt.setupMocks(mockStore)
+			server := &HelixAPIServer{Store: mockStore}
+
+			req := httptest.NewRequest(http.MethodPost,
+				"/api/v1/admin/users/"+tt.targetUserID+"/api-keys?name="+tt.keyName, nil)
+			req = mux.SetURLVars(req, map[string]string{"id": tt.targetUserID})
+			req = req.WithContext(setTestRequestUser(req.Context(), tt.caller))
+
+			result, httpErr := server.adminMintUserAPIKey(httptest.NewRecorder(), req)
+
+			if tt.expectedError != "" {
+				require.NotNil(t, httpErr)
+				assert.Contains(t, httpErr.Error(), tt.expectedError)
+				httpError, ok := httpErr.(*system.HTTPError)
+				require.True(t, ok, "expected *system.HTTPError")
+				assert.Equal(t, tt.expectedStatus, httpError.StatusCode)
+			} else {
+				require.Nil(t, httpErr)
+				require.NotNil(t, result)
+				assert.Equal(t, tt.expectedKey, result.Key)
+				assert.Equal(t, tt.targetUserID, result.Owner)
+			}
+		})
+	}
+}

--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -988,6 +988,80 @@ func (apiServer *HelixAPIServer) adminResetPassword(_ http.ResponseWriter, req *
 	return updatedUser, nil
 }
 
+// adminMintUserAPIKey godoc
+// @Summary Mint an API key for a user (Admin only)
+// @Description Create (or return the existing) named API key owned by another user, so a trusted orchestrator can act as the people it runs work for instead of putting the whole fleet on one shared account. Idempotent per (user, name).
+// @Tags    users
+// @Success 200 {object} types.ApiKey
+// @Param   id path string true "User ID"
+// @Param   name query string true "Key name, e.g. the orchestrator's slug"
+// @Router  /api/v1/admin/users/{id}/api-keys [post]
+// @Security BearerAuth
+func (apiServer *HelixAPIServer) adminMintUserAPIKey(_ http.ResponseWriter, req *http.Request) (*types.ApiKey, error) {
+	ctx := req.Context()
+	adminUser := getRequestUser(req)
+
+	if !adminUser.Admin {
+		return nil, system.NewHTTPError403("only admins can mint API keys for other users")
+	}
+
+	targetUserID := mux.Vars(req)["id"]
+	if targetUserID == "" {
+		return nil, system.NewHTTPError400("user ID is required")
+	}
+	name := req.URL.Query().Get("name")
+	if name == "" {
+		return nil, system.NewHTTPError400("name is required so the key is identifiable and re-mintable")
+	}
+
+	// The target must already be a Helix user. This is the boundary that keeps
+	// this endpoint safe once the orchestrator calling it is web-facing: signing
+	// up there must not be enough to get a Helix identity minted for you. Both
+	// sides share an IdP, so a person who has logged into Helix already has a row
+	// here; one who hasn't is not someone we will act as.
+	targetUser, err := apiServer.Store.GetUser(ctx, &store.GetUserQuery{ID: targetUserID})
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, system.NewHTTPError404("user not found")
+		}
+		return nil, system.NewHTTPError500("failed to get user: " + err.Error())
+	}
+
+	// Idempotent per (user, name): an orchestrator mints on every login, and a
+	// fresh key each time would leave a pile of live credentials behind.
+	existing, err := apiServer.Store.ListAPIKeys(ctx, &store.ListAPIKeysQuery{
+		Owner:     targetUserID,
+		OwnerType: types.OwnerTypeUser,
+	})
+	if err != nil {
+		return nil, system.NewHTTPError500("failed to list API keys: " + err.Error())
+	}
+	for _, key := range existing {
+		if key.Name == name {
+			return key, nil
+		}
+	}
+
+	created, err := apiServer.Store.CreateAPIKey(ctx, &types.ApiKey{
+		Owner:     targetUserID,
+		OwnerType: types.OwnerTypeUser,
+		Name:      name,
+		Type:      types.APIkeytypeAPI,
+	})
+	if err != nil {
+		return nil, system.NewHTTPError500("failed to create API key: " + err.Error())
+	}
+
+	log.Info().
+		Str("admin_id", adminUser.ID).
+		Str("target_user_id", targetUserID).
+		Str("target_user_email", targetUser.Email).
+		Str("key_name", name).
+		Msg("admin minted an API key on behalf of a user")
+
+	return created, nil
+}
+
 // adminDeleteUser godoc
 // @Summary Delete a user (Admin only)
 // @Description Permanently delete a user and all associated data. Only admins can use this endpoint.

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1261,6 +1261,7 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	adminRouter.HandleFunc("/users", system.DefaultWrapper(apiServer.createUser)).Methods(http.MethodPost)
 
 	adminRouter.HandleFunc("/admin/users/{id}/password", system.DefaultWrapper(apiServer.adminResetPassword)).Methods(http.MethodPut)
+	adminRouter.HandleFunc("/admin/users/{id}/api-keys", system.DefaultWrapper(apiServer.adminMintUserAPIKey)).Methods(http.MethodPost)
 	adminRouter.HandleFunc("/admin/users/{id}", system.DefaultWrapper(apiServer.adminDeleteUser)).Methods(http.MethodDelete)
 	adminRouter.HandleFunc("/admin/users/{id}/approve", system.DefaultWrapper(apiServer.adminApproveUser)).Methods(http.MethodPost)
 	adminRouter.HandleFunc("/admin/users/{id}/trial-activate", system.DefaultWrapper(apiServer.adminActivateTrial)).Methods(http.MethodPost)


### PR DESCRIPTION
Pairs with helixml/helixos#90.

An orchestrator that runs agents for a team currently holds one shared API key, so
Helix records every agent's work against that one account and resolves its Claude
subscription. One person's expired token breaks the whole fleet, and nobody can
run their own agent on their own subscription.

#2899 and #2900 addressed that by *routing credentials* — `CredentialOwnerID`
plus a delegation grant. That works, but the grant is org-shaped: it says "this
org's automation may spend my quota", which is broader than "my own agents may".

Holding a key per person removes the need for any of that. Sessions and triggers
the orchestrator creates are genuinely owned by the person, so their subscription
applies through Helix's ordinary resolution — no delegation, no new concepts.

## The endpoint

`POST /api/v1/admin/users/{id}/api-keys?name=…`, admin-only, returns the key.

- **Idempotent per (user, name).** An orchestrator mints on every login or
  reconcile pass; a fresh key each time would leave a pile of live credentials.
- **Refuses to mint for a subject with no Helix user.** This is the boundary that
  keeps it safe once the orchestrator is web-facing: signing up *there* must not
  be enough to get an identity minted *here*. Both sides share an IdP, so someone
  who has logged into Helix already has a row; someone who hasn't is not a person
  we will act as.

Nothing else changes. This is additive — no existing behaviour is touched.

## Why this is safe to add

The privilege already exists: an admin key can already do anything, including
minting keys. What changes is that the orchestrator's sessions stop all being
attributed to one service account, so "who ran this" becomes answerable — an
audit improvement, not just a credentials one.

Worth stating plainly, though: this lets an admin act as any user without their
involvement, which is exactly the property #2899's consent gate was designed to
avoid. That gate remains the right mechanism for member-to-member delegation.
This is for the narrower case of a trusted first-party orchestrator, where the
alternative is the whole fleet sharing one account.

## Testing

`go build ./pkg/server/` clean, `go test -run TestAdmin ./pkg/server/` passes.
Five new cases: the key is owned by the **target user** and not the caller;
re-minting the same name returns the existing key without creating another;
non-admins get 403; an unknown user gets 404 rather than a minted identity; and
name is required.

`go vet` reports two pre-existing issues in `mcp_backend_external.go`, untouched
here.

**NOT tested against a running stack** — no Helix dev stack in this environment.
The handler logic is unit-tested; the round trip from the orchestrator is not.

## Deploy note

The HelixOS service account on meta.helix.ml is **not currently an admin** —
verified: `GET /api/v1/users` returns 401 with its key. Until that's granted, the
paired PR mints nothing and every bot stays on the shared key, so both sides are
inert rather than broken.
