### PR TITLE
feat(org): add asset management MCP tools

### DIFF
--- a/api/pkg/org/domain/seedprompts/seedprompts.go
+++ b/api/pkg/org/domain/seedprompts/seedprompts.go
@@ -49,6 +49,13 @@ Nodes only see git repositories attached to their Helix project. After you creat
 
 Without attached repos a coding bot has nothing to clone and cannot do real work.
 
+## Add and manage servers
+Use ` + "`list_org_assets`" + ` and ` + "`get_org_asset`" + ` to inspect the organization's complete asset inventory. Use ` + "`create_server_asset`" + ` to add a server; it links the new asset to you automatically. Use ` + "`update_server_asset`" + ` and ` + "`delete_asset`" + ` to maintain it, and ` + "`list_asset_links`" + `, ` + "`link_asset`" + `, and ` + "`unlink_asset`" + ` to control which bots can use it.
+
+SSH-key creation returns a public key and an exact ` + "`install_command`" + `. The generated private key remains inside Helix. If you already have independent SSH access to the server, use normal ` + "`ssh`" + ` from your shell to run that command yourself. If you do not, send the owner the exact command with ` + "`ask_human`" + ` and ask them to run it as the configured server user. Never ask them for the Helix private key and never claim setup is complete merely because the asset row exists.
+
+After the key is installed, call ` + "`get_asset_health`" + `. Both ` + "`tcp_reachable`" + ` and ` + "`ssh_reachable`" + ` must be true. Then exercise the immediately following normal operation with ` + "`server_run_command`" + ` before reporting that the server is ready. The linked operational tools appear immediately; call them directly.
+
 ## How to call your tools
 Your tools are helix MCP tools (` + "`mcp__helix__…`" + `). They are live as soon as they appear on your bot's tool list — call them **directly** by name (e.g. ` + "`mcp__helix__list_bot_repositories`" + `). Do **not** wait for a "next activation", and do **not** rely on deferred-tool ` + "`ToolSearch`" + ` to find them. If ` + "`tools/list`" + ` / your tool list shows a name, invoke it now.
 

--- a/api/pkg/org/interfaces/mcptools/builtins.go
+++ b/api/pkg/org/interfaces/mcptools/builtins.go
@@ -25,6 +25,7 @@ import (
 	"github.com/helixml/helix/api/pkg/org/domain/store"
 	"github.com/helixml/helix/api/pkg/org/domain/streaming"
 	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/assetssh"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/runtime"
 	"github.com/helixml/helix/api/pkg/org/infrastructure/wakebus"
 )
