### PR TITLE
Add first-class MiniMax provider support

### DIFF
--- a/api/pkg/anthropic/anthropic_proxy.go
+++ b/api/pkg/anthropic/anthropic_proxy.go
@@ -206,6 +206,8 @@ func (s *Proxy) anthropicAPIProxyDirector(r *http.Request) {
 	}
 	r.URL.Host = u.Host
 	r.URL.Scheme = u.Scheme
+	r.URL.Path = joinAnthropicAPIPath(u.Path, r.URL.Path)
+	r.URL.RawPath = ""
 
 	r.Host = u.Host
 
@@ -214,12 +216,32 @@ func (s *Proxy) anthropicAPIProxyDirector(r *http.Request) {
 		r.Header.Set(key, value)
 	}
 
-	// If x-api-key not explicitly set in Headers, use endpoint.APIKey
-	// This allows Anthropic providers to use the standard APIKey field
-	// instead of requiring manual Headers["x-api-key"] configuration
-	if r.Header.Get("x-api-key") == "" && endpoint.APIKey != "" {
-		r.Header.Set("x-api-key", endpoint.APIKey)
+	if r.Header.Get("Authorization") == "" && r.Header.Get("x-api-key") == "" && endpoint.APIKey != "" {
+		if usesAnthropicBearerAuth(endpoint) {
+			r.Header.Set("Authorization", "Bearer "+endpoint.APIKey)
+		} else {
+			r.Header.Set("x-api-key", endpoint.APIKey)
+		}
 	}
+}
+
+func joinAnthropicAPIPath(basePath, requestPath string) string {
+	basePath = strings.TrimSuffix(basePath, "/")
+	if basePath == "" {
+		return requestPath
+	}
+	if strings.HasSuffix(basePath, "/v1") && (requestPath == "/v1" || strings.HasPrefix(requestPath, "/v1/")) {
+		return basePath + strings.TrimPrefix(requestPath, "/v1")
+	}
+	return basePath + "/" + strings.TrimPrefix(requestPath, "/")
+}
+
+func usesAnthropicBearerAuth(endpoint *types.ProviderEndpoint) bool {
+	if endpoint.APIFormat != types.ProviderAPIFormatAnthropic {
+		return false
+	}
+	u, err := url.Parse(endpoint.BaseURL)
+	return err != nil || !strings.EqualFold(u.Hostname(), "api.anthropic.com")
 }
 
 // getVertexTokenSource returns the appropriate OAuth2 token source for a Vertex request.

--- a/api/pkg/anthropic/anthropic_proxy_test.go
+++ b/api/pkg/anthropic/anthropic_proxy_test.go
@@ -290,3 +290,50 @@ func Test_stripDateFromModelName(t *testing.T) {
 		})
 	}
 }
+
+func TestAnthropicAPIProxyDirector_EndpointProtocol(t *testing.T) {
+	tests := []struct {
+		name       string
+		endpoint   *types.ProviderEndpoint
+		wantPath   string
+		wantBearer string
+		wantAPIKey string
+	}{
+		{
+			name: "MiniMax path and bearer authentication",
+			endpoint: &types.ProviderEndpoint{
+				Name:      string(types.ProviderMiniMax),
+				BaseURL:   types.MiniMaxGlobalAnthropicBaseURL,
+				APIFormat: types.ProviderAPIFormatAnthropic,
+				APIKey:    "provider-key",
+			},
+			wantPath:   "/anthropic/v1/messages",
+			wantBearer: "Bearer provider-key",
+		},
+		{
+			name: "native base does not duplicate v1",
+			endpoint: &types.ProviderEndpoint{
+				Name:    string(types.ProviderAnthropic),
+				BaseURL: "https://api.anthropic.com/v1",
+				APIKey:  "provider-key",
+			},
+			wantPath:   "/v1/messages",
+			wantAPIKey: "provider-key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://helix.example/v1/messages", nil)
+			req.Header.Set("Authorization", "Bearer helix-token")
+			req = SetRequestProviderEndpoint(req, tt.endpoint)
+
+			proxy := &Proxy{}
+			proxy.anthropicAPIProxyDirector(req)
+
+			assert.Equal(t, tt.wantPath, req.URL.Path)
+			assert.Equal(t, tt.wantBearer, req.Header.Get("Authorization"))
+			assert.Equal(t, tt.wantAPIKey, req.Header.Get("x-api-key"))
+		})
+	}
+}

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -472,6 +472,7 @@ type Providers struct {
 	OpenAI                    OpenAI
 	TogetherAI                TogetherAI
 	Anthropic                 Anthropic
+	MiniMax                   MiniMax
 	Helix                     Helix
 	VLLM                      VLLM
 	EnableCustomUserProviders bool   `envconfig:"ENABLE_CUSTOM_USER_PROVIDERS" default:"false"` // Allow users to configure their own providers, if "false" then only admins can add them
@@ -523,6 +524,58 @@ type Anthropic struct {
 	// Users can connect their Claude Pro/Max subscription via OAuth
 	OAuthClientID     string `envconfig:"ANTHROPIC_OAUTH_CLIENT_ID"`
 	OAuthClientSecret string `envconfig:"ANTHROPIC_OAUTH_CLIENT_SECRET"`
+}
+
+type MiniMax struct {
+	Region                string                  `envconfig:"MINIMAX_REGION" default:"global"`
+	APIFormat             types.ProviderAPIFormat `envconfig:"MINIMAX_API_FORMAT" default:"openai"`
+	OpenAIBaseURL         string                  `envconfig:"MINIMAX_OPENAI_BASE_URL"`
+	AnthropicBaseURL      string                  `envconfig:"MINIMAX_ANTHROPIC_BASE_URL"`
+	APIKey                string                  `envconfig:"MINIMAX_API_KEY"`
+	APIKeyFromFile        string                  `envconfig:"MINIMAX_API_KEY_FILE"`
+	APIKeyRefreshInterval time.Duration           `envconfig:"MINIMAX_API_KEY_REFRESH_INTERVAL" default:"3s"`
+	Models                []string                `envconfig:"MINIMAX_MODELS"`
+}
+
+func (c MiniMax) ResolvedAPIFormat() types.ProviderAPIFormat {
+	if c.APIFormat == types.ProviderAPIFormatAnthropic {
+		return types.ProviderAPIFormatAnthropic
+	}
+	return types.ProviderAPIFormatOpenAI
+}
+
+func (c MiniMax) ResolvedOpenAIBaseURL() string {
+	if c.OpenAIBaseURL != "" {
+		return strings.TrimSuffix(c.OpenAIBaseURL, "/")
+	}
+	if strings.EqualFold(c.Region, "cn") {
+		return types.MiniMaxCNOpenAIBaseURL
+	}
+	return types.MiniMaxGlobalOpenAIBaseURL
+}
+
+func (c MiniMax) ResolvedAnthropicBaseURL() string {
+	if c.AnthropicBaseURL != "" {
+		return strings.TrimSuffix(c.AnthropicBaseURL, "/")
+	}
+	if strings.EqualFold(c.Region, "cn") {
+		return types.MiniMaxCNAnthropicBaseURL
+	}
+	return types.MiniMaxGlobalAnthropicBaseURL
+}
+
+func (c MiniMax) ResolvedBaseURL() string {
+	if c.ResolvedAPIFormat() == types.ProviderAPIFormatAnthropic {
+		return c.ResolvedAnthropicBaseURL()
+	}
+	return c.ResolvedOpenAIBaseURL()
+}
+
+func (c MiniMax) ResolvedModels() []string {
+	if len(c.Models) > 0 {
+		return append([]string(nil), c.Models...)
+	}
+	return append([]string(nil), types.MiniMaxModels...)
 }
 
 type Helix struct {

--- a/api/pkg/config/minimax_test.go
+++ b/api/pkg/config/minimax_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/helixml/helix/api/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMiniMaxResolvedConfiguration(t *testing.T) {
+	tests := []struct {
+		name          string
+		cfg           MiniMax
+		wantOpenAI    string
+		wantAnthropic string
+		wantSelected  string
+	}{
+		{
+			name:          "global defaults",
+			cfg:           MiniMax{},
+			wantOpenAI:    types.MiniMaxGlobalOpenAIBaseURL,
+			wantAnthropic: types.MiniMaxGlobalAnthropicBaseURL,
+			wantSelected:  types.MiniMaxGlobalOpenAIBaseURL,
+		},
+		{
+			name: "China Anthropic-compatible endpoint",
+			cfg: MiniMax{
+				Region:    "cn",
+				APIFormat: types.ProviderAPIFormatAnthropic,
+			},
+			wantOpenAI:    types.MiniMaxCNOpenAIBaseURL,
+			wantAnthropic: types.MiniMaxCNAnthropicBaseURL,
+			wantSelected:  types.MiniMaxCNAnthropicBaseURL,
+		},
+		{
+			name: "custom endpoints are normalized",
+			cfg: MiniMax{
+				APIFormat:        types.ProviderAPIFormatAnthropic,
+				OpenAIBaseURL:    "https://openai.example/v1/",
+				AnthropicBaseURL: "https://anthropic.example/api/",
+			},
+			wantOpenAI:    "https://openai.example/v1",
+			wantAnthropic: "https://anthropic.example/api",
+			wantSelected:  "https://anthropic.example/api",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantOpenAI, tt.cfg.ResolvedOpenAIBaseURL())
+			assert.Equal(t, tt.wantAnthropic, tt.cfg.ResolvedAnthropicBaseURL())
+			assert.Equal(t, tt.wantSelected, tt.cfg.ResolvedBaseURL())
+		})
+	}
+
+	assert.Equal(t, types.MiniMaxModels, (MiniMax{}).ResolvedModels())
+}

