### PR TITLE
fix: return 404 for missing organizations

### DIFF
--- a/api/pkg/server/organization_handlers.go
+++ b/api/pkg/server/organization_handlers.go
@@ -199,7 +199,11 @@ func (apiServer *HelixAPIServer) getOrganization(rw http.ResponseWriter, r *http
 	organization, err := apiServer.lookupOrg(r.Context(), reference)
 	if err != nil {
 		log.Err(err).Msg("error getting organization")
-		http.Error(rw, "Could not get organization: "+err.Error(), http.StatusInternalServerError)
+		status := http.StatusInternalServerError
+		if errors.Is(err, store.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		http.Error(rw, "Could not get organization: "+err.Error(), status)
 		return
 	}
 

--- a/api/pkg/server/organization_handlers_test.go
+++ b/api/pkg/server/organization_handlers_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -168,6 +169,49 @@ func findSubstring(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestGetOrganization_ErrorStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		storeError     error
+		expectedStatus int
+	}{
+		{
+			name:           "organization not found",
+			storeError:     store.ErrNotFound,
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "store failure",
+			storeError:     errors.New("database unavailable"),
+			expectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockStore := store.NewMockStore(ctrl)
+			server := &HelixAPIServer{Store: mockStore}
+
+			orgID := "org_missing"
+			mockStore.EXPECT().GetOrganization(gomock.Any(), &store.GetOrganizationQuery{
+				ID: orgID,
+			}).Return(nil, tt.storeError)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/organizations/"+orgID, nil)
+			req = mux.SetURLVars(req, map[string]string{"id": orgID})
+			req = req.WithContext(setRequestUser(req.Context(), types.User{
+				ID: "user_1",
+			}))
+
+			rr := httptest.NewRecorder()
+			server.getOrganization(rr, req)
+
+			require.Equal(t, tt.expectedStatus, rr.Code)
+		})
+	}
 }
 
 func TestDeleteOrganization_OrganizationNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

- map wrapped `store.ErrNotFound` errors from organization lookup to HTTP 404
- preserve HTTP 500 for genuine store failures
- add regression coverage for both status-code paths

Closes #2780

## Why

`lookupOrg` preserves `store.ErrNotFound` with `%w`, but `getOrganization` previously mapped every lookup error to HTTP 500. Missing or deleted organizations are a normal not-found condition and should not be reported as server failures.

## Tests

- `go test ./api/pkg/server -run '^TestGetOrganization_ErrorStatus$' -count=1`
- `go test ./api/pkg/server -run '^Test(Get|Delete)Organization' -count=1`
- `git diff --check`