@@ -92,6 +93,7 @@ type Deps struct {
 	AssetSSH             ServerAssetRuntime
 	AssetSSHIssuer       AssetSSHIdentityIssuer
 	AssetSSHProxyAddress string
+	AssetHealth          func(ctx context.Context, orgID, assetRef string) assetssh.Health
 
 	// Workspace is the per-runtime file-mirror port: set_bot_content calls
 	// MirrorFile after the service persists, so the running session sees
@@ -186,6 +188,7 @@ type Config struct {
 	AssetSSH             ServerAssetRuntime
 	AssetSSHIssuer       AssetSSHIdentityIssuer
 	AssetSSHProxyAddress string
+	AssetHealth          func(ctx context.Context, orgID, assetRef string) assetssh.Health
 	Publishing           *publishing.Publishing
 	// HumanDelivery sends ask_human messages through the person's configured route.
 	HumanDelivery HumanDelivery
@@ -207,6 +210,7 @@ func (c Config) Build() Deps {
 		AssetSSH:             c.AssetSSH,
 		AssetSSHIssuer:       c.AssetSSHIssuer,
 		AssetSSHProxyAddress: c.AssetSSHProxyAddress,
+		AssetHealth:          c.AssetHealth,
 		Workspace:            c.Workspace,
 		AgentContentUpdater:  c.AgentContentUpdater,
 		AgentProfileReader:   c.AgentProfileReader,
@@ -465,6 +469,15 @@ func RegisterBuiltins(reg *Registry, deps Deps) error {
 		&BotLog{deps: deps},
 		&ListProcessors{deps: deps},
 		&GetProcessor{deps: deps},
+		&ListOrgAssets{deps: deps},
+		&GetOrgAsset{deps: deps},
+		&CreateServerAsset{deps: deps},
+		&UpdateServerAsset{deps: deps},
+		&DeleteAsset{deps: deps},
+		&ListAssetLinks{deps: deps},
+		&LinkAsset{deps: deps},
+		&UnlinkAsset{deps: deps},
+		&GetAssetHealth{deps: deps},
 		&ListAssets{deps: deps},
 		&GetAsset{deps: deps},
 		&ServerRunCommand{deps: deps},

--- a/api/pkg/org/interfaces/mcptools/defaults.go
+++ b/api/pkg/org/interfaces/mcptools/defaults.go
@@ -48,6 +48,21 @@ var BaseReadTools = []tool.Name{
 	GetProcessorName,
 }
 
+// AssetManagementTools is the org-wide asset inventory and mutation surface.
+// It is granted to the owner Bot, not to every Bot. Link-derived operational
+// asset tools live in assets.ServerTools and remain a separate capability.
+var AssetManagementTools = []tool.Name{
+	ListOrgAssetsName,
+	GetOrgAssetName,
+	CreateServerAssetName,
+	UpdateServerAssetName,
+	DeleteAssetName,
+	ListAssetLinksName,
+	LinkAssetName,
+	UnlinkAssetName,
+	GetAssetHealthName,
+}
+
 // OwnerBotTools is the canonical tool set the bootstrap owner Bot
 // (Chief of Staff) receives: every mutation in the system plus the
 // universal base read set (via MergeBaseReadTools). It lives here —
@@ -86,6 +101,8 @@ func OwnerBotTools() []tool.Name {
 		StopBotName,
 		RestartBotName,
 	}
+	// Org assets: create/configure inventory and grant/revoke Bot access.
+	ownerMutations = append(ownerMutations, AssetManagementTools...)
 	return MergeBaseReadTools(ownerMutations)
 }
 

--- a/api/pkg/org/interfaces/mcptools/manage_assets.go
+++ b/api/pkg/org/interfaces/mcptools/manage_assets.go
@@ -1,0 +1,501 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/jsonschema-go/jsonschema"
+
+	assetapp "github.com/helixml/helix/api/pkg/org/application/assets"
+	"github.com/helixml/helix/api/pkg/org/domain/asset"
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+)
+
+// Asset management tools expose the org-wide inventory to manager Bots. The
+// existing assets.go tools deliberately remain link-scoped operational tools.
+
+type managedServerView struct {
+	Address            string         `json:"address"`
+	Port               uint16         `json:"port"`
+	User               string         `json:"user"`
+	AuthType           asset.AuthType `json:"auth_type"`
+	PublicKey          string         `json:"public_key,omitempty"`
+	PasswordConfigured bool           `json:"password_configured"`
+	HostKeyConfigured  bool           `json:"host_key_configured"`
+}
+
+type managedAssetView struct {
+	ID             string             `json:"id"`
+	OrganizationID string             `json:"organization_id"`
+	Name           string             `json:"name"`
+	Description    string             `json:"description,omitempty"`
+	NotesForAgents string             `json:"notes_for_agents,omitempty"`
+	Kind           asset.Kind         `json:"kind"`
+	Server         *managedServerView `json:"server,omitempty"`
+	AgentIDs       []string           `json:"agent_ids"`
+	CreatedAt      time.Time          `json:"created_at"`
+	UpdatedAt      time.Time          `json:"updated_at"`
+}
+
+type serverAssetSetup struct {
+	PublicKey            string `json:"public_key"`
+	AuthorizedKeysPath   string `json:"authorized_keys_path"`
+	InstallCommand       string `json:"install_command"`
+	VerificationToolName string `json:"verification_tool"`
+}
+
+type managedAssetResult struct {
+	Asset managedAssetView  `json:"asset"`
+	Setup *serverAssetSetup `json:"setup,omitempty"`
+}
+
+type orgAssetsResult struct {
+	Assets []managedAssetView `json:"assets"`
+}
+
+type assetLinksResult struct {
+	AssetID  string   `json:"asset_id"`
+	AgentIDs []string `json:"agent_ids"`
+}
+
+type assetMutationResult struct {
+	AssetID string `json:"asset_id"`
+	Status  string `json:"status"`
+}
+
+func listAssetLinksResult(ctx context.Context, deps Deps, orgID string, value asset.Asset) (assetLinksResult, error) {
+	links, err := deps.Assets.ListLinks(ctx, orgID, value.ID)
+	if err != nil {
+		return assetLinksResult{}, err
+	}
+	ids := make([]string, 0, len(links))
+	for _, link := range links {
+		ids = append(ids, link.AgentID)
+	}
+	return assetLinksResult{AssetID: value.ID, AgentIDs: ids}, nil
+}
+
+func managedAssetsOrgID(inv tool.Invocation, operation string) (string, error) {
+	if inv.Caller == nil {
+		return "", fmt.Errorf("%s: caller is missing", operation)
+	}
+	orgID := inv.Caller.OrganizationID()
+	if orgID == "" {
+		return "", fmt.Errorf("%s: caller has no organization ID", operation)
+	}
+	return orgID, nil
+}
+
+func managedAsset(t Deps, ctx context.Context, orgID string, value asset.Asset) (managedAssetView, error) {
+	links, err := t.Assets.ListLinks(ctx, orgID, value.ID)
+	if err != nil {
+		return managedAssetView{}, err
+	}
+	agentIDs := make([]string, 0, len(links))
+	for _, link := range links {
+		agentIDs = append(agentIDs, link.AgentID)
+	}
+	view := managedAssetView{
+		ID: value.ID, OrganizationID: orgID, Name: value.Name,
+		Description: value.Description, NotesForAgents: value.NotesForAgents,
+		Kind: value.Kind, AgentIDs: agentIDs,
+		CreatedAt: value.CreatedAt, UpdatedAt: value.UpdatedAt,
+	}
+	if value.Config.Server != nil {
+		server := value.Config.Server
+		view.Server = &managedServerView{
+			Address: server.Address, Port: server.Port, User: server.User,
+			AuthType: server.AuthType, PublicKey: server.PublicKey,
+			PasswordConfigured: server.EncryptedPassword != "",
+			HostKeyConfigured:  server.HostKey != "",
+		}
+	}
+	return view, nil
+}
+
+func resolveManagedAsset(t Deps, ctx context.Context, orgID, ref string) (asset.Asset, error) {
+	if t.Assets == nil {
+		return asset.Asset{}, errors.New("assets service is not wired")
+	}
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return asset.Asset{}, errors.New("asset is required")
+	}
+	value, err := t.Assets.Resolve(ctx, orgID, ref)
+	if err != nil {
+		return asset.Asset{}, err
+	}
+	return value, nil
+}
+
+func setupForServer(value asset.Asset) *serverAssetSetup {
+	if value.Config.Server == nil || value.Config.Server.AuthType != asset.AuthSSHKey || value.Config.Server.PublicKey == "" {
+		return nil
+	}
+	publicKey := strings.TrimSpace(value.Config.Server.PublicKey)
+	encoded := base64.StdEncoding.EncodeToString([]byte(publicKey + "\n"))
+	command := "install -d -m 700 \"$HOME/.ssh\" && touch \"$HOME/.ssh/authorized_keys\" && " +
+		"chmod 600 \"$HOME/.ssh/authorized_keys\" && " +
+		"(printf '%s' '" + encoded + "' | base64 -d | grep -qxFf - \"$HOME/.ssh/authorized_keys\" || " +
+		"printf '%s' '" + encoded + "' | base64 -d >> \"$HOME/.ssh/authorized_keys\")"
+	return &serverAssetSetup{
+		PublicKey: publicKey, AuthorizedKeysPath: "$HOME/.ssh/authorized_keys",
+		InstallCommand: command, VerificationToolName: string(GetAssetHealthName),
+	}
+}
+
+// --- list_org_assets ------------------------------------------------------
+
+const ListOrgAssetsName tool.Name = "list_org_assets"
+
+type ListOrgAssets struct{ deps Deps }
+
+func (t *ListOrgAssets) Name() tool.Name                 { return ListOrgAssetsName }
+func (t *ListOrgAssets) InputSchema() *jsonschema.Schema { return mustSchema[struct{}]() }
+func (t *ListOrgAssets) Description() string {
+	return "List every asset in the organization, including linked agent IDs and public connection configuration. Unlike list_assets, this owner-management view is not limited to assets linked to the caller."
+}
+func (t *ListOrgAssets) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	orgID, err := managedAssetsOrgID(inv, string(ListOrgAssetsName))
+	if err != nil {
+		return nil, err
+	}
+	if t.deps.Assets == nil {
+		return nil, errors.New("assets service is not wired")
+	}
+	values, err := t.deps.Assets.List(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("list org assets: %w", err)
+	}
+	views := make([]managedAssetView, 0, len(values))
+	for _, value := range values {
+		view, err := managedAsset(t.deps, ctx, orgID, value)
+		if err != nil {
+			return nil, fmt.Errorf("list links for asset %q: %w", value.ID, err)
+		}
+		views = append(views, view)
+	}
+	return json.Marshal(orgAssetsResult{Assets: views})
+}
+
+// --- get_org_asset --------------------------------------------------------
+
+const GetOrgAssetName tool.Name = "get_org_asset"
+
+type GetOrgAsset struct{ deps Deps }
+
+func (t *GetOrgAsset) Name() tool.Name                 { return GetOrgAssetName }
+func (t *GetOrgAsset) InputSchema() *jsonschema.Schema { return mustSchema[assetRefArgs]() }
+func (t *GetOrgAsset) Description() string {
+	return "Get any org asset by ID or name, including linked agent IDs and public connection configuration."
+}
+func (t *GetOrgAsset) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	var args assetRefArgs
+	if err := json.Unmarshal(inv.Args, &args); err != nil {
+		return nil, fmt.Errorf("parse args: %w", err)
+	}
+	orgID, err := managedAssetsOrgID(inv, string(GetOrgAssetName))
+	if err != nil {
+		return nil, err
+	}
+	value, err := resolveManagedAsset(t.deps, ctx, orgID, args.Asset)
+	if err != nil {
+		return nil, fmt.Errorf("get org asset: %w", err)
+	}
+	view, err := managedAsset(t.deps, ctx, orgID, value)
+	if err != nil {
+		return nil, fmt.Errorf("get asset links: %w", err)
+	}
+	return json.Marshal(view)
+}
+
+// --- create_server_asset --------------------------------------------------
+
+const CreateServerAssetName tool.Name = "create_server_asset"
+
+type CreateServerAsset struct{ deps Deps }
+
+type createServerAssetArgs struct {
+	Name           string         `json:"name"`
+	Description    string         `json:"description,omitempty"`
+	NotesForAgents string         `json:"notes_for_agents,omitempty"`
+	Address        string         `json:"address"`
+	Port           uint16         `json:"port,omitempty"`
+	User           string         `json:"user"`
+	AuthType       asset.AuthType `json:"auth_type,omitempty"`
+	Password       string         `json:"password,omitempty"`
+	HostKey        string         `json:"host_key,omitempty"`
+	AgentIDs       []string       `json:"agent_ids,omitempty"`
+}
+
+func (t *CreateServerAsset) Name() tool.Name { return CreateServerAssetName }
+func (t *CreateServerAsset) InputSchema() *jsonschema.Schema {
+	return mustSchema[createServerAssetArgs]()
+}
+func (t *CreateServerAsset) Description() string {
+	return "Create a server asset and link it to the calling Bot in one action; agent_ids adds more links. auth_type defaults to ssh_key. SSH-key creation returns the Helix public key and an idempotent install_command. If you already have independent SSH access, run that command on the server; otherwise send it to the owner with ask_human. Then call get_asset_health and a server operation before claiming readiness."
+}
+func (t *CreateServerAsset) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	var args createServerAssetArgs
+	if err := json.Unmarshal(inv.Args, &args); err != nil {
+		return nil, fmt.Errorf("parse args: %w", err)
+	}
+	orgID, err := managedAssetsOrgID(inv, string(CreateServerAssetName))
+	if err != nil {
+		return nil, err
+	}
+	if t.deps.Assets == nil {
+		return nil, errors.New("assets service is not wired")
+	}
+	value, err := t.deps.Assets.CreateServer(ctx, orgID, assetapp.CreateServerParams{
+		Name: args.Name, Description: args.Description, NotesForAgents: args.NotesForAgents,
+		Address: args.Address, Port: args.Port, User: args.User, AuthType: args.AuthType,
+		Password: args.Password, HostKey: args.HostKey,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create server asset: %w", err)
+	}
+	ids := append([]string{inv.Caller.ID()}, args.AgentIDs...)
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		if _, err := t.deps.Assets.Link(ctx, orgID, value.ID, id); err != nil {
+			if cleanupErr := t.deps.Assets.Delete(ctx, orgID, value.ID); cleanupErr != nil {
+				return nil, fmt.Errorf("link new asset to agent %q: %w; rollback asset: %v", id, err, cleanupErr)
+			}
+			return nil, fmt.Errorf("link new asset to agent %q: %w", id, err)
+		}
+	}
+	view, err := managedAsset(t.deps, ctx, orgID, value)
+	if err != nil {
+		return nil, fmt.Errorf("read created asset: %w", err)
+	}
+	return json.Marshal(managedAssetResult{Asset: view, Setup: setupForServer(value)})
+}
+
+// --- update_server_asset --------------------------------------------------
+
+const UpdateServerAssetName tool.Name = "update_server_asset"
+
+type UpdateServerAsset struct{ deps Deps }
+
+type updateServerAssetArgs struct {
+	Asset          string          `json:"asset"`
+	Name           *string         `json:"name,omitempty"`
+	Description    *string         `json:"description,omitempty"`
+	NotesForAgents *string         `json:"notes_for_agents,omitempty"`
+	Address        *string         `json:"address,omitempty"`
+	Port           *uint16         `json:"port,omitempty"`
+	User           *string         `json:"user,omitempty"`
+	AuthType       *asset.AuthType `json:"auth_type,omitempty"`
+	Password       *string         `json:"password,omitempty"`
+	HostKey        *string         `json:"host_key,omitempty"`
+}
+
+func (t *UpdateServerAsset) Name() tool.Name { return UpdateServerAssetName }
+func (t *UpdateServerAsset) InputSchema() *jsonschema.Schema {
+	return mustSchema[updateServerAssetArgs]()
+}
+func (t *UpdateServerAsset) Description() string {
+	return "Patch a server asset by ID or name. Only supplied fields change. Switching to ssh_key generates a new key and returns its install_command; switching to password requires password."
+}
+func (t *UpdateServerAsset) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	var args updateServerAssetArgs
+	if err := json.Unmarshal(inv.Args, &args); err != nil {
+		return nil, fmt.Errorf("parse args: %w", err)
+	}
+	orgID, err := managedAssetsOrgID(inv, string(UpdateServerAssetName))
+	if err != nil {
+		return nil, err
+	}
+	current, err := resolveManagedAsset(t.deps, ctx, orgID, args.Asset)
+	if err != nil {
+		return nil, fmt.Errorf("resolve server asset: %w", err)
+	}
+	value, err := t.deps.Assets.UpdateServer(ctx, orgID, current.ID, assetapp.UpdateServerParams{
+		Name: args.Name, Description: args.Description, NotesForAgents: args.NotesForAgents,
+		Address: args.Address, Port: args.Port, User: args.User, AuthType: args.AuthType,
+		Password: args.Password, HostKey: args.HostKey,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("update server asset: %w", err)
+	}
+	view, err := managedAsset(t.deps, ctx, orgID, value)
+	if err != nil {
+		return nil, fmt.Errorf("read updated asset: %w", err)
+	}
+	return json.Marshal(managedAssetResult{Asset: view, Setup: setupForServer(value)})
+}
+
+// --- delete_asset ---------------------------------------------------------
+
+const DeleteAssetName tool.Name = "delete_asset"
+
+type DeleteAsset struct{ deps Deps }
+
+func (t *DeleteAsset) Name() tool.Name                 { return DeleteAssetName }
+func (t *DeleteAsset) InputSchema() *jsonschema.Schema { return mustSchema[assetRefArgs]() }
+func (t *DeleteAsset) Description() string {
+	return "Delete an org asset by ID or name. This also removes every agent link and its derived operational tools."
+}
+func (t *DeleteAsset) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	var args assetRefArgs
+	if err := json.Unmarshal(inv.Args, &args); err != nil {
+		return nil, fmt.Errorf("parse args: %w", err)
+	}
+	orgID, err := managedAssetsOrgID(inv, string(DeleteAssetName))
+	if err != nil {
+		return nil, err
+	}
+	value, err := resolveManagedAsset(t.deps, ctx, orgID, args.Asset)
+	if err != nil {
+		return nil, fmt.Errorf("resolve asset: %w", err)
+	}
+	if err := t.deps.Assets.Delete(ctx, orgID, value.ID); err != nil {
+		return nil, fmt.Errorf("delete asset: %w", err)
+	}
+	return json.Marshal(assetMutationResult{AssetID: value.ID, Status: "deleted"})
+}
+
+// --- asset links ----------------------------------------------------------
+
+const ListAssetLinksName tool.Name = "list_asset_links"
+const LinkAssetName tool.Name = "link_asset"
+const UnlinkAssetName tool.Name = "unlink_asset"
+
+type ListAssetLinks struct{ deps Deps }
+type LinkAsset struct{ deps Deps }
+type UnlinkAsset struct{ deps Deps }
+
+type assetLinkArgs struct {
+	Asset   string `json:"asset"`
+	AgentID string `json:"agent_id"`
+}
+
+func (t *ListAssetLinks) Name() tool.Name                 { return ListAssetLinksName }
+func (t *ListAssetLinks) InputSchema() *jsonschema.Schema { return mustSchema[assetRefArgs]() }
+func (t *ListAssetLinks) Description() string {
+	return "List the agent IDs linked to an asset. These links determine who receives and may invoke its operational tools."
+}
+func (t *ListAssetLinks) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	var args assetRefArgs
+	if err := json.Unmarshal(inv.Args, &args); err != nil {
+		return nil, fmt.Errorf("parse args: %w", err)
+	}
+	orgID, err := managedAssetsOrgID(inv, string(ListAssetLinksName))
+	if err != nil {
+		return nil, err
+	}
+	value, err := resolveManagedAsset(t.deps, ctx, orgID, args.Asset)
+	if err != nil {
+		return nil, fmt.Errorf("resolve asset: %w", err)
+	}
+	result, err := listAssetLinksResult(ctx, t.deps, orgID, value)
+	if err != nil {
+		return nil, fmt.Errorf("list asset links: %w", err)
+	}
+	return json.Marshal(result)
+}
+
+func (t *LinkAsset) Name() tool.Name                 { return LinkAssetName }
+func (t *LinkAsset) InputSchema() *jsonschema.Schema { return mustSchema[assetLinkArgs]() }
+func (t *LinkAsset) Description() string {
+	return "Link an asset to an agent, granting that agent the asset's operational MCP tools."
+}
+func (t *LinkAsset) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	var args assetLinkArgs
+	if err := json.Unmarshal(inv.Args, &args); err != nil {
+		return nil, fmt.Errorf("parse args: %w", err)
+	}
+	orgID, err := managedAssetsOrgID(inv, string(LinkAssetName))
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(args.AgentID) == "" {
+		return nil, errors.New("agent_id is required")
+	}
+	value, err := resolveManagedAsset(t.deps, ctx, orgID, args.Asset)
+	if err != nil {
+		return nil, fmt.Errorf("resolve asset: %w", err)
+	}
+	if _, err := t.deps.Assets.Link(ctx, orgID, value.ID, args.AgentID); err != nil {
+		return nil, fmt.Errorf("link asset: %w", err)
+	}
+	result, err := listAssetLinksResult(ctx, t.deps, orgID, value)
+	if err != nil {
+		return nil, fmt.Errorf("list asset links after link: %w", err)
+	}
+	return json.Marshal(result)
+}
+
+func (t *UnlinkAsset) Name() tool.Name                 { return UnlinkAssetName }
+func (t *UnlinkAsset) InputSchema() *jsonschema.Schema { return mustSchema[assetLinkArgs]() }
+func (t *UnlinkAsset) Description() string {
+	return "Unlink an asset from an agent. Its derived operational tools are removed when no other linked asset still requires them."
+}
+func (t *UnlinkAsset) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	var args assetLinkArgs
+	if err := json.Unmarshal(inv.Args, &args); err != nil {
+		return nil, fmt.Errorf("parse args: %w", err)
+	}
+	orgID, err := managedAssetsOrgID(inv, string(UnlinkAssetName))
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(args.AgentID) == "" {
+		return nil, errors.New("agent_id is required")
+	}
+	value, err := resolveManagedAsset(t.deps, ctx, orgID, args.Asset)
+	if err != nil {
+		return nil, fmt.Errorf("resolve asset: %w", err)
+	}
+	if err := t.deps.Assets.Unlink(ctx, orgID, value.ID, args.AgentID); err != nil {
+		return nil, fmt.Errorf("unlink asset: %w", err)
+	}
+	result, err := listAssetLinksResult(ctx, t.deps, orgID, value)
+	if err != nil {
+		return nil, fmt.Errorf("list asset links after unlink: %w", err)
+	}
+	return json.Marshal(result)
+}
+
+// --- get_asset_health -----------------------------------------------------
+
+const GetAssetHealthName tool.Name = "get_asset_health"
+
+type GetAssetHealth struct{ deps Deps }
+
+func (t *GetAssetHealth) Name() tool.Name                 { return GetAssetHealthName }
+func (t *GetAssetHealth) InputSchema() *jsonschema.Schema { return mustSchema[assetRefArgs]() }
+func (t *GetAssetHealth) Description() string {
+	return "Check TCP and authenticated SSH reachability for any org server asset. Run this after installing a generated Helix public key, then exercise a server operation before claiming setup is complete."
+}
+func (t *GetAssetHealth) Invoke(ctx context.Context, inv tool.Invocation) (json.RawMessage, error) {
+	var args assetRefArgs
+	if err := json.Unmarshal(inv.Args, &args); err != nil {
+		return nil, fmt.Errorf("parse args: %w", err)
+	}
+	orgID, err := managedAssetsOrgID(inv, string(GetAssetHealthName))
+	if err != nil {
+		return nil, err
+	}
+	if t.deps.AssetHealth == nil {
+		return nil, errors.New("asset health checker is not wired")
+	}
+	if _, err := resolveManagedAsset(t.deps, ctx, orgID, args.Asset); err != nil {
+		return nil, fmt.Errorf("resolve asset: %w", err)
+	}
+	return json.Marshal(t.deps.AssetHealth(ctx, orgID, args.Asset))
+}

