### PR TITLE
feat(frontend): customize org chart controls

### DIFF
--- a/api/pkg/org/domain/seedprompts/seedprompts.go
+++ b/api/pkg/org/domain/seedprompts/seedprompts.go
@@ -1,0 +1,69 @@
+// Package seedprompts holds the built-in instruction prompts a new org is
+// seeded with. It is data, not behaviour: the org bootstrap writes these
+// into the Bot's Content on create, and the "reset instructions" surface
+// hands the same text back so an operator can undo local edits.
+//
+// It lives in domain/ (rather than next to the seeder in pkg/server) so
+// both the bootstrap path and the org REST API can read it — pkg/org
+// cannot import pkg/server without a cycle.
+package seedprompts
+
+import "github.com/helixml/helix/api/pkg/org/domain/orgchart"
+
+// ChiefOfStaffBotID is the fixed node id of the Chief of Staff bot every
+// new org is seeded with.
+const ChiefOfStaffBotID orgchart.NodeID = "chief-of-staff"
+
+// ChiefOfStaff is the seed prompt for the Chief of Staff bot every new
+// org gets. Originally lived in the frontend (EditOrgWindow.tsx), then in
+// pkg/server's org_graph_seed.go; moved here so org bootstrap and the
+// reset-instructions API share one source of truth.
+const ChiefOfStaff = `# Chief of Staff
+
+You are the Chief of Staff for this organization - the owner's right hand, here to support them and the team.
+
+## First, reach the owner
+On your first activation you do not yet know what this organization is for. Find the owner and ask them - do NOT guess, and do NOT just write the question into your own transcript (they will not see that).
+
+1. Call ` + "`read_bots`" + ` and find the **person** - the node whose ` + "`kind`" + ` is ` + "`human`" + ` (its id looks like ` + "`h-…`" + `). On a new org there is exactly one: the owner who created it.
+2. Use ` + "`ask_human`" + ` with that person's id to deliver the initial message through Helix notifications. Ask them, in one friendly message:
+   - what this organization is for and what they want to accomplish,
+   - who the key people are and what they are responsible for,
+   - whether future messages should arrive in Helix or Slack,
+   - and anything else you need to set it up well.
+
+Keep it to a single, concise message - you can follow up once they reply.
+
+If they choose Slack, ask them to install the org's Slack workspace from the Helix Slack integration settings, then ask for their Slack email and, if they prefer a shared channel, its channel name. Do not make them find opaque Slack IDs. Use ` + "`mint_credential`" + ` with provider ` + "`slack`" + `, then call Slack's ` + "`users.lookupByEmail`" + ` and ` + "`conversations.list`" + ` APIs to resolve the canonical user, channel, and team IDs. Use ` + "`set_human_contact`" + ` to set ` + "`preferred_contact=slack`" + `, ` + "`slack_user_id`" + `, and optionally ` + "`slack_channel_id`" + ` and ` + "`slack_team_id`" + `. Ask for IDs only if lookup fails. If they choose Helix, set ` + "`preferred_contact=helix`" + `. Do not claim Slack is ready until the workspace is installed and the contact update succeeds.
+
+## Then set things up
+When the owner answers, use what they told you to build the org: bring in assistant bots for the concrete pieces of work, give each a clear purpose, connect who works with whom, and subscribe them to the topics they need. Coordinate and keep things organized, and delegate the hands-on work to the assistants you bring in rather than doing it all yourself. Reach the owner again with ` + "`ask_human`" + ` whenever you need a decision or their input.
+
+## Give bots the code they need
+Nodes only see git repositories attached to their Helix project. After you create a bot (and it has been activated so its project exists):
+
+1. Call ` + "`list_repositories`" + ` to see every repo in this organization.
+2. Call ` + "`attach_repository`" + ` with ` + "`bot_id`" + ` + ` + "`repo_id`" + ` (and ` + "`primary: true`" + ` when it should be their main working repo).
+3. To **check** what a bot has attached: call ` + "`list_bot_repositories`" + ` with that ` + "`bot_id`" + `, or ` + "`get_bot`" + ` (the response includes a ` + "`repositories`" + ` array). Do **not** guess from memory of who attached what — the UI or another agent may have attached repos.
+4. Use ` + "`detach_repository`" + ` to remove an attachment.
+
+Without attached repos a coding bot has nothing to clone and cannot do real work.
+
+## How to call your tools
+Your tools are helix MCP tools (` + "`mcp__helix__…`" + `). They are live as soon as they appear on your bot's tool list — call them **directly** by name (e.g. ` + "`mcp__helix__list_bot_repositories`" + `). Do **not** wait for a "next activation", and do **not** rely on deferred-tool ` + "`ToolSearch`" + ` to find them. If ` + "`tools/list`" + ` / your tool list shows a name, invoke it now.
+
+## Start, stop, and restart bots
+Use ` + "`start_bot`" + ` to bring a bot's desktop online (also after create — activation provisions the project). Use ` + "`stop_bot`" + ` to shut the desktop down without losing the transcript. Use ` + "`restart_bot`" + ` when you need a brand-new session (e.g. after changing tools or repo attachments).`
+
+// Default returns the built-in instructions for a seeded node, and
+// whether one exists. Nodes an operator created themselves have no
+// built-in default — the caller should hide the reset affordance rather
+// than offer a reset to empty.
+func Default(id orgchart.NodeID) (string, bool) {
+	switch id {
+	case ChiefOfStaffBotID:
+		return ChiefOfStaff, true
+	default:
+		return "", false
+	}
+}

--- a/api/pkg/org/interfaces/server/api/bots.go
+++ b/api/pkg/org/interfaces/server/api/bots.go
@@ -13,6 +13,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
 	"github.com/helixml/helix/api/pkg/org/application/nodes"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/seedprompts"
 	"github.com/helixml/helix/api/pkg/org/domain/streaming"
 	"github.com/helixml/helix/api/pkg/org/domain/tool"
 	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
@@ -175,6 +176,12 @@ func (a *apiHandler) getBot(w http.ResponseWriter, r *http.Request) {
 	if err := a.canonicalAgentProfile(ctx, b, &dto); err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
+	}
+	// Seeded nodes carry their built-in prompt so the UI can offer a
+	// reset to it; operator-created nodes have none and the field stays
+	// empty, which is the UI's signal to hide the affordance.
+	if def, ok := seedprompts.Default(id); ok {
+		dto.DefaultInstructions = def
 	}
 	dto.AgentStatus = "stopped"
 	// Populate the agent app id + project id from the helix-runtime

--- a/api/pkg/org/interfaces/server/api/dto.go
+++ b/api/pkg/org/interfaces/server/api/dto.go
@@ -77,6 +77,13 @@ type BotDTO struct {
 	ReasoningEffort         string                        `json:"reasoning_effort,omitempty"`
 	CreatedAt               string                        `json:"created_at,omitempty"`
 	UpdatedAt               string                        `json:"updated_at,omitempty"`
+	// DefaultInstructions is the built-in seed prompt for this node, when
+	// one exists (currently only the Chief of Staff every org is seeded
+	// with). It lets the UI offer "reset instructions" and hide that
+	// affordance for operator-created nodes, which have no default to
+	// reset to. Detail-only: GET /bots/{id} populates it, the list does
+	// not (it would repeat kilobytes of prompt per row).
+	DefaultInstructions string `json:"default_instructions,omitempty"`
 }
 
 func (d BotDTO) MarshalJSON() ([]byte, error) {

--- a/api/pkg/server/docs.go
+++ b/api/pkg/server/docs.go
@@ -838,6 +838,44 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/admin/users/{id}/api-keys": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create (or return the existing) named API key owned by another user, so a trusted orchestrator can act as the people it runs work for instead of putting the whole fleet on one shared account. Idempotent per (user, name).",
+                "tags": [
+                    "users"
+                ],
+                "summary": "Mint an API key for a user (Admin only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Key name, e.g. the orchestrator's slug",
+                        "name": "name",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.ApiKey"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/users/{id}/approve": {
             "post": {
                 "security": [
@@ -3392,18 +3430,26 @@ const docTemplate = `{
                         }
                     }
                 }
-            },
-            "delete": {
+            }
+        },
+        "/api/v1/claude-subscriptions/{id}/delegation": {
+            "put": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
-                "description": "Disconnect a Claude subscription",
+                "description": "Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Only the subscription owner may change this.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
                 "tags": [
                     "Claude"
                 ],
-                "summary": "Delete a Claude subscription",
+                "summary": "Set which orgs may use a Claude subscription for delegated agent runs",
                 "parameters": [
                     {
                         "type": "string",
@@ -3411,16 +3457,28 @@ const docTemplate = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Delegated organizations",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.UpdateClaudeSubscriptionDelegationRequest"
+                        }
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/types.ClaudeSubscription"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
                         }
                     },
                     "401": {
@@ -22502,6 +22560,10 @@ const docTemplate = `{
                 "created_at": {
                     "type": "string"
                 },
+                "default_instructions": {
+                    "description": "DefaultInstructions is the built-in seed prompt for this node, when\none exists (currently only the Chief of Staff every org is seeded\nwith). It lets the UI offer \"reset instructions\" and hide that\naffordance for operator-created nodes, which have no default to\nreset to. Detail-only: GET /bots/{id} populates it, the list does\nnot (it would repeat kilobytes of prompt per row).",
+                    "type": "string"
+                },
                 "helix_user_id": {
                     "type": "string"
                 },
@@ -22635,6 +22697,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "created_at": {
+                    "type": "string"
+                },
+                "default_instructions": {
+                    "description": "DefaultInstructions is the built-in seed prompt for this node, when\none exists (currently only the Chief of Staff every org is seeded\nwith). It lets the UI offer \"reset instructions\" and hide that\naffordance for operator-created nodes, which have no default to\nreset to. Detail-only: GET /bots/{id} populates it, the list does\nnot (it would repeat kilobytes of prompt per row).",
                     "type": "string"
                 },
                 "helix_user_id": {
@@ -26788,6 +26854,18 @@ const docTemplate = `{
                 }
             }
         },
+        "server.UpdateClaudeSubscriptionDelegationRequest": {
+            "description": "Disconnect a Claude subscription",
+            "type": "object",
+            "properties": {
+                "delegated_org_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "server.VideoStreamingStats": {
             "type": "object",
             "properties": {
@@ -28556,6 +28634,13 @@ const docTemplate = `{
                     "description": "\"oauth\" or \"setup_token\"",
                     "type": "string"
                 },
+                "delegated_org_ids": {
+                    "description": "DelegatedOrgIDs lists the organizations whose agent sessions may\nauthenticate with this subscription on the owner's behalf, even when the\nsession itself is owned by someone else (a service account dispatching\nwork for this person — see SpecTask.CredentialOwnerID).\n\nThis is the consent gate. Without it, any member who can create a task\ncould name another user as credential owner and spend their Claude quota.\nEmpty (the default) means the subscription is only ever used for sessions\nits owner owns, which is the pre-existing behaviour.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "id": {
                     "type": "string"
                 },
@@ -28929,6 +29014,10 @@ const docTemplate = `{
                             "$ref": "#/definitions/types.CodeAgentRuntime"
                         }
                     ]
+                },
+                "uses_subscription": {
+                    "description": "UsesSubscription is true when the agent authenticates against the upstream\nprovider with the user's own subscription (Claude Pro/Max, ChatGPT) instead\nof an API key routed through the Helix proxy. It mirrors the assistant's\nCodeAgentCredentialType and is what gates credential injection into the\ncontainer — an api_key agent must never receive subscription credentials,\nbecause the CLI prefers them over the proxy and would silently bypass it.",
+                    "type": "boolean"
                 }
             }
         },
@@ -29456,6 +29545,10 @@ const docTemplate = `{
                     "description": "For new mode: user-specified prefix (task# appended)",
                     "type": "string"
                 },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate this task's agent, for orchestrators dispatching work on a\nhuman's behalf under one service API key. Credential resolution only — the\ntask is still created by, owned by, and attributed to the caller. Ignored\nunless that user has delegated their subscription to this organization.",
+                    "type": "string"
+                },
                 "depends_on": {
                     "description": "Optional: IDs of tasks this task depends on",
                     "type": "array",
@@ -29569,6 +29662,10 @@ const docTemplate = `{
                 },
                 "callback_url": {
                     "description": "Webhook URL to POST on completion",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate the agent this trigger starts. An orchestrator writing triggers\non people's behalf under one service API key sets it so a scheduled run\nauthenticates as the person it acts for, exactly as CreateTaskRequest does\nfor a run dispatched by hand. Credential resolution only: the task is still\ncreated by, owned by, and attributed to the trigger's app owner, and the\nnamed user must have delegated their subscription to this organization or it\nis ignored. Currently honoured by the spec_task action.",
                     "type": "string"
                 },
                 "emails": {
@@ -35604,6 +35701,10 @@ const docTemplate = `{
                     "description": "Container fields (Hydra executor)",
                     "type": "string"
                 },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID mirrors SpecTask.CredentialOwnerID onto the session: the\nuser whose Claude subscription authenticates this session's agent, when\nthat differs from Owner. Affects credential resolution ONLY — Owner still\nowns and is attributed the session. Honoured only with an explicit\ndelegation grant; see ResolveClaudeCredentialOwner.",
+                    "type": "string"
+                },
                 "dev_container_id": {
                     "description": "Dev container ID for streaming",
                     "type": "string"
@@ -36198,6 +36299,10 @@ const docTemplate = `{
                 },
                 "created_by": {
                     "description": "Metadata",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID names the user whose Claude subscription authenticates\nthis task's agent sessions, when that differs from CreatedBy. It changes\nONLY credential resolution — the task and its sessions are still owned by,\nand attributed to, CreatedBy. Nothing \"runs as\" the credential owner.\n\nThis exists for orchestrators (HelixOS) that dispatch every task with one\nservice API key but run work on behalf of different humans: without it the\nservice account's subscription authenticates everyone's bots, so one\nperson's expired token breaks all of them and no one can use their own\nClaude account.\n\nHonoured only when the named user has delegated their subscription to this\norganization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able\nto create a task could spend another user's Claude quota. See\nResolveClaudeCredentialOwner.",
                     "type": "string"
                 },
                 "depends_on": {
@@ -36996,6 +37101,10 @@ const docTemplate = `{
                 },
                 "created_by": {
                     "description": "Metadata",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID names the user whose Claude subscription authenticates\nthis task's agent sessions, when that differs from CreatedBy. It changes\nONLY credential resolution — the task and its sessions are still owned by,\nand attributed to, CreatedBy. Nothing \"runs as\" the credential owner.\n\nThis exists for orchestrators (HelixOS) that dispatch every task with one\nservice API key but run work on behalf of different humans: without it the\nservice account's subscription authenticates everyone's bots, so one\nperson's expired token breaks all of them and no one can use their own\nClaude account.\n\nHonoured only when the named user has delegated their subscription to this\norganization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able\nto create a task could spend another user's Claude quota. See\nResolveClaudeCredentialOwner.",
                     "type": "string"
                 },
                 "depends_on": {

--- a/api/pkg/server/org_graph_seed.go
+++ b/api/pkg/server/org_graph_seed.go
@@ -10,53 +10,19 @@ import (
 	"github.com/helixml/helix/api/pkg/org/application/lifecycle"
 	"github.com/helixml/helix/api/pkg/org/application/nodes"
 	"github.com/helixml/helix/api/pkg/org/domain/orgchart"
+	"github.com/helixml/helix/api/pkg/org/domain/seedprompts"
 	"github.com/helixml/helix/api/pkg/org/domain/store"
 	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
 	helixstore "github.com/helixml/helix/api/pkg/store"
 	"github.com/helixml/helix/api/pkg/types"
 )
 
-// chiefOfStaffContent is the seed prompt for the Chief of Staff bot every
-// new org gets. Moved here from the frontend (EditOrgWindow.tsx) so org
-// bootstrap is server-owned and robust — the FE no longer creates it.
-const chiefOfStaffContent = `# Chief of Staff
+// The Chief of Staff seed prompt lives in domain/seedprompts so this
+// bootstrap path and the reset-instructions API share one source of
+// truth (pkg/org cannot import pkg/server without a cycle).
+const chiefOfStaffContent = seedprompts.ChiefOfStaff
 
-You are the Chief of Staff for this organization - the owner's right hand, here to support them and the team.
-
-## First, reach the owner
-On your first activation you do not yet know what this organization is for. Find the owner and ask them - do NOT guess, and do NOT just write the question into your own transcript (they will not see that).
-
-1. Call ` + "`read_bots`" + ` and find the **person** - the node whose ` + "`kind`" + ` is ` + "`human`" + ` (its id looks like ` + "`h-…`" + `). On a new org there is exactly one: the owner who created it.
-2. Use ` + "`ask_human`" + ` with that person's id to deliver the initial message through Helix notifications. Ask them, in one friendly message:
-   - what this organization is for and what they want to accomplish,
-   - who the key people are and what they are responsible for,
-   - whether future messages should arrive in Helix or Slack,
-   - and anything else you need to set it up well.
-
-Keep it to a single, concise message - you can follow up once they reply.
-
-If they choose Slack, ask them to install the org's Slack workspace from the Helix Slack integration settings, then ask for their Slack email and, if they prefer a shared channel, its channel name. Do not make them find opaque Slack IDs. Use ` + "`mint_credential`" + ` with provider ` + "`slack`" + `, then call Slack's ` + "`users.lookupByEmail`" + ` and ` + "`conversations.list`" + ` APIs to resolve the canonical user, channel, and team IDs. Use ` + "`set_human_contact`" + ` to set ` + "`preferred_contact=slack`" + `, ` + "`slack_user_id`" + `, and optionally ` + "`slack_channel_id`" + ` and ` + "`slack_team_id`" + `. Ask for IDs only if lookup fails. If they choose Helix, set ` + "`preferred_contact=helix`" + `. Do not claim Slack is ready until the workspace is installed and the contact update succeeds.
-
-## Then set things up
-When the owner answers, use what they told you to build the org: bring in assistant bots for the concrete pieces of work, give each a clear purpose, connect who works with whom, and subscribe them to the topics they need. Coordinate and keep things organized, and delegate the hands-on work to the assistants you bring in rather than doing it all yourself. Reach the owner again with ` + "`ask_human`" + ` whenever you need a decision or their input.
-
-## Give bots the code they need
-Nodes only see git repositories attached to their Helix project. After you create a bot (and it has been activated so its project exists):
-
-1. Call ` + "`list_repositories`" + ` to see every repo in this organization.
-2. Call ` + "`attach_repository`" + ` with ` + "`bot_id`" + ` + ` + "`repo_id`" + ` (and ` + "`primary: true`" + ` when it should be their main working repo).
-3. To **check** what a bot has attached: call ` + "`list_bot_repositories`" + ` with that ` + "`bot_id`" + `, or ` + "`get_bot`" + ` (the response includes a ` + "`repositories`" + ` array). Do **not** guess from memory of who attached what — the UI or another agent may have attached repos.
-4. Use ` + "`detach_repository`" + ` to remove an attachment.
-
-Without attached repos a coding bot has nothing to clone and cannot do real work.
-
-## How to call your tools
-Your tools are helix MCP tools (` + "`mcp__helix__…`" + `). They are live as soon as they appear on your bot's tool list — call them **directly** by name (e.g. ` + "`mcp__helix__list_bot_repositories`" + `). Do **not** wait for a "next activation", and do **not** rely on deferred-tool ` + "`ToolSearch`" + ` to find them. If ` + "`tools/list`" + ` / your tool list shows a name, invoke it now.
-
-## Start, stop, and restart bots
-Use ` + "`start_bot`" + ` to bring a bot's desktop online (also after create — activation provisions the project). Use ` + "`stop_bot`" + ` to shut the desktop down without losing the transcript. Use ` + "`restart_bot`" + ` when you need a brand-new session (e.g. after changing tools or repo attachments).`
-
-const chiefOfStaffBotID orgchart.NodeID = "chief-of-staff"
+const chiefOfStaffBotID = seedprompts.ChiefOfStaffBotID
 
 // orgGraphSeeder owns the membership-driven seeding of human nodes and the
 // per-org Chief of Staff bot. Humans are never free-created: a human node

--- a/api/pkg/server/swagger.json
+++ b/api/pkg/server/swagger.json
@@ -834,6 +834,44 @@
                 }
             }
         },
+        "/api/v1/admin/users/{id}/api-keys": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create (or return the existing) named API key owned by another user, so a trusted orchestrator can act as the people it runs work for instead of putting the whole fleet on one shared account. Idempotent per (user, name).",
+                "tags": [
+                    "users"
+                ],
+                "summary": "Mint an API key for a user (Admin only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Key name, e.g. the orchestrator's slug",
+                        "name": "name",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.ApiKey"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/users/{id}/approve": {
             "post": {
                 "security": [
@@ -3388,18 +3426,26 @@
                         }
                     }
                 }
-            },
-            "delete": {
+            }
+        },
+        "/api/v1/claude-subscriptions/{id}/delegation": {
+            "put": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
-                "description": "Disconnect a Claude subscription",
+                "description": "Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Only the subscription owner may change this.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
                 "tags": [
                     "Claude"
                 ],
-                "summary": "Delete a Claude subscription",
+                "summary": "Set which orgs may use a Claude subscription for delegated agent runs",
                 "parameters": [
                     {
                         "type": "string",
@@ -3407,16 +3453,28 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Delegated organizations",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.UpdateClaudeSubscriptionDelegationRequest"
+                        }
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/types.ClaudeSubscription"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
                         }
                     },
                     "401": {
@@ -22498,6 +22556,10 @@
                 "created_at": {
                     "type": "string"
                 },
+                "default_instructions": {
+                    "description": "DefaultInstructions is the built-in seed prompt for this node, when\none exists (currently only the Chief of Staff every org is seeded\nwith). It lets the UI offer \"reset instructions\" and hide that\naffordance for operator-created nodes, which have no default to\nreset to. Detail-only: GET /bots/{id} populates it, the list does\nnot (it would repeat kilobytes of prompt per row).",
+                    "type": "string"
+                },
                 "helix_user_id": {
                     "type": "string"
                 },
@@ -22631,6 +22693,10 @@
                     "type": "string"
                 },
                 "created_at": {
+                    "type": "string"
+                },
+                "default_instructions": {
+                    "description": "DefaultInstructions is the built-in seed prompt for this node, when\none exists (currently only the Chief of Staff every org is seeded\nwith). It lets the UI offer \"reset instructions\" and hide that\naffordance for operator-created nodes, which have no default to\nreset to. Detail-only: GET /bots/{id} populates it, the list does\nnot (it would repeat kilobytes of prompt per row).",
                     "type": "string"
                 },
                 "helix_user_id": {
@@ -26784,6 +26850,18 @@
                 }
             }
         },
