### PR TITLE
Generate key material when minting an API key for a user

### DIFF
--- a/api/pkg/server/admin_handlers_test.go
+++ b/api/pkg/server/admin_handlers_test.go
@@ -505,9 +505,7 @@ func TestAdminMintUserAPIKey(t *testing.T) {
 			if tt.expectedError != "" {
 				require.NotNil(t, httpErr)
 				assert.Contains(t, httpErr.Error(), tt.expectedError)
-				httpError, ok := httpErr.(*system.HTTPError)
-				require.True(t, ok, "expected *system.HTTPError")
-				assert.Equal(t, tt.expectedStatus, httpError.StatusCode)
+				assert.Equal(t, tt.expectedStatus, httpErr.StatusCode)
 			} else {
 				require.Nil(t, httpErr)
 				require.NotNil(t, result)

--- a/api/pkg/server/admin_handlers_test.go
+++ b/api/pkg/server/admin_handlers_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/helixml/helix/api/pkg/auth"
+	"github.com/helixml/helix/api/pkg/controller"
 	"github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/system"
 	"github.com/helixml/helix/api/pkg/types"
@@ -417,8 +418,10 @@ func TestAdminMintUserAPIKey(t *testing.T) {
 					DoAndReturn(func(_ context.Context, key *types.ApiKey) (*types.ApiKey, error) {
 						// The whole point: owned by them, not by the admin who asked.
 						assert.Equal(t, "user-456", key.Owner)
-						assert.Equal(t, types.OwnerTypeUser, key.OwnerType)
 						assert.Equal(t, "helixos", key.Name)
+						// Real key material, generated for us rather than left empty
+						// (the store rejects an unset Key).
+						assert.NotEmpty(t, key.Key)
 						key.Key = "hl-minted"
 						return key, nil
 					})
@@ -487,7 +490,10 @@ func TestAdminMintUserAPIKey(t *testing.T) {
 
 			mockStore := store.NewMockStore(ctrl)
 			tt.setupMocks(mockStore)
-			server := &HelixAPIServer{Store: mockStore}
+			server := &HelixAPIServer{
+				Store:      mockStore,
+				Controller: &controller.Controller{Options: controller.Options{Store: mockStore}},
+			}
 
 			req := httptest.NewRequest(http.MethodPost,
 				"/api/v1/admin/users/"+tt.targetUserID+"/api-keys?name="+tt.keyName, nil)

--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -997,7 +997,7 @@ func (apiServer *HelixAPIServer) adminResetPassword(_ http.ResponseWriter, req *
 // @Param   name query string true "Key name, e.g. the orchestrator's slug"
 // @Router  /api/v1/admin/users/{id}/api-keys [post]
 // @Security BearerAuth
-func (apiServer *HelixAPIServer) adminMintUserAPIKey(_ http.ResponseWriter, req *http.Request) (*types.ApiKey, error) {
+func (apiServer *HelixAPIServer) adminMintUserAPIKey(_ http.ResponseWriter, req *http.Request) (*types.ApiKey, *system.HTTPError) {
 	ctx := req.Context()
 	adminUser := getRequestUser(req)
 

--- a/api/pkg/server/handlers.go
+++ b/api/pkg/server/handlers.go
@@ -1042,11 +1042,12 @@ func (apiServer *HelixAPIServer) adminMintUserAPIKey(_ http.ResponseWriter, req 
 		}
 	}
 
-	created, err := apiServer.Store.CreateAPIKey(ctx, &types.ApiKey{
-		Owner:     targetUserID,
-		OwnerType: types.OwnerTypeUser,
-		Name:      name,
-		Type:      types.APIkeytypeAPI,
+	// Via the controller, not the store: it generates the key material and stamps
+	// the owner from the user passed in. Going straight to the store leaves Key
+	// empty, which it rejects with "key not specified".
+	created, err := apiServer.Controller.CreateAPIKey(ctx, targetUser, &types.ApiKey{
+		Name: name,
+		Type: types.APIkeytypeAPI,
 	})
 	if err != nil {
 		return nil, system.NewHTTPError500("failed to create API key: " + err.Error())

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -1261,7 +1261,10 @@ func (apiServer *HelixAPIServer) registerRoutes(ctx context.Context) (*mux.Route
 	adminRouter.HandleFunc("/users", system.DefaultWrapper(apiServer.createUser)).Methods(http.MethodPost)
 
 	adminRouter.HandleFunc("/admin/users/{id}/password", system.DefaultWrapper(apiServer.adminResetPassword)).Methods(http.MethodPut)
-	adminRouter.HandleFunc("/admin/users/{id}/api-keys", system.DefaultWrapper(apiServer.adminMintUserAPIKey)).Methods(http.MethodPost)
+	// system.Wrapper, not DefaultWrapper: DefaultWrapper flattens every error to
+	// 500, and a caller must be able to tell "this person has no Helix account"
+	// (expected, fall back quietly) from "Helix is broken" (shout).
+	adminRouter.HandleFunc("/admin/users/{id}/api-keys", system.Wrapper(apiServer.adminMintUserAPIKey)).Methods(http.MethodPost)
 	adminRouter.HandleFunc("/admin/users/{id}", system.DefaultWrapper(apiServer.adminDeleteUser)).Methods(http.MethodDelete)
 	adminRouter.HandleFunc("/admin/users/{id}/approve", system.DefaultWrapper(apiServer.adminApproveUser)).Methods(http.MethodPost)
 	adminRouter.HandleFunc("/admin/users/{id}/trial-activate", system.DefaultWrapper(apiServer.adminActivateTrial)).Methods(http.MethodPost)


### PR DESCRIPTION
Follow-up to #2902 — that endpoint 500s on every call.

It went straight to `Store.CreateAPIKey`, which requires `Key` to be populated
already and rejects an empty one:

```
POST /api/v1/admin/users/{id}/api-keys?name=probe
500  failed to create API key: key not specified
```

Caught by probing the deployed endpoint on meta.helix.ml rather than by the unit
tests, which mocked the store and so happily accepted a key with no key in it.
That's the tell: the mock was asserting my assumption back at me.

`Controller.CreateAPIKey` is the correct path and what the self-serve create
handler already uses — it calls `system.GenerateAPIKey()` and stamps
`Owner`/`OwnerType` from the user passed in, so handing it `targetUser` keeps the
"owned by them, not by the admin who asked" property that #2902 was built around.

## Testing

`go test -run TestAdmin ./pkg/server/` passes. The mint test now builds a real
`Controller` around the mock store instead of calling the store directly, and
asserts the created key actually has key material — the thing whose absence the
previous version couldn't see.

Verified against the live endpoint that the route is deployed and reached my
handler; will re-probe once this ships to confirm a key actually comes back.