--- a/api/pkg/org/interfaces/mcptools/manage_assets_mcp_test.go
+++ b/api/pkg/org/interfaces/mcptools/manage_assets_mcp_test.go
@@ -1,0 +1,71 @@
+package mcptools_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	assetapp "github.com/helixml/helix/api/pkg/org/application/assets"
+	orgmemory "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
+	"github.com/helixml/helix/api/pkg/org/interfaces/mcptools"
+	"github.com/helixml/helix/api/pkg/org/interfaces/server"
+)
+
+func TestChiefOfStaffCreatesAssetAndReceivesOperationalToolsOverMCP(t *testing.T) {
+	t.Parallel()
+	st := orgmemory.New()
+	seedActingBot(t, st, "org-test", "chief-of-staff", mcptools.OwnerBotTools())
+
+	cfg := mcptools.DefaultDeps(st)
+	injectTestPublishing(&cfg)
+	assets, err := assetapp.New(assetapp.Deps{
+		Assets: st.Assets, Links: st.AssetLinks, Nodes: st.Nodes,
+		GenerateKey: func() (string, string, error) {
+			return "private", "ssh-ed25519 AAAA-public\n", nil
+		},
+		Encrypt: func(value []byte) (string, error) { return "encrypted", nil },
+		Now:     func() time.Time { return time.Now().UTC() },
+		NewID:   func() string { return "mcp-server" },
+	})
+	require.NoError(t, err)
+	cfg.Assets = assets
+
+	reg := mcptools.NewRegistry()
+	require.NoError(t, mcptools.RegisterBuiltins(reg, cfg.Build()))
+	srv := httptest.NewServer(server.NewFromStore(st, reg, nil, nil, nil).Handler())
+	t.Cleanup(srv.Close)
+	session := connectMCP(t, srv.URL, "chief-of-staff")
+
+	before, err := session.ListTools(context.Background(), nil)
+	require.NoError(t, err)
+	beforeNames := listedToolNames(before.Tools)
+	for _, name := range mcptools.AssetManagementTools {
+		assert.True(t, beforeNames[string(name)], "Chief of Staff missing %q", name)
+	}
+	assert.False(t, beforeNames[string(mcptools.ServerRunCommandName)])
+
+	_, err = invokeTool(t, session, mcptools.CreateServerAssetName, map[string]any{
+		"name": "production", "address": "10.0.0.8", "user": "ubuntu",
+	})
+	require.NoError(t, err)
+
+	after, err := session.ListTools(context.Background(), nil)
+	require.NoError(t, err)
+	afterNames := listedToolNames(after.Tools)
+	for _, name := range assetapp.ServerTools {
+		assert.True(t, afterNames[string(name)], "linked Chief of Staff missing %q", name)
+	}
+}
+
+func listedToolNames(tools []*mcp.Tool) map[string]bool {
+	names := make(map[string]bool, len(tools))
+	for _, value := range tools {
+		names[value.Name] = true
+	}
+	return names
+}