+        "server.UpdateClaudeSubscriptionDelegationRequest": {
+            "description": "Disconnect a Claude subscription",
+            "type": "object",
+            "properties": {
+                "delegated_org_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "server.VideoStreamingStats": {
             "type": "object",
             "properties": {
@@ -28552,6 +28630,13 @@
                     "description": "\"oauth\" or \"setup_token\"",
                     "type": "string"
                 },
+                "delegated_org_ids": {
+                    "description": "DelegatedOrgIDs lists the organizations whose agent sessions may\nauthenticate with this subscription on the owner's behalf, even when the\nsession itself is owned by someone else (a service account dispatching\nwork for this person — see SpecTask.CredentialOwnerID).\n\nThis is the consent gate. Without it, any member who can create a task\ncould name another user as credential owner and spend their Claude quota.\nEmpty (the default) means the subscription is only ever used for sessions\nits owner owns, which is the pre-existing behaviour.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "id": {
                     "type": "string"
                 },
@@ -28925,6 +29010,10 @@
                             "$ref": "#/definitions/types.CodeAgentRuntime"
                         }
                     ]
+                },
+                "uses_subscription": {
+                    "description": "UsesSubscription is true when the agent authenticates against the upstream\nprovider with the user's own subscription (Claude Pro/Max, ChatGPT) instead\nof an API key routed through the Helix proxy. It mirrors the assistant's\nCodeAgentCredentialType and is what gates credential injection into the\ncontainer — an api_key agent must never receive subscription credentials,\nbecause the CLI prefers them over the proxy and would silently bypass it.",
+                    "type": "boolean"
                 }
             }
         },
@@ -29452,6 +29541,10 @@
                     "description": "For new mode: user-specified prefix (task# appended)",
                     "type": "string"
                 },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate this task's agent, for orchestrators dispatching work on a\nhuman's behalf under one service API key. Credential resolution only — the\ntask is still created by, owned by, and attributed to the caller. Ignored\nunless that user has delegated their subscription to this organization.",
+                    "type": "string"
+                },
                 "depends_on": {
                     "description": "Optional: IDs of tasks this task depends on",
                     "type": "array",
@@ -29565,6 +29658,10 @@
                 },
                 "callback_url": {
                     "description": "Webhook URL to POST on completion",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate the agent this trigger starts. An orchestrator writing triggers\non people's behalf under one service API key sets it so a scheduled run\nauthenticates as the person it acts for, exactly as CreateTaskRequest does\nfor a run dispatched by hand. Credential resolution only: the task is still\ncreated by, owned by, and attributed to the trigger's app owner, and the\nnamed user must have delegated their subscription to this organization or it\nis ignored. Currently honoured by the spec_task action.",
                     "type": "string"
                 },
                 "emails": {
@@ -35600,6 +35697,10 @@
                     "description": "Container fields (Hydra executor)",
                     "type": "string"
                 },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID mirrors SpecTask.CredentialOwnerID onto the session: the\nuser whose Claude subscription authenticates this session's agent, when\nthat differs from Owner. Affects credential resolution ONLY — Owner still\nowns and is attributed the session. Honoured only with an explicit\ndelegation grant; see ResolveClaudeCredentialOwner.",