--- a/api/pkg/external-agent/zed_config.go
+++ b/api/pkg/external-agent/zed_config.go
@@ -127,6 +127,7 @@ func GenerateZedMCPConfig(
 	// real pick — doing so made GLM/Goose agents boot as openai/gpt-4o while a
 	// sibling Claude agent (empty GenerationModel) worked.
 	var provider, model string
+	var providerAPIFormat types.ProviderAPIFormat
 	if assistant != nil {
 		provider = assistant.Provider
 		if provider == "" {
@@ -208,6 +209,7 @@ func GenerateZedMCPConfig(
 				Msg("zed-config: agent stores provider by name (legacy); re-save the agent so it stores the immutable provider ID")
 		}
 		provider = resolved.Name
+		providerAPIFormat = resolved.APIFormat
 	}
 
 	// Configure agent. AlwaysAllowToolActions / ShowOnboarding / AutoOpenPanel
@@ -222,7 +224,7 @@ func GenerateZedMCPConfig(
 		// Map Helix provider to Zed's provider type and format model name
 		// Zed only knows: anthropic, openai, google, ollama, copilot, lmstudio, deepseek
 		// All other providers (nebius, together, openrouter, etc.) use OpenAI-compatible API
-		zedProvider, zedModel := mapHelixToZedProvider(provider, model)
+		zedProvider, zedModel := mapHelixToZedProvider(provider, model, providerAPIFormat)
 		// Set feature-specific models to prevent Zed from using its hardcoded
 		// gpt-4.1-mini default for "fast" operations (see
 		// zed-industries/zed#31420). If not set, these fall back to
@@ -539,8 +541,9 @@ func getAPIKeyForProvider(provider string) string {
 // stored IDs. After such a fallback the agent should be re-saved so it picks
 // up the immutable reference.
 type ProviderRef struct {
-	ID   string // empty for env-baked global providers (openai, anthropic, ...)
-	Name string // current canonical name; for DB-backed providers this is the admin-set label
+	ID        string // empty for env-baked global providers
+	Name      string // current canonical name; for DB-backed providers this is the admin-set label
+	APIFormat types.ProviderAPIFormat
 }
 
 // FindZedExternalAssistant returns the assistant config that owns the
@@ -723,7 +726,7 @@ func buildLanguageModels(snapshot []ProviderRef, helixAPIURL string) map[string]
 	hasAnthropic := false
 	hasOpenAICompat := false
 	for _, p := range snapshot {
-		if strings.EqualFold(p.Name, "anthropic") {
+		if providerUsesAnthropicAPI(p.Name, p.APIFormat) {
 			hasAnthropic = true
 		} else {
 			hasOpenAICompat = true
@@ -754,11 +757,13 @@ func buildLanguageModels(snapshot []ProviderRef, helixAPIURL string) map[string]
 //	helixProvider="anthropic", model="claude-opus-4-8" → zedProvider="anthropic", zedModel="claude-opus-4-8"
 //	helixProvider="openai", model="gpt-4o" → zedProvider="openai", zedModel="openai/gpt-4o"
 //	helixProvider="nebius", model="Qwen/Qwen3-Coder" → zedProvider="openai", zedModel="nebius/Qwen/Qwen3-Coder"
-func mapHelixToZedProvider(helixProvider, model string) (zedProvider, zedModel string) {
-	provider := strings.ToLower(helixProvider)
+func mapHelixToZedProvider(helixProvider, model string, apiFormats ...types.ProviderAPIFormat) (zedProvider, zedModel string) {
+	var apiFormat types.ProviderAPIFormat
+	if len(apiFormats) > 0 {
+		apiFormat = apiFormats[0]
+	}
 
-	switch provider {
-	case "anthropic":
+	if providerUsesAnthropicAPI(helixProvider, apiFormat) {
 		// Zed discovers Anthropic models from the provider's /v1/models listing
 		// (Helix's proxy) and resolves agent.default_model by exact id. The stored
 		// model id already comes from that same listing (the picker sources it), so
@@ -767,13 +772,17 @@ func mapHelixToZedProvider(helixProvider, model string) (zedProvider, zedModel s
 		// form matches nothing, and Zed silently falls back to its built-in default
 		// (gpt-5-mini) — which has no Helix route, so the agent returns empty.
 		return "anthropic", model
-
-	default:
-		// All other providers (openai, nebius, together, openrouter, azure, google, etc.)
-		// route through Zed's OpenAI provider → Helix's OpenAI-compatible proxy.
-		// Model is prefixed with provider name so Helix can route to the correct backend.
-		return "openai", fmt.Sprintf("%s/%s", helixProvider, model)
 	}
+
+	// OpenAI-compatible endpoints route through Helix's chat-completions proxy.
+	return "openai", fmt.Sprintf("%s/%s", helixProvider, model)
+}
+
+func providerUsesAnthropicAPI(provider string, apiFormat types.ProviderAPIFormat) bool {
+	if apiFormat != "" {
+		return apiFormat == types.ProviderAPIFormatAnthropic
+	}
+	return strings.EqualFold(provider, string(types.ProviderAnthropic))
 }
 
 // GetZedConfigForSession retrieves Zed MCP config for a session

--- a/api/pkg/external-agent/zed_config_test.go
+++ b/api/pkg/external-agent/zed_config_test.go
@@ -37,6 +37,8 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 		dbScalewayPrime = ProviderRef{ID: dbScalewayID, Name: "scaleway-prime"} // same ID, renamed
 		dbGLMID         = "pe_glm_01"
 		dbGLM           = ProviderRef{ID: dbGLMID, Name: "glm-helix"}
+		dbMiniMaxID     = "pe_minimax_01"
+		dbMiniMax       = ProviderRef{ID: dbMiniMaxID, Name: "minimax", APIFormat: types.ProviderAPIFormatAnthropic}
 	)
 
 	cases := []struct {
@@ -132,6 +134,18 @@ func TestGenerateZedMCPConfig_AgentDefaultModel(t *testing.T) {
 			wantDefaultModel: &ModelConfig{Provider: "anthropic", Model: "claude-sonnet-4-5"},
 			wantMisconfig:    false,
 			why:              "control case: env-baked global (no ID) resolves by canonical name; anthropic model id passes through verbatim to match Zed's /v1/models listing",
+		},
+		{
+			name: "explicit Anthropic-compatible provider passes through",
+			assistants: []types.AssistantConfig{{
+				AgentType:               types.AgentTypeZedExternal,
+				GenerationModelProvider: dbMiniMaxID,
+				GenerationModel:         types.MiniMaxModelM3,
+			}},
+			snapshot:         []ProviderRef{dbMiniMax},
+			wantDefaultModel: &ModelConfig{Provider: "anthropic", Model: types.MiniMaxModelM3},
+			wantMisconfig:    false,
+			why:              "the saved API format controls Zed routing independently of the provider name",
 		},
 		{
 			name: "legacy_name_match_still_works_for_unsaved_agents",
@@ -238,6 +252,7 @@ func TestMapHelixToZedProvider(t *testing.T) {
 		name         string
 		provider     string
 		model        string
+		apiFormat    types.ProviderAPIFormat
 		wantProvider string
 		wantModel    string
 	}{
@@ -249,11 +264,13 @@ func TestMapHelixToZedProvider(t *testing.T) {
 		// OpenAI-compatible providers — prefixed so Helix routes to the backend.
 		{name: "openai prefixed", provider: "openai", model: "gpt-4o", wantProvider: "openai", wantModel: "openai/gpt-4o"},
 		{name: "nebius prefixed", provider: "nebius", model: "Qwen/Qwen3-Coder", wantProvider: "openai", wantModel: "nebius/Qwen/Qwen3-Coder"},
+		{name: "explicit Anthropic-compatible format", provider: "minimax", model: types.MiniMaxModelM3, apiFormat: types.ProviderAPIFormatAnthropic, wantProvider: "anthropic", wantModel: types.MiniMaxModelM3},
+		{name: "explicit OpenAI-compatible format", provider: "anthropic", model: "custom-model", apiFormat: types.ProviderAPIFormatOpenAI, wantProvider: "openai", wantModel: "anthropic/custom-model"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotProvider, gotModel := mapHelixToZedProvider(tt.provider, tt.model)
+			gotProvider, gotModel := mapHelixToZedProvider(tt.provider, tt.model, tt.apiFormat)
 			assert.Equal(t, tt.wantProvider, gotProvider)
 			assert.Equal(t, tt.wantModel, gotModel)
 		})
@@ -470,6 +487,17 @@ func TestBuildLanguageModels(t *testing.T) {
 			snapshot: []ProviderRef{
 				{Name: "Anthropic"},
 				{Name: "OpenAI"},
+			},
+			want: map[string]LanguageModelConfig{
+				"anthropic": {APIURL: helixURL},
+				"openai":    {APIURL: helixURL + "/v1"},
+			},
+		},
+		{
+			name: "explicit API formats override provider names",
+			snapshot: []ProviderRef{
+				{Name: "minimax", APIFormat: types.ProviderAPIFormatAnthropic},
+				{Name: "anthropic", APIFormat: types.ProviderAPIFormatOpenAI},
 			},
 			want: map[string]LanguageModelConfig{
 				"anthropic": {APIURL: helixURL},

--- a/api/pkg/model/model_info.go
+++ b/api/pkg/model/model_info.go
@@ -77,12 +77,70 @@ func NewBaseModelInfoProvider() (*BaseModelInfoProvider, error) {
 		}
 	}
 
+	for _, mi := range miniMaxModelInfo() {
+		data[mi.ProviderModelID] = mi
+	}
+	for _, baseURL := range []string{
+		types.MiniMaxGlobalOpenAIBaseURL,
+		types.MiniMaxGlobalAnthropicBaseURL,
+		types.MiniMaxCNOpenAIBaseURL,
+		types.MiniMaxCNAnthropicBaseURL,
+	} {
+		providers[baseURL] = string(types.ProviderMiniMax)
+	}
+
 	return &BaseModelInfoProvider{
 		dataMu:     &sync.RWMutex{},
 		data:       data,
 		normalized: normalized,
 		providers:  providers,
 	}, nil
+}
+
+func miniMaxModelInfo() []types.ModelInfo {
+	return []types.ModelInfo{
+		{
+			ProviderSlug:    string(types.ProviderMiniMax),
+			ProviderModelID: types.MiniMaxModelM3,
+			Slug:            string(types.ProviderMiniMax) + "/" + types.MiniMaxModelM3,
+			Permaslug:       string(types.ProviderMiniMax) + "/" + types.MiniMaxModelM3,
+			Name:            "MiniMax: MiniMax-M3",
+			Author:          string(types.ProviderMiniMax),
+			Description:     "MiniMax-M3 with adaptive reasoning and multimodal input.",
+			InputModalities: []types.Modality{
+				types.ModalityText,
+				types.ModalityImage,
+				types.ModalityVideo,
+			},
+			OutputModalities:  []types.Modality{types.ModalityText},
+			SupportsReasoning: true,
+			ContextLength:     1000000,
+			Pricing: types.Pricing{
+				Prompt:         "0.0000006",
+				Completion:     "0.0000024",
+				InputCacheRead: "0.00000012",
+			},
+		},
+		{
+			ProviderSlug:      string(types.ProviderMiniMax),
+			ProviderModelID:   types.MiniMaxModelM27,
+			Slug:              string(types.ProviderMiniMax) + "/" + types.MiniMaxModelM27,
+			Permaslug:         string(types.ProviderMiniMax) + "/" + types.MiniMaxModelM27,
+			Name:              "MiniMax: MiniMax-M2.7",
+			Author:            string(types.ProviderMiniMax),
+			Description:       "MiniMax-M2.7 with always-on reasoning.",
+			InputModalities:   []types.Modality{types.ModalityText},
+			OutputModalities:  []types.Modality{types.ModalityText},
+			SupportsReasoning: true,
+			ContextLength:     204800,
+			Pricing: types.Pricing{
+				Prompt:          "0.0000003",
+				Completion:      "0.0000012",
+				InputCacheRead:  "0.00000006",
+				InputCacheWrite: "0.000000375",
+			},
+		},
+	}
 }
 
 func toModelInfo(m ModelInfoData) types.ModelInfo {

--- a/api/pkg/model/model_info_test.go
+++ b/api/pkg/model/model_info_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -131,6 +132,34 @@ func Test_GetOpenAIo3Mini_CustomUserProvider(t *testing.T) {
 
 	assert.Equal(t, "OpenAI: o3 Mini", modelInfo.Name)
 	assert.Equal(t, "0.0000044", modelInfo.Pricing.Completion)
+}
+
+func Test_GetMiniMaxModels(t *testing.T) {
+	b, err := NewBaseModelInfoProvider()
+	require.NoError(t, err)
+
+	m3, err := b.GetModelInfo(context.Background(), &ModelInfoRequest{
+		BaseURL: types.MiniMaxGlobalAnthropicBaseURL,
+		Model:   types.MiniMaxModelM3,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1000000, m3.ContextLength)
+	assert.Equal(t, []types.Modality{types.ModalityText, types.ModalityImage, types.ModalityVideo}, m3.InputModalities)
+	assert.Equal(t, "0.0000006", m3.Pricing.Prompt)
+	assert.Equal(t, "0.0000024", m3.Pricing.Completion)
+	assert.Equal(t, "0.00000012", m3.Pricing.InputCacheRead)
+
+	m27, err := b.GetModelInfo(context.Background(), &ModelInfoRequest{
+		BaseURL: types.MiniMaxCNOpenAIBaseURL,
+		Model:   types.MiniMaxModelM27,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 204800, m27.ContextLength)
+	assert.Equal(t, []types.Modality{types.ModalityText}, m27.InputModalities)
+	assert.Equal(t, "0.0000003", m27.Pricing.Prompt)
+	assert.Equal(t, "0.0000012", m27.Pricing.Completion)
+	assert.Equal(t, "0.00000006", m27.Pricing.InputCacheRead)
+	assert.Equal(t, "0.000000375", m27.Pricing.InputCacheWrite)
 }
 
 func Test_GetClaudeSonnet4(t *testing.T) {

--- a/api/pkg/openai/manager/anthropic_endpoint_test.go
+++ b/api/pkg/openai/manager/anthropic_endpoint_test.go
@@ -21,6 +21,8 @@ func TestIsAnthropicAPIEndpoint(t *testing.T) {
 		{"base url match", types.ProviderEndpoint{Name: "custom", BaseURL: "https://api.anthropic.com/v1"}, true},
 		{"lookalike host not matched", types.ProviderEndpoint{Name: "custom", BaseURL: "https://api.anthropic.com.proxy.evil.com/v1"}, false},
 		{"openai", types.ProviderEndpoint{Name: "openai", BaseURL: "https://api.openai.com/v1"}, false},
+		{"explicit anthropic format", types.ProviderEndpoint{Name: "custom", BaseURL: "https://api.example/anthropic", APIFormat: types.ProviderAPIFormatAnthropic}, true},
+		{"explicit openai format overrides name", types.ProviderEndpoint{Name: "anthropic", BaseURL: "https://api.anthropic.com/v1", APIFormat: types.ProviderAPIFormatOpenAI}, false},
 		{"renamed proxy (known gap)", types.ProviderEndpoint{Name: "claude-prod", BaseURL: "https://gw.internal/anthropic"}, false},
 		{"vertex anthropic excluded", types.ProviderEndpoint{Name: "anthropic", VertexProjectID: "proj-1"}, false},
 		{"vertex googleapis not matched", types.ProviderEndpoint{Name: "x", BaseURL: "https://anthropic.googleapis.com"}, false},
@@ -46,6 +48,7 @@ func (suite *MultiClientManagerTestSuite) Test_InitializeClient_AnthropicAuth() 
 		{"anthropic by name", types.ProviderEndpoint{Name: "anthropic", APIKey: "test-key"}, true},
 		{"Anthropic display name", types.ProviderEndpoint{Name: "Anthropic", APIKey: "test-key"}, true},
 		{"openai falls through to bearer", types.ProviderEndpoint{Name: "openai", APIKey: "test-key"}, false},
+		{"explicit Anthropic-compatible endpoint uses bearer", types.ProviderEndpoint{Name: "minimax", APIKey: "test-key", APIFormat: types.ProviderAPIFormatAnthropic}, false},
 		{"vertex excluded -> bearer", types.ProviderEndpoint{Name: "anthropic", VertexProjectID: "proj-1", APIKey: "test-key"}, false},
 	}
 

--- a/api/pkg/openai/manager/provider_manager.go
+++ b/api/pkg/openai/manager/provider_manager.go
@@ -149,6 +149,23 @@ func NewProviderManager(cfg *config.ServerConfig, store store.Store, helixInfere
 		clients[types.ProviderAnthropic] = &providerClient{client: loggedClient}
 	}
 
+	if cfg.Providers.MiniMax.APIKey != "" {
+		baseURL := cfg.Providers.MiniMax.ResolvedOpenAIBaseURL()
+		log.Info().
+			Str("base_url", baseURL).
+			Msg("using MiniMax provider for controller inference")
+
+		miniMaxClient := openai.NewWithOptions(
+			cfg.Providers.MiniMax.APIKey,
+			baseURL,
+			cfg.Stripe.BillingEnabled,
+			tlsOpts,
+			cfg.Providers.MiniMax.ResolvedModels()...)
+
+		loggedClient := logger.Wrap(cfg, types.ProviderMiniMax, miniMaxClient, modelInfoProvider, billingLogger, logStores...)
+		clients[types.ProviderMiniMax] = &providerClient{client: loggedClient}
+	}
+
 	// For VLLM, as long as the base URL is set, we can use it
 	if cfg.Providers.VLLM.BaseURL != "" {
 		log.Info().
@@ -204,6 +221,13 @@ func (m *MultiClientManager) StartRefresh(ctx context.Context) {
 		err := m.watchAndUpdateClient(ctx, types.ProviderAnthropic, m.cfg.Providers.Anthropic.APIKeyRefreshInterval, m.cfg.Providers.Anthropic.BaseURL, m.cfg.Providers.Anthropic.APIKeyFromFile)
 		if err != nil {
 			log.Error().Err(err).Msg("error watching and updating Anthropic client")
+		}
+	}
+
+	if m.cfg.Providers.MiniMax.APIKeyFromFile != "" {
+		err := m.watchAndUpdateClient(ctx, types.ProviderMiniMax, m.cfg.Providers.MiniMax.APIKeyRefreshInterval, m.cfg.Providers.MiniMax.ResolvedOpenAIBaseURL(), m.cfg.Providers.MiniMax.APIKeyFromFile)
+		if err != nil {
+			log.Error().Err(err).Msg("error watching and updating MiniMax client")
 		}
 	}
 
@@ -283,9 +307,13 @@ func (m *MultiClientManager) updateClientAPIKeyFromFile(provider types.Provider,
 	}
 
 	// Recreate the client with the new key
+	var models []string
+	if provider == types.ProviderMiniMax {
+		models = m.cfg.Providers.MiniMax.ResolvedModels()
+	}
 	openaiClient := openai.NewWithOptions(newKey, baseURL, m.cfg.Stripe.BillingEnabled, openai.ClientOptions{
 		TLSSkipVerify: m.cfg.Tools.TLSSkipVerify,
-	})
+	}, models...)
 
 	// Preserve x-api-key auth across key rotation for the Anthropic global provider.
 	if provider == types.ProviderAnthropic {
@@ -355,10 +383,16 @@ func (m *MultiClientManager) ListProviderEndpoints(ctx context.Context, owner st
 	m.globalClientsMu.RLock()
 	endpoints := make([]*types.ProviderEndpoint, 0, len(m.globalClients))
 	for provider := range m.globalClients {
-		endpoints = append(endpoints, &types.ProviderEndpoint{
+		endpoint := &types.ProviderEndpoint{
 			Name:         string(provider),
 			EndpointType: types.ProviderEndpointTypeGlobal,
-		})
+		}
+		if provider == types.ProviderMiniMax {
+			endpoint.BaseURL = m.cfg.Providers.MiniMax.ResolvedBaseURL()
+			endpoint.APIFormat = m.cfg.Providers.MiniMax.ResolvedAPIFormat()
+			endpoint.Models = m.cfg.Providers.MiniMax.ResolvedModels()
+		}
+		endpoints = append(endpoints, endpoint)
 	}
 	m.globalClientsMu.RUnlock()
 
@@ -439,6 +473,9 @@ func isAnthropicAPIEndpoint(endpoint *types.ProviderEndpoint) bool {
 	if endpoint.VertexProjectID != "" {
 		return false
 	}
+	if endpoint.APIFormat != "" {
+		return endpoint.APIFormat == types.ProviderAPIFormatAnthropic
+	}
 	if strings.EqualFold(endpoint.Name, string(types.ProviderAnthropic)) {
 		return true
 	}
@@ -448,6 +485,13 @@ func isAnthropicAPIEndpoint(endpoint *types.ProviderEndpoint) bool {
 		return strings.EqualFold(u.Hostname(), "api.anthropic.com")
 	}
 	return false
+}
+
+func isNativeAnthropicAPIEndpoint(endpoint *types.ProviderEndpoint) bool {
+	if u, err := url.Parse(endpoint.BaseURL); err == nil && u.Hostname() != "" {
+		return strings.EqualFold(u.Hostname(), "api.anthropic.com")
+	}
+	return endpoint.APIFormat == "" && strings.EqualFold(endpoint.Name, string(types.ProviderAnthropic))
 }
 
 func (m *MultiClientManager) initializeClient(endpoint *types.ProviderEndpoint) (openai.Client, error) {
@@ -477,7 +521,11 @@ func (m *MultiClientManager) initializeClient(endpoint *types.ProviderEndpoint) 
 	// DB/UI-configured Anthropic providers must use x-api-key auth (not Bearer) for
 	// /v1/models. See isAnthropicAPIEndpoint.
 	if isAnthropicAPIEndpoint(endpoint) {
-		openaiClient.SetIsAnthropic(true)
+		if endpoint.APIFormat == types.ProviderAPIFormatAnthropic && !isNativeAnthropicAPIEndpoint(endpoint) {
+			openaiClient.SetAnthropicBearerAuth(true)
+		} else {
+			openaiClient.SetIsAnthropic(true)
+		}
 	}
 
 	// If it's a personal endpoint, replace the billing logger with a NoopBillingLogger

--- a/api/pkg/openai/manager/provider_manager_test.go
+++ b/api/pkg/openai/manager/provider_manager_test.go
@@ -56,6 +56,31 @@ func (suite *MultiClientManagerTestSuite) Test_VLLM() {
 	suite.NotNil(client)
 }
 
+func (suite *MultiClientManagerTestSuite) Test_MiniMaxGlobalProvider() {
+	suite.cfg.Providers.MiniMax = config.MiniMax{
+		APIKey:    "test-key",
+		Region:    "cn",
+		APIFormat: types.ProviderAPIFormatAnthropic,
+	}
+
+	manager := NewProviderManager(suite.cfg, suite.store, nil, suite.modelInfoProvider)
+	client, err := manager.GetClient(context.Background(), &GetClientRequest{Provider: string(types.ProviderMiniMax)})
+	suite.Require().NoError(err)
+	suite.Equal(types.MiniMaxCNOpenAIBaseURL, client.BaseURL())
+
+	endpoints, err := manager.ListProviderEndpoints(context.Background(), "")
+	suite.Require().NoError(err)
+	for _, endpoint := range endpoints {
+		if endpoint.Name == string(types.ProviderMiniMax) {
+			suite.Equal(types.MiniMaxCNAnthropicBaseURL, endpoint.BaseURL)
+			suite.Equal(types.ProviderAPIFormatAnthropic, endpoint.APIFormat)
+			suite.Equal(types.MiniMaxModels, []string(endpoint.Models))
+			return
+		}
+	}
+	suite.Fail("MiniMax endpoint was not listed")
+}
+
 func (suite *MultiClientManagerTestSuite) Test_WatchAndUpdateClient() {
 	// Create a temporary file for testing
 	tmpDir := suite.T().TempDir()

--- a/api/pkg/openai/openai_client.go
+++ b/api/pkg/openai/openai_client.go
@@ -118,18 +118,25 @@ func NewWithOptions(apiKey string, baseURL string, billingEnabled bool, opts Cli
 type RetryableClient struct {
 	apiClient *openai.Client
 
-	httpClient     *http.Client
-	baseURL        string
-	apiKey         string
-	models         []string
-	billingEnabled bool
-	isAnthropic    bool // true if this client is for an Anthropic-compatible provider
+	httpClient          *http.Client
+	baseURL             string
+	apiKey              string
+	models              []string
+	billingEnabled      bool
+	isAnthropic         bool // true if this client is for an Anthropic-compatible provider
+	anthropicBearerAuth bool
 }
 
 // SetIsAnthropic marks this client as an Anthropic-compatible provider.
 // This is used to determine the correct API format for model listing.
 func (c *RetryableClient) SetIsAnthropic(isAnthropic bool) {
 	c.isAnthropic = isAnthropic
+}
+
+// SetAnthropicBearerAuth uses bearer authentication for an Anthropic-compatible API.
+func (c *RetryableClient) SetAnthropicBearerAuth(enabled bool) {
+	c.isAnthropic = enabled
+	c.anthropicBearerAuth = enabled
 }
 
 // APIKey - returns the API key used by the client, used for testing

--- a/api/pkg/openai/openai_client_anthropic.go
+++ b/api/pkg/openai/openai_client_anthropic.go
@@ -52,7 +52,11 @@ func (c *RetryableClient) listAnthropicModels(ctx context.Context) ([]types.Open
 	}
 
 	req.Header.Set("anthropic-version", "2023-06-01")
-	req.Header.Set("x-api-key", c.apiKey)
+	if c.anthropicBearerAuth {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	} else {
+		req.Header.Set("x-api-key", c.apiKey)
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/api/pkg/server/anthropic_api_proxy_handler.go
+++ b/api/pkg/server/anthropic_api_proxy_handler.go
@@ -137,6 +137,9 @@ func (s *HelixAPIServer) anthropicAPIProxyHandler(w http.ResponseWriter, r *http
 // /v1/messages API format. Currently only the built-in "anthropic" provider and
 // endpoints whose base URL points to Anthropic's API (or a Vertex AI proxy) qualify.
 func isAnthropicCompatible(ep *types.ProviderEndpoint) bool {
+	if ep.APIFormat != "" {
+		return ep.APIFormat == types.ProviderAPIFormatAnthropic
+	}
 	if ep.Name == string(types.ProviderAnthropic) {
 		return true
 	}
@@ -301,7 +304,35 @@ func (s *HelixAPIServer) getProviderEndpoint(ctx context.Context, user *types.Us
 // — and the synthetic carries enough (Name, EndpointType=Global) to drive that
 // branch instead of the cryptic "provider %q not found" error.
 func (s *HelixAPIServer) getBuiltInProviderEndpoint(ctx context.Context, provider string) (*types.ProviderEndpoint, error) {
-	if provider != string(types.ProviderAnthropic) {
+	if strings.EqualFold(provider, string(types.ProviderMiniMax)) {
+		apiKey := s.Cfg.Providers.MiniMax.APIKey
+		if apiKey == "" && s.Cfg.Providers.MiniMax.APIKeyFromFile != "" {
+			data, err := os.ReadFile(s.Cfg.Providers.MiniMax.APIKeyFromFile)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read MINIMAX_API_KEY_FILE: %w", err)
+			}
+			apiKey = strings.TrimSpace(string(data))
+		}
+		if apiKey == "" {
+			return nil, fmt.Errorf("minimax provider not configured: set MINIMAX_API_KEY or MINIMAX_API_KEY_FILE")
+		}
+
+		return &types.ProviderEndpoint{
+			ID:             string(types.ProviderMiniMax),
+			Name:           string(types.ProviderMiniMax),
+			Description:    "Built-in MiniMax provider",
+			BaseURL:        s.Cfg.Providers.MiniMax.ResolvedBaseURL(),
+			APIFormat:      s.Cfg.Providers.MiniMax.ResolvedAPIFormat(),
+			APIKey:         apiKey,
+			Models:         s.Cfg.Providers.MiniMax.ResolvedModels(),
+			EndpointType:   types.ProviderEndpointTypeGlobal,
+			Owner:          string(types.OwnerTypeSystem),
+			OwnerType:      types.OwnerTypeSystem,
+			BillingEnabled: s.Cfg.Providers.BillingEnabled,
+		}, nil
+	}
+
+	if !strings.EqualFold(provider, string(types.ProviderAnthropic)) {
 		// Resolve env-baked globals (openai etc.) from the provider manager so
 		// callers get a real endpoint they can interrogate, not a "not found".
 		if s.providerManager != nil {

--- a/api/pkg/server/anthropic_api_proxy_handler_test.go
+++ b/api/pkg/server/anthropic_api_proxy_handler_test.go
@@ -326,7 +326,25 @@ func Test_isAnthropicCompatible(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "empty endpoint is not anthropic compatible",
+			name: "explicit Anthropic-compatible format",
+			endpoint: &types.ProviderEndpoint{
+				Name:      string(types.ProviderMiniMax),
+				BaseURL:   types.MiniMaxGlobalAnthropicBaseURL,
+				APIFormat: types.ProviderAPIFormatAnthropic,
+			},
+			want: true,
+		},
+		{
+			name: "explicit OpenAI-compatible format overrides name",
+			endpoint: &types.ProviderEndpoint{
+				Name:      string(types.ProviderAnthropic),
+				BaseURL:   "https://api.anthropic.com/v1",
+				APIFormat: types.ProviderAPIFormatOpenAI,
+			},
+			want: false,
+		},
+		{
+			name:     "empty endpoint is not anthropic compatible",
 			endpoint: &types.ProviderEndpoint{},
 			want:     false,
 		},
@@ -338,6 +356,26 @@ func Test_isAnthropicCompatible(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func Test_getBuiltInProviderEndpoint_MiniMax(t *testing.T) {
+	server := &HelixAPIServer{Cfg: &config.ServerConfig{
+		Providers: config.Providers{
+			BillingEnabled: true,
+			MiniMax: config.MiniMax{
+				APIKey:    "test-key",
+				Region:    "cn",
+				APIFormat: types.ProviderAPIFormatAnthropic,
+			},
+		},
+	}}
+
+	endpoint, err := server.getBuiltInProviderEndpoint(context.Background(), string(types.ProviderMiniMax))
+	require.NoError(t, err)
+	assert.Equal(t, types.MiniMaxCNAnthropicBaseURL, endpoint.BaseURL)
+	assert.Equal(t, types.ProviderAPIFormatAnthropic, endpoint.APIFormat)
+	assert.Equal(t, types.MiniMaxModels, []string(endpoint.Models))
+	assert.True(t, endpoint.BillingEnabled)
 }
 
 func Test_getBuiltInProviderEndpoint_envBakedNonAnthropic(t *testing.T) {

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -838,6 +838,44 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/admin/users/{id}/api-keys": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create (or return the existing) named API key owned by another user, so a trusted orchestrator can act as the people it runs work for instead of putting the whole fleet on one shared account. Idempotent per (user, name).",
+                "tags": [
+                    "users"
+                ],
+                "summary": "Mint an API key for a user (Admin only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Key name, e.g. the orchestrator's slug",
+                        "name": "name",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.ApiKey"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/users/{id}/approve": {
             "post": {
                 "security": [
@@ -3392,18 +3430,26 @@ const docTemplate = `{
                         }
                     }
                 }
-            },
-            "delete": {
+            }
+        },
+        "/api/v1/claude-subscriptions/{id}/delegation": {
+            "put": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
-                "description": "Disconnect a Claude subscription",
+                "description": "Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Only the subscription owner may change this.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
                 "tags": [
                     "Claude"
                 ],
-                "summary": "Delete a Claude subscription",
+                "summary": "Set which orgs may use a Claude subscription for delegated agent runs",
                 "parameters": [
                     {
                         "type": "string",
@@ -3411,16 +3457,28 @@ const docTemplate = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Delegated organizations",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.UpdateClaudeSubscriptionDelegationRequest"
+                        }
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/types.ClaudeSubscription"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
                         }
                     },
                     "401": {
@@ -26788,6 +26846,18 @@ const docTemplate = `{
                 }
             }
         },
+        "server.UpdateClaudeSubscriptionDelegationRequest": {
+            "description": "Disconnect a Claude subscription",
+            "type": "object",
+            "properties": {
+                "delegated_org_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "server.VideoStreamingStats": {
             "type": "object",
             "properties": {
@@ -28556,6 +28626,13 @@ const docTemplate = `{
                     "description": "\"oauth\" or \"setup_token\"",
                     "type": "string"
                 },
+                "delegated_org_ids": {
+                    "description": "DelegatedOrgIDs lists the organizations whose agent sessions may\nauthenticate with this subscription on the owner's behalf, even when the\nsession itself is owned by someone else (a service account dispatching\nwork for this person — see SpecTask.CredentialOwnerID).\n\nThis is the consent gate. Without it, any member who can create a task\ncould name another user as credential owner and spend their Claude quota.\nEmpty (the default) means the subscription is only ever used for sessions\nits owner owns, which is the pre-existing behaviour.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "id": {
                     "type": "string"
                 },
@@ -28929,6 +29006,10 @@ const docTemplate = `{
                             "$ref": "#/definitions/types.CodeAgentRuntime"
                         }
                     ]
+                },
+                "uses_subscription": {
+                    "description": "UsesSubscription is true when the agent authenticates against the upstream\nprovider with the user's own subscription (Claude Pro/Max, ChatGPT) instead\nof an API key routed through the Helix proxy. It mirrors the assistant's\nCodeAgentCredentialType and is what gates credential injection into the\ncontainer — an api_key agent must never receive subscription credentials,\nbecause the CLI prefers them over the proxy and would silently bypass it.",
+                    "type": "boolean"
                 }
             }
         },
@@ -29456,6 +29537,10 @@ const docTemplate = `{
                     "description": "For new mode: user-specified prefix (task# appended)",
                     "type": "string"
                 },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate this task's agent, for orchestrators dispatching work on a\nhuman's behalf under one service API key. Credential resolution only — the\ntask is still created by, owned by, and attributed to the caller. Ignored\nunless that user has delegated their subscription to this organization.",
+                    "type": "string"
+                },
                 "depends_on": {
                     "description": "Optional: IDs of tasks this task depends on",
                     "type": "array",
@@ -29569,6 +29654,10 @@ const docTemplate = `{
                 },
                 "callback_url": {
                     "description": "Webhook URL to POST on completion",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate the agent this trigger starts. An orchestrator writing triggers\non people's behalf under one service API key sets it so a scheduled run\nauthenticates as the person it acts for, exactly as CreateTaskRequest does\nfor a run dispatched by hand. Credential resolution only: the task is still\ncreated by, owned by, and attributed to the trigger's app owner, and the\nnamed user must have delegated their subscription to this organization or it\nis ignored. Currently honoured by the spec_task action.",
                     "type": "string"
                 },
                 "emails": {
@@ -31621,12 +31710,14 @@ const docTemplate = `{
             "enum": [
                 "text",
                 "image",
-                "file"
+                "file",
+                "video"
             ],
             "x-enum-varnames": [
                 "ModalityText",
                 "ModalityImage",
-                "ModalityFile"
+                "ModalityFile",
+                "ModalityVideo"
             ]
         },
         "types.Model": {
@@ -33604,6 +33695,7 @@ const docTemplate = `{
                 "openai",
                 "togetherai",
                 "anthropic",
+                "minimax",
                 "helix",
                 "vllm"
             ],
@@ -33611,13 +33703,33 @@ const docTemplate = `{
                 "ProviderOpenAI",
                 "ProviderTogetherAI",
                 "ProviderAnthropic",
+                "ProviderMiniMax",
                 "ProviderHelix",
                 "ProviderVLLM"
+            ]
+        },
+        "types.ProviderAPIFormat": {
+            "type": "string",
+            "enum": [
+                "openai",
+                "anthropic"
+            ],
+            "x-enum-varnames": [
+                "ProviderAPIFormatOpenAI",
+                "ProviderAPIFormatAnthropic"
             ]
         },
         "types.ProviderEndpoint": {
             "type": "object",
             "properties": {
+                "api_format": {
+                    "description": "openai or anthropic; empty preserves legacy detection",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.ProviderAPIFormat"
+                        }
+                    ]
+                },
                 "api_key": {
                     "type": "string"
                 },
@@ -35604,6 +35716,10 @@ const docTemplate = `{
                     "description": "Container fields (Hydra executor)",
                     "type": "string"
                 },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID mirrors SpecTask.CredentialOwnerID onto the session: the\nuser whose Claude subscription authenticates this session's agent, when\nthat differs from Owner. Affects credential resolution ONLY — Owner still\nowns and is attributed the session. Honoured only with an explicit\ndelegation grant; see ResolveClaudeCredentialOwner.",
+                    "type": "string"
+                },
                 "dev_container_id": {
                     "description": "Dev container ID for streaming",
                     "type": "string"
@@ -36198,6 +36314,10 @@ const docTemplate = `{
                 },
                 "created_by": {
                     "description": "Metadata",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID names the user whose Claude subscription authenticates\nthis task's agent sessions, when that differs from CreatedBy. It changes\nONLY credential resolution — the task and its sessions are still owned by,\nand attributed to, CreatedBy. Nothing \"runs as\" the credential owner.\n\nThis exists for orchestrators (HelixOS) that dispatch every task with one\nservice API key but run work on behalf of different humans: without it the\nservice account's subscription authenticates everyone's bots, so one\nperson's expired token breaks all of them and no one can use their own\nClaude account.\n\nHonoured only when the named user has delegated their subscription to this\norganization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able\nto create a task could spend another user's Claude quota. See\nResolveClaudeCredentialOwner.",
                     "type": "string"
                 },
                 "depends_on": {
@@ -36996,6 +37116,10 @@ const docTemplate = `{
                 },
                 "created_by": {
                     "description": "Metadata",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID names the user whose Claude subscription authenticates\nthis task's agent sessions, when that differs from CreatedBy. It changes\nONLY credential resolution — the task and its sessions are still owned by,\nand attributed to, CreatedBy. Nothing \"runs as\" the credential owner.\n\nThis exists for orchestrators (HelixOS) that dispatch every task with one\nservice API key but run work on behalf of different humans: without it the\nservice account's subscription authenticates everyone's bots, so one\nperson's expired token breaks all of them and no one can use their own\nClaude account.\n\nHonoured only when the named user has delegated their subscription to this\norganization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able\nto create a task could spend another user's Claude quota. See\nResolveClaudeCredentialOwner.",
                     "type": "string"
                 },
                 "depends_on": {
@@ -38466,6 +38590,9 @@ const docTemplate = `{
         "types.UpdateProviderEndpoint": {
             "type": "object",
             "properties": {
+                "api_format": {
+                    "$ref": "#/definitions/types.ProviderAPIFormat"
+                },
                 "api_key": {
                     "type": "string"
                 },

--- a/api/pkg/server/openai_model_handlers.go
+++ b/api/pkg/server/openai_model_handlers.go
@@ -111,7 +111,7 @@ func (apiServer *HelixAPIServer) listModelsForProvider(rw http.ResponseWriter, r
 	writeResponse(rw, types.OpenAIModelsList{Models: models}, http.StatusOK)
 }
 
-// listModelsAnthropic proxies the request to the upstream Anthropic provider.
+// listModelsAnthropic proxies the request to the selected Anthropic-compatible provider.
 func (apiServer *HelixAPIServer) listModelsAnthropic(rw http.ResponseWriter, r *http.Request) {
 	user := getRequestUser(r)
 	if user == nil {
@@ -119,10 +119,14 @@ func (apiServer *HelixAPIServer) listModelsAnthropic(rw http.ResponseWriter, r *
 		return
 	}
 
-	endpoint, err := apiServer.getBuiltInProviderEndpoint(r.Context(), string(types.ProviderAnthropic))
+	endpoint, err := apiServer.getProviderEndpoint(r.Context(), user)
 	if err != nil {
-		log.Err(err).Msg("failed to get Anthropic provider endpoint")
-		http.Error(rw, "Anthropic provider not configured: "+err.Error(), http.StatusInternalServerError)
+		log.Err(err).Msg("failed to get Anthropic-compatible provider endpoint")
+		http.Error(rw, "Anthropic-compatible provider not configured: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if !isAnthropicCompatible(endpoint) {
+		http.Error(rw, fmt.Sprintf("Provider %q is not Anthropic-compatible", endpoint.Name), http.StatusBadRequest)
 		return
 	}
 

--- a/api/pkg/server/provider_handlers.go
+++ b/api/pkg/server/provider_handlers.go
@@ -290,13 +290,15 @@ func (s *HelixAPIServer) globalProviderEndpoint(provider types.Provider) *types.
 		baseURL = s.Cfg.Providers.OpenAI.BaseURL
 	case types.ProviderTogetherAI:
 		baseURL = s.Cfg.Providers.TogetherAI.BaseURL
+	case types.ProviderMiniMax:
+		baseURL = s.Cfg.Providers.MiniMax.ResolvedBaseURL()
 	case types.ProviderVLLM:
 		baseURL = s.Cfg.Providers.VLLM.BaseURL
 	case types.ProviderHelix:
 		baseURL = "internal"
 	}
 
-	return &types.ProviderEndpoint{
+	endpoint := &types.ProviderEndpoint{
 		ID:             "-",
 		Name:           string(provider),
 		Description:    "",
@@ -306,6 +308,11 @@ func (s *HelixAPIServer) globalProviderEndpoint(provider types.Provider) *types.
 		APIKey:         "",
 		BillingEnabled: s.Cfg.Providers.BillingEnabled, // Controlled by PROVIDERS_BILLING_ENABLED env var
 	}
+	if provider == types.ProviderMiniMax {
+		endpoint.APIFormat = s.Cfg.Providers.MiniMax.ResolvedAPIFormat()
+		endpoint.Models = s.Cfg.Providers.MiniMax.ResolvedModels()
+	}
+	return endpoint
 }
 
 // resolveModelProviderLive is the last-resort routing resolver for
@@ -618,6 +625,11 @@ func (s *HelixAPIServer) createProviderEndpoint(rw http.ResponseWriter, r *http.
 		http.Error(rw, "Invalid request body: "+err.Error(), http.StatusBadRequest)
 		return
 	}
+	if !endpoint.APIFormat.Valid() {
+		http.Error(rw, "Invalid API format", http.StatusBadRequest)
+		return
+	}
+	endpoint.BaseURL = strings.TrimSpace(endpoint.BaseURL)
 
 	// If org ID is set, authorize
 	if endpoint.OwnerType == types.OwnerTypeOrg && endpoint.Owner != "" {
@@ -752,6 +764,10 @@ func (s *HelixAPIServer) updateProviderEndpoint(rw http.ResponseWriter, r *http.
 		http.Error(rw, "Invalid request body: "+err.Error(), http.StatusBadRequest)
 		return
 	}
+	if updatedEndpoint.APIFormat != nil && !updatedEndpoint.APIFormat.Valid() {
+		http.Error(rw, "Invalid API format", http.StatusBadRequest)
+		return
+	}
 
 	// For global endpoints, only allow updates by admins. Gate on the stored
 	// row, not the request payload: a global endpoint now retains its original
@@ -815,6 +831,9 @@ func (s *HelixAPIServer) updateProviderEndpoint(rw http.ResponseWriter, r *http.
 	existingEndpoint.Description = updatedEndpoint.Description
 	existingEndpoint.Models = updatedEndpoint.Models
 	existingEndpoint.BaseURL = strings.TrimSpace(updatedEndpoint.BaseURL)
+	if updatedEndpoint.APIFormat != nil {
+		existingEndpoint.APIFormat = *updatedEndpoint.APIFormat
+	}
 	if updatedEndpoint.APIKey != nil {
 		existingEndpoint.APIKey = strings.TrimSpace(*updatedEndpoint.APIKey)
 	}
@@ -1183,10 +1202,7 @@ func (s *HelixAPIServer) refreshAllProviderModels(ctx context.Context) {
 		log.Warn().Err(err).Msg("failed to list global providers for cache refresh")
 	} else {
 		for _, provider := range globalProviders {
-			endpoint := &types.ProviderEndpoint{
-				Name:  string(provider),
-				Owner: string(types.OwnerTypeSystem),
-			}
+			endpoint := s.globalProviderEndpoint(provider)
 
 			// Skip helix provider - it uses the internal scheduler, not external models
 			if provider == types.ProviderHelix {

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -834,6 +834,44 @@
                 }
             }
         },
+        "/api/v1/admin/users/{id}/api-keys": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create (or return the existing) named API key owned by another user, so a trusted orchestrator can act as the people it runs work for instead of putting the whole fleet on one shared account. Idempotent per (user, name).",
+                "tags": [
+                    "users"
+                ],
+                "summary": "Mint an API key for a user (Admin only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Key name, e.g. the orchestrator's slug",
+                        "name": "name",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.ApiKey"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/users/{id}/approve": {
             "post": {
                 "security": [
@@ -3388,18 +3426,26 @@
                         }
                     }
                 }
-            },
-            "delete": {
+            }
+        },
+        "/api/v1/claude-subscriptions/{id}/delegation": {
+            "put": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
-                "description": "Disconnect a Claude subscription",
+                "description": "Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Only the subscription owner may change this.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
                 "tags": [
                     "Claude"
                 ],
-                "summary": "Delete a Claude subscription",
+                "summary": "Set which orgs may use a Claude subscription for delegated agent runs",
                 "parameters": [
                     {
                         "type": "string",
@@ -3407,16 +3453,28 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Delegated organizations",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.UpdateClaudeSubscriptionDelegationRequest"
+                        }
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/types.ClaudeSubscription"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
                         }
                     },
                     "401": {
@@ -26784,6 +26842,18 @@
                 }
             }
         },
+        "server.UpdateClaudeSubscriptionDelegationRequest": {
+            "description": "Disconnect a Claude subscription",
+            "type": "object",
+            "properties": {
+                "delegated_org_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "server.VideoStreamingStats": {
             "type": "object",
             "properties": {
@@ -28552,6 +28622,13 @@
                     "description": "\"oauth\" or \"setup_token\"",
                     "type": "string"
                 },
+                "delegated_org_ids": {
+                    "description": "DelegatedOrgIDs lists the organizations whose agent sessions may\nauthenticate with this subscription on the owner's behalf, even when the\nsession itself is owned by someone else (a service account dispatching\nwork for this person — see SpecTask.CredentialOwnerID).\n\nThis is the consent gate. Without it, any member who can create a task\ncould name another user as credential owner and spend their Claude quota.\nEmpty (the default) means the subscription is only ever used for sessions\nits owner owns, which is the pre-existing behaviour.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "id": {
                     "type": "string"
                 },
@@ -28925,6 +29002,10 @@
                             "$ref": "#/definitions/types.CodeAgentRuntime"
                         }
                     ]
+                },
+                "uses_subscription": {
+                    "description": "UsesSubscription is true when the agent authenticates against the upstream\nprovider with the user's own subscription (Claude Pro/Max, ChatGPT) instead\nof an API key routed through the Helix proxy. It mirrors the assistant's\nCodeAgentCredentialType and is what gates credential injection into the\ncontainer — an api_key agent must never receive subscription credentials,\nbecause the CLI prefers them over the proxy and would silently bypass it.",
+                    "type": "boolean"
                 }
             }
         },
@@ -29452,6 +29533,10 @@
                     "description": "For new mode: user-specified prefix (task# appended)",
                     "type": "string"
                 },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate this task's agent, for orchestrators dispatching work on a\nhuman's behalf under one service API key. Credential resolution only — the\ntask is still created by, owned by, and attributed to the caller. Ignored\nunless that user has delegated their subscription to this organization.",
+                    "type": "string"
+                },
                 "depends_on": {
                     "description": "Optional: IDs of tasks this task depends on",
                     "type": "array",
@@ -29565,6 +29650,10 @@
                 },
                 "callback_url": {
                     "description": "Webhook URL to POST on completion",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate the agent this trigger starts. An orchestrator writing triggers\non people's behalf under one service API key sets it so a scheduled run\nauthenticates as the person it acts for, exactly as CreateTaskRequest does\nfor a run dispatched by hand. Credential resolution only: the task is still\ncreated by, owned by, and attributed to the trigger's app owner, and the\nnamed user must have delegated their subscription to this organization or it\nis ignored. Currently honoured by the spec_task action.",
                     "type": "string"
                 },
                 "emails": {
@@ -31617,12 +31706,14 @@
             "enum": [
                 "text",
                 "image",
-                "file"
+                "file",
+                "video"
             ],
             "x-enum-varnames": [
                 "ModalityText",
                 "ModalityImage",
-                "ModalityFile"
+                "ModalityFile",
+                "ModalityVideo"
             ]
         },
         "types.Model": {
@@ -33600,6 +33691,7 @@
                 "openai",
                 "togetherai",
                 "anthropic",
+                "minimax",
                 "helix",
                 "vllm"
             ],
@@ -33607,13 +33699,33 @@
                 "ProviderOpenAI",
                 "ProviderTogetherAI",
                 "ProviderAnthropic",
+                "ProviderMiniMax",
                 "ProviderHelix",
                 "ProviderVLLM"
+            ]
+        },
+        "types.ProviderAPIFormat": {
+            "type": "string",
+            "enum": [
+                "openai",
+                "anthropic"
+            ],
+            "x-enum-varnames": [
+                "ProviderAPIFormatOpenAI",
+                "ProviderAPIFormatAnthropic"
             ]
         },
         "types.ProviderEndpoint": {
             "type": "object",
             "properties": {
+                "api_format": {
+                    "description": "openai or anthropic; empty preserves legacy detection",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.ProviderAPIFormat"
+                        }
+                    ]
+                },
                 "api_key": {
                     "type": "string"
                 },
@@ -35600,6 +35712,10 @@
                     "description": "Container fields (Hydra executor)",
                     "type": "string"
                 },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID mirrors SpecTask.CredentialOwnerID onto the session: the\nuser whose Claude subscription authenticates this session's agent, when\nthat differs from Owner. Affects credential resolution ONLY — Owner still\nowns and is attributed the session. Honoured only with an explicit\ndelegation grant; see ResolveClaudeCredentialOwner.",
+                    "type": "string"
+                },
                 "dev_container_id": {
                     "description": "Dev container ID for streaming",
                     "type": "string"
@@ -36194,6 +36310,10 @@
                 },
                 "created_by": {
                     "description": "Metadata",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID names the user whose Claude subscription authenticates\nthis task's agent sessions, when that differs from CreatedBy. It changes\nONLY credential resolution — the task and its sessions are still owned by,\nand attributed to, CreatedBy. Nothing \"runs as\" the credential owner.\n\nThis exists for orchestrators (HelixOS) that dispatch every task with one\nservice API key but run work on behalf of different humans: without it the\nservice account's subscription authenticates everyone's bots, so one\nperson's expired token breaks all of them and no one can use their own\nClaude account.\n\nHonoured only when the named user has delegated their subscription to this\norganization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able\nto create a task could spend another user's Claude quota. See\nResolveClaudeCredentialOwner.",
                     "type": "string"
                 },
                 "depends_on": {
@@ -36992,6 +37112,10 @@
                 },
                 "created_by": {
                     "description": "Metadata",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID names the user whose Claude subscription authenticates\nthis task's agent sessions, when that differs from CreatedBy. It changes\nONLY credential resolution — the task and its sessions are still owned by,\nand attributed to, CreatedBy. Nothing \"runs as\" the credential owner.\n\nThis exists for orchestrators (HelixOS) that dispatch every task with one\nservice API key but run work on behalf of different humans: without it the\nservice account's subscription authenticates everyone's bots, so one\nperson's expired token breaks all of them and no one can use their own\nClaude account.\n\nHonoured only when the named user has delegated their subscription to this\norganization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able\nto create a task could spend another user's Claude quota. See\nResolveClaudeCredentialOwner.",
                     "type": "string"
                 },
                 "depends_on": {
@@ -38462,6 +38586,9 @@
         "types.UpdateProviderEndpoint": {
             "type": "object",
             "properties": {
+                "api_format": {
+                    "$ref": "#/definitions/types.ProviderAPIFormat"
+                },
                 "api_key": {
                     "type": "string"
                 },

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -3066,6 +3066,14 @@ definitions:
       technical_design:
         type: string
     type: object
+  server.UpdateClaudeSubscriptionDelegationRequest:
+    description: Disconnect a Claude subscription
+    properties:
+      delegated_org_ids:
+        items:
+          type: string
+        type: array
+    type: object
   server.VideoStreamingStats:
     properties:
       client_buffers:
@@ -4389,6 +4397,20 @@ definitions:
       credential_type:
         description: '"oauth" or "setup_token"'
         type: string
+      delegated_org_ids:
+        description: |-
+          DelegatedOrgIDs lists the organizations whose agent sessions may
+          authenticate with this subscription on the owner's behalf, even when the
+          session itself is owned by someone else (a service account dispatching
+          work for this person — see SpecTask.CredentialOwnerID).
+
+          This is the consent gate. Without it, any member who can create a task
+          could name another user as credential owner and spend their Claude quota.
+          Empty (the default) means the subscription is only ever used for sessions
+          its owner owns, which is the pre-existing behaviour.
+        items:
+          type: string
+        type: array
       id:
         type: string
       last_error:
@@ -4662,6 +4684,15 @@ definitions:
         - $ref: '#/definitions/types.CodeAgentRuntime'
         description: 'Runtime specifies which code agent runtime to use: "zed_agent"
           or "qwen_code"'
+      uses_subscription:
+        description: |-
+          UsesSubscription is true when the agent authenticates against the upstream
+          provider with the user's own subscription (Claude Pro/Max, ChatGPT) instead
+          of an API key routed through the Helix proxy. It mirrors the assistant's
+          CodeAgentCredentialType and is what gates credential injection into the
+          container — an api_key agent must never receive subscription credentials,
+          because the CLI prefers them over the proxy and would silently bypass it.
+        type: boolean
     type: object
   types.CodeAgentCredentialType:
     enum:
@@ -5029,6 +5060,14 @@ definitions:
       branch_prefix:
         description: 'For new mode: user-specified prefix (task# appended)'
         type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID optionally names the user whose Claude subscription should
+          authenticate this task's agent, for orchestrators dispatching work on a
+          human's behalf under one service API key. Credential resolution only — the
+          task is still created by, owned by, and attributed to the caller. Ignored
+          unless that user has delegated their subscription to this organization.
+        type: string
       depends_on:
         description: 'Optional: IDs of tasks this task depends on'
         items:
@@ -5112,6 +5151,17 @@ definitions:
         type: string
       callback_url:
         description: Webhook URL to POST on completion
+        type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID optionally names the user whose Claude subscription should
+          authenticate the agent this trigger starts. An orchestrator writing triggers
+          on people's behalf under one service API key sets it so a scheduled run
+          authenticates as the person it acts for, exactly as CreateTaskRequest does
+          for a run dispatched by hand. Credential resolution only: the task is still
+          created by, owned by, and attributed to the trigger's app owner, and the
+          named user must have delegated their subscription to this organization or it
+          is ignored. Currently honoured by the spec_task action.
         type: string
       emails:
         items:
@@ -6593,11 +6643,13 @@ definitions:
     - text
     - image
     - file
+    - video
     type: string
     x-enum-varnames:
     - ModalityText
     - ModalityImage
     - ModalityFile
+    - ModalityVideo
   types.Model:
     properties:
       allocated_gpu_count:
@@ -7996,6 +8048,7 @@ definitions:
     - openai
     - togetherai
     - anthropic
+    - minimax
     - helix
     - vllm
     type: string
@@ -8003,10 +8056,23 @@ definitions:
     - ProviderOpenAI
     - ProviderTogetherAI
     - ProviderAnthropic
+    - ProviderMiniMax
     - ProviderHelix
     - ProviderVLLM
+  types.ProviderAPIFormat:
+    enum:
+    - openai
+    - anthropic
+    type: string
+    x-enum-varnames:
+    - ProviderAPIFormatOpenAI
+    - ProviderAPIFormatAnthropic
   types.ProviderEndpoint:
     properties:
+      api_format:
+        allOf:
+        - $ref: '#/definitions/types.ProviderAPIFormat'
+        description: openai or anthropic; empty preserves legacy detection
       api_key:
         type: string
       api_key_file:
@@ -9542,6 +9608,14 @@ definitions:
       container_name:
         description: Container fields (Hydra executor)
         type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID mirrors SpecTask.CredentialOwnerID onto the session: the
+          user whose Claude subscription authenticates this session's agent, when
+          that differs from Owner. Affects credential resolution ONLY — Owner still
+          owns and is attributed the session. Honoured only with an explicit
+          delegation grant; see ResolveClaudeCredentialOwner.
+        type: string
       dev_container_id:
         description: Dev container ID for streaming
         type: string
@@ -9972,6 +10046,24 @@ definitions:
         type: string
       created_by:
         description: Metadata
+        type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID names the user whose Claude subscription authenticates
+          this task's agent sessions, when that differs from CreatedBy. It changes
+          ONLY credential resolution — the task and its sessions are still owned by,
+          and attributed to, CreatedBy. Nothing "runs as" the credential owner.
+
+          This exists for orchestrators (HelixOS) that dispatch every task with one
+          service API key but run work on behalf of different humans: without it the
+          service account's subscription authenticates everyone's bots, so one
+          person's expired token breaks all of them and no one can use their own
+          Claude account.
+
+          Honoured only when the named user has delegated their subscription to this
+          organization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able
+          to create a task could spend another user's Claude quota. See
+          ResolveClaudeCredentialOwner.
         type: string
       depends_on:
         items:
@@ -10577,6 +10669,24 @@ definitions:
         type: string
       created_by:
         description: Metadata
+        type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID names the user whose Claude subscription authenticates
+          this task's agent sessions, when that differs from CreatedBy. It changes
+          ONLY credential resolution — the task and its sessions are still owned by,
+          and attributed to, CreatedBy. Nothing "runs as" the credential owner.
+
+          This exists for orchestrators (HelixOS) that dispatch every task with one
+          service API key but run work on behalf of different humans: without it the
+          service account's subscription authenticates everyone's bots, so one
+          person's expired token breaks all of them and no one can use their own
+          Claude account.
+
+          Honoured only when the named user has delegated their subscription to this
+          organization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able
+          to create a task could spend another user's Claude quota. See
+          ResolveClaudeCredentialOwner.
         type: string
       depends_on:
         items:
@@ -11632,6 +11742,8 @@ definitions:
     type: object
   types.UpdateProviderEndpoint:
     properties:
+      api_format:
+        $ref: '#/definitions/types.ProviderAPIFormat'
       api_key:
         type: string
       api_key_file:
@@ -12919,6 +13031,32 @@ paths:
       security:
       - BearerAuth: []
       summary: Delete a user (Admin only)
+      tags:
+      - users
+  /api/v1/admin/users/{id}/api-keys:
+    post:
+      description: Create (or return the existing) named API key owned by another
+        user, so a trusted orchestrator can act as the people it runs work for instead
+        of putting the whole fleet on one shared account. Idempotent per (user, name).
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Key name, e.g. the orchestrator's slug
+        in: query
+        name: name
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.ApiKey'
+      security:
+      - BearerAuth: []
+      summary: Mint an API key for a user (Admin only)
       tags:
       - users
   /api/v1/admin/users/{id}/approve:
@@ -14460,38 +14598,6 @@ paths:
       tags:
       - Claude
   /api/v1/claude-subscriptions/{id}:
-    delete:
-      description: Disconnect a Claude subscription
-      parameters:
-      - description: Subscription ID
-        in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Delete a Claude subscription
-      tags:
-      - Claude
     get:
       description: Get details of a specific Claude subscription (no secrets)
       parameters:
@@ -14522,6 +14628,53 @@ paths:
       security:
       - BearerAuth: []
       summary: Get a Claude subscription
+      tags:
+      - Claude
+  /api/v1/claude-subscriptions/{id}/delegation:
+    put:
+      consumes:
+      - application/json
+      description: Grant (or revoke) permission for an organization's orchestrated
+        agents to authenticate as the subscription owner. Only the subscription owner
+        may change this.
+      parameters:
+      - description: Subscription ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Delegated organizations
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/server.UpdateClaudeSubscriptionDelegationRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.ClaudeSubscription'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Set which orgs may use a Claude subscription for delegated agent runs
       tags:
       - Claude
   /api/v1/claude-subscriptions/models:

--- a/api/pkg/server/zed_config_handlers.go
+++ b/api/pkg/server/zed_config_handlers.go
@@ -640,6 +640,7 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.C
 	if modelName == "" {
 		modelName = assistant.GenerationModel
 	}
+	var providerAPIFormat types.ProviderAPIFormat
 
 	// Resolve the agent's stored provider token (ID or legacy name) to the
 	// provider's current canonical name. Required so the model prefix here
@@ -648,6 +649,7 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.C
 	if providerSnapshot != nil && providerName != "" {
 		if resolved, _, ok := external_agent.ResolveProvider(providerName, providerSnapshot); ok {
 			providerName = resolved.Name
+			providerAPIFormat = resolved.APIFormat
 		}
 	}
 
@@ -728,11 +730,17 @@ func (apiServer *HelixAPIServer) buildCodeAgentConfigFromAssistant(ctx context.C
 			agentName = "zed-agent"
 			model = modelName
 		default:
-			// For other providers (OpenAI, OpenRouter, etc.), use OpenAI-compatible API
-			baseURL = helixURL + "/v1"
-			apiType = "openai"
-			agentName = "zed-agent"
-			model = fmt.Sprintf("%s/%s", providerName, modelName)
+			if providerAPIFormat == types.ProviderAPIFormatAnthropic {
+				baseURL = helixURL + "/v1"
+				apiType = "anthropic"
+				agentName = "zed-agent"
+				model = modelName
+			} else {
+				baseURL = helixURL + "/v1"
+				apiType = "openai"
+				agentName = "zed-agent"
+				model = fmt.Sprintf("%s/%s", providerName, modelName)
+			}
 		}
 	}
 
@@ -982,7 +990,7 @@ func (apiServer *HelixAPIServer) getProviderSnapshot(ctx context.Context, actorI
 	}
 	refs := make([]external_agent.ProviderRef, 0, len(endpoints))
 	for _, ep := range endpoints {
-		refs = append(refs, external_agent.ProviderRef{ID: ep.ID, Name: ep.Name})
+		refs = append(refs, external_agent.ProviderRef{ID: ep.ID, Name: ep.Name, APIFormat: ep.APIFormat})
 	}
 	return refs, nil
 }

--- a/api/pkg/server/zed_config_handlers_test.go
+++ b/api/pkg/server/zed_config_handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	external_agent "github.com/helixml/helix/api/pkg/external-agent"
 	"github.com/helixml/helix/api/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,6 +19,7 @@ func TestBuildCodeAgentConfigFromAssistant(t *testing.T) {
 	tests := []struct {
 		name      string
 		assistant *types.AssistantConfig
+		snapshot  []external_agent.ProviderRef
 		want      *types.CodeAgentConfig
 	}{
 		{
@@ -52,6 +54,27 @@ func TestBuildCodeAgentConfigFromAssistant(t *testing.T) {
 				APIType:         "openai",
 				Runtime:         types.CodeAgentRuntimeZedAgent,
 				ReasoningEffort: types.ReasoningEffortNone,
+			},
+		},
+		{
+			name: "explicit Anthropic-compatible endpoint with zed_agent runtime",
+			assistant: &types.AssistantConfig{
+				GenerationModelProvider: "pe_minimax",
+				GenerationModel:         types.MiniMaxModelM3,
+				CodeAgentRuntime:        types.CodeAgentRuntimeZedAgent,
+			},
+			snapshot: []external_agent.ProviderRef{{
+				ID:        "pe_minimax",
+				Name:      "minimax",
+				APIFormat: types.ProviderAPIFormatAnthropic,
+			}},
+			want: &types.CodeAgentConfig{
+				Provider:  "minimax",
+				Model:     types.MiniMaxModelM3,
+				AgentName: "zed-agent",
+				BaseURL:   "http://localhost:8080/v1",
+				APIType:   "anthropic",
+				Runtime:   types.CodeAgentRuntimeZedAgent,
 			},
 		},
 		{
@@ -249,7 +272,7 @@ func TestBuildCodeAgentConfigFromAssistant(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := apiServer.buildCodeAgentConfigFromAssistant(ctx, tt.assistant, helixURL, nil)
+			got := apiServer.buildCodeAgentConfigFromAssistant(ctx, tt.assistant, helixURL, tt.snapshot)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/api/pkg/types/models.go
+++ b/api/pkg/types/models.go
@@ -182,6 +182,7 @@ const (
 	ModalityText  Modality = "text"
 	ModalityImage Modality = "image"
 	ModalityFile  Modality = "file"
+	ModalityVideo Modality = "video"
 )
 
 type DynamicModelInfo struct {

--- a/api/pkg/types/provider.go
+++ b/api/pkg/types/provider.go
@@ -12,14 +12,28 @@ const (
 	ProviderOpenAI     Provider = "openai"
 	ProviderTogetherAI Provider = "togetherai"
 	ProviderAnthropic  Provider = "anthropic"
+	ProviderMiniMax    Provider = "minimax"
 	ProviderHelix      Provider = "helix"
 	ProviderVLLM       Provider = "vllm"
 )
+
+const (
+	MiniMaxModelM3  = "MiniMax-M3"
+	MiniMaxModelM27 = "MiniMax-M2.7"
+
+	MiniMaxGlobalOpenAIBaseURL    = "https://api.minimax.io/v1"
+	MiniMaxGlobalAnthropicBaseURL = "https://api.minimax.io/anthropic"
+	MiniMaxCNOpenAIBaseURL        = "https://api.minimaxi.com/v1"
+	MiniMaxCNAnthropicBaseURL     = "https://api.minimaxi.com/anthropic"
+)
+
+var MiniMaxModels = []string{MiniMaxModelM3, MiniMaxModelM27}
 
 var GlobalProviders = []string{
 	string(ProviderOpenAI),
 	string(ProviderTogetherAI),
 	string(ProviderAnthropic),
+	string(ProviderMiniMax),
 	string(ProviderHelix),
 	string(ProviderVLLM),
 }
@@ -51,6 +65,17 @@ const (
 	ProviderEndpointStatusDisabled ProviderEndpointStatus = "disabled"
 )
 
+type ProviderAPIFormat string
+
+const (
+	ProviderAPIFormatOpenAI    ProviderAPIFormat = "openai"
+	ProviderAPIFormatAnthropic ProviderAPIFormat = "anthropic"
+)
+
+func (f ProviderAPIFormat) Valid() bool {
+	return f == "" || f == ProviderAPIFormatOpenAI || f == ProviderAPIFormatAnthropic
+}
+
 type ProviderEndpoint struct {
 	ID             string               `json:"id" gorm:"primaryKey"`
 	Created        time.Time            `json:"created"`
@@ -62,6 +87,7 @@ type ProviderEndpoint struct {
 	Owner          string               `json:"owner"`
 	OwnerType      OwnerType            `json:"owner_type"` // user, system, org
 	BaseURL        string               `json:"base_url"`
+	APIFormat      ProviderAPIFormat    `json:"api_format,omitempty"` // openai or anthropic; empty preserves legacy detection
 	APIKey         string               `json:"api_key"`
 	APIKeyFromFile string               `json:"api_key_file"`     // Must be mounted to the container
 	Default        bool                 `json:"default" gorm:"-"` // Set from environment variable
@@ -125,10 +151,11 @@ type UpdateProviderEndpoint struct {
 	Models       []string             `json:"models"`
 	EndpointType ProviderEndpointType `json:"endpoint_type"` // global, user (TODO: orgs, teams)
 
-	BaseURL        string            `json:"base_url"`
-	APIKey         *string           `json:"api_key,omitempty"`
-	APIKeyFromFile *string           `json:"api_key_file,omitempty"` // Must be mounted to the container
-	Headers        map[string]string `json:"headers,omitempty"`      // Custom headers for the endpoint
+	BaseURL        string             `json:"base_url"`
+	APIFormat      *ProviderAPIFormat `json:"api_format,omitempty"`
+	APIKey         *string            `json:"api_key,omitempty"`
+	APIKeyFromFile *string            `json:"api_key_file,omitempty"` // Must be mounted to the container
+	Headers        map[string]string  `json:"headers,omitempty"`      // Custom headers for the endpoint
 
 	// Google Vertex AI fields
 	VertexProjectID       *string `json:"vertex_project_id,omitempty"`

--- a/charts/helix-controlplane/templates/deployment.yaml
+++ b/charts/helix-controlplane/templates/deployment.yaml
@@ -260,6 +260,40 @@ spec:
             - name: ANTHROPIC_VERTEX_CREDENTIALS_FILE
               value: "/run/secrets/vertex-credentials/{{ .Values.controlplane.providers.anthropic.vertexCredentialsSecretKey | default "key" }}"
             {{- end }}
+            {{- if .Values.controlplane.providers.minimax }}
+            {{- with (default "" .Values.controlplane.providers.minimax.region) }}
+            - name: MINIMAX_REGION
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with (default "" .Values.controlplane.providers.minimax.apiFormat) }}
+            - name: MINIMAX_API_FORMAT
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with (default "" .Values.controlplane.providers.minimax.openaiBaseUrl) }}
+            - name: MINIMAX_OPENAI_BASE_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with (default "" .Values.controlplane.providers.minimax.anthropicBaseUrl) }}
+            - name: MINIMAX_ANTHROPIC_BASE_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with (default "" .Values.controlplane.providers.minimax.models) }}
+            - name: MINIMAX_MODELS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if .Values.controlplane.providers.minimax.existingSecret }}
+            - name: MINIMAX_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.controlplane.providers.minimax.existingSecret }}
+                  key: {{ .Values.controlplane.providers.minimax.existingSecretApiKeyKey | default "api-key" }}
+            {{- else }}
+            {{- with (default "" .Values.controlplane.providers.minimax.apiKey) }}
+            - name: MINIMAX_API_KEY
+              value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.controlplane.providers.togetherai }}
             {{- with (default "" .Values.controlplane.providers.togetherai.baseUrl) }}
             - name: TOGETHER_BASE_URL

--- a/charts/helix-controlplane/values-example.yaml
+++ b/charts/helix-controlplane/values-example.yaml
@@ -99,7 +99,7 @@ controlplane:
 
   # Inference configuration
   inference:
-    # Valid values: openai, togetherai, anthropic, helix, vllm
+    # Valid values: openai, togetherai, anthropic, minimax, helix, vllm
     defaultProvider: "helix"
 
   # Fine-tuning configuration
@@ -138,6 +138,18 @@ controlplane:
     #   # vertexCredentialsJSON: '{"type":"service_account","project_id":"...","private_key":"..."}' # preferred for containers
     #   # vertexCredentialsSecret: "gcp-vertex-credentials"  # alternative: k8s secret with service account JSON file
     #   # vertexCredentialsSecretKey: "key"
+    #
+    # minimax:
+    #   region: "global" # Use "cn" for api.minimaxi.com defaults
+    #   apiFormat: "openai" # Or "anthropic"
+    #   models: "MiniMax-M3,MiniMax-M2.7"
+    #   apiKey: "your-api-key"
+    #   # Optional endpoint overrides:
+    #   # openaiBaseUrl: "https://api.minimax.io/v1"
+    #   # anthropicBaseUrl: "https://api.minimax.io/anthropic"
+    #   # Option: Use existing secret for API key
+    #   # existingSecret: "minimax-credentials"
+    #   # existingSecretApiKeyKey: "api-key"
     #
     # togetherai:
     #   baseUrl: "https://api.together.xyz/v1"

--- a/charts/helix-controlplane/values.yaml
+++ b/charts/helix-controlplane/values.yaml
@@ -115,6 +115,15 @@ controlplane:
       vertexCredentialsJSON: "" # service account JSON string; takes precedence over vertexCredentialsSecret
       vertexCredentialsSecret: "" # k8s secret name containing service-account.json
       vertexCredentialsSecretKey: "key" # key within the secret
+    minimax:
+      region: "global"
+      apiFormat: "openai"
+      openaiBaseUrl: ""
+      anthropicBaseUrl: ""
+      models: "MiniMax-M3,MiniMax-M2.7"
+      apiKey: ""
+      existingSecret: ""
+      existingSecretApiKeyKey: ""
     togetherai:
       baseUrl: ""
       apiKey: ""

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1967,6 +1967,11 @@ export interface ServerTaskSpecsResponse {
   technical_design?: string;
 }
 
+/** Disconnect a Claude subscription */
+export interface ServerUpdateClaudeSubscriptionDelegationRequest {
+  delegated_org_ids?: string[];
+}
+
 export interface ServerVideoStreamingStats {
   client_buffers?: ServerClientBufferStats[];
   client_count?: number;
@@ -2793,6 +2798,18 @@ export interface TypesClaudeSubscription {
   created_by?: string;
   /** "oauth" or "setup_token" */
   credential_type?: string;
+  /**
+   * DelegatedOrgIDs lists the organizations whose agent sessions may
+   * authenticate with this subscription on the owner's behalf, even when the
+   * session itself is owned by someone else (a service account dispatching
+   * work for this person — see SpecTask.CredentialOwnerID).
+   *
+   * This is the consent gate. Without it, any member who can create a task
+   * could name another user as credential owner and spend their Claude quota.
+   * Empty (the default) means the subscription is only ever used for sessions
+   * its owner owns, which is the pre-existing behaviour.
+   */
+  delegated_org_ids?: string[];
   id?: string;
   last_error?: string;
   last_refreshed_at?: string;
@@ -2967,6 +2984,15 @@ export interface TypesCodeAgentConfig {
   reasoning_effort?: string;
   /** Runtime specifies which code agent runtime to use: "zed_agent" or "qwen_code" */
   runtime?: TypesCodeAgentRuntime;
+  /**
+   * UsesSubscription is true when the agent authenticates against the upstream
+   * provider with the user's own subscription (Claude Pro/Max, ChatGPT) instead
+   * of an API key routed through the Helix proxy. It mirrors the assistant's
+   * CodeAgentCredentialType and is what gates credential injection into the
+   * container — an api_key agent must never receive subscription credentials,
+   * because the CLI prefers them over the proxy and would silently bypass it.
+   */
+  uses_subscription?: boolean;
 }
 
 export enum TypesCodeAgentCredentialType {
@@ -3204,6 +3230,14 @@ export interface TypesCreateTaskRequest {
   branch_mode?: TypesBranchMode;
   /** For new mode: user-specified prefix (task# appended) */
   branch_prefix?: string;
+  /**
+   * CredentialOwnerID optionally names the user whose Claude subscription should
+   * authenticate this task's agent, for orchestrators dispatching work on a
+   * human's behalf under one service API key. Credential resolution only — the
+   * task is still created by, owned by, and attributed to the caller. Ignored
+   * unless that user has delegated their subscription to this organization.
+   */
+  credential_owner_id?: string;
   /** Optional: IDs of tasks this task depends on */
   depends_on?: string[];
   /**
@@ -3259,6 +3293,17 @@ export interface TypesCronTrigger {
   agent_type?: string;
   /** Webhook URL to POST on completion */
   callback_url?: string;
+  /**
+   * CredentialOwnerID optionally names the user whose Claude subscription should
+   * authenticate the agent this trigger starts. An orchestrator writing triggers
+   * on people's behalf under one service API key sets it so a scheduled run
+   * authenticates as the person it acts for, exactly as CreateTaskRequest does
+   * for a run dispatched by hand. Credential resolution only: the task is still
+   * created by, owned by, and attributed to the trigger's app owner, and the
+   * named user must have delegated their subscription to this organization or it
+   * is ignored. Currently honoured by the spec_task action.
+   */
+  credential_owner_id?: string;
   emails?: string[];
   enabled?: boolean;
   input?: string;
@@ -4182,6 +4227,7 @@ export enum TypesModality {
   ModalityText = "text",
   ModalityImage = "image",
   ModalityFile = "file",
+  ModalityVideo = "video",
 }
 
 export interface TypesModel {
@@ -5016,11 +5062,19 @@ export enum TypesProvider {
   ProviderOpenAI = "openai",
   ProviderTogetherAI = "togetherai",
   ProviderAnthropic = "anthropic",
+  ProviderMiniMax = "minimax",
   ProviderHelix = "helix",
   ProviderVLLM = "vllm",
 }
 
+export enum TypesProviderAPIFormat {
+  ProviderAPIFormatOpenAI = "openai",
+  ProviderAPIFormatAnthropic = "anthropic",
+}
+
 export interface TypesProviderEndpoint {
+  /** openai or anthropic; empty preserves legacy detection */
+  api_format?: TypesProviderAPIFormat;
   api_key?: string;
   /** Must be mounted to the container */
   api_key_file?: string;
@@ -6016,6 +6070,14 @@ export interface TypesSessionMetadata {
   container_ip?: string;
   /** Container fields (Hydra executor) */
   container_name?: string;
+  /**
+   * CredentialOwnerID mirrors SpecTask.CredentialOwnerID onto the session: the
+   * user whose Claude subscription authenticates this session's agent, when
+   * that differs from Owner. Affects credential resolution ONLY — Owner still
+   * owns and is attributed the session. Honoured only with an explicit
+   * delegation grant; see ResolveClaudeCredentialOwner.
+   */
+  credential_owner_id?: string;
   /** Dev container ID for streaming */
   dev_container_id?: string;
   document_group_id?: string;
@@ -6277,6 +6339,24 @@ export interface TypesSpecTask {
   created_at?: string;
   /** Metadata */
   created_by?: string;
+  /**
+   * CredentialOwnerID names the user whose Claude subscription authenticates
+   * this task's agent sessions, when that differs from CreatedBy. It changes
+   * ONLY credential resolution — the task and its sessions are still owned by,
+   * and attributed to, CreatedBy. Nothing "runs as" the credential owner.
+   *
+   * This exists for orchestrators (HelixOS) that dispatch every task with one
+   * service API key but run work on behalf of different humans: without it the
+   * service account's subscription authenticates everyone's bots, so one
+   * person's expired token breaks all of them and no one can use their own
+   * Claude account.
+   *
+   * Honoured only when the named user has delegated their subscription to this
+   * organization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able
+   * to create a task could spend another user's Claude quota. See
+   * ResolveClaudeCredentialOwner.
+   */
+  credential_owner_id?: string;
   depends_on?: TypesSpecTask[];
   description?: string;
   design_doc_path?: string;
@@ -6623,6 +6703,24 @@ export interface TypesSpecTaskWithProject {
   created_at?: string;
   /** Metadata */
   created_by?: string;
+  /**
+   * CredentialOwnerID names the user whose Claude subscription authenticates
+   * this task's agent sessions, when that differs from CreatedBy. It changes
+   * ONLY credential resolution — the task and its sessions are still owned by,
+   * and attributed to, CreatedBy. Nothing "runs as" the credential owner.
+   *
+   * This exists for orchestrators (HelixOS) that dispatch every task with one
+   * service API key but run work on behalf of different humans: without it the
+   * service account's subscription authenticates everyone's bots, so one
+   * person's expired token breaks all of them and no one can use their own
+   * Claude account.
+   *
+   * Honoured only when the named user has delegated their subscription to this
+   * organization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able
+   * to create a task could spend another user's Claude quota. See
+   * ResolveClaudeCredentialOwner.
+   */
+  credential_owner_id?: string;
   depends_on?: TypesSpecTask[];
   description?: string;
   design_doc_path?: string;
@@ -7262,6 +7360,7 @@ export interface TypesUpdateOrganizationMemberRequest {
 }
 
 export interface TypesUpdateProviderEndpoint {
+  api_format?: TypesProviderAPIFormat;
   api_key?: string;
   /** Must be mounted to the container */
   api_key_file?: string;
@@ -8230,6 +8329,31 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         method: "DELETE",
         secure: true,
         format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Create (or return the existing) named API key owned by another user, so a trusted orchestrator can act as the people it runs work for instead of putting the whole fleet on one shared account. Idempotent per (user, name).
+     *
+     * @tags users
+     * @name V1AdminUsersApiKeysCreate
+     * @summary Mint an API key for a user (Admin only)
+     * @request POST:/api/v1/admin/users/{id}/api-keys
+     * @secure
+     */
+    v1AdminUsersApiKeysCreate: (
+      id: string,
+      query: {
+        /** Key name, e.g. the orchestrator's slug */
+        name: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesApiKey, any>({
+        path: `/api/v1/admin/users/${id}/api-keys`,
+        method: "POST",
+        query: query,
+        secure: true,
         ...params,
       }),
 
@@ -9412,23 +9536,6 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Disconnect a Claude subscription
-     *
-     * @tags Claude
-     * @name V1ClaudeSubscriptionsDelete
-     * @summary Delete a Claude subscription
-     * @request DELETE:/api/v1/claude-subscriptions/{id}
-     * @secure
-     */
-    v1ClaudeSubscriptionsDelete: (id: string, params: RequestParams = {}) =>
-      this.request<Record<string, string>, SystemHTTPError>({
-        path: `/api/v1/claude-subscriptions/${id}`,
-        method: "DELETE",
-        secure: true,
-        ...params,
-      }),
-
-    /**
      * @description Get details of a specific Claude subscription (no secrets)
      *
      * @tags Claude
@@ -9442,6 +9549,30 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         path: `/api/v1/claude-subscriptions/${id}`,
         method: "GET",
         secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Only the subscription owner may change this.
+     *
+     * @tags Claude
+     * @name V1ClaudeSubscriptionsDelegationUpdate
+     * @summary Set which orgs may use a Claude subscription for delegated agent runs
+     * @request PUT:/api/v1/claude-subscriptions/{id}/delegation
+     * @secure
+     */
+    v1ClaudeSubscriptionsDelegationUpdate: (
+      id: string,
+      body: ServerUpdateClaudeSubscriptionDelegationRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesClaudeSubscription, SystemHTTPError>({
+        path: `/api/v1/claude-subscriptions/${id}/delegation`,
+        method: "PUT",
+        body: body,
+        secure: true,
+        type: ContentType.Json,
         format: "json",
         ...params,
       }),

--- a/frontend/src/components/providers/AddProviderDialog.tsx
+++ b/frontend/src/components/providers/AddProviderDialog.tsx
@@ -12,12 +12,13 @@ import {
   Alert,
   IconButton,
   InputAdornment,
+  MenuItem,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import DarkDialog from '../dialog/DarkDialog';
 import useLightTheme from '../../hooks/useLightTheme';
 import { useCreateProviderEndpoint, useUpdateProviderEndpoint, useDeleteProviderEndpoint } from '../../services/providersService';
-import { TypesProviderEndpointType } from '../../api/api';
+import { TypesProviderAPIFormat, TypesProviderEndpointType } from '../../api/api';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 
@@ -38,6 +39,14 @@ interface AddProviderDialogProps {
     configurable_base_url?: boolean;
     optional_api_key?: boolean; // If provider doesn't need an API key
     is_custom?: boolean; // If true, the user picks the endpoint name
+    api_format?: 'openai' | 'anthropic';
+    endpoints?: Array<{
+      id: string;
+      label: string;
+      base_url: string;
+      api_format: 'openai' | 'anthropic';
+    }>;
+    models?: string[];
     setup_instructions: string;
   };
   // Only set if we are editing an existing provider
@@ -79,6 +88,7 @@ const AddProviderDialog: React.FC<AddProviderDialogProps> = ({
 
   const [apiKey, setApiKey] = useState('');
   const [baseUrl, setBaseUrl] = useState('');
+  const [apiFormat, setApiFormat] = useState<'openai' | 'anthropic' | undefined>();
   const [customName, setCustomName] = useState('');
   const [customNameError, setCustomNameError] = useState<string | null>(null);
   const [modelName, setModelName] = useState('');
@@ -95,7 +105,13 @@ const AddProviderDialog: React.FC<AddProviderDialogProps> = ({
   const isPending = isCreating || isUpdating || isDeleting;
 
   useEffect(() => {
-    setBaseUrl(existingProvider?.base_url ?? provider.base_url)
+    const existingFormat = existingProvider?.api_format as 'openai' | 'anthropic' | undefined;
+    const selectedEndpoint = provider.endpoints?.find((endpoint) =>
+      endpoint.base_url === existingProvider?.base_url &&
+      (!existingFormat || endpoint.api_format === existingFormat)
+    ) ?? provider.endpoints?.[0];
+    setBaseUrl(existingProvider?.base_url ?? selectedEndpoint?.base_url ?? provider.base_url)
+    setApiFormat(existingFormat ?? selectedEndpoint?.api_format ?? provider.api_format)
     setCustomName(existingProvider?.name ?? '')
     setCustomNameError(null)
     setModelName(existingProvider?.models?.[0] ?? '')
@@ -119,6 +135,7 @@ const AddProviderDialog: React.FC<AddProviderDialogProps> = ({
 
   const handleClose = () => {
     setApiKey('');
+    setApiFormat(provider.api_format);
     setCustomName('');
     setCustomNameError(null);
     setBaseUrlError(null);
@@ -182,7 +199,12 @@ const AddProviderDialog: React.FC<AddProviderDialogProps> = ({
       // Custom providers can pin a single preset model. When set, this is the
       // only model the endpoint exposes (no /v1/models lookup needed upstream).
       const trimmedModel = modelName.trim();
-      const presetModels = provider.is_custom && trimmedModel ? [trimmedModel] : undefined;
+      const presetModels = provider.models ?? (provider.is_custom && trimmedModel ? [trimmedModel] : undefined);
+      const serializedAPIFormat = apiFormat === 'anthropic'
+        ? TypesProviderAPIFormat.ProviderAPIFormatAnthropic
+        : apiFormat === 'openai'
+          ? TypesProviderAPIFormat.ProviderAPIFormatOpenAI
+          : undefined;
 
       if (isEditing && existingProvider?.id) {
         // Update existing provider
@@ -190,10 +212,11 @@ const AddProviderDialog: React.FC<AddProviderDialogProps> = ({
           id: existingProvider.id,
           body: {
             base_url: baseUrl,
+            ...(serializedAPIFormat ? { api_format: serializedAPIFormat } : {}),
             api_key: apiKeyToUse,
             endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeUser,
             description: provider.description,
-            ...(provider.is_custom ? { models: presetModels ?? [] } : {}),
+            ...((provider.is_custom || provider.models) ? { models: presetModels ?? [] } : {}),
           },
         });
         snackbarSuccess('Provider updated successfully');
@@ -202,6 +225,7 @@ const AddProviderDialog: React.FC<AddProviderDialogProps> = ({
         await createProviderEndpoint({
           name: endpointName,
           base_url: baseUrl,
+          ...(serializedAPIFormat ? { api_format: serializedAPIFormat } : {}),
           api_key: apiKey,
           endpoint_type: TypesProviderEndpointType.ProviderEndpointTypeUser,
           description: provider.description,
@@ -299,6 +323,32 @@ const AddProviderDialog: React.FC<AddProviderDialogProps> = ({
               />
             </Box>
             </>) : (<></>)}
+            { provider.endpoints?.length ? (
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+              <Typography variant="body2" sx={{ minWidth: 80, mr: 2, color: 'text.primary', fontWeight: 500 }}>
+                Endpoint
+              </Typography>
+              <TextField
+                select
+                fullWidth
+                value={provider.endpoints.find((endpoint) => endpoint.base_url === baseUrl && endpoint.api_format === apiFormat)?.id ?? ''}
+                onChange={(event) => {
+                  const endpoint = provider.endpoints?.find((candidate) => candidate.id === event.target.value);
+                  if (endpoint) {
+                    setBaseUrl(endpoint.base_url);
+                    setApiFormat(endpoint.api_format);
+                  }
+                }}
+                sx={{ flex: 1 }}
+              >
+                {provider.endpoints.map((endpoint) => (
+                  <MenuItem key={endpoint.id} value={endpoint.id}>
+                    {endpoint.label}
+                  </MenuItem>
+                ))}
+              </TextField>
+            </Box>
+            ) : null}
             { provider.is_custom ? (
             <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 2 }}>
               <Typography variant="body2" sx={{ minWidth: 80, mr: 2, mt: 1, color: 'text.primary', fontWeight: 500 }}>

--- a/frontend/src/components/providers/logos/minimax.tsx
+++ b/frontend/src/components/providers/logos/minimax.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const MiniMaxLogo = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 48 48" role="img" aria-label="MiniMax" {...props}>
+    <rect width="48" height="48" rx="10" fill="#111827" />
+    <path d="M9 34V14h6l9 12 9-12h6v20h-6V23l-9 11-9-11v11H9Z" fill="#FFFFFF" />
+  </svg>
+);
+
+export default MiniMaxLogo;

--- a/frontend/src/components/providers/types.ts
+++ b/frontend/src/components/providers/types.ts
@@ -7,6 +7,7 @@ import AWSLogo from './logos/aws';
 import XaiLogo from './logos/xai';
 import NvidiaLogo from './logos/nvidia';
 import CustomLogo from './logos/custom';
+import MiniMaxLogo from './logos/minimax';
 
 // Direct image imports
 import togetheraiLogo from '../../../assets/img/together-logo.png'
@@ -23,6 +24,15 @@ export interface Provider {
   
   base_url: string;
   configurable_base_url?: boolean;
+
+  api_format?: 'openai' | 'anthropic';
+  endpoints?: Array<{
+    id: string;
+    label: string;
+    base_url: string;
+    api_format: 'openai' | 'anthropic';
+  }>;
+  models?: string[];
 
   optional_api_key?: boolean; // If provider doesn't need an API key
 
@@ -68,6 +78,43 @@ export const PROVIDERS: Provider[] = [
     base_url: "https://api.anthropic.com/v1",
     setup_instructions: "Get your API key from https://platform.claude.com/settings/keys",
     api_key_url: "https://platform.claude.com/settings/keys"
+  },
+  {
+    id: 'user/minimax',
+    alias: ['minimax', 'minimax-api'],
+    name: 'MiniMax',
+    description: 'Use MiniMax models through OpenAI-compatible or Anthropic-compatible APIs.',
+    logo: MiniMaxLogo,
+    base_url: 'https://api.minimax.io/v1',
+    api_format: 'openai',
+    endpoints: [
+      {
+        id: 'global-openai',
+        label: 'Global - OpenAI-compatible',
+        base_url: 'https://api.minimax.io/v1',
+        api_format: 'openai',
+      },
+      {
+        id: 'global-anthropic',
+        label: 'Global - Anthropic-compatible',
+        base_url: 'https://api.minimax.io/anthropic',
+        api_format: 'anthropic',
+      },
+      {
+        id: 'cn-openai',
+        label: 'China - OpenAI-compatible',
+        base_url: 'https://api.minimaxi.com/v1',
+        api_format: 'openai',
+      },
+      {
+        id: 'cn-anthropic',
+        label: 'China - Anthropic-compatible',
+        base_url: 'https://api.minimaxi.com/anthropic',
+        api_format: 'anthropic',
+      },
+    ],
+    models: ['MiniMax-M3', 'MiniMax-M2.7'],
+    setup_instructions: 'Create an API key in the MiniMax platform and select the endpoint that matches your account region and client API format.',
   },
   {
     id: 'user/nvidia',

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -3066,6 +3066,14 @@ definitions:
       technical_design:
         type: string
     type: object
+  server.UpdateClaudeSubscriptionDelegationRequest:
+    description: Disconnect a Claude subscription
+    properties:
+      delegated_org_ids:
+        items:
+          type: string
+        type: array
+    type: object
   server.VideoStreamingStats:
     properties:
       client_buffers:
@@ -4389,6 +4397,20 @@ definitions:
       credential_type:
         description: '"oauth" or "setup_token"'
         type: string
+      delegated_org_ids:
+        description: |-
+          DelegatedOrgIDs lists the organizations whose agent sessions may
+          authenticate with this subscription on the owner's behalf, even when the
+          session itself is owned by someone else (a service account dispatching
+          work for this person — see SpecTask.CredentialOwnerID).
+
+          This is the consent gate. Without it, any member who can create a task
+          could name another user as credential owner and spend their Claude quota.
+          Empty (the default) means the subscription is only ever used for sessions
+          its owner owns, which is the pre-existing behaviour.
+        items:
+          type: string
+        type: array
       id:
         type: string
       last_error:
@@ -4662,6 +4684,15 @@ definitions:
         - $ref: '#/definitions/types.CodeAgentRuntime'
         description: 'Runtime specifies which code agent runtime to use: "zed_agent"
           or "qwen_code"'
+      uses_subscription:
+        description: |-
+          UsesSubscription is true when the agent authenticates against the upstream
+          provider with the user's own subscription (Claude Pro/Max, ChatGPT) instead
+          of an API key routed through the Helix proxy. It mirrors the assistant's
+          CodeAgentCredentialType and is what gates credential injection into the
+          container — an api_key agent must never receive subscription credentials,
+          because the CLI prefers them over the proxy and would silently bypass it.
+        type: boolean
     type: object
   types.CodeAgentCredentialType:
     enum:
@@ -5029,6 +5060,14 @@ definitions:
       branch_prefix:
         description: 'For new mode: user-specified prefix (task# appended)'
         type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID optionally names the user whose Claude subscription should
+          authenticate this task's agent, for orchestrators dispatching work on a
+          human's behalf under one service API key. Credential resolution only — the
+          task is still created by, owned by, and attributed to the caller. Ignored
+          unless that user has delegated their subscription to this organization.
+        type: string
       depends_on:
         description: 'Optional: IDs of tasks this task depends on'
         items:
@@ -5112,6 +5151,17 @@ definitions:
         type: string
       callback_url:
         description: Webhook URL to POST on completion
+        type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID optionally names the user whose Claude subscription should
+          authenticate the agent this trigger starts. An orchestrator writing triggers
+          on people's behalf under one service API key sets it so a scheduled run
+          authenticates as the person it acts for, exactly as CreateTaskRequest does
+          for a run dispatched by hand. Credential resolution only: the task is still
+          created by, owned by, and attributed to the trigger's app owner, and the
+          named user must have delegated their subscription to this organization or it
+          is ignored. Currently honoured by the spec_task action.
         type: string
       emails:
         items:
@@ -6593,11 +6643,13 @@ definitions:
     - text
     - image
     - file
+    - video
     type: string
     x-enum-varnames:
     - ModalityText
     - ModalityImage
     - ModalityFile
+    - ModalityVideo
   types.Model:
     properties:
       allocated_gpu_count:
@@ -7996,6 +8048,7 @@ definitions:
     - openai
     - togetherai
     - anthropic
+    - minimax
     - helix
     - vllm
     type: string
@@ -8003,10 +8056,23 @@ definitions:
     - ProviderOpenAI
     - ProviderTogetherAI
     - ProviderAnthropic
+    - ProviderMiniMax
     - ProviderHelix
     - ProviderVLLM
+  types.ProviderAPIFormat:
+    enum:
+    - openai
+    - anthropic
+    type: string
+    x-enum-varnames:
+    - ProviderAPIFormatOpenAI
+    - ProviderAPIFormatAnthropic
   types.ProviderEndpoint:
     properties:
+      api_format:
+        allOf:
+        - $ref: '#/definitions/types.ProviderAPIFormat'
+        description: openai or anthropic; empty preserves legacy detection
       api_key:
         type: string
       api_key_file:
@@ -9542,6 +9608,14 @@ definitions:
       container_name:
         description: Container fields (Hydra executor)
         type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID mirrors SpecTask.CredentialOwnerID onto the session: the
+          user whose Claude subscription authenticates this session's agent, when
+          that differs from Owner. Affects credential resolution ONLY — Owner still
+          owns and is attributed the session. Honoured only with an explicit
+          delegation grant; see ResolveClaudeCredentialOwner.
+        type: string
       dev_container_id:
         description: Dev container ID for streaming
         type: string
@@ -9972,6 +10046,24 @@ definitions:
         type: string
       created_by:
         description: Metadata
+        type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID names the user whose Claude subscription authenticates
+          this task's agent sessions, when that differs from CreatedBy. It changes
+          ONLY credential resolution — the task and its sessions are still owned by,
+          and attributed to, CreatedBy. Nothing "runs as" the credential owner.
+
+          This exists for orchestrators (HelixOS) that dispatch every task with one
+          service API key but run work on behalf of different humans: without it the
+          service account's subscription authenticates everyone's bots, so one
+          person's expired token breaks all of them and no one can use their own
+          Claude account.
+
+          Honoured only when the named user has delegated their subscription to this
+          organization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able
+          to create a task could spend another user's Claude quota. See
+          ResolveClaudeCredentialOwner.
         type: string
       depends_on:
         items:
@@ -10577,6 +10669,24 @@ definitions:
         type: string
       created_by:
         description: Metadata
+        type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID names the user whose Claude subscription authenticates
+          this task's agent sessions, when that differs from CreatedBy. It changes
+          ONLY credential resolution — the task and its sessions are still owned by,
+          and attributed to, CreatedBy. Nothing "runs as" the credential owner.
+
+          This exists for orchestrators (HelixOS) that dispatch every task with one
+          service API key but run work on behalf of different humans: without it the
+          service account's subscription authenticates everyone's bots, so one
+          person's expired token breaks all of them and no one can use their own
+          Claude account.
+
+          Honoured only when the named user has delegated their subscription to this
+          organization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able
+          to create a task could spend another user's Claude quota. See
+          ResolveClaudeCredentialOwner.
         type: string
       depends_on:
         items:
@@ -11632,6 +11742,8 @@ definitions:
     type: object
   types.UpdateProviderEndpoint:
     properties:
+      api_format:
+        $ref: '#/definitions/types.ProviderAPIFormat'
       api_key:
         type: string
       api_key_file:
@@ -12919,6 +13031,32 @@ paths:
       security:
       - BearerAuth: []
       summary: Delete a user (Admin only)
+      tags:
+      - users
+  /api/v1/admin/users/{id}/api-keys:
+    post:
+      description: Create (or return the existing) named API key owned by another
+        user, so a trusted orchestrator can act as the people it runs work for instead
+        of putting the whole fleet on one shared account. Idempotent per (user, name).
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Key name, e.g. the orchestrator's slug
+        in: query
+        name: name
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.ApiKey'
+      security:
+      - BearerAuth: []
+      summary: Mint an API key for a user (Admin only)
       tags:
       - users
   /api/v1/admin/users/{id}/approve:
@@ -14460,38 +14598,6 @@ paths:
       tags:
       - Claude
   /api/v1/claude-subscriptions/{id}:
-    delete:
-      description: Disconnect a Claude subscription
-      parameters:
-      - description: Subscription ID
-        in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Delete a Claude subscription
-      tags:
-      - Claude
     get:
       description: Get details of a specific Claude subscription (no secrets)
       parameters:
@@ -14522,6 +14628,53 @@ paths:
       security:
       - BearerAuth: []
       summary: Get a Claude subscription
+      tags:
+      - Claude
+  /api/v1/claude-subscriptions/{id}/delegation:
+    put:
+      consumes:
+      - application/json
+      description: Grant (or revoke) permission for an organization's orchestrated
+        agents to authenticate as the subscription owner. Only the subscription owner
+        may change this.
+      parameters:
+      - description: Subscription ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Delegated organizations
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/server.UpdateClaudeSubscriptionDelegationRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.ClaudeSubscription'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Set which orgs may use a Claude subscription for delegated agent runs
       tags:
       - Claude
   /api/v1/claude-subscriptions/models:

--- a/openapi.json
+++ b/openapi.json
@@ -994,6 +994,52 @@
                 }
             }
         },
+        "/api/v1/admin/users/{id}/api-keys": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create (or return the existing) named API key owned by another user, so a trusted orchestrator can act as the people it runs work for instead of putting the whole fleet on one shared account. Idempotent per (user, name).",
+                "tags": [
+                    "users"
+                ],
+                "summary": "Mint an API key for a user (Admin only)",
+                "parameters": [
+                    {
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Key name, e.g. the orchestrator's slug",
+                        "name": "name",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.ApiKey"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/users/{id}/approve": {
             "post": {
                 "security": [
@@ -4033,18 +4079,20 @@
                         }
                     }
                 }
-            },
-            "delete": {
+            }
+        },
+        "/api/v1/claude-subscriptions/{id}/delegation": {
+            "put": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
-                "description": "Disconnect a Claude subscription",
+                "description": "Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Only the subscription owner may change this.",
                 "tags": [
                     "Claude"
                 ],
-                "summary": "Delete a Claude subscription",
+                "summary": "Set which orgs may use a Claude subscription for delegated agent runs",
                 "parameters": [
                     {
                         "description": "Subscription ID",
@@ -4056,16 +4104,34 @@
                         }
                     }
                 ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/server.UpdateClaudeSubscriptionDelegationRequest"
+                            }
+                        }
+                    },
+                    "description": "Delegated organizations",
+                    "required": true
+                },
                 "responses": {
                     "200": {
                         "description": "OK",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    }
+                                    "$ref": "#/components/schemas/types.ClaudeSubscription"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
                                 }
                             }
                         }
@@ -4073,7 +4139,7 @@
                     "401": {
                         "description": "Unauthorized",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/system.HTTPError"
                                 }
@@ -4083,7 +4149,7 @@
                     "403": {
                         "description": "Forbidden",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/system.HTTPError"
                                 }
@@ -4093,7 +4159,7 @@
                     "404": {
                         "description": "Not Found",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/system.HTTPError"
                                 }
@@ -31345,6 +31411,18 @@
                     }
                 }
             },
+            "server.UpdateClaudeSubscriptionDelegationRequest": {
+                "description": "Disconnect a Claude subscription",
+                "type": "object",
+                "properties": {
+                    "delegated_org_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "server.VideoStreamingStats": {
                 "type": "object",
                 "properties": {
@@ -33113,6 +33191,13 @@
                         "description": "\"oauth\" or \"setup_token\"",
                         "type": "string"
                     },
+                    "delegated_org_ids": {
+                        "description": "DelegatedOrgIDs lists the organizations whose agent sessions may\nauthenticate with this subscription on the owner's behalf, even when the\nsession itself is owned by someone else (a service account dispatching\nwork for this person — see SpecTask.CredentialOwnerID).\n\nThis is the consent gate. Without it, any member who can create a task\ncould name another user as credential owner and spend their Claude quota.\nEmpty (the default) means the subscription is only ever used for sessions\nits owner owns, which is the pre-existing behaviour.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "id": {
                         "type": "string"
                     },
@@ -33486,6 +33571,10 @@
                                 "$ref": "#/components/schemas/types.CodeAgentRuntime"
                             }
                         ]
+                    },
+                    "uses_subscription": {
+                        "description": "UsesSubscription is true when the agent authenticates against the upstream\nprovider with the user's own subscription (Claude Pro/Max, ChatGPT) instead\nof an API key routed through the Helix proxy. It mirrors the assistant's\nCodeAgentCredentialType and is what gates credential injection into the\ncontainer — an api_key agent must never receive subscription credentials,\nbecause the CLI prefers them over the proxy and would silently bypass it.",
+                        "type": "boolean"
                     }
                 }
             },
@@ -34013,6 +34102,10 @@
                         "description": "For new mode: user-specified prefix (task# appended)",
                         "type": "string"
                     },
+                    "credential_owner_id": {
+                        "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate this task's agent, for orchestrators dispatching work on a\nhuman's behalf under one service API key. Credential resolution only — the\ntask is still created by, owned by, and attributed to the caller. Ignored\nunless that user has delegated their subscription to this organization.",
+                        "type": "string"
+                    },
                     "depends_on": {
                         "description": "Optional: IDs of tasks this task depends on",
                         "type": "array",
@@ -34126,6 +34219,10 @@
                     },
                     "callback_url": {
                         "description": "Webhook URL to POST on completion",
+                        "type": "string"
+                    },
+                    "credential_owner_id": {
+                        "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate the agent this trigger starts. An orchestrator writing triggers\non people's behalf under one service API key sets it so a scheduled run\nauthenticates as the person it acts for, exactly as CreateTaskRequest does\nfor a run dispatched by hand. Credential resolution only: the task is still\ncreated by, owned by, and attributed to the trigger's app owner, and the\nnamed user must have delegated their subscription to this organization or it\nis ignored. Currently honoured by the spec_task action.",
                         "type": "string"
                     },
                     "emails": {
@@ -36178,12 +36275,14 @@
                 "enum": [
                     "text",
                     "image",
-                    "file"
+                    "file",
+                    "video"
                 ],
                 "x-enum-varnames": [
                     "ModalityText",
                     "ModalityImage",
-                    "ModalityFile"
+                    "ModalityFile",
+                    "ModalityVideo"
                 ]
             },
             "types.Model": {
@@ -38161,6 +38260,7 @@
                     "openai",
                     "togetherai",
                     "anthropic",
+                    "minimax",
                     "helix",
                     "vllm"
                 ],
@@ -38168,13 +38268,33 @@
                     "ProviderOpenAI",
                     "ProviderTogetherAI",
                     "ProviderAnthropic",
+                    "ProviderMiniMax",
                     "ProviderHelix",
                     "ProviderVLLM"
+                ]
+            },
+            "types.ProviderAPIFormat": {
+                "type": "string",
+                "enum": [
+                    "openai",
+                    "anthropic"
+                ],
+                "x-enum-varnames": [
+                    "ProviderAPIFormatOpenAI",
+                    "ProviderAPIFormatAnthropic"
                 ]
             },
             "types.ProviderEndpoint": {
                 "type": "object",
                 "properties": {
+                    "api_format": {
+                        "description": "openai or anthropic; empty preserves legacy detection",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/types.ProviderAPIFormat"
+                            }
+                        ]
+                    },
                     "api_key": {
                         "type": "string"
                     },
@@ -40161,6 +40281,10 @@
                         "description": "Container fields (Hydra executor)",
                         "type": "string"
                     },
+                    "credential_owner_id": {
+                        "description": "CredentialOwnerID mirrors SpecTask.CredentialOwnerID onto the session: the\nuser whose Claude subscription authenticates this session's agent, when\nthat differs from Owner. Affects credential resolution ONLY — Owner still\nowns and is attributed the session. Honoured only with an explicit\ndelegation grant; see ResolveClaudeCredentialOwner.",
+                        "type": "string"
+                    },
                     "dev_container_id": {
                         "description": "Dev container ID for streaming",
                         "type": "string"
@@ -40755,6 +40879,10 @@
                     },
                     "created_by": {
                         "description": "Metadata",
+                        "type": "string"
+                    },
+                    "credential_owner_id": {
+                        "description": "CredentialOwnerID names the user whose Claude subscription authenticates\nthis task's agent sessions, when that differs from CreatedBy. It changes\nONLY credential resolution — the task and its sessions are still owned by,\nand attributed to, CreatedBy. Nothing \"runs as\" the credential owner.\n\nThis exists for orchestrators (HelixOS) that dispatch every task with one\nservice API key but run work on behalf of different humans: without it the\nservice account's subscription authenticates everyone's bots, so one\nperson's expired token breaks all of them and no one can use their own\nClaude account.\n\nHonoured only when the named user has delegated their subscription to this\norganization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able\nto create a task could spend another user's Claude quota. See\nResolveClaudeCredentialOwner.",
                         "type": "string"
                     },
                     "depends_on": {
@@ -41553,6 +41681,10 @@
                     },
                     "created_by": {
                         "description": "Metadata",
+                        "type": "string"
+                    },
+                    "credential_owner_id": {
+                        "description": "CredentialOwnerID names the user whose Claude subscription authenticates\nthis task's agent sessions, when that differs from CreatedBy. It changes\nONLY credential resolution — the task and its sessions are still owned by,\nand attributed to, CreatedBy. Nothing \"runs as\" the credential owner.\n\nThis exists for orchestrators (HelixOS) that dispatch every task with one\nservice API key but run work on behalf of different humans: without it the\nservice account's subscription authenticates everyone's bots, so one\nperson's expired token breaks all of them and no one can use their own\nClaude account.\n\nHonoured only when the named user has delegated their subscription to this\norganization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able\nto create a task could spend another user's Claude quota. See\nResolveClaudeCredentialOwner.",
                         "type": "string"
                     },
                     "depends_on": {
@@ -43023,6 +43155,9 @@
             "types.UpdateProviderEndpoint": {
                 "type": "object",
                 "properties": {
+                    "api_format": {
+                        "$ref": "#/components/schemas/types.ProviderAPIFormat"
+                    },
                     "api_key": {
                         "type": "string"
                     },

--- a/swagger.json
+++ b/swagger.json
@@ -834,6 +834,44 @@
                 }
             }
         },
+        "/api/v1/admin/users/{id}/api-keys": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create (or return the existing) named API key owned by another user, so a trusted orchestrator can act as the people it runs work for instead of putting the whole fleet on one shared account. Idempotent per (user, name).",
+                "tags": [
+                    "users"
+                ],
+                "summary": "Mint an API key for a user (Admin only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Key name, e.g. the orchestrator's slug",
+                        "name": "name",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.ApiKey"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/users/{id}/approve": {
             "post": {
                 "security": [
@@ -3388,18 +3426,26 @@
                         }
                     }
                 }
-            },
-            "delete": {
+            }
+        },
+        "/api/v1/claude-subscriptions/{id}/delegation": {
+            "put": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
-                "description": "Disconnect a Claude subscription",
+                "description": "Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Only the subscription owner may change this.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
                 "tags": [
                     "Claude"
                 ],
-                "summary": "Delete a Claude subscription",
+                "summary": "Set which orgs may use a Claude subscription for delegated agent runs",
                 "parameters": [
                     {
                         "type": "string",
@@ -3407,16 +3453,28 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Delegated organizations",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.UpdateClaudeSubscriptionDelegationRequest"
+                        }
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/types.ClaudeSubscription"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
                         }
                     },
                     "401": {
@@ -26784,6 +26842,18 @@
                 }
             }
         },
+        "server.UpdateClaudeSubscriptionDelegationRequest": {
+            "description": "Disconnect a Claude subscription",
+            "type": "object",
+            "properties": {
+                "delegated_org_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "server.VideoStreamingStats": {
             "type": "object",
             "properties": {
@@ -28552,6 +28622,13 @@
                     "description": "\"oauth\" or \"setup_token\"",
                     "type": "string"
                 },
+                "delegated_org_ids": {
+                    "description": "DelegatedOrgIDs lists the organizations whose agent sessions may\nauthenticate with this subscription on the owner's behalf, even when the\nsession itself is owned by someone else (a service account dispatching\nwork for this person — see SpecTask.CredentialOwnerID).\n\nThis is the consent gate. Without it, any member who can create a task\ncould name another user as credential owner and spend their Claude quota.\nEmpty (the default) means the subscription is only ever used for sessions\nits owner owns, which is the pre-existing behaviour.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "id": {
                     "type": "string"
                 },
@@ -28925,6 +29002,10 @@
                             "$ref": "#/definitions/types.CodeAgentRuntime"
                         }
                     ]
+                },
+                "uses_subscription": {
+                    "description": "UsesSubscription is true when the agent authenticates against the upstream\nprovider with the user's own subscription (Claude Pro/Max, ChatGPT) instead\nof an API key routed through the Helix proxy. It mirrors the assistant's\nCodeAgentCredentialType and is what gates credential injection into the\ncontainer — an api_key agent must never receive subscription credentials,\nbecause the CLI prefers them over the proxy and would silently bypass it.",
+                    "type": "boolean"
                 }
             }
         },
@@ -29452,6 +29533,10 @@
                     "description": "For new mode: user-specified prefix (task# appended)",
                     "type": "string"
                 },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate this task's agent, for orchestrators dispatching work on a\nhuman's behalf under one service API key. Credential resolution only — the\ntask is still created by, owned by, and attributed to the caller. Ignored\nunless that user has delegated their subscription to this organization.",
+                    "type": "string"
+                },
                 "depends_on": {
                     "description": "Optional: IDs of tasks this task depends on",
                     "type": "array",
@@ -29565,6 +29650,10 @@
                 },
                 "callback_url": {
                     "description": "Webhook URL to POST on completion",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate the agent this trigger starts. An orchestrator writing triggers\non people's behalf under one service API key sets it so a scheduled run\nauthenticates as the person it acts for, exactly as CreateTaskRequest does\nfor a run dispatched by hand. Credential resolution only: the task is still\ncreated by, owned by, and attributed to the trigger's app owner, and the\nnamed user must have delegated their subscription to this organization or it\nis ignored. Currently honoured by the spec_task action.",
                     "type": "string"
                 },
                 "emails": {
@@ -31617,12 +31706,14 @@
             "enum": [
                 "text",
                 "image",
-                "file"
+                "file",
+                "video"
             ],
             "x-enum-varnames": [
                 "ModalityText",
                 "ModalityImage",
-                "ModalityFile"
+                "ModalityFile",
+                "ModalityVideo"
             ]
         },
         "types.Model": {
@@ -33600,6 +33691,7 @@
                 "openai",
                 "togetherai",
                 "anthropic",
+                "minimax",
                 "helix",
                 "vllm"
             ],
@@ -33607,13 +33699,33 @@
                 "ProviderOpenAI",
                 "ProviderTogetherAI",
                 "ProviderAnthropic",
+                "ProviderMiniMax",
                 "ProviderHelix",
                 "ProviderVLLM"
+            ]
+        },
+        "types.ProviderAPIFormat": {
+            "type": "string",
+            "enum": [
+                "openai",
+                "anthropic"
+            ],
+            "x-enum-varnames": [
+                "ProviderAPIFormatOpenAI",
+                "ProviderAPIFormatAnthropic"
             ]
         },
         "types.ProviderEndpoint": {
             "type": "object",
             "properties": {
+                "api_format": {
+                    "description": "openai or anthropic; empty preserves legacy detection",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.ProviderAPIFormat"
+                        }
+                    ]
+                },
                 "api_key": {
                     "type": "string"
                 },
@@ -35600,6 +35712,10 @@
                     "description": "Container fields (Hydra executor)",
                     "type": "string"
                 },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID mirrors SpecTask.CredentialOwnerID onto the session: the\nuser whose Claude subscription authenticates this session's agent, when\nthat differs from Owner. Affects credential resolution ONLY — Owner still\nowns and is attributed the session. Honoured only with an explicit\ndelegation grant; see ResolveClaudeCredentialOwner.",
+                    "type": "string"
+                },
                 "dev_container_id": {
                     "description": "Dev container ID for streaming",
                     "type": "string"
@@ -36194,6 +36310,10 @@
                 },
                 "created_by": {
                     "description": "Metadata",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID names the user whose Claude subscription authenticates\nthis task's agent sessions, when that differs from CreatedBy. It changes\nONLY credential resolution — the task and its sessions are still owned by,\nand attributed to, CreatedBy. Nothing \"runs as\" the credential owner.\n\nThis exists for orchestrators (HelixOS) that dispatch every task with one\nservice API key but run work on behalf of different humans: without it the\nservice account's subscription authenticates everyone's bots, so one\nperson's expired token breaks all of them and no one can use their own\nClaude account.\n\nHonoured only when the named user has delegated their subscription to this\norganization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able\nto create a task could spend another user's Claude quota. See\nResolveClaudeCredentialOwner.",
                     "type": "string"
                 },
                 "depends_on": {
@@ -36992,6 +37112,10 @@
                 },
                 "created_by": {
                     "description": "Metadata",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID names the user whose Claude subscription authenticates\nthis task's agent sessions, when that differs from CreatedBy. It changes\nONLY credential resolution — the task and its sessions are still owned by,\nand attributed to, CreatedBy. Nothing \"runs as\" the credential owner.\n\nThis exists for orchestrators (HelixOS) that dispatch every task with one\nservice API key but run work on behalf of different humans: without it the\nservice account's subscription authenticates everyone's bots, so one\nperson's expired token breaks all of them and no one can use their own\nClaude account.\n\nHonoured only when the named user has delegated their subscription to this\norganization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able\nto create a task could spend another user's Claude quota. See\nResolveClaudeCredentialOwner.",
                     "type": "string"
                 },
                 "depends_on": {
@@ -38462,6 +38586,9 @@
         "types.UpdateProviderEndpoint": {
             "type": "object",
             "properties": {
+                "api_format": {
+                    "$ref": "#/definitions/types.ProviderAPIFormat"
+                },
                 "api_key": {
                     "type": "string"
                 },


### PR DESCRIPTION
Reason: Helix lacks a first-class MiniMax preset and protocol-aware routing for current models and regional endpoints.

- Add global and user provider configuration for current MiniMax models and regional endpoints.
- Persist API format selection and route compatible requests with the required authentication and base paths.
- Add provider UI, Helm values, model metadata, generated API definitions, and focused tests.

Checks:
- `go test -count=1 ./api/pkg/config ./api/pkg/model ./api/pkg/openai/manager ./api/pkg/anthropic ./api/pkg/external-agent ./api/pkg/server`
- `npm --prefix frontend run build-frontend`
- `PATH="$(go env GOPATH)/bin:$PATH" ./stack update_openapi`
- `git diff origin/main --check`
- Secret scan against `origin/main`
- `npm --prefix frontend run tsc` reports 11 existing UI typing errors outside the changed files and no errors in changed files.