--- a/api/pkg/org/interfaces/mcptools/manage_assets_registration_test.go
+++ b/api/pkg/org/interfaces/mcptools/manage_assets_registration_test.go
@@ -1,0 +1,35 @@
+package mcptools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	orgmemory "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
+)
+
+func TestAssetManagementToolsRegisteredAndGrantedToOwner(t *testing.T) {
+	t.Parallel()
+	st := orgmemory.New()
+	cfg := DefaultDeps(st)
+	injectTestPublishing(&cfg)
+	reg := NewRegistry()
+	require.NoError(t, RegisterBuiltins(reg, cfg.Build()))
+
+	owner := make(map[tool.Name]bool, len(OwnerBotTools()))
+	for _, name := range OwnerBotTools() {
+		owner[name] = true
+	}
+	base := make(map[tool.Name]bool, len(BaseReadTools))
+	for _, name := range BaseReadTools {
+		base[name] = true
+	}
+	for _, name := range AssetManagementTools {
+		_, err := reg.Get(name)
+		assert.NoError(t, err, "tool %q must be registered", name)
+		assert.True(t, owner[name], "OwnerBotTools missing %q", name)
+		assert.False(t, base[name], "asset management tool %q must not be universal", name)
+	}
+}

--- a/api/pkg/org/interfaces/mcptools/manage_assets_test.go
+++ b/api/pkg/org/interfaces/mcptools/manage_assets_test.go
@@ -1,0 +1,162 @@
+package mcptools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	assetapp "github.com/helixml/helix/api/pkg/org/application/assets"
+	"github.com/helixml/helix/api/pkg/org/application/nodes"
+	"github.com/helixml/helix/api/pkg/org/domain/asset"
+	orgstore "github.com/helixml/helix/api/pkg/org/domain/store"
+	"github.com/helixml/helix/api/pkg/org/domain/tool"
+	"github.com/helixml/helix/api/pkg/org/infrastructure/assetssh"
+	orgmemory "github.com/helixml/helix/api/pkg/org/infrastructure/persistence/memory"
+)
+
+func managedAssetTestDeps(t *testing.T) (Deps, *assetapp.Service, *orgstore.Store) {
+	t.Helper()
+	st := orgmemory.New()
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	nodeSvc := nodes.New(nodes.Deps{Nodes: st.Nodes})
+	_, err := nodeSvc.Create(context.Background(), "org-1", nodes.CreateParams{
+		ID: "chief-of-staff", Content: "# Chief of Staff", Tools: OwnerBotTools(),
+	})
+	require.NoError(t, err)
+	_, err = nodeSvc.Create(context.Background(), "org-1", nodes.CreateParams{
+		ID: "b-operator", Content: "# Operator",
+	})
+	require.NoError(t, err)
+
+	service, err := assetapp.New(assetapp.Deps{
+		Assets: st.Assets, Links: st.AssetLinks, Nodes: st.Nodes,
+		GenerateKey: func() (string, string, error) {
+			return "PRIVATE KEY MATERIAL", "ssh-ed25519 AAAA-helix-public\n", nil
+		},
+		Encrypt: func(value []byte) (string, error) {
+			return "encrypted:" + string(value), nil
+		},
+		Now: func() time.Time { return now }, NewID: func() string { return "server-1" },
+	})
+	require.NoError(t, err)
+	deps := Deps{
+		Assets: service,
+		AssetHealth: func(_ context.Context, _, _ string) assetssh.Health {
+			return assetssh.Health{TCPReachable: true, SSHReachable: true, LatencyMS: 4, CheckedAt: now}
+		},
+	}
+	return deps, service, st
+}
+
+func invokeManagedAssetTool(t *testing.T, target tool.Tool, caller assetCallerIdentity, args string) json.RawMessage {
+	t.Helper()
+	raw, err := target.Invoke(context.Background(), tool.Invocation{Caller: caller, Args: json.RawMessage(args)})
+	require.NoError(t, err)
+	return raw
+}
+
+func TestChiefOfStaffManagesServerAssetLifecycle(t *testing.T) {
+	t.Parallel()
+	deps, service, st := managedAssetTestDeps(t)
+	ctx := context.Background()
+	caller := assetCallerIdentity{agentID: "chief-of-staff", orgID: "org-1"}
+
+	raw := invokeManagedAssetTool(t, &CreateServerAsset{deps: deps}, caller,
+		`{"name":"production","description":"Primary API","notes_for_agents":"Check the runbook","address":"10.0.0.8","user":"ubuntu"}`)
+	var created managedAssetResult
+	require.NoError(t, json.Unmarshal(raw, &created))
+	assert.Equal(t, "production", created.Asset.Name)
+	assert.Equal(t, []string{"chief-of-staff"}, created.Asset.AgentIDs)
+	require.NotNil(t, created.Setup)
+	assert.Equal(t, "ssh-ed25519 AAAA-helix-public", created.Setup.PublicKey)
+	assert.Contains(t, created.Setup.InstallCommand, "authorized_keys")
+	assert.Equal(t, "get_asset_health", created.Setup.VerificationToolName)
+	assert.NotContains(t, string(raw), "PRIVATE KEY MATERIAL")
+	assert.NotContains(t, string(raw), "encrypted:")
+
+	assetID := created.Asset.ID
+	chief, err := st.Nodes.Get(ctx, "org-1", "chief-of-staff")
+	require.NoError(t, err)
+	for _, name := range assetapp.ServerTools {
+		assert.Contains(t, chief.Tools, name)
+	}
+
+	invokeManagedAssetTool(t, &LinkAsset{deps: deps}, caller,
+		`{"asset":"production","agent_id":"b-operator"}`)
+	raw = invokeManagedAssetTool(t, &ListAssetLinks{deps: deps}, caller,
+		`{"asset":"production"}`)
+	var links assetLinksResult
+	require.NoError(t, json.Unmarshal(raw, &links))
+	assert.ElementsMatch(t, []string{"chief-of-staff", "b-operator"}, links.AgentIDs)
+
+	raw = invokeManagedAssetTool(t, &UpdateServerAsset{deps: deps}, caller,
+		`{"asset":"production","description":"Primary production API","address":"10.0.0.9"}`)
+	var updated managedAssetResult
+	require.NoError(t, json.Unmarshal(raw, &updated))
+	assert.Equal(t, "Primary production API", updated.Asset.Description)
+	require.NotNil(t, updated.Asset.Server)
+	assert.Equal(t, "10.0.0.9", updated.Asset.Server.Address)
+
+	raw = invokeManagedAssetTool(t, &GetAssetHealth{deps: deps}, caller,
+		`{"asset":"production"}`)
+	var health assetssh.Health
+	require.NoError(t, json.Unmarshal(raw, &health))
+	assert.True(t, health.TCPReachable)
+	assert.True(t, health.SSHReachable)
+
+	raw = invokeManagedAssetTool(t, &ListOrgAssets{deps: deps}, caller, `{}`)
+	var listed orgAssetsResult
+	require.NoError(t, json.Unmarshal(raw, &listed))
+	require.Len(t, listed.Assets, 1)
+	assert.Equal(t, assetID, listed.Assets[0].ID)
+
+	invokeManagedAssetTool(t, &UnlinkAsset{deps: deps}, caller,
+		`{"asset":"production","agent_id":"b-operator"}`)
+	invokeManagedAssetTool(t, &DeleteAsset{deps: deps}, caller,
+		`{"asset":"production"}`)
+	_, err = service.Get(ctx, "org-1", assetID)
+	require.Error(t, err)
+
+	// Exercise the immediately following normal operation: the same name can
+	// be recreated after deletion and receives a fresh working link.
+	raw = invokeManagedAssetTool(t, &CreateServerAsset{deps: deps}, caller,
+		`{"name":"production","address":"10.0.0.10","user":"ubuntu"}`)
+	require.NoError(t, json.Unmarshal(raw, &created))
+	assert.Equal(t, "production", created.Asset.Name)
+	assert.Equal(t, []string{"chief-of-staff"}, created.Asset.AgentIDs)
+}
+
+func TestCreateServerAssetRollsBackWhenLinkFails(t *testing.T) {
+	t.Parallel()
+	deps, service, _ := managedAssetTestDeps(t)
+	caller := assetCallerIdentity{agentID: "chief-of-staff", orgID: "org-1"}
+	_, err := (&CreateServerAsset{deps: deps}).Invoke(context.Background(), tool.Invocation{
+		Caller: caller,
+		Args:   json.RawMessage(`{"name":"broken","address":"10.0.0.20","user":"ubuntu","agent_ids":["missing-agent"]}`),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing-agent")
+	values, listErr := service.List(context.Background(), "org-1")
+	require.NoError(t, listErr)
+	assert.Empty(t, values)
+}
+
+func TestListOrgAssetsIncludesUnlinkedInventory(t *testing.T) {
+	t.Parallel()
+	deps, service, _ := managedAssetTestDeps(t)
+	_, err := service.CreateServer(context.Background(), "org-1", assetapp.CreateServerParams{
+		Name: "unlinked", Address: "10.0.0.30", User: "root", AuthType: asset.AuthSSHKey,
+	})
+	require.NoError(t, err)
+	caller := assetCallerIdentity{agentID: "chief-of-staff", orgID: "org-1"}
+	raw := invokeManagedAssetTool(t, &ListOrgAssets{deps: deps}, caller, `{}`)
+	assert.Contains(t, string(raw), `"name":"unlinked"`)
+
+	linkedRaw := invokeManagedAssetTool(t, &ListAssets{deps: deps}, caller, `{}`)
+	assert.False(t, strings.Contains(string(linkedRaw), `"name":"unlinked"`))
+}

--- a/api/pkg/server/helix_org.go
+++ b/api/pkg/server/helix_org.go
@@ -952,6 +952,7 @@ func initHelixOrgHandler(cfg helixOrgConfig, helixStore helixstore.Store) (*heli
 	deps.AssetSSH = assetSSH
 	deps.AssetSSHIssuer = assetSSHIssuer
 	deps.AssetSSHProxyAddress = cfg.APIServer.Cfg.WebServer.AssetSSHProxyAddress
+	deps.AssetHealth = assetSSH.Health
 
 	reg := mcptools.NewRegistry()
 	if err := mcptools.RegisterBuiltins(reg, deps.Build()); err != nil {

--- a/api/pkg/server/org_graph_seed_test.go
+++ b/api/pkg/server/org_graph_seed_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/helixml/helix/api/pkg/org/application/nodes"
@@ -40,6 +41,11 @@ func TestSeedChiefOfStaffPreservesContextForNewBotOnly(t *testing.T) {
 	if !created.PreserveContext {
 		t.Fatal("new chief of staff must preserve conversation context")
 	}
+	for _, name := range mcptools.AssetManagementTools {
+		if !slices.Contains(created.Tools, name) {
+			t.Errorf("new chief of staff missing asset management tool %q", name)
+		}
+	}
 	if len(dispatcher.ids) != 0 {
 		t.Fatalf("seed dispatched bots = %v, want none before runtime selection", dispatcher.ids)
 	}
@@ -67,5 +73,10 @@ func TestSeedChiefOfStaffPreservesContextForNewBotOnly(t *testing.T) {
 	}
 	if existing.PreserveContext {
 		t.Fatal("reseed must not override an existing chief of staff's context preference")
+	}
+	for _, name := range mcptools.AssetManagementTools {
+		if !slices.Contains(existing.Tools, name) {
+			t.Errorf("reseeded chief of staff missing asset management tool %q", name)
+		}
 	}
 }

--- a/design/2026-08-01-org-assets.md
+++ b/design/2026-08-01-org-assets.md
@@ -105,11 +105,15 @@ or encrypted credentials.
 - `server_list_commands`, `server_get_command`, `server_kill_command`
 - `server_list_files`, `server_read_file`, `server_write_file`
 - `server_ssh_access`
+- owner management: `list_org_assets`, `get_org_asset`,
+  `create_server_asset`, `update_server_asset`, `delete_asset`,
+  `list_asset_links`, `link_asset`, `unlink_asset`, `get_asset_health`
 
 All server tools select an asset by ID or org-scoped name and require a live
-link from the invoking agent. The owner can manage assets through REST in this
-slice; mutation MCP tools can be added later if there is a concrete agent-driven
-workflow.
+link from the invoking agent. The initial slice limited management to REST. The
+2026-08-02 follow-up in `design/2026-08-02-org-asset-mcp-management.md` adds the
+owner-management MCP surface to Chief of Staff without widening the linked
+operational tools.
 
 ## SSH proxy
 

--- a/design/2026-08-02-org-asset-mcp-management.md
+++ b/design/2026-08-02-org-asset-mcp-management.md
@@ -1,0 +1,57 @@
+# Org asset MCP management
+
+## Goal
+
+Let the seeded Chief of Staff create and manage org server assets without
+requiring the owner to switch to the REST or chart UI. Creating an SSH-key
+asset must return everything needed to bootstrap access, while never exposing
+Helix's generated private key.
+
+## Tool surface
+
+The Chief of Staff receives these owner-management tools through
+`OwnerBotTools`:
+
+- `list_org_assets`, `get_org_asset`
+- `create_server_asset`, `update_server_asset`, `delete_asset`
+- `list_asset_links`, `link_asset`, `unlink_asset`
+- `get_asset_health`
+
+The existing `list_assets`, `get_asset`, and `server_*` tools remain
+link-scoped operational capabilities. They are not widened: ordinary agents
+must only discover and operate assets explicitly linked to them.
+
+`create_server_asset` links the new asset to the caller in the same action and
+can link additional agents through `agent_ids`. If any link fails, creation is
+rolled back so the caller does not receive a partially configured result.
+
+For SSH-key authentication the response includes the generated public key and
+an idempotent command that installs it in the remote user's
+`~/.ssh/authorized_keys`. The private key remains encrypted in Helix and is
+never returned. Chief of Staff may run the installation command over normal
+SSH when independent access is already available. Otherwise it sends the exact
+command to the owner with `ask_human`. It must verify `get_asset_health`, then
+exercise a following `server_run_command`, before claiming the asset is ready.
+
+## Boundaries
+
+Tool possession is the org-graph capability boundary, matching the existing
+bot/topic/processor/repository mutation tools. The management set is seeded
+only onto Chief of Staff, but remains assignable explicitly through the normal
+tool-management surface.
+
+All operations derive the organization from the MCP caller. Asset references
+resolve only inside that organization. Management projections expose public
+connection configuration, links, and public keys, but never encrypted private
+keys or passwords.
+
+## Verification
+
+- Unit tests cover create plus caller-link, public-key bootstrap output,
+  org-wide discovery, update, link/unlink, health, delete, and recreate.
+- Registration tests pin the complete management set in `OwnerBotTools` and
+  keep it out of `BaseReadTools`.
+- The Chief of Staff seed/backfill path is exercised with the new tools.
+- Run targeted org tests and required Go builds.
+- In the inner Helix, create an org, activate Chief of Staff, invoke the MCP
+  management flow, and verify the following linked operation.


### PR DESCRIPTION
## Summary

- add org-wide asset inventory, CRUD, link, and health MCP tools to Chief of Staff
- auto-link newly created server assets to the caller and return public-key installation material without exposing private credentials
- teach Chief of Staff to install the key through independent SSH access or ask the owner to run the exact command, then verify health and a following server operation
- preserve existing link-scoped operational asset tools for ordinary bots

## Verification

- `go test ./pkg/org/... -count=1`
- `go test ./pkg/server -run TestSeedChiefOfStaffPreservesContextForNewBotOnly -count=1`
- `go build ./pkg/server/ ./pkg/store/ ./pkg/types/`
- live inner-Helix MCP gateway: management tools present; create auto-linked Chief of Staff; public-key setup returned; operational tools appeared immediately; health checked; delete followed by recreate passed; test asset cleaned up