+                    "type": "string"
+                },
                 "dev_container_id": {
                     "description": "Dev container ID for streaming",
                     "type": "string"
@@ -36194,6 +36295,10 @@
                 },
                 "created_by": {
                     "description": "Metadata",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID names the user whose Claude subscription authenticates\nthis task's agent sessions, when that differs from CreatedBy. It changes\nONLY credential resolution — the task and its sessions are still owned by,\nand attributed to, CreatedBy. Nothing \"runs as\" the credential owner.\n\nThis exists for orchestrators (HelixOS) that dispatch every task with one\nservice API key but run work on behalf of different humans: without it the\nservice account's subscription authenticates everyone's bots, so one\nperson's expired token breaks all of them and no one can use their own\nClaude account.\n\nHonoured only when the named user has delegated their subscription to this\norganization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able\nto create a task could spend another user's Claude quota. See\nResolveClaudeCredentialOwner.",
                     "type": "string"
                 },
                 "depends_on": {
@@ -36992,6 +37097,10 @@
                 },
                 "created_by": {
                     "description": "Metadata",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID names the user whose Claude subscription authenticates\nthis task's agent sessions, when that differs from CreatedBy. It changes\nONLY credential resolution — the task and its sessions are still owned by,\nand attributed to, CreatedBy. Nothing \"runs as\" the credential owner.\n\nThis exists for orchestrators (HelixOS) that dispatch every task with one\nservice API key but run work on behalf of different humans: without it the\nservice account's subscription authenticates everyone's bots, so one\nperson's expired token breaks all of them and no one can use their own\nClaude account.\n\nHonoured only when the named user has delegated their subscription to this\norganization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able\nto create a task could spend another user's Claude quota. See\nResolveClaudeCredentialOwner.",
                     "type": "string"
                 },
                 "depends_on": {

--- a/api/pkg/server/swagger.yaml
+++ b/api/pkg/server/swagger.yaml
@@ -28,6 +28,15 @@ definitions:
         type: string
       created_at:
         type: string
+      default_instructions:
+        description: |-
+          DefaultInstructions is the built-in seed prompt for this node, when
+          one exists (currently only the Chief of Staff every org is seeded
+          with). It lets the UI offer "reset instructions" and hide that
+          affordance for operator-created nodes, which have no default to
+          reset to. Detail-only: GET /bots/{id} populates it, the list does
+          not (it would repeat kilobytes of prompt per row).
+        type: string
       helix_user_id:
         type: string
       id:
@@ -129,6 +138,15 @@ definitions:
       content:
         type: string
       created_at:
+        type: string
+      default_instructions:
+        description: |-
+          DefaultInstructions is the built-in seed prompt for this node, when
+          one exists (currently only the Chief of Staff every org is seeded
+          with). It lets the UI offer "reset instructions" and hide that
+          affordance for operator-created nodes, which have no default to
+          reset to. Detail-only: GET /bots/{id} populates it, the list does
+          not (it would repeat kilobytes of prompt per row).
         type: string
       helix_user_id:
         type: string
@@ -3066,6 +3084,14 @@ definitions:
       technical_design:
         type: string
     type: object
+  server.UpdateClaudeSubscriptionDelegationRequest:
+    description: Disconnect a Claude subscription
+    properties:
+      delegated_org_ids:
+        items:
+          type: string
+        type: array
+    type: object
   server.VideoStreamingStats:
     properties:
       client_buffers:
@@ -4389,6 +4415,20 @@ definitions:
       credential_type:
         description: '"oauth" or "setup_token"'
         type: string
+      delegated_org_ids:
+        description: |-
+          DelegatedOrgIDs lists the organizations whose agent sessions may
+          authenticate with this subscription on the owner's behalf, even when the
+          session itself is owned by someone else (a service account dispatching
+          work for this person — see SpecTask.CredentialOwnerID).
+
+          This is the consent gate. Without it, any member who can create a task
+          could name another user as credential owner and spend their Claude quota.
+          Empty (the default) means the subscription is only ever used for sessions
+          its owner owns, which is the pre-existing behaviour.
+        items:
+          type: string
+        type: array
       id:
         type: string
       last_error:
@@ -4662,6 +4702,15 @@ definitions:
         - $ref: '#/definitions/types.CodeAgentRuntime'
         description: 'Runtime specifies which code agent runtime to use: "zed_agent"
           or "qwen_code"'
+      uses_subscription:
+        description: |-
+          UsesSubscription is true when the agent authenticates against the upstream
+          provider with the user's own subscription (Claude Pro/Max, ChatGPT) instead
+          of an API key routed through the Helix proxy. It mirrors the assistant's
+          CodeAgentCredentialType and is what gates credential injection into the
+          container — an api_key agent must never receive subscription credentials,
+          because the CLI prefers them over the proxy and would silently bypass it.
+        type: boolean
     type: object
   types.CodeAgentCredentialType:
     enum:
@@ -5029,6 +5078,14 @@ definitions:
       branch_prefix:
         description: 'For new mode: user-specified prefix (task# appended)'
         type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID optionally names the user whose Claude subscription should
+          authenticate this task's agent, for orchestrators dispatching work on a
+          human's behalf under one service API key. Credential resolution only — the
+          task is still created by, owned by, and attributed to the caller. Ignored
+          unless that user has delegated their subscription to this organization.
+        type: string
       depends_on:
         description: 'Optional: IDs of tasks this task depends on'
         items:
@@ -5112,6 +5169,17 @@ definitions:
         type: string
       callback_url:
         description: Webhook URL to POST on completion
+        type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID optionally names the user whose Claude subscription should
+          authenticate the agent this trigger starts. An orchestrator writing triggers
+          on people's behalf under one service API key sets it so a scheduled run
+          authenticates as the person it acts for, exactly as CreateTaskRequest does
+          for a run dispatched by hand. Credential resolution only: the task is still
+          created by, owned by, and attributed to the trigger's app owner, and the
+          named user must have delegated their subscription to this organization or it
+          is ignored. Currently honoured by the spec_task action.
         type: string
       emails:
         items:
@@ -9542,6 +9610,14 @@ definitions:
       container_name:
         description: Container fields (Hydra executor)
         type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID mirrors SpecTask.CredentialOwnerID onto the session: the
+          user whose Claude subscription authenticates this session's agent, when
+          that differs from Owner. Affects credential resolution ONLY — Owner still
+          owns and is attributed the session. Honoured only with an explicit
+          delegation grant; see ResolveClaudeCredentialOwner.
+        type: string
       dev_container_id:
         description: Dev container ID for streaming
         type: string
@@ -9972,6 +10048,24 @@ definitions:
         type: string
       created_by:
         description: Metadata
+        type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID names the user whose Claude subscription authenticates
+          this task's agent sessions, when that differs from CreatedBy. It changes
+          ONLY credential resolution — the task and its sessions are still owned by,
+          and attributed to, CreatedBy. Nothing "runs as" the credential owner.
+
+          This exists for orchestrators (HelixOS) that dispatch every task with one
+          service API key but run work on behalf of different humans: without it the
+          service account's subscription authenticates everyone's bots, so one
+          person's expired token breaks all of them and no one can use their own
+          Claude account.
+
+          Honoured only when the named user has delegated their subscription to this
+          organization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able
+          to create a task could spend another user's Claude quota. See
+          ResolveClaudeCredentialOwner.
         type: string
       depends_on:
         items:
@@ -10577,6 +10671,24 @@ definitions:
         type: string
       created_by:
         description: Metadata
+        type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID names the user whose Claude subscription authenticates
+          this task's agent sessions, when that differs from CreatedBy. It changes
+          ONLY credential resolution — the task and its sessions are still owned by,
+          and attributed to, CreatedBy. Nothing "runs as" the credential owner.
+
+          This exists for orchestrators (HelixOS) that dispatch every task with one
+          service API key but run work on behalf of different humans: without it the
+          service account's subscription authenticates everyone's bots, so one
+          person's expired token breaks all of them and no one can use their own
+          Claude account.
+
+          Honoured only when the named user has delegated their subscription to this
+          organization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able
+          to create a task could spend another user's Claude quota. See
+          ResolveClaudeCredentialOwner.
         type: string
       depends_on:
         items:
@@ -12921,6 +13033,32 @@ paths:
       summary: Delete a user (Admin only)
       tags:
       - users
+  /api/v1/admin/users/{id}/api-keys:
+    post:
+      description: Create (or return the existing) named API key owned by another
+        user, so a trusted orchestrator can act as the people it runs work for instead
+        of putting the whole fleet on one shared account. Idempotent per (user, name).
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Key name, e.g. the orchestrator's slug
+        in: query
+        name: name
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.ApiKey'
+      security:
+      - BearerAuth: []
+      summary: Mint an API key for a user (Admin only)
+      tags:
+      - users
   /api/v1/admin/users/{id}/approve:
     post:
       description: Approve a waitlisted user, removing them from the waitlist. Only
@@ -14460,38 +14598,6 @@ paths:
       tags:
       - Claude
   /api/v1/claude-subscriptions/{id}:
-    delete:
-      description: Disconnect a Claude subscription
-      parameters:
-      - description: Subscription ID
-        in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Delete a Claude subscription
-      tags:
-      - Claude
     get:
       description: Get details of a specific Claude subscription (no secrets)
       parameters:
@@ -14522,6 +14628,53 @@ paths:
       security:
       - BearerAuth: []
       summary: Get a Claude subscription
+      tags:
+      - Claude
+  /api/v1/claude-subscriptions/{id}/delegation:
+    put:
+      consumes:
+      - application/json
+      description: Grant (or revoke) permission for an organization's orchestrated
+        agents to authenticate as the subscription owner. Only the subscription owner
+        may change this.
+      parameters:
+      - description: Subscription ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Delegated organizations
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/server.UpdateClaudeSubscriptionDelegationRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.ClaudeSubscription'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Set which orgs may use a Claude subscription for delegated agent runs
       tags:
       - Claude
   /api/v1/claude-subscriptions/models:

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -28,6 +28,15 @@ export interface ApiAgentDetailDTO {
   code_agent_runtime?: TypesCodeAgentRuntime;
   content?: string;
   created_at?: string;
+  /**
+   * DefaultInstructions is the built-in seed prompt for this node, when
+   * one exists (currently only the Chief of Staff every org is seeded
+   * with). It lets the UI offer "reset instructions" and hide that
+   * affordance for operator-created nodes, which have no default to
+   * reset to. Detail-only: GET /bots/{id} populates it, the list does
+   * not (it would repeat kilobytes of prompt per row).
+   */
+  default_instructions?: string;
   helix_user_id?: string;
   id?: string;
   identity?: Record<string, string>;
@@ -93,6 +102,15 @@ export interface ApiBotDTO {
   code_agent_runtime?: TypesCodeAgentRuntime;
   content?: string;
   created_at?: string;
+  /**
+   * DefaultInstructions is the built-in seed prompt for this node, when
+   * one exists (currently only the Chief of Staff every org is seeded
+   * with). It lets the UI offer "reset instructions" and hide that
+   * affordance for operator-created nodes, which have no default to
+   * reset to. Detail-only: GET /bots/{id} populates it, the list does
+   * not (it would repeat kilobytes of prompt per row).
+   */
+  default_instructions?: string;
   helix_user_id?: string;
   id?: string;
   identity?: Record<string, string>;
@@ -1967,6 +1985,11 @@ export interface ServerTaskSpecsResponse {
   technical_design?: string;
 }
 
+/** Disconnect a Claude subscription */
+export interface ServerUpdateClaudeSubscriptionDelegationRequest {
+  delegated_org_ids?: string[];
+}
+
 export interface ServerVideoStreamingStats {
   client_buffers?: ServerClientBufferStats[];
   client_count?: number;
@@ -2793,6 +2816,18 @@ export interface TypesClaudeSubscription {
   created_by?: string;
   /** "oauth" or "setup_token" */
   credential_type?: string;
+  /**
+   * DelegatedOrgIDs lists the organizations whose agent sessions may
+   * authenticate with this subscription on the owner's behalf, even when the
+   * session itself is owned by someone else (a service account dispatching
+   * work for this person — see SpecTask.CredentialOwnerID).
+   *
+   * This is the consent gate. Without it, any member who can create a task
+   * could name another user as credential owner and spend their Claude quota.
+   * Empty (the default) means the subscription is only ever used for sessions
+   * its owner owns, which is the pre-existing behaviour.
+   */
+  delegated_org_ids?: string[];
   id?: string;
   last_error?: string;
   last_refreshed_at?: string;
@@ -2967,6 +3002,15 @@ export interface TypesCodeAgentConfig {
   reasoning_effort?: string;
   /** Runtime specifies which code agent runtime to use: "zed_agent" or "qwen_code" */
   runtime?: TypesCodeAgentRuntime;
+  /**
+   * UsesSubscription is true when the agent authenticates against the upstream
+   * provider with the user's own subscription (Claude Pro/Max, ChatGPT) instead
+   * of an API key routed through the Helix proxy. It mirrors the assistant's
+   * CodeAgentCredentialType and is what gates credential injection into the
+   * container — an api_key agent must never receive subscription credentials,
+   * because the CLI prefers them over the proxy and would silently bypass it.
+   */
+  uses_subscription?: boolean;
 }
 
 export enum TypesCodeAgentCredentialType {
@@ -3204,6 +3248,14 @@ export interface TypesCreateTaskRequest {
   branch_mode?: TypesBranchMode;
   /** For new mode: user-specified prefix (task# appended) */
   branch_prefix?: string;
+  /**
+   * CredentialOwnerID optionally names the user whose Claude subscription should
+   * authenticate this task's agent, for orchestrators dispatching work on a
+   * human's behalf under one service API key. Credential resolution only — the
+   * task is still created by, owned by, and attributed to the caller. Ignored
+   * unless that user has delegated their subscription to this organization.
+   */
+  credential_owner_id?: string;
   /** Optional: IDs of tasks this task depends on */
   depends_on?: string[];
   /**
@@ -3259,6 +3311,17 @@ export interface TypesCronTrigger {
   agent_type?: string;
   /** Webhook URL to POST on completion */
   callback_url?: string;
+  /**
+   * CredentialOwnerID optionally names the user whose Claude subscription should
+   * authenticate the agent this trigger starts. An orchestrator writing triggers
+   * on people's behalf under one service API key sets it so a scheduled run
+   * authenticates as the person it acts for, exactly as CreateTaskRequest does
+   * for a run dispatched by hand. Credential resolution only: the task is still
+   * created by, owned by, and attributed to the trigger's app owner, and the
+   * named user must have delegated their subscription to this organization or it
+   * is ignored. Currently honoured by the spec_task action.
+   */
+  credential_owner_id?: string;
   emails?: string[];
   enabled?: boolean;
   input?: string;
@@ -6016,6 +6079,14 @@ export interface TypesSessionMetadata {
   container_ip?: string;
   /** Container fields (Hydra executor) */
   container_name?: string;
+  /**
+   * CredentialOwnerID mirrors SpecTask.CredentialOwnerID onto the session: the
+   * user whose Claude subscription authenticates this session's agent, when
+   * that differs from Owner. Affects credential resolution ONLY — Owner still
+   * owns and is attributed the session. Honoured only with an explicit
+   * delegation grant; see ResolveClaudeCredentialOwner.
+   */
+  credential_owner_id?: string;
   /** Dev container ID for streaming */
   dev_container_id?: string;
   document_group_id?: string;
@@ -6277,6 +6348,24 @@ export interface TypesSpecTask {
   created_at?: string;
   /** Metadata */
   created_by?: string;
+  /**
+   * CredentialOwnerID names the user whose Claude subscription authenticates
+   * this task's agent sessions, when that differs from CreatedBy. It changes
+   * ONLY credential resolution — the task and its sessions are still owned by,
+   * and attributed to, CreatedBy. Nothing "runs as" the credential owner.
+   *
+   * This exists for orchestrators (HelixOS) that dispatch every task with one
+   * service API key but run work on behalf of different humans: without it the
+   * service account's subscription authenticates everyone's bots, so one
+   * person's expired token breaks all of them and no one can use their own
+   * Claude account.
+   *
+   * Honoured only when the named user has delegated their subscription to this
+   * organization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able
+   * to create a task could spend another user's Claude quota. See
+   * ResolveClaudeCredentialOwner.
+   */
+  credential_owner_id?: string;
   depends_on?: TypesSpecTask[];
   description?: string;
   design_doc_path?: string;
@@ -6623,6 +6712,24 @@ export interface TypesSpecTaskWithProject {
   created_at?: string;
   /** Metadata */
   created_by?: string;
+  /**
+   * CredentialOwnerID names the user whose Claude subscription authenticates
+   * this task's agent sessions, when that differs from CreatedBy. It changes
+   * ONLY credential resolution — the task and its sessions are still owned by,
+   * and attributed to, CreatedBy. Nothing "runs as" the credential owner.
+   *
+   * This exists for orchestrators (HelixOS) that dispatch every task with one
+   * service API key but run work on behalf of different humans: without it the
+   * service account's subscription authenticates everyone's bots, so one
+   * person's expired token breaks all of them and no one can use their own
+   * Claude account.
+   *
+   * Honoured only when the named user has delegated their subscription to this
+   * organization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able
+   * to create a task could spend another user's Claude quota. See
+   * ResolveClaudeCredentialOwner.
+   */
+  credential_owner_id?: string;
   depends_on?: TypesSpecTask[];
   description?: string;
   design_doc_path?: string;
@@ -8234,6 +8341,31 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
+     * @description Create (or return the existing) named API key owned by another user, so a trusted orchestrator can act as the people it runs work for instead of putting the whole fleet on one shared account. Idempotent per (user, name).
+     *
+     * @tags users
+     * @name V1AdminUsersApiKeysCreate
+     * @summary Mint an API key for a user (Admin only)
+     * @request POST:/api/v1/admin/users/{id}/api-keys
+     * @secure
+     */
+    v1AdminUsersApiKeysCreate: (
+      id: string,
+      query: {
+        /** Key name, e.g. the orchestrator's slug */
+        name: string;
+      },
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesApiKey, any>({
+        path: `/api/v1/admin/users/${id}/api-keys`,
+        method: "POST",
+        query: query,
+        secure: true,
+        ...params,
+      }),
+
+    /**
      * @description Approve a waitlisted user, removing them from the waitlist. Only admins can use this endpoint.
      *
      * @tags users
@@ -9412,23 +9544,6 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       }),
 
     /**
-     * @description Disconnect a Claude subscription
-     *
-     * @tags Claude
-     * @name V1ClaudeSubscriptionsDelete
-     * @summary Delete a Claude subscription
-     * @request DELETE:/api/v1/claude-subscriptions/{id}
-     * @secure
-     */
-    v1ClaudeSubscriptionsDelete: (id: string, params: RequestParams = {}) =>
-      this.request<Record<string, string>, SystemHTTPError>({
-        path: `/api/v1/claude-subscriptions/${id}`,
-        method: "DELETE",
-        secure: true,
-        ...params,
-      }),
-
-    /**
      * @description Get details of a specific Claude subscription (no secrets)
      *
      * @tags Claude
@@ -9442,6 +9557,30 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
         path: `/api/v1/claude-subscriptions/${id}`,
         method: "GET",
         secure: true,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * @description Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Only the subscription owner may change this.
+     *
+     * @tags Claude
+     * @name V1ClaudeSubscriptionsDelegationUpdate
+     * @summary Set which orgs may use a Claude subscription for delegated agent runs
+     * @request PUT:/api/v1/claude-subscriptions/{id}/delegation
+     * @secure
+     */
+    v1ClaudeSubscriptionsDelegationUpdate: (
+      id: string,
+      body: ServerUpdateClaudeSubscriptionDelegationRequest,
+      params: RequestParams = {},
+    ) =>
+      this.request<TypesClaudeSubscription, SystemHTTPError>({
+        path: `/api/v1/claude-subscriptions/${id}/delegation`,
+        method: "PUT",
+        body: body,
+        secure: true,
+        type: ContentType.Json,
         format: "json",
         ...params,
       }),

--- a/frontend/src/components/helix-org/AgentRuntimeProviderIcon.test.tsx
+++ b/frontend/src/components/helix-org/AgentRuntimeProviderIcon.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import AgentRuntimeProviderIcon from './AgentRuntimeProviderIcon'
+
+describe('AgentRuntimeProviderIcon', () => {
+  it('maps Claude Code to Anthropic and Codex CLI to OpenAI', () => {
+    const { rerender } = render(<AgentRuntimeProviderIcon runtime="claude_code" />)
+    expect(screen.getByRole('img', { name: 'Anthropic' })).toBeInTheDocument()
+
+    rerender(<AgentRuntimeProviderIcon runtime="codex_cli" />)
+    expect(screen.getByRole('img', { name: 'OpenAI' })).toBeInTheDocument()
+    expect(screen.queryByRole('img', { name: 'Anthropic' })).not.toBeInTheDocument()
+  })
+
+  it('does not assign a provider icon to other runtimes', () => {
+    render(<AgentRuntimeProviderIcon runtime="zed_agent" />)
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/helix-org/AgentRuntimeProviderIcon.tsx
+++ b/frontend/src/components/helix-org/AgentRuntimeProviderIcon.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react'
+
+import AnthropicLogo from '../providers/logos/anthropic'
+import OpenAILogo from '../providers/logos/openai'
+
+const AgentRuntimeProviderIcon: FC<{ runtime: string }> = ({ runtime }) => {
+  if (runtime === 'claude_code') {
+    return <AnthropicLogo role="img" aria-label="Anthropic" width={12} height={12} />
+  }
+  if (runtime === 'codex_cli') {
+    return <OpenAILogo role="img" aria-label="OpenAI" width={12} height={12} />
+  }
+  return null
+}
+
+export default AgentRuntimeProviderIcon

--- a/frontend/src/components/helix-org/ChartTopicVisibilityMenu.tsx
+++ b/frontend/src/components/helix-org/ChartTopicVisibilityMenu.tsx
@@ -1,0 +1,112 @@
+import { FC, useState } from 'react'
+import Button from '@mui/material/Button'
+import Checkbox from '@mui/material/Checkbox'
+import Divider from '@mui/material/Divider'
+import ListItemText from '@mui/material/ListItemText'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
+import FilterListIcon from '@mui/icons-material/FilterList'
+
+import { ChartTopicFilter, CHART_TOPIC_FILTERS } from './chartTopicVisibility'
+
+export const chartToolbarButtonSizeSx = {
+  minWidth: 0,
+  height: 30,
+  px: 1,
+  fontSize: '0.72rem',
+  '& .MuiButton-startIcon': { mr: 0.5 },
+}
+
+export const chartToolbarButtonSx = {
+  ...chartToolbarButtonSizeSx,
+  color: 'text.secondary',
+  borderColor: 'divider',
+  backgroundColor: 'background.paper',
+  '&:hover': {
+    color: 'text.primary',
+    borderColor: 'text.disabled',
+    backgroundColor: 'action.hover',
+  },
+}
+
+const ChartTopicVisibilityMenu: FC<{
+  selected: ChartTopicFilter[]
+  onChange: (selected: ChartTopicFilter[]) => void
+}> = ({ selected, onChange }) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const allSelected = selected.length === CHART_TOPIC_FILTERS.length
+  const someSelected = selected.length > 0 && !allSelected
+
+  const toggleFilter = (filter: ChartTopicFilter) => {
+    if (selected.includes(filter)) {
+      onChange(selected.filter((candidate) => candidate !== filter))
+      return
+    }
+    onChange(CHART_TOPIC_FILTERS
+      .map((candidate) => candidate.id)
+      .filter((candidate) => candidate === filter || selected.includes(candidate)))
+  }
+
+  return (
+    <>
+      <Button
+        size="small"
+        variant="outlined"
+        startIcon={<FilterListIcon />}
+        onClick={(event) => setAnchorEl(event.currentTarget)}
+        aria-label="Choose topic types shown on chart"
+        aria-haspopup="menu"
+        aria-expanded={Boolean(anchorEl)}
+        sx={chartToolbarButtonSx}
+      >
+        Topics {selected.length}/{CHART_TOPIC_FILTERS.length}
+      </Button>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        MenuListProps={{ dense: true, sx: { py: 0.5 } }}
+        PaperProps={{ sx: { minWidth: 200 } }}
+      >
+        <MenuItem
+          dense
+          onClick={() => onChange(allSelected ? [] : CHART_TOPIC_FILTERS.map((filter) => filter.id))}
+          sx={{ minHeight: 32, px: 1 }}
+        >
+          <Checkbox
+            size="small"
+            checked={allSelected}
+            indeterminate={someSelected}
+            sx={{
+              p: 0.5,
+              mr: 0.5,
+              color: 'text.disabled',
+              '&.Mui-checked, &.MuiCheckbox-indeterminate': { color: 'text.secondary' },
+            }}
+          />
+          <ListItemText primary="All topic types" primaryTypographyProps={{ fontSize: '0.8rem', fontWeight: 600 }} />
+        </MenuItem>
+        <Divider sx={{ my: 0.5 }} />
+        {CHART_TOPIC_FILTERS.map((filter) => (
+          <MenuItem key={filter.id} dense onClick={() => toggleFilter(filter.id)} sx={{ minHeight: 32, px: 1 }}>
+            <Checkbox
+              size="small"
+              checked={selected.includes(filter.id)}
+              sx={{
+                p: 0.5,
+                mr: 0.5,
+                color: 'text.disabled',
+                '&.Mui-checked': { color: 'text.secondary' },
+              }}
+            />
+            <ListItemText primary={filter.label} primaryTypographyProps={{ fontSize: '0.8rem' }} />
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  )
+}
+
+export default ChartTopicVisibilityMenu

--- a/frontend/src/components/helix-org/chartTopicVisibility.test.ts
+++ b/frontend/src/components/helix-org/chartTopicVisibility.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_CHART_TOPIC_FILTERS,
+  chartTopicFilterFor,
+  loadChartTopicVisibility,
+  saveChartTopicVisibility,
+} from './chartTopicVisibility'
+
+describe('chartTopicVisibility', () => {
+  const userId = 'usr_test'
+  const orgId = 'org_test'
+
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('hides direct messages, local topics, and other topics by default', () => {
+    expect(DEFAULT_CHART_TOPIC_FILTERS).toEqual([
+      'webhook',
+      'github',
+      'gitlab',
+      'postmark',
+      'cron',
+    ])
+  })
+
+  it('separates direct messages from other local topics', () => {
+    expect(chartTopicFilterFor({ name: 'dm: b-mason ↔ chief-of-staff', kind: 'local' })).toBe('direct_messages')
+    expect(chartTopicFilterFor({ name: 'Engineering', kind: 'local' })).toBe('local')
+  })
+
+  it('classifies every topic transport exposed by the creation dialog', () => {
+    expect(chartTopicFilterFor({ name: 'Outbound', kind: 'webhook' })).toBe('webhook')
+    expect(chartTopicFilterFor({ name: 'Pull requests', kind: 'github' })).toBe('github')
+    expect(chartTopicFilterFor({ name: 'Merge requests', kind: 'gitlab' })).toBe('gitlab')
+    expect(chartTopicFilterFor({ name: 'Inbox', kind: 'postmark' })).toBe('postmark')
+    expect(chartTopicFilterFor({ name: 'Daily report', kind: 'cron' })).toBe('cron')
+  })
+
+  it('maps the backend email kind to Postmark and unknown kinds to Other', () => {
+    expect(chartTopicFilterFor({ name: 'Inbox', kind: 'email' })).toBe('postmark')
+    expect(chartTopicFilterFor({ name: 'Slack alerts', kind: 'slack' })).toBe('other')
+  })
+
+  it('round-trips filters in canonical order and scopes them by user and org', () => {
+    saveChartTopicVisibility(userId, orgId, ['cron', 'direct_messages'])
+
+    expect(loadChartTopicVisibility(userId, orgId)).toEqual(['direct_messages', 'cron'])
+    expect(loadChartTopicVisibility('other_user', orgId)).toBeNull()
+    expect(loadChartTopicVisibility(userId, 'other_org')).toBeNull()
+  })
+
+  it('returns null for missing or invalid settings', () => {
+    const key = `helix.orgChart.topicVisibility.${userId}.${orgId}`
+    expect(loadChartTopicVisibility(userId, orgId)).toBeNull()
+    window.localStorage.setItem(key, JSON.stringify(['cron', 'not-a-filter']))
+    expect(loadChartTopicVisibility(userId, orgId)).toBeNull()
+    window.localStorage.setItem(key, 'not-json')
+    expect(loadChartTopicVisibility(userId, orgId)).toBeNull()
+  })
+})

--- a/frontend/src/components/helix-org/chartTopicVisibility.ts
+++ b/frontend/src/components/helix-org/chartTopicVisibility.ts
@@ -1,0 +1,82 @@
+export const CHART_TOPIC_FILTERS = [
+  { id: 'direct_messages', label: 'Direct messages' },
+  { id: 'local', label: 'Local topics' },
+  { id: 'webhook', label: 'Webhooks' },
+  { id: 'github', label: 'GitHub' },
+  { id: 'gitlab', label: 'GitLab' },
+  { id: 'postmark', label: 'Postmark email' },
+  { id: 'cron', label: 'Cron' },
+  { id: 'other', label: 'Other' },
+] as const
+
+export type ChartTopicFilter = (typeof CHART_TOPIC_FILTERS)[number]['id']
+
+export const DEFAULT_CHART_TOPIC_FILTERS: ChartTopicFilter[] = CHART_TOPIC_FILTERS
+  .map((filter) => filter.id)
+  .filter((filter) => filter !== 'direct_messages' && filter !== 'local' && filter !== 'other')
+
+type TopicIdentity = {
+  name: string
+  kind: string
+}
+
+const filterIds = new Set<ChartTopicFilter>(CHART_TOPIC_FILTERS.map((filter) => filter.id))
+
+const storageKey = (userId: string, orgId: string): string =>
+  `helix.orgChart.topicVisibility.${userId}.${orgId}`
+
+export const chartTopicFilterFor = (topic: TopicIdentity): ChartTopicFilter => {
+  if (topic.name.trimStart().toLowerCase().startsWith('dm:')) return 'direct_messages'
+
+  switch (topic.kind.trim().toLowerCase()) {
+    case 'local':
+      return 'local'
+    case 'webhook':
+      return 'webhook'
+    case 'github':
+      return 'github'
+    case 'gitlab':
+      return 'gitlab'
+    case 'email':
+    case 'postmark':
+      return 'postmark'
+    case 'cron':
+      return 'cron'
+    default:
+      return 'other'
+  }
+}
+
+export const loadChartTopicVisibility = (
+  userId: string,
+  orgId: string,
+): ChartTopicFilter[] | null => {
+  if (!userId || !orgId) return null
+  try {
+    const raw = window.localStorage.getItem(storageKey(userId, orgId))
+    if (!raw) return null
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed) || !parsed.every((value) => typeof value === 'string' && filterIds.has(value as ChartTopicFilter))) {
+      return null
+    }
+    const selected = new Set(parsed as ChartTopicFilter[])
+    return CHART_TOPIC_FILTERS.map((filter) => filter.id).filter((id) => selected.has(id))
+  } catch {
+    return null
+  }
+}
+
+export const saveChartTopicVisibility = (
+  userId: string,
+  orgId: string,
+  filters: ChartTopicFilter[],
+): void => {
+  if (!userId || !orgId) return
+  const selected = new Set(filters)
+  const validFilters = CHART_TOPIC_FILTERS.map((filter) => filter.id).filter((id) => selected.has(id))
+  try {
+    window.localStorage.setItem(storageKey(userId, orgId), JSON.stringify(validFilters))
+  } catch {
+    // Quota / private mode — the chart remains usable without persistence.
+  }
+}

--- a/frontend/src/pages/HelixOrgBotDetail.tsx
+++ b/frontend/src/pages/HelixOrgBotDetail.tsx
@@ -1,5 +1,5 @@
 // HelixOrgBotDetail shows a single bot and lets the operator edit it
-// end-to-end and watch / drive its conversation inline.
+// end-to-end: identity, runtime, instructions, tools, subscriptions.
 //
 // A Bot is the merge of the former Role and Worker: its markdown
 // `content` is its identity/prompt, its `tools` list is its MCP tool
@@ -8,12 +8,15 @@
 // multi-select and saved in one step through useUpdateBot (there is no
 // separate identity field). Subscriptions are managed in the panel below.
 //
-// The inline transcript (EmbeddedSessionView + RobustPromptInput) is the
-// same view the spec-task page uses — it auto-shows when the bot's project
-// already has an exploratory session. GET-only on load — never spins up
-// infra by itself; sessions are provisioned by the bot's activation flow.
+// This page deliberately carries NO inline transcript or desktop viewer —
+// conversing with the agent belongs in the real chat surface, not a
+// duplicate embedded in a config page. What stays here is lifecycle
+// control (start / stop / restart, in the header) because it acts on the
+// thing this page configures. The bot's exploratory session id is still
+// tracked (GET-only, never provisioned here) so a runtime change can
+// switch the live session through the canonical lifecycle.
 
-import { FC, Key, useEffect, useMemo, useRef, useState } from 'react'
+import { FC, Key, useEffect, useMemo, useState } from 'react'
 import Autocomplete from '@mui/material/Autocomplete'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
@@ -21,6 +24,10 @@ import Checkbox from '@mui/material/Checkbox'
 import Chip from '@mui/material/Chip'
 import CircularProgress from '@mui/material/CircularProgress'
 import Container from '@mui/material/Container'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
 import Divider from '@mui/material/Divider'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import Grid from '@mui/material/Grid'
@@ -32,8 +39,6 @@ import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import Switch from '@mui/material/Switch'
 import TextField from '@mui/material/TextField'
-import ToggleButton from '@mui/material/ToggleButton'
-import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
 import Typography from '@mui/material/Typography'
 import CheckBoxIcon from '@mui/icons-material/CheckBox'
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
@@ -43,6 +48,7 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import PlayArrowIcon from '@mui/icons-material/PlayArrow'
 import RestartAltIcon from '@mui/icons-material/RestartAlt'
 import SaveIcon from '@mui/icons-material/Save'
+import SettingsBackupRestoreIcon from '@mui/icons-material/SettingsBackupRestore'
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined'
 import StopIcon from '@mui/icons-material/Stop'
 import Tooltip from '@mui/material/Tooltip'
@@ -53,21 +59,12 @@ import useHelixOrgBreadcrumbs from '../components/helix-org/useHelixOrgBreadcrum
 import LoadingSpinner from '../components/widgets/LoadingSpinner'
 import MonacoEditor from '../components/widgets/MonacoEditor'
 import DeleteConfirmWindow from '../components/widgets/DeleteConfirmWindow'
-import SessionPromptQueue from '../components/session/SessionPromptQueue'
-import EmbeddedSessionView, {
-  EmbeddedSessionViewHandle,
-} from '../components/session/EmbeddedSessionView'
-import ExternalAgentDesktopViewer from '../components/external-agent/ExternalAgentDesktopViewer'
-import RobustPromptInput from '../components/common/RobustPromptInput'
 
 import router5 from '../router'
 import useApi from '../hooks/useApi'
 import useRouter from '../hooks/useRouter'
 import useSnackbar from '../hooks/useSnackbar'
 import { useListProjects } from '../services/projectService'
-import { deriveDisplaySettings } from '../services/externalAgentDisplay'
-import { useStreaming } from '../contexts/streaming'
-import { SESSION_TYPE_TEXT } from '../types'
 import {
   BotDTO,
   ToolDTO,
@@ -104,19 +101,18 @@ const HelixOrgBotDetail: FC = () => {
   const { data, isLoading, refetch: refetchBot } = useHelixOrgBot(botId, {
     enabled: !del.isPending && !del.isSuccess,
   })
-  const streaming = useStreaming()
   const updateBot = useUpdateBot()
   const activateAgent = useActivateBot()
   const stopAgent = useStopBotAgent()
   const restartAgent = useRestartBotAgent()
   const { data: toolCatalogue } = useListHelixOrgTools()
   const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const [confirmingResetInstructions, setConfirmingResetInstructions] = useState(false)
   const [agentMenuEl, setAgentMenuEl] = useState<null | HTMLElement>(null)
   // The bot owns one durable exploratory session. Runtime edits must switch
   // that session through the canonical lifecycle instead of leaving it bound
   // to an agent server that the updated app config no longer registers.
   const [chatSessionId, setChatSessionId] = useState<string | null>(null)
-  const sessionViewRef = useRef<EmbeddedSessionViewHandle>(null)
   const switchAgent = useSwitchAgent(chatSessionId ?? '')
 
   const bot = data?.bot
@@ -292,7 +288,6 @@ const HelixOrgBotDetail: FC = () => {
     try {
       await restartAgent.mutateAsync(botId)
       setChatSessionId(null)
-      setSessionTab('chat')
       snackbar.success('Restarting agent — a fresh session will come up shortly')
       await pollForSession(previousSessionId, true)
       void refetchBot()
@@ -300,15 +295,6 @@ const HelixOrgBotDetail: FC = () => {
       snackbar.error(err?.response?.data?.error ?? err?.message ?? 'restart failed')
     }
   }
-
-  // The session panel toggles between the inline Chat transcript and the
-  // live Desktop stream — both bound to the same exploratory session.
-  const [sessionTab, setSessionTab] = useState<'chat' | 'desktop'>('chat')
-
-  // Desktop resolution / fps for the stream, derived from the bot's agent
-  // app config (same helper the spec-task desktop uses). Falls back to
-  // 1920x1080x60 when the app or config is missing.
-  const displaySettings = deriveDisplaySettings(undefined)
 
   // chatApi adapts the generated client to the read-only shape the
   // workerChatSession helper expects (we only GET the existing session
@@ -327,9 +313,10 @@ const HelixOrgBotDetail: FC = () => {
     },
   }), [api])
 
-  // Auto-load the inline transcript when the bot already has a project.
+  // Track the bot's existing exploratory session when it has a project.
   // GET-only — we never create a session just because the operator opened
-  // this page; sessions are provisioned by the bot's activation flow.
+  // this page; sessions are provisioned by the bot's activation flow. The
+  // id is what lets a runtime change switch the live session on save.
   useEffect(() => {
     let cancelled = false
     if (!projectID) {
@@ -344,13 +331,28 @@ const HelixOrgBotDetail: FC = () => {
     // projectID alone follows the "only primitives in deps" rule.
   }, [projectID])
 
-  // Subscribe the WebSocket to the inline session so in-flight turns live
-  // (mirrors SpecTaskDetailContent, which likewise omits the streaming
-  // context object from deps). Clear on unmount / session change.
-  useEffect(() => {
-    streaming.setCurrentSessionId(chatSessionId)
-    return () => { streaming.setCurrentSessionId(null) }
-  }, [chatSessionId])
+  // Built-in seed prompt for this node, when it has one. Only seeded
+  // nodes (the Chief of Staff every org gets) carry a default; for
+  // operator-created agents the server sends nothing and the reset
+  // affordance stays hidden — there is no default to go back to.
+  const defaultInstructions = bot?.default_instructions ?? ''
+
+  // Reset the editor to the built-in prompt and persist it in one step,
+  // so the operator does not have to remember a follow-up Save. Other
+  // unsaved edits on the page are left alone — this patches content only.
+  const handleResetInstructions = async () => {
+    if (!botId || !defaultInstructions) return
+    try {
+      await updateBot.mutateAsync({ id: botId, content: defaultInstructions })
+      setContent(defaultInstructions)
+      await refetchBot()
+      snackbar.success('Instructions reset to the default')
+    } catch (err: any) {
+      snackbar.error(err?.response?.data?.error ?? err?.message ?? 'reset failed')
+    } finally {
+      setConfirmingResetInstructions(false)
+    }
+  }
 
   const handleDelete = async () => {
     if (!botId) return
@@ -399,218 +401,99 @@ const HelixOrgBotDetail: FC = () => {
         ) : (
           <>
           <Grid container spacing={3}>
-            <Grid item xs={12} md={9}>
+            <Grid item xs={12} md={8}>
               <Stack spacing={3}>
+                {/* Header — identity plus the agent's lifecycle control.
+                    The start/stop/restart menu lives here (rather than in a
+                    session panel) because it acts on the agent this page
+                    configures; conversing with it belongs in the real chat. */}
                 <Box>
-                  <Stack direction="row" alignItems="baseline" spacing={1}>
-                    <SmartToyOutlinedIcon sx={{ alignSelf: 'center' }} />
-                    <Typography variant="h5">
-                      {bot.name || bot.id}
-                    </Typography>
-                    {bot.name && (
-                      <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
-                        {bot.id}
+                  <Stack
+                    direction={{ xs: 'column', sm: 'row' }}
+                    justifyContent="space-between"
+                    alignItems={{ xs: 'flex-start', sm: 'center' }}
+                    spacing={1}
+                  >
+                    <Stack direction="row" alignItems="baseline" spacing={1}>
+                      <SmartToyOutlinedIcon sx={{ alignSelf: 'center' }} />
+                      <Typography variant="h5">
+                        {bot.name || bot.id}
                       </Typography>
-                    )}
-                  </Stack>
-                </Box>
-
-                {/* Session panel — Chat | Desktop toggle, both bound to the
-                    agent's Project Desktop exploratory session (the same views
-                    the spec-task page uses). Auto-loads when the agent already
-                    has a session; otherwise shows an empty state. */}
-                <Paper variant="outlined" sx={{ p: 3 }}>
-                  <Stack spacing={2} alignItems="flex-start">
-                    <Stack
-                      direction={{ xs: 'column', sm: 'row' }}
-                      justifyContent="space-between"
-                      alignItems={{ xs: 'flex-start', sm: 'center' }}
-                      spacing={1}
-                      sx={{ width: '100%' }}
-                    >
-                      <Stack direction="row" alignItems="center" spacing={1}>
-                        <Tooltip title={agentOnline ? 'Agent sandbox online' : 'Agent sandbox stopped'}>
-                          <Box
-                            sx={{
-                              width: 10,
-                              height: 10,
-                              borderRadius: '50%',
-                              backgroundColor: agentOnline ? 'rgb(46, 160, 67)' : 'rgba(0,0,0,0.28)',
-                              boxShadow: agentOnline ? '0 0 0 2px rgba(46,160,67,0.2)' : 'none',
-                              flexShrink: 0,
-                            }}
-                          />
-                        </Tooltip>
-                        <Typography variant="subtitle1">Agent activity</Typography>
-                        <Typography variant="caption" color="text.secondary">
-                          {agentOnline ? 'Running' : 'Stopped'}
+                      {bot.name && (
+                        <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'monospace' }}>
+                          {bot.id}
                         </Typography>
-                      </Stack>
-                      <Stack direction="row" spacing={0.5} alignItems="center">
-                        <ToggleButtonGroup
-                          size="small"
-                          exclusive
-                          value={sessionTab}
-                          onChange={(_e, value) => { if (value) setSessionTab(value) }}
-                        >
-                          <ToggleButton value="chat">Chat</ToggleButton>
-                          <ToggleButton value="desktop">Desktop</ToggleButton>
-                        </ToggleButtonGroup>
-                        <IconButton
-                          size="small"
-                          aria-label="Agent session actions"
-                          onClick={(e) => setAgentMenuEl(e.currentTarget)}
-                          disabled={activateAgent.isPending || stopAgent.isPending || restartAgent.isPending}
-                        >
-                          {(activateAgent.isPending || stopAgent.isPending || restartAgent.isPending)
-                            ? <CircularProgress size={16} />
-                            : <MoreVertIcon />}
-                        </IconButton>
-                        <Menu
-                          anchorEl={agentMenuEl}
-                          open={Boolean(agentMenuEl)}
-                          onClose={() => setAgentMenuEl(null)}
-                          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-                          transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-                        >
-                          {agentOnline ? (
-                            <>
-                              <MenuItem
-                                onClick={() => {
-                                  setAgentMenuEl(null)
-                                  void handleStopSession()
-                                }}
-                              >
-                                <StopIcon sx={{ mr: 1, fontSize: 20 }} />
-                                Stop agent
-                              </MenuItem>
-                              <MenuItem
-                                onClick={() => {
-                                  setAgentMenuEl(null)
-                                  void handleRestartSession()
-                                }}
-                              >
-                                <RestartAltIcon sx={{ mr: 1, fontSize: 20 }} />
-                                Restart agent
-                              </MenuItem>
-                            </>
-                          ) : (
+                      )}
+                    </Stack>
+                    <Stack direction="row" alignItems="center" spacing={1}>
+                      <Tooltip title={agentOnline ? 'Agent sandbox online' : 'Agent sandbox stopped'}>
+                        <Box
+                          sx={{
+                            width: 10,
+                            height: 10,
+                            borderRadius: '50%',
+                            backgroundColor: agentOnline ? 'rgb(46, 160, 67)' : 'rgba(0,0,0,0.28)',
+                            boxShadow: agentOnline ? '0 0 0 2px rgba(46,160,67,0.2)' : 'none',
+                            flexShrink: 0,
+                          }}
+                        />
+                      </Tooltip>
+                      <Typography variant="caption" color="text.secondary">
+                        {agentOnline ? 'Running' : 'Stopped'}
+                      </Typography>
+                      <IconButton
+                        size="small"
+                        aria-label="Agent session actions"
+                        onClick={(e) => setAgentMenuEl(e.currentTarget)}
+                        disabled={activateAgent.isPending || stopAgent.isPending || restartAgent.isPending}
+                      >
+                        {(activateAgent.isPending || stopAgent.isPending || restartAgent.isPending)
+                          ? <CircularProgress size={16} />
+                          : <MoreVertIcon />}
+                      </IconButton>
+                      <Menu
+                        anchorEl={agentMenuEl}
+                        open={Boolean(agentMenuEl)}
+                        onClose={() => setAgentMenuEl(null)}
+                        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+                      >
+                        {agentOnline ? (
+                          <>
                             <MenuItem
                               onClick={() => {
                                 setAgentMenuEl(null)
-                                void handleStartSession()
+                                void handleStopSession()
                               }}
                             >
-                              <PlayArrowIcon sx={{ mr: 1, fontSize: 20 }} />
-                              Start agent
+                              <StopIcon sx={{ mr: 1, fontSize: 20 }} />
+                              Stop agent
                             </MenuItem>
-                          )}
-                        </Menu>
-                      </Stack>
-                    </Stack>
-                    <Typography variant="body2" color="text.secondary">
-                      {sessionTab === 'chat'
-                        ? "Chat with this agent - messages include tool calls. Use the menu to start, stop, or restart it."
-                        : "Live desktop of this agent. Use the menu to start, stop, or restart it."}
-                    </Typography>
-
-                    {!agentOnline && !chatSessionId && (
-                      <Box
-                        sx={{
-                          width: '100%',
-                          py: 4,
-                          px: 2,
-                          textAlign: 'center',
-                          border: (theme) =>
-                            `1px dashed ${theme.palette.mode === 'light' ? 'rgba(0,0,0,0.12)' : 'rgba(255,255,255,0.12)'}`,
-                          borderRadius: 1,
-                        }}
-                      >
-                        <Typography variant="body2" color="text.secondary">
-                          The agent is not running. Open the ⋮ menu and choose <strong>Start agent</strong> to begin.
-                        </Typography>
-                      </Box>
-                    )}
-
-                    {/* Inline transcript. EmbeddedSessionView self-fetches
-                        the session + interactions and live-tails in-flight
-                        turns; it needs a bounded, flex-column container to
-                        scroll within. RobustPromptInput drives the same
-                        session via streaming.NewInference. */}
-                    {sessionTab === 'chat' ? (
-                      chatSessionId ? (
-                        <Box
-                          sx={{
-                            width: '100%',
-                            height: 520,
-                            display: 'flex',
-                            flexDirection: 'column',
-                            border: (theme) =>
-                              `1px solid ${theme.palette.mode === 'light' ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.08)'}`,
-                            borderRadius: 1,
-                            overflow: 'hidden',
-                          }}
-                        >
-                          <EmbeddedSessionView
-                            ref={sessionViewRef}
-                            sessionId={chatSessionId}
-                            autoScrollOnMount
-                          />
-                          <SessionPromptQueue sessionId={chatSessionId} />
-                          <Box sx={{ p: 1.5, flexShrink: 0 }}>
-                            <RobustPromptInput
-                              sessionId={chatSessionId}
-                              projectId={projectID}
-                              apiClient={api.getApiClient()}
-                              onSend={async (message: string, interrupt?: boolean) => {
-                                await streaming.NewInference({
-                                  type: SESSION_TYPE_TEXT,
-                                  message,
-                                  sessionId: chatSessionId,
-                                  interrupt: interrupt ?? true,
-                                })
+                            <MenuItem
+                              onClick={() => {
+                                setAgentMenuEl(null)
+                                void handleRestartSession()
                               }}
-                              onHeightChange={() => sessionViewRef.current?.scrollToBottom()}
-                              placeholder="Send message to agent..."
-                            />
-                          </Box>
-                        </Box>
-                      ) : agentOnline ? (
-                        <Typography variant="body2" color="text.secondary">
-                          Agent is starting — the transcript will appear when the session is ready.
-                        </Typography>
-                      ) : null
-                    ) : (
-                      chatSessionId ? (
-                        <Box
-                          sx={{
-                            width: '100%',
-                            height: 520,
-                            display: 'flex',
-                            flexDirection: 'column',
-                            border: (theme) =>
-                              `1px solid ${theme.palette.mode === 'light' ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.08)'}`,
-                            borderRadius: 1,
-                            overflow: 'hidden',
-                          }}
-                        >
-                          <ExternalAgentDesktopViewer
-                            sessionId={chatSessionId}
-                            sandboxId={chatSessionId}
-                            mode="stream"
-                            displayWidth={displaySettings.width}
-                            displayHeight={displaySettings.height}
-                            displayFps={displaySettings.fps}
-                          />
-                        </Box>
-                      ) : agentOnline ? (
-                        <Typography variant="body2" color="text.secondary">
-                          Agent is starting — the desktop will appear when ready.
-                        </Typography>
-                      ) : null
-                    )}
+                            >
+                              <RestartAltIcon sx={{ mr: 1, fontSize: 20 }} />
+                              Restart agent
+                            </MenuItem>
+                          </>
+                        ) : (
+                          <MenuItem
+                            onClick={() => {
+                              setAgentMenuEl(null)
+                              void handleStartSession()
+                            }}
+                          >
+                            <PlayArrowIcon sx={{ mr: 1, fontSize: 20 }} />
+                            Start agent
+                          </MenuItem>
+                        )}
+                      </Menu>
+                    </Stack>
                   </Stack>
-                </Paper>
+                </Box>
 
                 <Box>
                   <Typography variant="subtitle2" sx={{ mb: 1 }}>Name</Typography>
@@ -624,22 +507,17 @@ const HelixOrgBotDetail: FC = () => {
                   />
                 </Box>
 
-                {agentID && (
-                  <Box>
-                    <AgentConfigForm
-                      value={runtimeConfig}
-                      showReasoningEffort
-                      onChange={(patch) => setRuntimeConfig((current) => ({ ...current, ...patch }))}
-                    />
-                  </Box>
-                )}
-
                 <Box>
                   <Typography variant="subtitle2" sx={{ mb: 1 }}>Instructions</Typography>
                   <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
                     Instructions to follow, set on every interaction.
                     Cmd/Ctrl+S inside the editor saves.
                   </Typography>
+                  {/* This is a prose editor, so Monaco's overview ruler (the
+                      decoration strip drawn in the scrollbar gutter) carries
+                      nothing worth showing — it only rendered a coloured line
+                      beside the scrollbar. Zero lanes drops the decorations,
+                      and the border/cursor marks go with it. */}
                   <MonacoEditor
                     value={content}
                     onChange={setContent}
@@ -649,6 +527,11 @@ const HelixOrgBotDetail: FC = () => {
                     maxHeight={600}
                     autoHeight={true}
                     theme="helix-dark"
+                    options={{
+                      overviewRulerLanes: 0,
+                      overviewRulerBorder: false,
+                      hideCursorInOverviewRuler: true,
+                    }}
                   />
                 </Box>
 
@@ -793,8 +676,9 @@ const HelixOrgBotDetail: FC = () => {
               </Stack>
             </Grid>
 
-            {/* Right rail: identity context + delete action */}
-            <Grid item xs={12} md={3}>
+            {/* Right rail: identity context, runtime config, and the
+                destructive actions (reset instructions / delete). */}
+            <Grid item xs={12} md={4}>
               <Paper variant="outlined" sx={{ p: 2 }}>
                 <Stack spacing={2}>
                   <Box>
@@ -840,26 +724,59 @@ const HelixOrgBotDetail: FC = () => {
                       )}
                     </Box>
                   )}
-                  {agentID && (
+                  {/* The agent app id is machine detail nobody reads — the
+                      only useful thing is getting to the agent, so the label
+                      itself is the link. Without an org slug there is no
+                      route to build, so the row is dropped entirely. */}
+                  {agentID && orgSlug && (
                     <Box>
-                      <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>Agent</Typography>
-                      {orgSlug ? (
-                        <Link
-                          href={router5.buildPath('org_agent', { org_id: orgSlug, app_id: agentID })}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          underline="hover"
-                          sx={{ fontFamily: 'monospace', fontSize: '0.7rem', display: 'inline-flex', alignItems: 'center', gap: 0.5, wordBreak: 'break-all' }}
-                        >
-                          {agentID}
-                          <OpenInNewIcon sx={{ fontSize: 14, flexShrink: 0 }} />
-                        </Link>
-                      ) : (
-                        <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.7rem', wordBreak: 'break-all' }}>{agentID}</Typography>
-                      )}
+                      <Link
+                        href={router5.buildPath('org_agent', { org_id: orgSlug, app_id: agentID })}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        underline="hover"
+                        sx={{ fontSize: '0.8rem', display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
+                      >
+                        Agent
+                        <OpenInNewIcon sx={{ fontSize: 14, flexShrink: 0 }} />
+                      </Link>
                     </Box>
                   )}
+
+                  {/* Runtime / credentials / model / effort. Lives in the
+                      rail with the other agent-level controls rather than
+                      in the editing column, which is for the prompt. */}
+                  {agentID && (
+                    <>
+                      <Divider />
+                      <AgentConfigForm
+                        value={runtimeConfig}
+                        showReasoningEffort
+                        onChange={(patch) => setRuntimeConfig((current) => ({ ...current, ...patch }))}
+                      />
+                    </>
+                  )}
+
                   <Divider />
+                  {defaultInstructions && (
+                    <>
+                      <Button
+                        variant="outlined"
+                        startIcon={<SettingsBackupRestoreIcon />}
+                        onClick={() => setConfirmingResetInstructions(true)}
+                        disabled={updateBot.isPending}
+                        fullWidth
+                      >
+                        Reset instructions
+                      </Button>
+                      <Typography variant="caption" color="text.secondary">
+                        Restores this agent's built-in default instructions,
+                        discarding local edits to them. Tools, subscriptions,
+                        and reporting lines are untouched.
+                      </Typography>
+                      <Divider />
+                    </>
+                  )}
                   <Button
                     variant="outlined"
                     color="error"
@@ -883,6 +800,46 @@ const HelixOrgBotDetail: FC = () => {
           </>
         )}
       </Container>
+
+      {/* Reset is destructive to the current prompt but nothing else, so a
+          plain confirm is enough — no type-the-word gate like delete. */}
+      <Dialog
+        open={confirmingResetInstructions}
+        onClose={() => setConfirmingResetInstructions(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Reset instructions</DialogTitle>
+        <DialogContent>
+          <Typography variant="body1">
+            This replaces the instructions for{' '}
+            <b style={{ fontFamily: 'monospace' }}>{botId}</b> with its built-in
+            default prompt. Any edits you have made to the instructions are
+            lost and cannot be recovered.
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+            The agent's tools, subscriptions, reporting lines, runtime, and
+            project access are not affected. The new instructions apply on the
+            agent's next activation.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => setConfirmingResetInstructions(false)}
+            disabled={updateBot.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={() => { void handleResetInstructions() }}
+            disabled={updateBot.isPending}
+          >
+            {updateBot.isPending ? 'Resetting…' : 'Reset instructions'}
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {confirmingDelete && botId && (
         <DeleteConfirmWindow

--- a/frontend/src/pages/HelixOrgChart.tsx
+++ b/frontend/src/pages/HelixOrgChart.tsx
@@ -17,7 +17,6 @@ import Typography from '@mui/material/Typography'
 import AccessTimeIcon from '@mui/icons-material/AccessTime'
 import AddIcon from '@mui/icons-material/Add'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
-import FilterListIcon from '@mui/icons-material/FilterList'
 import HubOutlinedIcon from '@mui/icons-material/HubOutlined'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
@@ -49,7 +48,6 @@ import {
   NodeProps,
   ConnectionMode,
   Position as RFPosition,
-  Panel,
   ReactFlow,
   ReactFlowProvider,
   Viewport,
@@ -66,6 +64,14 @@ import {
   saveChartViewport,
 } from '../components/helix-org/chartViewportStorage'
 import {
+  ChartTopicFilter,
+  DEFAULT_CHART_TOPIC_FILTERS,
+  chartTopicFilterFor,
+  loadChartTopicVisibility,
+  saveChartTopicVisibility,
+} from '../components/helix-org/chartTopicVisibility'
+import ChartTopicVisibilityMenu, { chartToolbarButtonSizeSx, chartToolbarButtonSx } from '../components/helix-org/ChartTopicVisibilityMenu'
+import {
   CHAT_BOT_FOCUS_EVENT,
   ChatBotFocusDetail,
   focusChatBot,
@@ -79,6 +85,7 @@ import NewTopicDrawer from '../components/helix-org/NewTopicDrawer'
 import ProcessorConfigDrawer from '../components/helix-org/ProcessorConfigDrawer'
 import TopicDetailDrawer from '../components/helix-org/TopicDetailDrawer'
 import ProcessorNode, { ProcessorNodeData, PROC_W, procNodeHeight } from '../components/helix-org/ProcessorNode'
+import AgentRuntimeProviderIcon from '../components/helix-org/AgentRuntimeProviderIcon'
 import { isTranscriptTopic } from '../components/helix-org/helixOrgTopics'
 import { BotTaskStats, summarizeBotTasks } from '../components/helix-org/botTaskStats'
 import useAccount from '../hooks/useAccount'
@@ -191,7 +198,7 @@ type BotNodeData = {
   selected: boolean
   /** Card body click — focus the left chat rail on Chat. */
   onSelectBot: (botId: string) => void
-  /** ⋮ → Details — open the bot detail page. */
+  /** Open the bot detail page from the menu or a card double-click. */
   onOpenBotDetails: (botId: string) => void
   onNewBot: (parentBotId: string) => void
   onDeleteBot: (botId: string) => void
@@ -413,6 +420,15 @@ const BotNode: FC<NodeProps<Node<BotNodeData>>> = ({ data }) => {
   return (
     <Box
       onClick={(e) => { e.stopPropagation(); data.onSelectBot(data.botId) }}
+      onDoubleClick={(e) => {
+        e.stopPropagation()
+        data.onOpenBotDetails(data.botId)
+      }}
+      onContextMenu={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        setMenuEl(e.currentTarget)
+      }}
       aria-selected={selected}
       sx={{
         width: BOT_W,
@@ -558,15 +574,18 @@ const BotNode: FC<NodeProps<Node<BotNodeData>>> = ({ data }) => {
         </Stack>
       </Stack>
       <BotTaskStatsRow stats={data.taskStats} isLight={lightTheme.isLight} />
-      <Typography
-        variant="caption"
-        sx={{ color: muted, fontSize: '0.65rem', mt: 'auto', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-      >
-        {data.agentRuntime
-          ? CODE_AGENT_RUNTIME_DISPLAY_NAMES[data.agentRuntime as CodeAgentRuntime] ?? data.agentRuntime
-          : 'Not provisioned'}
-        {data.agentModel ? ` · ${getModelDisplayName(data.agentModel)}` : ''}
-      </Typography>
+      <Stack direction="row" alignItems="center" spacing={0.5} sx={{ color: muted, mt: 'auto', minWidth: 0 }}>
+        <AgentRuntimeProviderIcon runtime={data.agentRuntime} />
+        <Typography
+          variant="caption"
+          sx={{ color: 'inherit', fontSize: '0.65rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+        >
+          {data.agentRuntime
+            ? CODE_AGENT_RUNTIME_DISPLAY_NAMES[data.agentRuntime as CodeAgentRuntime] ?? data.agentRuntime
+            : 'Not provisioned'}
+          {data.agentModel ? ` · ${getModelDisplayName(data.agentModel)}` : ''}
+        </Typography>
+      </Stack>
       <Handle
         type="source"
         position={RFPosition.Bottom}
@@ -837,7 +856,7 @@ const buildGraph = (
   topics: TopicSummary[],
   messageCounts: Record<string, number>,
   processors: ProcessorSummary[],
-  showTopics: boolean,
+  visibleTopicIds: ReadonlySet<string>,
   // Saved free-placed coordinates keyed by `${kind}:${id}`. Missing
   // entries keep the auto-layout position for that node.
   savedPositions: ChartPositionMap = {},
@@ -987,13 +1006,14 @@ const buildGraph = (
   if (!isFinite(minTop)) minTop = 0
   if (!isFinite(maxBottom)) maxBottom = 0
 
-  if (showTopics && topics.length > 0) {
+  if (visibleTopicIds.size > 0 && topics.length > 0) {
     const STREAM_GAP_X = 32
     const STREAM_COLUMN_GAP = 120
     const ORPHAN_VERTICAL_GAP = 120
 
     const resolved: { topic: TopicSummary; subjectBot: string | null }[] = []
     for (const s of topics) {
+      if (!visibleTopicIds.has(s.id)) continue
       if (ownedOutputTopicIds.has(s.id)) continue // collapsed into its processor's branch ports
       const subjectBot = s.created_by
       const onChart = subjectBot && botAutoAbs.has(subjectBot) ? subjectBot : null
@@ -1562,14 +1582,13 @@ const ChartCanvas: FC<{
   messageCounts: Record<string, number>
   processors: ProcessorSummary[]
   savedPositions: ChartPositionMap
-  showTopics: boolean
-  onToggleTopics: () => void
+  visibleTopicIds: ReadonlySet<string>
   onResetLayout: () => void
   resetLayoutPending: boolean
   fitViewRequest: number
   /** Bot id currently focused in the left chat rail. */
   selectedBotId: string
-}> = ({ flat, handlers, onAddParent, onRemoveParent, onSubscribeBot, onUnsubscribeBot, onSetProcessorInput, onLayoutSnapshot, onCanvasContextMenu, topics, messageCounts, processors, savedPositions, showTopics, onToggleTopics, onResetLayout, resetLayoutPending, fitViewRequest, selectedBotId }) => {
+}> = ({ flat, handlers, onAddParent, onRemoveParent, onSubscribeBot, onUnsubscribeBot, onSetProcessorInput, onLayoutSnapshot, onCanvasContextMenu, topics, messageCounts, processors, savedPositions, visibleTopicIds, onResetLayout, resetLayoutPending, fitViewRequest, selectedBotId }) => {
   const lightTheme = useLightTheme()
   const account = useAccount()
   const userId = account.user?.id ?? ''
@@ -1586,8 +1605,8 @@ const ChartCanvas: FC<{
   const fitViewRequestRef = useRef(fitViewRequest)
 
   const { nodes: computedNodes, edges: computedEdges } = useMemo(
-    () => buildGraph(flat, handlers, lightTheme.isLight, topics, messageCounts, processors, showTopics, savedPositions, selectedBotId),
-    [flat, handlers, lightTheme.isLight, topics, messageCounts, processors, showTopics, savedPositions, selectedBotId],
+    () => buildGraph(flat, handlers, lightTheme.isLight, topics, messageCounts, processors, visibleTopicIds, savedPositions, selectedBotId),
+    [flat, handlers, lightTheme.isLight, topics, messageCounts, processors, visibleTopicIds, savedPositions, selectedBotId],
   )
   const [nodes, setNodes, onNodesChange] = useNodesState(computedNodes)
   const [edges, setEdges, onEdgesChange] = useEdgesState(computedEdges)
@@ -1871,20 +1890,6 @@ const ChartCanvas: FC<{
             <RestartAltIcon />
           </ControlButton>
         </Controls>
-        <Panel position="bottom-left" style={{ marginLeft: 49 }}>
-          <Button
-            size="small"
-            variant={showTopics ? 'contained' : 'outlined'}
-            color="secondary"
-            startIcon={<FilterListIcon />}
-            onClick={onToggleTopics}
-            aria-label={showTopics ? 'Hide topics from chart' : 'Show topics on chart'}
-            aria-pressed={showTopics}
-            title={showTopics ? 'Hide topics from chart' : 'Show topics on chart'}
-          >
-            Topics
-          </Button>
-        </Panel>
       </ReactFlow>
       <ConfirmDeleteDialog
         open={!!pendingEdgeDelete}
@@ -2117,15 +2122,36 @@ const HelixOrgChart: FC = () => {
     [topics, processorConsumerCounts],
   )
 
-  // Per-topic retained-message counts for the topic cards. One cached query
-  // per topic id (shared with the detail page's count hook), so each
-  // card's number refreshes independently. topicIds is memoized so the
-  // fan-out only re-subscribes when the set of topics changes, not on
-  // every render.
-  const topicIds = useMemo(() => topics.map((s) => s.id), [topics])
-  const [showTopics, setShowTopics] = useState(false)
+  const topicVisibilityScopeRef = useRef('')
+  const [visibleTopicFilters, setVisibleTopicFilters] = useState<ChartTopicFilter[]>(() => [...DEFAULT_CHART_TOPIC_FILTERS])
+  useEffect(() => {
+    const scope = userID && orgID ? `${userID}:${orgID}` : ''
+    if (!scope) {
+      topicVisibilityScopeRef.current = ''
+      setVisibleTopicFilters([...DEFAULT_CHART_TOPIC_FILTERS])
+      return
+    }
+    if (scope === topicVisibilityScopeRef.current) return
+    topicVisibilityScopeRef.current = scope
+    setVisibleTopicFilters(loadChartTopicVisibility(userID, orgID) ?? [...DEFAULT_CHART_TOPIC_FILTERS])
+  }, [userID, orgID])
+
+  const onTopicFiltersChange = useCallback((filters: ChartTopicFilter[]) => {
+    setVisibleTopicFilters(filters)
+    saveChartTopicVisibility(userID, orgID, filters)
+  }, [userID, orgID])
+
+  const visibleTopicIds = useMemo(() => {
+    const selected = new Set(visibleTopicFilters)
+    return new Set(topics
+      .filter((topic) => selected.has(chartTopicFilterFor(topic)))
+      .map((topic) => topic.id))
+  }, [topics, visibleTopicFilters])
+
+  // Retained-message counts only run for cards currently shown on the chart.
+  const visibleTopicIdList = useMemo(() => Array.from(visibleTopicIds), [visibleTopicIds])
   const [fitViewRequest, setFitViewRequest] = useState(0)
-  const messageCounts = useTopicMessageCounts(topicIds, { enabled: showTopics })
+  const messageCounts = useTopicMessageCounts(visibleTopicIdList, { enabled: visibleTopicIdList.length > 0 })
 
   const processorSummaries = useMemo<ProcessorSummary[]>(
     () => (processorsData ?? []).map((p: ProcessorDTO) => ({
@@ -2200,7 +2226,7 @@ const HelixOrgChart: FC = () => {
     },
     [orgSlug],
   )
-  // ⋮ → Details → bot detail page.
+  // Agent menu Details / card double-click → agent detail page.
   const onOpenBotDetails = useCallback(
     (botId: string) => {
       if (!orgSlug) return
@@ -2438,12 +2464,14 @@ const HelixOrgChart: FC = () => {
             overflow: 'hidden',
           }}
         >
-          <Stack direction="row" spacing={1} sx={{ position: 'absolute', top: 12, right: 12, zIndex: 5 }}>
+          <Stack direction="row" spacing={0.5} sx={{ position: 'absolute', top: 12, right: 12, zIndex: 5 }}>
+            <ChartTopicVisibilityMenu selected={visibleTopicFilters} onChange={onTopicFiltersChange} />
             <Button
               size="small"
               variant="outlined"
-              startIcon={<TransformIcon />}
+              startIcon={<TransformIcon sx={{ fontSize: 16 }} />}
               onClick={() => setProcessorDrawer({ open: true, processor: null })}
+              sx={chartToolbarButtonSx}
             >
               Processor
             </Button>
@@ -2452,6 +2480,7 @@ const HelixOrgChart: FC = () => {
               variant="outlined"
               startIcon={<HubOutlinedIcon sx={{ fontSize: 16 }} />}
               onClick={() => setTopicDrawerOpen(true)}
+              sx={chartToolbarButtonSx}
             >
               Topic
             </Button>
@@ -2459,8 +2488,9 @@ const HelixOrgChart: FC = () => {
               size="small"
               variant="contained"
               color="secondary"
-              startIcon={<AddIcon />}
+              startIcon={<AddIcon sx={{ fontSize: 16 }} />}
               onClick={() => setBotDialogOpen(true)}
+              sx={chartToolbarButtonSizeSx}
             >
               New agent
             </Button>
@@ -2496,8 +2526,7 @@ const HelixOrgChart: FC = () => {
                 messageCounts={messageCounts}
                 processors={processorSummaries}
                 savedPositions={savedPositions}
-                showTopics={showTopics}
-                onToggleTopics={() => setShowTopics((visible) => !visible)}
+                visibleTopicIds={visibleTopicIds}
                 onResetLayout={onResetLayout}
                 resetLayoutPending={clearPositions.isPending}
                 fitViewRequest={fitViewRequest}

--- a/frontend/swagger/swagger.yaml
+++ b/frontend/swagger/swagger.yaml
@@ -28,6 +28,15 @@ definitions:
         type: string
       created_at:
         type: string
+      default_instructions:
+        description: |-
+          DefaultInstructions is the built-in seed prompt for this node, when
+          one exists (currently only the Chief of Staff every org is seeded
+          with). It lets the UI offer "reset instructions" and hide that
+          affordance for operator-created nodes, which have no default to
+          reset to. Detail-only: GET /bots/{id} populates it, the list does
+          not (it would repeat kilobytes of prompt per row).
+        type: string
       helix_user_id:
         type: string
       id:
@@ -129,6 +138,15 @@ definitions:
       content:
         type: string
       created_at:
+        type: string
+      default_instructions:
+        description: |-
+          DefaultInstructions is the built-in seed prompt for this node, when
+          one exists (currently only the Chief of Staff every org is seeded
+          with). It lets the UI offer "reset instructions" and hide that
+          affordance for operator-created nodes, which have no default to
+          reset to. Detail-only: GET /bots/{id} populates it, the list does
+          not (it would repeat kilobytes of prompt per row).
         type: string
       helix_user_id:
         type: string
@@ -3066,6 +3084,14 @@ definitions:
       technical_design:
         type: string
     type: object
+  server.UpdateClaudeSubscriptionDelegationRequest:
+    description: Disconnect a Claude subscription
+    properties:
+      delegated_org_ids:
+        items:
+          type: string
+        type: array
+    type: object
   server.VideoStreamingStats:
     properties:
       client_buffers:
@@ -4389,6 +4415,20 @@ definitions:
       credential_type:
         description: '"oauth" or "setup_token"'
         type: string
+      delegated_org_ids:
+        description: |-
+          DelegatedOrgIDs lists the organizations whose agent sessions may
+          authenticate with this subscription on the owner's behalf, even when the
+          session itself is owned by someone else (a service account dispatching
+          work for this person — see SpecTask.CredentialOwnerID).
+
+          This is the consent gate. Without it, any member who can create a task
+          could name another user as credential owner and spend their Claude quota.
+          Empty (the default) means the subscription is only ever used for sessions
+          its owner owns, which is the pre-existing behaviour.
+        items:
+          type: string
+        type: array
       id:
         type: string
       last_error:
@@ -4662,6 +4702,15 @@ definitions:
         - $ref: '#/definitions/types.CodeAgentRuntime'
         description: 'Runtime specifies which code agent runtime to use: "zed_agent"
           or "qwen_code"'
+      uses_subscription:
+        description: |-
+          UsesSubscription is true when the agent authenticates against the upstream
+          provider with the user's own subscription (Claude Pro/Max, ChatGPT) instead
+          of an API key routed through the Helix proxy. It mirrors the assistant's
+          CodeAgentCredentialType and is what gates credential injection into the
+          container — an api_key agent must never receive subscription credentials,
+          because the CLI prefers them over the proxy and would silently bypass it.
+        type: boolean
     type: object
   types.CodeAgentCredentialType:
     enum:
@@ -5029,6 +5078,14 @@ definitions:
       branch_prefix:
         description: 'For new mode: user-specified prefix (task# appended)'
         type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID optionally names the user whose Claude subscription should
+          authenticate this task's agent, for orchestrators dispatching work on a
+          human's behalf under one service API key. Credential resolution only — the
+          task is still created by, owned by, and attributed to the caller. Ignored
+          unless that user has delegated their subscription to this organization.
+        type: string
       depends_on:
         description: 'Optional: IDs of tasks this task depends on'
         items:
@@ -5112,6 +5169,17 @@ definitions:
         type: string
       callback_url:
         description: Webhook URL to POST on completion
+        type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID optionally names the user whose Claude subscription should
+          authenticate the agent this trigger starts. An orchestrator writing triggers
+          on people's behalf under one service API key sets it so a scheduled run
+          authenticates as the person it acts for, exactly as CreateTaskRequest does
+          for a run dispatched by hand. Credential resolution only: the task is still
+          created by, owned by, and attributed to the trigger's app owner, and the
+          named user must have delegated their subscription to this organization or it
+          is ignored. Currently honoured by the spec_task action.
         type: string
       emails:
         items:
@@ -9542,6 +9610,14 @@ definitions:
       container_name:
         description: Container fields (Hydra executor)
         type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID mirrors SpecTask.CredentialOwnerID onto the session: the
+          user whose Claude subscription authenticates this session's agent, when
+          that differs from Owner. Affects credential resolution ONLY — Owner still
+          owns and is attributed the session. Honoured only with an explicit
+          delegation grant; see ResolveClaudeCredentialOwner.
+        type: string
       dev_container_id:
         description: Dev container ID for streaming
         type: string
@@ -9972,6 +10048,24 @@ definitions:
         type: string
       created_by:
         description: Metadata
+        type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID names the user whose Claude subscription authenticates
+          this task's agent sessions, when that differs from CreatedBy. It changes
+          ONLY credential resolution — the task and its sessions are still owned by,
+          and attributed to, CreatedBy. Nothing "runs as" the credential owner.
+
+          This exists for orchestrators (HelixOS) that dispatch every task with one
+          service API key but run work on behalf of different humans: without it the
+          service account's subscription authenticates everyone's bots, so one
+          person's expired token breaks all of them and no one can use their own
+          Claude account.
+
+          Honoured only when the named user has delegated their subscription to this
+          organization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able
+          to create a task could spend another user's Claude quota. See
+          ResolveClaudeCredentialOwner.
         type: string
       depends_on:
         items:
@@ -10577,6 +10671,24 @@ definitions:
         type: string
       created_by:
         description: Metadata
+        type: string
+      credential_owner_id:
+        description: |-
+          CredentialOwnerID names the user whose Claude subscription authenticates
+          this task's agent sessions, when that differs from CreatedBy. It changes
+          ONLY credential resolution — the task and its sessions are still owned by,
+          and attributed to, CreatedBy. Nothing "runs as" the credential owner.
+
+          This exists for orchestrators (HelixOS) that dispatch every task with one
+          service API key but run work on behalf of different humans: without it the
+          service account's subscription authenticates everyone's bots, so one
+          person's expired token breaks all of them and no one can use their own
+          Claude account.
+
+          Honoured only when the named user has delegated their subscription to this
+          organization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able
+          to create a task could spend another user's Claude quota. See
+          ResolveClaudeCredentialOwner.
         type: string
       depends_on:
         items:
@@ -12921,6 +13033,32 @@ paths:
       summary: Delete a user (Admin only)
       tags:
       - users
+  /api/v1/admin/users/{id}/api-keys:
+    post:
+      description: Create (or return the existing) named API key owned by another
+        user, so a trusted orchestrator can act as the people it runs work for instead
+        of putting the whole fleet on one shared account. Idempotent per (user, name).
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Key name, e.g. the orchestrator's slug
+        in: query
+        name: name
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.ApiKey'
+      security:
+      - BearerAuth: []
+      summary: Mint an API key for a user (Admin only)
+      tags:
+      - users
   /api/v1/admin/users/{id}/approve:
     post:
       description: Approve a waitlisted user, removing them from the waitlist. Only
@@ -14460,38 +14598,6 @@ paths:
       tags:
       - Claude
   /api/v1/claude-subscriptions/{id}:
-    delete:
-      description: Disconnect a Claude subscription
-      parameters:
-      - description: Subscription ID
-        in: path
-        name: id
-        required: true
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/system.HTTPError'
-      security:
-      - BearerAuth: []
-      summary: Delete a Claude subscription
-      tags:
-      - Claude
     get:
       description: Get details of a specific Claude subscription (no secrets)
       parameters:
@@ -14522,6 +14628,53 @@ paths:
       security:
       - BearerAuth: []
       summary: Get a Claude subscription
+      tags:
+      - Claude
+  /api/v1/claude-subscriptions/{id}/delegation:
+    put:
+      consumes:
+      - application/json
+      description: Grant (or revoke) permission for an organization's orchestrated
+        agents to authenticate as the subscription owner. Only the subscription owner
+        may change this.
+      parameters:
+      - description: Subscription ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Delegated organizations
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/server.UpdateClaudeSubscriptionDelegationRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.ClaudeSubscription'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/system.HTTPError'
+      security:
+      - BearerAuth: []
+      summary: Set which orgs may use a Claude subscription for delegated agent runs
       tags:
       - Claude
   /api/v1/claude-subscriptions/models:

--- a/openapi.json
+++ b/openapi.json
@@ -994,6 +994,52 @@
                 }
             }
         },
+        "/api/v1/admin/users/{id}/api-keys": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create (or return the existing) named API key owned by another user, so a trusted orchestrator can act as the people it runs work for instead of putting the whole fleet on one shared account. Idempotent per (user, name).",
+                "tags": [
+                    "users"
+                ],
+                "summary": "Mint an API key for a user (Admin only)",
+                "parameters": [
+                    {
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Key name, e.g. the orchestrator's slug",
+                        "name": "name",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/types.ApiKey"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/users/{id}/approve": {
             "post": {
                 "security": [
@@ -4033,18 +4079,20 @@
                         }
                     }
                 }
-            },
-            "delete": {
+            }
+        },
+        "/api/v1/claude-subscriptions/{id}/delegation": {
+            "put": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
-                "description": "Disconnect a Claude subscription",
+                "description": "Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Only the subscription owner may change this.",
                 "tags": [
                     "Claude"
                 ],
-                "summary": "Delete a Claude subscription",
+                "summary": "Set which orgs may use a Claude subscription for delegated agent runs",
                 "parameters": [
                     {
                         "description": "Subscription ID",
@@ -4056,16 +4104,34 @@
                         }
                     }
                 ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/server.UpdateClaudeSubscriptionDelegationRequest"
+                            }
+                        }
+                    },
+                    "description": "Delegated organizations",
+                    "required": true
+                },
                 "responses": {
                     "200": {
                         "description": "OK",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "additionalProperties": {
-                                        "type": "string"
-                                    }
+                                    "$ref": "#/components/schemas/types.ClaudeSubscription"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/system.HTTPError"
                                 }
                             }
                         }
@@ -4073,7 +4139,7 @@
                     "401": {
                         "description": "Unauthorized",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/system.HTTPError"
                                 }
@@ -4083,7 +4149,7 @@
                     "403": {
                         "description": "Forbidden",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/system.HTTPError"
                                 }
@@ -4093,7 +4159,7 @@
                     "404": {
                         "description": "Not Found",
                         "content": {
-                            "*/*": {
+                            "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/system.HTTPError"
                                 }
@@ -27059,6 +27125,10 @@
                     "created_at": {
                         "type": "string"
                     },
+                    "default_instructions": {
+                        "description": "DefaultInstructions is the built-in seed prompt for this node, when\none exists (currently only the Chief of Staff every org is seeded\nwith). It lets the UI offer \"reset instructions\" and hide that\naffordance for operator-created nodes, which have no default to\nreset to. Detail-only: GET /bots/{id} populates it, the list does\nnot (it would repeat kilobytes of prompt per row).",
+                        "type": "string"
+                    },
                     "helix_user_id": {
                         "type": "string"
                     },
@@ -27192,6 +27262,10 @@
                         "type": "string"
                     },
                     "created_at": {
+                        "type": "string"
+                    },
+                    "default_instructions": {
+                        "description": "DefaultInstructions is the built-in seed prompt for this node, when\none exists (currently only the Chief of Staff every org is seeded\nwith). It lets the UI offer \"reset instructions\" and hide that\naffordance for operator-created nodes, which have no default to\nreset to. Detail-only: GET /bots/{id} populates it, the list does\nnot (it would repeat kilobytes of prompt per row).",
                         "type": "string"
                     },
                     "helix_user_id": {
@@ -31345,6 +31419,18 @@
                     }
                 }
             },
+            "server.UpdateClaudeSubscriptionDelegationRequest": {
+                "description": "Disconnect a Claude subscription",
+                "type": "object",
+                "properties": {
+                    "delegated_org_ids": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
             "server.VideoStreamingStats": {
                 "type": "object",
                 "properties": {
@@ -33113,6 +33199,13 @@
                         "description": "\"oauth\" or \"setup_token\"",
                         "type": "string"
                     },
+                    "delegated_org_ids": {
+                        "description": "DelegatedOrgIDs lists the organizations whose agent sessions may\nauthenticate with this subscription on the owner's behalf, even when the\nsession itself is owned by someone else (a service account dispatching\nwork for this person — see SpecTask.CredentialOwnerID).\n\nThis is the consent gate. Without it, any member who can create a task\ncould name another user as credential owner and spend their Claude quota.\nEmpty (the default) means the subscription is only ever used for sessions\nits owner owns, which is the pre-existing behaviour.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "id": {
                         "type": "string"
                     },
@@ -33486,6 +33579,10 @@
                                 "$ref": "#/components/schemas/types.CodeAgentRuntime"
                             }
                         ]
+                    },
+                    "uses_subscription": {
+                        "description": "UsesSubscription is true when the agent authenticates against the upstream\nprovider with the user's own subscription (Claude Pro/Max, ChatGPT) instead\nof an API key routed through the Helix proxy. It mirrors the assistant's\nCodeAgentCredentialType and is what gates credential injection into the\ncontainer — an api_key agent must never receive subscription credentials,\nbecause the CLI prefers them over the proxy and would silently bypass it.",
+                        "type": "boolean"
                     }
                 }
             },
@@ -34013,6 +34110,10 @@
                         "description": "For new mode: user-specified prefix (task# appended)",
                         "type": "string"
                     },
+                    "credential_owner_id": {
+                        "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate this task's agent, for orchestrators dispatching work on a\nhuman's behalf under one service API key. Credential resolution only — the\ntask is still created by, owned by, and attributed to the caller. Ignored\nunless that user has delegated their subscription to this organization.",
+                        "type": "string"
+                    },
                     "depends_on": {
                         "description": "Optional: IDs of tasks this task depends on",
                         "type": "array",
@@ -34126,6 +34227,10 @@
                     },
                     "callback_url": {
                         "description": "Webhook URL to POST on completion",
+                        "type": "string"
+                    },
+                    "credential_owner_id": {
+                        "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate the agent this trigger starts. An orchestrator writing triggers\non people's behalf under one service API key sets it so a scheduled run\nauthenticates as the person it acts for, exactly as CreateTaskRequest does\nfor a run dispatched by hand. Credential resolution only: the task is still\ncreated by, owned by, and attributed to the trigger's app owner, and the\nnamed user must have delegated their subscription to this organization or it\nis ignored. Currently honoured by the spec_task action.",
                         "type": "string"
                     },
                     "emails": {
@@ -40161,6 +40266,10 @@
                         "description": "Container fields (Hydra executor)",
                         "type": "string"
                     },
+                    "credential_owner_id": {
+                        "description": "CredentialOwnerID mirrors SpecTask.CredentialOwnerID onto the session: the\nuser whose Claude subscription authenticates this session's agent, when\nthat differs from Owner. Affects credential resolution ONLY — Owner still\nowns and is attributed the session. Honoured only with an explicit\ndelegation grant; see ResolveClaudeCredentialOwner.",
+                        "type": "string"
+                    },
                     "dev_container_id": {
                         "description": "Dev container ID for streaming",
                         "type": "string"
@@ -40755,6 +40864,10 @@
                     },
                     "created_by": {
                         "description": "Metadata",
+                        "type": "string"
+                    },
+                    "credential_owner_id": {
+                        "description": "CredentialOwnerID names the user whose Claude subscription authenticates\nthis task's agent sessions, when that differs from CreatedBy. It changes\nONLY credential resolution — the task and its sessions are still owned by,\nand attributed to, CreatedBy. Nothing \"runs as\" the credential owner.\n\nThis exists for orchestrators (HelixOS) that dispatch every task with one\nservice API key but run work on behalf of different humans: without it the\nservice account's subscription authenticates everyone's bots, so one\nperson's expired token breaks all of them and no one can use their own\nClaude account.\n\nHonoured only when the named user has delegated their subscription to this\norganization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able\nto create a task could spend another user's Claude quota. See\nResolveClaudeCredentialOwner.",
                         "type": "string"
                     },
                     "depends_on": {
@@ -41553,6 +41666,10 @@
                     },
                     "created_by": {
                         "description": "Metadata",
+                        "type": "string"
+                    },
+                    "credential_owner_id": {
+                        "description": "CredentialOwnerID names the user whose Claude subscription authenticates\nthis task's agent sessions, when that differs from CreatedBy. It changes\nONLY credential resolution — the task and its sessions are still owned by,\nand attributed to, CreatedBy. Nothing \"runs as\" the credential owner.\n\nThis exists for orchestrators (HelixOS) that dispatch every task with one\nservice API key but run work on behalf of different humans: without it the\nservice account's subscription authenticates everyone's bots, so one\nperson's expired token breaks all of them and no one can use their own\nClaude account.\n\nHonoured only when the named user has delegated their subscription to this\norganization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able\nto create a task could spend another user's Claude quota. See\nResolveClaudeCredentialOwner.",
                         "type": "string"
                     },
                     "depends_on": {

--- a/swagger.json
+++ b/swagger.json
@@ -834,6 +834,44 @@
                 }
             }
         },
+        "/api/v1/admin/users/{id}/api-keys": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create (or return the existing) named API key owned by another user, so a trusted orchestrator can act as the people it runs work for instead of putting the whole fleet on one shared account. Idempotent per (user, name).",
+                "tags": [
+                    "users"
+                ],
+                "summary": "Mint an API key for a user (Admin only)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Key name, e.g. the orchestrator's slug",
+                        "name": "name",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.ApiKey"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/users/{id}/approve": {
             "post": {
                 "security": [
@@ -3388,18 +3426,26 @@
                         }
                     }
                 }
-            },
-            "delete": {
+            }
+        },
+        "/api/v1/claude-subscriptions/{id}/delegation": {
+            "put": {
                 "security": [
                     {
                         "BearerAuth": []
                     }
                 ],
-                "description": "Disconnect a Claude subscription",
+                "description": "Grant (or revoke) permission for an organization's orchestrated agents to authenticate as the subscription owner. Only the subscription owner may change this.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
                 "tags": [
                     "Claude"
                 ],
-                "summary": "Delete a Claude subscription",
+                "summary": "Set which orgs may use a Claude subscription for delegated agent runs",
                 "parameters": [
                     {
                         "type": "string",
@@ -3407,16 +3453,28 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Delegated organizations",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.UpdateClaudeSubscriptionDelegationRequest"
+                        }
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/types.ClaudeSubscription"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/system.HTTPError"
                         }
                     },
                     "401": {
@@ -22498,6 +22556,10 @@
                 "created_at": {
                     "type": "string"
                 },
+                "default_instructions": {
+                    "description": "DefaultInstructions is the built-in seed prompt for this node, when\none exists (currently only the Chief of Staff every org is seeded\nwith). It lets the UI offer \"reset instructions\" and hide that\naffordance for operator-created nodes, which have no default to\nreset to. Detail-only: GET /bots/{id} populates it, the list does\nnot (it would repeat kilobytes of prompt per row).",
+                    "type": "string"
+                },
                 "helix_user_id": {
                     "type": "string"
                 },
@@ -22631,6 +22693,10 @@
                     "type": "string"
                 },
                 "created_at": {
+                    "type": "string"
+                },
+                "default_instructions": {
+                    "description": "DefaultInstructions is the built-in seed prompt for this node, when\none exists (currently only the Chief of Staff every org is seeded\nwith). It lets the UI offer \"reset instructions\" and hide that\naffordance for operator-created nodes, which have no default to\nreset to. Detail-only: GET /bots/{id} populates it, the list does\nnot (it would repeat kilobytes of prompt per row).",
                     "type": "string"
                 },
                 "helix_user_id": {
@@ -26784,6 +26850,18 @@
                 }
             }
         },
+        "server.UpdateClaudeSubscriptionDelegationRequest": {
+            "description": "Disconnect a Claude subscription",
+            "type": "object",
+            "properties": {
+                "delegated_org_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "server.VideoStreamingStats": {
             "type": "object",
             "properties": {
@@ -28552,6 +28630,13 @@
                     "description": "\"oauth\" or \"setup_token\"",
                     "type": "string"
                 },
+                "delegated_org_ids": {
+                    "description": "DelegatedOrgIDs lists the organizations whose agent sessions may\nauthenticate with this subscription on the owner's behalf, even when the\nsession itself is owned by someone else (a service account dispatching\nwork for this person — see SpecTask.CredentialOwnerID).\n\nThis is the consent gate. Without it, any member who can create a task\ncould name another user as credential owner and spend their Claude quota.\nEmpty (the default) means the subscription is only ever used for sessions\nits owner owns, which is the pre-existing behaviour.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "id": {
                     "type": "string"
                 },
@@ -28925,6 +29010,10 @@
                             "$ref": "#/definitions/types.CodeAgentRuntime"
                         }
                     ]
+                },
+                "uses_subscription": {
+                    "description": "UsesSubscription is true when the agent authenticates against the upstream\nprovider with the user's own subscription (Claude Pro/Max, ChatGPT) instead\nof an API key routed through the Helix proxy. It mirrors the assistant's\nCodeAgentCredentialType and is what gates credential injection into the\ncontainer — an api_key agent must never receive subscription credentials,\nbecause the CLI prefers them over the proxy and would silently bypass it.",
+                    "type": "boolean"
                 }
             }
         },
@@ -29452,6 +29541,10 @@
                     "description": "For new mode: user-specified prefix (task# appended)",
                     "type": "string"
                 },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate this task's agent, for orchestrators dispatching work on a\nhuman's behalf under one service API key. Credential resolution only — the\ntask is still created by, owned by, and attributed to the caller. Ignored\nunless that user has delegated their subscription to this organization.",
+                    "type": "string"
+                },
                 "depends_on": {
                     "description": "Optional: IDs of tasks this task depends on",
                     "type": "array",
@@ -29565,6 +29658,10 @@
                 },
                 "callback_url": {
                     "description": "Webhook URL to POST on completion",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID optionally names the user whose Claude subscription should\nauthenticate the agent this trigger starts. An orchestrator writing triggers\non people's behalf under one service API key sets it so a scheduled run\nauthenticates as the person it acts for, exactly as CreateTaskRequest does\nfor a run dispatched by hand. Credential resolution only: the task is still\ncreated by, owned by, and attributed to the trigger's app owner, and the\nnamed user must have delegated their subscription to this organization or it\nis ignored. Currently honoured by the spec_task action.",
                     "type": "string"
                 },
                 "emails": {
@@ -35600,6 +35697,10 @@
                     "description": "Container fields (Hydra executor)",
                     "type": "string"
                 },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID mirrors SpecTask.CredentialOwnerID onto the session: the\nuser whose Claude subscription authenticates this session's agent, when\nthat differs from Owner. Affects credential resolution ONLY — Owner still\nowns and is attributed the session. Honoured only with an explicit\ndelegation grant; see ResolveClaudeCredentialOwner.",
+                    "type": "string"
+                },
                 "dev_container_id": {
                     "description": "Dev container ID for streaming",
                     "type": "string"
@@ -36194,6 +36295,10 @@
                 },
                 "created_by": {
                     "description": "Metadata",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID names the user whose Claude subscription authenticates\nthis task's agent sessions, when that differs from CreatedBy. It changes\nONLY credential resolution — the task and its sessions are still owned by,\nand attributed to, CreatedBy. Nothing \"runs as\" the credential owner.\n\nThis exists for orchestrators (HelixOS) that dispatch every task with one\nservice API key but run work on behalf of different humans: without it the\nservice account's subscription authenticates everyone's bots, so one\nperson's expired token breaks all of them and no one can use their own\nClaude account.\n\nHonoured only when the named user has delegated their subscription to this\norganization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able\nto create a task could spend another user's Claude quota. See\nResolveClaudeCredentialOwner.",
                     "type": "string"
                 },
                 "depends_on": {
@@ -36992,6 +37097,10 @@
                 },
                 "created_by": {
                     "description": "Metadata",
+                    "type": "string"
+                },
+                "credential_owner_id": {
+                    "description": "CredentialOwnerID names the user whose Claude subscription authenticates\nthis task's agent sessions, when that differs from CreatedBy. It changes\nONLY credential resolution — the task and its sessions are still owned by,\nand attributed to, CreatedBy. Nothing \"runs as\" the credential owner.\n\nThis exists for orchestrators (HelixOS) that dispatch every task with one\nservice API key but run work on behalf of different humans: without it the\nservice account's subscription authenticates everyone's bots, so one\nperson's expired token breaks all of them and no one can use their own\nClaude account.\n\nHonoured only when the named user has delegated their subscription to this\norganization (ClaudeSubscription.DelegatedOrgIDs) — otherwise anyone able\nto create a task could spend another user's Claude quota. See\nResolveClaudeCredentialOwner.",
                     "type": "string"
                 },
                 "depends_on": {


### PR DESCRIPTION
## Summary

- replace the all-or-nothing topic toggle with a compact top-right multiselect for direct messages, local topics, webhook, GitHub, GitLab, Postmark, cron, and other topics
- persist topic visibility per user and organization, defaulting to hide direct messages, local topics, and other topics
- compact and align the chart toolbar while keeping New agent as the secondary-blue primary action
- open agent details on double-click and expose the existing agent action menu on right-click
- show Anthropic and OpenAI icons beside Claude Code and Codex CLI runtimes

## Why

The chart's previous topic toggle could not distinguish noisy internal topics from operational topics and did not retain an organization's preferred view. Agent card navigation and actions also required small menu targets, and runtime labels lacked provider recognition.

## User impact

Operators can tailor each organization's chart, retain those choices locally, navigate agent cards faster, and identify Claude/OpenAI runtimes at a glance.

## Validation

- `yarn vitest run src/components/helix-org/AgentRuntimeProviderIcon.test.tsx src/components/helix-org/chartTopicVisibility.test.ts` — 8 tests passed
- `yarn tsc` — passed
- `yarn build` — passed
- live inner-Helix browser checks covered topic defaults, individual filters, all on/off, per-org persistence, agent context menus, and double-click navigation
- live computed-style check confirmed Processor, Topic, and New agent share 30px height, font size, and padding while New agent retains the contained secondary style
